### PR TITLE
refactor(arel): drop invented caster arg from Attribute

### DIFF
--- a/packages/arel/src/attributes/attribute.test.ts
+++ b/packages/arel/src/attributes/attribute.test.ts
@@ -1061,35 +1061,39 @@ describe("AttributeTest", () => {
 
   describe("type casting", () => {
     it("does not type cast by default", () => {
-      const attr = new Nodes.Attribute(users, "name");
-      const node = attr.eq("hello");
-      const visitor = new Visitors.ToSql();
-      expect(visitor.compile(node)).toBe('"users"."name" = \'hello\'');
+      const table = new Table("foo");
+      const condition = table.get("id").eq("1");
+
+      expect(table.isAbleToTypeCast()).toBe(false);
+      expect(new Visitors.ToSql().compile(condition)).toBe('"foo"."id" = \'1\'');
     });
 
     it("type casts when given an explicit caster", () => {
-      const caster = {
-        typeCastForDatabase(value: unknown) {
-          return String(value).toUpperCase();
+      const fakeCaster = {
+        typeCastForDatabase(attrName: string, value: unknown) {
+          return attrName === "id" ? Number(value) : value;
         },
       };
-      const attr = new Nodes.Attribute(users, "name", caster);
-      const node = attr.eq("hello");
-      const visitor = new Visitors.ToSql();
-      expect(visitor.compile(node)).toBe('"users"."name" = \'HELLO\'');
+      const table = new Table("foo", { typeCaster: fakeCaster });
+      const condition = table.get("id").eq("1").and(table.get("other_id").eq("2"));
+
+      expect(table.isAbleToTypeCast()).toBe(true);
+      expect(new Visitors.ToSql().compile(condition)).toBe(
+        '"foo"."id" = 1 AND "foo"."other_id" = \'2\'',
+      );
     });
 
     it("does not type cast SqlLiteral nodes", () => {
-      const caster = {
-        typeCastForDatabase(value: unknown) {
-          return String(value).toUpperCase();
+      const fakeCaster = {
+        typeCastForDatabase(_attrName: string, value: unknown) {
+          return Number(value);
         },
       };
-      const attr = new Nodes.Attribute(users, "name", caster);
-      const literal = new Nodes.SqlLiteral("raw_value");
-      const node = attr.eq(literal);
-      const visitor = new Visitors.ToSql();
-      expect(visitor.compile(node)).toContain("raw_value");
+      const table = new Table("foo", { typeCaster: fakeCaster });
+      const condition = table.get("id").eq(new Nodes.SqlLiteral("(select 1)"));
+
+      expect(table.isAbleToTypeCast()).toBe(true);
+      expect(new Visitors.ToSql().compile(condition)).toBe('"foo"."id" = (select 1)');
     });
   });
 

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -80,9 +80,9 @@ export interface RelationLike {
   // `Table#tableAlias` is a plain string-or-nil. Both flow through here as
   // `o.relation.table_alias`.
   tableAlias?: string | SqlLiteral | null;
-  typeCastForDatabase?: (attrName: string, value: unknown) => unknown;
-  typeForAttribute?: (name: string) => unknown;
-  isAbleToTypeCast?: () => boolean;
+  typeCastForDatabase: (attrName: string, value: unknown) => unknown;
+  typeForAttribute: (name: string) => unknown;
+  isAbleToTypeCast: () => boolean;
 }
 
 /**
@@ -108,7 +108,7 @@ export class Attribute extends Node {
   }
 
   get typeCaster(): unknown {
-    return this.relation.typeForAttribute ? this.relation.typeForAttribute(this.name) : undefined;
+    return this.relation.typeForAttribute(this.name);
   }
 
   // -- String functions --
@@ -118,15 +118,11 @@ export class Attribute extends Node {
   }
 
   typeCastForDatabase(value: unknown): unknown {
-    return this.relation.typeCastForDatabase
-      ? this.relation.typeCastForDatabase(this.name, value)
-      : value;
+    return this.relation.typeCastForDatabase(this.name, value);
   }
 
   isAbleToTypeCast(): boolean {
-    return typeof this.relation.isAbleToTypeCast === "function"
-      ? this.relation.isAbleToTypeCast()
-      : false;
+    return this.relation.isAbleToTypeCast();
   }
 
   /**

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -71,10 +71,6 @@ function groupedAll(nodes: Node[]): Grouping {
  *
  * Mirrors: Arel::Attributes::Attribute
  */
-export interface TypeCaster {
-  typeCastForDatabase(value: unknown): unknown;
-}
-
 export interface RelationLike {
   // A `SqlLiteral` name (e.g. a `SelectManager#as` / set-op `from()` derived
   // table) renders bare; `quoteTableName` returns its value unchanged.
@@ -104,13 +100,11 @@ export class Attribute extends Node {
   readonly [ATTRIBUTE_BRAND] = true;
   readonly relation: RelationLike;
   readonly name: string;
-  readonly caster?: TypeCaster;
 
-  constructor(relation: RelationLike, name: string, caster?: TypeCaster) {
+  constructor(relation: RelationLike, name: string) {
     super();
     this.relation = relation;
     this.name = name;
-    this.caster = caster;
   }
 
   get typeCaster(): unknown {

--- a/packages/arel/src/nodes/casted.ts
+++ b/packages/arel/src/nodes/casted.ts
@@ -67,18 +67,14 @@ export class Casted extends NodeExpression {
     this.attribute = attribute;
   }
 
-  valueForDatabase(): unknown {
-    const attr = this.attribute as unknown as {
-      isAbleToTypeCast?: () => boolean;
-      typeCastForDatabase?: (v: unknown) => unknown;
-    };
-    if (attr?.isAbleToTypeCast?.() && attr.typeCastForDatabase) {
-      return attr.typeCastForDatabase(this.value);
-    }
+  valueBeforeTypeCast(): unknown {
     return this.value;
   }
 
-  valueBeforeTypeCast(): unknown {
+  valueForDatabase(): unknown {
+    if (this.attribute.isAbleToTypeCast()) {
+      return this.attribute.typeCastForDatabase(this.value);
+    }
     return this.value;
   }
 
@@ -101,6 +97,10 @@ export class Quoted extends Unary {
     return this.expr;
   }
 
+  valueBeforeTypeCast(): unknown {
+    return this.value;
+  }
+
   valueForDatabase(): unknown {
     return this.value;
   }
@@ -109,10 +109,6 @@ export class Quoted extends Unary {
     if (this.value === Infinity) return 1;
     if (this.value === -Infinity) return -1;
     return null;
-  }
-
-  valueBeforeTypeCast(): unknown {
-    return this.value;
   }
 
   accept<T>(visitor: NodeVisitor<T>): T {

--- a/packages/arel/src/nodes/casted.ts
+++ b/packages/arel/src/nodes/casted.ts
@@ -69,13 +69,9 @@ export class Casted extends NodeExpression {
 
   valueForDatabase(): unknown {
     const attr = this.attribute as unknown as {
-      caster?: { typeCastForDatabase(v: unknown): unknown };
       isAbleToTypeCast?: () => boolean;
       typeCastForDatabase?: (v: unknown) => unknown;
     };
-    if (attr?.caster?.typeCastForDatabase) {
-      return attr.caster.typeCastForDatabase(this.value);
-    }
     if (attr?.isAbleToTypeCast?.() && attr.typeCastForDatabase) {
       return attr.typeCastForDatabase(this.value);
     }

--- a/packages/arel/src/nodes/casted.ts
+++ b/packages/arel/src/nodes/casted.ts
@@ -97,11 +97,11 @@ export class Quoted extends Unary {
     return this.expr;
   }
 
-  valueBeforeTypeCast(): unknown {
+  valueForDatabase(): unknown {
     return this.value;
   }
 
-  valueForDatabase(): unknown {
+  valueBeforeTypeCast(): unknown {
     return this.value;
   }
 


### PR DESCRIPTION
Rails' `Arel::Attributes::Attribute` is a two-member struct (`Struct.new :relation, :name`, `arel/attributes/attribute.rb:5`) — type casting delegates solely to `relation`, and `Nodes::Casted#value_for_database` (`casted.rb:17-23`) has exactly one arm.

Trails invented an optional third `caster` constructor arg on `Attribute` plus a matching first arm in `Casted#valueForDatabase`. No production site passed a caster (`Table#get`, `Table#get("*")`, `TableAlias#get` are all two-arg), so the arm only fired for attributes hand-constructed in tests. Both are removed here, along with the now-unreferenced `TypeCaster` interface.

Follow-on convergences, all on the same "invented extra on `Attribute`" theme:

- `Casted#valueForDatabase` now reads exactly like `casted.rb:17-23`. With `caster` gone, `Casted#attribute` is provably always a real `Attribute` (`ATTRIBUTE_BRAND` is set *only* at `attribute.ts:100`, and both construction sites — `attribute.ts:151` and the `isAttribute`-guarded `casted.ts:44` — pass one), so the defensive structural cast and optional chaining were dead weight.
- `RelationLike` now requires `typeCastForDatabase` / `typeForAttribute` / `isAbleToTypeCast`, and `Attribute`'s three delegators are bare, matching `attribute.rb:12-14, 22-24, 26-28`. Both implementers already provide all three as required methods (`table.ts:154,166,178`; `table-alias.ts:35,40,45`).

## On the tests

The story anticipated deleting the two caster tests as a trails-only surface. They are in fact **Rails tests verbatim** (`attribute_test.rb:1132`, `:1148`) — Rails just passes the caster to the **Table** (`Table.new(:foo, type_caster: fake_caster)`), which trails' `Table` already supports end-to-end (`table.ts:29,154,178`). Deleting them would have dropped Rails-named coverage, so they are ported to the Rails form instead, along with `does not type cast by default` (`:1124`). They now exercise the real `able_to_type_cast?` / `type_cast_for_database` path rather than the invented shortcut, and assert Rails' exact expectations — including the `other_id` arm and the `able_to_type_cast?` assertions the trails versions had dropped.

## Review replies

**`Quoted` member order (round 2, fixed).** Correct catch, and the cause is worth recording. The reorder was **not** intentional: it was a pre-commit auto-fix artifact. The `blazetrails/rails-file-structure-method-order` rule keys its order data **per file and name-deduped**, so `casted.ts` — which defines two classes sharing method names — collapses to one flat list (`["value","attribute","valueBeforeTypeCast","constructor","valueForDatabase",...]`), imposing `Casted`'s order on `Quoted`. Both classes now match Rails: `Casted` is `valueBeforeTypeCast` → `valueForDatabase` (`casted.rb:7,17`), `Quoted` is `valueForDatabase` → `valueBeforeTypeCast` (`casted.rb:38-39`).

That rule turns out to be **dormant in CI**: its manifest is gitignored (`.gitignore:27`), written only by `pnpm api:compare`, and the loader returns an empty manifest when absent (`rails-file-structure-method-order.mjs:36-39`). CI's lint job (`ci.yml:375-385`) never runs `api:compare`. Verified: `casted.ts` on `origin/main` fails the rule with 5 mismatches once the manifest exists locally, while `main` is green in CI. Registered as `0025-fidelity-verification-tooling/rails-file-structure-method-order-dormant-and-per-file`.

**`Table` / `TableAlias` fallbacks (round 3) — registered, not ridden.** Facts confirmed: `table.rb:102-108` and `table_alias.rb:18-24` both delegate bare, and only `table_alias.rb:26-28`'s `respond_to?` guard is Rails-backed (which `table-alias.ts:45-48` already mirrors). Registered as `0023-surfaced-deviations/arel-table-type-cast-fallbacks-are-invented` rather than ridden here: it is a different Rails source (`table.rb` / `table_alias.rb`, not `attribute.rb` / `casted.rb`) and outside this story's acceptance criteria, and per CLAUDE.md discovered work belongs in its own scheduled story.

One correction to the review's framing, captured in that story: the two fallbacks are **not** equally dead. `typeCastForDatabase`'s is unreachable as described (the `isAbleToTypeCast()` gate short-circuits), but `typeForAttribute`'s is **reachable and ungated** — `Attribute#typeCaster` (`attribute.ts:110-112`) calls it with no gate, and `HomogeneousIn#castedValues` (`homogeneous-in.ts:62-78`) consumes it. Since our Rails-ported `fakeCaster` is deliberately partial (only `typeCastForDatabase`, mirroring `attribute_test.rb:1132-1146`), converging that one needs a reachability check first — which is exactly why it wants its own PR.

## Verification

- **Gate 1 (matches Rails):** `Attribute` is two-member per `attribute.rb:5`; `valueForDatabase` mirrors `casted.rb:17-23` line for line; delegators bare per `attribute.rb:12-14,22-24,26-28`; `Quoted`/`Casted` member order per `casted.rb:7,17,38-39`.
- **Gate 2 (no stubs):** net removal (39 insertions / 53 deletions); no stubs or placeholders added.
- **Gate 3 (compare deltas non-negative):** measured, not assumed. Baselined `attribute.test.ts` against `origin/main` and re-ran `test:compare`: `attributes/attribute_test.rb 128 ✓` and Overall `14442/21656 (66.7%)` on **both** — delta exactly **0**. `api:compare` reports **arel at 100%** (938/938 methods, 69/69 files, 69/69 inheritance, 681/681 arity); Overall unchanged at `11416/16975`. Both call-mismatch ratchets pass (`19` / `6858` baselined) — the `valueForDatabase` convergence stranded no baseline entry.
- `homogeneous-in.ts:53-72` confirmed unaffected: it reads `Attribute#typeCaster`, the Rails `type_caster` method (`attribute.rb:12-14`), a different thing from the removed field.
- Full arel suite (1481 tests / 71 files) plus the ActiveRecord `Casted` consumers (predicate-builder, table-metadata, type-caster — 34 tests) pass. Full-repo `pnpm typecheck` green, confirming no caller depended on the removed optionality.
- The `@internal` DEVIATION note this story expected to remove is not on `main` (#4874 not yet merged); if it lands first I will drop it on rebase.

Closes-story: arel-attribute-caster-is-a-trails-invention
