### PR TITLE
fix(query-cache): converge dirties_query_cache wiring to Rails

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2548,19 +2548,25 @@ function ensureAbstractAdapterMixinsApplied(): void {
     });
   }
 
-  // `dirties_query_cache` wiring (Rails query_cache.rb:13). trails' writes funnel
-  // through the low-level `execUpdate`/`execDelete`/`execInsertAll` (model
-  // `_performUpdate`/`_performDelete` call these directly, NOT the public
-  // `update`/`delete`) plus `truncate`/`truncateTables`/`restartDbTransaction`,
-  // so each logical write passes through exactly one of them. Wire the methods
-  // that are NOT overridden by a concrete adapter here — they're only defined on
-  // AbstractAdapter, and a subclass prototype doesn't yet inherit them when the
-  // per-adapter module runs (circular-import load order), so they must be wired
-  // on AbstractAdapter. The OVERRIDDEN write methods (`execInsert`, `execQuery`,
-  // `execute`, `rollbackDbTransaction`, `rollbackToSavepoint`, and sqlite's
-  // `truncate`) are wired on each concrete adapter instead — wiring them here too
-  // would leave the override unwrapped. Reads route through `internalExecQuery`
-  // and never trip the wrapper.
+  // `dirties_query_cache` wiring (Rails query_cache.rb:13). Rails wires the public
+  // `update`/`delete`/`insert`/`create`; trails wires one layer lower, on
+  // `execUpdate`/`execDelete`/`execInsert`/`execInsertAll`, because that is the
+  // single funnel every logical write shares. Two distinct update paths converge
+  // there: the model save path (`_performUpdate`/`_destroyRow` in base.ts) calls
+  // `execUpdate`/`execDelete` DIRECTLY, bypassing the public `update`/`delete`
+  // entirely, while `update_all`/`updateColumns` (persistence.ts `_updateRecord`)
+  // go through the public `update`/`delete` — which themselves call
+  // `execUpdate`/`execDelete`. Wiring the public methods would miss the direct
+  // save path; wiring the low-level method catches both, exactly once each (the
+  // still-lower `executeMutation` stays unwrapped). Wire the methods NOT overridden
+  // by a concrete adapter here — they're only defined on AbstractAdapter, and a
+  // subclass prototype doesn't yet inherit them when the per-adapter module runs
+  // (circular-import load order), so they must be wired on AbstractAdapter. The
+  // OVERRIDDEN write methods (`execInsert`, `execQuery`, `execute`,
+  // `rollbackDbTransaction`, `rollbackToSavepoint`, and sqlite's `truncate`) are
+  // wired on each concrete adapter instead — wiring them here too would leave the
+  // override unwrapped. Reads route through `internalExecQuery` and never trip
+  // the wrapper.
   dirtiesQueryCache(
     AbstractAdapter,
     "execUpdate",

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2548,29 +2548,26 @@ function ensureAbstractAdapterMixinsApplied(): void {
     });
   }
 
-  // Rails: `QueryCache.included` runs `dirties_query_cache base, :exec_query,
-  // :execute, :create, :insert, :update, :delete, ...` (query_cache.rb:13).
-  // trails' writes don't funnel through `execQuery` (that's the read path); they
-  // go through the `exec{Insert,Update,Delete}` / `create`/`insert`/`update`/`delete`
-  // methods mixed in from DatabaseStatements, plus rollback paths. Wrapping
-  // those clears the cache on every write while leaving reads untouched.
-  // `create` is Rails' `alias create insert`; Rails lists it explicitly in the
-  // dirties set, so we register it alongside `insert` for parity even though it
-  // delegates there.
+  // `dirties_query_cache` wiring (Rails query_cache.rb:13). trails' writes funnel
+  // through the low-level `execUpdate`/`execDelete`/`execInsertAll` (model
+  // `_performUpdate`/`_performDelete` call these directly, NOT the public
+  // `update`/`delete`) plus `truncate`/`truncateTables`/`restartDbTransaction`,
+  // so each logical write passes through exactly one of them. Wire the methods
+  // that are NOT overridden by a concrete adapter here — they're only defined on
+  // AbstractAdapter, and a subclass prototype doesn't yet inherit them when the
+  // per-adapter module runs (circular-import load order), so they must be wired
+  // on AbstractAdapter. The OVERRIDDEN write methods (`execInsert`, `execQuery`,
+  // `execute`, `rollbackDbTransaction`, `rollbackToSavepoint`, and sqlite's
+  // `truncate`) are wired on each concrete adapter instead — wiring them here too
+  // would leave the override unwrapped. Reads route through `internalExecQuery`
+  // and never trip the wrapper.
   dirtiesQueryCache(
     AbstractAdapter,
-    "execInsert",
     "execUpdate",
     "execDelete",
     "execInsertAll",
-    "create",
-    "insert",
-    "update",
-    "delete",
     "truncate",
     "truncateTables",
-    "rollbackDbTransaction",
-    "rollbackToSavepoint",
     "restartDbTransaction",
   );
 }

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -1539,6 +1539,12 @@ interface DatabaseStatementsDefaultsHost {
     binds?: unknown[],
     options?: { prepare?: boolean; allowRetry?: boolean },
   ): Promise<Result>;
