### PR TITLE
fix(arel): in/notIn thread the attribute through quotedArray

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1166,8 +1166,8 @@ export class Relation<T extends Base> {
     rel._orderClauses.push(orderNode);
 
     // Add WHERE col IN (values) filter — mirrors Rails' arel_column.in(values.compact).
-    // Attribute#in uses buildQuoted (no type-caster context); the values were already
-    // database-cast above via type_cast_for_database, matching Rails.
+    // The values were already database-cast above via type_cast_for_database, matching
+    // Rails — Attribute#in's own quoted_array cast is a no-op on already-cast values.
     if (filter) {
       const hasNull = normalized.includes(null);
       const nonNull = normalized.filter((v) => v !== null);

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1166,8 +1166,11 @@ export class Relation<T extends Base> {
     rel._orderClauses.push(orderNode);
 
     // Add WHERE col IN (values) filter — mirrors Rails' arel_column.in(values.compact).
-    // The values were already database-cast above via type_cast_for_database, matching
-    // Rails — Attribute#in's own quoted_array cast is a no-op on already-cast values.
+    // The values were already database-cast above via type_cast_for_database, and `in`
+    // wraps each in Casted, which casts again on value_for_database. That double-cast is
+    // faithful because Rails does the identical one (query_methods.rb:724 then :735,
+    // casted.rb:19-20) — not because the second cast is inert; a non-idempotent
+    // serialize would run twice here exactly as it does in Rails.
     if (filter) {
       const hasNull = normalized.includes(null);
       const nonNull = normalized.filter((v) => v !== null);

--- a/packages/arel/src/attributes/attribute.test.ts
+++ b/packages/arel/src/attributes/attribute.test.ts
@@ -1095,6 +1095,46 @@ describe("AttributeTest", () => {
       expect(table.isAbleToTypeCast()).toBe(true);
       expect(new Visitors.ToSql().compile(condition)).toBe('"foo"."id" = (select 1)');
     });
+
+    it("type casts IN list elements through the attribute", () => {
+      const fakeCaster = {
+        typeCastForDatabase(attrName: string, value: unknown) {
+          return attrName === "id" ? Number(value) : value;
+        },
+      };
+      const table = new Table("foo", { typeCaster: fakeCaster });
+      const condition = table.get("id").in(["1", "2"]);
+
+      expect(new Visitors.ToSql().compile(condition)).toBe('"foo"."id" IN (1, 2)');
+    });
+
+    it("type casts NOT IN list elements through the attribute", () => {
+      const fakeCaster = {
+        typeCastForDatabase(attrName: string, value: unknown) {
+          return attrName === "id" ? Number(value) : value;
+        },
+      };
+      const table = new Table("foo", { typeCaster: fakeCaster });
+      const condition = table.get("id").notIn(["1", "2"]);
+
+      expect(new Visitors.ToSql().compile(condition)).toBe('"foo"."id" NOT IN (1, 2)');
+    });
+
+    it("builds Casted nodes so a null in an IN list casts through the column", () => {
+      const fakeCaster = {
+        typeCastForDatabase(_attrName: string, value: unknown) {
+          return value === null ? 0 : value;
+        },
+      };
+      const table = new Table("foo", { typeCaster: fakeCaster });
+      const attr = table.get("id");
+      const node = attr.in([null]);
+      const right = (node.right as unknown as Nodes.Node[])[0];
+
+      expect(right).toBeInstanceOf(Nodes.Casted);
+      expect((right as Nodes.Casted).attribute).toBe(attr);
+      expect(new Visitors.ToSql().compile(node)).toBe('"foo"."id" IN (0)');
+    });
   });
 
   it("notEq(null) generates IS NOT NULL", () => {

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -570,12 +570,12 @@ export class Attribute extends Node {
    *
    * Mirrors: `OVER` support on Arel expressions.
    */
-  // Mirrors Arel::Predications#quoted_array → delegates to private
-  // `quoted_node`, which is `Nodes.build_quoted(other, self)` — passing
-  // self as the attribute argument so non-Node values become `Casted`
-  // (carrying the type-cast context) rather than bare `Quoted`.
+  // Mirrors Arel::Predications#quoted_array — `others.map { |v| quoted_node(v) }`
+  // (predications.rb:227-229). Delegates to `quotedNode` rather than calling
+  // `buildQuoted` directly: `quoted_node` is the hook subclasses override, so
+  // routing through it keeps every element on the same path as a scalar RHS.
   quotedArray(others: unknown[]): Node[] {
-    return others.map((v) => buildQuoted(v, this));
+    return others.map((v) => this.quotedNode(v));
   }
 
   over(window?: Window | NamedWindow | string | null): Over {

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -193,14 +193,14 @@ export class Attribute extends Node {
     if (!Array.isArray(values) && values && typeof values === "object" && "ast" in values) {
       return new In(this, (values as { ast: Node }).ast);
     }
-    return new In(this, values.map(buildQuoted) as unknown as Node);
+    return new In(this, this.quotedArray(values) as unknown as Node);
   }
 
   notIn(values: unknown[] | { ast: Node }): NotIn {
     if (!Array.isArray(values) && values && typeof values === "object" && "ast" in values) {
       return new NotIn(this, (values as { ast: Node }).ast);
     }
-    return new NotIn(this, values.map(buildQuoted) as unknown as Node);
+    return new NotIn(this, this.quotedArray(values) as unknown as Node);
   }
   between(range: [unknown, unknown]): Node;
   between(begin: unknown, end: unknown, excludeEnd?: boolean): Node;

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -43003,13 +43003,6 @@
   {
     "package": "arel",
     "tsFile": "attributes/attribute.ts",
-    "rubyName": "quoted_array",
-    "call": "quoted_node",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "attributes/attribute.ts",
     "rubyName": "when",
     "call": "quoted_node",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -42829,13 +42829,6 @@
     "package": "arel",
     "tsFile": "attributes/attribute.ts",
     "rubyName": "in",
-    "call": "quoted_array",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "attributes/attribute.ts",
-    "rubyName": "in",
     "call": "quoted_node",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -42984,13 +42977,6 @@
     "tsFile": "attributes/attribute.ts",
     "rubyName": "not_eq_any",
     "call": "grouping_any",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "attributes/attribute.ts",
-    "rubyName": "not_in",
-    "call": "quoted_array",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {


### PR DESCRIPTION
## Problem

Rails' `Predications#in` routes Enumerable elements through `quoted_array`, which maps each value to `quoted_node(v)` → `build_quoted(v, self)`, so every element becomes `Casted(v, attr)` and type-casts through the column (`predications.rb:65-74`, `quoted_array` at 227-229, `quoted_node` at 244-246).

Trails did `new In(this, values.map(buildQuoted))`, which had two defects:

1. **No attribute was threaded**, so elements became bare `Quoted` and skipped the column type-cast. `attr.in([null])` built `Quoted(null)` — the same divergence #4874 fixed for `eq`. Any type whose `serialize` is non-identity (serialized / normalized / enum columns) diverged.
2. **`values.map(buildQuoted)` passed the array index as the attribute.** `Array#map` invokes `(value, index, array)`, so this called `buildQuoted(v, 0)`, `buildQuoted(v, 1)`, … `isAttribute(0)` is false, so it fell through to `Quoted` — reaching the current (wrong) answer for the wrong reason, and it would start mis-binding if the second arg were ever honored. Same pattern on `notIn`.

`Attribute#quotedArray` already did the right thing; `in` / `notIn` simply did not call it.

## Change

`in` / `notIn` now call `this.quotedArray(values)`. The `SelectManager` arm still yields `In(self, other.ast)`.

`quotedArray` itself now delegates to `this.quotedNode` rather than calling `buildQuoted` directly, matching `quoted_array`'s delegation to the overridable `quoted_node` hook (`predications.rb:227-229`). Behaviorally identical — `quotedNode` is exactly `buildQuoted(value, this)` since #4874 — but it keeps every element on the same path as a scalar RHS, and it converges a third ratchet entry.

Rebased onto main to pick up #4874, which removed `quotedNode`'s `null` → `Quoted(null)` special-case. With that in, `eq(null)` and `in([null])` agree: both build `Casted(null, attr)`, matching `build_quoted`, which has no nil arm (`casted.rb:47-58`).

## On the `in_order_of` pre-cast in relation.ts

The original comment claimed AR compensates because "Attribute#in uses buildQuoted (no type-caster context)". That was wrong. Rails genuinely **double-casts**: it pre-casts via `type_cast_for_database` (`query_methods.rb:724`), then `arel_column.in(values)` (`:735`) wraps each value in `Casted`, which casts *again* on `value_for_database` (`casted.rb:19-20`). So the pre-cast stays — it is faithful because Rails does the identical double-cast, not because the second cast is inert (it wouldn't be for a non-idempotent `serialize`). Comment corrected to say that; code unchanged. `FieldOrderedValuesTest` (enum columns included) is green.

## Ratchet

Three entries converged and removed by hand, no reseed (the ratchet only shrinks): `in quoted_array`, `not_in quoted_array`, and `quoted_array quoted_node`. `pnpm api:calls:wide` → `OK (6852 baselined)`.

## Known remaining gap (follow-up story)

Rails has a third arm — a scalar falls to `else` → `quoted_node(other)`. Trails implements only the SelectManager and Enumerable arms; a scalar falls past both guards into `quotedArray(scalar)` and raises TypeError. That is a distinct divergence from this story's `quoted_array` threading and widens the public signature, so per the no-fan-out rule it is registered separately as `0023-surfaced-deviations/arel-in-not-in-scalar-arm-quoted-node` rather than expanded here. The `in quoted_node` / `not_in quoted_node` ratchet entries stay and are that story's to remove.

## Testing

- `packages/arel/src/attributes/attribute.test.ts` — including three new cases: `IN` / `NOT IN` elements type-cast through the attribute, and `attr.in([null])` builds `Casted` bound to the attribute and casts through the column. Plain-scalar `IN` / `NOT IN` SQL unchanged (existing tests).
- Full arel suite + `FieldOrderedValuesTest`: 1526 passing.
- `pnpm typecheck`, eslint, prettier clean. api:compare / test:compare deltas zero (a method-body change moves no method counts; the new tests land as extra/TS-only).

Closes-story: arel-in-not-in-threads-attribute-through-quoted-array