### PR TITLE
refactor(activemodel): port NoMethodError/RuntimeError in serialization + attribute

### DIFF
--- a/eslint/rails-error-parity-exclude.json
+++ b/eslint/rails-error-parity-exclude.json
@@ -1,9 +1,7 @@
 [
-  "packages/activemodel/src/attribute.ts",
   "packages/activemodel/src/errors.ts",
   "packages/activemodel/src/i18n.ts",
   "packages/activemodel/src/lint.ts",
-  "packages/activemodel/src/serialization.ts",
   "packages/activerecord/src/adapters/postgresql/pg-range.ts",
   "packages/activerecord/src/aggregations.ts",
   "packages/activerecord/src/associations.ts",

--- a/packages/activemodel/src/attribute-assignment.ts
+++ b/packages/activemodel/src/attribute-assignment.ts
@@ -246,6 +246,20 @@ class TypeError extends globalThis.Error {
 }
 
 /**
+ * Mirror of Ruby's `RuntimeError` (the default `raise "msg"` class). The
+ * activemodel home for the ported root class, so trails-invented guards with no
+ * Rails equivalent (serialization.ts' unloaded-collection guard, attribute.ts'
+ * `UserProvidedDefault not loaded` module-load-order guard) share one identity
+ * and stay `instanceof`-consistent across files.
+ */
+class RuntimeError extends globalThis.Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RuntimeError";
+  }
+}
+
+/**
  * Mirror of Ruby's `NameError`. Raised when a name reference is invalid —
  * e.g. `record.method(:missing)`, which Ruby answers with `NameError`
  * (not its `NoMethodError` subclass).
@@ -282,4 +296,4 @@ class NotImplementedError extends globalThis.Error {
   }
 }
 
-export { ArgumentError, TypeError, NameError, NoMethodError, NotImplementedError };
+export { ArgumentError, TypeError, NameError, NoMethodError, NotImplementedError, RuntimeError };

--- a/packages/activemodel/src/attribute.ts
+++ b/packages/activemodel/src/attribute.ts
@@ -226,7 +226,7 @@ export abstract class Attribute {
 
   withUserDefault(value: unknown): Attribute {
     if (!_UserProvidedDefaultCtor) {
-      throw new Error(
+      throw new RuntimeError(
         "UserProvidedDefault not loaded. Import '@blazetrails/activemodel' " +
           "or './attribute/user-provided-default.js' before calling withUserDefault().",
       );
@@ -371,5 +371,17 @@ export class Uninitialized extends Attribute {
 
   isInitialized(): boolean {
     return false;
+  }
+}
+
+/**
+ * Mirror of Ruby's `RuntimeError` (the default `raise "msg"` class). Guards the
+ * trails-invented module-load-order failure in `withUserDefault`, which has no
+ * Rails equivalent (Ruby loads `UserProvidedDefault` eagerly).
+ */
+class RuntimeError extends globalThis.Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RuntimeError";
   }
 }

--- a/packages/activemodel/src/attribute.ts
+++ b/packages/activemodel/src/attribute.ts
@@ -1,6 +1,7 @@
 import { Type } from "./type/value.js";
 import { typeRegistry } from "./type/registry.js";
 import { MissingAttributeError } from "./attribute-methods.js";
+import { RuntimeError } from "./attribute-assignment.js";
 
 // Symbol so identity comparisons work across module copies and can't collide with any user value.
 export const UNINITIALIZED_ORIGINAL_VALUE: unique symbol = Symbol.for(
@@ -371,17 +372,5 @@ export class Uninitialized extends Attribute {
 
   isInitialized(): boolean {
     return false;
-  }
-}
-
-/**
- * Mirror of Ruby's `RuntimeError` (the default `raise "msg"` class). Guards the
- * trails-invented module-load-order failure in `withUserDefault`, which has no
- * Rails equivalent (Ruby loads `UserProvidedDefault` eagerly).
- */
-class RuntimeError extends globalThis.Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "RuntimeError";
   }
 }

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -27,6 +27,8 @@ export {
   sanitizeForMassAssignment,
   isMassAssignmentEmpty,
   ArgumentError,
+  NoMethodError,
+  RuntimeError,
 } from "./attribute-assignment.js";
 export type { AttributeAssignment } from "./attribute-assignment.js";
 export {

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { instant } from "@blazetrails/activesupport/testing/temporal-helpers";
 import { Model } from "./index.js";
 import { readAttributeForSerialization, type SerializationRecord } from "./serialization.js";
+import { NoMethodError } from "./attribute-assignment.js";
 
 // Plain ActiveModel serializes `include:` entries via `send(association)` —
 // the value behind a Ruby `attr_accessor :address` / `:friends` (see Rails'
@@ -91,6 +92,7 @@ describe("SerializationTest", () => {
       attributes: { name: "x" },
       constructor: { name: "Host" },
     } as unknown as SerializationRecord;
+    expect(() => readAttributeForSerialization(host, "nope")).toThrow(NoMethodError);
     expect(() => readAttributeForSerialization(host, "nope")).toThrow(/undefined method 'nope'/);
   });
 
