### PR TITLE
feat(rails-find): pnpm rails:find test/method → vendored file:line lookup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,10 @@ package list, and the `declare` / associations / enums / schema reference, see
   `vendor/rails/activerecord/test/fixtures/` (ours:
   `packages/activerecord/src/test-helpers/fixtures/`) — mirror those too
   rather than making up models or fixture rows.
+- To map a trails test name or method/constant to its vendored Rails
+  `file:line` instead of hand-grepping, run `pnpm rails:find <query>` — it
+  reuses the test-compare / api-compare manifests and falls back to a scoped
+  grep of `vendor/rails/activerecord/`, tagging each result with the mode.
 - Do NOT use subagents unless explicitly requested.
 - **AR work tracking lives in the `tasks` repo, not in docs.** Pick work via
   `pnpm tasks` (`ready` / `next-bundle` / `claim`) — never by hand-editing an

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "api:conventions": "pnpm tsx scripts/api-compare/conventions-doc.ts",
     "lint:deps": "pnpm vendor:fetch && LIB_PATHS_JSON=$(pnpm -s vendor:fetch --print-lib-paths) LOCKFILE_PATH=$PWD/vendor/sources.lock.json ruby scripts/api-compare/extract-ruby-api.rb && pnpm tsx scripts/api-compare/lint-deps.ts",
     "test:compare": "bash scripts/test-compare/run.sh",
+    "rails:find": "bash scripts/rails-find/run.sh",
     "test:deps": "pnpm vendor:fetch >/dev/null && pnpm tsx scripts/test-deps/rails-test-deps.ts",
     "fixture-baseline:refresh": "pnpm test:deps >/dev/null && pnpm tsx scripts/test-deps/build-fixture-baseline.ts",
     "fixture-parity-baseline:refresh": "pnpm tsx scripts/generate-fixture-parity-exclude.ts",

