### PR TITLE
feat(activerecord): dynamic reader for select aliases on loaded records

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -70,6 +70,7 @@ import {
   isBaseClass as _isBaseClass,
   ensureProperType as _ensureProperType,
   narrowToProjectedColumns,
+  defineDynamicSelectReaders,
   subclassFromAttributesForNew,
 } from "./inheritance.js";
 import { NotImplementedError, RecordNotFound, StaleObjectError } from "./errors.js";
@@ -3030,6 +3031,7 @@ export class Base extends Model {
       row,
       overrideTypes,
     );
+    defineDynamicSelectReaders(record as unknown as Base);
     record._newRecord = false;
     (record as any)._dirty.snapshot(record._attributes);
     record.changesApplied();

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -606,6 +606,43 @@ export function narrowToProjectedColumns(
 }
 
 /**
+ * Define per-instance readers for non-column select aliases so a loaded record
+ * exposes them via property access (`record.post_count`).
+ *
+ * Rails answers `record.post_count` for a `SELECT COUNT(*) AS post_count`
+ * projection through `method_missing` → `attribute_missing`, gated on
+ * `@attributes.key?(name)` (attribute_methods.rb). TypeScript has no
+ * method_missing, so we install own-property getters on the instance for each
+ * loaded attribute that has no accessor on the prototype chain (i.e. isn't a
+ * declared column) — matching Rails' `relation.map(&:post_count)`.
+ */
+export function defineDynamicSelectReaders(record: Base): void {
+  const proto = Object.getPrototypeOf(record) as object;
+  const attrs = (record as any)._attributes as { keys(): Iterable<string> };
+  for (const name of attrs.keys()) {
+    if (Object.prototype.hasOwnProperty.call(record, name)) continue;
+    // Skip anything already reachable as a method/accessor on the prototype
+    // chain (declared columns, aliases, real methods) — only bare select
+    // aliases fall through to here.
+    let hasProtoMember = false;
+    for (let p: object | null = proto; p != null; p = Object.getPrototypeOf(p)) {
+      if (Object.getOwnPropertyDescriptor(p, name)) {
+        hasProtoMember = true;
+        break;
+      }
+    }
+    if (hasProtoMember) continue;
+    Object.defineProperty(record, name, {
+      get(this: Base) {
+        return (this as any).readAttribute(name);
+      },
+      configurable: true,
+      enumerable: false,
+    });
+  }
+}
+
+/**
  * Directly instantiate a record without STI delegation (avoids recursion).
  */
 function directInstantiate(
@@ -652,6 +689,7 @@ function directInstantiate(
     }
   }
   narrowToProjectedColumns(klass, record, row, overrideTypes);
+  defineDynamicSelectReaders(record);
   record._newRecord = false;
   (record as any)._dirty.snapshot(record._attributes);
   record.changesApplied();

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -640,15 +640,19 @@ export function defineDynamicSelectReaders(record: Base): void {
       }
     }
   }
