### PR TITLE
fix(arel): Dot routes derived records to visitHash and names them Hash

### DIFF
--- a/packages/arel/src/visitors/dot.test.ts
+++ b/packages/arel/src/visitors/dot.test.ts
@@ -458,17 +458,17 @@ describe("TestDot", () => {
       expect(out).not.toContain("inherited");
     });
 
-    it("an inherited valueBeforeTypeCast takes the attribute arm, not the Hash arm", () => {
-      // Pins the duck-typed split: isActiveModelAttribute uses `in`, which
-      // reaches through the prototype chain, and visit() checks it before
-      // the Hash arm. Real ActiveModel::Attribute exposes
-      // valueBeforeTypeCast as a prototype getter (activemodel
-      // attribute.ts:60), so the check cannot be scoped to own keys.
-      const derived = Object.create({ valueBeforeTypeCast: 42 }) as object;
+    it("a record inheriting valueBeforeTypeCast is a Hash, not an attribute", () => {
+      // The attribute arm is a class check (`instanceof ModelAttribute`), so
+      // it cannot swallow a record that merely carries the property — in
+      // Ruby such a value is a Hash and routes to visit_Hash (dot.rb:220).
+      const derived: Record<string, unknown> = Object.create({ valueBeforeTypeCast: 42 });
+      derived.alpha = "A";
       const out = visitStandalone(derived);
-      expect(out).toMatch(/-> \d+ \[label="valueBeforeTypeCast"\];/);
-      expect(out).not.toContain('[label="pair_0"]');
-      expect(out).not.toContain("<f0>Hash");
+      expect(out).toMatch(/\d+ \[label="<f0>Hash"\];/);
+      expect(out).toContain('[label="pair_0"]');
+      expect(out).toContain("alpha");
+      expect(out).not.toMatch(/-> \d+ \[label="valueBeforeTypeCast"\];/);
     });
 
     it("a Set emits index-labeled edges like an Array", () => {

--- a/packages/arel/src/visitors/dot.test.ts
+++ b/packages/arel/src/visitors/dot.test.ts
@@ -443,6 +443,34 @@ describe("TestDot", () => {
       expect(out).toContain("alpha");
     });
 
+    it("a record derived from a null-prototype record routes to visit_Hash", () => {
+      // The prototype here has no `constructor` at all, which must not be
+      // read as "some class other than Object" — both halves are records,
+      // so the derived value is a Hash like any other.
+      const base: Record<string, unknown> = Object.create(null);
+      base.inherited = "nope";
+      const derived: Record<string, unknown> = Object.create(base);
+      derived.alpha = "A";
+      const out = visitStandalone(derived);
+      expect(out).toMatch(/\d+ \[label="<f0>Hash"\];/);
+      expect(out).toContain('[label="pair_0"]');
+      expect(out).toContain("alpha");
+      expect(out).not.toContain("inherited");
+    });
+
+    it("an inherited valueBeforeTypeCast takes the attribute arm, not the Hash arm", () => {
+      // Pins the duck-typed split: isActiveModelAttribute uses `in`, which
+      // reaches through the prototype chain, and visit() checks it before
+      // the Hash arm. Real ActiveModel::Attribute exposes
+      // valueBeforeTypeCast as a prototype getter (activemodel
+      // attribute.ts:60), so the check cannot be scoped to own keys.
+      const derived = Object.create({ valueBeforeTypeCast: 42 }) as object;
+      const out = visitStandalone(derived);
+      expect(out).toMatch(/-> \d+ \[label="valueBeforeTypeCast"\];/);
+      expect(out).not.toContain('[label="pair_0"]');
+      expect(out).not.toContain("<f0>Hash");
+    });
+
     it("a class instance is not a Hash and keeps its own class name", () => {
       // Ruby's `class Config < Object` finds no visit_Object ancestor and so
       // never reaches visit_Hash; the JS analogue is any class instance,

--- a/packages/arel/src/visitors/dot.test.ts
+++ b/packages/arel/src/visitors/dot.test.ts
@@ -12,6 +12,17 @@ import {
 } from "../index.js";
 import { DotNode } from "./dot.js";
 
+/**
+ * Drive Dot#visit on a bare value (rather than an AST root) and render the
+ * graph, so dispatch for non-Node values can be asserted directly.
+ */
+function visitStandalone(value: unknown): string {
+  const v = new Visitors.Dot();
+  v.compile(new Nodes.SqlLiteral("")); // initialize state
+  (v as unknown as { visit(o: unknown): void }).visit(value);
+  return (v as unknown as { toDot(): string }).toDot();
+}
+
 describe("TestDot", () => {
   const users = new Table("users");
   const dot = new Visitors.Dot();
@@ -390,17 +401,58 @@ describe("TestDot", () => {
       // labeled "pair_<i>" pointing at an Array node, which itself emits
       // index-labeled edges for the [key, value] tuple. Both halves of
       // the entry must end up in the graph.
-      const v = new Visitors.Dot();
-      type Internals = { visit(o: unknown): void };
-      v.compile(new Nodes.SqlLiteral("")); // initialize state
-      (v as unknown as Internals).visit({ alpha: "A", beta: "B" });
-      const out = (v as unknown as { toDot(): string }).toDot();
+      const out = visitStandalone({ alpha: "A", beta: "B" });
       expect(out).toContain('[label="pair_0"]');
       expect(out).toContain('[label="pair_1"]');
       expect(out).toContain("alpha");
       expect(out).toContain("beta");
       expect(out).toContain("A");
       expect(out).toContain("B");
+    });
+
+    it("names a hash node Hash, not the JS ctor name", () => {
+      // Rails' Dot#visit labels the node `o.class.name` (dot.rb:253), which
+      // is "Hash" for a plain hash. JS's ctor name for an object literal is
+      // "Object" — the label follows Rails.
+      const out = visitStandalone({ alpha: "A" });
+      expect(out).toMatch(/\d+ \[label="<f0>Hash"\];/);
+      expect(out).not.toContain("<f0>Object");
+    });
+
+    it("a record derived from a plain object routes to visit_Hash", () => {
+      // Rails' Visitor#visit walks object.class.ancestors (visitor.rb:36-41),
+      // so a Hash subclass reaches visit_Hash. Object.create over a plain
+      // prototype is the JS form of deriving a record from another record.
+      const derived: Record<string, unknown> = Object.create({ inherited: "nope" });
+      derived.alpha = "A";
+      const out = visitStandalone(derived);
+      expect(out).toContain('[label="pair_0"]');
+      expect(out).toContain("alpha");
+      expect(out).toContain("A");
+      // Object.entries ignores prototype-chain keys, so the inherited pair
+      // is not an edge — mirroring the own-pairs Rails' each would yield.
+      expect(out).not.toContain("inherited");
+    });
+
+    it("a null-prototype record routes to visit_Hash", () => {
+      const bare: Record<string, unknown> = Object.create(null);
+      bare.alpha = "A";
+      const out = visitStandalone(bare);
+      expect(out).toMatch(/\d+ \[label="<f0>Hash"\];/);
+      expect(out).toContain('[label="pair_0"]');
+      expect(out).toContain("alpha");
+    });
+
+    it("a class instance is not a Hash and keeps its own class name", () => {
+      // Ruby's `class Config < Object` finds no visit_Object ancestor and so
+      // never reaches visit_Hash; the JS analogue is any class instance,
+      // whose prototype's constructor is the class rather than Object.
+      class Config {
+        alpha = "A";
+      }
+      const out = visitStandalone(new Config());
+      expect(out).toContain("<f0>Config");
+      expect(out).not.toContain('[label="pair_0"]');
     });
   });
 });

--- a/packages/arel/src/visitors/dot.test.ts
+++ b/packages/arel/src/visitors/dot.test.ts
@@ -471,6 +471,18 @@ describe("TestDot", () => {
       expect(out).not.toContain("<f0>Hash");
     });
 
+    it("a Set emits index-labeled edges like an Array", () => {
+      // Rails: `alias :visit_Set :visit_Array` (dot.rb:231). A Set is not a
+      // Hash (its prototype's ctor is Set), so without a dedicated arm it
+      // would fall to the leaf and stringify instead of walking members.
+      const out = visitStandalone(new Set(["A", "B"]));
+      expect(out).toMatch(/\d+ \[label="<f0>Set"\];/);
+      expect(out).toContain('[label="0"]');
+      expect(out).toContain('[label="1"]');
+      expect(out).toContain("A");
+      expect(out).toContain("B");
+    });
+
     it("a class instance is not a Hash and keeps its own class name", () => {
       // Ruby's `class Config < Object` finds no visit_Object ancestor and so
       // never reaches visit_Hash; the JS analogue is any class instance,

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -617,20 +617,54 @@ export class Dot extends Visitor {
     return o instanceof ModelAttribute;
   }
 
+  /**
+   * The trails analogue of "is a Hash, or a subclass of one".
+   *
+   * Rails' `Visitor#visit` (visitor.rb:36-41) walks `object.class.ancestors`
+   * for a visitable class, so `class MyHash < Hash` reaches `visit_Hash`
+   * while `class Config < Object` finds no handler and raises TypeError.
+   * JS has no Hash class — the object literal *is* the Hash — so the
+   * equivalent of that ancestor split is whether the prototype chain is
+   * made only of plain objects:
+   *
+   *   - `{ a: 1 }` and `Object.create(null)` are Hashes;
+   *   - `Object.create({ a: 1 })` is the JS way to derive a record from
+   *     another record — Ruby's `MyHash < Hash` — so it's a Hash too;
+   *   - a class instance (including `class Config extends Object`) has a
+   *     prototype whose `constructor` is that class, which is Ruby's
+   *     `Config < Object`: no ancestor handler, so it does not route here.
+   *
+   * `visitHash` reads `Object.entries`, which sees only own enumerable
+   * string keys — inherited and symbol keys are not walked, matching the
+   * fields Rails' `each_with_index` over a Hash would yield for the
+   * derived record's own pairs.
+   */
   private isPlainObject(o: unknown): boolean {
     if (!o || typeof o !== "object") return false;
     if (Array.isArray(o)) return false;
     // Node covers Table (which extends Node).
     if (o instanceof Node) return false;
-    const proto = Object.getPrototypeOf(o);
-    return proto === Object.prototype || proto === null;
+    for (
+      let proto = Object.getPrototypeOf(o);
+      proto !== null;
+      proto = Object.getPrototypeOf(proto)
+    ) {
+      if (proto === Object.prototype) return true;
+      const ctor = (proto as { constructor?: unknown }).constructor;
+      if (ctor !== Object) return false;
+    }
+    return true;
   }
 
   /**
    * Rails: `o.class.name`. We use the JS ctor name for objects and emit
    * Rails-style class names for primitives and nil values — `String`,
    * `Integer`, `Float`, `TrueClass`, `FalseClass`, `NilClass`, `Symbol`,
-   * `Time` — so leaf nodes match Rails' shape.
+   * `Time` — so leaf nodes match Rails' shape. Values matching the Hash
+   * analogue (see isPlainObject) are named `Hash` rather than JS's ctor
+   * name `Object`: Rails labels a plain hash's node "Hash" (dot.rb:253),
+   * and a record derived via `Object.create` has no class name of its own
+   * the way an anonymous `Class.new(Hash)` doesn't in Ruby.
    */
   private classNameOf(o: unknown): string {
     if (o === null) return "NilClass";
@@ -642,6 +676,10 @@ export class Dot extends Visitor {
     if (typeof o === "symbol") return "Symbol";
     // boundary: legacy JS Date values stringify to Rails' `Time` class name.
     if (o instanceof Date) return "Time";
+    // Mirrors visit()'s arm ordering: an ActiveModel::Attribute-shaped
+    // value routes to visitActiveModelAttribute, not visitHash, so it
+    // keeps its own class name.
+    if (!this.isActiveModelAttribute(o) && this.isPlainObject(o)) return "Hash";
     const ctor = (o as { constructor?: { name?: string } }).constructor;
     return ctor?.name ?? "Object";
   }

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -688,10 +688,7 @@ export class Dot extends Visitor {
     if (typeof o === "symbol") return "Symbol";
     // boundary: legacy JS Date values stringify to Rails' `Time` class name.
     if (o instanceof Date) return "Time";
-    // Mirrors visit()'s arm ordering: an ActiveModel::Attribute-shaped
-    // value routes to visitActiveModelAttribute, not visitHash, so it
-    // keeps its own class name.
-    if (!this.isActiveModelAttribute(o) && this.isHash(o)) return "Hash";
+    if (this.isHash(o)) return "Hash";
     const ctor = (o as { constructor?: { name?: string } }).constructor;
     return ctor?.name ?? "Object";
   }

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -650,8 +650,11 @@ export class Dot extends Visitor {
       proto = Object.getPrototypeOf(proto)
     ) {
       if (proto === Object.prototype) return true;
+      // A prototype with no `constructor` at all descends from
+      // Object.create(null) — still a record, so keep walking. Only a
+      // constructor naming some *other* class marks a class prototype.
       const ctor = (proto as { constructor?: unknown }).constructor;
-      if (ctor !== Object) return false;
+      if (ctor !== undefined && ctor !== Object) return false;
     }
     return true;
   }
@@ -660,11 +663,16 @@ export class Dot extends Visitor {
    * Rails: `o.class.name`. We use the JS ctor name for objects and emit
    * Rails-style class names for primitives and nil values — `String`,
    * `Integer`, `Float`, `TrueClass`, `FalseClass`, `NilClass`, `Symbol`,
-   * `Time` — so leaf nodes match Rails' shape. Values matching the Hash
-   * analogue (see isHash) are named `Hash` rather than JS's ctor
-   * name `Object`: Rails labels a plain hash's node "Hash" (dot.rb:253),
-   * and a record derived via `Object.create` has no class name of its own
-   * the way an anonymous `Class.new(Hash)` doesn't in Ruby.
+   * `Time` — so leaf nodes match Rails' shape.
+   *
+   * Values matching the Hash analogue (see isHash) are named `Hash` rather
+   * than JS's ctor name `Object`. Rails labels the node `o.class.name`
+   * (dot.rb:253), so a *named* Hash subclass would be "MyHash" — but no
+   * value reaching this arm can supply such a name: isHash admits only
+   * object literals, `Object.create(null)`, and records derived from those,
+   * every one of which reports a ctor name of `Object`. Class instances,
+   * the only objects with a distinct ctor name, are Ruby's `Config < Object`
+   * and never route here. So "Hash" is the whole of the analogue's range.
    */
   private classNameOf(o: unknown): string {
     if (o === null) return "NilClass";

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -506,7 +506,7 @@ export class Dot extends Visitor {
         // Ruby reaches by class dispatch — including via the ancestor walk in
         // visitor.rb:36-41, so every Attribute subclass lands here too.
         this.visitActiveModelAttribute(object);
-      } else if (this.isPlainObject(object)) {
+      } else if (this.isHash(object)) {
         this.visitHash(object as Record<string, unknown>);
       } else {
         // Unknown non-Node object — render as a leaf with its String form
@@ -618,7 +618,7 @@ export class Dot extends Visitor {
   }
 
   /**
-   * The trails analogue of "is a Hash, or a subclass of one".
+   * The trails analogue of Ruby's `o.is_a?(Hash)`.
    *
    * Rails' `Visitor#visit` (visitor.rb:36-41) walks `object.class.ancestors`
    * for a visitable class, so `class MyHash < Hash` reaches `visit_Hash`
@@ -639,7 +639,7 @@ export class Dot extends Visitor {
    * fields Rails' `each_with_index` over a Hash would yield for the
    * derived record's own pairs.
    */
-  private isPlainObject(o: unknown): boolean {
+  private isHash(o: unknown): boolean {
     if (!o || typeof o !== "object") return false;
     if (Array.isArray(o)) return false;
     // Node covers Table (which extends Node).
@@ -661,7 +661,7 @@ export class Dot extends Visitor {
    * Rails-style class names for primitives and nil values — `String`,
    * `Integer`, `Float`, `TrueClass`, `FalseClass`, `NilClass`, `Symbol`,
    * `Time` — so leaf nodes match Rails' shape. Values matching the Hash
-   * analogue (see isPlainObject) are named `Hash` rather than JS's ctor
+   * analogue (see isHash) are named `Hash` rather than JS's ctor
    * name `Object`: Rails labels a plain hash's node "Hash" (dot.rb:253),
    * and a record derived via `Object.create` has no class name of its own
    * the way an anonymous `Class.new(Hash)` doesn't in Ruby.
@@ -679,7 +679,7 @@ export class Dot extends Visitor {
     // Mirrors visit()'s arm ordering: an ActiveModel::Attribute-shaped
     // value routes to visitActiveModelAttribute, not visitHash, so it
     // keeps its own class name.
-    if (!this.isActiveModelAttribute(o) && this.isPlainObject(o)) return "Hash";
+    if (!this.isActiveModelAttribute(o) && this.isHash(o)) return "Hash";
     const ctor = (o as { constructor?: { name?: string } }).constructor;
     return ctor?.name ?? "Object";
   }

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -499,6 +499,10 @@ export class Dot extends Visitor {
         this.visitString(object);
       } else if (Array.isArray(object)) {
         this.visitArray(object);
+      } else if (object instanceof Set) {
+        // Rails: `alias :visit_Set :visit_Array` (dot.rb:231). Without this
+        // arm a Set reaches no handler and falls to the leaf below.
+        this.visitSet(object);
       } else if (object instanceof Node) {
         super.visit(object);
       } else if (this.isActiveModelAttribute(object)) {


### PR DESCRIPTION
Rails' `Arel::Visitors::Visitor#visit` walks `object.class.ancestors`
(`visitor.rb:36-41`) to find a visitable superclass, so **any `Hash`
subclass** routes to `visit_Hash` (`dot.rb:220`), and `visit` labels the
node `o.class.name` (`dot.rb:253`) — `"Hash"` for a plain hash. Trails'
`Dot` diverged on both halves.

Rebased onto `main` after #4880 (`Dot` dispatches `ActiveModel::Attribute`
by class, not shape) — see "Interaction with #4880" below.

## The Hash analogue

The ancestor walk gives Ruby a real split: `class MyHash < Hash` reaches
`visit_Hash`, while `class Config < Object` finds no handler and raises.
JS has no Hash class — the object literal **is** the Hash — so the
equivalent of that split is whether the prototype chain is made only of
plain objects:

- `{ a: 1 }` and `Object.create(null)` are Hashes;
- `Object.create({ a: 1 })` is the JS way to derive a record from another
  record, i.e. Ruby's `MyHash < Hash` — so it's a Hash too, as is a record
  derived from a null-prototype record;
- a class instance (including `class Config extends Object`) has a
  prototype whose `constructor` is that class. That is Ruby's
  `Config < Object`: no ancestor handler, so it does not route to
  `visitHash` and falls to the unknown-object arm that the sibling story
  `arel-dot-unknown-class-leaf-fallback-should-raise` covers.

A prototype with **no** `constructor` descends from `Object.create(null)`
and is still a record, so the walk continues past it; only a constructor
naming some other class marks a class prototype.

`Map` is deliberately **not** in the analogue: its prototype's constructor
is `Map`, and `visitHash` reads `Object.entries`, which sees only own
enumerable string keys — so a Map has no pairs to walk. Inherited and
symbol keys are likewise not walked, matching the own-pairs Rails'
`each_with_index` would yield.

## classNameOf

Converged rather than kept: a hash node is now labeled `"Hash"`, not JS's
ctor name `"Object"`. Rails labels the node `o.class.name`, so a *named*
Hash subclass would be `"MyHash"` — but no value reaching this arm can
supply such a name. `isHash` admits only object literals,
`Object.create(null)`, and records derived from those, every one of which
reports a ctor name of `Object`; class instances, the only objects with a
distinct ctor name, never route here. So `"Hash"` is the whole of the
analogue's range.

## Set dispatch

Surfaced in review. Rails aliases `visit_Set` to `visit_Array`
(`dot.rb:231`), but nothing reached trails' `visitSet`: a Set is not
primitive, not `Array.isArray`, not a `Node`, and `isHash` rejects it (its
prototype's ctor is `Set`), so `visit()` fell to the leaf arm and
stringified it. Fixed here rather than deferred — it is a two-line arm in
the same list this PR reworks, and the sibling story turns that `else` into
a `raise`, which would escalate the wrong-output into a crash.

## Interaction with #4880

#4880 converged `isActiveModelAttribute` from `"valueBeforeTypeCast" in o`
to `instanceof ModelAttribute`. That inverts two things this branch assumed
under the old duck-type, both reconciled in the rebase:

- A record merely *carrying* `valueBeforeTypeCast` is no longer claimed by
  the attribute arm, so it is a Hash — which is what Ruby does with
  `{ value_before_type_cast: 42 }`. The test that pinned the old
  attribute-arm behaviour now asserts the Hash arm.
- `classNameOf`'s `!isActiveModelAttribute(o)` guard became dead code: a
  real Attribute is a class instance, which `isHash` already rejects, so
  the arms are disjoint. Removed.

An earlier revision of this PR registered
`arel-dot-activemodel-attribute-duck-type-vs-is-a` for that convergence;
#4880 landed it first, so the story is closed as done against #4880 rather
than left stale.

## Known limitation

A record whose *prototype* carries a literal `constructor` key
(`Object.create({ constructor: "x" })`) is classified as a non-Hash.
Discriminating it needs property-descriptor enumerability checks, which
seemed poor value for a debug visualizer.

## Tests

Seven added in `dot.test.ts`, plus a `visitStandalone` helper that drives
`visit` on a bare value (the existing hash test now uses it): hash-node
naming, `Object.create` record dispatch, null-prototype record dispatch,
null-prototype-derived record dispatch, an inherited-`valueBeforeTypeCast`
record routing to the Hash arm, Set index-edge dispatch, and a class
instance staying out of the Hash arm. Rails has no Set test in
`dot_test.rb`, so that name is a TS-only extra rather than a Rails match.

## Gates

- api:compare — no Rails-mapped method added, removed, or moved; delta 0.
- test:compare — `visitors/dot.test.ts` matches 16/16 Rails tests on both
  `main` and this branch (re-verified against the rebased base by running
  both); the new tests are TS-only extras (22 → 29). Delta 0.
- No stubs.
- Full `packages/arel` suite green (1524 tests); typecheck and lint clean.

Closes-story: arel-dot-hash-subclass-dispatch-and-classname