--- a/scripts/rails-find/bin.ts
+++ b/scripts/rails-find/bin.ts
@@ -37,17 +37,21 @@ function render(results: FindResult[]): string {
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   const all = args.includes("--all");
+  // `--refresh` is consumed by run.sh (it rebuilds the manifests before this
+  // runs); strip it here too so a direct invocation doesn't treat it as a token.
   const query = args
-    .filter((a) => a !== "--all")
+    .filter((a) => a !== "--all" && a !== "--refresh")
     .join(" ")
     .trim();
   if (!query) {
-    console.error("usage: pnpm rails:find [--all] <test-name | method | constant | token>");
+    console.error(
+      "usage: pnpm rails:find [--all] [--refresh] <test-name | method | constant | token>",
+    );
     process.exit(2);
   }
   const dir = path.dirname(fileURLToPath(import.meta.url));
   const root = path.resolve(dir, "../..");
-  const { results, exactOnly, suppressed } = await railsFind(root, query, { all });
+  const { results, exactOnly, suppressed, stale } = await railsFind(root, query, { all });
   if (results.length === 0) {
     console.error(`no matches for "${query}" (index or grep)`);
     process.exit(1);
@@ -56,6 +60,12 @@ async function main(): Promise<void> {
   if (suppressed > 0) {
     const why = exactOnly ? "substring/capped" : "capped";
     console.log(`\n… ${suppressed} more (${why}) — re-run with --all to see them`);
+  }
+  if (stale.length > 0) {
+    console.error(
+      `\n! stale index (older than vendor lockfile): ${stale.join(", ")}\n` +
+        `  file:line may be outdated — rebuild with 'pnpm rails:find --refresh <query>'`,
+    );
   }
 }
 

--- a/scripts/rails-find/bin.ts
+++ b/scripts/rails-find/bin.ts
@@ -1,0 +1,62 @@
+// Thin CLI entry for `pnpm rails:find [--all] <query>`. Owns argv/exit;
+// delegates all matching to ./core.ts (pure, so it stays unit-testable and
+// worktree-agnostic). run.sh guarantees the manifests exist first. <query> is a
+// Rails/trails test name, a method/constant, or any token; output is
+// `file:line label` grouped by the mode that produced each match. `--all` keeps
+// substring hits even when exact ones exist and lifts the per-mode cap.
+import * as path from "path";
+import { fileURLToPath } from "url";
+
+import { railsFind, type FindMode, type FindResult } from "./core.js";
+
+const MODE_HEADINGS: Record<FindMode, string> = {
+  test: "test-index (rails-tests.json)",
+  method: "api-index (rails-api.json)",
+  constant: "api-index (rails-api.json)",
+  grep: "grep fallback (vendor/rails/activerecord)",
+};
+
+function render(results: FindResult[]): string {
+  const byMode = new Map<FindMode, FindResult[]>();
+  for (const r of results) {
+    const list = byMode.get(r.mode) ?? [];
+    list.push(r);
+    byMode.set(r.mode, list);
+  }
+  const out: string[] = [];
+  for (const [mode, list] of byMode) {
+    out.push(`\n# ${MODE_HEADINGS[mode]} — ${list.length} match(es)`);
+    for (const r of list) {
+      const loc = r.line > 0 ? `${r.file}:${r.line}` : r.file;
+      out.push(`  ${loc}\t${r.label}`);
+    }
+  }
+  return out.join("\n");
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const all = args.includes("--all");
+  const query = args
+    .filter((a) => a !== "--all")
+    .join(" ")
+    .trim();
+  if (!query) {
+    console.error("usage: pnpm rails:find [--all] <test-name | method | constant | token>");
+    process.exit(2);
+  }
+  const dir = path.dirname(fileURLToPath(import.meta.url));
+  const root = path.resolve(dir, "../..");
+  const { results, exactOnly, suppressed } = await railsFind(root, query, { all });
+  if (results.length === 0) {
+    console.error(`no matches for "${query}" (index or grep)`);
+    process.exit(1);
+  }
+  console.log(render(results));
+  if (suppressed > 0) {
+    const why = exactOnly ? "substring/capped" : "capped";
+    console.log(`\n… ${suppressed} more (${why}) — re-run with --all to see them`);
+  }
+}
+
+void main();

--- a/scripts/rails-find/core.test.ts
+++ b/scripts/rails-find/core.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, writeFile, rm } from "fs/promises";
+import { mkdtemp, mkdir, writeFile, rm, utimes } from "fs/promises";
 import { tmpdir } from "os";
 import * as path from "path";
 
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   API_MANIFEST,
+  LOCKFILE,
   TEST_MANIFEST,
   findMethods,
   findTests,
@@ -59,6 +60,15 @@ describe("findTests", () => {
       line: 25,
     });
     expect(findTests(TEST_MANIFEST_FIXTURE as never, "test_has_primary_key")).toHaveLength(1);
+  });
+
+  it("synthesizes the Rails method name preserving punctuation (gsub(/\\s+/) only)", () => {
+    const tc = { path: "T > x", description: "doesn't raise when a != b", file: "t.rb", line: 7 };
+    const fixture = { packages: { activerecord: { files: [{ file: "t.rb", testCases: [tc] }] } } };
+    // Rails method: test_doesn't_raise_when_a_!=_b — punctuation survives, only
+    // whitespace runs collapse. A sanitizing regex would drop `'`/`!=` and miss.
+    const [r] = findTests(fixture as never, "test_doesn't_raise_when_a_!=_b");
+    expect(r).toMatchObject({ mode: "test", line: 7, exact: true });
   });
 });
 
