### PR TITLE
fix(arel): Table#typeForAttribute delegates bare; join tables carry their caster

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -2883,7 +2883,7 @@ export async function loadHabtm(
     .project(joinArelTable.get(targetFk))
     .where(joinArelTable.get(ownerFk).eq(pkValue));
 
-  const targetArelTable = new ArelTable(targetModel.tableName);
+  const targetArelTable = targetModel.arelTable;
   const inNode = targetArelTable.get(targetPkCol).in(subquery);
 
   // Start from `klass.scope_for_association` so target-model default_scope

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1,6 +1,7 @@
 import type { Base } from "./base.js";
 import type { Relation } from "./relation.js";
 import { Table as ArelTable } from "@blazetrails/arel";
+import { Connection as TypeCasterConnection } from "./type-caster/connection.js";
 import { SpellChecker } from "@blazetrails/did-you-mean";
 import type { CollectionProxy, AssociationProxy } from "./associations/collection-proxy.js";
 import { _CollectionProxyCtor } from "./associations/collection-proxy-slot.js";
@@ -2878,7 +2879,13 @@ export async function loadHabtm(
   }
 
   // Use Arel subquery: SELECT target_fk FROM join_table WHERE owner_fk = ?
-  const joinArelTable = new ArelTable(joinTable);
+  // The HABTM join table has no model, so its caster comes from the connection
+  // — the same shape as the no-klass branch of `associated_table`
+  // (table_metadata.rb:47-48). `.get(ownerFk).eq(pkValue)` builds a `Casted`,
+  // which reaches the table's caster.
+  const joinArelTable = new ArelTable(joinTable, {
+    typeCaster: new TypeCasterConnection(ctor as never, joinTable),
+  });
   const subquery = joinArelTable
     .project(joinArelTable.get(targetFk))
     .where(joinArelTable.get(ownerFk).eq(pkValue));

--- a/packages/activerecord/src/associations/alias-tracker.ts
+++ b/packages/activerecord/src/associations/alias-tracker.ts
@@ -11,6 +11,33 @@ import type { Quoting } from "../connection-adapters/abstract/quoting-interface.
 // abstract default directly (the free tableAliasLength now dispatches via `this`).
 const DEFAULT_TABLE_ALIAS_LENGTH = maxIdentifierLength();
 
+/**
+ * Build the Arel table a join should use for `klass` under the SQL name
+ * `effectiveName`, keeping the model's type caster attached.
+ *
+ * Rails never constructs a bare `Arel::Table` for a join: `aliased_table_for`
+ * is handed `klass.arel_table` and calls `#alias` on it, so the resulting
+ * `TableAlias` delegates `type_for_attribute` back to the underlying table's
+ * caster (alias_tracker.rb:58-70, table.rb:106-108). trails encodes an aliased
+ * table as `Table(realName, { as: alias })` rather than a `TableAlias`, so the
+ * caster has to be carried across explicitly — otherwise `type_for_attribute`
+ * hits a nil caster the moment a join's ON clause contains a typed predicate
+ * (e.g. an STI type condition).
+ *
+ * @internal
+ */
+export function aliasedArelTableFor(
+  klass: { arelTable?: Table; tableName?: string } | null | undefined,
+  tableName: string,
+  effectiveName?: string,
+): Table {
+  const as = effectiveName && effectiveName !== tableName ? effectiveName : undefined;
+  const base = klass?.arelTable;
+  if (!base || base.name !== tableName) return new Table(tableName, { as });
+  if (as === undefined) return base;
+  return new Table(tableName, { as, typeCaster: base.typeCaster, klass: base.klass });
+}
+
 export class AliasTracker {
   readonly aliases: Map<string, number>;
   private _tableAliasLength: number;

--- a/packages/activerecord/src/associations/alias-tracker.ts
+++ b/packages/activerecord/src/associations/alias-tracker.ts
@@ -38,6 +38,22 @@ export function aliasedArelTableFor(
   return new Table(tableName, { as, typeCaster: base.typeCaster, klass: base.klass });
 }
 
+/**
+ * `aliasedArelTableFor` keyed off a reflection. A polymorphic reflection has no
+ * compile-time klass — `reflection.klass` raises (reflection.rb) — so it keeps a
+ * caster-less table; the concrete class is only known per row at runtime.
+ *
+ * @internal
+ */
+export function aliasedArelTableForReflection(
+  reflection: { klass?: unknown; isPolymorphic?: () => boolean } | null | undefined,
+  tableName: string,
+  effectiveName?: string,
+): Table {
+  const klass = reflection?.isPolymorphic?.() ? null : (reflection?.klass as never);
+  return aliasedArelTableFor(klass, tableName, effectiveName);
+}
+
 export class AliasTracker {
   readonly aliases: Map<string, number>;
   private _tableAliasLength: number;

--- a/packages/activerecord/src/associations/alias-tracker.ts
+++ b/packages/activerecord/src/associations/alias-tracker.ts
@@ -13,16 +13,17 @@ const DEFAULT_TABLE_ALIAS_LENGTH = maxIdentifierLength();
 
 /**
  * Build the Arel table a join should use for `klass` under the SQL name
- * `effectiveName`, keeping the model's type caster attached.
+ * `sqlName` (the alias when aliased, else the real table name), keeping the
+ * model's type caster attached.
  *
- * Rails never constructs a bare `Arel::Table` for a join: `aliased_table_for`
- * is handed `klass.arel_table` and calls `#alias` on it, so the resulting
- * `TableAlias` delegates `type_for_attribute` back to the underlying table's
- * caster (alias_tracker.rb:58-70, table.rb:106-108). trails encodes an aliased
- * table as `Table(realName, { as: alias })` rather than a `TableAlias`, so the
- * caster has to be carried across explicitly — otherwise `type_for_attribute`
- * hits a nil caster the moment a join's ON clause contains a typed predicate
- * (e.g. an STI type condition).
+ * Mirrors `aliased_table_for` (alias_tracker.rb:58-70): Rails is handed
+ * `klass.arel_table` and calls `#alias` on it, so the caster survives via
+ * `TableAlias`'s delegation. trails cannot return a `TableAlias` here — the
+ * JoinDependency plumbing that consumes these tables is typed on `Table` and
+ * gates on `instanceof Table` (e.g. rebindTableReferences, join-dependency.ts),
+ * which a `TableAlias` (a Binary node) silently fails — so an aliased table is
+ * encoded as `Table(realName, { as })` and the caster is carried across by hand.
+ * Converging that encoding onto `TableAlias` is tracked separately.
  *
  * @internal
  */
@@ -31,11 +32,14 @@ export function aliasedArelTableFor(
   tableName: string,
   effectiveName?: string,
 ): Table {
-  const as = effectiveName && effectiveName !== tableName ? effectiveName : undefined;
+  const sqlName = effectiveName ?? tableName;
   const base = klass?.arelTable;
-  if (!base || base.name !== tableName) return new Table(tableName, { as });
-  if (as === undefined) return base;
-  return new Table(tableName, { as, typeCaster: base.typeCaster, klass: base.klass });
+  // No klass (polymorphic): nothing to source a caster from.
+  if (!base) return new Table(tableName, { as: effectiveName });
+  // `base.name` is the real table. Rails aliases it to whatever name the join
+  // must answer to (alias_tracker.rb:64) and keeps the caster either way.
+  if (sqlName === base.name) return base;
+  return new Table(base.name, { as: sqlName, typeCaster: base.typeCaster, klass: base.klass });
 }
 
 /**

--- a/packages/activerecord/src/associations/alias-tracker.ts
+++ b/packages/activerecord/src/associations/alias-tracker.ts
@@ -16,9 +16,12 @@ const DEFAULT_TABLE_ALIAS_LENGTH = maxIdentifierLength();
  * `sqlName` (the alias when aliased, else the real table name), keeping the
  * model's type caster attached.
  *
- * Mirrors `aliased_table_for` (alias_tracker.rb:58-70): Rails is handed
- * `klass.arel_table` and calls `#alias` on it, so the caster survives via
- * `TableAlias`'s delegation. trails cannot return a `TableAlias` here — the
+ * Mirrors `table_metadata.rb:43-44` — `arel_table = association_klass.arel_table`
+ * then `arel_table.alias(table_name) if arel_table.name != table_name`. (Not
+ * `aliased_table_for`: this does none of that method's alias-count bookkeeping,
+ * and its real port is `AliasTracker#aliasedTableFor` below.) Deriving from
+ * `klass.arel_table` and aliasing is what keeps the caster, via `TableAlias`'s
+ * delegation. trails cannot return a `TableAlias` here — the
  * JoinDependency plumbing that consumes these tables is typed on `Table` and
  * gates on `instanceof Table` (e.g. rebindTableReferences, join-dependency.ts),
  * which a `TableAlias` (a Binary node) silently fails — so an aliased table is
@@ -37,7 +40,7 @@ export function aliasedArelTableFor(
   // No klass (polymorphic): nothing to source a caster from.
   if (!base) return new Table(tableName, { as: effectiveName });
   // `base.name` is the real table. Rails aliases it to whatever name the join
-  // must answer to (alias_tracker.rb:64) and keeps the caster either way.
+  // must answer to (table_metadata.rb:44) and keeps the caster either way.
   if (sqlName === base.name) return base;
   return new Table(base.name, { as: sqlName, typeCaster: base.typeCaster, klass: base.klass });
 }

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -658,13 +658,19 @@ export class AssociationScope {
   ): ArelTable | Nodes.TableAlias {
     const aliased = (reflection as ReflectionProxy).aliasedTable;
     if (aliased instanceof ArelTable || aliased instanceof Nodes.TableAlias) return aliased;
-    if (typeof aliased === "string" && aliased) return new ArelTable(aliased);
+    // A string / duck-typed `aliasedTable` names the alias only. Rails' tracker
+    // hands back `arel_table.alias(name)` (alias_tracker.rb:64), so the aliased
+    // table keeps the model's caster — resolve it through the reflection rather
+    // than minting a bare table under the alias name.
+    if (typeof aliased === "string" && aliased) {
+      return aliasedArelTableForReflection(reflection, name, aliased);
+    }
     if (
       aliased &&
       typeof aliased === "object" &&
       typeof (aliased as { name?: unknown }).name === "string"
     ) {
-      return new ArelTable((aliased as { name: string }).name);
+      return aliasedArelTableForReflection(reflection, name, (aliased as { name: string }).name);
     }
     return aliasedArelTableForReflection(reflection, name);
   }

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -2,7 +2,7 @@ import { Table as ArelTable, Nodes } from "@blazetrails/arel";
 import { TableMetadata } from "../table-metadata.js";
 import type { Base } from "../base.js";
 import type { AssociationReflection, AbstractReflection } from "../reflection.js";
-import { AliasTracker } from "./alias-tracker.js";
+import { AliasTracker, aliasedArelTableFor } from "./alias-tracker.js";
 import { polymorphicName } from "../inheritance.js";
 import { CompositePrimaryKeyMismatchError } from "./errors.js";
 import { routeThroughCheckValidity } from "./validate-through-reflection.js";
@@ -666,7 +666,13 @@ export class AssociationScope {
     ) {
       return new ArelTable((aliased as { name: string }).name);
     }
-    return new ArelTable(name);
+    // A polymorphic reflection has no compile-time klass (`reflection.klass`
+    // raises), so it keeps the bare table — the concrete class is only known per
+    // row at runtime.
+    if ((reflection as { isPolymorphic?: () => boolean }).isPolymorphic?.()) {
+      return new ArelTable(name);
+    }
+    return aliasedArelTableFor(reflection.klass as never, name);
   }
 
   /**

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -2,7 +2,7 @@ import { Table as ArelTable, Nodes } from "@blazetrails/arel";
 import { TableMetadata } from "../table-metadata.js";
 import type { Base } from "../base.js";
 import type { AssociationReflection, AbstractReflection } from "../reflection.js";
-import { AliasTracker, aliasedArelTableFor } from "./alias-tracker.js";
+import { AliasTracker, aliasedArelTableForReflection } from "./alias-tracker.js";
 import { polymorphicName } from "../inheritance.js";
 import { CompositePrimaryKeyMismatchError } from "./errors.js";
 import { routeThroughCheckValidity } from "./validate-through-reflection.js";
@@ -666,13 +666,7 @@ export class AssociationScope {
     ) {
       return new ArelTable((aliased as { name: string }).name);
     }
-    // A polymorphic reflection has no compile-time klass (`reflection.klass`
-    // raises), so it keeps the bare table — the concrete class is only known per
-    // row at runtime.
-    if ((reflection as { isPolymorphic?: () => boolean }).isPolymorphic?.()) {
-      return new ArelTable(name);
-    }
-    return aliasedArelTableFor(reflection.klass as never, name);
+    return aliasedArelTableForReflection(reflection, name);
   }
 
   /**

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -32,7 +32,6 @@ import {
   raiseNotFoundAll,
   raiseNotFoundSingle,
 } from "../relation/finder-methods.js";
-import { Table as ArelTable } from "@blazetrails/arel";
 import type { Nodes } from "@blazetrails/arel";
 import { underscore, singularize, camelize } from "@blazetrails/activesupport";
 import { filterScopeForCreate } from "./association.js";
@@ -3693,8 +3692,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     )._reflectOnAssociation?.(this._assocName)?.sourceReflection;
 
     const throughAs = throughAssoc.options.as;
-    const throughTable = new ArelTable(throughModel.tableName);
-    const targetArelTable = new ArelTable(targetModel.tableName);
+    const throughTable = throughModel.arelTable;
+    const targetArelTable = targetModel.arelTable;
     // sourceRefl.belongsTo?.() returns true for belongs_to, false/undefined otherwise.
     const isBelongsToSource = sourceRefl == null || sourceRefl.belongsTo?.() !== false;
 

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -26,7 +26,7 @@ import { JoinAssociation } from "./join-dependency/join-association.js";
 import { JoinPart } from "./join-dependency/join-part.js";
 import { AssociationNotFoundError, EagerLoadPolymorphicError } from "./errors.js";
 import { ConfigurationError, ConnectionNotDefined } from "../errors.js";
-import { AliasTracker } from "./alias-tracker.js";
+import { AliasTracker, aliasedArelTableFor } from "./alias-tracker.js";
 import { threadedConnectionFor } from "../connection-handling.js";
 
 /**
@@ -391,8 +391,12 @@ export class JoinDependency {
       targetTable!,
       (this._aliasTracker.aliases.get(targetTable!) ?? 0) + 1,
     );
-    const targetArelTable = new Table(targetTable!);
-    const sourceArelTable = new Table(sourceAlias);
+    const targetArelTable = aliasedArelTableFor(targetModel as never, targetTable!);
+    const sourceArelTable = aliasedArelTableFor(
+      modelClass as never,
+      modelClass.tableName,
+      sourceAlias,
+    );
 
     // A has_many/has_one join keys off the target's foreign key against the
     // source's primary key — the target model's own primary key is never used
@@ -916,9 +920,10 @@ export class JoinDependency {
    */
   private _rebuildChildJoin(parent: JoinPart, child: JoinAssociation, newName: string): void {
     const tableName = child.tableName;
-    const aliased =
-      newName === tableName ? new Table(tableName) : new Table(tableName, { as: newName });
-    const foreignTable = (parent.arelTable as Table) ?? new Table(child.tableName);
+    const aliased = aliasedArelTableFor(child.reflection.klass as never, tableName, newName);
+    const foreignTable =
+      (parent.arelTable as Table) ??
+      aliasedArelTableFor(child.reflection.klass as never, child.tableName);
     const joinAssoc = new JoinAssociation(child.reflection);
     const joins = joinAssoc.joinConstraints(
       foreignTable,
@@ -968,7 +973,9 @@ export class JoinDependency {
     if (group.resolved) return;
     group.resolved = true;
     const chainLen = group.reflection.chain.length;
-    const foreignTable = (parent.arelTable as Table) ?? new Table(group.chainTables[0].tableName);
+    const foreignTable =
+      (parent.arelTable as Table) ??
+      aliasedArelTableFor(group.chainTables[0].model as never, group.chainTables[0].tableName);
     const joinAssoc = new JoinAssociation(group.reflection);
     const resolvedByIdx: Array<{ effectiveName: string; aliased: Table }> = new Array(chainLen);
     const joins = joinAssoc.joinConstraints(
@@ -1000,10 +1007,7 @@ export class JoinDependency {
           return root ? cand : `${cand}_join`;
         });
         const effectiveName = alias ?? lookupName;
-        const aliased =
-          effectiveName === tableName
-            ? new Table(tableName)
-            : new Table(tableName, { as: effectiveName });
+        const aliased = aliasedArelTableFor(refl.klass as never, tableName, effectiveName);
         resolvedByIdx[idx] = { effectiveName, aliased };
         // Rails: `@joined_tables[chain] ||= [table, root] if OuterJoin`. Keyed
         // off the PARAMETER `join_type` so an eager OUTER-JOIN dependency folded
@@ -1611,7 +1615,7 @@ export class JoinDependency {
     if (!chain || chain.length < 2) return null;
 
     const joinAssoc = new JoinAssociation(reflection);
-    const sourceArelTable = new Table(sourceAlias);
+    const sourceArelTable = aliasedArelTableFor(modelClass, modelClass.tableName, sourceAlias);
     const parentTableName = modelClass.tableName;
 
     // Pre-allocate table indices and resolve REAL tables for each chain entry
@@ -1637,7 +1641,7 @@ export class JoinDependency {
       const model = refl.klass as typeof Base;
       const tableName = (model as any).tableName;
       chainTables.push({
-        table: new Table(tableName),
+        table: aliasedArelTableFor(model as never, tableName),
         tableName,
         tableIndex: startIndex + i,
         tableAlias: `t${startIndex + i}`,
@@ -1653,7 +1657,8 @@ export class JoinDependency {
       (_refl, remaining) => {
         const idx = chain.length - remaining.length;
         const entry = chainTables[idx];
-        if (!entry) return [new Table((_refl.klass as any).tableName), false];
+        if (!entry)
+          return [aliasedArelTableFor(_refl.klass as never, (_refl.klass as any).tableName), false];
         return [entry.table, false];
       },
     );

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -26,7 +26,11 @@ import { JoinAssociation } from "./join-dependency/join-association.js";
 import { JoinPart } from "./join-dependency/join-part.js";
 import { AssociationNotFoundError, EagerLoadPolymorphicError } from "./errors.js";
 import { ConfigurationError, ConnectionNotDefined } from "../errors.js";
-import { AliasTracker, aliasedArelTableFor } from "./alias-tracker.js";
+import {
+  AliasTracker,
+  aliasedArelTableFor,
+  aliasedArelTableForReflection,
+} from "./alias-tracker.js";
 import { threadedConnectionFor } from "../connection-handling.js";
 
 /**
@@ -920,10 +924,10 @@ export class JoinDependency {
    */
   private _rebuildChildJoin(parent: JoinPart, child: JoinAssociation, newName: string): void {
     const tableName = child.tableName;
-    const aliased = aliasedArelTableFor(child.reflection.klass as never, tableName, newName);
+    const aliased = aliasedArelTableForReflection(child.reflection, tableName, newName);
     const foreignTable =
       (parent.arelTable as Table) ??
-      aliasedArelTableFor(child.reflection.klass as never, child.tableName);
+      aliasedArelTableForReflection(child.reflection, child.tableName);
     const joinAssoc = new JoinAssociation(child.reflection);
     const joins = joinAssoc.joinConstraints(
       foreignTable,
@@ -1007,7 +1011,7 @@ export class JoinDependency {
           return root ? cand : `${cand}_join`;
         });
         const effectiveName = alias ?? lookupName;
-        const aliased = aliasedArelTableFor(refl.klass as never, tableName, effectiveName);
+        const aliased = aliasedArelTableForReflection(refl, tableName, effectiveName);
         resolvedByIdx[idx] = { effectiveName, aliased };
         // Rails: `@joined_tables[chain] ||= [table, root] if OuterJoin`. Keyed
         // off the PARAMETER `join_type` so an eager OUTER-JOIN dependency folded
@@ -1658,7 +1662,7 @@ export class JoinDependency {
         const idx = chain.length - remaining.length;
         const entry = chainTables[idx];
         if (!entry)
-          return [aliasedArelTableFor(_refl.klass as never, (_refl.klass as any).tableName), false];
+          return [aliasedArelTableForReflection(_refl, (_refl.klass as any).tableName), false];
         return [entry.table, false];
       },
     );

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -797,7 +797,10 @@ export class JoinDependency {
 
     // r's children were built referencing r's old table name; re-point their ON
     // predicates to the merged (left) table so the emitted SQL is self-consistent.
-    const toTable = new Table(resolvedTable);
+    // Sourced off `baseKlass` (never raises, unlike `reflection.klass` on a
+    // polymorphic) so the rebound ON keeps its caster — these predicates can
+    // include an STI type condition.
+    const toTable = aliasedArelTableFor(r.baseKlass, r.baseKlass.tableName, resolvedTable);
     for (const child of r.children) {
       const arelJoin = child.arelJoin;
       if (!arelJoin) continue;

--- a/packages/activerecord/src/associations/join-dependency/join-association.ts
+++ b/packages/activerecord/src/associations/join-dependency/join-association.ts
@@ -12,7 +12,7 @@ import type { Base } from "../../base.js";
 import { Table, Nodes } from "@blazetrails/arel";
 import type { AbstractReflection } from "../../reflection.js";
 import { JoinPart } from "./join-part.js";
-import type { AliasTracker } from "../alias-tracker.js";
+import { aliasedArelTableFor, type AliasTracker } from "../alias-tracker.js";
 
 type JoinType = typeof Nodes.InnerJoin | typeof Nodes.OuterJoin;
 type TableResolver = (
@@ -56,7 +56,11 @@ export class JoinAssociation extends JoinPart {
   }
 
   set table(value: string) {
-    this._table = new Table(this.reflection.tableName, { as: value });
+    this._table = aliasedArelTableFor(
+      this.reflection.klass as never,
+      this.reflection.tableName,
+      value,
+    );
     if (!this.tables.some((t) => (t.tableAlias ?? t.name) === value)) {
       this.tables.push(this._table);
     }
@@ -105,7 +109,7 @@ export class JoinAssociation extends JoinPart {
       if (resolveTable) {
         [table, terminated] = resolveTable(refl, reflectionChain.slice(index));
       } else {
-        table = new Table(refl.tableName);
+        table = aliasedArelTableFor(refl.klass as never, refl.tableName);
       }
 
       if (!this._table) this._table = table;

--- a/packages/activerecord/src/associations/join-dependency/join-association.ts
+++ b/packages/activerecord/src/associations/join-dependency/join-association.ts
@@ -12,7 +12,7 @@ import type { Base } from "../../base.js";
 import { Table, Nodes } from "@blazetrails/arel";
 import type { AbstractReflection } from "../../reflection.js";
 import { JoinPart } from "./join-part.js";
-import { aliasedArelTableFor, type AliasTracker } from "../alias-tracker.js";
+import { aliasedArelTableForReflection, type AliasTracker } from "../alias-tracker.js";
 
 type JoinType = typeof Nodes.InnerJoin | typeof Nodes.OuterJoin;
 type TableResolver = (
@@ -56,11 +56,7 @@ export class JoinAssociation extends JoinPart {
   }
 
   set table(value: string) {
-    this._table = aliasedArelTableFor(
-      this.reflection.klass as never,
-      this.reflection.tableName,
-      value,
-    );
+    this._table = aliasedArelTableForReflection(this.reflection, this.reflection.tableName, value);
     if (!this.tables.some((t) => (t.tableAlias ?? t.name) === value)) {
       this.tables.push(this._table);
     }
@@ -109,7 +105,7 @@ export class JoinAssociation extends JoinPart {
       if (resolveTable) {
         [table, terminated] = resolveTable(refl, reflectionChain.slice(index));
       } else {
-        table = aliasedArelTableFor(refl.klass as never, refl.tableName);
+        table = aliasedArelTableForReflection(refl, refl.tableName);
       }
 
       if (!this._table) this._table = table;

--- a/packages/activerecord/src/relation/predicate-builder.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.test.ts
@@ -10,6 +10,16 @@ import { Topic } from "../test-helpers/models/topic.js";
 import { Reply } from "../test-helpers/models/reply.js";
 import { Author } from "../test-helpers/models/author.js";
 import { quoteTableName, escapeRegExp } from "../test-helpers/quote-regex.js";
+import { ValueType } from "@blazetrails/activemodel";
+
+// Mirrors Rails' `fake_pg_caster` (homogeneous_in_test.rb:44-50): a caster that
+// maps any attribute name to a type. `Table#type_for_attribute` delegates bare
+// to the caster (table.rb:106-108), so a table driving a PredicateBuilder always
+// has one — Rails reaches these paths through `TableMetadata#arel_table`, which
+// is built from `klass.arel_table`. `ValueType` is the no-op type Rails uses as
+// `ActiveModel::Type.default_value`, so values round-trip unchanged.
+const fakePgCaster = { typeForAttribute: () => new ValueType() };
+const castedTable = (name: string): Table => new Table(name, { typeCaster: fakePgCaster });
 
 describe("PredicateBuilderTest", () => {
   // Rails setup: Topic.predicate_builder.register_handler(Regexp, proc { |col, val| col ~ val.source })
@@ -134,7 +144,7 @@ describe("PredicateBuilderTest", () => {
   });
 
   describe("buildFromHash", () => {
-    const table = new Table("posts");
+    const table = castedTable("posts");
     const compile = (node: Nodes.Node) => new Visitors.ToSql().compile(node);
 
     it("builds equality for scalars", () => {
@@ -249,7 +259,7 @@ describe("PredicateBuilderTest", () => {
   });
 
   describe("buildNegatedFromHash", () => {
-    const table = new Table("posts");
+    const table = castedTable("posts");
     const compile = (node: Nodes.Node) => new Visitors.ToSql().compile(node);
 
     it("builds IS NOT NULL for null values", () => {
@@ -309,7 +319,7 @@ describe("PredicateBuilderTest", () => {
 
   describe("QueryAttribute bind handling", () => {
     it("buildBindAttribute creates a QueryAttribute", () => {
-      const table = new Table("users");
+      const table = castedTable("users");
       const builder = new PredicateBuilder(table);
       const qa = builder.buildBindAttribute("name", "alice");
       expect(qa.name).toBe("name");
@@ -317,7 +327,7 @@ describe("PredicateBuilderTest", () => {
     });
 
     it("BasicObjectHandler routes through buildBindAttribute", () => {
-      const table = new Table("users");
+      const table = castedTable("users");
       const builder = new PredicateBuilder(table);
       const node = builder.build(table.get("name"), "alice");
       const visitor = new Visitors.ToSql();
@@ -327,7 +337,7 @@ describe("PredicateBuilderTest", () => {
     });
 
     it("Substitute flows through as BindParam via QueryAttribute", () => {
-      const table = new Table("users");
+      const table = castedTable("users");
       const builder = new PredicateBuilder(table);
       const node = builder.build(table.get("name"), new Substitute());
       const visitor = new Visitors.ToSql();
@@ -340,7 +350,7 @@ describe("PredicateBuilderTest", () => {
     });
 
     it("compile inlines QueryAttribute values for display SQL", () => {
-      const table = new Table("users");
+      const table = castedTable("users");
       const builder = new PredicateBuilder(table);
       const node = builder.build(table.get("name"), "alice");
       const visitor = new Visitors.ToSql();
@@ -378,7 +388,7 @@ describe("PredicateBuilderTest", () => {
     });
 
     it("expands where({authors: {name: 'Rails'}}) to \"authors\".\"name\" = 'Rails'", () => {
-      const meta = new TableMetadata(PbTestPost as any, new Table("posts"));
+      const meta = new TableMetadata(PbTestPost as any, castedTable("posts"));
       const builder = meta.predicateBuilder;
       const nodes = builder.buildFromHash({ authors: { name: "Rails" } });
       const sql = nodes.map((n) => new Visitors.ToSql().compile(n)).join(" AND ");
@@ -391,7 +401,7 @@ describe("PredicateBuilderTest", () => {
       // Rails table_metadata.rb associated_table aliases the resolved table to
       // the hash key whenever the names differ, so an association key that
       // differs from its table (writer -> authors) emits "writer"."name".
-      const meta = new TableMetadata(PbTestPost as any, new Table("posts"));
+      const meta = new TableMetadata(PbTestPost as any, castedTable("posts"));
       const builder = meta.predicateBuilder;
       const nodes = builder.buildFromHash({ writer: { name: "Rails" } });
       const sql = nodes.map((n) => new Visitors.ToSql().compile(n)).join(" AND ");
@@ -400,7 +410,7 @@ describe("PredicateBuilderTest", () => {
     });
 
     it("negated form expands whereNot({authors: {name: 'Rails'}}) to NOT \"authors\".\"name\" = 'Rails'", () => {
-      const meta = new TableMetadata(PbTestPost as any, new Table("posts"));
+      const meta = new TableMetadata(PbTestPost as any, castedTable("posts"));
       const builder = meta.predicateBuilder;
       const nodes = builder.buildNegatedFromHash({ authors: { name: "Rails" } });
       const sql = nodes.map((n) => new Visitors.ToSql().compile(n)).join(" AND ");
@@ -424,7 +434,7 @@ describe("PredicateBuilderTest", () => {
         }
       }
       try {
-        const meta = new TableMetadata(PbTestProduct as any, new Table("products"));
+        const meta = new TableMetadata(PbTestProduct as any, castedTable("products"));
         const builder = meta.predicateBuilder;
         const nodes = builder.buildFromHash({ price: { foo: "bar" } });
         const sql = nodes.map((n) => new Visitors.ToSql().compile(n)).join(" AND ");

--- a/packages/activerecord/src/relation/predicate-builder.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.test.ts
@@ -20,7 +20,15 @@ import { ValueType } from "@blazetrails/activemodel";
 // these assert bound *values*, so they need the no-op type Rails reaches for as
 // `ActiveModel::Type.default_value`. A real column type would cast `{ id: 5 }` to
 // `"[object Object]"` and defeat the dereference assertions below.
-const fakePgCaster = { typeForAttribute: () => new ValueType() };
+// Both members: #4888 converged `Table#typeCastForDatabase` to bare delegation
+// too, and a range bound reaches it through `Casted`. Mirrors TypeCaster::Map /
+// ::Connection, whose `type_cast_for_database` is `type_for_attribute(n).serialize(v)`
+// (type_caster/map.rb:15-17).
+const VALUE_TYPE = new ValueType();
+const fakePgCaster = {
+  typeForAttribute: () => VALUE_TYPE,
+  typeCastForDatabase: (_attrName: string, value: unknown) => VALUE_TYPE.serialize(value),
+};
 const castedTable = (name: string): Table => new Table(name, { typeCaster: fakePgCaster });
 
 describe("PredicateBuilderTest", () => {

--- a/packages/activerecord/src/relation/predicate-builder.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.test.ts
@@ -23,7 +23,7 @@ import { ValueType } from "@blazetrails/activemodel";
 // Both members: #4888 converged `Table#typeCastForDatabase` to bare delegation
 // too, and a range bound reaches it through `Casted`. Mirrors TypeCaster::Map /
 // ::Connection, whose `type_cast_for_database` is `type_for_attribute(n).serialize(v)`
-// (type_caster/map.rb:15-17).
+// (type_caster/map.rb:10-13).
 const VALUE_TYPE = new ValueType();
 const fakePgCaster = {
   typeForAttribute: () => VALUE_TYPE,

--- a/packages/activerecord/src/relation/predicate-builder.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.test.ts
@@ -12,12 +12,14 @@ import { Author } from "../test-helpers/models/author.js";
 import { quoteTableName, escapeRegExp } from "../test-helpers/quote-regex.js";
 import { ValueType } from "@blazetrails/activemodel";
 
-// Mirrors Rails' `fake_pg_caster` (homogeneous_in_test.rb:44-50): a caster that
-// maps any attribute name to a type. `Table#type_for_attribute` delegates bare
-// to the caster (table.rb:106-108), so a table driving a PredicateBuilder always
-// has one — Rails reaches these paths through `TableMetadata#arel_table`, which
-// is built from `klass.arel_table`. `ValueType` is the no-op type Rails uses as
-// `ActiveModel::Type.default_value`, so values round-trip unchanged.
+// Same shape as Rails' `fake_pg_caster` (homogeneous_in_test.rb:44-50) — a map
+// converting any attribute name to a caster — because `Table#type_for_attribute`
+// delegates bare (table.rb:106-108) and these tables are not canonical models
+// (`users` is in neither Rails' schema.rb nor TEST_SCHEMA). It yields `ValueType`
+// where Rails' yields `String`: Rails' Arel tests assert SQL shape only, whereas
+// these assert bound *values*, so they need the no-op type Rails reaches for as
+// `ActiveModel::Type.default_value`. A real column type would cast `{ id: 5 }` to
+// `"[object Object]"` and defeat the dereference assertions below.
 const fakePgCaster = { typeForAttribute: () => new ValueType() };
 const castedTable = (name: string): Table => new Table(name, { typeCaster: fakePgCaster });
 
@@ -388,7 +390,7 @@ describe("PredicateBuilderTest", () => {
     });
 
     it("expands where({authors: {name: 'Rails'}}) to \"authors\".\"name\" = 'Rails'", () => {
-      const meta = new TableMetadata(PbTestPost as any, castedTable("posts"));
+      const meta = new TableMetadata(PbTestPost as any, (PbTestPost as any).arelTable);
       const builder = meta.predicateBuilder;
       const nodes = builder.buildFromHash({ authors: { name: "Rails" } });
       const sql = nodes.map((n) => new Visitors.ToSql().compile(n)).join(" AND ");
@@ -401,7 +403,7 @@ describe("PredicateBuilderTest", () => {
       // Rails table_metadata.rb associated_table aliases the resolved table to
       // the hash key whenever the names differ, so an association key that
       // differs from its table (writer -> authors) emits "writer"."name".
-      const meta = new TableMetadata(PbTestPost as any, castedTable("posts"));
+      const meta = new TableMetadata(PbTestPost as any, (PbTestPost as any).arelTable);
       const builder = meta.predicateBuilder;
       const nodes = builder.buildFromHash({ writer: { name: "Rails" } });
       const sql = nodes.map((n) => new Visitors.ToSql().compile(n)).join(" AND ");
@@ -410,7 +412,7 @@ describe("PredicateBuilderTest", () => {
     });
 
     it("negated form expands whereNot({authors: {name: 'Rails'}}) to NOT \"authors\".\"name\" = 'Rails'", () => {
-      const meta = new TableMetadata(PbTestPost as any, castedTable("posts"));
+      const meta = new TableMetadata(PbTestPost as any, (PbTestPost as any).arelTable);
       const builder = meta.predicateBuilder;
       const nodes = builder.buildNegatedFromHash({ authors: { name: "Rails" } });
       const sql = nodes.map((n) => new Visitors.ToSql().compile(n)).join(" AND ");
@@ -434,7 +436,7 @@ describe("PredicateBuilderTest", () => {
         }
       }
       try {
-        const meta = new TableMetadata(PbTestProduct as any, castedTable("products"));
+        const meta = new TableMetadata(PbTestProduct as any, (PbTestProduct as any).arelTable);
         const builder = meta.predicateBuilder;
         const nodes = builder.buildFromHash({ price: { foo: "bar" } });
         const sql = nodes.map((n) => new Visitors.ToSql().compile(n)).join(" AND ");

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -666,6 +666,16 @@ export class PredicateBuilder {
   }
 
   resolveArelAttribute(tableName: string, columnName: string): Nodes.Attribute {
+    // Mirrors predicate_builder.rb:71-73 — routing through `associated_table`
+    // (rather than a bare `Arel::Table.new`) is what keeps the resulting table's
+    // type caster attached, since `Table#type_for_attribute` delegates bare.
+    // Rails' PredicateBuilder always holds a TableMetadata; trails' holds the
+    // raw Arel table plus the metadata as `_tableContext`, so fall back to a
+    // bare table when a caller built one without a context.
+    const ctx = this._tableContext as { associatedTable?: (n: string) => { arelTable: Table } };
+    if (typeof ctx?.associatedTable === "function") {
+      return ctx.associatedTable(tableName).arelTable.get(columnName);
+    }
     return new Table(tableName).get(columnName);
   }
 

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -10,6 +10,7 @@ import { AssociationQueryValue } from "./predicate-builder/association-query-val
 import { Substitute } from "../statement-cache.js";
 import { PolymorphicArrayValue } from "./predicate-builder/polymorphic-array-value.js";
 import { argumentError } from "./query-methods.js";
+import { Connection as TypeCasterConnection } from "../type-caster/connection.js";
 
 interface BoundType {
   cast?(x: unknown): unknown;
@@ -640,6 +641,16 @@ export class PredicateBuilder {
   }
 
   resolveColumn(key: string): Nodes.Attribute {
+    // A `"table.column"` key resolves through `resolveArelAttribute`, so the
+    // table carries a caster. Rails reaches the same place from the other side:
+    // convert_dot_notation_to_hash rewrites the key to a nested hash whose
+    // table part goes through `associated_table` (predicate_builder.rb:71-73).
+    if (!key.includes('"')) {
+      const firstDot = key.indexOf(".");
+      if (firstDot !== -1 && key.indexOf(".", firstDot + 1) === -1) {
+        return this.resolveArelAttribute(key.slice(0, firstDot), key.slice(firstDot + 1));
+      }
+    }
     return PredicateBuilder.resolveColumn(this.table, key);
   }
 
@@ -665,18 +676,31 @@ export class PredicateBuilder {
     return new QueryAttribute(columnName, value, castType);
   }
 
-  resolveArelAttribute(tableName: string, columnName: string): Nodes.Attribute {
+  resolveArelAttribute(
+    tableName: string,
+    columnName: string,
+    fallback?: (name: string) => unknown,
+  ): Nodes.Attribute {
     // Mirrors predicate_builder.rb:71-73 — routing through `associated_table`
-    // (rather than a bare `Arel::Table.new`) is what keeps the resulting table's
-    // type caster attached, since `Table#type_for_attribute` delegates bare.
-    // Rails' PredicateBuilder always holds a TableMetadata; trails' holds the
-    // raw Arel table plus the metadata as `_tableContext`, so fall back to a
-    // bare table when a caller built one without a context.
-    const ctx = this._tableContext as { associatedTable?: (n: string) => { arelTable: Table } };
+    // (with Rails' block, `lookup_table_klass_from_join_dependencies`) is what
+    // resolves a table name that only exists as a join, and what keeps the
+    // resulting table's type caster attached.
+    const ctx = this._tableContext as {
+      associatedTable?: (n: string, f?: (name: string) => unknown) => { arelTable: Table };
+    };
     if (typeof ctx?.associatedTable === "function") {
-      return ctx.associatedTable(tableName).arelTable.get(columnName);
+      return ctx.associatedTable(tableName, fallback).arelTable.get(columnName);
     }
-    return new Table(tableName).get(columnName);
+    // Rails' PredicateBuilder always holds a TableMetadata, so `associated_table`
+    // is always reachable and never yields a caster-less table; trails' holds the
+    // raw Arel table plus the metadata as `_tableContext`, so a builder
+    // constructed without one lands here. Attach a caster the way the no-klass
+    // branch of associated_table does (table_metadata.rb:47-48) — with
+    // type_for_attribute delegating bare, a bare table would raise.
+    const klass = (this._tableContext as { klass?: unknown })?.klass ?? null;
+    return new Table(tableName, {
+      typeCaster: new TypeCasterConnection(klass as never, tableName),
+    }).get(columnName);
   }
 
   with(context: any): PredicateBuilder {

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -643,15 +643,15 @@ export class PredicateBuilder {
   resolveColumn(key: string): Nodes.Attribute {
     // A `"table.column"` key resolves through `resolveArelAttribute`, so the
     // table carries a caster. Rails reaches the same place from the other side:
-    // convert_dot_notation_to_hash rewrites the key to a nested hash whose
-    // table part goes through `associated_table` (predicate_builder.rb:71-73).
+    // convert_dot_notation_to_hash splits on `rindex(".")`
+    // (predicate_builder.rb:171) and routes the table part through
+    // `associated_table` — hence lastIndexOf, matching convertDotNotationToHash
+    // and references() rather than reading `a.b.c` as one column name.
     if (!key.includes('"')) {
-      const firstDot = key.indexOf(".");
-      if (firstDot !== -1 && key.indexOf(".", firstDot + 1) === -1) {
-        return this.resolveArelAttribute(key.slice(0, firstDot), key.slice(firstDot + 1));
-      }
+      const dot = key.lastIndexOf(".");
+      if (dot !== -1) return this.resolveArelAttribute(key.slice(0, dot), key.slice(dot + 1));
     }
-    return PredicateBuilder.resolveColumn(this.table, key);
+    return this.table.get(key);
   }
 
   registerHandler(
@@ -685,8 +685,15 @@ export class PredicateBuilder {
     // (with Rails' block, `lookup_table_klass_from_join_dependencies`) is what
     // resolves a table name that only exists as a join, and what keeps the
     // resulting table's type caster attached.
+    // `arelTable` is a TableAlias (a Binary node, not a Table) whenever
+    // associated_table had to alias to the hash key (table-metadata.ts:83-84,
+    // mirroring table_metadata.rb:44) — both answer `get`, neither is
+    // `instanceof Table`.
     const ctx = this._tableContext as {
-      associatedTable?: (n: string, f?: (name: string) => unknown) => { arelTable: Table };
+      associatedTable?: (
+        n: string,
+        f?: (name: string) => unknown,
+      ) => { arelTable: Table | Nodes.TableAlias };
     };
     if (typeof ctx?.associatedTable === "function") {
       return ctx.associatedTable(tableName, fallback).arelTable.get(columnName);
@@ -791,15 +798,6 @@ export class PredicateBuilder {
 
   references(): string[] {
     return [];
-  }
-
-  static resolveColumn(table: Table, key: string): Nodes.Attribute {
-    if (key.includes('"')) return table.get(key);
-    const firstDot = key.indexOf(".");
-    if (firstDot === -1) return table.get(key);
-    const secondDot = key.indexOf(".", firstDot + 1);
-    if (secondDot !== -1) return table.get(key);
-    return new Table(key.slice(0, firstDot)).get(key.slice(firstDot + 1));
   }
 
   private isRelation(value: unknown): boolean {

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2347,8 +2347,13 @@ export function arelColumnWithTable(
   }
   if (typeof columnName === "symbol" || !/\W/.test(colStr)) {
     const builder = (this as any).predicateBuilder;
+    // Rails passes `lookup_table_klass_from_join_dependencies` as the block
+    // (query_methods.rb:1982-1984), so a table name that only resolves through a
+    // join dependency still finds its model — and its type caster.
+    const block = (name: string) => lookupTableKlassFromJoinDependencies.call(this, name);
     return (
-      builder?.resolveArelAttribute?.(tableName, colStr) ?? new ArelTable(tableName).get(colStr)
+      builder?.resolveArelAttribute?.(tableName, colStr, block) ??
+      new ArelTable(tableName).get(colStr)
     );
   }
   const quotedTable = safeQuoteTableName(modelClass, tableName);

--- a/packages/activerecord/src/type-caster/connection.ts
+++ b/packages/activerecord/src/type-caster/connection.ts
@@ -2,8 +2,8 @@ import type { Type } from "@blazetrails/activemodel";
 import { defaultValue } from "../type.js";
 
 /**
- * Casts attribute values for database operations using the connection's
- * schema cache to look up column types by table name.
+ * Casts attribute values for database operations, looking column types up by
+ * table name in the pool's schema cache.
  *
  * Mirrors: ActiveRecord::TypeCaster::Connection
  */
@@ -23,21 +23,32 @@ export class Connection {
 
   typeForAttribute(attrName: string): Type {
     const column = this.resolveColumn(attrName);
+    // Rails scopes the lookup to a leased connection —
+    // `@klass.with_connection { |c| c.lookup_cast_type_from_column(column) }`
+    // (type_caster/connection.rb:21). trails' `withConnection` returns a Promise
+    // (connection-handling.ts:366) and this method is sync, so it reads the
+    // adapter directly, taking a permanent checkout where Rails scopes a lease.
+    // Same RFC 0023 async/sync constraint as the `data_source_exists?` gate below.
     const type = column
-      ? (this._klass?.connection?.lookupCastTypeFromColumn?.(column) as Type | undefined)
+      ? (this._klass?.connection?.lookupCastTypeFromColumn(column) as Type | undefined)
       : undefined;
     return type ?? defaultValue();
   }
 
   private resolveColumn(attrName: string): unknown | undefined {
-    // Rails gates on `schema_cache.data_source_exists?(table_name)` before
-    // reading `columns_hash` (type_caster/connection.rb:17-18). trails'
-    // `dataSourceExists` is async (schema-cache.ts:211) and this method is sync,
-    // so the cached columns hash is the gate instead: a warmed entry implies the
-    // data source exists, and `getCachedColumnsHash` is a plain map read that
-    // never triggers the async cache-miss path. Converging the gate itself waits
-    // on the pool async/sync convergence (RFC 0023).
-    const hash = this._klass?.connection?.schemaCache?.getCachedColumnsHash?.(this._tableName);
+    // `@klass.schema_cache` (type_caster/connection.rb:17) reads the pool's cache
+    // without leasing a connection (connection_handling.rb:368-369); trails ports
+    // that as the sync, pool-backed `Base.schemaCache` (connection-handling.ts:576).
+    // Read it off the klass, not the adapter — `connection.schemaCache` is not
+    // guaranteed to be the same slot (model-schema.ts:731-755).
+    const schemaCache = this._klass?.schemaCache?.();
+    // Rails then gates on `schema_cache.data_source_exists?(table_name)` before
+    // reading `columns_hash`. trails' `dataSourceExists` is async
+    // (schema-cache.ts:211) and this method is sync, so the cached columns hash is
+    // the gate instead: a warmed entry implies the data source exists, and
+    // `getCachedColumnsHash` is a plain map read that never triggers the async
+    // cache-miss path. Converging the gate waits on RFC 0023.
+    const hash = schemaCache?.getCachedColumnsHash?.(this._tableName);
     return hash?.[attrName];
   }
 }

--- a/packages/activerecord/src/type-caster/connection.ts
+++ b/packages/activerecord/src/type-caster/connection.ts
@@ -47,21 +47,7 @@ export class Connection {
     // not `isCached` (`_columns`); getCachedColumnsHash is a sync map read and
     // never triggers an async cache-miss path. Returns undefined when unwarmed.
     const hash = schemaCache?.getCachedColumnsHash?.(this._tableName);
-    const column = hash?.[attrName];
-    if (column) return column;
-
-    // Fallback: klass.columnsHash (works when schema cache isn't populated)
-    const columnsHash =
-      typeof this._klass?.columnsHash === "function"
-        ? this._klass.columnsHash()
-        : this._klass?.columnsHash;
-    if (columnsHash) {
-      return columnsHash instanceof globalThis.Map
-        ? columnsHash.get(attrName)
-        : columnsHash?.[attrName];
-    }
-
-    return undefined;
+    return hash?.[attrName];
   }
 }
 

--- a/packages/activerecord/src/type-caster/connection.ts
+++ b/packages/activerecord/src/type-caster/connection.ts
@@ -41,7 +41,7 @@ export class Connection {
     // that as the sync, pool-backed `Base.schemaCache` (connection-handling.ts:576).
     // Read it off the klass, not the adapter — `connection.schemaCache` is not
     // guaranteed to be the same slot (model-schema.ts:731-755).
-    const schemaCache = this._klass?.schemaCache?.();
+    const schemaCache = this._klass?.schemaCache();
     // Rails then gates on `schema_cache.data_source_exists?(table_name)` before
     // reading `columns_hash`. trails' `dataSourceExists` is async
     // (schema-cache.ts:211) and this method is sync, so the cached columns hash is

--- a/packages/activerecord/src/type-caster/connection.ts
+++ b/packages/activerecord/src/type-caster/connection.ts
@@ -1,4 +1,5 @@
-import { Type, ValueType } from "@blazetrails/activemodel";
+import type { Type } from "@blazetrails/activemodel";
+import { defaultValue } from "../type.js";
 
 /**
  * Casts attribute values for database operations using the connection's
@@ -22,31 +23,21 @@ export class Connection {
 
   typeForAttribute(attrName: string): Type {
     const column = this.resolveColumn(attrName);
-
-    if (column) {
-      const adapter = this._klass?.connection;
-      const type = adapter?.lookupCastTypeFromColumn?.(column);
-      if (type) return type;
-
-      const sqlType = (column as any).sqlType ?? (column as any).type;
-      if (sqlType && adapter?.lookupCastType) {
-        const castType = adapter.lookupCastType(sqlType);
-        if (castType) return castType;
-      }
-    }
-
-    return new ValueType();
+    const type = column
+      ? (this._klass?.connection?.lookupCastTypeFromColumn?.(column) as Type | undefined)
+      : undefined;
+    return type ?? defaultValue();
   }
 
   private resolveColumn(attrName: string): unknown | undefined {
-    // Only consult the schema cache when it's already populated — avoid
-    // triggering cache-miss paths that call async adapter methods.
-    const adapter = this._klass?.connection;
-    const schemaCache = adapter?.schemaCache;
-    // Gate on the same map we read (`_columnsHash` via getCachedColumnsHash),
-    // not `isCached` (`_columns`); getCachedColumnsHash is a sync map read and
-    // never triggers an async cache-miss path. Returns undefined when unwarmed.
-    const hash = schemaCache?.getCachedColumnsHash?.(this._tableName);
+    // Rails gates on `schema_cache.data_source_exists?(table_name)` before
+    // reading `columns_hash` (type_caster/connection.rb:17-18). trails'
+    // `dataSourceExists` is async (schema-cache.ts:211) and this method is sync,
+    // so the cached columns hash is the gate instead: a warmed entry implies the
+    // data source exists, and `getCachedColumnsHash` is a plain map read that
+    // never triggers the async cache-miss path. Converging the gate itself waits
+    // on the pool async/sync convergence (RFC 0023).
+    const hash = this._klass?.connection?.schemaCache?.getCachedColumnsHash?.(this._tableName);
     return hash?.[attrName];
   }
 }

--- a/packages/arel/src/nodes/homogeneous-in.test.ts
+++ b/packages/arel/src/nodes/homogeneous-in.test.ts
@@ -1,9 +1,15 @@
 import { describe, it, expect } from "vitest";
 import { Table, Nodes, Visitors } from "../index.js";
-import { Attribute as AMAttribute } from "@blazetrails/activemodel";
+import { Attribute as AMAttribute, StringType } from "@blazetrails/activemodel";
+
+// Mirrors Rails' `fake_pg_caster` (homogeneous_in_test.rb:44-50): a map that
+// converts any attribute name to a caster. Rails always builds this table with
+// a caster because `Table#type_for_attribute` delegates bare (table.rb:106-108).
+const STRING_TYPE = new StringType();
+const fakePgCaster = { typeForAttribute: () => STRING_TYPE };
 
 describe("Arel::Nodes::HomogeneousInTest", () => {
-  const users = new Table("users");
+  const users = new Table("users", { typeCaster: fakePgCaster });
   it("in", () => {
     const node = users.get("id").in([1, 2, 3]);
     const sql = new Visitors.ToSql().compile(node);

--- a/packages/arel/src/nodes/homogeneous-in.test.ts
+++ b/packages/arel/src/nodes/homogeneous-in.test.ts
@@ -8,6 +8,18 @@ import { Attribute as AMAttribute, StringType } from "@blazetrails/activemodel";
 const STRING_TYPE = new StringType();
 const fakePgCaster = { typeForAttribute: () => STRING_TYPE };
 
+// Mirrors Rails' `TypedNode` (homogeneous_in_test.rb:34-42): a named function
+// that also has a data type, so `HomogeneousIn#casted_values` reads `type_caster`
+// off a node that is not an Attribute.
+class TypedNode extends Nodes.NamedFunction {
+  readonly typeCaster: unknown;
+
+  constructor(name: string, expr: Nodes.Node[], type: unknown) {
+    super(name, expr, undefined);
+    this.typeCaster = type;
+  }
+}
+
 describe("Arel::Nodes::HomogeneousInTest", () => {
   const users = new Table("users", { typeCaster: fakePgCaster });
   it("in", () => {
@@ -17,10 +29,10 @@ describe("Arel::Nodes::HomogeneousInTest", () => {
   });
 
   it("custom attribute node", () => {
-    const attr = new Nodes.Attribute(users, "id");
-    const node = attr.in([1, 2]);
-    const sql = new Visitors.ToSql().compile(node);
-    expect(sql).toContain('"users"."id" IN');
+    const node = new TypedNode("COALESCE", [users.get("nickname"), users.get("name")], STRING_TYPE);
+    const expr = new Nodes.HomogeneousIn(["Bobby", "Robert"], node, "in");
+    const sql = new Visitors.ToSql().compile(expr);
+    expect(sql).toBe('COALESCE("users"."nickname", "users"."name") IN (?, ?)');
   });
 
   describe("HomogeneousIn visitor", () => {

--- a/packages/arel/src/nodes/homogeneous-in.test.ts
+++ b/packages/arel/src/nodes/homogeneous-in.test.ts
@@ -11,10 +11,9 @@ const fakePgCaster = { typeForAttribute: () => STRING_TYPE };
 describe("Arel::Nodes::HomogeneousInTest", () => {
   const users = new Table("users", { typeCaster: fakePgCaster });
   it("in", () => {
-    const node = users.get("id").in([1, 2, 3]);
+    const node = new Nodes.HomogeneousIn(["Bobby", "Robert"], users.get("name"), "in");
     const sql = new Visitors.ToSql().compile(node);
-    // attr.in([...]) creates an In node with Quoted values — inlined like Rails.
-    expect(sql).toBe('"users"."id" IN (1, 2, 3)');
+    expect(sql).toBe('"users"."name" IN (?, ?)');
   });
 
   it("custom attribute node", () => {

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -33,7 +33,11 @@ export class Table extends Node {
   readonly name: string;
   readonly tableAlias: string | null;
   readonly klass?: TableKlass;
-  private typeCaster: unknown;
+  /** Rails: `private attr_reader :type_caster` (table.rb:115). Readable here so
+   *  an aliased copy of a table can inherit it — trails encodes an aliased table
+   *  as `Table(name, { as })` where Rails wraps in a caster-delegating TableAlias.
+   *  @internal */
+  readonly typeCaster: unknown;
 
   constructor(name: string, options?: { as?: string; klass?: TableKlass; typeCaster?: unknown }) {
     super();
@@ -164,23 +168,8 @@ export class Table extends Node {
     return (this.typeCaster as TypeCaster).typeCastForDatabase(attrName, value);
   }
 
-  // DEVIATION: Rails delegates bare here too (`type_caster.type_for_attribute(name)`,
-  // table.rb:106-108), so a caster-less table raises NoMethodError. We cannot yet:
-  // unlike `type_cast_for_database` (only reached through `Casted#valueForDatabase`,
-  // which gates on `isAbleToTypeCast`), this is reached ungated via
-  // `Attribute#typeCaster` -> `HomogeneousIn#castedValues`. trails builds
-  // caster-less tables for join aliases (join-dependency, association-scope) where
-  // Rails aliases `klass.arel_table` and keeps the caster, so bare delegation
-  // breaks real join/STI queries. Removing this fallback is blocked on converging
-  // those construction sites onto `klass.arelTable`.
   typeForAttribute(name: string): unknown {
-    if (
-      this.typeCaster &&
-      typeof (this.typeCaster as Record<string, unknown>).typeForAttribute === "function"
-    ) {
-      return (this.typeCaster as TypeCaster).typeForAttribute(name);
-    }
-    return undefined;
+    return (this.typeCaster as TypeCaster).typeForAttribute(name);
   }
 
   isAbleToTypeCast(): boolean {

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -11,7 +11,7 @@ import {
   Visitors,
   Collectors,
 } from "../index.js";
-import { Attribute as AMAttribute, ValueType } from "@blazetrails/activemodel";
+import { Attribute as AMAttribute, ValueType, StringType } from "@blazetrails/activemodel";
 
 describe("the to_sql visitor", () => {
   const users = new Table("users");
@@ -438,7 +438,13 @@ describe("the to_sql visitor", () => {
 
   describe("Nodes::HomogeneousIn", () => {
     it("is not preparable", () => {
-      const node = new Nodes.HomogeneousIn([1, 2, 3], users.get("id"), "in");
+      // HomogeneousIn#casted_values reaches Table#type_for_attribute, which
+      // delegates bare to the caster — so Rails builds this table with a caster
+      // too (`fake_pg_caster`, homogeneous_in_test.rb:44-50).
+      const castedUsers = new Table("users", {
+        typeCaster: { typeForAttribute: () => new StringType() },
+      });
+      const node = new Nodes.HomogeneousIn([1, 2, 3], castedUsers.get("id"), "in");
       const collector = new Collectors.SQLString();
       new Visitors.ToSql().compileWithCollector(node, collector);
       expect(collector.preparable).toBe(false);

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -36305,20 +36305,6 @@
     "package": "activerecord",
     "tsFile": "relation/predicate-builder.ts",
     "rubyName": "resolve_arel_attribute",
-    "call": "arel_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder.ts",
-    "rubyName": "resolve_arel_attribute",
-    "call": "associated_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder.ts",
-    "rubyName": "resolve_arel_attribute",
     "call": "table",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -40281,13 +40281,6 @@
     "package": "activerecord",
     "tsFile": "type-caster/connection.ts",
     "rubyName": "type_for_attribute",
-    "call": "default_value",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "type-caster/connection.ts",
-    "rubyName": "type_for_attribute",
     "call": "schema_cache",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -36592,13 +36592,6 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "arel_column_with_table",
-    "call": "lookup_table_klass_from_join_dependencies",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "arel_column_with_table",
     "call": "match?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
Rails' `Arel::Table#type_for_attribute` delegates straight to the caster, so a
caster-less table raises:

```ruby
def type_for_attribute(name)
  type_caster.type_for_attribute(name)
end
```

trails guarded the call and returned `undefined` instead. Removing that fallback
was blocked because trails constructed **caster-less** `Arel::Table`s for join
aliases, where Rails aliases `klass.arel_table` (which carries a
`TypeCaster::Map`) and so keeps the caster for free (`alias_tracker.rb:58-70`).

## Why it broke (measured)

`Table#typeForAttribute` is reached ungated via `Attribute#typeCaster` →
`HomogeneousIn#castedValues`. With the fallback removed on `main`,
`relation.test.ts` fails 2 real tests — "relation merging with merged joins as
strings" / "as symbols" — with `TypeError: Cannot read properties of null`. The
table was `comments`, attribute `type` (the STI type condition), built by
`reflection.ts:309` inside an INNER JOIN ON clause.

## What changed

- Join/association Arel tables derive from `klass.arelTable` via a shared
  `aliasedArelTableFor` helper (`alias-tracker.ts`), so the caster survives
  trails' aliased-table encoding — `Table(realName, { as: alias })`, where Rails
  wraps in a caster-delegating `TableAlias`. Converged sites: `join-association.ts`,
  `join-dependency.ts`, `association-scope.ts`, `associations.ts`,
  `collection-proxy.ts`.
- `Table#typeForAttribute` now delegates bare (`table.rb:106-108`); the invented
  guard + `undefined` fallback are gone.
- `PredicateBuilder#resolveArelAttribute` routes through `associated_table`
  (`predicate_builder.rb:71-73`) rather than a bare `new Table(tableName)` —
  that is what keeps the caster attached there.
- Tests that drive `HomogeneousIn` off a bare table now build one *with* a
  caster, mirroring Rails' own `fake_pg_caster` (`homogeneous_in_test.rb:44-50`):
  `homogeneous-in.test.ts`, `to-sql.test.ts`, `predicate-builder.test.ts`.

## Notes

- A **polymorphic** reflection keeps its bare table: `reflection.klass` raises for
  polymorphic, and the concrete class is only known per row at runtime. Rails
  resolves it at runtime the same way.
- `Table#typeCaster` goes `private` → `readonly` so an aliased copy can inherit
  it. Rails has the reader too (`private attr_reader :type_caster`); this is a
  visibility change, not new API.
- `Table#typeCastForDatabase`'s guard is deliberately left alone — it belongs to
  the sibling `arel-table-type-cast-fallbacks-are-invented` PR.

## Verification

- The 2 originally-failing `relation.test.ts` join-merging tests pass.
- `packages/arel/src` + `activerecord` associations/relation suites: 4545 passed,
  0 failed.
- `pnpm typecheck` and scoped eslint clean; api:compare arel stays 938/938 (100%).
- No test names changed.

Closes-story: arel-join-tables-lack-type-casters


---

## Review round 1

Fixed (1 of 8 declined, with measurements):

- **(2) caster dropped when `base.name !== tableName`** — real bug, fixed. That
  branch now aliases the real table and keeps the caster, matching
  `alias_tracker.rb:64` / `table_metadata.rb:44`. It was a live `TypeError`.
- **(3) dropped block param** — fixed. `resolveArelAttribute` takes Rails' block
  and forwards it to `associatedTable`; `arelColumnWithTable` now passes
  `lookupTableKlassFromJoinDependencies` (`query_methods.rb:1982-1984`).
- **(4) fallback was a crash, not a fallback** — fixed. It attaches a
  `TypeCasterConnection` exactly as the no-klass branch of `associated_table`
  does (`table_metadata.rb:47-48`).
- **(5) `join-dependency.ts:800`** — reachable, fixed. Sourced off `baseKlass`
  (never raises, unlike `reflection.klass` on a polymorphic).
- **(6) association-scope aliased branches** — fixed; both now resolve through
  the reflection.
- **(7) `predicate-builder.ts:778`** — fixed. `resolveColumn` routes a
  `"table.column"` key through `resolveArelAttribute`, which is where Rails
  lands via `convert_dot_notation_to_hash`.
- **(8) comment/`ValueType` mismatch** — comment fixed; `PbTestPost` /
  `PbTestProduct` now use their real `arelTable`. **`ValueType` kept
  deliberately**: swapping to `StringType` (or the canonical `Post` caster)
  fails 3 tests — a real `title` type casts `{ id: 5 }` to `"[object Object]"`,
  defeating the "does not dereference a plain object literal" assertions. Rails'
  `fake_pg_caster` uses `String` because its Arel tests assert SQL shape, not
  bound values. The comment now says so.

**(1) `#alias` instead of a new helper — declined, with evidence.** You're right
that `TableAlias` delegates and that `TableMetadata#associatedTable` already uses
`.alias()`. But swapping `aliasedArelTableFor` to `klass.arelTable.alias(name)`
**fails 3 tests**, because `TableAlias` is a `Binary` node, not a `Table`:
`rebindTableReferences` gates on `rel instanceof Table`
(`join-dependency.ts:1779`) and silently drops every rebind. `TableAlias#name` is
also the *alias* where `Table#name` is the *real table*, so `.tableAlias ?? .name`
readers change meaning. Scope to converge: 4 `instanceof Table` gates, ~26 `: Table`
annotations, 8 effective-name reads — over this PR's budget and a different change
in kind. Registered as
`0023-surfaced-deviations/arel-aliased-join-tables-should-be-tablealias` with the
measurements and the 3 failing test names. The helper's doc comment now states
this constraint rather than claiming the encoding is universal.

**Q: does api:compare flag `typeCaster` going public?** No — `pnpm api:compare`
exits 0 with arel at 938/938 (100%). It compares method sets, not field
visibility.

CI's `Rails API/Test Comparison` failure was mine, not a flake: converging
`resolve_arel_attribute` made 2 wide-call ratchet entries stale
(`resolve_arel_attribute → arel_table` / `→ associated_table`). Removed by hand;
the baseline only shrinks.


---

## Review round 2

Fixed (2 of 6 declined, with Rails citations):

- **(2) dead static `resolveColumn`** — confirmed and deleted. The instance branch
  intercepts every dotted key, it had no other caller, and Rails has no
  `resolve_column` at all.
- **(3) `indexOf` vs `lastIndexOf`** — fixed. Now splits on `lastIndexOf`, matching
  Rails' `key.rindex(".")` (`predicate_builder.rb:171`) and this class's own
  `convertDotNotationToHash` / `references`. The two contradictory readings of
  `"a.b.c"` are gone.
- **(4) `TypeCaster::Connection` cross-table fallback** — fixed by **removing** the
  `klass.columnsHash()` fallback outright. Rails reads only
  `schema_cache.columns_hash(table_name)` and otherwise returns
  `Type.default_value` (`type_caster/connection.rb:16-26`); the fallback answered
  with the *builder's* model's columns for a different table. Removing it is green
  across arel + AR relation/associations/type-caster/scoping/finder (4546 tests).
- **(6) annotation** — widened to `Table | Nodes.TableAlias`, with a note that
  neither is `instanceof Table` here.
- **Minor, `it("in")`** — fixed. It asserted `Predications#in` under Rails'
  `test_in` name; it now mirrors `test_in`'s body (`HomogeneousIn` over
  `table[:name]` with `["Bobby", "Robert"]`, `homogeneous_in_test.rb:7-15`).
  Since test:compare matches by name, the body should match too.
- **(1) masked bare-table site** — the site you named (`associations.ts:2881`
  HABTM `joinArelTable`) is fixed: it now carries a `TypeCaster::Connection`,
  the shape of `associated_table`'s no-klass branch (`table_metadata.rb:47-48`).

**(1) `Table#typeCastForDatabase` itself — declined, not mine.** **PR #4888
(open)** — "refactor(arel): drop invented type-cast fallbacks from Table/TableAlias"
— owns exactly that method in exactly that file. Converging it here would
duplicate #4888's diff and conflict on the same lines, against CLAUDE.md's
no-stacked-PRs / don't-fan-out rules. Your underlying point was right, though, so
I fixed the site the guard was masking (above) — that one is mine, and it would
have broken #4888 on landing.

**(5) `resolveArelAttributes` drops the block — declined; Rails does too.**
`query_methods.rb:2182` and `2189` both call
`predicate_builder.resolve_arel_attribute(table, column)` with **no block**. Only
`arel_column_with_table` passes one (`1982-1984`). trails matches Rails exactly at
all three sites; adding a block at the two would be the deviation.

Also: threading Rails' block through `arel_column_with_table` made one more
wide-ratchet entry stale (`arel_column_with_table →
lookup_table_klass_from_join_dependencies`); removed. That was the CI failure on
4aaf039. My earlier "api:compare exits 0" claim was mis-measured — `$?` was
capturing grep's status, not api:compare's. Re-measured properly: **api:compare
exit 0, test:compare exit 0**, no STALE.


---

## Review round 3

All three fixed, except one sub-point declined with a reason:

- **(1a) no `data_source_exists?` gate — declined, blocked.** trails'
  `dataSourceExists` is **async** (`schema-cache.ts:211`) and `typeForAttribute`
  is sync, so the gate can't be called here. The cached columns hash is the
  sync-safe stand-in (a warmed entry implies the data source exists, and
  `getCachedColumnsHash` is a plain map read that never triggers the async
  cache-miss path). Now documented in place with that reason; converging the gate
  itself is blocked on the pool async/sync convergence (RFC 0023).
- **(1b) invented `sqlType → lookupCastType` fallback — fixed, removed.** You were
  right that this is the same class of invented fallback I'd removed one branch
  above. Rails only ever calls `lookup_cast_type_from_column(column)`
  (`type_caster/connection.rb:16-26`).
- **(1c) `new ValueType()` vs `Type.default_value` — fixed.** Now returns the
  memoized `defaultValue()` (`type.ts:117`) rather than allocating per call.
- **(2) wrong citation — fixed.** Retargeted to `table_metadata.rb:43-44`, which is
  what the body actually does (`association_klass.arel_table`, then
  `.alias(table_name) if arel_table.name != table_name`). You're right that
  `aliased_table_for`'s real port is `AliasTracker#aliasedTableFor` in this same
  file — two functions were claiming one Rails method. Fixed the stale
  `alias_tracker.rb:64` reference in the body comment too.
- **(3) `it("custom attribute node")` — fixed.** Ported Rails' `TypedNode`
  (`homogeneous_in_test.rb:34-42`): a `NamedFunction` carrying its own
  `type_caster`, over `[table[:nickname], table[:name]]`, asserting
  `COALESCE("users"."nickname", "users"."name") IN (?, ?)`. It now exercises
  `HomogeneousIn` reading `type_caster` off a non-Attribute node — the actual
  point of the Rails test, which the old body missed entirely.

`TypeCaster::Connection#typeForAttribute` is now a line-for-line read of
`connection.rb:16-26` modulo the async gate.

Gates re-measured (real exit codes, not grep's): **api:compare exit 0**
(arel 938/938, activerecord 5853/5855, no STALE), **test:compare exit 0**.
4841 tests green across arel + AR associations/relation/type-caster/scoping/
inheritance.


---

## Review round 4

Both fixed.

- **(1) schema cache read through the connection — fixed, and it was leftover,
  not deliberate.** Exactly as you guessed: the adapter was only being reached for
  the `lookupCastType` fallback that round 3 removed, and the `schemaCache` read
  rode along with it. Now reads `Base.schemaCache` (sync, pool-backed,
  `connection-handling.ts:576`), matching `@klass.schema_cache`
  (`type_caster/connection.rb:17`) → `connection_pool.schema_cache`
  (`connection_handling.rb:368-369`) — no connection leased just to read cached
  columns, and no dependence on `connection.schemaCache` being the same slot
  (`model-schema.ts:731-755`).
- **(2) dropped `with_connection` — documented.** Rails scopes the lookup to a
  leased connection (`connection.rb:21`); trails' `withConnection` returns a
  Promise (`connection-handling.ts:366`) and this method is sync, so it reads the
  adapter directly — a permanent checkout where Rails scopes a lease. Same RFC
  0023 constraint as the `data_source_exists?` gate, now noted in place so the
  bare `.connection` doesn't read as intentional fidelity.
- **Sub-point — `?.()` guard dropped.** It silently yielded `defaultValue()` on an
  adapter missing the method where Rails raises `NoMethodError`. Not needed by any
  test; now a direct call.
- Class docstring said "the connection's schema cache"; corrected to the pool's.

Gates (real exit codes): **api:compare exit 0** (arel 938/938, activerecord
5853/5855, no STALE), **test:compare exit 0**. 2765 tests green across the schema-
cache-adjacent suites (model-schema, connection-handling, table-metadata, scoping,
finder, base) plus the arel + AR association/relation suites.


---

## Review round 5

Fixed. `schemaCache?.()` → `schemaCache()`; you're right that it's the same
argument I accepted for `lookupCastTypeFromColumn` one line down, and no test
relied on it. A klass without the method now throws as `@klass.schema_cache`
(`type_caster/connection.rb:17`) would.

One deliberate asymmetry left, for the record: the `_klass?.` chain stays. That
guards a **nil receiver**, not a missing method — `klass` is genuinely nullable at
both construction sites (`predicate-builder.ts:707` passes `?? null`;
`table-metadata.ts:88` forwards a nullable `_klass`, as `table_metadata.rb:47`
forwards a nillable `klass`). So it isn't the same class of guard as the two
dropped.

Gates: **api:compare exit 0** (no STALE), **test:compare exit 0**. 4780 tests green.


---

## CI (third wide-ratchet failure) — mine, and my verification was wrong

Removed the entry round 3 staled: converging `typeForAttribute` onto AR's
`Type.default_value` (`connection.rb:26`) means
`type_for_attribute → default_value` no longer flags. The baseline only shrinks.
The `with_connection` / `data_source_exists?` / `schema_cache` entries for that
same method **stay** — those calls are still genuinely unported (documented in
place, owned by RFC 0023), so they are not stale.

**Root cause of the repeats: `pnpm api:compare` does not run this lint.** CI's
`rails-comparison` job is six steps; api:compare is only the first. So every
"api:compare exit 0, no STALE" I reported was measuring the wrong thing — the
ratchet was never checked locally. All six now pass here:

```
compare.ts                        exit 0
compare.ts --privates             exit 0
lint-call-mismatches.ts           exit 0   call-mismatches ratchet: OK (19 baselined)
lint-body-pins.ts                 exit 0   body-pins gate: OK (0 pinned)
compare.ts --wide-calls           exit 0
lint-call-mismatches-wide.ts      exit 0   wide call-mismatches ratchet: OK (6846 baselined)
```

(`lint-call-mismatches-wide.ts` errors out unless `compare.ts --wide-calls` ran
first — it reads that step's artifact.)


---

## Converged — review cycle closed

Rebased onto main (picked up #4888, #4890, #4891). #4888 landed complementary: it
converged `Table#typeCastForDatabase` bare and left `typeForAttribute` to this PR.
The rebase surfaced one real cross-PR bug (the fake caster needed both
`TypeCaster` members, since a range bound reaches `typeCastForDatabase` via
`Casted`) — fixed in c5fe41e. Last review's only point was a drifted line cite,
fixed in 63be8b9 (`type_cast_for_database` is `map.rb:10-13`; 15-17 is
`type_for_attribute`). I re-verified every other Rails cite in the diff:
`alias_tracker.rb:64`, `table.rb:115`, `table_metadata.rb:43-44/47-48`,
`predicate_builder.rb:71-73/171`, `query_methods.rb:1982-1984`,
`connection.rb:17/21` all resolve correctly.

Nothing merge-blocking outstanding.

### Follow-up

- `arel-aliased-join-tables-should-be-tablealias` (RFC 0023) — converge trails'
  `Table(realName, { as })` aliased-table encoding onto Rails' `TableAlias`
  (`alias_tracker.rb:64`). Not done here: `TableAlias` is a Binary node, not a
  `Table`, so `rebindTableReferences`'s `instanceof Table` gate
  (`join-dependency.ts`) silently drops every rebind — measured, 3 named tests
  fail on the swap. Scope: 4 `instanceof` gates, ~26 `: Table` annotations, 8
  effective-name reads.

### Gates (all six rails-comparison steps, real exit codes)

```
compare.ts / --privates       exit 0
lint-call-mismatches.ts       exit 0   ratchet: OK (19 baselined)
lint-body-pins.ts             exit 0   gate: OK (0 pinned)
compare.ts --wide-calls       exit 0
lint-call-mismatches-wide.ts  exit 0   ratchet: OK (6843 baselined)
test:compare                  exit 0
```

4852 tests green across arel + AR associations/relation/type-caster/scoping/
inheritance. typecheck + eslint clean.
