### PR TITLE
fix(arel): route PG array booleans through unquoted_true/unquoted_false

### DIFF
--- a/packages/arel/src/quote-array.test.ts
+++ b/packages/arel/src/quote-array.test.ts
@@ -119,9 +119,8 @@ describe("quoteArrayLiteral", () => {
       // The encoder stage never inspects type — it sees only the text
       // `type_cast` produced. These strings need no quoting, so they emit bare
       // and become indistinguishable from the scalars they resemble, exactly
-      // as `PG::TextEncoder::Array` does. (The *boolean* `true` still encodes
-      // as `{TRUE}` until #4869 converges the type_cast arm onto
-      // `unquoted_true`; that divergence lives in the cast stage, not here.)
+      // as `PG::TextEncoder::Array` does — the boolean `true` also encodes
+      // bare, via `unquoted_true`.
       expect(quoteArrayLiteral(["true"], defaultQuoter)).toBe("{true}");
       expect(quoteArrayLiteral(["1"], defaultQuoter)).toBe("{1}");
     });

--- a/packages/arel/src/quote-array.test.ts
+++ b/packages/arel/src/quote-array.test.ts
@@ -1,95 +1,118 @@
 import { describe, it, expect } from "vitest";
 import { quoteArrayLiteral } from "./quote-array.js";
