### PR TITLE
fix(instrumentation): log/instrument yield the notification payload

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.query-logging.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.query-logging.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { AbstractAdapter } from "./abstract-adapter.js";
 import { ActiveRecordError, StatementInvalid } from "../errors.js";
 import { Notifications } from "@blazetrails/activesupport";
+import type { EventPayload } from "@blazetrails/activesupport";
 import { Collectors } from "@blazetrails/arel";
 
 describe("AbstractAdapter query/logging infrastructure (PR 25b)", () => {
@@ -70,13 +71,13 @@ describe("AbstractAdapter query/logging infrastructure (PR 25b)", () => {
 
     it("yields the notification payload so the block can report row_count", async () => {
       const a = new AbstractAdapter();
-      const events: any[] = [];
-      const sub = Notifications.subscribe("sql.active_record", (e) => events.push(e));
+      const payloads: EventPayload[] = [];
+      const sub = Notifications.subscribe("sql.active_record", (e) => payloads.push(e.payload));
       try {
         await a.log("SELECT 1", "SQL", [], [], false, async (payload) => {
           payload.row_count = 7;
         });
-        expect(events[0].payload.row_count).toBe(7);
+        expect(payloads[0].row_count).toBe(7);
       } finally {
         Notifications.unsubscribe(sub);
       }

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.query-logging.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.query-logging.test.ts
@@ -68,6 +68,20 @@ describe("AbstractAdapter query/logging infrastructure (PR 25b)", () => {
       }
     });
 
+    it("yields the notification payload so the block can report row_count", async () => {
+      const a = new AbstractAdapter();
+      const events: any[] = [];
+      const sub = Notifications.subscribe("sql.active_record", (e) => events.push(e));
+      try {
+        await a.log("SELECT 1", "SQL", [], [], false, async (payload) => {
+          payload.row_count = 7;
+        });
+        expect(events[0].payload.row_count).toBe(7);
+      } finally {
+        Notifications.unsubscribe(sub);
+      }
+    });
+
     it("re-throws StatementInvalid with query attached", async () => {
       const a = new AbstractAdapter();
       const inner = new StatementInvalid("oops");

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.query-logging.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.query-logging.test.ts
@@ -83,6 +83,39 @@ describe("AbstractAdapter query/logging infrastructure (PR 25b)", () => {
       }
     });
 
+    it("reports an open transaction in the payload", async () => {
+      const a = new AbstractAdapter();
+      const openTx = { isOpen: () => true };
+      vi.spyOn(a, "currentTransaction").mockReturnValue({
+        userTransaction: openTx,
+      } as never);
+      const payloads: EventPayload[] = [];
+      const sub = Notifications.subscribe("sql.active_record", (e) => payloads.push(e.payload));
+      try {
+        await a.log("SELECT 1", "SQL", [], [], false, async () => undefined);
+        expect(payloads[0].transaction).toBe(openTx);
+      } finally {
+        Notifications.unsubscribe(sub);
+      }
+    });
+
+    // Rails' `user_transaction.presence` — Transaction aliases blank? to
+    // closed?, so a closed transaction is reported as nil, not as itself.
+    it("reports a closed transaction as null in the payload", async () => {
+      const a = new AbstractAdapter();
+      vi.spyOn(a, "currentTransaction").mockReturnValue({
+        userTransaction: { isOpen: () => false },
+      } as never);
+      const payloads: EventPayload[] = [];
+      const sub = Notifications.subscribe("sql.active_record", (e) => payloads.push(e.payload));
+      try {
+        await a.log("SELECT 1", "SQL", [], [], false, async () => undefined);
+        expect(payloads[0].transaction).toBeNull();
+      } finally {
+        Notifications.unsubscribe(sub);
+      }
+    });
+
     it("re-throws StatementInvalid with query attached", async () => {
       const a = new AbstractAdapter();
       const inner = new StatementInvalid("oops");

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.query-logging.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.query-logging.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { AbstractAdapter } from "./abstract-adapter.js";
 import { ActiveRecordError, StatementInvalid } from "../errors.js";
+import { Transaction } from "../transaction.js";
 import { Notifications } from "@blazetrails/activesupport";
 import type { EventPayload } from "@blazetrails/activesupport";
 import { Collectors } from "@blazetrails/arel";
@@ -83,37 +84,38 @@ describe("AbstractAdapter query/logging infrastructure (PR 25b)", () => {
       }
     });
 
-    it("reports an open transaction in the payload", async () => {
+    const logTransactionPayload = async (userTransaction: Transaction) => {
       const a = new AbstractAdapter();
-      const openTx = { isOpen: () => true };
-      vi.spyOn(a, "currentTransaction").mockReturnValue({
-        userTransaction: openTx,
-      } as never);
+      vi.spyOn(a, "currentTransaction").mockReturnValue({ userTransaction } as never);
       const payloads: EventPayload[] = [];
       const sub = Notifications.subscribe("sql.active_record", (e) => payloads.push(e.payload));
       try {
         await a.log("SELECT 1", "SQL", [], [], false, async () => undefined);
-        expect(payloads[0].transaction).toBe(openTx);
+        return payloads[0].transaction;
       } finally {
         Notifications.unsubscribe(sub);
       }
+    };
+
+    it("reports an open transaction in the payload", async () => {
+      // A real Transaction wrapping a non-finalized internal transaction, so
+      // this exercises Transaction#isBlank rather than a hand-stubbed shape.
+      const openTx = new Transaction({ state: { finalized: false } } as never);
+      expect(await logTransactionPayload(openTx)).toBe(openTx);
     });
 
     // Rails' `user_transaction.presence` — Transaction aliases blank? to
     // closed?, so a closed transaction is reported as nil, not as itself.
     it("reports a closed transaction as null in the payload", async () => {
-      const a = new AbstractAdapter();
-      vi.spyOn(a, "currentTransaction").mockReturnValue({
-        userTransaction: { isOpen: () => false },
-      } as never);
-      const payloads: EventPayload[] = [];
-      const sub = Notifications.subscribe("sql.active_record", (e) => payloads.push(e.payload));
-      try {
-        await a.log("SELECT 1", "SQL", [], [], false, async () => undefined);
-        expect(payloads[0].transaction).toBeNull();
-      } finally {
-        Notifications.unsubscribe(sub);
-      }
+      const finalizedTx = new Transaction({ state: { finalized: true } } as never);
+      expect(await logTransactionPayload(finalizedTx)).toBeNull();
+    });
+
+    // NullTransaction#userTransaction hands back NULL_TRANSACTION rather than
+    // null, so the no-transaction case only reads as "no transaction" because
+    // NULL_TRANSACTION wraps a null internal transaction and is therefore blank.
+    it("reports no transaction as null in the payload", async () => {
+      expect(await logTransactionPayload(Transaction.NULL_TRANSACTION)).toBeNull();
     });
 
     it("re-throws StatementInvalid with query attached", async () => {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2329,14 +2329,20 @@ export class AbstractAdapter implements Quoting {
     return arError;
   }
 
-  /** Mirrors: AbstractAdapter#log */
+  /**
+   * Mirrors: AbstractAdapter#log
+   *
+   * `block` receives the notification payload, mirroring Rails' `yield payload`.
+   * `raw_execute` threads it into `perform_query`, which reports back by
+   * mutating it (`row_count`, `statement_name`) before subscribers read it.
+   */
   async log<T>(
     sql: string,
     name: string | null | undefined = "SQL",
     binds: unknown[] = [],
     typeCastedBinds: unknown[] = [],
     isAsync = false,
-    block?: () => Promise<T>,
+    block?: (payload: Record<string, unknown>) => Promise<T>,
   ): Promise<T | void> {
     try {
       const tx = this.currentTransaction();

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2352,7 +2352,11 @@ export class AbstractAdapter implements Quoting {
   ): Promise<T | void> {
     try {
       const tx = this.currentTransaction();
+      // Rails: `current_transaction.user_transaction.presence`. Transaction
+      // aliases `blank?` to `closed?` (transaction.rb:122), so a closed
+      // transaction reports as nil rather than as itself.
       const userTx = (tx as any).userTransaction ?? null;
+      const openTx = userTx?.isOpen?.() ? userTx : null;
       return await Notifications.instrumentAsync(
         "sql.active_record",
         {
@@ -2362,7 +2366,7 @@ export class AbstractAdapter implements Quoting {
           type_casted_binds: typeCastedBinds,
           async: isAsync,
           connection: this,
-          transaction: userTx,
+          transaction: openTx,
           row_count: 0,
         },
         block,

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -22,6 +22,7 @@ import {
   type SQLWarning,
 } from "../errors.js";
 import { Notifications } from "@blazetrails/activesupport";
+import type { EventPayload } from "@blazetrails/activesupport";
 import { disablePreparedStatements } from "../ar-config.js";
 import { Result, type ColumnTypes } from "../result.js";
 import { SchemaCache, SchemaReflection, BoundSchemaReflection } from "./schema-cache.js";
@@ -2333,8 +2334,13 @@ export class AbstractAdapter implements Quoting {
    * Mirrors: AbstractAdapter#log
    *
    * `block` receives the notification payload, mirroring Rails' `yield payload`.
-   * `raw_execute` threads it into `perform_query`, which reports back by
-   * mutating it (`row_count`, `statement_name`) before subscribers read it.
+   * It is the same object subscribers read after the block returns, so a block
+   * reports back by mutating it — which is how Rails' `raw_execute` hands
+   * `notification_payload` to `perform_query` for `row_count`/`statement_name`.
+   *
+   * trails' `rawExecute` does not call `log` yet; wiring that up is part of
+   * `unify-execute-mutation-into-perform-query` (RFC 0023), which first needs
+   * `performQuery` on sqlite3/mysql2 (only PG assigns one today).
    */
   async log<T>(
     sql: string,
@@ -2342,7 +2348,7 @@ export class AbstractAdapter implements Quoting {
     binds: unknown[] = [],
     typeCastedBinds: unknown[] = [],
     isAsync = false,
-    block?: (payload: Record<string, unknown>) => Promise<T>,
+    block?: (payload: EventPayload) => Promise<T>,
   ): Promise<T | void> {
     try {
       const tx = this.currentTransaction();

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2351,12 +2351,11 @@ export class AbstractAdapter implements Quoting {
     block?: (payload: EventPayload) => Promise<T>,
   ): Promise<T | void> {
     try {
-      const tx = this.currentTransaction();
       // Rails: `current_transaction.user_transaction.presence`. Transaction
       // aliases `blank?` to `closed?` (transaction.rb:122), so a closed
       // transaction reports as nil rather than as itself.
-      const userTx = (tx as any).userTransaction ?? null;
-      const openTx = userTx?.isOpen?.() ? userTx : null;
+      const userTx = this.currentTransaction().userTransaction;
+      const presentTx = userTx.isBlank() ? null : userTx;
       return await Notifications.instrumentAsync(
         "sql.active_record",
         {
@@ -2366,7 +2365,7 @@ export class AbstractAdapter implements Quoting {
           type_casted_binds: typeCastedBinds,
           async: isAsync,
           connection: this,
-          transaction: openTx,
+          transaction: presentTx,
           row_count: 0,
         },
         block,

--- a/packages/activesupport/src/notifications.test.ts
+++ b/packages/activesupport/src/notifications.test.ts
@@ -21,17 +21,22 @@ describe("SubscribeEventObjectsTest", () => {
   });
 
   it("subscribe to events where payload is changed during instrumentation", () => {
-    const captured: unknown[] = [];
-    Notifications.subscribe("foo", (e) => captured.push(e.payload));
-    Notifications.instrument("foo", { status: "pending" });
-    expect((captured[0] as any).status).toBe("pending");
+    const events: Event[] = [];
+    Notifications.subscribe("foo", (e) => events.push(e));
+    Notifications.instrument("foo", {}, (payload) => {
+      payload.my_key = "success!";
+    });
+    expect(events[0].payload.my_key).toBe("success!");
   });
 
   it("subscribe to events can handle nested hashes in the paylaod", () => {
     const events: Event[] = [];
     Notifications.subscribe("foo", (e) => events.push(e));
-    Notifications.instrument("foo", { nested: { key: "value" } });
-    expect((events[0].payload.nested as any).key).toBe("value");
+    Notifications.instrument("foo", { some_key: { key_one: "success!" } }, (payload) => {
+      (payload.some_key as Record<string, unknown>).key_two = "great_success!";
+    });
+    expect((events[0].payload.some_key as any).key_one).toBe("success!");
+    expect((events[0].payload.some_key as any).key_two).toBe("great_success!");
   });
 
   it("subscribe via top level api", () => {
@@ -258,8 +263,20 @@ describe("InstrumentationTest", () => {
   it("instrument yields the payload for further modification", () => {
     const events: Event[] = [];
     Notifications.subscribe("modify", (e) => events.push(e));
-    Notifications.instrument("modify", { original: true });
+    Notifications.instrument("modify", { original: true }, (payload) => {
+      payload.added = "later";
+    });
     expect(events[0].payload.original).toBe(true);
+    expect(events[0].payload.added).toBe("later");
+  });
+
+  it("instrumentAsync yields the payload for further modification", async () => {
+    const events: Event[] = [];
+    Notifications.subscribe("modify.async", (e) => events.push(e));
+    await Notifications.instrumentAsync("modify.async", { row_count: 0 }, async (payload) => {
+      payload.row_count = 3;
+    });
+    expect(events[0].payload.row_count).toBe(3);
   });
 
   it("instrumenter exposes its id", () => {

--- a/packages/activesupport/src/notifications.test.ts
+++ b/packages/activesupport/src/notifications.test.ts
@@ -23,7 +23,9 @@ describe("SubscribeEventObjectsTest", () => {
   it("subscribe to events where payload is changed during instrumentation", () => {
     const events: Event[] = [];
     Notifications.subscribe("foo", (e) => events.push(e));
-    Notifications.instrument("foo", {}, (payload) => {
+    // Rails passes no payload here, so the block mutates the default one the
+    // event was built with — the subscriber must observe that same object.
+    Notifications.instrument("foo", undefined, (payload) => {
       payload.my_key = "success!";
     });
     expect(events[0].payload.my_key).toBe("success!");

--- a/packages/activesupport/src/notifications.ts
+++ b/packages/activesupport/src/notifications.ts
@@ -111,7 +111,7 @@ export class Notifications {
   static instrument<T>(
     name: string,
     payload?: EventPayload,
-    block?: () => T,
+    block?: (payload: EventPayload) => T,
   ): T extends undefined ? void : T {
     const current = this._eventStack();
     const event = this._buildEvent(name, payload, current);
@@ -129,7 +129,7 @@ export class Notifications {
     const inner = [...current, event];
     let result: T;
     try {
-      result = this._runWithStack(inner, block);
+      result = this._runWithStack(inner, () => block(event.payload));
     } finally {
       event.finish();
       this._notify(event);
@@ -139,11 +139,16 @@ export class Notifications {
 
   /**
    * instrumentAsync — like instrument but for async blocks.
+   *
+   * The block receives the event payload — the same object passed in, which
+   * subscribers read after the block returns. Mutating it (e.g. `row_count`)
+   * is how a caller reports back into the notification, mirroring Rails'
+   * `yield payload` in ActiveSupport::Notifications::Instrumenter#instrument.
    */
   static async instrumentAsync<T>(
     name: string,
     payload?: EventPayload,
-    block?: () => Promise<T>,
+    block?: (payload: EventPayload) => Promise<T>,
   ): Promise<T extends undefined ? void : T> {
     const current = this._eventStack();
     const event = this._buildEvent(name, payload, current);
@@ -161,7 +166,7 @@ export class Notifications {
     const inner = [...current, event];
     let result: T;
     try {
-      result = await this._runWithStack(inner, block);
+      result = await this._runWithStack(inner, () => block(event.payload));
     } finally {
       event.finish();
       this._notify(event);

--- a/packages/activesupport/src/notifications/instrumenter.test.ts
+++ b/packages/activesupport/src/notifications/instrumenter.test.ts
@@ -22,8 +22,11 @@ describe("InstrumenterTest", () => {
     Notifications.subscribe("foo", (e) => {
       received = e.payload;
     });
-    Notifications.instrument("foo", { key: "original" }, () => {});
+    Notifications.instrument("foo", { key: "original" }, (payload) => {
+      payload.added = "modified";
+    });
     expect(received.key).toBe("original");
+    expect(received.added).toBe("modified");
   });
 
   it("instrument works without a block", () => {
@@ -58,8 +61,11 @@ describe("InstrumenterTest", () => {
   it("record yields the payload for further modification", () => {
     const events: Event[] = [];
     Notifications.subscribe("modify.test", (e) => events.push(e));
-    Notifications.instrument("modify.test", { original: true }, () => {});
+    Notifications.instrument("modify.test", { original: true }, (payload) => {
+      payload.added = "later";
+    });
     expect(events[0].payload.original).toBe(true);
+    expect(events[0].payload.added).toBe("later");
   });
 
   it("record works without a block", () => {


### PR DESCRIPTION
## What

Rails' `AbstractAdapter#log` passes its block to `instrumenter.instrument`,
which does `yield payload`
(`activesupport/lib/active_support/notifications/instrumenter.rb:24`).

That yield is the seam `raw_execute` depends on
(`activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:552-559`):

```ruby
log(sql, name, binds, type_casted_binds, async: async) do |notification_payload|
  with_raw_connection(...) do |conn|
    perform_query(..., notification_payload: notification_payload, batch: batch)
  end
end
```

`perform_query` reports back by mutating that payload (`row_count`,
`statement_name`) before subscribers read it.

trails' `log` already existed in the Rails-matching location
(`abstract-adapter.ts:2332`, mirroring `abstract_adapter.rb:1134`), but handed
its block straight to `Notifications.instrumentAsync`, whose block was typed
`() => Promise<T>` — zero-arg. So the payload could never be threaded into
`performQuery`, which on PG **already accepts a `notificationPayload`**
(`postgresql/database-statements.ts:123-135`) and was silently receiving
`undefined`.

## How

- `Notifications.instrument` / `instrumentAsync` now yield `event.payload`.
- `AbstractAdapter#log` threads it through, typed with the exported `EventPayload`.

`Event` stores the payload **by reference** (`notifications/instrumenter.ts:30`),
so block mutations are visible to subscribers at notify time — matching Rails,
where the subscriber reads the same hash the block mutated.

The parameter is additive: every existing caller passes a zero-arg block and is
unaffected (TypeScript accepts fewer-arg callbacks). Verified no caller in the
tree passes an arg-taking block.

## Tests

Rails-ported tests for exactly this behaviour already existed **by name** but had
hollow bodies — they passed an empty block and never mutated a payload, so they
passed against the non-yielding implementation. That is why the gap went
unnoticed. Names are unchanged; the bodies now mirror the Rails originals
(`activesupport/test/notifications_test.rb:44-63`):

- `subscribe to events where payload is changed during instrumentation` — now
  passes **no** payload, like Rails, so the block mutates the `payload ?? {}`
  default the event was built with. This covers the riskier branch: it proves
  the subscriber observes that same defaulted object.
- `subscribe to events can handle nested hashes in the paylaod`
- `instrument yields the payload for further modification` (×2, incl. the
  `Instrumenter` suite)
- `record yields the payload for further modification`

Plus an `instrumentAsync` yield test and a `log` test asserting a block can
report `row_count` back into the notification.

**7 payload tests fail against the pre-change source and pass after** — verified
by reverting the implementation.

Regression: full activesupport notifications + cache suites (342), actionpack
controller suites (1393), and the AR sqlite3/sql-capture instrumentation slices
all pass.

## Also fixed: `log` reported a closed transaction

Rails builds the payload with `current_transaction.user_transaction.presence`.
`Transaction` aliases `blank?` to `closed?`
(`activerecord/lib/active_record/transaction.rb:122`), so `.presence` yields
**nil for a closed transaction**, not the transaction itself.

trails' `log` used `userTransaction ?? null` — always reporting the transaction,
so `payload[:transaction]` would hold a closed transaction where Rails has nil.
`sqlite3-adapter.ts:575` already gets this right in its hand-rolled payload;
`log` was the odd one out.

Per review, this now uses the **literal `presence` shape**:
`userTx.isBlank() ? null : userTx`. trails already ports Rails' `blank?`/`closed?`
alias as `Transaction#isBlank` (`transaction.ts:74` ← `transaction.rb:122`) and it
had no callers; this gives it one. The earlier `userTx?.isOpen?.()` was
semantically equivalent but deviated twice — wrong side of the alias, plus dead
optional-chaining that would have degraded a missing method to "no transaction"
instead of throwing. `userTransaction` is non-null on both arms of
`currentTransaction()`'s union (`abstract/transaction.ts:253` returns
`UserTransaction.NULL_TRANSACTION`; `:325` declares
`readonly userTransaction: UserTransaction`), so the guards were also the only
reason an `as any` cast was needed. Every other payload site calls it unguarded.

Latent today (no production callers), but wiring `log` into `rawExecute` is
precisely what this seam exists for — so it is fixed before it ships.

Tests build real `Transaction` instances (null / non-finalized / finalized
internal transaction) rather than hand-stubbed `{ isOpen }` literals, so they
exercise the real `isBlank` contract and would catch naming drift. Includes the
`NULL_TRANSACTION` arm — the case that only reads as "no transaction" because
NULL_TRANSACTION wraps a null internal transaction and is therefore blank. The
closed and no-transaction arms both fail without the presence logic.

## Scope

Carved out of `unify-execute-mutation-into-perform-query` (RFC 0023) as a
standalone prerequisite. **No `Closes-story` trailer** — this closes neither that
story nor `converge-execute-batch-through-raw-execute`.

Deliberately **not** wiring `log` into `rawExecute` here. `internalExecute` (the
one live `rawExecute` caller) is used by savepoints and mysql2 `BEGIN`, so making
`rawExecute` emit `sql.active_record` is a real behavioural change with blast
radius on notification counts. It belongs with the per-adapter `performQuery`
work, where it can be done coherently.

`converge-execute-batch-through-raw-execute` remains blocked on the independent
blocker: `performQuery` is assigned on PG's prototype only
(`postgresql-adapter.ts:5244`); sqlite3 never imports its own exported
`performQuery` and mysql2 uses its own only inline in a single read path — so
`rawExecute` still raises `NotImplementedError` on 2 of 3 adapters.

## Follow-up filed

`converge-instrumenter-yield-payload` (RFC 0023): trails' `Instrumenter`
**instance** methods (`notifications/instrumenter.ts:60,88`) yield the `Event`,
not the payload, so the two trails APIs now disagree. Also covers the
trails-invented `payloadOrFn` overload and Rails' `payload[:exception]` arm,
which neither implementation ports.


