### PR TITLE
refactor(quoting): abstract quote self-dispatches Type::Binary::Data

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1028,9 +1028,11 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   quotedBinary(value: unknown): string {
-    // The standalone accepts BinaryData too, so the Rails-shaped call
-    // (`quoted_binary(Type::Binary::Data)`, mysql/quoting.rb:80) works here.
-    return mysqlQuotedBinary(value as Buffer | Uint8Array | string | BinaryData);
+    // The standalone accepts BinaryData and ArrayBuffer too (both via toBytes),
+    // so the Rails-shaped call (`quoted_binary(Type::Binary::Data)`,
+    // mysql/quoting.rb:80) works here and the union matches the PG/SQLite
+    // overrides. It raises on anything else rather than hexing garbage.
+    return mysqlQuotedBinary(value as Buffer | Uint8Array | ArrayBuffer | string | BinaryData);
   }
 
   unquoteIdentifier(identifier: string | null | undefined): string | null {

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1028,10 +1028,11 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   quotedBinary(value: unknown): string {
-    // The standalone accepts BinaryData and ArrayBuffer too (both via toBytes),
-    // so the Rails-shaped call (`quoted_binary(Type::Binary::Data)`,
-    // mysql/quoting.rb:80) works here and the union matches the PG/SQLite
-    // overrides. It raises on anything else rather than hexing garbage.
+    // The standalone shares the `toBytes` byte union (Uint8Array/ArrayBuffer/
+    // Buffer/BinaryData) with the PG and SQLite overrides, so the Rails-shaped
+    // call (`quoted_binary(Type::Binary::Data)`, mysql/quoting.rb:80) works here
+    // and raises on a non-byte source rather than hexing garbage. The latin1
+    // `string` form on top is MySQL's own (PG accepts one too; SQLite rejects it).
     return mysqlQuotedBinary(value as Buffer | Uint8Array | ArrayBuffer | string | BinaryData);
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -94,6 +94,7 @@ import {
   FloatType,
   BooleanType,
   BinaryType,
+  BinaryData,
   DecimalType,
 } from "@blazetrails/activemodel";
 
@@ -1027,7 +1028,9 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   quotedBinary(value: unknown): string {
-    return mysqlQuotedBinary(value as Buffer | Uint8Array | string);
+    // The standalone accepts BinaryData too, so the Rails-shaped call
+    // (`quoted_binary(Type::Binary::Data)`, mysql/quoting.rb:80) works here.
+    return mysqlQuotedBinary(value as Buffer | Uint8Array | string | BinaryData);
   }
 
   unquoteIdentifier(identifier: string | null | undefined): string | null {

--- a/packages/activerecord/src/connection-adapters/abstract/quoting-helpers.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting-helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
+import { BinaryData } from "@blazetrails/activemodel";
 import { quote, quoteTableName, quotedDate, quotedTime, typeCast } from "./quoting.js";
 
 describe("quotedDate", () => {
@@ -79,6 +80,34 @@ describe("quote dispatches through quoted_date/quoted_time", () => {
   it("falls back to the module quoted_time helper for PlainTime without a host", () => {
     const v = Temporal.PlainTime.from("14:23:55");
     expect(quote.call({}, v)).toBe("'14:23:55'");
+  });
+});
+
+describe("quote dispatches through quoted_binary", () => {
+  it("routes Type::Binary::Data through this.quotedBinary", () => {
+    const host = { quotedBinary: () => "DISPATCHED_BINARY" };
+    expect(quote.call(host, new BinaryData(new Uint8Array([0xde, 0xad])))).toBe(
+      "DISPATCHED_BINARY",
+    );
+  });
+
+  it("passes the unwrapped bytes to this.quotedBinary", () => {
+    let received: unknown;
+    const host = {
+      quotedBinary: (value: unknown) => {
+        received = value;
+        return "";
+      },
+    };
+    const bytes = new Uint8Array([0xde, 0xad]);
+    quote.call(host, new BinaryData(bytes));
+    expect(received).toBe(bytes);
+  });
+
+  it("falls back to the module quoted_binary helper without a host", () => {
+    // Rails' abstract quoted_binary is `"'#{quote_string(value.to_s)}'"` —
+    // the raw byte string, not a comma-joined element list.
+    expect(quote.call({}, new BinaryData("ab"))).toBe("'ab'");
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/abstract/quoting-helpers.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting-helpers.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { BinaryData } from "@blazetrails/activemodel";
-import { quote, quoteTableName, quotedDate, quotedTime, typeCast } from "./quoting.js";
+import {
+  quote,
+  quoteTableName,
+  quotedBinary,
+  quotedDate,
+  quotedTime,
+  typeCast,
+} from "./quoting.js";
 
 describe("quotedDate", () => {
   it("formats a Temporal.Instant as UTC datetime string", () => {
@@ -108,6 +115,13 @@ describe("quote dispatches through quoted_binary", () => {
     // Rails' abstract quoted_binary is `"'#{quote_string(value.to_s)}'"` —
     // the raw byte string, not a comma-joined element list.
     expect(quote.call({}, new BinaryData("ab"))).toBe("'ab'");
+  });
+
+  it("normalises ArrayBuffer in the module quoted_binary fallback", () => {
+    // SQLite's boundary branch dispatches ArrayBuffer; String(arraybuffer) would
+    // emit '[object ArrayBuffer]'.
+    expect(quotedBinary(new Uint8Array([0x61, 0x62]).buffer)).toBe("'ab'");
+    expect(quotedBinary(new Uint8Array([0x61, 0x62]))).toBe("'ab'");
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/abstract/quoting-helpers.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting-helpers.test.ts
@@ -117,11 +117,25 @@ describe("quote dispatches through quoted_binary", () => {
     expect(quote.call({}, new BinaryData("ab"))).toBe("'ab'");
   });
 
-  it("normalises ArrayBuffer in the module quoted_binary fallback", () => {
-    // SQLite's boundary branch dispatches ArrayBuffer; String(arraybuffer) would
-    // emit '[object ArrayBuffer]'.
-    expect(quotedBinary(new Uint8Array([0x61, 0x62]).buffer)).toBe("'ab'");
+  it("normalises every byte source in the module quoted_binary fallback", () => {
+    // SQLite's boundary branch dispatches ArrayBuffer, and Rails' signature
+    // (abstract/quoting.rb:206) takes the Data itself.
     expect(quotedBinary(new Uint8Array([0x61, 0x62]))).toBe("'ab'");
+    expect(quotedBinary(new Uint8Array([0x61, 0x62]).buffer)).toBe("'ab'");
+    expect(quotedBinary(new BinaryData("ab"))).toBe("'ab'");
+  });
+
+  it("keeps non-UTF-8 bytes byte-exact in the module quoted_binary fallback", () => {
+    // Rails' `value.to_s` returns a BINARY-encoded String, so quoted_binary is
+    // byte-exact. BinaryData#toString() UTF-8-decodes, which turns invalid
+    // sequences into U+FFFD — String(value) would silently corrupt 0xde 0xad
+    // 0xbe 0xef into 3 replacement chars. Normalise to bytes instead.
+    const bytes = [0xde, 0xad, 0xbe, 0xef];
+    const expected = `'${bytes.map((b) => String.fromCharCode(b)).join("")}'`;
+    expect(quotedBinary(new BinaryData(new Uint8Array(bytes)))).toBe(expected);
+    expect(quotedBinary(new Uint8Array(bytes))).toBe(expected);
+    expect(Array.from(quotedBinary(new Uint8Array(bytes)).slice(1, -1), (c) => c.charCodeAt(0))) //
+      .toEqual(bytes);
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -450,7 +450,10 @@ export function isSqlLiteral(value: unknown): value is { value: string } {
  *
  * Takes `unknown` rather than `Uint8Array`: the rb:83 branch passes a
  * `BinaryData`'s bytes, but SQLite's boundary branch dispatches a raw
- * `ArrayBuffer`, and every `quotedBinary` normalises through {@link toBytes}.
+ * `ArrayBuffer`, and the abstract/MySQL/SQLite `quotedBinary` normalise through
+ * {@link toBytes} (PG's exception is noted there — it is unreachable from this
+ * dispatch, which only sees a raw `ArrayBuffer` from SQLite's branch, with a
+ * SQLite host).
  * @internal
  */
 export function dispatchQuotedBinary(host: QuotingDispatchHost, value: unknown): string {

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -98,9 +98,17 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
   // and quoted bare — Rails: `when BigDecimal then value.to_s("F")`.
   if (value instanceof BigDecimal) return value.toString("F");
   if (typeof value === "number" || typeof value === "bigint") return String(value);
-  // Rails: `when Type::Binary::Data then quoted_binary(value)` — self-dispatched
-  // so an adapter's `quoted_binary` override (PG's bytea escape, MySQL/SQLite's
-  // `x'..'` hex) is honored. Thread `this` to mirror that.
+  // Rails: `when Type::Binary::Data then quoted_binary(value)` (rb:83) —
+  // self-dispatched so an adapter's `quoted_binary` override (PG's bytea escape,
+  // MySQL/SQLite's `x'..'` hex) is honored. Thread `this` to mirror that.
+  //
+  // Deviation: Rails passes the `Type::Binary::Data` itself and each override
+  // unwraps it (`value.to_s` / `value.hex`); we pass the unwrapped bytes, so
+  // trails' `quotedBinary` implementations take a byte source instead. This is
+  // what lets the adapters' raw-view boundary branches (Uint8Array/ArrayBuffer,
+  // which Rails never sees here) share one dispatch path with `BinaryData`.
+  // Consequence: a Rails-shaped override calling `value.hex()` would not work
+  // here — trails overrides must accept bytes.
   if (value instanceof BinaryData) return dispatchQuotedBinary(this, value.bytes);
   // Rails dispatches date/time literals through `self.quoted_time` (Time::Value)
   // and `self.quoted_date` (Date/Time) so adapter overrides — e.g. PostgreSQL's
@@ -310,9 +318,18 @@ export function unquotedFalse(): boolean {
 export function quotedBinary(value: unknown): string {
   // Rails quotes `value.to_s` — for `Type::Binary::Data` that is the raw byte
   // string, not a comma-joined element list. `String(uint8array)` would yield
-  // "1,2,3", so decode byte-for-byte first.
-  if (value instanceof Uint8Array) {
-    return `'${quoteString(Array.from(value, (b) => String.fromCharCode(b)).join(""))}'`;
+  // "1,2,3" and `String(arraybuffer)` "[object ArrayBuffer]", so normalise both
+  // byte sources first. `dispatchQuotedBinary` receives raw views from the
+  // adapters' boundary branches (SQLite's passes ArrayBuffer), and this is the
+  // fallback when a host defines no `quotedBinary`.
+  const bytes =
+    value instanceof Uint8Array
+      ? value
+      : value instanceof ArrayBuffer
+        ? new Uint8Array(value)
+        : null;
+  if (bytes) {
+    return `'${quoteString(Array.from(bytes, (b) => String.fromCharCode(b)).join(""))}'`;
   }
   return `'${quoteString(String(value))}'`;
 }

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -31,6 +31,8 @@ import {
  */
 export interface QuotingDispatchHost {
   /** @internal */
+  quote?(value: unknown): string;
+  /** @internal */
   quotedDate?(value: TemporalDateLike): string;
   /** @internal */
   quotedTime?(value: Temporal.PlainTime | Temporal.PlainDateTime): string;
@@ -103,12 +105,15 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
   // MySQL/SQLite's `x'..'` hex) is honored. Thread `this` to mirror that.
   //
   // Deviation: Rails passes the `Type::Binary::Data` itself and each override
-  // unwraps it (`value.to_s` / `value.hex`); we pass the unwrapped bytes, so
-  // trails' `quotedBinary` implementations take a byte source instead. This is
-  // what lets the adapters' raw-view boundary branches (Uint8Array/ArrayBuffer,
-  // which Rails never sees here) share one dispatch path with `BinaryData`.
-  // Consequence: a Rails-shaped override calling `value.hex()` would not work
-  // here — trails overrides must accept bytes.
+  // unwraps it (`value.to_s` / `value.hex`); we pass the unwrapped bytes, which
+  // is what lets the adapters' raw-view boundary branches (Uint8Array/
+  // ArrayBuffer, which Rails never sees here) share one dispatch path with
+  // `BinaryData`. Every trails `quotedBinary` therefore accepts the union —
+  // Data *and* raw views — so a Rails-shaped `quotedBinary(data)` call still
+  // works; only an override that assumed a `Data` arg (reading `.hex()` off it)
+  // would see bytes instead. The root cause is that `BinaryType#serialize`
+  // returns bare bytes rather than Rails' `Data.new(super)`; converging that is
+  // story `binary-type-serialize-returns-data-wrapper` (RFC 0023).
   if (value instanceof BinaryData) return dispatchQuotedBinary(this, value.bytes);
   // Rails dispatches date/time literals through `self.quoted_time` (Time::Value)
   // and `self.quoted_date` (Date/Time) so adapter overrides — e.g. PostgreSQL's
@@ -254,10 +259,13 @@ export function quoteDefaultExpression(
     );
   }
   if (isSqlLiteral(value)) return ` DEFAULT ${value.value}`;
-  // `quote` requires a host receiver; thread our own (the adapter-free
-  // ABSTRACT_SCHEMA_QUOTER / mysql schema-quoter bind `this` to the quoter
-  // object, an empty QuotingDispatchHost that falls back to module helpers).
-  return ` DEFAULT ${quote.call(this || {}, value)}`;
+  // Rails: `quote(value)` (abstract/quoting.rb:162) — self-dispatched, so a host
+  // that overrides `quote` (the mysql schema-quoter binds the dialect's) gets its
+  // own dialect quoting, including the raw-view branches the abstract `quote`
+  // deliberately lacks. Falling straight to the module `quote` here would bypass
+  // the dialect entirely and raise `can't quote Uint8Array` on a binary default.
+  // Hosts without a `quote` (ABSTRACT_SCHEMA_QUOTER) keep the module helper.
+  return ` DEFAULT ${dispatchQuote(this || {}, value)}`;
 }
 
 /**
@@ -311,23 +319,37 @@ export function unquotedFalse(): boolean {
 }
 
 /**
+ * Normalise every byte source `quotedBinary` may receive to a `Uint8Array`, or
+ * `null` if the value is not one. Rails' `quoted_binary` family takes a
+ * `Type::Binary::Data` and calls `value.to_s` / `value.hex`; trails' `quote`
+ * unwraps to bytes before dispatching, and the adapters' boundary branches pass
+ * raw views — so every implementation must accept the union.
+ *
+ * @internal
+ */
+export function toBytes(value: unknown): Uint8Array | null {
+  if (value instanceof BinaryData) return value.bytes;
+  if (value instanceof Uint8Array) return value;
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  return null;
+}
+
+/**
  * Quote binary data for SQL.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quoted_binary
  */
 export function quotedBinary(value: unknown): string {
-  // Rails quotes `value.to_s` — for `Type::Binary::Data` that is the raw byte
-  // string, not a comma-joined element list. `String(uint8array)` would yield
-  // "1,2,3" and `String(arraybuffer)` "[object ArrayBuffer]", so normalise both
-  // byte sources first. `dispatchQuotedBinary` receives raw views from the
-  // adapters' boundary branches (SQLite's passes ArrayBuffer), and this is the
-  // fallback when a host defines no `quotedBinary`.
-  const bytes =
-    value instanceof Uint8Array
-      ? value
-      : value instanceof ArrayBuffer
-        ? new Uint8Array(value)
-        : null;
+  // Rails quotes `value.to_s`, which for `Type::Binary::Data` is a BINARY-encoded
+  // String — byte-exact. `String(value)` can't stand in for it: for a Uint8Array
+  // it yields "1,2,3", for an ArrayBuffer "[object ArrayBuffer]", and for a
+  // BinaryData it runs `toString()`, which UTF-8-decodes and silently replaces
+  // any invalid sequence with U+FFFD (0xde 0xad 0xbe 0xef → 3 lossy chars). So
+  // normalise every byte source and map bytes 1:1 instead. Rails' signature takes
+  // the `Data` itself (rb:206), so accept it even though our `quote` unwraps
+  // first; `dispatchQuotedBinary` also receives raw views from the adapters'
+  // boundary branches (SQLite's passes ArrayBuffer).
+  const bytes = toBytes(value);
   if (bytes) {
     return `'${quoteString(Array.from(bytes, (b) => String.fromCharCode(b)).join(""))}'`;
   }
@@ -399,6 +421,19 @@ export function dispatchQuotedDate(host: QuotingDispatchHost, value: TemporalDat
     return host.quotedDate(value);
   }
   return quotedDate(value);
+}
+
+/**
+ * Dispatch through the host's `quote` override if it defines one, else the
+ * module-level helper. Mirrors Rails' bare `quote(value)` self-dispatch inside
+ * `quote_default_expression` (abstract/quoting.rb:162).
+ * @internal
+ */
+export function dispatchQuote(host: QuotingDispatchHost, value: unknown): string {
+  if (typeof host.quote === "function") {
+    return host.quote(value);
+  }
+  return quote.call(host, value);
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -336,7 +336,15 @@ export function unquotedFalse(): boolean {
  * `null` if the value is not one. Rails' `quoted_binary` family takes a
  * `Type::Binary::Data` and calls `value.to_s` / `value.hex`; trails' `quote`
  * unwraps to bytes before dispatching, and the adapters' boundary branches pass
- * raw views — so every implementation must accept the union.
+ * raw views — so an implementation has to accept that union to be callable
+ * either way.
+ *
+ * The abstract, MySQL and SQLite `quotedBinary` route through this. PG's
+ * hand-rolls the unwrap instead and omits `ArrayBuffer` from its signature, so
+ * a direct `pgQuotedBinary(dataView)` raises where the other two hex it —
+ * unreachable via `quote` (which normalises views first) and via PG's own
+ * adapter override (which handles `ArrayBuffer` separately). Converging it is
+ * story `pg-quoted-binary-route-through-tobytes` (RFC 0023).
  *
  * @internal
  */

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -10,7 +10,7 @@
 
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { BigDecimal } from "@blazetrails/activesupport";
-import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
+import { Attribute as ModelAttribute, BinaryData } from "@blazetrails/activemodel";
 import { NotImplementedError } from "../../errors.js";
 import type { SchemaQuoter } from "./assert-schema-adapter.js";
 import {
@@ -26,13 +26,16 @@ import {
  * Threading `this` lets an adapter override (e.g. PostgreSQL's BC-aware
  * `quotedDate`) flow into the inherited `quote`. A host receiver is required —
  * every invocation goes through an adapter via `.call(this, value)`; a host
- * that omits `quotedDate` / `quotedTime` falls back to the module-level helpers.
+ * that omits `quotedDate` / `quotedTime` / `quotedBinary` falls back to the
+ * module-level helpers.
  */
 export interface QuotingDispatchHost {
   /** @internal */
   quotedDate?(value: TemporalDateLike): string;
   /** @internal */
   quotedTime?(value: Temporal.PlainTime | Temporal.PlainDateTime): string;
+  /** @internal */
+  quotedBinary?(value: unknown): string;
   /** @internal */
   quoteColumnName?(name: string): string;
 }
@@ -95,6 +98,10 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
   // and quoted bare — Rails: `when BigDecimal then value.to_s("F")`.
   if (value instanceof BigDecimal) return value.toString("F");
   if (typeof value === "number" || typeof value === "bigint") return String(value);
+  // Rails: `when Type::Binary::Data then quoted_binary(value)` — self-dispatched
+  // so an adapter's `quoted_binary` override (PG's bytea escape, MySQL/SQLite's
+  // `x'..'` hex) is honored. Thread `this` to mirror that.
+  if (value instanceof BinaryData) return dispatchQuotedBinary(this, value.bytes);
   // Rails dispatches date/time literals through `self.quoted_time` (Time::Value)
   // and `self.quoted_date` (Date/Time) so adapter overrides — e.g. PostgreSQL's
   // BC-suffixing `quoted_date` — are honored. Thread `this` to mirror that.
@@ -301,6 +308,12 @@ export function unquotedFalse(): boolean {
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quoted_binary
  */
 export function quotedBinary(value: unknown): string {
+  // Rails quotes `value.to_s` — for `Type::Binary::Data` that is the raw byte
+  // string, not a comma-joined element list. `String(uint8array)` would yield
+  // "1,2,3", so decode byte-for-byte first.
+  if (value instanceof Uint8Array) {
+    return `'${quoteString(Array.from(value, (b) => String.fromCharCode(b)).join(""))}'`;
+  }
   return `'${quoteString(String(value))}'`;
 }
 
@@ -369,6 +382,18 @@ export function dispatchQuotedDate(host: QuotingDispatchHost, value: TemporalDat
     return host.quotedDate(value);
   }
   return quotedDate(value);
+}
+
+/**
+ * Dispatch through the host's `quotedBinary` override if it defines one, else
+ * the module-level helper — the binary twin of {@link dispatchQuotedDate}.
+ * @internal
+ */
+export function dispatchQuotedBinary(host: QuotingDispatchHost, value: unknown): string {
+  if (typeof host.quotedBinary === "function") {
+    return host.quotedBinary(value);
+  }
+  return quotedBinary(value);
 }
 
 /** @internal */

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
@@ -134,6 +134,27 @@ describe("MySQL quoting — quotedBinary", () => {
   it("formats a Uint8Array as hex literal", () => {
     expect(quotedBinary(new Uint8Array([0xde, 0xad, 0xbe, 0xef]))).toBe("x'deadbeef'");
   });
+
+  it("formats an ArrayBuffer as hex literal", () => {
+    // Shares the toBytes union with the PG/SQLite overrides rather than relying
+    // on Buffer.from(arraybuffer, "binary") silently ignoring the encoding arg.
+    expect(quotedBinary(new Uint8Array([0xde, 0xad, 0xbe, 0xef]).buffer)).toBe("x'deadbeef'");
+  });
+
+  it("formats a byte-offset view over a larger buffer", () => {
+    // Buffer.from(bytes.buffer, ...) must honour byteOffset/byteLength — a
+    // subarray view would otherwise hex the whole backing buffer.
+    expect(quotedBinary(new Uint8Array([0x00, 0xde, 0xad, 0x00]).subarray(1, 3))).toBe("x'dead'");
+  });
+
+  it("accepts the Type::Binary::Data Rails' quoted_binary is given", () => {
+    // mysql/quoting.rb:80 is `quoted_binary(value)` → `x'#{value.hex}'`.
+    expect(quotedBinary(new BinaryData(new Uint8Array([0xde, 0xad])))).toBe("x'dead'");
+  });
+
+  it("raises on a non-byte source rather than hexing garbage", () => {
+    expect(() => quotedBinary(42 as unknown as Uint8Array)).toThrow(TypeError);
+  });
 });
 
 describe("MySQL quoting — quoteIdentifier", () => {

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -98,9 +98,11 @@ export function quoteString(value: string): string {
  * Mirrors: MySQL::Quoting#quoted_binary (`x'#{value.hex}'`, mysql/quoting.rb:80).
  * Rails' signature takes the `Type::Binary::Data` itself, so accept it alongside
  * the raw views our `quote` unwraps to — a Rails-shaped call then works here too.
- * Shares {@link toBytes} with the PG/SQLite overrides so all three accept the
- * same union. A latin1 `string` stays supported on top: Ruby's `Data#hex` reads
- * a byte String, and callers here pass the JS stand-in for one.
+ * Shares {@link toBytes} with the abstract and SQLite overrides, so those three
+ * accept the same union (PG's hand-rolls the unwrap — exception noted on
+ * `toBytes`). A latin1 `string` stays supported on top: Ruby's `Data#hex` reads
+ * a byte String, and callers here pass the JS stand-in for one. PG accepts one
+ * too; SQLite's override rejects it.
  */
 export function quotedBinary(
   value: Buffer | Uint8Array | ArrayBuffer | string | BinaryData,

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -19,6 +19,7 @@ import {
 } from "../abstract/sql-datetime.js";
 import {
   quote as abstractQuote,
+  toBytes,
   dispatchQuotedBinary,
   dispatchQuotedDate,
   dispatchQuotedTime,
@@ -97,15 +98,23 @@ export function quoteString(value: string): string {
  * Mirrors: MySQL::Quoting#quoted_binary (`x'#{value.hex}'`, mysql/quoting.rb:80).
  * Rails' signature takes the `Type::Binary::Data` itself, so accept it alongside
  * the raw views our `quote` unwraps to — a Rails-shaped call then works here too.
+ * Shares {@link toBytes} with the PG/SQLite overrides so all three accept the
+ * same union. A latin1 `string` stays supported on top: Ruby's `Data#hex` reads
+ * a byte String, and callers here pass the JS stand-in for one.
  */
-export function quotedBinary(value: Buffer | Uint8Array | string | BinaryData): string {
-  const bytes = value instanceof BinaryData ? value.bytes : value;
-  const hex = Buffer.isBuffer(bytes)
-    ? bytes.toString("hex")
-    : bytes instanceof Uint8Array
-      ? Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).toString("hex")
-      : Buffer.from(bytes, "binary").toString("hex");
-  return `x'${hex}'`;
+export function quotedBinary(
+  value: Buffer | Uint8Array | ArrayBuffer | string | BinaryData,
+): string {
+  const bytes = toBytes(value);
+  if (bytes) {
+    return `x'${Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).toString("hex")}'`;
+  }
+  if (typeof value === "string") return `x'${Buffer.from(value, "binary").toString("hex")}'`;
+  throw new TypeError(
+    `quotedBinary expects a Uint8Array, ArrayBuffer, Buffer, string, or BinaryData; got ${
+      value === null ? "null" : typeof value
+    }`,
+  );
 }
 
 /** @internal */

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -19,13 +19,13 @@ import {
 } from "../abstract/sql-datetime.js";
 import {
   quote as abstractQuote,
+  dispatchQuotedBinary,
   dispatchQuotedDate,
   dispatchQuotedTime,
   type QuotingDispatchHost,
 } from "../abstract/quoting.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { BigDecimal } from "@blazetrails/activesupport";
-import { BinaryData } from "@blazetrails/activemodel";
 
 export interface Quoting {
   unquotedTrue(): number;
@@ -173,8 +173,8 @@ export function columnNameWithOrderMatcher(): RegExp {
  * `quote` runs the abstract `quote` and the MySQL-specific behaviour flows in
  * through the dispatched helpers (`quote_string`, `quoted_binary`,
  * `quoted_date`/`quoted_time`). We mirror that here: only the branches whose
- * dispatch the abstract `quote` doesn't thread through `this` (binary, symbols,
- * strings — plus the trails-only non-finite guard) stay inline; everything else
+ * dispatch the abstract `quote` doesn't thread through `this` (symbols, strings
+ * — plus the trails-only raw-bytes and non-finite guards) stay inline; the rest
  * delegates to {@link abstractQuote} with `this` threaded so the date/time
  * dispatch lands on MySQL's {@link quotedDate}. Booleans fall through to the
  * abstract `"TRUE"`/`"FALSE"`; binds serialize to 1/0 via {@link castBoundValue}.
@@ -185,9 +185,12 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
   // throws "Unknown column 'Infinity'". Mirror PG's behavior and quote them as
   // strings; MySQL coerces or rejects at the column-type boundary.
   if (typeof value === "number" && !Number.isFinite(value)) return quoteString(String(value));
-  if (value instanceof Buffer || value instanceof Uint8Array) return quotedBinary(value);
-  // Mirrors Rails abstract/quoting.rb: `when Type::Binary::Data then quoted_binary(value)`.
-  if (value instanceof BinaryData) return quotedBinary(value.bytes);
+  // Raw byte views have no Rails counterpart (Rails only ever sees
+  // `Type::Binary::Data` here) — trails callers pass them at the boundary.
+  // Self-dispatch so MySQL's `quotedBinary` override is honored, the same way
+  // the inherited abstract `quote` handles `BinaryData` (abstract/quoting.rb:83).
+  // `Buffer` needs no separate branch: it extends `Uint8Array`.
+  if (value instanceof Uint8Array) return dispatchQuotedBinary(this, value);
   if (typeof value === "symbol") {
     const desc = value.description;
     if (desc === undefined) throw new TypeError("Cannot quote a Symbol without a description");

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -26,6 +26,7 @@ import {
 } from "../abstract/quoting.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { BigDecimal } from "@blazetrails/activesupport";
+import { BinaryData } from "@blazetrails/activemodel";
 
 export interface Quoting {
   unquotedTrue(): number;
@@ -92,12 +93,18 @@ export function quoteString(value: string): string {
   return `'${value.replace(MYSQL_ESCAPE_RE, (ch) => MYSQL_ESCAPE_MAP[ch] ?? ch)}'`;
 }
 
-export function quotedBinary(value: Buffer | Uint8Array | string): string {
-  const hex = Buffer.isBuffer(value)
-    ? value.toString("hex")
-    : value instanceof Uint8Array
-      ? Buffer.from(value.buffer, value.byteOffset, value.byteLength).toString("hex")
-      : Buffer.from(value, "binary").toString("hex");
+/**
+ * Mirrors: MySQL::Quoting#quoted_binary (`x'#{value.hex}'`, mysql/quoting.rb:80).
+ * Rails' signature takes the `Type::Binary::Data` itself, so accept it alongside
+ * the raw views our `quote` unwraps to — a Rails-shaped call then works here too.
+ */
+export function quotedBinary(value: Buffer | Uint8Array | string | BinaryData): string {
+  const bytes = value instanceof BinaryData ? value.bytes : value;
+  const hex = Buffer.isBuffer(bytes)
+    ? bytes.toString("hex")
+    : bytes instanceof Uint8Array
+      ? Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).toString("hex")
+      : Buffer.from(bytes, "binary").toString("hex");
   return `x'${hex}'`;
 }
 

--- a/packages/activerecord/src/connection-adapters/mysql/schema-quoter.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-quoter.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { BinaryData } from "@blazetrails/activemodel";
+import { mysqlSchemaQuoter } from "./schema-quoter.js";
+
+describe("mysqlSchemaQuoter", () => {
+  // `quote` self-dispatches binary through its receiver, and the quoter object
+  // *is* that receiver (both `quote` and the abstract `quoteDefaultExpression`
+  // are invoked as its methods). Without `quotedBinary` on it, binary silently
+  // degrades to the abstract byte-string form instead of MySQL's `x'..'` hex
+  // (mysql/quoting.rb:80).
+  it("quotes binary through MySQL's quotedBinary when host-less", () => {
+    const q = mysqlSchemaQuoter();
+    expect(q.quote(new Uint8Array([0xde, 0xad]))).toBe("x'dead'");
+    expect(q.quote(new BinaryData(new Uint8Array([0xde, 0xad])))).toBe("x'dead'");
+  });
+
+  it("quotes a binary default through MySQL's quotedBinary when host-less", () => {
+    const q = mysqlSchemaQuoter();
+    expect(q.quoteDefaultExpression(new BinaryData(new Uint8Array([0xde, 0xad])))).toBe(
+      " DEFAULT x'dead'",
+    );
+  });
+
+  it("dispatches binary through a threaded host's quotedBinary override", () => {
+    const q = mysqlSchemaQuoter({ quotedBinary: () => "OVERRIDDEN" });
+    expect(q.quote(new BinaryData(new Uint8Array([0xde, 0xad])))).toBe("OVERRIDDEN");
+  });
+});

--- a/packages/activerecord/src/connection-adapters/mysql/schema-quoter.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-quoter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { BinaryData } from "@blazetrails/activemodel";
+import { BinaryData, BinaryType } from "@blazetrails/activemodel";
 import { mysqlSchemaQuoter } from "./schema-quoter.js";
 
 describe("mysqlSchemaQuoter", () => {
@@ -16,9 +16,20 @@ describe("mysqlSchemaQuoter", () => {
 
   it("quotes a binary default through MySQL's quotedBinary when host-less", () => {
     const q = mysqlSchemaQuoter();
+    // The abstract quoteDefaultExpression self-dispatches `quote`
+    // (abstract/quoting.rb:162), so both shapes reach MySQL's `x'..'` — the raw
+    // Uint8Array trails' BinaryType#serialize actually returns (which the
+    // abstract `quote` alone would reject with "can't quote Uint8Array") and the
+    // BinaryData Rails' Binary#serialize returns.
+    expect(q.quoteDefaultExpression(new Uint8Array([0xde, 0xad]))).toBe(" DEFAULT x'dead'");
     expect(q.quoteDefaultExpression(new BinaryData(new Uint8Array([0xde, 0xad])))).toBe(
       " DEFAULT x'dead'",
     );
+  });
+
+  it("quotes a binary default produced by BinaryType#serialize", () => {
+    const q = mysqlSchemaQuoter();
+    expect(q.quoteDefaultExpression(new BinaryType().serialize("ab"))).toBe(" DEFAULT x'6162'");
   });
 
   it("dispatches binary through a threaded host's quotedBinary override", () => {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-quoter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-quoter.ts
@@ -10,7 +10,7 @@
  * to preserve the exact emitted SQL.
  */
 
-import { quote, quoteIdentifier, quoteTableName } from "./quoting.js";
+import { quote, quoteIdentifier, quoteTableName, quotedBinary } from "./quoting.js";
 import { quoteDefaultExpression } from "../abstract/quoting.js";
 
 /** @internal Schema-quoter surface the MySQL visitor depends on. */
@@ -19,6 +19,7 @@ export interface MysqlSchemaQuoter {
   quoteTableName(name: string): string;
   quoteDefaultExpression(value: unknown, column?: unknown): string;
   quote(value: unknown): string;
+  quotedBinary(value: unknown): string;
 }
 
 /** @internal */
@@ -27,6 +28,12 @@ export function mysqlSchemaQuoter(host?: Partial<MysqlSchemaQuoter>): MysqlSchem
     quoteIdentifier: host?.quoteIdentifier?.bind(host) ?? quoteIdentifier,
     quoteTableName: host?.quoteTableName?.bind(host) ?? quoteTableName,
     quote: host?.quote?.bind(host) ?? quote,
+    // `quote` binary self-dispatches through its receiver, and both `quote` and
+    // the abstract `quoteDefaultExpression` are invoked as methods of this
+    // object — so it *is* the dispatch host and must carry `quotedBinary`, or
+    // binary falls through to the abstract byte-string form instead of MySQL's
+    // `x'..'` hex (mysql/quoting.rb:80).
+    quotedBinary: host?.quotedBinary?.bind(host) ?? quotedBinary,
     quoteDefaultExpression,
   };
 }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1,6 +1,6 @@
 import pg from "pg";
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { type Type, ValueType, ArgumentError } from "@blazetrails/activemodel";
+import { type Type, ValueType, ArgumentError, BinaryData } from "@blazetrails/activemodel";
 import {
   singularize,
   Notifications,
@@ -4172,11 +4172,13 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * and emit malformed bytea literals on PG.
    */
   override quotedBinary(value: unknown): string {
-    if (value instanceof Uint8Array) return pgQuotedBinary(value);
+    // Rails passes the `Type::Binary::Data` itself; our `quote` unwraps to bytes
+    // before dispatching, so accept both and this stays callable Rails-shaped.
+    if (value instanceof BinaryData || value instanceof Uint8Array) return pgQuotedBinary(value);
     if (value instanceof ArrayBuffer) return pgQuotedBinary(new Uint8Array(value));
     if (typeof value === "string") return pgQuotedBinary(value);
     throw new TypeError(
-      `quotedBinary expects Uint8Array, ArrayBuffer, Buffer, or string; got ${
+      `quotedBinary expects Uint8Array, ArrayBuffer, Buffer, string, or BinaryData; got ${
         value === null ? "null" : typeof value
       }`,
     );

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
@@ -104,6 +104,14 @@ describe("PostgreSQL quoting", () => {
     expect(quoteDefaultExpression(41, column, typeMap)).toBe(" DEFAULT 42");
   });
 
+  it("quotes a binary default through PG's quotedBinary", () => {
+    // Receiver-less: the fallback host must still reach the bytea escape form,
+    // not the abstract byte-string fallback.
+    expect(quoteDefaultExpression(new BinaryData(new Uint8Array([0x1f, 0x8b])))).toBe(
+      " DEFAULT '\\x1f8b'",
+    );
+  });
+
   it("serializes array defaults via fallback OidArray when type map misses", () => {
     const column = { sqlType: "text[]", array: true };
     const nullTypeMap = {

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
@@ -1,4 +1,4 @@
-import { BinaryData } from "@blazetrails/activemodel";
+import { BinaryData, BinaryType } from "@blazetrails/activemodel";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { describe, expect, it } from "vitest";
 import { Data as ArrayData, Array as OidArray } from "./oid/array.js";
@@ -106,10 +106,30 @@ describe("PostgreSQL quoting", () => {
 
   it("quotes a binary default through PG's quotedBinary", () => {
     // Receiver-less: the fallback host must still reach the bytea escape form,
-    // not the abstract byte-string fallback.
+    // not the abstract byte-string fallback. Cover both shapes that reach here —
+    // the raw Uint8Array trails' BinaryType#serialize actually returns, and the
+    // BinaryData Rails' Binary#serialize returns (activemodel/.../binary.rb:31).
+    expect(quoteDefaultExpression(new Uint8Array([0x1f, 0x8b]))).toBe(" DEFAULT '\\x1f8b'");
     expect(quoteDefaultExpression(new BinaryData(new Uint8Array([0x1f, 0x8b])))).toBe(
       " DEFAULT '\\x1f8b'",
     );
+  });
+
+  it("quotes a BC date default through PG's quotedDate", () => {
+    // Receiver-less: the fallback host must reach PG's BC-suffixing quotedDate
+    // (postgresql/quoting.rb:143), not the abstract formatter which drops " BC".
+    expect(quoteDefaultExpression(Temporal.PlainDate.from("-000043-03-15"))).toBe(
+      " DEFAULT '0044-03-15 BC'",
+    );
+  });
+
+  it("quotes a binary default produced by BinaryType#serialize", () => {
+    // Guards the real quoteDefaultExpression path: whatever the type map's
+    // serialize emits must still reach PG's bytea form.
+    // `array` must be present: the serialize branch is gated on `"array" in column`.
+    const column = { sqlType: "bytea", array: false };
+    const typeMap = { lookup: () => new BinaryType() };
+    expect(quoteDefaultExpression("ab", column, typeMap)).toBe(" DEFAULT '\\x6162'");
   });
 
   it("serializes array defaults via fallback OidArray when type map misses", () => {

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
@@ -221,6 +221,11 @@ describe("PostgreSQL quoting", () => {
     expect(quoteSchemaName("public")).toBe('"public"');
   });
 
+  it("accepts the Type::Binary::Data Rails' quoted_binary is given", () => {
+    // postgresql/quoting.rb:152 is `quoted_binary(value)` → `escape_bytea(value.to_s)`.
+    expect(quotedBinary(new BinaryData(new Uint8Array([0x1f, 0x8b])))).toBe("'\\x1f8b'");
+  });
+
   it("quotedBinary wraps escape_bytea output in SQL quotes", () => {
     expect(quotedBinary(Buffer.from("ab"))).toBe("'\\x6162'");
     expect(quotedBinary("ab")).toBe("'\\x6162'");

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
@@ -25,8 +25,10 @@ import {
 } from "./quoting.js";
 
 // `quote` / `typeCast` require a host receiver (no receiver-less dispatch); bind
-// PG's quotedDate so date/time values reach the BC-suffixing override.
-const HOST = { quotedDate };
+// PG's quotedDate so date/time values reach the BC-suffixing override, and
+// quotedBinary so binary self-dispatch reaches PG's bytea escape — the same
+// overrides PostgreSQLAdapter supplies.
+const HOST = { quotedDate, quotedBinary };
 const quote = (value: unknown): string => quoteFn.call(HOST, value);
 const typeCast = (value: unknown): unknown => typeCastFn.call(HOST, value);
 

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -127,10 +127,12 @@ export function quoteSchemaName(schemaName: string): string {
 /**
  * Mirrors: PostgreSQL::Quoting#quoted_binary. Rails passes `value.to_s`
  * through escape_bytea so the result is always a string wrapped in SQL
- * quotes, never nil.
+ * quotes, never nil. Rails' signature takes the `Type::Binary::Data` itself
+ * (`postgresql/quoting.rb:152`), so accept it alongside the raw views our
+ * `quote` unwraps to — a Rails-shaped call then works here too.
  */
-export function quotedBinary(value: Buffer | Uint8Array | string): string {
-  return `'${escapeBytea(value)}'`;
+export function quotedBinary(value: Buffer | Uint8Array | string | BinaryData): string {
+  return `'${escapeBytea(value instanceof BinaryData ? value.bytes : value)}'`;
 }
 
 export function quote(this: QuotingDispatchHost, value: unknown): string {

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -7,6 +7,7 @@
 import { BinaryData } from "@blazetrails/activemodel";
 import {
   quote as abstractQuote,
+  dispatchQuotedBinary,
   quotedDate as abstractQuotedDate,
   quotedFalse as abstractQuotedFalse,
   quotedTrue as abstractQuotedTrue,
@@ -160,9 +161,11 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
     if (quotingConfig.raiseIntWiderThan64Bit) checkIntegerRange(value);
     return String(value);
   }
-  if (value instanceof Uint8Array) return quotedBinary(value);
-  // Mirrors Rails abstract/quoting.rb: `when Type::Binary::Data then quoted_binary(value)`.
-  if (value instanceof BinaryData) return quotedBinary(value.bytes);
+  // Raw byte views have no Rails counterpart (Rails only ever sees
+  // `Type::Binary::Data` here) — trails callers pass them at the boundary.
+  // Self-dispatch so the adapter's `quotedBinary` override is honored, the same
+  // way the inherited abstract `quote` handles `BinaryData` (abstract/quoting.rb:83).
+  if (value instanceof Uint8Array) return dispatchQuotedBinary(this, value);
   if (typeof value === "string") return quoteString(value);
   // Thread `this` so the inherited date/time dispatch reaches PG's
   // BC-suffixing `quotedDate` (mirrors Rails' `super` call in PG#quote).

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -217,10 +217,11 @@ export function quoteDefaultExpression(
       serialized = castType.serialize(value);
     }
   }
-  // `quote` requires a host receiver; thread our own so a binary column's
-  // default (BinaryType#serialize returns BinaryData) reaches PG's bytea
-  // `quotedBinary` rather than the abstract byte-string fallback.
-  return ` DEFAULT ${quote.call(this || { quotedBinary }, serialized)}`;
+  // `quote` requires a host receiver; thread our own so a receiver-less binary
+  // default reaches PG's bytea `quotedBinary` rather than the abstract
+  // byte-string fallback, and a date default reaches PG's BC-suffixing
+  // `quotedDate` (postgresql/quoting.rb:143) rather than the abstract format.
+  return ` DEFAULT ${quote.call(this || { quotedDate, quotedBinary }, serialized)}`;
 }
 
 export function typeCast(this: QuotingDispatchHost, value: unknown): unknown {

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -217,7 +217,10 @@ export function quoteDefaultExpression(
       serialized = castType.serialize(value);
     }
   }
-  return ` DEFAULT ${quote.call(this || {}, serialized)}`;
+  // `quote` requires a host receiver; thread our own so a binary column's
+  // default (BinaryType#serialize returns BinaryData) reaches PG's bytea
+  // `quotedBinary` rather than the abstract byte-string fallback.
+  return ` DEFAULT ${quote.call(this || { quotedBinary }, serialized)}`;
 }
 
 export function typeCast(this: QuotingDispatchHost, value: unknown): unknown {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -44,7 +44,7 @@ import {
   DatabaseConnectionError,
   TransactionIsolationError,
 } from "../errors.js";
-import { ArgumentError } from "@blazetrails/activemodel";
+import { ArgumentError, BinaryData } from "@blazetrails/activemodel";
 import { TypeMap } from "../type/type-map.js";
 import { Date as DateType } from "../type/date.js";
 import { DateTime as ARDateTimeType } from "../type/date-time.js";
@@ -1039,14 +1039,17 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     // values. The TS standalone iterates the value as a byte source,
     // so non-binary inputs (strings, plain arrays) silently produce
     // garbage hex. Validate at the interface boundary.
-    if (value instanceof Uint8Array) {
+    //
+    // Rails passes the `Type::Binary::Data` itself; our `quote` unwraps to bytes
+    // before dispatching, so accept both and this stays callable Rails-shaped.
+    if (value instanceof BinaryData || value instanceof Uint8Array) {
       return sqliteQuotedBinary(value);
     }
     if (value instanceof ArrayBuffer) {
       return sqliteQuotedBinary(new Uint8Array(value));
     }
     throw new TypeError(
-      `quotedBinary expects a Uint8Array, ArrayBuffer, or Buffer; got ${
+      `quotedBinary expects a Uint8Array, ArrayBuffer, Buffer, or BinaryData; got ${
         value === null ? "null" : typeof value
       }`,
     );

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
@@ -191,6 +191,12 @@ describe("SQLite3::Quoting", () => {
       expect(quotedBinary(new Uint8Array([0xde, 0xad, 0xbe, 0xef]))).toBe("x'deadbeef'");
     });
 
+    it("accepts the Type::Binary::Data Rails' quoted_binary is given", () => {
+      // sqlite3/quoting.rb:79 is `quoted_binary(value)` → `value.hex`.
+      expect(quotedBinary(new BinaryData(new Uint8Array([0xde, 0xad])))).toBe("x'dead'");
+      expect(quotedBinary(new Uint8Array([0xde, 0xad]).buffer)).toBe("x'dead'");
+    });
+
     it("quote(BinaryData) unwraps to bytes via quotedBinary", () => {
       expect(quote(new BinaryData(new Uint8Array([0xde, 0xad, 0xbe, 0xef])))).toBe("x'deadbeef'");
     });

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
@@ -215,7 +215,12 @@ describe("SQLite3::Quoting", () => {
 
     it("quotes a binary default through SQLite's quotedBinary", () => {
       // Receiver-less: the fallback host must still reach the `x'..'` hex form,
-      // not the abstract byte-string fallback.
+      // not the abstract byte-string fallback. Cover both shapes that reach here
+      // — the raw Uint8Array trails' BinaryType#serialize actually returns, the
+      // ArrayBuffer the boundary branch accepts, and the BinaryData Rails'
+      // Binary#serialize returns (activemodel/.../binary.rb:31).
+      expect(quoteDefaultExpression(new Uint8Array([0xde, 0xad]))).toBe("x'dead'");
+      expect(quoteDefaultExpression(new Uint8Array([0xde, 0xad]).buffer)).toBe("x'dead'");
       expect(quoteDefaultExpression(new BinaryData(new Uint8Array([0xde, 0xad])))).toBe("x'dead'");
     });
   });

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
@@ -212,6 +212,12 @@ describe("SQLite3::Quoting", () => {
     it("returns non-function results as raw SQL", () => {
       expect(quoteDefaultExpression(() => "CURRENT_TIMESTAMP")).toBe("CURRENT_TIMESTAMP");
     });
+
+    it("quotes a binary default through SQLite's quotedBinary", () => {
+      // Receiver-less: the fallback host must still reach the `x'..'` hex form,
+      // not the abstract byte-string fallback.
+      expect(quoteDefaultExpression(new BinaryData(new Uint8Array([0xde, 0xad])))).toBe("x'dead'");
+    });
   });
 
   describe("typeCast", () => {

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
@@ -18,8 +18,9 @@ import {
 
 // `quote` / `typeCast` require a host receiver (no receiver-less dispatch); bind
 // SQLite's quotedDate / quotedTime so date/time literals keep the 2000-01-01
-// prefix on times.
-const HOST = { quotedDate, quotedTime };
+// prefix on times, and quotedBinary so binary self-dispatch reaches SQLite's
+// `x'..'` hex form — the same overrides AbstractSQLite3Adapter supplies.
+const HOST = { quotedDate, quotedTime, quotedBinary };
 const quote = (value: unknown): string => quoteFn.call(HOST, value);
 const typeCast = (value: unknown): unknown => typeCastFn.call(HOST, value);
 

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -11,13 +11,13 @@
 import {
   quote as abstractQuote,
   quotedDate as abstractQuotedDate,
+  dispatchQuotedBinary,
   dispatchQuotedDate,
   dispatchQuotedTime,
   type QuotingDispatchHost,
 } from "../abstract/quoting.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { BigDecimal } from "@blazetrails/activesupport";
-import { BinaryData } from "@blazetrails/activemodel";
 
 export interface Quoting {
   quotedTrue(): string;
@@ -71,11 +71,12 @@ export function quoteString(value: string): string {
  * `quotedTime`. A host receiver is required — every invocation routes through
  * an adapter via `.call(this, value)`.
  *
- * The boolean, symbol, string, and binary branches stay inline because our
- * abstract `quote` renders those through module-level helpers (TRUE/FALSE,
+ * The boolean, symbol, and string branches stay inline because our abstract
+ * `quote` renders those through module-level helpers (TRUE/FALSE,
  * backslash-escaping `quoteString`) rather than dispatching through `this`, so
- * delegating would lose SQLite's overrides (1/0, `''`-only escaping, `x'..'`
- * hex). These are exactly the quoting primitives SQLite3::Quoting overrides.
+ * delegating would lose SQLite's overrides (1/0, `''`-only escaping). These are
+ * exactly the quoting primitives SQLite3::Quoting overrides. Binary does
+ * dispatch through `this`, so `BinaryData` rides the inherited abstract branch.
  */
 export function quote(this: QuotingDispatchHost, value: unknown): string {
   if (typeof value === "number" && !Number.isFinite(value)) return quoteString(String(value));
@@ -87,10 +88,13 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
     return quoteString(value.description);
   }
   if (typeof value === "string") return quoteString(value);
-  if (value instanceof Uint8Array || value instanceof ArrayBuffer) return quotedBinary(value);
-  // Mirrors Rails abstract/quoting.rb: `when Type::Binary::Data then quoted_binary(value)`.
-  // BinaryData wraps raw bytes from serialize() (e.g. encryption ciphertext for binary columns).
-  if (value instanceof BinaryData) return quotedBinary(value.bytes);
+  // Raw byte views have no Rails counterpart (Rails only ever sees
+  // `Type::Binary::Data` here) — trails callers pass them at the boundary.
+  // Self-dispatch so SQLite's `quotedBinary` override is honored, the same way
+  // the inherited abstract `quote` handles `BinaryData` (abstract/quoting.rb:83).
+  if (value instanceof Uint8Array || value instanceof ArrayBuffer) {
+    return dispatchQuotedBinary(this, value);
+  }
   return abstractQuote.call(this, value);
 }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -11,6 +11,7 @@
 import {
   quote as abstractQuote,
   quotedDate as abstractQuotedDate,
+  toBytes,
   dispatchQuotedBinary,
   dispatchQuotedDate,
   dispatchQuotedTime,
@@ -18,6 +19,7 @@ import {
 } from "../abstract/quoting.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { BigDecimal } from "@blazetrails/activesupport";
+import { BinaryData } from "@blazetrails/activemodel";
 
 export interface Quoting {
   quotedTrue(): string;
@@ -146,8 +148,18 @@ export function quotedTime(value: Temporal.PlainTime | Temporal.PlainDateTime): 
   return quotedDate(dt).replace(/^\d{4}-\d{2}-\d{2} /, "2000-01-01 ");
 }
 
-export function quotedBinary(value: Uint8Array | ArrayBuffer): string {
-  const bytes = value instanceof Uint8Array ? value : new Uint8Array(value);
+export function quotedBinary(value: Uint8Array | ArrayBuffer | BinaryData): string {
+  // Rails' signature is `quoted_binary(value)` taking the Type::Binary::Data
+  // itself (`value.hex`, sqlite3/quoting.rb:79). Accept it alongside the raw
+  // views our `quote` unwraps to, so the Rails-shaped call works too.
+  const bytes = toBytes(value);
+  if (!bytes) {
+    throw new TypeError(
+      `quotedBinary expects a Uint8Array, ArrayBuffer, Buffer, or BinaryData; got ${
+        value === null ? "null" : typeof value
+      }`,
+    );
+  }
   const hex = Array.from(bytes)
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -166,8 +166,9 @@ export function quoteDefaultExpression(this: QuotingDispatchHost | void, value: 
     return str;
   }
   // `quote` requires a host receiver; thread our own so date/time defaults reach
-  // SQLite's quotedDate / quotedTime overrides (the adapter binds `this`).
-  return quote.call(this || { quotedDate, quotedTime }, value);
+  // SQLite's quotedDate / quotedTime overrides and binary defaults reach its
+  // `x'..'` quotedBinary (the adapter binds `this`).
+  return quote.call(this || { quotedDate, quotedTime, quotedBinary }, value);
 }
 
 export function typeCast(this: QuotingDispatchHost, value: unknown, bindsAsFloat = false): unknown {

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -19693,6 +19693,20 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/quoting.ts",
+    "rubyName": "quote_default_expression",
+    "call": "quote",
+    "reason": "Satisfied via dispatchQuote, mirroring rb:162's bare `quote(value)` self-dispatch (host override, else the module helper) \u2014 same shape as the existing quote/quoted_date and quote/quoted_binary entries."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/quoting.ts",
+    "rubyName": "quote_default_expression",
+    "call": "call",
+    "reason": "Rails' `value.call` invokes the Proc default; TS invokes it as `(value as () => unknown)()`, which has no `call` member. Previously matched only incidentally, by the `quote.call(...)` token that dispatchQuote replaced."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/quoting.ts",
     "rubyName": "quoted_binary",
     "call": "to_s",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
## What

Ports `when Type::Binary::Data then quoted_binary(value)`
([`abstract/quoting.rb:83`](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb#L83))
to trails' abstract `quote`, self-dispatched through the host so an adapter's
`quotedBinary` override applies. Adds `dispatchQuotedBinary`, mirroring the
existing `dispatchQuotedDate` pattern.

Before this, the abstract `quote` had no `BinaryData` branch — it threw
`can't quote BinaryData` where Rails quotes it — and each of the three adapters
re-implemented rb:83 locally, short-circuiting raw byte views to their
**module-level** `quotedBinary` and bypassing the adapter's own override. The
same value class took two dispatch paths depending on view type.

## The port

- `abstract/quoting.ts`: `BinaryData` branch at the rb:83 position (after
  Numeric, before Time/Date); `dispatchQuotedBinary`; `quotedBinary?` on
  `QuotingDispatchHost`.
- PG / MySQL / SQLite `quoting.ts`: `BinaryData` branches collapse onto the
  inherited abstract dispatch. The raw-bytes (`Uint8Array`/`ArrayBuffer`)
  branches stay — Rails only ever sees `Type::Binary::Data` here, but trails
  callers pass views at the boundary — and now self-dispatch through the host.
  MySQL's separate `Buffer` branch is gone: `Buffer` extends `Uint8Array`.

### Deviation from rb:83, stated at the call site

Rails passes the `Data` object; we pass the unwrapped bytes, which is what lets
the raw-view branches share one dispatch path. Every trails `quotedBinary` now
accepts **the union** (Data *and* raw views), matching Rails' signature
(`abstract:206`, `pg:152`, `mysql:80`, `sqlite3:79`), so a Rails-shaped
`quotedBinary(data)` call works. Root cause is `BinaryType#serialize` returning
bare bytes instead of Rails' `Data.new(super)` — see follow-up below.

## Dispatch gaps found and fixed in review

Routing binary through host dispatch means the host must carry `quotedBinary`.
The adapter classes do; several *adapter-free* hosts did not:

| Host | Gap | Fix |
| --- | --- | --- |
| PG `quoteDefaultExpression` | `this \|\| {}` | bind `quotedBinary` |
| SQLite `quoteDefaultExpression` | `{ quotedDate, quotedTime }` | add `quotedBinary` |
| `mysql/schema-quoter.ts` | quoter object *is* the receiver | bind `quotedBinary` |
| PG `quoteDefaultExpression` | no `quotedDate` → BC date default lost `" BC"` ([`pg/quoting.rb:143`](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb#L143)) | add `quotedDate` |
| abstract `quotedBinary` | `ArrayBuffer` → `'[object ArrayBuffer]'` | normalise it |

**Root cause, third round:** the abstract module `quoteDefaultExpression` called
the module `quote` rather than self-dispatching. Rails is a bare `quote(value)`
([`abstract/quoting.rb:162`](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb#L162)),
so the mysql schema-quoter's own `quote` was dead for that path and a raw
`Uint8Array` default raised `can't quote Uint8Array`. Now routed through
`dispatchQuote`, which fixes the class of bug rather than one more host.

### One finding corrected

The review flagged the abstract fallback as emitting `'[object Object]'` for
`BinaryData`. That does not reproduce — `BinaryData#toString()` decodes, so
`String(value)` yields `"ab"`. The **real** defect is worse: `toString()`
UTF-8-decodes, so non-UTF-8 bytes (`0xde 0xad 0xbe 0xef`) were silently replaced
with U+FFFD. Rails' `value.to_s` is a BINARY-encoded String and byte-exact. The
fix stands; the test now pins byte-exactness rather than the symptom that never
existed.

Every fix is pinned by a test **verified to fail when the fix is reverted**.

### Fourth round: MySQL `quotedBinary` uniformity

MySQL hand-rolled its byte union while PG/SQLite use the new `toBytes`, so an
`ArrayBuffer` landed on `Buffer.from(bytes, "binary")` — which works only because
the encoding arg is ignored for an ArrayBuffer, and reads as an accident. Now
routed through `toBytes`, so all three overrides accept the same union and raise
the same way; the latin1 `string` form stays as MySQL's extra (Ruby's `Data#hex`
reads a byte String).

**This one is a genuine no-op**, as the review said. The four added tests
(ArrayBuffer, byte-offset view, BinaryData, non-byte raises) were re-run against
the previous implementation and *all pass there too* — they characterize the
now-uniform surface rather than pin a regression. Flagging that explicitly so
they aren't mistaken for regression coverage.

## Follow-ups (filed, not fixed here)

Deviations surfaced while porting this branch. Each is registered under
RFC `0023-surfaced-deviations` rather than ratified in a comment or fixed
in-scope:

| Story | What |
| --- | --- |
| `binary-type-serialize-returns-data-wrapper` | `BinaryType#serialize` returns bare bytes; Rails returns `Data.new(super)` ([`binary.rb:31`](https://github.com/rails/rails/blob/main/activemodel/lib/active_model/type/binary.rb#L31)). Root cause of why the adapters need raw-view branches at all. |
| `quote-default-expression-serialize-and-default-prefix` | Skips rb:161's `lookup_cast_type(...).serialize`, and folds in the ` DEFAULT ` prefix Rails leaves to `schema_creation.rb:150`. Also internally inconsistent: abstract/PG prefix it, SQLite doesn't. |
| `pg-quoted-binary-route-through-tobytes` | PG's `quotedBinary` is the one not routed through `toBytes` (review #7). Not a live bug — `quote` normalises views first and PG's override branches `ArrayBuffer` separately. |
| `abstract-quote-string-symbol-branch-order` | trails' String/Symbol branch sits near-last; Rails has it first (rb:75). Behaviorally equivalent — the branch types don't overlap. |

## Notes

- `dispatchQuotedBinary` was slated for #4868, still open — this adds the helper
  itself. Expect a small conflict in `abstract/quoting.ts` for whichever lands
  second.
- **No behavior change on the adapter path** — each override delegates to the
  same module function this replaces. The behavior changes are the fixes above,
  all of which move output toward Rails.
- No test names changed.

## Verification

`pnpm typecheck` and eslint clean on all changed files; quoting suites pass —
278 tests. (5 pre-existing `rails-private-jsdoc` lint errors in `query-cache.ts` /
`schema-definitions.ts` are untouched by this PR — those files are byte-identical
to `origin/main`.) api:compare data layer unchanged at 7472/7474 (100%).

Closes-story: abstract-quote-binary-data-self-dispatch