@@ -125,6 +135,20 @@ describe("grepVendor + railsFind fallback", () => {
     await writeManifests(root, TEST_MANIFEST_FIXTURE, API_MANIFEST_FIXTURE);
     const { modes } = await railsFind(root, "save");
     expect(modes).toEqual(["method"]);
+  });
+
+  it("flags a used manifest older than the vendor lockfile as stale", async () => {
+    await writeManifests(root, TEST_MANIFEST_FIXTURE, API_MANIFEST_FIXTURE);
+    // Lockfile newer than the manifests → the used api manifest is stale.
+    await writeFile(path.join(root, LOCKFILE), "{}");
+    const future = new Date(Date.now() + 60_000);
+    await utimes(path.join(root, LOCKFILE), future, future);
+    const { stale } = await railsFind(root, "save");
+    expect(stale).toEqual([API_MANIFEST]);
+    // Fresh manifests (lockfile older) → nothing flagged.
+    const old = new Date(Date.now() - 60_000);
+    await utimes(path.join(root, LOCKFILE), old, old);
+    expect((await railsFind(root, "save")).stale).toEqual([]);
   });
 
   it("drops substring noise when an exact hit exists, restored by --all", async () => {

--- a/scripts/rails-find/core.test.ts
+++ b/scripts/rails-find/core.test.ts
@@ -1,0 +1,158 @@
+import { mkdtemp, mkdir, writeFile, rm } from "fs/promises";
+import { tmpdir } from "os";
+import * as path from "path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  API_MANIFEST,
+  TEST_MANIFEST,
+  findMethods,
+  findTests,
+  grepVendor,
+  railsFind,
+} from "./core.js";
+
+const TEST_MANIFEST_FIXTURE = {
+  packages: {
+    activerecord: {
+      files: [
+        {
+          file: "active_record_schema_test.rb",
+          testCases: [
+            {
+              path: "ActiveRecordSchemaTest > has primary key",
+              description: "has primary key",
+              file: "active_record_schema_test.rb",
+              line: 25,
+            },
+          ],
+        },
+      ],
+    },
+  },
+};
+
+const API_MANIFEST_FIXTURE = {
+  packages: {
+    activerecord: {
+      classes: {
+        "ActiveRecord::Base": {
+          instanceMethods: [{ name: "save", file: "persistence.rb", line: 60 }],
+          classMethods: [{ name: "find_by", file: "querying.rb", line: 80 }],
+        },
+      },
+      modules: {},
+      fileConstants: {
+        "version.rb": { VERSION: { kind: "expr" } },
+      },
+    },
+  },
+};
+
+describe("findTests", () => {
+  it("matches a description substring or synthesized test_ name → vendor file:line", () => {
+    const [r] = findTests(TEST_MANIFEST_FIXTURE as never, "primary key");
+    expect(r).toMatchObject({
+      mode: "test",
+      file: "vendor/rails/activerecord/test/cases/active_record_schema_test.rb",
+      line: 25,
+    });
+    expect(findTests(TEST_MANIFEST_FIXTURE as never, "test_has_primary_key")).toHaveLength(1);
+  });
+});
+
+describe("findMethods", () => {
+  it("resolves instance/class methods and file constants to lib file:line", () => {
+    const [inst] = findMethods(API_MANIFEST_FIXTURE as never, "save");
+    expect(inst).toMatchObject({
+      mode: "method",
+      file: "vendor/rails/activerecord/lib/active_record/persistence.rb",
+      line: 60,
+      label: "ActiveRecord::Base#save", // # for instance
+    });
+    expect(findMethods(API_MANIFEST_FIXTURE as never, "find_by")[0].label).toBe(
+      "ActiveRecord::Base.find_by", // . for class method
+    );
+    expect(findMethods(API_MANIFEST_FIXTURE as never, "VERSION")[0]).toMatchObject({
+      mode: "constant",
+      label: "VERSION",
+    });
+  });
+});
+
+async function writeManifests(root: string, test: unknown, api: unknown): Promise<void> {
+  await mkdir(path.join(root, path.dirname(TEST_MANIFEST)), { recursive: true });
+  await mkdir(path.join(root, path.dirname(API_MANIFEST)), { recursive: true });
+  await writeFile(path.join(root, TEST_MANIFEST), JSON.stringify(test));
+  await writeFile(path.join(root, API_MANIFEST), JSON.stringify(api));
+}
+
+describe("grepVendor + railsFind fallback", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), "rails-find-"));
+    const arDir = path.join(root, "vendor/rails/activerecord/lib/active_record");
+    await mkdir(arDir, { recursive: true });
+    await writeFile(
+      path.join(arDir, "sample.rb"),
+      "class Sample\n  def unique_marker_token\n  end\nend\n",
+    );
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("greps vendored .rb files and reports file:line relative to root", async () => {
+    const results = await grepVendor(root, "unique_marker_token");
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      mode: "grep",
+      file: "vendor/rails/activerecord/lib/active_record/sample.rb",
+      line: 2,
+    });
+  });
+
+  it("railsFind falls back to grep when no manifest matches", async () => {
+    const { results, modes } = await railsFind(root, "unique_marker_token");
+    expect(modes).toEqual(["grep"]);
+    expect(results).toHaveLength(1);
+  });
+
+  it("railsFind prefers index hits over grep when manifests are present", async () => {
+    await writeManifests(root, TEST_MANIFEST_FIXTURE, API_MANIFEST_FIXTURE);
+    const { modes } = await railsFind(root, "save");
+    expect(modes).toEqual(["method"]);
+  });
+
+  it("drops substring noise when an exact hit exists, restored by --all", async () => {
+    // `primary_key` is an exact method name but only a substring of the test
+    // description "has primary key" (→ test_has_primary_key).
+    const api = {
+      packages: {
+        activerecord: {
+          classes: {
+            "ActiveRecord::Base": {
+              instanceMethods: [{ name: "primary_key", file: "core.rb", line: 5 }],
+              classMethods: [],
+            },
+          },
+          modules: {},
+        },
+      },
+    };
+    await writeManifests(root, TEST_MANIFEST_FIXTURE, api);
+
+    const { results, exactOnly, suppressed } = await railsFind(root, "primary_key");
+    expect(exactOnly).toBe(true);
+    expect(suppressed).toBe(1);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ mode: "method", exact: true });
+
+    const withAll = await railsFind(root, "primary_key", { all: true });
+    expect(withAll.exactOnly).toBe(false);
+    expect(withAll.results).toHaveLength(2);
+  });
+});

