### PR TITLE
refactor(arel): quote delegates to the connection like Rails

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -3,9 +3,15 @@
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting
  *
- * @boundary-file: SQL quoting accepts caller-supplied values; legacy callers
- *   may pass JS `Date` for date-typed columns. The dispatcher branches on
- *   `instanceof Date` alongside Temporal types and handles each separately.
+ * @boundary-file: SQL quoting accepts caller-supplied values of unknown type,
+ *   so the dispatcher branches on runtime shape.
+ *
+ *   Rails' `when Date, Time then "'#{quoted_date(value)}'"` (quoting.rb:85)
+ *   accepts Ruby's native time objects; trails' analogue is Temporal, not JS
+ *   `Date` — #939 ("close the dual-typed window") made Temporal the sole
+ *   date/time representation, so `quote` and `typeCast` both reject a JS `Date`
+ *   with guidance rather than formatting it. rb:85 is ported onto the Temporal
+ *   branches via `dispatchQuotedDate`.
  */
 
 import { Temporal } from "@blazetrails/activesupport/temporal";
@@ -97,13 +103,19 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
   // and quoted bare — Rails: `when BigDecimal then value.to_s("F")`.
   if (value instanceof BigDecimal) return value.toString("F");
   if (typeof value === "number" || typeof value === "bigint") return String(value);
