### PR TITLE
test(fixtures): register a lions fixture set for the abstract Cat enum

### DIFF
--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -780,7 +780,10 @@ describe("EnumTest", () => {
   // (attribute_registration.rb:81-87), so the enum block runs and raises
   // `Undeclared attribute type for enum` while `_default_attributes`
   // materializes. Constructing a record (or bare `_defaultAttributes()`) is
-  // enough; no prior `type_for_attribute` lookup is required.
+  // enough; no prior `type_for_attribute` lookup is required. (The green
+  // counterpart — a subclass that DOES back the inherited enum — is the
+  // `Lion < abstract Cat` case, covered on the canonical models in
+  // enum.trails.test.ts.)
   it("enum on abstract parent raises through subclass materialization", () => {
     class AbstractParent extends Base {
       static {
@@ -800,14 +803,6 @@ describe("EnumTest", () => {
       /Undeclared attribute type for enum 'typeless_genre' in Concrete/,
     );
   });
-
-  // The green path — a concrete subclass that DOES back the inherited enum, so
-  // the replayed superclass decorator resolves against the subclass's own
-  // columns and the `is{Value}()` predicate serializes through the record's
-  // class rather than the tableless parent — is the `Lion < abstract Cat` case.
-  // It is covered on the canonical models in enum.trails.test.ts (the synthetic
-  // `books`-backed stand-in that used to live here was only needed while `lions`
-  // had no registered fixture set).
 
   it("query state by predicate with prefix", () => {
     expect((book as any).isAuthorVisibilityVisible()).toBe(true);

--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -801,36 +801,13 @@ describe("EnumTest", () => {
     );
   });
 
-  // A concrete subclass that DOES back the inherited enum materializes cleanly:
+  // The green path — a concrete subclass that DOES back the inherited enum, so
   // the replayed superclass decorator resolves against the subclass's own
-  // columns (books.nullable_status), so no false raise and — crucially — no
-  // `TableNotSpecified` from routing the predicate through the abstract parent.
-  // The generated `is{Value}()` predicate must serialize through the *record's*
-  // class, not the abstract parent it was declared on (which has no table): this
-  // is the `Lion < abstract Cat` case, exercised here with a canonical books
-  // column since `lions` has no registered fixture set.
-  it("enum on abstract parent materializes green against a backing subclass column", () => {
-    class AbstractParent extends Base {
-      static {
-        this._abstractClass = true;
-        this.enum("nullable_status", ["single", "married"] as any);
-      }
-    }
-    class Backed extends AbstractParent {
-      static _tableName = "books"; // books.nullable_status is an integer column
-    }
-    registerModel(Backed);
-
-    expect(() => (Backed as any)._defaultAttributes()).not.toThrow();
-    const record = new (Backed as any)({ nullable_status: "married" });
-    // The predicate (`castEnumValue` on the record's own class) must not route
-    // through the abstract parent's tableless schema. Pre-fix this raised
-    // `TableNotSpecified: AbstractParent has no table configured`.
-    expect(() => record.isMarried()).not.toThrow();
-    expect(record.isMarried()).toBe(true);
-    expect(record.isSingle()).toBe(false);
-    expect(record.nullable_status).toBe("married");
-  });
+  // columns and the `is{Value}()` predicate serializes through the record's
+  // class rather than the tableless parent — is the `Lion < abstract Cat` case.
+  // It is covered on the canonical models in enum.trails.test.ts (the synthetic
+  // `books`-backed stand-in that used to live here was only needed while `lions`
+  // had no registered fixture set).
 
   it("query state by predicate with prefix", () => {
     expect((book as any).isAuthorVisibilityVisible()).toBe(true);

--- a/packages/activerecord/src/enum.trails.test.ts
+++ b/packages/activerecord/src/enum.trails.test.ts
@@ -21,6 +21,7 @@ import { Map as MapCaster } from "./type-caster/map.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { rebuildCanonicalTables } from "./test-helpers/canonical-schema.js";
 import { Book } from "./test-helpers/models/book.js";
+import { Lion } from "./test-helpers/models/cat.js";
 
 describe("Enum name conflict detection", () => {
   // Rails' `detect_enum_conflict!(name, name)` uses `dangerous_attribute_method?`,
@@ -550,5 +551,32 @@ describe("Enum acronym method name consistency", () => {
         }
       }
     }).toThrow(/generate a instance method "isValid", which is already defined/);
+  });
+});
+
+// The `Lion < abstract Cat` case with the real canonical models: `Cat` is
+// abstract and declares `enum :gender`, but only the concrete `Lion` has the
+// backing `lions.gender` column. Rails replays the abstract parent's pending
+// decorator into the subclass's attribute set, so the enum must resolve — and
+// its generated predicate must serialize through the *record's* class, not the
+// tableless parent it was declared on (pre-fix that raised `TableNotSpecified`;
+// PR #4814 covered it only with synthetic `books`-backed classes).
+describe("Enum inherited from an abstract parent (Lion < Cat)", () => {
+  fixtures(["lions"]);
+
+  it("materializes and answers predicates on the concrete subclass", async () => {
+    expect(() => Lion._defaultAttributes()).not.toThrow();
+
+    const lion = new Lion({ gender: "female" });
+    expect(lion.isFemale()).toBe(true);
+    expect(lion.isMale()).toBe(false);
+
+    // Cat's `default_scope { where(is_vegetarian: false) }` must materialize
+    // its scope-for-create cleanly through the abstract parent.
+    expect(lion.is_vegetarian).toBe(false);
+
+    await lion.save();
+    const found = await Lion.find(lion.id);
+    expect(found.isFemale()).toBe(true);
   });
 });

--- a/packages/activerecord/src/enum.trails.test.ts
+++ b/packages/activerecord/src/enum.trails.test.ts
@@ -562,21 +562,33 @@ describe("Enum acronym method name consistency", () => {
 // tableless parent it was declared on (pre-fix that raised `TableNotSpecified`;
 // PR #4814 covered it only with synthetic `books`-backed classes).
 describe("Enum inherited from an abstract parent (Lion < Cat)", () => {
-  fixtures(["lions"]);
+  const { lions } = fixtures(["lions"]);
 
-  it("materializes and answers predicates on the concrete subclass", async () => {
+  it("answers the inherited predicate on the concrete subclass", () => {
     expect(() => Lion._defaultAttributes()).not.toThrow();
 
     const lion = new Lion({ gender: "female" });
     expect(lion.isFemale()).toBe(true);
     expect(lion.isMale()).toBe(false);
+  });
 
-    // Cat's `default_scope { where(is_vegetarian: false) }` must materialize
-    // its scope-for-create cleanly through the abstract parent.
-    expect(lion.is_vegetarian).toBe(false);
-
+  it("resolves the inherited enum on a row read back from the table", async () => {
+    const lion = new Lion({ gender: "female" });
     await lion.save();
+
     const found = await Lion.find(lion.id);
     expect(found.isFemale()).toBe(true);
+    expect(found.gender).toBe("female");
+  });
+
+  it("applies Cat's default scope to a new Lion and to its queries", async () => {
+    // scope-for-create materializes the parent's `where(is_vegetarian: false)`
+    // through the tableless abstract class...
+    expect(new Lion().is_vegetarian).toBe(false);
+
+    // ...and the same scope filters reads: only the meat-eating fixture row
+    // survives it.
+    const ids = await Lion.all().pluck("id");
+    expect(ids).toEqual([lions("meat_eating_lion").id]);
   });
 });

--- a/packages/activerecord/src/enum.trails.test.ts
+++ b/packages/activerecord/src/enum.trails.test.ts
@@ -559,8 +559,10 @@ describe("Enum acronym method name consistency", () => {
 // backing `lions.gender` column. Rails replays the abstract parent's pending
 // decorator into the subclass's attribute set, so the enum must resolve — and
 // its generated predicate must serialize through the *record's* class, not the
-// tableless parent it was declared on (pre-fix that raised `TableNotSpecified`;
-// PR #4814 covered it only with synthetic `books`-backed classes).
+// tableless parent it was declared on (pre-fix that raised `TableNotSpecified`,
+// fixed in PR #4814). This supersedes the synthetic `books`-backed stand-in that
+// used to carry this coverage in enum.test.ts, which existed only because
+// `lions` had no registered fixture set.
 describe("Enum inherited from an abstract parent (Lion < Cat)", () => {
   const { lions } = fixtures(["lions"]);
 

--- a/packages/activerecord/src/enum.trails.test.ts
+++ b/packages/activerecord/src/enum.trails.test.ts
@@ -581,14 +581,21 @@ describe("Enum inherited from an abstract parent (Lion < Cat)", () => {
     expect(found.gender).toBe("female");
   });
 
-  it("applies Cat's default scope to a new Lion and to its queries", async () => {
-    // scope-for-create materializes the parent's `where(is_vegetarian: false)`
-    // through the tableless abstract class...
-    expect(new Lion().is_vegetarian).toBe(false);
-
-    // ...and the same scope filters reads: only the meat-eating fixture row
-    // survives it.
+  it("applies Cat's default scope to Lion's queries", async () => {
+    // The parent's `where(is_vegetarian: false)` filters reads through the
+    // tableless abstract class: only the meat-eating fixture row survives.
+    // (`lions.is_vegetarian` also defaults to false in the schema, so asserting
+    // the flag on a `new Lion` would pass with or without scope-for-create —
+    // filtering is what's actually observable here. The scope's SQL is asserted
+    // in scoping/default-scoping.test.ts, mirroring Rails'
+    // default_scoping_test.rb:708-709.)
     const ids = await Lion.all().pluck("id");
     expect(ids).toEqual([lions("meat_eating_lion").id]);
+  });
+
+  it("builds a new Lion without routing the parent's default scope through a tableless class", () => {
+    // The acceptance-criterion case: scope-for-create must materialize Cat's
+    // `default_scope` cleanly. Pre-fix this path raised `TableNotSpecified`.
+    expect(() => new Lion()).not.toThrow();
   });
 });

--- a/packages/activerecord/src/test-helpers/fixtures-registry.ts
+++ b/packages/activerecord/src/test-helpers/fixtures-registry.ts
@@ -378,6 +378,10 @@ export const fixtureRegistry = {
     model: () => import("./models/legacy-thing.js").then((m) => m.LegacyThing),
     data: FixtureData.legacyThingFixtureData,
   },
+  lions: {
+    model: () => import("./models/cat.js").then((m) => m.Lion),
+    data: FixtureData.lionFixtureData,
+  },
   liveParrots: {
     model: () => import("./models/parrot.js").then((m) => m.LiveParrot),
     data: FixtureData.liveParrotFixtureData,

--- a/packages/activerecord/src/test-helpers/fixtures/index.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/index.ts
@@ -68,6 +68,7 @@ export * from "./interests.js";
 export * from "./items.js";
 export * from "./jobs.js";
 export * from "./legacy-things.js";
+export * from "./lions.js";
 export * from "./live-parrots.js";
 export * from "./mateys.js";
 export * from "./member-details.js";

--- a/packages/activerecord/src/test-helpers/fixtures/lions.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/lions.ts
@@ -1,0 +1,17 @@
+// Rails has no test/fixtures/lions.yml — `lions` (schema.rb:740) is a
+// schema-only table whose tests build records directly. The set exists so
+// `fixtures(["lions"])` wires the connection handler for `Lion < abstract Cat`;
+// the single row satisfies the registry's non-empty-data conformance guard and
+// respects Cat's `default_scope { where(is_vegetarian: false) }`.
+export const lionFixtureData = {
+  vegetarian_lion: {
+    id: 1,
+    gender: 0,
+    is_vegetarian: true,
+  },
+  meat_eating_lion: {
+    id: 2,
+    gender: 1,
+    is_vegetarian: false,
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/lions.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/lions.ts
@@ -1,8 +1,9 @@
 // Rails has no test/fixtures/lions.yml — `lions` (schema.rb:740) is a
-// schema-only table whose tests build records directly. The set exists so
-// `fixtures(["lions"])` wires the connection handler for `Lion < abstract Cat`;
-// the single row satisfies the registry's non-empty-data conformance guard and
-// respects Cat's `default_scope { where(is_vegetarian: false) }`.
+// schema-only table whose own Rails tests (default_scoping_test.rb:689-709)
+// only assert generated SQL, so they never need rows. The set exists so
+// `fixtures(["lions"])` wires the connection handler for `Lion < abstract Cat`.
+// The two rows straddle Cat's `default_scope { where(is_vegetarian: false) }`
+// so a test can prove the inherited scope actually filters.
 export const lionFixtureData = {
   vegetarian_lion: {
     id: 1,

--- a/packages/activerecord/src/test-helpers/models/cat.ts
+++ b/packages/activerecord/src/test-helpers/models/cat.ts
@@ -19,7 +19,10 @@ export class Cat extends Base {
   }
 }
 
+// Rails' `Lion` is an empty subclass (test/models/cat.rb:11); the `declare`s are
+// trails-only typing for the reflected `lions` columns. `gender` reads back as
+// its enum label, not the stored integer, so it is typed as the label union.
 export class Lion extends Cat {
-  declare gender: number;
+  declare gender: "female" | "male" | null;
   declare is_vegetarian: boolean | null;
 }


### PR DESCRIPTION
Rails's `lions` table (schema.rb:740) is already canonical in `test-schema.ts` and `canonical-schema.ts`, but it had no fixture-set entry — so `fixtures(["lions"])` threw `no fixture set named "lions"`, and `rebuildCanonicalTables(["lions"])` alone left the connection handler unwired (`ConnectionNotDefined`). PR #4814 therefore had to cover the `Lion < abstract Cat` inherited-enum path with synthetic classes riding `books.nullable_status` instead of the real models.

This registers the set, covers the path on the actual `Lion`/`Cat` models, and retires the synthetic stand-in.

## Changes

- `test-helpers/fixtures/lions.ts` — new fixture data. Rails has no `lions.yml` (its own lions tests, `default_scoping_test.rb:689-709`, only assert generated SQL and never need rows), but the registry conformance guard requires a non-empty set. The two rows straddle Cat's `default_scope { where(is_vegetarian: false) }` so they carry their weight: a test uses them to prove the inherited scope actually filters.
- `test-helpers/fixtures-registry.ts` — `lions` entry resolving to `Lion`.
- `enum.trails.test.ts` — regression tests (trails-only; Rails's `enum_test.rb` has no Cat/Lion case) covering the inherited-enum predicate on the concrete subclass, the enum resolving on a row read back from the table, Cat's default scope filtering Lion's queries, and `new Lion` not raising `TableNotSpecified` through the tableless parent.
- `enum.test.ts` — delete the synthetic `AbstractParent`/`Backed` green-path test. It was a bespoke-class stand-in in a Rails-mirroring file, needed only while `lions` had no fixture set; the canonical Lion test now proves the same thing. The sibling *raise* test stays — no canonical model has an unbacked inherited enum.
- `test-helpers/models/cat.ts` — type `Lion#gender` as its enum label union. Enum attributes read back as the label string, so `declare gender: number` was a type lie contradicted by this PR's own `expect(found.gender).toBe("female")`. Rails' `Lion` is an empty subclass (`test/models/cat.rb:11`), so the `declare` is trails-only typing and must describe the read surface.

## Out of scope

The same enum-column type inaccuracy exists on other canonical models (`book.ts:143,146` declare the `status` / `nullable_status` enums as `number`). Those are outside this diff and are tracked by story `0050-enum-fidelity/type-enum-column-declares-as-label-union` rather than fanned out here.

## Verification

`enum.trails.test.ts`, `enum.test.ts`, `use-fixtures.test.ts` (registry conformance + seed-every-entry guards), and `scoping/default-scoping.test.ts` pass locally on SQLite. CI green.

Closes-story: register-lions-fixture-set-for-abstract-cat-enum