### PR TITLE
refactor(arel): dispatch visitNodeOrValue integers to the visitInteger port

### DIFF
--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1966,4 +1966,47 @@ describe("ArelQuoter / defaultQuoter wiring", () => {
     new Visitors.ToSql(stubQuoter).compile(node);
     expect(received).toContain(bytes);
   });
+
+  it("integers in raw value position bypass quote(), matching Rails visit_Integer", () => {
+    // Rails' raw-value dispatch sends an Integer to `visit_Integer`, which is
+    // `collector << o.to_s` (to_sql.rb:824-826) — the connection is never
+    // consulted. `quote` governs the Casted-node path (to_sql.rb:87-90), not
+    // this one. A quoter that mangles everything must therefore not be able to
+    // reach an integer here.
+    const quoted: unknown[] = [];
+    class RecordingToSql extends Visitors.ToSql {
+      protected override quote(value: unknown): string {
+        quoted.push(value);
+        return `<<${String(value)}>>`;
+      }
+    }
+    // A raw JS number reaches the visitor only when placed directly into a
+    // node; `.in([1, 2])` instead wraps each value in a Casted node via
+    // `quotedNode`, which is the to_sql.rb:87-90 path and does route through
+    // quote(). InfixOperation carries the raw value through unwrapped.
+    const sql = new RecordingToSql().compile(
+      new Nodes.InfixOperation(
+        "+",
+        new Nodes.InfixOperation("+", users.get("id"), 1),
+        9007199254740993n,
+      ),
+    );
+    expect(quoted).toEqual([]);
+    expect(sql).toContain("+ 1");
+    expect(sql).toContain("+ 9007199254740993");
+  });
+
+  it("Casted values do route through quote(), unlike raw integers", () => {
+    // The companion to the guard above: to_sql.rb:87-90 sends a Casted /
+    // Quoted node's value through quote(), so the two paths must differ.
+    const quoted: unknown[] = [];
+    class RecordingToSql extends Visitors.ToSql {
+      protected override quote(value: unknown): string {
+        quoted.push(value);
+        return super.quote(value);
+      }
+    }
+    new RecordingToSql().compile(users.get("id").in([1, 2]));
+    expect(quoted).toEqual([1, 2]);
+  });
 });

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1354,8 +1354,19 @@ export class ToSql extends Visitor {
   // for stray values that drift into the visitor).
   // ---------------------------------------------------------------------
 
-  /** Mirrors Rails: `visit_Integer`. */
-  protected visitInteger(o: number, collector: SQLString): SQLString {
+  /**
+   * Mirrors Rails: `visit_Integer` (to_sql.rb:824-826) — a bare
+   * `collector << o.to_s`, with no `@connection` involvement. Accepts `bigint`
+   * as well as `number`: Ruby's `Integer` is arbitrary-precision and Arel has
+   * no separate bignum visitor, so both JS numeric types land here.
+   *
+   * Callers: `visitNodeOrValue` routes every `bigint` here, and every *finite*
+   * `number` — not merely integral ones. That `Number.isFinite` split is
+   * invented; Rails only ever reaches `visit_Integer` for an `Integer` and
+   * raises on `Float` (rb:839), so `1.5` arrives here where Rails would raise.
+   * See the note at the call site.
+   */
+  protected visitInteger(o: number | bigint, collector: SQLString): SQLString {
     collector.append(String(o));
     return collector;
   }
@@ -1374,10 +1385,16 @@ export class ToSql extends Visitor {
   // Rails aliases every Ruby value class with no SQL rendering to
   // `unsupported` (to_sql.rb:832-845): visiting one raises
   // `UnsupportedVisitError`. TS has no method-alias, so each delegates to
-  // the shared helper. They aren't wired into the dispatch table — the
-  // trails Arel pipeline never threads a raw JS Date/Class/Hash/etc. as a
-  // node — but the names exist so the unsupported contract is documented
-  // and directly testable. Each keeps the Rails `(o, collector)` shape.
+  // the shared helper. Each keeps the Rails `(o, collector)` shape.
+  //
+  // These are NOT wired into the dispatch table, and — contrary to what this
+  // comment claimed until #4871 — that is a deviation, not a no-op. Raw
+  // values (dates, strings, booleans, floats) *do* reach the visitor via
+  // `visitNodeOrValue`, which renders them instead of dispatching here, so
+  // the "unsupported contract" these names document is currently unenforced
+  // on the one path that could violate it. Converging that is tracked by
+  // story `arel-raw-value-dispatch-raises-like-rails` (RFC 0023); until then
+  // they stand as the documented contract and are directly testable.
 
   /** Rails: `alias :visit_ActiveSupport_Multibyte_Chars :unsupported`. */
   protected visitActiveSupportMultibyteChars(o: Node, collector: SQLString): never {
@@ -1982,18 +1999,42 @@ export class ToSql extends Visitor {
       }
       return this.visit(v, collector);
     }
+    // Raw-value dispatch — trails' stand-in for Rails' `visit` class dispatch
+    // on a stray Ruby value. Rails renders exactly ONE raw scalar here,
+    // Integer, via `visit_Integer` (to_sql.rb:824-826); the integral branches
+    // below delegate to our port of it (`visitInteger`) so the anchor is
+    // structural rather than a comment that can drift. NilClass (rb:841),
+    // String (rb:842), Float (rb:839), TrueClass (rb:845), FalseClass
+    // (rb:838), Date (rb:836), Time (rb:844), BigDecimal (rb:834), Symbol
+    // (rb:843) and Hash (rb:840) all alias to `unsupported` and raise
+    // (rb:828-845) — their ports exist below but this method renders instead
+    // of dispatching to them, which is the whole of the deviation. Note
+    // to_sql.rb:87-90 (`visit_Arel_Nodes_Casted`) is the *other* path, the one
+    // that routes through quote(); it is ported in `visitArelNodesCasted` and
+    // is what ActiveRecord actually uses.
+    // Converging the tolerances is a caller-facing narrowing tracked by story
+    // `arel-raw-value-dispatch-raises-like-rails` (RFC 0023).
     if (v === null || v === undefined) {
       collector.append("NULL");
     } else if (typeof v === "string") {
       collector.append(this.quote(v));
     } else if (typeof v === "number") {
-      // Non-finite numbers must route through quote() so the adapter can emit
-      // a string literal ('Infinity' / 'NaN') rather than a bareword identifier.
-      collector.append(Number.isFinite(v) ? String(v) : this.quote(v));
+      // The `Number.isFinite` split is INVENTED — it has no Rails analogue, so
+      // this branch does not mirror Rails' dispatch. Rails splits Integer
+      // (renders, rb:824-826) vs Float (raises via `unsupported`, rb:839); we
+      // split finite vs non-finite, so a Rails-shaped predicate would be
+      // `Number.isInteger`. Both halves therefore deviate: `1.5` is finite so
+      // it reaches visitInteger here where Rails raises, and the non-finite
+      // fallback to quote() (which lets the connection emit 'Infinity' rather
+      // than a bareword identifier) has no counterpart either — Infinity/NaN
+      // are Ruby Floats and also raise at rb:839. Tracked by story
+      // `arel-raw-value-dispatch-raises-like-rails` (RFC 0023).
+      if (Number.isFinite(v)) return this.visitInteger(v, collector);
+      collector.append(this.quote(v));
     } else if (typeof v === "boolean") {
       collector.append(this.quote(v));
     } else if (typeof v === "bigint") {
-      collector.append(v.toString());
+      return this.visitInteger(v, collector);
     } else {
       // Everything else — dates, binary, Temporal types, unknown objects —
       // defers to `quote()`, which hands the value to the connection. Rails'


### PR DESCRIPTION
**This PR does not make the change its story asked for.** Reading the Rails source shows the story is mis-specified: `visitNodeOrValue`'s bare-appended integers are the *faithful* port, and routing them through `quote()` — which is what I first pushed here — would have introduced a deviation while claiming to remove one.

So instead of routing integers to `quote()`, this PR routes them to **`visitInteger`**, the `visit_Integer` port that already existed but sat unreachable. Same rendering, now structurally anchored to Rails rather than argued for in a comment. The residue that has no Rails anchor is documented in place — the acceptance criteria's second branch ("or the residue is documented with the Rails anchor for why it must stay") — and the broader tolerance is filed as its own story rather than ratified.

## Rails has two value paths, and the story conflated them

- **Casted / Quoted node** — `visit_Arel_Nodes_Casted` is `collector << quote(o.value_for_database).to_s` (`to_sql.rb:87-90`). This is the anchor the story cites, and the only value path through `quote`. Trails **already ports it** in `visitArelNodesCasted` (`to-sql.ts:231`), which does route through `quote()`.
- **Raw value reaching `visit`** — dispatches on the Ruby class. `Integer` hits `visit_Integer`, a bare `collector << o.to_s` (`to_sql.rb:824-826`), with no `@connection` involvement. Every other raw scalar aliases to `unsupported` and **raises** (`to_sql.rb:828-845`).

`visitNodeOrValue` is the second path. So rendering an integer with a bare `String(v)` was `visit_Integer` ported correctly, not a bypass — it just wasn't *saying* so, which is what the delegation below fixes.

The distinction is load-bearing rather than academic: the story's premise implies ActiveRecord's numerics skip the connection today, and they do not. `predications`' `in()` / `eq()` wrap every value via `quotedNode` (`predications.ts:142-151`) into a `Casted` node, so the AR-facing path already goes through `quote()`. The raw-value branch is reachable only by putting a bare JS number directly into a node — exactly where Rails bare-appends too.

## #4868 has now merged — which sharpens this, and kills the story's stated motive

`ToSql#quote` is now Rails' two-liner (`to-sql.ts:1509-1512`: `SqlLiteral` passthrough, else `this.connection.quote(value)`). Rebased onto it; all green. Two consequences, one of which corrects an earlier revision of this body:

**1. The "it's a no-op" argument is now retired — and the change would have real teeth.** Before #4868, trails' `quote` was an invented body returning `String(value)` for finite numbers, so the story's change was a no-op contained inside `ToSql`. Now `quote` genuinely reaches the connection, so routing integers through it would hand them to the adapter. Output happens to be identical today (`abstract/quoting.ts:105` and `default-quoter.ts` both return `String(value)` for `number`/`bigint`), but the dispatch would become adapter-overridable — on the exact path where `visit_Integer` gives the connection no say. So the change went from harmless-but-pointless to an actual deviation. The thesis holds either way; only the reason it is wrong has changed.

**2. The story's motive — "any BigDecimal/precision handling in the adapter is unreachable from this path" — is false, and #4868 makes that checkable.** A `BigDecimal` is an *object*, not a JS `number`, so it never enters the numeric branch at all: it falls to the `else`, which calls `quote()` → `connection.quote` → `value instanceof BigDecimal → value.toString("F")` (`abstract/quoting.ts:104`). I verified the routing empirically (a `BigDecimal`-shaped object does reach `quote()` from `InfixOperation`) rather than by inspection. **BigDecimal already gets exactly the adapter precision handling the story wanted** — the numeric branch was never what stood between it and the adapter. Which is the deeper point: the branch the story targeted only ever carries JS `number`/`bigint`, i.e. precisely the Ruby `Integer` case Rails bare-appends.

## What changed

Originally comment-only; review #3 pointed out that the argument could be made **structural** instead, and it was right, so the integral branches now delegate:

```ts
} else if (typeof v === "number") {
  if (Number.isFinite(v)) return this.visitInteger(v, collector);
  collector.append(this.quote(v));
} else if (typeof v === "bigint") {
  return this.visitInteger(v, collector);
}
```

`visitInteger` (`to-sql.ts:1358`) already existed — a faithful `collector << o.to_s` — but was **unreachable**, while these branches re-inlined `String(v)` / `v.toString()`. So the port and its only real caller had drifted apart, and the PR was arguing in prose for an anchor the code could simply *point at*. Now it does, and the comment shrinks to the residue that has no anchor. Its signature widened to `number | bigint` (Ruby's `Integer` is arbitrary-precision; Arel has no separate bignum visitor, confirmed by `git grep visit_Bignum` returning nothing). Behavior-preserving — SQL output is byte-identical, and `arity: 681/681` still holds.

The remaining prose covers only what is genuinely **invented**: the `Number.isFinite` predicate has no Rails analogue (Rails splits Integer-renders vs Float-raises, so the Rails-shaped predicate is `Number.isInteger`), so `1.5` reaches `visitInteger` where Rails raises, and the non-finite → `quote()` fallback is equally invented (`Infinity`/`NaN` are Ruby Floats, raising at `rb:839`).

The chain comment enumerates each raising alias with its own anchor (`NilClass` rb:841, `String` rb:842, `Float` rb:839, `TrueClass` rb:845, `FalseClass` rb:838, `Date` rb:836, `Time` rb:844, `BigDecimal` rb:834, `Symbol` rb:843, `Hash` rb:840).

`visitInteger`'s own JSDoc names its callers precisely — every `bigint` and every *finite* `number`, **not** merely integral ones. Review #4 caught it claiming "integral values", which the `Number.isFinite` call site contradicts; that is the same two-accounts-of-one-fact defect fixed in the alias block below, reintroduced by this PR's own new comment, so it is corrected rather than deferred.

**Also fixed a contradiction this PR would otherwise have left behind.** The pre-existing alias-block comment (`to-sql.ts:1373-1379`) claimed "the trails Arel pipeline never threads a raw JS Date/Class/Hash/etc. as a node" — which `visitNodeOrValue` and its `else` branch flatly disprove. Two incompatible accounts of the same question in one file is exactly the failure this PR exists to prevent, so it is corrected in the same pass rather than left for whoever reads it first.

## Follow-up registered, not ratified

The raw-scalar tolerance is a tracked story rather than a code comment: **`arel-raw-value-dispatch-raises-like-rails`** (RFC 0023), created with the anchors in hand (`to_sql.rb:828-845`) and citing this PR. It covers converging the raw-value branches to raise, replacing `Number.isFinite` with the Rails-shaped `Number.isInteger`, and the caller audit that gates both — the reason it is a separate story is that converging is a caller-facing narrowing, not that the deviation is acceptable. The code comment cites the story id. Standing rule is converge-never-ratify; this is filed to converge.

It has since been claimed and is in progress as **#4873**. Two corrections pushed to it on the review's prompt, since that agent is working from this context right now: its residue list described a `quotedDate` branch that #4868 deleted (dates now fall to the `else` → `quote()`), and it pinned a `to-sql.ts` line range that had already drifted — now method-anchored with a note to grep rather than trust the range.

## Verification

- `pnpm vitest run packages/arel/src` — 1472 passed, 0 failed (rebased onto #4868 + #4867, both of which touched this file; #4868 removed the date-like branch, so dates now fall to the `else` → `quote()` and the chain comment accounts for that).
- `pnpm typecheck`, `pnpm lint` — clean.
- Deltas zero: `arel 701/705 (58/58 files)`, `Data layer 7472/7474 (407/407 files)`. No methods added or removed; the new tests count as TS-only extras, so the matched numerator is untouched.
- No stubs. Behavior-preserving: `visitInteger` emits `String(o)`, byte-identical to the `String(v)` / `v.toString()` it replaces, so the SQLite `1` vs `1n` bind-shape trap is untouched. AR SQL-generation suites (`relation`, `relations`, `insert-all`, `quoting`, `persistence`) — 1330 passed.

Two guards added, both exercising the branch for real — the first version of this test asserted on `.in([1, 2])`, which wraps values in `Casted` nodes and never touched the edited code at all:

- `integers in raw value position bypass quote(), matching Rails visit_Integer` — via `InfixOperation`, which visits `o.right` raw (`to_sql.rb:847-851`). Re-mutation-checked against the new delegating structure: re-applying the story's change fails it (`expected [ 1, 9007199254740993n ] to deeply equal []` — it now catches both numeric types, where before it caught only `number`).
- `Casted values do route through quote(), unlike raw integers` — the companion, pinning that the two paths stay different.

## If you disagree

The reviewable question is narrow: **is `visitNodeOrValue` the raw-value dispatch path (`visit_Integer`) or the Casted path (`87-90`)?** I read it as the former, because `visitArelNodesCasted` already exists and separately covers the latter. If it is meant to be the Casted path, then the two methods are redundant and the fix is to converge them — a different and larger change than the story describes.

Closes-story: arel-visit-node-or-value-numerics-through-quote
