### PR TITLE
fix(relation): inspect renders the qualified Rails wrapper class name

### DIFF
--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -20,6 +20,9 @@ import { ArgumentError } from "@blazetrails/activemodel";
  * Mirrors: ActiveRecord::AssociationRelation
  */
 export class AssociationRelation<T extends Base> extends Relation<T> {
+  /** @internal */
+  static override _railsClassName = "ActiveRecord::AssociationRelation";
+
   /**
    * @internal The owning association. CollectionProxy-backed when created
    * via the collection proxy (the normal user-facing path); Association-backed

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -169,6 +169,9 @@ function assertValidLimit(n: number): void {
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class CollectionProxy<T extends Base = Base> extends Relation<T> {
+  /** @internal */
+  static override _railsClassName = "ActiveRecord::Associations::CollectionProxy";
+
   private _record: Base;
   private _assocName: string;
   private _assocDef: AssociationDefinition;
@@ -3860,7 +3863,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       : await this.annotate("loading for inspect").limit(take);
     const entries = subject.slice(0, take).map((r) => (r as any).inspect() as string);
     if (entries.length === 11) entries[10] = "...";
-    return `#<${this.constructor.name} [${entries.join(", ")}]>`;
+    return `#<${(this.constructor as typeof Relation)._railsClassName} [${entries.join(", ")}]>`;
   }
 
   /**

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -85,6 +85,9 @@ function serializeKey(v: unknown, composite: boolean): unknown {
 }
 
 export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T> {
+  /** @internal */
+  static override _railsClassName = "ActiveRecord::DisableJoinsAssociationRelation";
+
   readonly key: DjarKey;
   /** Stored IDs (uniq'd at construction). Exposed as `ids()` to match
    * Rails' `attr_reader :ids` which shadows `Relation#ids` here. For

--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -12,6 +12,7 @@ import { Nodes, Table as ArelTable } from "@blazetrails/arel";
 import { Base } from "./index.js";
 import { registerModel, modelRegistry } from "./associations.js";
 import { performMerge } from "./relation/spawn-methods.js";
+import { AssociationRelation } from "./association-relation.js";
 
 import { fixtures } from "./test-helpers/fixtures.js";
 import { Post as CanonPost } from "./test-helpers/models/post.js";
@@ -836,7 +837,16 @@ describe("inspect wrapper class name", () => {
   it("renders the qualified Rails class name for an AssociationRelation", async () => {
     const author = await CanonAuthor.first();
     const relation = (author!.posts as any).where({});
+    expect(relation).toBeInstanceOf(AssociationRelation);
     await relation.load();
     expect(relation.inspect().startsWith("#<ActiveRecord::AssociationRelation [")).toBe(true);
+  });
+
+  // The unloaded branch elides entries with `[...]` (sync JS can't block on the
+  // load Rails does here), but the wrapper name is Rails' either way.
+  it("renders the qualified Rails class name for an unloaded relation", () => {
+    const relation = CanonPost.all();
+    expect(relation.isLoaded).toBe(false);
+    expect(relation.inspect()).toBe("#<ActiveRecord::Relation [...]>");
   });
 });

--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -817,3 +817,26 @@ describe("RelationTest", () => {
     expect((subquery as any)._isDeferredDistinctPkSubquery()).toBe(true);
   });
 });
+
+// Ruby's `self.class.name` is namespace-qualified, so Rails' inspect wrapper
+// reads `#<ActiveRecord::Relation ...>` — pinned for the plain Relation by
+// relations_test.rb:2108-2111. Its sibling wrapper classes have no like-named
+// Rails test, so guard their qualified names here: JS `constructor.name` is
+// unqualified (and bundler-manglable), which is why each class pins the Rails
+// constant path on `_railsClassName`.
+describe("inspect wrapper class name", () => {
+  fixtures(["authors", "posts"]);
+
+  it("renders the qualified Rails class name for a CollectionProxy", async () => {
+    const author = await CanonAuthor.first();
+    const str = await (author!.posts as any).inspect();
+    expect(str.startsWith("#<ActiveRecord::Associations::CollectionProxy [")).toBe(true);
+  });
+
+  it("renders the qualified Rails class name for an AssociationRelation", async () => {
+    const author = await CanonAuthor.first();
+    const relation = (author!.posts as any).where({});
+    await relation.load();
+    expect(relation.inspect().startsWith("#<ActiveRecord::AssociationRelation [")).toBe(true);
+  });
+});

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -329,6 +329,14 @@ const EMPTY_VALUE_ARRAY: readonly never[] = Object.freeze([]);
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Relation<T extends Base> {
+  /**
+   * @internal Ruby's `self.class.name` is the namespace-qualified constant path
+   * ("ActiveRecord::Relation"); JS `constructor.name` is unqualified and gets
+   * mangled by bundlers. Each relation class pins its Rails constant path here
+   * so `inspect` renders the wrapper Rails names.
+   */
+  static _railsClassName = "ActiveRecord::Relation";
+
   private _modelClass: typeof Base;
   /** @internal */
   _whereClause: WhereClause = WhereClause.empty();
