### PR TITLE
fix(arel): Dot raises TypeError on a class with no visitable ancestor

### DIFF
--- a/packages/arel/src/temporal-tag.ts
+++ b/packages/arel/src/temporal-tag.ts
@@ -1,0 +1,16 @@
+/**
+ * Temporal types carry a `Temporal.X` `Symbol.toStringTag`. Reading it keeps
+ * Temporal checks structural rather than pulling the namespace into arel's
+ * runtime imports — arel has no activesupport dependency at runtime.
+ *
+ * Shared by the visitors so the tag-shape knowledge lives in one place; each
+ * caller maps the tag to its own Rails analogue (to-sql dispatches on
+ * supported-vs-unsupported, dot labels leaf nodes with a Ruby class name).
+ *
+ * @internal
+ */
+export function temporalTag(v: unknown): string | null {
+  if (typeof v !== "object" || v === null) return null;
+  const tag = (v as Record<symbol, unknown>)[Symbol.toStringTag];
+  return typeof tag === "string" && tag.startsWith("Temporal.") ? tag : null;
+}

--- a/packages/arel/src/visitors/dot.test.ts
+++ b/packages/arel/src/visitors/dot.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Attribute as ModelAttribute, ValueType } from "@blazetrails/activemodel";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import {
   Table,
   star,
@@ -262,6 +263,39 @@ describe("TestDot", () => {
       // visit_Array walks each member under an index-labeled edge.
       expect(out).toMatch(/-> \d+ \[label="0"\];/);
       expect(out).toMatch(/-> \d+ \[label="1"\];/);
+    });
+
+    it("raises TypeError on a class with no visitable ancestor (visitor.rb:39)", () => {
+      // Rails' Visitor#visit walks object.class.ancestors and raises
+      // `TypeError, "Cannot visit #{object.class}"` when none answers. Trails
+      // used to render such a value as a visitString leaf instead.
+      class Money {
+        toString(): string {
+          return "$5";
+        }
+      }
+      const v = new Visitors.Dot();
+      type Internals = { visit(o: unknown): void };
+      v.compile(new Nodes.SqlLiteral("seed"));
+      expect(() => (v as unknown as Internals).visit(new Money())).toThrow(
+        new TypeError("Cannot visit Money"),
+      );
+    });
+
+    it("Temporal values reach visit_Date / visit_Time instead of raising", () => {
+      // Temporal is this codebase's Time/Date analogue, so these have a
+      // visitable Rails ancestor and must not hit the TypeError arm.
+      const v = new Visitors.Dot();
+      type Internals = { visit(o: unknown): void; toDot(): string };
+      const iv = v as unknown as Internals;
+      v.compile(new Nodes.SqlLiteral("seed"));
+      iv.visit(Temporal.PlainDate.from("2024-01-02"));
+      iv.visit(Temporal.PlainDateTime.from("2024-01-02T03:04:05"));
+      iv.visit(Temporal.Instant.from("2024-01-02T03:04:05Z"));
+      const out = iv.toDot();
+      expect(out).toContain("<f0>Date|<f1>2024-01-02");
+      expect(out).toContain("<f0>DateTime|<f1>2024-01-02T03:04:05");
+      expect(out).toContain("<f0>Time|<f1>2024-01-02T03:04:05Z");
     });
 
     it("visitEdge throws on a typo'd field (Rails NoMethodError parity)", () => {

--- a/packages/arel/src/visitors/dot.test.ts
+++ b/packages/arel/src/visitors/dot.test.ts
@@ -298,6 +298,20 @@ describe("TestDot", () => {
       expect(out).toContain("<f0>Time|<f1>2024-01-02T03:04:05Z");
     });
 
+    it("Temporal types with no Ruby analogue raise rather than becoming Time leaves", () => {
+      // Duration / PlainYearMonth / PlainMonthDay have no visitable Rails
+      // ancestor — dot.rb defines no visitor for ActiveSupport::Duration
+      // (a plain Object subclass, not a Numeric), so Rails raises at
+      // visitor.rb:39. Only the Date/DateTime/Time analogues are whitelisted.
+      const v = new Visitors.Dot();
+      type Internals = { visit(o: unknown): void };
+      const iv = v as unknown as Internals;
+      v.compile(new Nodes.SqlLiteral("seed"));
+      expect(() => iv.visit(Temporal.Duration.from({ hours: 1 }))).toThrow(TypeError);
+      expect(() => iv.visit(Temporal.PlainYearMonth.from("2024-01"))).toThrow(TypeError);
+      expect(() => iv.visit(Temporal.PlainMonthDay.from("01-02"))).toThrow(TypeError);
+    });
+
     it("visitEdge throws on a typo'd field (Rails NoMethodError parity)", () => {
       // Regression: Rails' visit_edge uses public_send which raises
       // NoMethodError on a typo; the TS port silently treated missing
@@ -521,12 +535,12 @@ describe("TestDot", () => {
       // Ruby's `class Config < Object` finds no visit_Object ancestor and so
       // never reaches visit_Hash; the JS analogue is any class instance,
       // whose prototype's constructor is the class rather than Object.
+      // Finding no handler is exactly visitor.rb:39, so it raises rather than
+      // rendering — the class name survives in the message.
       class Config {
         alpha = "A";
       }
-      const out = visitStandalone(new Config());
-      expect(out).toContain("<f0>Config");
-      expect(out).not.toContain('[label="pair_0"]');
+      expect(() => visitStandalone(new Config())).toThrow(new TypeError("Cannot visit Config"));
     });
   });
 });

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -7,6 +7,15 @@ import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 
 type AppendableCollector = { append(s: string): unknown; value: string };
 
+// Temporal types carry a `Temporal.X` Symbol.toStringTag; matching on it keeps
+// the check structural rather than importing the namespace into arel (same
+// approach as to-sql.ts).
+function temporalTag(v: unknown): string | null {
+  if (typeof v !== "object" || v === null) return null;
+  const tag = (v as Record<symbol, unknown>)[Symbol.toStringTag];
+  return typeof tag === "string" && tag.startsWith("Temporal.") ? tag : null;
+}
+
 function isAppendableCollector(c: unknown): c is AppendableCollector {
   if (typeof c !== "object" || c === null) return false;
   const obj = c as Record<string, unknown>;
@@ -503,6 +512,8 @@ export class Dot extends Visitor {
         // Rails: `alias :visit_Set :visit_Array` (dot.rb:231). Without this
         // arm a Set reaches no handler and falls to the leaf below.
         this.visitSet(object);
+      } else if (temporalTag(object) !== null) {
+        this.visitTemporal(object);
       } else if (object instanceof Node) {
         super.visit(object);
       } else if (this.isActiveModelAttribute(object)) {
@@ -513,9 +524,8 @@ export class Dot extends Visitor {
       } else if (this.isHash(object)) {
         this.visitHash(object as Record<string, unknown>);
       } else {
-        // Unknown non-Node object — render as a leaf with its String form
-        // so unfamiliar value classes don't crash the visitor.
-        this.visitString(object);
+        // visitor.rb:39 — no ancestor answered the dispatch.
+        throw new TypeError(`Cannot visit ${this.classNameOf(object)}`);
       }
     });
     return undefined;
@@ -603,6 +613,24 @@ export class Dot extends Visitor {
     this.visitEdge(o, "hints");
   }
 
+  /**
+   * Temporal is this codebase's Time/Date analogue, so a Temporal value has a
+   * visitable Rails ancestor (`visit_Date` / `visit_DateTime` / `visit_Time`)
+   * and must route there rather than falling through to the TypeError.
+   */
+  private visitTemporal(o: unknown): void {
+    switch (temporalTag(o)) {
+      case "Temporal.PlainDate":
+        this.visitDate(o);
+        break;
+      case "Temporal.PlainDateTime":
+        this.visitDateTime(o);
+        break;
+      default:
+        this.visitTime(o);
+    }
+  }
+
   private isPrimitive(o: unknown): boolean {
     if (o === null || o === undefined) return true;
     const t = typeof o;
@@ -688,6 +716,16 @@ export class Dot extends Visitor {
     if (typeof o === "symbol") return "Symbol";
     // boundary: legacy JS Date values stringify to Rails' `Time` class name.
     if (o instanceof Date) return "Time";
+    switch (temporalTag(o)) {
+      case null:
+        break;
+      case "Temporal.PlainDate":
+        return "Date";
+      case "Temporal.PlainDateTime":
+        return "DateTime";
+      default:
+        return "Time";
+    }
     if (this.isHash(o)) return "Hash";
     const ctor = (o as { constructor?: { name?: string } }).constructor;
     return ctor?.name ?? "Object";

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -7,13 +7,23 @@ import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 
 type AppendableCollector = { append(s: string): unknown; value: string };
 
-// Temporal types carry a `Temporal.X` Symbol.toStringTag; matching on it keeps
-// the check structural rather than importing the namespace into arel (same
-// approach as to-sql.ts).
-function temporalTag(v: unknown): string | null {
+/**
+ * The Ruby class a Temporal value stands in for, or `null` if `v` isn't one.
+ * Temporal is this codebase's Time/Date analogue, so these values have a
+ * visitable Rails ancestor (`visit_Date` / `visit_DateTime` / `visit_Time`,
+ * dot.rb:200-202) and must not fall through to `visit`'s TypeError.
+ *
+ * Matched on `Temporal.X`'s `Symbol.toStringTag` rather than `instanceof` so
+ * the check stays structural and the namespace stays out of arel's imports —
+ * the same approach to-sql.ts uses.
+ */
+function temporalClassName(v: unknown): "Date" | "DateTime" | "Time" | null {
   if (typeof v !== "object" || v === null) return null;
   const tag = (v as Record<symbol, unknown>)[Symbol.toStringTag];
-  return typeof tag === "string" && tag.startsWith("Temporal.") ? tag : null;
+  if (typeof tag !== "string" || !tag.startsWith("Temporal.")) return null;
+  if (tag === "Temporal.PlainDate") return "Date";
+  if (tag === "Temporal.PlainDateTime") return "DateTime";
+  return "Time";
 }
 
 function isAppendableCollector(c: unknown): c is AppendableCollector {
@@ -503,6 +513,7 @@ export class Dot extends Visitor {
       this.seen.set(seenKey, node);
     }
     this.nodes.push(node);
+    const temporalClass = temporalClassName(object);
     this.withNode(node, () => {
       if (this.isPrimitive(object)) {
         this.visitString(object);
@@ -512,8 +523,12 @@ export class Dot extends Visitor {
         // Rails: `alias :visit_Set :visit_Array` (dot.rb:231). Without this
         // arm a Set reaches no handler and falls to the leaf below.
         this.visitSet(object);
-      } else if (temporalTag(object) !== null) {
-        this.visitTemporal(object);
+      } else if (temporalClass === "Date") {
+        this.visitDate(object);
+      } else if (temporalClass === "DateTime") {
+        this.visitDateTime(object);
+      } else if (temporalClass !== null) {
+        this.visitTime(object);
       } else if (object instanceof Node) {
         super.visit(object);
       } else if (this.isActiveModelAttribute(object)) {
@@ -613,24 +628,6 @@ export class Dot extends Visitor {
     this.visitEdge(o, "hints");
   }
 
-  /**
-   * Temporal is this codebase's Time/Date analogue, so a Temporal value has a
-   * visitable Rails ancestor (`visit_Date` / `visit_DateTime` / `visit_Time`)
-   * and must route there rather than falling through to the TypeError.
-   */
-  private visitTemporal(o: unknown): void {
-    switch (temporalTag(o)) {
-      case "Temporal.PlainDate":
-        this.visitDate(o);
-        break;
-      case "Temporal.PlainDateTime":
-        this.visitDateTime(o);
-        break;
-      default:
-        this.visitTime(o);
-    }
-  }
-
   private isPrimitive(o: unknown): boolean {
     if (o === null || o === undefined) return true;
     const t = typeof o;
@@ -716,16 +713,8 @@ export class Dot extends Visitor {
     if (typeof o === "symbol") return "Symbol";
     // boundary: legacy JS Date values stringify to Rails' `Time` class name.
     if (o instanceof Date) return "Time";
-    switch (temporalTag(o)) {
-      case null:
-        break;
-      case "Temporal.PlainDate":
-        return "Date";
-      case "Temporal.PlainDateTime":
-        return "DateTime";
-      default:
-        return "Time";
-    }
+    const temporalClass = temporalClassName(o);
+    if (temporalClass) return temporalClass;
     if (this.isHash(o)) return "Hash";
     const ctor = (o as { constructor?: { name?: string } }).constructor;
     return ctor?.name ?? "Object";

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -4,26 +4,33 @@ import { Table } from "../table.js";
 import { Visitor, type NodeCtor } from "./visitor.js";
 import { PlainString } from "../collectors/plain-string.js";
 import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
+import { temporalTag } from "../temporal-tag.js";
 
 type AppendableCollector = { append(s: string): unknown; value: string };
 
 /**
- * The Ruby class a Temporal value stands in for, or `null` if `v` isn't one.
- * Temporal is this codebase's Time/Date analogue, so these values have a
- * visitable Rails ancestor (`visit_Date` / `visit_DateTime` / `visit_Time`,
- * dot.rb:200-202) and must not fall through to `visit`'s TypeError.
+ * The Ruby class each Temporal type stands in for. Temporal is this codebase's
+ * Time/Date analogue, so these values have a visitable Rails ancestor
+ * (`visit_Date` / `visit_DateTime` / `visit_Time`, dot.rb:200-202) and must not
+ * fall through to `visit`'s TypeError.
  *
- * Matched on `Temporal.X`'s `Symbol.toStringTag` rather than `instanceof` so
- * the check stays structural and the namespace stays out of arel's imports —
- * the same approach to-sql.ts uses.
+ * Deliberately a whitelist, not a `startsWith("Temporal.")` catch-all: the
+ * Temporal types absent here (`Duration`, `PlainYearMonth`, `PlainMonthDay`)
+ * have NO visitable Rails ancestor — dot.rb defines no visitor for
+ * `ActiveSupport::Duration`, which is a plain `Object` subclass rather than a
+ * `Numeric` — so Rails raises on them at visitor.rb:39 and so must we.
  */
+const TEMPORAL_CLASS_NAMES: Readonly<Record<string, "Date" | "DateTime" | "Time">> = {
+  "Temporal.PlainDate": "Date",
+  "Temporal.PlainDateTime": "DateTime",
+  "Temporal.Instant": "Time",
+  "Temporal.ZonedDateTime": "Time",
+  "Temporal.PlainTime": "Time",
+};
+
 function temporalClassName(v: unknown): "Date" | "DateTime" | "Time" | null {
-  if (typeof v !== "object" || v === null) return null;
-  const tag = (v as Record<symbol, unknown>)[Symbol.toStringTag];
-  if (typeof tag !== "string" || !tag.startsWith("Temporal.")) return null;
-  if (tag === "Temporal.PlainDate") return "Date";
-  if (tag === "Temporal.PlainDateTime") return "DateTime";
-  return "Time";
+  const tag = temporalTag(v);
+  return tag === null ? null : (TEMPORAL_CLASS_NAMES[tag] ?? null);
 }
 
 function isAppendableCollector(c: unknown): c is AppendableCollector {

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -16,6 +16,7 @@ import { UnsupportedVisitError, NotImplementedError, BindError } from "../errors
 export { UnsupportedVisitError };
 
 import { defaultQuoter } from "./default-quoter.js";
+import { temporalTag } from "../temporal-tag.js";
 export type { ArelConnection } from "./connection.js";
 import type { ArelConnection } from "./connection.js";
 
@@ -74,14 +75,6 @@ function isPlainObject(v: unknown): boolean {
   if (typeof v !== "object" || v === null) return false;
   const proto = Object.getPrototypeOf(v);
   return proto === Object.prototype || proto === null;
-}
-
-// Temporal types carry a `Temporal.X` Symbol.toStringTag; matching on it keeps
-// the check structural rather than importing the namespace into arel.
-function temporalTag(v: unknown): string | null {
-  if (typeof v !== "object" || v === null) return null;
-  const tag = (v as Record<symbol, unknown>)[Symbol.toStringTag];
-  return typeof tag === "string" && tag.startsWith("Temporal.") ? tag : null;
 }
 
 // The analogue of Ruby's Date, which Rails aliases to `unsupported`


### PR DESCRIPTION
Rails's `Arel::Visitors::Visitor#visit` walks `object.class.ancestors` for a visitable superclass and raises when none answers ([visitor.rb:39](https://github.com/rails/rails/blob/main/activerecord/lib/arel/visitors/visitor.rb#L39)):

```ruby
raise(TypeError, "Cannot visit #{object.class}") unless superklass
```

Trails' `Dot#visit` instead rendered any unknown non-Node object as a leaf via `visitString`, so `Dot.compile(new Money())` emitted `$5` where Rails raises `TypeError: Cannot visit Money`. PR #4880 removed the test that pinned the leaf behaviour but left the fallback in place.

## What changed

The final `else` in `Dot#visit` now raises `TypeError` with Rails' message. The old `dot.test.ts` note ("Dot must not raise `UnsupportedVisitError` on a class instance the dispatch table didn't know about") is honoured in spirit — Rails does raise here, just a `TypeError` rather than Arel's `UnsupportedVisitError`, so that is the error type surfaced.

## Temporal values keep their leaf

Removing the fallback would have wrongly escalated Temporal values into crashes: Temporal is this codebase's Time analogue, so they have a visitable Rails ancestor and must reach `visit_Date` / `visit_DateTime` / `visit_Time` (the `visit_String` aliases at dot.rb:200-202). Those Rails-named visitors were previously unreachable dead code; they are now wired up.

The mapping is a **whitelist of five tags**, not a `startsWith("Temporal.")` catch-all. `Duration` / `PlainYearMonth` / `PlainMonthDay` have no visitable Rails ancestor — `dot.rb` defines no visitor for `ActiveSupport::Duration`, which is a plain `Object` subclass rather than a `Numeric` — so Rails raises on them at visitor.rb:39 and so do we. A catch-all would have re-introduced, for those three types, exactly the invented leaf this PR removes. Pinned by a test.

## Rebased onto #4883 and #4880

Both sibling PRs landed in `Dot#visit` while this was in review, and both interact with it:

- **#4883** (`Dot` routes derived records to `visitHash`) anticipated this story explicitly — its class-instance arm "falls to the unknown-object arm that the sibling story covers". Its `isHash` prototype-walk now sits directly before this `else`, so class instances reach the raise exactly as it predicted. It also added the `Set` → `visit_Array` arm that an earlier revision of this PR carried, so **that arm and its test are dropped here** — #4883 owns them.
- #4883's test `a class instance is not a Hash and keeps its own class name` asserted the *leaf* rendering, which only existed because of the fallback. Its intent — a class instance must not route to the Hash arm — is still exactly right, and the raise proves it more directly, with the class name still observable in `Cannot visit Config`. Name kept verbatim; only the assertion is adapted.
- **#4880** converged the Attribute arm to `instanceof ModelAttribute`; it remains after the `Node` arm, unaffected.

### One behaviour change worth flagging

`visitArelNodesHomogeneousIn` walks a `type` edge holding an ActiveModel `Type` instance — a non-Node class instance that used to render as a leaf and now raises. **This matches Rails**: `dot.rb` has no `visit_ActiveModel_Type_*`, no `visit_Object` catch-all, and `Type::Value`'s ancestors answer nothing, so Rails raises `TypeError` on the same graph. Rails' `dot_test.rb` has no HomogeneousIn coverage, so nothing pins it either way. Porting the sharp edge faithfully rather than keeping the trails-invented leaf that hid it.

`Dot` is diagnostic-only (`tree-manager#toDot` plus tests) — no production caller relied on the leaf.

## Shared Temporal tag reader

`dot.ts` and `to-sql.ts` had duplicate copies of the `Symbol.toStringTag` reader. A structural check defeats its own purpose if two copies can drift, so it now lives in `temporal-tag.ts` and both import it. Each caller still maps the tag to its own Rails analogue. `temporal-tag.ts` is a trails-invented module in the shape of the existing `quote-array.ts`, and does not disturb api:compare's file mapping (`files: 69/69`, unchanged).

## Verification

- **api:compare non-negative**: `visitors/dot.rb → dot.ts 60/60 (100%) ✓`, `visitors/to_sql.rb → to-sql.ts 135/135 (100%) ✓`; arel overall `938/938 (100%)`, `files: 69/69`. No ported method removed or renamed.
- **test:compare non-negative**: net +3 TS-only tests (Rails' `dot_test.rb` has no counterpart for the raise); no matched test lost, no test renamed.
- Full arel package green: 72 files, 1540 tests — including #4883's and #4880's suites. `tsc --noEmit` clean for arel; eslint + prettier clean.
- No stubs added — this removes dead code by making the Rails-named Date/DateTime/Time visitors reachable.

Closes-story: arel-dot-unknown-class-leaf-fallback-should-raise