### PR TITLE
fix(arel): route PG array date elements through quoted_date formatting

### DIFF
--- a/packages/arel/src/quote-array.test.ts
+++ b/packages/arel/src/quote-array.test.ts
@@ -70,5 +70,21 @@ describe("quoteArrayLiteral", () => {
     it("applies to nested array elements", () => {
       expect(quoteArrayLiteral([["x"]], (v) => (v === "x" ? "X" : undefined))).toBe('{{"X"}}');
     });
+
+    it("is offered numbers and booleans, which Rails also sends through type_cast", () => {
+      // type_cast_array recurses only `when ::Array`; every other element goes
+      // to type_cast, so the hook must see numbers/booleans too. Without this
+      // ordering a caller could never converge them (e.g. unquoted_true).
+      const seen: unknown[] = [];
+      quoteArrayLiteral([1, true, "s"], (v) => {
+        seen.push(v);
+        return undefined;
+      });
+      expect(seen).toEqual([1, true, "s"]);
+    });
+
+    it("lets the hook format a number element", () => {
+      expect(quoteArrayLiteral([1], (v) => (v === 1 ? "one" : undefined))).toBe('{"one"}');
+    });
   });
 });

--- a/packages/arel/src/quote-array.test.ts
+++ b/packages/arel/src/quote-array.test.ts
@@ -52,4 +52,23 @@ describe("quoteArrayLiteral", () => {
   it("handles bigint values inside objects", () => {
     expect(quoteArrayLiteral([{ id: 42n }])).toBe('{"{\\"id\\":\\"42\\"}"}');
   });
+
+  describe("formatElement", () => {
+    it("wraps a formatted element in the array element quoting", () => {
+      const d = new Date("2026-03-26T12:00:00.000Z");
+      expect(quoteArrayLiteral([d], () => "2026-03-26 12:00:00")).toBe('{"2026-03-26 12:00:00"}');
+    });
+
+    it("falls through to the default handling when it returns undefined", () => {
+      expect(quoteArrayLiteral(["a", 1], () => undefined)).toBe('{"a",1}');
+    });
+
+    it("escapes quotes and backslashes in a formatted element", () => {
+      expect(quoteArrayLiteral(["x"], () => 'a\\b"c')).toBe('{"a\\\\b\\"c"}');
+    });
+
+    it("applies to nested array elements", () => {
+      expect(quoteArrayLiteral([["x"]], (v) => (v === "x" ? "X" : undefined))).toBe('{{"X"}}');
+    });
+  });
 });

--- a/packages/arel/src/quote-array.ts
+++ b/packages/arel/src/quote-array.ts
@@ -1,10 +1,9 @@
 /**
- * Formats a single array element as its bare (un-quoted) literal content, or
- * returns `undefined` to fall through to the default handling. Callers that own
- * a dialect's date formatting (the Arel PostgreSQL visitor's `quotedDate`) pass
- * one so array elements match what the same value gets on the scalar path —
- * Rails' `type_cast_array` sends each element through the same `type_cast` a
- * scalar takes (`postgresql/quoting.rb:221-226`).
+ * Formats an element as its BARE (un-quoted) content — `quoteArrayLiteral`
+ * applies the `"..."` quoting itself. Returning `undefined` falls through to
+ * the default handling. Lets a caller that owns a dialect's formatting give
+ * array elements what the same value gets on the scalar path, mirroring Rails'
+ * `type_cast_array` (`postgresql/quoting.rb:221-226`).
  */
 export type FormatArrayElement = (value: unknown) => string | undefined;
 

--- a/packages/arel/src/quote-array.ts
+++ b/packages/arel/src/quote-array.ts
@@ -1,15 +1,29 @@
 /**
+ * Formats a single array element as its bare (un-quoted) literal content, or
+ * returns `undefined` to fall through to the default handling. Callers that own
+ * a dialect's date formatting (the Arel PostgreSQL visitor's `quotedDate`) pass
+ * one so array elements match what the same value gets on the scalar path —
+ * Rails' `type_cast_array` sends each element through the same `type_cast` a
+ * scalar takes (`postgresql/quoting.rb:221-226`).
+ */
+export type FormatArrayElement = (value: unknown) => string | undefined;
+
+/**
  * Formats a JS array as a PostgreSQL array literal string (without outer single quotes).
  * e.g. ["a", "b"] => {"a","b"}
  *
  * Shared between the Arel PostgreSQL visitor and ActiveRecord's inline SQL quoting.
  */
