### PR TITLE
docs(arel): record the BindParam-wrap decision for ActiveModel::Attribute

### DIFF
--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -139,6 +139,19 @@ export class Attribute extends Node {
    */
   quotedNode(value: unknown): Node {
     return buildQuoted(value, this);
+||||||| parent of c47f4e3c2 (docs(arel): correct the wrap-site lockstep claim; file predicate convergence)
+    if (value instanceof Node) return value;
+    if (value === null || value === undefined) return new Quoted(null);
+    // ActiveModel::Attribute instances (QueryAttribute etc.) carry their
+    // own type + value. Wrap in BindParam so the visitor extracts them
+    // as binds rather than inlining via Casted. This mirrors the wrap in
+    // `Nodes.buildQuoted` and must move with it — both wrap-sites together,
+    // or the AST shape diverges by call path. See the equivalence proof in
+    // nodes/casted.ts for why the wrap is Rails-equivalent.
+    if (value instanceof ModelAttribute) {
+      return new BindParam(value);
+    }
+    return new Casted(value, this);
   }
 
   // -- Predicates --

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -139,19 +139,6 @@ export class Attribute extends Node {
    */
   quotedNode(value: unknown): Node {
     return buildQuoted(value, this);
-||||||| parent of c47f4e3c2 (docs(arel): correct the wrap-site lockstep claim; file predicate convergence)
-    if (value instanceof Node) return value;
-    if (value === null || value === undefined) return new Quoted(null);
-    // ActiveModel::Attribute instances (QueryAttribute etc.) carry their
-    // own type + value. Wrap in BindParam so the visitor extracts them
-    // as binds rather than inlining via Casted. This mirrors the wrap in
-    // `Nodes.buildQuoted` and must move with it — both wrap-sites together,
-    // or the AST shape diverges by call path. See the equivalence proof in
-    // nodes/casted.ts for why the wrap is Rails-equivalent.
-    if (value instanceof ModelAttribute) {
-      return new BindParam(value);
-    }
-    return new Casted(value, this);
   }
 
   // -- Predicates --

--- a/packages/arel/src/nodes/casted.ts
+++ b/packages/arel/src/nodes/casted.ts
@@ -81,13 +81,14 @@ export function buildQuoted(other: unknown, attribute?: unknown): Node {
     //
     // The "structural so we don't need a runtime import" rationale this used to
     // carry is stale: arel already depends on @blazetrails/activemodel, which
-    // does not depend back (no cycle), and visitors/to-sql.ts already imports
-    // Attribute from it at runtime. Rails identifies it by class
-    // (casted.rb:50), so `instanceof` is the convergent shape; this check also
-    // disagrees with the other two in arel — to-sql's `isActiveModelAttribute`
-    // omits the `name` half, dot's tests `valueBeforeTypeCast` instead.
-    // Tracked by story `arel-am-attribute-predicates-diverge-across-sites` — a
-    // behaviour change (a duck-typed object stops binding), so not folded in.
+    // does not depend back (no cycle), and visitors/to-sql.ts + visitors/dot.ts
+    // already import Attribute from it at runtime. Rails identifies it by class
+    // (casted.rb:50), so `instanceof` is the convergent shape — #4880 already
+    // moved `Dot` to it. The two structural checks left in arel are this one and
+    // to-sql's `isActiveModelAttribute`, which omits the `name` half, so they
+    // disagree with each other as well as with Rails. Tracked by story
+    // `arel-am-attribute-predicates-diverge-across-sites` — a behaviour change
+    // (a duck-typed object stops binding), so not folded in.
     if (
       "valueForDatabase" in (other as Record<string, unknown>) &&
       "name" in (other as Record<string, unknown>)

--- a/packages/arel/src/nodes/casted.ts
+++ b/packages/arel/src/nodes/casted.ts
@@ -34,10 +34,18 @@ import { BindParam } from "./bind-param.js";
  *       collector.add_bind(o.value, &bind_block)   # to_sql.rb:760-762
  *     end
  *
- * Rails' bare `attr` reaches `add_bind(attr)`; trails' `BindParam(attr)`
- * reaches `add_bind(o.value)` — which *is* `attr`. Same payload, so
- * `type_casted_binds` / prepared-statement paths still see the attribute
- * and call `value_for_database` on it exactly as before.
+ * Rails' bare `attr` reaches `add_bind(attr)`; Rails' `BindParam(attr)`
+ * reaches `add_bind(o.value)` — which *is* `attr`. Same payload.
+ *
+ * Trails arrives at the same payload by a different route, so be precise:
+ * `visitArelNodesBindParam` (to-sql.ts) pushes the *node*, not `node.value`,
+ * because `compile` needs it to render the `?` marker. The unwrap to the
+ * attribute happens later, at the two extraction sites —
+ * `ToSql#compileWithBinds` and `SubstituteBinds#extractValue`
+ * (collectors/substitute-binds.ts), which recurse through `.value`. Net bind
+ * payload is the attribute either way, so `type_casted_binds` /
+ * prepared-statement paths still see it and call `value_for_database` on it
+ * exactly as before.
  *
  * The predicate delegations survive the wrap too: BindParam#isUnboundable
  * (bind-param.ts:50-52) and #isNil (:39-43) forward to the wrapped value,
@@ -46,9 +54,14 @@ import { BindParam } from "./bind-param.js";
  * We wrap rather than pass through because a bare ActiveModel::Attribute is
  * not a `Node`, and trails' AST is statically typed against `Node` — Ruby
  * duck-types its way past this, TS cannot without widening every node slot.
- * `ToSql#visitActiveModelAttribute` is still ported and dispatch-registered
- * (to-sql.ts), so a bare attribute arriving from a path that bypasses
- * buildQuoted / Attribute#quotedNode is handled Rails-identically.
+ * `ToSql#visitActiveModelAttribute` is still ported, and a bare attribute
+ * arriving from a path that bypasses buildQuoted / Attribute#quotedNode
+ * reaches it two ways, mirroring Rails' own two:
+ * - via `visit` — dispatch-registered against the abstract base (to-sql.ts),
+ *   the analogue of Ruby's name-derived dispatch + ancestors walk;
+ * - via `visitNodeOrValue` — the explicit branch, the analogue of Rails'
+ *   `when ... ActiveModel::Attribute` at to_sql.rb:109 (ValuesList) and
+ *   to_sql.rb:632 (Assignment), which likewise pre-empt class dispatch.
  */
 export function buildQuoted(other: unknown, attribute?: unknown): Node {
   if (other instanceof Node) return other;

--- a/packages/arel/src/nodes/casted.ts
+++ b/packages/arel/src/nodes/casted.ts
@@ -62,7 +62,8 @@ import { BindParam } from "./bind-param.js";
  * bypasses this function still reaches it. Both of Rails' own pre-emptive
  * `when ... ActiveModel::Attribute` arms are ported and each gets there by its
  * own route:
- * - `visitArelNodesValuesList` (Rails to_sql.rb:110) calls `visit` on it,
+ * - `visitArelNodesValuesList` (Rails to_sql.rb:109-110 — the `when` arm at
+ *   :109, its `visit(value)` at :110) calls `visit` on it,
  *   which resolves via the ActiveModel::Attribute dispatch registration —
  *   trails' analogue of Ruby's name-derived dispatch + ancestors walk;
  * - `visitArelNodesAssignment` (Rails to_sql.rb:632) hands it to

--- a/packages/arel/src/nodes/casted.ts
+++ b/packages/arel/src/nodes/casted.ts
@@ -17,11 +17,38 @@ import { BindParam } from "./bind-param.js";
  *   handles them via duck-type in specific contexts (see visitIn). When
  *   their AST is what's wanted, unwrap to the ast node so downstream
  *   visitors always receive a real Node.
- * - ActiveModel::Attribute isn't an Arel node either. Rails has
- *   visit_ActiveModel_Attribute that routes it through add_bind; we
- *   wrap it in BindParam so the value participates in prepared-statement
- *   bind extraction (visitBindParam handles valueForDatabase — both the
- *   method form on QueryAttribute and the getter form on AM Attribute).
+ * - ActiveModel::Attribute isn't an Arel node either. Rails passes it
+ *   through bare (casted.rb:50); we wrap it in BindParam. This is a
+ *   deliberate, behaviorally-equivalent shape difference — see below.
+ *
+ * ## Why the BindParam wrap is equivalent to Rails' bare pass-through
+ *
+ * Do not "fix" this as a bug. The two shapes emit identical SQL and record
+ * an identical bind payload, because Rails' two visitors converge:
+ *
+ *     def visit_ActiveModel_Attribute(o, collector)
+ *       collector.add_bind(o, &bind_block)         # to_sql.rb:756-758
+ *     end
+ *
+ *     def visit_Arel_Nodes_BindParam(o, collector)
+ *       collector.add_bind(o.value, &bind_block)   # to_sql.rb:760-762
+ *     end
+ *
+ * Rails' bare `attr` reaches `add_bind(attr)`; trails' `BindParam(attr)`
+ * reaches `add_bind(o.value)` — which *is* `attr`. Same payload, so
+ * `type_casted_binds` / prepared-statement paths still see the attribute
+ * and call `value_for_database` on it exactly as before.
+ *
+ * The predicate delegations survive the wrap too: BindParam#isUnboundable
+ * (bind-param.ts:50-52) and #isNil (:39-43) forward to the wrapped value,
+ * so `IS NULL` collapsing and unboundable-range handling behave the same.
+ *
+ * We wrap rather than pass through because a bare ActiveModel::Attribute is
+ * not a `Node`, and trails' AST is statically typed against `Node` — Ruby
+ * duck-types its way past this, TS cannot without widening every node slot.
+ * `ToSql#visitActiveModelAttribute` is still ported and dispatch-registered
+ * (to-sql.ts), so a bare attribute arriving from a path that bypasses
+ * buildQuoted / Attribute#quotedNode is handled Rails-identically.
  */
 export function buildQuoted(other: unknown, attribute?: unknown): Node {
   if (other instanceof Node) return other;

--- a/packages/arel/src/nodes/casted.ts
+++ b/packages/arel/src/nodes/casted.ts
@@ -54,14 +54,16 @@ import { BindParam } from "./bind-param.js";
  * We wrap rather than pass through because a bare ActiveModel::Attribute is
  * not a `Node`, and trails' AST is statically typed against `Node` — Ruby
  * duck-types its way past this, TS cannot without widening every node slot.
- * `ToSql#visitActiveModelAttribute` is still ported, and a bare attribute
- * arriving from a path that bypasses buildQuoted / Attribute#quotedNode
- * reaches it two ways, mirroring Rails' own two:
- * - via `visit` — dispatch-registered against the abstract base (to-sql.ts),
- *   the analogue of Ruby's name-derived dispatch + ancestors walk;
- * - via `visitNodeOrValue` — the explicit branch, the analogue of Rails'
- *   `when ... ActiveModel::Attribute` at to_sql.rb:109 (ValuesList) and
- *   to_sql.rb:632 (Assignment), which likewise pre-empt class dispatch.
+ * `ToSql#visitActiveModelAttribute` is still ported, and a bare attribute that
+ * bypasses buildQuoted / Attribute#quotedNode still reaches it. Both of Rails'
+ * own pre-emptive `when ... ActiveModel::Attribute` arms are ported and each
+ * gets there by its own route:
+ * - `visitArelNodesValuesList` (Rails to_sql.rb:110) calls `visit` on it,
+ *   which resolves via the ActiveModel::Attribute dispatch registration —
+ *   trails' analogue of Ruby's name-derived dispatch + ancestors walk;
+ * - `visitArelNodesAssignment` (Rails to_sql.rb:632) hands it to
+ *   `visitNodeOrValue`, which branches on it before raw-value dispatch.
+ * Both are load-bearing: drop either and that arm raises instead of binding.
  */
 export function buildQuoted(other: unknown, attribute?: unknown): Node {
   if (other instanceof Node) return other;

--- a/packages/arel/src/nodes/casted.ts
+++ b/packages/arel/src/nodes/casted.ts
@@ -54,10 +54,14 @@ import { BindParam } from "./bind-param.js";
  * We wrap rather than pass through because a bare ActiveModel::Attribute is
  * not a `Node`, and trails' AST is statically typed against `Node` — Ruby
  * duck-types its way past this, TS cannot without widening every node slot.
+ * This is the only wrap-site: `Attribute#quotedNode` delegates straight here
+ * (`buildQuoted(value, this)`, matching Rails' `Nodes.build_quoted(other,
+ * self)`), so the AST shape cannot diverge by call path.
+ *
  * `ToSql#visitActiveModelAttribute` is still ported, and a bare attribute that
- * bypasses buildQuoted / Attribute#quotedNode still reaches it. Both of Rails'
- * own pre-emptive `when ... ActiveModel::Attribute` arms are ported and each
- * gets there by its own route:
+ * bypasses this function still reaches it. Both of Rails' own pre-emptive
+ * `when ... ActiveModel::Attribute` arms are ported and each gets there by its
+ * own route:
  * - `visitArelNodesValuesList` (Rails to_sql.rb:110) calls `visit` on it,
  *   which resolves via the ActiveModel::Attribute dispatch registration —
  *   trails' analogue of Ruby's name-derived dispatch + ancestors walk;
@@ -76,13 +80,13 @@ export function buildQuoted(other: unknown, attribute?: unknown): Node {
     //
     // The "structural so we don't need a runtime import" rationale this used to
     // carry is stale: arel already depends on @blazetrails/activemodel, which
-    // does not depend back (no cycle), and attributes/attribute.ts +
-    // visitors/to-sql.ts already import Attribute from it at runtime. Rails
-    // identifies it by class (casted.rb:50), so `instanceof` is the convergent
-    // shape; the structural check also disagrees with the other two arel
-    // predicates. Tracked by story
-    // `arel-am-attribute-predicates-diverge-across-sites` — a behaviour change
-    // (a duck-typed object stops binding), so not folded into #4879.
+    // does not depend back (no cycle), and visitors/to-sql.ts already imports
+    // Attribute from it at runtime. Rails identifies it by class
+    // (casted.rb:50), so `instanceof` is the convergent shape; this check also
+    // disagrees with the other two in arel — to-sql's `isActiveModelAttribute`
+    // omits the `name` half, dot's tests `valueBeforeTypeCast` instead.
+    // Tracked by story `arel-am-attribute-predicates-diverge-across-sites` — a
+    // behaviour change (a duck-typed object stops binding), so not folded in.
     if (
       "valueForDatabase" in (other as Record<string, unknown>) &&
       "name" in (other as Record<string, unknown>)

--- a/packages/arel/src/nodes/casted.ts
+++ b/packages/arel/src/nodes/casted.ts
@@ -72,8 +72,17 @@ export function buildQuoted(other: unknown, attribute?: unknown): Node {
     if ((other as Record<symbol, unknown>)[ATTRIBUTE_BRAND] === true) return other as Node;
     // ActiveModel::Attribute duck-type (Rails: casted.rb:50-51 — the
     // `when ..., ActiveModel::Attribute` arm returning `other`).
-    // Structural check so buildQuoted doesn't require a runtime import here.
     // valueForDatabase is a getter (not a method) on the TS port; check via 'in'.
+    //
+    // The "structural so we don't need a runtime import" rationale this used to
+    // carry is stale: arel already depends on @blazetrails/activemodel, which
+    // does not depend back (no cycle), and attributes/attribute.ts +
+    // visitors/to-sql.ts already import Attribute from it at runtime. Rails
+    // identifies it by class (casted.rb:50), so `instanceof` is the convergent
+    // shape; the structural check also disagrees with the other two arel
+    // predicates. Tracked by story
+    // `arel-am-attribute-predicates-diverge-across-sites` — a behaviour change
+    // (a duck-typed object stops binding), so not folded into #4879.
     if (
       "valueForDatabase" in (other as Record<string, unknown>) &&
       "name" in (other as Record<string, unknown>)

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -613,6 +613,19 @@ export class Dot extends Visitor {
     );
   }
 
+  /**
+   * Why this is an `instanceof` branch inside `visit` rather than a
+   * dispatch-table registration like `ToSql`'s (to-sql.ts):
+   *
+   * Registration only works where `visit` does the dispatching. `Dot`
+   * overrides `visit` and routes non-Node values structurally *before*
+   * reaching `super.visit` (see the `instanceof Node` branch above), so a
+   * ctor registration here would be dead code — an attribute would never
+   * reach the dispatch table to match it. `Dot` needs a branch here
+   * regardless, because Rails' Dot also dispatches raw Ruby values that have
+   * no Node ctor to key on: `visit_Hash` (dot.rb:220), `visit_Array`,
+   * `visit_String`.
+   */
   private isActiveModelAttribute(o: unknown): o is ModelAttribute {
     return o instanceof ModelAttribute;
   }

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -11,6 +11,7 @@ import {
   Visitors,
   Collectors,
 } from "../index.js";
+import { Attribute as AMAttribute, ValueType } from "@blazetrails/activemodel";
 
 describe("the to_sql visitor", () => {
   const users = new Table("users");
@@ -1819,9 +1820,8 @@ describe("the to_sql visitor", () => {
     });
 
     it("visitActiveModelAttribute routes through bindBlock (Rails parity)", () => {
-      // ActiveModel::Attribute isn't a Node ctor so it's not reachable
-      // through standard dispatch — exercise the visitor method directly
-      // to confirm Rails' add_bind(o, &bind_block) shape is preserved.
+      // Exercise the visitor method directly to confirm Rails'
+      // add_bind(o, &bind_block) shape is preserved.
       class NumberedVisitor extends Visitors.ToSql {
         idx = 0;
         protected override bindBlock(): (i: number) => string {
@@ -1835,6 +1835,17 @@ describe("the to_sql visitor", () => {
       ).visitActiveModelAttribute({ value: "x" }, collector);
       // bindIndex starts at 1; the block receives 1, so `$1`
       expect(collector.value).toBe("$1");
+    });
+
+    it("dispatches a bare ActiveModel::Attribute to visitActiveModelAttribute", () => {
+      // Rails dispatches ActiveModel::Attribute by class name like any other
+      // visitable object (to_sql.rb:756). Trails registers the abstract base,
+      // so concrete subclasses resolve via the prototype-chain walk rather
+      // than raising UnsupportedVisitError.
+      const amAttr = AMAttribute.withCastValue("id", 7, new ValueType());
+      const [sql, binds] = new Visitors.ToSql().compileWithBinds(amAttr as unknown as Nodes.Node);
+      expect(sql).toBe("?");
+      expect(binds).toEqual([amAttr]);
     });
 
     it("visitArelSelectManager wraps the manager's AST in parens", () => {

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1848,6 +1848,28 @@ describe("the to_sql visitor", () => {
       expect(binds).toEqual([amAttr]);
     });
 
+    it("binds a bare ActiveModel::Attribute in a values row rather than quoting it", () => {
+      // Rails' visit_Arel_Nodes_ValuesList branches on ActiveModel::Attribute
+      // before dispatching (to_sql.rb:108-113) — an attribute in an INSERT
+      // values row binds. Without the visitNodeOrValue branch it would fall to
+      // the raw-value path and be quoted as an opaque object.
+      const amAttr = AMAttribute.withCastValue("name", "Aaron", new ValueType());
+      const values = new Nodes.ValuesList([[amAttr as unknown as Nodes.Node]]);
+      const [sql, binds] = new Visitors.ToSql().compileWithBinds(values);
+      expect(sql).toBe("VALUES (?)");
+      expect(binds).toEqual([amAttr]);
+    });
+
+    it("binds a bare ActiveModel::Attribute on the right of an assignment", () => {
+      // Mirrors visit_Arel_Nodes_Assignment's `when ... ActiveModel::Attribute`
+      // arm (to_sql.rb:631-637).
+      const amAttr = AMAttribute.withCastValue("name", "Aaron", new ValueType());
+      const assign = new Nodes.Assignment(users.get("name"), amAttr as unknown as Nodes.Node);
+      const [sql, binds] = new Visitors.ToSql().compileWithBinds(assign);
+      expect(sql).toBe('"users"."name" = ?');
+      expect(binds).toEqual([amAttr]);
+    });
+
     it("visitArelSelectManager wraps the manager's AST in parens", () => {
       // Called directly — SelectManager isn't in the dispatch table because
       // it's a TreeManager, not a Node. Mirrors Rails' `visit_Arel_SelectManager`

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -541,8 +541,8 @@ export class ToSql extends Visitor {
     // by Node ctors; dispatch only ever reads `object.constructor`.
     //
     // This is load-bearing, not a safety net: `visitArelNodesValuesList` ports
-    // Rails' `when ..., ActiveModel::Attribute` arm (to_sql.rb:110) by calling
-    // `visit(value)` on it. Without an entry here that call finds no dispatch
+    // Rails' `when ..., ActiveModel::Attribute` arm (to_sql.rb:109) by calling
+    // `visit(value)` on it (:110). Without an entry here that call finds no dispatch
     // target and raises UnsupportedVisitError, so an attribute in an INSERT
     // values row cannot bind.
     reg(ModelAttribute as unknown as NodeCtor, "visitActiveModelAttribute");

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -539,6 +539,12 @@ export class ToSql extends Visitor {
     // (FromUser / FromDatabase / QueryAttribute / ...), mirroring Ruby's
     // ancestors walk. The cast is required because the dispatch table is keyed
     // by Node ctors; dispatch only ever reads `object.constructor`.
+    //
+    // This is load-bearing, not a safety net: `visitArelNodesValuesList` ports
+    // Rails' `when ..., ActiveModel::Attribute` arm (to_sql.rb:110) by calling
+    // `visit(value)` on it. Without an entry here that call finds no dispatch
+    // target and raises UnsupportedVisitError, so an attribute in an INSERT
+    // values row cannot bind.
     reg(ModelAttribute as unknown as NodeCtor, "visitActiveModelAttribute");
     reg(Nodes.Fragments, "visitArelNodesFragments");
     // Functions
@@ -2088,15 +2094,16 @@ export class ToSql extends Visitor {
       // arrays both flow through here, joined by ", ".
       return this.visitArray(v, collector);
     }
-    // An ActiveModel::Attribute binds, it does not quote. Rails branches on it
-    // explicitly before dispatching in the two places a bare one shows up —
-    // `visit_Arel_Nodes_ValuesList` (to_sql.rb:108-113, the INSERT values row)
-    // and `visit_Arel_Nodes_Assignment` (to_sql.rb:631-637) — and everywhere
-    // else Ruby's class dispatch would route it to visit_ActiveModel_Attribute
-    // anyway. There is no Rails path on which a bare one is quoted, so this
-    // branch is convergent for every caller of this helper, not just those two.
-    if (v instanceof ModelAttribute) {
-      return this.visit(v as unknown as Node, collector);
+    // An ActiveModel::Attribute binds, it does not quote. Reached from
+    // `visitArelNodesAssignment`, which mirrors Rails' `case` (to_sql.rb:631)
+    // by testing `isActiveModelAttribute` and then handing the right here —
+    // so this branch is what makes that arm land on `visit_ActiveModel_Attribute`
+    // (to_sql.rb:756) rather than falling through to raw-value dispatch and
+    // raising. Uses the same predicate as the Assignment/ValuesList call sites
+    // on purpose: if the two disagreed, a value those sites accept would arrive
+    // here, miss, and raise instead of binding.
+    if (isActiveModelAttribute(v)) {
+      return this.visit(v as Node, collector);
     }
     if (v instanceof Node) {
       // Duck-type check to avoid circular dependency (SelectManager → ToSql → SelectManager)

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -2088,6 +2088,16 @@ export class ToSql extends Visitor {
       // arrays both flow through here, joined by ", ".
       return this.visitArray(v, collector);
     }
+    // An ActiveModel::Attribute binds, it does not quote. Rails branches on it
+    // explicitly before dispatching in the two places a bare one shows up —
+    // `visit_Arel_Nodes_ValuesList` (to_sql.rb:108-113, the INSERT values row)
+    // and `visit_Arel_Nodes_Assignment` (to_sql.rb:631-637) — and everywhere
+    // else Ruby's class dispatch would route it to visit_ActiveModel_Attribute
+    // anyway. There is no Rails path on which a bare one is quoted, so this
+    // branch is convergent for every caller of this helper, not just those two.
+    if (v instanceof ModelAttribute) {
+      return this.visit(v as unknown as Node, collector);
+    }
     if (v instanceof Node) {
       // Duck-type check to avoid circular dependency (SelectManager → ToSql → SelectManager)
       if ("ast" in v && "toSql" in v) {

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -6,6 +6,7 @@ import { SubstituteBinds } from "../collectors/substitute-binds.js";
 import * as Nodes from "../nodes/index.js";
 import { Table } from "../table.js";
 import { Visitor, type NodeCtor } from "./visitor.js";
+import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 import { UnsupportedVisitError, NotImplementedError, BindError } from "../errors.js";
 
 // Mirrors Arel::Visitors::UnsupportedVisitError (defined in to_sql.rb:5
@@ -532,6 +533,13 @@ export class ToSql extends Visitor {
     reg(Nodes.InfixOperation, "visitArelNodesInfixOperation");
     reg(Nodes.BoundSqlLiteral, "visitArelNodesBoundSqlLiteral");
     reg(Nodes.BindParam, "visitArelNodesBindParam");
+    // ActiveModel::Attribute is not an Arel Node, but Rails dispatches it by
+    // class name like any other visitable object. Registering the abstract base
+    // lets the prototype-chain walk in `resolveDispatch` resolve every subclass
+    // (FromUser / FromDatabase / QueryAttribute / ...), mirroring Ruby's
+    // ancestors walk. The cast is required because the dispatch table is keyed
+    // by Node ctors; dispatch only ever reads `object.constructor`.
+    reg(ModelAttribute as unknown as NodeCtor, "visitActiveModelAttribute");
     reg(Nodes.Fragments, "visitArelNodesFragments");
     // Functions
     reg(Nodes.NamedFunction, "visitArelNodesNamedFunction");


### PR DESCRIPTION
## Summary

Resolves the `build_quoted` / `ActiveModel::Attribute` deviation surfaced twice
in review of #4876. **Decision: option (b) — keep the `BindParam` wrap**, and
record the equivalence proof at `casted.ts` so the next reviewer does not
re-derive it.

### Why (b), not (a)

The two shapes are behaviorally identical, not merely close. Rails' visitors
converge on the same payload:

```ruby
def visit_ActiveModel_Attribute(o, collector)
  collector.add_bind(o, &bind_block)         # to_sql.rb:756-758
end

def visit_Arel_Nodes_BindParam(o, collector)
  collector.add_bind(o.value, &bind_block)   # to_sql.rb:760-762
end
```

Rails' bare `attr` reaches `add_bind(attr)`; trails' `BindParam(attr)` reaches
`add_bind(o.value)` — which *is* `attr`. So `type_casted_binds` /
prepared-statement paths still see the attribute and call `value_for_database`
on it, unchanged (no producer converged in isolation — see
`project_type_casted_binds_17_producers_diverge`).

Option (a) would mean putting a bare `ActiveModel::Attribute` — not a `Node` —
into an AST that is statically typed against `Node`, across every node slot in
arel. Ruby duck-types past this; TS cannot without widening the whole type
surface, and the payoff is zero behavioral difference.

### The one real gap, closed

The story says `ToSql` has no `visitActiveModelAttribute`. That premise is
stale — the method exists (`to-sql.ts:1283`), but it was **unreachable**:
dispatch is ctor-keyed and nothing registered it, so a bare attribute arriving
from a path that bypasses `buildQuoted` / `quotedNode` would raise
`UnsupportedVisitError`.

This registers the abstract `ActiveModel::Attribute` base in the dispatch
table, so concrete subclasses (`FromUser` / `FromDatabase` / `QueryAttribute` /
…) resolve via `resolveDispatch`'s prototype-chain walk — mirroring Ruby's
ancestors walk, where Rails dispatches it by class name like any other
visitable object. AST shape and bind extraction are unchanged on every existing
path; this is a safety net, not a behavior change.

## Changes

- `nodes/casted.ts` — the `add_bind(o)` vs `add_bind(o.value)` equivalence
  proof, and why the wrap exists (TS typing, not an oversight).
- `attributes/attribute.ts` — note that `quotedNode`'s `ModelAttribute` arm is
  the sibling wrap-site and must move with `buildQuoted` or the AST shape
  diverges by call path.
- `visitors/to-sql.ts` — register `ActiveModel::Attribute` in the dispatch table.
- `visitors/to-sql.test.ts` — new test: a bare `ActiveModel::Attribute`
  dispatches to `visitActiveModelAttribute` and collects as a bind. Drops the
  now-false "not reachable through standard dispatch" caveat.

## Verification

- `pnpm vitest run packages/arel/src` — 71 files, 1487 tests pass, including
  #4876's `unboundable?` / `nil?` visitor tests.
- `pnpm --filter @blazetrails/arel... build` clean.
- 60 insertions / 9 deletions.

Closes-story: arel-build-quoted-passes-model-attribute-unwrapped

---

## Review round 1 — all four points addressed

**1. "handled Rails-identically" overbroad / bare attr never reaches the visitor — FIXED, and it was a live bug.**
Confirmed against source: `visit_Arel_Nodes_ValuesList` (to_sql.rb:108-113) and
`visit_Arel_Nodes_Assignment` (to_sql.rb:631-637) both branch on
`when ... ActiveModel::Attribute` *before* dispatching, and trails routed both
through `visitNodeOrValue` → raw-value branch. Took the fix rather than the
doc-narrowing: a bare `QueryAttribute` in an INSERT values row emitted
**`VALUES ('[object Object]')`** — the attribute was being stringified into SQL,
not merely quoted. Two regression tests added; verified load-bearing by
reverting the branch (both fail with `'[object Object]'`, and pass with it).

The branch sits in the shared helper rather than only at the two call sites
because it is convergent for every caller: there is no Rails path on which a
bare `ActiveModel::Attribute` is quoted rather than bound. The doc claim is now
narrowed to the two paths that actually exist (`visit` + `visitNodeOrValue`).
Also corrected the raw-value branch comment, which asserted "Only
BindParam/ActiveModel::Attribute go through addBind" — true only after this fix.

**2. Proof mis-describes trails' route — FIXED.** Correct: `visitArelNodesBindParam`
pushes the *node*, not `node.value`, because `compile` needs it to render `?`.
The doc now says so and cites the real unwrap sites (`compileWithBinds`,
`SubstituteBinds#extractValue`). Net payload unchanged; a proof should not cite
a call that isn't made.

**3. Stale cite `casted.rb:55` → `casted.rb:50` — FIXED.**

**4. Why register in `ToSql` but duck-type in `Dot`? — intentional; no follow-up needed.**
Not an inconsistency between the two visitors, but a consequence of `Dot`
overriding `visit`. Rails' `Dot` dispatches raw Ruby values by class —
`visit_Hash` (dot.rb:220), `visit_Array`, `visit_String` — none of which have a
Node ctor to key a registration on, so trails' `Dot` must branch structurally
regardless. Critically, `Dot.visit` intercepts *before* `super.visit`
(dot.ts:502: `object instanceof Node → super.visit`), so a non-Node
`ActiveModel::Attribute` never reaches the dispatch table — registering it there
would be dead code. Registration is the right mechanism precisely where `visit`
does the dispatching, which is `ToSql`; `Dot` can't use it. Both land on their
Rails-named `visit_ActiveModel_Attribute` port.

### Re-verification
- `pnpm vitest run packages/arel/src` — 71 files, **1489 tests pass** (+2).
- `pnpm --filter @blazetrails/arel... build` clean; eslint + prettier clean.
- api:compare delta 0 (no methods added/removed/moved); test:compare +2 TS-only
  tests — non-negative.


---

## Review round 2 — Dot answered, in code this time

**Fair hit on "undocumented":** my round-1 answer lived only in this PR
description, which is precisely why it got re-derived. It now lives at
`dot.ts`'s `isActiveModelAttribute`, where the next reader will actually meet it.

**Why `Dot` can't take the same `reg` line — justification stands.**
You're right that `Dot` has its own `dispatchCache()` (dot.ts:652) that would
*accept* the line, but it would be dead code: `Dot` overrides `visit` and routes
non-`Node` values structurally *before* reaching `super.visit` (dot.ts:501-503,
the `instanceof Node` branch), so an attribute never reaches the dispatch table
to match against. `Dot` needs the structural path regardless, because Rails' Dot
dispatches raw Ruby values that have no Node ctor to key on — `visit_Hash`
(dot.rb:220), `visit_Array`, `visit_String`. Registration is the right mechanism
exactly where `visit` does the dispatching, which is `ToSql` and not `Dot`. So
the convergence for `Dot` is *tightening the predicate*, not switching mechanism.

**Your second point stands and I have no counter — filed, not fixed here.**
`"valueBeforeTypeCast" in o` is looser than Rails' class dispatch: any object
exposing that property matches, whereas Rails reaches
`visit_ActiveModel_Attribute` (dot.rb:216) only for a real
`ActiveModel::Attribute` — a Ruby `{ value_before_type_cast: 42 }` is a Hash and
routes to `visit_Hash`.

Not fixed in this PR because it changes `Dot` behavior and forces an existing
test to change: `dot.test.ts:~368` deliberately feeds a fake
`{ valueBeforeTypeCast: 42 }` and asserts a `valueBeforeTypeCast` edge, so
tightening drops it to `visitHash`. Its stated regression (Dot must not raise
`UnsupportedVisitError` on an unknown class instance) is real and has to stay
covered by the `visitHash`/`visitString` fallback. That's a separate PR under
CLAUDE.md's no-fan-out rule, so it's registered as story
**`arel-dot-am-attribute-structural-check-looser-than-rails`** (RFC 0023,
tasks `2d81b5033`), carrying the full Rails cites, the "reg would be dead code"
reasoning, and the test blocker — so none of this gets re-derived a third time.
`dot.ts` carries a Known-deviation note pointing at it.

### Re-verification
- `pnpm vitest run packages/arel/src` — 1489 tests pass; dot + to-sql 305 pass.
- eslint + prettier clean; build clean. Diff unchanged except the `dot.ts` note.


---

## Rebased onto main — and the justification got stronger

Rebased past #4873 (raw-value dispatch raises like Rails), #4876, #4877, #4878.
Two conflicts, both resolved in main's favour:

- **`to-sql.ts`** — #4873 rewrote `visitNodeOrValue`'s raw-value block. The
  `else { quote(v) }` arm this PR had *corrected* no longer exists; it now
  dispatches to `visitFloat`/`visitString`/… and raises via `unsupported`. Took
  main's block wholesale and dropped my now-obsolete comment fix.
- **`casted.ts`** — main independently fixed the same stale cite, more precisely
  (`casted.rb:50-51`, naming the `when` arm). Took main's.

### Correction to my earlier claim

I reported the bug as emitting **`VALUES ('[object Object]')`**. That was true
at the time and is **no longer the symptom** — post-#4873 the raw path raises
instead of quoting. Correcting it rather than leaving a stale claim in the
record.

### What the rebase revealed — main's own ported call sites are broken today

#4873 independently ported *both* Rails `when ..., ActiveModel::Attribute` arms
(`visitArelNodesValuesList` ← to_sql.rb:106-114, `visitArelNodesAssignment` ←
to_sql.rb:630-641) with a module-level `isActiveModelAttribute` helper. Those
ports are faithful — but neither works on main, which upgrades both of this
PR's changes from "safety net for a path nothing takes" to "the thing that makes
main's existing code run". Verified by ablation, each covered by its own test:

| change | main's call site | without it |
|---|---|---|
| dispatch registration | ValuesList calls `visit(value)` (rb:110) | `UnsupportedVisitError: Unknown node type: WithCastValue` |
| `visitNodeOrValue` branch | Assignment hands right to `visitNodeOrValue` (rb:632) | `Unsupported argument type: WithCastValue` |

So the story's premise — "today nothing bypasses the wrap-sites" — is now
decisively false: main's own ValuesList and Assignment ports do, and an
attribute in an INSERT values row cannot bind on main today.

### One design change

The branch now uses main's `isActiveModelAttribute` helper rather than the
`instanceof ModelAttribute` predicate I'd added — one predicate per concept in
the file, and more importantly the branch and the call sites **must** agree: if
Assignment accepted a value the branch missed, it would arrive at raw dispatch
and raise instead of binding. (`ModelAttribute` is still imported for the `reg`
line.) I did not touch main's helper itself — its duck-typing is #4873's
deliberate, documented decision, and tightening it is not this PR's call.

### Re-verification (post-rebase)
- `pnpm vitest run packages/arel/src` — 71 files, **1509 tests pass**.
- Both changes ablation-tested: disabling either reds exactly its own test.
- build / eslint / prettier clean; conflicts fully resolved.


---

## Review round 4 — converging

Nothing merge-blocking remained. One fix (a false comment this PR introduced),
two follow-ups filed.

**Fixed — the lockstep claim contradicted itself.** `attribute.ts` said the two
wrap-sites "must move together, or the AST shape diverges by call path", while
the sites already use different predicates (`instanceof` vs a
`valueForDatabase` + `name` duck-type) — the exact divergence it warned about.
It now states what is true: same wrap, different predicates today, story linked.
This is the same failure mode as round 1's point 2, in a comment I added, which
is why it was worth spending the cycle on.

**Answered — the "runtime import" rationale is stale, and I removed it.**
Verified: `arel` already depends on `@blazetrails/activemodel`, which does not
depend back (no `@blazetrails/arel` in its `package.json` or anywhere under
`packages/activemodel/src`), and `attributes/attribute.ts:31` +
`visitors/to-sql.ts:9` already import `Attribute` from it at runtime. Nothing
blocks the import in `casted.ts`; the reason had just outlived its truth.

**Filed — the three-predicate divergence.** Correct on all counts, including
that `{ valueForDatabase: 1 }` is `Quoted` via `buildQuoted` but raises via
`visitNodeOrValue`. Converging onto `instanceof` (Rails identifies an
ActiveModel::Attribute by class, casted.rb:50) is a **behaviour change** — a
duck-typed object stops binding, and rb:110's narrow `when` means some of those
should route to `quote()` instead — so it is not a comment fix and does not
belong in this PR.

| story | scope |
| --- | --- |
| `arel-am-attribute-predicates-diverge-across-sites` | `buildQuoted`, `quotedNode`, to-sql's `isActiveModelAttribute` → `instanceof`; drops the stale rationale and the lockstep caveat (est 60 LOC) |
| `arel-dot-am-attribute-structural-check-looser-than-rails` | `Dot` only — separate because `Dot` overrides `visit`, so it cannot use the dispatch registration and the fix is predicate-only |

Both carry the predicate table, the concrete divergences, and the Rails cites;
they cross-reference each other and touch different files, so they can land in
either order.

### Final state
- `pnpm vitest run packages/arel/src` — 71 files, **1509 tests pass**.
- Both code changes ablation-verified load-bearing against main's own ported
  call sites (ValuesList → `reg`, Assignment → `visitNodeOrValue` branch).
- build / eslint / prettier clean; rebased on main; `MERGEABLE`.


---

## Rebased again — #4874 resolved one of the deviations outright

Rebased onto main past **#4874** (`Attribute#quotedNode` builds Casted for nil,
like build_quoted). It rewrote `quotedNode` to delegate straight to
`buildQuoted(value, this)` — Rails' `Nodes.build_quoted(other, self)` — deleting
the `instanceof ModelAttribute` arm this PR had been commenting on.

That is a better outcome than the comment I was defending: there is now a
**single wrap-site**, so the AST shape cannot diverge by call path, and round
4's "must move in lockstep" caveat has nothing left to warn about. Both
conflicts resolved to main wholesale. **This PR no longer touches
`attribute.ts` at all.**

### Docs retargeted at what now exists
`casted.ts` states it is the only wrap-site and that `quotedNode` delegates
here. Two of its claims had gone stale in the same commit and are corrected
rather than left standing:
- `attributes/attribute.ts` no longer imports activemodel at all (#4874 removed
  it with the arm), so the note citing it as precedent for the import was wrong.
- the predicate roster is now `buildQuoted` + to-sql's `isActiveModelAttribute`
  + dot's — named explicitly instead of counted.

### Story updated, not left to rot
`arel-am-attribute-predicates-diverge-across-sites`: one of its two concrete
divergences (the two wrap-sites disagreeing) is **fixed on main** and marked as
such, the table drops to three predicates, and the AC now flags that `casted.ts`
importing activemodel would be the *first* re-introduction after #4874 — to be
re-verified at that time rather than trusted from my note.

### Re-verification (post-rebase)
- `pnpm vitest run packages/arel/src` — 71 files, **1516 tests pass**.
- Both changes re-ablated and still load-bearing: `reg` → ValuesList (rb:110)
  raises `Unknown node type: WithCastValue` without it; `visitNodeOrValue`
  branch → Assignment (rb:632) raises `Unsupported argument type` without it.
- Diff is now 4 files; build / eslint / prettier clean; `MERGEABLE`.


---

## Review round 6 — converging

Both points were real. Neither blocked merge; both are fixed.

**1. The story update was never pushed — the reviewer is right, and my commit
message was wrong.** `pnpm tasks new` auto-pushes; my two follow-up
`git commit`s in the tasks repo did not, so `db10b2431`'s message asserted an
update that existed only on my disk. That is a reporting failure, not a
formatting one: `casted.ts` points readers at that story as the deferral
target, so the next agent would have inherited a spec for code that no longer
exists.

Pushed, then verified on tasks `origin/main` (`3cc5a7566`) rather than trusting
my own message a second time. Verifying is how I found that my earlier edit had
**silently partially failed** — markdownlint had padded the table columns, so an
exact-string replace no-op'd and left the `quotedNode` row and the
`attributes/attribute.ts:31` import claim (false since #4874) in place. Both are
now actually gone, along with two stale counts ("four sites", "remaining three").

**2. `to_sql.rb:110` → `:109` for the `when` arm.** Correct: :109 is
`when Nodes::SqlLiteral, Nodes::BindParam, ActiveModel::Attribute`, and :110 is
its `collector = visit(value, collector)`. The `reg` comment attributed :110 to
the `when` itself; it now names both, and `casted.ts` cites the `:109-110` pair.
Left main's pre-existing `:110` cites (to-sql.ts:57, :63) alone — not this PR's,
and churning them is work a reviewer would have to re-derive. Story cites
corrected to `:109` / `:111-112` in the same push.

### Follow-up stories (unchanged, both on tasks `origin/main`)
| story | scope |
| --- | --- |
| `arel-am-attribute-predicates-diverge-across-sites` | `buildQuoted` + to-sql's `isActiveModelAttribute` → `instanceof` (est 60 LOC) |
| `arel-dot-am-attribute-structural-check-looser-than-rails` | `Dot` only — it overrides `visit`, so no registration; predicate-only fix |

### Final state
- `pnpm vitest run packages/arel/src` — 71 files, **1516 tests pass**.
- Both changes ablation-verified load-bearing (reg → ValuesList rb:109;
  `visitNodeOrValue` branch → Assignment rb:632).
- 4 files; build / eslint / prettier clean; `MERGEABLE`.


---

## Rebased again — #4880 shipped one of this PR's follow-ups

Rebased past **#4880** (Dot dispatches ActiveModel::Attribute by class, not
shape) and **#4887**. #4880 *implements the story this PR filed* —
`arel-dot-am-attribute-structural-check-looser-than-rails`, now `done` — so
`Dot`'s predicate is `o instanceof ModelAttribute` and the "Known deviation"
note has nothing left to describe. Dropped it.

Kept the half that is still true and still non-obvious, since it is the question
reviewers asked twice: **why `Dot` uses a branch inside `visit` rather than a
registration like `ToSql`'s.** It overrides `visit` and routes non-Node values
before `super.visit`, so a `reg` line there would be dead code — and it needs the
branch regardless for Rails' raw-value visitors (`visit_Hash` dot.rb:220,
`visit_Array`, `visit_String`). Retitled to match what it now explains.

### Stale claims this rebase invalidated, both corrected
- `casted.ts` said "dot's tests `valueBeforeTypeCast` instead" — **false as of
  #4880**. Two structural predicates remain in arel (this one and to-sql's) and
  they disagree with each other as well as with Rails; it now says that.
- The sibling story `arel-am-attribute-predicates-diverge-across-sites` carried
  the same stale `Dot` row. It is **in-progress under #4882 right now**, so an
  agent is implementing against that spec — corrected on tasks `origin/main` and
  verified there, marking the row `CONVERGED, #4880` rather than deleting it so
  the target shape stays visible.

One known wart: commit `6738c2d35`'s subject still reads "record why Dot
duck-types ActiveModel::Attribute", which #4880 made inaccurate. Rewording it
needs an interactive rebase, which this environment does not support; the comment
it lands and this description are both correct, so I left the subject rather than
risk churning history to fix a log line.

### Re-verification (post-rebase)
- `pnpm vitest run packages/arel/src` — 71 files, **1530 tests pass**.
- Both changes re-ablated, still load-bearing: `reg` → ValuesList (rb:109)
  raises `Unknown node type: WithCastValue`; `visitNodeOrValue` branch →
  Assignment (rb:632) raises `Unsupported argument type`.
- 4 files; no conflict markers anywhere under `packages/`; build / eslint /
  prettier clean.
