### PR TITLE
fix(attribute-methods): readAttribute raises MissingAttributeError for unselected column

### DIFF
--- a/packages/activemodel/src/attribute-methods.ts
+++ b/packages/activemodel/src/attribute-methods.ts
@@ -221,15 +221,16 @@ export function missingAttribute(this: InstanceHost, attrName: string, stack?: s
  */
 export function _readAttribute(
   this: InstanceHost & {
-    _attributes?: { fetchValue(name: string): unknown };
-    _readAttribute?(name: string): unknown;
+    _attributes?: { fetchValue(name: string, block?: (name: string) => unknown): unknown };
+    _readAttribute?(name: string, block?: (name: string) => unknown): unknown;
   },
   attr: string,
+  block?: (name: string) => unknown,
 ): unknown {
   if (typeof this._readAttribute === "function" && this._readAttribute !== _readAttribute) {
-    return this._readAttribute(attr);
+    return this._readAttribute(attr, block);
   }
-  return this._attributes?.fetchValue(attr) ?? null;
+  return this._attributes?.fetchValue(attr, block) ?? null;
 }
 
 // -- Public ClassMethods (use `this`, assigned to Model directly) -----------

--- a/packages/activemodel/src/attribute-set.ts
+++ b/packages/activemodel/src/attribute-set.ts
@@ -1,4 +1,4 @@
-import { Attribute } from "./attribute.js";
+import { Attribute, Uninitialized } from "./attribute.js";
 import { typeRegistry } from "./type/registry.js";
 
 const LAZY_ATTR = Symbol("lazyAttr");
@@ -107,8 +107,17 @@ export class AttributeSet {
     return result;
   }
 
-  fetchValue(name: string): unknown {
-    return this.getAttribute(name).value;
+  fetchValue(name: string, block?: (name: string) => unknown): unknown {
+    // Mirrors ActiveModel::AttributeSet#fetch_value → `self[name].value(&block)`.
+    // A known-but-unselected column is stored as an Uninitialized attribute
+    // whose `value(&block)` yields the name to the block (letting `[]` raise
+    // MissingAttributeError); an unknown name resolves to the Null default,
+    // which ignores the block and returns nil.
+    const attr = this.getAttribute(name);
+    if (block !== undefined && attr instanceof Uninitialized) {
+      return block(name);
+    }
+    return attr.value;
   }
 
   writeFromDatabase(

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -67,6 +67,8 @@ import {
   attributeMethodSuffix,
   attributeMethodAffix,
   aliasAttribute,
+  missingAttribute,
+  type InstanceHost,
   resolveAliasName,
   undefineAttributeMethods,
   attributeMissing,
@@ -1649,11 +1651,17 @@ export class Model {
     // Rails resolves alias_attribute names in `read_attribute`
     // (attribute_aliases[name] || name); `_read_attribute` skips it.
     const resolved = resolveAliasName(this.constructor as typeof Model, name);
-    if (!this._attributes.has(resolved)) {
-      return null;
+    if (this._attributes.has(resolved)) {
+      this._accessedFields.add(resolved);
     }
-    this._accessedFields.add(resolved);
-    return this._attributes.fetchValue(resolved) ?? null;
+    // Mirrors AR `record[attr]` (attribute_methods.rb#[]): read_attribute is
+    // called with a block that raises MissingAttributeError, so a known column
+    // that wasn't selected raises while an unknown name still returns nil.
+    return (
+      this._attributes.fetchValue(resolved, (n) =>
+        missingAttribute.call(this as unknown as InstanceHost, n),
+      ) ?? null
+    );
   }
 
   /** @internal */

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -67,8 +67,6 @@ import {
   attributeMethodSuffix,
   attributeMethodAffix,
   aliasAttribute,
-  missingAttribute,
-  type InstanceHost,
   resolveAliasName,
   undefineAttributeMethods,
   attributeMissing,
@@ -1651,25 +1649,23 @@ export class Model {
     // Rails resolves alias_attribute names in `read_attribute`
     // (attribute_aliases[name] || name); `_read_attribute` skips it.
     const resolved = resolveAliasName(this.constructor as typeof Model, name);
-    if (this._attributes.has(resolved)) {
-      this._accessedFields.add(resolved);
-    }
-    // Mirrors AR `record[attr]` (attribute_methods.rb#[]): read_attribute is
-    // called with a block that raises MissingAttributeError, so a known column
-    // that wasn't selected raises while an unknown name still returns nil.
-    return (
-      this._attributes.fetchValue(resolved, (n) =>
-        missingAttribute.call(this as unknown as InstanceHost, n),
-      ) ?? null
-    );
-  }
-
-  /** @internal */
-  _readAttribute(name: string): unknown {
-    if (!this._attributes.has(name)) {
+    if (!this._attributes.has(resolved)) {
       return null;
     }
-    return this._attributes.fetchValue(name) ?? null;
+    this._accessedFields.add(resolved);
+    return this._attributes.fetchValue(resolved) ?? null;
+  }
+
+  /**
+   * @internal
+   * Mirrors AR `_read_attribute(attr_name, &block)` — reads directly from the
+   * attribute store, optionally yielding a known-but-unselected column's name to
+   * `block` (which the generated getters / `[]` use to raise
+   * MissingAttributeError). Without a block, an unselected column reads as nil,
+   * matching plain `read_attribute`/`_read_attribute`.
+   */
+  _readAttribute(name: string, block?: (name: string) => unknown): unknown {
+    return this._attributes.fetchValue(name, block) ?? null;
   }
 
   /**

--- a/packages/activerecord/src/attribute-methods.test.ts
+++ b/packages/activerecord/src/attribute-methods.test.ts
@@ -308,15 +308,19 @@ describe("AttributeMethodsTest", () => {
     await Post.create({ title: "sel_test" });
     const result = await Post.select("title").first();
     // Mirrors: computer[:developer] → assert_raises MissingAttributeError.
+    // Rails `[]` reads via `_read_attribute(attr) { |n| missing_attribute(n) }`;
+    // trails has no `[]` operator, so its equivalent is the generated
+    // per-attribute getter, which supplies the same raising block.
     // `legacy_comments_count` is a real canonical `posts` column that wasn't in
-    // the SELECT, so reading it raises (the synthetic `score` attribute isn't a
-    // column and so wouldn't).
-    expect(() => result?.readAttribute("legacy_comments_count")).toThrow(
+    // the SELECT, so reading it raises.
+    expect(() => (result as any).legacy_comments_count).toThrow(
       "missing attribute 'legacy_comments_count'",
     );
     // Mirrors: assert_nothing_raised { computer[:extendedWarranty] }
+    // (block-less `read_attribute` never raises; a selected column reads back).
     expect(result?.readAttribute("title")).toBe("sel_test");
-    // Mirrors: assert_nothing_raised { computer[:no_column_exists] }
+    // Mirrors: assert_nothing_raised { computer[:no_column_exists] } — an unknown
+    // name returns nil even through the raising getter/`[]` block.
     expect(result?.readAttribute("no_column_exists")).toBeNull();
   });
   it("user-defined time attribute predicate", async () => {

--- a/packages/activerecord/src/attribute-methods.test.ts
+++ b/packages/activerecord/src/attribute-methods.test.ts
@@ -311,7 +311,7 @@ describe("AttributeMethodsTest", () => {
     // `legacy_comments_count` is a real canonical `posts` column that wasn't in
     // the SELECT, so reading it raises (the synthetic `score` attribute isn't a
     // column and so wouldn't).
-    expect(() => (result as any).legacy_comments_count).toThrow(
+    expect(() => result?.readAttribute("legacy_comments_count")).toThrow(
       "missing attribute 'legacy_comments_count'",
     );
     // Mirrors: assert_nothing_raised { computer[:extendedWarranty] }

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -69,6 +69,8 @@ interface InstanceMethodHost {
 /** Minimal shape for inline property-descriptor get/set callbacks. */
 interface AttributeAccessorHost {
   readAttribute(name: string): unknown;
+  /** @internal */
+  _readAttribute(name: string, block?: (name: string) => unknown): unknown;
   writeAttribute(name: string, value: unknown): void;
 }
 
@@ -281,17 +283,15 @@ export function aliasAttributeMethodDefinition(
   // Define a direct getter/setter for the alias name.
   if (this.prototype && !(newName in this.prototype)) {
     Object.defineProperty(this.prototype, newName, {
-      get(
-        this: AttributeAccessorHost & {
-          _attributes: { getAttribute(n: string): { isInitialized(): boolean } };
-        },
-      ) {
-        if (!this._attributes.getAttribute(oldName).isInitialized()) {
+      get(this: AttributeAccessorHost) {
+        // Rails' generated alias reader is `_read_attribute(canonical) { |n|
+        // missing_attribute(n, caller) }` — a known-but-unselected column yields
+        // to the block and raises, matching `record[attr]`.
+        return this._readAttribute(oldName, (n) => {
           throw new MissingAttributeError(
-            `missing attribute '${oldName}' for ${(this.constructor as { name?: string }).name ?? "unknown"}`,
+            `missing attribute '${n}' for ${(this.constructor as { name?: string }).name ?? "unknown"}`,
           );
-        }
-        return this.readAttribute(oldName);
+        });
       },
       set(this: AttributeAccessorHost, value: unknown) {
         this.writeAttribute(oldName, value);
@@ -390,17 +390,15 @@ function generateConcreteAttributeMethods(this: AttributeMethodsHost): void {
       const ownDesc = Object.getOwnPropertyDescriptor(proto, name);
       const newDesc: PropertyDescriptor = { configurable: true };
       if (needsGetter) {
-        newDesc.get = function (
-          this: AttributeAccessorHost & {
-            _attributes: { getAttribute(n: string): { isInitialized(): boolean } };
-          },
-        ) {
-          if (!this._attributes.getAttribute(name).isInitialized()) {
+        newDesc.get = function (this: AttributeAccessorHost) {
+          // Rails' generated reader is `_read_attribute(name) { |n|
+          // missing_attribute(n, caller) }` — a known-but-unselected column
+          // yields to the block and raises, matching `record[attr]`.
+          return this._readAttribute(name, (n) => {
             throw new MissingAttributeError(
-              `missing attribute '${name}' for ${(this.constructor as { name?: string }).name ?? "unknown"}`,
+              `missing attribute '${n}' for ${(this.constructor as { name?: string }).name ?? "unknown"}`,
             );
-          }
-          return this.readAttribute(name);
+          });
         };
       } else if (ownDesc?.get) {
         newDesc.get = ownDesc.get;

--- a/packages/activerecord/src/attribute-methods/read.ts
+++ b/packages/activerecord/src/attribute-methods/read.ts
@@ -36,8 +36,12 @@ interface AttributeHolder {
  *
  * Mirrors: ActiveRecord::AttributeMethods::Read#_read_attribute
  */
-export function _readAttribute(this: AttributeHolder, name: string): unknown {
-  return this._attributes.fetchValue(name) ?? null;
+export function _readAttribute(
+  this: AttributeHolder,
+  name: string,
+  block?: (name: string) => unknown,
+): unknown {
+  return this._attributes.fetchValue(name, block) ?? null;
 }
 
 // Mirrors: ActiveRecord::AttributeMethods::Read::ClassMethods private#define_method_attribute


### PR DESCRIPTION
## Summary

Rails only raises `ActiveModel::MissingAttributeError` for a known-but-unselected
column through the block that `[]`/the generated per-attribute getters supply —
`attribute_methods.rb#[]` → `read_attribute(attr) { |n| missing_attribute(n, caller) }`
and the generated reader `def #{m}; _read_attribute(attr) { |n| missing_attribute(n, caller) }; end`.
Plain `read_attribute`/`_read_attribute` (no block) return `nil` for an
unselected column (`read.rb:29-40` → `attribute_set.rb#fetch_value`).

This threads an optional block through `AttributeSet#fetchValue` (mirroring
`fetch_value(name, &block)`) — an `Uninitialized` attribute yields to it
(matching `Uninitialized#value(&block)`), the `Null` default ignores it — and
through `_readAttribute`. The generated per-attribute getters (trails' `[]`
equivalent, since JS has no `[]` operator) now route through
`_readAttribute(name, raisingBlock)`, structurally identical to Rails' generated
reader, replacing the ad-hoc `isInitialized()` check.

`readAttribute`/`_readAttribute` themselves stay **block-less and non-raising**,
matching Rails `read_attribute`/`_read_attribute` — so internal callers
(`attribute_present?`, dirty-tracking fallbacks, etc.) keep returning `null`
for an unselected column exactly as their Rails counterparts (which call
`_read_attribute`) do.

The test exercises the raise via the generated getter (the trails `[]` stand-in,
mirroring Rails `computer[:developer]`), and the non-raising cases
(`extendedWarranty` selected, `no_column_exists` unknown) via `readAttribute`.

### Note on an earlier revision
An earlier commit baked the raising block into `readAttribute` itself. Code
review correctly flagged that this regressed every internal `readAttribute`
caller (e.g. `attribute_present?`, whose Rails counterpart uses non-raising
`_read_attribute`). This revision moves the raise to where Rails actually
supplies the block — the getters — and keeps `readAttribute` non-raising.

## Testing

- `pnpm vitest run` — activerecord attribute-methods, attribute-methods/read,
  dirty, persistence, store, enum, serialization, timestamp; activemodel
  attribute-set, attribute-methods, model — all pass.
- `node scripts/typecheck.mjs` clean.
- `API_COMPARE_FORCE=1 pnpm api:compare` / `pnpm test:compare` — no regression
  (optional `&block` params make `_read_attribute`/`fetch_value` more faithful).

Closes-story: readattribute-missing-attribute-error-unselected-column