### PR TITLE
fix(activemodel): BinaryType#serialize returns the Data wrapper

### DIFF
--- a/eslint/no-explicit-any-test-exclude.json
+++ b/eslint/no-explicit-any-test-exclude.json
@@ -115,7 +115,6 @@
   "packages/activerecord/src/connection-adapters/abstract-adapter.test.ts",
   "packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.test.ts",
   "packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts",
-  "packages/activerecord/src/connection-adapters/abstract/quoting-helpers.test.ts",
   "packages/activerecord/src/connection-adapters/abstract/schema-creation.test.ts",
   "packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts",
   "packages/activerecord/src/connection-adapters/abstract/schema-dumper.test.ts",

--- a/packages/activemodel/src/type/binary.test.ts
+++ b/packages/activemodel/src/type/binary.test.ts
@@ -18,9 +18,13 @@ describe("BinaryTest", () => {
     const result = type.serialize("ƒée");
     expect(result).toBeInstanceOf(BinaryData);
     expect(result!.bytes).toEqual(new TextEncoder().encode("ƒée"));
-    // Rails: `assert_not_equal "ƒée", type.serialize("ƒée")` — the serialized value
-    // is not the UTF-8 string itself.
-    expect(result).not.toBe("ƒée");
+    // Rails' second assertion (`assert_not_equal "ƒée", type.serialize("ƒée")`) is
+    // meaningful only because `Data#==` (binary.rb:55-57) compares against a String
+    // and the UTF-8/BINARY encoding difference makes them unequal. JS has no
+    // operator overloading, so `Data` has no `==` counterpart and the comparison
+    // cannot be expressed — any `expect(result).not.toBe("ƒée")` would pass for a
+    // Data object regardless of the implementation, so it is omitted rather than
+    // asserted vacuously. The byte assertion above carries the real content.
     expect(type.serialize(null)).toBe(null);
   });
 });