@@ -102,6 +104,7 @@ describe("SerializationTest", () => {
       attributes: { name: "x" },
       constructor: { name: "Host" },
     } as unknown as SerializationRecord;
+    expect(() => readAttributeForSerialization(host, "name")).toThrow(NoMethodError);
     expect(() => readAttributeForSerialization(host, "name")).toThrow(/undefined method 'name'/);
   });
 
@@ -246,6 +249,7 @@ describe("SerializationTest", () => {
       }
     }
     const p = new Person({ name: "test" });
+    expect(() => p.serializableHash({ methods: ["nonexistent"] })).toThrow(NoMethodError);
     expect(() => p.serializableHash({ methods: ["nonexistent"] })).toThrow(
       /undefined method 'nonexistent'/,
     );

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -85,7 +85,7 @@ export function serializableHash(
       } else if (method in record) {
         safeSet(result, method, record[method]);
       } else {
-        throw new Error(
+        throw new NoMethodError(
           `undefined method '${method}' for an instance of ${record.constructor.name}`,
         );
       }
@@ -102,7 +102,7 @@ export function serializableHash(
     // with no `loaded` flag (plain arrays, `to_ary`-style wrappers) are ready.
     if (isSerializableCollection(records)) {
       if ((records as { loaded?: unknown }).loaded === false) {
-        throw new Error(
+        throw new RuntimeError(
           `Cannot serialize the '${assocName}' association: its collection is not ` +
             `loaded. Load it first (await the association, or eager-load via ` +
             `includes / preload) — synchronous serialization cannot query the database.`,
@@ -213,7 +213,9 @@ export function readAttributeForSerialization(record: SerializationRecord, key: 
   // A genuine function member is invoked (`send`); an absent member raises like
   // `send`'s `NoMethodError`.
   if (inRecord) return (reader as () => unknown).call(record);
-  throw new Error(`undefined method '${key}' for an instance of ${record.constructor.name}`);
+  throw new NoMethodError(
+    `undefined method '${key}' for an instance of ${record.constructor.name}`,
+  );
 }
 
 /** @internal */
@@ -520,7 +522,9 @@ export function thenableHash(
  */
 function sendAssociation(record: SerializationRecord, name: string): unknown {
   if (!(name in record)) {
-    throw new Error(`undefined method '${name}' for an instance of ${record.constructor.name}`);
+    throw new NoMethodError(
+      `undefined method '${name}' for an instance of ${record.constructor.name}`,
+    );
   }
   const reader = record[name];
   return typeof reader === "function" ? (reader as () => unknown).call(record) : reader;
@@ -751,4 +755,40 @@ function normalizeIncludes(
     safeSet(result as Record<string, unknown>, k, v);
   }
   return result;
+}
+
+/**
+ * Mirror of Ruby's `NameError` — the base for `NoMethodError`. Kept local so
+ * the hierarchy is observable via `instanceof` without cross-file coupling.
+ */
+class NameError extends globalThis.Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NameError";
+  }
+}
+
+/**
+ * Mirror of Ruby's `NoMethodError` (a subclass of `NameError`). Rails'
+ * `serializable_hash` calls `send(method)` / `send(association)` unconditionally
+ * (serialization.rb:191); an undefined name answers with `NoMethodError`.
+ */
+class NoMethodError extends NameError {
+  constructor(message: string) {
+    super(message);
+    this.name = "NoMethodError";
+  }
+}
+
+/**
+ * Mirror of Ruby's `RuntimeError` (the default `raise "msg"` class). Used for
+ * the trails-invented unloaded-collection guard on the synchronous
+ * serialization path, which has no Rails equivalent (`to_ary` would lazily
+ * load from the DB — RFC 0022 b2).
+ */
+class RuntimeError extends globalThis.Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RuntimeError";
+  }
 }

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -1,4 +1,5 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
+import { NoMethodError, RuntimeError } from "./attribute-assignment.js";
 
 /** Minimum shape required of a record object passed to serialization helpers. */
 export interface SerializationRecord {
@@ -755,40 +756,4 @@ function normalizeIncludes(
     safeSet(result as Record<string, unknown>, k, v);
   }
   return result;
-}
-
-/**
- * Mirror of Ruby's `NameError` — the base for `NoMethodError`. Kept local so
- * the hierarchy is observable via `instanceof` without cross-file coupling.
- */
-class NameError extends globalThis.Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "NameError";
-  }
-}
-
-/**
- * Mirror of Ruby's `NoMethodError` (a subclass of `NameError`). Rails'
- * `serializable_hash` calls `send(method)` / `send(association)` unconditionally
- * (serialization.rb:191); an undefined name answers with `NoMethodError`.
- */
-class NoMethodError extends NameError {
-  constructor(message: string) {
-    super(message);
-    this.name = "NoMethodError";
-  }
-}
-
-/**
- * Mirror of Ruby's `RuntimeError` (the default `raise "msg"` class). Used for
- * the trails-invented unloaded-collection guard on the synchronous
- * serialization path, which has no Rails equivalent (`to_ary` would lazily
- * load from the DB — RFC 0022 b2).
- */
-class RuntimeError extends globalThis.Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "RuntimeError";
-  }
 }


