### PR TITLE
fix(associations): rebase new-owner seed for updateAll/deleteAll/touchAll mutation terminals

### DIFF
--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -65,9 +65,8 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
    * query terminal (`toArray`/`exists`/`pluck`/`count`/the bounded finders) and
    * every mutation terminal (`updateAll`/`deleteAll`/`touchAll`/
    * `updateCounters`) consults this before returning its empty result, so
-   * rebasing a stale
-   * new-owner `1=0` seed here covers all of them from one place. Reports the
-   * (possibly rebased) `_isNone`.
+   * rebasing a stale new-owner `1=0` seed here covers all of them from one
+   * place. Reports the (possibly rebased) `_isNone`.
    */
   _isEmptyRelation(): boolean {
     this._maybeRebaseAssociationSeed();

--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -62,8 +62,10 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
 
   /**
    * The none-short-circuit chokepoint (see `Relation#_isEmptyRelation`): every
-   * query terminal (`toArray`/`exists`/`pluck`/`count`/the bounded finders)
-   * consults this before returning its empty result, so rebasing a stale
+   * query terminal (`toArray`/`exists`/`pluck`/`count`/the bounded finders) and
+   * every mutation terminal (`updateAll`/`deleteAll`/`touchAll`/
+   * `updateCounters`) consults this before returning its empty result, so
+   * rebasing a stale
    * new-owner `1=0` seed here covers all of them from one place. Reports the
    * (possibly rebased) `_isNone`.
    */

--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -63,10 +63,11 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
   /**
    * The none-short-circuit chokepoint (see `Relation#_isEmptyRelation`): every
    * query terminal (`toArray`/`exists`/`pluck`/`count`/the bounded finders) and
-   * every mutation terminal (`updateAll`/`deleteAll`/`touchAll`/
-   * `updateCounters`) consults this before returning its empty result, so
-   * rebasing a stale new-owner `1=0` seed here covers all of them from one
-   * place. Reports the (possibly rebased) `_isNone`.
+   * the mutation terminals (`updateAll`/`deleteAll`, plus `touchAll`/
+   * `updateCounters` via their `updateAll` delegation) consult this before
+   * returning an empty result, so rebasing a stale new-owner `1=0` seed here
+   * covers all of them from one place. Reports the (possibly rebased)
+   * `_isNone`.
    */
   _isEmptyRelation(): boolean {
     this._maybeRebaseAssociationSeed();

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -782,6 +782,41 @@ describe("CollectionProxy — mutated finder requery on stale new-owner seed", (
     expect(await rel.pick("title")).toBe("match");
     expect((await rel.find(match.id)).id).toBe(match.id);
   });
+
+  it("resolves the persisted FK on updateAll/updateCounters after save", async () => {
+    // The mutation terminals carry their own none short-circuits, so they must
+    // consult the same `_isEmptyRelation()` chokepoint the read terminals do.
+    const author = new Author({ name: "New Owner Four" });
+    const rel = (association<Post>(author, "posts") as any).where({ title: "match" });
+
+    await author.save();
+    const authorId = author.id as number;
+    const match = await Post.create({ title: "match", body: "1", author_id: authorId });
+    // A non-matching sibling proves the mutation (`where(title:)`) is still
+    // applied on top of the rebuilt scope, not dropped.
+    const other = await Post.create({ title: "other", body: "2", author_id: authorId });
+
+    expect(await rel.updateCounters({ tags_count: 1 })).toBe(1);
+    expect((await Post.find(match.id)).tags_count).toBe(1);
+    expect((await Post.find(other.id)).tags_count).toBe(0);
+
+    expect(await rel.updateAll({ body: "updated" })).toBe(1);
+    expect((await Post.find(match.id)).body).toBe("updated");
+    expect((await Post.find(other.id)).body).toBe("2");
+  });
+
+  it("resolves the persisted FK on deleteAll after save", async () => {
+    const author = new Author({ name: "New Owner Five" });
+    const rel = (association<Post>(author, "posts") as any).where({ title: "match" });
+
+    await author.save();
+    const authorId = author.id as number;
+    await Post.create({ title: "match", body: "1", author_id: authorId });
+    const other = await Post.create({ title: "other", body: "2", author_id: authorId });
+
+    expect(await rel.deleteAll()).toBe(1);
+    expect(await Post.where({ author_id: authorId }).pluck("id")).toEqual([other.id]);
+  });
 });
 
 // The in-memory `CollectionProxy#find` path (loaded `inverse_of` collection,

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -23,6 +23,8 @@ import { CpkAuthor, CpkBook } from "../test-helpers/models/cpk.js";
 import { Pet } from "../test-helpers/models/pet.js";
 import { Toy } from "../test-helpers/models/toy.js";
 import { Firm, Client } from "../test-helpers/models/company.js";