+import { defaultQuoter } from "./visitors/default-quoter.js";
 
 describe("quoteArrayLiteral", () => {
   it("formats simple string arrays", () => {
-    expect(quoteArrayLiteral(["a", "b", "c"])).toBe("{a,b,c}");
+    expect(quoteArrayLiteral(["a", "b", "c"], defaultQuoter)).toBe("{a,b,c}");
   });
 
   it("formats integer arrays", () => {
-    expect(quoteArrayLiteral([1, 2, 3])).toBe("{1,2,3}");
+    expect(quoteArrayLiteral([1, 2, 3], defaultQuoter)).toBe("{1,2,3}");
   });
 
   it("handles null elements", () => {
-    expect(quoteArrayLiteral(["a", null, "b"])).toBe("{a,NULL,b}");
+    expect(quoteArrayLiteral(["a", null, "b"], defaultQuoter)).toBe("{a,NULL,b}");
   });
 
   it("handles nested arrays", () => {
     expect(
-      quoteArrayLiteral([
-        [1, 2],
-        [3, 4],
-      ]),
+      quoteArrayLiteral(
+        [
+          [1, 2],
+          [3, 4],
+        ],
+        defaultQuoter,
+      ),
     ).toBe("{{1,2},{3,4}}");
   });
 
   it("escapes double quotes", () => {
-    expect(quoteArrayLiteral(['he said "hi"'])).toBe('{"he said \\"hi\\""}');
+    expect(quoteArrayLiteral(['he said "hi"'], defaultQuoter)).toBe('{"he said \\"hi\\""}');
   });
 
   it("escapes backslashes", () => {
-    expect(quoteArrayLiteral(["a\\b"])).toBe('{"a\\\\b"}');
+    expect(quoteArrayLiteral(["a\\b"], defaultQuoter)).toBe('{"a\\\\b"}');
   });
 
   it("handles booleans", () => {
-    expect(quoteArrayLiteral([true, false])).toBe("{TRUE,FALSE}");
+    // type_cast -> unquoted_true/false (abstract/quoting.rb:94-107); PG inherits
+    // Ruby true/false and the encoder leaves them bare. Verified against Ruby:
+    // PG::TextEncoder::Array.new.encode([true, false]) => "{true,false}".
+    expect(quoteArrayLiteral([true, false], defaultQuoter)).toBe("{true,false}");
+  });
+
+  describe("unquoted_true / unquoted_false", () => {
+    it("dispatches booleans through the connection's unquoted pair", () => {
+      // MySQL and SQLite both override the pair to 1/0 (mysql/quoting.rb:72-79,
+      // sqlite3/quoting.rb:87-97); a hard-coded TRUE/FALSE could never reach it.
+      const oneZero = { unquotedTrue: () => 1, unquotedFalse: () => 0 };
+      expect(quoteArrayLiteral([true, false], oneZero)).toBe("{1,0}");
+    });
+
+    it("dispatches nested array booleans through the connection too", () => {
+      const oneZero = { unquotedTrue: () => 1, unquotedFalse: () => 0 };
+      expect(quoteArrayLiteral([[true], false], oneZero)).toBe("{{1},0}");
+    });
   });
 
   it("handles Date values with toISOString", () => {
     const d = new Date("2026-03-26T12:00:00.000Z");
-    expect(quoteArrayLiteral([d])).toBe(`{${d.toISOString()}}`);
+    expect(quoteArrayLiteral([d], defaultQuoter)).toBe(`{${d.toISOString()}}`);
   });
 
   it("handles empty arrays", () => {
-    expect(quoteArrayLiteral([])).toBe("{}");
+    expect(quoteArrayLiteral([], defaultQuoter)).toBe("{}");
   });
 
   it("handles objects with toISOString", () => {
     const obj = { toISOString: () => "2026-01-01T00:00:00Z" };
-    expect(quoteArrayLiteral([obj])).toBe("{2026-01-01T00:00:00Z}");
+    expect(quoteArrayLiteral([obj], defaultQuoter)).toBe("{2026-01-01T00:00:00Z}");
   });
 
   it("handles bigint values inside objects", () => {
-    expect(quoteArrayLiteral([{ id: 42n }])).toBe('{"{\\"id\\":\\"42\\"}"}');
+    expect(quoteArrayLiteral([{ id: 42n }], defaultQuoter)).toBe('{"{\\"id\\":\\"42\\"}"}');
   });
 
   // Each expectation below was captured from `PG::TextEncoder::Array#encode`,
   // the encoder Rails hands the type_cast values to (`postgresql/quoting.rb:212`).
   describe("quotes elements by content, as PG::TextEncoder::Array does", () => {
     it("leaves an unambiguous element bare", () => {
-      expect(quoteArrayLiteral(["a"])).toBe("{a}");
+      expect(quoteArrayLiteral(["a"], defaultQuoter)).toBe("{a}");
     });
 
     it("quotes an empty element", () => {
-      expect(quoteArrayLiteral([""])).toBe('{""}');
+      expect(quoteArrayLiteral([""], defaultQuoter)).toBe('{""}');
     });
 
     it("quotes an element that would otherwise read as the NULL literal", () => {
-      expect(quoteArrayLiteral(["NULL"])).toBe('{"NULL"}');
-      expect(quoteArrayLiteral(["null"])).toBe('{"null"}');
-      expect(quoteArrayLiteral(["NuLl"])).toBe('{"NuLl"}');
+      expect(quoteArrayLiteral(["NULL"], defaultQuoter)).toBe('{"NULL"}');
+      expect(quoteArrayLiteral(["null"], defaultQuoter)).toBe('{"null"}');
+      expect(quoteArrayLiteral(["NuLl"], defaultQuoter)).toBe('{"NuLl"}');
     });
 
     it("leaves an element merely containing NULL bare", () => {
-      expect(quoteArrayLiteral(["NULLx", "xNULL"])).toBe("{NULLx,xNULL}");
+      expect(quoteArrayLiteral(["NULLx", "xNULL"], defaultQuoter)).toBe("{NULLx,xNULL}");
     });
 
     it("quotes an element containing whitespace", () => {
-      expect(quoteArrayLiteral(["a b"])).toBe('{"a b"}');
-      expect(quoteArrayLiteral([" a"])).toBe('{" a"}');
-      expect(quoteArrayLiteral(["a "])).toBe('{"a "}');
-      expect(quoteArrayLiteral(["a\tb"])).toBe('{"a\tb"}');
-      expect(quoteArrayLiteral(["a\nb"])).toBe('{"a\nb"}');
+      expect(quoteArrayLiteral(["a b"], defaultQuoter)).toBe('{"a b"}');
+      expect(quoteArrayLiteral([" a"], defaultQuoter)).toBe('{" a"}');
+      expect(quoteArrayLiteral(["a "], defaultQuoter)).toBe('{"a "}');
+      expect(quoteArrayLiteral(["a\tb"], defaultQuoter)).toBe('{"a\tb"}');
+      expect(quoteArrayLiteral(["a\nb"], defaultQuoter)).toBe('{"a\nb"}');
     });
 
     it("quotes an element containing a delimiter", () => {
-      expect(quoteArrayLiteral(["a,b"])).toBe('{"a,b"}');
-      expect(quoteArrayLiteral(["a{b"])).toBe('{"a{b"}');
-      expect(quoteArrayLiteral(["a}b"])).toBe('{"a}b"}');
+      expect(quoteArrayLiteral(["a,b"], defaultQuoter)).toBe('{"a,b"}');
+      expect(quoteArrayLiteral(["a{b"], defaultQuoter)).toBe('{"a{b"}');
+      expect(quoteArrayLiteral(["a}b"], defaultQuoter)).toBe('{"a}b"}');
     });
 
     it("leaves an element with other punctuation bare", () => {
-      expect(quoteArrayLiteral(["a.b", "a-b", "a|b", "a(b"])).toBe("{a.b,a-b,a|b,a(b}");
+      expect(quoteArrayLiteral(["a.b", "a-b", "a|b", "a(b"], defaultQuoter)).toBe(
+        "{a.b,a-b,a|b,a(b}",
+      );
     });
 
     it("leaves a string that reads as a literal bare", () => {
@@ -99,41 +122,44 @@ describe("quoteArrayLiteral", () => {
       // as `PG::TextEncoder::Array` does. (The *boolean* `true` still encodes
       // as `{TRUE}` until #4869 converges the type_cast arm onto
       // `unquoted_true`; that divergence lives in the cast stage, not here.)
-      expect(quoteArrayLiteral(["true"])).toBe("{true}");
-      expect(quoteArrayLiteral(["1"])).toBe("{1}");
+      expect(quoteArrayLiteral(["true"], defaultQuoter)).toBe("{true}");
+      expect(quoteArrayLiteral(["1"], defaultQuoter)).toBe("{1}");
     });
 
     it("leaves a bare nested array element unquoted", () => {
-      expect(quoteArrayLiteral([["x"]])).toBe("{{x}}");
+      expect(quoteArrayLiteral([["x"]], defaultQuoter)).toBe("{{x}}");
     });
 
     it("encodes a mixed array as the Ruby encoder does", () => {
-      // The hook stands in for the `unquoted_true` cast arm #4869 converges;
-      // without it the booleans would still cast to `TRUE`/`FALSE` here.
-      expect(
-        quoteArrayLiteral([true, false, "a", "2026-04-26 14:23:55", 1], (v) =>
-          typeof v === "boolean" ? String(v) : undefined,
-        ),
-      ).toBe('{true,false,a,"2026-04-26 14:23:55",1}');
+      // Booleans need no hook now that the cast arm dispatches to
+      // unquoted_true/unquoted_false. Matches Ruby exactly:
+      //   PG::TextEncoder::Array.new.encode([true, false, "a", "2026-04-26 14:23:55", 1])
+      expect(quoteArrayLiteral([true, false, "a", "2026-04-26 14:23:55", 1], defaultQuoter)).toBe(
+        '{true,false,a,"2026-04-26 14:23:55",1}',
+      );
     });
   });
 
   describe("formatElement", () => {
     it("quotes a formatted element whose content needs it", () => {
       const d = new Date("2026-03-26T12:00:00.000Z");
-      expect(quoteArrayLiteral([d], () => "2026-03-26 12:00:00")).toBe('{"2026-03-26 12:00:00"}');
+      expect(quoteArrayLiteral([d], defaultQuoter, () => "2026-03-26 12:00:00")).toBe(
+        '{"2026-03-26 12:00:00"}',
+      );
     });
 
     it("falls through to the default handling when it returns undefined", () => {
-      expect(quoteArrayLiteral(["a", 1], () => undefined)).toBe("{a,1}");
+      expect(quoteArrayLiteral(["a", 1], defaultQuoter, () => undefined)).toBe("{a,1}");
     });
 
     it("escapes quotes and backslashes in a formatted element", () => {
-      expect(quoteArrayLiteral(["x"], () => 'a\\b"c')).toBe('{"a\\\\b\\"c"}');
+      expect(quoteArrayLiteral(["x"], defaultQuoter, () => 'a\\b"c')).toBe('{"a\\\\b\\"c"}');
     });
 
     it("applies to nested array elements", () => {
-      expect(quoteArrayLiteral([["x"]], (v) => (v === "x" ? "X" : undefined))).toBe("{{X}}");
+      expect(quoteArrayLiteral([["x"]], defaultQuoter, (v) => (v === "x" ? "X" : undefined))).toBe(
+        "{{X}}",
+      );
     });
 
     it("is offered numbers and booleans, which Rails also sends through type_cast", () => {
@@ -141,7 +167,7 @@ describe("quoteArrayLiteral", () => {
       // to type_cast, so the hook must see numbers/booleans too. Without this
       // ordering a caller could never converge them (e.g. unquoted_true).
       const seen: unknown[] = [];
-      quoteArrayLiteral([1, true, "s"], (v) => {
+      quoteArrayLiteral([1, true, "s"], defaultQuoter, (v) => {
         seen.push(v);
         return undefined;
       });
@@ -151,7 +177,7 @@ describe("quoteArrayLiteral", () => {
     it("is offered nil, which Rails' type_cast takes through `when nil`", () => {
       const seen: unknown[] = [];
       expect(
-        quoteArrayLiteral([null], (v) => {
+        quoteArrayLiteral([null], defaultQuoter, (v) => {
           seen.push(v);
           return undefined;
         }),
@@ -160,7 +186,9 @@ describe("quoteArrayLiteral", () => {
     });
 
     it("lets the hook format a number element", () => {
-      expect(quoteArrayLiteral([1], (v) => (v === 1 ? "one" : undefined))).toBe("{one}");
+      expect(quoteArrayLiteral([1], defaultQuoter, (v) => (v === 1 ? "one" : undefined))).toBe(
+        "{one}",
+      );
     });
   });
 });

--- a/packages/arel/src/quote-array.ts
+++ b/packages/arel/src/quote-array.ts
@@ -1,3 +1,8 @@
+import type { ArelConnection } from "./visitors/connection.js";
+
+/** The slice of the connection an array element's `type_cast` needs. */
+export type ArrayElementQuoter = Pick<ArelConnection, "unquotedTrue" | "unquotedFalse">;
+
 /**
  * Type-casts an element to the text `PG::TextEncoder::Array` would be handed,
  * i.e. the BARE content — the encoder decides `"..."` quoting from that text.
@@ -45,14 +50,24 @@ function encodeArrayElement(text: string | null): string {
   return text;
 }
 
-function typeCastArrayElement(value: unknown, formatElement?: FormatArrayElement): string | null {
+function typeCastArrayElement(
+  value: unknown,
+  connection: ArrayElementQuoter,
+  formatElement?: FormatArrayElement,
+): string | null {
   const formatted = formatElement?.(value);
   if (formatted !== undefined) return formatted;
   // boundary: JS has no nil/undefined distinction to port — Rails' type_cast
   // takes nil through `when nil` and raises TypeError on anything unmapped.
   if (value === null || value === undefined) return null;
   if (typeof value === "number") return String(value);
-  if (typeof value === "boolean") return value ? "TRUE" : "FALSE";
+  // `when true then unquoted_true` / `when false then unquoted_false`
+  // (`abstract/quoting.rb:94-107`) — NOT the `quoted_true`/`quoted_false` pair
+  // `quote` uses (`:166-180`). PG inherits Ruby true/false, so this yields the
+  // bare `true` encodeArrayElement then leaves unquoted; MySQL and SQLite
+  // override the pair to 1/0.
+  if (typeof value === "boolean")
+    return String(value ? connection.unquotedTrue() : connection.unquotedFalse());
   // boundary: defensive Date formatting for caller-supplied array literals.
   // Duck-typed rather than `instanceof Date` so cross-realm dates and Temporal
   // land here too; a real Date satisfies it, so it needs no arm of its own.
@@ -80,13 +95,17 @@ function typeCastArrayElement(value: unknown, formatElement?: FormatArrayElement
  *
  * Shared between the Arel PostgreSQL visitor and ActiveRecord's inline SQL quoting.
  */
-export function quoteArrayLiteral(arr: unknown[], formatElement?: FormatArrayElement): string {
+export function quoteArrayLiteral(
+  arr: unknown[],
+  connection: ArrayElementQuoter,
+  formatElement?: FormatArrayElement,
+): string {
   const elements = arr.map((v) => {
     // Nested arrays recurse before the hook, per `type_cast_array`'s
     // `when ::Array` arm; every other element is offered to it uniformly,
     // as Rails dispatches all non-array elements into `type_cast`.
-    if (Array.isArray(v)) return quoteArrayLiteral(v, formatElement);
-    return encodeArrayElement(typeCastArrayElement(v, formatElement));
+    if (Array.isArray(v)) return quoteArrayLiteral(v, connection, formatElement);
+    return encodeArrayElement(typeCastArrayElement(v, connection, formatElement));
   });
   return `{${elements.join(",")}}`;
 }

--- a/packages/arel/src/visitors/connection.ts
+++ b/packages/arel/src/visitors/connection.ts
@@ -24,6 +24,18 @@ export interface ArelConnection {
   /** @internal */
   quotedFalse(): string;
   /**
+   * The bare (un-quoted) boolean literals. Rails' `type_cast` uses this pair —
+   * not `quoted_true`/`quoted_false` — for booleans (`abstract/quoting.rb:94-107`),
+   * and PostgreSQL's `encode_array` routes every array element through
+   * `type_cast_array` -> `type_cast`. MySQL and SQLite both override the pair to
+   * `1`/`0` (`mysql/quoting.rb:72-79`, `sqlite3/quoting.rb:87-97`), so array
+   * elements must dispatch through the connection to reach the right literal.
+   * @internal
+   */
+  unquotedTrue(): boolean | number;
+  /** @internal */
+  unquotedFalse(): boolean | number;
+  /**
    * Sanitize a string for inclusion inside a SQL comment (optimizer hints,
    * query annotations). Mirrors Rails' `@connection.sanitize_as_sql_comment`,
    * which the Arel visitor delegates to so each adapter applies its own

--- a/packages/arel/src/visitors/default-quoter.ts
+++ b/packages/arel/src/visitors/default-quoter.ts
@@ -121,6 +121,16 @@ export const mysqlDefaultQuoter: ArelConnection = {
     return "FALSE";
   },
 
+  // Mirrors ActiveRecord MySQL::Quoting — `quoted_true`/`quoted_false` are
+  // inherited, but the unquoted pair is overridden to 1/0
+  // (`mysql/quoting.rb:72-79`).
+  unquotedTrue(): number {
+    return 1;
+  },
+  unquotedFalse(): number {
+    return 0;
+  },
+
   // Mirrors ActiveRecord MySQL::Quoting#cast_bound_value: numerics/booleans
   // serialize to their string form (1/0 for booleans) before binding.
   castBoundValue(value: unknown): unknown {
@@ -175,6 +185,16 @@ export const defaultQuoter: ArelConnection = {
     return "FALSE";
   },
 
+  // Mirrors ActiveRecord Quoting#unquoted_true/#unquoted_false: the abstract
+  // adapter returns Ruby true/false (`abstract/quoting.rb:170-180`). PostgreSQL
+  // does not override the pair, so it inherits these.
+  unquotedTrue(): boolean {
+    return true;
+  },
+  unquotedFalse(): boolean {
+    return false;
+  },
+
   // Mirrors ActiveRecord Quoting#cast_bound_value: the abstract adapter
   // returns the value unchanged.
   castBoundValue(value: unknown): unknown {
@@ -202,7 +222,9 @@ export const postgresqlDefaultQuoter: ArelConnection = {
       // `type_cast_array` → `type_cast` → `when Date, Time then quoted_date`
       // (abstract/quoting.rb:94-107). quoteArrayLiteral applies the `"..."`
       // quoting, so the hook returns the bare form.
-      const literal = quoteArrayLiteral(value, (v) => (isDateLike(v) ? quotedDate(v) : undefined));
+      const literal = quoteArrayLiteral(value, this, (v) =>
+        isDateLike(v) ? quotedDate(v) : undefined,
+      );
       return `'${literal.replace(/'/g, "''")}'`;
     }
     return quoteScalar.call(this, value);

--- a/packages/arel/src/visitors/postgres.test.ts
+++ b/packages/arel/src/visitors/postgres.test.ts
@@ -380,6 +380,18 @@ describe("PostgresTest", () => {
       const sql = new Visitors.PostgreSQL().compile(users.get("ats").eq([[d]]));
       expect(sql).toContain("'{{\"2026-04-26 14:23:55\"}}'");
     });
+
+    it("emits boolean array elements unquoted, as encode_array does", () => {
+      // PostgreSQL does not override unquoted_true (only mysql/quoting.rb:72 and
+      // sqlite3/quoting.rb:87 do), so it inherits Ruby true/false and
+      // encode_array emits '{true,false}'. The scalar path keeps quoted_true's
+      // TRUE — the two pairs legitimately differ.
+      const sql = new Visitors.PostgreSQL().compile(users.get("flags").eq([true, false]));
+      expect(sql).toContain("'{true,false}'");
+
+      const scalar = new Visitors.PostgreSQL().compile(users.get("flag").eq(true));
+      expect(scalar).toContain("TRUE");
+    });
   });
 });
 

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1934,6 +1934,8 @@ describe("ArelQuoter / defaultQuoter wiring", () => {
       quotedBinary: (v) => `'${v}'`,
       quotedTrue: () => "TRUE",
       quotedFalse: () => "FALSE",
+      unquotedTrue: () => true,
+      unquotedFalse: () => false,
       sanitizeAsSqlComment: (v) => v,
       castBoundValue: (v) => v,
     };
@@ -1958,6 +1960,8 @@ describe("ArelQuoter / defaultQuoter wiring", () => {
       },
       quotedTrue: () => "TRUE",
       quotedFalse: () => "FALSE",
+      unquotedTrue: () => true,
+      unquotedFalse: () => false,
       sanitizeAsSqlComment: (v) => v,
       castBoundValue: (v) => v,
     };


### PR DESCRIPTION
## What

Rails' `type_cast` sends booleans through **`unquoted_true`/`unquoted_false`**
(`abstract/quoting.rb:94-107`), not the `quoted_true`/`quoted_false` pair `quote`
uses (`:166-180`):

```ruby
when true       then unquoted_true
when false      then unquoted_false
```

PostgreSQL's `encode_array` → `type_cast_array` → `type_cast` routes every array
element through that same arm. trails' cast arm hard-coded `TRUE`/`FALSE`, which
#4872's content-based encoder then correctly left bare — as `'{TRUE,FALSE}'`.
Rails emits `'{true,false}'`.

## Why bare `true`, not `{"true"}` or `{t}`

PG overrides **neither** `quoted_true` nor `unquoted_true` — only
`mysql/quoting.rb:72-79` and `sqlite3/quoting.rb:87-97` do, and **both return
integer `1`/`0`**. (The story Context claimed SQLite returns `"t"`; that is
wrong — `quoted_true` there is the *string* `"1"`, which is likely the source of
the confusion. Caught in review.)

So PG inherits Ruby `true`, and the encoder leaves it bare because `"true"`
carries no delimiter, whitespace, quote or backslash. Verified against Ruby:

```ruby
PG::TextEncoder::Array.new.encode([true, false, "a", "2026-04-26 14:23:55", 1])
# => {true,false,a,"2026-04-26 14:23:55",1}
```

Against PG this is cosmetic (it parses boolean input case-insensitively), so this
is a **fidelity/structural** fix, not a live bug. The teeth are in the dispatch:
MySQL and SQLite both need `1`/`0`, which a hard-coded `TRUE`/`FALSE` can never
reach.

## Shape

Rebased onto #4868 (`quote` delegates to the connection) and #4872 (quote array
elements by content). #4872 split the function into the two Rails stages —
`typeCastArrayElement` returning bare text, `encodeArrayElement` deciding quoting
from content — and **explicitly deferred the boolean arm to this PR**:

> `// The hook stands in for the unquoted_true cast arm #4869 converges;`
> `// without it the booleans would still cast to TRUE/FALSE here.`

This fills that arm in. `typeCastArrayElement` now takes the connection and
dispatches `when true then unquoted_true`, mirroring Rails, so:

- the workaround hook in #4872's mixed-array test is **removed** — the literal
  now matches the Ruby encoder natively;
- `unquotedTrue()/unquotedFalse()` join `ArelConnection` (typed `boolean | number`,
  matching `abstract/quoting-interface.ts:55-58`), supplied by the abstract host
  (`true`/`false`, which PG inherits) and the MySQL host (`1`/`0`);
- the scalar path is untouched — `quote` keeps `quoted_true`'s `TRUE`. The two
  pairs legitimately differ in Rails, and a test pins both halves.

## Scope note (changed by #4868)

The reachable surface narrowed. After #4868 the **real** PG adapter raises
`TypeError: can't quote Array` on a bare JS array — which is faithful: Rails' PG
`quote` only encodes an `OID::Array::Data` (`postgresql/quoting.rb:117`) and
sends a bare `::Array` to `super`. So `quoteArrayLiteral` is now reached only via
`postgresqlDefaultQuoter`, the connection-less host that stands in for an adapter
on the `Node#toSql()` debug path. Earlier revisions of this PR verified against
the live adapter; that path no longer exists, and the verification below targets
the actual call site instead.

## Verification

- `pnpm typecheck`, `eslint`, `prettier --check` clean; all **1484**
  `packages/arel` tests pass (including #4872's and #4867's, unmodified except
  for the now-unnecessary boolean workaround).
- Exercised at the real call site, `postgresqlDefaultQuoter.quote(...)`:
  `[true, false]` → `'{true,false}'`; `[true, false, "a", d, 1]` →
  `'{true,false,a,"2026-04-26 14:23:55",1}'` (exactly the Ruby transcript above);
  scalar `true` → `TRUE`; MySQL host pair → `1`/`0`.

## Surfaced in review, deliberately NOT fixed here

`packages/activerecord/src/connection-adapters/postgresql/quoting.ts` declares
and exports `quotedTrue`/`unquotedTrue`/`quotedFalse`/`unquotedFalse`. Rails'
`postgresql/quoting.rb` defines **none** of the four — PG inherits them from
`abstract/quoting.rb:165-180`, and that inheritance is exactly why `encode_array`
emits `'{true}'`. They also look dead: `postgresql-adapter.ts` imports twelve
symbols from that module and none of these, and `AbstractAdapter` already
supplies the pair at `:840-846`.

Left alone here on purpose — different package, and it moves the api:compare
surface. Registered as `drop-pg-quoting-boolean-literal-extras`
(0023-surfaced-deviations), status `ready`.

**To the next reviewer:** a prior pass concluded these declarations "no longer
exist" and that no follow-up was needed. They do exist, on this branch and on
`origin/main` — `grep -rn "unquotedTrue" packages/activerecord/src/connection-adapters/`
returns hits at `postgresql/quoting.ts:52,54,80,88`. The story stays open.

Closes-story: converge-arel-array-booleans-to-unquoted-true