-export function quoteArrayLiteral(arr: unknown[]): string {
+export function quoteArrayLiteral(arr: unknown[], formatElement?: FormatArrayElement): string {
   const elements = arr.map((v) => {
     if (v === null || v === undefined) return "NULL";
-    if (Array.isArray(v)) return quoteArrayLiteral(v);
+    if (Array.isArray(v)) return quoteArrayLiteral(v, formatElement);
     if (typeof v === "number") return String(v);
     if (typeof v === "boolean") return v ? "TRUE" : "FALSE";
+    const formatted = formatElement?.(v);
+    if (formatted !== undefined) {
+      return `"${formatted.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+    }
     // boundary: defensive Date quoting for caller-supplied array literals.
     if (v instanceof Date) {
       return `"${v.toISOString()}"`;

--- a/packages/arel/src/quote-array.ts
+++ b/packages/arel/src/quote-array.ts
@@ -1,9 +1,11 @@
 /**
  * Formats an element as its BARE (un-quoted) content — `quoteArrayLiteral`
  * applies the `"..."` quoting itself. Returning `undefined` falls through to
- * the default handling. Lets a caller that owns a dialect's formatting give
- * array elements what the same value gets on the scalar path, mirroring Rails'
- * `type_cast_array` (`postgresql/quoting.rb:221-226`).
+ * the default handling. Offered every element except nested arrays (which
+ * recurse first), mirroring how Rails' `type_cast_array` dispatches all
+ * non-array elements into `type_cast` (`postgresql/quoting.rb:221-226`). Lets a
+ * caller that owns a dialect's formatting give array elements what the same
+ * value gets on the scalar path.
  */
 export type FormatArrayElement = (value: unknown) => string | undefined;
 
@@ -16,13 +18,16 @@ export type FormatArrayElement = (value: unknown) => string | undefined;
 export function quoteArrayLiteral(arr: unknown[], formatElement?: FormatArrayElement): string {
   const elements = arr.map((v) => {
     if (v === null || v === undefined) return "NULL";
+    // Nested arrays recurse before the hook, per `type_cast_array`'s
+    // `when ::Array` arm; every other element is offered to it uniformly,
+    // as Rails dispatches all non-array elements into `type_cast`.
     if (Array.isArray(v)) return quoteArrayLiteral(v, formatElement);
-    if (typeof v === "number") return String(v);
-    if (typeof v === "boolean") return v ? "TRUE" : "FALSE";
     const formatted = formatElement?.(v);
     if (formatted !== undefined) {
       return `"${formatted.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
     }
+    if (typeof v === "number") return String(v);
+    if (typeof v === "boolean") return v ? "TRUE" : "FALSE";
     // boundary: defensive Date quoting for caller-supplied array literals.
     if (v instanceof Date) {
       return `"${v.toISOString()}"`;

--- a/packages/arel/src/visitors/postgres.test.ts
+++ b/packages/arel/src/visitors/postgres.test.ts
@@ -353,6 +353,30 @@ describe("PostgresTest", () => {
       const sql = new Visitors.PostgreSQL().compile(node);
       expect(sql).toContain("'{\"O''Reilly\"}'");
     });
+
+    it("quotes a Date array element as a db date, matching the scalar path", () => {
+      // Rails' type_cast_array sends each element through the same type_cast a
+      // scalar takes (`when Date, Time then quoted_date`), so the array element
+      // must carry the db form the scalar path emits — not ISO-8601.
+      const d = new Date(Date.UTC(2026, 3, 26, 14, 23, 55));
+      const scalar = new Visitors.PostgreSQL().compile(users.get("at").eq(d));
+      expect(scalar).toContain("'2026-04-26 14:23:55'");
+
+      const sql = new Visitors.PostgreSQL().compile(users.get("ats").eq([d]));
+      expect(sql).toContain("'{\"2026-04-26 14:23:55\"}'");
+    });
+
+    it("emits fixed-6 microseconds for a sub-second date array element", () => {
+      const d = new Date(Date.UTC(2026, 3, 26, 14, 23, 55, 123));
+      const sql = new Visitors.PostgreSQL().compile(users.get("ats").eq([d]));
+      expect(sql).toContain("'{\"2026-04-26 14:23:55.123000\"}'");
+    });
+
+    it("quotes date elements of a nested array as db dates", () => {
+      const d = new Date(Date.UTC(2026, 3, 26, 14, 23, 55));
+      const sql = new Visitors.PostgreSQL().compile(users.get("ats").eq([[d]]));
+      expect(sql).toContain("'{{\"2026-04-26 14:23:55\"}}'");
+    });
   });
 });
 

--- a/packages/arel/src/visitors/postgresql.ts
+++ b/packages/arel/src/visitors/postgresql.ts
@@ -131,10 +131,30 @@ export class PostgreSQL extends ToSql {
 
   protected override quote(value: unknown): string {
     if (Array.isArray(value)) {
-      const literal = quoteArrayLiteral(value);
+      const literal = quoteArrayLiteral(value, (v) => this.formatArrayDate(v));
       return `'${literal.replace(/'/g, "''")}'`;
     }
     return super.quote(value);
+  }
+
+  /**
+   * Routes a date-like array element through the same formatting the scalar
+   * path takes (`quotedDate`), mirroring Rails' `type_cast_array` → `type_cast`
+   * → `when Date, Time then quoted_date` (`abstract/quoting.rb:94-107`). Uses
+   * the bare `formatDate` rather than `quotedDate` because `quoteArrayLiteral`
+   * applies its own `"..."` quoting — passing the `'`-wrapped form would
+   * double-quote. `undefined` leaves non-date elements to the default handling.
+   */
+  private formatArrayDate(value: unknown): string | undefined {
+    if (
+      typeof value === "object" &&
+      value !== null &&
+      "toISOString" in value &&
+      typeof (value as { toISOString: unknown }).toISOString === "function"
+    ) {
+      return this.formatDate(value as { toISOString(): string });
+    }
+    return undefined;
   }
 }
 

--- a/packages/arel/src/visitors/postgresql.ts
+++ b/packages/arel/src/visitors/postgresql.ts
@@ -137,14 +137,10 @@ export class PostgreSQL extends ToSql {
     return super.quote(value);
   }
 
-  /**
-   * Routes a date-like array element through the same formatting the scalar
-   * path takes (`quotedDate`), mirroring Rails' `type_cast_array` → `type_cast`
-   * → `when Date, Time then quoted_date` (`abstract/quoting.rb:94-107`). Uses
-   * the bare `formatDate` rather than `quotedDate` because `quoteArrayLiteral`
-   * applies its own `"..."` quoting — passing the `'`-wrapped form would
-   * double-quote. `undefined` leaves non-date elements to the default handling.
-   */
+  // Mirrors Rails' `type_cast_array` → `type_cast` → `when Date, Time then
+  // quoted_date` (`abstract/quoting.rb:94-107`), so an array element matches
+  // the scalar path. Uses bare `formatDate`, not `quotedDate`: the latter is
+  // already `'`-wrapped and `quoteArrayLiteral` adds its own quoting.
   private formatArrayDate(value: unknown): string | undefined {
     if (
       typeof value === "object" &&

--- a/packages/arel/src/visitors/postgresql.ts
+++ b/packages/arel/src/visitors/postgresql.ts
@@ -139,8 +139,7 @@ export class PostgreSQL extends ToSql {
 
   // Mirrors Rails' `type_cast_array` → `type_cast` → `when Date, Time then
   // quoted_date` (`abstract/quoting.rb:94-107`), so an array element matches
-  // the scalar path. Uses bare `formatDate`, not `quotedDate`: the latter is
-  // already `'`-wrapped and `quoteArrayLiteral` adds its own quoting.
+  // the scalar path.
   private formatArrayDate(value: unknown): string | undefined {
     if (
       typeof value === "object" &&
@@ -148,7 +147,7 @@ export class PostgreSQL extends ToSql {
       "toISOString" in value &&
       typeof (value as { toISOString: unknown }).toISOString === "function"
     ) {
-      return this.formatDate(value as { toISOString(): string });
+      return this.quotedDate(value as { toISOString(): string });
     }
     return undefined;
   }

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -2065,17 +2065,23 @@ export class ToSql extends Visitor {
   // packages/activerecord/src/connection-adapters/abstract/quoting.ts is the
   // authoritative path for timezone-aware bound values.
   protected quotedDate(d: { toISOString(): string }): string {
+    return `'${this.formatDate(d).replace(/'/g, "''")}'`;
+  }
+
+  // The bare (un-single-quoted) form behind `quotedDate`. PG array literals
+  // need the element content without the `'` wrapper — `quoteArrayLiteral`
+  // supplies its own `"..."` quoting — so the formatting lives here and
+  // `quotedDate` is the scalar `'`-quoting wrapper over it.
+  protected formatDate(d: { toISOString(): string }): string {
     // Matches "YYYY-MM-DDTHH:MM:SS.mmmZ", "YYYY-MM-DDTHH:MM:SSZ", or
     // the same without trailing Z (treated as UTC).
     const match = d.toISOString().match(/^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})(?:\.(\d+))?Z?$/);
-    if (!match) return `'${d.toISOString().replace(/'/g, "''")}'`;
+    if (!match) return d.toISOString();
     const [, date, time, frac] = match;
     // Normalise to exactly 6 digits: pad short fractions, truncate long ones.
     // "729" → "729000" (μs), "7" → "700000", "1234" → "123400", "729000" → "729000".
     const micros = frac ? parseInt((frac + "000000").slice(0, 6), 10) : 0;
-    return micros > 0
-      ? `'${date} ${time}.${String(micros).padStart(6, "0")}'`
-      : `'${date} ${time}'`;
+    return micros > 0 ? `${date} ${time}.${String(micros).padStart(6, "0")}` : `${date} ${time}`;
   }
 
   /**

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1528,7 +1528,7 @@ export class ToSql extends Visitor {
       "toISOString" in value &&
       typeof (value as { toISOString: unknown }).toISOString === "function"
     ) {
-      return this.quotedDate(value as { toISOString(): string });
+      return `'${this.quotedDate(value as { toISOString(): string }).replace(/'/g, "''")}'`;
     }
     if (typeof value === "object" && value !== null) {
       const proto = Object.getPrototypeOf(value);
@@ -2041,7 +2041,7 @@ export class ToSql extends Visitor {
     ) {
       // Mirrors Rails quote behavior: date-like values are formatted and inlined.
       // Only BindParam/ActiveModel::Attribute go through addBind.
-      collector.append(this.quotedDate(v as { toISOString(): string }));
+      collector.append(`'${this.quotedDate(v as { toISOString(): string }).replace(/'/g, "''")}'`);
     } else {
       // Unknown object types (e.g. Temporal.Instant) — defer to `quote()`
       // so the value is properly escaped/quoted rather than concatenated
@@ -2052,7 +2052,10 @@ export class ToSql extends Visitor {
   }
 
   // Formats a date-like value as a SQL datetime string matching Rails'
-  // AbstractAdapter#quoted_date: 'YYYY-MM-DD HH:MM:SS[.microseconds]'.
+  // AbstractAdapter#quoted_date: YYYY-MM-DD HH:MM:SS[.microseconds].
+  // Returns the BARE form, as Rails does (`result = value.to_fs(:db)` plus the
+  // %06d usec suffix, abstract/quoting.rb:184-198) — callers add their own
+  // quoting (`"'#{quoted_date(value)}'"`, abstract/quoting.rb:99).
   // When ms > 0 the fractional part is emitted as 6-digit microseconds,
   // matching AR quoting.ts and preserving sub-second DB precision. When ms = 0
   // the bare seconds form is used — matching Rails' default output for
@@ -2065,14 +2068,6 @@ export class ToSql extends Visitor {
   // packages/activerecord/src/connection-adapters/abstract/quoting.ts is the
   // authoritative path for timezone-aware bound values.
   protected quotedDate(d: { toISOString(): string }): string {
-    return `'${this.formatDate(d).replace(/'/g, "''")}'`;
-  }
-
-  // The bare (un-single-quoted) form behind `quotedDate`. PG array literals
-  // need the element content without the `'` wrapper — `quoteArrayLiteral`
-  // supplies its own `"..."` quoting — so the formatting lives here and
-  // `quotedDate` is the scalar `'`-quoting wrapper over it.
-  protected formatDate(d: { toISOString(): string }): string {
     // Matches "YYYY-MM-DDTHH:MM:SS.mmmZ", "YYYY-MM-DDTHH:MM:SSZ", or
     // the same without trailing Z (treated as UTC).
     const match = d.toISOString().match(/^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})(?:\.(\d+))?Z?$/);


### PR DESCRIPTION
## Problem

The Arel PostgreSQL visitor's **scalar** path routes a date-like value through
`quotedDate` and emits the db form (`2026-04-26 14:23:55`), but its **array**
path (`postgresql.ts:134`) called `quoteArrayLiteral(value)` with no element
formatter, so a date element fell to the duck-typed `toISOString` branch
(`quote-array.ts:36-41`) and emitted ISO-8601 (`2026-04-26T14:23:55.000Z`).

Rails' `quote(OID::Array::Data)` → `encode_array` → `type_cast_array` recurses
each element (including nested arrays) into the same `type_cast` a scalar
takes — `when Date, Time then quoted_date` (`abstract/quoting.rb:94-107`) — so
scalar and array must agree.

## Change

- Made `ToSql#quotedDate` **bare**, matching Rails' `quoted_date` contract
  (`result = value.to_fs(:db)` + `%06d` usec, `abstract/quoting.rb:184-198`),
  and moved the `'`-quoting to its two call sites — exactly as Rails does
  (`"'#{quoted_date(value)}'"`, `abstract/quoting.rb:99`). The array path calls
  `quotedDate` directly, so the double-quoting hazard is designed out.
- Thread an optional `formatElement` hook through `quoteArrayLiteral`
  (recursing into nested arrays); returning `undefined` falls through to the
  existing default handling, so the other caller is unaffected.
- The PG visitor passes a `formatElement` that sends date-like elements to
  `quotedDate`. The hook is offered every non-array element (nested arrays
  recurse first), mirroring `type_cast_array`'s uniform dispatch into
  `type_cast` — no pre-filter for numbers/booleans.

## On the JS `Date` array element

Acceptance criteria asked to decide + converge this. A `Date` **has**
`toISOString`, so it flows through the same duck-typed branch as a Temporal
sibling — no separate `Date` case is needed, and the visitor's array path now
matches its own scalar path for both. The dialect-neutral default (no
`formatElement`) keeps ISO, so `base.ts`'s scalar `quoteSqlValue` stays
self-consistent with its array path; the Rails-shaped formatting is injected by
the caller that owns it, which is also the direction #4851 takes for the
`base.ts` sites.

## Tests

`packages/arel/src/visitors/postgres.test.ts` — a `Date` array element emits the
db form and is asserted **against the scalar path's output in the same test**,
plus fixed-6 μs and nested-array coverage. `quote-array.test.ts` covers the hook
itself: wrapping, fall-through, escaping, and nesting.

Full `packages/arel` suite green (1468 tests).


## Fidelity review vs. Rails (read before merging)

Rails' Arel does **no** value formatting: `ToSql#quote` delegates
(`to_sql.rb:867-870`), `Visitors::PostgreSQL` has **no** `quote` override, and
`grep -rn "quoted_date|encode_array|quote_array" vendor/rails/.../lib/arel/`
returns nothing. Formatting lives in the adapter.

So trails' arel-side `quotedDate` / `quoteArrayLiteral` / PG `quote` override
are **pre-existing trails inventions**, and this PR adds `formatArrayDate` to
that surface rather than removing it (review round 2 removed the invented
`formatDate` by converging `quotedDate` onto the Rails contract). Being
straight about the tradeoff:

- It **converges behavior** — array elements now emit the `quoted_date` form
  Rails' `type_cast_array` produces, and match trails' own scalar path.
- It **does not converge structure** — the invented surface remains.

The structural fix (arel `quote` → `connection.quote`) is blocked here because
trails constructs visitors with **no connection** (`new Visitors.PostgreSQL()`
throughout `postgres.test.ts`); Rails always has one. That's a refactor, not a
formatting fix, so per "always converge, never ratify" it is registered as
`0023-surfaced-deviations/arel-quote-delegates-to-connection-like-rails`
rather than ratified here. It is the same direction #4851 takes for `base.ts`.

**Gates:** no stubs. test:compare `14437/21656` and api:compare
`11416/16975` — **identical before and after (delta 0)**, measured against
`origin/main` versions of the touched files. My additions land as
`extra (TS only)` (3954→3957), which doesn't move the ratio.

## Review round 2

- **`quotedDate` naming** — fixed, and the reviewer was right: Rails' `quoted_date`
  IS the bare form. `quotedDate` is now bare, `formatDate` is deleted, and the
  two call sites quote. To answer the question: the wrapped shape was pre-existing
  trails, kept only to keep the diff small — no subclass override depends on it
  (`grep` finds no override; the only callers are `to-sql.ts:1531`/`2044`).
- **Hook ordering** — fixed rather than documented: `formatElement` now runs
  above the number/boolean branches, after the array recursion.
- **Booleans** — registered as
  `0023-surfaced-deviations/converge-arel-array-booleans-to-unquoted-true`.
  One correction: PG does **not** override `unquoted_true`. `grep -rn "def unquoted_true"
  vendor/rails/activerecord/lib/` matches only `abstract/quoting.rb:170`,
  `mysql/quoting.rb:72`, `sqlite3/quoting.rb:87`. PG inherits Ruby `true`, so
  `encode_array` emits `'{true}'`, not `'{t}'` — and PG parses booleans
  case-insensitively, so trails' `'{TRUE}'` is accepted. The divergence is real
  (`quoted_*` where Rails uses `unquoted_*`) but structural, not a live bug; the
  story is scoped that way.

Closes-story: converge-arel-array-date-elements-to-quoted-date
