### PR TITLE
fix(arel): Dot dispatches ActiveModel::Attribute by class, not shape

### DIFF
--- a/packages/arel/src/visitors/dot.test.ts
+++ b/packages/arel/src/visitors/dot.test.ts
@@ -377,31 +377,12 @@ describe("TestDot", () => {
 
     it("a non-Attribute object with valueBeforeTypeCast is not visited as an Attribute", () => {
       // Rails reaches visit_ActiveModel_Attribute (dot.rb:216) by class
-      // dispatch, so a duck-typed value is a Hash there and routes to
-      // visit_Hash (dot.rb:220). It must still not raise.
-      const v = new Visitors.Dot();
-      type Internals = { visit(o: unknown): void };
-      v.compile(new Nodes.SqlLiteral("")); // initialize state
-      (v as unknown as Internals).visit({ valueBeforeTypeCast: 42 });
-      const out = (v as unknown as { toDot(): string }).toDot();
+      // dispatch, so a duck-typed value is a plain Hash there and routes to
+      // visit_Hash (dot.rb:220).
+      const out = dot.compile(new Nodes.BindParam({ valueBeforeTypeCast: 42 }));
       expect(out).not.toMatch(/-> \d+ \[label="valueBeforeTypeCast"\];/);
       expect(out).toContain('[label="pair_0"]');
       expect(out).toContain("42");
-    });
-
-    it("an unknown class instance renders as a leaf rather than raising", () => {
-      // The original regression this file guards: Dot must not raise
-      // UnsupportedVisitError on a value class its dispatch table lacks.
-      class Money {
-        toString(): string {
-          return "$5";
-        }
-      }
-      const v = new Visitors.Dot();
-      type Internals = { visit(o: unknown): void };
-      v.compile(new Nodes.SqlLiteral("")); // initialize state
-      expect(() => (v as unknown as Internals).visit(new Money())).not.toThrow();
-      expect((v as unknown as { toDot(): string }).toDot()).toContain("$5");
     });
 
     it("visitHash preserves both key and value (Rails parity)", () => {

--- a/packages/arel/src/visitors/dot.test.ts
+++ b/packages/arel/src/visitors/dot.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { Attribute as ModelAttribute, ValueType } from "@blazetrails/activemodel";
 import {
   Table,
   star,
@@ -365,15 +366,42 @@ describe("TestDot", () => {
       // Regression: Dot.visit used to call super.visit on any non-primitive
       // non-array non-plain-object value, throwing UnsupportedVisitError
       // on a class instance the dispatch table didn't know about.
-      const fakeAttribute = {
-        valueBeforeTypeCast: 42,
-      };
-      const bind = new Nodes.BindParam(fakeAttribute);
+      const attribute = ModelAttribute.fromDatabase("x", 42, new ValueType());
+      const bind = new Nodes.BindParam(attribute);
       const out = dot.compile(bind);
       expect(out).toContain("BindParam");
       // visitActiveModelAttribute walks valueBeforeTypeCast.
       expect(out).toMatch(/-> \d+ \[label="valueBeforeTypeCast"\];/);
       expect(out).toContain("42");
+    });
+
+    it("a non-Attribute object with valueBeforeTypeCast is not visited as an Attribute", () => {
+      // Rails reaches visit_ActiveModel_Attribute (dot.rb:216) by class
+      // dispatch, so a duck-typed value is a Hash there and routes to
+      // visit_Hash (dot.rb:220). It must still not raise.
+      const v = new Visitors.Dot();
+      type Internals = { visit(o: unknown): void };
+      v.compile(new Nodes.SqlLiteral("")); // initialize state
+      (v as unknown as Internals).visit({ valueBeforeTypeCast: 42 });
+      const out = (v as unknown as { toDot(): string }).toDot();
+      expect(out).not.toMatch(/-> \d+ \[label="valueBeforeTypeCast"\];/);
+      expect(out).toContain('[label="pair_0"]');
+      expect(out).toContain("42");
+    });
+
+    it("an unknown class instance renders as a leaf rather than raising", () => {
+      // The original regression this file guards: Dot must not raise
+      // UnsupportedVisitError on a value class its dispatch table lacks.
+      class Money {
+        toString(): string {
+          return "$5";
+        }
+      }
+      const v = new Visitors.Dot();
+      type Internals = { visit(o: unknown): void };
+      v.compile(new Nodes.SqlLiteral("")); // initialize state
+      expect(() => (v as unknown as Internals).visit(new Money())).not.toThrow();
+      expect((v as unknown as { toDot(): string }).toDot()).toContain("$5");
     });
 
     it("visitHash preserves both key and value (Rails parity)", () => {

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -382,7 +382,6 @@ export class Dot extends Visitor {
     this.visitEdge(o, "value");
   }
 
-  /** Rails: `visit_ActiveModel_Attribute` (dot.rb:216). */
   protected visitActiveModelAttribute(o: ModelAttribute): void {
     this.visitEdge(o, "valueBeforeTypeCast");
   }
@@ -507,7 +506,7 @@ export class Dot extends Visitor {
         // the Node branch — Trails' BindParam *also* exposes
         // `valueBeforeTypeCast` via NodeExpression, and must keep routing to
         // visitArelNodesBindParam (dot.rb:212-214).
-        this.visitActiveModelAttribute(object as ModelAttribute);
+        this.visitActiveModelAttribute(object);
       } else if (this.isPlainObject(object)) {
         this.visitHash(object as Record<string, unknown>);
       } else {
@@ -615,7 +614,7 @@ export class Dot extends Visitor {
     );
   }
 
-  private isActiveModelAttribute(o: unknown): boolean {
+  private isActiveModelAttribute(o: unknown): o is ModelAttribute {
     return o instanceof ModelAttribute;
   }
 

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -502,10 +502,9 @@ export class Dot extends Visitor {
       } else if (object instanceof Node) {
         super.visit(object);
       } else if (this.isActiveModelAttribute(object)) {
-        // Mirrors Rails' `visit_ActiveModel_Attribute` (dot.rb:216). Kept after
-        // the Node branch — Trails' BindParam *also* exposes
-        // `valueBeforeTypeCast` via NodeExpression, and must keep routing to
-        // visitArelNodesBindParam (dot.rb:212-214).
+        // Mirrors Rails' `visit_ActiveModel_Attribute` (dot.rb:216), which
+        // Ruby reaches by class dispatch — including via the ancestor walk in
+        // visitor.rb:36-41, so every Attribute subclass lands here too.
         this.visitActiveModelAttribute(object);
       } else if (this.isPlainObject(object)) {
         this.visitHash(object as Record<string, unknown>);

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -3,6 +3,7 @@ import * as Nodes from "../nodes/index.js";
 import { Table } from "../table.js";
 import { Visitor, type NodeCtor } from "./visitor.js";
 import { PlainString } from "../collectors/plain-string.js";
+import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 
 type AppendableCollector = { append(s: string): unknown; value: string };
 
@@ -381,7 +382,8 @@ export class Dot extends Visitor {
     this.visitEdge(o, "value");
   }
 
-  protected visitActiveModelAttribute(o: { valueBeforeTypeCast?: unknown }): void {
+  /** Rails: `visit_ActiveModel_Attribute` (dot.rb:216). */
+  protected visitActiveModelAttribute(o: ModelAttribute): void {
     this.visitEdge(o, "valueBeforeTypeCast");
   }
 
@@ -501,11 +503,11 @@ export class Dot extends Visitor {
       } else if (object instanceof Node) {
         super.visit(object);
       } else if (this.isActiveModelAttribute(object)) {
-        // Mirrors Rails' `visit_ActiveModel_Attribute`. Checked after the
-        // Node branch — Trails' BindParam *also* exposes a
-        // `valueBeforeTypeCast` method via NodeExpression duck-typing, so
-        // we only fall here for non-Node value objects.
-        this.visitActiveModelAttribute(object as { valueBeforeTypeCast?: unknown });
+        // Mirrors Rails' `visit_ActiveModel_Attribute` (dot.rb:216). Kept after
+        // the Node branch — Trails' BindParam *also* exposes
+        // `valueBeforeTypeCast` via NodeExpression, and must keep routing to
+        // visitArelNodesBindParam (dot.rb:212-214).
+        this.visitActiveModelAttribute(object as ModelAttribute);
       } else if (this.isPlainObject(object)) {
         this.visitHash(object as Record<string, unknown>);
       } else {
@@ -614,9 +616,7 @@ export class Dot extends Visitor {
   }
 
   private isActiveModelAttribute(o: unknown): boolean {
-    return (
-      typeof o === "object" && o !== null && "valueBeforeTypeCast" in (o as Record<string, unknown>)
-    );
+    return o instanceof ModelAttribute;
   }
 
   private isPlainObject(o: unknown): boolean {


### PR DESCRIPTION
Rails reaches `visit_ActiveModel_Attribute` (`dot.rb:216`) by class dispatch, so it fires only for a real `ActiveModel::Attribute`. Trails `Dot` used a structural check (`"valueBeforeTypeCast" in o`), which matched any object exposing that property — in Ruby, a `{ value_before_type_cast: 42 }` is a Hash and routes to `visit_Hash` (`dot.rb:220`).

## What changed

- `Dot#isActiveModelAttribute` is now a type predicate narrowing on `o instanceof ModelAttribute`, importing activemodel `Attribute` the same way `attributes/attribute.ts:31` and `nodes/homogeneous-in.ts:3` already do — no new dependency edge.
- Matching the abstract base reproduces Ruby's ancestor walk (`visitor.rb:36-41`): `Attribute::FromDatabase`/`FromUser`/`WithCastValue`/`Null`/`Uninitialized` and `QueryAttribute` all resolve to `visit_ActiveModel_Attribute` in Ruby and all extend `Attribute` in trails, so `instanceof` catches the same set.
- `Dot` keeps its structural `visit` override rather than a `reg` line — Rails Dot dispatches raw Ruby values with no Node ctor to key on (`visit_Hash`, `visit_Array`, `visit_String`), so a dispatch-table entry would be dead code here.

Branch ordering after `instanceof Node` is preserved, but note it is no longer load-bearing: under `instanceof ModelAttribute` a `BindParam` can never match structurally, so the arms are disjoint and the order simply mirrors Rails' class dispatch.

## Tests

`"non-Node bind values (ActiveModel::Attribute shape) don't crash"` now feeds a real `Attribute.fromDatabase` instead of a duck-typed literal, so it exercises the class it names. A new test pins the duck-typed object to `visitHash`, driven through the public `compile()` surface.

38 tests pass in `packages/arel/src/visitors/dot.test.ts`. No `dot.ts` typecheck errors. api:compare arel 938/938 (100%), `dot.rb → dot.ts` 60/60; test:compare `dot_test.rb → dot.test.ts` 16 matched / 0 missing — both unchanged.

## Deviations found during review, registered not ratified

Review surfaced that Rails' `visitor.rb:39` raises `TypeError, "Cannot visit #{object.class}"` when no ancestor is visitable, so Dot's `else { visitString(o) }` leaf fallback is a trails invention. An earlier revision of this PR added a test pinning that leaf behaviour; it has been removed rather than ratified. The fallback predates this change and converging it affects every unknown value class, which is wider than this story's scope:

- `arel-dot-unknown-class-leaf-fallback-should-raise` — converge the leaf fallback to `visitor.rb:39`'s `TypeError`.
- `arel-dot-hash-subclass-dispatch-and-classname` — `isPlainObject` rejects Hash subclasses that Rails' ancestor walk routes to `visit_Hash`, and `classNameOf` emits `"Object"` where Rails emits `"Hash"`.

Closes-story: arel-dot-am-attribute-structural-check-looser-than-rails