### PR TITLE
fix(arel): Attribute#quotedNode builds Casted for nil, like build_quoted

### DIFF
--- a/packages/arel/src/attribute-alignment.test.ts
+++ b/packages/arel/src/attribute-alignment.test.ts
@@ -64,11 +64,10 @@ describe("Attribute concat / contains / overlaps return typed infix subclasses",
 });
 
 describe("Attribute#quotedNode (the public PredicationHost contract)", () => {
-  // Mirrors Rails' Arel::Predications#quoted_node — Predications calls
-  // `this.quotedNode(other)` on its host. Attribute's impl preserves the
-  // column type-cast path: scalars become Casted(value, this), nulls
-  // become Quoted(null), ActiveModel::Attribute instances become
-  // BindParam, and raw Nodes pass through.
+  // Mirrors Rails' Arel::Predications#quoted_node — `build_quoted(other, self)`.
+  // Passing the attribute means every non-pass-through value, nil included,
+  // becomes Casted(value, this) and keeps the column type-cast path;
+  // ActiveModel::Attribute instances become BindParam and raw Nodes pass through.
   it("wraps a scalar in Casted(value, attribute)", () => {
     const attr = users.attr("id");
     const out = attr.quotedNode(42);
@@ -77,9 +76,14 @@ describe("Attribute#quotedNode (the public PredicationHost contract)", () => {
     expect((out as Nodes.Casted).attribute).toBe(attr);
   });
 
-  it("returns Quoted(null) for null/undefined", () => {
-    expect(users.attr("id").quotedNode(null)).toBeInstanceOf(Nodes.Quoted);
-    expect(users.attr("id").quotedNode(undefined)).toBeInstanceOf(Nodes.Quoted);
+  it("wraps null/undefined in Casted(nil, attribute)", () => {
+    for (const nil of [null, undefined]) {
+      const attr = users.attr("id");
+      const out = attr.quotedNode(nil);
+      expect(out).toBeInstanceOf(Nodes.Casted);
+      expect((out as Nodes.Casted).attribute).toBe(attr);
+      expect((out as Nodes.Casted).isNil()).toBe(true);
+    }
   });
 
   it("passes through raw Nodes unchanged", () => {

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -25,10 +25,8 @@ import { Count } from "../nodes/count.js";
 import { Sum, Max, Min, Avg } from "../nodes/function.js";
 import { Ascending } from "../nodes/ascending.js";
 import { Descending } from "../nodes/descending.js";
-import { Quoted, Casted, buildQuoted } from "../nodes/casted.js";
+import { Quoted, buildQuoted } from "../nodes/casted.js";
 import { parseRange, betweenFromRange, notBetweenFromRange } from "../predications-range.js";
-import { BindParam } from "../nodes/bind-param.js";
-import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 import { Grouping } from "../nodes/grouping.js";
 import { And } from "../nodes/and.js";
 import { Or } from "../nodes/or.js";
@@ -126,25 +124,15 @@ export class Attribute extends Node {
   }
 
   /**
-   * Mirrors: Arel::Predications#quoted_node — the type-aware wrapper
-   * that the Predications mixin calls to bring an arbitrary right-hand
-   * value into the AST. Attribute's impl wraps in `Casted(value, this)`
-   * so the visitor can apply column-level type-casting; ActiveModel
-   * attribute instances become BindParam so they extract as binds; raw
-   * Nodes are passed through.
+   * Mirrors: Arel::Predications#quoted_node — `Nodes.build_quoted(other, self)`
+   * (arel/predications.rb). Passing `self` as the attribute means every
+   * non-pass-through raw value — nil included — becomes `Casted(value, this)`
+   * (casted.rb:48-58), so the visitor can apply column-level type-casting.
    *
    * @internal
    */
   quotedNode(value: unknown): Node {
-    if (value instanceof Node) return value;
-    if (value === null || value === undefined) return new Quoted(null);
-    // ActiveModel::Attribute instances (QueryAttribute etc.) carry their
-    // own type + value. Wrap in BindParam so the visitor extracts them
-    // as binds rather than inlining via Casted.
-    if (value instanceof ModelAttribute) {
-      return new BindParam(value);
-    }
-    return new Casted(value, this);
+    return buildQuoted(value, this);
   }
 
   // -- Predicates --

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -25,7 +25,7 @@ import { Count } from "../nodes/count.js";
 import { Sum, Max, Min, Avg } from "../nodes/function.js";
 import { Ascending } from "../nodes/ascending.js";
 import { Descending } from "../nodes/descending.js";
-import { Quoted, buildQuoted } from "../nodes/casted.js";
+import { buildQuoted } from "../nodes/casted.js";
 import { parseRange, betweenFromRange, notBetweenFromRange } from "../predications-range.js";
 import { Grouping } from "../nodes/grouping.js";
 import { And } from "../nodes/and.js";

--- a/packages/arel/src/nodes/casted.test.ts
+++ b/packages/arel/src/nodes/casted.test.ts
@@ -80,6 +80,20 @@ describe("Arel::Nodes.build_quoted", () => {
     expect((node as Nodes.Quoted).value).toBe(42);
   });
 
+  it("wraps nil in Casted when the second arg is an Arel::Attribute", () => {
+    const attr = users.get("age");
+    const node = buildQuoted(null, attr);
+    expect(node).toBeInstanceOf(Nodes.Casted);
+    expect((node as Nodes.Casted).value).toBeNull();
+    expect((node as Nodes.Casted).attribute).toBe(attr);
+  });
+
+  it("wraps nil in Quoted when no attribute is given", () => {
+    const node = buildQuoted(null);
+    expect(node).toBeInstanceOf(Nodes.Quoted);
+    expect((node as Nodes.Quoted).value).toBeNull();
+  });
+
   it("wraps duck-typed ActiveModel::Attribute in BindParam without requiring activemodel import", () => {
     const duckAttr = { name: "age", valueForDatabase: 42 };
     const node = buildQuoted(duckAttr);
@@ -90,5 +104,40 @@ describe("Arel::Nodes.build_quoted", () => {
   it("does not treat plain objects with only name as ActiveModel::Attribute", () => {
     const node = buildQuoted({ name: "x" });
     expect(node).toBeInstanceOf(Nodes.Quoted);
+  });
+});
+
+describe("Arel::Nodes::Casted#nil?", () => {
+  const users = new Table("users");
+
+  it("is true for a nil value and false otherwise", () => {
+    const attr = users.get("age");
+    expect(new Nodes.Casted(null, attr).isNil()).toBe(true);
+    expect(new Nodes.Casted(0, attr).isNil()).toBe(false);
+  });
+
+  // casted.rb:15 reads the raw `value`, NOT `value_for_database` — a type whose
+  // serialize(nil) is non-nil must still spell IS NULL.
+  it("reads the raw value, not value_for_database", () => {
+    const table = new Table("users");
+    (table as unknown as { isAbleToTypeCast?: () => boolean }).isAbleToTypeCast = () => true;
+    (
+      table as unknown as { typeCastForDatabase?: (n: string, v: unknown) => unknown }
+    ).typeCastForDatabase = (_name, value) => (value === null ? "NIL" : value);
+
+    const node = new Nodes.Casted(null, table.get("age"));
+    expect(node.valueForDatabase()).toBe("NIL");
+    expect(node.isNil()).toBe(true);
+  });
+
+  // quoted_node is build_quoted(other, self), so a nil from an Attribute is
+  // Casted — carrying the column's type-cast context — not a bare Quoted.
+  it("is what an Attribute's quoted_node builds for nil, and still renders IS NULL", () => {
+    const attr = users.get("id");
+    const eq = attr.eq(null);
+    expect(eq.right).toBeInstanceOf(Nodes.Casted);
+    expect((eq.right as Nodes.Casted).attribute).toBe(attr);
+    const [sql] = new Visitors.ToSql().compileWithBinds(eq);
+    expect(sql).toBe('"users"."id" IS NULL');
   });
 });

--- a/packages/arel/src/nodes/casted.test.ts
+++ b/packages/arel/src/nodes/casted.test.ts
@@ -116,6 +116,27 @@ describe("Arel::Nodes::Casted#nil?", () => {
     expect(new Nodes.Casted(0, attr).isNil()).toBe(false);
   });
 
+  // Ruby has one nil, so undefined is a nil? here too. This keeps
+  // attr.eq(undefined) spelling IS NULL: before this change quotedNode
+  // normalized undefined to Quoted(null), so a null-only isNil() would
+  // regress it to `= NULL`.
+  it("treats undefined as nil, so eq(undefined) still renders IS NULL", () => {
+    const attr = users.get("age");
+    expect(new Nodes.Casted(undefined, attr).isNil()).toBe(true);
+    expect(new Nodes.Quoted(undefined).isNil()).toBe(true);
+
+    const [sql] = new Visitors.ToSql().compileWithBinds(users.get("id").eq(undefined));
+    expect(sql).toBe('"users"."id" IS NULL');
+  });
+
+  // `= NULL` is never true in SQL; Quoted#nil? (casted.rb:41) is defined
+  // identically to Casted's, so an undefined-valued Quoted spells IS NULL too.
+  it("renders IS NULL for a Quoted(undefined) right-hand side", () => {
+    const eq = new Nodes.Equality(users.get("id"), new Nodes.Quoted(undefined));
+    const [sql] = new Visitors.ToSql().compileWithBinds(eq);
+    expect(sql).toBe('"users"."id" IS NULL');
+  });
+
   // casted.rb:15 reads the raw `value`, NOT `value_for_database` — a type whose
   // serialize(nil) is non-nil must still spell IS NULL.
   it("reads the raw value, not value_for_database", () => {

--- a/packages/arel/src/nodes/casted.ts
+++ b/packages/arel/src/nodes/casted.ts
@@ -72,6 +72,20 @@ export class Casted extends NodeExpression {
     return this.value;
   }
 
+  /**
+   * Mirrors: Arel::Nodes::Casted#nil? (casted.rb:15) — `value.nil?`.
+   *
+   * Both of TS' nils count: Ruby has only `nil`, so `undefined` is as much a
+   * `nil?` here as `null` is. This is deliberately WIDER than
+   * `BindParam#isNil` (bind_param.rb:23-25), which excludes `undefined`
+   * because a valueless `new BindParam()` is a trails positional-bind marker
+   * rather than a value. A `Casted`/`Quoted` always wraps a value, so that
+   * carve-out does not apply.
+   */
+  isNil(): boolean {
+    return this.value === null || this.value === undefined;
+  }
+
   valueForDatabase(): unknown {
     if (this.attribute.isAbleToTypeCast()) {
       return this.attribute.typeCastForDatabase(this.value);
@@ -104,6 +118,14 @@ export class Quoted extends Unary {
 
   valueBeforeTypeCast(): unknown {
     return this.value;
+  }
+
+  /**
+   * Mirrors: Arel::Nodes::Quoted#nil? (casted.rb:41) — `value.nil?`, defined
+   * identically to Casted's; see the note there on why `undefined` counts.
+   */
+  isNil(): boolean {
+    return this.value === null || this.value === undefined;
   }
 
   isInfinite(): number | null {

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -43024,13 +43024,6 @@
   {
     "package": "arel",
     "tsFile": "attributes/attribute.ts",
-    "rubyName": "quoted_node",
-    "call": "build_quoted",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "attributes/attribute.ts",
     "rubyName": "when",
     "call": "quoted_node",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
## What

Rails' `Predications#quoted_node(other)` is `Nodes.build_quoted(other, self)`
(`arel/predications.rb`), and `build_quoted` (`casted.rb:48-58`) has **no nil
special-case** — with an attribute supplied, every non-pass-through raw value,
nil included, becomes `Casted(value, attribute)`.

Trails' `Attribute#quotedNode` short-circuited nil to `Quoted(null)`, so
`attr.eq(null)` built `Equality(attr, Quoted(null))` where Rails builds
`Equality(attr, Casted(nil, attr))`.

This matters beyond node identity: `Casted#value_for_database` type-casts
through the attribute (`casted.rb:17-23`) whereas `Quoted#value_for_database`
is a bare `alias` (`casted.rb:38`). A nil routed through `Quoted` therefore
skipped the column's type-cast, diverging for any type whose `serialize(nil)`
is non-nil (serialized / normalized columns).

## How

- `quotedNode` now delegates to `buildQuoted(value, this)` — `buildQuoted`
  already mirrored `build_quoted` faithfully, so the hand-rolled duplicate
  (with its nil deviation) is gone. This also resolves the last acceptance
  criterion: the `ModelAttribute → BindParam` arm was a re-implementation of
  the same arm `buildQuoted` already carries as a documented TS deviation for
  Rails' `visit_ActiveModel_Attribute` `add_bind` routing.
- Ported Rails' `nil?` (`casted.rb:15`, `casted.rb:41`) onto both `Casted` and
  `Quoted` as `isNil()`.

### `IS NULL` is preserved without touching `to-sql.ts`

The story anticipated relying on the `Casted(null)` arm that #4873 adds to
`rightIsNull`. That PR is still open and edits `to-sql.ts`, so rather than
conflict with it, this PR ports `nil?` onto the nodes — which is what Rails'
guard (`right.nil?`) actually reads. `rightIsNull`'s existing duck-typed
`isNil()` arm then picks up `Casted.isNil()` automatically, so **`to-sql.ts`
needs no change** and the two PRs don't overlap.

## Testing

- Rails' own `"should handle nil"` tests (`attribute_test.rb:23,408`) for
  `eq(nil)` / `not_eq(nil)` still render `IS NULL` / `IS NOT NULL` — unchanged
  and green.
- New coverage in `casted.test.ts`: nil → `Casted` with an attribute vs
  `Quoted` without; `Casted#nil?` reads the **raw** value, not
  `value_for_database`, so a type whose cast of nil is non-nil still spells
  `IS NULL`; and `attr.eq(null)` builds `Casted(nil, attr)` yet compiles to
  `IS NULL`.
- Updated one trails-invented test in `attribute-alignment.test.ts` that
  asserted the old `Quoted(null)` deviation. It is not a Rails port (the file
  is trails-only behavior tests), and its name encoded the deviation being
  converged, so it changes with the behavior.
- `pnpm vitest run packages/arel/src` — 1486 passed. Plus
  `packages/activerecord/src/relation/`, `finder`, `base`, `relation` — green.
- api:compare Data layer 7472/7474, files 407/407 — no delta.

Closes-story: arel-attribute-quoted-node-nil-builds-casted

## Wide-call ratchet

Converging `quotedNode` onto `buildQuoted` made the baselined
`arel attributes/attribute.ts quoted_node build_quoted` wide call-set flag
stop firing — `pnpm api:calls:wide` fails on stale entries, so the converged
entry is removed by hand (the baseline only shrinks; not reseeded). Ratchet is
green: `OK (6857 baselined)`, one fewer than before.


## Review responses

**1. `in`/`notIn` don't thread the attribute — agreed, story registered.**
Confirmed against `predications.rb:65-74`: `in` builds
`Nodes::In.new self, quoted_array(other)` → `quoted_node(v)` →
`Casted(v, self)`, while trails does bare `values.map(buildQuoted)`. Same
type-cast hole as this PR fixes, one arm over. There's a second defect the
review didn't catch: `values.map(buildQuoted)` passes `Array#map`'s **index**
as the second arg, so it calls `buildQuoted(v, 0)` — the attribute slot gets a
number, `isAttribute(0)` is false, and it lands on `Quoted` for the wrong
reason. Registered as
`0023-surfaced-deviations/arel-in-not-in-threads-attribute-through-quoted-array`,
including the `relation.ts:1169` pre-cast workaround to re-check and a warning
about the five wide-ratchet entries that convergence will strand. Kept out of
this PR for scope.

**2. `caster` arm — not dead; documented, story registered.**
Audited: no production site passes a caster — the only `new Attribute(...)`
calls are `table.ts:188`, `table.ts:206`, `table-alias.ts:67`, all two-arg.
But it isn't dead: `attributes/attribute.test.ts:1070-1090` exercises it
("type casts when given an explicit caster" ×2), so the 3-line delete would
have silently dropped two tests. The deviation is deeper than the arm — Rails'
`Attribute` is `Struct.new :relation, :name` (`attributes/attribute.rb:5`)
with **no** caster member at all, so the invented constructor arg has to go
with it. Added the `@internal` DEVIATION note citing `attribute.rb:5` /
`casted.rb:17-23`, and registered
`0023-surfaced-deviations/arel-attribute-caster-is-a-trails-invention` to drop
the arg, the arm, and its tests together.

**3. Rename is safe — verified, no manifest entry.**
`pnpm rails:find "returns Quoted(null) for null/undefined"` → no matches. No
`*align*` file exists under `vendor/rails/activerecord/test/cases/arel/`, and
`attribute-alignment.test.ts` appears in **0** mapped rows of the test:compare
table — all 13 of its tests count as "extra (TS only)", so there is no mapping
to drop. (`attributes/attribute_test.rb` → `attributes/attribute.test.ts`
holds at 128 OK / 0 miss.)

**Question — duck-type vs `instanceof`: audited, equivalent for real inputs.**
Every producer of `valueForDatabase` is an `ActiveModel::Attribute` subclass:
`FromDatabase`, `FromUser`, `WithCastValue`, `Null`, `Uninitialized`
(`activemodel/src/attribute.ts`) and `QueryAttribute`
(`relation/query-attribute.ts:42 extends Attribute`). Nothing in AR carries
both `name` and `valueForDatabase` without being one, so duck-type ≡
`instanceof` for all production inputs; it is broader only for plain objects,
which is intentional and covered by the existing
"wraps duck-typed ActiveModel::Attribute in BindParam" test. The `.ast` arm is
a genuine improvement — `casted.rb:50` lists `Arel::SelectManager` in the
pass-through set, where trails previously built `Casted(manager, attr)`.


## Review round 2

**1. `isNull` / `isNotNull` build `Quoted(null)` — agreed, story registered.**
Confirmed the stronger claim: there is no `is_null` / `not_null` /
`is_not_null` anywhere in `vendor/rails/activerecord/lib/arel/` (grepped the
whole lib, not just `predications.rb`), so these are trails inventions on top
of a `Quoted(null)` deviation. Rails spells it `attr.eq(nil)` →
`Casted(nil, attr)`. Registered as
`0023-surfaced-deviations/arel-attribute-is-null-builds-quoted-not-casted`,
which also captures the delete-vs-delegate decision and the dangling `Quoted`
import. Kept out of this PR for scope.

**2. `undefined` in `isNil()` — intended; measured, and a null-only version
would regress.** Good catch that the body didn't claim it. I probed
`origin/main` directly (baselining the two files in place) rather than
reasoning about it:

| expression | `origin/main` | this PR |
| --- | --- | --- |
| `attr.eq(undefined)` | `IS NULL` | `IS NULL` (preserved) |
| `Quoted(undefined)` as an Equality RHS | `= NULL` | `IS NULL` (changed) |

So the `undefined` arm is load-bearing, not incidental: main's `quotedNode`
normalized `undefined` to `Quoted(null)`, so restricting `isNil()` to `null`
would have **regressed** `attr.eq(undefined)` from `IS NULL` to `= NULL`. The
second row is the change you spotted, and it is intended: `casted.rb:41`
defines `Quoted#nil?` identically to `Casted#nil?` (`casted.rb:15`), so the two
must agree, Ruby has exactly one nil (making `undefined` TS' other nil), and
`= NULL` is never true in SQL — that row was a latent bug. Both rows are now
pinned by tests, and the `undefined` semantics carry an anchor noting the
deliberate divergence from `BindParam#isNil` (which excludes `undefined`
because a valueless `new BindParam()` is a positional-bind marker — a
`Casted`/`Quoted` always wraps a value, so that carve-out doesn't apply).

**On `to-sql.ts:2049` being redundant:** agreed, and left alone deliberately —
#4873 is still open on that file. The `arel-attribute-is-null-builds-quoted-not-casted`
story is the natural home for that deletion once #4873 lands.


## Rebased onto main (#4873 / #4876 / #4877 / #4878 landed)

Main moved a lot under this branch; rebased and re-verified. Net effect is that
this PR got **smaller** — three of the four things flagged in review are now
fixed on main by other agents, so the follow-up stories are closed rather than
carried:

- **#4877 dropped the invented `caster` arg**, so `Casted#valueForDatabase` on
  main is already exactly `casted.rb:17-23`. My "flag the caster arm as a
  deviation" commit is obsolete and was **dropped from this branch**; story
  `arel-attribute-caster-is-a-trails-invention` closed as done (#4877).
- **#4878 deleted the invented `isNull` / `isNotNull` predicates**; story
  `arel-attribute-is-null-builds-quoted-not-casted` closed as done (#4878).
  Their removal plus this PR's `quotedNode` change retires the last `Quoted`
  use in `attribute.ts`, so the now-unused import is dropped here (predicted by
  that story's acceptance criteria).
- **#4873 landed** and added explicit `Quoted`/`Casted` null arms to
  `rightIsNull` (`to-sql.ts:2173-2174`). The duck-typed `isNil()` arm is still
  load-bearing: those arms test `value === null`, so `Casted(undefined)` /
  `Quoted(undefined)` still reach `IS NULL` only via `isNil()`. Both remain
  pinned by tests.
- `arel-in-not-in-threads-attribute-through-quoted-array` stays open — still
  unconverged on main (`attribute.ts:208,215`).

`casted.ts` is now a purely additive diff (the two `isNil` methods + docs) with
no member-reorder hunk: `pnpm api:compare` writes a gitignored manifest that
arms a pre-commit autofix which silently reorders class members, and it is
wrong for this file (it flattens two classes into one name-deduped list, but
Rails orders `value_for_database` / `value_before_type_cast` oppositely in
`Casted` (`casted.rb:7,17`) vs `Quoted` (`casted.rb:38,39`)). The manifest is
removed before each commit here; `isNil` is placed to match Rails per class —
`nil?` before `value_for_database` in `Casted` (`casted.rb:15,17`), and
`vfd, vbtc, nil?, infinite?` in `Quoted` (`casted.rb:38,39,41,43`).

Re-verified after rebase: `pnpm vitest run packages/arel/src` 1513 passed;
`packages/activerecord/src/relation/` 652 passed; wide ratchet
`OK (6855 baselined)`.
