### PR TITLE
fix(reflection): self-heal klass cache when the model registry rebinds a name

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -489,62 +489,6 @@ describe("PreloaderTest", () => {
     registerModel("EssaySpecial", EssaySpecial);
     registerModel("Postesque", PostesquePL);
     registerModel("AuthorAddress", AuthorAddress);
-
-    // A reflection memoizes the resolved target class in `_klassCache` (and the
-    // through/source reflection it derives from it) the first time it's touched,
-    // keyed by class NAME via the global modelRegistry. When a sibling test file
-    // that shares this worker registers a bespoke model under a canonical name
-    // (e.g. nested-through-associations.test.ts registers a `Tagging` with no
-    // `tag` source) and that resolution happens first, the canonical reflection
-    // caches the wrong class permanently — surfacing here as
-    // `HasManyThroughSourceAssociationNotFoundError` on Post.tags. The registry
-    // entries above are already corrected to the canonical models; drop the stale
-    // klass/through/source caches so resolution re-runs against them. Covers every
-    // model this beforeEach re-registers (not just the Post→taggings→tag chain that
-    // fails today) so a future file-size reschedule poisoning a different canonical
-    // name — Sharded*, Cpk*, Essay, … — is hardened too. (FK/PK caches are
-    // intentionally left intact — they don't depend on cross-model name resolution
-    // and resetting them mid-suite regresses unrelated tests.)
-    const preloaderModels = [
-      Author,
-      AuthorFavorite,
-      Post,
-      CategoryPost,
-      Comment,
-      Book,
-      Category,
-      SpecialCategory,
-      Tag,
-      Tagging,
-      Essay,
-      Invoice,
-      LineItem,
-      LineItemDiscountApplication,
-      ShippingLine,
-      ShippingLineDiscountApplication,
-      Discount,
-      ShardedBlogPL,
-      ShardedBlogPostPL,
-      ShardedCommentPL,
-      ShardedTagPL,
-      ShardedBlogPostTagPL,
-      CpkOrderPL,
-      CpkOrderAgreementPL,
-      Dog,
-      EssaySpecial,
-      PostesquePL,
-      AuthorAddress,
-    ];
-    for (const M of preloaderModels) {
-      const reflections = (M as { _reflections?: Record<string, unknown> })._reflections ?? {};
-      for (const reflection of Object.values(reflections) as Record<string, unknown>[]) {
-        reflection._klassCache = null;
-        if ("_throughReflectionCache" in reflection) reflection._throughReflectionCache = undefined;
-        if ("_sourceReflectionCache" in reflection) reflection._sourceReflectionCache = undefined;
-        if ("_sourceReflectionNameCache" in reflection)
-          reflection._sourceReflectionNameCache = undefined;
-      }
-    }
   });
 
   it("preload with scope", async () => {

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -224,21 +224,26 @@ interface ReflectionLike {
  * @internal
  */
 class ModelRegistry extends Map<string, typeof Base> {
-  generation = 0;
+  #generation = 0;
+
+  /** Bumps only on a mutation that can change what a name resolves to. */
+  get generation(): number {
+    return this.#generation;
+  }
 
   override set(name: string, model: typeof Base): this {
-    if (super.get(name) !== model) this.generation++;
+    if (super.get(name) !== model) this.#generation++;
     return super.set(name, model);
   }
 
   override delete(name: string): boolean {
     const deleted = super.delete(name);
-    if (deleted) this.generation++;
+    if (deleted) this.#generation++;
     return deleted;
   }
 
   override clear(): void {
-    if (this.size > 0) this.generation++;
+    if (this.size > 0) this.#generation++;
     super.clear();
   }
 }

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -214,10 +214,40 @@ interface ReflectionLike {
 }
 
 /**
+ * Model registry that tracks a monotonic `generation`, bumped whenever a name
+ * is bound to a different class (or unbound). Reflections memoize their
+ * resolved `klass` alongside the generation it was resolved at, so a
+ * re-registration under the same name invalidates every stale memo at once
+ * instead of poisoning it permanently. Without this, a test file registering a
+ * bespoke model under a canonical name poisons the canonical reflections for
+ * the rest of the vitest worker's life.
+ * @internal
+ */
+class ModelRegistry extends Map<string, typeof Base> {
+  generation = 0;
+
+  override set(name: string, model: typeof Base): this {
+    if (super.get(name) !== model) this.generation++;
+    return super.set(name, model);
+  }
+
+  override delete(name: string): boolean {
+    const deleted = super.delete(name);
+    if (deleted) this.generation++;
+    return deleted;
+  }
+
+  override clear(): void {
+    if (this.size > 0) this.generation++;
+    super.clear();
+  }
+}
+
+/**
  * Registry to hold model classes by name. Models must be registered
  * here so associations can resolve class references.
  */
-export const modelRegistry = new Map<string, typeof Base>();
+export const modelRegistry = new ModelRegistry();
 
 /**
  * Find the framework `Base` class in `model`'s prototype chain without

--- a/packages/activerecord/src/reflection.trails.test.ts
+++ b/packages/activerecord/src/reflection.trails.test.ts
@@ -11,6 +11,7 @@ import { Base, reflectOnAssociation, registerModel } from "./index.js";
 import { Associations, modelRegistry } from "./associations.js";
 import {
   AssociationReflection,
+  ThroughReflection,
   belongsToCounterCacheColumn,
   counterCacheColumnOption,
   resolveAliasedColumn,
@@ -196,6 +197,48 @@ describe("ReflectionTest", () => {
     registerModel("ShInvTarget", ShInvSecond);
     expect(ref.klass).toBe(ShInvSecond);
     expect(ref.inverseOf()!.activeRecord).toBe(ShInvSecond);
+  });
+
+  it("through reflection inverse_of re-resolves when the registry rebinds the class name", () => {
+    // ThroughReflection keeps its own _inverseOfCache holding a reflection
+    // resolved off its klass, so it needs the same gate as the
+    // AssociationReflection memo — a healed klass must not still hand back an
+    // inverse owned by the previous target.
+    class TiTagFirst extends Base {
+      static {
+        this.attribute("name", "string");
+        this.hasMany("tiPosts", { className: "TiPost" });
+      }
+    }
+    class TiTagSecond extends Base {
+      static {
+        this.attribute("name", "string");
+        this.hasMany("tiPosts", { className: "TiPost" });
+      }
+    }
+    class TiTagging extends Base {
+      static {
+        this.attribute("name", "string");
+        this.belongsTo("tiTag", { className: "TiTag" });
+      }
+    }
+    class TiPost extends Base {
+      static {
+        this.attribute("name", "string");
+        this.hasMany("tiTaggings", { className: "TiTagging" });
+        this.hasMany("tiTags", { through: "tiTaggings", source: "tiTag", inverseOf: "tiPosts" });
+      }
+    }
+    registerModel("TiPost", TiPost);
+    registerModel("TiTagging", TiTagging);
+    registerModel("TiTag", TiTagFirst);
+
+    const ref = reflectOnAssociation(TiPost, "tiTags") as ThroughReflection;
+    expect(ref.inverseOf()!.activeRecord).toBe(TiTagFirst);
+
+    registerModel("TiTag", TiTagSecond);
+    expect(ref.klass).toBe(TiTagSecond);
+    expect(ref.inverseOf()!.activeRecord).toBe(TiTagSecond);
   });
 
   it("through reflection source re-resolves when the through target is rebound", () => {

--- a/packages/activerecord/src/reflection.trails.test.ts
+++ b/packages/activerecord/src/reflection.trails.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { Base, reflectOnAssociation, registerModel } from "./index.js";
-import { Associations } from "./associations.js";
+import { Associations, modelRegistry } from "./associations.js";
 import {
   belongsToCounterCacheColumn,
   counterCacheColumnOption,
@@ -102,6 +102,107 @@ describe("ReflectionTest", () => {
     // When className is explicitly qualified it bypasses the demodulize path
     const nsRef = reflectOnAssociation(NsAdminUser, "adminUser");
     expect(nsRef!.klass).toBe(NsAdminUser);
+  });
+
+  it("reflection klass re-resolves when the registry rebinds the class name", () => {
+    // The klass memo is keyed by class NAME via the global modelRegistry, so a
+    // model re-registered under a name a reflection already resolved must not
+    // keep serving the old class (a bespoke registration in one test file would
+    // otherwise poison canonical reflections for the whole vitest worker).
+    class ShFirstTarget extends Base {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    class ShSecondTarget extends Base {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    class ShOwner extends Base {
+      static {
+        this.attribute("name", "string");
+        this.hasMany("shTargets", { className: "ShTarget" });
+      }
+    }
+    registerModel("ShOwner", ShOwner);
+    registerModel("ShTarget", ShFirstTarget);
+
+    const ref = reflectOnAssociation(ShOwner, "shTargets")!;
+    expect(ref.klass).toBe(ShFirstTarget);
+    // Memoized while the registry is unchanged.
+    expect(ref.klass).toBe(ShFirstTarget);
+
+    registerModel("ShTarget", ShSecondTarget);
+    expect(ref.klass).toBe(ShSecondTarget);
+  });
+
+  it("re-registering the same class under the same name keeps the klass memo", () => {
+    // Registration is idempotent and happens constantly during model loading;
+    // only a rebind to a *different* class may invalidate a memo.
+    class ShStableTarget extends Base {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    class ShStableOwner extends Base {
+      static {
+        this.attribute("name", "string");
+        this.hasMany("shStableTargets", { className: "ShStableTarget" });
+      }
+    }
+    registerModel("ShStableOwner", ShStableOwner);
+    registerModel("ShStableTarget", ShStableTarget);
+
+    const ref = reflectOnAssociation(ShStableOwner, "shStableTargets")!;
+    expect(ref.klass).toBe(ShStableTarget);
+    const generationBefore = modelRegistry.generation;
+    expect(typeof generationBefore).toBe("number");
+    registerModel("ShStableTarget", ShStableTarget);
+    expect(modelRegistry.generation).toBe(generationBefore);
+    expect(ref.klass).toBe(ShStableTarget);
+  });
+
+  it("through reflection source re-resolves when the through target is rebound", () => {
+    // The shape of the PreloaderTest failure this fix targets: a bespoke
+    // through model with no source association is registered first, poisoning
+    // Post.tags' source/through memos; re-registering the real model must heal
+    // them rather than keep raising SourceAssociationNotFound.
+    class ShTag extends Base {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    class ShSourcelessTagging extends Base {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    class ShRealTagging extends Base {
+      static {
+        this.attribute("name", "string");
+        this.belongsTo("shTag", { className: "ShTag" });
+      }
+    }
+    class ShTaggedPost extends Base {
+      static {
+        this.attribute("name", "string");
+        this.hasMany("shTaggings", { className: "ShTagging" });
+        this.hasMany("shTags", { through: "shTaggings", source: "shTag" });
+      }
+    }
+    registerModel("ShTag", ShTag);
+    registerModel("ShTaggedPost", ShTaggedPost);
+    registerModel("ShTagging", ShSourcelessTagging);
+
+    const ref = reflectOnAssociation(ShTaggedPost, "shTags")!;
+    // Sourceless target: no source reflection resolvable, and the memo sticks.
+    expect(ref.sourceReflection).toBeNull();
+
+    registerModel("ShTagging", ShRealTagging);
+    expect(ref.sourceReflection).not.toBeNull();
+    expect(ref.sourceReflection!.name).toBe("shTag");
+    expect(ref.klass).toBe(ShTag);
   });
 
   it("counter cache column option extracts the explicit column from raw forms", () => {

--- a/packages/activerecord/src/reflection.trails.test.ts
+++ b/packages/activerecord/src/reflection.trails.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect } from "vitest";
 import { Base, reflectOnAssociation, registerModel } from "./index.js";
 import { Associations, modelRegistry } from "./associations.js";
 import {
+  AssociationReflection,
   belongsToCounterCacheColumn,
   counterCacheColumnOption,
   resolveAliasedColumn,
@@ -161,6 +162,40 @@ describe("ReflectionTest", () => {
     registerModel("ShStableTarget", ShStableTarget);
     expect(modelRegistry.generation).toBe(generationBefore);
     expect(ref.klass).toBe(ShStableTarget);
+  });
+
+  it("inverse_of re-resolves when the registry rebinds the class name", () => {
+    // inverseOf/inverseName memo values resolved off `this.klass` — an inverse
+    // reflection owned by the target class, and a name derived from scanning it.
+    // They have to heal with `klass`, or a healed klass still hands back the
+    // previous target's reflection.
+    class ShInvFirst extends Base {
+      static {
+        this.attribute("name", "string");
+        this.belongsTo("shInvOwner", { className: "ShInvOwner" });
+      }
+    }
+    class ShInvSecond extends Base {
+      static {
+        this.attribute("name", "string");
+        this.belongsTo("shInvOwner", { className: "ShInvOwner" });
+      }
+    }
+    class ShInvOwner extends Base {
+      static {
+        this.attribute("name", "string");
+        this.hasMany("shInvTargets", { className: "ShInvTarget" });
+      }
+    }
+    registerModel("ShInvOwner", ShInvOwner);
+    registerModel("ShInvTarget", ShInvFirst);
+
+    const ref = reflectOnAssociation(ShInvOwner, "shInvTargets") as AssociationReflection;
+    expect(ref.inverseOf()!.activeRecord).toBe(ShInvFirst);
+
+    registerModel("ShInvTarget", ShInvSecond);
+    expect(ref.klass).toBe(ShInvSecond);
+    expect(ref.inverseOf()!.activeRecord).toBe(ShInvSecond);
   });
 
   it("through reflection source re-resolves when the through target is rebound", () => {

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -933,25 +933,50 @@ export class AssociationReflection extends MacroReflection {
   }
 
   inverseOf(): AssociationReflection | ThroughReflection | null {
+    this.expireInverseCachesIfRegistryChanged();
     const name = this.inverseName();
     if (!name) return null;
     if (this._inverseOfCache !== undefined) return this._inverseOfCache;
     const result = this.klass._reflectOnAssociation(name) ?? null;
     this._inverseOfCache = result;
+    // Re-stamp post-resolve for the same reason `klass` does (see its comment).
+    this._inverseCacheGeneration = modelRegistry.generation;
     return result;
   }
 
   private _inverseNameCache: string | null | undefined = undefined;
   private _inverseOfCache: AssociationReflection | ThroughReflection | null | undefined = undefined;
+  private _inverseCacheGeneration = -1;
+
+  /**
+   * Both inverse memos hold values resolved off `this.klass` — an inverse
+   * reflection *owned by* the target class, and a name derived from scanning
+   * it. `klass` self-heals on a registry rebind, so these must too, or they
+   * keep serving the previous target's reflection after it has healed.
+   * (`_foreignKeyCache` / `_activeRecordPrimaryKeyCache` derive from
+   * `activeRecord` and options rather than the resolved target, so they are
+   * deliberately not gated.)
+   * @internal
+   */
+  private expireInverseCachesIfRegistryChanged(): void {
+    if (this._inverseCacheGeneration === modelRegistry.generation) return;
+    this._inverseCacheGeneration = modelRegistry.generation;
+    this._inverseOfCache = undefined;
+    this._inverseNameCache = undefined;
+  }
 
   /** @internal */
   override inverseName(): string | null {
+    this.expireInverseCachesIfRegistryChanged();
     if (this._inverseNameCache !== undefined) return this._inverseNameCache;
     const explicit = this.options.inverseOf;
     if (explicit !== undefined) {
       this._inverseNameCache = explicit === false ? null : (explicit as string);
     } else {
       this._inverseNameCache = this.automaticInverseOf();
+      // automaticInverseOf scans `this.klass`, which can autoload-and-register
+      // mid-scan; re-stamp so the memo isn't written already flagged stale.
+      this._inverseCacheGeneration = modelRegistry.generation;
     }
     return this._inverseNameCache;
   }
@@ -1491,6 +1516,12 @@ export class ThroughReflection extends AbstractReflection {
    * @internal
    */
   private expireCachesIfRegistryChanged(): void {
+    // Stamps at *entry* so a nested getter (sourceReflection → sourceReflectionName
+    // → throughReflection) doesn't re-clear what its caller is mid-way through
+    // computing. Each getter re-stamps after it resolves, so a mid-flight autoload
+    // bump doesn't leave the memo stale on write and force a full recompute of the
+    // through/source chain on the next touch.
+
     if (this._cacheGeneration === modelRegistry.generation) return;
     this._cacheGeneration = modelRegistry.generation;
     this._klassCache = null;
@@ -1600,8 +1631,14 @@ export class ThroughReflection extends AbstractReflection {
     const anonymousClass = this._delegate.options.anonymousClass as typeof Base | undefined;
     this._klassCache = anonymousClass ?? this._delegate._klass(this.className);
     // Resolving can autoload-and-register the target, bumping the generation
-    // mid-flight; re-sync so this memo isn't stale the moment it's written. The
-    // sibling memos were just cleared, so they recompute on demand regardless.
+    // mid-flight; re-sync so this memo isn't stale the moment it's written.
+    //
+    // This also certifies any sibling memo repopulated during the resolve (e.g.
+    // `className` above can derive through `sourceReflection`) at the post-bump
+    // generation. That is sound because the only bump reachable inside a
+    // synchronous resolve is an autoload registering a name that was, by
+    // definition, absent from the registry — a registry *miss* is what triggers
+    // the autoload — so it cannot change what any earlier lookup resolved to.
     this._cacheGeneration = modelRegistry.generation;
     return this._klassCache;
   }
@@ -1669,6 +1706,7 @@ export class ThroughReflection extends AbstractReflection {
     try {
       const src = throughRef.klass._reflectOnAssociation(srcName) ?? null;
       this._sourceReflectionCache = src;
+      this._cacheGeneration = modelRegistry.generation;
       return src;
     } catch {
       this._sourceReflectionCache = null;
@@ -1681,6 +1719,7 @@ export class ThroughReflection extends AbstractReflection {
     if (this._throughReflectionCache !== undefined) return this._throughReflectionCache;
     const through = this.activeRecord._reflectOnAssociation(this.through) ?? null;
     this._throughReflectionCache = through;
+    this._cacheGeneration = modelRegistry.generation;
     return through;
   }
 
@@ -1833,6 +1872,7 @@ export class ThroughReflection extends AbstractReflection {
         );
       }
       this._sourceReflectionNameCache = matching[0] ?? null;
+      this._cacheGeneration = modelRegistry.generation;
     } catch (e: unknown) {
       if (e instanceof AmbiguousSourceReflectionForThroughAssociation) throw e;
       this._sourceReflectionNameCache = null;

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1509,41 +1509,43 @@ export class ThroughReflection extends AbstractReflection {
   }
 
   /**
-   * Every memo this class owns (klass, through/source, and the inverse
-   * reflection resolved off `klass`) derives from classes resolved out of the
-   * model registry, so they all go stale together when a name is rebound to a
-   * different class. Drop them as a unit rather than returning a target that
-   * the registry no longer maps this reflection to. `inverseName` is absent
-   * because it delegates to the AssociationReflection memo, which gates itself.
-   * @internal
-   */
-  /**
    * Record the generation this reflection's memos are valid at.
    *
-   * Every resolving caller stamps *after* it resolves, never before: resolving
-   * can autoload-and-register a class and bump the generation mid-flight, and
-   * stamping the pre-resolve value would leave the memo flagged stale the moment
-   * it is written, forcing the next touch of any memo here to wipe and recompute
-   * the whole through/source chain. The error paths stamp too — a resolve that
-   * threw can have bumped the generation just as easily as one that succeeded (a
-   * namespaced candidate walk may register a class and then reject it), and the
-   * negative memo they write is just as much a memo.
+   * The rule here is unconditional and greppable: **every write to a memo on
+   * this class is immediately followed by a stamp.** Never stamp before the
+   * resolve — resolving can autoload-and-register a class and bump the
+   * generation mid-flight, and stamping the pre-resolve value would leave the
+   * memo flagged stale the moment it is written, forcing the next touch to wipe
+   * and recompute the whole through/source chain. Error paths stamp too: a
+   * resolve that threw can have bumped the generation just as easily as one that
+   * succeeded (a namespaced candidate walk may register a class and then reject
+   * it), and the negative memo they write is just as much a memo.
    *
-   * `expireCachesIfRegistryChanged` is the one caller that stamps at entry; see
-   * its comment for why.
+   * Two exits deliberately do not stamp, and neither writes a memo:
+   * `sourceReflectionName`'s ambiguity rethrow (it escapes before the write), and
+   * `inverseOf`'s no-inverse-name return. `expireCachesIfRegistryChanged` is the
+   * one caller that stamps at *entry*; see its comment for why.
    * @internal
    */
   private stampGeneration(): void {
     this._cacheGeneration = modelRegistry.generation;
   }
 
+  /**
+   * Every memo this class owns (klass, through/source, and the inverse
+   * reflection resolved off `klass`) derives from classes resolved out of the
+   * model registry, so they all go stale together when a name is rebound to a
+   * different class. Drop them as a unit rather than returning a target that
+   * the registry no longer maps this reflection to. `inverseName` is absent
+   * because it delegates to the AssociationReflection memo, which gates itself.
+   *
+   * Stamps at *entry*, uniquely, so a nested getter (sourceReflection →
+   * sourceReflectionName → throughReflection) doesn't re-clear what its caller is
+   * mid-way through computing. Each getter re-stamps after it resolves, so a
+   * mid-flight autoload bump doesn't leave a memo stale on write.
+   * @internal
+   */
   private expireCachesIfRegistryChanged(): void {
-    // Stamps at *entry* so a nested getter (sourceReflection → sourceReflectionName
-    // → throughReflection) doesn't re-clear what its caller is mid-way through
-    // computing. Each getter re-stamps after it resolves, so a mid-flight autoload
-    // bump doesn't leave the memo stale on write and force a full recompute of the
-    // through/source chain on the next touch.
-
     if (this._cacheGeneration === modelRegistry.generation) return;
     this.stampGeneration();
     this._klassCache = null;
@@ -1719,11 +1721,13 @@ export class ThroughReflection extends AbstractReflection {
     const srcName = this.sourceReflectionName();
     if (!srcName) {
       this._sourceReflectionCache = null;
+      this.stampGeneration();
       return null;
     }
     const throughRef = this.throughReflection;
     if (!throughRef) {
       this._sourceReflectionCache = null;
+      this.stampGeneration();
       return null;
     }
     try {
@@ -1876,12 +1880,14 @@ export class ThroughReflection extends AbstractReflection {
 
     if (this.options.source) {
       this._sourceReflectionNameCache = this.options.source as string;
+      this.stampGeneration();
       return this._sourceReflectionNameCache;
     }
 
     const throughRef = this.throughReflection;
     if (!throughRef) {
       this._sourceReflectionNameCache = null;
+      this.stampGeneration();
       return null;
     }
 
@@ -1900,6 +1906,7 @@ export class ThroughReflection extends AbstractReflection {
       this._sourceReflectionNameCache = matching[0] ?? null;
       this.stampGeneration();
     } catch (e: unknown) {
+      // Escapes before any memo write, so there is nothing to stamp.
       if (e instanceof AmbiguousSourceReflectionForThroughAssociation) throw e;
       this._sourceReflectionNameCache = null;
       this.stampGeneration();

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -581,6 +581,7 @@ export class MacroReflection extends AbstractReflection {
   readonly pluralName: string;
   private _scope: ((...args: any[]) => any) | null;
   private _klassCache: typeof Base | null = null;
+  private _klassCacheGeneration = -1;
 
   constructor(
     name: string,
@@ -625,7 +626,13 @@ export class MacroReflection extends AbstractReflection {
   }
 
   get klass(): typeof Base {
-    if (this._klassCache) return this._klassCache;
+    // Rails memoizes `@klass ||=`. We additionally gate the memo on the model
+    // registry's generation so a class re-registered under this reflection's
+    // className re-resolves instead of returning a stale target forever.
+    if (this._klassCache && this._klassCacheGeneration === modelRegistry.generation) {
+      return this._klassCache;
+    }
+    this._klassCacheGeneration = modelRegistry.generation;
     if (this.options.anonymousClass) {
       this._klassCache = this.options.anonymousClass as typeof Base;
       return this._klassCache;
@@ -1465,11 +1472,28 @@ export class ThroughReflection extends AbstractReflection {
     undefined;
   private _sourceReflectionNameCache: string | null | undefined = undefined;
   private _klassCache: typeof Base | null = null;
+  private _cacheGeneration = -1;
 
   constructor(delegate: AssociationReflection) {
     super();
     this._delegate = delegate;
     this.ensureOptionNotGivenAsClassBang("sourceType");
+  }
+
+  /**
+   * Every memo below is derived from classes resolved out of the model
+   * registry, so they all go stale together when a name is rebound to a
+   * different class. Drop them as a unit rather than returning a target that
+   * the registry no longer maps this reflection to.
+   * @internal
+   */
+  private expireCachesIfRegistryChanged(): void {
+    if (this._cacheGeneration === modelRegistry.generation) return;
+    this._cacheGeneration = modelRegistry.generation;
+    this._klassCache = null;
+    this._sourceReflectionCache = undefined;
+    this._throughReflectionCache = undefined;
+    this._sourceReflectionNameCache = undefined;
   }
 
   get name(): string {
@@ -1568,6 +1592,7 @@ export class ThroughReflection extends AbstractReflection {
   get klass(): typeof Base {
     // Rails: @klass ||= delegate_reflection._klass(class_name), where @klass is
     // seeded with options[:anonymous_class] in the constructor.
+    this.expireCachesIfRegistryChanged();
     if (this._klassCache) return this._klassCache;
     const anonymousClass = this._delegate.options.anonymousClass as typeof Base | undefined;
     this._klassCache = anonymousClass ?? this._delegate._klass(this.className);
@@ -1622,6 +1647,7 @@ export class ThroughReflection extends AbstractReflection {
   }
 
   get sourceReflection(): AssociationReflection | ThroughReflection | null {
+    this.expireCachesIfRegistryChanged();
     if (this._sourceReflectionCache !== undefined) return this._sourceReflectionCache;
     const srcName = this.sourceReflectionName();
     if (!srcName) {
@@ -1644,6 +1670,7 @@ export class ThroughReflection extends AbstractReflection {
   }
 
   get throughReflection(): AssociationReflection | ThroughReflection | null {
+    this.expireCachesIfRegistryChanged();
     if (this._throughReflectionCache !== undefined) return this._throughReflectionCache;
     const through = this.activeRecord._reflectOnAssociation(this.through) ?? null;
     this._throughReflectionCache = through;
@@ -1772,6 +1799,7 @@ export class ThroughReflection extends AbstractReflection {
   }
 
   sourceReflectionName(): string | null {
+    this.expireCachesIfRegistryChanged();
     if (this._sourceReflectionNameCache !== undefined) return this._sourceReflectionNameCache;
 
     if (this.options.source) {

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1509,12 +1509,34 @@ export class ThroughReflection extends AbstractReflection {
   }
 
   /**
-   * Every memo below is derived from classes resolved out of the model
-   * registry, so they all go stale together when a name is rebound to a
+   * Every memo this class owns (klass, through/source, and the inverse
+   * reflection resolved off `klass`) derives from classes resolved out of the
+   * model registry, so they all go stale together when a name is rebound to a
    * different class. Drop them as a unit rather than returning a target that
-   * the registry no longer maps this reflection to.
+   * the registry no longer maps this reflection to. `inverseName` is absent
+   * because it delegates to the AssociationReflection memo, which gates itself.
    * @internal
    */
+  /**
+   * Record the generation this reflection's memos are valid at.
+   *
+   * Every resolving caller stamps *after* it resolves, never before: resolving
+   * can autoload-and-register a class and bump the generation mid-flight, and
+   * stamping the pre-resolve value would leave the memo flagged stale the moment
+   * it is written, forcing the next touch of any memo here to wipe and recompute
+   * the whole through/source chain. The error paths stamp too — a resolve that
+   * threw can have bumped the generation just as easily as one that succeeded (a
+   * namespaced candidate walk may register a class and then reject it), and the
+   * negative memo they write is just as much a memo.
+   *
+   * `expireCachesIfRegistryChanged` is the one caller that stamps at entry; see
+   * its comment for why.
+   * @internal
+   */
+  private stampGeneration(): void {
+    this._cacheGeneration = modelRegistry.generation;
+  }
+
   private expireCachesIfRegistryChanged(): void {
     // Stamps at *entry* so a nested getter (sourceReflection → sourceReflectionName
     // → throughReflection) doesn't re-clear what its caller is mid-way through
@@ -1523,11 +1545,12 @@ export class ThroughReflection extends AbstractReflection {
     // through/source chain on the next touch.
 
     if (this._cacheGeneration === modelRegistry.generation) return;
-    this._cacheGeneration = modelRegistry.generation;
+    this.stampGeneration();
     this._klassCache = null;
     this._sourceReflectionCache = undefined;
     this._throughReflectionCache = undefined;
     this._sourceReflectionNameCache = undefined;
+    this._inverseOfCache = undefined;
   }
 
   get name(): string {
@@ -1639,7 +1662,7 @@ export class ThroughReflection extends AbstractReflection {
     // synchronous resolve is an autoload registering a name that was, by
     // definition, absent from the registry — a registry *miss* is what triggers
     // the autoload — so it cannot change what any earlier lookup resolved to.
-    this._cacheGeneration = modelRegistry.generation;
+    this.stampGeneration();
     return this._klassCache;
   }
 
@@ -1706,10 +1729,11 @@ export class ThroughReflection extends AbstractReflection {
     try {
       const src = throughRef.klass._reflectOnAssociation(srcName) ?? null;
       this._sourceReflectionCache = src;
-      this._cacheGeneration = modelRegistry.generation;
+      this.stampGeneration();
       return src;
     } catch {
       this._sourceReflectionCache = null;
+      this.stampGeneration();
       return null;
     }
   }
@@ -1719,7 +1743,7 @@ export class ThroughReflection extends AbstractReflection {
     if (this._throughReflectionCache !== undefined) return this._throughReflectionCache;
     const through = this.activeRecord._reflectOnAssociation(this.through) ?? null;
     this._throughReflectionCache = through;
-    this._cacheGeneration = modelRegistry.generation;
+    this.stampGeneration();
     return through;
   }
 
@@ -1824,10 +1848,12 @@ export class ThroughReflection extends AbstractReflection {
     // the underlying reflection would resolve the inverse against the delegate's
     // name-derived klass (`leadDeveloper` → nonexistent `LeadDeveloper`) instead
     // of the source class (`Developer`).
+    this.expireCachesIfRegistryChanged();
     const name = this.inverseName();
     if (!name) return null;
     if (this._inverseOfCache !== undefined) return this._inverseOfCache;
     this._inverseOfCache = this.klass._reflectOnAssociation(name) ?? null;
+    this.stampGeneration();
     return this._inverseOfCache;
   }
   private _inverseOfCache: AssociationReflection | ThroughReflection | null | undefined = undefined;
@@ -1872,10 +1898,11 @@ export class ThroughReflection extends AbstractReflection {
         );
       }
       this._sourceReflectionNameCache = matching[0] ?? null;
-      this._cacheGeneration = modelRegistry.generation;
+      this.stampGeneration();
     } catch (e: unknown) {
       if (e instanceof AmbiguousSourceReflectionForThroughAssociation) throw e;
       this._sourceReflectionNameCache = null;
+      this.stampGeneration();
     }
     return this._sourceReflectionNameCache ?? null;
   }

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -357,11 +357,12 @@ export class AbstractReflection {
         const normFk = (fk: unknown): string[] =>
           Array.isArray(fk) ? fk.map(String) : [String(fk)];
         const btFkNorm = normFk(btFk);
-        // Use a live registry lookup (not self.klass) to avoid poisoning _klassCache
-        // with a stale registry entry during class-definition time (addCounterCacheCallbacks
-        // fires while the module is first loaded, potentially before the target class
-        // is properly registered — a bespoke registration in an earlier test would
-        // otherwise be cached permanently on the reflection's _klassCache).
+        // Use a live registry lookup (not self.klass): addCounterCacheCallbacks fires
+        // while the module is first loaded, potentially before the target class is
+        // properly registered, so resolving through the reflection here would seed its
+        // memo from a half-built registry. (`klass` now self-heals on re-registration
+        // via the registry generation, so this is no longer a permanent-poisoning
+        // hazard — it just avoids the needless early resolve.)
         const klassName = self.className;
         const resolvedKlass = modelRegistry.get(klassName);
         if (!resolvedKlass) throw new Error(`${klassName} not in registry`);
@@ -632,13 +633,15 @@ export class MacroReflection extends AbstractReflection {
     if (this._klassCache && this._klassCacheGeneration === modelRegistry.generation) {
       return this._klassCache;
     }
+    const resolved = this.options.anonymousClass
+      ? (this.options.anonymousClass as typeof Base)
+      : this._klass(this.className);
+    // Read the generation *after* resolving: an autoload miss registers the class
+    // it just found, bumping the generation mid-resolve. Recording the pre-resolve
+    // value would leave this memo flagged stale the moment it's written.
     this._klassCacheGeneration = modelRegistry.generation;
-    if (this.options.anonymousClass) {
-      this._klassCache = this.options.anonymousClass as typeof Base;
-      return this._klassCache;
-    }
-    this._klassCache = this._klass(this.className);
-    return this._klassCache;
+    this._klassCache = resolved;
+    return resolved;
   }
 
   /** @internal */
@@ -1596,6 +1599,10 @@ export class ThroughReflection extends AbstractReflection {
     if (this._klassCache) return this._klassCache;
     const anonymousClass = this._delegate.options.anonymousClass as typeof Base | undefined;
     this._klassCache = anonymousClass ?? this._delegate._klass(this.className);
+    // Resolving can autoload-and-register the target, bumping the generation
+    // mid-flight; re-sync so this memo isn't stale the moment it's written. The
+    // sibling memos were just cleared, so they recompute on demand regardless.
+    this._cacheGeneration = modelRegistry.generation;
     return this._klassCache;
   }
 


### PR DESCRIPTION
A reflection memoizes its resolved target class by NAME the first time it is touched, so a bespoke model registered under a canonical name by a sibling test file sharing a vitest worker can be resolved first and cached permanently — restoring `modelRegistry` / `Base._modelsByName` afterwards does NOT un-poison it (hazard already documented at `reflection.ts:360-364`). Concretely: `nested-through-associations.test.ts` registers a bespoke `Tagging` with no `tag` source, and when vitest co-schedules it with `associations.test.ts`, canonical `Post.tags` caches the wrong source class and PreloaderTest fails with `HasManyThroughSourceAssociationNotFoundError`. Worker layout is driven by test-file byte sizes, so any PR can reshuffle it and trigger this — a latent CI-flake generator.

## Approach

`modelRegistry` becomes a `Map` subclass tracking a monotonic `generation`, bumped only when a name is bound to a *different* class (or unbound). Every memo whose value derives from a registry-resolved class gates on that generation: an unchanged registry keeps the memoized read, a rebind re-resolves. Subclassing the Map (rather than policing call sites) means every mutation site participates, including tests that `set`/`delete` directly. This mirrors the live-lookup precedent already established for counter-cache resolution (`reflection.ts:360-372`).

With the framework fix in place, the PreloaderTest `beforeEach` cache-reset band-aid from #4006 is removed.

### Memo inventory

Every memo of this shape was swept, not just the one that flaked:

| Memo | Gated? | Why |
|---|---|---|
| `MacroReflection#klass` | ✅ | resolved from the registry by name |
| `AssociationReflection` `inverseOf`/`inverseName` | ✅ | inverse reflection *owned by* the target; name derived by scanning it |
| `ThroughReflection#klass`, through/source memos | ✅ | same, via the delegate |
| `ThroughReflection#inverseOf` | ✅ | a second, independent memo from the AssociationReflection one |
| `_foreignKeyCache` / `_activeRecordPrimaryKeyCache` | ❌ | derive from `activeRecord` + options, not the resolved target |
| `_counterCacheColumn` | ❌ (n/a) | already keyed on resolved-class *identity* via a live lookup — self-heals by construction |
| `Association#klass` | ❌ (n/a) | live getter, no memo — inherits the heal |
| `_normalizedReflectionsCache` | ❌ (n/a) | keyed by *owner* class; holds no klass-derived value |

### On Rails fidelity

Rails memoizes `@klass ||= compute_class(class_name)` (reflection.rb:422-423, 989-990) and `@inverse_of ||=` (reflection.rb:258-261), and is in isolation equally poisonable — but the situation cannot arise there: Zeitwerk reloading discards the model classes *and* their reflections wholesale, so resolution is always fresh. Our test harness instead re-registers models into a registry shared across a worker, which is what makes the stale memo reachable. Self-healing restores the property Rails gets structurally (a rebind yields fresh resolution); it never returns a class the live registry does not map the reflection to.

### Why mid-resolve generation bumps are safe

Resolution can autoload-and-register a class, bumping the generation *during* a resolve. Every memo therefore stamps the generation **after** resolving — including the error paths, since a resolve that throws can bump just as easily as one that succeeds (a namespaced candidate walk may register a class and then reject it). Stamping is centralized in `stampGeneration()` so the rule and its single entry-stamp exception are stated once rather than at seven call sites.

This also certifies sibling memos repopulated mid-resolve (e.g. `className` deriving through `sourceReflection`) at the post-bump generation, which is sound: the only bump reachable inside a synchronous resolve is an autoload registering a name that was, by definition, absent from the registry — a registry *miss* is what triggers the autoload (`associations.ts:363-372`) — so it cannot change what any earlier lookup resolved to.

## Verification

Two-file repro:

```
pnpm vitest run --no-file-parallelism \
  packages/activerecord/src/associations/nested-through-associations.test.ts \
  packages/activerecord/src/associations.test.ts
```

- Before: `Tests 4 failed | 207 passed`
- After, band-aid removed: `Tests 211 passed | 1 todo`

Direct regression coverage lands in `reflection.trails.test.ts` (TS-only invariants — Ruby constant lookup has no such memo — with uniquely-named models). Every behavior test was confirmed to **fail against the code without its fix** and pass with it, so they are real guards rather than tautologies.

Broad suites (`reflection*.test.ts`, `associations.test.ts`, all of `associations/`): 74 files, 2028 tests, no regressions — including `AutomaticInverseFindingTests`, which exercises the gated inverse path.

### Perf

Measured 5M memoized reads, best-of-3, against the built `dist` — not the vitest transform, whose SSR import-namespace indirection inflates this ~7x and is not a real cost:

| | `origin/main` | this PR | delta |
|---|---|---|---|
| `klass` | 2.30 ns/op | 4.14 ns/op | +1.8 ns |
| `inverseOf` | 7.24 ns/op | 10.46 ns/op | +3.2 ns |

Single-digit nanoseconds per memoized read — an integer compare, orders of magnitude below the DB I/O of the association resolve it guards. Encapsulating `generation` behind a `#private` field costs nothing measurable, so it stays read-only from outside.

Closes-story: reflection-klass-cache-self-heal