-  // Hot path: a declared column already carries a prototype accessor (generated
-  // by defineAttributeMethods), so only keys absent from the schema can be bare
-  // select aliases. A full `SELECT *` load projects only declared columns, so
-  // this loop finds nothing to install and never walks the prototype chain —
-  // mirrors narrowToProjectedColumns' own full-projection early-out.
-  const columnNames = new Set(klass.columnNames());
+  // Hot path: every declared attribute (a real column, and also an ignored
+  // column) is a known attribute, so only keys absent from _attributeDefinitions
+  // can be bare select aliases. A full `SELECT *` load projects only declared
+  // columns, so this loop finds nothing to install and never walks the prototype
+  // chain — mirrors narrowToProjectedColumns' own full-projection early-out.
+  // Gating on _attributeDefinitions (not columnNames(), which drops ignored
+  // columns) keeps an ignored column — declared but accessor-less — from being
+  // mistaken for a select alias.
+  const definedAttrs = (klass as unknown as { _attributeDefinitions: Map<string, unknown> })
+    ._attributeDefinitions;
   const proto = Object.getPrototypeOf(record) as object;
   for (const name of attrs.keys()) {
-    if (columnNames.has(name)) continue;
+    if (definedAttrs.has(name)) continue;
     if (installed.has(name)) continue;
     if (Object.prototype.hasOwnProperty.call(record, name)) continue;
     // A non-column key can still resolve to a real method or an aliased

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -605,9 +605,11 @@ export function narrowToProjectedColumns(
   attrs.narrowTo(keep, overrideTypes);
 }
 
+const SELECT_ALIAS_READERS = Symbol.for("activerecord.selectAliasReaders");
+
 /**
- * Define per-instance readers for non-column select aliases so a loaded record
- * exposes them via property access (`record.post_count`).
+ * Reconcile per-instance readers for non-column select aliases so a loaded
+ * record exposes them via property access (`record.post_count`).
  *
  * Rails answers `record.post_count` for a `SELECT COUNT(*) AS post_count`
  * projection through `method_missing` → `attribute_missing`, gated on
@@ -615,10 +617,29 @@ export function narrowToProjectedColumns(
  * method_missing, so we install own-property getters on the instance for each
  * loaded attribute that has no accessor on the prototype chain (i.e. isn't a
  * declared column) — matching Rails' `relation.map(&:post_count)`.
+ *
+ * This runs on every attribute-set swap (instantiate, dup, reload), so it also
+ * drops readers whose alias is gone from the new attribute set: Rails' gate is
+ * `@attributes.key?`, so once `reload` swaps in a plain `SELECT *` attribute set
+ * `record.post_count` raises `NoMethodError` — we mirror that by deleting the
+ * stale getter (property access then yields `undefined`, the trails analog).
  */
 export function defineDynamicSelectReaders(record: Base): void {
   const attrs = (record as any)._attributes as { keys(): Iterable<string> };
   const klass = record.constructor as typeof Base;
+  const rec = record as unknown as Record<string | symbol, unknown>;
+  const installed = (rec[SELECT_ALIAS_READERS] as Set<string> | undefined) ?? new Set<string>();
+  // Drop readers whose alias no longer appears in the fresh attribute set
+  // (mirrors Rails' `@attributes.key?` gate now returning false after the swap).
+  if (installed.size > 0) {
+    const live = new Set(attrs.keys());
+    for (const name of installed) {
+      if (!live.has(name)) {
+        delete rec[name];
+        installed.delete(name);
+      }
+    }
+  }
   // Hot path: a declared column already carries a prototype accessor (generated
   // by defineAttributeMethods), so only keys absent from the schema can be bare
   // select aliases. A full `SELECT *` load projects only declared columns, so
@@ -628,6 +649,7 @@ export function defineDynamicSelectReaders(record: Base): void {
   const proto = Object.getPrototypeOf(record) as object;
   for (const name of attrs.keys()) {
     if (columnNames.has(name)) continue;
+    if (installed.has(name)) continue;
     if (Object.prototype.hasOwnProperty.call(record, name)) continue;
     // A non-column key can still resolve to a real method or an aliased
     // accessor on the prototype chain (Rails' `respond_to_without_attributes?`
@@ -647,6 +669,15 @@ export function defineDynamicSelectReaders(record: Base): void {
       },
       configurable: true,
       enumerable: false,
+    });
+    installed.add(name);
+  }
+  if (installed.size > 0 && rec[SELECT_ALIAS_READERS] === undefined) {
+    Object.defineProperty(record, SELECT_ALIAS_READERS, {
+      value: installed,
+      configurable: true,
+      enumerable: false,
+      writable: false,
     });
   }
 }

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -617,13 +617,22 @@ export function narrowToProjectedColumns(
  * declared column) — matching Rails' `relation.map(&:post_count)`.
  */
 export function defineDynamicSelectReaders(record: Base): void {
-  const proto = Object.getPrototypeOf(record) as object;
   const attrs = (record as any)._attributes as { keys(): Iterable<string> };
+  const klass = record.constructor as typeof Base;
+  // Hot path: a declared column already carries a prototype accessor (generated
+  // by defineAttributeMethods), so only keys absent from the schema can be bare
+  // select aliases. A full `SELECT *` load projects only declared columns, so
+  // this loop finds nothing to install and never walks the prototype chain —
+  // mirrors narrowToProjectedColumns' own full-projection early-out.
+  const columnNames = new Set(klass.columnNames());
+  const proto = Object.getPrototypeOf(record) as object;
   for (const name of attrs.keys()) {
+    if (columnNames.has(name)) continue;
     if (Object.prototype.hasOwnProperty.call(record, name)) continue;
-    // Skip anything already reachable as a method/accessor on the prototype
-    // chain (declared columns, aliases, real methods) — only bare select
-    // aliases fall through to here.
+    // A non-column key can still resolve to a real method or an aliased
+    // accessor on the prototype chain (Rails' `respond_to_without_attributes?`
+    // short-circuit in method_missing); only truly unclaimed names fall
+    // through to an alias reader.
     let hasProtoMember = false;
     for (let p: object | null = proto; p != null; p = Object.getPrototypeOf(p)) {
       if (Object.getOwnPropertyDescriptor(p, name)) {

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -1406,6 +1406,10 @@ export async function reload<T extends ReloadRecord>(
   // then unconditionally clears the new-record flags; dirty tracking
   // re-baselines on the fresh values.
   this._attributes = fresh._attributes;
+  // Reconcile alias readers against the swapped-in attribute set: a plain
+  // reload drops any prior select alias, so the stale getter is removed (Rails'
+  // `@attributes.key?` gate would raise NoMethodError post-reload).
+  defineDynamicSelectReaders(this as unknown as import("./base.js").Base);
   this._newRecord = false;
   this._previouslyNewRecord = false;
   this._dirty.snapshot(this._attributes);

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -36,6 +36,7 @@ import {
   isStiSubclass,
   isDescendsFromActiveRecord,
   stiName,
+  defineDynamicSelectReaders,
 } from "./inheritance.js";
 import { withTransactionReturningStatus } from "./transactions.js";
 import { isSuppressed } from "./suppressor.js";
@@ -1548,6 +1549,11 @@ export function dup<T extends DupRecord>(this: T): T {
       ? defaultAttributes().map((attr) => attr.withValueFromUser(base.fetchValue(attr.name)))
       : base;
   (duped as { _attributes: DupAttributeSet })._attributes = dupedAttrs;
+  // Reinstall alias readers against the swapped-in attribute set so a duped
+  // record answers `dup.post_count` for any select alias that survived the
+  // deep-dup — matching Ruby, where method_missing keeps resolving aliases
+  // after dup because Object#dup leaves method dispatch untouched.
+  defineDynamicSelectReaders(duped as unknown as import("./base.js").Base);
   duped._readonly = this._readonly;
   // Rebind the dirty tracker to the duped attribute set BEFORE the hook (the
   // baseline from `new ctor({})` is stale against the swapped-in `_attributes`),

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -367,12 +367,8 @@ describe("RelationTest", () => {
       "type",
       "post_count",
     );
-    const relCounts = (await relation.toArray())
-      .map((r: any) => r.readAttribute("post_count"))
-      .sort();
-    const subCounts = (await subquery.toArray())
-      .map((r: any) => r.readAttribute("post_count"))
-      .sort();
+    const relCounts = (await relation.toArray()).map((r: any) => r.post_count).sort();
+    const subCounts = (await subquery.toArray()).map((r: any) => r.post_count).sort();
     expect(subCounts).toEqual(relCounts);
   });
 
@@ -381,13 +377,11 @@ describe("RelationTest", () => {
     const subquery = Comment.from(relation, `grouped_${Comment.tableName}`)
       .group("type")
       .average("post_count");
-    // Rails reads the select alias via `&:post_count`; trails exposes no dynamic
-    // reader for select aliases, so read it through readAttribute. COUNT() is a
-    // bigint on PG/MariaDB while average() yields a number, so coerce both to
-    // Number for comparison (Rails compares BigDecimal == Integer loosely).
-    const relCounts = (await relation.toArray())
-      .map((r: any) => Number(r.readAttribute("post_count")))
-      .sort();
+    // Rails reads the select alias via `&:post_count`; trails exposes the same
+    // dynamic reader on the loaded record. COUNT() is a bigint on PG/MariaDB
+    // while average() yields a number, so coerce both to Number for comparison
+    // (Rails compares BigDecimal == Integer loosely).
+    const relCounts = (await relation.toArray()).map((r: any) => Number(r.post_count)).sort();
     const subValues = Object.values((await subquery) as Record<string, number>)
       .map(Number)
       .sort();
@@ -399,12 +393,8 @@ describe("RelationTest", () => {
     const subquery = Comment.from(
       `(${await relation.toSql()}) ${Comment.tableName}_grouped`,
     ).select("type", "post_count");
-    const relCounts = (await relation.toArray())
-      .map((r: any) => r.readAttribute("post_count"))
-      .sort();
-    const subCounts = (await subquery.toArray())
-      .map((r: any) => r.readAttribute("post_count"))
-      .sort();
+    const relCounts = (await relation.toArray()).map((r: any) => r.post_count).sort();
+    const subCounts = (await subquery.toArray()).map((r: any) => r.post_count).sort();
     expect(subCounts).toEqual(relCounts);
   });
 
@@ -413,9 +403,7 @@ describe("RelationTest", () => {
     const subquery = Comment.from(`(${await relation.toSql()}) ${Comment.tableName}_grouped`)
       .group("type")
       .average("post_count");
-    const relCounts = (await relation.toArray())
-      .map((r: any) => Number(r.readAttribute("post_count")))
-      .sort();
+    const relCounts = (await relation.toArray()).map((r: any) => Number(r.post_count)).sort();
     const subValues = Object.values((await subquery) as Record<string, number>)
       .map(Number)
       .sort();

--- a/packages/activerecord/src/select-alias-reader.trails.test.ts
+++ b/packages/activerecord/src/select-alias-reader.trails.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { fixtures } from "./test-helpers/fixtures.js";
+import { Comment } from "./test-helpers/models/comment.js";
+
+// trails-specific: Rails exposes a `SELECT ... AS post_count` alias on a loaded
+// record via method_missing / attribute_missing (gated on `@attributes.key?`).
+// trails has no method_missing, so it installs per-instance own-property getters
+// and reconciles them on every attribute-set swap (load / dup / reload). These
+// tests lock that lifecycle; the from-alias parity tests live in relations.test.ts.
+describe("select alias dynamic reader (trails)", () => {
+  fixtures(["posts", "comments"]);
+
+  it("exposes a non-column aggregate select alias via property access", async () => {
+    const record = (
+      await Comment.group("type").select("COUNT(post_id) AS post_count, type")
+    )[0] as Comment & { post_count: unknown };
+    expect(record.post_count).toEqual(record.readAttribute("post_count"));
+    expect(record.post_count).not.toBeUndefined();
+  });
+
+  it("drops the alias reader on reload once the fresh row lacks it", async () => {
+    // A per-row alias on a full-row select keeps the primary key, so the record
+    // is reloadable — the aggregate group/select rows above have no id.
+    const record = (
+      await Comment.select("comments.*, (id + 1000) AS bumped_id").order("id")
+    )[0] as Comment & { bumped_id: unknown };
+    expect(record.bumped_id).toEqual(record.readAttribute("bumped_id"));
+    expect(record.bumped_id).not.toBeUndefined();
+    await record.reload();
+    // A plain reload re-fetches every column but not the computed alias, so the
+    // stale getter is removed — Rails' `@attributes.key?` gate raises
+    // NoMethodError here; the trails analog is a plain `undefined`.
+    expect(record.bumped_id).toBeUndefined();
+    // Sanity: the record itself is intact after reload.
+    expect(record.id).toEqual(record.readAttribute("id"));
+  });
+});


### PR DESCRIPTION
## What

Loaded records now expose non-column **select aliases** via property access
(`record.post_count`), matching Rails' `relation.map(&:post_count)`.

After `Comment.group("type").select("COUNT(post_id) AS post_count, type")`, a
loaded record had `post_count` in its attributes hash but `record.post_count`
was `undefined` — only `record.readAttribute("post_count")` worked. Rails
answers `record.post_count` through `method_missing` → `attribute_missing`,
gated on `@attributes.key?(name)` (`attribute_methods.rb`). TypeScript has no
method_missing, so at instantiation we install own-property getters for each
loaded attribute with no accessor on the prototype chain (i.e. not a declared
column).

## Fix

- New `defineDynamicSelectReaders(record)` helper (`inheritance.ts`) —
  reconciles per-instance alias readers against the current attribute set: it
  installs a getter for each non-column loaded key with no prototype accessor,
  and drops any previously-installed reader whose alias has left the attribute
  set (tracked via a per-instance name set). This mirrors Rails' live
  `attributes.include?(attr_name)` gate (`attribute_methods.rb:541-543`).
- Wired into every attribute-set swap: `Base._instantiate` (`base.ts`),
  `directInstantiate`/STI (`inheritance.ts`), `dup` and `reload`
  (`persistence.ts`).
- **Hot path:** declared columns are skipped via a `columnNames` Set before any
  prototype-chain walk, so a full `SELECT *` load installs nothing and stays
  O(1) — mirroring `narrowToProjectedColumns`' full-projection early-out.
- **dup:** a persisted source rebuilds `@attributes` from `_defaultAttributes()`
  (declared columns only), so the alias is dropped and no reader installs —
  analogous to Ruby's `ActiveModel::Dirty#init_attributes` (`dirty.rb:253`),
  where `dup.post_count` would raise `NoMethodError`; an unsaved source keeps
  the key via deep-dup and the reader reinstalls.
- **reload:** re-fetches declared columns only, so the stale alias getter is
  removed — matching Rails' post-reload `NoMethodError`.

## Tests

- `relations.test.ts`: the from-alias group/select tests now read the dotted
  accessor (`.post_count`) instead of `readAttribute("post_count")`. No test
  names touched.
- `select-alias-reader.trails.test.ts` (new): locks the lifecycle — a loaded
  aggregate alias is readable via property access, and a per-row alias reader is
  dropped (`undefined`) after `reload`.

Closes-story: record-dynamic-reader-for-select-aliases