+import { Ship } from "../test-helpers/models/ship.js";
+import { ShipPart } from "../test-helpers/models/ship-part.js";
 
 // `authors`, `posts`, `cpkAuthors`, `cpkBooks`, `pets`, and `toys` are declared
 // fixture sets below, so their models (`Author`, `Post`, `CpkAuthor`, `CpkBook`,
@@ -816,6 +818,27 @@ describe("CollectionProxy — mutated finder requery on stale new-owner seed", (
 
     expect(await rel.deleteAll()).toBe(1);
     expect(await Post.where({ author_id: authorId }).pluck("id")).toEqual([other.id]);
+  });
+
+  // `posts` has no timestamps, so touchAll rides `ship.parts` (ship_parts has
+  // `updated_at`). touchAll routes through updateAll, but its OWN short-circuit
+  // runs first — so it needs the chokepoint independently.
+  it("resolves the persisted FK on touchAll after save", async () => {
+    const ship = new Ship({ name: "New Owner Six" });
+    const rel = (association<ShipPart>(ship, "parts") as any).where({ name: "mast" });
+
+    await ship.save();
+    const shipId = ship.id as number;
+    const stale = "2000-01-01T00:00:00Z";
+    const mast = await ShipPart.create({ name: "mast", ship_id: shipId, updated_at: stale });
+    const sail = await ShipPart.create({ name: "sail", ship_id: shipId, updated_at: stale });
+
+    expect(await rel.touchAll()).toBe(1);
+    // The matching part is touched; the non-matching sibling proves the
+    // `where(...)` mutation still rides on top of the rebuilt scope.
+    expect((await ShipPart.find(mast.id)).updated_at).not.toEqual(
+      (await ShipPart.find(sail.id)).updated_at,
+    );
   });
 });
 

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -834,11 +834,12 @@ describe("CollectionProxy — mutated finder requery on stale new-owner seed", (
     const sail = await ShipPart.create({ name: "sail", ship_id: shipId, updated_at: stale });
 
     expect(await rel.touchAll()).toBe(1);
-    // The matching part is touched; the non-matching sibling proves the
-    // `where(...)` mutation still rides on top of the rebuilt scope.
-    expect((await ShipPart.find(mast.id)).updated_at).not.toEqual(
-      (await ShipPart.find(sail.id)).updated_at,
-    );
+    // Assert each row absolutely, not just that the two differ: the matching
+    // part moved off the stale timestamp, and the non-matching sibling is
+    // untouched — proving the `where(...)` mutation still rides on top of the
+    // rebuilt scope, and that touchAll hit the RIGHT row.
+    expect(String((await ShipPart.find(mast.id)).updated_at)).not.toBe(stale);
+    expect(String((await ShipPart.find(sail.id)).updated_at)).toBe(stale);
   });
 });
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3701,7 +3701,7 @@ export class Relation<T extends Base> {
       const [sql, ...binds] = updates;
       if (!sql || typeof sql !== "string")
         throw new ArgumentError("Empty list of attributes to change");
-      if (this._isNone) return 0;
+      if (this._isEmptyRelation()) return 0;
       await this._materializeDeferredDistinctPkPredicates();
       const boundSql = new Nodes.BoundSqlLiteral(
         sql,
@@ -3714,14 +3714,14 @@ export class Relation<T extends Base> {
     }
     if (typeof updates === "string") {
       if (!updates) throw new ArgumentError("Empty list of attributes to change");
-      if (this._isNone) return 0;
+      if (this._isEmptyRelation()) return 0;
       await this._materializeDeferredDistinctPkPredicates();
       return this._execUpdateAll(new Nodes.SqlLiteral(updates));
     }
     // Mirrors Rails: blank check precedes none? check (relation.rb:588-591).
     if (Object.keys(updates).length === 0)
       throw new ArgumentError("Empty list of attributes to change");
-    if (this._isNone) return 0;
+    if (this._isEmptyRelation()) return 0;
     await this._materializeDeferredDistinctPkPredicates();
 
     const table = this._modelClass.arelTable;
@@ -3808,7 +3808,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#delete_all
    */
   async deleteAll(): Promise<number> {
-    if (this._isNone) return 0;
+    if (this._isEmptyRelation()) return 0;
     await this._materializeDeferredDistinctPkPredicates();
 
     // Mirrors Rails `INVALID_METHODS_FOR_DELETE_ALL = [:distinct, :with,
@@ -3885,7 +3885,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#touch_all
    */
   async touchAll(...names: string[]): Promise<number> {
-    if (this._isNone) return 0;
+    if (this._isEmptyRelation()) return 0;
 
     // Use touchAttributesWithTime so alias-resolved column names are used
     // (e.g. Developer.updated_at → legacy_updated_at). Route through updateAll
@@ -6053,7 +6053,7 @@ export class Relation<T extends Base> {
     counters: Record<string, number | { time?: Temporal.Instant }>,
     options?: { touch?: CounterCacheTouchOption },
   ): Promise<number> {
-    if (this._isNone) return 0;
+    if (this._isEmptyRelation()) return 0;
 
     // Rails extracts :touch from the counters hash itself (relation.rb: `touch = counters.delete(:touch)`)
     const touchFromCounters = (counters as Record<string, unknown>).touch;
@@ -6261,10 +6261,11 @@ export class Relation<T extends Base> {
 
   /**
    * The single none-short-circuit chokepoint consulted by every query terminal
-   * (`toArray`/`exists`/`pluck`/`count`/the bounded finders) BEFORE it returns
-   * its empty result. On a plain relation this is just `_isNone`; the override
-   * in `AssociationRelation` first rebases a stale new-owner `1=0` seed onto the
-   * live association scope, so a relation spawned off a new owner
+   * (`toArray`/`exists`/`pluck`/`count`/the bounded finders) and every mutation
+   * terminal (`updateAll`/`deleteAll`/`touchAll`/`updateCounters`) BEFORE it
+   * returns its empty result. On a plain relation this is just `_isNone`; the
+   * override in `AssociationRelation` first rebases a stale new-owner `1=0` seed
+   * onto the live association scope, so a relation spawned off a new owner
    * (`owner.things.where(...)`) resolves the persisted FK across all terminals
    * once the owner is saved — mirroring Rails' CollectionProxy delegating every
    * query to `association.scope`, rather than each terminal carrying its own

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3885,7 +3885,11 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#touch_all
    */
   async touchAll(...names: string[]): Promise<number> {
-    if (this._isEmptyRelation()) return 0;
+    // No `none?` guard here: Rails' touch_all (relation.rb:969-971) is a bare
+    // `update_all model.touch_attributes_with_time(...)` and inherits the
+    // `return 0 if @none` from update_all (relation.rb:592). Delegating rather
+    // than short-circuiting also routes the new-owner seed rebase through
+    // updateAll's chokepoint.
 
     // Use touchAttributesWithTime so alias-resolved column names are used
     // (e.g. Developer.updated_at → legacy_updated_at). Route through updateAll
@@ -3897,6 +3901,9 @@ export class Relation<T extends Base> {
       updates[col] = new Nodes.Quoted(time);
     }
 
+    // Deviation: Rails passes the empty hash straight to update_all, which
+    // raises ArgumentError (relation.rb:589). Tracked by the
+    // `touch-all-update-counters-empty-updates-raise` story.
     if (Object.keys(updates).length === 0) return 0;
 
     return this.updateAll(updates);
@@ -6053,7 +6060,9 @@ export class Relation<T extends Base> {
     counters: Record<string, number | { time?: Temporal.Instant }>,
     options?: { touch?: CounterCacheTouchOption },
   ): Promise<number> {
-    if (this._isEmptyRelation()) return 0;
+    // No `none?` guard here: Rails' update_counters (relation.rb:926-944) ends
+    // in `update_all updates` and inherits the `return 0 if @none` from there
+    // (relation.rb:592), which is also what routes the new-owner seed rebase.
 
     // Rails extracts :touch from the counters hash itself (relation.rb: `touch = counters.delete(:touch)`)
     const touchFromCounters = (counters as Record<string, unknown>).touch;
@@ -6261,15 +6270,24 @@ export class Relation<T extends Base> {
 
   /**
    * The single none-short-circuit chokepoint consulted by every query terminal
-   * (`toArray`/`exists`/`pluck`/`count`/the bounded finders) and every mutation
-   * terminal (`updateAll`/`deleteAll`/`touchAll`/`updateCounters`) BEFORE it
-   * returns its empty result. On a plain relation this is just `_isNone`; the
-   * override in `AssociationRelation` first rebases a stale new-owner `1=0` seed
-   * onto the live association scope, so a relation spawned off a new owner
-   * (`owner.things.where(...)`) resolves the persisted FK across all terminals
-   * once the owner is saved — mirroring Rails' CollectionProxy delegating every
-   * query to `association.scope`, rather than each terminal carrying its own
-   * rebase hook.
+   * (`toArray`/`exists`/`pluck`/`count`/the bounded finders) and by the mutation
+   * terminals (`updateAll`/`deleteAll`) BEFORE returning an empty result.
+   * `touchAll`/`updateCounters` reach it by delegating to `updateAll`, as they
+   * do in Rails.
+   *
+   * On a plain relation this is just `_isNone`; the override in
+   * `AssociationRelation` first rebases a stale new-owner `1=0` seed onto the
+   * live association scope, so a relation SPAWNED off a new owner
+   * (`owner.things.where(...)`) resolves the persisted FK once the owner is
+   * saved — mirroring Rails' CollectionProxy delegating every query to
+   * `association.scope`, rather than each terminal carrying its own rebase hook.
+   *
+   * Note the scope of that override: `CollectionProxy` extends `Relation`, not
+   * `AssociationRelation`, and does not override this, so mutation terminals
+   * invoked on the PROXY itself (`owner.things.updateAll(...)`) still see the
+   * raw `_isNone`. Reads dodge this via `CollectionProxy#_finderScope`; the
+   * mutation side has no equivalent. Tracked by the
+   * `rebase-new-owner-seed-for-collection-proxy-mutations` story.
    *
    * @internal
    */


### PR DESCRIPTION
## What

PR #4859 consolidated the stale new-owner `1=0` seed rebase behind a single
none-short-circuit chokepoint, `Relation#_isEmptyRelation()`, overridden in
`AssociationRelation` to rebase before reporting `_isNone`. Every READ terminal
routes through it — but the MUTATION terminals still short-circuited on the raw
`this._isNone` field, so a relation spawned off a new-owner seed affected 0 rows
after the owner was saved:

```ts
const author = new Author({ name: "Gap" });
const rel = association(author, "posts").where({ title: "GG" }); // 1=0 seed
await author.save();
await Post.create({ title: "GG", author_id: author.id });
await rel.updateAll({ title: "H" }); // was 0 rows → now updates the persisted row
await rel.deleteAll();               // was 0 rows → now deletes it
```

Rails' `CollectionProxy` delegates every query — `update_all` / `delete_all`
included — to the live `association.scope`, so all of them resolve the persisted FK.

## Fix

Route the mutation short-circuits through the chokepoint — on exactly the two
terminals Rails guards:

- `updateAll` (all three arg shapes: Array, String, Hash) — `relation.rb:592`
- `deleteAll` — `relation.rb:1012`

`touchAll` / `updateCounters` inherit it by delegating to `updateAll`, as they do
in Rails. No new rebase hooks — the existing `AssociationRelation#_isEmptyRelation()`
override (idempotent since #4859) covers everything from one place.

Rails' ordering is preserved: the `ArgumentError` blank check still throws before
the chokepoint runs (`relation.rb:589-592`), and `deleteAll` keeps none? ahead of
`INVALID_METHODS_FOR_DELETE_ALL` (`relation.rb:1012-1018`).

`execMainQuery` deliberately stays on the raw `_isNone`: it is a downstream
internal guard reached only after a terminal has already run the chokepoint.

## Review replies

**#1 — `CollectionProxy` never gets the rebase on mutation terminals.** Correct,
and fixed as a doc claim + registered story rather than silently overclaiming.
Verified empirically on this tree:

| proxy call | result | |
|---|---|---|
| `posts.updateAll(...)` | `0` | broken — no rebase |
| `posts.updateCounters(...)` | `0` | broken |
| `posts.deleteAll()` | `1`, row deleted | **works** — non-diverged branch routes via `this.scope().deleteAll()` → `AssociationRelation` |

So the claim holds for `updateAll`/`touchAll`/`updateCounters`; `deleteAll`'s
non-diverged branch already works, though your point about the `diverged` branch
(`super.deleteAll()`, collection-proxy.ts:3997) being the stale-seed case stands.
The doc comment at `relation.ts` now scopes the claim to `AssociationRelation` and
names the gap. Fixing it properly means giving the proxy a mutation equivalent of
`_finderScope()` — new surface, outside this story's AC, and per CLAUDE.md I'm not
fanning out sibling PRs. Registered with full context (repro, file:line, the
`wrapCollectionProxy` trap analysis, AC) as
**`0023-surfaced-deviations/rebase-new-owner-seed-for-collection-proxy-mutations`**.

**#2 — Rails has no `@none` guard in `touch_all` / `update_counters`.** Correct —
confirmed in vendored Rails: `@none` appears in exactly `update_all`
(`relation.rb:591`) and `delete_all` (`relation.rb:1012`); `touch_all`
(`relation.rb:969-971`) and `update_counters` (`relation.rb:926-944`) both inherit
it via `update_all`. **Converged rather than ratified: both trails guards are
deleted.** The chokepoint now sits on exactly the two terminals Rails guards, and
`touchAll`/`updateCounters` reach it by delegation. Behaviorally free — verified
`.none().touchAll()` / `.none().updateCounters()` still return 0 and mutate
nothing, and all 552 tests across the dependent suites pass.

The residual deviation you named (`Model.none().touchAll()` on a model with no
timestamp columns → Rails raises `ArgumentError`, trails returns 0) comes from a
*separate* empty-updates guard, which Rails also lacks. It's an observable
behavior change beyond this story's scope, so it's marked in-code and registered
as **`0023-surfaced-deviations/touch-all-update-counters-empty-updates-raise`**.

**#4 — confirm the two referenced stories are actually registered.** Verified via
`pnpm tasks show` (you can't see them from the review worktree — no `tasks/` symlink
— so recording the output here). Both slugs resolve, match the in-code citations
exactly, are `status: ready` in the ready queue, and are **pushed** (tasks repo
`HEAD == origin/main`, so they're visible fleet-wide, not just locally):

| cited at | slug | status |
|---|---|---|
| `relation.ts` touchAll | `touch-all-update-counters-empty-updates-raise` | ready |
| `relation.ts` _isEmptyRelation | `rebase-new-owner-seed-for-collection-proxy-mutations` | ready |

Both were registered slug-titled (I omitted `tasks new --title`); fixed to
descriptive titles so they read correctly in `pnpm tasks ready`, where work is
picked by title:
- "Rebase new-owner seed for mutation terminals invoked on the CollectionProxy itself"
- "touchAll/updateCounters must raise ArgumentError on empty updates, not return 0"

**#3 — touchAll sibling assertion.** Already fixed in 1fe5caa65 before your
re-review (you confirmed it resolved). For the record, the underlying worry —
that create overwrites the explicit `updated_at: stale` — was disproven by probe:
both rows retain `2000-01-01T00:00:00Z` after create. The assertion is now
absolute in both directions anyway.

## Tests

In `collection-proxy.test.ts`, mirroring the read-terminal tests from #4859 — a
relation spawned off a new `Author`'s `posts` seed resolves the persisted FK on
`updateCounters` + `updateAll`, `deleteAll`, and `touchAll` (which rides
`ship.parts`, since `posts` has no timestamps and `ship_parts` has `updated_at`).

Each test carries a non-matching sibling proving the `where(...)` mutation still
rides on top of the rebuilt scope. All three fail against a reverted tree and pass
here — and they still fail after the #2 convergence, now exercising the
`touchAll`/`updateCounters` → `updateAll` delegation path too.

Verified two properties the change could have broken:

- **Explicit `.none()` still refuses to mutate** — `deleteAll`/`updateAll`/
  `touchAll`/`updateCounters` all return 0, rows untouched. The rebase only fires
  when `_seededNoneNewOwner` is set, which `none()` never sets.
- **`touchAll` → `updateAll` re-entry is safe** — the second chokepoint call
  no-ops because the rebase clears the seed marker (idempotent since #4859).

No HABTM `deleteAll` test: `delete_all` raises on `distinct`
(`INVALID_METHODS_FOR_DELETE_ALL`), so a rebased HABTM seed correctly raises
rather than returning a stale 0 — intended convergence, not a regression.

552 tests pass locally across the dependent paths (`has-many-associations`,
`collection-proxy`, `update-all`, `delete-all`, `counter-cache`, `timestamp`,
`finder-methods`).

Closes-story: rebase-new-owner-seed-for-mutation-terminals
