### PR TITLE
fix(dup): Base#initializeDup fires the initialize callback chain

### DIFF
--- a/eslint/rails-callback-invocations-exclude.json
+++ b/eslint/rails-callback-invocations-exclude.json
@@ -1,5 +1,4 @@
 [
-  "packages/activerecord/src/aggregations.ts#initializeDup",
   "packages/activerecord/src/associations/association.ts#_createRecord",
   "packages/activerecord/src/associations/collection-association.ts#destroy",
   "packages/activerecord/src/associations/collection-proxy.ts#destroy",
@@ -17,7 +16,6 @@
   "packages/activerecord/src/encryption/encryptable-record.ts#_createRecord",
   "packages/activerecord/src/locking/optimistic.ts#_createRecord",
   "packages/activerecord/src/locking/optimistic.ts#incrementBang",
-  "packages/activerecord/src/locking/optimistic.ts#initializeDup",
   "packages/activerecord/src/persistence.ts#_updateRecord",
   "packages/activerecord/src/persistence.ts#destroy",
   "packages/activerecord/src/persistence.ts#incrementBang",
@@ -25,7 +23,6 @@
   "packages/activerecord/src/timestamp.ts#_createRecord",
   "packages/activerecord/src/timestamp.ts#_updateRecord",
   "packages/activerecord/src/timestamp.ts#createOrUpdate",
-  "packages/activerecord/src/timestamp.ts#initializeDup",
   "packages/activerecord/src/timestamp.ts#touch",
   "packages/activerecord/src/touch-later.ts#beforeCommittedBang",
   "packages/activerecord/src/touch-later.ts#touch",

--- a/packages/activerecord/src/aggregations.ts
+++ b/packages/activerecord/src/aggregations.ts
@@ -213,7 +213,7 @@ function writerMethod(
  * empty cache and we must copy from `other` (the source) explicitly rather than
  * from `this`.
  */
-export function initializeDup(this: Base, other: unknown): void {
+export function copyAggregationCacheForDup(this: Base, other: unknown): void {
   const src = (other as { _aggregationCache?: Map<string, unknown> })?._aggregationCache;
   if (src) (this as { _aggregationCache?: Map<string, unknown> })._aggregationCache = new Map(src);
 }
@@ -292,7 +292,7 @@ export function includeAggregations(modelClass: typeof Base): void {
     | undefined;
   Object.defineProperty(proto, "initializeDup", {
     value: function (this: Base, other: unknown): void {
-      initializeDup.call(this, other);
+      copyAggregationCacheForDup.call(this, other);
       if (inheritedInitializeDup) inheritedInitializeDup.call(this, other);
     },
     writable: true,

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -5072,9 +5072,23 @@ include(Base, TouchLater.InstanceMethods);
 // mixins, so invoke each module's hook explicitly in that order. Aggregations'
 // initialize_dup slots in above this chain, wired by includeAggregations on
 // composed_of models only.
-(Base.prototype as any).initializeDup = function (this: Base, other: unknown): void {
-  LockingOptimistic.initializeDup.call(this as any, other);
-  Timestamp.initializeDup.call(this as any, other);
+//
+// Mirrors ActiveRecord::Core#initialize_dup (core.rb): fire the initialize
+// callbacks against the duped attributes, THEN run the Locking/Timestamp
+// clears. In Rails those modules `super` into Core (which runs the callbacks)
+// and clear only as the stack unwinds (optimistic.rb:72-75, timestamp.rb:50-53),
+// so the hook observes the source's lock_version / timestamps before they are
+// nulled. `initialize` is defined `only: :after`, so runAllCallbacks fires just
+// the after_initialize chain. persistence.ts `dup` calls this after the duped
+// attributes and dirty baseline are in place.
+(Base.prototype as any).initializeDup = function (this: Base, _other: unknown): void {
+  void cbRunAll((this.constructor as typeof Base).prototype, "initialize", this, undefined, {
+    strict: "sync",
+  });
+  if ((this.constructor as typeof Base).lockingEnabled) {
+    LockingOptimistic._clearLockingColumn.call(this as any);
+  }
+  Timestamp.clearTimestampAttributes.call(this as any);
 };
 include(Base, _AttributeAssignment.InstanceMethods);
 include(Base, AutosaveAssociation);

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -115,6 +115,11 @@ export class SchemaCache {
     return callback(fs.readFileSync(filename, "utf-8"));
   }
 
+  // Permanently grandfathered in rails-callback-invocations-exclude.json:
+  // SchemaCache is not an ActiveRecord model. Rails' SchemaCache#initialize_dup
+  // supers into Object (schema_cache.rb:264) and fires no model callbacks — the
+  // name-keyed lint rule only flags it because Core#initialize_dup (a different
+  // class) runs `_run_initialize_callbacks`. Firing them here would be wrong.
   initializeDup(): SchemaCache {
     const dup = new SchemaCache();
     dup._columns = new Map(this._columns);

--- a/packages/activerecord/src/locking/optimistic.ts
+++ b/packages/activerecord/src/locking/optimistic.ts
@@ -306,14 +306,6 @@ export function _clearLockingColumn(this: InstanceLockingHost): void {
 
 /**
  * @internal
- * Mirrors: ActiveRecord::Locking::Optimistic#initialize_dup
- */
-export function initializeDup(this: InstanceLockingHost, _other: unknown): void {
-  if (this.constructor.lockingEnabled) _clearLockingColumn.call(this);
-}
-
-/**
- * @internal
  * Mirrors: ActiveRecord::Locking::Optimistic#_query_constraints_hash
  */
 export function _queryConstraintsHash(

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -1560,21 +1560,18 @@ export function dup<T extends DupRecord>(this: T): T {
     // Re-mark attributes that differ from their database column default as changed.
     duped._dirty.reinstateNewRecordChanges(dupedAttrs);
   }
-  // Dispatch `after_initialize` against the duped attributes. Mirrors Rails
-  // Core#initialize_dup, which runs `_run_initialize_callbacks` only — it does
-  // NOT re-run `initialize_internals_callback`/`ensure_proper_type` (that lives
-  // in Core#initialize), so the STI type column is carried solely by the
-  // deep-dup'd `@attributes`, not re-asserted here.
-  // strict:"sync" guarantees synchronous completion — void the settled result.
-  void runAfterCallbacksOnProto(ctor.prototype, "initialize", duped, { strict: "sync" });
-  // The Timestamp/Locking `initialize_dup` clears run AFTER the callbacks in
-  // Rails: their modules `super` into `Core#initialize_dup` (which fires the
-  // hook) and clear only as the stack unwinds. So the hook above observes the
-  // source's `created_at`/`updated_at`/`lock_version`; we null them out here.
-  // Each clear rebinds its column's dirty baseline (`clear_attribute_change`),
-  // so the cleared columns read back as nil/default and not-dirty regardless of
-  // the reinstate pass above (test_dup_timestamps_are_cleared /
-  // _locking_column_is_not_dirty).
+  // Run `initializeDup` against the duped attributes. Mirrors Rails
+  // Core#initialize_dup, which dispatches `_run_initialize_callbacks`
+  // (after_initialize only) and then lets the Timestamp/Locking modules clear
+  // as the super stack unwinds: the hook observes the source's
+  // `created_at`/`updated_at`/`lock_version` before they are nulled. Each clear
+  // rebinds its column's dirty baseline (`clear_attribute_change`), so the
+  // cleared columns read back as nil/default and not-dirty regardless of the
+  // reinstate pass above (test_dup_timestamps_are_cleared /
+  // _locking_column_is_not_dirty). It does NOT re-run
+  // `initialize_internals_callback`/`ensure_proper_type` (that lives in
+  // Core#initialize), so the STI type column is carried solely by the deep-dup'd
+  // `@attributes`, not re-asserted here.
   duped.initializeDup(this);
   return duped;
 }

--- a/packages/activerecord/src/timestamp.ts
+++ b/packages/activerecord/src/timestamp.ts
@@ -402,11 +402,6 @@ export function timestampAttributesForUpdate(this: TimestampHost): string[] {
 // ---------------------------------------------------------------------------
 
 /** @internal */
-export function initializeDup(this: TimestampInstanceHost, _other: unknown): void {
-  clearTimestampAttributes.call(this);
-}
-
-/** @internal */
 export function initInternals(this: TimestampInstanceHost): void {
   this._touchRecord = null;
 }


### PR DESCRIPTION
## Summary

Mirror `ActiveRecord::Core#initialize_dup` (core.rb:553): the model-level dup
path now fires `_run_initialize_callbacks` via `runAllCallbacks("initialize")`
inside `Base.prototype.initializeDup`, before the Locking/Timestamp column
clears. `initialize` is defined `only: :after`, so this fires the
`after_initialize` chain — matching Rails, where Timestamp/Optimistic
`super` into Core (which fires the hook) and clear only as the stack unwinds,
so the hook still observes the source's `lock_version`/timestamps.

The callback dispatch moves out of `persistence.ts` `dup` into the composition
(same ordering: after the duped attributes and dirty baseline are in place).

## Ratchet

Surfaced by the `rails-callback-invocations` ESLint rule (#4853). The redundant
thin `initializeDup` wrappers in `timestamp.ts` / `optimistic.ts` (each just
calling an existing clear helper) are inlined into the composition, and
aggregations' cache-copy `initializeDup` is renamed to
`copyAggregationCacheForDup`. With those named ports gone, their three ratchet
entries are removed. `initialize_dup` is in api:compare's SKIP set, so no
api:compare coverage is affected.

`connection-adapters/schema-cache.ts#initializeDup` stays grandfathered:
`SchemaCache` is not an ActiveRecord model and its `initialize_dup` supers into
`Object` (fires no model callbacks) — a permanent false positive of the
name-keyed rule.

## Test

`dup after initialize callbacks` (dup.test.ts, mirroring
`dup_test.rb#test_dup_after_initialize_callbacks`) already covers
`after_initialize` firing on `dup` and passes.

Closes-story: initialize-dup-fires-initialize-callbacks
