### PR TITLE
fix(arel): unboundableSign duck-types unboundable? like Rails, not infinite?

### DIFF
--- a/packages/arel/src/nodes/casted.ts
+++ b/packages/arel/src/nodes/casted.ts
@@ -28,7 +28,8 @@ export function buildQuoted(other: unknown, attribute?: unknown): Node {
   if (other && typeof other === "object") {
     // Arel::Attributes::Attribute (duck-typed via symbol brand)
     if ((other as Record<symbol, unknown>)[ATTRIBUTE_BRAND] === true) return other as Node;
-    // ActiveModel::Attribute duck-type (Rails: casted.rb:55 `ActiveModel::Attribute`).
+    // ActiveModel::Attribute duck-type (Rails: casted.rb:50-51 — the
+    // `when ..., ActiveModel::Attribute` arm returning `other`).
     // Structural check so buildQuoted doesn't require a runtime import here.
     // valueForDatabase is a getter (not a method) on the TS port; check via 'in'.
     if (
@@ -67,6 +68,10 @@ export class Casted extends NodeExpression {
     this.attribute = attribute;
   }
 
+  valueBeforeTypeCast(): unknown {
+    return this.value;
+  }
+
   valueForDatabase(): unknown {
     const attr = this.attribute as unknown as {
       caster?: { typeCastForDatabase(v: unknown): unknown };
@@ -79,10 +84,6 @@ export class Casted extends NodeExpression {
     if (attr?.isAbleToTypeCast?.() && attr.typeCastForDatabase) {
       return attr.typeCastForDatabase(this.value);
     }
-    return this.value;
-  }
-
-  valueBeforeTypeCast(): unknown {
     return this.value;
   }
 
@@ -105,6 +106,10 @@ export class Quoted extends Unary {
     return this.expr;
   }
 
+  valueBeforeTypeCast(): unknown {
+    return this.value;
+  }
+
   valueForDatabase(): unknown {
     return this.value;
   }
@@ -113,10 +118,6 @@ export class Quoted extends Unary {
     if (this.value === Infinity) return 1;
     if (this.value === -Infinity) return -1;
     return null;
-  }
-
-  valueBeforeTypeCast(): unknown {
-    return this.value;
   }
 
   accept<T>(visitor: NodeVisitor<T>): T {

--- a/packages/arel/src/nodes/casted.ts
+++ b/packages/arel/src/nodes/casted.ts
@@ -68,10 +68,6 @@ export class Casted extends NodeExpression {
     this.attribute = attribute;
   }
 
-  valueBeforeTypeCast(): unknown {
-    return this.value;
-  }
-
   valueForDatabase(): unknown {
     const attr = this.attribute as unknown as {
       caster?: { typeCastForDatabase(v: unknown): unknown };
@@ -84,6 +80,10 @@ export class Casted extends NodeExpression {
     if (attr?.isAbleToTypeCast?.() && attr.typeCastForDatabase) {
       return attr.typeCastForDatabase(this.value);
     }
+    return this.value;
+  }
+
+  valueBeforeTypeCast(): unknown {
     return this.value;
   }
 
@@ -106,10 +106,6 @@ export class Quoted extends Unary {
     return this.expr;
   }
 
-  valueBeforeTypeCast(): unknown {
-    return this.value;
-  }
-
   valueForDatabase(): unknown {
     return this.value;
   }
@@ -118,6 +114,10 @@ export class Quoted extends Unary {
     if (this.value === Infinity) return 1;
     if (this.value === -Infinity) return -1;
     return null;
+  }
+
+  valueBeforeTypeCast(): unknown {
+    return this.value;
   }
 
   accept<T>(visitor: NodeVisitor<T>): T {

--- a/packages/arel/src/predications-range.test.ts
+++ b/packages/arel/src/predications-range.test.ts
@@ -49,14 +49,30 @@ describe("Predications range semantics", () => {
       expect(((node as Nodes.NotIn).right as unknown[]).length).toBe(0);
     });
 
-    it("Infinity..end (unboundable begin) collapses to In([])", () => {
+    // A bare ±Infinity is open-ended, not unboundable: Float has no
+    // `unboundable?` (predications.rb:252-253), so Rails skips the `in([])` arm
+    // and treats the bound as absent (predications.rb:38-51). Rails' own
+    // `Float::INFINITY..` → `In([])` case (attribute_test.rb:679-684) reaches
+    // `in([])` through the nested `infinity?` check at predications.rb:42,
+    // which only applies when *both* bounds are open-ended.
+    it("Infinity..end (open-ended begin) becomes LessThanOrEqual on the real end", () => {
       const node = id.between({ begin: Infinity, end: 3 });
+      expect(node).toBeInstanceOf(Nodes.LessThanOrEqual);
+    });
+
+    it("begin..-Infinity (open-ended end) becomes GreaterThanOrEqual on the real begin", () => {
+      const node = id.between({ begin: 1, end: -Infinity });
+      expect(node).toBeInstanceOf(Nodes.GreaterThanOrEqual);
+    });
+
+    it("Infinity.. (both bounds open-ended) still collapses to In([]) via infinity?", () => {
+      const node = id.between({ begin: Infinity, end: null });
       expect(node).toBeInstanceOf(Nodes.In);
       expect(((node as Nodes.In).right as unknown[]).length).toBe(0);
     });
 
-    it("begin..-Infinity (unboundable end) collapses to In([])", () => {
-      const node = id.between({ begin: 1, end: -Infinity });
+    it("..-Infinity (both bounds open-ended) still collapses to In([]) via infinity?", () => {
+      const node = id.between({ begin: null, end: -Infinity });
       expect(node).toBeInstanceOf(Nodes.In);
       expect(((node as Nodes.In).right as unknown[]).length).toBe(0);
     });
@@ -127,8 +143,8 @@ describe("Predications range semantics", () => {
       expect(sql(id.between({ begin: -Infinity, end: Infinity }))).toBe("1=1");
     });
 
-    it("Infinity..end (unboundable begin) → 1=0", () => {
-      expect(sql(id.between({ begin: Infinity, end: 3 }))).toBe("1=0");
+    it("Infinity..end (open-ended begin) → col <= end", () => {
+      expect(sql(id.between({ begin: Infinity, end: 3 }))).toBe('"users"."id" <= 3');
     });
   });
 
@@ -194,13 +210,21 @@ describe("Predications range semantics", () => {
       expect(node).toBeInstanceOf(Nodes.In);
     });
 
-    it("Infinity..end (unboundable begin) becomes NotIn([])", () => {
+    // Same split as #between: a bare ±Infinity is open-ended, not unboundable,
+    // so it falls to the `gt(other.end)` / `lt(other.begin)` arms rather than
+    // the `not_in([])` arm (predications.rb:85-100).
+    it("Infinity..end (open-ended begin) becomes GreaterThan on the real end", () => {
       const node = id.notBetween({ begin: Infinity, end: 3 });
-      expect(node).toBeInstanceOf(Nodes.NotIn);
+      expect(node).toBeInstanceOf(Nodes.GreaterThan);
     });
 
-    it("begin..-Infinity (unboundable end) becomes NotIn([])", () => {
+    it("begin..-Infinity (open-ended end) becomes LessThan on the real begin", () => {
       const node = id.notBetween({ begin: 1, end: -Infinity });
+      expect(node).toBeInstanceOf(Nodes.LessThan);
+    });
+
+    it("Infinity.. (both bounds open-ended) still becomes NotIn([]) via infinity?", () => {
+      const node = id.notBetween({ begin: Infinity, end: null });
       expect(node).toBeInstanceOf(Nodes.NotIn);
     });
   });

--- a/packages/arel/src/predications-range.test.ts
+++ b/packages/arel/src/predications-range.test.ts
@@ -227,5 +227,12 @@ describe("Predications range semantics", () => {
       const node = id.notBetween({ begin: Infinity, end: null });
       expect(node).toBeInstanceOf(Nodes.NotIn);
     });
+
+    it("..-Infinity (both bounds open-ended) still becomes NotIn([]) via infinity?", () => {
+      // Covers the second disjunct of predications.rb:89,
+      // `infinity?(other.end) == -1`.
+      const node = id.notBetween({ begin: null, end: -Infinity });
+      expect(node).toBeInstanceOf(Nodes.NotIn);
+    });
   });
 });

--- a/packages/arel/src/predications-range.ts
+++ b/packages/arel/src/predications-range.ts
@@ -82,12 +82,18 @@ export function infinitySign(value: unknown): 1 | -1 | 0 {
   return 0;
 }
 
-// Mirrors Rails Predications#unboundable? — a bound is unboundable when it is
-// out of range for its column type. Trails threads that through a bound value
-// exposing `isUnboundable()` (a QueryAttribute bind, or the RangeHandler's
-// out-of-range sentinel), which returns a signed value (`1` past the max, `-1`
-// past the min) mirroring Ruby's `value <=> 0`. Falls back to infinitySign for
-// bare ±Infinity bounds.
+// Mirrors Rails Predications#unboundable? (predications.rb:252-253) —
+// `value.respond_to?(:unboundable?) && value.unboundable?`, the same duck-typed
+// predicate the visitor uses (to_sql.rb:905-907). A bound is unboundable when it
+// serializes out of range for its column type; trails threads that through a
+// bound exposing `isUnboundable()` (a QueryAttribute bind, or the RangeHandler's
+// out-of-range sentinel), returning the sign of Ruby's `value <=> 0`.
+//
+// A bare ±Infinity is NOT unboundable — Float has no `unboundable?`, so Rails
+// answers false and the bound falls through to the `open_ended?` / `infinity?`
+// arms of the between decision tree (predications.rb:38-51). `Float::INFINITY..`
+// still collapses to `in([])`, but via the nested `infinity?` check at
+// predications.rb:42, not this predicate.
 export function unboundableSign(value: unknown): 1 | -1 | 0 {
   if (
     value &&
@@ -95,11 +101,10 @@ export function unboundableSign(value: unknown): 1 | -1 | 0 {
     typeof (value as UnboundableLike).isUnboundable === "function"
   ) {
     const r = (value as UnboundableLike).isUnboundable!();
-    if (r === 1 || r === true) return 1;
+    if (r === 1) return 1;
     if (r === -1) return -1;
-    if (r === 0) return 0;
   }
-  return infinitySign(value);
+  return 0;
 }
 
 interface InfiniteLike {

--- a/packages/arel/src/predications-range.ts
+++ b/packages/arel/src/predications-range.ts
@@ -18,11 +18,17 @@ import { Between } from "./nodes/binary.js";
  *   `infinity?` / `unboundable?` / `open_ended?` — private helpers
  *
  * TS deviations (deliberate, called out in the audit):
- * - `infinitySign` / `unboundableSign` read the signed `isInfinite()` /
- *   `isUnboundable()` a bound value may expose (a QueryAttribute bind, or the
- *   RangeHandler out-of-range sentinel) — Trails' stand-in for Ruby's
- *   `infinity?` / `unboundable?` value protocols — plus bare `±Infinity`
- *   (and a `Quoted` wrapper around it).
+ * - `infinitySign` and `unboundableSign` are Trails' stand-ins for Ruby's
+ *   `infinity?` / `unboundable?` value protocols, and they read *different*
+ *   things — the two are not interchangeable:
+ *   - `infinitySign` mirrors `infinity?` (predications.rb:248-250): bare
+ *     `±Infinity`, a `Quoted` wrapper around it (`Quoted#infinite?`,
+ *     casted.rb:43-45), or a bound exposing `isInfinite()`. It deliberately
+ *     does NOT unwrap `Casted`, which defines no `infinite?` in Rails
+ *     (casted.rb:5-35) — see the note at `infinitySign` before "fixing" that.
+ *   - `unboundableSign` mirrors `unboundable?` (predications.rb:252-253) and is
+ *     purely duck-typed: only a bound exposing `isUnboundable()` answers it. A
+ *     bare `±Infinity` is open-ended, NOT unboundable.
  * - The TS port accepts three input shapes (array, object, positional)
  *   instead of Ruby's single `Range`.
  */
@@ -62,10 +68,26 @@ export function parseRange(beginOrRange: unknown, end: unknown, excludeEnd?: boo
   return { begin: beginOrRange, end, excludeEnd: excludeEnd === true };
 }
 
-// Mirrors Rails Predications#infinity? — signed infinity check. Recognizes
-// +/-Infinity (and a Quoted wrapper around the same) plus any bound value
-// exposing a signed `isInfinite()` (e.g. a QueryAttribute bind whose value is
-// ±Float::INFINITY).
+// Mirrors Rails Predications#infinity? (predications.rb:248-250) —
+// `value.respond_to?(:infinite?) && value.infinite?`, which yields the *sign*
+// because `Float#infinite?` returns `1 | -1 | nil`.
+//
+// Unwraps `Quoted` (whose `infinite?` lives at casted.rb:43-45) but deliberately
+// NOT `Casted`: Rails' `Casted` defines no `infinite?` (casted.rb:5-35), so
+// `open_ended?(Casted(INFINITY))` is false there and must be false here. Do not
+// "fix" this to unwrap Casted — it would silently change `between`.
+//
+// The `r === true` arm is NOT the same dead coercion removed from
+// `unboundableSign`: it compensates for a live producer. Rails'
+// `QueryAttribute#infinite?` (query_attribute.rb:42-44) returns
+// `infinity?(...)`, i.e. the sign; trails' returns a plain `boolean`
+// (`activerecord/src/relation/query-attribute.ts:89-94`), and `BindParam#isInfinite`
+// delegates to it (bind-param.ts:45-48) despite its `number | null` annotation.
+// Dropping the arm would stop detecting +Infinity binds; keeping it reports +1
+// for a -Infinity bind. Both are wrong — the root cause is the boolean return,
+// tracked in story `arel-predications-unboundable-duck-types-like-rails`. Latent
+// today: trails' RangeHandler passes cast values / UnboundableBound, never a
+// QueryAttribute, as a range bound.
 export function infinitySign(value: unknown): 1 | -1 | 0 {
   if (value === Infinity) return 1;
   if (value === -Infinity) return -1;

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1792,9 +1792,13 @@ describe("the to_sql visitor", () => {
       });
 
       it("honours an isUnboundable() protocol returning a sign or boolean", () => {
+        // Rails `case`s on the sign (`when 1` / `when -1`, to_sql.rb:438-475),
+        // so only those two values collapse. Every producer returns
+        // `1 | -1 | false`: QueryAttribute yields `value <=> 0`
+        // (query_attribute.rb:46-51), BindParam delegates, and RangeHandler's
+        // UnboundableBound carries the sign.
         expect(v().unboundableSign({ isUnboundable: () => 1 })).toBe(1);
         expect(v().unboundableSign({ isUnboundable: () => -1 })).toBe(-1);
-        expect(v().unboundableSign({ isUnboundable: () => true })).toBe(1);
         expect(v().unboundableSign({ isUnboundable: () => false })).toBe(0);
       });
 

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -83,7 +83,8 @@ describe("the to_sql visitor", () => {
   // `values.delete_if { |v| unboundable?(v) }`.
   describe("unboundable values in IN / NOT IN lists", () => {
     // Rails' PredicateBuilder wraps out-of-range bounds in a QueryAttribute,
-    // which `Nodes.build_quoted` passes through unwrapped (casted.rb:55) so it
+    // which `Nodes.build_quoted` passes through unwrapped (casted.rb:50-51 —
+    // the `when ..., ActiveModel::Attribute` arm returning `other`) so it
     // answers `unboundable?` to the visitor directly (to_sql.rb:905-907).
     // Trails' equivalent is a BindParam, whose `isUnboundable` delegates to its
     // value (bind_param.rb:39-40). Only that shape short-circuits.

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1437,8 +1437,10 @@ describe("the to_sql visitor", () => {
     });
 
     it("an infinite-but-bounded BindParam does not short-circuit", () => {
+      // Infinity has no `unboundable?`, so the bind is bounded and renders as a
+      // placeholder rather than collapsing.
       const node = new Nodes.GreaterThan(users.get("id"), new Nodes.BindParam(Infinity));
-      expect(new Visitors.ToSql().compile(node)).not.toContain("1=");
+      expect(new Visitors.ToSql().compile(node)).toBe('"users"."id" > ?');
     });
   });
 
@@ -1776,9 +1778,11 @@ describe("the to_sql visitor", () => {
       });
 
       it("does not consult isInfinite(), which is a different predicate", () => {
-        // `infinite?` lives on Casted (casted.rb:43-45) for
-        // `Predications#open_ended?` (predications.rb:248); the visitor never
-        // calls it, and neither Quoted nor Casted defines `unboundable?`.
+        // `infinite?` serves `Predications#open_ended?` (predications.rb:256-258);
+        // the visitor never calls it, and neither Quoted nor Casted defines
+        // `unboundable?`. It is defined on Quoted (casted.rb:43-45 — the Quoted
+        // class lives in casted.rb) and NOT on Casted (casted.rb:5-35), which is
+        // why Casted answers 0 below on both predicates.
         expect(v().unboundableSign(new Nodes.Quoted(Infinity))).toBe(0);
         expect(v().unboundableSign(new Nodes.Quoted(-Infinity))).toBe(0);
         expect(v().unboundableSign({ isInfinite: () => 1 })).toBe(0);

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -82,7 +82,12 @@ describe("the to_sql visitor", () => {
   // from an IN / NOT IN list, mirroring Rails' `visit_Arel_Nodes_In`
   // `values.delete_if { |v| unboundable?(v) }`.
   describe("unboundable values in IN / NOT IN lists", () => {
-    const unboundable = { isUnboundable: () => 1 as const };
+    // Rails' PredicateBuilder wraps out-of-range bounds in a QueryAttribute,
+    // which `Nodes.build_quoted` passes through unwrapped (casted.rb:55) so it
+    // answers `unboundable?` to the visitor directly (to_sql.rb:905-907).
+    // Trails' equivalent is a BindParam, whose `isUnboundable` delegates to its
+    // value (bind_param.rb:39-40). Only that shape short-circuits.
+    const unboundable = new Nodes.BindParam({ isUnboundable: () => 1 as const });
 
     it("drops an unboundable value from an IN list", () => {
       const sql = new Visitors.ToSql().compile(users.get("id").in([1, unboundable]));
@@ -1405,27 +1410,35 @@ describe("the to_sql visitor", () => {
     });
   });
 
-  describe("BindParam infinite short-circuit", () => {
-    const infinite = (sign: 1 | -1) => new Nodes.BindParam({ isInfinite: () => sign });
+  // `BindParam#unboundable?` (bind_param.rb:39-40) delegates to its value's
+  // `unboundable?`; the visitor never consults `infinite?` (bind_param.rb:35-37),
+  // which exists for `Predications#open_ended?` (predications.rb:248).
+  describe("BindParam unboundable short-circuit", () => {
+    const unboundable = (sign: 1 | -1) => new Nodes.BindParam({ isUnboundable: () => sign });
 
-    it("GreaterThan short-circuits to 1=0 for positive infinite", () => {
-      const node = new Nodes.GreaterThan(users.get("id"), infinite(1));
+    it("GreaterThan short-circuits to 1=0 for positive unboundable", () => {
+      const node = new Nodes.GreaterThan(users.get("id"), unboundable(1));
       expect(new Visitors.ToSql().compile(node)).toBe("1=0");
     });
 
-    it("GreaterThan short-circuits to 1=1 for negative infinite", () => {
-      const node = new Nodes.GreaterThan(users.get("id"), infinite(-1));
+    it("GreaterThan short-circuits to 1=1 for negative unboundable", () => {
+      const node = new Nodes.GreaterThan(users.get("id"), unboundable(-1));
       expect(new Visitors.ToSql().compile(node)).toBe("1=1");
     });
 
-    it("LessThan short-circuits to 1=1 for positive infinite", () => {
-      const node = new Nodes.LessThan(users.get("id"), infinite(1));
+    it("LessThan short-circuits to 1=1 for positive unboundable", () => {
+      const node = new Nodes.LessThan(users.get("id"), unboundable(1));
       expect(new Visitors.ToSql().compile(node)).toBe("1=1");
     });
 
-    it("LessThan short-circuits to 1=0 for negative infinite", () => {
-      const node = new Nodes.LessThan(users.get("id"), infinite(-1));
+    it("LessThan short-circuits to 1=0 for negative unboundable", () => {
+      const node = new Nodes.LessThan(users.get("id"), unboundable(-1));
       expect(new Visitors.ToSql().compile(node)).toBe("1=0");
+    });
+
+    it("an infinite-but-bounded BindParam does not short-circuit", () => {
+      const node = new Nodes.GreaterThan(users.get("id"), new Nodes.BindParam(Infinity));
+      expect(new Visitors.ToSql().compile(node)).not.toContain("1=");
     });
   });
 
@@ -1671,49 +1684,66 @@ describe("the to_sql visitor", () => {
       const tbl = new Table("users");
       const compile = (n: Nodes.Node) => new Visitors.ToSql().compile(n);
       const id = tbl.get("id");
+      // Rails' `unboundable?` is duck-typed (to_sql.rb:905-907) and only
+      // BindParam / QueryAttribute answer it. A raw `Float::INFINITY` — or a
+      // Quoted/Casted wrapping one — is *bounded* to the visitor, so it renders
+      // as a value instead of collapsing.
+      const unbounded = (sign: 1 | -1) => new Nodes.BindParam({ isUnboundable: () => sign });
 
-      it("Equality with +Infinity collapses to 1=0", () => {
-        expect(compile(id.eq(Infinity))).toBe("1=0");
+      it("Equality with an unboundable bind collapses to 1=0", () => {
+        expect(compile(id.eq(unbounded(1)))).toBe("1=0");
+        expect(compile(id.eq(unbounded(-1)))).toBe("1=0");
       });
-      it("Equality with -Infinity collapses to 1=0", () => {
-        expect(compile(id.eq(-Infinity))).toBe("1=0");
+      it("NotEqual with an unboundable bind collapses to 1=1", () => {
+        expect(compile(id.notEq(unbounded(1)))).toBe("1=1");
+        expect(compile(id.notEq(unbounded(-1)))).toBe("1=1");
       });
-      it("NotEqual with +Infinity collapses to 1=1", () => {
-        expect(compile(id.notEq(Infinity))).toBe("1=1");
+      it("GreaterThan +1 → 1=0; -1 → 1=1", () => {
+        expect(compile(id.gt(unbounded(1)))).toBe("1=0");
+        expect(compile(id.gt(unbounded(-1)))).toBe("1=1");
       });
-      it("NotEqual with -Infinity collapses to 1=1", () => {
-        expect(compile(id.notEq(-Infinity))).toBe("1=1");
+      it("GreaterThanOrEqual +1 → 1=0; -1 → 1=1", () => {
+        expect(compile(id.gteq(unbounded(1)))).toBe("1=0");
+        expect(compile(id.gteq(unbounded(-1)))).toBe("1=1");
       });
-      it("GreaterThan +Infinity → 1=0; -Infinity → 1=1", () => {
-        expect(compile(id.gt(Infinity))).toBe("1=0");
-        expect(compile(id.gt(-Infinity))).toBe("1=1");
+      it("LessThan +1 → 1=1; -1 → 1=0", () => {
+        expect(compile(id.lt(unbounded(1)))).toBe("1=1");
+        expect(compile(id.lt(unbounded(-1)))).toBe("1=0");
       });
-      it("GreaterThanOrEqual +Infinity → 1=0; -Infinity → 1=1", () => {
-        expect(compile(id.gteq(Infinity))).toBe("1=0");
-        expect(compile(id.gteq(-Infinity))).toBe("1=1");
-      });
-      it("LessThan +Infinity → 1=1; -Infinity → 1=0", () => {
-        expect(compile(id.lt(Infinity))).toBe("1=1");
-        expect(compile(id.lt(-Infinity))).toBe("1=0");
-      });
-      it("LessThanOrEqual +Infinity → 1=1; -Infinity → 1=0", () => {
-        expect(compile(id.lteq(Infinity))).toBe("1=1");
-        expect(compile(id.lteq(-Infinity))).toBe("1=0");
+      it("LessThanOrEqual +1 → 1=1; -1 → 1=0", () => {
+        expect(compile(id.lteq(unbounded(1)))).toBe("1=1");
+        expect(compile(id.lteq(unbounded(-1)))).toBe("1=0");
       });
       it("In filters unboundable values; all-unboundable collapses to 1=0", () => {
-        expect(compile(id.in([Infinity, -Infinity]))).toBe("1=0");
+        expect(compile(id.in([unbounded(1), unbounded(-1)]))).toBe("1=0");
       });
       it("In retains bounded values when mixed with unboundable", () => {
-        const sql = compile(id.in([1, Infinity, 2]));
-        expect(sql).toBe('"users"."id" IN (1, 2)');
+        expect(compile(id.in([1, unbounded(1), 2]))).toBe('"users"."id" IN (1, 2)');
       });
       it("NotIn filters unboundable values; all-unboundable collapses to 1=1", () => {
-        expect(compile(id.notIn([Infinity, -Infinity]))).toBe("1=1");
+        expect(compile(id.notIn([unbounded(1), unbounded(-1)]))).toBe("1=1");
       });
       it("NotIn retains bounded values when mixed with unboundable", () => {
-        const sql = compile(id.notIn([1, Infinity, 2]));
-        expect(sql).toBe('"users"."id" NOT IN (1, 2)');
+        expect(compile(id.notIn([1, unbounded(1), 2]))).toBe('"users"."id" NOT IN (1, 2)');
       });
+
+      it("a raw Float::INFINITY is bounded and renders as a value", () => {
+        // Rails: Float has no `unboundable?`, so `attr.eq(Float::INFINITY)`
+        // builds Casted(INFINITY) and renders `= Infinity` via `quote` →
+        // `when Numeric then value.to_s` (abstract/quoting.rb:82), which is what
+        // the AR adapter path emits. The connection-less default quoter
+        // string-quotes non-finite numbers (default-quoter.ts:48-52) because
+        // bare `Infinity` is not valid SQL in every dialect.
+        expect(compile(id.eq(Infinity))).toBe('"users"."id" = \'Infinity\'');
+        expect(compile(id.gt(-Infinity))).toBe('"users"."id" > \'-Infinity\'');
+        expect(compile(id.in([1, Infinity, 2]))).toBe('"users"."id" IN (1, \'Infinity\', 2)');
+      });
+
+      it("Quoted wrapping INFINITY is bounded too (Quoted has no unboundable?)", () => {
+        const eq = new Nodes.Equality(id, new Nodes.Quoted(Infinity));
+        expect(compile(eq)).toBe('"users"."id" = \'Infinity\'');
+      });
+
       it("bounded comparisons are unaffected", () => {
         expect(compile(id.gt(5))).toBe('"users"."id" > 5');
         expect(compile(id.lt(5))).toBe('"users"."id" < 5');
@@ -1726,13 +1756,6 @@ describe("the to_sql visitor", () => {
         expect(compile(id.eq(null))).toBe('"users"."id" IS NULL');
         expect(compile(id.notEq(null))).toBe('"users"."id" IS NOT NULL');
       });
-
-      it("short-circuits when wrapped directly in Nodes.Quoted (not via buildQuoted)", () => {
-        const eq = new Nodes.Equality(id, new Nodes.Quoted(Infinity));
-        expect(compile(eq)).toBe("1=0");
-        const gt = new Nodes.GreaterThan(id, new Nodes.Quoted(-Infinity));
-        expect(compile(gt)).toBe("1=1");
-      });
     });
 
     describe("unboundableSign protocol", () => {
@@ -1742,25 +1765,30 @@ describe("the to_sql visitor", () => {
       }
       const v = () => new Visitors.ToSql() as unknown as Internals;
 
-      it("returns +1 for +Infinity, -1 for -Infinity, 0 otherwise", () => {
-        expect(v().unboundableSign(Infinity)).toBe(1);
-        expect(v().unboundableSign(-Infinity)).toBe(-1);
+      it("returns 0 for values that do not respond to isUnboundable", () => {
+        // to_sql.rb:905 — `value.respond_to?(:unboundable?) && value.unboundable?`.
+        expect(v().unboundableSign(Infinity)).toBe(0);
+        expect(v().unboundableSign(-Infinity)).toBe(0);
         expect(v().unboundableSign(0)).toBe(0);
         expect(v().unboundableSign(null)).toBe(0);
         expect(v().unboundableSign(undefined)).toBe(0);
         expect(v().unboundableSign("foo")).toBe(0);
       });
 
-      it("unwraps Quoted via isInfinite()", () => {
-        expect(v().unboundableSign(new Nodes.Quoted(Infinity))).toBe(1);
-        expect(v().unboundableSign(new Nodes.Quoted(-Infinity))).toBe(-1);
-        expect(v().unboundableSign(new Nodes.Quoted(5))).toBe(0);
+      it("does not consult isInfinite(), which is a different predicate", () => {
+        // `infinite?` lives on Casted (casted.rb:43-45) for
+        // `Predications#open_ended?` (predications.rb:248); the visitor never
+        // calls it, and neither Quoted nor Casted defines `unboundable?`.
+        expect(v().unboundableSign(new Nodes.Quoted(Infinity))).toBe(0);
+        expect(v().unboundableSign(new Nodes.Quoted(-Infinity))).toBe(0);
+        expect(v().unboundableSign({ isInfinite: () => 1 })).toBe(0);
+        const casted = new Nodes.Casted(Infinity, new Table("users").get("id"));
+        expect(v().unboundableSign(casted)).toBe(0);
       });
 
-      it("descends through nodes that expose .value (e.g. Casted)", () => {
-        const tbl = new Table("users");
-        const casted = new Nodes.Casted(Infinity, tbl.get("id"));
-        expect(v().unboundableSign(casted)).toBe(1);
+      it("BindParam delegates isUnboundable to its value (bind_param.rb:39-40)", () => {
+        expect(v().unboundableSign(new Nodes.BindParam({ isUnboundable: () => -1 }))).toBe(-1);
+        expect(v().unboundableSign(new Nodes.BindParam(Infinity))).toBe(0);
       });
 
       it("honours an isUnboundable() protocol returning a sign or boolean", () => {
@@ -1771,8 +1799,9 @@ describe("the to_sql visitor", () => {
       });
 
       it("isUnboundable is the truthy wrapper of unboundableSign", () => {
-        expect(v().isUnboundable(Infinity)).toBe(true);
-        expect(v().isUnboundable(-Infinity)).toBe(true);
+        expect(v().isUnboundable({ isUnboundable: () => 1 })).toBe(true);
+        expect(v().isUnboundable({ isUnboundable: () => -1 })).toBe(true);
+        expect(v().isUnboundable(Infinity)).toBe(false);
         expect(v().isUnboundable(5)).toBe(false);
         expect(v().isUnboundable(null)).toBe(false);
       });

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -2026,7 +2026,7 @@ export class ToSql extends Visitor {
     const v = value as { isUnboundable?: () => unknown } | null | undefined;
     if (typeof v?.isUnboundable !== "function") return 0;
     const r = v.isUnboundable();
-    if (r === 1 || r === true) return 1;
+    if (r === 1) return 1;
     if (r === -1) return -1;
     return 0;
   }

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -2016,11 +2016,13 @@ export class ToSql extends Visitor {
    * `QueryAttribute` (query_attribute.rb:46-51), where it means "serializes
    * out of the column's range" (`value <=> 0`) — NOT "is infinite".
    *
-   * `infinite?` is a different predicate: it exists on `Casted`
-   * (casted.rb:43-45) for `Predications#open_ended?` (predications.rb:248) and
-   * is never consulted by the visitor. So a raw `Float::INFINITY`, or a
-   * `Quoted`/`Casted` wrapping one, is bounded here and renders as a value
-   * rather than collapsing.
+   * `infinite?` is a different predicate and is never consulted by the visitor;
+   * it serves `Predications#open_ended?` (predications.rb:256-258). Note it is
+   * defined on `Quoted` (casted.rb:43-45 — the `Quoted` class lives in
+   * casted.rb), NOT on `Casted`, which defines no `infinite?` at all
+   * (casted.rb:5-35). So a raw `Float::INFINITY`, or a `Quoted`/`Casted`
+   * wrapping one, is bounded here and renders as a value rather than
+   * collapsing.
    */
   protected unboundableSign(value: unknown): 1 | -1 | 0 {
     const v = value as { isUnboundable?: () => unknown } | null | undefined;

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -2006,35 +2006,28 @@ export class ToSql extends Visitor {
   }
 
   /**
-   * Mirrors `to_sql.rb#unboundable?` returning a sign — `1` for +∞, `-1`
-   * for -∞, `0` for bounded values. Comparison visitors `case` on the
-   * sign; equality/IN visitors use a truthy check (`sign !== 0`).
+   * Mirrors `to_sql.rb#unboundable?` (to_sql.rb:905-907), returning the sign
+   * the Ruby predicate yields so the comparison visitors can `case` on it:
    *
-   * Unwraps Quoted/Casted/BindParam to inspect the wrapped value, and
-   * recognises `Float::INFINITY` analogues (`±Infinity`) plus any value
-   * exposing `isInfinite()` / `isUnboundable()`.
+   *     value.respond_to?(:unboundable?) && value.unboundable?
+   *
+   * It is purely duck-typed. Only two types answer it: `BindParam`
+   * (bind_param.rb:39-40, itself delegating to its value) and
+   * `QueryAttribute` (query_attribute.rb:46-51), where it means "serializes
+   * out of the column's range" (`value <=> 0`) — NOT "is infinite".
+   *
+   * `infinite?` is a different predicate: it exists on `Casted`
+   * (casted.rb:43-45) for `Predications#open_ended?` (predications.rb:248) and
+   * is never consulted by the visitor. So a raw `Float::INFINITY`, or a
+   * `Quoted`/`Casted` wrapping one, is bounded here and renders as a value
+   * rather than collapsing.
    */
   protected unboundableSign(value: unknown): 1 | -1 | 0 {
-    if (value === Infinity) return 1;
-    if (value === -Infinity) return -1;
-    if (value && typeof value === "object") {
-      const v = value as {
-        value?: unknown;
-        isInfinite?: () => unknown;
-        isUnboundable?: () => unknown;
-      };
-      if (typeof v.isInfinite === "function") {
-        const r = v.isInfinite();
-        if (r === 1) return 1;
-        if (r === -1) return -1;
-      }
-      if (typeof v.isUnboundable === "function") {
-        const r = v.isUnboundable();
-        if (r === 1 || r === true) return 1;
-        if (r === -1) return -1;
-      }
-      if ("value" in v) return this.unboundableSign(v.value);
-    }
+    const v = value as { isUnboundable?: () => unknown } | null | undefined;
+    if (typeof v?.isUnboundable !== "function") return 0;
+    const r = v.isUnboundable();
+    if (r === 1 || r === true) return 1;
+    if (r === -1) return -1;
     return 0;
   }
 


### PR DESCRIPTION
Surfaced by review of #4873. Converges **both** live copies of `unboundableSign` onto Rails' duck-typed `unboundable?`.

## Problem

Rails defines `unboundable?` twice, identically, and it is purely duck-typed:

```ruby
# arel/visitors/to_sql.rb:905-907  AND  arel/predications.rb:252-253
def unboundable?(value)
  value.respond_to?(:unboundable?) && value.unboundable?
end
```

Only `Arel::Nodes::BindParam` (`bind_param.rb:39-40`, delegating to its value) and `ActiveRecord::Relation::QueryAttribute` (`query_attribute.rb:46-51`) answer it, where it means **"serializes out of the column's range"** (`value <=> 0`) — not "is infinite".

Trails conflated it with `infinite?` — a *different* predicate that serves `Predications#open_ended?` (`predications.rb:256-258`) — in both copies.

> **Citation correction (from review):** `infinite?` at `casted.rb:43-45` is **`Quoted#infinite?`**, not `Casted#infinite?` — `Casted` defines no `infinite?` at all (`casted.rb:5-35`); the `Quoted` class merely also lives in `casted.rb`. This is load-bearing, not pedantic: `open_ended?(Quoted(INFINITY))` is true in Rails but `open_ended?(Casted(INFINITY))` is **false**, which is exactly why `infinitySign` unwraps `Quoted` only. Trails' node layout already matched Rails (probed: `infinitySign(Casted(INF))` = 0, `isOpenEnded(Casted(INF))` = false); only my comments were wrong, and they'd have led a reader to "fix" `infinitySign` into breaking `between`. Corrected in code and here.

## Fix 1 — the visitor (`to-sql.ts`)

`unboundableSign` invented a raw-scalar branch (`if (value === Infinity) return 1`) and recursed through `.value`, so a raw `Float::INFINITY` — and `Quoted`/`Casted` wrapping one — collapsed to `1=0`/`1=1`. Neither class defines `unboundable?` in Rails. It now consults only the `unboundable?` analogue. The recursion existed solely to bottom out on the invented raw check, which is why deleting those two lines alone failed 11 tests on #4873.

A second commit drops one more unanchored branch, `true → 1`: Rails `case`s on the sign (`when 1`/`when -1`, `to_sql.rb:438-475`), so `true` falls through. Every producer of `unboundable?` returns `1 | -1 | false`, so it was dead as well as invented.

`attr.eq(Float::INFINITY)` now renders `= Infinity` on the AR adapter path via `quote` → `when Numeric then value.to_s` (`abstract/quoting.rb:82`).

## Fix 2 — `Predications#unboundable?` (`predications-range.ts`), added after review

The same inventions lived here, and this copy **diverged live**:

| | trails (before) | Rails |
|---|---|---|
| `between(Float::INFINITY..3)` | `1=0` | `"users"."id" <= 3` |
| `between(1..-Float::INFINITY)` | `1=0` | `"users"."id" >= 1` |

Rails answers `unboundable?(INFINITY) == 1` → **false**, falls through to `open_ended?(begin)`, and emits `lteq(other.end)` (`predications.rb:38-51`).

Rails' own tests pin the split: `between(Float::INFINITY..)` and `between(..-Float::INFINITY)` **do** collapse to `In([])` (`attribute_test.rb:679-691`) — but via the nested `infinity?` check at `predications.rb:42`, which fires only when *both* bounds are open-ended. Verified across the tree:

```
between(INFINITY..3)  => "users"."id" <= 3   | rails: <= 3
between(1..-INFINITY) => "users"."id" >= 1   | rails: >= 1
between(INFINITY..)   => 1=0                 | rails: 1=0   (via infinity?)
between(..-INFINITY)  => 1=0                 | rails: 1=0   (via infinity?)
between(-INF..INF)    => 1=1                 | rails: 1=1
between(0..INFINITY)  => "users"."id" >= 0   | rails: >= 0
between(unb(1)..3)    => 1=0                 | rails: 1=0   (#4433)
between(1..unb(-1))   => 1=0                 | rails: 1=0   (#4433)
```

Bundled rather than deferred: same predicate, ~6 LOC of source, and fixing only the visitor would have left two same-named `unboundableSign` functions disagreeing.

**Out-of-range bignum collapse (#4433) is preserved throughout** — it routes through `QueryAttribute#isUnboundable`.

## `infinitySign`'s `r === true` stays — with evidence

Review asked why `infinitySign` keeps the `true → 1` coercion that commit 7380477 removed from `unboundableSign` one function up. The parallel doesn't hold, and the disanalogy is the interesting part:

Rails' `QueryAttribute#infinite?` (`query_attribute.rb:42-44`) is `infinity?(value_before_type_cast) || serializable? && infinity?(value_for_database)`, and `infinity?` is `value.respond_to?(:infinite?) && value.infinite?`. Since `Float#infinite?` returns `1 | -1 | nil`, **Rails' `infinite?` yields the sign**. Trails' `QueryAttribute#isInfinite` (`query-attribute.ts:89-94`) returns a plain `boolean`, and `BindParam#isInfinite` delegates to it (`bind-param.ts:45-48`) despite its `number | null` annotation. Probed:

```
BindParam({isInfinite: () => true}).isInfinite()  =>  true
```

So `true` genuinely reaches `infinitySign` — unlike `unboundableSign`, where every producer returns `1 | -1 | false`. Dropping the arm alone would **regress** +Infinity detection; keeping it reports `+1` for a -Infinity bind. Both are wrong, and the root cause is the boolean return in a third package on a different predicate. Latent today (RangeHandler never passes a QueryAttribute as a range bound). Documented at `infinitySign` and tracked in the follow-up story rather than reached for here.

## Test reconciliation

None of the touched tests map to a Rails test, so `test:compare` is unaffected — **14442/21656 on `origin/main` and on this branch**.

- `to-sql.test.ts`: collapse now driven through `BindParam`, the shape `build_quoted` produces for a `QueryAttribute` (`casted.rb:55`); new tests pin that raw/`Quoted`/`Casted` INFINITY does *not* collapse and that `isInfinite()` is never consulted. The bounded-bind test now asserts the exact `"users"."id" > ?` instead of a negative substring that would pass for any SQL.
- `predications-range.test.ts`: 5 tests asserted the divergent arms and named a bare `Infinity` "unboundable" — the exact conflation this story removes. Re-pointed at Rails' answers; added coverage for the both-bounds-open-ended cases Rails *does* collapse.

Renames are confined to trails inventions whose names asserted the wrong predicate as their premise; no Rails-mapped test name changed.

## Follow-ups registered (not fanned out)

- **`arel-predications-unboundable-duck-types-like-rails`** (RFC 0023) — re-scoped after this review. Now covers only the **latent** third copy: `Predications.isUnboundable` (`predications.ts:363-368`) still `return false` behind a comment this PR falsifies, reachable only via the call-site-less `Attribute#isOpenEnded`; plus the `predications.ts`/`predications-range.ts` duplication question and the `QueryAttribute#isInfinite` sign-vs-boolean root cause above. It explicitly excludes the two sites fixed here and carries the probes, including a "do not unwrap `Casted`" warning.
- **`arel-build-quoted-passes-model-attribute-unwrapped`** (RFC 0023) — new, answering the repeated `buildQuoted` question. Records that the `BindParam` wrap is **behaviorally identical**, not merely close: Rails' `visit_ActiveModel_Attribute` does `add_bind(o)` (`to_sql.rb:756-758`) and `visit_Arel_Nodes_BindParam` does `add_bind(o.value)` (`to_sql.rb:760-762`), so both produce the same payload. The real gap is the missing `visitActiveModelAttribute` on `ToSql` (only `dot.ts` has one) — an api:compare surface matter. Now registered so it stops being re-derived.

## Gates

- api:compare: unchanged — data layer 7472/7474, overall 11416/16975 (delta 0).
- test:compare: unchanged — 14442/21656, measured both sides (delta 0).
- Full `packages/arel`: 71 files, 1485 passing. `activerecord/relation/**`, `finder`, `batches`: 1437 passing.
- No stubs added. 320 LOC across 5 files, single PR from `main`. `casted.ts` is comment-only.

## A note on the reverted reorder

An earlier commit briefly carried a member reorder in `casted.ts`. That was **not** an intentional change: it was a pre-commit autofix from `blazetrails/rails-file-structure-method-order`, armed by my own local `pnpm api:compare` run (which writes the rule's gitignored manifest, `.gitignore:27`). The rule is **dormant in CI** — the lint job never runs `api:compare`, so the manifest is absent and the rule no-ops — meaning it only fires locally, silently reordering members of files unrelated to the commit. The same symptom hit #4877.

Review caught that the reorder was also *wrong*: Rails declares `value_for_database` before `value_before_type_cast` in `Quoted` (`casted.rb:38-39`) but the reverse in `Casted` (`casted.rb:7`, `:17`), and the manifest is per-file and name-deduped, so a two-class file collapses to one flat list and `Casted`'s order got applied to `Quoted`. Rather than hand-swap `Quoted`, I removed the stray manifest and reverted the hunk entirely — `casted.ts` is now comment-only against main, and lint is verified green in the CI-equivalent (manifest-absent) state. Both rule defects are tracked in `rails-file-structure-method-order-dormant-and-per-file` (RFC 0025); `casted.ts`'s pre-existing mismatch against Rails' declaration order belongs to that story, not here.

Closes-story: arel-unboundable-sign-duck-types-like-rails
