### PR TITLE
fix(arel): delete invented isNull/isNotNull predicates; use eq(null)/notEq(null)

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -3878,7 +3878,7 @@ export class Base extends Model {
       );
     if (ctor.lockingEnabled) {
       if (lockWhereValue == null) {
-        um.where(table.get(lockCol).isNull());
+        um.where(table.get(lockCol).eq(null));
       } else {
         um.where(table.get(lockCol).eq(Number(lockWhereValue) || 0));
       }
@@ -4078,7 +4078,7 @@ export class Base extends Model {
             ? lockAttr.valueForDatabase
             : lockAttr.originalValueForDatabase();
           if (lockWhereValue == null) {
-            dm.where(table.get(lockCol).isNull());
+            dm.where(table.get(lockCol).eq(null));
           } else {
             dm.where(table.get(lockCol).eq(Number(lockWhereValue) || 0));
           }

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -189,7 +189,7 @@ export function buildWhereNodeFromConstraints(
   const conditions: InstanceType<typeof Nodes.Node>[] = [];
   for (const [col, value] of Object.entries(constraints)) {
     const attr = table.get(col);
-    conditions.push(value === undefined || value === null ? attr.isNull() : attr.eq(value));
+    conditions.push(value === undefined || value === null ? attr.eq(null) : attr.eq(value));
   }
   if (conditions.length === 1) return conditions[0];
   return new Nodes.And(conditions);

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -352,7 +352,7 @@ export class PredicateBuilder {
       value = (value as { id: unknown }).id;
     }
     if (value === null || value === undefined) {
-      return attribute.isNotNull();
+      return attribute.notEq(null);
     }
     if (value instanceof Set) {
       value = Array.from(value);
@@ -420,7 +420,7 @@ export class PredicateBuilder {
     }
 
     if (hasNull) {
-      parts.push(attribute.isNotNull());
+      parts.push(attribute.notEq(null));
     }
 
     for (const range of ranges) {
@@ -460,11 +460,11 @@ export class PredicateBuilder {
     if (this.isScalarQueryValue(value)) {
       const normalized = this.normalizeQueryValue(attribute.name, value);
       if (normalized === null || normalized === undefined) {
-        return attribute.isNull();
+        return attribute.eq(null);
       }
     }
     if (value === null || value === undefined) {
-      return attribute.isNull();
+      return attribute.eq(null);
     }
     // Rails checks `table.type(attribute.name).force_equality?(value)` at the top
     // of `build` — right after the `id` deref and BEFORE any handler dispatch

--- a/packages/activerecord/src/relation/predicate-builder/array-handler.ts
+++ b/packages/activerecord/src/relation/predicate-builder/array-handler.ts
@@ -83,8 +83,8 @@ export class ArrayHandler {
     if (hasNull) {
       valuesPredicate =
         valuesPredicate === NullPredicate
-          ? attribute.isNull()
-          : groupedOr(valuesPredicate as Nodes.Node, attribute.isNull());
+          ? attribute.eq(null)
+          : groupedOr(valuesPredicate as Nodes.Node, attribute.eq(null));
     }
 
     if (ranges.length === 0) {

--- a/packages/activerecord/src/timestamp.ts
+++ b/packages/activerecord/src/timestamp.ts
@@ -164,7 +164,7 @@ async function touchRow(this: Base, touchCols: string[], now: Temporal.Instant):
 
   if (ctor.lockingEnabled) {
     if (rawDbVersion == null) {
-      um.where(table.get(lockCol).isNull());
+      um.where(table.get(lockCol).eq(null));
     } else {
       um.where(table.get(lockCol).eq(Number(rawDbVersion) || 0));
     }

--- a/packages/arel/src/attributes/attribute.test.ts
+++ b/packages/arel/src/attributes/attribute.test.ts
@@ -1145,18 +1145,6 @@ describe("AttributeTest", () => {
     );
   });
 
-  it("isNull generates IS NULL", () => {
-    expect(users.project(star).where(users.get("name").isNull()).toSql()).toBe(
-      'SELECT * FROM "users" WHERE "users"."name" IS NULL',
-    );
-  });
-
-  it("isNotNull generates IS NOT NULL", () => {
-    expect(users.project(star).where(users.get("name").isNotNull()).toSql()).toBe(
-      'SELECT * FROM "users" WHERE "users"."name" IS NOT NULL',
-    );
-  });
-
   it("and combines with AND", () => {
     const cond = users.get("name").eq("dean").and(users.get("age").gt(21));
     expect(users.project(star).where(cond).toSql()).toBe(

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -239,14 +239,6 @@ export class Attribute extends Node {
     return notBetweenFromRange(this, parseRange(beginOrRange, end, excludeEnd));
   }
 
-  isNull(): Equality {
-    return new Equality(this, new Quoted(null));
-  }
-
-  isNotNull(): NotEqual {
-    return new NotEqual(this, new Quoted(null));
-  }
-
   // -- _any / _all variants --
 
   eqAny(others: unknown[]): Grouping {

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -13,7 +13,6 @@ import { Equality } from "./nodes/equality.js";
 import { Matches, DoesNotMatch } from "./nodes/matches.js";
 import { In } from "./nodes/in.js";
 import { Regexp as RegexpNode, NotRegexp } from "./nodes/regexp.js";
-import { Quoted } from "./nodes/casted.js";
 import { SqlLiteral } from "./nodes/sql-literal.js";
 import { And } from "./nodes/and.js";
 import { Or } from "./nodes/or.js";
@@ -223,13 +222,6 @@ export const Predications = {
       end: unknown,
       excludeEnd?: boolean,
     ): Node;
-  },
-
-  isNull(this: Node & PredicationHost): Equality {
-    return new Equality(this, new Quoted(null));
-  },
-  isNotNull(this: Node & PredicationHost): NotEqual {
-    return new NotEqual(this, new Quoted(null));
   },
 
   // -- _any / _all variants --

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -36333,13 +36333,6 @@
     "package": "activerecord",
     "tsFile": "relation/predicate-builder/array-handler.ts",
     "rubyName": "call",
-    "call": "eq",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder/array-handler.ts",
-    "rubyName": "call",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
## What

`Arel::Attributes::Attribute#isNull` / `#isNotNull` (and their twins in
`predications.ts`) are trails inventions that hard-coded `Quoted(null)`
instead of routing a nil right-hand side through `quotedNode`.

This PR removes the invention and routes every caller through the Rails path.
It is **one half of a two-PR convergence** — see "Relationship to #4874" below.

## Decision: delete (option a), not delegate

The story offered two options. Going with **(a) delete**, on two findings:

1. **No Rails counterpart.** `is_null` / `not_null` / `is_not_null` appear
   nowhere in `vendor/rails/activerecord/lib/arel/` (grep over the whole arel
   lib, not just `predications.rb`). Rails spells this `attr.eq(nil)` /
   `attr.not_eq(nil)` → `quoted_node` → `build_quoted(other, self)`
   (`predications.rb:244-246`) → `Casted(nil, attr)` (`casted.rb:48-58`).
   Rails uses this exact form in its own AR internals — `array_handler.rb:27`
   reads `values_predicate.or(attribute.eq(nil))`, which `array-handler.ts`
   now mirrors verbatim.
2. **Caller audit (repo-wide, all receivers): 10 call sites, every one on an
   `Attribute`**, so all take `eq(null)` / `notEq(null)` directly.

| File | Sites |
| --- | --- |
| `relation/predicate-builder.ts` | 4 |
| `relation/predicate-builder/array-handler.ts` | 2 |
| `base.ts` (optimistic locking) | 2 |
| `model-schema.ts` | 1 |
| `timestamp.ts` | 1 |

### Audit scope for the `predications.ts` deletion

Deleting the generic `Predications.isNull`/`isNotNull` is the riskier of the
two deletions, so stating the scope explicitly: the audit was **repo-wide, not
`Attribute`-only**. `git grep` across the entire tree (excluding
`vendor/rails`) plus a scan of every built `dist/**/*.d.ts` finds **no caller
on any receiver** — no `SqlLiteral`, no function node, no other
`PredicationHost`. `packages/arel/dist` declares no `isNull` surface at all.
Every surviving hit is an unrelated homonym: `Scope#isNull(): boolean`
(actionpack's port of Ruby `null?`), `isNullRelation`, `isNullable`,
`isNullScope`, and a `changeNull` parameter.

## Relationship to #4874 — the `Casted` half

**This PR deliberately does not touch `quotedNode`.** `attribute.ts:150` still
short-circuits nil to `Quoted(null)`, so after this PR the tree still builds
`Quoted`, not `Casted`. That is correct scoping, not an oversight:

- **Rails has no nil short-circuit.** `quoted_node` is exactly
  `Nodes.build_quoted(other, self)`; `build_quoted` cases only on the *type*
  of `other`, so `nil` falls to the `else` and becomes
  `Casted.new(nil, attribute)` (`casted.rb:47-58`). Our own `buildQuoted`
  (`nodes/casted.ts:26-46`) already gets this right.
- **Open PR #4874 already implements precisely that fix** — it rewrites
  `quotedNode` to `buildQuoted(value, this)` and collapses the hand-rolled
  `ModelAttribute`→`BindParam` re-implementation into the structural check
  `buildQuoted` already does. Duplicating it here would mean two open PRs
  editing the same method, a guaranteed conflict, and a stacked/overlapping
  diff the repo rules forbid.

The story scoped it this way on purpose: *"isNull / isNotNull are the same
Quoted(null) deviation one method over, and were left out of that PR for
scope."* The two compose — this PR makes nil **route through `quotedNode`**;
#4874 makes `quotedNode` **return `Casted`**. Neither alone reaches
`Casted(nil, attr)` from `isNull`'s old callers; together they do, and the
convergence is complete.

**On the surviving `Quoted` import:** an earlier revision of this body read it
as expected-and-fine. That was the wrong framing — it is the *tell* that the
deviation still lives at line 150, which is now the file's **only** `Quoted`
use. It drops out with #4874. The story's criterion "if no `Quoted` uses
remain, the import goes too" is therefore satisfied by #4874, not here.

**Why the residual deviation matters beyond SQL:** `Casted#eql?`/`#hash`
include the attribute (`casted.rb:24-33`) while `Quoted` is a bare `Unary`, so
node equality/dedup diverges even though the emitted SQL is identical. This
PR does not regress that; #4874 fixes it.

## SQL is unchanged

`IS NULL` / `IS NOT NULL` output is identical for every caller — `Casted` and
`Quoted` both define `nil?` as `value.nil?` (`casted.rb:15`, `casted.rb:41`),
and `visit_Arel_Nodes_Quoted` is aliased to `visit_Arel_Nodes_Casted`
(`to_sql.rb:87-90`). Green: attribute (244), attribute-alignment (13),
predicate-builder (31), locking / timestamp / where / model-schema (156).

Existing `eq(null)` / `notEq(null)` SQL coverage already lives at
`attribute.test.ts:1096` and `:1420`, so deleting the two invented
`isNull generates IS NULL` tests loses no coverage.

## Compare deltas

| | matched | extra (TS-only) |
| --- | --- | --- |
| `origin/main` | 14442 | 3961 |
| this PR | 14442 | **3959** |

test:compare matched delta **0**; TS-only extras drop by exactly 2 (the two
invented tests). api:compare data layer 7472/7474 (100%), unchanged. Wide call
ratchet green — 13 entries, none touching the changed files.

Closes-story: arel-attribute-is-null-builds-quoted-not-casted