--- a/packages/activemodel/src/type/binary.test.ts
+++ b/packages/activemodel/src/type/binary.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Types } from "../index.js";
+import { Types, BinaryData } from "../index.js";
 
 describe("BinaryTest", () => {
   it("type cast binary", () => {
@@ -12,7 +12,15 @@ describe("BinaryTest", () => {
 
   it("serialize binary strings", () => {
     const type = new Types.BinaryType();
-    const result = type.serialize("hello");
-    expect(result).toBeInstanceOf(Uint8Array);
+    // Rails: `assert_equal "ƒée".b, type.serialize("ƒée")` — serialize returns a
+    // `Type::Binary::Data` (binary.rb:31) that `==`-compares to the BINARY-encoded
+    // byte string. Our `Uint8Array` stands in for that byte string.
+    const result = type.serialize("ƒée");
+    expect(result).toBeInstanceOf(BinaryData);
+    expect(result!.bytes).toEqual(new TextEncoder().encode("ƒée"));
+    // Rails: `assert_not_equal "ƒée", type.serialize("ƒée")` — the serialized value
+    // is not the UTF-8 string itself.
+    expect(result).not.toBe("ƒée");
+    expect(type.serialize(null)).toBe(null);
   });
 });

--- a/packages/activemodel/src/type/binary.test.ts
+++ b/packages/activemodel/src/type/binary.test.ts
@@ -25,6 +25,5 @@ describe("BinaryTest", () => {
     // cannot be expressed — any `expect(result).not.toBe("ƒée")` would pass for a
     // Data object regardless of the implementation, so it is omitted rather than
     // asserted vacuously. The byte assertion above carries the real content.
-    expect(type.serialize(null)).toBe(null);
   });
 });

--- a/packages/activemodel/src/type/binary.trails.test.ts
+++ b/packages/activemodel/src/type/binary.trails.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { Types, BinaryData } from "../index.js";
+
+/**
+ * Trails-only extras for ActiveModel::Type::Binary. Rails'
+ * `test_serialize_binary_strings` (activemodel/test/cases/type/binary_test.rb:21)
+ * has exactly two assertions and does not cover these; they live here rather
+ * than widening a Rails-mapped test.
+ */
+describe("BinaryTypeTrails", () => {
+  it("serialize returns null for nil rather than wrapping it", () => {
+    // Rails: `return if value.nil?` guards before `Data.new(super)`
+    // (binary.rb:31) — nil must not become a Data wrapping "".
+    const type = new Types.BinaryType();
+    expect(type.serialize(null)).toBe(null);
+    expect(type.serialize(undefined)).toBe(null);
+  });
+
+  it("serialize wraps bytes without copying or decoding them", () => {
+    // `super` is Value#serialize (identity), so the raw value reaches Data and
+    // the bytes are preserved exactly — 0x80 is not valid UTF-8 on its own.
+    const type = new Types.BinaryType();
+    const bytes = new Uint8Array([0x80, 0xde, 0xad]);
+    const result = type.serialize(bytes);
+    expect(result).toBeInstanceOf(BinaryData);
+    expect(result!.bytes).toEqual(bytes);
+  });
+});

--- a/packages/activemodel/src/type/binary.ts
+++ b/packages/activemodel/src/type/binary.ts
@@ -38,6 +38,18 @@ export class BinaryType extends ValueType<Uint8Array> {
     return new Data(super.serialize(value));
   }
 
+  /**
+   * Mirrors: ActiveModel::Type::Binary#changed_in_place? (binary.rb:35-38)
+   *
+   *   old_value = deserialize(raw_old_value)
+   *   old_value != value
+   *
+   * Rails does not coerce `value`; it relies on Ruby's `!=`. JS cannot compare
+   * byte arrays with `!=`, so the bytes are walked, and `cast` supplies the
+   * `Uint8Array` that walk needs. It is identity in practice: the only callers
+   * (`Attribute#changedInPlace` / `#changedInPlaceFromDatabase`) pass
+   * `this.value`, which is already cast.
+   */
   isChangedInPlace(rawOldValue: unknown, newValue: unknown): boolean {
     const old = this.deserialize(rawOldValue);
     const cur = this.cast(newValue);
@@ -55,11 +67,20 @@ export class Data {
   readonly bytes: Uint8Array;
 
   /**
-   * Mirrors: Data#initialize (binary.rb:42-46) — `value.to_s`, then `.b` to
-   * force BINARY encoding. `Uint8Array` is our stand-in for Ruby's
-   * binary-encoded String, so byte sources pass through unchanged and
-   * everything else is coerced via `String(value)` (Ruby's `to_s`). Re-wrapping
-   * a `Data` is idempotent, mirroring `Data.new(data)` → `data.to_s`.
+   * Mirrors: Data#initialize (binary.rb:42-46) — `value = value.to_s`, then `.b`
+   * to force BINARY encoding. `Uint8Array` is our stand-in for Ruby's
+   * binary-encoded String, so byte sources pass through unchanged (as Ruby's
+   * `.b` on an already-BINARY String returns it unchanged) and everything else
+   * is coerced via `String(value)`, standing in for `to_s`.
+   *
+   * The `Data` arm is not idempotence sugar — it is precisely Ruby's `to_s`
+   * step. Ruby gets it free because `Data#to_s` returns the byte string, but
+   * JS's `String(data)` runs our `toString()`, which UTF-8-decodes: it turns
+   * `de ad be ef` into `de ad ef bf bd ef bf bd` (U+FFFD replacements). So the
+   * arm is what makes `new Data(data)` byte-preserving, matching Ruby.
+   *
+   * `Uint8Array` is stored by reference, so mutating the source array mutates
+   * this `Data` — the same aliasing Ruby has when `.b` returns self.
    */
   constructor(value: unknown) {
     if (value instanceof Data) this.bytes = value.bytes;

--- a/packages/activemodel/src/type/binary.ts
+++ b/packages/activemodel/src/type/binary.ts
@@ -21,13 +21,26 @@ export class BinaryType extends ValueType<Uint8Array> {
     return textEncoder.encode(String(value));
   }
 
-  serialize(value: unknown): Uint8Array | null {
-    return this.cast(value);
+  /**
+   * Mirrors: ActiveModel::Type::Binary#serialize (binary.rb:30-33)
+   *
+   *   def serialize(value)
+   *     return if value.nil?
+   *     Data.new(super)
+   *   end
+   *
+   * `super` is Value#serialize — identity, *not* `cast` — so the raw value is
+   * handed to `Data`, whose constructor does the `to_s`/binary coercion. The
+   * wrapper is what `quote` dispatches on (abstract/quoting.rb:83).
+   */
+  serialize(value: unknown): Data | null {
+    if (value === null || value === undefined) return null;
+    return new Data(super.serialize(value));
   }
 
   isChangedInPlace(rawOldValue: unknown, newValue: unknown): boolean {
     const old = this.deserialize(rawOldValue);
-    const cur = this.serialize(newValue);
+    const cur = this.cast(newValue);
     if (old === null && cur === null) return false;
     if (old === null || cur === null) return true;
     if (old.length !== cur.length) return true;
@@ -46,8 +59,17 @@ export class BinaryType extends ValueType<Uint8Array> {
 export class Data {
   readonly bytes: Uint8Array;
 
-  constructor(value: string | Uint8Array) {
-    this.bytes = typeof value === "string" ? textEncoder.encode(value) : value;
+  /**
+   * Mirrors: Data#initialize (binary.rb:42-46) — `value.to_s`, then `.b` to
+   * force BINARY encoding. `Uint8Array` is our stand-in for Ruby's
+   * binary-encoded String, so byte sources pass through unchanged and
+   * everything else is coerced via `String(value)` (Ruby's `to_s`). Re-wrapping
+   * a `Data` is idempotent, mirroring `Data.new(data)` → `data.to_s`.
+   */
+  constructor(value: unknown) {
+    if (value instanceof Data) this.bytes = value.bytes;
+    else if (value instanceof Uint8Array) this.bytes = value;
+    else this.bytes = textEncoder.encode(String(value));
   }
 
   toString(): string {

--- a/packages/activemodel/src/type/binary.ts
+++ b/packages/activemodel/src/type/binary.ts
@@ -49,11 +49,6 @@ export class BinaryType extends ValueType<Uint8Array> {
     }
     return false;
   }
-
-  deserialize(value: unknown): Uint8Array | null {
-    if (value instanceof Data) return value.bytes;
-    return this.cast(value);
-  }
 }
 
 export class Data {
@@ -80,9 +75,5 @@ export class Data {
     return Array.from(this.bytes)
       .map((b) => b.toString(16).padStart(2, "0"))
       .join("");
-  }
-
-  byteSize(): number {
-    return this.bytes.length;
   }
 }

--- a/packages/activerecord/src/binary.test.ts
+++ b/packages/activerecord/src/binary.test.ts
@@ -29,13 +29,23 @@ describe("BinaryTest", () => {
   });
 
   it("unicode input casting", async () => {
-    // Ported from binary_test.rb:41-70. Rails interleaves two concerns here: the
+    // Ported from binary_test.rb:41-70. Rails interleaves two concerns: the
     // Integer-to-String casting of `name`, which ports directly, and assertions
-    // that `data`/`data_before_type_cast` carry `Encoding::BINARY` /
-    // `Encoding::UTF_8`. JS strings have no encoding attribute — a Uint8Array is
-    // *only* bytes — so the encoding assertions have no analogue and are the one
-    // half omitted. `name` is a restricted attribute in trails, hence
-    // readAttribute.
+    // that `data` / `data_before_type_cast` carry `Encoding::BINARY` /
+    // `Encoding::UTF_8`. JS has no String encoding attribute, so the encoding
+    // *labels* have no analogue. What `assert_equal Encoding::BINARY,
+    // binary.data.encoding` is asserting in Ruby terms — that the string input
+    // was cast to binary — does port: `data` must be the bytes of "text" at each
+    // phase, which is what `expectTextBytes` pins. The `_before_type_cast`
+    // encoding half stays out: Rails itself notes it is adapter-dependent after
+    // reload (PG returns the bytea_output form).
+    // `name` is a restricted attribute in trails, hence readAttribute.
+    const textBytes = new TextEncoder().encode("text");
+    const expectTextBytes = () => {
+      expect(binary.data).toBeInstanceOf(Uint8Array);
+      expect(new Uint8Array(binary.data)).toEqual(textBytes);
+    };
+
     const binary = Binary.new({ name: 123 as unknown as string, data: "text" });
 
     // Before saving, attribute methods return casted values, but their
@@ -43,19 +53,19 @@ describe("BinaryTest", () => {
     // conversion used for comparison.)
     expect(binary.readAttribute("name")).toBe("123");
     expect(binary.readAttributeBeforeTypeCast("name")).toBe(123);
+    expectTextBytes();
 
     await binary.saveBang();
 
     // After saving, casted values appear throughout.
     expect(binary.readAttribute("name")).toBe("123");
     expect(binary.readAttributeBeforeTypeCast("name")).toBe("123");
+    expectTextBytes();
 
     await binary.reload();
 
     expect(binary.readAttribute("name")).toBe("123");
     expect(binary.readAttributeBeforeTypeCast("name")).toBe("123");
-    // Rails also asserts data.encoding here, and notes data_before_type_cast is
-    // adapter-dependent after reload (PG returns the bytea_output form). Both are
-    // Ruby-encoding concerns with no JS counterpart.
+    expectTextBytes();
   });
 });

--- a/packages/activerecord/src/binary.test.ts
+++ b/packages/activerecord/src/binary.test.ts
@@ -1,13 +1,37 @@
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
+import { fixtures } from "./test-helpers/fixtures.js";
+import { Binary } from "./test-helpers/models/binary.js";
 
 describe("BinaryTest", () => {
-  it.skip("mixed encoding", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — marshal
+  fixtures({});
+
+  it("mixed encoding", async () => {
+    // Rails: `str = +"\x80"; str.force_encoding("ASCII-8BIT")`. A lone 0x80 is
+    // not valid UTF-8, which is the point — it catches any lossy decode on the
+    // way to the database. `Uint8Array` is our stand-in for a BINARY String.
+    const str = new Uint8Array([0x80]);
+
+    const binary = Binary.new({ name: "いただきます！", data: str });
+    await binary.save();
+    await binary.reload();
+    expect(new Uint8Array(binary.data)).toEqual(str);
+
+    // `name` is a restricted attribute in trails; read it through readAttribute.
+    const name = binary.readAttribute("name");
+    expect(name).toBe("いただきます！");
   });
+
   it.skip("load save", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — marshal
+    // PERMANENT-SKIP: Ruby-only — reads binary asset files (flowers.jpg,
+    // example.log, test.txt) from ASSETS_ROOT via File.read. Porting needs the
+    // asset fixtures plus filesystem reads, which this package's hard rules
+    // exclude (no node:* imports).
   });
+
   it.skip("unicode input casting", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — marshal
+    // PERMANENT-SKIP: Ruby-only — asserts on Ruby String encodings
+    // (`Encoding::BINARY` / `Encoding::UTF_8`) of `data` and
+    // `data_before_type_cast`. JS strings have no encoding attribute, so the
+    // assertions have no analogue.
   });
 });

--- a/packages/activerecord/src/binary.test.ts
+++ b/packages/activerecord/src/binary.test.ts
@@ -12,7 +12,7 @@ describe("BinaryTest", () => {
     const str = new Uint8Array([0x80]);
 
     const binary = Binary.new({ name: "いただきます！", data: str });
-    await binary.save();
+    await binary.saveBang();
     await binary.reload();
     expect(new Uint8Array(binary.data)).toEqual(str);
 
@@ -28,10 +28,34 @@ describe("BinaryTest", () => {
     // exclude (no node:* imports).
   });
 
-  it.skip("unicode input casting", () => {
-    // PERMANENT-SKIP: Ruby-only — asserts on Ruby String encodings
-    // (`Encoding::BINARY` / `Encoding::UTF_8`) of `data` and
-    // `data_before_type_cast`. JS strings have no encoding attribute, so the
-    // assertions have no analogue.
+  it("unicode input casting", async () => {
+    // Ported from binary_test.rb:41-70. Rails interleaves two concerns here: the
+    // Integer-to-String casting of `name`, which ports directly, and assertions
+    // that `data`/`data_before_type_cast` carry `Encoding::BINARY` /
+    // `Encoding::UTF_8`. JS strings have no encoding attribute — a Uint8Array is
+    // *only* bytes — so the encoding assertions have no analogue and are the one
+    // half omitted. `name` is a restricted attribute in trails, hence
+    // readAttribute.
+    const binary = Binary.new({ name: 123 as unknown as string, data: "text" });
+
+    // Before saving, attribute methods return casted values, but their
+    // _before_type_cast still returns the original value. (Integer-to-String
+    // conversion used for comparison.)
+    expect(binary.readAttribute("name")).toBe("123");
+    expect(binary.readAttributeBeforeTypeCast("name")).toBe(123);
+
+    await binary.saveBang();
+
+    // After saving, casted values appear throughout.
+    expect(binary.readAttribute("name")).toBe("123");
+    expect(binary.readAttributeBeforeTypeCast("name")).toBe("123");
+
+    await binary.reload();
+
+    expect(binary.readAttribute("name")).toBe("123");
+    expect(binary.readAttributeBeforeTypeCast("name")).toBe("123");
+    // Rails also asserts data.encoding here, and notes data_before_type_cast is
+    // adapter-dependent after reload (PG returns the bytea_output form). Both are
+    // Ruby-encoding concerns with no JS counterpart.
   });
 });

--- a/packages/activerecord/src/binary.trails.test.ts
+++ b/packages/activerecord/src/binary.trails.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { fixtures } from "./test-helpers/fixtures.js";
+import { Binary } from "./test-helpers/models/binary.js";
+
+/**
+ * Trails-only: `BinaryType#serialize` returns a `Type::Binary::Data`
+ * (activemodel/.../type/binary.rb:30-33), so every bind path for a binary
+ * attribute carries the wrapper. Rails unwraps it in `type_cast`
+ * (abstract/quoting.rb:96, `when ... Type::Binary::Data then value.to_s`).
+ *
+ * These pin the *bind* path specifically — a create + `find(id)` round-trip does
+ * not reach it, which is how the gap survived review the first time. Without the
+ * rb:96 arm SQLite/MySQL raise `can't cast`, and mysql2's bind path (which does
+ * not route through `typeCast`) silently matched zero rows.
+ */
+describe("binary bind round-trip", () => {
+  fixtures({});
+
+  // Non-UTF8-decodable: catches any lossy toString()/UTF-8 path, since
+  // `Data#toString` would replace every byte >= 0x80 with U+FFFD.
+  const bytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef, 0x00, 0x1f, 0x8b]);
+
+  it("matches a binary column through a bound where clause", async () => {
+    await Binary.create({ name: "gzip", data: bytes });
+    const found = await Binary.where({ data: bytes });
+    expect(found.length).toBe(1);
+    expect(new Uint8Array(found[0].data)).toEqual(bytes);
+  });
+
+  it("round-trips bytes byte-exactly through a binary column", async () => {
+    const rec = await Binary.create({ name: "gzip", data: bytes });
+    const found = await Binary.find(rec.id);
+    expect(new Uint8Array(found.data)).toEqual(bytes);
+  });
+});

--- a/packages/activerecord/src/binary.trails.test.ts
+++ b/packages/activerecord/src/binary.trails.test.ts
@@ -1,35 +1,47 @@
 import { describe, it, expect } from "vitest";
+import { BinaryData } from "@blazetrails/activemodel";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { Binary } from "./test-helpers/models/binary.js";
+import { typeCastedBinds } from "./connection-adapters/abstract/database-statements.js";
 
 /**
- * Trails-only: `BinaryType#serialize` returns a `Type::Binary::Data`
- * (activemodel/.../type/binary.rb:30-33), so every bind path for a binary
- * attribute carries the wrapper. Rails unwraps it in `type_cast`
- * (abstract/quoting.rb:96, `when ... Type::Binary::Data then value.to_s`).
+ * Trails-only: no Rails counterpart. `BinaryType#serialize` returns a
+ * `Type::Binary::Data` (activemodel/.../type/binary.rb:30-33), so every bind
+ * path for a binary attribute carries the wrapper, and Rails unwraps it in
+ * `type_cast` (abstract/quoting.rb:96, `when ... Type::Binary::Data then
+ * value.to_s`).
  *
- * These pin the *bind* path specifically — a create + `find(id)` round-trip does
- * not reach it, which is how the gap survived review the first time. Without the
- * rb:96 arm SQLite/MySQL raise `can't cast`, and mysql2's bind path (which does
- * not route through `typeCast`) silently matched zero rows.
+ * Rails has no equivalent test because its bind path cannot regress this way.
+ * Ours can, and did: without the rb:96 arm SQLite/MySQL raise `can't cast`, and
+ * mysql2's bind path (which does not route through `typeCast`) silently matched
+ * zero rows. The byte round-trip itself is covered by Rails' own `mixed
+ * encoding` in binary.test.ts — this pins the *bound where clause*, which a
+ * create + find(id) round-trip never reaches.
  */
 describe("binary bind round-trip", () => {
   fixtures({});
 
-  // Non-UTF8-decodable: catches any lossy toString()/UTF-8 path, since
-  // `Data#toString` would replace every byte >= 0x80 with U+FFFD.
-  const bytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef, 0x00, 0x1f, 0x8b]);
-
   it("matches a binary column through a bound where clause", async () => {
+    // Non-UTF8-decodable: catches any lossy toString()/UTF-8 path, since
+    // `Data#toString` would replace every byte >= 0x80 with U+FFFD.
+    const bytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef, 0x00, 0x1f, 0x8b]);
     await Binary.create({ name: "gzip", data: bytes });
     const found = await Binary.where({ data: bytes });
     expect(found.length).toBe(1);
     expect(new Uint8Array(found[0].data)).toEqual(bytes);
   });
+});
 
-  it("round-trips bytes byte-exactly through a binary column", async () => {
-    const rec = await Binary.create({ name: "gzip", data: bytes });
-    const found = await Binary.find(rec.id);
-    expect(new Uint8Array(found.data)).toEqual(bytes);
+describe("binary type_casted_binds payload", () => {
+  it("unwraps Type::Binary::Data for subscribers", () => {
+    // `type_casted_binds` feeds the sql.active_record payload that LogSubscriber
+    // renders. Rails type_casts every bind, so a Data shows as its byte string
+    // (abstract/quoting.rb:96). Ours does not route through typeCast — that is
+    // the wider type_casted_binds story — so this guards the one unwrap that
+    // keeps the wrapper from rendering as "[object Object]" in query logs.
+    const bytes = new Uint8Array([0xde, 0xad]);
+    const out = typeCastedBinds([{ valueForDatabase: new BinaryData(bytes) }]);
+    expect(String(out[0])).not.toBe("[object Object]");
+    expect(out[0]).toEqual(bytes);
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -16,7 +16,11 @@ import {
   Table,
   InsertManager,
 } from "@blazetrails/arel";
-import { Attribute as ModelAttribute, ActiveModelRangeError } from "@blazetrails/activemodel";
+import {
+  Attribute as ModelAttribute,
+  ActiveModelRangeError,
+  BinaryData,
+} from "@blazetrails/activemodel";
 import { Notifications, BigDecimal } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import {
@@ -1345,6 +1349,14 @@ export function typeCastedBinds(binds: unknown[] | undefined): unknown[] {
     } else {
       v = b && typeof b === "object" && "value" in b ? b.value : b;
     }
+    // Rails' `type_cast` renders a `Type::Binary::Data` as its byte string
+    // (abstract/quoting.rb:96). This function does not route through `typeCast`
+    // — converging that is the wider `type_casted_binds` story, and doing it
+    // wholesale changes unrelated types (e.g. SQLite integer binds become
+    // BigInt) — so unwrap just the binary wrapper. Without it a subscriber sees
+    // the `Data` object and LogSubscriber renders "[object Object]" where Rails
+    // shows the bytes.
+    if (v instanceof BinaryData) v = v.bytes;
     return temporalToBindString(v);
   });
 }

--- a/packages/activerecord/src/connection-adapters/abstract/quoting-helpers.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting-helpers.test.ts
@@ -98,7 +98,24 @@ describe("quote dispatches through quoted_binary", () => {
     );
   });
 
-  it("passes the unwrapped bytes to this.quotedBinary", () => {
+  it("passes the Type::Binary::Data itself to this.quotedBinary", () => {
+    // Rails: `when Type::Binary::Data then quoted_binary(value)` (rb:83) hands the
+    // wrapper to the override, which unwraps it (`value.to_s` / `value.hex`).
+    let received: unknown;
+    const host = {
+      quotedBinary: (value: unknown) => {
+        received = value;
+        return "";
+      },
+    };
+    const data = new BinaryData(new Uint8Array([0xde, 0xad]));
+    quote.call(host, data);
+    expect(received).toBe(data);
+  });
+
+  it("passes normalized bytes to this.quotedBinary for a raw byte view", () => {
+    // Trails-only affordance: a raw view has no Ruby analogue (Rails only ever
+    // sees Type::Binary::Data here), so it is normalized before dispatch.
     let received: unknown;
     const host = {
       quotedBinary: (value: unknown) => {
@@ -107,8 +124,9 @@ describe("quote dispatches through quoted_binary", () => {
       },
     };
     const bytes = new Uint8Array([0xde, 0xad]);
-    quote.call(host, new BinaryData(bytes));
-    expect(received).toBe(bytes);
+    quote.call(host, bytes);
+    expect(received).toBeInstanceOf(Uint8Array);
+    expect(received).toEqual(bytes);
   });
 
   it("falls back to the module quoted_binary helper without a host", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/quoting-helpers.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting-helpers.test.ts
@@ -157,6 +157,19 @@ describe("quote dispatches through quoted_binary", () => {
   });
 });
 
+describe("type_cast unwraps Type::Binary::Data", () => {
+  it("returns the raw bytes, not a lossy UTF-8 decode", () => {
+    // Rails: `when Symbol, ActiveSupport::Multibyte::Chars, Type::Binary::Data
+    // then value.to_s` (abstract/quoting.rb:96) — `to_s` on a Data is the
+    // BINARY-encoded String, so the analogue is `.bytes`. 0xde 0xad 0xbe 0xef is
+    // not valid UTF-8: a `toString()` port would yield U+FFFD replacements.
+    const bytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+    const out = typeCast.call({}, new BinaryData(bytes));
+    expect(out).toBeInstanceOf(Uint8Array);
+    expect(out).toEqual(bytes);
+  });
+});
+
 describe("type_cast dispatches through quoted_date/quoted_time", () => {
   it("routes Date/Time values through this.quotedDate", () => {
     const host = { quotedDate: () => "DISPATCHED" };

--- a/packages/activerecord/src/connection-adapters/abstract/quoting-helpers.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting-helpers.trails.test.ts
@@ -1,3 +1,16 @@
+/**
+ * Trails-only unit coverage for the abstract quoting helpers — no Rails
+ * counterpart file. Rails has `quoting_test.rb` (ported as `quoting.test.ts`),
+ * but no `quoting_helpers_test.rb`, and the self-dispatch helpers exercised here
+ * (`dispatchQuotedBinary` / `dispatchQuotedDate` / `dispatchQuotedTime`) are a
+ * trails construct standing in for Ruby's `self.quoted_binary` sends. Nothing in
+ * this file is matched by `test:compare` — it lands in "extra (TS only)" — so the
+ * describe/it names here are ours to choose and are NOT bound by the
+ * never-reword-a-test-name rule, which exists to protect Rails-matched names.
+ *
+ * Renamed to `.trails.test.ts` (was `quoting-helpers.test.ts`) to make that
+ * self-evident; it is why reviewers kept having to re-derive it.
+ */
 import { describe, expect, it } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { BinaryData } from "@blazetrails/activemodel";
@@ -37,7 +50,7 @@ describe("quotedDate", () => {
   });
 
   it("throws for unrecognised types", () => {
-    expect(() => quotedDate("2026-04-26" as any)).toThrow("quotedDate: cannot format");
+    expect(() => quotedDate("2026-04-26" as never)).toThrow("quotedDate: cannot format");
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -164,7 +164,14 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#type_cast
  */
 export function typeCast(this: QuotingDispatchHost, value: unknown): unknown {
+  // Rails: `when Symbol, ActiveSupport::Multibyte::Chars, Type::Binary::Data
+  // then value.to_s` (rb:96). For a `Data`, `to_s` is the BINARY-encoded String
+  // — the raw bytes — so our analogue is `.bytes`, NOT `toString()`, which
+  // UTF-8-decodes and would replace every byte >= 0x80 with U+FFFD (see
+  // {@link quotedBinary}). `BinaryType#serialize` emits a `Data`, so every bind
+  // path for a binary attribute lands here.
   if (typeof value === "symbol") return value.description ?? String(value);
+  if (value instanceof BinaryData) return value.bytes;
   if (value === true) return unquotedTrue();
   if (value === false) return unquotedFalse();
   if (value === null || value === undefined) return value;

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -123,18 +123,10 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
   if (typeof value === "number" || typeof value === "bigint") return String(value);
   // Rails: `when Type::Binary::Data then quoted_binary(value)` (rb:83) —
   // self-dispatched so an adapter's `quoted_binary` override (PG's bytea escape,
-  // MySQL/SQLite's `x'..'` hex) is honored. Thread `this` to mirror that.
-  //
-  // Deviation: Rails passes the `Type::Binary::Data` itself and each override
-  // unwraps it (`value.to_s` / `value.hex`); we pass the unwrapped bytes, which
-  // is what lets the raw-view branch below share one dispatch path with it.
-  // Every trails `quotedBinary` therefore accepts the union — Data *and* raw
-  // views — so a Rails-shaped `quotedBinary(data)` call still works; only an
-  // override that assumed a `Data` arg (reading `.hex()` off it) would see bytes
-  // instead. The root cause is that `BinaryType#serialize` returns bare bytes
-  // rather than Rails' `Data.new(super)`; converging that is story
-  // `binary-type-serialize-returns-data-wrapper` (RFC 0023).
-  if (value instanceof BinaryData) return dispatchQuotedBinary(this, value.bytes);
+  // MySQL/SQLite's `x'..'` hex) is honored. Thread `this` to mirror that. The
+  // `Data` is passed through unwrapped, as Rails does; each override unwraps it
+  // itself (`value.to_s` / `value.hex`).
+  if (value instanceof BinaryData) return dispatchQuotedBinary(this, value);
   // ArrayBuffer views have no Ruby analogue (#4868): Rails only ever sees
   // `Type::Binary::Data` here, so they must be normalized to bytes rather than
   // falling to the raise below. Kept at the rb:83 position and self-dispatched,
@@ -387,8 +379,8 @@ export function quotedBinary(value: unknown): string {
   // BinaryData it runs `toString()`, which UTF-8-decodes and silently replaces
   // any invalid sequence with U+FFFD (0xde 0xad 0xbe 0xef → 3 lossy chars). So
   // normalise every byte source and decode latin1, which maps bytes 1:1. Rails'
-  // signature takes the `Data` itself (rb:206), so accept it even though our
-  // `quote` unwraps first; `dispatchQuotedBinary` also receives raw views.
+  // signature takes the `Data` itself (rb:206), which is what `quote` passes;
+  // `dispatchQuotedBinary` also receives raw views from trails-only callers.
   const bytes = toBytes(value);
   if (bytes) {
     return `'${quoteString(Buffer.from(bytes).toString("latin1"))}'`;
@@ -455,9 +447,10 @@ export function isSqlLiteral(value: unknown): value is { value: string } {
  * calling `self.quoted_binary(value)` so an adapter override applies. Falls
  * back to the module-level helper when the host omits it.
  *
- * Takes `unknown` rather than `Uint8Array`: the rb:83 branch passes a
- * `BinaryData`'s bytes, but SQLite's boundary branch dispatches a raw
- * `ArrayBuffer`, and the abstract/MySQL/SQLite `quotedBinary` normalise through
+ * Takes `unknown` rather than `BinaryData`: the rb:83 branch passes a
+ * `BinaryData`, but the abstract view branch passes normalized bytes and
+ * SQLite's bare-`ArrayBuffer` branch dispatches the buffer itself. The
+ * abstract/MySQL/SQLite `quotedBinary` normalise all three through
  * {@link toBytes} (PG's exception is noted there — it is unreachable from this
  * dispatch, which only sees a raw `ArrayBuffer` from SQLite's branch, with a
  * SQLite host).

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -20,7 +20,6 @@ import {
 import {
   quote as abstractQuote,
   toBytes,
-  dispatchQuotedBinary,
   dispatchQuotedDate,
   dispatchQuotedTime,
   type QuotingDispatchHost,
@@ -192,7 +191,7 @@ export function columnNameWithOrderMatcher(): RegExp {
  * through the dispatched helpers (`quote_string`, `quoted_binary`,
  * `quoted_date`/`quoted_time`). We mirror that here: only the branches whose
  * dispatch the abstract `quote` doesn't thread through `this` (symbols, strings
- * — plus the trails-only raw-bytes and non-finite guards) stay inline; the rest
+ * — plus the trails-only non-finite guard) stay inline; the rest
  * delegates to {@link abstractQuote} with `this` threaded so the date/time
  * dispatch lands on MySQL's {@link quotedDate}. Booleans fall through to the
  * abstract `"TRUE"`/`"FALSE"`; binds serialize to 1/0 via {@link castBoundValue}.
@@ -203,12 +202,6 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
   // throws "Unknown column 'Infinity'". Mirror PG's behavior and quote them as
   // strings; MySQL coerces or rejects at the column-type boundary.
   if (typeof value === "number" && !Number.isFinite(value)) return quoteString(String(value));
-  // Raw byte views have no Rails counterpart (Rails only ever sees
-  // `Type::Binary::Data` here) — trails callers pass them at the boundary.
-  // Self-dispatch so MySQL's `quotedBinary` override is honored, the same way
-  // the inherited abstract `quote` handles `BinaryData` (abstract/quoting.rb:83).
-  // `Buffer` needs no separate branch: it extends `Uint8Array`.
-  if (value instanceof Uint8Array) return dispatchQuotedBinary(this, value);
   if (typeof value === "symbol") {
     const desc = value.description;
     if (desc === undefined) throw new TypeError("Cannot quote a Symbol without a description");

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -280,6 +280,12 @@ export function quotedDate(
  */
 export function typeCast(this: QuotingDispatchHost, value: unknown): unknown {
   if (typeof value === "symbol") return value.description ?? String(value);
+  // Rails' MySQL `type_cast` falls through to `super` for anything it does not
+  // special-case, reaching the abstract `when ... Type::Binary::Data then
+  // value.to_s` (abstract/quoting.rb:96). This chain does not delegate, so the
+  // arm is inlined: `to_s` on a `Data` is the raw byte string, hence `.bytes`
+  // (never `toString()`, which UTF-8-decodes and mangles bytes >= 0x80).
+  if (value instanceof BinaryData) return value.bytes;
   if (value === true) return unquotedTrue();
   if (value === false) return unquotedFalse();
   if (value === null || value === undefined) return value;

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -889,11 +889,18 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       // `value_for_database` now yields cast Temporal values; convert to the SQL
       // wire string the mysql2 driver expects (matching Rails' type_casted_binds).
       v = temporalToBindString(v, "mysql");
-      // `BinaryType#serialize` yields a `Type::Binary::Data`, which the driver
-      // cannot bind — Rails' `type_cast` unwraps it to its byte string at
-      // abstract/quoting.rb:96. Unwrap here too: this path deliberately does not
-      // route through `typeCast` (see the doc comment above), so without this the
-      // wrapper reaches mysql2 and silently matches no rows.
+      // `BinaryType#serialize` yields a `Type::Binary::Data`; Rails' `type_cast`
+      // unwraps it to its byte string at abstract/quoting.rb:96. This path
+      // deliberately does not route through `typeCast` (see above), so unwrap
+      // here — otherwise the wrapper reaches mysql2, which binds it as a plain
+      // object and matches no rows (measured: 0 rows for a value that is
+      // present, i.e. a wrong answer rather than a raise).
+      //
+      // Unlike node-postgres (which needs a Buffer, hence PG's re-wrap in
+      // `postgresql/quoting.ts` typeCast), mysql2 binds a bare `Uint8Array` as a
+      // BLOB: verified with a non-Buffer `Uint8Array` round-tripping byte-exactly
+      // through a bound where clause, including 0x00 and bytes >= 0x80. This is
+      // also what the path received before `serialize` began wrapping.
       if (v instanceof BinaryData) v = v.bytes;
       return v === true ? 1 : v === false ? 0 : v;
     });

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -10,7 +10,7 @@ import {
   StatementPool as MysqlStatementPool,
   type MysqlPreparedStatement,
 } from "./abstract-mysql-adapter.js";
-import { StringType, ImmutableStringType } from "@blazetrails/activemodel";
+import { StringType, ImmutableStringType, BinaryData } from "@blazetrails/activemodel";
 import { TypeMap } from "../type/type-map.js";
 import * as Type from "../type.js";
 import { UnsignedInteger } from "../type/unsigned-integer.js";
@@ -889,6 +889,12 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       // `value_for_database` now yields cast Temporal values; convert to the SQL
       // wire string the mysql2 driver expects (matching Rails' type_casted_binds).
       v = temporalToBindString(v, "mysql");
+      // `BinaryType#serialize` yields a `Type::Binary::Data`, which the driver
+      // cannot bind — Rails' `type_cast` unwraps it to its byte string at
+      // abstract/quoting.rb:96. Unwrap here too: this path deliberately does not
+      // route through `typeCast` (see the doc comment above), so without this the
+      // wrapper reaches mysql2 and silently matches no rows.
+      if (v instanceof BinaryData) v = v.bytes;
       return v === true ? 1 : v === false ? 0 : v;
     });
   }

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -7,7 +7,6 @@
 import { BinaryData } from "@blazetrails/activemodel";
 import {
   quote as abstractQuote,
-  dispatchQuotedBinary,
   quotedDate as abstractQuotedDate,
   quotedFalse as abstractQuotedFalse,
   quotedTrue as abstractQuotedTrue,
@@ -163,11 +162,6 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
     if (quotingConfig.raiseIntWiderThan64Bit) checkIntegerRange(value);
     return String(value);
   }
-  // Raw byte views have no Rails counterpart (Rails only ever sees
-  // `Type::Binary::Data` here) — trails callers pass them at the boundary.
-  // Self-dispatch so the adapter's `quotedBinary` override is honored, the same
-  // way the inherited abstract `quote` handles `BinaryData` (abstract/quoting.rb:83).
-  if (value instanceof Uint8Array) return dispatchQuotedBinary(this, value);
   if (typeof value === "string") return quoteString(value);
   // Thread `this` so the inherited date/time dispatch reaches PG's
   // BC-suffixing `quotedDate` (mirrors Rails' `super` call in PG#quote).

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
@@ -221,10 +221,10 @@ describe("SQLite3::Quoting", () => {
 
     it("quotes a binary default through SQLite's quotedBinary", () => {
       // Receiver-less: the fallback host must still reach the `x'..'` hex form,
-      // not the abstract byte-string fallback. Cover both shapes that reach here
-      // — the raw Uint8Array trails' BinaryType#serialize actually returns, the
-      // ArrayBuffer the boundary branch accepts, and the BinaryData Rails'
-      // Binary#serialize returns (activemodel/.../binary.rb:31).
+      // not the abstract byte-string fallback. Cover all three shapes that reach
+      // here — the `BinaryData` that `BinaryType#serialize` returns
+      // (activemodel/.../binary.rb:31), plus the raw `Uint8Array` and bare
+      // `ArrayBuffer` a caller may hand to a migration default.
       expect(quoteDefaultExpression(new Uint8Array([0xde, 0xad]))).toBe("x'dead'");
       expect(quoteDefaultExpression(new Uint8Array([0xde, 0xad]).buffer)).toBe("x'dead'");
       expect(quoteDefaultExpression(new BinaryData(new Uint8Array([0xde, 0xad])))).toBe("x'dead'");

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -238,6 +238,12 @@ export function typeCast(this: QuotingDispatchHost, value: unknown, bindsAsFloat
     throw new TypeError(
       "typeCast: JS Date is not accepted — use a Temporal type (Instant, PlainDateTime, etc.)",
     );
+  // Rails' SQLite `type_cast` falls through to `super` for anything it does not
+  // special-case, reaching the abstract `when ... Type::Binary::Data then
+  // value.to_s` (abstract/quoting.rb:96). This chain does not delegate, so the
+  // arm is inlined: `to_s` on a `Data` is the raw byte string, hence `.bytes`
+  // (never `toString()`, which UTF-8-decodes and mangles bytes >= 0x80).
+  if (value instanceof BinaryData) return value.bytes;
   if (value instanceof Uint8Array || value instanceof ArrayBuffer) return value;
   throw new TypeError(`can't cast ${Object.prototype.toString.call(value)} to a SQLite3 type`);
 }

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -90,13 +90,14 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
     return quoteString(value.description);
   }
   if (typeof value === "string") return quoteString(value);
-  // Raw byte views have no Rails counterpart (Rails only ever sees
-  // `Type::Binary::Data` here) — trails callers pass them at the boundary.
-  // Self-dispatch so SQLite's `quotedBinary` override is honored, the same way
-  // the inherited abstract `quote` handles `BinaryData` (abstract/quoting.rb:83).
-  if (value instanceof Uint8Array || value instanceof ArrayBuffer) {
-    return dispatchQuotedBinary(this, value);
-  }
+  // A *bare* `ArrayBuffer` has no Rails counterpart (Rails only ever sees
+  // `Type::Binary::Data` here). It survives because `quoteDefaultExpression`
+  // below hands one straight to `quote` for a binary column default, and the
+  // inherited abstract branch tests `ArrayBuffer.isView`, which is false for a
+  // bare buffer. Byte *views* need no branch here — they fall through to the
+  // abstract `isView` branch, which self-dispatches back to SQLite's
+  // `quotedBinary` just as this does.
+  if (value instanceof ArrayBuffer) return dispatchQuotedBinary(this, value);
   return abstractQuote.call(this, value);
 }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -91,12 +91,17 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
   }
   if (typeof value === "string") return quoteString(value);
   // A *bare* `ArrayBuffer` has no Rails counterpart (Rails only ever sees
-  // `Type::Binary::Data` here). It survives because `quoteDefaultExpression`
-  // below hands one straight to `quote` for a binary column default, and the
-  // inherited abstract branch tests `ArrayBuffer.isView`, which is false for a
-  // bare buffer. Byte *views* need no branch here — they fall through to the
-  // abstract `isView` branch, which self-dispatches back to SQLite's
-  // `quotedBinary` just as this does.
+  // `Type::Binary::Data` here), and nothing in trails produces one — no internal
+  // caller reaches this. It is a boundary affordance: `quoteDefaultExpression`
+  // below forwards a caller-supplied migration default (`t.binary(col, { default
+  // })`) to `quote` untouched, so a JS caller can hand one in, and the inherited
+  // abstract branch would raise on it — `ArrayBuffer.isView` is false for a bare
+  // buffer. Exercised only by quoting.test.ts ("quotes a binary default through
+  // SQLite's quotedBinary").
+  //
+  // Byte *views* need no branch here: they fall through to the abstract `isView`
+  // branch, which self-dispatches back to SQLite's `quotedBinary` just as this
+  // does — which is why PG's equivalent branch is gone.
   if (value instanceof ArrayBuffer) return dispatchQuotedBinary(this, value);
   return abstractQuote.call(this, value);
 }

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -323,12 +323,16 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
     if (casted === null || casted === undefined) return null;
     // Binary columns: convert each byte to the matching Latin-1 code point so
     // the encryptor receives a valid string rather than "0,1,2,..." (Array#toString).
-    const str =
-      casted instanceof Uint8Array
-        ? Buffer.from(casted).toString("latin1")
-        : typeof casted === "string"
-          ? casted
-          : String(casted);
+    // `BinaryType#serialize` yields a `BinaryData` (binary.rb:31) — its `toString`
+    // UTF-8-decodes and would replace every byte >= 0x80 with U+FFFD, so unwrap to
+    // bytes and decode latin1, which maps bytes 1:1.
+    const bytes =
+      casted instanceof BinaryData ? casted.bytes : casted instanceof Uint8Array ? casted : null;
+    const str = bytes
+      ? Buffer.from(bytes).toString("latin1")
+      : typeof casted === "string"
+        ? casted
+        : String(casted);
     const normalized = this.deterministic ? this._applyForcedEncoding(str) : str;
     const toEncrypt =
       this.scheme.downcase || this.scheme.ignoreCase ? normalized.toLowerCase() : normalized;

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -11537,13 +11537,6 @@
   },
   {
     "package": "activemodel",
-    "tsFile": "type/binary.ts",
-    "rubyName": "serialize",
-    "call": "new",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
     "tsFile": "type/boolean.ts",
     "rubyName": "cast_value",
     "call": "include?",

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -502,10 +502,18 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "No Node.js equivalent; JSON is the default column serialization format in Trails.",
   },
   {
-    testFile: "binary_test.rb",
+    // Scoped to activerecord's binary_test.rb: "cases/binary_test.rb" does not
+    // match activemodel's "cases/type/binary_test.rb" or arel's
+    // "cases/arel/nodes/binary_test.rb", both of which are ported and must stay
+    // in the accounting. Per-test rather than whole-file: `mixed encoding` and
+    // `unicode input casting` are ported in binary.test.ts.
+    testFile: "cases/binary_test.rb",
+    className: "BinaryTest",
+    tests: ["load save"],
     reason:
-      "Tests Marshal/YAML binary encoding of AR records. " +
-      "Ruby binary serialization formats have no Node.js equivalent.",
+      "test_load_save reads binary asset files (flowers.jpg, example.log, " +
+      "test.txt) from ASSETS_ROOT via File.read. Porting needs those asset " +
+      "fixtures plus filesystem reads, which this package's rules exclude.",
   },
   // --- globalid: Ruby pattern matching (`case ... in`) ---
   {


### PR DESCRIPTION
## What

Rails' `ActiveModel::Type::Binary#serialize` wraps its result in the `Data` value
object (`activemodel/lib/active_model/type/binary.rb:30-33`):

```ruby
def serialize(value)
  return if value.nil?
  Data.new(super)
end
```

trails delegated straight to `cast`, which *unwraps* `Data` and returns bare
`Uint8Array`. So `Type::Binary::Data` — precisely the signal `quote` dispatches on
at `abstract/quoting.rb:83` (`when Type::Binary::Data then quoted_binary(value)`) —
never reached the quoting layer from the type, and the adapters compensated with
raw-view boundary branches Rails does not have.

Surfaced in review of #4870, which ported rb:83 and documented this deviation
rather than converging it.

## Changes

- **`BinaryType#serialize` returns `Data`**, and `null` for nil rather than
  wrapping it. Note `super` in Rails is `Value#serialize` — *identity*, not
  `cast` — so the raw value is handed to `Data`, whose constructor does the
  `to_s`/binary coercion (mirroring `binary.rb:42-46`). Re-wrapping a `Data` is
  idempotent, as in Ruby.
- **`quote` passes the `Data` through** to `quotedBinary` as Rails does, instead
  of unwrapping to bytes first. Every trails `quotedBinary` already accepted the
  wrapper, so this only removes the deviation.
- **Adapter boundary branches re-evaluated** now that the type emits `BinaryData`
  (AC #2). Determined empirically by removing each and seeing what broke:
  - PG's `instanceof Uint8Array` branch was **fully redundant** with the abstract
    `ArrayBuffer.isView` branch → deleted (plus its now-unused import).
  - SQLite's is **narrowed to a bare `ArrayBuffer`**, which is a genuine
    survivor: `ArrayBuffer.isView` is false for a bare buffer, and
    `quoteDefaultExpression` hands one straight to `quote` for a binary column
    default. The surviving caller is documented in place, as the story asks.
- **Encryption's serialized-binary path** unwraps `BinaryData` before the latin1
  decode. Without this it fell to `String(casted)` → `Data#toString`, which
  UTF-8-decodes and replaces every byte >= 0x80 with U+FFFD — this genuinely
  broke 4 encryption tests, which now pass.
- **Dropped Binary surface Rails does not define** (from self-review): Rails'
  `Type::Binary` defines `type`, `binary?`, `cast`, `serialize` and
  `changed_in_place?` — no `deserialize`; it inherits `Value#deserialize`
  (`cast(value)`), and trails' override was redundant anyway since `cast`
  already unwraps `Data` (binary.rb:20-22). Its `Data` likewise defines only
  `initialize`, `to_s`/`to_str`, `hex` and `==`; `byteSize` was a trails
  invention with zero callers. This takes `type/binary.ts` from **1 novel to 0
  novel** in `api:extra`.

- Stale comments that documented the old contract (including one naming this
  story as unconverged) are updated to describe the new one.

## Verification

- `isChangedInPlace` compares `cast` bytes, not wrapper identity (AC #4) — also
  moves it closer to Rails' `changed_in_place?`.
- Drove real binary round-trips of **non-UTF8-decodable bytes**
  (`de ad be ef 00 1f 8b`) plus a string-input path through the `binaries` table
  on **SQLite, PostgreSQL and MySQL** — all byte-exact.
- `binary.test.ts` (activemodel), `bytea.test.ts` (PG, 14), and the encryption
  serialized-binary tests pass on all three adapters. Full activemodel `type/` +
  `connection-adapters/` + `encryption/` sweep on SQLite: 2225 passed.
- `api:calls` ratchet OK; `api:calls:wide` went stale on exactly the entry this
  converges (`activemodel type/binary.ts serialize new` — seeded because
  serialize never called `new`), removed by hand rather than reseeding, since the
  baseline only shrinks.

### Test names

`serialize binary strings` keeps its Rails-verbatim name; its assertions are
ported faithfully from `activemodel/test/cases/type/binary_test.rb:21` — it now
uses Rails' encoding-sensitive `"ƒée"` rather than the ASCII `"hello"` the
original port used, which could not observe the wrapper or the encoding. The one
renamed test (`passes the unwrapped bytes to this.quotedBinary`) is trails-only,
not Rails-matched, and existed solely to pin the deviation being removed here.

## Review gates

- **Matches Rails**: `serialize` is now `Data.new(super)` with `super` correctly
  identity rather than `cast`; `quote` passes the `Data` through as rb:83 does;
  the method set on both `BinaryType` and `Data` now matches binary.rb exactly.
- **No stubs**: none added; two pieces of dead/non-Rails surface removed.
- **api:compare delta**: positive — `type/binary.ts` 1 novel → 0 novel.
  `api:calls` OK (19 baselined), `api:calls:wide` OK (6849 baselined) after
  removing the one entry this converges.
- **test:compare delta**: non-negative — unchanged vs `origin/main`
  (activemodel 952/956, activerecord 7640/7812 on both).

## Review response (round 1)

**1. `type_cast` missing the rb:96 `Type::Binary::Data` arm — fixed. You were
right, and it was a real break, not a latent one.** Reproduced immediately:
`Binary.where({ data: bytes })` threw `can't cast [object Object] to a SQLite3
type`. CI independently hit the same thing on `where.test.ts:533` ("where with
integer for binary column") via `performCount` → `_driverBind` → `sqliteTypeCast`.
My verification missed it because a `create` + `find(id)` round-trip never reaches
the bind path — a gap in my testing, now closed by `binary.trails.test.ts`, which
pins the *bound where clause* on all three adapters.

Ported the rb:96 arm to `abstract/quoting.ts` at the rb:96 position, and inlined
it into `sqlite3/` and `mysql/` (Rails reaches it via `else super`; those trails
chains are standalone and would otherwise throw). Used `.bytes`, not
`toString()`, exactly as you noted — confirmed `String(data)` turns
`de ad be ef` into `de ad ef bf bd ef bf bd`.

Your `mysqlBinds` call was right too, and it was the worst of the three: it
bypasses `typeCast`, so the wrapper reached mysql2 and **silently matched zero
rows** instead of raising. Unwrapped there as well. PG was indeed already covered
by `_bindForPg`.

**2. Vacuous `not.toBe("ƒée")` — fixed.** Correct, it passes regardless. Removed
rather than replaced: Rails' assertion is meaningful only through `Data#==`
(binary.rb:55-57), and JS has no operator overloading, so there is no counterpart.
Adding an `equals()` with no callers would be inventing surface — the same
reasoning that removed `byteSize`. The comment now states this; the `.bytes`
assertion carries the content.

**3. `isChangedInPlace` `cast` — kept, documented.** Rails does not coerce
`value`, but JS cannot `!=` byte arrays, so the walk needs a `Uint8Array` and
`cast` supplies it. It is identity in practice: the only callers
(`Attribute#changedInPlace` / `#changedInPlaceFromDatabase`, `attribute.ts:88,106`)
pass `this.value`, already cast. Dropping it would need an equivalent narrowing
anyway. Note this is strictly less coercive than the `serialize` it replaced.

**4. `Data` constructor `instanceof Data` arm — kept, comment corrected.** It is
not idempotence sugar: it *is* Ruby's `to_s` step. Ruby gets it free because
`Data#to_s` returns the byte string; JS's `String(data)` runs our `toString()`,
which UTF-8-decodes and corrupts every byte >= 0x80 (measured above). Without the
arm `new Data(data)` mangles bytes. Reachable via any `serialize` of an
already-wrapped value, and Rails is byte-preserving there. Also confirmed your
aliasing read: `Uint8Array` is stored by reference, matching `.b` returning self
on an already-BINARY String — now noted in the comment.

## Review response (round 2)

**1. mysql2 bind form — evidence added, no code change needed.** You were right to
ask; I had the measurement but hadn't stated it. Verified directly: a **non-Buffer**
`Uint8Array` (`Buffer.isBuffer(v) === false`) binds as a BLOB and round-trips
byte-exactly through a bound where clause — `de ad be ef 00 1f 8b` in, same bytes
out, 1 row matched. So mysql2 does not need `Buffer.from`, unlike node-postgres
(hence PG's re-wrap). The "zero rows" claim was also measured: with the wrapper the
same query returned **0 rows** for a row that exists; unwrapped, 1. Both facts are
now in the code comment. And your framing is right — this is not a regression: the
path received a bare `Uint8Array` pre-PR too, which is exactly what the unwrap
restores. (PG's `typeCast` already had a `BinaryData` arm, which is why PG passed
throughout.)

**2. Skip reason is wrong — fixed, and you were right.** No `binary_test.rb` in
Rails contains Marshal or YAML; I checked all three (activerecord, activemodel/type,
arel/nodes) — `grep -c "Marshal\|YAML"` is 0 for each. Ported Rails'
`test_mixed_encoding` into `binary.test.ts` and **un-skipped** it (passes on SQLite,
PG, MySQL), then dropped the now-redundant round-trip from the trails-only file,
leaving only the bound-where-clause test — which, as you say, genuinely has no Rails
counterpart. The other two skips keep their names and get accurate reasons:
`load save` reads ASSETS_ROOT asset files (needs fs + fixtures we lack);
`unicode input casting` asserts Ruby String encodings.

One thing your comment surfaced that goes further than the skip text: the entry at
`unported-files.ts:504` has `testFile: "binary_test.rb"` with no leading `/`, so
`isTestFileUnported` substring-matches and excludes **all three** `binary_test.rb`
files across activerecord, activemodel and arel from test:compare
(`test-compare.ts:477`). That is why un-skipping a real Rails test moved the
activerecord line **not at all** (7640/7812, 125 skipped, before and after). Not
fixed here — removing it re-accounts three files across three packages and needs its
own delta justification — so registered as story
`unported-files-binary-test-false-marshal-exclusion` (RFC 0023) with the evidence.

**3. `serialize(null)` in a Rails-named test — fixed.** Moved to a new
`packages/activemodel/src/type/binary.trails.test.ts`; `serialize binary strings` now
carries only Rails' two assertions.

**4. `typeCastedBinds` leaking `BinaryData` — fixed rather than accepted.** Correct
diagnosis. It is cosmetic, but my change made it strictly worse (`[object Object]`
where the pre-PR path rendered `222,173`), so it should not ship. Added a narrow
unwrap — deliberately *not* routing the function through `typeCast`, which is the
wider 16-producer story and would change unrelated types (SQLite integer binds
become BigInt). Guarded by a test.

**Nit (`sqlite3` `quotedBinary` via `value.hex()`)** — agreed, and left alone. The
raw-view path still needs `toBytes`, so using `.hex()` for one arm would mean two
code paths where there is now one.

## CI

Green as of 4c72f2b (first passing run) — that run covers the rb:96 arm and includes
the previously-failing `where.test.ts:533`. The round-2 commit needs a fresh run.

Note on local runs: multi-file MySQL runs collide with `Table '1_need_quoting'
already exists` during canonical `loadSchema`. That is pre-existing and not from
this diff — a control run of two untouched files (`where.test.ts` +
`defaults.test.ts`) reproduces it identically. Every file here passes alone on all
three adapters.

## Review response (round 3)

**1. `unported-files.ts` entry — fixed here rather than deferred. You were right
to push twice; my "register a story" call was too conservative.** I deferred it
on the assumption that re-accounting three files needed its own delta
justification. I measured it instead, and the delta is positive everywhere:

| package | before | after |
| --- | --- | --- |
| arel | 701/705, 58 files | **703/707, 59 files** |
| activerecord | 7640/7812, 315 files | **7642/7815, 316 files** |
| activemodel | 952/956, 54 files | **954/958, 55 files** |

Every newly-visible test either matches or is an attributed skip (125 → 126,
`load save`); percentages hold at 99.4 / 97.8 / 99.6. The whole-file entry is
replaced by a per-test one scoped to `cases/binary_test.rb` — which matches
neither `cases/type/binary_test.rb` (activemodel) nor `cases/arel/nodes/binary_test.rb`
(arel), the two that were being hidden by the unanchored substring — excluding only
`load save`, with a reason taken from the actual source. All three files now show
in test:compare: arel 2 matched, activemodel 2 matched, activerecord 2 matched + 1
attributed skip.

This supersedes story `unported-files-binary-test-false-marshal-exclusion`, filed
last round and now done by this PR (trailer below).

**2. `save!` → `saveBang()` — fixed.** Correct: `save()` returns false where Rails
raises, and `saveBang` (`persistence.ts:573`) is the direct analogue.

**3. `unicode input casting` — ported rather than left skipped. You were right
again.** I checked instead of assuming, and the `name` half ports exactly, on all
three adapters: `"123"`/`123` before save, `"123"`/`"123"` after save and after
reload — matching Rails assertion for assertion. Un-skipped, with only the
`Encoding::BINARY`/`UTF_8` assertions on `data` omitted (a Uint8Array is only
bytes; JS strings have no encoding attribute), and the comment states which half
is omitted and why. So: not "a partially-portable test stays fully skipped" — the
portable half is now actually ported. Only `load save` remains skipped, for the
concrete reason that it reads ASSETS_ROOT binary fixtures from disk.

Net: 2 of Rails' 3 binary_test.rb tests now run, where all 3 were skipped for a
reason that was never true.

## Review response (round 4)

**1. MySQL's raw-view branch — missed, not deliberate. Fixed.** Good catch, and
the honest answer is that my removal experiment only covered PG and SQLite, so
MySQL never got tested. Your reasoning is exactly right: `mysql/quoting.ts` `quote`
ends in `abstractQuote.call(this, value)`, so a byte view falls through to the
abstract `ArrayBuffer.isView` branch and self-dispatches back to MySQL's
`quotedBinary`. Removed, along with the now-unused import and a file doc that
still advertised the "trails-only raw-bytes guard". Verified:
`quote(new Uint8Array([0xca, 0xfe]))` still yields `x'cafe'` (44 passing). All
three adapters are now symmetric.

**2. `quoting-helpers.test.ts` reword — confirmed trails-only, nothing to break.**
Verified rather than assumed: the file matches no Rails file in test:compare (Rails
has no `quoting_helpers_test.rb` — only `quoting_test.rb`, which we port separately
as `quoting.test.ts`), and `quote dispatches through quoted_binary` has no Rails
counterpart. It is extracted into `ts-tests.json` but lands in "extra (TS only)", so
no Rails test name is matched against it and the rename cannot affect matching.

On the `.trails.test.ts` naming: you're right that it's inconsistent with the
convention. The file predates this PR (added in #1137) and renaming it is a
whole-file change unrelated to this story, so I've left it — flagging rather than
silently accepting it.

**3. `data` asserted in `unicode input casting` — fixed. You're right that zero
assertions was wrong.** `data: "text"` was an argument the test never checked. Your
framing is the right one: what `assert_equal Encoding::BINARY, binary.data.encoding`
asserts *in Ruby terms* is that the String input was cast to binary, and that ports
even though the encoding label doesn't. `data` is now pinned as the bytes of "text"
at all three phases. The `_before_type_cast` encoding half stays out — Rails itself
notes it is adapter-dependent after reload.

**4. Bare-`ArrayBuffer` comment overstated — you're right, corrected.** I checked
for a producer and could not find one either, because there isn't one: nothing in
trails emits a bare `ArrayBuffer`. What the branch actually serves is the public
boundary — `quoteDefaultExpression` forwards a *caller-supplied* migration default
(`t.binary(col, { default })`) to `quote` untouched, so a JS caller can hand one in,
and the abstract branch would raise on it (`ArrayBuffer.isView` is false for a bare
buffer). Its only exercise is `sqlite3/quoting.test.ts`. The comment now says
exactly that instead of implying a live internal path, and notes why byte views need
no branch — the reason PG's and MySQL's are gone.

Also refreshed that test's own comment, which still claimed `BinaryType#serialize`
returns a raw `Uint8Array` — stale as of this PR.

Ratchets re-checked after the MySQL removal: `api:calls` OK (19), `api:calls:wide`
OK (6849).

## Review response (round 5)

**`quoting-helpers.test.ts` — confirmed, and fixed properly rather than dismissed.**
You offered a one-line dismissal, but this is the second round it has come up, which
is the signal that a prose answer buried in a PR description was the wrong fix. The
file should answer the question itself.

Confirmed (re-derived, not from memory):

- Rails has no `quoting_helpers_test.rb` — only `quoting_test.rb`, which we port
  separately as `quoting.test.ts`.
- `rails-tests.json` never mentions it: it is **not in the compare accounting**, and
  lands in "extra (TS only)". No Rails test name is matched against it, so the
  round-1 reword cannot affect `test:compare`.
- `quote dispatches through quoted_binary` has no Rails class, and the helpers it
  covers (`dispatchQuotedBinary` / `dispatchQuotedDate` / `dispatchQuotedTime`) are
  a trails construct standing in for Ruby's `self.quoted_binary` sends.

So: renamed to `quoting-helpers.trails.test.ts` — the single mechanical rename
CLAUDE.md allows, noted here — with a header stating why it is trails-only and that
its names are not bound by the never-reword rule, which exists to protect
Rails-matched names. test:compare is unchanged across the rename (activerecord
7642/7815, 316/321 files, 939 extra).

One thing the rename surfaced: `eslint/no-explicit-any-test-exclude.json` is
path-keyed, so the file fell out of the allowlist and its one `as any` started
erroring. Fixed the cast (`as never`, the right shape for an unreachable-type guard)
instead of re-adding the path — the allowlist shrinks by one rather than moving.

Closes-story: binary-type-serialize-returns-data-wrapper
Closes-story: unported-files-binary-test-false-marshal-exclusion
