### PR TITLE
fix(arel): raw-value dispatch raises like Rails

### DIFF
--- a/packages/activerecord/src/schema-migration.ts
+++ b/packages/activerecord/src/schema-migration.ts
@@ -199,7 +199,12 @@ export class SchemaMigration {
     if (toInsert.length > 0) {
       const col = this.arelTable.get(this.primaryKey);
       const im = new InsertManager(this.arelTable);
-      const rows = toInsert.map((v) => [new Nodes.Quoted(v)]);
+      // Rows carry the version raw, as Rails' rows do — `create_version` passes
+      // it straight to `im.insert` (schema_migration.rb:21), and the ValuesList
+      // visitor quotes it (to_sql.rb:112). A Quoted wrap would fall to `quote()`,
+      // which raises TypeError on a node (abstract/quoting.ts:151), matching
+      // Rails (quoting.rb:86).
+      const rows = toInsert.map((v) => [v]);
       im.ast.columns = [col];
       im.values = im.createValuesList(rows);
       await this._adapter.executeMutation(this._adapter.toSql(im));

--- a/packages/arel/src/insert-manager.test.ts
+++ b/packages/arel/src/insert-manager.test.ts
@@ -9,9 +9,12 @@ describe("InsertManagerTest", () => {
       const mgr = new InsertManager();
       mgr.into(users);
       mgr.ast.columns = [users.get("name"), users.get("age")];
+      // Rails' create_values_list carries RAW row values (`%w{ a b }`,
+      // insert_manager_test.rb:10); the visitor quotes them (to_sql.rb:112).
+      // A Quoted row would hit `quote()` and raise TypeError in Rails.
       mgr.values = new Nodes.ValuesList([
-        [new Nodes.Quoted("dean"), new Nodes.Quoted(30)],
-        [new Nodes.Quoted("sam"), new Nodes.Quoted(25)],
+        ["dean", 30],
+        ["sam", 25],
       ]);
       expect(mgr.toSql()).toBe(
         `INSERT INTO "users" ("name", "age") VALUES ('dean', 30), ('sam', 25)`,
@@ -169,9 +172,12 @@ describe("InsertManagerTest", () => {
       const mgr = new InsertManager();
       mgr.into(users);
       mgr.ast.columns = [users.get("name"), users.get("age")];
+      // Rails' create_values_list carries RAW row values (`%w{ a b }`,
+      // insert_manager_test.rb:10); the visitor quotes them (to_sql.rb:112).
+      // A Quoted row would hit `quote()` and raise TypeError in Rails.
       mgr.values = new Nodes.ValuesList([
-        [new Nodes.Quoted("dean"), new Nodes.Quoted(30)],
-        [new Nodes.Quoted("sam"), new Nodes.Quoted(25)],
+        ["dean", 30],
+        ["sam", 25],
       ]);
       expect(mgr.toSql()).toBe(
         `INSERT INTO "users" ("name", "age") VALUES ('dean', 30), ('sam', 25)`,

--- a/packages/arel/src/insert-manager.ts
+++ b/packages/arel/src/insert-manager.ts
@@ -103,9 +103,12 @@ export class InsertManager extends TreeManager {
   /**
    * Create a ValuesList from multiple rows.
    *
-   * Mirrors: Arel::InsertManager#create_values_list
+   * Mirrors: Arel::InsertManager#create_values_list — rows carry arbitrary
+   * values, not necessarily Nodes (`create_values_list([%w{ a b }, %w{ c d }])`,
+   * insert_manager_test.rb:10); the visitor quotes raw entries (to_sql.rb:112).
+   * Matches `createValues` and the ValuesList node, which both take `unknown`.
    */
-  createValuesList(rows: Node[][]): ValuesList {
+  createValuesList(rows: unknown[][]): ValuesList {
     return new ValuesList(rows);
   }
 }

--- a/packages/arel/src/nodes/matches.test.ts
+++ b/packages/arel/src/nodes/matches.test.ts
@@ -6,7 +6,7 @@ describe("MatchesTest", () => {
 
   describe("escape", () => {
     it("wraps a string escape in a Quoted node (matches Rails build_quoted)", () => {
-      const node = new Nodes.Matches(users.get("name"), "x%", "!");
+      const node = users.get("name").matches("x%", "!");
       expect(node.escape).toBeInstanceOf(Nodes.Quoted);
       expect((node.escape as Nodes.Quoted).value).toBe("!");
     });
@@ -26,7 +26,7 @@ describe("MatchesTest", () => {
   describe("ESCAPE under bind extraction (compileWithBinds)", () => {
     it("inlines a string escape literal even in bind-extraction mode", async () => {
       const { Visitors } = await import("../index.js");
-      const node = new Nodes.Matches(users.get("name"), "x%", "!");
+      const node = users.get("name").matches("x%", "!");
       const visitor = new Visitors.ToSql();
       const [sql] = visitor.compileWithBinds(node);
       // ESCAPE value must be inlined ('!'), not turned into a bind placeholder.

--- a/packages/arel/src/visitors/postgres.test.ts
+++ b/packages/arel/src/visitors/postgres.test.ts
@@ -455,19 +455,19 @@ describe("PostgreSQL dialect overrides (audit follow-up)", () => {
 
   describe("Matches ESCAPE", () => {
     it("hard-quotes a string escape", () => {
-      const node = new Nodes.Matches(users.get("name"), "x%", "!");
+      const node = users.get("name").matches("x%", "!");
       const sql = new Visitors.PostgreSQL().compile(node);
       expect(sql).toContain("ESCAPE '!'");
     });
 
     it("visits a Node escape", () => {
-      const node = new Nodes.Matches(users.get("name"), "x%", new Nodes.Quoted("!"));
+      const node = users.get("name").matches("x%", new Nodes.Quoted("!"));
       const sql = new Visitors.PostgreSQL().compile(node);
       expect(sql).toContain("ESCAPE '!'");
     });
 
     it("visits a Node escape on DoesNotMatch", () => {
-      const node = new Nodes.DoesNotMatch(users.get("name"), "x%", new Nodes.Quoted("!"));
+      const node = users.get("name").doesNotMatch("x%", new Nodes.Quoted("!"));
       const sql = new Visitors.PostgreSQL().compile(node);
       expect(sql).toContain("ESCAPE '!'");
     });

--- a/packages/arel/src/visitors/sqlite.test.ts
+++ b/packages/arel/src/visitors/sqlite.test.ts
@@ -30,10 +30,10 @@ describe("SqliteTest", () => {
     const visitor = new Visitors.SQLite();
     expect(visitor.compile(new Nodes.True())).toBe("1");
     expect(visitor.compile(new Nodes.False())).toBe("0");
+    // `eq` wraps the raw `true` via quotedNode into a Casted node, which is
+    // how a boolean reaches the visitor; a raw `true` placed straight into
+    // Equality raises UnsupportedVisitError, as it does in Rails.
     expect(visitor.compile(users.get("active").eq(true))).toBe('"users"."active" = 1');
-    expect(visitor.compile(new Nodes.Equality(users.get("active"), true))).toBe(
-      '"users"."active" = 1',
-    );
   });
 
   describe("Nodes::IsNotDistinctFrom", () => {

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -494,6 +494,60 @@ describe("the to_sql visitor", () => {
       });
     }
 
+    describe("raw values reaching visit dispatch on their class", () => {
+      // Rails' raw-value dispatch: only `visit_Integer` renders
+      // (`collector << o.to_s`, to_sql.rb:824-826); every other scalar aliases
+      // to `unsupported` and raises (to_sql.rb:828-845). Equality visits its
+      // right (to_sql.rb:643), so a raw value placed there hits that dispatch.
+      const compileRight = (right: unknown): string =>
+        new Visitors.ToSql().compile(
+          new Nodes.Equality(new Table("users").get("id"), right as Nodes.NodeOrValue),
+        );
+
+      it("renders an Integer bare", () => {
+        expect(compileRight(1)).toBe('"users"."id" = 1');
+        // Ruby has no fixnum/bignum split at this layer — both are Integer.
+        expect(compileRight(9007199254740993n)).toBe('"users"."id" = 9007199254740993');
+      });
+
+      for (const [label, value] of [
+        ["a String", "x"],
+        ["a Float", 1.5],
+        ["NaN", NaN],
+        ["TrueClass", true],
+        ["FalseClass", false],
+        ["NilClass", null],
+        ["a Time", new Date("2024-01-01T00:00:00Z")],
+        ["a Hash", { a: 1 }],
+      ] as const) {
+        it(`raises UnsupportedVisitError for ${label}`, () => {
+          expect(() => compileRight(value)).toThrow(Visitors.UnsupportedVisitError);
+        });
+      }
+
+      it("raises UnsupportedVisitError for a non-finite Float", () => {
+        // Not asserted through Equality: an unboundable Infinity short-circuits
+        // to 1=0/1=1 before dispatch. visitArray (`inject_join`, to_sql.rb:858)
+        // reaches the raw-value path directly. Infinity is not integral, so it
+        // lands on the Float branch — there is no separate non-finite rule.
+        const v = new Visitors.ToSql();
+        const visitArray = (
+          v as unknown as { visitArray(a: ReadonlyArray<unknown>, c: unknown): void }
+        ).visitArray;
+        expect(() => visitArray.call(v, [Infinity], new Collectors.SQLString())).toThrow(
+          Visitors.UnsupportedVisitError,
+        );
+      });
+
+      it("renders once wrapped via quotedNode, as predications do", () => {
+        // The AR-facing path: `eq` wraps the raw value in a Casted node, which
+        // routes through quote() (to_sql.rb:87-90) rather than raw dispatch.
+        expect(new Visitors.ToSql().compile(new Table("users").get("id").eq("x"))).toBe(
+          '"users"."id" = \'x\'',
+        );
+      });
+    });
+
     it("visit_Set is aliased to visit_Array (joins with ', ')", () => {
       // Rails: `alias :visit_Set :visit_Array` (to_sql.rb:861).
       const v = new Visitors.ToSql();
@@ -1782,11 +1836,17 @@ describe("the to_sql visitor", () => {
       const tbl = new Table("users");
       const v = new Visitors.ToSql();
       const collector = new Collectors.SQLString();
-      (v as unknown as { visitArray(a: ReadonlyArray<unknown>, c: unknown): void }).visitArray(
-        [tbl.get("a"), 1, "text"],
-        collector,
+      const visitArray = (
+        v as unknown as { visitArray(a: ReadonlyArray<unknown>, c: unknown): void }
+      ).visitArray;
+      // Rails' `visit_Array` is `inject_join` (to_sql.rb:858-860): each entry
+      // goes through `visit`, so a Node and an Integer render while a raw
+      // String hits `visit_String` and raises.
+      visitArray.call(v, [tbl.get("a"), 1], collector);
+      expect(collector.value).toBe('"users"."a", 1');
+      expect(() => visitArray.call(v, ["text"], new Collectors.SQLString())).toThrow(
+        Visitors.UnsupportedVisitError,
       );
-      expect(collector.value).toBe('"users"."a", 1, \'text\'');
     });
   });
 

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -549,10 +549,19 @@ describe("the to_sql visitor", () => {
       });
 
       it("raises UnsupportedVisitError for a non-finite Float", () => {
-        // Not asserted through Equality: an unboundable Infinity short-circuits
-        // to 1=0/1=1 before dispatch. visitArray (`inject_join`, to_sql.rb:858)
-        // reaches the raw-value path directly. Infinity is not integral, so it
-        // lands on the Float branch — there is no separate non-finite rule.
+        // Infinity is not integral, so it lands on the Float branch — there is
+        // no separate non-finite rule.
+        //
+        // Asserted through visitArray (`inject_join`, to_sql.rb:858) rather
+        // than Equality because trails' `unboundableSign` short-circuits a raw
+        // Infinity to 1=0/1=1 first. That short-circuit is a KNOWN DEVIATION,
+        // not the rule this file documents: Rails' `unboundable?` is purely
+        // duck-typed (`value.respond_to?(:unboundable?) && value.unboundable?`,
+        // to_sql.rb:905-907) and a Float answers it false, so Rails reaches
+        // visit_Float and raises. Tracked by story
+        // arel-unboundable-sign-duck-types-like-rails; converging it is out of
+        // scope here (it also changes Quoted(INFINITY), which Rails renders as
+        // `= Infinity`).
         const v = new Visitors.ToSql();
         const visitArray = (
           v as unknown as { visitArray(a: ReadonlyArray<unknown>, c: unknown): void }
@@ -562,11 +571,46 @@ describe("the to_sql visitor", () => {
         );
       });
 
+      it("dispatches a bare Temporal on its Rails analogue", () => {
+        // Temporal is the Time analogue, so an Instant must reach visit_Time
+        // (`alias :visit_Time :unsupported`, to_sql.rb:844) and a PlainDate
+        // visit_Date (to_sql.rb:837) — not the generic no-handler tail.
+        // Temporal exposes no toISOString, so the tag is what routes them.
+        const v = new Visitors.ToSql();
+        const seen: string[] = [];
+        const spy = Object.create(v) as Record<string, unknown> & { compile(n: unknown): string };
+        spy.visitTime = () => {
+          seen.push("Time");
+          throw new Visitors.UnsupportedVisitError("x");
+        };
+        spy.visitDate = () => {
+          seen.push("Date");
+          throw new Visitors.UnsupportedVisitError("x");
+        };
+        const attr = new Table("users").get("id");
+        expect(() =>
+          spy.compile(
+            new Nodes.Equality(
+              attr,
+              Temporal.Instant.from("2026-04-30T12:34:56Z") as unknown as Nodes.NodeOrValue,
+            ),
+          ),
+        ).toThrow(Visitors.UnsupportedVisitError);
+        expect(() =>
+          spy.compile(
+            new Nodes.Equality(
+              attr,
+              Temporal.PlainDate.from("2026-04-30") as unknown as Nodes.NodeOrValue,
+            ),
+          ),
+        ).toThrow(Visitors.UnsupportedVisitError);
+        expect(seen).toEqual(["Time", "Date"]);
+      });
+
       it("raises for a bare Temporal but still renders it wrapped", () => {
-        // Temporal is the Time analogue, and `alias :visit_Time :unsupported`
-        // (to_sql.rb:844) — so a bare one raises. Wrapped in Quoted it routes
-        // through quote() (to_sql.rb:87-90) and still inlines, which is the
-        // only shape any AR caller produces.
+        // A bare Temporal raises; wrapped in Quoted it routes through quote()
+        // (to_sql.rb:87-90) and still inlines, which is the only shape any AR
+        // caller produces.
         const instant = Temporal.Instant.from("2026-04-30T12:34:56.000Z");
         expect(() => compileRight(instant)).toThrow(Visitors.UnsupportedVisitError);
         // Rendering shape here is whatever the quoter already does with a

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1407,9 +1407,57 @@ describe("the to_sql visitor", () => {
   });
 
   it("works with lists", () => {
-    const node = new Nodes.ValuesList([[new Nodes.Quoted(1)], [new Nodes.Quoted(2)]]);
+    const node = new Nodes.ValuesList([[1], [2]]);
     const sql = new Visitors.ToSql().compile(node);
     expect(sql).toBe("VALUES (1), (2)");
+  });
+
+  describe("Nodes::ValuesList row dispatch", () => {
+    // Rails' `case` (to_sql.rb:106-114) visits only SqlLiteral/BindParam/
+    // ActiveModel::Attribute; everything else — including a Casted/Quoted —
+    // falls to `quote()`. Routing is asserted through a connection whose
+    // `quote` is distinguishable, so this pins which branch each row takes
+    // rather than just the rendered text.
+    const probe = {
+      quoteTableName: (n: string) => `"${n}"`,
+      quoteColumnName: (n: string) => `"${n}"`,
+      quoteString: (s: string) => s,
+      quote: (v: unknown) => `Q(${String(v)})`,
+      quotedBinary: (v: unknown) => `'${String(v)}'`,
+      quotedTrue: () => "TRUE",
+      quotedFalse: () => "FALSE",
+      unquotedTrue: () => true,
+      unquotedFalse: () => false,
+      sanitizeAsSqlComment: (v: string) => v,
+    } as unknown as Visitors.ArelConnection;
+
+    it("quotes a raw row value instead of visiting it", () => {
+      const sql = new Visitors.ToSql(probe).compile(new Nodes.ValuesList([[1, "a"]]));
+      expect(sql).toBe("VALUES (Q(1), Q(a))");
+    });
+
+    it("visits a SqlLiteral row without quoting it", () => {
+      const sql = new Visitors.ToSql(probe).compile(
+        new Nodes.ValuesList([[new Nodes.SqlLiteral("DEFAULT")]]),
+      );
+      expect(sql).toBe("VALUES (DEFAULT)");
+    });
+
+    it("sends a Quoted row to quote(), which is where Rails raises TypeError", () => {
+      // Rails: quote(Quoted) → to_sql.rb:867-870 → quoting.rb:86
+      // `else raise TypeError, "can't quote Arel::Nodes::Quoted"`. Trails'
+      // adapter quote does the same (abstract/quoting.ts:151), so a connection
+      // that raises proves the row reaches quote() rather than visit.
+      const raising = {
+        ...probe,
+        quote: (v: unknown) => {
+          throw new TypeError(`can't quote ${(v as object)?.constructor?.name}`);
+        },
+      } as unknown as Visitors.ArelConnection;
+      expect(() =>
+        new Visitors.ToSql(raising).compile(new Nodes.ValuesList([[new Nodes.Quoted(1)]])),
+      ).toThrow(/can't quote Quoted/);
+    });
   });
 
   describe("Nodes::BoundSqlLiteral", () => {

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -516,7 +516,6 @@ describe("the to_sql visitor", () => {
         ["NaN", NaN],
         ["TrueClass", true],
         ["FalseClass", false],
-        ["NilClass", null],
         ["a Time", new Date("2024-01-01T00:00:00Z")],
         ["a Hash", { a: 1 }],
       ] as const) {
@@ -524,6 +523,30 @@ describe("the to_sql visitor", () => {
           expect(() => compileRight(value)).toThrow(Visitors.UnsupportedVisitError);
         });
       }
+
+      it("renders IS NULL for a bare NilClass rather than dispatching", () => {
+        // Rails tests `right.nil?` (to_sql.rb:649) before visiting, and that is
+        // true for a bare nil as well as Quoted(nil) (`Quoted#nil?` delegates
+        // to `value.nil?`, casted.rb:41) — so nil never reaches raw dispatch
+        // here, even though visit_NilClass is aliased to `unsupported`.
+        expect(compileRight(null)).toBe('"users"."id" IS NULL');
+        const attr = new Table("users").get("id");
+        expect(new Visitors.ToSql().compile(new Nodes.NotEqual(attr, null))).toBe(
+          '"users"."id" IS NOT NULL',
+        );
+      });
+
+      it("raises UnsupportedVisitError for NilClass on a path that reaches dispatch", () => {
+        // visit_NilClass is aliased to `unsupported` (to_sql.rb:840); visitArray
+        // reaches it because there is no `nil?` guard on that path.
+        const v = new Visitors.ToSql();
+        const visitArray = (
+          v as unknown as { visitArray(a: ReadonlyArray<unknown>, c: unknown): void }
+        ).visitArray;
+        expect(() => visitArray.call(v, [null], new Collectors.SQLString())).toThrow(
+          Visitors.UnsupportedVisitError,
+        );
+      });
 
       it("raises UnsupportedVisitError for a non-finite Float", () => {
         // Not asserted through Equality: an unboundable Infinity short-circuits
@@ -537,6 +560,18 @@ describe("the to_sql visitor", () => {
         expect(() => visitArray.call(v, [Infinity], new Collectors.SQLString())).toThrow(
           Visitors.UnsupportedVisitError,
         );
+      });
+
+      it("raises for a bare Temporal but still renders it wrapped", () => {
+        // Temporal is the Time analogue, and `alias :visit_Time :unsupported`
+        // (to_sql.rb:844) — so a bare one raises. Wrapped in Quoted it routes
+        // through quote() (to_sql.rb:87-90) and still inlines, which is the
+        // only shape any AR caller produces.
+        const instant = Temporal.Instant.from("2026-04-30T12:34:56.000Z");
+        expect(() => compileRight(instant)).toThrow(Visitors.UnsupportedVisitError);
+        // Rendering shape here is whatever the quoter already does with a
+        // Temporal; this pins only that the wrapped path still inlines.
+        expect(compileRight(new Nodes.Quoted(instant))).toContain("2026-04-30");
       });
 
       it("renders once wrapped via quotedNode, as predications do", () => {

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -524,6 +524,15 @@ describe("the to_sql visitor", () => {
         });
       }
 
+      it("renders IS NULL for Casted(nil) as well as Quoted(nil)", () => {
+        // Rails defines `nil?` as `value.nil?` on both wrappers — Casted
+        // (casted.rb:15) and Quoted (casted.rb:41) — so `right.nil?`
+        // (to_sql.rb:649) is true for either and both emit IS NULL.
+        const attr = new Table("users").get("id");
+        expect(compileRight(new Nodes.Quoted(null))).toBe('"users"."id" IS NULL');
+        expect(compileRight(new Nodes.Casted(null, attr))).toBe('"users"."id" IS NULL');
+      });
+
       it("renders IS NULL for a bare NilClass rather than dispatching", () => {
         // Rails tests `right.nil?` (to_sql.rb:649) before visiting, and that is
         // true for a bare nil as well as Quoted(nil) (`Quoted#nil?` delegates

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -19,8 +19,12 @@ export { UnsupportedVisitError };
 // Assignment visitors (to_sql.rb:109, 632). trails has no Arel-visible class
 // for it, so it is duck-typed on `valueForDatabase` — the same shape
 // `resolveValueForDatabase` above accepts.
+// Arel's own Casted/Quoted also expose `valueForDatabase` (casted.ts:70,108),
+// but Rails' `case` lists only SqlLiteral/BindParam/ActiveModel::Attribute
+// (to_sql.rb:110, 632) — a Casted is none of those and falls to the `quote()`
+// branch. Excluding Nodes keeps the duck-type to non-Arel attributes.
 function isActiveModelAttribute(v: unknown): boolean {
-  return typeof v === "object" && v !== null && "valueForDatabase" in v;
+  return typeof v === "object" && v !== null && !(v instanceof Node) && "valueForDatabase" in v;
 }
 
 // The analogue of Ruby's Hash — an object literal, i.e. one whose prototype is
@@ -303,15 +307,18 @@ export class ToSql extends Visitor {
       collector.append("(");
       for (let j = 0; j < node.rows[i].length; j++) {
         if (j > 0) collector.append(", ");
-        // Mirrors Rails (to_sql.rb:106-114): only SqlLiteral/BindParam/
-        // Attribute are visited; every other row entry is a raw value and is
-        // quoted directly, never dispatched through `visit`.
+        // Mirrors Rails (to_sql.rb:106-114): a raw row entry is quoted
+        // directly and never dispatched through `visit`.
+        //
+        // Rails' `case` lists SqlLiteral/BindParam/ActiveModel::Attribute; we
+        // visit any Node. The lists agree on every *raw* value, which is what
+        // this branch exists to decide. They differ only for other Arel nodes
+        // (Casted/Quoted), where Rails falls to `quote()` — and `quote()` has
+        // no node branch (to_sql.rb:867-870 → quoting.rb `else raise
+        // TypeError`), so Rails raises there. Visiting renders instead of
+        // emitting a garbage literal for a case no caller reaches.
         const value = node.rows[i][j];
-        if (
-          value instanceof Nodes.SqlLiteral ||
-          value instanceof Nodes.BindParam ||
-          isActiveModelAttribute(value)
-        ) {
+        if (value instanceof Node || isActiveModelAttribute(value)) {
           this.visit(value as Node, collector);
         } else {
           collector.append(this.quote(value));
@@ -2128,6 +2135,12 @@ export class ToSql extends Visitor {
    * so honour a duck-typed `isNil()` on the right node too.
    */
   protected rightIsNull(right: unknown): boolean {
+    // Rails tests `right.nil?` (to_sql.rb:649), which is true for a bare nil as
+    // well as for a Quoted(nil) — `Quoted#nil?` delegates to `value.nil?`
+    // (casted.rb:41). A bare null therefore renders IS NULL and never reaches
+    // the raw-value dispatch, even though visit_NilClass is aliased to
+    // `unsupported` for the paths that do reach it.
+    if (right === null || right === undefined) return true;
     if (right instanceof Nodes.Quoted && right.value === null) return true;
     // A bound scalar arrives wrapped in a BindParam whose `isNil()` delegates
     // to its wrapped value (bind_param.rb:23-25) — so a raw-null bind or an

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -15,10 +15,43 @@ import { UnsupportedVisitError, NotImplementedError, BindError } from "../errors
 // here so api:compare finds it where Rails defines it.
 export { UnsupportedVisitError };
 
-// The analogue of Rails' `ActiveModel::Attribute` case in the ValuesList /
-// Assignment visitors (to_sql.rb:109, 632). trails has no Arel-visible class
-// for it, so it is duck-typed on `valueForDatabase` — the same shape
-// `resolveValueForDatabase` above accepts.
+import { defaultQuoter } from "./default-quoter.js";
+export type { ArelConnection } from "./connection.js";
+import type { ArelConnection } from "./connection.js";
+
+/**
+ * Connection-quoting surface exposed to the Arel visitor.
+ *
+ * Mirrors Rails' `@connection` object passed to `Arel::Visitors::ToSql`.
+ * Rails dispatches every quoting decision through the connection so adapters
+ * can specialise (PG hex-escapes binary, MySQL backtick-quotes identifiers,
+ * etc.).  We accept this subset so `arel` stays dependency-free from
+ * `activerecord`; `AbstractAdapter` is a structural superset and always
+ * satisfies this interface.
+ *
+ * @deprecated Use `ArelConnection` — this alias will be removed in a future release.
+ */
+export type ArelQuoter = ArelConnection;
+
+/**
+ * Resolve a bind's database value. QueryAttribute exposes
+ * `valueForDatabase` as a method; ActiveModel::Attribute (TS port)
+ * exposes it as a getter. A normal property read handles both shapes —
+ * the getter evaluates to its value, a method reference yields a
+ * function that we then invoke.
+ */
+export function resolveValueForDatabase(value: unknown): unknown {
+  if (!value || typeof value !== "object" || !("valueForDatabase" in value)) return value;
+  const v = (value as Record<string, unknown>).valueForDatabase;
+  return typeof v === "function" ? (v as () => unknown).call(value) : v;
+}
+
+// -- Raw-value dispatch helpers --
+//
+// Rails dispatches a raw value on its Ruby class (visitor.rb:29-30). These map
+// each JS analogue onto the class Rails would pick, so `visitNodeOrValue` can
+// hand off to the matching visit_* method.
+
 // The analogue of Rails' `ActiveModel::Attribute` case in the ValuesList /
 // Assignment visitors (to_sql.rb:110, 632). trails has no Arel-visible class
 // for it, so it is duck-typed on `valueForDatabase` — the same shape
@@ -72,36 +105,6 @@ function isTimeLike(v: unknown): boolean {
 function constructorName(v: unknown): string {
   if (v === null || v === undefined) return "NilClass";
   return (v as { constructor?: { name?: string } }).constructor?.name ?? typeof v;
-}
-import { defaultQuoter } from "./default-quoter.js";
-export type { ArelConnection } from "./connection.js";
-import type { ArelConnection } from "./connection.js";
-
-/**
- * Connection-quoting surface exposed to the Arel visitor.
- *
- * Mirrors Rails' `@connection` object passed to `Arel::Visitors::ToSql`.
- * Rails dispatches every quoting decision through the connection so adapters
- * can specialise (PG hex-escapes binary, MySQL backtick-quotes identifiers,
- * etc.).  We accept this subset so `arel` stays dependency-free from
- * `activerecord`; `AbstractAdapter` is a structural superset and always
- * satisfies this interface.
- *
- * @deprecated Use `ArelConnection` — this alias will be removed in a future release.
- */
-export type ArelQuoter = ArelConnection;
-
-/**
- * Resolve a bind's database value. QueryAttribute exposes
- * `valueForDatabase` as a method; ActiveModel::Attribute (TS port)
- * exposes it as a getter. A normal property read handles both shapes —
- * the getter evaluates to its value, a method reference yields a
- * function that we then invoke.
- */
-export function resolveValueForDatabase(value: unknown): unknown {
-  if (!value || typeof value !== "object" || !("valueForDatabase" in value)) return value;
-  const v = (value as Record<string, unknown>).valueForDatabase;
-  return typeof v === "function" ? (v as () => unknown).call(value) : v;
 }
 
 /** Default placeholder block; mirrors Rails' module-level `BIND_BLOCK`. */

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -19,12 +19,14 @@ export { UnsupportedVisitError };
 // Assignment visitors (to_sql.rb:109, 632). trails has no Arel-visible class
 // for it, so it is duck-typed on `valueForDatabase` — the same shape
 // `resolveValueForDatabase` above accepts.
-// Arel's own Casted/Quoted also expose `valueForDatabase` (casted.ts:70,108),
-// but Rails' `case` lists only SqlLiteral/BindParam/ActiveModel::Attribute
-// (to_sql.rb:110, 632) — a Casted is none of those and falls to the `quote()`
-// branch. Excluding Nodes keeps the duck-type to non-Arel attributes.
+// The analogue of Rails' `ActiveModel::Attribute` case in the ValuesList /
+// Assignment visitors (to_sql.rb:110, 632). trails has no Arel-visible class
+// for it, so it is duck-typed on `valueForDatabase` — the same shape
+// `resolveValueForDatabase` accepts. Arel's own Casted/Quoted expose that
+// property too (casted.ts:70,108), but both call sites test `instanceof Node`
+// first, so this only ever sees non-Node values.
 function isActiveModelAttribute(v: unknown): boolean {
-  return typeof v === "object" && v !== null && !(v instanceof Node) && "valueForDatabase" in v;
+  return typeof v === "object" && v !== null && "valueForDatabase" in v;
 }
 
 // The analogue of Ruby's Hash — an object literal, i.e. one whose prototype is
@@ -36,9 +38,26 @@ function isPlainObject(v: unknown): boolean {
   return proto === Object.prototype || proto === null;
 }
 
-// A JS Date (or any date-like duck-type) is the analogue of Ruby's Time, which
-// Rails aliases to `unsupported` (to_sql.rb:844).
-function isDateLike(v: unknown): boolean {
+// Temporal types carry a `Temporal.X` Symbol.toStringTag; matching on it keeps
+// the check structural rather than importing the namespace into arel.
+function temporalTag(v: unknown): string | null {
+  if (typeof v !== "object" || v === null) return null;
+  const tag = (v as Record<symbol, unknown>)[Symbol.toStringTag];
+  return typeof tag === "string" && tag.startsWith("Temporal.") ? tag : null;
+}
+
+// The analogue of Ruby's Date, which Rails aliases to `unsupported`
+// (to_sql.rb:837). Temporal.PlainDate is the only wall-clock-date type here.
+function isDateOnly(v: unknown): boolean {
+  return temporalTag(v) === "Temporal.PlainDate";
+}
+
+// The analogue of Ruby's Time (to_sql.rb:844, also aliased to `unsupported`).
+// Temporal is the Time analogue in this codebase, and Temporal types expose no
+// `toISOString`, so they must be matched on their tag; a JS Date (or any
+// toISOString duck-type) is an instant-in-time and maps here too.
+function isTimeLike(v: unknown): boolean {
+  if (temporalTag(v) !== null) return !isDateOnly(v);
   return (
     typeof v === "object" &&
     v !== null &&
@@ -2085,7 +2104,8 @@ export class ToSql extends Visitor {
       return v ? this.visitTrueClass(v, collector) : this.visitFalseClass(v, collector);
     }
     if (typeof v === "symbol") return this.visitSymbol(v, collector);
-    if (isDateLike(v)) return this.visitTime(v, collector);
+    if (isDateOnly(v)) return this.visitDate(v, collector);
+    if (isTimeLike(v)) return this.visitTime(v, collector);
     if (isPlainObject(v)) return this.visitHash(v, collector);
     // Rails dispatches on the object's actual class (visitor.rb:29-30), so an
     // arbitrary object never reaches visit_Hash — it finds no handler and

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -2158,13 +2158,15 @@ export class ToSql extends Visitor {
    * so honour a duck-typed `isNil()` on the right node too.
    */
   protected rightIsNull(right: unknown): boolean {
-    // Rails tests `right.nil?` (to_sql.rb:649), which is true for a bare nil as
-    // well as for a Quoted(nil) — `Quoted#nil?` delegates to `value.nil?`
-    // (casted.rb:41). A bare null therefore renders IS NULL and never reaches
-    // the raw-value dispatch, even though visit_NilClass is aliased to
-    // `unsupported` for the paths that do reach it.
+    // Rails tests `right.nil?` (to_sql.rb:649), which is true for a bare nil
+    // and for the two wrappers that define `nil?` as `value.nil?` — Casted
+    // (casted.rb:15) and Quoted (casted.rb:41). A bare null therefore renders
+    // IS NULL and never reaches the raw-value dispatch, even though
+    // visit_NilClass is aliased to `unsupported` for the paths that do reach
+    // it.
     if (right === null || right === undefined) return true;
     if (right instanceof Nodes.Quoted && right.value === null) return true;
+    if (right instanceof Nodes.Casted && right.value === null) return true;
     // A bound scalar arrives wrapped in a BindParam whose `isNil()` delegates
     // to its wrapped value (bind_param.rb:23-25) — so a raw-null bind or an
     // enum/normalized bind that serializes to nil is caught.

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -55,11 +55,16 @@ export function resolveValueForDatabase(value: unknown): unknown {
 // The analogue of Rails' `ActiveModel::Attribute` case in the ValuesList /
 // Assignment visitors (to_sql.rb:110, 632). trails has no Arel-visible class
 // for it, so it is duck-typed on `valueForDatabase` — the same shape
-// `resolveValueForDatabase` accepts. Arel's own Casted/Quoted expose that
-// property too (casted.ts:70,108), but both call sites test `instanceof Node`
-// first, so this only ever sees non-Node values.
+// `resolveValueForDatabase` accepts.
+//
+// The `instanceof Node` exclusion is load-bearing: Arel's own Casted/Quoted
+// expose `valueForDatabase` too (casted.ts:70,108), and ValuesList's Rails
+// `case` (to_sql.rb:110) does NOT list them — without this they would take the
+// visit branch there instead of falling to `quote()`, which is where Rails
+// sends them. Assignment tests `instanceof Node` itself before calling this,
+// matching its own wider `case` (to_sql.rb:631).
 function isActiveModelAttribute(v: unknown): boolean {
-  return typeof v === "object" && v !== null && "valueForDatabase" in v;
+  return typeof v === "object" && v !== null && !(v instanceof Node) && "valueForDatabase" in v;
 }
 
 // The analogue of Ruby's Hash — an object literal, i.e. one whose prototype is
@@ -329,18 +334,23 @@ export class ToSql extends Visitor {
       collector.append("(");
       for (let j = 0; j < node.rows[i].length; j++) {
         if (j > 0) collector.append(", ");
-        // Mirrors Rails (to_sql.rb:106-114): a raw row entry is quoted
-        // directly and never dispatched through `visit`.
+        // Mirrors Rails' `case` exactly (to_sql.rb:106-114): only SqlLiteral,
+        // BindParam and ActiveModel::Attribute are visited; every other row
+        // entry is a raw value and is quoted directly, never dispatched
+        // through `visit`.
         //
-        // Rails' `case` lists SqlLiteral/BindParam/ActiveModel::Attribute; we
-        // visit any Node. The lists agree on every *raw* value, which is what
-        // this branch exists to decide. They differ only for other Arel nodes
-        // (Casted/Quoted), where Rails falls to `quote()` — and `quote()` has
-        // no node branch (to_sql.rb:867-870 → quoting.rb `else raise
-        // TypeError`), so Rails raises there. Visiting renders instead of
-        // emitting a garbage literal for a case no caller reaches.
+        // The list is deliberately narrower than Assignment's (which visits any
+        // Node, to_sql.rb:631). Rails' rows carry raw values — see
+        // `create_values_list([%w{ a b }, ...])`, insert_manager_test.rb:10 —
+        // so a Casted/Quoted row falls to `quote()`, which has no node branch
+        // (to_sql.rb:867-870 → quoting.rb:86 `else raise TypeError`) and
+        // raises. Keeping the list narrow preserves that.
         const value = node.rows[i][j];
-        if (value instanceof Node || isActiveModelAttribute(value)) {
+        if (
+          value instanceof Nodes.SqlLiteral ||
+          value instanceof Nodes.BindParam ||
+          isActiveModelAttribute(value)
+        ) {
           this.visit(value as Node, collector);
         } else {
           collector.append(this.quote(value));

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -23,6 +23,15 @@ function isActiveModelAttribute(v: unknown): boolean {
   return typeof v === "object" && v !== null && "valueForDatabase" in v;
 }
 
+// The analogue of Ruby's Hash — an object literal, i.e. one whose prototype is
+// Object.prototype (or null). Anything else is an instance of some other class
+// and dispatches on that class in Rails, not on Hash.
+function isPlainObject(v: unknown): boolean {
+  if (typeof v !== "object" || v === null) return false;
+  const proto = Object.getPrototypeOf(v);
+  return proto === Object.prototype || proto === null;
+}
+
 // A JS Date (or any date-like duck-type) is the analogue of Ruby's Time, which
 // Rails aliases to `unsupported` (to_sql.rb:844).
 function isDateLike(v: unknown): boolean {
@@ -2068,8 +2077,14 @@ export class ToSql extends Visitor {
     if (typeof v === "boolean") {
       return v ? this.visitTrueClass(v, collector) : this.visitFalseClass(v, collector);
     }
+    if (typeof v === "symbol") return this.visitSymbol(v, collector);
     if (isDateLike(v)) return this.visitTime(v, collector);
-    return this.visitHash(v, collector);
+    if (isPlainObject(v)) return this.visitHash(v, collector);
+    // Rails dispatches on the object's actual class (visitor.rb:29-30), so an
+    // arbitrary object never reaches visit_Hash — it finds no handler and
+    // raises. Going straight to `unsupported` keeps the reported class honest
+    // rather than mislabelling it as a Hash.
+    return this.unsupported(v, collector);
   }
 
   /**

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -14,6 +14,33 @@ import { UnsupportedVisitError, NotImplementedError, BindError } from "../errors
 // hierarchy alongside BindError/EmptyJoinError, but re-exports it from
 // here so api:compare finds it where Rails defines it.
 export { UnsupportedVisitError };
+
+// The analogue of Rails' `ActiveModel::Attribute` case in the ValuesList /
+// Assignment visitors (to_sql.rb:109, 632). trails has no Arel-visible class
+// for it, so it is duck-typed on `valueForDatabase` — the same shape
+// `resolveValueForDatabase` above accepts.
+function isActiveModelAttribute(v: unknown): boolean {
+  return typeof v === "object" && v !== null && "valueForDatabase" in v;
+}
+
+// A JS Date (or any date-like duck-type) is the analogue of Ruby's Time, which
+// Rails aliases to `unsupported` (to_sql.rb:844).
+function isDateLike(v: unknown): boolean {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    "toISOString" in v &&
+    typeof (v as { toISOString: unknown }).toISOString === "function"
+  );
+}
+
+// Rails' UnsupportedVisitError message interpolates `object.class.name`
+// (to_sql.rb:5-8). `null`/`undefined` have no constructor; Ruby's analogue for
+// both is NilClass.
+function constructorName(v: unknown): string {
+  if (v === null || v === undefined) return "NilClass";
+  return (v as { constructor?: { name?: string } }).constructor?.name ?? typeof v;
+}
 import { defaultQuoter } from "./default-quoter.js";
 export type { ArelConnection } from "./connection.js";
 import type { ArelConnection } from "./connection.js";
@@ -267,7 +294,19 @@ export class ToSql extends Visitor {
       collector.append("(");
       for (let j = 0; j < node.rows[i].length; j++) {
         if (j > 0) collector.append(", ");
-        this.visitNodeOrValue(node.rows[i][j] as Nodes.NodeOrValue, collector);
+        // Mirrors Rails (to_sql.rb:106-114): only SqlLiteral/BindParam/
+        // Attribute are visited; every other row entry is a raw value and is
+        // quoted directly, never dispatched through `visit`.
+        const value = node.rows[i][j];
+        if (
+          value instanceof Nodes.SqlLiteral ||
+          value instanceof Nodes.BindParam ||
+          isActiveModelAttribute(value)
+        ) {
+          this.visit(value as Node, collector);
+        } else {
+          collector.append(this.quote(value));
+        }
       }
       collector.append(")");
     }
@@ -1105,12 +1144,17 @@ export class ToSql extends Visitor {
   }
 
   private visitArelNodesAssignment(node: Nodes.Assignment, collector: SQLString): SQLString {
-    // Mirrors Rails: bare `visit(left) = visit(right)`. Column-name
-    // unqualification is the responsibility of `UnqualifiedColumn`,
+    // Column-name unqualification is the responsibility of `UnqualifiedColumn`,
     // which `UpdateManager#set` wraps each LHS in.
     this.visitNodeOrValue(node.left, collector);
     collector.append(" = ");
-    this.visitNodeOrValue(node.right, collector);
+    // Mirrors Rails (to_sql.rb:630-641): a Node/Attribute right is visited; a
+    // raw value is quoted directly rather than dispatched through `visit`.
+    if (node.right instanceof Node || isActiveModelAttribute(node.right)) {
+      this.visitNodeOrValue(node.right, collector);
+    } else {
+      collector.append(this.quote(node.right));
+    }
     return collector;
   }
 
@@ -1360,11 +1404,10 @@ export class ToSql extends Visitor {
    * as well as `number`: Ruby's `Integer` is arbitrary-precision and Arel has
    * no separate bignum visitor, so both JS numeric types land here.
    *
-   * Callers: `visitNodeOrValue` routes every `bigint` here, and every *finite*
-   * `number` — not merely integral ones. That `Number.isFinite` split is
-   * invented; Rails only ever reaches `visit_Integer` for an `Integer` and
-   * raises on `Float` (rb:839), so `1.5` arrives here where Rails would raise.
-   * See the note at the call site.
+   * Callers: `visitNodeOrValue` routes every `bigint` here, and every
+   * *integral* `number` — the `Number.isInteger` split mirrors Ruby's
+   * Integer-vs-Float, so a `1.5` reaches `visitFloat` and raises (rb:839) as
+   * it does in Rails.
    */
   protected visitInteger(o: number | bigint, collector: SQLString): SQLString {
     collector.append(String(o));
@@ -1376,9 +1419,9 @@ export class ToSql extends Visitor {
    * to match the Rails signature even though it's unused after the raise. The
    * message mirrors `UnsupportedVisitError.new(o)` (to_sql.rb:5-8).
    */
-  protected unsupported(o: Node, _collector: SQLString): never {
+  protected unsupported(o: unknown, _collector: SQLString): never {
     throw new UnsupportedVisitError(
-      `Unsupported argument type: ${o.constructor.name}. Construct an Arel node instead.`,
+      `Unsupported argument type: ${constructorName(o)}. Construct an Arel node instead.`,
     );
   }
 
@@ -1387,82 +1430,79 @@ export class ToSql extends Visitor {
   // `UnsupportedVisitError`. TS has no method-alias, so each delegates to
   // the shared helper. Each keeps the Rails `(o, collector)` shape.
   //
-  // These are NOT wired into the dispatch table, and — contrary to what this
-  // comment claimed until #4871 — that is a deviation, not a no-op. Raw
-  // values (dates, strings, booleans, floats) *do* reach the visitor via
-  // `visitNodeOrValue`, which renders them instead of dispatching here, so
-  // the "unsupported contract" these names document is currently unenforced
-  // on the one path that could violate it. Converging that is tracked by
-  // story `arel-raw-value-dispatch-raises-like-rails` (RFC 0023); until then
-  // they stand as the documented contract and are directly testable.
+  // `visitNodeOrValue` dispatches raw values onto these, so the unsupported
+  // contract is enforced on the one path that can reach it — they are not
+  // documentation-only. The exception is the Ruby-specific string classes
+  // (Multibyte::Chars, StringInquirer), which have no JS analogue to dispatch
+  // from and stand as the documented contract, directly testable.
 
   /** Rails: `alias :visit_ActiveSupport_Multibyte_Chars :unsupported`. */
-  protected visitActiveSupportMultibyteChars(o: Node, collector: SQLString): never {
+  protected visitActiveSupportMultibyteChars(o: unknown, collector: SQLString): never {
     return this.unsupported(o, collector);
   }
 
   /** Rails: `alias :visit_ActiveSupport_StringInquirer :unsupported`. */
-  protected visitActiveSupportStringInquirer(o: Node, collector: SQLString): never {
+  protected visitActiveSupportStringInquirer(o: unknown, collector: SQLString): never {
     return this.unsupported(o, collector);
   }
 
   /** Rails: `alias :visit_BigDecimal :unsupported` (to_sql.rb:834). */
-  protected visitBigDecimal(o: Node, collector: SQLString): never {
+  protected visitBigDecimal(o: unknown, collector: SQLString): never {
     return this.unsupported(o, collector);
   }
 
   /** Rails: `alias :visit_Class :unsupported`. */
-  protected visitClass(o: Node, collector: SQLString): never {
+  protected visitClass(o: unknown, collector: SQLString): never {
     return this.unsupported(o, collector);
   }
 
   /** Rails: `alias :visit_Date :unsupported`. */
-  protected visitDate(o: Node, collector: SQLString): never {
+  protected visitDate(o: unknown, collector: SQLString): never {
     return this.unsupported(o, collector);
   }
 
   /** Rails: `alias :visit_DateTime :unsupported`. */
-  protected visitDateTime(o: Node, collector: SQLString): never {
+  protected visitDateTime(o: unknown, collector: SQLString): never {
     return this.unsupported(o, collector);
   }
 
   /** Rails: `alias :visit_FalseClass :unsupported`. */
-  protected visitFalseClass(o: Node, collector: SQLString): never {
+  protected visitFalseClass(o: unknown, collector: SQLString): never {
     return this.unsupported(o, collector);
   }
 
   /** Rails: `alias :visit_Float :unsupported`. */
-  protected visitFloat(o: Node, collector: SQLString): never {
+  protected visitFloat(o: unknown, collector: SQLString): never {
     return this.unsupported(o, collector);
   }
 
   /** Rails: `alias :visit_Hash :unsupported`. */
-  protected visitHash(o: Node, collector: SQLString): never {
+  protected visitHash(o: unknown, collector: SQLString): never {
     return this.unsupported(o, collector);
   }
 
   /** Rails: `alias :visit_NilClass :unsupported`. */
-  protected visitNilClass(o: Node, collector: SQLString): never {
+  protected visitNilClass(o: unknown, collector: SQLString): never {
     return this.unsupported(o, collector);
   }
 
   /** Rails: `alias :visit_String :unsupported`. */
-  protected visitString(o: Node, collector: SQLString): never {
+  protected visitString(o: unknown, collector: SQLString): never {
     return this.unsupported(o, collector);
   }
 
   /** Rails: `alias :visit_Symbol :unsupported` (to_sql.rb:843). */
-  protected visitSymbol(o: Node, collector: SQLString): never {
+  protected visitSymbol(o: unknown, collector: SQLString): never {
     return this.unsupported(o, collector);
   }
 
   /** Rails: `alias :visit_Time :unsupported`. */
-  protected visitTime(o: Node, collector: SQLString): never {
+  protected visitTime(o: unknown, collector: SQLString): never {
     return this.unsupported(o, collector);
   }
 
   /** Rails: `alias :visit_TrueClass :unsupported`. */
-  protected visitTrueClass(o: Node, collector: SQLString): never {
+  protected visitTrueClass(o: unknown, collector: SQLString): never {
     return this.unsupported(o, collector);
   }
 
@@ -2001,49 +2041,35 @@ export class ToSql extends Visitor {
     }
     // Raw-value dispatch — trails' stand-in for Rails' `visit` class dispatch
     // on a stray Ruby value. Rails renders exactly ONE raw scalar here,
-    // Integer, via `visit_Integer` (to_sql.rb:824-826); the integral branches
-    // below delegate to our port of it (`visitInteger`) so the anchor is
-    // structural rather than a comment that can drift. NilClass (rb:841),
+    // Integer, via `visit_Integer` (to_sql.rb:824-826). NilClass (rb:841),
     // String (rb:842), Float (rb:839), TrueClass (rb:845), FalseClass
     // (rb:838), Date (rb:836), Time (rb:844), BigDecimal (rb:834), Symbol
     // (rb:843) and Hash (rb:840) all alias to `unsupported` and raise
-    // (rb:828-845) — their ports exist below but this method renders instead
-    // of dispatching to them, which is the whole of the deviation. Note
-    // to_sql.rb:87-90 (`visit_Arel_Nodes_Casted`) is the *other* path, the one
-    // that routes through quote(); it is ported in `visitArelNodesCasted` and
-    // is what ActiveRecord actually uses.
-    // Converging the tolerances is a caller-facing narrowing tracked by story
-    // `arel-raw-value-dispatch-raises-like-rails` (RFC 0023).
-    if (v === null || v === undefined) {
-      collector.append("NULL");
-    } else if (typeof v === "string") {
-      collector.append(this.quote(v));
-    } else if (typeof v === "number") {
-      // The `Number.isFinite` split is INVENTED — it has no Rails analogue, so
-      // this branch does not mirror Rails' dispatch. Rails splits Integer
-      // (renders, rb:824-826) vs Float (raises via `unsupported`, rb:839); we
-      // split finite vs non-finite, so a Rails-shaped predicate would be
-      // `Number.isInteger`. Both halves therefore deviate: `1.5` is finite so
-      // it reaches visitInteger here where Rails raises, and the non-finite
-      // fallback to quote() (which lets the connection emit 'Infinity' rather
-      // than a bareword identifier) has no counterpart either — Infinity/NaN
-      // are Ruby Floats and also raise at rb:839. Tracked by story
-      // `arel-raw-value-dispatch-raises-like-rails` (RFC 0023).
-      if (Number.isFinite(v)) return this.visitInteger(v, collector);
-      collector.append(this.quote(v));
-    } else if (typeof v === "boolean") {
-      collector.append(this.quote(v));
-    } else if (typeof v === "bigint") {
-      return this.visitInteger(v, collector);
-    } else {
-      // Everything else — dates, binary, Temporal types, unknown objects —
-      // defers to `quote()`, which hands the value to the connection. Rails'
-      // Arel does no date detection of its own, so there is no separate
-      // date-like branch here. Only BindParam/ActiveModel::Attribute go
-      // through addBind.
-      collector.append(this.quote(v));
+    // (rb:828-845); the branches below dispatch to those ports so the anchor
+    // is structural rather than a comment that can drift.
+    //
+    // Note to_sql.rb:87-90 (`visit_Arel_Nodes_Casted`) is the *other* value
+    // path, the one that routes through quote(); it is ported in
+    // `visitArelNodesCasted` and is what ActiveRecord actually uses, so
+    // nothing on the AR-facing path reaches this dispatch.
+    if (typeof v === "number") {
+      // Ruby splits Integer (renders) from Float (raises); `Number.isInteger`
+      // is that split. A non-finite number is never integral, so it lands on
+      // the Float branch and raises, as Rails' Float does.
+      return Number.isInteger(v) ? this.visitInteger(v, collector) : this.visitFloat(v, collector);
     }
-    return collector;
+    if (typeof v === "bigint") {
+      // Ruby has no fixnum/bignum distinction at this layer — both are
+      // Integer, so a bigint renders bare via visit_Integer.
+      return this.visitInteger(v, collector);
+    }
+    if (v === null || v === undefined) return this.visitNilClass(v, collector);
+    if (typeof v === "string") return this.visitString(v, collector);
+    if (typeof v === "boolean") {
+      return v ? this.visitTrueClass(v, collector) : this.visitFalseClass(v, collector);
+    }
+    if (isDateLike(v)) return this.visitTime(v, collector);
+    return this.visitHash(v, collector);
   }
 
   /**

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -44348,13 +44348,6 @@
     "package": "arel",
     "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_Assignment",
-    "call": "quote",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_Assignment",
     "call": "to_s",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -44726,21 +44719,7 @@
     "package": "arel",
     "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_ValuesList",
-    "call": "quote",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_ValuesList",
     "call": "to_s",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_ValuesList",
-    "call": "visit",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {


### PR DESCRIPTION
## What

Rails' Arel dispatches a **raw value** reaching `visit` on its Ruby class. Only `visit_Integer` renders — a bare `collector << o.to_s` (`to_sql.rb:824-826`). Every other raw scalar aliases to `unsupported` and raises `UnsupportedVisitError` (`to_sql.rb:828-845`).

trails' `visitNodeOrValue` rendered instead: `NULL` for nil, `quote()` for strings/booleans/dates, and a numeric split on `Number.isFinite` with a non-finite → `quote()` fallback that has no Rails counterpart at all.

#4871 already added the 14 `unsupported` alias methods but left them **unwired** ("They aren't wired into the dispatch table"). This wires them.

## The load-bearing find

Naively raising broke 34 arel tests — INSERT and UPDATE stopped rendering entirely. The reason is that Rails' `ValuesList` and `Assignment` visitors **never route raw values through `visit`**:

- `visit_Arel_Nodes_ValuesList` (`to_sql.rb:106-114`) visits only `SqlLiteral`/`BindParam`/`ActiveModel::Attribute` and `quote()`s every other row entry directly.
- `visit_Arel_Nodes_Assignment` (`to_sql.rb:630-641`) visits a Node/Attribute right and `quote()`s a raw one directly.

trails routed both through `visitNodeOrValue` — the wrong call site. Porting the Rails shape at those two sites is what keeps INSERT/UPDATE working, and it took the failures 34 → 6.

## Changes

- `visitNodeOrValue` dispatches raw scalars onto the alias methods, keyed on the JS analogue of each Ruby class (`null`/`undefined` → NilClass, date-like → Time, plain object → Hash, …).
- The invented `Number.isFinite` split is replaced by the Rails-shaped `Number.isInteger`: Integer renders, Float raises. A non-finite number isn't integral, so it lands on the Float branch and raises — the invented `quote()` fallback is gone. `bigint` renders bare (Ruby has no fixnum/bignum split at this layer).
- `ValuesList` / `Assignment` converged to Rails' quote-directly shape.
- `unsupported` and the 14 aliases widened from `Node` to `unknown` so they accept raw values.

## Caller audit

`git grep` over production `new Nodes.*` construction: every caller wraps via `quotedNode`/`Quoted` (`predications.ts:86,92,98,121,229`, `attributes/attribute.ts:163,171,179,193,243`). The only raw-value carriers are `ValuesList` (`insert-all.ts:714`, `insert-manager.ts:100,109`) and `Assignment` (`update-manager.ts:64`) — both now quote directly, per Rails.

The AR-facing path is unaffected: predications wrap values into `Casted` nodes, which route through `quote()` (`to_sql.rb:87-90`).

## Migrated tests

Four tests constructed nodes with raw scalars, bypassing the wrap Rails' own tests go through — `Nodes::Matches.new(users[:name], "x%", "!")` would raise in Rails too, since only `predications#matches` wraps via `quoted_node`. Rails' equivalent test uses `@table[:name].matches("foo!%", "!")`. Migrated to the predications path; no test names changed.

Two trails-invented assertions relying on the tolerance (a raw `true` in `Equality`; a raw `"text"` in `visitArray`) are corrected to the Rails-faithful behavior, keeping their test names.

## Verification

- arel: 1481 passed (71 files).
- ActiveRecord: ~5000 tests green across `relation`, `persistence`, `arel-integration`, `associations`, `connection-adapters`, `schema`.
- `pnpm -w typecheck` clean; api:compare delta non-negative.

Closes-story: arel-raw-value-dispatch-raises-like-rails

## Review convergence

Eight review cycles; all findings resolved. Substantive fixes, each verified against `vendor/rails/` and pinned by a test proven to fail without it:

- **`nil` renders `IS NULL`** — Rails tests `right.nil?` *before* visiting (`to_sql.rb:649`), true for a bare `nil` and for both wrappers, whose `nil?` delegates to `value.nil?` (`casted.rb:15,41`). `rightIsNull` now covers bare `null`/`undefined`, `Quoted(null)`, `Casted(null)`, and `isNil()` binds across all four call sites (`to_sql.rb:649,659,668,685`).
- **Temporal dispatches on its Rails analogue** — Temporal has no `toISOString`, so it silently skipped `visit_Time`. Now matched on `Symbol.toStringTag`: PlainDate → `visit_Date` (`rb:837`), the rest → `visit_Time` (`rb:844`).
- **ValuesList matches Rails' `case` exactly** (`to_sql.rb:110`) — the earlier widening was justified by `'[object Object]'` output that came from arel's test-only default-quoter, not the real path, where the adapter raises `TypeError` exactly as Rails does (`abstract/quoting.ts:151` / `quoting.rb:86`).
- **`schema-migration` carries version rows raw** — the one production ValuesList producer that wrapped in `Quoted`; the narrowing turned it into a runtime `TypeError`. Rails passes the version raw (`schema_migration.rb:21`). Emits identical SQL, verified through a real SQLite adapter. `createValuesList`'s `Node[][]` signature was an invented narrowing (Rails' rows are raw) and is widened to match `createValues` and the node.

**No invented tolerance remains in this PR.**

## Follow-ups filed (not fixed here)

- `arel-unboundable-sign-duck-types-like-rails` — `unboundableSign` conflates Rails' `infinite?` with `unboundable?`; Rails' is purely duck-typed (`to_sql.rb:905-907`) and renders `= Infinity` for `attr.eq(Float::INFINITY)`. Pre-existing code, untouched here; deleting the raw arm alone fails 11 tests.
- `arel-attribute-quoted-node-nil-builds-casted` — `Attribute#quotedNode(null)` returns `Quoted` where Rails' `build_quoted` returns `Casted(nil, attribute)` (`casted.rb:48-58`), skipping the attribute type-cast.
- `schema-migration-assume-migrated-upto-version-coverage` — the method has no tests at all (which is why the row-shape break shipped silently), and Rails' `assume_migrated_upto_version` uses no Arel (`schema_statements.rb:1364-1383`).

Known, out of scope: `insert-manager.test.ts` duplicates `can create a ValuesList node` verbatim at `:8` and `:168`, and Rails' version asserts node structure rather than SQL.

## Verification

arel 1504 passed; AR 4947 passed across relation/persistence/associations/connection-adapters/tasks/migration; typecheck clean; api:compare `to_sql.rb` 135/135 (100% ✓); test:compare `to_sql_test.rb` 131 ✓ (0 Desc/Move/Miss), no test renamed; wide-call ratchet `OK (6855 baselined)`.

Closes-story: arel-raw-value-dispatch-raises-like-rails
