### PR TITLE
refactor(quoting): move abstract quote's String/Symbol branch to the rb:75 position

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -111,11 +111,11 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
   // BigDecimals need to be put in a non-normalized (fixed, ".0"-bearing) form
   // and quoted bare — Rails: `when BigDecimal then value.to_s("F")`.
   //
-  // Rails must keep this ahead of Numeric (rb:82-83) because Ruby's BigDecimal
+  // Rails must keep this ahead of Numeric (rb:81-82) because Ruby's BigDecimal
   // *is* a Numeric, so a later arm would never be reached. That constraint does
   // not carry over: this chain dispatches on typeof/instanceof, under which
   // BigDecimal is an "object" and the Numeric arm below cannot swallow it. The
-  // order is kept to mirror rb:82-83, not because TS depends on it.
+  // order is kept to mirror rb:81-82, not because TS depends on it.
   if (value instanceof BigDecimal) return value.toString("F");
   if (typeof value === "number" || typeof value === "bigint") return String(value);
   // ArrayBuffer views have no Ruby analogue: they must be normalized to bytes
@@ -173,7 +173,7 @@ export function typeCast(this: QuotingDispatchHost, value: unknown): unknown {
   if (typeof value === "number" || typeof value === "bigint") return value;
   if (typeof value === "string") return value;
   // Rails dispatches `Type::Time::Value` through `self.quoted_time` and
-  // `Date`/`Time` through `self.quoted_date` (abstract/quoting.rb:93-101), the
+  // `Date`/`Time` through `self.quoted_date` (abstract/quoting.rb:103-104), the
   // same self-dispatch `quote` uses. Thread `this` so adapter overrides — e.g.
   // PostgreSQL's BC-suffixing `quotedDate` — flow into `type_cast` too.
   if (value instanceof Temporal.PlainTime) return dispatchQuotedTime(this, value);

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -109,8 +109,13 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
   if (typeof value === "boolean") return value ? quotedTrue() : quotedFalse();
   if (value === null || value === undefined) return "NULL";
   // BigDecimals need to be put in a non-normalized (fixed, ".0"-bearing) form
-  // and quoted bare — Rails: `when BigDecimal then value.to_s("F")`. Must stay
-  // ahead of the Numeric branch (rb:82-83): a BigDecimal is also Numeric in Ruby.
+  // and quoted bare — Rails: `when BigDecimal then value.to_s("F")`.
+  //
+  // Rails must keep this ahead of Numeric (rb:82-83) because Ruby's BigDecimal
+  // *is* a Numeric, so a later arm would never be reached. That constraint does
+  // not carry over: this chain dispatches on typeof/instanceof, under which
+  // BigDecimal is an "object" and the Numeric arm below cannot swallow it. The
+  // order is kept to mirror rb:82-83, not because TS depends on it.
   if (value instanceof BigDecimal) return value.toString("F");
   if (typeof value === "number" || typeof value === "bigint") return String(value);
   // ArrayBuffer views have no Ruby analogue: they must be normalized to bytes

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -97,10 +97,20 @@ export function quoteTableName(this: QuotingDispatchHost | void, name: string): 
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote
  */
 export function quote(this: QuotingDispatchHost, value: unknown): string {
-  if (value === null || value === undefined) return "NULL";
+  // rb:75 — `when String, Symbol, ActiveSupport::Multibyte::Chars`.
+  if (typeof value === "string") {
+    return `'${quoteString(value)}'`;
+  }
+  if (typeof value === "symbol") {
+    const desc = value.description;
+    if (desc === undefined) throw new TypeError("Cannot quote a Symbol without a description");
+    return `'${quoteString(desc)}'`;
+  }
   if (typeof value === "boolean") return value ? quotedTrue() : quotedFalse();
+  if (value === null || value === undefined) return "NULL";
   // BigDecimals need to be put in a non-normalized (fixed, ".0"-bearing) form
-  // and quoted bare — Rails: `when BigDecimal then value.to_s("F")`.
+  // and quoted bare — Rails: `when BigDecimal then value.to_s("F")`. Must stay
+  // ahead of the Numeric branch (rb:82-83): a BigDecimal is also Numeric in Ruby.
   if (value instanceof BigDecimal) return value.toString("F");
   if (typeof value === "number" || typeof value === "bigint") return String(value);
   // ArrayBuffer views have no Ruby analogue: they must be normalized to bytes
@@ -136,14 +146,6 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
     throw new TypeError(
       "quote: JS Date is not accepted — use a Temporal type (Instant, PlainDateTime, etc.)",
     );
-  if (typeof value === "symbol") {
-    const desc = value.description;
-    if (desc === undefined) throw new TypeError("Cannot quote a Symbol without a description");
-    return `'${quoteString(desc)}'`;
-  }
-  if (typeof value === "string") {
-    return `'${quoteString(value)}'`;
-  }
   // Rails: when Class then "'#{value}'"
   if (typeof value === "function" && value.name) {
     return `'${value.name}'`;


### PR DESCRIPTION
Rails' abstract `quote` (`abstract/quoting.rb:73-88`) orders its `case` as:

```ruby
when String, Symbol, ActiveSupport::Multibyte::Chars  # rb:75 — FIRST
when true / false / nil                               # rb:77-79
when BigDecimal / Numeric                             # rb:81-82
when Type::Binary::Data                               # rb:83
when Type::Time::Value                                # rb:84
when Date, Time                                       # rb:85
when Class                                            # rb:86
```

trails put the String/Symbol branch **second-to-last**, after null/boolean/BigDecimal/Numeric/binary/Temporal and immediately before the `Class` branch. This reorders the if-chain in `packages/activerecord/src/connection-adapters/abstract/quoting.ts` to match rb:75-88. Fidelity/readability only — no semantic change.

## Behavior is unchanged, and here is why that is safe

Every arm of the TS chain is **disjoint**, so each input matches the same arm either way:

| Arm | Discriminator |
| --- | --- |
| String / Symbol (rb:75) | `typeof "string"` / `"symbol"` |
| true / false (rb:77-78) | `typeof "boolean"` |
| nil (rb:79) | `=== null \|\| undefined` |
| BigDecimal (rb:81) | `instanceof BigDecimal` |
| Numeric (rb:82) | `typeof "number" \|\| "bigint"` |
| Binary (rb:83) | `ArrayBuffer.isView` |
| Time::Value / Date, Time (rb:84-85) | `instanceof Temporal.*` |
| Class (rb:86) | `typeof "function"` |

The boolean-before-nil swap is part of the same convergence — it matches rb:77-79.

## On the "ordering hazard" in the acceptance criteria

The story asks to guard that BigDecimal stays ahead of Numeric and binary ahead of Time/Date. **Both orderings are preserved**, but worth recording precisely: those are *Ruby* hazards that do **not** reproduce here.

- Ruby needs BigDecimal first (rb:81-82) because `BigDecimal < Numeric` — a later arm would be unreachable. In TS a `BigDecimal` instance is `typeof "object"`, so the Numeric arm (`typeof "number" || "bigint"`) **cannot** swallow it. Verified directly.
- `ArrayBuffer.isView(temporalInstant)` is `false` and a `Uint8Array` is not a Temporal instance, so binary (rb:83) and Time/Date (rb:84-85) cannot capture each other either.

So the order mirrors Rails rather than TS depending on it, and the comment on the BigDecimal branch now says exactly that instead of implying a constraint that does not exist. The real guard is behavioral: every arm is locked by an existing Rails-named test (`quote nil`, `quote true/false`, `quote float/integer/bignum`, `quote bigdecimal`, `quote string`, `quote string no column`, `quote as mb chars no column`, `quoting classes`, `quoted binary`, `dates and times`, `quote object instance`).

## Review follow-up: Rails line cites corrected

Review caught that the new BigDecimal comment cited **rb:82-83**, which is wrong — BigDecimal/Numeric are **rb:81-82**, and rb:83 is `Type::Binary::Data` (already cited correctly by the binary comment below), so the file cited 83 for two different arms. The bad cite came from the story text and I propagated it without checking the vendored source. Now `rb:81-82` in both the comment and this description.

Auditing the rest of the file's cites found one more of the same class, fixed as a drive-by since it is one line in a file already being touched: `type_cast`'s `Type::Time::Value` / `Date, Time` arms are **rb:103-104**, but the comment cited **rb:93-101** — a range that ends at BigDecimal and excludes both arms it describes. The remaining cites (rb:61, 66, 75, 83, 85, 203, 206) all verify against `vendor/rails/`.

## Dialect overrides

`postgresql/`, `mysql/`, and `sqlite3/quoting.ts` keep the dialect branches they front-load before delegating to the abstract `quote`. That mirrors Rails, where `PostgreSQL#quote` / `Mysql2#quote` `case` on their own types and fall through to `super` — legitimate, so left alone. All three also intercept string/symbol before `abstractQuote.call`, so no adapter path changes behavior either.

## Verification

- **237 tests pass** across all six quoting suites (abstract, helpers, precision-roundtrip, mysql, postgresql, sqlite3).
- `api:compare` (forced): data layer **7472/7474 (100%)**, unchanged.
- Ratchets all green: `call-mismatches: OK (19 baselined)`, `wide call-mismatches: OK (6858 baselined)`, `body-pins: OK`. The reorder changes no call set, so no ratchet entry needed hand-editing.

One file, 27 LOC.

Closes-story: abstract-quote-string-symbol-branch-order