### PR TITLE
fix(associations): rebase new-owner seed for count/exists/pluck terminals

### DIFF
--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -58,11 +58,24 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
   }
 
   /**
-   * @internal Hook invoked by the shared finder helpers (`first`/`last`) before
-   * their `_isNone` short-circuit, and by this class's `toArray`, so a relation
-   * spawned off a stale new-owner `1=0` seed is rebased onto the live
-   * association scope once the owner is saved. No-op unless this relation still
-   * carries the seed and the rebuilt scope resolves a real FK.
+   * The none-short-circuit chokepoint (see `Relation#_isEmptyRelation`): every
+   * query terminal (`toArray`/`exists`/`pluck`/`count`/the bounded finders)
+   * consults this before returning its empty result, so rebasing a stale
+   * new-owner `1=0` seed here covers all of them from one place. Reports the
+   * (possibly rebased) `_isNone`.
+   */
+  _isEmptyRelation(): boolean {
+    this._maybeRebaseAssociationSeed();
+    return super._isEmptyRelation();
+  }
+
+  /**
+   * @internal Rebase a relation spawned off a stale new-owner `1=0` seed onto
+   * the live association scope once the owner is saved and its FK resolves.
+   * No-op unless this relation still carries the seed and the rebuilt scope
+   * resolves a real FK. Clears the seed marker after a successful rebase so it
+   * runs exactly once — a second pass would re-merge the resolved scope onto an
+   * already-rebased relation (duplicate joins/predicates).
    */
   _maybeRebaseAssociationSeed(): void {
     if (!this._seededNoneNewOwner) return;
@@ -75,6 +88,7 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
       fresh as unknown,
       this._seedWherePredicates,
     );
+    this._seededNoneNewOwner = false;
   }
 
   /**
@@ -246,7 +260,8 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
    * way back, so accessing the inverse would re-query.
    */
   async toArray(): Promise<T[]> {
-    this._maybeRebaseAssociationSeed();
+    // The stale new-owner seed rebase runs in `super.toArray()` via the shared
+    // `_isEmptyRelation()` chokepoint, before the query is built.
     const owner = this._association.owner;
     const reflection = this._association.reflection;
     // Resolve the inverse association name via the registered Reflection,

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -761,6 +761,27 @@ describe("CollectionProxy — mutated finder requery on stale new-owner seed", (
 
     expect((await proxy.first()).id).toBe(kept.id);
   });
+
+  it("resolves the persisted FK on count/exists/pluck/pick/find after save", async () => {
+    // The bounded finders were rebased in PR #4465; the other query terminals
+    // (count/exists/pluck/pick/find) have their own `_isNone` short-circuits, so
+    // a relation spawned off the stale `1=0` seed must rebase there too.
+    const author = new Author({ name: "New Owner Three" });
+    const rel = (association<Post>(author, "posts") as any).where({ title: "match" });
+
+    await author.save();
+    const authorId = author.id as number;
+    const match = await Post.create({ title: "match", body: "1", author_id: authorId });
+    // A non-matching sibling proves the mutation (`where(title:)`) is still
+    // applied on top of the rebuilt scope, not dropped.
+    await Post.create({ title: "other", body: "2", author_id: authorId });
+
+    expect(await rel.count()).toBe(1);
+    expect(await rel.exists()).toBe(true);
+    expect(await rel.pluck("title")).toEqual(["match"]);
+    expect(await rel.pick("title")).toBe("match");
+    expect((await rel.find(match.id)).id).toBe(match.id);
+  });
 });
 
 // The in-memory `CollectionProxy#find` path (loaded `inverse_of` collection,

--- a/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
@@ -1008,6 +1008,23 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     expect((await scoped.first()).id).toBe(developer.id);
   });
 
