### PR TITLE
refactor(arel): drop invented type-cast fallbacks from Table/TableAlias

### DIFF
--- a/packages/arel/src/nodes/table-alias.ts
+++ b/packages/arel/src/nodes/table-alias.ts
@@ -34,25 +34,30 @@ export class TableAlias extends Binary {
   }
 
   get tableName(): string {
-    const rel = this.relation as unknown as TypeCastable;
-    return typeof rel?.name === "string" ? rel.name : this.nameString;
+    const rel = this.rel;
+    return typeof rel.name === "string" ? rel.name : this.nameString;
   }
 
   typeCastForDatabase(attrName: string, value: unknown): unknown {
-    return (this.relation as unknown as TypeCastable).typeCastForDatabase(attrName, value);
+    return this.rel.typeCastForDatabase(attrName, value);
   }
 
   typeForAttribute(name: string): unknown {
-    return (this.relation as unknown as TypeCastable).typeForAttribute(name);
+    return this.rel.typeForAttribute(name);
   }
 
   isAbleToTypeCast(): boolean {
-    const rel = this.relation as unknown as TypeCastable;
-    return typeof rel?.isAbleToTypeCast === "function" ? rel.isAbleToTypeCast() : false;
+    const rel = this.rel;
+    return typeof rel.isAbleToTypeCast === "function" ? rel.isAbleToTypeCast() : false;
   }
 
   toCte(): Cte {
     return new Cte(this.nameString, this.relation);
+  }
+
+  /** `relation` is a `Node`; Ruby duck-types it instead. */
+  private get rel(): TypeCastable {
+    return this.relation as unknown as TypeCastable;
   }
 
   /** The alias as a bare string, unwrapping a `SqlLiteral` name. */

--- a/packages/arel/src/nodes/table-alias.ts
+++ b/packages/arel/src/nodes/table-alias.ts
@@ -4,11 +4,15 @@ import { Cte } from "./cte.js";
 import { SqlLiteral } from "./sql-literal.js";
 import { Attribute } from "../attributes/attribute.js";
 
