### PR TITLE
fix(arel): Dot dispatches ActiveModel::Attribute by instanceof, not duck-typing

### DIFF
--- a/packages/arel/src/visitors/dot.test.ts
+++ b/packages/arel/src/visitors/dot.test.ts
@@ -10,6 +10,7 @@ import {
   Visitors,
 } from "../index.js";
 import { DotNode } from "./dot.js";
+import { Attribute as AMAttribute, ValueType } from "@blazetrails/activemodel";
 
 describe("TestDot", () => {
   const users = new Table("users");
@@ -371,7 +372,18 @@ describe("TestDot", () => {
       const bind = new Nodes.BindParam(fakeAttribute);
       const out = dot.compile(bind);
       expect(out).toContain("BindParam");
-      // visitActiveModelAttribute walks valueBeforeTypeCast.
+      // A bare object literal is a Hash in Rails, not an ActiveModel::Attribute:
+      // Dot#visit dispatches on `o.is_a?(ActiveModel::Attribute)`, so carrying a
+      // `valueBeforeTypeCast` key does not buy the attribute arm.
+      expect(out).toMatch(/\[label="pair_0"\]/);
+      expect(out).toContain("valueBeforeTypeCast");
+      expect(out).toContain("42");
+    });
+
+    it("a real ActiveModel::Attribute takes the attribute arm", () => {
+      const bind = new Nodes.BindParam(AMAttribute.fromDatabase("id", 42, new ValueType()));
+      const out = dot.compile(bind);
+      expect(out).toContain("BindParam");
       expect(out).toMatch(/-> \d+ \[label="valueBeforeTypeCast"\];/);
       expect(out).toContain("42");
     });

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -3,6 +3,7 @@ import * as Nodes from "../nodes/index.js";
 import { Table } from "../table.js";
 import { Visitor, type NodeCtor } from "./visitor.js";
 import { PlainString } from "../collectors/plain-string.js";
+import { Attribute as AMAttribute } from "@blazetrails/activemodel";
 
 type AppendableCollector = { append(s: string): unknown; value: string };
 
@@ -501,10 +502,8 @@ export class Dot extends Visitor {
       } else if (object instanceof Node) {
         super.visit(object);
       } else if (this.isActiveModelAttribute(object)) {
-        // Mirrors Rails' `visit_ActiveModel_Attribute`. Checked after the
-        // Node branch — Trails' BindParam *also* exposes a
-        // `valueBeforeTypeCast` method via NodeExpression duck-typing, so
-        // we only fall here for non-Node value objects.
+        // Mirrors Rails' `visit_ActiveModel_Attribute`, reached in Rails via
+        // Visitor#visit's ancestor walk (`o.is_a?(ActiveModel::Attribute)`).
         this.visitActiveModelAttribute(object as { valueBeforeTypeCast?: unknown });
       } else if (this.isPlainObject(object)) {
         this.visitHash(object as Record<string, unknown>);
@@ -614,9 +613,7 @@ export class Dot extends Visitor {
   }
 
   private isActiveModelAttribute(o: unknown): boolean {
-    return (
-      typeof o === "object" && o !== null && "valueBeforeTypeCast" in (o as Record<string, unknown>)
-    );
+    return o instanceof AMAttribute;
   }
 
   private isPlainObject(o: unknown): boolean {

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -382,7 +382,7 @@ export class Dot extends Visitor {
     this.visitEdge(o, "value");
   }
 
-  protected visitActiveModelAttribute(o: { valueBeforeTypeCast?: unknown }): void {
+  protected visitActiveModelAttribute(o: AMAttribute): void {
     this.visitEdge(o, "valueBeforeTypeCast");
   }
 
@@ -504,7 +504,7 @@ export class Dot extends Visitor {
       } else if (this.isActiveModelAttribute(object)) {
         // Mirrors Rails' `visit_ActiveModel_Attribute`, reached in Rails via
         // Visitor#visit's ancestor walk (`o.is_a?(ActiveModel::Attribute)`).
-        this.visitActiveModelAttribute(object as { valueBeforeTypeCast?: unknown });
+        this.visitActiveModelAttribute(object);
       } else if (this.isPlainObject(object)) {
         this.visitHash(object as Record<string, unknown>);
       } else {
@@ -612,7 +612,7 @@ export class Dot extends Visitor {
     );
   }
 
-  private isActiveModelAttribute(o: unknown): boolean {
+  private isActiveModelAttribute(o: unknown): o is AMAttribute {
     return o instanceof AMAttribute;
   }
 


### PR DESCRIPTION
Rails's `Dot#visit` reaches `visit_ActiveModel_Attribute` (`dot.rb:216-218`) through `Visitor#visit`'s ancestor walk (`visitor.rb:36-41`) — i.e. via `o.is_a?(ActiveModel::Attribute)`, a class check.

Trails duck-typed on `"valueBeforeTypeCast" in o`. Because `in` reaches through the prototype chain, any object literal (or prototype-derived record) carrying that key took the attribute arm; in Rails such a value is a Hash. Own-key scoping is not an option — a real `ActiveModel::Attribute` exposes `valueBeforeTypeCast` as a **prototype getter** (`packages/activemodel/src/attribute.ts:60`), so `Object.hasOwn` is `false` for every real attribute.

`isActiveModelAttribute` now uses `instanceof AMAttribute`.

## No cycle

`arel` already depends on `@blazetrails/activemodel` (`packages/arel/package.json`) and already imports `Attribute as AMAttribute` in `packages/arel/src/nodes/homogeneous-in.ts:3`. `activemodel` does not import `arel` (verified by grep over `packages/activemodel/`). Topological build of `arel` + deps is clean.

## Tests

The TS-only extra "non-Node bind values (ActiveModel::Attribute shape) don't crash" passes a plain object literal `{ valueBeforeTypeCast: 42 }` and previously asserted the attribute arm. Under Rails semantics that literal is a Hash, so the assertions now pin the Hash arm — the test's original regression intent (an unknown non-Node value must not crash the visitor) is preserved, and the name is unchanged. Added "a real ActiveModel::Attribute takes the attribute arm" to keep direct coverage of the attribute path.

The inherited-key pin named in the story ("an inherited valueBeforeTypeCast takes the attribute arm, not the Hash arm") comes from #4883, which is not yet merged — it does not exist on `main`, so there was nothing to reconcile for it here.

`pnpm vitest run packages/arel/src/visitors/` — 463 passed.

Closes-story: arel-dot-activemodel-attribute-duck-type-vs-is-a

---

## Review responses

**1. `instanceof` across a package boundary / duplicate module copies.** Ruled out, and not a new hazard class either way. `arel` depends on activemodel as `workspace:*` (`packages/arel/package.json`), so pnpm symlinks the single `packages/activemodel` — a search for any second installed copy returns nothing. Cross-package `instanceof Attribute` is already load-bearing well beyond the `statement-cache.ts:143` precedent: `statement-cache.ts:66,155,258`, `log-subscriber.ts:214,239`, and `explain.ts:68` all do it across the same boundary, several on the hot query path. If a duplicate copy were ever loaded, those would break first and harder; `dot.ts` is a debug visitor.

The `Symbol.for` at `attribute.ts:6-9` points at a *different* concern, not this one. It guards `UNINITIALIZED_ORIGINAL_VALUE`, a **sentinel value** compared by `===`. A module-level sentinel has no identity anchor other than itself, so it needs the global symbol registry. A class reached by import resolves through the same module graph as the values it constructs — the sentinel's problem doesn't generalize to the class check. Adopting a branded-symbol scheme for `Attribute` here would also diverge from Rails' plain `is_a?` and from the six existing sites above.

**2. Final `else` renders unknown non-Node objects via `visitString` instead of raising `TypeError`.** Agreed, and agreed it's out of scope here. Already owned: story `arel-dot-unknown-class-leaf-fallback-should-raise` (RFC 0023, in-progress) cites `visitor.rb:38` and names this exact `else` arm. Not re-filing.

**3. `classNameOf` emits `"FromDatabase"` where Rails' `o.class.name` gives `"ActiveModel::Attribute::FromDatabase"`.** Seen, and confirmed pre-existing (`classNameOf` returns the bare JS ctor name). Already owned by story `arel-dot-hash-subclass-dispatch-and-classname` (= #4883), whose acceptance criteria include "Assess `classNameOf` emitting `"Object"` vs Rails' `"Hash"` — converge". The new test deliberately does not assert the node name, so it neither pins nor obstructs that convergence.

**Note for #4883:** it lands the pin "an inherited `valueBeforeTypeCast` takes the attribute arm, not the Hash arm", which asserts the pre-`instanceof` behaviour. Whichever of the two merges second must flip that assertion to the Hash arm.