-  // Rails: `when Type::Binary::Data then quoted_binary(value)`
-  // (abstract/quoting.rb:83) — binary dispatch sits here, before the
-  // Time/Date branches, and self-dispatches so each adapter's quoted_binary
-  // applies. Each adapter's `quote` short-circuits the common Uint8Array case
-  // before reaching here; this catches the other ArrayBuffer views (Int8Array,
-  // Float64Array, DataView), which have no Ruby analogue and must be
-  // normalized to bytes rather than falling to the raise below.
+  // ArrayBuffer views have no Ruby analogue: they must be normalized to bytes
+  // rather than falling to the raise below. Sited at the position Rails gives
+  // binary dispatch (`when Type::Binary::Data then quoted_binary(value)`,
+  // abstract/quoting.rb:83 — after Numeric, before Time/Date) and
+  // self-dispatched so each adapter's quotedBinary applies.
+  //
+  // This is NOT the rb:83 port: that line's `Type::Binary::Data` branch is
+  // still missing here and re-implemented per-adapter (postgresql/quoting.ts,
+  // mysql/quoting.ts, sqlite3/quoting.ts), which also short-circuit Uint8Array
+  // to the module quotedBinary and so bypass this self-dispatch. Porting rb:83
+  // and collapsing those copies is story
+  // `abstract-quote-binary-data-self-dispatch` — behaviorally a no-op today
+  // (each override delegates to the same module function), hence deferred.
   if (ArrayBuffer.isView(value)) {
     const bytes = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
     return dispatchQuotedBinary(this, bytes);

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -34,6 +34,8 @@ export interface QuotingDispatchHost {
   /** @internal */
   quotedTime?(value: Temporal.PlainTime | Temporal.PlainDateTime): string;
   /** @internal */
+  quotedBinary?(value: Uint8Array): string;
+  /** @internal */
   quoteColumnName?(name: string): string;
 }
 
@@ -111,6 +113,16 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
     throw new TypeError(
       "quote: JS Date is not accepted — use a Temporal type (Instant, PlainDateTime, etc.)",
     );
+  // Rails: `when Type::Binary::Data then quoted_binary(value)` — binary
+  // dispatch is the adapter's job, self-dispatched so each adapter's
+  // quoted_binary applies. Each adapter's `quote` short-circuits the common
+  // Uint8Array case before reaching here; this catches the other ArrayBuffer
+  // views (Int8Array, Float64Array, DataView), which have no Ruby analogue and
+  // must be normalized to bytes rather than falling to the raise below.
+  if (ArrayBuffer.isView(value)) {
+    const bytes = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+    return dispatchQuotedBinary(this, bytes);
+  }
   if (typeof value === "symbol") {
     const desc = value.description;
     if (desc === undefined) throw new TypeError("Cannot quote a Symbol without a description");
@@ -364,6 +376,19 @@ export function isSqlLiteral(value: unknown): value is { value: string } {
  * receiver-less callers (every invocation threads an adapter `this`).
  * @internal
  */
+/**
+ * Self-dispatch binary quoting through the host, mirroring Rails' `quote`
+ * calling `self.quoted_binary(value)` so an adapter override applies. Falls
+ * back to the module-level helper when the host omits it.
+ * @internal
+ */
+export function dispatchQuotedBinary(host: QuotingDispatchHost, value: Uint8Array): string {
+  if (typeof host.quotedBinary === "function") {
+    return host.quotedBinary(value);
+  }
+  return quotedBinary(value);
+}
+
 export function dispatchQuotedDate(host: QuotingDispatchHost, value: TemporalDateLike): string {
   if (typeof host.quotedDate === "function") {
     return host.quotedDate(value);

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -97,6 +97,17 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
   // and quoted bare — Rails: `when BigDecimal then value.to_s("F")`.
   if (value instanceof BigDecimal) return value.toString("F");
   if (typeof value === "number" || typeof value === "bigint") return String(value);
+  // Rails: `when Type::Binary::Data then quoted_binary(value)`
+  // (abstract/quoting.rb:83) — binary dispatch sits here, before the
+  // Time/Date branches, and self-dispatches so each adapter's quoted_binary
+  // applies. Each adapter's `quote` short-circuits the common Uint8Array case
+  // before reaching here; this catches the other ArrayBuffer views (Int8Array,
+  // Float64Array, DataView), which have no Ruby analogue and must be
+  // normalized to bytes rather than falling to the raise below.
+  if (ArrayBuffer.isView(value)) {
+    const bytes = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+    return dispatchQuotedBinary(this, bytes);
+  }
   // Rails dispatches date/time literals through `self.quoted_time` (Time::Value)
   // and `self.quoted_date` (Date/Time) so adapter overrides — e.g. PostgreSQL's
   // BC-suffixing `quoted_date` — are honored. Thread `this` to mirror that.
@@ -113,16 +124,6 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
     throw new TypeError(
       "quote: JS Date is not accepted — use a Temporal type (Instant, PlainDateTime, etc.)",
     );
-  // Rails: `when Type::Binary::Data then quoted_binary(value)` — binary
-  // dispatch is the adapter's job, self-dispatched so each adapter's
-  // quoted_binary applies. Each adapter's `quote` short-circuits the common
-  // Uint8Array case before reaching here; this catches the other ArrayBuffer
-  // views (Int8Array, Float64Array, DataView), which have no Ruby analogue and
-  // must be normalized to bytes rather than falling to the raise below.
-  if (ArrayBuffer.isView(value)) {
-    const bytes = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
-    return dispatchQuotedBinary(this, bytes);
-  }
   if (typeof value === "symbol") {
     const desc = value.description;
     if (desc === undefined) throw new TypeError("Cannot quote a Symbol without a description");
@@ -311,8 +312,19 @@ export function unquotedFalse(): boolean {
  * Quote binary data for SQL.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quoted_binary
+ * (abstract/quoting.rb:206 — `"'#{quote_string(value.to_s)}'"`).
+ *
+ * Rails' `value` is a `Type::Binary::Data` whose `to_s` is the raw byte
+ * string. JS has no such coercion — `String(new Uint8Array([0x1f, 0x8b]))` is
+ * `"31,139"`, the comma-joined decimals — so bytes are decoded latin1 to reach
+ * the byte string `quote_string` expects. Every real adapter overrides this
+ * with a dialect binary literal; this is the abstract fallback.
  */
 export function quotedBinary(value: unknown): string {
+  if (ArrayBuffer.isView(value)) {
+    const bytes = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+    return `'${quoteString(Buffer.from(bytes).toString("latin1"))}'`;
+  }
   return `'${quoteString(String(value))}'`;
 }
 
@@ -371,12 +383,6 @@ export function isSqlLiteral(value: unknown): value is { value: string } {
 }
 
 /**
- * Dispatch through the host's `quotedDate` override if it defines one, else
- * the module-level helper. A host receiver is required — there are no
- * receiver-less callers (every invocation threads an adapter `this`).
- * @internal
- */
-/**
  * Self-dispatch binary quoting through the host, mirroring Rails' `quote`
  * calling `self.quoted_binary(value)` so an adapter override applies. Falls
  * back to the module-level helper when the host omits it.
@@ -389,6 +395,12 @@ export function dispatchQuotedBinary(host: QuotingDispatchHost, value: Uint8Arra
   return quotedBinary(value);
 }
 
+/**
+ * Dispatch through the host's `quotedDate` override if it defines one, else
+ * the module-level helper. A host receiver is required — there are no
+ * receiver-less callers (every invocation threads an adapter `this`).
+ * @internal
+ */
 export function dispatchQuotedDate(host: QuotingDispatchHost, value: TemporalDateLike): string {
   if (typeof host.quotedDate === "function") {
     return host.quotedDate(value);

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
@@ -25,8 +25,10 @@ import {
 } from "./quoting.js";
 
 // `quote` / `typeCast` require a host receiver (no receiver-less dispatch); bind
-// PG's quotedDate so date/time values reach the BC-suffixing override.
-const HOST = { quotedDate };
+// PG's quotedDate so date/time values reach the BC-suffixing override, and its
+// quotedBinary so binary values reach the bytea-hex override — a real adapter
+// host carries both.
+const HOST = { quotedDate, quotedBinary };
 const quote = (value: unknown): string => quoteFn.call(HOST, value);
 const typeCast = (value: unknown): unknown => typeCastFn.call(HOST, value);
 
@@ -204,6 +206,14 @@ describe("PostgreSQL quoting", () => {
 
   it("quote(BinaryData) unwraps to bytes via quotedBinary", () => {
     expect(quote(new BinaryData(new Uint8Array([0x1f, 0x8b])))).toBe("'\\x1f8b'");
+  });
+
+  it("quote(non-Uint8Array ArrayBuffer view) normalizes to bytes via quotedBinary", () => {
+    // Views other than Uint8Array reach the inherited abstract quote, which
+    // normalizes them to bytes and self-dispatches to the adapter's
+    // quotedBinary rather than raising `can't quote Int8Array`.
+    expect(quote(new Int8Array([0x1f, 0x8b - 0x100]))).toBe("'\\x1f8b'");
+    expect(quote(new DataView(new Uint8Array([0x1f, 0x8b]).buffer))).toBe("'\\x1f8b'");
   });
 
   it("checkIntInRange is the Rails name for checkIntegerRange", () => {

--- a/packages/activerecord/src/quoting.test.ts
+++ b/packages/activerecord/src/quoting.test.ts
@@ -245,6 +245,16 @@ describe("QuoteBooleanTest", () => {
     expect(quotedBinary("binary data")).toBe("'binary data'");
   });
 
+  it("quoted binary decodes bytes rather than String()-joining them", () => {
+    // Rails' quoted_binary is `'#{quote_string(value.to_s)}'` where value is a
+    // Type::Binary::Data whose to_s is the raw byte string. JS's
+    // String(Uint8Array) would emit the comma-joined decimals "31,139"; the
+    // byte string must round-trip instead.
+    const quoted = quotedBinary(new Uint8Array([0x1f, 0x8b]));
+    expect(quoted).not.toContain("31,139");
+    expect([...Buffer.from(quoted.slice(1, -1), "latin1")]).toEqual([0x1f, 0x8b]);
+  });
+
   it("sanitize as sql comment strips comment markers", () => {
     expect(sanitizeAsSqlComment("/* comment */")).toBe("comment");
     expect(sanitizeAsSqlComment("/*+ hint */")).toBe("hint");

--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -12,6 +12,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { Nodes } from "@blazetrails/arel";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import "../index.js";
 import { registerModel, RecordNotFound } from "../index.js";
 import { captureSql } from "../testing/sql-capture.js";
@@ -837,7 +838,10 @@ describe("DefaultScopingTest", () => {
     const post = posts("thinking") as any;
     const expected = [comments("does_it_hurt").id];
 
-    await post.specialComments.updateAll({ deleted_at: new Date() });
+    // Rails: `post.special_comments.update_all(deleted_at: Time.now)`. A JS Date
+    // is not a quotable value in trails (abstract/quoting.ts rejects it in favor
+    // of Temporal); Temporal.Now.instant() is the Time.now analogue.
+    await post.specialComments.updateAll({ deleted_at: Temporal.Now.instant() });
 
     await expect(Post.joins("specialComments").find(post.id)).rejects.toThrow(RecordNotFound);
     expect(await (await post.specialComments.reload()).toArray()).toEqual([]);

--- a/packages/arel/src/index.ts
+++ b/packages/arel/src/index.ts
@@ -9,7 +9,6 @@ export { DeleteManager } from "./delete-manager.js";
 import { TreeManager } from "./tree-manager.js";
 export { TreeManager };
 export { ArelError, EmptyJoinError, BindError } from "./errors.js";
-export { quoteArrayLiteral } from "./quote-array.js";
 export { relationName } from "./attributes/attribute.js";
 
 import { SqlLiteral } from "./nodes/sql-literal.js";

--- a/packages/arel/src/visitors/default-quoter.ts
+++ b/packages/arel/src/visitors/default-quoter.ts
@@ -1,5 +1,6 @@
 import type { ArelConnection } from "./connection.js";
 import { quoteSchemaQualifiedName } from "./split-schema-qualified-name.js";
+import { quoteArrayLiteral } from "../quote-array.js";
 
 // Standalone comment sanitize for connection-less `Node#toSql()` (debug aid):
 // strips block-comment delimiters (leaving `--` alone, like Rails' abstract
@@ -13,7 +14,36 @@ function defaultSanitizeAsSqlComment(value: string): string {
     .trim();
 }
 
-function quoteScalar(value: unknown): string {
+// Formats a date-like value as a SQL datetime string matching Rails'
+// AbstractAdapter#quoted_date. Returns the BARE form, as Rails does
+// (`result = value.to_fs(:db)` plus the %06d usec suffix,
+// abstract/quoting.rb:184-198) — callers add their own quoting
+// (`"'#{quoted_date(value)}'"`, abstract/quoting.rb:99). #4867 established that
+// contract on the visitor; it lives on the quoting host now because Rails' Arel
+// does no value formatting of its own — `quoted_date` is an adapter method
+// reached through `@connection.quote`. Real adapters own the authoritative,
+// timezone-aware version in
+// packages/activerecord/src/connection-adapters/abstract/quoting.ts; this copy
+// only serves the connection-less `Node#toSql()` debug path.
+function quotedDate(d: { toISOString(): string }): string {
+  const match = d.toISOString().match(/^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})(?:\.(\d+))?Z?$/);
+  if (!match) return d.toISOString();
+  const [, date, time, frac] = match;
+  // Normalise to exactly 6 digits: pad short fractions, truncate long ones.
+  const micros = frac ? parseInt((frac + "000000").slice(0, 6), 10) : 0;
+  return micros > 0 ? `${date} ${time}.${String(micros).padStart(6, "0")}` : `${date} ${time}`;
+}
+
+function isDateLike(value: unknown): value is { toISOString(): string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "toISOString" in value &&
+    typeof (value as { toISOString: unknown }).toISOString === "function"
+  );
+}
+
+function quoteScalar(this: ArelConnection, value: unknown): string {
   if (value === null || value === undefined) return "NULL";
   if (typeof value === "number") {
     // Non-finite numbers must be string-quoted; databases reject bare
@@ -21,7 +51,30 @@ function quoteScalar(value: unknown): string {
     return Number.isFinite(value) ? String(value) : `'${String(value)}'`;
   }
   if (typeof value === "bigint") return String(value);
-  if (typeof value === "boolean") return value ? "TRUE" : "FALSE";
+  if (typeof value === "boolean") return value ? this.quotedTrue() : this.quotedFalse();
+  // Normalise all typed-array views to Uint8Array before handing off so
+  // quotedBinary can rely on a consistent shape.
+  if (ArrayBuffer.isView(value)) {
+    const bytes =
+      value instanceof Uint8Array
+        ? value
+        : new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+    return this.quotedBinary(bytes);
+  }
+  if (isDateLike(value)) return `'${quotedDate(value).replace(/'/g, "''")}'`;
+  if (typeof value === "object") {
+    const proto = Object.getPrototypeOf(value);
+    const hasCustomToString =
+      proto === Object.prototype && value.toString !== Object.prototype.toString;
+    if ((proto === Object.prototype || proto === null) && !hasCustomToString) {
+      try {
+        const json = JSON.stringify(value);
+        if (json !== undefined) return `'${json.replace(/'/g, "''")}'`;
+      } catch {
+        // circular references, BigInt, etc. — fall through
+      }
+    }
+  }
   // Only escape single quotes here; backslash escaping is dialect-specific
   // and handled by quoteString (MySQL/PG adapters override quote() as needed).
   return `'${String(value).replace(/'/g, "''")}'`;
@@ -129,4 +182,29 @@ export const defaultQuoter: ArelConnection = {
   },
 
   sanitizeAsSqlComment: defaultSanitizeAsSqlComment,
+};
+
+/**
+ * PostgreSQL quoter used when `new PostgreSQL()` is constructed without a
+ * connection (test / debug use). Rails' `Arel::Visitors::PostgreSQL` has no
+ * `quote` override — array literals are formatted by the adapter
+ * (`quote(OID::Array::Data)` → `encode_array`, postgresql/quoting.rb:221-226).
+ * Trails' connection-less visitors have no adapter to reach, so this host
+ * carries the minimal array-literal encoding in the adapter's place.
+ */
+export const postgresqlDefaultQuoter: ArelConnection = {
+  ...defaultQuoter,
+
+  quote(value: unknown): string {
+    if (Array.isArray(value)) {
+      // formatElement keeps #4867's fix alive on this path: a date element gets
+      // the same `quoted_date` form the scalar path emits, mirroring Rails'
+      // `type_cast_array` → `type_cast` → `when Date, Time then quoted_date`
+      // (abstract/quoting.rb:94-107). quoteArrayLiteral applies the `"..."`
+      // quoting, so the hook returns the bare form.
+      const literal = quoteArrayLiteral(value, (v) => (isDateLike(v) ? quotedDate(v) : undefined));
+      return `'${literal.replace(/'/g, "''")}'`;
+    }
+    return quoteScalar.call(this, value);
+  },
 };

--- a/packages/arel/src/visitors/index.ts
+++ b/packages/arel/src/visitors/index.ts
@@ -1,5 +1,5 @@
 export { ToSql, type ArelConnection, type ArelQuoter } from "./to-sql.js";
-export { defaultQuoter, mysqlDefaultQuoter } from "./default-quoter.js";
+export { defaultQuoter, mysqlDefaultQuoter, postgresqlDefaultQuoter } from "./default-quoter.js";
 export { substituteBoundValues } from "./substitute-bound-values.js";
 export {
   splitSchemaQualifiedName,

--- a/packages/arel/src/visitors/postgresql.ts
+++ b/packages/arel/src/visitors/postgresql.ts
@@ -11,6 +11,13 @@ import type { ArelConnection } from "./connection.js";
  * Mirrors: Arel::Visitors::PostgreSQL
  */
 export class PostgreSQL extends ToSql {
+  // Rails' Arel::Visitors::PostgreSQL defines no constructor — it inherits
+  // ToSql's, and @connection is always a real adapter. Trails constructs
+  // visitors with no connection (Node#toSql(), visitor unit tests), so the
+  // default has to name a PG-flavoured quoting host rather than the ANSI one.
+  // This is the only Rails-absent member here; the quote override it replaces
+  // was the larger deviation (Rails formats arrays in the adapter's quote —
+  // postgresql/quoting.rb:221-226 — never in the visitor).
   constructor(connection: ArelConnection = postgresqlDefaultQuoter) {
     super(connection);
   }

--- a/packages/arel/src/visitors/postgresql.ts
+++ b/packages/arel/src/visitors/postgresql.ts
@@ -2,7 +2,8 @@ import { Node } from "../nodes/node.js";
 import * as Nodes from "../nodes/index.js";
 import { SQLString } from "../collectors/sql-string.js";
 import { ToSql } from "./to-sql.js";
-import { quoteArrayLiteral } from "../quote-array.js";
+import { postgresqlDefaultQuoter } from "./default-quoter.js";
+import type { ArelConnection } from "./connection.js";
 
 /**
  * PostgreSQL visitor — extends generic ToSql with PostgreSQL-specific features.
@@ -10,6 +11,10 @@ import { quoteArrayLiteral } from "../quote-array.js";
  * Mirrors: Arel::Visitors::PostgreSQL
  */
 export class PostgreSQL extends ToSql {
+  constructor(connection: ArelConnection = postgresqlDefaultQuoter) {
+    super(connection);
+  }
+
   protected override visitArelNodesMatches(node: Nodes.Matches, collector: SQLString): SQLString {
     this.visitNodeOrValue(node.left, collector);
     collector.append(node.caseSensitive ? " LIKE " : " ILIKE ");
@@ -127,29 +132,6 @@ export class PostgreSQL extends ToSql {
     });
     collector.append(" )");
     return collector;
-  }
-
-  protected override quote(value: unknown): string {
-    if (Array.isArray(value)) {
-      const literal = quoteArrayLiteral(value, (v) => this.formatArrayDate(v));
-      return `'${literal.replace(/'/g, "''")}'`;
-    }
-    return super.quote(value);
-  }
-
-  // Mirrors Rails' `type_cast_array` → `type_cast` → `when Date, Time then
-  // quoted_date` (`abstract/quoting.rb:94-107`), so an array element matches
-  // the scalar path.
-  private formatArrayDate(value: unknown): string | undefined {
-    if (
-      typeof value === "object" &&
-      value !== null &&
-      "toISOString" in value &&
-      typeof (value as { toISOString: unknown }).toISOString === "function"
-    ) {
-      return this.quotedDate(value as { toISOString(): string });
-    }
-    return undefined;
   }
 }
 

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1943,14 +1943,15 @@ describe("ArelQuoter / defaultQuoter wiring", () => {
 
   it("Uint8Array in value position is routed through quoter.quote(), not String()", () => {
     // Guards against the String(Uint8Array) → comma-joined decimals ('31,139')
-    // corruption path. The connection receives the Uint8Array via quotedBinary
-    // and emits the correct dialect binary literal.
+    // corruption path. The visitor hands the raw value to `connection.quote`
+    // (to_sql.rb:867-870); the connection dispatches binary to quotedBinary and
+    // emits the correct dialect binary literal.
     const received: unknown[] = [];
     const stubQuoter: Visitors.ArelConnection = {
       quoteTableName: (name) => `"${name}"`,
       quoteColumnName: (name) => `"${name}"`,
       quoteString: (s) => s.replace(/'/g, "''"),
-      quote: (v) => `'${v}'`,
+      quote: (v) => (v instanceof Uint8Array ? stubQuoter.quotedBinary(v) : `'${v}'`),
       quotedBinary: (v) => {
         received.push(v);
         return v instanceof Uint8Array ? `'\\x${Buffer.from(v).toString("hex")}'` : `'${v}'`;

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1499,54 +1499,15 @@ export class ToSql extends Visitor {
     return this.injectJoin(node.values, " ", collector);
   }
 
+  /**
+   * Mirrors `to_sql.rb#quote` (to_sql.rb:867-870): SqlLiteral passes through,
+   * everything else is handed to the connection. Rails' Arel does no value
+   * formatting of its own — every date/array/binary decision lives in the
+   * adapter's `quote`. Connection-less visitors reach the default quoters in
+   * `default-quoter.ts`, which stand in for an adapter.
+   */
   protected quote(value: unknown): string {
-    if (value === null || value === undefined) return "NULL";
-    if (typeof value === "number") {
-      // Non-finite numbers (Float::INFINITY / NaN) must be string-quoted so
-      // PostgreSQL parses them as float literals rather than identifiers.
-      // SQLite/MySQL reject the values either way; delegate to connection.quote
-      // for adapter-specific handling.
-      if (!Number.isFinite(value)) return this.connection.quote(value);
-      return String(value);
-    }
-    if (typeof value === "boolean")
-      return value ? this.connection.quotedTrue() : this.connection.quotedFalse();
-    if (typeof value === "bigint") return value.toString();
-    // Normalise all typed-array views (ArrayBuffer, SharedArrayBuffer) to
-    // Uint8Array before handing off so adapters' quotedBinary can rely on a
-    // consistent shape. Uint8Array itself passes through unchanged.
-    if (ArrayBuffer.isView(value)) {
-      const bytes =
-        value instanceof Uint8Array
-          ? value
-          : new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
-      return this.connection.quotedBinary(bytes);
-    }
-    if (
-      typeof value === "object" &&
-      value !== null &&
-      "toISOString" in value &&
-      typeof (value as { toISOString: unknown }).toISOString === "function"
-    ) {
-      return `'${this.quotedDate(value as { toISOString(): string }).replace(/'/g, "''")}'`;
-    }
-    if (typeof value === "object" && value !== null) {
-      const proto = Object.getPrototypeOf(value);
-      const hasCustomToString =
-        proto === Object.prototype && value.toString !== Object.prototype.toString;
-      if ((proto === Object.prototype || proto === null) && !hasCustomToString) {
-        try {
-          const json = JSON.stringify(value);
-          if (json !== undefined) {
-            return `'${json.replace(/'/g, "''")}'`;
-          }
-        } catch {
-          // circular references, BigInt, etc. — fall through
-        }
-      }
-    }
-    // Unknown object types (custom classes, Temporal types without toISOString,
-    // etc.) — delegate to the connection, which knows the adapter-specific rules.
+    if (value instanceof Nodes.SqlLiteral) return value.value;
     return this.connection.quote(value);
   }
 
@@ -2039,9 +2000,9 @@ export class ToSql extends Visitor {
       "toISOString" in v &&
       typeof (v as { toISOString: unknown }).toISOString === "function"
     ) {
-      // Mirrors Rails quote behavior: date-like values are formatted and inlined.
-      // Only BindParam/ActiveModel::Attribute go through addBind.
-      collector.append(`'${this.quotedDate(v as { toISOString(): string }).replace(/'/g, "''")}'`);
+      // Mirrors Rails quote behavior: date-like values are formatted and inlined
+      // by the connection. Only BindParam/ActiveModel::Attribute go through addBind.
+      collector.append(this.quote(v));
     } else {
       // Unknown object types (e.g. Temporal.Instant) — defer to `quote()`
       // so the value is properly escaped/quoted rather than concatenated
@@ -2049,34 +2010,6 @@ export class ToSql extends Visitor {
       collector.append(this.quote(v));
     }
     return collector;
-  }
-
-  // Formats a date-like value as a SQL datetime string matching Rails'
-  // AbstractAdapter#quoted_date: YYYY-MM-DD HH:MM:SS[.microseconds].
-  // Returns the BARE form, as Rails does (`result = value.to_fs(:db)` plus the
-  // %06d usec suffix, abstract/quoting.rb:184-198) — callers add their own
-  // quoting (`"'#{quoted_date(value)}'"`, abstract/quoting.rb:99).
-  // When ms > 0 the fractional part is emitted as 6-digit microseconds,
-  // matching AR quoting.ts and preserving sub-second DB precision. When ms = 0
-  // the bare seconds form is used — matching Rails' default output for
-  // whole-second values.
-  //
-  // UTC handling: JS Date#toISOString() always appends Z; the regex also
-  // accepts strings without a trailing Z (treating absent timezone as UTC),
-  // which covers non-standard date-like objects. The Arel layer has no access
-  // to AR's defaultTimezone — adapter-level quoting in
-  // packages/activerecord/src/connection-adapters/abstract/quoting.ts is the
-  // authoritative path for timezone-aware bound values.
-  protected quotedDate(d: { toISOString(): string }): string {
-    // Matches "YYYY-MM-DDTHH:MM:SS.mmmZ", "YYYY-MM-DDTHH:MM:SSZ", or
-    // the same without trailing Z (treated as UTC).
-    const match = d.toISOString().match(/^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})(?:\.(\d+))?Z?$/);
-    if (!match) return d.toISOString();
-    const [, date, time, frac] = match;
-    // Normalise to exactly 6 digits: pad short fractions, truncate long ones.
-    // "729" → "729000" (μs), "7" → "700000", "1234" → "123400", "729000" → "729000".
-    const micros = frac ? parseInt((frac + "000000").slice(0, 6), 10) : 0;
-    return micros > 0 ? `${date} ${time}.${String(micros).padStart(6, "0")}` : `${date} ${time}`;
   }
 
   /**

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1994,19 +1994,12 @@ export class ToSql extends Visitor {
       collector.append(this.quote(v));
     } else if (typeof v === "bigint") {
       collector.append(v.toString());
-    } else if (
-      typeof v === "object" &&
-      v !== null &&
-      "toISOString" in v &&
-      typeof (v as { toISOString: unknown }).toISOString === "function"
-    ) {
-      // Mirrors Rails quote behavior: date-like values are formatted and inlined
-      // by the connection. Only BindParam/ActiveModel::Attribute go through addBind.
-      collector.append(this.quote(v));
     } else {
-      // Unknown object types (e.g. Temporal.Instant) — defer to `quote()`
-      // so the value is properly escaped/quoted rather than concatenated
-      // raw, matching the visitQuoted path.
+      // Everything else — dates, binary, Temporal types, unknown objects —
+      // defers to `quote()`, which hands the value to the connection. Rails'
+      // Arel does no date detection of its own, so there is no separate
+      // date-like branch here. Only BindParam/ActiveModel::Attribute go
+      // through addBind.
       collector.append(this.quote(v));
     }
     return collector;

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -19693,13 +19693,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/quoting.ts",
-    "rubyName": "quoted_binary",
-    "call": "to_s",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/quoting.ts",
     "rubyName": "quoted_date",
     "call": "getlocal",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Rails' `Arel::Visitors::ToSql#quote` is a two-line delegation (`vendor/rails/activerecord/lib/arel/visitors/to_sql.rb:867-870`): `SqlLiteral` passes through, everything else goes to `@connection.quote`. `Arel::Visitors::PostgreSQL` has no `quote` override at all, and Rails' Arel contains no `quoted_date` / array-encoding code — all of that lives in the adapter (`abstract/quoting.rb:94-107,184-196`; `postgresql/quoting.rb:221-226`).

Trails diverged: `visitors/to-sql.ts` owned a `quotedDate` and inlined number/boolean/binary/date/JSON formatting decisions, and `visitors/postgresql.ts` overrode `quote` to emit array literals via `quoteArrayLiteral`.

## What changed

- `ToSql#quote` is now the Rails two-liner: `SqlLiteral` passthrough, then `this.connection.quote(value)`.
- `quotedDate` and the scalar-formatting branches move onto the quoting hosts in `visitors/default-quoter.ts`. Those hosts are the documented residue: they stand in for an adapter on the connection-less `Node#toSql()` debug path, which Rails never has (Rails always has a `@connection`). Real adapters already own the authoritative, timezone-aware `quote`.
- New `postgresqlDefaultQuoter` carries the array-literal encoding for connection-less PG visitors, so the `PostgreSQL` visitor's `quote` override is gone. Its constructor default mirrors the existing `MySQL` precedent (`mysql.ts:14`) and is the one Rails-absent member here; it's anchored in a comment.
- `quoteArrayLiteral` is no longer part of the public `@blazetrails/arel` surface; its only caller is the PG quoting host.
- ArrayBuffer-view normalization moves to the adapter's `quote` (`abstract/quoting.ts`), self-dispatched through a new `dispatchQuotedBinary` mirroring the existing `dispatchQuotedDate` pattern — see "connected path" below.

## The connected path

The visitor change only alters behavior where a real adapter is the quoter, so that path got specific scrutiny:

- **Bare arrays.** The deleted PG override caught `Array.isArray(value)`, which the PG adapter's `quote` does not (it handles `ArrayData` — `postgresql/quoting.ts:147`). No connected caller relied on it: `insert-all.ts:709-710`, the one site that quotes array columns, serializes through the type to an `OID::Array` `Data` and quotes via `connection.quote(value)` itself, handing the visitor a `SqlLiteral`. Rails agrees that a bare array should raise (`abstract/quoting.rb` `quote`'s `else raise TypeError`; `encode_array` is reachable only via `OID::Array::Data`).
- **Binary.** All three adapters' `quote` handle `Uint8Array` directly, but the other ArrayBuffer views (`Int8Array`, `DataView`) previously relied on the visitor normalizing them. That normalization now lives in the adapter's `quote`, where Rails puts binary dispatch (`when Type::Binary::Data then quoted_binary(value)`), with a regression test.
- **JS `Date` — a deliberate caller-facing narrowing.** `visitNodeOrValue` used to call `quotedDate` unconditionally, so the Arel layer formatted any `toISOString()`-bearing value. It now routes through `quote`, and a connected adapter rejects a JS `Date`. This narrows a caller-facing surface, so it is recorded here rather than only in the test edit.

  It is intended, and it is not a new policy: `quote` and `typeCast` have both rejected JS `Date` since #939 ("feat(temporal): PR 6 — close the dual-typed window"), pinned by dedicated tests (`quoting.test.ts` "quote(new Date()) throws with Temporal guidance"; `postgresql/quoting.test.ts` "quote(new Date()) throws — Date is no longer accepted"). Rails' `when Date, Time then "'#{quoted_date(value)}'"` (`abstract/quoting.rb:85`) accepts the language's native time object; trails' analogue is **Temporal, not JS `Date`**, by that prior decision — so rb:85 is already ported onto the Temporal branches via `dispatchQuotedDate`. Growing a `Date` branch would revert #939, so the Arel visitor's tolerance was the outlier: it let a `Date` reach the DB formatted behind the adapter's back, on the one path AR's policy didn't cover.

  CI found the single caller relying on it (my earlier local runs missed that file): `default-scoping.test.ts`'s "sti association with unscoped not affected by default scope" passed `new Date()` to `updateAll`. Rails passes `Time.now` (`default_scoping_test.rb:611`); the test now passes `Temporal.Now.instant()`, the analogue AR's `quote` accepts. Name untouched; a grep confirmed it was the only such caller. The root cause that let an uncast value reach Arel at all — trails has no `_substituteValues`, so `update_all` inline-quotes instead of cast-and-binding — is registered as a follow-up.

- **Stale `@boundary-file` header.** That header claimed callers "may pass JS `Date` … the dispatcher branches on `instanceof Date` … and handles each separately", which the code contradicts (it raises). Pre-existing staleness, but this PR makes it load-bearing for the question above, so it now states the #939 policy and where rb:85 actually lands.

## Follow-ups (registered, not widened into this PR)

Three deviations were surfaced during review and deliberately left for their own stories rather than expanded here:

- `abstract-quote-binary-data-self-dispatch` — abstract `quote` has no `BinaryData` branch (rb:83 unported); the three adapters re-implement it and bypass self-dispatch for `Uint8Array`, so the same bytes take two dispatch paths depending on view type. Behaviorally a no-op today (each override delegates to the same module function), so it is a structural port across abstract + 3 adapters + tests. **Explicitly deferred, not overlooked** — the new `isView` branch's comment says so in place, and is careful not to claim to be the rb:83 port.
- `arel-visit-node-or-value-numerics-through-quote` — `visitNodeOrValue`'s `number`/`bigint` branches still bare-append instead of routing through `quote()` (`to_sql.rb:87-90`). Pre-existing, same deviation class this PR retires.
- `relation-substitute-values-casts-and-binds` — the root cause behind the `Date` finding: trails has no `_substituteValues` (`relation.rb:1381-1393`), so `update_all` values are inline-quoted instead of cast-and-bound.

## Verification

- `pnpm vitest run packages/arel/src packages/activerecord/src/scoping packages/activerecord/src/connection-adapters packages/activerecord/src/relation packages/activerecord/src/relations.test.ts packages/activerecord/src/persistence.test.ts packages/activerecord/src/insert-all.test.ts packages/activerecord/src/quoting.test.ts` — 4565 passed, 0 failed. PG/MySQL-gated suites run in CI (no local server).
- Deltas measured against a real `origin/main` baseline (checked out `packages/arel/src` from main and reran both tools), not just absolute numbers: `arel 701/705 (58/58 files)`, `activerecord 7635/7812 (315/320)`, `Data layer 7472/7474` — identical before and after, so both deltas are zero.

One test stub changed: the `Uint8Array ... routed through quoter.quote()` guard's fake connection now dispatches binary to its own `quotedBinary`, which is what a real adapter does. The guarantee it tests (no `String(Uint8Array)` corruption) is unchanged; the test name is untouched.

Closes-story: arel-quote-delegates-to-connection-like-rails