+  internalExecQuery(
+    sql: string,
+    name?: string | null,
+    binds?: unknown[],
+    options?: { prepare?: boolean; allowRetry?: boolean },
+  ): Promise<Result>;
 }
 
 /**
@@ -1623,7 +1629,12 @@ export const DatabaseStatements = {
     const preparable = opts?.preparable ?? (binds != null && binds.length > 0);
     const prepare = !!((this as { preparedStatements?: boolean }).preparedStatements && preparable);
     try {
-      return await this.execQuery(sql, name, binds, {
+      // Rails' select_all runs `internal_exec_query` (the private work method),
+      // NOT the public `exec_query` — the latter is wrapped by
+      // `dirties_query_cache` and clearing the cache on every read would defeat
+      // it. Route reads through `internalExecQuery` so the cached read path
+      // never trips the write-dirtying wrapper on the public `execQuery`.
+      return await this.internalExecQuery(sql, name, binds, {
         allowRetry: opts?.allowRetry ?? false,
         prepare,
       });

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -469,6 +469,26 @@ export function makeCachedSelectAll(original: BaseSelectAll): BaseSelectAll {
   };
 }
 
+/** @internal Reassign each named prototype slot to a cache-dirtying wrapper. */
+function wireDirties(
+  base: { prototype: object },
+  methodNames: string[],
+  skipSchemaReflection: boolean,
+): void {
+  const proto = base.prototype as Record<string, unknown>;
+  for (const methodName of methodNames) {
+    const original = proto[methodName];
+    if (typeof original !== "function") continue;
+
+    proto[methodName] = function (this: QueryCacheHost, ...args: unknown[]) {
+      if (this._queryCache?.dirties && !(skipSchemaReflection && args.includes("SCHEMA"))) {
+        this._queryCache.clear();
+      }
+      return (original as (...a: unknown[]) => unknown).apply(this, args);
+    };
+  }
+}
+
 /**
  * Wraps the named write methods on `base.prototype` so each clears the
  * per-connection query cache (when its `dirties` flag is set) before
@@ -480,24 +500,27 @@ export function makeCachedSelectAll(original: BaseSelectAll): BaseSelectAll {
  * Mirrors: ActiveRecord::ConnectionAdapters::QueryCache.dirties_query_cache
  */
 export function dirtiesQueryCache(base: { prototype: object }, ...methodNames: string[]): void {
-  const proto = base.prototype as Record<string, unknown>;
-  for (const methodName of methodNames) {
-    const original = proto[methodName];
-    if (typeof original !== "function") continue;
+  wireDirties(base, methodNames, false);
+}
 
-    proto[methodName] = function (this: QueryCacheHost, ...args: unknown[]) {
-      // Rails routes schema reflection through the UNWRAPPED `internal_exec_query`
-      // (name "SCHEMA"), so those reads never dirty the query cache. trails reuses
-      // the wrapped `execute`/`exec_query` for schema reflection, passing the same
-      // "SCHEMA" name — skip the clear for them to reproduce Rails' behavior
-      // (otherwise re-reflecting columns inside a `cache` block would evict the
-      // cache). No cache-clearing write ever passes "SCHEMA" as its query name.
-      if (this._queryCache?.dirties && !args.includes("SCHEMA")) {
-        this._queryCache.clear();
-      }
-      return (original as (...a: unknown[]) => unknown).apply(this, args);
-    };
-  }
+/**
+ * Like {@link dirtiesQueryCache}, but skips the clear for schema-reflection
+ * queries (name `"SCHEMA"`). Use this ONLY for `execute`/`execQuery`: Rails
+ * routes schema reflection through the permanently-unwrapped `internal_exec_query`,
+ * so it never dirties the cache, whereas trails reuses the wrapped
+ * `execute`/`exec_query` (with name `"SCHEMA"`) for reflection. Skipping those
+ * reproduces Rails' behavior (otherwise re-reflecting columns inside a `cache`
+ * block would evict the cache). This is deliberately NOT applied to the generic
+ * write wiring — a real mutation whose `name` happened to be `"SCHEMA"` (e.g.
+ * `truncate(table, "SCHEMA")`) must still dirty — and within `execute`/`execQuery`
+ * the only non-SQL string argument is the `name`, so the check can't false-match
+ * a bind (binds are passed as an array, never the bare string `"SCHEMA"`).
+ */
+export function dirtiesQueryCacheExceptSchema(
+  base: { prototype: object },
+  ...methodNames: string[]
+): void {
+  wireDirties(base, methodNames, true);
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -486,7 +486,13 @@ export function dirtiesQueryCache(base: { prototype: object }, ...methodNames: s
     if (typeof original !== "function") continue;
 
     proto[methodName] = function (this: QueryCacheHost, ...args: unknown[]) {
-      if (this._queryCache?.dirties) {
+      // Rails routes schema reflection through the UNWRAPPED `internal_exec_query`
+      // (name "SCHEMA"), so those reads never dirty the query cache. trails reuses
+      // the wrapped `execute`/`exec_query` for schema reflection, passing the same
+      // "SCHEMA" name — skip the clear for them to reproduce Rails' behavior
+      // (otherwise re-reflecting columns inside a `cache` block would evict the
+      // cache). No cache-clearing write ever passes "SCHEMA" as its query name.
+      if (this._queryCache?.dirties && !args.includes("SCHEMA")) {
         this._queryCache.clear();
       }
       return (original as (...a: unknown[]) => unknown).apply(this, args);

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -600,7 +600,19 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     return super.execInsert(sql, name, binds, pk, sequenceName, returning);
   }
 
+  // Public `exec_query` is wrapped by `dirties_query_cache`; the actual work
+  // lives in `internal_exec_query` (Rails' structure), which `select_all`
+  // routes through so cached reads never clear the cache.
   override async execQuery(
+    sql: string,
+    name?: string | null,
+    binds?: unknown[],
+    options?: { prepare?: boolean },
+  ): Promise<Result> {
+    return this.internalExecQuery(sql, name, binds, options);
+  }
+
+  override async internalExecQuery(
     sql: string,
     name?: string | null,
     binds?: unknown[],
@@ -2152,12 +2164,22 @@ function isMysql2ConnectionError(e: unknown): boolean {
 (Mysql2Adapter.prototype as unknown as { castResult: typeof mysql2CastResult }).castResult =
   mysql2CastResult;
 
-dirtiesQueryCache(Mysql2Adapter, "executeMutation");
-// The multi-column RETURNING read-back in `execInsert` runs through `execQuery`
-// (a read primitive that does not dirty the cache) rather than `executeMutation`,
-// so dirty `execInsert` too; the single-column path delegates to
-// `executeMutation` via `super`, where the double-clear is a harmless no-op.
-dirtiesQueryCache(Mysql2Adapter, "execInsert");
+// `dirties_query_cache` for the write methods this adapter OVERRIDES (Rails
+// query_cache.rb:13). Overridden methods must be wrapped on the concrete class,
+// not on AbstractAdapter, or the override would run unwrapped. The write methods
+// this adapter does NOT override (`execUpdate`/`execDelete`/`execInsertAll`/
+// `truncateTables`/`restartDbTransaction`) are wired once on AbstractAdapter.
+// Each logical write clears the cache exactly once; the still-lower
+// `executeMutation` these funnel through stays unwrapped, and reads route
+// through `internalExecQuery` (never tripping the wrapper).
+dirtiesQueryCache(
+  Mysql2Adapter,
+  "execInsert",
+  "rollbackDbTransaction",
+  "rollbackToSavepoint",
+  "execQuery",
+  "execute",
+);
 
 // Mirrors: mysql2_adapter.rb:190-198 — adapter-scoped type registrations. The
 // mysql2 `:string`/`:immutable_string` types coerce booleans to `"1"`/`"0"`

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -20,7 +20,7 @@ import {
   RAW_CONNECTION_DEPRECATION_MESSAGE,
 } from "./abstract-adapter.js";
 import { deprecator } from "../deprecator.js";
-import { dirtiesQueryCache } from "./abstract/query-cache.js";
+import { dirtiesQueryCache, dirtiesQueryCacheExceptSchema } from "./abstract/query-cache.js";
 import {
   ActiveRecordError,
   AdapterError,
@@ -2172,14 +2172,11 @@ function isMysql2ConnectionError(e: unknown): boolean {
 // Each logical write clears the cache exactly once; the still-lower
 // `executeMutation` these funnel through stays unwrapped, and reads route
 // through `internalExecQuery` (never tripping the wrapper).
-dirtiesQueryCache(
-  Mysql2Adapter,
-  "execInsert",
-  "rollbackDbTransaction",
-  "rollbackToSavepoint",
-  "execQuery",
-  "execute",
-);
+dirtiesQueryCache(Mysql2Adapter, "execInsert", "rollbackDbTransaction", "rollbackToSavepoint");
+// Schema reflection reuses the wrapped `execute`/`exec_query` with name
+// "SCHEMA" (Rails routes it through the unwrapped `internal_exec_query`), so
+// use the schema-aware variant here — those reflection reads must not dirty.
+dirtiesQueryCacheExceptSchema(Mysql2Adapter, "execQuery", "execute");
 
 // Mirrors: mysql2_adapter.rb:190-198 — adapter-scoped type registrations. The
 // mysql2 `:string`/`:immutable_string` types coerce booleans to `"1"`/`"0"`

--- a/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
@@ -12,6 +12,7 @@ import { combineMultiStatements } from "../mysql/database-statements.js";
 
 export interface DatabaseStatementsHost {
   execQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;
+  internalExecQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;
   preparedStatements?: boolean;
 }
 
@@ -139,7 +140,10 @@ export async function selectAll(
   name?: string | null,
   binds?: unknown[],
 ): Promise<Result> {
-  return this.execQuery(sql, name, binds);
+  // Rails' `select_all` calls `super` → `internal_exec_query`, NOT the public
+  // `exec_query` (which `dirties_query_cache` wraps) — routing through the
+  // public method would clear the query cache on every read.
+  return this.internalExecQuery(sql, name, binds);
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -70,7 +70,7 @@ import {
 } from "../errors.js";
 import { AbstractAdapter, RAW_CONNECTION_DEPRECATION_MESSAGE } from "./abstract-adapter.js";
 import { deprecator } from "../deprecator.js";
-import { dirtiesQueryCache } from "./abstract/query-cache.js";
+import { dirtiesQueryCache, dirtiesQueryCacheExceptSchema } from "./abstract/query-cache.js";
 import { PostgreSQLSchemaStatements } from "./postgresql/schema-statements-class.js";
 import type { JoinTableOptions } from "./abstract/schema-statements.js";
 import {
@@ -5224,14 +5224,11 @@ const FORMAT_TYPE_ALIASES: Record<string, string> = {
 // Each logical write clears the cache exactly once; the still-lower
 // `executeMutation` these funnel through stays unwrapped, and reads route
 // through `internalExecQuery` (never tripping the wrapper).
-dirtiesQueryCache(
-  PostgreSQLAdapter,
-  "execInsert",
-  "rollbackDbTransaction",
-  "rollbackToSavepoint",
-  "execQuery",
-  "execute",
-);
+dirtiesQueryCache(PostgreSQLAdapter, "execInsert", "rollbackDbTransaction", "rollbackToSavepoint");
+// Schema reflection reuses the wrapped `execute`/`exec_query` with name
+// "SCHEMA" (Rails routes it through the unwrapped `internal_exec_query`), so
+// use the schema-aware variant here — those reflection reads must not dirty.
+dirtiesQueryCacheExceptSchema(PostgreSQLAdapter, "execQuery", "execute");
 
 // Mirrors `ActiveSupport.run_load_hooks(:active_record_postgresqladapter, self)`
 // at the bottom of Rails' postgresql_adapter.rb — lets railtie initializers

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -936,7 +936,19 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * this override is the Rails-faithful PG version that actually
    * populates them.
    */
+  // Public `exec_query` is wrapped by `dirties_query_cache`; the actual work
+  // lives in `internal_exec_query` (Rails' structure), which `select_all`
+  // routes through so cached reads never clear the cache.
   override async execQuery(
+    sql: string,
+    name?: string | null,
+    binds?: unknown[],
+    options?: { prepare?: boolean; allowRetry?: boolean },
+  ): Promise<Result> {
+    return this.internalExecQuery(sql, name, binds, options);
+  }
+
+  override async internalExecQuery(
     sql: string,
     name?: string | null,
     binds?: unknown[],
@@ -5204,17 +5216,22 @@ const FORMAT_TYPE_ALIASES: Record<string, string> = {
 // the abstract `truncateTables` emits Rails' combined form instead of N per-table ones.
 (PostgreSQLAdapter.prototype as any).buildTruncateStatements = pgBuildTruncateStatements;
 
-// `executeMutation` is this adapter's write/DDL primitive (reads go through the
-// overridden `execQuery`), so dirtying it clears the query cache on writes and
-// schema changes — the trails analogue of Rails' `dirties_query_cache base,
-// :execute` for the write side.
-dirtiesQueryCache(PostgreSQLAdapter, "executeMutation");
-// `execInsert`'s multi-column RETURNING read-back runs through `internalExecQuery`
-// rather than `executeMutation`, so dirty it too — otherwise a subsequent read
-// could be served stale from the query cache after such an INSERT. (The
-// single-column path delegates to `executeMutation`, which is already dirtied;
-// the double-clear there is a harmless no-op.)
-dirtiesQueryCache(PostgreSQLAdapter, "execInsert");
+// `dirties_query_cache` for the write methods this adapter OVERRIDES (Rails
+// query_cache.rb:13). Overridden methods must be wrapped on the concrete class,
+// not on AbstractAdapter, or the override would run unwrapped. The write methods
+// this adapter does NOT override (`execUpdate`/`execDelete`/`execInsertAll`/
+// `truncateTables`/`restartDbTransaction`) are wired once on AbstractAdapter.
+// Each logical write clears the cache exactly once; the still-lower
+// `executeMutation` these funnel through stays unwrapped, and reads route
+// through `internalExecQuery` (never tripping the wrapper).
+dirtiesQueryCache(
+  PostgreSQLAdapter,
+  "execInsert",
+  "rollbackDbTransaction",
+  "rollbackToSavepoint",
+  "execQuery",
+  "execute",
+);
 
 // Mirrors `ActiveSupport.run_load_hooks(:active_record_postgresqladapter, self)`
 // at the bottom of Rails' postgresql_adapter.rb — lets railtie initializers

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -3158,17 +3158,23 @@ function translateException(
   return new StatementInvalid(message, { sql, binds, connectionPool, cause: exception });
 }
 
-// `executeMutation` is this adapter's write/DDL primitive (reads go through
-// `execute`/`execQuery`), so dirtying it clears the query cache on writes and
-// schema changes — the trails analogue of Rails' `dirties_query_cache base,
-// :execute` for the write side.
-dirtiesQueryCache(AbstractSQLite3Adapter, "executeMutation");
-// `execInsert`'s multi-column RETURNING read-back runs through `internalExecQuery`
-// rather than `executeMutation`, so dirty it too — otherwise a subsequent read
-// could be served stale from the query cache after such an INSERT. (The
-// single-column path delegates to `executeMutation`, which is already dirtied;
-// the double-clear there is a harmless no-op.)
-dirtiesQueryCache(AbstractSQLite3Adapter, "execInsert");
+// `dirties_query_cache` for the write methods this adapter OVERRIDES (Rails
+// query_cache.rb:13). Overridden methods must be wrapped on the concrete class,
+// not on AbstractAdapter, or the override would run unwrapped. The write methods
+// this adapter does NOT override (`execUpdate`/`execDelete`/`execInsertAll`/
+// `truncateTables`/`restartDbTransaction`) are wired once on AbstractAdapter.
+// Each logical write clears the cache exactly once; the still-lower
+// `executeMutation` these funnel through stays unwrapped, and reads route
+// through `internalExecQuery` (never tripping the wrapper).
+dirtiesQueryCache(
+  AbstractSQLite3Adapter,
+  "execInsert",
+  "rollbackDbTransaction",
+  "rollbackToSavepoint",
+  "truncate",
+  "execQuery",
+  "execute",
+);
 
 // Mirrors `ActiveSupport.run_load_hooks(:active_record_sqlite3adapter, self)`
 // at the bottom of Rails' sqlite3_adapter.rb — lets railtie initializers

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -25,7 +25,7 @@ import {
   indexExistsForRemoveFrom,
   canRemoveIndexByName,
 } from "./abstract/schema-statements.js";
-import { dirtiesQueryCache } from "./abstract/query-cache.js";
+import { dirtiesQueryCache, dirtiesQueryCacheExceptSchema } from "./abstract/query-cache.js";
 import { execInsertReturningReadback } from "./abstract/database-statements.js";
 import { StatementPool as GenericStatementPool } from "./statement-pool.js";
 import {
@@ -3172,9 +3172,11 @@ dirtiesQueryCache(
   "rollbackDbTransaction",
   "rollbackToSavepoint",
   "truncate",
-  "execQuery",
-  "execute",
 );
+// Schema reflection reuses the wrapped `execute`/`exec_query` with name
+// "SCHEMA" (Rails routes it through the unwrapped `internal_exec_query`), so
+// use the schema-aware variant here — those reflection reads must not dirty.
+dirtiesQueryCacheExceptSchema(AbstractSQLite3Adapter, "execQuery", "execute");
 
 // Mirrors `ActiveSupport.run_load_hooks(:active_record_sqlite3adapter, self)`
 // at the bottom of Rails' sqlite3_adapter.rb — lets railtie initializers

--- a/packages/activerecord/src/query-cache.test.ts
+++ b/packages/activerecord/src/query-cache.test.ts
@@ -11,6 +11,7 @@ import { Topic } from "./test-helpers/models/topic.js";
 import { Category } from "./test-helpers/models/category.js";
 import { Post } from "./test-helpers/models/post.js";
 import { association } from "./associations.js";
+import { Rollback } from "./errors.js";
 import { assertQueriesCount, assertNoQueries } from "./testing/query-assertions.js";
 import { QueryCache } from "./query-cache.js";
 import { LogSubscriber } from "./log-subscriber.js";
@@ -67,16 +68,32 @@ describe("QueryCacheTest", () => {
     Base.connectionPool().disableQueryCacheBang();
   });
 
-  it.skip("execute clear cache", () => {
-    // TRACKED-PENDING-CONVERGENCE (0023-surfaced-deviations:
-    // query-cache-dirties-wiring-incomplete): Rails clears the query cache
-    // on any `execute`, trails only dirties on `executeMutation` (write path).
+  it("execute clear cache", async () => {
+    assertCache("off");
+
+    const mw = middleware(async () => {
+      await Post.first();
+      expect(Base.connectionPool().queryCache.size).toBe(1);
+      await (await Post.leaseConnection()).execute("SELECT 1");
+      expect(Base.connectionPool().queryCache.size).toBe(0);
+    });
+    await mw();
+
+    assertCache("off");
   });
 
-  it.skip("exec query clear cache", () => {
-    // TRACKED-PENDING-CONVERGENCE (0023-surfaced-deviations:
-    // query-cache-dirties-wiring-incomplete): Rails clears the query cache
-    // on any `exec_query`, trails only dirties on `executeMutation`.
+  it("exec query clear cache", async () => {
+    assertCache("off");
+
+    const mw = middleware(async () => {
+      await Post.first();
+      expect(Base.connectionPool().queryCache.size).toBe(1);
+      await (await Post.leaseConnection()).execQuery("SELECT 1");
+      expect(Base.connectionPool().queryCache.size).toBe(0);
+    });
+    await mw();
+
+    assertCache("off");
   });
 
   it("writes should always clear cache", async () => {
@@ -245,11 +262,13 @@ describe("QueryCacheTest", () => {
     });
   });
 
-  it.skip("exists queries with cache", () => {
-    // TRACKED-PENDING-CONVERGENCE (0023-surfaced-deviations:
-    // query-cache-dirties-wiring-incomplete): trails `exists()` runs its probe
-    // via the raw `execute()` path, bypassing the cached `selectAll` override,
-    // so the second probe is not served from the query cache.
+  it("exists queries with cache", async () => {
+    await Post.cache(async () => {
+      await assertQueriesCount(1, false, async () => {
+        await Post.exists();
+        await Post.exists();
+      });
+    });
   });
 
   it("select all with cache", async () => {
@@ -432,11 +451,41 @@ describe("QueryCacheTest", () => {
     });
   });
 
-  it.skip("query cache doesnt leak cached results of rolled back queries", () => {
-    // TRACKED-PENDING-CONVERGENCE (0023-surfaced-deviations:
-    // query-cache-dirties-wiring-incomplete): Rails dirties the query cache on
-    // `rollback_to_savepoint` / `rollback_db_transaction`; trails only dirties
-    // on `executeMutation`, so a rolled-back write's cached SELECT result leaks.
+  it("query cache doesnt leak cached results of rolled back queries", async () => {
+    (await Base.leaseConnection()).enableQueryCacheBang();
+    const post = await Post.first();
+
+    await Post.transaction(async () => {
+      await post!.update({ title: "rollback" });
+      expect((await Post.where({ title: "rollback" })).length).toBe(1);
+      throw new Rollback();
+    });
+
+    expect((await Post.where({ title: "rollback" })).length).toBe(0);
+
+    await (
+      await Base.leaseConnection()
+    ).uncached(async () => {
+      expect((await Post.where({ title: "rollback" })).length).toBe(0);
+    });
+
+    try {
+      await Post.transaction(async () => {
+        await post!.update({ title: "rollback" });
+        expect((await Post.where({ title: "rollback" })).length).toBe(1);
+        throw new Error("broken");
+      });
+    } catch {
+      // Rails: `rescue Exception` — swallow the non-Rollback error.
+    }
+
+    expect((await Post.where({ title: "rollback" })).length).toBe(0);
+
+    await (
+      await Base.leaseConnection()
+    ).uncached(async () => {
+      expect((await Post.where({ title: "rollback" })).length).toBe(0);
+    });
   });
 
   it("query cached even when types are reset", async () => {
@@ -698,14 +747,98 @@ describe("QueryCacheExpiryTest", () => {
   // several nested layers (insert → insertStatement → execInsert), clearing 2–3
   // times. These `assert_called(query_cache, :clear, times: 1)` tests stay
   // skipped until the dirties wiring moves to the public-method layer.
-  it.skip("update", () => {});
-  it.skip("destroy", () => {});
-  it.skip("insert", () => {});
-  it.skip("insert all", () => {});
-  it.skip("insert all bang", () => {});
-  it.skip("upsert all", () => {});
-  it.skip("cache is expired by habtm update", () => {});
-  it.skip("cache is expired by habtm delete", () => {});
+  it("update", async () => {
+    await Task.cache(async () => {
+      await assertClears(1, async () => {
+        const task = (await Task.find(1)) as never as {
+          starting: unknown;
+          save(): Promise<unknown>;
+        };
+        task.starting = new Date().toISOString();
+        await task.save();
+      });
+    });
+  });
+
+  it("destroy", async () => {
+    await Task.cache(async () => {
+      await assertClears(1, async () => {
+        await ((await Task.find(1)) as never as { destroy(): Promise<unknown> }).destroy();
+      });
+    });
+  });
+
+  it("insert", async () => {
+    await Task.cache(async () => {
+      await assertClears(1, async () => {
+        await Task.create();
+      });
+    });
+  });
+
+  // Rails guards with `skip unless supports_insert_on_duplicate_skip?`; every
+  // trails adapter (sqlite/postgresql/mysql2) supports it, so run unconditionally.
+  it("insert all", async () => {
+    await Task.cache(async () => {
+      await assertClears(1, async () => {
+        await Task.insert({ starting: new Date().toISOString() });
+      });
+
+      await assertClears(1, async () => {
+        await Task.insertAll([{ starting: new Date().toISOString() }]);
+      });
+    });
+  });
+
+  it("insert all bang", async () => {
+    await Task.cache(async () => {
+      await assertClears(1, async () => {
+        await Task.insertBang({ starting: new Date().toISOString() });
+      });
+
+      await assertClears(1, async () => {
+        await Task.insertAllBang([{ starting: new Date().toISOString() }]);
+      });
+    });
+  });
+
+  // Rails guards with `skip unless supports_insert_on_duplicate_update?`; every
+  // trails adapter supports it, so run unconditionally.
+  it("upsert all", async () => {
+    await Task.cache(async () => {
+      await assertClears(1, async () => {
+        await Task.upsert({ starting: new Date().toISOString() });
+      });
+
+      await assertClears(1, async () => {
+        await Task.upsertAll([{ starting: new Date().toISOString() }]);
+      });
+    });
+  });
+
+  it("cache is expired by habtm update", async () => {
+    await Base.cache(async () => {
+      await assertClears(1, async () => {
+        const c = await Category.first();
+        const p = await Post.first();
+        await (
+          p as never as { categories: { concat(...c: unknown[]): Promise<unknown> } }
+        ).categories.concat(c);
+      });
+    });
+  });
+
+  it("cache is expired by habtm delete", async () => {
+    await Base.cache(async () => {
+      await assertClears(1, async () => {
+        const p = (await Post.find(1)) as never as {
+          categories: { count(): Promise<number>; deleteAll(): Promise<unknown> };
+        };
+        expect(await p.categories.count()).toBeGreaterThan(0);
+        await p.categories.deleteAll();
+      });
+    });
+  });
 
   it.skip("query cache lru eviction", () => {
     // BLOCKED: relies on swapping `connection.query_cache=` to a Store with a

--- a/packages/activerecord/src/querying.test.ts
+++ b/packages/activerecord/src/querying.test.ts
@@ -212,7 +212,9 @@ describe("_queryBySql — kwargs pass-through (Story J gap 1)", () => {
   afterEach(() => vi.restoreAllMocks());
 
   it("accepts preparable/async/allowRetry opts without error", async () => {
-    vi.spyOn(Topic.connection, "execQuery").mockResolvedValueOnce(Result.fromRowHashes([]));
+    // `find_by_sql` → `select_all` → `internal_exec_query` (Rails); trails'
+    // `selectAll` routes through `internalExecQuery`, so that is the seam.
+    vi.spyOn(Topic.connection, "internalExecQuery").mockResolvedValueOnce(Result.fromRowHashes([]));
     // _queryBySql returns the full Result so _loadFromSql can read column_types.
     const result = await _queryBySql.call(Topic, "SELECT 1", [], {
       preparable: true,
@@ -223,7 +225,7 @@ describe("_queryBySql — kwargs pass-through (Story J gap 1)", () => {
   });
 
   it("opts default to empty object — omitting opts still works", async () => {
-    vi.spyOn(Topic.connection, "execQuery").mockResolvedValueOnce(
+    vi.spyOn(Topic.connection, "internalExecQuery").mockResolvedValueOnce(
       Result.fromRowHashes([{ id: 1 }]),
     );
     const result = await _queryBySql.call(Topic, "SELECT 1");

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3345,8 +3345,12 @@ export class Relation<T extends Base> {
     // finder_methods.rb) — so LogSubscriber labels it instead of falling back
     // to the adapter's generic "SQL" default.
     const [existsSql, existsBinds] = this._compileAstWithBinds(probe.toArel().ast);
+    // Rails: `select_rows(relation.arel, "#{name} Exists?")` — the cached read
+    // path (select_rows → select_all), so repeated `exists?` probes inside a
+    // `cache` block are served from the query cache. Routing through the raw
+    // `execute()` here would bypass the cached `selectAll` override.
     const rows = await this._withQueryConnection(() =>
-      this._conn().execute(existsSql, existsBinds, `${this._modelClass.name} Exists?`),
+      this._conn().selectRows(existsSql, `${this._modelClass.name} Exists?`, existsBinds),
     );
     // Rails: `select_rows(...).size == 1` — with LIMIT 1 the probe returns at
     // most one row, so a non-empty result means a match.

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -32938,13 +32938,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "exists?",
-    "call": "select_rows",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "exists?",
     "call": "size",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
## Summary

Faithfully porting `query_cache_test.rb` surfaced that trails' `dirties_query_cache` wiring diverged from Rails in three ways. This converges all three and un-skips the 12 tracked-pending-convergence tests.

1. **Over-clearing on writes.** trails wired `dirties_query_cache` on the low-level `executeMutation`, through which a single logical write funnels at several nested layers (`insert → insertStatement → execInsert → executeMutation`), clearing the query cache 2–3× per write. The wiring now sits on the write methods trails actually funnels through, once each:
   - `execUpdate`/`execDelete`/`execInsertAll`/`truncate`/`truncateTables`/`restartDbTransaction` on `AbstractAdapter` (not overridden by adapters).
   - `execInsert`/`rollbackDbTransaction`/`rollbackToSavepoint`/`execQuery`/`execute` (and sqlite's `truncate`) per concrete adapter, since those are overridden there. (`_performUpdate`/`_performDelete` call `execUpdate`/`execDelete` directly rather than the public `update`/`delete`, so those low-level methods are the single funnel point.)
2. **No dirty on rollback.** The rollback methods are now wired, so a rolled-back write's cached SELECT result no longer leaks.
3. **`exists?` / raw `execute`/`exec_query` bypassed the cache.** `Relation#exists` now routes through `selectRows` (cached) so repeated probes hit the cache. `select_all` now routes through `internalExecQuery` (Rails' private work method) instead of the public `execQuery`, so wiring `execQuery`/`execute` to dirty does not clear the cache on every cached read — pg/mysql expose their read impl as `internalExecQuery` with a thin `execQuery` wrapper, matching Rails' structure. Schema-reflection queries (name `"SCHEMA"`, which trails routes through `execute`/`exec_query` where Rails uses the unwrapped `internal_exec_query`) are skipped by the dirties wrapper so re-reflecting columns inside a `cache` block doesn't evict the cache.

## Tests

Un-skipped and ported the 12 cases: `execute clear cache`, `exec query clear cache`, `exists queries with cache`, `query cache doesnt leak cached results of rolled back queries`, and QueryCacheExpiryTest `update`/`destroy`/`insert`/`insert all`/`insert all bang`/`upsert all`/`cache is expired by habtm update`/`cache is expired by habtm delete`. Full `query-cache.test.ts` passes (49 passed, 18 remaining skips are permanent/blocked). Verified no regressions in finder/persistence/dirty/transactions/habtm/exec-query suites. `pnpm typecheck` clean.

Closes-story: query-cache-dirties-wiring-incomplete