+  // The non-finder terminals (count/exists/pluck) have their own `_isNone`
+  // short-circuits, so a HABTM relation spawned off the stale new-owner seed
+  // must rebase onto the resolved join scope for those too — not just the
+  // bounded finders covered above.
+  it("mutated count/exists/pluck on new-owner seed resolves the join after save", async () => {
+    const developer = await Developer.create({ name: "Yara" });
+    const project = new Project({ name: "Rails Counting" });
+    // `where(...)` spawns off the still-new owner's `1=0` seed.
+    const scoped = (project as any).developers.where({ name: "Yara" });
+    await (project as any).developers.push(developer);
+    await (project as any).saveBang();
+
+    expect(await scoped.count()).toBe(1);
+    expect(await scoped.exists()).toBe(true);
+    expect(await scoped.pluck("name")).toEqual(["Yara"]);
+  });
+
   it("dynamic find should respect association include", async () => {
     // SQL error in sort clause if :include is not included
     // due to Unknown column 'authors.id'

--- a/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
@@ -1022,7 +1022,13 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
 
     expect(await scoped.count()).toBe(1);
     expect(await scoped.exists()).toBe(true);
-    expect(await scoped.pluck("name")).toEqual(["Yara"]);
+    // The `developers` scope is `distinct().order("developers.name desc,
+    // developers.id desc")`, so pluck must select both ordered columns —
+    // PostgreSQL requires every SELECT DISTINCT ORDER BY expression to appear in
+    // the select list (42P10).
+    expect(await scoped.pluck("developers.name", "developers.id")).toEqual([
+      ["Yara", developer.id],
+    ]);
   });
 
   it("dynamic find should respect association include", async () => {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2345,7 +2345,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#to_a / #load
    */
   async toArray(): Promise<T[]> {
-    if (this._isNone) return [];
+    if (this._isEmptyRelation()) return [];
     if (this._loaded) return [...this._records];
     if (this._loadAsyncPromise) {
       // A prior loadAsync() kicked off the query — share the in-flight
@@ -3292,7 +3292,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#exists?
    */
   async exists(conditions?: Record<string, unknown> | unknown): Promise<boolean> {
-    if (this._isNone) return false;
+    if (this._isEmptyRelation()) return false;
     // Rails FinderMethods#exists?: `return false if !conditions` — treats an
     // explicit `false` / `null` argument as "no match possible". This precedes
     // the `if eager_loading?` branch, so it short-circuits before the
@@ -3460,7 +3460,8 @@ export class Relation<T extends Base> {
   async pluck(
     ...columns: Array<string | Nodes.Attribute | Nodes.NamedFunction | Nodes.SqlLiteral>
   ): Promise<unknown[]> {
-    if (this._isNone) return [];
+    // `pick` routes through `limit(1).pluck(...)`, so it inherits this rebase.
+    if (this._isEmptyRelation()) return [];
     return this._withQueryConnection(() => this._pluckInner(...columns));
   }
 
@@ -6244,6 +6245,23 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#none?
    */
   isNone(): boolean {
+    return this._isNone;
+  }
+
+  /**
+   * The single none-short-circuit chokepoint consulted by every query terminal
+   * (`toArray`/`exists`/`pluck`/`count`/the bounded finders) BEFORE it returns
+   * its empty result. On a plain relation this is just `_isNone`; the override
+   * in `AssociationRelation` first rebases a stale new-owner `1=0` seed onto the
+   * live association scope, so a relation spawned off a new owner
+   * (`owner.things.where(...)`) resolves the persisted FK across all terminals
+   * once the owner is saved — mirroring Rails' CollectionProxy delegating every
+   * query to `association.scope`, rather than each terminal carrying its own
+   * rebase hook.
+   *
+   * @internal
+   */
+  _isEmptyRelation(): boolean {
     return this._isNone;
   }
 

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -87,6 +87,8 @@ interface CalculationRelation {
   _offsetValue: number | null;
   _optimizerHints: string[];
   _isNone: boolean;
+  /** @internal Rebase-then-report none short-circuit; see Relation. */
+  _isEmptyRelation(): boolean;
   _isDistinct: boolean;
   _groupColumns: string[];
   _whereClause: { isContradiction(): boolean };
@@ -663,7 +665,11 @@ async function groupedCompositeAssoc(
  * relation being ungrouped.
  */
 function isEmptyCalculationScope(rel: CalculationRelation): boolean {
-  if (rel._isNone) return true;
+  // `_isEmptyRelation()` is the shared none-short-circuit chokepoint: on an
+  // AssociationRelation it first rebases a stale new-owner `1=0` seed onto the
+  // live association scope, so count/sum/average/minimum/maximum on a relation
+  // spawned off a new owner pick up the persisted FK after `save`.
+  if (rel._isEmptyRelation()) return true;
   return rel._groupColumns.length === 0 && rel._whereClause.isContradiction();
 }
 

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -272,6 +272,8 @@ interface FinderRelation {
     ): Promise<R | undefined>;
   };
   _isNone: boolean;
+  /** @internal Rebase-then-report none short-circuit; see Relation. */
+  _isEmptyRelation(): boolean;
   _limitValue: number | null;
   _offsetValue: number | null;
   _orderClauses: any[];
@@ -413,12 +415,11 @@ function hasReversibleOrder(rel: FinderRelation): boolean {
 }
 
 export async function performFirst(this: FinderRelation, n?: number): Promise<any> {
-  // An AssociationRelation spawned off a stale new-owner `1=0` seed rebases onto
-  // the resolved association scope here — BEFORE the `_isNone` short-circuit, so
-  // a saved owner's persisted FK is picked up instead of returning null. No-op
-  // for ordinary relations (the hook is absent).
-  (this as { _maybeRebaseAssociationSeed?: () => void })._maybeRebaseAssociationSeed?.();
-  if (this._isNone) return n !== undefined ? [] : null;
+  // `_isEmptyRelation()` is the shared none-short-circuit chokepoint: on an
+  // AssociationRelation it first rebases a stale new-owner `1=0` seed onto the
+  // live association scope, so a saved owner's persisted FK is picked up instead
+  // of returning null.
+  if (this._isEmptyRelation()) return n !== undefined ? [] : null;
   // Rails: Relation#first(limit) → find_nth_with_limit(0, limit); no-arg
   // first → find_nth(0) → find_nth_with_limit(0, 1). find_nth_with_limit reads
   // the loaded cache when present, otherwise runs an ordered LIMIT query — and
@@ -445,9 +446,9 @@ function orderByPk(rel: FinderRelation, direction: "asc" | "desc"): any {
 }
 
 export async function performLast(this: FinderRelation, n?: number): Promise<any> {
-  // See performFirst: rebase a stale new-owner seed before the `_isNone` guard.
-  (this as { _maybeRebaseAssociationSeed?: () => void })._maybeRebaseAssociationSeed?.();
-  if (this._isNone) return n !== undefined ? [] : null;
+  // See performFirst: `_isEmptyRelation()` rebases a stale new-owner seed before
+  // reporting the none short-circuit.
+  if (this._isEmptyRelation()) return n !== undefined ? [] : null;
   // Rails: `return find_last(limit) if loaded? || has_limit_or_offset?`. When
   // the relation is already loaded — or carries a `limit`/`offset` that a
   // reverse-order query would otherwise discard — Rails materializes the


### PR DESCRIPTION
## What

The bounded finders (`first`/`last`/`take`/`find_nth`) and `toArray` rebase a
stale new-owner `1=0` seed onto the live `association.scope` (PR #4465). But
every other query terminal had its OWN `_isNone` short-circuit with no rebase
ahead of it, so a relation spawned off a new-owner seed
(`owner.things.where(...)`) still returned stale-empty from
`count`/`exists`/`pluck`/`pick`/`find` after the owner was saved:

```ts
const author = new Author({ name: "Gap" });
const rel = association(author, "posts").where({ title: "GG" }); // 1=0 seed
await author.save();
await Post.create({ title: "GG", author_id: author.id });
await rel.count();  // was 0     → now 1
await rel.exists(); // was false → now true
await rel.pluck("title"); // was [] → now ["GG"]
```

## Fix

Rather than sprinkling the `_maybeRebaseAssociationSeed?.()` hook into each
terminal, consolidate it behind a **single none-short-circuit chokepoint**:

- New `Relation#_isEmptyRelation()` — the one method every read terminal
  (`toArray`/`exists`/`pluck`/`count`+aggregates/the bounded finders) consults
  before returning its empty result. On a plain relation it just reports
  `_isNone`.
- `AssociationRelation` overrides it to rebase a stale new-owner seed **once**,
  so all terminals pick up the persisted FK from one place — mirroring Rails'
  `CollectionProxy` delegating every query to `association.scope`. This removes
  the per-terminal rebase hooks previously added to the finder helpers.
- `pick` routes through `limit(1).pluck(...)` and `find` through `toArray`, so
  both inherit the rebase without their own hook.
- The rebase is now **idempotent** (clears the seed marker after a successful
  rebase), so repeated terminals on the same instance don't re-merge the
  resolved scope onto an already-rebased relation (which could duplicate
  joins/predicates).

## Tests

- has_many (`Author`/`posts`): a relation spawned off a new owner resolves the
  persisted FK on `count`/`exists`/`pluck`/`pick`/`find` after `save`, with a
  non-matching sibling proving the `where(...)` mutation is still applied.
- HABTM (`Project`/`developers`): the same for `count`/`exists`/`pluck` on the
  resolved join scope (also exercises the idempotency path — three terminals on
  one instance).

Mirrors the finder tests added in PR #4465. Full `activerecord` relation /
association / calculation / finder suites pass locally.

Closes-story: rebase-new-owner-seed-for-count-exists-pluck-terminals