--- a/scripts/rails-find/core.ts
+++ b/scripts/rails-find/core.ts
@@ -67,12 +67,26 @@ export const LIB_BASE: Record<string, string> = {
 export const TEST_MANIFEST = "scripts/test-compare/output/rails-tests.json";
 export const API_MANIFEST = "scripts/api-compare/output/rails-api.json";
 
+// Bumped by `pnpm vendor:fetch` whenever the pinned Rails/gem versions change;
+// a manifest older than it was built against a prior vendor tree and may be
+// stale. (New trails tests/methods can also stale it, but the vendored version
+// is the coarse, always-present signal — cf. api-compare's ts-cache drift.)
+export const LOCKFILE = "vendor/sources.lock.json";
+
 /** Grep fallback is scoped here — the fidelity work that drives this is AR. */
 const GREP_SCOPE = "vendor/rails/activerecord";
 const MAX_GREP_RESULTS = 40;
 
 function toPosix(p: string): string {
   return p.split(path.sep).join("/");
+}
+
+async function mtimeMs(root: string, rel: string): Promise<number | null> {
+  try {
+    return (await fs.stat(path.join(root, rel))).mtimeMs;
+  } catch {
+    return null;
+  }
 }
 
 async function readJson<T>(root: string, rel: string): Promise<T | null> {
@@ -85,17 +99,18 @@ async function readJson<T>(root: string, rel: string): Promise<T | null> {
 
 // ── Test-name lookup (reuses test-compare's rails-tests.json) ──
 
-// A test matches when the query (case-insensitive) is a substring of its human
-// description or qualified path, OR of the synthesized `test_snake_case` form —
-// so a trails description ("has primary key") and a Rails method name
-// (`test_has_primary_key`) both hit.
-// Returns `false` for no match, `"exact"` when the query equals the description
-// or synthesized `test_snake_case`, `"partial"` for a substring hit of either
-// (or the qualified path). So a trails description ("has primary key") and a
-// Rails method name (`test_has_primary_key`) both hit; exact wins.
+// A test matches when the query (case-insensitive) equals ("exact") or is a
+// substring ("partial") of its description, qualified path, or the Rails method
+// name Minitest derives from the description — so a trails description ("has
+// primary key") and the Rails method name (`test_has_primary_key`) both hit.
+// Rails builds that name as `test_#{name.gsub(/\s+/, '_')}` — collapsing
+// whitespace runs ONLY, preserving case and punctuation (activesupport/lib/
+// active_support/testing/declarative.rb). Replicate it exactly (lowercased,
+// since `needle` is), not a broader sanitize, or punctuation-bearing
+// descriptions ("doesn't …", "a != b") would diverge from the real method name.
 function testMatch(tc: TestCaseInfo, needle: string): "exact" | "partial" | false {
   const desc = tc.description.toLowerCase();
-  const railsName = "test_" + desc.replace(/[^a-z0-9]+/g, "_").replace(/^_|_$/g, "");
+  const railsName = ("test_" + tc.description.replace(/\s+/g, "_")).toLowerCase();
   if (desc === needle || railsName === needle) return "exact";
   if (desc.includes(needle) || railsName.includes(needle) || tc.path.toLowerCase().includes(needle))
     return "partial";
@@ -241,6 +256,12 @@ export interface FindOutput {
   exactOnly: boolean;
   /** How many matches were dropped by the exact filter + per-mode cap. */
   suppressed: number;
+  /**
+   * Manifest paths that predate `vendor/sources.lock.json` — i.e. built against
+   * an older vendor tree, so their `file:line` may be stale. Empty when fresh
+   * or when the manifest fell back to grep. Rebuild via `run.sh --refresh`.
+   */
+  stale: string[];
 }
 
 export interface FindOptions {
@@ -267,6 +288,19 @@ export async function railsFind(
   if (apiManifest) results.push(...findMethods(apiManifest, query));
   if (results.length === 0) results = await grepVendor(root, query);
 
+  // Flag any USED manifest whose mtime predates the vendor lockfile — its
+  // file:line may point into a since-changed Rails tree.
+  const lockMs = await mtimeMs(root, LOCKFILE);
+  const stale: string[] = [];
+  for (const [manifest, present, used] of [
+    [TEST_MANIFEST, testManifest, results.some((r) => r.mode === "test")],
+    [API_MANIFEST, apiManifest, results.some((r) => r.mode === "method" || r.mode === "constant")],
+  ] as const) {
+    if (lockMs === null || !present || !used) continue;
+    const m = await mtimeMs(root, manifest);
+    if (m !== null && m < lockMs) stale.push(manifest);
+  }
+
   const total = results.length;
   const exactOnly = !opts.all && results.some((r) => r.exact);
   if (exactOnly) results = results.filter((r) => r.exact);
@@ -281,5 +315,5 @@ export async function railsFind(
   }
 
   const modes = [...new Set(results.map((r) => r.mode))];
-  return { results, modes, exactOnly, suppressed: total - results.length };
+  return { results, modes, exactOnly, suppressed: total - results.length, stale };
 }

--- a/scripts/rails-find/core.ts
+++ b/scripts/rails-find/core.ts
@@ -1,0 +1,285 @@
+/**
+ * Core lookup for `pnpm rails:find` — map a trails test name or method/constant
+ * to a vendored Rails `file:line`, so fidelity work needn't hand-grep
+ * `vendor/rails/`. Reuses the manifests the existing pipelines emit
+ * (test-compare's `rails-tests.json`, api-compare's `rails-api.json`) and falls
+ * back to a scoped grep of `vendor/rails/activerecord/` when neither hits.
+ *
+ * Constraints (mirrors scripts/api-compare/shared-cache.ts): async fs only, no
+ * `node:` specifiers, no `process` — pure I/O over the root bin.ts supplies, so
+ * it resolves against ANY worktree and stays unit-testable.
+ */
+import * as fs from "fs/promises";
+import * as path from "path";
+
+import type { ApiManifest } from "../api-compare/types.js";
+import type { TestCaseInfo, TestManifest } from "../test-compare/types.js";
+
+/** Where each result came from — printed so the caller knows how it matched. */
+export type FindMode = "test" | "method" | "constant" | "grep";
+
+export interface FindResult {
+  mode: FindMode;
+  /** Path relative to the worktree root (POSIX), e.g. `vendor/rails/...`. */
+  file: string;
+  line: number;
+  /** Test path, qualified method name, or the matched source line. */
+  label: string;
+  /** The name/description equalled the query (vs merely contained it). */
+  exact: boolean;
+}
+
+// Per-package base dir (relative to the worktree root) for vendored test cases
+// and lib source. Mirrors `vendor/sources.ts` (`vendor:fetch --print-{test,lib}
+// -paths`); static so the lookup needs no subprocess, and relative so joining
+// with the CURRENT root resolves in any worktree. Add a row per new vendored gem.
+export const TEST_BASE: Record<string, string> = {
+  arel: "vendor/rails/activerecord/test/cases/arel",
+  activerecord: "vendor/rails/activerecord/test/cases",
+  activemodel: "vendor/rails/activemodel/test/cases",
+  activesupport: "vendor/rails/activesupport/test",
+  actiondispatch: "vendor/rails/actionpack/test",
+  actioncontroller: "vendor/rails/actionpack/test",
+  abstractcontroller: "vendor/rails/actionpack/test/abstract",
+  actionview: "vendor/rails/actionview/test",
+  trailties: "vendor/rails/railties/test",
+  rack: "vendor/rack/test",
+  "did-you-mean": "vendor/did_you_mean/test",
+  globalid: "vendor/globalid/test/cases",
+};
+
+export const LIB_BASE: Record<string, string> = {
+  arel: "vendor/rails/activerecord/lib/arel",
+  activerecord: "vendor/rails/activerecord/lib/active_record",
+  activemodel: "vendor/rails/activemodel/lib/active_model",
+  activesupport: "vendor/rails/activesupport/lib/active_support",
+  actiondispatch: "vendor/rails/actionpack/lib/action_dispatch",
+  actioncontroller: "vendor/rails/actionpack/lib/action_controller",
+  abstractcontroller: "vendor/rails/actionpack/lib/abstract_controller",
+  actionpackversion: "vendor/rails/actionpack/lib/action_pack",
+  actionview: "vendor/rails/actionview/lib/action_view",
+  trailties: "vendor/rails/railties/lib/rails",
+  rack: "vendor/rack/lib/rack",
+  "did-you-mean": "vendor/did_you_mean/lib/did_you_mean",
+  globalid: "vendor/globalid/lib/global_id",
+};
+
+export const TEST_MANIFEST = "scripts/test-compare/output/rails-tests.json";
+export const API_MANIFEST = "scripts/api-compare/output/rails-api.json";
+
+/** Grep fallback is scoped here — the fidelity work that drives this is AR. */
+const GREP_SCOPE = "vendor/rails/activerecord";
+const MAX_GREP_RESULTS = 40;
+
+function toPosix(p: string): string {
+  return p.split(path.sep).join("/");
+}
+
+async function readJson<T>(root: string, rel: string): Promise<T | null> {
+  try {
+    return JSON.parse(await fs.readFile(path.join(root, rel), "utf-8")) as T;
+  } catch {
+    return null;
+  }
+}
+
+// ── Test-name lookup (reuses test-compare's rails-tests.json) ──
+
+// A test matches when the query (case-insensitive) is a substring of its human
+// description or qualified path, OR of the synthesized `test_snake_case` form —
+// so a trails description ("has primary key") and a Rails method name
+// (`test_has_primary_key`) both hit.
+// Returns `false` for no match, `"exact"` when the query equals the description
+// or synthesized `test_snake_case`, `"partial"` for a substring hit of either
+// (or the qualified path). So a trails description ("has primary key") and a
+// Rails method name (`test_has_primary_key`) both hit; exact wins.
+function testMatch(tc: TestCaseInfo, needle: string): "exact" | "partial" | false {
+  const desc = tc.description.toLowerCase();
+  const railsName = "test_" + desc.replace(/[^a-z0-9]+/g, "_").replace(/^_|_$/g, "");
+  if (desc === needle || railsName === needle) return "exact";
+  if (desc.includes(needle) || railsName.includes(needle) || tc.path.toLowerCase().includes(needle))
+    return "partial";
+  return false;
+}
+
+export function findTests(manifest: TestManifest, query: string): FindResult[] {
+  const needle = query.toLowerCase();
+  const results: FindResult[] = [];
+  for (const [pkg, info] of Object.entries(manifest.packages)) {
+    const base = TEST_BASE[pkg];
+    if (!base) continue;
+    for (const tf of info.files) {
+      for (const tc of tf.testCases) {
+        const m = testMatch(tc, needle);
+        if (m) {
+          results.push({
+            mode: "test",
+            file: toPosix(path.join(base, tf.file)),
+            line: tc.line,
+            label: tc.path,
+            exact: m === "exact",
+          });
+        }
+      }
+    }
+  }
+  return sortResults(results);
+}
+
+// Exact matches first, then alphabetically by label — stable across runs.
+function sortResults(results: FindResult[]): FindResult[] {
+  return results.sort(
+    (a, b) => Number(b.exact) - Number(a.exact) || a.label.localeCompare(b.label),
+  );
+}
+
+// ── Method / constant lookup (reuses api-compare's rails-api.json) ──
+
+type Method = { name: string; file?: string; line?: number };
+
+export function findMethods(manifest: ApiManifest, query: string): FindResult[] {
+  const needle = query.toLowerCase();
+  const results: FindResult[] = [];
+  for (const [pkg, info] of Object.entries(manifest.packages)) {
+    const base = LIB_BASE[pkg];
+    if (!base) continue;
+    const pushMethod = (owner: string, m: Method, isStatic: boolean) => {
+      if (!m.file) return;
+      const name = m.name.toLowerCase();
+      if (name !== needle && !name.includes(needle)) return;
+      results.push({
+        mode: "method",
+        file: toPosix(path.join(base, m.file)),
+        line: m.line ?? 0,
+        label: `${owner}${isStatic ? "." : "#"}${m.name}`,
+        exact: name === needle,
+      });
+    };
+    for (const group of [info.classes, info.modules]) {
+      for (const [owner, ci] of Object.entries(group)) {
+        for (const m of ci.instanceMethods) pushMethod(owner, m, false);
+        for (const m of ci.classMethods) pushMethod(owner, m, true);
+      }
+    }
+    for (const [file, consts] of Object.entries(info.fileConstants ?? {})) {
+      for (const cname of Object.keys(consts)) {
+        const name = cname.toLowerCase();
+        if (name !== needle && !name.includes(needle)) continue;
+        results.push({
+          mode: "constant",
+          file: toPosix(path.join(base, file)),
+          line: 0,
+          label: cname,
+          exact: name === needle,
+        });
+      }
+    }
+  }
+  return sortResults(results);
+}
+
+// ── Grep fallback (pure fs walk of vendor/rails/activerecord) ──
+
+async function walk(dir: string): Promise<string[]> {
+  let entries;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const e of entries) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      out.push(...(await walk(full)));
+    } else if (e.name.endsWith(".rb")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+export async function grepVendor(root: string, query: string): Promise<FindResult[]> {
+  const scope = path.join(root, GREP_SCOPE);
+  const files = await walk(scope);
+  const needle = query.toLowerCase();
+  const results: FindResult[] = [];
+  for (const file of files) {
+    let text;
+    try {
+      text = await fs.readFile(file, "utf-8");
+    } catch {
+      continue;
+    }
+    const lines = text.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].toLowerCase().includes(needle)) {
+        results.push({
+          mode: "grep",
+          file: toPosix(path.relative(root, file)),
+          line: i + 1,
+          label: lines[i].trim(),
+          exact: false,
+        });
+        if (results.length >= MAX_GREP_RESULTS) return results;
+      }
+    }
+  }
+  return results;
+}
+
+// ── Orchestration ──
+
+/** Per-mode cap on displayed matches; excess is counted in `suppressed`. */
+export const MAX_PER_MODE = 25;
+
+export interface FindOutput {
+  results: FindResult[];
+  /** Which mode(s) actually produced results, in priority order. */
+  modes: FindMode[];
+  /** True when substring hits were dropped because exact hits existed. */
+  exactOnly: boolean;
+  /** How many matches were dropped by the exact filter + per-mode cap. */
+  suppressed: number;
+}
+
+export interface FindOptions {
+  /** Keep substring hits even when exact ones exist, and lift the per-mode cap. */
+  all?: boolean;
+}
+
+// Index hits (test + method/constant) win; grep runs only when neither hits. A
+// missing manifest simply skips that mode. When exact hits exist we drop the
+// substring noise (e.g. a `find_by` query buried under 100 test descriptions
+// that merely contain "find_by") unless `all` is set. Each mode is then capped.
+export async function railsFind(
+  root: string,
+  query: string,
+  opts: FindOptions = {},
+): Promise<FindOutput> {
+  const [testManifest, apiManifest] = await Promise.all([
+    readJson<TestManifest>(root, TEST_MANIFEST),
+    readJson<ApiManifest>(root, API_MANIFEST),
+  ]);
+
+  let results: FindResult[] = [];
+  if (testManifest) results.push(...findTests(testManifest, query));
+  if (apiManifest) results.push(...findMethods(apiManifest, query));
+  if (results.length === 0) results = await grepVendor(root, query);
+
+  const total = results.length;
+  const exactOnly = !opts.all && results.some((r) => r.exact);
+  if (exactOnly) results = results.filter((r) => r.exact);
+
+  if (!opts.all) {
+    const perMode = new Map<FindMode, number>();
+    results = results.filter((r) => {
+      const n = (perMode.get(r.mode) ?? 0) + 1;
+      perMode.set(r.mode, n);
+      return n <= MAX_PER_MODE;
+    });
+  }
+
+  const modes = [...new Set(results.map((r) => r.mode))];
+  return { results, modes, exactOnly, suppressed: total - results.length };
+}

--- a/scripts/rails-find/run.sh
+++ b/scripts/rails-find/run.sh
@@ -1,14 +1,22 @@
 #!/usr/bin/env bash
-# Driver for `pnpm rails:find <query>`. Ensures the two manifests the lookup
-# reads exist (building them once via the SAME extractors test:compare /
+# Driver for `pnpm rails:find [--refresh] <query>`. Ensures the two manifests the
+# lookup reads exist (building them once via the SAME extractors test:compare /
 # api:compare use), then runs the pure lookup in bin.ts. Subsequent runs are
-# fast — they hit the cached manifests and skip the build.
+# fast — they hit the cached manifests and skip the build. `--refresh` deletes
+# the cached manifests first, forcing a rebuild against the current vendor tree
+# (bin.ts warns when a manifest predates the vendor lockfile).
 set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$DIR/../.." && pwd)"
 TEST_JSON="$ROOT/scripts/test-compare/output/rails-tests.json"
 API_JSON="$ROOT/scripts/api-compare/output/rails-api.json"
+
+for arg in "$@"; do
+  if [[ "$arg" == "--refresh" ]]; then
+    rm -f "$TEST_JSON" "$API_JSON"
+  fi
+done
 
 if [[ ! -f "$TEST_JSON" ]]; then
   echo "==> rails:find: building test manifest (one-time)…" >&2

--- a/scripts/rails-find/run.sh
+++ b/scripts/rails-find/run.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Driver for `pnpm rails:find <query>`. Ensures the two manifests the lookup
+# reads exist (building them once via the SAME extractors test:compare /
+# api:compare use), then runs the pure lookup in bin.ts. Subsequent runs are
+# fast — they hit the cached manifests and skip the build.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$DIR/../.." && pwd)"
+TEST_JSON="$ROOT/scripts/test-compare/output/rails-tests.json"
+API_JSON="$ROOT/scripts/api-compare/output/rails-api.json"
+
+if [[ ! -f "$TEST_JSON" ]]; then
+  echo "==> rails:find: building test manifest (one-time)…" >&2
+  TEST_PATHS_JSON="$(pnpm -s vendor:fetch --print-test-paths)" \
+    ruby "$ROOT/scripts/test-compare/extract-ruby-tests.rb" >&2
+fi
+
+if [[ ! -f "$API_JSON" ]]; then
+  echo "==> rails:find: building api manifest (one-time)…" >&2
+  LIB_PATHS_JSON="$(pnpm -s vendor:fetch --print-lib-paths)" \
+    LOCKFILE_PATH="$ROOT/vendor/sources.lock.json" \
+    ruby "$ROOT/scripts/api-compare/extract-ruby-api.rb" >&2
+fi
+
+pnpm tsx "$DIR/bin.ts" "$@"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -400,6 +400,7 @@ export default defineConfig({
             "scripts/test-deps/*.test.ts",
             "scripts/tasks/*.test.ts",
             "scripts/test-compare/*.test.ts",
+            "scripts/rails-find/*.test.ts",
             "eslint/*.test.mjs",
             "vendor/*.test.ts",
           ],


### PR DESCRIPTION
## Summary

Adds `pnpm rails:find [--all] <query>` — maps a trails test name or a
method/constant to a vendored Rails `file:line` so fidelity work needn't
hand-grep `vendor/rails/`. This is the manual lookup step whose omission traced
to repeated mis-specified stories (encrypted_posts, cpk_orders composite-PK,
firms/clients "missing tables").

## How it works

- **Test names** → test-compare's `rails-tests.json` (matches the human
  description, the qualified path, or the synthesized `test_snake_case`, so a
  trails name and a Rails `test_*` method both hit).
- **Methods/constants** → api-compare's `rails-api.json` (`Owner#method` /
  `Owner.method` / file constant).
- **Fallback**: a scoped grep of `vendor/rails/activerecord/` when neither
  index hits. Every result is tagged with the mode that produced it.
- **Relevance**: exact name/description matches suppress substring noise (a
  `find_by` query otherwise buries the method under 100+ test descriptions);
  `--all` restores them and lifts the per-mode cap.

`run.sh` builds the two manifests once (reusing the same Ruby extractors as
`test:compare` / `api:compare`), then runs the pure lookup in `bin.ts`.
`core.ts` is pure — async fs only, no `node:` specifiers, no `process` — so it
resolves against any worktree's `vendor/rails` and is unit-tested directly. It
imports the canonical manifest types from the two pipelines rather than
re-declaring shapes.

Documented with one line in CLAUDE.md "Working in this repo".

## Review fixes (Claude review, round 1)

1. **Faithful Rails test-name synthesis** — `testMatch` now replicates
   Minitest's `test_#{name.gsub(/\s+/, '_')}` exactly (whitespace-runs only,
   case + punctuation preserved) instead of a broader sanitize that dropped
   apostrophes/operators and lowercased. Punctuation-bearing descriptions
   ("doesn't …", "a != b") now match their real `test_*` method name. Added a
   regression test.
2. **Stale-manifest detection** — `railsFind` flags any *used* manifest whose
   mtime predates `vendor/sources.lock.json` (bumped by `pnpm vendor:fetch`);
   `bin.ts` warns and points at `--refresh`, which `run.sh` honors by deleting
   the cached JSON and rebuilding. Covered by a test.

## Note on size

~613 LOC (code, excluding the docs line) — over the 500 ceiling. The overage is
the exact-match relevance filter and the two review-required correctness
features above, each with tests. Splitting is not applicable (single cohesive
tool; sibling/stacked PRs are disallowed) and trimming the stale-detection or
name-synthesis logic would re-introduce the defects just fixed. Flagging for
waiver.

Closes-story: rails-find-source-lookup
