### PR TITLE
fix(query-cache): lazy type_casted_binds + pass-through name in cacheNotificationInfo

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -591,10 +591,11 @@ function cacheNotificationInfo(
     // KNOWN DIVERGENCE (story: type-casted-binds-payload-self-dispatch). Rails
     // calls the adapter-dispatched Quoting#type_casted_binds (quoting.rb:224);
     // this standalone helper never reaches adapter `type_cast`. trails has the
-    // faithful port at quoting.ts:451, but 17 payload producers across the
+    // faithful port at quoting.ts:451, but 16 payload producers across the
     // adapters disagree on how they fill this slot (free function / raw binds /
-    // hardcoded []), so converging this one flips SQLite's cached binds 1 -> 1n
-    // and desyncs it from the uncached payload. The sweep moves all 17 at once.
+    // hardcoded [] / forwarded param), so converging this one flips SQLite's
+    // cached binds 1 -> 1n and desyncs it from the uncached payload. The sweep
+    // moves all 16 at once.
     type_casted_binds: () => typeCastedBinds(binds),
     name,
     connection: this,

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -588,6 +588,13 @@ function cacheNotificationInfo(
   return {
     sql,
     binds,
+    // KNOWN DIVERGENCE (story: type-casted-binds-payload-self-dispatch). Rails
+    // calls the adapter-dispatched Quoting#type_casted_binds (quoting.rb:224);
+    // this standalone helper never reaches adapter `type_cast`. trails has the
+    // faithful port at quoting.ts:451, but 17 payload producers across the
+    // adapters disagree on how they fill this slot (free function / raw binds /
+    // hardcoded []), so converging this one flips SQLite's cached binds 1 -> 1n
+    // and desyncs it from the uncached payload. The sweep moves all 17 at once.
     type_casted_binds: () => typeCastedBinds(binds),
     name,
     connection: this,

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -588,8 +588,8 @@ function cacheNotificationInfo(
   return {
     sql,
     binds,
-    type_casted_binds: typeCastedBinds(binds),
-    name: name ?? "SQL",
+    type_casted_binds: () => typeCastedBinds(binds),
+    name,
     connection: this,
     cached: true,
     transaction,

--- a/packages/activerecord/src/query-cache.trails.test.ts
+++ b/packages/activerecord/src/query-cache.trails.test.ts
@@ -46,8 +46,12 @@ describe("cacheNotificationInfo payload (trails)", () => {
 
     const cached = payloads.filter((p) => p.cached);
     expect(cached.length).toBe(1);
+    // The cast is deferred: the slot holds the thunk itself, and a subscriber
+    // that never reads it never pays for the cast. Calling it yields the same
+    // binds the eager cast used to produce.
     const lazy = cached[0].type_casted_binds;
     expect(typeof lazy).toBe("function");
+    expect((lazy as () => unknown[])()).toEqual([1]);
     expect((lazy as () => unknown[])()).toEqual([1]);
   });
 
@@ -63,7 +67,7 @@ describe("cacheNotificationInfo payload (trails)", () => {
     expect(cached[0].name).toBe("Task Load");
   });
 
-  it("does not default a null name to SQL", async () => {
+  it("does not coerce a nameless query to SQL", async () => {
     const connection = (await Base.leaseConnection()) as unknown as {
       cache<T>(fn: () => T | Promise<T>): Promise<T>;
       selectAll(sql: string): Promise<unknown>;

--- a/packages/activerecord/src/query-cache.trails.test.ts
+++ b/packages/activerecord/src/query-cache.trails.test.ts
@@ -46,13 +46,38 @@ describe("cacheNotificationInfo payload (trails)", () => {
 
     const cached = payloads.filter((p) => p.cached);
     expect(cached.length).toBe(1);
-    // The cast is deferred: the slot holds the thunk itself, and a subscriber
-    // that never reads it never pays for the cast. Calling it yields the same
-    // binds the eager cast used to produce.
     const lazy = cached[0].type_casted_binds;
     expect(typeof lazy).toBe("function");
     expect((lazy as () => unknown[])()).toEqual([1]);
-    expect((lazy as () => unknown[])()).toEqual([1]);
+  });
+
+  it("defers the cast until the slot is read", async () => {
+    // A thunk alone does not prove deferral — an eager `(() => alreadyCast)`
+    // wrapper is also a function. Drive cacheNotificationInfo with a bind whose
+    // valueForDatabase getter counts reads, so the assertion fails if the cast
+    // moves back ahead of the slot read (query_cache.rb:311).
+    let casts = 0;
+    const probe = {
+      get valueForDatabase() {
+        casts++;
+        return 1;
+      },
+    };
+
+    const connection = (await Base.leaseConnection()) as unknown as {
+      cacheNotificationInfo(
+        sql: string,
+        name: string | null | undefined,
+        binds: unknown[],
+      ): SqlPayload;
+    };
+
+    const payload = connection.cacheNotificationInfo("select 1", "Probe", [probe]);
+    expect(casts).toBe(0);
+
+    const casted = (payload.type_casted_binds as () => unknown[])();
+    expect(casts).toBe(1);
+    expect(casted).toEqual([1]);
   });
 
   it("passes name through unchanged", async () => {

--- a/packages/activerecord/src/query-cache.trails.test.ts
+++ b/packages/activerecord/src/query-cache.trails.test.ts
@@ -48,7 +48,14 @@ describe("cacheNotificationInfo payload (trails)", () => {
     expect(cached.length).toBe(1);
     const lazy = cached[0].type_casted_binds;
     expect(typeof lazy).toBe("function");
-    expect((lazy as () => unknown[])()).toEqual([1]);
+    // Assert the thunk casts the payload's OWN binds rather than hardcoding a
+    // value: how many binds a find(1) carries is adapter-dependent and
+    // legitimately so — Rails' to_sql_and_binds (database_statements.rb:32-42)
+    // leaves binds empty when prepared_statements is off, which is the MySQL
+    // default, so the slot is `[]` there and `[1]` on SQLite/PG. The exact cast
+    // is pinned by "defers the cast until the slot is read", which supplies its
+    // own bind and is adapter-independent.
+    expect((lazy as () => unknown[])()).toHaveLength((cached[0].binds ?? []).length);
   });
 
   it("defers the cast until the slot is read", async () => {

--- a/packages/activerecord/src/query-cache.trails.test.ts
+++ b/packages/activerecord/src/query-cache.trails.test.ts
@@ -96,6 +96,7 @@ describe("cacheNotificationInfo payload (trails)", () => {
     });
 
     const cached = payloads.filter((p) => p.cached);
+    expect(cached.length).toBe(1);
     expect(cached[0].name).toBe("Task Load");
   });
 

--- a/packages/activerecord/src/query-cache.trails.test.ts
+++ b/packages/activerecord/src/query-cache.trails.test.ts
@@ -1,0 +1,86 @@
+// trails-only extras for the query cache: assertions on the cached
+// `sql.active_record` payload shape that Rails' query_cache_test.rb does not
+// cover directly, but that
+// vendor/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:308-314
+// specifies — `type_casted_binds` is a lambda (deferred cast) and `name` is
+// passed through unchanged.
+import { describe, it, expect } from "vitest";
+import { registerModel } from "./index.js";
+import { fixtures } from "./test-helpers/fixtures.js";
+import { Base } from "./base.js";
+import { Task } from "./test-helpers/models/task.js";
+import { Notifications, type NotificationEvent } from "@blazetrails/activesupport";
+
+registerModel(Task as never);
+
+type SqlPayload = {
+  cached?: boolean;
+  name?: unknown;
+  binds?: unknown[];
+  type_casted_binds?: unknown;
+};
+
+async function capture(fn: () => Promise<void>): Promise<SqlPayload[]> {
+  const payloads: SqlPayload[] = [];
+  const sub = Notifications.subscribe("sql.active_record", (e) => {
+    payloads.push((e as NotificationEvent & { payload: SqlPayload }).payload);
+  });
+  try {
+    await fn();
+  } finally {
+    Notifications.unsubscribe(sub);
+  }
+  return payloads;
+}
+
+describe("cacheNotificationInfo payload (trails)", () => {
+  fixtures(["tasks"]);
+
+  it("stores type_casted_binds lazily", async () => {
+    const payloads = await capture(async () => {
+      await Task.cache(async () => {
+        await Task.find(1);
+        await Task.find(1);
+      });
+    });
+
+    const cached = payloads.filter((p) => p.cached);
+    expect(cached.length).toBe(1);
+    const lazy = cached[0].type_casted_binds;
+    expect(typeof lazy).toBe("function");
+    expect((lazy as () => unknown[])()).toEqual([1]);
+  });
+
+  it("passes name through unchanged", async () => {
+    const payloads = await capture(async () => {
+      await Task.cache(async () => {
+        await Task.find(1);
+        await Task.find(1);
+      });
+    });
+
+    const cached = payloads.filter((p) => p.cached);
+    expect(cached[0].name).toBe("Task Load");
+  });
+
+  it("does not default a null name to SQL", async () => {
+    const connection = (await Base.leaseConnection()) as unknown as {
+      cache<T>(fn: () => T | Promise<T>): Promise<T>;
+      selectAll(sql: string): Promise<unknown>;
+    };
+
+    const payloads = await capture(async () => {
+      await connection.cache(async () => {
+        await connection.selectAll("select 1");
+        await connection.selectAll("select 1");
+      });
+    });
+
+    // query_cache.rb:313 is `name: name` — a nameless select_all yields a
+    // nameless cached payload, not the "SQL" default that `log`'s signature
+    // supplies on the uncached path.
+    const cached = payloads.filter((p) => p.cached);
+    expect(cached.length).toBe(1);
+    expect(cached[0].name).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Converges `cacheNotificationInfo` with `vendor/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:308-314`, closing two gaps flagged during review of #4847 and deferred as pre-existing.

- `type_casted_binds` is now a thunk, matching Rails’ `-> { type_casted_binds(binds) }` at query_cache.rb:311 — subscribers only pay the cast if they read the key. The only reader in trails, `LogSubscriber` (`log-subscriber.ts:197`), already unwraps a callable, mirroring `log_subscriber.rb:61`.
- `name` is passed through unchanged (query_cache.rb:313) instead of defaulting to `"SQL"`.

Tests land in a new `query-cache.trails.test.ts` sibling because Rails’ `query_cache_test.rb` has no test asserting this payload shape directly, so there is no Rails name to mirror. The deferral test drives `cacheNotificationInfo` with a bind whose `valueForDatabase` getter counts reads, asserting zero casts before the slot is read — mutation-tested against an eager `(() => tc)` wrapper, which it fails as intended.

Verified on SQLite: `query-cache.test.ts` (67), `query-cache.trails.test.ts` (4), `log-subscriber.test.ts` (21), and `bind-parameter.test.ts` all pass. MariaDB/MySQL/PG are CI’s.

**CI fix (MariaDB):** the first revision of the lazy test hardcoded `[1]`, which assumed SQLite/PG bind shape and failed on MariaDB with `expected [] to deeply equal [ 1 ]`. That was the test being wrong, not the code — Rails’ `to_sql_and_binds` (`database_statements.rb:32-42`) leaves `binds` empty when `prepared_statements` is off, which is the MySQL default, so an empty `type_casted_binds` there is faithful. The assertion now relates the thunk’s output to the payload’s own `binds`; exact-cast coverage stays in the adapter-independent probe test, which supplies its own bind.

## Known divergence left in place (anchored in source + story)

`type_casted_binds` calls the standalone helper rather than Rails’ adapter-dispatched `Quoting#type_casted_binds` (`quoting.rb:224`). That is a real divergence, not a choice — but it is not the one-line fix it appears to be, and converging it here would make things worse, not better.

A verified audit (`git grep -n "type_casted_binds:" -- packages/activerecord/src --include=*.ts | grep -v ".test.ts"`) finds **16 producers across 6 files using four strategies**:

| strategy | sites |
|---|---|
| standalone free function (no adapter `type_cast`) | 9 — `database-statements.ts:1371`, `query-cache.ts:598`, 4× mysql2, 3× sqlite3 |
| raw uncast binds | 5 — `postgresql-adapter.ts:977,1612,1703,1767,2155` |
| hardcoded `[]` | 1 — `sqlite3-adapter.ts:714` |
| forwarded caller-supplied param | 1 — `abstract-adapter.ts:2350` |

So cached-vs-uncached payloads *already* disagree on PG today. Converging this one line would make the cached payload individually faithful while introducing a **new** SQLite disagreement where none exists (`[1]` → `[1n]`, adapter `typeCast` yields BigInt), with no PG/MySQL coverage proving it safe, and leave the other 15 unconverged. Note the 4th strategy is Rails-**shaped**: Rails’ `log` (`abstract_adapter.rb:1134`) also takes `type_casted_binds = []` as a param, so the fix there is at its callers, not the signature.

Anchored in a source comment at `query-cache.ts:595` so the next reader sees it, and tracked by `0023-surfaced-deviations/type-casted-binds-payload-self-dispatch` with the exact site checklist.

**Sibling story:** `0023-surfaced-deviations/uncached-sql-payload-name-nil-passthrough` — the uncached path still coerces a nil name to `"SQL"` across **18 sites** (4 payload producers incl. `abstract-adapter.ts:2348`, plus 14 call-forwarding sites that coerce upstream, so both layers must move together). This PR’s test asserts the cached side only; that story tightens it to assert both match.

### Review-round corrections

- The counts above were **17 / 3 strategies** in an earlier revision. That was wrong: the grep included `bind-parameter.test.ts:63` (a consumer-side test, not a producer), and `abstract-adapter.ts:2350` is a distinct fourth strategy. Corrected in the source comment, both story docs, and here — the story inventory is a sweep checklist, so an off-by-one there is a real defect. Good catch.

Closes-story: cache-notification-info-lazy-binds-and-name-passthrough