### PR TITLE
fix(arel): Attribute#in/#notIn build quotedNode for a scalar, like Rails

### DIFF
--- a/packages/arel/src/attributes/attribute.test.ts
+++ b/packages/arel/src/attributes/attribute.test.ts
@@ -749,24 +749,6 @@ describe("AttributeTest", () => {
 
   describe("#not_in", () => {
     it("can be constructed with a subquery", () => {
-      const subquery = users.project(users.get("id"));
-      const node = users.get("id").in(subquery);
-      const visitor = new Visitors.ToSql();
-      expect(visitor.compile(node)).toBe('"users"."id" IN (SELECT "users"."id" FROM "users")');
-    });
-
-    it("can be constructed with a list", () => {
-      const node = users.get("id").in([1, 2, 3]);
-      const visitor = new Visitors.ToSql();
-      expect(visitor.compile(node)).toBe('"users"."id" IN (1, 2, 3)');
-    });
-
-    it("can be constructed with a random object", () => {
-      const node = users.get("id").notIn(["random_thing"] as unknown[]);
-      expect(node).toBeInstanceOf(Nodes.NotIn);
-    });
-
-    it("can be constructed with a subquery", () => {
       const mgr = users.project(users.get("id"));
       const node = users.get("id").notIn(mgr);
       expect(node).toBeInstanceOf(Nodes.NotIn);
@@ -778,8 +760,11 @@ describe("AttributeTest", () => {
     });
 
     it("can be constructed with a random object", () => {
-      const node = users.get("id").notIn([42]);
-      expect(node).toBeInstanceOf(Nodes.NotIn);
+      const attribute = users.get("id");
+      const randomObject = {};
+      const node = attribute.notIn(randomObject);
+
+      expect(node).toEqual(new Nodes.NotIn(attribute, new Nodes.Casted(randomObject, attribute)));
     });
   });
 
@@ -792,18 +777,25 @@ describe("AttributeTest", () => {
 
     it("can be constructed with a subquery", () => {
       const mgr = users.project(users.get("id"));
-      const node = users.get("id").in(mgr);
-      expect(node).toBeInstanceOf(Nodes.In);
+      const attribute = users.get("id");
+      const node = attribute.in(mgr);
+
+      expect(node).toEqual(new Nodes.In(attribute, mgr.ast));
+      expect(visitor.compile(node)).toBe('"users"."id" IN (SELECT "users"."id" FROM "users")');
     });
 
     it("can be constructed with a list", () => {
       const node = users.get("id").in([1, 2, 3]);
       expect(node).toBeInstanceOf(Nodes.In);
+      expect(visitor.compile(node)).toBe('"users"."id" IN (1, 2, 3)');
     });
 
     it("can be constructed with a random object", () => {
-      const node = users.get("id").in([42]);
-      expect(node).toBeInstanceOf(Nodes.In);
+      const attribute = users.get("id");
+      const randomObject = {};
+      const node = attribute.in(randomObject);
+
+      expect(node).toEqual(new Nodes.In(attribute, new Nodes.Casted(randomObject, attribute)));
     });
   });
 

--- a/packages/arel/src/attributes/attribute.trails.test.ts
+++ b/packages/arel/src/attributes/attribute.trails.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { Table, Nodes, Visitors } from "../index.js";
+
+// TS-only coverage for the `when Enumerable` arm of Attribute#in / #notIn
+// (arel/predications.rb:65-74, 112-121). Ruby's Enumerable spans Set, Hash and
+// Range as well as Array, so the port matches any JS iterable rather than
+// Array.isArray. Rails has no equivalent test because in Ruby these are all
+// simply Enumerable; the distinction only exists on this side of the port.
+describe("AttributeTest (trails)", () => {
+  const users = new Table("users");
+  const visitor = new Visitors.ToSql();
+
+  describe("#in", () => {
+    it("expands a Set through the Enumerable arm", () => {
+      const node = users.get("id").in(new Set([1, 2, 3]));
+      expect(visitor.compile(node)).toBe('"users"."id" IN (1, 2, 3)');
+    });
+
+    it("expands a generator through the Enumerable arm", () => {
+      function* ids(): Generator<number> {
+        yield 1;
+        yield 2;
+      }
+      const node = users.get("id").in(ids());
+      expect(visitor.compile(node)).toBe('"users"."id" IN (1, 2)');
+    });
+
+    it("casts a non-iterable object through the scalar arm", () => {
+      const attribute = users.get("id");
+      const randomObject = {};
+      expect(attribute.in(randomObject)).toEqual(
+        new Nodes.In(attribute, new Nodes.Casted(randomObject, attribute)),
+      );
+    });
+
+    it("casts a string through the scalar arm, since Ruby's String is not Enumerable", () => {
+      const attribute = users.get("id");
+      expect(attribute.in("abc")).toEqual(
+        new Nodes.In(attribute, new Nodes.Casted("abc", attribute)),
+      );
+    });
+  });
+
+  describe("#not_in", () => {
+    it("expands a Set through the Enumerable arm", () => {
+      const node = users.get("id").notIn(new Set([1, 2]));
+      expect(visitor.compile(node)).toBe('"users"."id" NOT IN (1, 2)');
+    });
+
+    it("casts a string through the scalar arm, since Ruby's String is not Enumerable", () => {
+      const attribute = users.get("id");
+      expect(attribute.notIn("abc")).toEqual(
+        new Nodes.NotIn(attribute, new Nodes.Casted("abc", attribute)),
+      );
+    });
+  });
+});

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -71,6 +71,41 @@ function groupedAll(nodes: Node[]): Grouping {
 }
 
 /**
+ * Stands in for Rails' `when Arel::SelectManager` arm (predications.rb:65-74
+ * for `in`, 112-121 for `not_in`), duck-typed on the `ast` reader as
+ * `buildQuoted` matches managers (casted.ts:41-44) — a structural check keeps
+ * the runtime import out. The `instanceof Node` half matters: a bare
+ * `"ast" in value` also admits `{ ast: undefined }`, which would build
+ * `In(this, undefined)`.
+ */
+function isSelectManagerLike(value: unknown): value is { ast: Node } {
+  return (
+    typeof value === "object" && value !== null && (value as { ast?: unknown }).ast instanceof Node
+  );
+}
+
+/**
+ * Stands in for Rails' `when Enumerable` arm. Ruby's `Enumerable` covers Set,
+ * Hash and Range as well as Array, so matching only `Array.isArray` would drop
+ * a Set/Map/generator into the scalar arm and silently cast the container
+ * itself.
+ *
+ * Two deliberate edges:
+ * - JS strings are iterable, but Ruby's String is NOT Enumerable, so they must
+ *   reach `quoted_node`. `typeof value === "object"` excludes them.
+ * - A plain JS object is not iterable, so it reaches `quoted_node` — matching
+ *   `Object.new` at attribute_test.rb:747-757. Note this DIVERGES for a Ruby
+ *   Hash, which IS Enumerable: Rails' `in({a: 1})` takes the `quoted_array`
+ *   arm and expands to `[Casted([:a, 1], self)]`, where this casts the object
+ *   whole. Ruby's Hash maps to a JS Map (iterable, so it expands correctly);
+ *   an object literal is the closer analogue of `Object.new`, so the scalar
+ *   arm is the better of the two readings, not an exact one.
+ */
+function isEnumerable(value: unknown): value is Iterable<unknown> {
+  return typeof value === "object" && value !== null && Symbol.iterator in value;
+}
+
+/**
  * Attribute — represents a column on a table.
  *
  * Mirrors: Arel::Attributes::Attribute
@@ -195,18 +230,17 @@ export class Attribute extends Node {
     return new NotRegexp(this, this.quotedNode(pattern), caseSensitive);
   }
 
-  in(values: unknown[] | { ast: Node }): In {
-    if (!Array.isArray(values) && values && typeof values === "object" && "ast" in values) {
-      return new In(this, (values as { ast: Node }).ast);
-    }
-    return new In(this, this.quotedArray(values) as unknown as Node);
+  in(values: unknown): In {
+    if (isSelectManagerLike(values)) return new In(this, values.ast);
+    if (isEnumerable(values)) return new In(this, this.quotedArray([...values]) as unknown as Node);
+    return new In(this, this.quotedNode(values));
   }
 
-  notIn(values: unknown[] | { ast: Node }): NotIn {
-    if (!Array.isArray(values) && values && typeof values === "object" && "ast" in values) {
-      return new NotIn(this, (values as { ast: Node }).ast);
-    }
-    return new NotIn(this, this.quotedArray(values) as unknown as Node);
+  notIn(values: unknown): NotIn {
+    if (isSelectManagerLike(values)) return new NotIn(this, values.ast);
+    if (isEnumerable(values))
+      return new NotIn(this, this.quotedArray([...values]) as unknown as Node);
+    return new NotIn(this, this.quotedNode(values));
   }
   between(range: [unknown, unknown]): Node;
   between(begin: unknown, end: unknown, excludeEnd?: boolean): Node;

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -42814,13 +42814,6 @@
   {
     "package": "arel",
     "tsFile": "attributes/attribute.ts",
-    "rubyName": "in",
-    "call": "quoted_node",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "attributes/attribute.ts",
     "rubyName": "in_all",
     "call": "grouping_all",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -42963,13 +42956,6 @@
     "tsFile": "attributes/attribute.ts",
     "rubyName": "not_eq_any",
     "call": "grouping_any",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "attributes/attribute.ts",
-    "rubyName": "not_in",
-    "call": "quoted_node",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {


### PR DESCRIPTION
Rails `arel/predications.rb:65-74` (`in`) and `112-121` (`not_in`) dispatch on three arms — `SelectManager`, `Enumerable`, and an `else` that builds `In(self, quoted_node(other))`. Trails implemented only the first two, and its signature (`in(values: unknown[] | { ast: Node })`) had no room for the third, so a scalar fell past both guards into `quotedArray` and raised `TypeError: values.map is not a function`. Rails instead builds `In(self, Casted(scalar, self))`, casting through the column.

This adds the `else` arm to both methods and widens the parameter to `unknown` (Rails takes any object here).

## Rebased onto #4881

#4881 landed `quotedArray` in the meantime and touched these same lines. Resolved in its favour: the Enumerable arm now routes through `this.quotedArray(...)`, so list elements are `Casted` rather than bare `Quoted` — the gap this PR previously flagged as out of scope is now closed upstream, and no longer needs a note. #4881's three type-cast tests are preserved verbatim.

## Arm matching

Both guards are duck-typed to keep runtime imports out, mirroring how `buildQuoted` already matches managers:

- **SelectManager** — `value.ast instanceof Node`, the same guard as `casted.ts:41-44`. A bare `"ast" in value` would also admit `{ ast: undefined }` and build `In(this, undefined)`.
- **Enumerable** — any JS iterable, not just `Array.isArray`. Ruby's `Enumerable` spans Set, Hash and Range as well as Array, so an `Array.isArray` check would drop a Set/Map/generator into the scalar arm and cast the *container* — a wrong AST where the old code at least threw loudly.

### Known divergence: Ruby Hash

JS strings are iterable but Ruby's `String` is not Enumerable, so they reach `quoted_node` — correct. A plain JS object is not iterable and also reaches `quoted_node`, which matches `Object.new` at `attribute_test.rb:747-757` but **diverges for a Ruby Hash**, which *is* Enumerable: Rails' `in({a: 1})` takes the `quoted_array` arm and expands to `[Casted([:a, 1], self)]`, where this casts the object whole.

Ruby's Hash maps to a JS `Map` (iterable, so it expands correctly); an object literal is the closer analogue of `Object.new`. The scalar arm is the better of the two readings, not an exact one — documented at the guard rather than asserted correct.

## Test structure

The three `can be constructed with a random object` tests were each passing an **array** to work around the missing arm, so they never exercised it. They now mirror Rails verbatim (`attribute_test.rb:747-757`, `984-993`), asserting `Casted(randomObject, attribute)` rather than a bare `Quoted`. Verified they bite: reverting the implementation makes all three fail with the exact `values.map is not a function` TypeError.

`describe("#not_in")` also held six tests — two mis-nested `#in` tests (calling `.in()`, duplicating `describe("#in")`) plus a random-object slot. Rails has exactly one `describe "#in"` (`attribute_test.rb:721`) and one `describe "#not_in"` (`946`), so that trio is deleted rather than split into a second block. Their `compile()` assertions were stronger than the `#in` block's bare `instanceof` and existed nowhere else, so they are folded into `describe("#in")` first — no coverage lost, and the subquery test now also asserts Rails' `must_equal In.new(attribute, mgr.ast)`.

`attribute.trails.test.ts` carries the iterable coverage (Set, generator, string, plain object). It is trails-only because in Ruby these are all simply `Enumerable` — the distinction exists only on this side of the port.

## Checks (post-rebase)

- `packages/arel` — 1530 tests pass (72 files).
- `pnpm api:calls:wide` — green (6848 baselined). The two now-legitimate `attributes/attribute.ts in|not_in → quoted_node` ratchet entries are deleted by hand; the ratchet only shrinks, nothing reseeded.
- api:compare / test:compare deltas non-negative.

Closes-story: arel-in-not-in-scalar-arm-quoted-node
