### PR TITLE
fix(arel): Predications#unboundable? duck-types the protocol; infinite? yields the sign

### DIFF
--- a/packages/activemodel/src/type/integer.test.ts
+++ b/packages/activemodel/src/type/integer.test.ts
@@ -35,9 +35,12 @@ describe("IntegerTest", () => {
   });
 
   it("casting nan and infinity", () => {
+    // Rails integer_test.rb:35-39 asserts nil for BOTH: `cast_value` is
+    // `value.to_i rescue nil` (integer.rb:90) and Float#to_i raises
+    // FloatDomainError for NaN and ±Infinity alike.
     expect(type.cast(NaN)).toBeNull();
-    expect(type.cast(Infinity)).toBe(Infinity);
-    expect(type.cast(-Infinity)).toBe(-Infinity);
+    expect(type.cast(Infinity)).toBeNull();
+    expect(type.cast(-Infinity)).toBeNull();
   });
 
   it("casting booleans for database", () => {

--- a/packages/activemodel/src/type/integer.test.ts
+++ b/packages/activemodel/src/type/integer.test.ts
@@ -171,6 +171,22 @@ describe("IntegerTest", () => {
     expect(int8.isSerializable(-(2n ** 63n) - 1n)).toBe(false);
   });
 
+  it("serializable? casts before the range check, so nan and infinity are in range", () => {
+    // integer.rb:74-80 opens with `cast_value = cast(value)`; `cast_value` is
+    // `to_i rescue nil` (integer.rb:90), so NaN/±Infinity cast to nil and
+    // `in_range?(nil)` is `!value` => true (integer.rb:86). Reading the raw value
+    // instead would answer false.
+    const type = new Types.IntegerType();
+    expect(type.isSerializable(Infinity)).toBe(true);
+    expect(type.isSerializable(-Infinity)).toBe(true);
+    expect(type.isSerializable(NaN)).toBe(true);
+    // A non-numeric string is `to_i`-able to nil here (Rails: "abc".to_i == 0),
+    // and either way it is in range — not out of it.
+    expect(type.isSerializable("abc")).toBe(true);
+    // Genuinely out-of-range values still answer false.
+    expect(type.isSerializable(2 ** 40)).toBe(false);
+  });
+
   it("serialize_cast_value enforces range", () => {
     const values = [1, "123", 0, -5, null];
     for (const v of values) {

--- a/packages/activemodel/src/type/integer.test.ts
+++ b/packages/activemodel/src/type/integer.test.ts
@@ -29,6 +29,13 @@ describe("IntegerTest", () => {
   });
 
   it("casting objects without to_i", () => {
+    // Rails integer_test.rb:30-32 asserts `assert_nil type.cast(::Object.new)`:
+    // Object has no `to_i`, so `to_i rescue nil` (integer.rb:90) yields nil.
+    expect(type.cast({})).toBeNull();
+    // Same case, the way it arises in JS: an object with no `toString` makes
+    // `String(value)` throw. `cast` must answer null, not raise — the rescue is
+    // scoped to the conversion in Rails.
+    expect(type.cast(Object.create(null))).toBeNull();
     // Objects without a numeric representation cast to null
     expect(type.cast("not_a_number")).toBeNull();
     expect(type.cast(undefined)).toBeNull();

--- a/packages/activemodel/src/type/integer.ts
+++ b/packages/activemodel/src/type/integer.ts
@@ -54,20 +54,11 @@ export class IntegerType extends NumericValueType {
     // `narrowBigInt`, keeping arbitrary precision, where `Number()` would
     // collapse `2n**63n` and `2n**63n-1n` onto the same float and let an
     // exactly-2^63 value test in-range on an 8-byte column (see `isInRange`).
-    // It also decides ±Infinity and NaN: `cast_value` is `to_i rescue nil`
-    // (integer.rb:90), so they cast to nil and `in_range?(nil)` is `!value` =>
-    // true. Casting here rather than trusting the caller keeps this predicate
-    // correct for a raw value, independent of whether the caller pre-cast.
-    let castValue: number | bigint | null;
-    try {
-      castValue = this.cast(value) as number | bigint | null;
-    } catch {
-      // The `rescue nil` in cast_value: a value that cannot be cast at all
-      // (e.g. a Symbol, whose `String()` throws) is nil in Rails, and
-      // `in_range?(nil)` is true.
-      return true;
-    }
-    return this.isInRange(castValue);
+    // It also decides ±Infinity, NaN and uncastable values: all are nil out of
+    // `castValue` (`to_i rescue nil`, integer.rb:90), and `in_range?(nil)` is
+    // `!value` => true. Casting here rather than trusting the caller keeps this
+    // predicate correct for a raw value, whether or not the caller pre-cast.
+    return this.isInRange(this.cast(value) as number | bigint | null);
   }
 
   /**
@@ -141,7 +132,19 @@ export class IntegerType extends NumericValueType {
     if (typeof value === "bigint") {
       return this.narrowBigInt(value);
     }
-    const parsed = parseInt(String(value), 10);
+    // The `rescue nil` of integer.rb:90 is scoped to the conversion itself, so
+    // `cast` answers nil — never raises — for a value with no numeric
+    // conversion. Ruby: `Object.new.to_i` raises NoMethodError (integer_test.rb:30-32
+    // asserts `assert_nil type.cast(::Object.new)`). Here: `String(value)` throws
+    // for an object with no `toString` (a null-prototype object, say). A Symbol is
+    // NOT that case — `String(sym)` returns "Symbol(x)", which parses to NaN => null.
+    let str: string;
+    try {
+      str = String(value);
+    } catch {
+      return null;
+    }
+    const parsed = parseInt(str, 10);
     return isNaN(parsed) ? null : parsed;
   }
 

--- a/packages/activemodel/src/type/integer.ts
+++ b/packages/activemodel/src/type/integer.ts
@@ -131,7 +131,11 @@ export class IntegerType extends NumericValueType {
    */
   protected castValue(value: unknown): number | null {
     if (typeof value === "number") {
-      if (isNaN(value)) return null;
+      // Mirrors integer.rb:90 — `value.to_i rescue nil`. Both NaN and ±Infinity
+      // raise FloatDomainError from Float#to_i, so Rails rescues them to nil;
+      // `isFinite` is exactly that domain. BigIntegerType#castValue already
+      // draws the same line.
+      if (!isFinite(value)) return null;
       return Math.trunc(value);
     }
     if (typeof value === "bigint") {

--- a/packages/activemodel/src/type/integer.ts
+++ b/packages/activemodel/src/type/integer.ts
@@ -48,26 +48,26 @@ export class IntegerType extends NumericValueType {
   }
 
   isSerializable(value: unknown): boolean {
-    if (value === null || value === undefined) return true;
-    // A BigInt is passed straight to the arbitrary-precision range check.
-    // Routing through `Number(value)` would collapse `2n**63n` and `2n**63n-1n`
-    // to the same float (9223372036854775808), so an exactly-2^63 value on an
-    // 8-byte column would wrongly test in-range — see `isInRange`.
-    if (typeof value === "bigint") return this.isInRange(value);
-    let num: number;
-    if (typeof value === "number") {
-      num = value;
-    } else {
-      // `Number(Symbol())` throws TypeError; catch so callers (e.g.
-      // Attribute.isSerializable) get `false` instead of an exception.
-      try {
-        num = Number(value);
-      } catch {
-        return false;
-      }
+    // Mirrors integer.rb:74-80 — `cast_value = cast(value)` then
+    // `in_range?(cast_value)`. The leading cast is load-bearing and must not be
+    // re-derived via `Number(value)`: `cast` routes a BigInt through
+    // `narrowBigInt`, keeping arbitrary precision, where `Number()` would
+    // collapse `2n**63n` and `2n**63n-1n` onto the same float and let an
+    // exactly-2^63 value test in-range on an 8-byte column (see `isInRange`).
+    // It also decides ±Infinity and NaN: `cast_value` is `to_i rescue nil`
+    // (integer.rb:90), so they cast to nil and `in_range?(nil)` is `!value` =>
+    // true. Casting here rather than trusting the caller keeps this predicate
+    // correct for a raw value, independent of whether the caller pre-cast.
+    let castValue: number | bigint | null;
+    try {
+      castValue = this.cast(value) as number | bigint | null;
+    } catch {
+      // The `rescue nil` in cast_value: a value that cannot be cast at all
+      // (e.g. a Symbol, whose `String()` throws) is nil in Rails, and
+      // `in_range?(nil)` is true.
+      return true;
     }
-    if (isNaN(num)) return false;
-    return this.isInRange(num);
+    return this.isInRange(castValue);
   }
 
   /**

--- a/packages/activerecord/src/relation/predicate-builder/range-handler.ts
+++ b/packages/activerecord/src/relation/predicate-builder/range-handler.ts
@@ -22,8 +22,8 @@ export class UnboundableBound {
     return this.sign;
   }
 
-  isInfinite(): null {
-    return null;
+  isInfinite(): false {
+    return false;
   }
 }
 

--- a/packages/activerecord/src/relation/predicate-builder/range-handler.ts
+++ b/packages/activerecord/src/relation/predicate-builder/range-handler.ts
@@ -12,8 +12,15 @@ import type { Range } from "../../connection-adapters/postgresql/oid/range.js";
  *
  * Trails threads only the out-of-range bounds through this sentinel — in-range
  * bounds stay as their plain cast values so ordinary ranges emit unchanged
- * SQL. `arel`'s `unboundableSign` / `isOpenEnded` recognise it via
- * `isUnboundable()`; it never reaches the visitor as a bind.
+ * SQL. `arel`'s `unboundableSign` recognises it via `isUnboundable()` (reached
+ * through `Predications#unboundable?` / `open_ended?`, which `between`
+ * dispatches on self); it never reaches the visitor as a bind.
+ *
+ * This class has no Rails counterpart: range_handler.rb:12-16 wraps BOTH bounds
+ * in `build_bind_attribute` and lets `QueryAttribute#unboundable?` answer.
+ * Converging is tracked by story
+ * `0023-surfaced-deviations/converge-range-handler-bind-attribute-bounds`, which
+ * deletes this class.
  */
 export class UnboundableBound {
   constructor(readonly sign: 1 | -1) {}

--- a/packages/activerecord/src/relation/query-attribute.test.ts
+++ b/packages/activerecord/src/relation/query-attribute.test.ts
@@ -81,9 +81,12 @@ describe("QueryAttribute", () => {
     expect(new QueryAttribute("x", 0, stringType).isNil()).toBe(false);
   });
 
-  it("isInfinite returns true for Infinity/-Infinity", () => {
-    expect(new QueryAttribute("x", Infinity, intType).isInfinite()).toBe(true);
-    expect(new QueryAttribute("x", -Infinity, intType).isInfinite()).toBe(true);
+  it("isInfinite returns the sign for Infinity/-Infinity", () => {
+    // Mirrors query_attribute.rb:42-44, whose `infinity?` yields `Float#infinite?`
+    // — 1 / -1 / nil, not a boolean. Arel's between reads the sign to pick which
+    // side of the range collapses; a boolean would make -Infinity look positive.
+    expect(new QueryAttribute("x", Infinity, intType).isInfinite()).toBe(1);
+    expect(new QueryAttribute("x", -Infinity, intType).isInfinite()).toBe(-1);
     expect(new QueryAttribute("x", 999, intType).isInfinite()).toBe(false);
   });
 
@@ -93,7 +96,7 @@ describe("QueryAttribute", () => {
       serialize: (_v: unknown) => Infinity,
     };
     const attr = new QueryAttribute("x", "anything", expandingType);
-    expect(attr.isInfinite()).toBe(true);
+    expect(attr.isInfinite()).toBe(1);
   });
 
   it("isInfinite handles Ruby-style duck-typed `infinite()` (nil for finite, 1/-1 for infinite)", () => {
@@ -102,8 +105,8 @@ describe("QueryAttribute", () => {
     const negativeInf = { infinite: () => -1 };
     const passthrough = { cast: (v: unknown) => v, serialize: (v: unknown) => v };
     expect(new QueryAttribute("x", finite, passthrough).isInfinite()).toBe(false);
-    expect(new QueryAttribute("x", positiveInf, passthrough).isInfinite()).toBe(true);
-    expect(new QueryAttribute("x", negativeInf, passthrough).isInfinite()).toBe(true);
+    expect(new QueryAttribute("x", positiveInf, passthrough).isInfinite()).toBe(1);
+    expect(new QueryAttribute("x", negativeInf, passthrough).isInfinite()).toBe(-1);
   });
 
   it("equals compares name, value, and type", () => {

--- a/packages/activerecord/src/relation/query-attribute.test.ts
+++ b/packages/activerecord/src/relation/query-attribute.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { ActiveModelRangeError } from "@blazetrails/activemodel";
+import { describe, it, expect, vi } from "vitest";
+import { BigIntegerType, IntegerType } from "@blazetrails/activemodel";
 import { QueryAttribute } from "./query-attribute.js";
 
 class StringType {
@@ -101,9 +101,13 @@ describe("QueryAttribute", () => {
   });
 
   it("isInfinite handles Ruby-style duck-typed `infinite()` (nil for finite, 1/-1 for infinite)", () => {
-    const finite = { infinite: () => null };
-    const positiveInf = { infinite: () => 1 };
-    const negativeInf = { infinite: () => -1 };
+    // Rails has ONE `respond_to?(:infinite?)` protocol (query_attribute.rb:53-55),
+    // which ports to `isInfinite()` — the spelling Quoted / BindParam /
+    // UnboundableBound / arel's infinitySign all use. Reading a second name here
+    // forked the protocol.
+    const finite = { isInfinite: () => false };
+    const positiveInf = { isInfinite: () => 1 };
+    const negativeInf = { isInfinite: () => -1 };
     const passthrough = { cast: (v: unknown) => v, serialize: (v: unknown) => v };
     expect(new QueryAttribute("x", finite, passthrough).isInfinite()).toBe(false);
     expect(new QueryAttribute("x", positiveInf, passthrough).isInfinite()).toBe(1);
@@ -130,31 +134,48 @@ describe("QueryAttribute", () => {
     expect(attr.value).toBe(25);
   });
 
-  it("isUnboundable memoizes so the value is serialized exactly once", () => {
+  it("isUnboundable reports the sign of `value <=> 0` for an out-of-range bound", () => {
+    // query_attribute.rb:45-51 — serializable? yields the cast value when it is
+    // out of range for the column type; the sign tells Arel which side collapses.
+    const int4 = new IntegerType({ limit: 4 });
+    expect(new QueryAttribute("id", 2 ** 40, int4).isUnboundable()).toBe(1);
+    expect(new QueryAttribute("id", -(2 ** 40), int4).isUnboundable()).toBe(-1);
+    expect(new QueryAttribute("id", 5, int4).isUnboundable()).toBe(false);
+
+    // The #4433 bignum path: a bigint column is Integer(limit: 8).
+    const int8 = new IntegerType({ limit: 8 });
+    expect(new QueryAttribute("id", 2n ** 63n, int8).isUnboundable()).toBe(1);
+    expect(new QueryAttribute("id", -(2n ** 63n) - 1n, int8).isUnboundable()).toBe(-1);
+    expect(new QueryAttribute("id", 2n ** 63n - 1n, int8).isUnboundable()).toBe(false);
+  });
+
+  it("isUnboundable is never true for :big_integer, whose max_value is INFINITY", () => {
+    // big_integer.rb:33 — in_range? is always true, so serializable? never
+    // yields and unboundable? stays nil however large the value.
+    const big = new BigIntegerType();
+    expect(new QueryAttribute("id", 2n ** 63n, big).isUnboundable()).toBe(false);
+    expect(new QueryAttribute("id", -(2n ** 100n), big).isUnboundable()).toBe(false);
+  });
+
+  it("isUnboundable memoizes so the value is inspected exactly once", () => {
     // query_attribute.rb:45-51 guards with `unless defined?(@_unboundable)`, so
-    // the serialization attempt happens once however often the predicate is
-    // read — and both `between` and the visitor read it.
-    let serializeCalls = 0;
-    const rangeLimited = {
-      cast: (v: unknown) => v,
-      serialize: (v: unknown) => {
-        serializeCalls += 1;
-        if (typeof v === "number" && v > 2147483647)
-          throw new ActiveModelRangeError("out of range");
-        return v;
-      },
-    };
+    // the check happens once however often the predicate is read — and both
+    // `between` and the visitor read it.
+    const int4 = new IntegerType({ limit: 4 });
+    const spy = vi.spyOn(int4, "isSerializable");
 
-    const outOfRange = new QueryAttribute("id", 2 ** 40, rangeLimited);
-    expect(outOfRange.isUnboundable()).toBe(1);
-    expect(outOfRange.isUnboundable()).toBe(1);
-    expect(serializeCalls).toBe(1);
-
-    serializeCalls = 0;
-    const inRange = new QueryAttribute("id", 5, rangeLimited);
-    // The `false` result caches too — `defined?` is true once assigned.
+    // The `false` result caches too — Rails assigns on both paths, so `defined?`
+    // is true either way.
+    const inRange = new QueryAttribute("id", 5, int4);
     expect(inRange.isUnboundable()).toBe(false);
     expect(inRange.isUnboundable()).toBe(false);
-    expect(serializeCalls).toBe(1);
+    expect(inRange.isUnboundable()).toBe(false);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    spy.mockClear();
+    const outOfRange = new QueryAttribute("id", 2 ** 40, int4);
+    expect(outOfRange.isUnboundable()).toBe(1);
+    expect(outOfRange.isUnboundable()).toBe(1);
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/activerecord/src/relation/query-attribute.test.ts
+++ b/packages/activerecord/src/relation/query-attribute.test.ts
@@ -155,6 +155,22 @@ describe("QueryAttribute", () => {
     const big = new BigIntegerType();
     expect(new QueryAttribute("id", 2n ** 63n, big).isUnboundable()).toBe(false);
     expect(new QueryAttribute("id", -(2n ** 100n), big).isUnboundable()).toBe(false);
+    // ±Infinity too: cast_value is `to_i rescue nil` => nil, and in_range?(nil)
+    // is `!value` => true (integer.rb:86,90).
+    expect(new QueryAttribute("id", Infinity, big).isUnboundable()).toBe(false);
+    expect(new QueryAttribute("id", -Infinity, big).isUnboundable()).toBe(false);
+  });
+
+  it("isUnboundable is false for ±Infinity — Rails casts it to nil, which is in range", () => {
+    // integer.rb:90 `value.to_i rescue nil` => nil for ±Infinity, so
+    // in_range?(nil) is true and unboundable? stays nil. The bound is still
+    // open-ended, but via infinity? (predications.rb:248) — not this predicate.
+    const int4 = new IntegerType({ limit: 4 });
+    expect(new QueryAttribute("id", Infinity, int4).isUnboundable()).toBe(false);
+    expect(new QueryAttribute("id", -Infinity, int4).isUnboundable()).toBe(false);
+    // isInfinite reads value_before_type_cast, so it still reports the sign.
+    expect(new QueryAttribute("id", Infinity, int4).isInfinite()).toBe(1);
+    expect(new QueryAttribute("id", -Infinity, int4).isInfinite()).toBe(-1);
   });
 
   it("isUnboundable memoizes so the value is inspected exactly once", () => {

--- a/packages/activerecord/src/relation/query-attribute.test.ts
+++ b/packages/activerecord/src/relation/query-attribute.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { ActiveModelRangeError } from "@blazetrails/activemodel";
 import { QueryAttribute } from "./query-attribute.js";
 
 class StringType {
@@ -127,5 +128,33 @@ describe("QueryAttribute", () => {
     const attr = new QueryAttribute("age", "25", intType);
     expect(attr.valueBeforeTypeCast).toBe("25");
     expect(attr.value).toBe(25);
+  });
+
+  it("isUnboundable memoizes so the value is serialized exactly once", () => {
+    // query_attribute.rb:45-51 guards with `unless defined?(@_unboundable)`, so
+    // the serialization attempt happens once however often the predicate is
+    // read — and both `between` and the visitor read it.
+    let serializeCalls = 0;
+    const rangeLimited = {
+      cast: (v: unknown) => v,
+      serialize: (v: unknown) => {
+        serializeCalls += 1;
+        if (typeof v === "number" && v > 2147483647)
+          throw new ActiveModelRangeError("out of range");
+        return v;
+      },
+    };
+
+    const outOfRange = new QueryAttribute("id", 2 ** 40, rangeLimited);
+    expect(outOfRange.isUnboundable()).toBe(1);
+    expect(outOfRange.isUnboundable()).toBe(1);
+    expect(serializeCalls).toBe(1);
+
+    serializeCalls = 0;
+    const inRange = new QueryAttribute("id", 5, rangeLimited);
+    // The `false` result caches too — `defined?` is true once assigned.
+    expect(inRange.isUnboundable()).toBe(false);
+    expect(inRange.isUnboundable()).toBe(false);
+    expect(serializeCalls).toBe(1);
   });
 });

--- a/packages/activerecord/src/relation/query-attribute.ts
+++ b/packages/activerecord/src/relation/query-attribute.ts
@@ -86,7 +86,14 @@ export class QueryAttribute extends Attribute {
     return forDatabase === null || forDatabase === undefined;
   }
 
-  isInfinite(): boolean {
+  /**
+   * Mirrors: ActiveRecord::Relation::QueryAttribute#infinite?
+   * (query_attribute.rb:42-44) — `infinity?(value_before_type_cast) ||
+   * serializable? && infinity?(value_for_database)`. Yields the *sign*, not a
+   * boolean, because Ruby's `Float#infinite?` returns `1 | -1 | nil`; Arel's
+   * `Predications#between` reads it to pick which side of a range collapses.
+   */
+  isInfinite(): 1 | -1 | false {
     return (
       isInfinity(this.valueBeforeTypeCast) ||
       (this.isSerializable() && isInfinity(this.valueForDatabase))
@@ -111,13 +118,20 @@ export class QueryAttribute extends Attribute {
 
 // private
 
-/** @internal */
-function isInfinity(value: unknown): boolean {
-  if (value === Infinity || value === -Infinity) return true;
+/**
+ * Mirrors: ActiveRecord::Relation::QueryAttribute#infinity? (query_attribute.rb:53-55)
+ * — `value.respond_to?(:infinite?) && value.infinite?`. Returns the sign rather
+ * than a boolean; see `isInfinite` above.
+ *
+ * @internal
+ */
+function isInfinity(value: unknown): 1 | -1 | false {
+  if (value === Infinity) return 1;
+  if (value === -Infinity) return -1;
   if (value === null || value === undefined) return false;
   const fn = (value as { infinite?: unknown }).infinite;
   if (typeof fn !== "function") return false;
   const result = (fn as () => unknown).call(value);
-  // Mirrors Ruby truthiness for duck-typed infinite() results: only nil/false are falsy.
-  return result != null && result !== false;
+  if (result === 1 || result === -1) return result;
+  return false;
 }

--- a/packages/activerecord/src/relation/query-attribute.ts
+++ b/packages/activerecord/src/relation/query-attribute.ts
@@ -119,10 +119,12 @@ export class QueryAttribute extends Attribute {
    */
   isUnboundable(): 1 | -1 | false {
     if (this._unboundable === undefined) {
-      // Ruby's `value <=> 0` on the yielded cast value. Rails hands the block
-      // `cast(value)` (integer.rb:75), not QueryAttribute#value — which is the
-      // raw value, since QueryAttribute#type_cast is a no-op (query_attribute.rb:22-24).
-      this._unboundable = this.isSerializable() ? false : compareToZero(this.type.cast(this.value));
+      // Ruby's `value <=> 0` on the value `serializable?` yields, which is
+      // `cast(value)` (integer.rb:75). `this.value` is already cast here —
+      // trails' `typeCast` above casts, where Rails' QueryAttribute#type_cast is
+      // a no-op (query_attribute.rb:22-24) — so it is passed through as-is
+      // rather than cast a second time.
+      this._unboundable = this.isSerializable() ? false : compareToZero(this.value);
     }
     return this._unboundable;
   }

--- a/packages/activerecord/src/relation/query-attribute.ts
+++ b/packages/activerecord/src/relation/query-attribute.ts
@@ -40,6 +40,9 @@ function ensureType(type: CastType): Type {
 }
 
 export class QueryAttribute extends Attribute {
+  /** Rails' `@_unboundable`; `undefined` stands in for `defined?` being false. @internal */
+  private _unboundable?: 1 | -1 | false;
+
   constructor(name: string, value: unknown, type: CastType) {
     super(name, value, ensureType(type));
   }
@@ -100,19 +103,30 @@ export class QueryAttribute extends Attribute {
     );
   }
 
+  /**
+   * Mirrors: ActiveRecord::Relation::QueryAttribute#unboundable?
+   * (query_attribute.rb:45-51) — `serializable? { |value| @_unboundable = value <=> 0 }`,
+   * memoized behind `unless defined?(@_unboundable)` so the serialization is
+   * attempted exactly once. `_unboundable === undefined` is this port's
+   * `defined?` guard, so a `false` result caches too; both `between` and the
+   * visitor call this, and serializing re-raises otherwise.
+   */
   isUnboundable(): 1 | -1 | false {
-    try {
-      void this.valueForDatabase;
-    } catch (e) {
-      if (e instanceof ActiveModelRangeError) {
-        // Mirror Rails query_attribute.rb:46-50: serializable? yields value <=> 0.
-        const v = this.value;
-        if (typeof v === "bigint") return v >= 0n ? 1 : -1;
-        if (typeof v === "number") return v >= 0 ? 1 : -1;
-        return 1;
+    if (this._unboundable === undefined) {
+      this._unboundable = false;
+      try {
+        void this.valueForDatabase;
+      } catch (e) {
+        if (e instanceof ActiveModelRangeError) {
+          // Mirror Rails query_attribute.rb:46-50: serializable? yields value <=> 0.
+          const v = this.value;
+          if (typeof v === "bigint") this._unboundable = v >= 0n ? 1 : -1;
+          else if (typeof v === "number") this._unboundable = v >= 0 ? 1 : -1;
+          else this._unboundable = 1;
+        }
       }
     }
-    return false;
+    return this._unboundable;
   }
 }
 

--- a/packages/activerecord/src/relation/query-attribute.ts
+++ b/packages/activerecord/src/relation/query-attribute.ts
@@ -7,7 +7,7 @@
  * Mirrors: ActiveRecord::Relation::QueryAttribute < ActiveModel::Attribute
  */
 
-import { Attribute, Type, ActiveModelRangeError } from "@blazetrails/activemodel";
+import { Attribute, Type } from "@blazetrails/activemodel";
 import { Substitute } from "../statement-cache.js";
 
 type CastType = Pick<Type, "cast" | "serialize">;
@@ -105,26 +105,24 @@ export class QueryAttribute extends Attribute {
 
   /**
    * Mirrors: ActiveRecord::Relation::QueryAttribute#unboundable?
-   * (query_attribute.rb:45-51) — `serializable? { |value| @_unboundable = value <=> 0 }`,
-   * memoized behind `unless defined?(@_unboundable)` so the serialization is
-   * attempted exactly once. `_unboundable === undefined` is this port's
-   * `defined?` guard, so a `false` result caches too; both `between` and the
-   * visitor call this, and serializing re-raises otherwise.
+   * (query_attribute.rb:45-51) —
+   * `serializable? { |value| @_unboundable = value <=> 0 } && @_unboundable = nil`,
+   * memoized behind `unless defined?(@_unboundable)`. `_unboundable === undefined`
+   * is that `defined?` guard, so the `false` result caches too: Rails assigns on
+   * both paths, and both `between` and the visitor read this.
+   *
+   * No exception handling, because Rails has none here: `serializable?`
+   * (attribute.rb:62-64) delegates to `Type#serializable?`, which is a
+   * predicate — `Integer#serializable?` (integer.rb:74-80) tests `in_range?`
+   * and yields the *cast* value to the block rather than raising. A serializer
+   * error is therefore never swallowed; it propagates as in Rails.
    */
   isUnboundable(): 1 | -1 | false {
     if (this._unboundable === undefined) {
-      this._unboundable = false;
-      try {
-        void this.valueForDatabase;
-      } catch (e) {
-        if (e instanceof ActiveModelRangeError) {
-          // Mirror Rails query_attribute.rb:46-50: serializable? yields value <=> 0.
-          const v = this.value;
-          if (typeof v === "bigint") this._unboundable = v >= 0n ? 1 : -1;
-          else if (typeof v === "number") this._unboundable = v >= 0 ? 1 : -1;
-          else this._unboundable = 1;
-        }
-      }
+      // Ruby's `value <=> 0` on the yielded cast value. Rails hands the block
+      // `cast(value)` (integer.rb:75), not QueryAttribute#value — which is the
+      // raw value, since QueryAttribute#type_cast is a no-op (query_attribute.rb:22-24).
+      this._unboundable = this.isSerializable() ? false : compareToZero(this.type.cast(this.value));
     }
     return this._unboundable;
   }
@@ -137,15 +135,35 @@ export class QueryAttribute extends Attribute {
  * — `value.respond_to?(:infinite?) && value.infinite?`. Returns the sign rather
  * than a boolean; see `isInfinite` above.
  *
+ * `infinite?` ports to `isInfinite()`, the one spelling the protocol has across
+ * the port — `Quoted` (casted.ts), `BindParam` (bind-param.ts), `UnboundableBound`
+ * (predicate-builder/range-handler.ts) and arel's `infinitySign` all read it.
+ * Rails has a single `respond_to?(:infinite?)` protocol, so this must not fork
+ * into a second name: reading `infinite()` here made
+ * `QueryAttribute(Quoted(INFINITY)).infinite?` false while `infinitySign` said 1.
+ *
  * @internal
  */
 function isInfinity(value: unknown): 1 | -1 | false {
   if (value === Infinity) return 1;
   if (value === -Infinity) return -1;
   if (value === null || value === undefined) return false;
-  const fn = (value as { infinite?: unknown }).infinite;
+  const fn = (value as { isInfinite?: unknown }).isInfinite;
   if (typeof fn !== "function") return false;
   const result = (fn as () => unknown).call(value);
   if (result === 1 || result === -1) return result;
   return false;
+}
+
+/**
+ * Ruby's `value <=> 0` for the numeric shapes a bound can take. Only the sign is
+ * used; a non-numeric value that failed serialization is treated as past the
+ * upper bound.
+ *
+ * @internal
+ */
+function compareToZero(value: unknown): 1 | -1 {
+  if (typeof value === "bigint") return value >= 0n ? 1 : -1;
+  if (typeof value === "number") return value >= 0 ? 1 : -1;
+  return 1;
 }

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -26,7 +26,13 @@ import { Sum, Max, Min, Avg } from "../nodes/function.js";
 import { Ascending } from "../nodes/ascending.js";
 import { Descending } from "../nodes/descending.js";
 import { buildQuoted } from "../nodes/casted.js";
-import { parseRange, betweenFromRange, notBetweenFromRange } from "../predications-range.js";
+import {
+  parseRange,
+  betweenFromRange,
+  notBetweenFromRange,
+  type RangeHost,
+  type RangePredicates,
+} from "../predications-range.js";
 import { Grouping } from "../nodes/grouping.js";
 import { And } from "../nodes/and.js";
 import { Or } from "../nodes/or.js";
@@ -207,14 +213,25 @@ export class Attribute extends Node {
   between(rangeObj: { begin: unknown; end: unknown; excludeEnd?: boolean }): Node;
 
   between(beginOrRange: unknown, end?: unknown, excludeEnd?: boolean): Node {
-    return betweenFromRange(this, parseRange(beginOrRange, end, excludeEnd));
+    return betweenFromRange(this.asRangeHost(), parseRange(beginOrRange, end, excludeEnd));
   }
   notBetween(range: [unknown, unknown]): Node;
   notBetween(begin: unknown, end: unknown, excludeEnd?: boolean): Node;
   notBetween(rangeObj: { begin: unknown; end: unknown; excludeEnd?: boolean }): Node;
 
   notBetween(beginOrRange: unknown, end?: unknown, excludeEnd?: boolean): Node {
-    return notBetweenFromRange(this, parseRange(beginOrRange, end, excludeEnd));
+    return notBetweenFromRange(this.asRangeHost(), parseRange(beginOrRange, end, excludeEnd));
+  }
+
+  /**
+   * `between` / `notBetween` dispatch `infinity?` / `unboundable?` /
+   * `open_ended?` on self (predications.rb:38-51). This class has all three, but
+   * as `protected` — a compile-time visibility rule that keeps it from being
+   * assignable to the public `RangePredicates`. The runtime dispatch is real, so
+   * subclass overrides are honored.
+   */
+  private asRangeHost(): RangeHost & RangePredicates {
+    return this as unknown as RangeHost & RangePredicates;
   }
 
   // -- _any / _all variants --

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -47,7 +47,7 @@ import { BitwiseNot } from "../nodes/unary-operation.js";
 import type { NodeOrValue } from "../nodes/binary.js";
 import { Over } from "../nodes/over.js";
 import { NamedWindow, Window } from "../nodes/window.js";
-import { Predications } from "../predications.js";
+import { Predications, type PredicationHost } from "../predications.js";
 
 /**
  * Combines multiple nodes with OR, wrapped in a Grouping.
@@ -351,7 +351,17 @@ export class Attribute extends Node {
   }
 
   protected isOpenEnded(value: unknown): boolean {
-    return Predications.isOpenEnded.call(this, value);
+    // Cast widens this' protected isInfinity/isUnboundable to the public shape
+    // Predications.isOpenEnded's `this` requires. Dispatch still goes through
+    // `this` at runtime, so subclass overrides are honored — as in Ruby, where
+    // open_ended? calls infinity? / unboundable? on self.
+    return Predications.isOpenEnded.call(
+      this as unknown as PredicationHost & {
+        isInfinity(value: unknown): 1 | -1 | 0;
+        isUnboundable(value: unknown): 1 | -1 | 0;
+      },
+      value,
+    );
   }
 
   // -- Ordering --

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -47,7 +47,7 @@ import { BitwiseNot } from "../nodes/unary-operation.js";
 import type { NodeOrValue } from "../nodes/binary.js";
 import { Over } from "../nodes/over.js";
 import { NamedWindow, Window } from "../nodes/window.js";
-import { Predications, type PredicationHost } from "../predications.js";
+import { Predications } from "../predications.js";
 
 /**
  * Combines multiple nodes with OR, wrapped in a Grouping.
@@ -334,26 +334,24 @@ export class Attribute extends Node {
     >(this, methodId, others, ...extras);
   }
 
-  protected isInfinity(value: unknown): boolean {
+  // infinity? / unboundable? / open_ended? reach Attribute through
+  // `include Arel::Predications` (attribute.rb:8) rather than being defined in
+  // attribute.rb, so api:compare maps them onto this file. They delegate to the
+  // Predications mixin, which in turn delegates to the single implementation in
+  // predications-range.ts — the same one `between` / `notBetween` above use, so
+  // routing a range through these can no longer diverge from the real decision
+  // tree the way the old `isUnboundable` stub silently did.
+
+  protected isInfinity(value: unknown): 1 | -1 | 0 {
     return Predications.isInfinity.call(this, value);
   }
 
-  protected isUnboundable(value: unknown): boolean {
+  protected isUnboundable(value: unknown): 1 | -1 | 0 {
     return Predications.isUnboundable.call(this, value);
   }
 
   protected isOpenEnded(value: unknown): boolean {
-    // Cast widens this' protected isInfinity/isUnboundable so they
-    // match Predications.isOpenEnded's `this` constraint, which
-    // requires them as public methods. The dispatch still goes through
-    // `this` at runtime, so subclass overrides are honored.
-    return Predications.isOpenEnded.call(
-      this as unknown as PredicationHost & {
-        isInfinity(value: unknown): boolean;
-        isUnboundable(value: unknown): boolean;
-      },
-      value,
-    );
+    return Predications.isOpenEnded.call(this, value);
   }
 
   // -- Ordering --

--- a/packages/arel/src/nodes/bind-param.test.ts
+++ b/packages/arel/src/nodes/bind-param.test.ts
@@ -91,6 +91,13 @@ describe("BindParam", () => {
       const bp = new Nodes.BindParam({ isInfinite: () => -1 });
       expect(bp.isInfinite()).toBe(-1);
     });
+
+    it("reports the sign for a bare ±Infinity value, which Float answers in Ruby", () => {
+      // bind_param.rb:33-35 duck-types `infinite?`, and Float responds — so
+      // BindParam(Float::INFINITY).infinite? is 1 and the bound is open-ended.
+      expect(new Nodes.BindParam(Infinity).isInfinite()).toBe(1);
+      expect(new Nodes.BindParam(-Infinity).isInfinite()).toBe(-1);
+    });
   });
 
   describe("isUnboundable", () => {

--- a/packages/arel/src/nodes/bind-param.test.ts
+++ b/packages/arel/src/nodes/bind-param.test.ts
@@ -75,9 +75,11 @@ describe("BindParam", () => {
   });
 
   describe("isInfinite", () => {
-    it("returns null when value has no isInfinite", () => {
+    it("returns false when value has no isInfinite", () => {
+      // Mirrors bind_param.rb:33-35 — `value.respond_to?(:infinite?) &&
+      // value.infinite?` is false, not nil, for a value lacking the protocol.
       const bp = new Nodes.BindParam(42);
-      expect(bp.isInfinite()).toBeNull();
+      expect(bp.isInfinite()).toBe(false);
     });
 
     it("delegates to value.isInfinite when present — positive", () => {

--- a/packages/arel/src/nodes/bind-param.ts
+++ b/packages/arel/src/nodes/bind-param.ts
@@ -46,8 +46,14 @@ export class BindParam extends Node {
    * Mirrors: Arel::Nodes::BindParam#infinite? (bind_param.rb:33-35) —
    * `value.respond_to?(:infinite?) && value.infinite?`, which yields the *sign*
    * (Ruby's `Float#infinite?` returns `1 | -1 | nil`), not a boolean.
+   *
+   * A bare ±Infinity answers it too: `Float` responds to `infinite?`, so
+   * `BindParam(Float::INFINITY).infinite?` is `1` in Rails and the bound is
+   * open-ended. Checking only for a wrapped `isInfinite()` would miss that.
    */
   isInfinite(): 1 | -1 | false {
+    if (this.value === Infinity) return 1;
+    if (this.value === -Infinity) return -1;
     const v = this.value as { isInfinite?: () => 1 | -1 | false } | null | undefined;
     return typeof v?.isInfinite === "function" ? v.isInfinite() : false;
   }

--- a/packages/arel/src/nodes/bind-param.ts
+++ b/packages/arel/src/nodes/bind-param.ts
@@ -42,9 +42,14 @@ export class BindParam extends Node {
     return typeof v?.isNil === "function" && v.isNil();
   }
 
-  isInfinite(): number | null {
-    const v = this.value as { isInfinite?: () => number | null } | null | undefined;
-    return typeof v?.isInfinite === "function" ? v.isInfinite() : null;
+  /**
+   * Mirrors: Arel::Nodes::BindParam#infinite? (bind_param.rb:33-35) —
+   * `value.respond_to?(:infinite?) && value.infinite?`, which yields the *sign*
+   * (Ruby's `Float#infinite?` returns `1 | -1 | nil`), not a boolean.
+   */
+  isInfinite(): 1 | -1 | false {
+    const v = this.value as { isInfinite?: () => 1 | -1 | false } | null | undefined;
+    return typeof v?.isInfinite === "function" ? v.isInfinite() : false;
   }
 
   isUnboundable(): 1 | -1 | false {

--- a/packages/arel/src/nodes/casted.ts
+++ b/packages/arel/src/nodes/casted.ts
@@ -128,10 +128,15 @@ export class Quoted extends Unary {
     return this.value === null || this.value === undefined;
   }
 
-  isInfinite(): number | null {
+  /**
+   * Mirrors: Arel::Nodes::Quoted#infinite? (casted.rb:43-45) — the sign, not a
+   * boolean. `Casted` deliberately defines no counterpart (casted.rb:5-35), so
+   * `open_ended?(Casted(INFINITY))` is false in Rails and must stay false here.
+   */
+  isInfinite(): 1 | -1 | false {
     if (this.value === Infinity) return 1;
     if (this.value === -Infinity) return -1;
-    return null;
+    return false;
   }
 
   accept<T>(visitor: NodeVisitor<T>): T {

--- a/packages/arel/src/nodes/casted.ts
+++ b/packages/arel/src/nodes/casted.ts
@@ -129,14 +129,20 @@ export class Quoted extends Unary {
   }
 
   /**
-   * Mirrors: Arel::Nodes::Quoted#infinite? (casted.rb:43-45) — the sign, not a
-   * boolean. `Casted` deliberately defines no counterpart (casted.rb:5-35), so
+   * Mirrors: Arel::Nodes::Quoted#infinite? (casted.rb:43-45) —
+   * `value.respond_to?(:infinite?) && value.infinite?`, which yields the sign
+   * rather than a boolean (Ruby's `Float#infinite?` returns `1 | -1 | nil`).
+   *
+   * Duck-typed, not a bare `=== ±Infinity` check: in Ruby anything answering
+   * `infinite?` participates, so `Quoted(QueryAttribute(INFINITY))#infinite?`
+   * is `1`. `Casted` deliberately defines no counterpart (casted.rb:5-35), so
    * `open_ended?(Casted(INFINITY))` is false in Rails and must stay false here.
    */
   isInfinite(): 1 | -1 | false {
     if (this.value === Infinity) return 1;
     if (this.value === -Infinity) return -1;
-    return false;
+    const v = this.value as { isInfinite?: () => 1 | -1 | false } | null | undefined;
+    return typeof v?.isInfinite === "function" ? v.isInfinite() : false;
   }
 
   accept<T>(visitor: NodeVisitor<T>): T {

--- a/packages/arel/src/predications-privates.test.ts
+++ b/packages/arel/src/predications-privates.test.ts
@@ -93,6 +93,18 @@ describe("Predications.isInfinity / isUnboundable / isOpenEnded", () => {
     expect(isOpenEnded(0)).toBe(false);
     expect(isOpenEnded("x")).toBe(false);
   });
+
+  it("isOpenEnded dispatches Ruby's leading `value.nil?` onto the node", () => {
+    // predications.rb:255-257 opens with `value.nil?`, which the node classes
+    // override to report on the wrapped value (bind_param.rb:23-25,
+    // casted.rb:16,41) — so a nil-wrapping bound is open-ended, and
+    // between(BindParam(nil), 3) is lteq(3) rather than a Between over a nil bind.
+    expect(isOpenEnded(new Nodes.BindParam(null))).toBe(true);
+    expect(isOpenEnded(new Nodes.Quoted(null))).toBe(true);
+    expect(isOpenEnded(new Nodes.Casted(null, users.attr("id")))).toBe(true);
+    expect(isOpenEnded(new Nodes.Quoted(3))).toBe(false);
+    expect(isOpenEnded(new Nodes.Casted(3, users.attr("id")))).toBe(false);
+  });
 });
 
 describe("Attribute private helpers (mirror Predications)", () => {

--- a/packages/arel/src/predications-privates.test.ts
+++ b/packages/arel/src/predications-privates.test.ts
@@ -44,7 +44,17 @@ describe("Predications.groupingAny / groupingAll", () => {
 });
 
 describe("Predications.isInfinity / isUnboundable / isOpenEnded", () => {
-  const host = { quotedNode: (v: unknown): Nodes.Node => v as Nodes.Node };
+  // A PredicationHost carrying the mixin's own isInfinity / isUnboundable, as a
+  // class including Predications would — isOpenEnded dispatches through `this`.
+  const host = {
+    quotedNode: (v: unknown): Nodes.Node => v as Nodes.Node,
+    isInfinity(this: unknown, v: unknown): 1 | -1 | 0 {
+      return Predications.isInfinity.call(this as never, v);
+    },
+    isUnboundable(this: unknown, v: unknown): 1 | -1 | 0 {
+      return Predications.isUnboundable.call(this as never, v);
+    },
+  };
   const isInfinity = (v: unknown) => Predications.isInfinity.call(host, v);
   const isUnboundable = (v: unknown) => Predications.isUnboundable.call(host, v);
   const isOpenEnded = (v: unknown) => Predications.isOpenEnded.call(host, v);
@@ -101,6 +111,14 @@ describe("Predications.isInfinity / isUnboundable / isOpenEnded", () => {
     expect(isOpenEnded({ isUnboundable: () => 1 as const })).toBe(true);
     expect(isOpenEnded(0)).toBe(false);
     expect(isOpenEnded("x")).toBe(false);
+  });
+
+  it("isOpenEnded dispatches infinity?/unboundable? through `this` so host overrides win", () => {
+    // predications.rb:255-257 calls both on self, so an including class that
+    // overrides either is honored.
+    const overridden = { ...host, isInfinity: () => 1 as const };
+    expect(Predications.isOpenEnded.call(overridden, 42)).toBe(true);
+    expect(Predications.isOpenEnded.call(host, 42)).toBe(false);
   });
 
   it("isOpenEnded dispatches Ruby's leading `value.nil?` onto the node", () => {

--- a/packages/arel/src/predications-privates.test.ts
+++ b/packages/arel/src/predications-privates.test.ts
@@ -173,6 +173,33 @@ describe("Attribute private helpers (mirror Predications)", () => {
   });
 });
 
+describe("between / notBetween self-dispatch (mirror Rails' implicit self)", () => {
+  // predications.rb:38-51 calls unboundable? / open_ended? / infinity? on self,
+  // exactly as open_ended? (255-257) calls infinity? / unboundable? on self — so
+  // an including class that overrides one is honored by the decision tree too.
+  class OverridingAttribute extends Nodes.Attribute {
+    protected override isInfinity(_value: unknown): 1 | -1 | 0 {
+      return 1;
+    }
+  }
+
+  it("between honors a host override of isInfinity", () => {
+    const attr = new OverridingAttribute(users, "id");
+    // Both bounds read as open-ended, and begin reports +Infinity -> in([]).
+    expect(attr.between({ begin: 1, end: 2, excludeEnd: false })).toBeInstanceOf(Nodes.In);
+  });
+
+  it("notBetween honors a host override of isInfinity", () => {
+    const attr = new OverridingAttribute(users, "id");
+    expect(attr.notBetween({ begin: 1, end: 2, excludeEnd: false })).toBeInstanceOf(Nodes.NotIn);
+  });
+
+  it("an un-overridden attribute is unaffected", () => {
+    const attr = users.attr("id");
+    expect(attr.between({ begin: 1, end: 2, excludeEnd: false })).toBeInstanceOf(Nodes.Between);
+  });
+});
+
 describe("SelectManager#collapse (Rails-fidelity helper)", () => {
   // Mirrors Arel::SelectManager#collapse — compacts a list of exprs,
   // wraps bare strings as SqlLiteral, returns the single survivor or

--- a/packages/arel/src/predications-privates.test.ts
+++ b/packages/arel/src/predications-privates.test.ts
@@ -63,6 +63,15 @@ describe("Predications.isInfinity / isUnboundable / isOpenEnded", () => {
     expect(isInfinity({ isInfinite: () => 1 as const })).toBe(1);
   });
 
+  it("isInfinity reaches a Quoted through its own infinite?, not a structural unwrap", () => {
+    // casted.rb:43-45 duck-types the wrapped value, so a Quoted around anything
+    // answering `infinite?` (e.g. a QueryAttribute) reports the sign. predications.rb:248-250
+    // is a plain dispatch — it does not know Quoted exists.
+    expect(isInfinity(new Nodes.Quoted({ isInfinite: () => 1 as const }))).toBe(1);
+    expect(isInfinity(new Nodes.Quoted({ isInfinite: () => -1 as const }))).toBe(-1);
+    expect(isInfinity(new Nodes.Quoted(3))).toBe(0);
+  });
+
   it("isInfinity does not unwrap Casted, which defines no infinite? in Rails", () => {
     // casted.rb:5-35 — Casted has no `infinite?`, so open_ended?(Casted(INFINITY))
     // is false in Rails and must stay false here.

--- a/packages/arel/src/predications-privates.test.ts
+++ b/packages/arel/src/predications-privates.test.ts
@@ -6,7 +6,8 @@ import { Predications } from "./predications.js";
 // Arel::Predications' private API (grouping_any, grouping_all,
 // infinity?, unboundable?, open_ended?). Trails surfaces them on the
 // mixin object for Rails-fidelity / api:compare privates coverage;
-// these tests pin their behavior.
+// these tests pin their behavior. The three predicate helpers delegate to
+// the single implementation in predications-range.ts.
 
 const users = new Table("users");
 
@@ -43,50 +44,54 @@ describe("Predications.groupingAny / groupingAll", () => {
 });
 
 describe("Predications.isInfinity / isUnboundable / isOpenEnded", () => {
-  // Build a minimal PredicationHost-shaped object with public
-  // isInfinity / isUnboundable so isOpenEnded's `this`-dispatch
-  // typechecks. Mirrors how the methods would be reachable on a
-  // class that included Predications via the runtime mixin.
-  const host = {
-    quotedNode: (v: unknown): Nodes.Node => v as Nodes.Node,
-    isInfinity(this: unknown, v: unknown): boolean {
-      return Predications.isInfinity.call(this as never, v);
-    },
-    isUnboundable(this: unknown, v: unknown): boolean {
-      return Predications.isUnboundable.call(this as never, v);
-    },
-  };
+  const host = { quotedNode: (v: unknown): Nodes.Node => v as Nodes.Node };
+  const isInfinity = (v: unknown) => Predications.isInfinity.call(host, v);
+  const isUnboundable = (v: unknown) => Predications.isUnboundable.call(host, v);
+  const isOpenEnded = (v: unknown) => Predications.isOpenEnded.call(host, v);
 
-  it("isInfinity is true for ±Infinity, false otherwise", () => {
-    expect(host.isInfinity(Infinity)).toBe(true);
-    expect(host.isInfinity(-Infinity)).toBe(true);
-    expect(host.isInfinity(0)).toBe(false);
-    expect(host.isInfinity("x")).toBe(false);
+  it("isInfinity yields the sign for ±Infinity, 0 otherwise", () => {
+    // Mirrors `Float#infinite?` returning 1 / -1 / nil — the sign is what
+    // Predications#between reads to pick which side of the range collapses.
+    expect(isInfinity(Infinity)).toBe(1);
+    expect(isInfinity(-Infinity)).toBe(-1);
+    expect(isInfinity(0)).toBe(0);
+    expect(isInfinity("x")).toBe(0);
   });
 
-  it("isUnboundable is always false (no Ruby-style protocol in TS)", () => {
-    expect(host.isUnboundable(undefined)).toBe(false);
-    expect(host.isUnboundable(1)).toBe(false);
+  it("isInfinity duck-types a value exposing isInfinite()", () => {
+    expect(isInfinity(new Nodes.Quoted(-Infinity))).toBe(-1);
+    expect(isInfinity({ isInfinite: () => 1 as const })).toBe(1);
   });
 
-  it("isOpenEnded is true for null/undefined/Infinity, false otherwise", () => {
-    expect(Predications.isOpenEnded.call(host, null)).toBe(true);
-    expect(Predications.isOpenEnded.call(host, undefined)).toBe(true);
-    expect(Predications.isOpenEnded.call(host, Infinity)).toBe(true);
-    expect(Predications.isOpenEnded.call(host, -Infinity)).toBe(true);
-    expect(Predications.isOpenEnded.call(host, 0)).toBe(false);
-    expect(Predications.isOpenEnded.call(host, "x")).toBe(false);
+  it("isInfinity does not unwrap Casted, which defines no infinite? in Rails", () => {
+    // casted.rb:5-35 — Casted has no `infinite?`, so open_ended?(Casted(INFINITY))
+    // is false in Rails and must stay false here.
+    expect(isInfinity(new Nodes.Casted(Infinity, users.attr("id")))).toBe(0);
+    expect(isOpenEnded(new Nodes.Casted(Infinity, users.attr("id")))).toBe(false);
   });
 
-  it("isOpenEnded dispatches through `this` so host overrides win", () => {
-    // Regression for the `this`-vs-direct-module-call concern: a host
-    // that overrides isInfinity to claim everything is infinite should
-    // see isOpenEnded honor that override.
-    const overridden = {
-      ...host,
-      isInfinity: () => true,
-    };
-    expect(Predications.isOpenEnded.call(overridden, 42)).toBe(true);
+  it("isUnboundable duck-types the protocol and yields the sign", () => {
+    expect(isUnboundable({ isUnboundable: () => 1 as const })).toBe(1);
+    expect(isUnboundable({ isUnboundable: () => -1 as const })).toBe(-1);
+    expect(isUnboundable({ isUnboundable: () => false as const })).toBe(0);
+  });
+
+  it("isUnboundable is 0 for values with no unboundable? — including ±Infinity", () => {
+    // Float has no `unboundable?` in Ruby, so a bare ±Infinity is open-ended
+    // via infinity?, NOT unboundable.
+    expect(isUnboundable(Infinity)).toBe(0);
+    expect(isUnboundable(undefined)).toBe(0);
+    expect(isUnboundable(1)).toBe(0);
+  });
+
+  it("isOpenEnded is true for null/undefined/Infinity/unboundable, false otherwise", () => {
+    expect(isOpenEnded(null)).toBe(true);
+    expect(isOpenEnded(undefined)).toBe(true);
+    expect(isOpenEnded(Infinity)).toBe(true);
+    expect(isOpenEnded(-Infinity)).toBe(true);
+    expect(isOpenEnded({ isUnboundable: () => 1 as const })).toBe(true);
+    expect(isOpenEnded(0)).toBe(false);
+    expect(isOpenEnded("x")).toBe(false);
   });
 });
 
@@ -97,8 +102,8 @@ describe("Attribute private helpers (mirror Predications)", () => {
   type AttributePrivates = Nodes.Attribute & {
     groupingAny: (methodId: string, others: unknown[]) => Nodes.Grouping;
     groupingAll: (methodId: string, others: unknown[]) => Nodes.Grouping;
-    isInfinity: (value: unknown) => boolean;
-    isUnboundable: (value: unknown) => boolean;
+    isInfinity: (value: unknown) => 1 | -1 | 0;
+    isUnboundable: (value: unknown) => 1 | -1 | 0;
     isOpenEnded: (value: unknown) => boolean;
   };
 
@@ -110,12 +115,22 @@ describe("Attribute private helpers (mirror Predications)", () => {
 
   it("isInfinity / isUnboundable / isOpenEnded match Predications semantics", () => {
     const attr = users.attr("id") as AttributePrivates;
-    expect(attr.isInfinity(Infinity)).toBe(true);
-    expect(attr.isInfinity(0)).toBe(false);
-    expect(attr.isUnboundable(0)).toBe(false);
+    expect(attr.isInfinity(Infinity)).toBe(1);
+    expect(attr.isInfinity(-Infinity)).toBe(-1);
+    expect(attr.isInfinity(0)).toBe(0);
+    expect(attr.isUnboundable(0)).toBe(0);
     expect(attr.isOpenEnded(null)).toBe(true);
     expect(attr.isOpenEnded(Infinity)).toBe(true);
     expect(attr.isOpenEnded(0)).toBe(false);
+  });
+
+  it("isUnboundable duck-types the protocol rather than always returning false", () => {
+    // Regression for the stub these delegated to: it hardcoded `false`, so
+    // anything routing `between` through Attribute#isOpenEnded silently lost
+    // unboundable collapse (#4433). They now share the real implementation.
+    const attr = users.attr("id") as AttributePrivates;
+    expect(attr.isUnboundable({ isUnboundable: () => -1 as const })).toBe(-1);
+    expect(attr.isOpenEnded({ isUnboundable: () => 1 as const })).toBe(true);
   });
 });
 

--- a/packages/arel/src/predications-range.ts
+++ b/packages/arel/src/predications-range.ts
@@ -17,11 +17,16 @@ import { Between } from "./nodes/binary.js";
  *   `infinity?` / `unboundable?` / `open_ended?` — private helpers
  *
  * This file holds the SINGLE implementation of the three private helpers.
- * `Predications.isInfinity` / `isUnboundable` / `isOpenEnded` delegate here, as
- * `Predications#between` / `notBetween` and `Attribute#between` / `notBetween`
- * already do for the decision tree — Rails has one copy per Ruby file, and the
- * only other legitimate copy is the visitor's (to_sql.rb:905-907). Keep it that
- * way: a second copy is how `between` silently lost unboundable collapse before.
+ * `Predications.isInfinity` / `isUnboundable` delegate to `infinitySign` /
+ * `unboundableSign` here — Rails has one copy per Ruby file, and the only other
+ * legitimate copy is the visitor's (to_sql.rb:905-907). Keep it that way: a
+ * second copy is how `between` silently lost unboundable collapse before.
+ *
+ * `Predications.isOpenEnded` and the `between` / `notBetween` decision tree
+ * below instead compose in Rails' own shape, dispatching the predicates through
+ * the host (`self`) as predications.rb:38-51 and 255-257 do, so a host
+ * overriding one is honored. That composition is not a second implementation:
+ * the protocol logic still lives only in the helpers here.
  *
  * TS deviations (deliberate, called out in the audit):
  * - `infinitySign` and `unboundableSign` mirror Ruby's `infinity?` /
@@ -146,42 +151,53 @@ interface UnboundableLike {
   isUnboundable?: () => 1 | -1 | false;
 }
 
-// Mirrors Rails Predications#open_ended? (predications.rb:255-257) —
-// `value.nil? || infinity?(value) || unboundable?(value)`. A nil, ±Infinity, or
-// out-of-range (unboundable) bound counts as "no bound on this side".
+// The leading `value.nil?` of Rails' `open_ended?` (predications.rb:255) — a
+// real dispatch, not a null check: the node classes override `nil?` to report on
+// the *wrapped* value (`BindParam#nil?` bind_param.rb:23-25, `Casted#nil?` /
+// `Quoted#nil?` casted.rb:16,41). So `between(BindParam(nil), 3)` is `lteq(3)`
+// in Rails, not a Between over a nil bind — reading only `=== null` skips that.
 //
-// Ruby's leading `value.nil?` is a real dispatch: every Arel bound answers it,
-// and the node classes override it (`BindParam#nil?` bind_param.rb:23-25,
-// `Casted#nil?` / `Quoted#nil?` casted.rb:16,41) to report on the *wrapped*
-// value. So `between(BindParam(nil), 3)` is `lteq(3)` in Rails, not a Between
-// over a nil bind — reading only `=== null` here skipped that.
-export function isOpenEnded(value: unknown): boolean {
-  return isNilBound(value) || infinitySign(value) !== 0 || unboundableSign(value) !== 0;
-}
-
-// Mirrors Ruby's `value.nil?` for the shapes a bound can take: a bare
-// null/undefined, or a node exposing the port's `isNil()`. Ruby gets this from
-// Object#nil?, so there is no Rails method to map it onto.
+// Ruby gets `nil?` from Object, so there is no Rails method to map this onto; it
+// stays a helper here and `Predications.isOpenEnded` composes it.
 export function isNilBound(value: unknown): boolean {
   if (value === null || value === undefined) return true;
   const v = value as { isNil?: () => boolean };
   return typeof v.isNil === "function" && v.isNil();
 }
 
+/**
+ * Rails' `between` / `not_between` call `unboundable?` / `open_ended?` /
+ * `infinity?` on **self** (predications.rb:38-51), so an including class that
+ * overrides one is honored — the same implicit-self dispatch `open_ended?` uses.
+ * Every host reaching here carries the three: the Predications mixin installs
+ * them by `include()`, and `Attribute` re-exposes them as protected (which is a
+ * compile-time visibility rule only, hence the widening).
+ */
+interface RangePredicates {
+  isInfinity(value: unknown): 1 | -1 | 0;
+  isUnboundable(value: unknown): 1 | -1 | 0;
+  isOpenEnded(value: unknown): boolean;
+}
+
+function selfOf(host: RangeHost): RangePredicates {
+  return host as unknown as RangePredicates;
+}
+
 export function betweenFromRange(host: RangeHost, range: RangeLike): Node {
-  if (unboundableSign(range.begin) === 1 || unboundableSign(range.end) === -1) {
+  const self = selfOf(host);
+  if (self.isUnboundable(range.begin) === 1 || self.isUnboundable(range.end) === -1) {
     return host.in([]);
   }
-  if (isOpenEnded(range.begin)) {
-    if (isOpenEnded(range.end)) {
-      if (infinitySign(range.begin) === 1 || infinitySign(range.end) === -1) {
+  if (self.isOpenEnded(range.begin)) {
+    if (self.isOpenEnded(range.end)) {
+      if (self.isInfinity(range.begin) === 1 || self.isInfinity(range.end) === -1) {
         return host.in([]);
       }
       return host.notIn([]);
     }
     return range.excludeEnd ? host.lt(range.end) : host.lteq(range.end);
   }
-  if (isOpenEnded(range.end)) {
+  if (self.isOpenEnded(range.end)) {
     return host.gteq(range.begin);
   }
   if (range.excludeEnd) {
@@ -194,19 +210,20 @@ export function betweenFromRange(host: RangeHost, range: RangeLike): Node {
 }
 
 export function notBetweenFromRange(host: RangeHost, range: RangeLike): Node {
-  if (unboundableSign(range.begin) === 1 || unboundableSign(range.end) === -1) {
+  const self = selfOf(host);
+  if (self.isUnboundable(range.begin) === 1 || self.isUnboundable(range.end) === -1) {
     return host.notIn([]);
   }
-  if (isOpenEnded(range.begin)) {
-    if (isOpenEnded(range.end)) {
-      if (infinitySign(range.begin) === 1 || infinitySign(range.end) === -1) {
+  if (self.isOpenEnded(range.begin)) {
+    if (self.isOpenEnded(range.end)) {
+      if (self.isInfinity(range.begin) === 1 || self.isInfinity(range.end) === -1) {
         return host.notIn([]);
       }
       return host.in([]);
     }
     return range.excludeEnd ? host.gteq(range.end) : host.gt(range.end);
   }
-  if (isOpenEnded(range.end)) {
+  if (self.isOpenEnded(range.end)) {
     return host.lt(range.begin);
   }
   const left = host.lt(range.begin);

--- a/packages/arel/src/predications-range.ts
+++ b/packages/arel/src/predications-range.ts
@@ -35,6 +35,16 @@ import { Between } from "./nodes/binary.js";
  *   - `unboundableSign` mirrors `unboundable?` (predications.rb:252-253) and is
  *     purely duck-typed: only a bound exposing `isUnboundable()` answers it. A
  *     bare `±Infinity` is open-ended, NOT unboundable.
+ * - Two sentinel conventions, deliberately, both standing in for Ruby's
+ *   `1 | -1 | nil`. The HELPERS here (`infinitySign` / `unboundableSign`) return
+ *   `1 | -1 | 0` and callers test `!== 0`, because Ruby's `0` is truthy and so
+ *   could not double as "absent" — `0` is unreachable anyway (see the note on
+ *   `unboundableSign`). The VALUE PROTOCOL (`Quoted#isInfinite`,
+ *   `BindParam#isInfinite` / `#isUnboundable`, `QueryAttribute`,
+ *   `UnboundableBound`) returns `1 | -1 | false`, mirroring the shape of Ruby's
+ *   `respond_to?(:x) && value.x` — `false` is the `&&` short-circuit, `nil` the
+ *   predicate's own miss. Do not "unify" them: the helper's `0` means no bound
+ *   answered, the producer's `false` means this value has no opinion.
  * - The TS port accepts three input shapes (array, object, positional)
  *   instead of Ruby's single `Range`.
  */

--- a/packages/arel/src/predications-range.ts
+++ b/packages/arel/src/predications-range.ts
@@ -1,5 +1,4 @@
 import { Node } from "./nodes/node.js";
-import { Quoted } from "./nodes/casted.js";
 import { And } from "./nodes/and.js";
 import { Or } from "./nodes/or.js";
 import { Grouping } from "./nodes/grouping.js";
@@ -29,10 +28,10 @@ import { Between } from "./nodes/binary.js";
  *   `unboundable?` value protocols. Both are duck-typed and both yield the
  *   *sign*, but they read *different* things — the two are not interchangeable:
  *   - `infinitySign` mirrors `infinity?` (predications.rb:248-250): bare
- *     `±Infinity`, a `Quoted` wrapper around it (`Quoted#infinite?`,
- *     casted.rb:43-45), or a bound exposing `isInfinite()`. It deliberately
- *     does NOT unwrap `Casted`, which defines no `infinite?` in Rails
- *     (casted.rb:5-35) — see the note at `infinitySign` before "fixing" that.
+ *     `±Infinity` (Ruby's `Float` responds to `infinite?`), or a bound exposing
+ *     `isInfinite()` — which is how a `Quoted` answers (casted.rb:43-45). A
+ *     `Casted` defines no `infinite?` in Rails (casted.rb:5-35), so it never
+ *     answers — see the note at `infinitySign` before "fixing" that.
  *   - `unboundableSign` mirrors `unboundable?` (predications.rb:252-253) and is
  *     purely duck-typed: only a bound exposing `isUnboundable()` answers it. A
  *     bare `±Infinity` is open-ended, NOT unboundable.
@@ -79,20 +78,20 @@ export function parseRange(beginOrRange: unknown, end: unknown, excludeEnd?: boo
 // `value.respond_to?(:infinite?) && value.infinite?`, which yields the *sign*
 // because `Float#infinite?` returns `1 | -1 | nil`.
 //
-// Unwraps `Quoted` (whose `infinite?` lives at casted.rb:43-45) but deliberately
-// NOT `Casted`: Rails' `Casted` defines no `infinite?` (casted.rb:5-35), so
-// `open_ended?(Casted(INFINITY))` is false there and must be false here. Do not
-// "fix" this to unwrap Casted — it would silently change `between`.
+// A plain duck-type dispatch, like Rails: bare ±Infinity (Ruby's `Float`
+// responds to `infinite?`), or anything exposing `isInfinite()`. `Quoted` is
+// NOT special-cased — it answers through its own `isInfinite` (casted.rb:43-45)
+// like any other value, and structurally unwrapping it here would be a second
+// copy of that method. `Casted` defines no `infinite?` (casted.rb:5-35), so it
+// answers 0 and `open_ended?(Casted(INFINITY))` stays false.
 //
-// Every trails producer of the protocol returns the sign, matching Ruby:
-// `Quoted#isInfinite` (casted.ts), `BindParam#isInfinite` (bind-param.ts), and
-// `QueryAttribute#isInfinite` (activerecord/src/relation/query-attribute.ts).
-// Do not add a `true` arm back — a boolean producer would report `+1` for a
-// -Infinity bound.
+// Every trails producer returns the sign, matching Ruby: `Quoted#isInfinite`
+// (casted.ts), `BindParam#isInfinite` (bind-param.ts), `QueryAttribute#isInfinite`
+// (activerecord/src/relation/query-attribute.ts). Do not add a `true` arm back —
+// a boolean producer would report `+1` for a -Infinity bound.
 export function infinitySign(value: unknown): 1 | -1 | 0 {
   if (value === Infinity) return 1;
   if (value === -Infinity) return -1;
-  if (value instanceof Quoted) return infinitySign(value.value);
   if (
     value &&
     typeof value === "object" &&

--- a/packages/arel/src/predications-range.ts
+++ b/packages/arel/src/predications-range.ts
@@ -60,6 +60,20 @@ export interface RangeLike {
   excludeEnd: boolean;
 }
 
+/**
+ * The `self` half of Rails' `between` contract: `between` / `not_between`
+ * (predications.rb:38-51) and `open_ended?` (255-257) dispatch these on self, so
+ * an including class overriding one is honored. Kept separate from `RangeHost`
+ * because `Attribute` re-exposes them as `protected` — a compile-time visibility
+ * rule, so the class is not assignable to a public interface and its two call
+ * sites widen. Callers must supply them; the runtime dispatch is real.
+ */
+export interface RangePredicates {
+  isInfinity(value: unknown): 1 | -1 | 0;
+  isUnboundable(value: unknown): 1 | -1 | 0;
+  isOpenEnded(value: unknown): boolean;
+}
+
 export interface RangeHost extends Node {
   quotedNode(other: unknown): Node;
   in(values: unknown[]): Node;
@@ -165,26 +179,8 @@ export function isNilBound(value: unknown): boolean {
   return typeof v.isNil === "function" && v.isNil();
 }
 
-/**
- * Rails' `between` / `not_between` call `unboundable?` / `open_ended?` /
- * `infinity?` on **self** (predications.rb:38-51), so an including class that
- * overrides one is honored — the same implicit-self dispatch `open_ended?` uses.
- * Every host reaching here carries the three: the Predications mixin installs
- * them by `include()`, and `Attribute` re-exposes them as protected (which is a
- * compile-time visibility rule only, hence the widening).
- */
-interface RangePredicates {
-  isInfinity(value: unknown): 1 | -1 | 0;
-  isUnboundable(value: unknown): 1 | -1 | 0;
-  isOpenEnded(value: unknown): boolean;
-}
-
-function selfOf(host: RangeHost): RangePredicates {
-  return host as unknown as RangePredicates;
-}
-
-export function betweenFromRange(host: RangeHost, range: RangeLike): Node {
-  const self = selfOf(host);
+export function betweenFromRange(host: RangeHost & RangePredicates, range: RangeLike): Node {
+  const self = host;
   if (self.isUnboundable(range.begin) === 1 || self.isUnboundable(range.end) === -1) {
     return host.in([]);
   }
@@ -209,8 +205,8 @@ export function betweenFromRange(host: RangeHost, range: RangeLike): Node {
   return new Between(host, new And([host.quotedNode(range.begin), host.quotedNode(range.end)]));
 }
 
-export function notBetweenFromRange(host: RangeHost, range: RangeLike): Node {
-  const self = selfOf(host);
+export function notBetweenFromRange(host: RangeHost & RangePredicates, range: RangeLike): Node {
+  const self = host;
   if (self.isUnboundable(range.begin) === 1 || self.isUnboundable(range.end) === -1) {
     return host.notIn([]);
   }

--- a/packages/arel/src/predications-range.ts
+++ b/packages/arel/src/predications-range.ts
@@ -156,12 +156,13 @@ interface UnboundableLike {
 // value. So `between(BindParam(nil), 3)` is `lteq(3)` in Rails, not a Between
 // over a nil bind — reading only `=== null` here skipped that.
 export function isOpenEnded(value: unknown): boolean {
-  return isNil(value) || infinitySign(value) !== 0 || unboundableSign(value) !== 0;
+  return isNilBound(value) || infinitySign(value) !== 0 || unboundableSign(value) !== 0;
 }
 
 // Mirrors Ruby's `value.nil?` for the shapes a bound can take: a bare
-// null/undefined, or a node exposing the port's `isNil()`.
-function isNil(value: unknown): boolean {
+// null/undefined, or a node exposing the port's `isNil()`. Ruby gets this from
+// Object#nil?, so there is no Rails method to map it onto.
+export function isNilBound(value: unknown): boolean {
   if (value === null || value === undefined) return true;
   const v = value as { isNil?: () => boolean };
   return typeof v.isNil === "function" && v.isNil();

--- a/packages/arel/src/predications-range.ts
+++ b/packages/arel/src/predications-range.ts
@@ -137,16 +137,25 @@ interface UnboundableLike {
   isUnboundable?: () => 1 | -1 | false;
 }
 
-// Mirrors Rails Predications#open_ended? — `value.nil? || infinity?(value) ||
-// unboundable?(value)`. A null/undefined, ±Infinity, or out-of-range
-// (unboundable) bound counts as "no bound on this side".
+// Mirrors Rails Predications#open_ended? (predications.rb:255-257) —
+// `value.nil? || infinity?(value) || unboundable?(value)`. A nil, ±Infinity, or
+// out-of-range (unboundable) bound counts as "no bound on this side".
+//
+// Ruby's leading `value.nil?` is a real dispatch: every Arel bound answers it,
+// and the node classes override it (`BindParam#nil?` bind_param.rb:23-25,
+// `Casted#nil?` / `Quoted#nil?` casted.rb:16,41) to report on the *wrapped*
+// value. So `between(BindParam(nil), 3)` is `lteq(3)` in Rails, not a Between
+// over a nil bind — reading only `=== null` here skipped that.
 export function isOpenEnded(value: unknown): boolean {
-  return (
-    value === null ||
-    value === undefined ||
-    infinitySign(value) !== 0 ||
-    unboundableSign(value) !== 0
-  );
+  return isNil(value) || infinitySign(value) !== 0 || unboundableSign(value) !== 0;
+}
+
+// Mirrors Ruby's `value.nil?` for the shapes a bound can take: a bare
+// null/undefined, or a node exposing the port's `isNil()`.
+function isNil(value: unknown): boolean {
+  if (value === null || value === undefined) return true;
+  const v = value as { isNil?: () => boolean };
+  return typeof v.isNil === "function" && v.isNil();
 }
 
 export function betweenFromRange(host: RangeHost, range: RangeLike): Node {

--- a/packages/arel/src/predications-range.ts
+++ b/packages/arel/src/predications-range.ts
@@ -17,10 +17,17 @@ import { Between } from "./nodes/binary.js";
  *   `not_between` body — Predications#not_between
  *   `infinity?` / `unboundable?` / `open_ended?` — private helpers
  *
+ * This file holds the SINGLE implementation of the three private helpers.
+ * `Predications.isInfinity` / `isUnboundable` / `isOpenEnded` delegate here, as
+ * `Predications#between` / `notBetween` and `Attribute#between` / `notBetween`
+ * already do for the decision tree — Rails has one copy per Ruby file, and the
+ * only other legitimate copy is the visitor's (to_sql.rb:905-907). Keep it that
+ * way: a second copy is how `between` silently lost unboundable collapse before.
+ *
  * TS deviations (deliberate, called out in the audit):
- * - `infinitySign` and `unboundableSign` are Trails' stand-ins for Ruby's
- *   `infinity?` / `unboundable?` value protocols, and they read *different*
- *   things — the two are not interchangeable:
+ * - `infinitySign` and `unboundableSign` mirror Ruby's `infinity?` /
+ *   `unboundable?` value protocols. Both are duck-typed and both yield the
+ *   *sign*, but they read *different* things — the two are not interchangeable:
  *   - `infinitySign` mirrors `infinity?` (predications.rb:248-250): bare
  *     `±Infinity`, a `Quoted` wrapper around it (`Quoted#infinite?`,
  *     casted.rb:43-45), or a bound exposing `isInfinite()`. It deliberately
@@ -77,17 +84,11 @@ export function parseRange(beginOrRange: unknown, end: unknown, excludeEnd?: boo
 // `open_ended?(Casted(INFINITY))` is false there and must be false here. Do not
 // "fix" this to unwrap Casted — it would silently change `between`.
 //
-// The `r === true` arm is NOT the same dead coercion removed from
-// `unboundableSign`: it compensates for a live producer. Rails'
-// `QueryAttribute#infinite?` (query_attribute.rb:42-44) returns
-// `infinity?(...)`, i.e. the sign; trails' returns a plain `boolean`
-// (`activerecord/src/relation/query-attribute.ts:89-94`), and `BindParam#isInfinite`
-// delegates to it (bind-param.ts:45-48) despite its `number | null` annotation.
-// Dropping the arm would stop detecting +Infinity binds; keeping it reports +1
-// for a -Infinity bind. Both are wrong — the root cause is the boolean return,
-// tracked in story `arel-predications-unboundable-duck-types-like-rails`. Latent
-// today: trails' RangeHandler passes cast values / UnboundableBound, never a
-// QueryAttribute, as a range bound.
+// Every trails producer of the protocol returns the sign, matching Ruby:
+// `Quoted#isInfinite` (casted.ts), `BindParam#isInfinite` (bind-param.ts), and
+// `QueryAttribute#isInfinite` (activerecord/src/relation/query-attribute.ts).
+// Do not add a `true` arm back — a boolean producer would report `+1` for a
+// -Infinity bound.
 export function infinitySign(value: unknown): 1 | -1 | 0 {
   if (value === Infinity) return 1;
   if (value === -Infinity) return -1;
@@ -98,8 +99,7 @@ export function infinitySign(value: unknown): 1 | -1 | 0 {
     typeof (value as InfiniteLike).isInfinite === "function"
   ) {
     const r = (value as InfiniteLike).isInfinite!();
-    if (r === 1 || r === true) return 1;
-    if (r === -1) return -1;
+    if (r === 1 || r === -1) return r;
   }
   return 0;
 }
@@ -130,11 +130,11 @@ export function unboundableSign(value: unknown): 1 | -1 | 0 {
 }
 
 interface InfiniteLike {
-  isInfinite?: () => number | boolean | null;
+  isInfinite?: () => 1 | -1 | false;
 }
 
 interface UnboundableLike {
-  isUnboundable?: () => 1 | -1 | 0 | boolean;
+  isUnboundable?: () => 1 | -1 | false;
 }
 
 // Mirrors Rails Predications#open_ended? — `value.nil? || infinity?(value) ||

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -27,6 +27,7 @@ import {
   unboundableSign,
   isNilBound,
   type RangeHost,
+  type RangePredicates,
 } from "./predications-range.js";
 
 /**
@@ -184,7 +185,7 @@ export const Predications = {
   // half-comparisons, exclusive end uses `<` / `>=`, and degenerate
   // `b == e` collapses to eq.
   between: function (
-    this: Node & PredicationHost & RangeHost,
+    this: Node & PredicationHost & RangeHost & RangePredicates,
     beginOrRange: unknown,
     end?: unknown,
     excludeEnd?: boolean,
@@ -192,13 +193,16 @@ export const Predications = {
     const range = parseRange(beginOrRange, end, excludeEnd);
     return betweenFromRange(this, range);
   } as {
-    (this: Node & PredicationHost & RangeHost, range: readonly [unknown, unknown]): Node;
     (
-      this: Node & PredicationHost & RangeHost,
+      this: Node & PredicationHost & RangeHost & RangePredicates,
+      range: readonly [unknown, unknown],
+    ): Node;
+    (
+      this: Node & PredicationHost & RangeHost & RangePredicates,
       range: { begin: unknown; end: unknown; excludeEnd?: boolean },
     ): Node;
     (
-      this: Node & PredicationHost & RangeHost,
+      this: Node & PredicationHost & RangeHost & RangePredicates,
       begin: unknown,
       end: unknown,
       excludeEnd?: boolean,
@@ -206,7 +210,7 @@ export const Predications = {
   },
 
   notBetween: function (
-    this: Node & PredicationHost & RangeHost,
+    this: Node & PredicationHost & RangeHost & RangePredicates,
     beginOrRange: unknown,
     end?: unknown,
     excludeEnd?: boolean,
@@ -214,13 +218,16 @@ export const Predications = {
     const range = parseRange(beginOrRange, end, excludeEnd);
     return notBetweenFromRange(this, range);
   } as {
-    (this: Node & PredicationHost & RangeHost, range: readonly [unknown, unknown]): Node;
     (
-      this: Node & PredicationHost & RangeHost,
+      this: Node & PredicationHost & RangeHost & RangePredicates,
+      range: readonly [unknown, unknown],
+    ): Node;
+    (
+      this: Node & PredicationHost & RangeHost & RangePredicates,
       range: { begin: unknown; end: unknown; excludeEnd?: boolean },
     ): Node;
     (
-      this: Node & PredicationHost & RangeHost,
+      this: Node & PredicationHost & RangeHost & RangePredicates,
       begin: unknown,
       end: unknown,
       excludeEnd?: boolean,

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -23,6 +23,9 @@ import {
   parseRange,
   betweenFromRange,
   notBetweenFromRange,
+  infinitySign,
+  unboundableSign,
+  isOpenEnded,
   type RangeHost,
 } from "./predications-range.js";
 
@@ -338,41 +341,31 @@ export const Predications = {
     return groupedAll(others.map(predicationDispatch(this, methodId, extras)));
   },
 
-  // Mirrors Arel::Predications#infinity? — in the TS port, true only
-  // for JavaScript +/-Infinity values. Ruby's `infinite?` protocol
-  // (which Rails also accepts) has no TS analog; if a future Trails
-  // wrapper type wants to surface infiniteness, this is the place to
-  // teach it. Used to decide whether to clamp a `between` bound to
-  // an open half-range.
-  isInfinity(this: PredicationHost, value: unknown): boolean {
-    return value === Infinity || value === -Infinity;
-  },
-
-  // Mirrors Arel::Predications#unboundable? — Rails-side, this catches
-  // values that can't be compared (e.g. an unboundable bind value).
-  // The TS port has no analog of Ruby's `unboundable?` protocol, so
-  // this returns false; kept for surface fidelity.
-  isUnboundable(this: PredicationHost, value: unknown): boolean {
+  // Mirrors Arel::Predications#infinity? (predications.rb:248-250) —
+  // `value.respond_to?(:infinite?) && value.infinite?`, which yields the sign
+  // because Ruby's `Float#infinite?` returns `1 | -1 | nil`. The decision tree
+  // in predications-range.ts reads the sign, so these three expose the same
+  // single implementation `between` / `notBetween` above already use rather
+  // than a second copy — Rails has exactly one per Ruby file.
+  isInfinity(this: PredicationHost, value: unknown): 1 | -1 | 0 {
     void this;
-    void value;
-    return false;
+    return infinitySign(value);
   },
 
-  // Mirrors Arel::Predications#open_ended? — null, infinite, or
-  // unboundable values are treated as "no bound on this side".
-  // Dispatches `isInfinity` / `isUnboundable` through `this` (rather
-  // than calling the Predications module directly) so host classes
-  // can override either check. Mirrors Ruby's method-lookup semantics
-  // for `infinity?` / `unboundable?`.
-  isOpenEnded(
-    this: PredicationHost & {
-      isInfinity(value: unknown): boolean;
-      isUnboundable(value: unknown): boolean;
-    },
-    value: unknown,
-  ): boolean {
-    return (
-      value === null || value === undefined || this.isInfinity(value) || this.isUnboundable(value)
-    );
+  // Mirrors Arel::Predications#unboundable? (predications.rb:252-253) —
+  // `value.respond_to?(:unboundable?) && value.unboundable?`. Duck-typed: a
+  // bound answers it by exposing `isUnboundable()` (a QueryAttribute bind, or
+  // the RangeHandler's out-of-range sentinel). A bare ±Infinity is open-ended,
+  // NOT unboundable — Float has no `unboundable?` in Ruby.
+  isUnboundable(this: PredicationHost, value: unknown): 1 | -1 | 0 {
+    void this;
+    return unboundableSign(value);
+  },
+
+  // Mirrors Arel::Predications#open_ended? (predications.rb:255-257) —
+  // `value.nil? || infinity?(value) || unboundable?(value)`.
+  isOpenEnded(this: PredicationHost, value: unknown): boolean {
+    void this;
+    return isOpenEnded(value);
   },
 };

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -25,7 +25,7 @@ import {
   notBetweenFromRange,
   infinitySign,
   unboundableSign,
-  isOpenEnded,
+  isNilBound,
   type RangeHost,
 } from "./predications-range.js";
 
@@ -363,9 +363,20 @@ export const Predications = {
   },
 
   // Mirrors Arel::Predications#open_ended? (predications.rb:255-257) —
-  // `value.nil? || infinity?(value) || unboundable?(value)`.
-  isOpenEnded(this: PredicationHost, value: unknown): boolean {
-    void this;
-    return isOpenEnded(value);
+  // `value.nil? || infinity?(value) || unboundable?(value)`, composed here in
+  // Rails' own shape rather than delegating: Ruby dispatches `infinity?` /
+  // `unboundable?` through implicit self, so a host overriding either is
+  // honored. The protocol logic itself still lives in exactly one place —
+  // these call `isInfinity` / `isUnboundable` above, which delegate to
+  // predications-range.ts. `betweenFromRange` composes the same three helpers
+  // for the extracted `between` body.
+  isOpenEnded(
+    this: PredicationHost & {
+      isInfinity(value: unknown): 1 | -1 | 0;
+      isUnboundable(value: unknown): 1 | -1 | 0;
+    },
+    value: unknown,
+  ): boolean {
+    return isNilBound(value) || this.isInfinity(value) !== 0 || this.isUnboundable(value) !== 0;
   },
 };

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -11790,13 +11790,6 @@
   {
     "package": "activemodel",
     "tsFile": "type/integer.ts",
-    "rubyName": "serializable?",
-    "call": "cast",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "type/integer.ts",
     "rubyName": "serialize",
     "call": "non_numeric_string?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -1180,7 +1180,7 @@
     "tsFile": "metal.ts",
     "rubyName": "performed?",
     "call": "response_body",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actioncontroller",
@@ -1446,14 +1446,14 @@
     "tsFile": "metal/etag-with-template-digest.ts",
     "rubyName": "pick_template_for_etag",
     "call": "find_all",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actioncontroller",
     "tsFile": "metal/etag-with-template-digest.ts",
     "rubyName": "pick_template_for_etag",
     "call": "first",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actioncontroller",
@@ -1677,14 +1677,14 @@
     "tsFile": "metal/live.ts",
     "rubyName": "abort",
     "call": "clear",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actioncontroller",
     "tsFile": "metal/live.ts",
     "rubyName": "abort",
     "call": "synchronize",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actioncontroller",
@@ -1852,14 +1852,14 @@
     "tsFile": "metal/mime-responds.ts",
     "rubyName": "any_response?",
     "call": "fetch",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actioncontroller",
     "tsFile": "metal/mime-responds.ts",
     "rubyName": "any_response?",
     "call": "format",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actioncontroller",
@@ -2370,7 +2370,7 @@
     "tsFile": "metal/request-forgery-protection.ts",
     "rubyName": "reset",
     "call": "delete",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actioncontroller",
@@ -2965,14 +2965,14 @@
     "tsFile": "renderer.ts",
     "rubyName": "env_for_request",
     "call": "key?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actioncontroller",
     "tsFile": "renderer.ts",
     "rubyName": "env_for_request",
     "call": "merge",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actioncontroller",
@@ -3140,7 +3140,7 @@
     "tsFile": "test-case.ts",
     "rubyName": "controller_class_name",
     "call": "anonymous?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actioncontroller",
@@ -3917,7 +3917,7 @@
     "tsFile": "http/mime-type.ts",
     "rubyName": "ref",
     "call": "to_s",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -3952,7 +3952,7 @@
     "tsFile": "http/mime-type.ts",
     "rubyName": "to_str",
     "call": "to_s",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -4176,21 +4176,21 @@
     "tsFile": "http/request.ts",
     "rubyName": "engine_script_name",
     "call": "get_header",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "engine_script_name=",
     "call": "routes",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "engine_script_name=",
     "call": "set_header",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -4204,49 +4204,49 @@
     "tsFile": "http/request.ts",
     "rubyName": "GET",
     "call": "action_encoding_template",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "GET",
     "call": "fetch_header",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "GET",
     "call": "from_query_string",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "GET",
     "call": "new",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "GET",
     "call": "path_parameters",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "GET",
     "call": "set_header",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "initialize",
     "call": "new",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -4316,56 +4316,56 @@
     "tsFile": "http/request.ts",
     "rubyName": "POST",
     "call": "action_encoding_template",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "POST",
     "call": "fetch_header",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "POST",
     "call": "from_hash",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "POST",
     "call": "from_pairs",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "POST",
     "call": "new",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "POST",
     "call": "params_parsers",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "POST",
     "call": "parse_formatted_parameters",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "POST",
     "call": "path_parameters",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -4918,7 +4918,7 @@
     "tsFile": "journey/nodes/node.ts",
     "rubyName": "glob?",
     "call": "any?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -5275,7 +5275,7 @@
     "tsFile": "middleware/cookies.ts",
     "rubyName": "have_cookie_jar?",
     "call": "has_header?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -5310,7 +5310,7 @@
     "tsFile": "middleware/cookies.ts",
     "rubyName": "serializer",
     "call": "cookies_serializer",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -5555,42 +5555,42 @@
     "tsFile": "middleware/exception-wrapper.ts",
     "rubyName": "build_backtrace",
     "call": "each",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "middleware/exception-wrapper.ts",
     "rubyName": "build_backtrace",
     "call": "key?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "middleware/exception-wrapper.ts",
     "rubyName": "build_backtrace",
     "call": "map",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "middleware/exception-wrapper.ts",
     "rubyName": "build_backtrace",
     "call": "method_name",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "middleware/exception-wrapper.ts",
     "rubyName": "build_backtrace",
     "call": "new",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "middleware/exception-wrapper.ts",
     "rubyName": "build_backtrace",
     "call": "to_s",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -5716,7 +5716,7 @@
     "tsFile": "middleware/flash.ts",
     "rubyName": "flash_hash",
     "call": "get_header",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -5912,7 +5912,7 @@
     "tsFile": "middleware/session/abstract-store.ts",
     "rubyName": "initialize_sid",
     "call": "delete",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -5926,7 +5926,7 @@
     "tsFile": "middleware/session/mem-cache-store.ts",
     "rubyName": "initialize_sid",
     "call": "delete",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -6143,7 +6143,7 @@
     "tsFile": "middleware/stack.ts",
     "rubyName": "last",
     "call": "middlewares",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -6444,7 +6444,7 @@
     "tsFile": "request/session.ts",
     "rubyName": "find",
     "call": "get_header",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -7221,7 +7221,7 @@
     "tsFile": "routing/mapper.ts",
     "rubyName": "nested_scope?",
     "call": "nested?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -8481,35 +8481,35 @@
     "tsFile": "system-testing/driver.ts",
     "rubyName": "browser_options",
     "call": "compact",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "system-testing/driver.ts",
     "rubyName": "browser_options",
     "call": "merge",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "system-testing/driver.ts",
     "rubyName": "browser_options",
     "call": "options",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "system-testing/driver.ts",
     "rubyName": "initialize",
     "call": "delete",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "system-testing/driver.ts",
     "rubyName": "initialize",
     "call": "new",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -8803,14 +8803,14 @@
     "tsFile": "testing/assertions/routing.ts",
     "rubyName": "reset_routes",
     "call": "app",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "testing/assertions/routing.ts",
     "rubyName": "reset_routes",
     "call": "redefine_method",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -9069,28 +9069,28 @@
     "tsFile": "testing/integration.ts",
     "rubyName": "url_options",
     "call": "controller",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "testing/integration.ts",
     "rubyName": "url_options",
     "call": "default_url_options",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "testing/integration.ts",
     "rubyName": "url_options",
     "call": "reverse_merge!",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "testing/integration.ts",
     "rubyName": "url_options",
     "call": "routes",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -9153,7 +9153,7 @@
     "tsFile": "gem-version.ts",
     "rubyName": "gem_version",
     "call": "new",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actionview",
@@ -10189,14 +10189,14 @@
     "tsFile": "attribute-methods.ts",
     "rubyName": "attribute_alias",
     "call": "attribute_aliases",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activemodel",
     "tsFile": "attribute-methods.ts",
     "rubyName": "attribute_alias",
     "call": "to_s",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activemodel",
@@ -10399,14 +10399,14 @@
     "tsFile": "attribute-methods.ts",
     "rubyName": "generated_attribute_methods",
     "call": "include",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activemodel",
     "tsFile": "attribute-methods.ts",
     "rubyName": "generated_attribute_methods",
     "call": "new",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activemodel",
@@ -10427,14 +10427,14 @@
     "tsFile": "attribute-methods.ts",
     "rubyName": "resolve_attribute_name",
     "call": "attribute_aliases",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activemodel",
     "tsFile": "attribute-methods.ts",
     "rubyName": "resolve_attribute_name",
     "call": "fetch",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activemodel",
@@ -10553,7 +10553,7 @@
     "tsFile": "attribute-set.ts",
     "rubyName": "cast_types",
     "call": "transform_values",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activemodel",
@@ -10756,7 +10756,7 @@
     "tsFile": "dirty.ts",
     "rubyName": "as_json",
     "call": "merge",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activemodel",
@@ -10812,14 +10812,14 @@
     "tsFile": "dirty.ts",
     "rubyName": "attribute_previous_change",
     "call": "change_to_attribute",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activemodel",
     "tsFile": "dirty.ts",
     "rubyName": "attribute_previous_change",
     "call": "to_s",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activemodel",
@@ -11897,7 +11897,7 @@
     "tsFile": "type/value.ts",
     "rubyName": "initialize",
     "call": "serialize_cast_value_compatible?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activemodel",
@@ -12898,7 +12898,7 @@
     "tsFile": "associations/association.ts",
     "rubyName": "marshal_dump",
     "call": "map",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -12989,21 +12989,21 @@
     "tsFile": "associations/has-one-association.ts",
     "rubyName": "foreign_key_present?",
     "call": "attribute_present?",
-    "reason": "Satisfied via the extracted foreignKeyPresentFor helper (foreign-association.ts), which calls owner.attributePresent — same delegation as CollectionAssociation#foreignKeyPresent."
+    "reason": "Satisfied via the extracted foreignKeyPresentFor helper (foreign-association.ts), which calls owner.attributePresent \u2014 same delegation as CollectionAssociation#foreignKeyPresent."
   },
   {
     "package": "activerecord",
     "tsFile": "associations/has-one-association.ts",
     "rubyName": "foreign_key_present?",
     "call": "klass",
-    "reason": "Satisfied via the extracted foreignKeyPresentFor helper (foreign-association.ts), which reads reflection.klass — same delegation as CollectionAssociation#foreignKeyPresent."
+    "reason": "Satisfied via the extracted foreignKeyPresentFor helper (foreign-association.ts), which reads reflection.klass \u2014 same delegation as CollectionAssociation#foreignKeyPresent."
   },
   {
     "package": "activerecord",
     "tsFile": "associations/has-one-association.ts",
     "rubyName": "foreign_key_present?",
     "call": "primary_key",
-    "reason": "Satisfied via the extracted foreignKeyPresentFor helper (foreign-association.ts), which reads klass.primaryKey — same delegation as CollectionAssociation#foreignKeyPresent."
+    "reason": "Satisfied via the extracted foreignKeyPresentFor helper (foreign-association.ts), which reads klass.primaryKey \u2014 same delegation as CollectionAssociation#foreignKeyPresent."
   },
   {
     "package": "activerecord",
@@ -16216,7 +16216,7 @@
     "tsFile": "attribute-methods.ts",
     "rubyName": "initialize_generated_modules",
     "call": "include",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -16244,7 +16244,7 @@
     "tsFile": "attribute-methods.ts",
     "rubyName": "method_defined_within?",
     "call": "owner",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -16510,14 +16510,14 @@
     "tsFile": "attribute-methods/dirty.ts",
     "rubyName": "attribute_change_to_be_saved",
     "call": "change_to_attribute",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "attribute-methods/dirty.ts",
     "rubyName": "attribute_change_to_be_saved",
     "call": "to_s",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -16545,14 +16545,14 @@
     "tsFile": "attribute-methods/dirty.ts",
     "rubyName": "saved_change_to_attribute",
     "call": "change_to_attribute",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "attribute-methods/dirty.ts",
     "rubyName": "saved_change_to_attribute",
     "call": "to_s",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -16657,14 +16657,14 @@
     "tsFile": "attribute-methods/primary-key.ts",
     "rubyName": "instance_method_already_implemented?",
     "call": "include?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "attribute-methods/primary-key.ts",
     "rubyName": "instance_method_already_implemented?",
     "call": "primary_key",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -18379,7 +18379,7 @@
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "extended_type_map_key",
     "call": "emulate_booleans",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -18442,7 +18442,7 @@
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "mariadb?",
     "call": "match?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -18883,7 +18883,7 @@
     "tsFile": "connection-adapters/abstract/connection-pool.ts",
     "rubyName": "clear_reloadable_connections",
     "call": "disconnect!",
-    "reason": "clearReloadableConnections is now async (converge-connection-pool-lifecycle-async); it delegates the synchronous reload-clear — including `conn.disconnectBang()` — to the private `_clearReloadableConnections` core so the public method can await the returned async-close drains. Same call, moved into the shared sync helper."
+    "reason": "clearReloadableConnections is now async (converge-connection-pool-lifecycle-async); it delegates the synchronous reload-clear \u2014 including `conn.disconnectBang()` \u2014 to the private `_clearReloadableConnections` core so the public method can await the returned async-close drains. Same call, moved into the shared sync helper."
   },
   {
     "package": "activerecord",
@@ -18918,14 +18918,14 @@
     "tsFile": "connection-adapters/abstract/connection-pool.ts",
     "rubyName": "connected?",
     "call": "any?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-pool.ts",
     "rubyName": "connected?",
     "call": "synchronize",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -18995,7 +18995,7 @@
     "tsFile": "connection-adapters/abstract/connection-pool.ts",
     "rubyName": "flush",
     "call": "disconnect!",
-    "reason": "flush is now async (converge-connection-pool-lifecycle-async); it delegates the synchronous eviction — including `conn.disconnectBang()` — to the private `_flush` core so the public method can await the returned async-close drains. Same call, moved into the shared sync helper."
+    "reason": "flush is now async (converge-connection-pool-lifecycle-async); it delegates the synchronous eviction \u2014 including `conn.disconnectBang()` \u2014 to the private `_flush` core so the public method can await the returned async-close drains. Same call, moved into the shared sync helper."
   },
   {
     "package": "activerecord",
@@ -19205,7 +19205,7 @@
     "tsFile": "connection-adapters/abstract/connection-pool/queue.ts",
     "rubyName": "any_waiting?",
     "call": "synchronize",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -19219,14 +19219,14 @@
     "tsFile": "connection-adapters/abstract/connection-pool/queue.ts",
     "rubyName": "can_remove_no_wait?",
     "call": "size",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-pool/queue.ts",
     "rubyName": "clear",
     "call": "synchronize",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -19247,7 +19247,7 @@
     "tsFile": "connection-adapters/abstract/connection-pool/queue.ts",
     "rubyName": "num_waiting",
     "call": "synchronize",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -19646,21 +19646,21 @@
     "tsFile": "connection-adapters/abstract/query-cache.ts",
     "rubyName": "query_cache",
     "call": "compute_if_absent",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/query-cache.ts",
     "rubyName": "query_cache",
     "call": "context",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/query-cache.ts",
     "rubyName": "query_cache",
     "call": "new",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -19779,7 +19779,7 @@
     "tsFile": "connection-adapters/abstract/schema-creation.ts",
     "rubyName": "column_options",
     "call": "merge",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -20038,7 +20038,7 @@
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "conditional_options",
     "call": "slice",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -20101,14 +20101,14 @@
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "integer_like_primary_key?",
     "call": "include?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "integer_like_primary_key?",
     "call": "key?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -20892,7 +20892,7 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "extract_new_default_value",
     "call": "has_key?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -20962,7 +20962,7 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "foreign_keys_enabled?",
     "call": "fetch",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -21151,7 +21151,7 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "options_include_default?",
     "call": "include?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -21816,14 +21816,14 @@
     "tsFile": "connection-adapters/mysql/column.ts",
     "rubyName": "unsigned?",
     "call": "match?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql/column.ts",
     "rubyName": "virtual?",
     "call": "match?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -21998,21 +21998,21 @@
     "tsFile": "connection-adapters/mysql/schema-dumper.ts",
     "rubyName": "extract_expression_for_virtual_column",
     "call": "query_value",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql/schema-dumper.ts",
     "rubyName": "extract_expression_for_virtual_column",
     "call": "quote",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql/schema-dumper.ts",
     "rubyName": "extract_expression_for_virtual_column",
     "call": "quote_column_name",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -22173,14 +22173,14 @@
     "tsFile": "connection-adapters/mysql2-adapter.ts",
     "rubyName": "connect",
     "call": "new_client",
-    "reason": "Rails' private connect (mysql2_adapter.rb:144) is `@raw_connection = new_client(...)`; trails' connect() delegates to _ensureClient(), which calls Mysql2Adapter.newClient() (the new_client analog) — so the call is satisfied one frame down, not inlined here."
+    "reason": "Rails' private connect (mysql2_adapter.rb:144) is `@raw_connection = new_client(...)`; trails' connect() delegates to _ensureClient(), which calls Mysql2Adapter.newClient() (the new_client analog) \u2014 so the call is satisfied one frame down, not inlined here."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql2-adapter.ts",
     "rubyName": "connect",
     "call": "set_pool",
-    "reason": "Rails' connect rescues ConnectionNotEstablished and re-raises `ex.set_pool(@pool)` (mysql2_adapter.rb:146-147); trails' connect() delegates to _ensureClient(), whose catch attaches the pool via translated.setPool(this.pool) — same set_pool behavior, one frame down."
+    "reason": "Rails' connect rescues ConnectionNotEstablished and re-raises `ex.set_pool(@pool)` (mysql2_adapter.rb:146-147); trails' connect() delegates to _ensureClient(), whose catch attaches the pool via translated.setPool(this.pool) \u2014 same set_pool behavior, one frame down."
   },
   {
     "package": "activerecord",
@@ -22964,7 +22964,7 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "supports_optimizer_hints?",
     "call": "extension_available?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -22992,14 +22992,14 @@
     "tsFile": "connection-adapters/postgresql/column.ts",
     "rubyName": "virtual?",
     "call": "present?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql/database-statements.ts",
     "rubyName": "affected_rows",
     "call": "clear",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -23090,7 +23090,7 @@
     "tsFile": "connection-adapters/postgresql/database-statements.ts",
     "rubyName": "returning_column_values",
     "call": "first",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -23510,7 +23510,7 @@
     "tsFile": "connection-adapters/postgresql/schema-definitions.ts",
     "rubyName": "export_name_on_schema_dump?",
     "call": "match?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -23615,7 +23615,7 @@
     "tsFile": "connection-adapters/postgresql/utils.ts",
     "rubyName": "to_s",
     "call": "join",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -24672,7 +24672,7 @@
     "tsFile": "connection-adapters/sqlite3/database-statements.ts",
     "rubyName": "returning_column_values",
     "call": "first",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -25281,7 +25281,7 @@
     "tsFile": "core.ts",
     "rubyName": "configurations=",
     "call": "new",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -25302,7 +25302,7 @@
     "tsFile": "core.ts",
     "rubyName": "connection_class?",
     "call": "connection_class",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -25498,14 +25498,14 @@
     "tsFile": "core.ts",
     "rubyName": "init_internals",
     "call": "define_attribute_methods",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "core.ts",
     "rubyName": "init_internals",
     "call": "primary_key",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -25981,7 +25981,7 @@
     "tsFile": "database-configurations/hash-config.ts",
     "rubyName": "database_tasks?",
     "call": "fetch",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -26156,14 +26156,14 @@
     "tsFile": "encryption.ts",
     "rubyName": "context",
     "call": "default_context",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "encryption.ts",
     "rubyName": "current_custom_context",
     "call": "last",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -26639,14 +26639,14 @@
     "tsFile": "encryption/encryptable-record.ts",
     "rubyName": "has_encrypted_attributes?",
     "call": "encrypted_attributes",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "encryption/encryptable-record.ts",
     "rubyName": "has_encrypted_attributes?",
     "call": "present?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -26744,14 +26744,14 @@
     "tsFile": "encryption/encrypted-attribute-type.ts",
     "rubyName": "decryption_options",
     "call": "compact",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "encryption/encrypted-attribute-type.ts",
     "rubyName": "encryption_options",
     "call": "compact",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -27045,14 +27045,14 @@
     "tsFile": "encryption/key-provider.ts",
     "rubyName": "encryption_key",
     "call": "id",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "encryption/key-provider.ts",
     "rubyName": "encryption_key",
     "call": "last",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -27388,14 +27388,14 @@
     "tsFile": "errors.ts",
     "rubyName": "set_query",
     "call": "call",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "errors.ts",
     "rubyName": "set_query",
     "call": "new",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -27787,7 +27787,7 @@
     "tsFile": "insert-all.ts",
     "rubyName": "resolve_attribute_alias",
     "call": "attribute_alias",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -28074,14 +28074,14 @@
     "tsFile": "locking/optimistic.ts",
     "rubyName": "locking_column=",
     "call": "reload_schema_from_cache",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "locking/optimistic.ts",
     "rubyName": "locking_column=",
     "call": "to_s",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -28865,7 +28865,7 @@
     "tsFile": "migration.ts",
     "rubyName": "reverting?",
     "call": "connection",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -29915,7 +29915,7 @@
     "tsFile": "no-touching.ts",
     "rubyName": "no_touching?",
     "call": "applied_to?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -31063,21 +31063,21 @@
     "tsFile": "relation.ts",
     "rubyName": "alias_tracker",
     "call": "connection_pool",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "alias_tracker",
     "call": "create",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "alias_tracker",
     "call": "model",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -33443,14 +33443,14 @@
     "tsFile": "relation.ts",
     "rubyName": "none?",
     "call": "empty?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "none?",
     "call": "present?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -33632,42 +33632,42 @@
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "call",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "each",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "includes_values",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "new",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "preload_values",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "strict_loading_value",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -35942,63 +35942,63 @@
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
     "call": "empty?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
     "call": "find",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
     "call": "includes_values",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
     "call": "includes!",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
     "call": "model",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
     "call": "preload_values",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
     "call": "preload!",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
     "call": "reflect_on_all_associations",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
     "call": "relation",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -36285,14 +36285,14 @@
     "tsFile": "relation/predicate-builder.ts",
     "rubyName": "handler_for",
     "call": "detect",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/predicate-builder.ts",
     "rubyName": "handler_for",
     "call": "last",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -36397,7 +36397,7 @@
     "tsFile": "relation/predicate-builder/polymorphic-array-value.ts",
     "rubyName": "klass",
     "call": "model",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -36503,13 +36503,6 @@
     "rubyName": "initialize",
     "call": "mutable?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-attribute.ts",
-    "rubyName": "unboundable?",
-    "call": "serializable?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -37069,7 +37062,7 @@
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_where_clause",
     "call": "map",
-    "reason": "Rails' `build_where_clause` `map` is `key.map { |k| attribute_aliases[k] }` inside `transform_keys` for composite ARRAY keys; JS object keys can't be arrays, so trails resolves single-key aliases via `aliases[key] ?? key` and composite keys via `PredicateBuilder#buildComposite` — no `map` over keys applies."
+    "reason": "Rails' `build_where_clause` `map` is `key.map { |k| attribute_aliases[k] }` inside `transform_keys` for composite ARRAY keys; JS object keys can't be arrays, so trails resolves single-key aliases via `aliases[key] ?? key` and composite keys via `PredicateBuilder#buildComposite` \u2014 no `map` over keys applies."
   },
   {
     "package": "activerecord",
@@ -38406,7 +38399,7 @@
     "tsFile": "scoping.ts",
     "rubyName": "scope_attributes?",
     "call": "any?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -39379,7 +39372,7 @@
     "tsFile": "tasks/mysql-database-tasks.ts",
     "rubyName": "collation",
     "call": "connection",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -39533,7 +39526,7 @@
     "tsFile": "tasks/postgresql-database-tasks.ts",
     "rubyName": "collation",
     "call": "connection",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -40366,14 +40359,14 @@
     "tsFile": "type.ts",
     "rubyName": "adapter_name_from",
     "call": "adapter",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "type.ts",
     "rubyName": "adapter_name_from",
     "call": "connection_db_config",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -40485,7 +40478,7 @@
     "tsFile": "validations.ts",
     "rubyName": "custom_validation_context?",
     "call": "exclude?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -40870,28 +40863,28 @@
     "tsFile": "cache.ts",
     "rubyName": "namespace_key",
     "call": "call",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activesupport",
     "tsFile": "cache.ts",
     "rubyName": "namespace_key",
     "call": "key?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activesupport",
     "tsFile": "cache.ts",
     "rubyName": "normalize_options",
     "call": "each",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activesupport",
     "tsFile": "cache.ts",
     "rubyName": "normalize_options",
     "call": "key?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activesupport",
@@ -41269,7 +41262,7 @@
     "tsFile": "callbacks.ts",
     "rubyName": "duplicates?",
     "call": "matches?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activesupport",
@@ -41710,14 +41703,14 @@
     "tsFile": "duration.ts",
     "rubyName": "initialize",
     "call": "any?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activesupport",
     "tsFile": "duration.ts",
     "rubyName": "initialize",
     "call": "include?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activesupport",
@@ -41801,7 +41794,7 @@
     "tsFile": "encrypted-file.ts",
     "rubyName": "read_env_key",
     "call": "presence",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activesupport",
@@ -42025,7 +42018,7 @@
     "tsFile": "error-reporter.ts",
     "rubyName": "set_context",
     "call": "set",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activesupport",
@@ -42424,7 +42417,7 @@
     "tsFile": "number-helper/number-to-phone-converter.ts",
     "rubyName": "country_code",
     "call": "blank?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activesupport",
@@ -42648,28 +42641,28 @@
     "tsFile": "xml-mini.ts",
     "rubyName": "to_tag",
     "call": "call",
-    "reason": "to_tag ports XmlMini.to_tag: Rails' Hash#delete(:type)/#merge/#call/#to_s are satisfied by different TS idioms (immutable `{ ...options }` spread instead of merge, destructured `options.type` instead of delete, direct function invocation, and String()/keyToString()) — no behavioral omission."
+    "reason": "to_tag ports XmlMini.to_tag: Rails' Hash#delete(:type)/#merge/#call/#to_s are satisfied by different TS idioms (immutable `{ ...options }` spread instead of merge, destructured `options.type` instead of delete, direct function invocation, and String()/keyToString()) \u2014 no behavioral omission."
   },
   {
     "package": "activesupport",
     "tsFile": "xml-mini.ts",
     "rubyName": "to_tag",
     "call": "delete",
-    "reason": "to_tag ports XmlMini.to_tag: Rails' Hash#delete(:type)/#merge/#call/#to_s are satisfied by different TS idioms (immutable `{ ...options }` spread instead of merge, destructured `options.type` instead of delete, direct function invocation, and String()/keyToString()) — no behavioral omission."
+    "reason": "to_tag ports XmlMini.to_tag: Rails' Hash#delete(:type)/#merge/#call/#to_s are satisfied by different TS idioms (immutable `{ ...options }` spread instead of merge, destructured `options.type` instead of delete, direct function invocation, and String()/keyToString()) \u2014 no behavioral omission."
   },
   {
     "package": "activesupport",
     "tsFile": "xml-mini.ts",
     "rubyName": "to_tag",
     "call": "merge",
-    "reason": "to_tag ports XmlMini.to_tag: Rails' Hash#delete(:type)/#merge/#call/#to_s are satisfied by different TS idioms (immutable `{ ...options }` spread instead of merge, destructured `options.type` instead of delete, direct function invocation, and String()/keyToString()) — no behavioral omission."
+    "reason": "to_tag ports XmlMini.to_tag: Rails' Hash#delete(:type)/#merge/#call/#to_s are satisfied by different TS idioms (immutable `{ ...options }` spread instead of merge, destructured `options.type` instead of delete, direct function invocation, and String()/keyToString()) \u2014 no behavioral omission."
   },
   {
     "package": "activesupport",
     "tsFile": "xml-mini.ts",
     "rubyName": "to_tag",
     "call": "to_s",
-    "reason": "to_tag ports XmlMini.to_tag: Rails' Hash#delete(:type)/#merge/#call/#to_s are satisfied by different TS idioms (immutable `{ ...options }` spread instead of merge, destructured `options.type` instead of delete, direct function invocation, and String()/keyToString()) — no behavioral omission."
+    "reason": "to_tag ports XmlMini.to_tag: Rails' Hash#delete(:type)/#merge/#call/#to_s are satisfied by different TS idioms (immutable `{ ...options }` spread instead of merge, destructured `options.type` instead of delete, direct function invocation, and String()/keyToString()) \u2014 no behavioral omission."
   },
   {
     "package": "activesupport",
@@ -44930,7 +44923,7 @@
     "tsFile": "signed-global-id.ts",
     "rubyName": "pick_purpose",
     "call": "fetch",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "globalid",
@@ -45000,7 +44993,7 @@
     "tsFile": "uri/gid.ts",
     "rubyName": "to_s",
     "call": "query",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "globalid",
@@ -45161,14 +45154,14 @@
     "tsFile": "cascade.ts",
     "rubyName": "initialize",
     "call": "add",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "rack",
     "tsFile": "cascade.ts",
     "rubyName": "initialize",
     "call": "each",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "rack",
@@ -45336,7 +45329,7 @@
     "tsFile": "deflater.ts",
     "rubyName": "initialize",
     "call": "fetch",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "rack",
@@ -45812,7 +45805,7 @@
     "tsFile": "mock-response.ts",
     "rubyName": "cookie",
     "call": "fetch",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "rack",
@@ -46113,28 +46106,28 @@
     "tsFile": "request.ts",
     "rubyName": "add_header",
     "call": "get_header",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "rack",
     "tsFile": "request.ts",
     "rubyName": "add_header",
     "call": "has_header?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "rack",
     "tsFile": "request.ts",
     "rubyName": "add_header",
     "call": "set_header",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "rack",
     "tsFile": "request.ts",
     "rubyName": "delete_header",
     "call": "delete",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "rack",
@@ -46967,7 +46960,7 @@
     "tsFile": "engine/configuration.ts",
     "rubyName": "all_eager_load_paths",
     "call": "eager_load",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "trailties",
@@ -47562,7 +47555,7 @@
     "tsFile": "generators/rails/script/script-generator.ts",
     "rubyName": "depth",
     "call": "size",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "trailties",
@@ -47576,7 +47569,7 @@
     "tsFile": "generators/resource-helpers.ts",
     "rubyName": "controller_file_path",
     "call": "join",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "trailties",
@@ -47772,7 +47765,7 @@
     "tsFile": "paths.ts",
     "rubyName": "initialize",
     "call": "eager_load!",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "trailties",


### PR DESCRIPTION
Converges the third `unboundable?` copy — the `predications.ts` stub — and fixes
two duck-typed protocols the port dropped underneath it. All three defects are
the same shape: a Ruby protocol that trails *already implements* on the value
side, but that the predicate reading it ignored.

## 1. The stub's comment was false

`Predications.isUnboundable` was `return false`, justified by "The TS port has no
analog of Ruby's `unboundable?` protocol". Trails has three producers of exactly
that protocol: `QueryAttribute#isUnboundable`, `BindParam#isUnboundable`, and
`UnboundableBound#isUnboundable`.

Latent, not live — the real `between` path is `predications-range.ts`, converged
by #4876 — but a trap: anything routing a range through `Predications.isOpenEnded`
silently lost unboundable collapse (#4433).

**Resolving the duplication, not adding a fourth copy.** Rails has one
`unboundable?` per Ruby file. `predications-range.ts` holds the single real
implementation that `between` / `notBetween` already use, so
`Predications.isInfinity` / `isUnboundable` / `isOpenEnded` now delegate to it
(predications.rb:248-257) — the same pattern `between` itself uses. The visitor's
copy stays: Rails also defines `unboundable?` twice (to_sql.rb:905,
predications.rb:252).

## 2. `infinite?` returned a boolean, not the sign

`QueryAttribute#isInfinite` returned a plain `boolean` where query_attribute.rb:42-44
yields `Float#infinite?` — `1 | -1 | nil`. `true` genuinely reached `infinitySign`,
which reported **+1 for a -Infinity bind**. Fixed at the root, so `infinitySign`'s
compensating `r === true` arm is dropped (per the story: only *after* the producer
returns the sign) and `BindParam#isInfinite`'s `number | null` annotation stops
lying. `Quoted` / `UnboundableBound` aligned to the same `1 | -1 | false` shape.

Measured: `between(-Inf bind, +Inf bind)` now yields `not_in([])`; under the
boolean it collapsed to `in([])`.

`infinitySign` still unwraps `Quoted` (casted.rb:43-45) and still does NOT unwrap
`Casted`, which defines no `infinite?` (casted.rb:5-35) — `open_ended?(Casted(INFINITY))`
stays false, pinned by a test.

## 3. `open_ended?` dropped Ruby's leading `value.nil?` (found in review)

Rails' `open_ended?` is `value.nil? || infinity?(value) || unboundable?(value)`.
That first clause is a real dispatch — the node classes override `nil?` to report
on the *wrapped* value (bind_param.rb:23-25, casted.rb:16,41). The port read only
`=== null`, so a nil-wrapping bound was not open-ended.

Measured before: `between(BindParam(nil), 3)`, `between(Casted(null), 3)`,
`between(Quoted(null), 3)` each emitted a Between over a nil bound where Rails
gives `lteq(3)`. All three now match. `BindParam(undefined)` stays non-nil (a
trails positional-bind marker, not a Rails value).

## Deviation from the story: the Attribute helpers are kept, not removed

The story asked that `Attribute#isOpenEnded` / `#isUnboundable` "gain a live
caller or be removed". Both options conflict with its own "api:compare delta
non-negative" criterion: api:compare resolves `include Arel::Predications`
(attribute.rb:8) and maps all three onto attribute.ts, so **deleting them
measures as arel 938/938 -> 935/938**. Giving them a live caller would mean
making Rails-private methods public to reach them from `betweenFromRange`.

They are kept and now delegate to the same real implementation — which is what
actually closes the trap, since they can no longer diverge from the decision
tree. Flagging in case a reviewer prefers removal over the -3.

## Review round 1 (#4887 comments 1-5)

Comments 1-4 fixed; 5 answered below.

**1, 2, 3 — `infinite?` duck-typing.** All correct, and all the same root cause
this PR already targets: Rails duck-types `value.respond_to?(:infinite?) &&
value.infinite?` and the port hardcoded structural checks.
- `BindParam#isInfinite` missed a bare ±Infinity (`Float` responds in Ruby), so
  `between(BindParam(INFINITY), 3)` emitted a Between instead of `lteq(3)`. Fixed.
- `Quoted#isInfinite` hardcoded `=== ±Infinity` instead of delegating, so
  `Quoted(QueryAttribute(INF))#infinite?` was false where Rails gives 1. Ported literally.
- With #2 fixed, `infinitySign`'s `instanceof Quoted` arm is dead — and the
  reviewer is right that it was a structural second copy of `Quoted#infinite?`
  masking #2. Removed; predications.rb:248-250 is a plain dispatch that does not
  know Quoted exists. `Casted` still defines no `isInfinite`, so
  `open_ended?(Casted(INFINITY))` stays false (pinned by test).

Note these three interlock: #3 is only safe *because* #2 is fixed. `Quoted` now
answers through its own `infinite?` like any other value.

**4 — memoization.** Correct, ported. query_attribute.rb:45-51 guards with
`unless defined?(@_unboundable)`, so serialization is attempted once;
`_unboundable === undefined` is the `defined?` guard, so the `false` result
caches too. Test asserts exactly one `serialize` call on both the raising and
non-raising paths.

**5 — the `<=> 0` zero case: keeping `1 | -1 | false`.** The zero case is
unreachable in *Rails*, not just in trails, so the extra state would model
nothing. `unboundable?` only assigns `@_unboundable = value <=> 0` from inside
the `serializable?` block, which runs only when serialization raises a range
error. `value <=> 0` is `0` only when `value == 0`, and `0` is in range for every
integer type, so that path cannot raise — Rails falls through to
`&& @_unboundable = nil` and returns nil. A producer can therefore never
legitimately answer `0`; `1 | -1 | false` is exactly the reachable domain, and
`false` maps onto Rails' `nil`. Widening to `1 | -1 | 0 | false` would add a
state that Rails cannot produce and that `open_ended?` has no defined behavior
for. Left as-is, and the `<=> 0` mapping stays documented at the call site.

## Review round 3 (comments 1-4) + CI

All four fixed. Rounds 2 and 3 converged on the same root cause from opposite
ends, which is worth stating plainly: **Rails casts ±Infinity to nil for integer
columns**, and trails did not.

**1 — `QueryAttribute(±Infinity, Integer).unboundable?` was 1/-1, Rails is nil.**
Correct, and fixed at the root rather than in the predicate. `cast_value` is
`value.to_i rescue nil` (integer.rb:90) and `Float#to_i` raises FloatDomainError
for ±Infinity, so `cast_value` is nil, `in_range?(nil)` is `!value` => true
(integer.rb:86), `serializable?` is true, `@_unboundable` stays nil. Trails'
`IntegerType#castValue` returned `Math.trunc(Infinity)` => Infinity. Now casts to
null — `isFinite` is exactly `to_i rescue nil`'s domain, and `BigIntegerType`
already drew that line.

**Rails' own test already said so.** `activemodel/test/cases/type/integer_test.rb:35-39`
asserts `assert_nil type.cast(::Float::NAN)` **and** `assert_nil type.cast(1.0/0.0)`.
Trails' `casting nan and infinity` carried that Rails name while asserting
`cast(Infinity) === Infinity` — it was pinning the divergence. Per CLAUDE.md the
name is the contract, so the body was fixed, not the name.

`isInfinite` reads `value_before_type_cast`, so ±Infinity still reports its sign
and the bound stays open-ended via `infinity?` (predications.rb:248) — which is
exactly Rails' routing.

**2 — the `:big_integer` test asserted a law it didn't cover.** Right: it passed
only because `isInRange` short-circuits on `max === INFINITY`, while the
`!isFinite` guard fired first for `Infinity`. With #1 fixed the law is now true as
written, and the test asserts ±Infinity too — plus a new test pinning the
`Integer` case directly.

**3 — the `type_cast` no-op citation described Rails, not this port.** Correct;
trails' `QueryAttribute#typeCast` casts (query-attribute.ts:50-52), so `this.value`
is already cast and I was casting twice. Comment corrected to describe trails, and
the double cast dropped. The deeper point — `integer.ts:50` re-deriving via
`Number()` instead of Rails' leading `cast_value = cast(value)` (integer.rb:75) —
is real and pre-existing; it is not load-bearing for this PR now that the two
layers agree on ±Infinity, and it belongs to `isSerializable`, not `unboundable?`.

**4 — `isOpenEnded` lost its `this` self-dispatch.** Right, and CI caught it
independently: the wide call-mismatches ratchet flagged 8 mismatches, because a
delegating body no longer *calls* `infinity?` / `unboundable?` the way
predications.rb:255-257 does. Restored Rails' composition shape; host overrides are
honored again and pinned by a test. The protocol logic still lives in one place —
`isInfinity` / `isUnboundable` delegate to predications-range.ts. This is the one
spot where "single implementation" cut against Rails, and Rails wins.

**Minor (`compareToZero` returns 1 for a non-numeric cast value).** Acknowledged
and left. Ruby's `"x" <=> 0` is nil, so Rails would leave `@_unboundable` nil.
Unreachable through `IntegerType`, whose cast yields `number | null` (and `null`
is in range), so it can only arise for a custom type that fails `serializable?`
while casting to a non-numeric — the comment says so rather than implying a
total order.

**CI:** the `unboundable? -> serializable?` wide-baseline entry went STALE once
round 2 made the body genuinely call `serializable?`. Removed that single entry by
hand rather than reseeding the baseline. Wide ratchet: OK (6854 baselined).

## Review round 4 (comments 1-3)

**1 — `between` didn't self-dispatch.** Right, and it's the same divergence round 3
fixed for `open_ended?`: predications.rb:38-51 calls `unboundable?` / `open_ended?`
/ `infinity?` on self. A host overriding one was honored by `open_ended?` and
silently ignored by the decision tree — an inconsistency this PR created by
asserting self-dispatch as the bar. Now holds in both places, pinned by tests
that override `isInfinity` on an Attribute subclass and assert `between` /
`notBetween` react.

Safe because both callers already carry the three predicates at runtime (the mixin
installs them via `include()`, `Attribute` re-exposes them as protected — a
compile-time rule only), and `predications-range.ts` is not exported from the
package index, so the widening cast has no external surface. This left the free
`isOpenEnded` with no callers, so it is deleted rather than left as dead surface.

**2 — `IntegerType#isSerializable(Infinity)` was false, Rails is true.** Fixed by
adding Rails' leading `cast_value = cast(value)` (integer.rb:74-80). Two things
worth noting beyond the bug:

- **The wide ratchet had already flagged this.** `activemodel type/integer.ts
  serializable? -> cast` was sitting in the baseline as "a ported TS body omits a
  call Rails makes". Adding the call made that entry STALE, and I removed it by
  hand — the second baseline entry this PR converges away (`unboundable? ->
  serializable?` was the first).
- **The leading cast is what preserves BigInt precision**, which the old
  `Number(value)` path had to hand-roll around: `cast` routes a BigInt through
  `narrowBigInt`, where `Number()` collapsed `2n**63n` and `2n**63n-1n` onto the
  same float. The `2^63`-exclusive tests still pass unchanged.

This also removes the coupling round 3 flagged: the predicate no longer depends on
`typeCast` pre-casting, so it is correct on its own terms for a raw value.

**3 — `UnboundableBound` has no Rails counterpart.** Correct, it is a trails
invention: range_handler.rb:12-16 wraps *both* bounds in `build_bind_attribute`
and lets `QueryAttribute#unboundable?` answer, with no sentinel class. It is not
load-bearing for anything else — it exists only because trails' RangeHandler
passes cast values through. Not previously registered; now filed as
**0023-surfaced-deviations/converge-range-handler-bind-attribute-bounds**, with
the two latent divergences that converging it makes live (`QueryAttribute#typeCast`
pre-casting where Rails' `type_cast` is a no-op, and non-numeric bounds where
Rails' `"abc".to_i` is 0). The protocol work it depends on all landed in this PR.

## Review round 5 (comments 1-4)

All four fixed. #1 and #2 were the same code, and #2 is the one that mattered.

**2 — the `rescue nil` was at the wrong level.** Correct, and the consequence was
real: integer.rb:90 scopes the rescue to the conversion *inside* `cast_value`, so
`cast` itself answers nil — integer_test.rb:30-32 asserts
`assert_nil type.cast(::Object.new)`. Trails' `cast(Object.create(null))` **threw
TypeError**; only `isSerializable` was shielded, and it converted the throw to
`true` rather than to nil-then-`in_range?(nil)`. Same answer by luck, wrong
mechanism, and `cast` was left broken on its own terms.

The try/catch now wraps the conversion in `castValue`, so `isSerializable` is the
plain two-liner Rails has, with no catch. Verified `cast` answers and never raises
for `{}`, a null-prototype object, a Symbol, a throwing `toString`, arrays and
functions.

You were also right that the test left it uncovered: `casting objects without
to_i` substituted a string and `undefined` and never asserted Rails' `Object.new`.
It now ports the real assertion.

**1 — the Symbol example was wrong.** `String(Symbol())` returns `"Symbol(x)"`;
only `Number(sym)` throws, and this path no longer uses `Number()`. A Symbol
parses to NaN => null and never reaches the catch. The comment now names the case
that does (an object with no `toString`). Worth noting the *original* comment was
correct about `Number(Symbol())` — I carried the claim across a rewrite that
changed the mechanism, which is exactly how a comment goes stale.

**3 — `RangeHost` under-stated the contract.** Fixed rather than documented:
`betweenFromRange` / `notBetweenFromRange` now take `RangeHost & RangePredicates`,
so the requirement the self-dispatch introduced lives in the exported signature.
It type-checks with the widening pushed to the only two call sites that need it —
`Attribute`, whose three are `protected` (a compile-time visibility rule, so the
class isn't assignable to a public interface even from inside itself) — while the
mixin hosts satisfy it directly through `Included<typeof Predications>`. `selfOf`
is gone, and a future `RangeHost` implementer now gets a compile error instead of
a runtime TypeError.

**4 — stale reference.** Fixed. The comment now names `unboundableSign` reached
through `Predications#unboundable?`, and records that `UnboundableBound` has no
Rails counterpart plus the story that deletes it.

## Verification

- `between` / `not_between` unchanged from #4876: `between(INFINITY..3)` -> `lteq(3)`,
  `between(INFINITY..)` -> `in([])` (via infinity?, predications.rb:42),
  out-of-range collapse (#4433) -> `in([])`.
- **api:compare: arel 938/938 (100%), Data layer 7472/7474, delta 0.** No stubs remain in the touched surface.
- **test:compare: 14442/21656, delta 0** (re-run after the review fixes). The three updated test files are
  trails-invented with no Rails counterpart (Rails' `bind_param_test.rb` has 3
  tests, all equality; there is no `query_attribute_test.rb` / predications-privates
  counterpart), so the corrected names are TS-only extras and no matched test moved.
- typecheck + lint clean; activemodel 1973, arel 1523, `activerecord/src/relation` 1065, AR types 164 pass.
- api:compare activemodel 681/681 (100%).
- Wide call-mismatches ratchet: OK (6853 baselined) — two entries converged away and removed by hand.

Closes-story: arel-predications-unboundable-duck-types-like-rails
