### PR TITLE
fix(arel): converge ActiveModel::Attribute predicates onto instanceof

### DIFF
--- a/packages/arel/src/nodes/casted.test.ts
+++ b/packages/arel/src/nodes/casted.test.ts
@@ -94,6 +94,13 @@ describe("Arel::Nodes.build_quoted", () => {
     expect((node as Nodes.Quoted).value).toBeNull();
   });
 
+  // KNOWN DEVIATION, not the target shape: casted.rb:50-51's `when` arm returns
+  // `other` UNWRAPPED, so Rails' AST holds the ActiveModel::Attribute itself.
+  // Tracked by story `arel-build-quoted-passes-model-attribute-unwrapped`
+  // (PR #4879), which owns the convergence. This test pins today's behaviour so
+  // that PR's change is visible in the diff — it does not ratify the wrap.
+  // Nothing here depends on the wrap: registering `visitActiveModelAttribute`
+  // (to-sql.ts, rb:756) means a bare Attribute is visitable on its own.
   it("wraps an ActiveModel::Attribute in BindParam", () => {
     const attr = AMAttribute.fromUser("age", 42, new ValueType());
     const node = buildQuoted(attr);

--- a/packages/arel/src/nodes/casted.test.ts
+++ b/packages/arel/src/nodes/casted.test.ts
@@ -94,16 +94,18 @@ describe("Arel::Nodes.build_quoted", () => {
     expect((node as Nodes.Quoted).value).toBeNull();
   });
 
-  it("wraps duck-typed ActiveModel::Attribute in BindParam without requiring activemodel import", () => {
-    const duckAttr = { name: "age", valueForDatabase: 42 };
-    const node = buildQuoted(duckAttr);
+  it("wraps an ActiveModel::Attribute in BindParam", () => {
+    const attr = AMAttribute.fromUser("age", 42, new ValueType());
+    const node = buildQuoted(attr);
     expect(node).toBeInstanceOf(Nodes.BindParam);
-    expect((node as Nodes.BindParam).value).toBe(duckAttr);
+    expect((node as Nodes.BindParam).value).toBe(attr);
   });
 
-  it("does not treat plain objects with only name as ActiveModel::Attribute", () => {
-    const node = buildQuoted({ name: "x" });
-    expect(node).toBeInstanceOf(Nodes.Quoted);
+  // Rails dispatches casted.rb:50's `when` arm on the class, so an object that
+  // merely looks like an ActiveModel::Attribute falls through to the `else`.
+  it("does not treat an ActiveModel::Attribute duck-type as one", () => {
+    expect(buildQuoted({ name: "age", valueForDatabase: 42 })).toBeInstanceOf(Nodes.Quoted);
+    expect(buildQuoted({ name: "x" })).toBeInstanceOf(Nodes.Quoted);
   });
 });
 

--- a/packages/arel/src/nodes/casted.test.ts
+++ b/packages/arel/src/nodes/casted.test.ts
@@ -95,12 +95,15 @@ describe("Arel::Nodes.build_quoted", () => {
   });
 
   // KNOWN DEVIATION, not the target shape: casted.rb:50-51's `when` arm returns
-  // `other` UNWRAPPED, so Rails' AST holds the ActiveModel::Attribute itself.
-  // Tracked by story `arel-build-quoted-passes-model-attribute-unwrapped`
-  // (PR #4879), which owns the convergence. This test pins today's behaviour so
-  // that PR's change is visible in the diff — it does not ratify the wrap.
-  // Nothing here depends on the wrap: registering `visitActiveModelAttribute`
-  // (to-sql.ts, rb:756) means a bare Attribute is visitable on its own.
+  // `other` UNWRAPPED, so Rails' AST holds the ActiveModel::Attribute itself;
+  // trails wraps it in BindParam. Output SQL agrees (rb:756's `add_bind(o)` vs
+  // rb:760's `add_bind(o.value)` land the same payload), but the AST shape does
+  // not, for callers that inspect the node.
+  //
+  // Tracked by story `arel-build-quoted-passes-model-attribute-unwrapped`,
+  // which owns the convergence to Rails' unwrapped shape. This test pins
+  // today's shape so that change is visible in the diff — it records the
+  // deviation, it does not endorse it.
   it("wraps an ActiveModel::Attribute in BindParam", () => {
     const attr = AMAttribute.fromUser("age", 42, new ValueType());
     const node = buildQuoted(attr);

--- a/packages/arel/src/nodes/casted.ts
+++ b/packages/arel/src/nodes/casted.ts
@@ -4,6 +4,7 @@ import { Unary } from "./unary.js";
 import type { Attribute } from "../attributes/attribute.js";
 import { ATTRIBUTE_BRAND } from "./binary.js";
 import { BindParam } from "./bind-param.js";
+import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 
 /**
  * Arel::Nodes.build_quoted — coerce `other` into a Node suitable for the AST.
@@ -28,15 +29,9 @@ export function buildQuoted(other: unknown, attribute?: unknown): Node {
   if (other && typeof other === "object") {
     // Arel::Attributes::Attribute (duck-typed via symbol brand)
     if ((other as Record<symbol, unknown>)[ATTRIBUTE_BRAND] === true) return other as Node;
-    // ActiveModel::Attribute duck-type (Rails: casted.rb:50-51 — the
-    // `when ..., ActiveModel::Attribute` arm returning `other`).
-    // Structural check so buildQuoted doesn't require a runtime import here.
-    // valueForDatabase is a getter (not a method) on the TS port; check via 'in'.
-    if (
-      "valueForDatabase" in (other as Record<string, unknown>) &&
-      "name" in (other as Record<string, unknown>)
-    )
-      return new BindParam(other);
+    // Rails: casted.rb:50-51 — the `when ..., ActiveModel::Attribute` arm
+    // returning `other`. Class dispatch, like Rails.
+    if (other instanceof ModelAttribute) return new BindParam(other);
     // SelectManager / TreeManager — expose a Node `ast`; use that so the
     // visitor always receives a real Node.
     const maybeAst = (other as { ast?: unknown }).ast;

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -11,6 +11,7 @@ import {
   Visitors,
   Collectors,
 } from "../index.js";
+import { Attribute as AMAttribute, ValueType } from "@blazetrails/activemodel";
 
 describe("the to_sql visitor", () => {
   const users = new Table("users");
@@ -1070,6 +1071,18 @@ describe("the to_sql visitor", () => {
     expect(sql).toBe('"users"."name" = \'x\'');
   });
 
+  // Rails: to_sql.rb:632's `when ..., ActiveModel::Attribute` arm visits the
+  // right, reaching visit_ActiveModel_Attribute (rb:756) and its add_bind.
+  it("visits an ActiveModel::Attribute assignment right instead of quoting it", () => {
+    // `NodeOrValue` doesn't name ActiveModel::Attribute — Rails' `case` accepts
+    // it at runtime, which is what this asserts.
+    const node = new Nodes.Assignment(
+      users.get("name"),
+      AMAttribute.fromUser("name", "x", new ValueType()) as unknown as Nodes.NodeOrValue,
+    );
+    expect(new Visitors.ToSql().compile(node)).toBe('"users"."name" = ?');
+  });
+
   it("should visit_Arel_Nodes_Or", () => {
     const node = new Nodes.Or(users.get("id").eq(1), users.get("id").eq(2));
     const sql = new Visitors.ToSql().compile(node);
@@ -1463,6 +1476,21 @@ describe("the to_sql visitor", () => {
       expect(() =>
         new Visitors.ToSql(raising).compile(new Nodes.ValuesList([[new Nodes.Quoted(1)]])),
       ).toThrow(/can't quote Quoted/);
+    });
+
+    it("visits an ActiveModel::Attribute row instead of quoting it", () => {
+      const attr = AMAttribute.fromUser("id", 1, new ValueType());
+      const sql = new Visitors.ToSql(probe).compile(new Nodes.ValuesList([[attr]]));
+      expect(sql).toBe("VALUES (?)");
+    });
+
+    // Rails' `when` at to_sql.rb:110 dispatches on the class, so an object that
+    // merely looks like an ActiveModel::Attribute is not one and reaches quote().
+    it("quotes an ActiveModel::Attribute duck-type instead of visiting it", () => {
+      const sql = new Visitors.ToSql(probe).compile(
+        new Nodes.ValuesList([[{ name: "id", valueForDatabase: 1 }]]),
+      );
+      expect(sql).toBe("VALUES (Q([object Object]))");
     });
   });
 

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -7,6 +7,7 @@ import * as Nodes from "../nodes/index.js";
 import { Table } from "../table.js";
 import { Visitor, type NodeCtor } from "./visitor.js";
 import { UnsupportedVisitError, NotImplementedError, BindError } from "../errors.js";
+import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 
 // Mirrors Arel::Visitors::UnsupportedVisitError (defined in to_sql.rb:5
 // in Rails as `class UnsupportedVisitError < StandardError`). Trails
@@ -53,18 +54,13 @@ export function resolveValueForDatabase(value: unknown): unknown {
 // hand off to the matching visit_* method.
 
 // The analogue of Rails' `ActiveModel::Attribute` case in the ValuesList /
-// Assignment visitors (to_sql.rb:110, 632). trails has no Arel-visible class
-// for it, so it is duck-typed on `valueForDatabase` — the same shape
-// `resolveValueForDatabase` accepts.
-//
-// The `instanceof Node` exclusion is load-bearing: Arel's own Casted/Quoted
-// expose `valueForDatabase` too (casted.ts:70,108), and ValuesList's Rails
-// `case` (to_sql.rb:110) does NOT list them — without this they would take the
-// visit branch there instead of falling to `quote()`, which is where Rails
-// sends them. Assignment tests `instanceof Node` itself before calling this,
-// matching its own wider `case` (to_sql.rb:631).
+// Assignment visitors (to_sql.rb:110, 632). Rails dispatches on the class, and
+// so does trails — the same predicate `Nodes.build_quoted` uses (casted.ts).
+// Arel's own Casted/Quoted expose `valueForDatabase` but are Nodes, not
+// ActiveModel::Attributes, so they keep falling to `quote()` in ValuesList as
+// rb:110's narrow `when` requires.
 function isActiveModelAttribute(v: unknown): boolean {
-  return typeof v === "object" && v !== null && !(v instanceof Node) && "valueForDatabase" in v;
+  return v instanceof ModelAttribute;
 }
 
 // The analogue of Ruby's Hash — an object literal, i.e. one whose prototype is
@@ -532,6 +528,11 @@ export class ToSql extends Visitor {
     reg(Nodes.InfixOperation, "visitArelNodesInfixOperation");
     reg(Nodes.BoundSqlLiteral, "visitArelNodesBoundSqlLiteral");
     reg(Nodes.BindParam, "visitArelNodesBindParam");
+    // Not an Arel node, but Rails' dispatch is by class for every object it
+    // visits (visitor.rb:29-30) and to_sql.rb:756 defines a handler for it,
+    // so ValuesList/Assignment's visit branch resolves here rather than
+    // raising UnsupportedVisitError.
+    reg(ModelAttribute as unknown as NodeCtor, "visitActiveModelAttribute");
     reg(Nodes.Fragments, "visitArelNodesFragments");
     // Functions
     reg(Nodes.NamedFunction, "visitArelNodesNamedFunction");
@@ -1198,8 +1199,14 @@ export class ToSql extends Visitor {
     collector.append(" = ");
     // Mirrors Rails (to_sql.rb:630-641): a Node/Attribute right is visited; a
     // raw value is quoted directly rather than dispatched through `visit`.
-    if (node.right instanceof Node || isActiveModelAttribute(node.right)) {
+    if (node.right instanceof Node) {
       this.visitNodeOrValue(node.right, collector);
+    } else if (isActiveModelAttribute(node.right)) {
+      // `visitNodeOrValue` is the raw-value path and has no class dispatch, so
+      // an ActiveModel::Attribute has to go through `visit` to reach
+      // `visitActiveModelAttribute` — which is what rb:634's `visit o.right`
+      // does for this arm.
+      this.visit(node.right as unknown as Node, collector);
     } else {
       collector.append(this.quote(node.right));
     }

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1199,13 +1199,9 @@ export class ToSql extends Visitor {
     collector.append(" = ");
     // Mirrors Rails (to_sql.rb:630-641): a Node/Attribute right is visited; a
     // raw value is quoted directly rather than dispatched through `visit`.
-    if (node.right instanceof Node) {
-      this.visitNodeOrValue(node.right, collector);
-    } else if (isActiveModelAttribute(node.right)) {
-      // `visitNodeOrValue` is the raw-value path and has no class dispatch, so
-      // an ActiveModel::Attribute has to go through `visit` to reach
-      // `visitActiveModelAttribute` — which is what rb:634's `visit o.right`
-      // does for this arm.
+    // `instanceof Node` covers rb:631's `Arel::Attributes::Attribute` arm too —
+    // Arel's Attribute extends Node here (attributes/attribute.ts).
+    if (node.right instanceof Node || isActiveModelAttribute(node.right)) {
       this.visit(node.right as unknown as Node, collector);
     } else {
       collector.append(this.quote(node.right));

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -44298,13 +44298,6 @@
   {
     "package": "arel",
     "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_Assignment",
-    "call": "visit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_BoundSqlLiteral",
     "call": "add_bind",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Rails identifies an `ActiveModel::Attribute` by **class** everywhere —
`casted.rb:50` (`build_quoted`'s `when` arm), `to_sql.rb:110` (ValuesList),
`to_sql.rb:632` (Assignment), `to_sql.rb:756` (the visitor). trails had two
different structural predicates, so an object could be classified differently
depending on the call path:

| site | before | after |
| --- | --- | --- |
| `nodes/casted.ts` `buildQuoted` | `"valueForDatabase" in o && "name" in o` | `o instanceof ModelAttribute` |
| `visitors/to-sql.ts` `isActiveModelAttribute` | `!(o instanceof Node) && "valueForDatabase" in o` | `o instanceof ModelAttribute` |

`attributes/attribute.ts` `quotedNode` is a third site only nominally — it
delegates to `buildQuoted`, so it converges with it. **`visitors/dot.ts` — the
fourth site — converged on `main` via #4880**, so with this PR all four use the
same class check.

The stale *"so `buildQuoted` doesn't require a runtime import here"* rationale
goes with it: `packages/arel` already depends on `@blazetrails/activemodel`,
which does not depend on `arel` in either direction. `QueryAttribute` extends
activemodel's `Attribute`, so one `instanceof` covers both, and the single
`reg(ModelAttribute, ...)` entry resolves for every subclass through
`resolveDispatch`'s prototype walk (the analogue of visitor.rb:36-41).

## Behaviour changes, each checked against Rails

| change | before | after | Rails |
| --- | --- | --- | --- |
| duck-typed object in a values row | bound | `quote()` | rb:110 — not in the `when` list |
| real AM Attribute in ValuesList / Assignment | `UnsupportedVisitError` | binds | rb:110/632 + rb:756 |
| `AdditionalValue` (encryption) in a values row / as an Assignment right | `UnsupportedVisitError` | `quote()` | rb:110/640 |

- The **AM Attribute raise** was latent behind the old duck-type predicate:
  `visitActiveModelAttribute` was never wired into the dispatch cache, and
  Assignment routed through `visitNodeOrValue` — the raw-value path, which has
  no class dispatch. Registering the handler (rb:756) fixes both.
- **`AdditionalValue`** (`encryption/extended-deterministic-queries.ts:271`)
  has a `valueForDatabase` getter and no `name`, so it matched the *old* to-sql
  predicate but not the old `buildQuoted` one — it raised on both paths and now
  quotes, per rb:110/640. It normally reaches the visitor through `Casted`
  (untouched here), so this path is not exercised in practice; verified by
  probe, and the encryption suite passes.

Assignment is now the literal rb:631-634 port — one `when` arm, one `visit`.
The previous split was shape-only: `visitNodeOrValue`'s SelectManager duck-type
is unreachable from an Assignment right (a SelectManager is neither a Node nor
an AM Attribute, so it never passes the guard — it quotes today), and no Node
subclass carries an `ast` (`TreeManager`, which does, is not a Node), so a Node
right always fell through to `this.visit` anyway.

The `!(v instanceof Node)` exclusion is **preserved in behaviour, verified not
assumed**: Arel's own `Casted`/`Quoted` expose `valueForDatabase` but are Nodes,
not `ActiveModel::Attribute`s, so they keep falling to `quote()` in ValuesList
per rb:110's narrow `when`. The existing *"sends a Quoted row to quote(), which
is where Rails raises TypeError"* test covers this and still passes.

## Coordination with #4879 — settled

Both PRs added the identical `reg(ModelAttribute, "visitActiveModelAttribute")`
line and touch `casted.ts` / `to-sql.ts`. Per the owner's decision:

- **This PR lands the `reg` line.** #4879 should rebase and drop it. The
  registration and the `instanceof` predicate are one thought — the predicate is
  what makes the registration meaningful.
- **The `BindParam` wrap converges; it is not ratified.** casted.rb:50-51
  returns `other` unwrapped. #4879's body currently decides *"option (b) — keep
  the wrap"*; the standing position is that deviation stories converge, and the
  owner has confirmed convergence stands. That work belongs to story
  `arel-build-quoted-passes-model-attribute-unwrapped`, not here — this PR only
  pins today's shape, with a comment marking it a deviation rather than intent.
  (An earlier revision of that comment claimed #4879 "owns the convergence";
  that was false as filed and is corrected.)
- #4879's `dot.ts` change is now moot — #4880 merged that convergence to `main`.

## Verification

- Rebased onto `main` (`0b3d440d1`); 1540 arel tests pass, plus `persistence` /
  `relation` / `statement-cache` / `predicate-builder` /
  `extended-deterministic-queries` on the ActiveRecord side.
- `pnpm typecheck` and `eslint packages/arel/src` clean.
- Ran the **rails-comparison job's actual gates**, not just `api:compare`:
  call-mismatches ratchet OK, body-pins OK, conventions-doc OK, lint-deps OK,
  **wide call ratchet** — this caught a real staleness: collapsing Assignment
  makes it call `visit` as Rails does, so its wide-exclude entry was obsolete.
  Removed that single entry by hand (not `--write`); the sibling `to_s` entry
  stands.
- **api:compare delta 0** — 11416/16975 on both this branch and `origin/main`.
- **test:compare delta 0** — 14448/21663 matched on both; `extra (TS only)`
  3999→4002, exactly the three added tests. Both baselines re-measured against
  current `main` after the rebase, not assumed.

Closes-story: arel-am-attribute-predicates-diverge-across-sites
