### PR TITLE
fix(arel): quote PG array elements by content, not by JS type

### DIFF
--- a/packages/arel/src/quote-array.test.ts
+++ b/packages/arel/src/quote-array.test.ts
@@ -74,6 +74,14 @@ describe("quoteArrayLiteral", () => {
       expect(quoteArrayLiteral(["NULLx", "xNULL"])).toBe("{NULLx,xNULL}");
     });
 
+    it("folds the NULL literal over ASCII only, as pg_strcasecmp does", () => {
+      // A Unicode-aware fold would be a wider net than pg casts. The Kelvin
+      // sign folds to "K" under toUpperCase() but must not participate here;
+      // no non-ASCII char may stand in for N, U or L.
+      expect(quoteArrayLiteral(["nulK"])).toBe("{nulK}");
+      expect(quoteArrayLiteral(["ɴull"])).toBe("{ɴull}");
+    });
+
     it("quotes an element containing whitespace", () => {
       expect(quoteArrayLiteral(["a b"])).toBe('{"a b"}');
       expect(quoteArrayLiteral([" a"])).toBe('{" a"}');
@@ -92,7 +100,13 @@ describe("quoteArrayLiteral", () => {
       expect(quoteArrayLiteral(["a.b", "a-b", "a|b", "a(b"])).toBe("{a.b,a-b,a|b,a(b}");
     });
 
-    it("never inspects type, so the string 'true' encodes like the boolean", () => {
+    it("leaves a string that reads as a literal bare", () => {
+      // The encoder stage never inspects type — it sees only the text
+      // `type_cast` produced. These strings need no quoting, so they emit bare
+      // and become indistinguishable from the scalars they resemble, exactly
+      // as `PG::TextEncoder::Array` does. (The *boolean* `true` still encodes
+      // as `{TRUE}` until #4869 converges the type_cast arm onto
+      // `unquoted_true`; that divergence lives in the cast stage, not here.)
       expect(quoteArrayLiteral(["true"])).toBe("{true}");
       expect(quoteArrayLiteral(["1"])).toBe("{1}");
     });
@@ -102,6 +116,8 @@ describe("quoteArrayLiteral", () => {
     });
 
     it("encodes a mixed array as the Ruby encoder does", () => {
+      // The hook stands in for the `unquoted_true` cast arm #4869 converges;
+      // without it the booleans would still cast to `TRUE`/`FALSE` here.
       expect(
         quoteArrayLiteral([true, false, "a", "2026-04-26 14:23:55", 1], (v) =>
           typeof v === "boolean" ? String(v) : undefined,

--- a/packages/arel/src/quote-array.test.ts
+++ b/packages/arel/src/quote-array.test.ts
@@ -3,7 +3,7 @@ import { quoteArrayLiteral } from "./quote-array.js";
 
 describe("quoteArrayLiteral", () => {
   it("formats simple string arrays", () => {
-    expect(quoteArrayLiteral(["a", "b", "c"])).toBe('{"a","b","c"}');
+    expect(quoteArrayLiteral(["a", "b", "c"])).toBe("{a,b,c}");
   });
 
   it("formats integer arrays", () => {
@@ -11,7 +11,7 @@ describe("quoteArrayLiteral", () => {
   });
 
   it("handles null elements", () => {
-    expect(quoteArrayLiteral(["a", null, "b"])).toBe('{"a",NULL,"b"}');
+    expect(quoteArrayLiteral(["a", null, "b"])).toBe("{a,NULL,b}");
   });
 
   it("handles nested arrays", () => {
@@ -37,7 +37,7 @@ describe("quoteArrayLiteral", () => {
 
   it("handles Date values with toISOString", () => {
     const d = new Date("2026-03-26T12:00:00.000Z");
-    expect(quoteArrayLiteral([d])).toBe(`{"${d.toISOString()}"}`);
+    expect(quoteArrayLiteral([d])).toBe(`{${d.toISOString()}}`);
   });
 
   it("handles empty arrays", () => {
@@ -46,21 +46,78 @@ describe("quoteArrayLiteral", () => {
 
   it("handles objects with toISOString", () => {
     const obj = { toISOString: () => "2026-01-01T00:00:00Z" };
-    expect(quoteArrayLiteral([obj])).toBe('{"2026-01-01T00:00:00Z"}');
+    expect(quoteArrayLiteral([obj])).toBe("{2026-01-01T00:00:00Z}");
   });
 
   it("handles bigint values inside objects", () => {
     expect(quoteArrayLiteral([{ id: 42n }])).toBe('{"{\\"id\\":\\"42\\"}"}');
   });
 
+  // Each expectation below was captured from `PG::TextEncoder::Array#encode`,
+  // the encoder Rails hands the type_cast values to (`postgresql/quoting.rb:212`).
+  describe("quotes elements by content, as PG::TextEncoder::Array does", () => {
+    it("leaves an unambiguous element bare", () => {
+      expect(quoteArrayLiteral(["a"])).toBe("{a}");
+    });
+
+    it("quotes an empty element", () => {
+      expect(quoteArrayLiteral([""])).toBe('{""}');
+    });
+
+    it("quotes an element that would otherwise read as the NULL literal", () => {
+      expect(quoteArrayLiteral(["NULL"])).toBe('{"NULL"}');
+      expect(quoteArrayLiteral(["null"])).toBe('{"null"}');
+      expect(quoteArrayLiteral(["NuLl"])).toBe('{"NuLl"}');
+    });
+
+    it("leaves an element merely containing NULL bare", () => {
+      expect(quoteArrayLiteral(["NULLx", "xNULL"])).toBe("{NULLx,xNULL}");
+    });
+
+    it("quotes an element containing whitespace", () => {
+      expect(quoteArrayLiteral(["a b"])).toBe('{"a b"}');
+      expect(quoteArrayLiteral([" a"])).toBe('{" a"}');
+      expect(quoteArrayLiteral(["a "])).toBe('{"a "}');
+      expect(quoteArrayLiteral(["a\tb"])).toBe('{"a\tb"}');
+      expect(quoteArrayLiteral(["a\nb"])).toBe('{"a\nb"}');
+    });
+
+    it("quotes an element containing a delimiter", () => {
+      expect(quoteArrayLiteral(["a,b"])).toBe('{"a,b"}');
+      expect(quoteArrayLiteral(["a{b"])).toBe('{"a{b"}');
+      expect(quoteArrayLiteral(["a}b"])).toBe('{"a}b"}');
+    });
+
+    it("leaves an element with other punctuation bare", () => {
+      expect(quoteArrayLiteral(["a.b", "a-b", "a|b", "a(b"])).toBe("{a.b,a-b,a|b,a(b}");
+    });
+
+    it("never inspects type, so the string 'true' encodes like the boolean", () => {
+      expect(quoteArrayLiteral(["true"])).toBe("{true}");
+      expect(quoteArrayLiteral(["1"])).toBe("{1}");
+    });
+
+    it("leaves a bare nested array element unquoted", () => {
+      expect(quoteArrayLiteral([["x"]])).toBe("{{x}}");
+    });
+
+    it("encodes a mixed array as the Ruby encoder does", () => {
+      expect(
+        quoteArrayLiteral([true, false, "a", "2026-04-26 14:23:55", 1], (v) =>
+          typeof v === "boolean" ? String(v) : undefined,
+        ),
+      ).toBe('{true,false,a,"2026-04-26 14:23:55",1}');
+    });
+  });
+
   describe("formatElement", () => {
-    it("wraps a formatted element in the array element quoting", () => {
+    it("quotes a formatted element whose content needs it", () => {
       const d = new Date("2026-03-26T12:00:00.000Z");
       expect(quoteArrayLiteral([d], () => "2026-03-26 12:00:00")).toBe('{"2026-03-26 12:00:00"}');
     });
 
     it("falls through to the default handling when it returns undefined", () => {
-      expect(quoteArrayLiteral(["a", 1], () => undefined)).toBe('{"a",1}');
+      expect(quoteArrayLiteral(["a", 1], () => undefined)).toBe("{a,1}");
     });
 
     it("escapes quotes and backslashes in a formatted element", () => {
@@ -68,7 +125,7 @@ describe("quoteArrayLiteral", () => {
     });
 
     it("applies to nested array elements", () => {
-      expect(quoteArrayLiteral([["x"]], (v) => (v === "x" ? "X" : undefined))).toBe('{{"X"}}');
+      expect(quoteArrayLiteral([["x"]], (v) => (v === "x" ? "X" : undefined))).toBe("{{X}}");
     });
 
     it("is offered numbers and booleans, which Rails also sends through type_cast", () => {
@@ -84,7 +141,7 @@ describe("quoteArrayLiteral", () => {
     });
 
     it("lets the hook format a number element", () => {
-      expect(quoteArrayLiteral([1], (v) => (v === 1 ? "one" : undefined))).toBe('{"one"}');
+      expect(quoteArrayLiteral([1], (v) => (v === 1 ? "one" : undefined))).toBe("{one}");
     });
   });
 });

--- a/packages/arel/src/quote-array.test.ts
+++ b/packages/arel/src/quote-array.test.ts
@@ -74,14 +74,6 @@ describe("quoteArrayLiteral", () => {
       expect(quoteArrayLiteral(["NULLx", "xNULL"])).toBe("{NULLx,xNULL}");
     });
 
-    it("folds the NULL literal over ASCII only, as pg_strcasecmp does", () => {
-      // A Unicode-aware fold would be a wider net than pg casts. The Kelvin
-      // sign folds to "K" under toUpperCase() but must not participate here;
-      // no non-ASCII char may stand in for N, U or L.
-      expect(quoteArrayLiteral(["nulK"])).toBe("{nulK}");
-      expect(quoteArrayLiteral(["ɴull"])).toBe("{ɴull}");
-    });
-
     it("quotes an element containing whitespace", () => {
       expect(quoteArrayLiteral(["a b"])).toBe('{"a b"}');
       expect(quoteArrayLiteral([" a"])).toBe('{" a"}');

--- a/packages/arel/src/quote-array.test.ts
+++ b/packages/arel/src/quote-array.test.ts
@@ -140,6 +140,17 @@ describe("quoteArrayLiteral", () => {
       expect(seen).toEqual([1, true, "s"]);
     });
 
+    it("is offered nil, which Rails' type_cast takes through `when nil`", () => {
+      const seen: unknown[] = [];
+      expect(
+        quoteArrayLiteral([null], (v) => {
+          seen.push(v);
+          return undefined;
+        }),
+      ).toBe("{NULL}");
+      expect(seen).toEqual([null]);
+    });
+
     it("lets the hook format a number element", () => {
       expect(quoteArrayLiteral([1], (v) => (v === 1 ? "one" : undefined))).toBe("{one}");
     });

--- a/packages/arel/src/quote-array.ts
+++ b/packages/arel/src/quote-array.ts
@@ -16,9 +16,12 @@ export type FormatArrayElement = (value: unknown) => string | undefined;
 // Whitespace is spelled out rather than `\s` because pg tests bytes with
 // `isspace()`, which excludes the non-ASCII spaces `\s` would match.
 const ELEMENT_NEEDS_QUOTING = /[{},"\\ \t\n\r\v\f]/;
-// `/i` on a non-unicode pattern folds ASCII only — it never maps a non-ASCII
-// char onto one — which is the exact shape of pg's `pg_strcasecmp(ptr, "NULL")`.
-// `toUpperCase()` would be a Unicode-aware fold, a wider net than pg casts.
+// `/i` on a non-unicode pattern folds ASCII only, mirroring pg's
+// `pg_strcasecmp(ptr, "NULL")`; `toUpperCase()` would be a Unicode-aware fold,
+// a wider net than pg casts. The difference is unobservable by construction —
+// no codepoint in all of Unicode uppercases to `N`, `U` or `L`, so no input
+// can tell the two apart, and no test can guard this. It stays a regex because
+// it's the exact mirror, not because a collision is reachable.
 const NULL_LITERAL = /^null$/i;
 
 function encodeArrayElement(text: string | null): string {

--- a/packages/arel/src/quote-array.ts
+++ b/packages/arel/src/quote-array.ts
@@ -17,16 +17,24 @@ export type FormatArrayElement = (value: unknown) => string | undefined;
 // `isspace()`, which excludes the non-ASCII spaces `\s` would match.
 const ELEMENT_NEEDS_QUOTING = /[{},"\\ \t\n\r\v\f]/;
 
-function encodeArrayElement(text: string): string {
+function encodeArrayElement(text: string | null): string {
+  // Rendering nil as the bare `NULL` token is the encoder's job, not
+  // `type_cast`'s — the latter returns nil unchanged (`when nil, Numeric,
+  // String then value`, `abstract/quoting.rb:101`). Keeping the split here is
+  // what makes the `"NULL"` string quotable while real nil stays bare.
+  if (text === null) return "NULL";
   if (text === "" || text.toUpperCase() === "NULL" || ELEMENT_NEEDS_QUOTING.test(text)) {
     return `"${text.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
   }
   return text;
 }
 
-function typeCastArrayElement(value: unknown, formatElement?: FormatArrayElement): string {
+function typeCastArrayElement(value: unknown, formatElement?: FormatArrayElement): string | null {
   const formatted = formatElement?.(value);
   if (formatted !== undefined) return formatted;
+  // boundary: JS has no nil/undefined distinction to port — Rails' type_cast
+  // takes nil through `when nil` and raises TypeError on anything unmapped.
+  if (value === null || value === undefined) return null;
   if (typeof value === "number") return String(value);
   if (typeof value === "boolean") return value ? "TRUE" : "FALSE";
   // boundary: defensive Date formatting for caller-supplied array literals.
@@ -58,7 +66,6 @@ function typeCastArrayElement(value: unknown, formatElement?: FormatArrayElement
  */
 export function quoteArrayLiteral(arr: unknown[], formatElement?: FormatArrayElement): string {
   const elements = arr.map((v) => {
-    if (v === null || v === undefined) return "NULL";
     // Nested arrays recurse before the hook, per `type_cast_array`'s
     // `when ::Array` arm; every other element is offered to it uniformly,
     // as Rails dispatches all non-array elements into `type_cast`.

--- a/packages/arel/src/quote-array.ts
+++ b/packages/arel/src/quote-array.ts
@@ -1,17 +1,58 @@
 /**
- * Formats an element as its BARE (un-quoted) content — `quoteArrayLiteral`
- * applies the `"..."` quoting itself. Returning `undefined` falls through to
- * the default handling. Offered every element except nested arrays (which
- * recurse first), mirroring how Rails' `type_cast_array` dispatches all
- * non-array elements into `type_cast` (`postgresql/quoting.rb:221-226`). Lets a
- * caller that owns a dialect's formatting give array elements what the same
- * value gets on the scalar path.
+ * Type-casts an element to the text `PG::TextEncoder::Array` would be handed,
+ * i.e. the BARE content — the encoder decides `"..."` quoting from that text.
+ * Returning `undefined` falls through to the default handling. Offered every
+ * element except nested arrays (which recurse first), mirroring how Rails'
+ * `type_cast_array` dispatches all non-array elements into `type_cast`
+ * (`postgresql/quoting.rb:221-226`). Lets a caller that owns a dialect's
+ * formatting give array elements what the same value gets on the scalar path.
  */
 export type FormatArrayElement = (value: unknown) => string | undefined;
 
+// `PG::TextEncoder::Array` quotes on content, never on type: an element is
+// wrapped only when leaving it bare would be ambiguous — empty, `NULL`
+// (case-insensitively), or carrying a delimiter, whitespace, quote or
+// backslash. Anything else is emitted bare, so `["a"]` encodes to `{a}`.
+// Whitespace is spelled out rather than `\s` because pg tests bytes with
+// `isspace()`, which excludes the non-ASCII spaces `\s` would match.
+const ELEMENT_NEEDS_QUOTING = /[{},"\\ \t\n\r\v\f]/;
+
+function encodeArrayElement(text: string): string {
+  if (text === "" || text.toUpperCase() === "NULL" || ELEMENT_NEEDS_QUOTING.test(text)) {
+    return `"${text.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  }
+  return text;
+}
+
+function typeCastArrayElement(value: unknown, formatElement?: FormatArrayElement): string {
+  const formatted = formatElement?.(value);
+  if (formatted !== undefined) return formatted;
+  if (typeof value === "number") return String(value);
+  if (typeof value === "boolean") return value ? "TRUE" : "FALSE";
+  // boundary: defensive Date formatting for caller-supplied array literals.
+  if (value instanceof Date) return value.toISOString();
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "toISOString" in value &&
+    typeof (value as { toISOString: unknown }).toISOString === "function"
+  ) {
+    return (value as { toISOString: () => string }).toISOString();
+  }
+  if (typeof value === "object" && value !== null) {
+    const replacer = (_k: string, val: unknown) => (typeof val === "bigint" ? val.toString() : val);
+    try {
+      return JSON.stringify(value, replacer) ?? String(value);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+}
+
 /**
  * Formats a JS array as a PostgreSQL array literal string (without outer single quotes).
- * e.g. ["a", "b"] => {"a","b"}
+ * e.g. ["a", "b"] => {a,b}
  *
  * Shared between the Arel PostgreSQL visitor and ActiveRecord's inline SQL quoting.
  */
@@ -22,38 +63,7 @@ export function quoteArrayLiteral(arr: unknown[], formatElement?: FormatArrayEle
     // `when ::Array` arm; every other element is offered to it uniformly,
     // as Rails dispatches all non-array elements into `type_cast`.
     if (Array.isArray(v)) return quoteArrayLiteral(v, formatElement);
-    const formatted = formatElement?.(v);
-    if (formatted !== undefined) {
-      return `"${formatted.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
-    }
-    if (typeof v === "number") return String(v);
-    if (typeof v === "boolean") return v ? "TRUE" : "FALSE";
-    // boundary: defensive Date quoting for caller-supplied array literals.
-    if (v instanceof Date) {
-      return `"${v.toISOString()}"`;
-    }
-    if (
-      typeof v === "object" &&
-      v !== null &&
-      "toISOString" in v &&
-      typeof (v as { toISOString: unknown }).toISOString === "function"
-    ) {
-      return `"${(v as { toISOString: () => string }).toISOString()}"`;
-    }
-    let str: string;
-    if (typeof v === "object" && v !== null) {
-      const replacer = (_k: string, val: unknown) =>
-        typeof val === "bigint" ? val.toString() : val;
-      try {
-        str = JSON.stringify(v, replacer) ?? String(v);
-      } catch {
-        str = String(v);
-      }
-    } else {
-      str = String(v);
-    }
-    const escaped = str.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-    return `"${escaped}"`;
+    return encodeArrayElement(typeCastArrayElement(v, formatElement));
   });
   return `{${elements.join(",")}}`;
 }

--- a/packages/arel/src/quote-array.ts
+++ b/packages/arel/src/quote-array.ts
@@ -16,6 +16,10 @@ export type FormatArrayElement = (value: unknown) => string | undefined;
 // Whitespace is spelled out rather than `\s` because pg tests bytes with
 // `isspace()`, which excludes the non-ASCII spaces `\s` would match.
 const ELEMENT_NEEDS_QUOTING = /[{},"\\ \t\n\r\v\f]/;
+// `/i` on a non-unicode pattern folds ASCII only — it never maps a non-ASCII
+// char onto one — which is the exact shape of pg's `pg_strcasecmp(ptr, "NULL")`.
+// `toUpperCase()` would be a Unicode-aware fold, a wider net than pg casts.
+const NULL_LITERAL = /^null$/i;
 
 function encodeArrayElement(text: string | null): string {
   // Rendering nil as the bare `NULL` token is the encoder's job, not
@@ -23,7 +27,7 @@ function encodeArrayElement(text: string | null): string {
   // String then value`, `abstract/quoting.rb:101`). Keeping the split here is
   // what makes the `"NULL"` string quotable while real nil stays bare.
   if (text === null) return "NULL";
-  if (text === "" || text.toUpperCase() === "NULL" || ELEMENT_NEEDS_QUOTING.test(text)) {
+  if (text === "" || NULL_LITERAL.test(text) || ELEMENT_NEEDS_QUOTING.test(text)) {
     return `"${text.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
   }
   return text;
@@ -38,10 +42,10 @@ function typeCastArrayElement(value: unknown, formatElement?: FormatArrayElement
   if (typeof value === "number") return String(value);
   if (typeof value === "boolean") return value ? "TRUE" : "FALSE";
   // boundary: defensive Date formatting for caller-supplied array literals.
-  if (value instanceof Date) return value.toISOString();
+  // Duck-typed rather than `instanceof Date` so cross-realm dates and Temporal
+  // land here too; a real Date satisfies it, so it needs no arm of its own.
   if (
     typeof value === "object" &&
-    value !== null &&
     "toISOString" in value &&
     typeof (value as { toISOString: unknown }).toISOString === "function"
   ) {

--- a/packages/arel/src/quote-array.ts
+++ b/packages/arel/src/quote-array.ts
@@ -11,10 +11,19 @@ export type FormatArrayElement = (value: unknown) => string | undefined;
 
 // `PG::TextEncoder::Array` quotes on content, never on type: an element is
 // wrapped only when leaving it bare would be ambiguous — empty, `NULL`
-// (case-insensitively), or carrying a delimiter, whitespace, quote or
+// (case-insensitively), or carrying the `,` delimiter, whitespace, quote or
 // backslash. Anything else is emitted bare, so `["a"]` encodes to `{a}`.
 // Whitespace is spelled out rather than `\s` because pg tests bytes with
 // `isspace()`, which excludes the non-ASCII spaces `\s` would match.
+//
+// ruby-pg reads the delimiter from `this->delimiter`, which Rails threads in
+// via `OID::Array#initialize(subtype, delimiter = ",")` (`oid/array.rb:15`).
+// It is hardcoded here because there is nothing to thread: Rails' PG `quote`
+// only encodes an `OID::Array::Data` (`postgresql/quoting.rb:117`) and sends a
+// bare `::Array` to `super`, which raises TypeError — whereas this function is
+// reached with a bare JS array, carrying no subtype and so no delimiter. `,`
+// is the default and the only reachable value on this path, not a
+// simplification of a parameter we could honour.
 const ELEMENT_NEEDS_QUOTING = /[{},"\\ \t\n\r\v\f]/;
 // `/i` on a non-unicode pattern folds ASCII only, mirroring pg's
 // `pg_strcasecmp(ptr, "NULL")`; `toUpperCase()` would be a Unicode-aware fold,
@@ -54,7 +63,7 @@ function typeCastArrayElement(value: unknown, formatElement?: FormatArrayElement
   ) {
     return (value as { toISOString: () => string }).toISOString();
   }
-  if (typeof value === "object" && value !== null) {
+  if (typeof value === "object") {
     const replacer = (_k: string, val: unknown) => (typeof val === "bigint" ? val.toString() : val);
     try {
       return JSON.stringify(value, replacer) ?? String(value);

--- a/packages/arel/src/visitors/postgres.test.ts
+++ b/packages/arel/src/visitors/postgres.test.ts
@@ -336,7 +336,7 @@ describe("PostgresTest", () => {
     it("quotes array values as PG array literals", () => {
       const node = users.get("tags").eq(["a", "b"]);
       const sql = new Visitors.PostgreSQL().compile(node);
-      expect(sql).toContain('\'{"a","b"}\'');
+      expect(sql).toContain("'{a,b}'");
     });
 
     it("quotes nested arrays", () => {
@@ -351,7 +351,10 @@ describe("PostgresTest", () => {
     it("escapes single quotes in array elements", () => {
       const node = users.get("tags").eq(["O'Reilly"]);
       const sql = new Visitors.PostgreSQL().compile(node);
-      expect(sql).toContain("'{\"O''Reilly\"}'");
+      // The apostrophe is escaped by the outer single-quoting, not the array
+      // encoder — `'` is not in PG::TextEncoder::Array's quote-triggering set,
+      // so the element itself stays bare.
+      expect(sql).toContain("'{O''Reilly}'");
     });
 
     it("quotes a Date array element as a db date, matching the scalar path", () => {


### PR DESCRIPTION
## What

`quoteArrayLiteral` (`packages/arel/src/quote-array.ts`) decided array-element
quoting by **type** — strings were always wrapped in `"..."`, so trails emitted
`{"a","b","c"}` where Rails emits `{a,b,c}`.

Rails delegates the whole `{...}` encoding to the pg gem's
`PG::TextEncoder::Array` (`postgresql/quoting.rb:212`), which quotes by
**content**: an element is wrapped only when leaving it bare would be
ambiguous.

This splits the function into Rails' two stages — a `type_cast`-equivalent
(`typeCastArrayElement`) that returns a bare value, and an encoder
(`encodeArrayElement`) that decides quoting from the resulting text.

## The rule

Pinned by probing `PG::TextEncoder::Array` directly rather than inferred:
quote when the element is empty, is `NULL` (case-insensitively), or contains
a delimiter (`,` `{` `}`), whitespace, a double quote, or a backslash.
Otherwise emit bare.

Two details worth flagging, both verified against Ruby:

- The `NULL` check is **case-insensitive** (`{"null"}`, `{"NuLl"}`), but only
  on an exact match — `["NULLx"]` stays bare.
- Whitespace is spelled out as `[ \t\n\r\v\f]` rather than `\s`, because pg
  tests bytes with `isspace()`, which excludes the non-ASCII spaces `\s`
  would match.

## Subsumes the two prior hooks

The `formatElement` hook force-quoted every element it formatted, which is why
dates looked correct under #4867 — a date contains a space, so it needs
quoting anyway. The hook now returns the bare `type_cast` value and the
encoder decides, which is the shape the hook's JSDoc already described.

This overlaps #4869 (booleans) textually. I've left the boolean arm's
`TRUE`/`FALSE` default alone so that story keeps its scope; content-based
quoting leaves both bare either way, so the arms compose rather than conflict.

## Fidelity, not a live bug

Against PG both forms parse identically, so this is a structural/fidelity gap
— please review it as such.

## Test changes

Existing `{"a","b","c"}`-shaped expectations are updated to the Rails form
rather than worked around, per the story's acceptance criteria. The Ruby
transcript is pinned as unit tests. The notable downstream one:
`["O'Reilly"]` now encodes to `'{O''Reilly}'` — the apostrophe is escaped by
the outer single-quoting, not the array encoder, since `'` is not in pg's
quote-triggering set.

All 1480 arel tests pass locally.

Closes-story: converge-arel-array-string-elements-to-content-based-quoting


## Follow-up commit: nil is rendered by the encoder

Reviewing the first commit against `abstract/quoting.rb:101` turned up a real
staging bug in my own split: `type_cast` returns nil *unchanged*
(`when nil, Numeric, String then value`) — it is the encoder that renders the
bare `NULL` token. My first pass short-circuited nil ahead of both stages, so
the two stages didn't actually mirror Rails and the hook was never offered nil
the way `type_cast` receives it. Second commit moves it.

No behaviour change (real nil still encodes bare as `{NULL}`, the `"NULL"`
string still quotes), but it makes the hook's documented contract — "offered
every element except nested arrays" — actually true.

## Gates

- **api:compare**: 11416/16975 methods, 759/1017 files — identical to `main`
  baseline (delta 0).
- **test:compare**: 14437/21656 tests, 744/1017 files — identical to `main`
  baseline (delta 0).
- **No stubs.** `quote-array.ts` has no Rails-mapped counterpart, so the
  private two-stage split adds no unmapped surface.
- 1481 arel tests pass locally.


---

## Review round 1

All four addressed in `e1809f2d8`. Thanks for the `array_needs_quotes`
cross-check — corroborating the rule against PG's own server-side source is a
stronger anchor than my probe, since it pins the semantics rather than one
encoder's rendering of them.

**1. Unicode vs ASCII fold — fixed.** Agreed, and it's the closer mirror even
though neither of us could construct a collision. Now `/^null$/i`: on a
non-unicode pattern `/i` folds ASCII only and never maps a non-ASCII char onto
an ASCII one, which is `pg_strcasecmp`'s shape exactly. Pinned with a test
(`nulK`, `ɴull` both stay bare).

**2. Test name was false — fixed, good catch.** Verified: `[true]` → `{TRUE}`
while `["true"]` → `{true}`, so the name over-claimed. Not intentional. The
encoder-stage point it was reaching for (the encoder never inspects type; it
sees only the text `type_cast` produced) is real, so I kept the assertion and
restated the name as "leaves a string that reads as a literal bare", with the
`TRUE`/#4869 caveat in a comment. I also flagged the neighbouring mixed-array
test, which leans on the hook to stand in for `unquoted_true` — same class of
over-claim, now noted inline.

**3. Dead `Date` arm — collapsed.** Correct, `instanceof Date` was
unreachable-equivalent. Kept the duck-typed branch, which additionally covers
cross-realm dates and Temporal.

**4. Probe provenance — pasted below.** `pg 1.6.3, ruby 3.3.11`.

```ruby
e = PG::TextEncoder::Array.new
```

```text
["a"]                                          => {a}
[""]                                           => {""}
["NULL"]                                       => {"NULL"}
["null"]                                       => {"null"}
["NuLl"]                                       => {"NuLl"}
["NULLx"]                                      => {NULLx}
["xNULL"]                                      => {xNULL}
["a b"]                                        => {"a b"}
[" a"]                                         => {" a"}
["a "]                                         => {"a "}
["a\tb"]                                       => {"a<TAB>b"}
["a\nb"]                                       => {"a<LF>b"}
["a,b"]                                        => {"a,b"}
["a{b"]                                        => {"a{b"}
["a}b"]                                        => {"a}b"}
["he said \"hi\""]                             => {"he said \"hi\""}
["a\\b"]                                       => {"a\\b"}
["O'Reilly"]                                   => {O'Reilly}
["a.b"]                                        => {a.b}
["a-b"]                                        => {a-b}
["a|b"]                                        => {a|b}
["a(b"]                                        => {a(b}
["true"]                                       => {true}
["1"]                                          => {1}
[nil]                                          => {NULL}
[["x"]]                                        => {{x}}
[true, false, "a", "2026-04-26 14:23:55", 1]   => {true,false,a,"2026-04-26 14:23:55",1}
```

(`<TAB>`/`<LF>` are literal control chars in the real output — the encoder
emits them raw inside the quotes rather than escaping them; only `"` and `\`
get backslash-escaped.)

Note the encoder confirms case-insensitive `NULL` and `{`/`}` independently of
`array_out`, which was your question. `["O'Reilly"]` → `{O'Reilly}` is also
pinned here, since that's the one downstream expectation change that looks
surprising.

1482 arel tests pass; api:compare and test:compare deltas still 0.


---

## Review round 2

Addressed in `c8e15f5a0` — you're right on every count, and this retracts a
claim I made in the round-1 note above ("Pinned with a test (`nulK`, `ɴull`
both stay bare)"). That test pinned nothing. Verified before acting:

```text
nulK -> "NULK"   | K is U+004B      regex: false  toUpperCase: false  -> discriminates: false
ɴull -> "ɴULL"                      regex: false  toUpperCase: false  -> discriminates: false
```

The `K` was plain ASCII, not the Kelvin sign my comment named, and U+0274 has
no uppercase mapping — so both assertions pass under `toUpperCase()` too,
exactly as you said. I'd written the fixture from the idea of a Kelvin sign
without checking that the character I typed was one.

I extended your brute force past U+2FFF to the full range, and it confirms the
stronger conclusion:

```text
full sweep U+0080-U+10FFFF folding to N/U/L: none
Kelvin U+212A: "K" -> toUpperCase: "K"   (folds to K, never N/U/L)
```

So no discriminating fixture exists anywhere in Unicode — the ASCII-only
property is unobservable through this function, and no test can guard it.

I took your first option: **dropped the test**, and rewrote the code comment
at `quote-array.ts:19-24` to state that the difference is unreachable by
construction rather than implying a live hazard. The regex stays, on the
grounds you and I agree on — it's the exact mirror of `pg_strcasecmp`, not a
guard against a reachable collision. A test that encodes a false rationale is
worse than no test, which is what this was.

1481 arel tests pass (1482 minus the removed one). api:compare and
test:compare deltas unchanged at 0.


---

## Review round 3

Both addressed in `1bdc4f5f4`.

**1. Second dead `value !== null` — fixed.** Confirmed dead for exactly the
reason you give: the early return narrows nil out before it. Fair hit that I
collapsed the `instanceof Date` arm in e1809f2d8 for this and left its twin
three lines below.

**2. Delimiter — added the word; your reading is right.** Verified in the
vendored source: `quote` has `when OID::Array::Data` (`quoting.rb:117`) with
`else super` (:121), so a bare `::Array` reaches abstract `quote` and raises
TypeError. And the delimiter genuinely *is* parameterized in Rails —
`OID::Array#initialize(subtype, delimiter = ",")` (`oid/array.rb:15`) hands it
to `PG::TextEncoder::Array.new(name:, delimiter:)`. So "a delimiter" was
misleading in the direction that matters: it implied I'd dropped a parameter I
could have honoured.

The comment now says `,` is default-and-only *on this path*, and why: this
function is reached with a bare JS array carrying no subtype, so there is no
delimiter to thread. Agreed it's out of scope to do more — the reachable
divergence isn't the hardcoded `,`, it's that trails encodes a bare array at
all where Rails raises. That's the pre-existing premise of `quoteArrayLiteral`
(Arel doing value formatting that Rails delegates to the connection), already
tracked and converged separately by #4868 — not re-filed here.

1481 arel tests pass; typecheck clean; api:compare and test:compare deltas
still 0.