### PR DESCRIPTION
## Summary

Continues the `blazetrails/rails-error-parity` bare-throw burndown (RFC 0025),
following continue-3. Un-excludes two `activemodel/src/` files from
`eslint/rails-error-parity-exclude.json`, replacing their banned bare
`throw new Error(...)` with manifest-correct ported classes.

- **`serialization.ts`** — the three `undefined method '...'` guards (Rails'
  `send` dispatch: `alias :read_attribute_for_serialization :send`
  serialization.rb:167, unguarded `send(m)` serialization.rb:138, unguarded
  `send(association)` serialization.rb:192) now throw a ported `NoMethodError`.
  The trails-invented unloaded-collection sync-serialization guard (no Rails
  equivalent — `to_ary` would lazily load from the DB, RFC 0022 b2) throws a
  ported `RuntimeError`.
- **`attribute.ts`** — the trails-invented `UserProvidedDefault not loaded`
  module-load-order guard in `withUserDefault` throws a ported `RuntimeError`.

The ported classes live in `attribute-assignment.ts`, the package's established
home for ported Ruby root classes (ArgumentError/TypeError/NameError/
NoMethodError from continue-3); both files import from there rather than
redeclaring, so a single identity stays `instanceof`-consistent across files.
Neither un-excluded file has a manifest error class mapped to it, so only the
bare-throw ban applies; the parity rule stays `error` with a strictly-smaller
baseline.

## Review resolutions (#4856)

1. **Weak assertions** — the three serialization tests now assert
   `toThrow(NoMethodError)` alongside the message regex (under the existing
   names), so the port is pinned.
2. **Duplicate `NameError`/`NoMethodError`/`RuntimeError`** — resolved in-PR:
   `RuntimeError` added to the shared `attribute-assignment.ts` home and
   imported into both files; serialization.ts no longer redefines the
   NameError/NoMethodError pair, fixing the cross-file `instanceof` break.
3. **Over-claiming doc comment** — removed with the local class definitions.

## Remainder (follow-up stories)

The other deferred files stay excluded: `errors.ts` (the `RangeError` rename is
a cross-package job for its own PR), `i18n.ts` (`MissingTranslationData`), and
`lint.ts` (Minitest-assertion-style failures).

## Testing

- `serialization.test.ts` + `attribute.test.ts` + `attribute-assignment.test.ts`
  green (152 tests).
- `eslint` clean on all touched files; baseline shrinks by two entries.

Closes-story: rails-error-parity-bare-throw-burndown-continue-4