@@ -1193,17 +1201,17 @@ export class Relation<T extends Base> {
     // model name: Rails' `self.class.name` is the relation class itself —
     // `"ActiveRecord::Relation"` for `Post.limit(2)`, not `Post` (relations_test
     // "relations show the records in #inspect", relations_test.rb:2108-2111) —
-    // so model identity surfaces only through the inspected records. We use
-    // `this.constructor.name` to keep that class-not-model semantics and to
-    // preserve the Relation / CollectionProxy / AssociationRelation distinction
-    // (three distinct Rails classes); the unqualified vs `ActiveRecord::`-
-    // namespaced gap is a pre-existing deviation shared with the loaded branch,
-    // not specific to this path.
+    // so model identity surfaces only through the inspected records. The name
+    // comes from the per-class `_railsClassName` rather than
+    // `constructor.name`, keeping the Relation / CollectionProxy /
+    // AssociationRelation distinction (three distinct Rails classes) while
+    // rendering each one's namespace-qualified Rails constant path.
+    const className = (this.constructor as typeof Relation)._railsClassName;
     if (this._loaded) {
       const max = this._limitValue !== null ? Math.min(this._limitValue, 11) : 11;
       const entries = this._records.slice(0, max).map((record) => record.inspect());
       if (entries.length === 11) entries[10] = "...";
-      return `#<${this.constructor.name} [${entries.join(", ")}]>`;
+      return `#<${className} [${entries.join(", ")}]>`;
     }
     // Unloaded: Rails blocks on DB I/O here to load the records; a synchronous
     // JS method returning a string cannot. Rather than invent a divergent
@@ -1212,7 +1220,7 @@ export class Relation<T extends Base> {
     // async — `await relation.toArray()` (or `prettyPrint`) loads first, after
     // which `inspect` takes the loaded branch above. This is the same sync-JS
     // deviation already documented on `prettyPrint`.
-    return `#<${this.constructor.name} [...]>`;
+    return `#<${className} [...]>`;
   }
 
   /**

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -2177,15 +2177,18 @@ describe("RelationTest", () => {
     const relation = Post.limit(2);
     const records = await Post.limit(2);
     await relation.load();
-    const str = relation.inspect();
-    for (const record of records) {
-      expect(str).toContain(`id: ${record.id}`);
-    }
+    expect(relation.inspect()).toBe(
+      `#<ActiveRecord::Relation [${records.map((r) => r.inspect()).join(", ")}]>`,
+    );
   });
 
   it("relations limit the records in #inspect at 10", async () => {
     const relation = Post.limit(11);
-    expect(relation.inspect()).toContain("...");
+    const records = await Post.limit(10);
+    await relation.load();
+    expect(relation.inspect()).toBe(
+      `#<ActiveRecord::Relation [${records.map((r) => r.inspect()).join(", ")}, ...]>`,
+    );
   });
 
   it("relations don't load all records in #inspect", () => {


### PR DESCRIPTION
## What

Ruby's `self.class.name` is the namespace-qualified constant path, so Rails' `Relation#inspect` renders `#<ActiveRecord::Relation [...]>` (relation.rb:1295, pinned by relations_test.rb:2108-2111). trails rendered the wrapper via `this.constructor.name`, which is unqualified (and manglable by bundlers), yielding `#<Relation [...]>` / `#<CollectionProxy [...]>` / `#<AssociationRelation [...]>`.

## How

Each relation class pins its Rails constant path on a `_railsClassName` static, read by both the loaded and unloaded branches of `Relation#inspect` and by `CollectionProxy`'s async `inspect` override. A static field (rather than a derived lookup) keeps the per-class distinction explicit and survives bundler renaming:

- `Relation` → `ActiveRecord::Relation`
- `AssociationRelation` → `ActiveRecord::AssociationRelation`
- `CollectionProxy` → `ActiveRecord::Associations::CollectionProxy`
- `DisableJoinsAssociationRelation` → `ActiveRecord::DisableJoinsAssociationRelation` (a fourth `Relation` subclass, `disable_joins_association_relation.rb:4`, that inherits the same wrapper)

`Relation#prettyPrint` is deliberately untouched: Rails' `pretty_print` pps the entries with no class wrapper, and `objectAddressGroup`'s `constructor.name` serves `Base#pretty_print`, where the unqualified *model* name is already correct.

## Tests

- `relations.test.ts`: the two Rails-named inspect cases now pin Rails' exact literals with `toBe` (matching `assert_equal` in relations_test.rb:2108-2111) instead of looser `toContain` checks. Test names unchanged. Note the at-10 case previously asserted only `toContain("...")`, which the unloaded branch emits unconditionally — it passed vacuously and never exercised truncation; it now loads and pins all 10 entries plus the `...`.
- `relation.trails.test.ts`: the CollectionProxy / AssociationRelation / unloaded-branch wrapper names have no like-named Rails test, so they're guarded in the trails sibling on canonical models. The AssociationRelation case carries an `instanceof` assertion so it can't pass vacuously against a plain `Relation`.
- All three new tests were confirmed to **fail** against the pre-fix sources (`expected '#<Relation [...]>' to be '#<ActiveRecord::Relation [...]>'`).

## Verification

- 780 tests pass across relations / relation.trails / relation / calculations / associations.
- **api:compare**: flat — activerecord 5853/5855 both on `origin/main` and this branch (the `@internal` static is not a Rails method).
- **test:compare**: improves — assertion-kind-mismatch 3979 → 3977 (the two converted assertions now match Rails' `assert_equal` kind); every other metric identical. Both measured against `origin/main` sources rather than assumed.

Closes-story: relation-inspect-wrapper-qualified-class-name