-/** Structural view of `TableAlias#relation`. `typeCastForDatabase` /
- *  `typeForAttribute` are required because Rails delegates to them bare
- *  (table_alias.rb:18-24); `isAbleToTypeCast` stays optional because
- *  table_alias.rb:26-28 is `respond_to?`-guarded — a relation may be a
- *  `SelectManager`, which has no such method. */
+/** Structural view of `TableAlias#relation`.
+ *
+ *  Optionality here mirrors Rails' *guards*, not what the relation actually
+ *  responds to — a `SelectManager` relation has none of these three members.
+ *  `isAbleToTypeCast` is optional because table_alias.rb:26-28 guards it with
+ *  `respond_to?`; the other two are required because table_alias.rb:18-24
+ *  delegates to them bare, so a relation lacking them raises — Ruby's
+ *  `NoMethodError`. The cast makes this unenforced either way; it documents
+ *  which calls Rails protects. */
 interface TypeCastable {
   name?: string;
   typeCastForDatabase(attrName: string, value: unknown): unknown;
@@ -34,30 +38,25 @@ export class TableAlias extends Binary {
   }
 
   get tableName(): string {
-    const rel = this.rel;
-    return typeof rel.name === "string" ? rel.name : this.nameString;
+    const rel = this.relation as unknown as TypeCastable;
+    return typeof rel?.name === "string" ? rel.name : this.nameString;
   }
 
   typeCastForDatabase(attrName: string, value: unknown): unknown {
-    return this.rel.typeCastForDatabase(attrName, value);
+    return (this.relation as unknown as TypeCastable).typeCastForDatabase(attrName, value);
   }
 
   typeForAttribute(name: string): unknown {
-    return this.rel.typeForAttribute(name);
+    return (this.relation as unknown as TypeCastable).typeForAttribute(name);
   }
 
   isAbleToTypeCast(): boolean {
-    const rel = this.rel;
-    return typeof rel.isAbleToTypeCast === "function" ? rel.isAbleToTypeCast() : false;
+    const rel = this.relation as unknown as TypeCastable;
+    return typeof rel?.isAbleToTypeCast === "function" ? rel.isAbleToTypeCast() : false;
   }
 
   toCte(): Cte {
     return new Cte(this.nameString, this.relation);
-  }
-
-  /** `relation` is a `Node`; Ruby duck-types it instead. */
-  private get rel(): TypeCastable {
-    return this.relation as unknown as TypeCastable;
   }
 
   /** The alias as a bare string, unwrapping a `SqlLiteral` name. */

--- a/packages/arel/src/nodes/table-alias.ts
+++ b/packages/arel/src/nodes/table-alias.ts
@@ -4,10 +4,15 @@ import { Cte } from "./cte.js";
 import { SqlLiteral } from "./sql-literal.js";
 import { Attribute } from "../attributes/attribute.js";
 
+/** Structural view of `TableAlias#relation`. `typeCastForDatabase` /
+ *  `typeForAttribute` are required because Rails delegates to them bare
+ *  (table_alias.rb:18-24); `isAbleToTypeCast` stays optional because
+ *  table_alias.rb:26-28 is `respond_to?`-guarded — a relation may be a
+ *  `SelectManager`, which has no such method. */
 interface TypeCastable {
   name?: string;
-  typeCastForDatabase?: (attrName: string, value: unknown) => unknown;
-  typeForAttribute?: (name: string) => unknown;
+  typeCastForDatabase(attrName: string, value: unknown): unknown;
+  typeForAttribute(name: string): unknown;
   isAbleToTypeCast?: () => boolean;
 }
 
@@ -29,22 +34,20 @@ export class TableAlias extends Binary {
   }
 
   get tableName(): string {
-    const rel = this.relation as TypeCastable;
+    const rel = this.relation as unknown as TypeCastable;
     return typeof rel?.name === "string" ? rel.name : this.nameString;
   }
 
   typeCastForDatabase(attrName: string, value: unknown): unknown {
-    const rel = this.relation as TypeCastable;
-    return rel?.typeCastForDatabase ? rel.typeCastForDatabase(attrName, value) : value;
+    return (this.relation as unknown as TypeCastable).typeCastForDatabase(attrName, value);
   }
 
   typeForAttribute(name: string): unknown {
-    const rel = this.relation as TypeCastable;
-    return rel?.typeForAttribute ? rel.typeForAttribute(name) : undefined;
+    return (this.relation as unknown as TypeCastable).typeForAttribute(name);
   }
 
   isAbleToTypeCast(): boolean {
-    const rel = this.relation as TypeCastable;
+    const rel = this.relation as unknown as TypeCastable;
     return typeof rel?.isAbleToTypeCast === "function" ? rel.isAbleToTypeCast() : false;
   }
 

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -12,6 +12,15 @@ export interface TableKlass {
   readonly _attributeAliases?: Record<string, string>;
 }
 
+/** Delegation target of `Table`'s type-cast methods (Rails' `TypeCaster::Map` /
+ *  `TypeCaster::Connection`). Rails' `type_caster` is duck-typed and the
+ *  delegators are bare, so the constructor still accepts anything and a caster
+ *  missing a member throws on call, as `NoMethodError` does in Ruby. */
+export interface TypeCaster {
+  typeCastForDatabase(attrName: string, value: unknown): unknown;
+  typeForAttribute(name: string): unknown;
+}
+
 /**
  * Table — represents a database table.
  *
@@ -152,25 +161,24 @@ export class Table extends Node {
   }
 
   typeCastForDatabase(attrName: string, value: unknown): unknown {
-    if (
-      this.typeCaster &&
-      typeof (this.typeCaster as Record<string, unknown>).typeCastForDatabase === "function"
-    ) {
-      return (
-        this.typeCaster as { typeCastForDatabase: (n: string, v: unknown) => unknown }
-      ).typeCastForDatabase(attrName, value);
-    }
-    return value;
+    return (this.typeCaster as TypeCaster).typeCastForDatabase(attrName, value);
   }
 
+  // DEVIATION: Rails delegates bare here too (`type_caster.type_for_attribute(name)`,
+  // table.rb:106-108), so a caster-less table raises NoMethodError. We cannot yet:
+  // unlike `type_cast_for_database` (only reached through `Casted#valueForDatabase`,
+  // which gates on `isAbleToTypeCast`), this is reached ungated via
+  // `Attribute#typeCaster` -> `HomogeneousIn#castedValues`. trails builds
+  // caster-less tables for join aliases (join-dependency, association-scope) where
+  // Rails aliases `klass.arel_table` and keeps the caster, so bare delegation
+  // breaks real join/STI queries. Removing this fallback is blocked on converging
+  // those construction sites onto `klass.arelTable`.
   typeForAttribute(name: string): unknown {
     if (
       this.typeCaster &&
       typeof (this.typeCaster as Record<string, unknown>).typeForAttribute === "function"
     ) {
-      return (this.typeCaster as { typeForAttribute: (n: string) => unknown }).typeForAttribute(
-        name,
-      );
+      return (this.typeCaster as TypeCaster).typeForAttribute(name);
     }
     return undefined;
   }


### PR DESCRIPTION
Rails' `Arel::Table` and `Arel::Nodes::TableAlias` delegate their type-cast
methods bare. trails guarded twice — on the delegate being non-null *and* on the
method existing — then fell back to `value` / `undefined`. This converges the
delegators whose fallbacks are provably unreachable or wrong.

## Changed

- **`Table#typeCastForDatabase`** → bare (`table.rb:102-104`). Its only consumer,
  `Casted#valueForDatabase`, gates on `isAbleToTypeCast()` first, so the fallback
  was dead code.
- **`TableAlias#typeCastForDatabase` / `#typeForAttribute`** → bare
  (`table_alias.rb:18-24`).
- **`TypeCastable`** (`table-alias.ts:7-12`) tightened so the optionality does not
  just move down a level: both delegated members are now required.

## Deliberately unchanged

- **`Table#isAbleToTypeCast`** already matched `table.rb:110-112`.
- **`TableAlias#isAbleToTypeCast`** keeps its `respond_to?`-equivalent guard —
  `table_alias.rb:26-28` is genuinely guarded, because a `TableAlias`'s relation
  may be a `SelectManager`, which has no such method. `isAbleToTypeCast` therefore
  stays optional on `TypeCastable`.

## One acceptance criterion is NOT met — `Table#typeForAttribute` keeps its fallback

The story asked for this one to go bare too. It can't yet, and the story's own
"Reachability — read before assuming this is dead code" section is why. I checked,
and the answer is worse than "reachable in a fixture":

`typeForAttribute` is reached **ungated** via `Attribute#typeCaster`
(`attribute.ts:110-112` — no `able_to_type_cast?` gate; Rails has none either) →
`HomogeneousIn#castedValues`. Going bare raises on **real production queries**, not
just tests: `packages/activerecord/src/relation.test.ts` "relation merging with
merged joins as strings" / "as symbols" fail with
`TypeError: Cannot read properties of null (reading 'typeForAttribute')`. Probed
origin: table `comments`, attribute `type` — the STI type condition built at
`reflection.ts:309` (`scope.where(typeCondition(targetKlass, table))`) inside an
INNER JOIN ON clause, where `table` arrived from join-dependency as a bare Table.

Root cause is one level further out: trails constructs caster-less Arel tables for
join aliases (~20 sites across `join-dependency.ts`, `association-scope.ts`,
`join-association.ts`), where Rails aliases `klass.arel_table` — and since
`Table#alias` wraps in a `TableAlias` that forwards to the underlying table, Rails'
aliases keep their caster for free (`alias_tracker.rb:58-70`).

Fixing that is a separate, sizable convergence with real blast radius across the
join suites, so per CLAUDE.md I registered it rather than fanning out:
`0023-surfaced-deviations/arel-join-tables-lack-type-casters`. The fallback stays
with a `// DEVIATION:` comment naming the blocker, and that story removes it.

## Testing

- `packages/arel`: 1513 passed.
- `packages/activerecord/src/{relation,associations,table-metadata}`: 3015 passed.
- No test names changed; no test files touched.

Closes-story: arel-table-type-cast-fallbacks-are-invented


---

## Review round 2 (#4888)

All three points fixed in `dc77d8de2`:

1. **`tableName` null-tolerance restored.** Correct catch — I regressed
   `rel?.name` → `rel.name`. Rails is
   `relation.respond_to?(:name) ? relation.name : name` (`table_alias.rb:16`),
   and `nil.respond_to?(:name)` is `false`, so a nil relation yields the alias
   name rather than raising. Out of scope for this story and strictly less
   faithful.
2. **`private get rel()` removed** — agreed, it was an invented layer in a PR
   about removing invented layers. Back to inline
   `(this.relation as unknown as TypeCastable)` per method, as Rails duck-types
   inline in each of the four.
3. **`TypeCastable` doc reworded.** The contradiction was real: a
   `SelectManager` relation responds to *none* of the three members, so
   "SelectManager" cannot be the reason only `isAbleToTypeCast` is optional.
   Optionality now tracks Rails' **guards** — `respond_to?` on
   `able_to_type_cast?` (`table_alias.rb:26-28`) — not the relation's
   capabilities, and the doc says so.

### On the `TableAlias#[]` non-`Table` branch — probed, and it does raise

Worth stating plainly, as asked. Built the derived-table case directly
(`users.project(...).as("dt")` → `TableAlias` whose relation is a
`SelectManager`) and drove `get("id")` through `HomogeneousIn#castedValues`:

```
RESULT: RAISED: this.relation.typeForAttribute is not a function
```

So yes — same hazard class as `Table#typeForAttribute`. I'm keeping this one
bare, on this distinction:

- **`Table#typeForAttribute`** breaks **working queries today** — measured:
  `relation.test.ts` join-merging, STI `comments`.`type` in an INNER JOIN ON.
  That's a regression, so it's deferred to
  `0023-surfaced-deviations/arel-join-tables-lack-type-casters`.
- **This branch** breaks nothing measurable: full `packages/arel` (1513) and
  `relation`/`associations` (3014) are green. Rails raises `NoMethodError` here
  identically, so bare is the faithful behavior — and the fallback it replaces
  returned `undefined`, which made `HomogeneousIn` silently emit raw uncast
  values. A raise is both more faithful *and* better than silently wrong SQL.

The deferral is about not regressing live paths, not about avoiding raises.
