### PR TITLE
fix(test-models): converge canonical enum declarations to Rails' array form

### DIFF
--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -347,7 +347,7 @@ describe("EnumTest", () => {
     class K extends Base {
       static _tableName = "books";
       static {
-        this.enum("status", ["proposed", "written"] as any, { validate: true });
+        this.enum("status", ["proposed", "written"], { validate: true });
       }
     }
 
@@ -368,7 +368,7 @@ describe("EnumTest", () => {
     class K extends Base {
       static _tableName = "books";
       static {
-        this.enum("status", ["proposed", "written"] as any, { validate: { allowNil: true } });
+        this.enum("status", ["proposed", "written"], { validate: { allowNil: true } });
       }
     }
 
@@ -513,7 +513,7 @@ describe("EnumTest", () => {
     class Klass extends Base {
       static _tableName = "books";
       static {
-        this.enum("status", ["proposed", "written", "published"] as any);
+        this.enum("status", ["proposed", "written", "published"]);
       }
     }
 
@@ -530,7 +530,7 @@ describe("EnumTest", () => {
     class Klass extends Base {
       static _tableName = "books";
       static {
-        this.enum("status", ["proposed", "written", "published"] as any);
+        this.enum("status", ["proposed", "written", "published"]);
       }
     }
 
@@ -565,8 +565,8 @@ describe("EnumTest", () => {
       class Klass extends Base {
         static _tableName = "books";
         static {
-          this.enum("status_1", ["id"] as any, { prefix: true });
-          this.enum("status_2", ["id"] as any, { suffix: true });
+          this.enum("status_1", ["id"], { prefix: true });
+          this.enum("status_2", ["id"], { suffix: true });
         }
       }
       void Klass;
@@ -582,7 +582,7 @@ describe("EnumTest", () => {
           return "do publish work...";
         }
         static {
-          this.enum("status", ["proposed", "written", "published"] as any);
+          this.enum("status", ["proposed", "written", "published"]);
         }
         writtenBang() {
           return "do written work...";
@@ -601,13 +601,13 @@ describe("EnumTest", () => {
     class Klass1 extends Base {
       static _tableName = "books";
       static {
-        this.enum("status", ["proposed", "written"] as any);
+        this.enum("status", ["proposed", "written"]);
       }
     }
     class Klass2 extends Base {
       static _tableName = "books";
       static {
-        this.enum("status", ["drafted", "uploaded"] as any);
+        this.enum("status", ["drafted", "uploaded"]);
       }
     }
 
@@ -624,7 +624,7 @@ describe("EnumTest", () => {
     class Subklass1 extends Book {}
     class Subklass2 extends Book {
       static {
-        this.enum("status", ["drafted", "uploaded"] as any);
+        this.enum("status", ["drafted", "uploaded"]);
       }
     }
 
@@ -656,8 +656,8 @@ describe("EnumTest", () => {
       static {
         this.attribute("status", "integer");
         this.attribute("last_read", "integer");
-        this.enum("status", ["value_1"] as any, { prefix: true });
-        this.enum("last_read", ["value_1"] as any, { prefix: true });
+        this.enum("status", ["value_1"], { prefix: true });
+        this.enum("last_read", ["value_1"], { prefix: true });
       }
     }
     const instance = new K();
@@ -671,8 +671,8 @@ describe("EnumTest", () => {
       static {
         this.attribute("status", "integer");
         this.attribute("last_read", "integer");
-        this.enum("status", ["value_1"] as any, { suffix: true });
-        this.enum("last_read", ["value_1"] as any, { suffix: true });
+        this.enum("status", ["value_1"], { suffix: true });
+        this.enum("last_read", ["value_1"], { suffix: true });
       }
     }
     const instance = new K();
@@ -686,7 +686,7 @@ describe("EnumTest", () => {
       static _tableName = "books";
       static {
         this.aliasAttribute("aliased_status", "status");
-        this.enum("aliased_status", ["proposed", "written", "published"] as any);
+        this.enum("aliased_status", ["proposed", "written", "published"]);
       }
     }
     registerModel(Klass);
@@ -708,7 +708,7 @@ describe("EnumTest", () => {
     class Klass extends Base {
       static _tableName = "books";
       static {
-        this.enum("aliased_status", ["proposed", "written", "published"] as any);
+        this.enum("aliased_status", ["proposed", "written", "published"]);
         this.aliasAttribute("aliased_status", "status");
       }
     }
@@ -738,7 +738,7 @@ describe("EnumTest", () => {
     class Klass extends Base {
       static _tableName = "books";
       static {
-        this.enum("nullable_status", ["single", "married"] as any);
+        this.enum("nullable_status", ["single", "married"]);
         this.aliasAttribute("nullable_status", "status");
       }
     }
@@ -761,7 +761,7 @@ describe("EnumTest", () => {
     class AbstractParent extends Base {
       static {
         this._abstractClass = true;
-        this.enum("typeless_genre", ["adventure", "comic"] as any);
+        this.enum("typeless_genre", ["adventure", "comic"]);
       }
     }
     class Concrete extends AbstractParent {
@@ -788,7 +788,7 @@ describe("EnumTest", () => {
     class AbstractParent extends Base {
       static {
         this._abstractClass = true;
-        this.enum("typeless_genre", ["adventure", "comic"] as any);
+        this.enum("typeless_genre", ["adventure", "comic"]);
       }
     }
     class Concrete extends AbstractParent {
@@ -877,7 +877,7 @@ describe("EnumTest", () => {
       static _tableName = "books";
       static {
         this.attribute("status", "integer", { default: 2 });
-        this.enum("status", ["proposed", "written", "published"] as any);
+        this.enum("status", ["proposed", "written", "published"]);
       }
     }
     expect((new K() as any).status).toBe("published");
@@ -887,7 +887,7 @@ describe("EnumTest", () => {
     class K extends Base {
       static _tableName = "books";
       static {
-        this.enum("status", ["proposed", "written", "published"] as any, {
+        this.enum("status", ["proposed", "written", "published"], {
           default: "published",
         });
       }
@@ -910,7 +910,7 @@ describe("EnumTest", () => {
       static _tableName = "books";
       static {
         this.attribute("status", "integer");
-        this.enum("status", ["proposed", "written"] as any, { scopes: false });
+        this.enum("status", ["proposed", "written"], { scopes: false });
       }
     }
     expect((K as any).proposed).toBeUndefined();
@@ -921,7 +921,7 @@ describe("EnumTest", () => {
       static _tableName = "books";
       static {
         this.attribute("status", "integer");
-        this.enum("status", ["proposed", "written"] as any, { instanceMethods: false });
+        this.enum("status", ["proposed", "written"], { instanceMethods: false });
       }
     }
     const instance = new K();
@@ -1065,7 +1065,7 @@ describe("EnumTest", () => {
   it("raises for attributes with undeclared type", () => {
     class Klass extends Book {
       static {
-        this.enum("typeless_genre", ["adventure", "comic"] as any);
+        this.enum("typeless_genre", ["adventure", "comic"]);
       }
     }
 
@@ -1077,7 +1077,7 @@ describe("EnumTest", () => {
     class Klass extends Book {
       static {
         this.attribute("my_genre", "integer");
-        this.enum("my_genre", ["adventure", "comic"] as any);
+        this.enum("my_genre", ["adventure", "comic"]);
       }
     }
 

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -482,7 +482,7 @@ export class EnumMethods {
  */
 export function enumMethod(
   this: typeof Base,
-  attribute: string,
+  name: string,
   values: string[] | Record<string, EnumValue>,
   options?: {
     prefix?: boolean | string;
@@ -493,7 +493,7 @@ export function enumMethod(
     default?: unknown;
   },
 ): void {
-  _enum.call(this, attribute, values, options);
+  _enum.call(this, name, values, options);
 }
 
 // Alias the Base.enum implementation under the Rails-idiomatic name so

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -483,7 +483,7 @@ export class EnumMethods {
 export function enumMethod(
   this: typeof Base,
   attribute: string,
-  mapping: Record<string, EnumValue>,
+  mapping: string[] | Record<string, EnumValue>,
   options?: {
     prefix?: boolean | string;
     suffix?: boolean | string;

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -483,7 +483,7 @@ export class EnumMethods {
 export function enumMethod(
   this: typeof Base,
   attribute: string,
-  mapping: string[] | Record<string, EnumValue>,
+  values: string[] | Record<string, EnumValue>,
   options?: {
     prefix?: boolean | string;
     suffix?: boolean | string;
@@ -493,7 +493,7 @@ export function enumMethod(
     default?: unknown;
   },
 ): void {
-  _enum.call(this, attribute, mapping, options);
+  _enum.call(this, attribute, values, options);
 }
 
 // Alias the Base.enum implementation under the Rails-idiomatic name so

--- a/packages/activerecord/src/test-helpers/models/book-destroy-async.ts
+++ b/packages/activerecord/src/test-helpers/models/book-destroy-async.ts
@@ -39,7 +39,7 @@ export class BookDestroyAsync extends Base {
       foreignKey: "book_id",
     });
     this.hasOne("content", { dependent: "destroy" });
-    this.enum("status", { proposed: 0, written: 1, published: 2 });
+    this.enum("status", ["proposed", "written", "published"]);
   }
 }
 

--- a/packages/activerecord/src/test-helpers/models/book.ts
+++ b/packages/activerecord/src/test-helpers/models/book.ts
@@ -170,14 +170,14 @@ export class Book extends Base {
     this.hasMany("subscribers", { through: "subscriptions" });
     this.hasOne("essay");
     this.aliasAttribute("title", "name");
-    this.enum("status", { proposed: 0, written: 1, published: 2 });
+    this.enum("status", ["proposed", "written", "published"]);
     this.enum("last_read", { unread: 0, reading: 2, read: 3, forgotten: null });
-    this.enum("nullable_status", { single: 0, married: 1 });
-    this.enum("language", { english: 0, spanish: 1, french: 2 }, { prefix: "in" });
-    this.enum("author_visibility", { visible: 0, invisible: 1 }, { prefix: true });
-    this.enum("illustrator_visibility", { visible: 0, invisible: 1 }, { prefix: true });
-    this.enum("font_size", { small: 0, medium: 1, large: 2 }, { prefix: "with", suffix: true });
-    this.enum("difficulty", { easy: 0, medium: 1, hard: 2 }, { suffix: "toRead" });
+    this.enum("nullable_status", ["single", "married"]);
+    this.enum("language", ["english", "spanish", "french"], { prefix: "in" });
+    this.enum("author_visibility", ["visible", "invisible"], { prefix: true });
+    this.enum("illustrator_visibility", ["visible", "invisible"], { prefix: true });
+    this.enum("font_size", ["small", "medium", "large"], { prefix: "with", suffix: true });
+    this.enum("difficulty", ["easy", "medium", "hard"], { suffix: "toRead" });
     this.enum("cover", { hard: "hard", soft: "soft" });
     this.enum("boolean_status", { enabled: true, disabled: false });
   }

--- a/packages/activerecord/src/test-helpers/models/cat.ts
+++ b/packages/activerecord/src/test-helpers/models/cat.ts
@@ -14,7 +14,7 @@ export class Cat extends Base {
 
   static {
     this._abstractClass = true;
-    this.enum("gender", { female: 0, male: 1 });
+    this.enum("gender", ["female", "male"]);
     this.defaultScope((q: any) => q.where({ is_vegetarian: false }));
   }
 }

--- a/packages/activerecord/src/test-helpers/models/comment.ts
+++ b/packages/activerecord/src/test-helpers/models/comment.ts
@@ -108,7 +108,7 @@ export class Comment extends Base {
       counterCache: "children_count",
       inverseOf: "children",
     });
-    this.enum("label", { default: 0, child: 1 });
+    this.enum("label", ["default", "child"]);
   }
 
   static allAsMethod() {

--- a/packages/activerecord/src/test-helpers/models/company.ts
+++ b/packages/activerecord/src/test-helpers/models/company.ts
@@ -56,7 +56,7 @@ export class Company extends AbstractCompany {
   static {
     this.sequenceName = "companies_nonstd_seq";
 
-    this.enum("status", { active: 0, suspended: 1 });
+    this.enum("status", ["active", "suspended"]);
 
     this.validatesPresenceOf("name");
 

--- a/packages/activerecord/src/test-helpers/models/membership.ts
+++ b/packages/activerecord/src/test-helpers/models/membership.ts
@@ -46,13 +46,13 @@ export class Membership extends Base {
     // trails needs STI enabled explicitly; with the enum on the same column the
     // `type_condition` serializes each subclass' sti_name (its class name) to
     // the enum integer (e.g. SelectedMembership → 3).
-    this.enum("type", {
-      Membership: 0,
-      CurrentMembership: 1,
-      SuperMembership: 2,
-      SelectedMembership: 3,
-      TenantMembership: 4,
-    });
+    this.enum("type", [
+      "Membership",
+      "CurrentMembership",
+      "SuperMembership",
+      "SelectedMembership",
+      "TenantMembership",
+    ]);
     this.inheritanceColumn = "type";
     this.belongsTo("member");
     this.belongsTo("club");


### PR DESCRIPTION
## What

The canonical test models spelled every enum with the **hash** form, while Rails' own models use the **array** form in 15 of 17 declarations. Behaviorally identical (`enum.rb:261`: `values.respond_to?(:each_pair) ? values.each_pair : values.each_with_index` — array ⇒ 0..n), so nothing was broken. Port-fidelity divergence in canonical test models, converged per "converge, never ratify".

Surfaced during review of #4864, where the reviewer flagged `cat.ts` while correcting an earlier claim that it mirrors `cat.rb` exactly. It was outside that PR's diff.

## The real finding: the array form was unreachable from the `enum` macro

The story asked whether the array form is supported at all, and said to file it rather than ratify the hash form if not. It is *almost* supported: `_enum` normalizes arrays, `defineEnum` accepts `string[]`, and the type-virtualization walker/synthesize handle array literals (fixture `14-define-enum-array-form`). But the **public `enumMethod` signature typed its values parameter as `Record<string, EnumValue>` only**, so no model could spell it Rails' way through `this.enum(...)`.

The proof: `enum.test.ts` already wanted the array form in **25 places**, every one written `this.enum("status", ["proposed", "written"] as any)`. Those casts were load-bearing workarounds for the narrow type — and they silently disabled type checking of the whole call.

So this PR fixes cause and symptom:

1. Widen the values parameter to `string[] | Record<string, EnumValue>`, matching what `_enum` and `defineEnum` already declared.
2. Delete all 25 `as any` casts — this puts those call sites under the type checker **for the first time**. `pnpm typecheck` passing with the casts gone is the actual evidence the array form type-checks, not just that it runs.
3. Parameter naming per Rails `def enum(name, values = nil, **options)` (`enum.rb:216`): `mapping` -> `values`, `attribute` -> `name`.

## Converged

`Cat`, `Book` (7 of 10), `BookDestroyAsync`, `Comment`, `Company`, `Membership`.

Left as hashes because **they are hashes in Rails too**: `Book#last_read` (`forgotten: nil`, non-contiguous), `Book#cover`, `Book#boolean_status`, `Parrot#breed`.

## Review replies

**1. `attribute` -> `name`** — fixed in `caba09d`. Confirmed against `enum.rb:216`; `_enum` already used `name`. Agreed the fidelity argument only half-landed.

**2. `values = nil` keyword form (`enum.rb:216-218`)** — **not a gap, and no story needed.** `values, options = options, {} unless values` exists to undo a *Ruby parser artifact*: Ruby cannot distinguish `enum :status, active: 0` (which binds to `**options`, leaving `values` nil) from a positional hash, so it swaps them back. **TypeScript has no kwargs** — `this.enum("status", { active: 0 })` binds directly to `values`, so there is nothing to disambiguate and no analogue to port. Porting the swap would be porting a workaround for a problem TS doesn't have.

Verified empirically rather than by argument — both Rails tests that cover this pass today against the plain positional hash, including the adversarial one where labels collide with option names (`enum_test.rb:907`, `enum :status, default: 0, scopes: 1, prefix: 2, suffix: 3`):

```
✓ option names can be used as label   → statuses === { default: 0, scopes: 1, prefix: 2, suffix: 3 }, isDefault/isScopes defined
✓ enum labels as keyword arguments    → statuses === { active: 0, archived: 1 }
```

Worth noting for the record: trails' ports of those two tests (`enum.test.ts:964,967`) *are* `it.skip`, but for an unrelated reason stated in their comments — an in-memory DB-default seeding gap (`new K()` doesn't seed `status` → 0 → `"active"` through `EnumType#cast`). That gap is real but orthogonal to the signature, and out of scope here; I've left it rather than conflate it with this change.

## Verification

- `pnpm typecheck` clean — meaningful here, per the cast removal.
- `enum.test.ts`, `enum.trails.test.ts`, `scoping/default-scoping.test.ts` — 231 passed. `Lion`'s `"female" | "male" | null` label union from #4864 still holds.
- `has-many-through-associations.test.ts`, `join-model.test.ts`, `relations.test.ts`, `inheritance.test.ts` — 633 passed, covering `Membership`, whose enum backs the STI `type` column.

~90 LOC, no behavior change.

Closes-story: converge-cat-enum-declaration-to-array-form