### PR TITLE
refactor(sqlite3): unify execute/executeMutation into one performQuery primitive

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
@@ -53,23 +53,20 @@ describeIfSqlite("SQLite3AdapterPerformQueryTest (trails)", () => {
     expect(adapter.affectedRows()).toBe(2);
   });
 
-  it("affectedRows survives a non-write statement in the run branch", async () => {
+  it("affectedRows is not reset by transaction control in the run branch", async () => {
     await adapter.executeMutation(`INSERT INTO "pq" ("nick") VALUES ('a')`);
     await adapter.executeMutation(`INSERT INTO "pq" ("nick") VALUES ('b')`);
     await adapter.executeMutation(`BEGIN`);
     expect(await adapter.executeMutation(`UPDATE "pq" SET "nick" = 'z'`)).toBe(2);
-    // sqlite3_changes() is not reset by COMMIT/DDL, so the last write's count
-    // survives them — assigning the per-statement `changes` here would clobber
-    // it to 0.
+    // BEGIN/COMMIT take the run branch but are not writes, so they don't touch
+    // the count — the last write's value survives them.
     await adapter.executeMutation(`COMMIT`);
-    expect(adapter.affectedRows()).toBe(2);
-    await adapter.execute(`CREATE TABLE "pq_ddl" ("id" INTEGER)`);
     expect(adapter.affectedRows()).toBe(2);
   });
 
   it("executeMutation returns the inserted id for INSERT ... RETURNING", async () => {
-    // RETURNING makes the statement row-returning, so it takes the `.all()`
-    // branch, which discards the RunResult the rowid would come from.
+    // A write takes the `.run()` branch even with RETURNING, so the id comes
+    // from the RunResult's lastInsertRowid, atomically with the insert.
     const id = await adapter.executeMutation(
       `INSERT INTO "pq" ("nick") VALUES ('a') RETURNING "id"`,
     );
@@ -80,6 +77,19 @@ describeIfSqlite("SQLite3AdapterPerformQueryTest (trails)", () => {
     );
     expect(second).toBe(2);
     expect(adapter.affectedRows()).toBe(1);
+  });
+
+  it("returns distinct insert ids for concurrent inserts", async () => {
+    // The count/rowid come from the RunResult, not a follow-up
+    // `last_insert_rowid()` read — so inserts issued concurrently (interleaving
+    // at await points) each get their own id rather than the last one written.
+    const ids = await Promise.all(
+      Array.from({ length: 5 }, (_, i) =>
+        adapter.executeMutation(`INSERT INTO "pq" ("nick") VALUES ('n${i}')`),
+      ),
+    );
+    expect(new Set(ids).size).toBe(5);
+    expect([...ids].sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5]);
   });
 
   it("errors when a write is routed through execute while preventing writes", async () => {

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
@@ -1,0 +1,84 @@
+/**
+ * trails-only coverage for the unified `perform_query` primitive.
+ *
+ * Rails' SQLite3 adapter has one SQL primitive, perform_query, which branches on
+ * `stmt.column_count.zero?` and sources affected rows from a separate
+ * `raw_connection.changes` read. These assert the branch and that read hold for
+ * the better-sqlite3 analogue (`stmt.reader` / `RunResult`), including the case
+ * where a statement both returns rows and writes (`INSERT ... RETURNING`).
+ */
+import { it, expect, beforeEach, afterEach } from "vitest";
+import { describeIfSqlite } from "./test-helper.js";
+import { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
+import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";
+import { ReadOnlyError } from "../../errors.js";
+
+let adapter: AbstractSQLite3Adapter;
+
+beforeEach(async () => {
+  adapter = new BetterSQLite3Adapter(":memory:");
+  await adapter.exec(`CREATE TABLE "pq" ("id" INTEGER PRIMARY KEY, "nick" TEXT)`);
+});
+
+afterEach(async () => {
+  await adapter
+    .exec(`DROP TABLE IF EXISTS "pq"; DROP TABLE IF EXISTS "pq_ddl"`)
+    .catch(() => undefined);
+  await adapter.close();
+});
+
+describeIfSqlite("SQLite3AdapterPerformQueryTest (trails)", () => {
+  it("execute runs a non-row-returning statement and returns no rows", async () => {
+    // `.all()` throws on a statement with no result columns, so this is the
+    // branch that lets DDL flow through the public `execute`.
+    await expect(adapter.execute(`CREATE TABLE "pq_ddl" ("id" INTEGER)`)).resolves.toEqual([]);
+    await expect(adapter.execute(`INSERT INTO "pq" ("nick") VALUES ('a')`)).resolves.toEqual([]);
+  });
+
+  it("execute still returns rows for a row-returning statement", async () => {
+    await adapter.executeMutation(`INSERT INTO "pq" ("nick") VALUES ('a')`);
+    await expect(adapter.execute(`SELECT "nick" FROM "pq"`)).resolves.toEqual([{ nick: "a" }]);
+  });
+
+  it("affectedRows reports the rows changed by the last write", async () => {
+    await adapter.executeMutation(`INSERT INTO "pq" ("nick") VALUES ('a')`);
+    await adapter.executeMutation(`INSERT INTO "pq" ("nick") VALUES ('b')`);
+
+    expect(await adapter.executeMutation(`UPDATE "pq" SET "nick" = 'z'`)).toBe(2);
+    expect(adapter.affectedRows()).toBe(2);
+
+    // A read leaves the count alone — it tracks the last write, as
+    // raw_connection.changes does in Rails.
+    await adapter.execute(`SELECT * FROM "pq"`);
+    expect(adapter.affectedRows()).toBe(2);
+  });
+
+  it("executeMutation returns the inserted id for INSERT ... RETURNING", async () => {
+    // RETURNING makes the statement row-returning, so it takes the `.all()`
+    // branch, which discards the RunResult the rowid would come from.
+    const id = await adapter.executeMutation(
+      `INSERT INTO "pq" ("nick") VALUES ('a') RETURNING "id"`,
+    );
+    expect(id).toBe(1);
+
+    const second = await adapter.executeMutation(
+      `INSERT INTO "pq" ("nick") VALUES ('b') RETURNING "id"`,
+    );
+    expect(second).toBe(2);
+    expect(adapter.affectedRows()).toBe(1);
+  });
+
+  it("errors when a write is routed through execute while preventing writes", async () => {
+    // The guard lives in preprocess_query's check_if_write_query, so it covers
+    // execute and executeMutation alike.
+    await expect(
+      adapter.withPreventedWrites(() => adapter.execute(`INSERT INTO "pq" ("nick") VALUES ('a')`)),
+    ).rejects.toThrow(ReadOnlyError);
+  });
+
+  it("does not prevent a read routed through execute while preventing writes", async () => {
+    await adapter.withPreventedWrites(async () => {
+      await expect(adapter.execute(`SELECT * FROM "pq"`)).resolves.toEqual([]);
+    });
+  });
+});

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
@@ -53,6 +53,20 @@ describeIfSqlite("SQLite3AdapterPerformQueryTest (trails)", () => {
     expect(adapter.affectedRows()).toBe(2);
   });
 
+  it("affectedRows survives a non-write statement in the run branch", async () => {
+    await adapter.executeMutation(`INSERT INTO "pq" ("nick") VALUES ('a')`);
+    await adapter.executeMutation(`INSERT INTO "pq" ("nick") VALUES ('b')`);
+    await adapter.executeMutation(`BEGIN`);
+    expect(await adapter.executeMutation(`UPDATE "pq" SET "nick" = 'z'`)).toBe(2);
+    // sqlite3_changes() is not reset by COMMIT/DDL, so the last write's count
+    // survives them — assigning the per-statement `changes` here would clobber
+    // it to 0.
+    await adapter.executeMutation(`COMMIT`);
+    expect(adapter.affectedRows()).toBe(2);
+    await adapter.execute(`CREATE TABLE "pq_ddl" ("id" INTEGER)`);
+    expect(adapter.affectedRows()).toBe(2);
+  });
+
   it("executeMutation returns the inserted id for INSERT ... RETURNING", async () => {
     // RETURNING makes the statement row-returning, so it takes the `.all()`
     // branch, which discards the RunResult the rowid would come from.

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
@@ -105,10 +105,24 @@ describeIfSqlite("SQLite3AdapterPerformQueryTest (trails)", () => {
     });
   });
 
-  it("does not dirty the current transaction for a read", async () => {
+  it("dirties the current transaction for a read too", async () => {
+    // Rails dirties in with_raw_connection's ensure gated on
+    // materialize_transactions, NOT on write — so a plain SELECT in an open
+    // transaction dirties it just like a write does.
     await adapter.transaction(async () => {
       await adapter.execute(`SELECT * FROM "pq"`);
-      expect(adapter.currentTransaction().isDirty()).toBe(false);
+      expect(adapter.currentTransaction().isDirty()).toBe(true);
+    });
+  });
+
+  it("dirties the current transaction even when the statement raises", async () => {
+    // The dirty runs in the primitive's finally, mirroring Rails' ensure — a
+    // failed write still leaves the transaction dirty.
+    await adapter.transaction(async () => {
+      await expect(
+        adapter.execute(`INSERT INTO "no_such_table" ("x") VALUES (1)`),
+      ).rejects.toThrow();
+      expect(adapter.currentTransaction().isDirty()).toBe(true);
     });
   });
 });

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
@@ -81,4 +81,20 @@ describeIfSqlite("SQLite3AdapterPerformQueryTest (trails)", () => {
       await expect(adapter.execute(`SELECT * FROM "pq"`)).resolves.toEqual([]);
     });
   });
+
+  it("dirties the current transaction for a write routed through execute", async () => {
+    // Dirtying hangs off the primitive rather than executeMutation, so a write
+    // reaching the connection through execute marks the transaction too.
+    await adapter.transaction(async () => {
+      await adapter.execute(`INSERT INTO "pq" ("nick") VALUES ('a')`);
+      expect(adapter.currentTransaction().isDirty()).toBe(true);
+    });
+  });
+
+  it("does not dirty the current transaction for a read", async () => {
+    await adapter.transaction(async () => {
+      await adapter.execute(`SELECT * FROM "pq"`);
+      expect(adapter.currentTransaction().isDirty()).toBe(false);
+    });
+  });
 });

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-perform-query.trails.test.ts
@@ -82,14 +82,23 @@ describeIfSqlite("SQLite3AdapterPerformQueryTest (trails)", () => {
   it("returns distinct insert ids for concurrent inserts", async () => {
     // The count/rowid come from the RunResult, not a follow-up
     // `last_insert_rowid()` read — so inserts issued concurrently (interleaving
-    // at await points) each get their own id rather than the last one written.
+    // at await points) each get their own id. The id is returned from
+    // _performQuery as a local rather than re-read from the shared
+    // this._lastInsertRowid, which a concurrent insert would overwrite before
+    // the post-await continuation reads it. NOTE: a race is timing-dependent —
+    // bare inserts interleave too little to reproduce it reliably here (the
+    // regression that motivated this reached CI through model `.create`, whose
+    // callbacks add denser interleaving; HasManyThroughAssociationsTest "should
+    // respect table alias" is the reliable guard). This is a smoke test of the
+    // happy path.
+    const n = 25;
     const ids = await Promise.all(
-      Array.from({ length: 5 }, (_, i) =>
+      Array.from({ length: n }, (_, i) =>
         adapter.executeMutation(`INSERT INTO "pq" ("nick") VALUES ('n${i}')`),
       ),
     );
-    expect(new Set(ids).size).toBe(5);
-    expect([...ids].sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5]);
+    expect(new Set(ids).size).toBe(n);
+    expect([...ids].sort((a, b) => a - b)).toEqual(Array.from({ length: n }, (_, i) => i + 1));
   });
 
   it("errors when a write is routed through execute while preventing writes", async () => {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -530,24 +530,32 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       // check_if_write_query uses (abstract-adapter.ts) — so the readonly guard
       // and the affected-rows gate can never disagree.
       const isWrite = this.isWriteQuery(sql);
-      // `.all()` throws on a non-row-returning statement (better-sqlite3), so
-      // readers take `.all()` and everything else `.run()`. `.run()`'s per-
-      // statement `changes` is NOT used: it is 0 for DDL, whereas Rails' source
-      // (`raw_connection.changes` = sqlite3_changes()) counts only DML and is
-      // preserved across DDL/COMMIT — see _readBackChanges.
+      // Reads take `.all()` (rows); everything else — writes (incl.
+      // `INSERT … RETURNING`) and transaction-control — takes `.run()`, whose
+      // RunResult carries the affected-row count and insert rowid ATOMICALLY.
+      // Sourcing those from `.run()` (not a separate `SELECT changes()`) is
+      // essential: concurrent inserts (Promise.all) interleave at await points,
+      // and a follow-up `last_insert_rowid()` read would report another
+      // statement's rowid. Gating on `!isWrite` also keeps a `SELECT`, which is
+      // reader=true, on the `.all()` path; a write is never misread as a reader
+      // because isWriteQuery classifies INSERT/UPDATE/DELETE/DDL as writes.
       let rows: Record<string, unknown>[];
-      if (stmt.reader) {
+      if (stmt.reader && !isWrite) {
         rows = (await stmt.all(driverBinds)) as Record<string, unknown>[];
       } else {
-        await stmt.run(driverBinds);
+        const result = await stmt.run(driverBinds);
+        // Only a write advances the counts (Rails' @last_affected_rows /
+        // last_insert_rowid); BEGIN/COMMIT/ROLLBACK/SAVEPOINT/RELEASE leave the
+        // last write's values intact. DDL takes this branch too and reports
+        // changes = 0 — a small deviation from Rails' sqlite3_changes(), which
+        // is preserved across DDL; matching that would need a per-statement
+        // handle read that isn't atomic under concurrency, and no caller reads
+        // affected_rows after a DDL (it is consumed right after its DML).
+        if (isWrite) {
+          this._lastAffectedRows = Number(result.changes ?? 0);
+          this._lastInsertRowid = result.lastInsertRowid;
+        }
         rows = [];
-      }
-      if (isWrite) {
-        // Rails reads raw_connection.changes / last_insert_rowid from the handle
-        // after every statement; only a write advances them. Gated on isWrite so
-        // reads and transaction-control (BEGIN/COMMIT/…) leave the last write's
-        // counts intact, as sqlite3_changes() does.
-        await this._readBackChanges();
       }
       // Rails' perform_query: `verified!` after @last_affected_rows, success
       // path only — a successful round-trip proves the connection is live.
@@ -557,21 +565,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     } finally {
       this.dirtyCurrentTransaction();
     }
-  }
-
-  // Rails' `@last_affected_rows = raw_connection.changes`. `changes()` and
-  // `last_insert_rowid()` are handle-level and survive intervening reads, so
-  // this reports the last write even though it runs as a separate statement.
-  private async _readBackChanges(): Promise<void> {
-    const stmt = await this._cachedStatement(
-      "SELECT changes() AS changes, last_insert_rowid() AS last_insert_rowid",
-    );
-    const row = (await stmt.get([])) as
-      | { changes: number | bigint; last_insert_rowid: number | bigint }
-      | undefined;
-    if (!row) return;
-    this._lastAffectedRows = Number(row.changes);
-    this._lastInsertRowid = row.last_insert_rowid;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -74,6 +74,7 @@ import {
   returningColumnValues as sqliteReturningColumnValues,
   buildTruncateStatement as sqliteBuildTruncateStatement,
   castResult as sqliteCastResult,
+  affectedRows as sqliteAffectedRows,
 } from "./sqlite3/database-statements.js";
 import { Result } from "../result.js";
 import { isWriteQuerySql } from "./sql-classification.js";
@@ -290,7 +291,8 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   private _readonly: boolean;
   private _strict: boolean;
   private _preventWrites = false;
-  private _lastAffectedRows = 0;
+  /** @internal Rails' `@last_affected_rows`; read by the affected_rows port. */
+  _lastAffectedRows = 0;
   private _lastInsertRowid: number | bigint = 0;
   private _nativeTypeMap: TypeMap;
   private _memoryDatabase: boolean;
@@ -502,6 +504,13 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
    * on a non-row-returning statement, so DDL/INSERT/UPDATE/DELETE take
    * `.run()` and yield an empty result.
    *
+   * NOTE: `sqlite3/database-statements.ts` also exports a `performQuery`. That
+   * one is an unwired port written against better-sqlite3's native sync API
+   * (raw connection, spread binds), which is not the async driver abstraction
+   * this adapter talks to, so it cannot be called from here as-is. Converging
+   * the two is tracked separately; until then this is the live primitive and
+   * that one has no callers.
+   *
    * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3::DatabaseStatements#perform_query
    */
   private async _performQuery(
@@ -510,6 +519,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     notificationPayload: Record<string, unknown>,
   ): Promise<Record<string, unknown>[]> {
     const stmt = await this._cachedStatement(sql);
+    const isWrite = isWriteQuerySql(sql);
     let rows: Record<string, unknown>[];
     if (stmt.reader) {
       rows = (await stmt.all(driverBinds)) as Record<string, unknown>[];
@@ -518,13 +528,20 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       // handle (`raw_connection.changes`) after every statement; better-sqlite3
       // exposes no such property, so read it back through SQL rather than leave
       // `_lastAffectedRows` stale from an earlier write.
-      if (isWriteQuerySql(sql)) await this._readBackChanges();
+      if (isWrite) await this._readBackChanges();
     } else {
       const result = await stmt.run(driverBinds);
       this._lastAffectedRows = result.changes;
       this._lastInsertRowid = result.lastInsertRowid;
       rows = [];
     }
+    // Dirtying belongs to the primitive, not to one entry point: `execute` now
+    // runs writes too, and Rails dirties from with_raw_connection's ensure
+    // (abstract_adapter.rb:1046) rather than from a write-only path. This path
+    // doesn't route through withRawConnection — where trails already mirrors
+    // that ensure — so dirty here, gated on the statement being a write to
+    // leave read behavior as it is.
+    if (isWrite) this.dirtyCurrentTransaction();
     notificationPayload.row_count = rows.length;
     return rows;
   }
@@ -545,12 +562,13 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   }
 
   /**
-   * Rows affected by the most recent write.
+   * Rows affected by the most recent write. Rails takes the statement result
+   * and ignores it, reading `@last_affected_rows` instead.
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3::DatabaseStatements#affected_rows
    */
-  affectedRows(): number {
-    return this._lastAffectedRows;
+  affectedRows(result?: unknown): number {
+    return sqliteAffectedRows.call(this, result);
   }
 
   // A statement prepared outside the pool — Rails' non-`prepare` branch, which
@@ -649,7 +667,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     return Notifications.instrumentAsync("sql.active_record", payload, async () => {
       try {
         await this._performQuery(sql, driverBinds, payload);
-        this.dirtyCurrentTransaction();
         // perform_query reports the returned-row count (0 for a write); this
         // path has always reported affected rows, and subscribers rely on it.
         payload.row_count = this._lastAffectedRows;

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -33,7 +33,6 @@ import {
 import { execInsertReturningReadback } from "./abstract/database-statements.js";
 import { StatementPool as GenericStatementPool } from "./statement-pool.js";
 import {
-  ReadOnlyError,
   StatementInvalid,
   RecordNotUnique,
   InvalidForeignKey,
@@ -291,6 +290,8 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   private _readonly: boolean;
   private _strict: boolean;
   private _preventWrites = false;
+  private _lastAffectedRows = 0;
+  private _lastInsertRowid: number | bigint = 0;
   private _nativeTypeMap: TypeMap;
   private _memoryDatabase: boolean;
   private _filename: string;
@@ -445,10 +446,11 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   }
 
   /**
-   * Execute a SELECT query and return rows. Wrapped in a
-   * `sql.active_record` instrumentation event — mirrors Rails'
-   * `AbstractAdapter#log`, so LogSubscriber / ExplainSubscriber /
-   * QueryCache / custom subscribers all observe the same query stream.
+   * Execute a statement and return its rows (empty for a statement that
+   * returns none, e.g. DDL). Wrapped in a `sql.active_record`
+   * instrumentation event — mirrors Rails' `AbstractAdapter#log`, so
+   * LogSubscriber / ExplainSubscriber / QueryCache / custom subscribers all
+   * observe the same query stream.
    */
   async execute(
     sql: string,
@@ -458,8 +460,31 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     sql = this.preprocessQuery(sql);
     await this.materializeTransactions();
 
+    const payload = this._notificationPayload(sql, binds, name);
+    // Type-cast binds to driver-compatible primitives. Phase 2 threads
+    // bind values through the visitor rather than inlining them, so the
+    // `execute` path now receives non-empty bind arrays where it received
+    // empty ones before.
+    const driverBinds = binds.map(_driverBind, this) as SqliteBinds;
+    return Notifications.instrumentAsync("sql.active_record", payload, async () => {
+      try {
+        return await this._performQuery(sql, driverBinds, payload);
+      } catch (e: any) {
+        const translated = this._translateException(e, sql, binds);
+        throw translated;
+      }
+    });
+  }
+
+  // Mirrors the `notification_payload` Rails' raw_execute builds before
+  // dispatching to perform_query.
+  private _notificationPayload(
+    sql: string,
+    binds: unknown[],
+    name: string,
+  ): Record<string, unknown> {
     const txPublic = this.currentTransaction().userTransaction;
-    const payload: Record<string, unknown> = {
+    return {
       sql,
       name,
       binds,
@@ -468,22 +493,64 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       row_count: 0,
       transaction: txPublic.isOpen() ? txPublic : null,
     };
-    // Type-cast binds to driver-compatible primitives. Phase 2 threads
-    // bind values through the visitor rather than inlining them, so the
-    // `execute` path now receives non-empty bind arrays where it received
-    // empty ones before.
-    const driverBinds = binds.map(_driverBind, this) as SqliteBinds;
-    return Notifications.instrumentAsync("sql.active_record", payload, async () => {
-      try {
-        const stmt = await this._cachedStatement(sql);
-        const rows = (await stmt.all(driverBinds)) as Record<string, unknown>[];
-        payload.row_count = rows.length;
-        return rows;
-      } catch (e: any) {
-        const translated = this._translateException(e, sql, binds);
-        throw translated;
-      }
-    });
+  }
+
+  /**
+   * The single SQL primitive: run a statement and return its rows, branching
+   * on whether it returns any. `stmt.reader` is better-sqlite3's analogue of
+   * the `stmt.column_count.zero?` check Rails branches on — `.all()` throws
+   * on a non-row-returning statement, so DDL/INSERT/UPDATE/DELETE take
+   * `.run()` and yield an empty result.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3::DatabaseStatements#perform_query
+   */
+  private async _performQuery(
+    sql: string,
+    driverBinds: SqliteBinds,
+    notificationPayload: Record<string, unknown>,
+  ): Promise<Record<string, unknown>[]> {
+    const stmt = await this._cachedStatement(sql);
+    let rows: Record<string, unknown>[];
+    if (stmt.reader) {
+      rows = (await stmt.all(driverBinds)) as Record<string, unknown>[];
+      // A row-returning statement can still be a write (`INSERT ... RETURNING`),
+      // and `.all()` discards the affected-row count. Rails reads it from the
+      // handle (`raw_connection.changes`) after every statement; better-sqlite3
+      // exposes no such property, so read it back through SQL rather than leave
+      // `_lastAffectedRows` stale from an earlier write.
+      if (isWriteQuerySql(sql)) await this._readBackChanges();
+    } else {
+      const result = await stmt.run(driverBinds);
+      this._lastAffectedRows = result.changes;
+      this._lastInsertRowid = result.lastInsertRowid;
+      rows = [];
+    }
+    notificationPayload.row_count = rows.length;
+    return rows;
+  }
+
+  // Rails' `@last_affected_rows = raw_connection.changes`. `changes()` and
+  // `last_insert_rowid()` are handle-level and survive intervening reads, so
+  // this reports the last write even though it runs as a separate statement.
+  private async _readBackChanges(): Promise<void> {
+    const stmt = await this._cachedStatement(
+      "SELECT changes() AS changes, last_insert_rowid() AS last_insert_rowid",
+    );
+    const row = (await stmt.get([])) as
+      | { changes: number | bigint; last_insert_rowid: number | bigint }
+      | undefined;
+    if (!row) return;
+    this._lastAffectedRows = Number(row.changes);
+    this._lastInsertRowid = row.last_insert_rowid;
+  }
+
+  /**
+   * Rows affected by the most recent write.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3::DatabaseStatements#affected_rows
+   */
+  affectedRows(): number {
+    return this._lastAffectedRows;
   }
 
   // A statement prepared outside the pool — Rails' non-`prepare` branch, which
@@ -548,6 +615,15 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   }
 
   /**
+   * Folds `withPreventedWrites`' local flag into the inherited pool/replica
+   * check so the guard reaches every statement through preprocess_query's
+   * check_if_write_query, rather than only the executeMutation entry point.
+   */
+  override isPreventingWrites(): boolean {
+    return this._preventWrites || super.isPreventingWrites();
+  }
+
+  /**
    * Execute a block with writes prevented.
    */
   async withPreventedWrites<R>(fn: () => R | Promise<R>): Promise<R> {
@@ -564,36 +640,27 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
    * Wrapped in a `sql.active_record` notification — see `execute`.
    */
   async executeMutation(sql: string, binds: unknown[] = [], name: string = "SQL"): Promise<number> {
+    // preprocessQuery runs Rails' check_if_write_query, which raises
+    // ReadOnlyError while writes are prevented — see isPreventingWrites below.
     sql = this.preprocessQuery(sql);
     await this.materializeTransactions();
-    if (this._preventWrites) {
-      throw new ReadOnlyError("Write query attempted while in readonly mode: " + sql);
-    }
-    const txPublic = this.currentTransaction().userTransaction;
-    const payload: Record<string, unknown> = {
-      sql,
-      name,
-      binds,
-      type_casted_binds: typeCastedBinds(binds),
-      connection: this,
-      row_count: 0,
-      transaction: txPublic.isOpen() ? txPublic : null,
-    };
+    const payload = this._notificationPayload(sql, binds, name);
     const driverBinds = binds.map(_driverBind, this) as SqliteBinds;
     return Notifications.instrumentAsync("sql.active_record", payload, async () => {
       try {
-        const stmt = await this._cachedStatement(sql);
-        const result = await stmt.run(driverBinds);
+        await this._performQuery(sql, driverBinds, payload);
         this.dirtyCurrentTransaction();
-        payload.row_count = typeof result.changes === "number" ? result.changes : 0;
+        // perform_query reports the returned-row count (0 for a write); this
+        // path has always reported affected rows, and subscribers rely on it.
+        payload.row_count = this._lastAffectedRows;
 
         // For INSERT, return the last inserted rowid
         if (sql.trimStart().toUpperCase().startsWith("INSERT")) {
-          return Number(result.lastInsertRowid);
+          return Number(this._lastInsertRowid);
         }
 
         // For UPDATE/DELETE, return affected rows
-        return result.changes;
+        return this.affectedRows();
       } catch (e: any) {
         const translated = this._translateException(e, sql, binds);
         throw translated;

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -498,11 +498,20 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   }
 
   /**
-   * The single SQL primitive: run a statement and return its rows, branching
-   * on whether it returns any. `stmt.reader` is better-sqlite3's analogue of
-   * the `stmt.column_count.zero?` check Rails branches on — `.all()` throws
-   * on a non-row-returning statement, so DDL/INSERT/UPDATE/DELETE take
-   * `.run()` and yield an empty result.
+   * The single SQL primitive: run a statement and return its rows. Reads take
+   * `.all()`; every write (incl. `INSERT … RETURNING`) and transaction-control
+   * takes `.run()` for its atomic RunResult.
+   *
+   * Follows Rails' `perform_query` for the read/affected-rows contract, but
+   * DEVIATES on the branch axis and the RETURNING return: Rails branches on
+   * `stmt.column_count.zero?`, so `INSERT … RETURNING` (nonzero column count)
+   * comes back as `Result.new(columns, to_a)` with `row_count = 1`. Here it
+   * takes `.run()` and returns `[]` (`row_count = 0`) — deliberately, so the
+   * insert id / count come from the RunResult ATOMICALLY rather than a
+   * follow-up `last_insert_rowid()` read that races under concurrent writes.
+   * Nothing calls this expecting RETURNING rows: multi-column RETURNING
+   * read-back goes through `internalExecQuery` (`.all()`) and single-column
+   * through `executeMutation`'s rowid.
    *
    * NOTE: `sqlite3/database-statements.ts` also exports a `performQuery`. That
    * one is an unwired port written against better-sqlite3's native sync API

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -519,31 +519,35 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     notificationPayload: Record<string, unknown>,
   ): Promise<Record<string, unknown>[]> {
     const stmt = await this._cachedStatement(sql);
-    const isWrite = isWriteQuerySql(sql);
+    // Dispatch through the virtual isWriteQuery — the same predicate
+    // check_if_write_query uses (abstract-adapter.ts) — so the readonly guard,
+    // the dirty gate, and the affected-rows gate can never disagree.
+    const isWrite = this.isWriteQuery(sql);
+    // `.all()` throws on a non-row-returning statement (better-sqlite3), so
+    // readers take `.all()` and everything else `.run()`. `.run()`'s per-
+    // statement `changes` is NOT used: it is 0 for DDL, whereas Rails' source
+    // (`raw_connection.changes` = sqlite3_changes()) counts only DML and is
+    // preserved across DDL/COMMIT — see _readBackChanges.
     let rows: Record<string, unknown>[];
     if (stmt.reader) {
       rows = (await stmt.all(driverBinds)) as Record<string, unknown>[];
-      // A row-returning statement can still be a write (`INSERT ... RETURNING`),
-      // and `.all()` discards the affected-row count. Rails reads it from the
-      // handle (`raw_connection.changes`) after every statement; better-sqlite3
-      // exposes no such property, so read it back through SQL rather than leave
-      // `_lastAffectedRows` stale from an earlier write.
-      if (isWrite) await this._readBackChanges();
     } else {
-      const result = await stmt.run(driverBinds);
-      // Number(): a driver may hand back a bigint count, and this feeds both
-      // executeMutation's return value and payload.row_count.
-      this._lastAffectedRows = Number(result.changes ?? 0);
-      this._lastInsertRowid = result.lastInsertRowid;
+      await stmt.run(driverBinds);
       rows = [];
     }
-    // Dirtying belongs to the primitive, not to one entry point: `execute` now
-    // runs writes too, and Rails dirties from with_raw_connection's ensure
-    // (abstract_adapter.rb:1046) rather than from a write-only path. This path
-    // doesn't route through withRawConnection — where trails already mirrors
-    // that ensure — so dirty here, gated on the statement being a write to
-    // leave read behavior as it is.
-    if (isWrite) this.dirtyCurrentTransaction();
+    if (isWrite) {
+      // Rails reads raw_connection.changes / last_insert_rowid from the handle
+      // after every statement; only a write advances them. Gated on isWrite so
+      // reads and transaction-control (BEGIN/COMMIT/…) leave the last write's
+      // counts intact, as sqlite3_changes() does.
+      await this._readBackChanges();
+      // Dirtying belongs to the primitive, not to one entry point: `execute`
+      // now runs writes too, and Rails dirties from with_raw_connection's
+      // ensure (abstract_adapter.rb:1046) rather than a write-only path. This
+      // path doesn't route through withRawConnection — where trails already
+      // mirrors that ensure — so dirty here.
+      this.dirtyCurrentTransaction();
+    }
     notificationPayload.row_count = rows.length;
     return rows;
   }
@@ -626,12 +630,14 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   }
 
   /**
-   * Prevent or allow write operations.
+   * Prevent or allow write operations. Delegates to the predicate so this and
+   * `isPreventingWrites()` — both Rails `preventing_writes?` — cannot disagree:
+   * the getter would otherwise miss the pool/replica component.
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3Adapter#preventing_writes?
    */
   get preventingWrites(): boolean {
-    return this._preventWrites;
+    return this.isPreventingWrites();
   }
 
   /**
@@ -689,14 +695,14 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
 
   /**
    * Mirrors Rails' abstract `exec_insert` → `sql_for_insert` → `internal_exec_query`
-   * for the multi-column RETURNING read-back. `executeMutation` runs INSERTs via
-   * better-sqlite3's `.run()`, which discards RETURNING rows, so a multi-column
-   * auto-populated-columns list (Rails `_create_record` zips every returning
-   * column) would come back with only the generated id. Route just that case
-   * through the row-returning `internalExecQuery` (`.all()`, bind-aware, and it
-   * materializes the transaction) and mark the transaction dirty as
-   * `executeMutation` would. Single-column / no-RETURNING inserts keep the
-   * `executeMutation` path (its `lastInsertRowid` yields the id).
+   * for the multi-column RETURNING read-back. `executeMutation` returns a single
+   * number (the id from `lastInsertRowid` / the changes readback), not the
+   * RETURNING row set, so a multi-column auto-populated-columns list (Rails
+   * `_create_record` zips every returning column) would come back with only the
+   * generated id. Route just that case through the row-returning
+   * `internalExecQuery` (`.all()`, bind-aware, and it materializes the
+   * transaction) and mark the transaction dirty as `executeMutation` would.
+   * Single-column / no-RETURNING inserts keep the `executeMutation` path.
    */
   override async execInsert(
     sql: string,

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -518,38 +518,45 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     driverBinds: SqliteBinds,
     notificationPayload: Record<string, unknown>,
   ): Promise<Record<string, unknown>[]> {
-    const stmt = await this._cachedStatement(sql);
-    // Dispatch through the virtual isWriteQuery — the same predicate
-    // check_if_write_query uses (abstract-adapter.ts) — so the readonly guard,
-    // the dirty gate, and the affected-rows gate can never disagree.
-    const isWrite = this.isWriteQuery(sql);
-    // `.all()` throws on a non-row-returning statement (better-sqlite3), so
-    // readers take `.all()` and everything else `.run()`. `.run()`'s per-
-    // statement `changes` is NOT used: it is 0 for DDL, whereas Rails' source
-    // (`raw_connection.changes` = sqlite3_changes()) counts only DML and is
-    // preserved across DDL/COMMIT — see _readBackChanges.
-    let rows: Record<string, unknown>[];
-    if (stmt.reader) {
-      rows = (await stmt.all(driverBinds)) as Record<string, unknown>[];
-    } else {
-      await stmt.run(driverBinds);
-      rows = [];
-    }
-    if (isWrite) {
-      // Rails reads raw_connection.changes / last_insert_rowid from the handle
-      // after every statement; only a write advances them. Gated on isWrite so
-      // reads and transaction-control (BEGIN/COMMIT/…) leave the last write's
-      // counts intact, as sqlite3_changes() does.
-      await this._readBackChanges();
-      // Dirtying belongs to the primitive, not to one entry point: `execute`
-      // now runs writes too, and Rails dirties from with_raw_connection's
-      // ensure (abstract_adapter.rb:1046) rather than a write-only path. This
-      // path doesn't route through withRawConnection — where trails already
-      // mirrors that ensure — so dirty here.
+    // Rails dirties in with_raw_connection's ensure (abstract_adapter.rb:1046),
+    // gated only on materialize_transactions — NOT on read/write, and it runs
+    // even when the query raises. execute/executeMutation (the only callers)
+    // both materialize unconditionally, so dirty in a finally regardless of
+    // outcome, mirroring this adapter's `exec`. `verified!` (below), by
+    // contrast, is on Rails' success path only.
+    try {
+      const stmt = await this._cachedStatement(sql);
+      // Dispatch through the virtual isWriteQuery — the same predicate
+      // check_if_write_query uses (abstract-adapter.ts) — so the readonly guard
+      // and the affected-rows gate can never disagree.
+      const isWrite = this.isWriteQuery(sql);
+      // `.all()` throws on a non-row-returning statement (better-sqlite3), so
+      // readers take `.all()` and everything else `.run()`. `.run()`'s per-
+      // statement `changes` is NOT used: it is 0 for DDL, whereas Rails' source
+      // (`raw_connection.changes` = sqlite3_changes()) counts only DML and is
+      // preserved across DDL/COMMIT — see _readBackChanges.
+      let rows: Record<string, unknown>[];
+      if (stmt.reader) {
+        rows = (await stmt.all(driverBinds)) as Record<string, unknown>[];
+      } else {
+        await stmt.run(driverBinds);
+        rows = [];
+      }
+      if (isWrite) {
+        // Rails reads raw_connection.changes / last_insert_rowid from the handle
+        // after every statement; only a write advances them. Gated on isWrite so
+        // reads and transaction-control (BEGIN/COMMIT/…) leave the last write's
+        // counts intact, as sqlite3_changes() does.
+        await this._readBackChanges();
+      }
+      // Rails' perform_query: `verified!` after @last_affected_rows, success
+      // path only — a successful round-trip proves the connection is live.
+      this.verifiedBang();
+      notificationPayload.row_count = rows.length;
+      return rows;
+    } finally {
       this.dirtyCurrentTransaction();
     }
-    notificationPayload.row_count = rows.length;
-    return rows;
   }
 
   // Rails' `@last_affected_rows = raw_connection.changes`. `changes()` and
@@ -573,6 +580,10 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3::DatabaseStatements#affected_rows
    */
+  // The arg is optional because this doubles as trails' public accessor for the
+  // tracked count (Rails' affected_rows(result) is framework-internal and always
+  // passed the result); the port ignores it either way. executeMutation passes
+  // the perform_query result to mirror Rails' call site.
   affectedRows(result?: unknown): number {
     return sqliteAffectedRows.call(this, result);
   }
@@ -674,7 +685,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     const driverBinds = binds.map(_driverBind, this) as SqliteBinds;
     return Notifications.instrumentAsync("sql.active_record", payload, async () => {
       try {
-        await this._performQuery(sql, driverBinds, payload);
+        const result = await this._performQuery(sql, driverBinds, payload);
         // perform_query reports the returned-row count (0 for a write); this
         // path has always reported affected rows, and subscribers rely on it.
         payload.row_count = this._lastAffectedRows;
@@ -685,7 +696,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
         }
 
         // For UPDATE/DELETE, return affected rows
-        return this.affectedRows();
+        return this.affectedRows(result);
       } catch (e: any) {
         const translated = this._translateException(e, sql, binds);
         throw translated;

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -531,7 +531,9 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       if (isWrite) await this._readBackChanges();
     } else {
       const result = await stmt.run(driverBinds);
-      this._lastAffectedRows = result.changes;
+      // Number(): a driver may hand back a bigint count, and this feeds both
+      // executeMutation's return value and payload.row_count.
+      this._lastAffectedRows = Number(result.changes ?? 0);
       this._lastInsertRowid = result.lastInsertRowid;
       rows = [];
     }

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -595,10 +595,12 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3::DatabaseStatements#affected_rows
    */
-  // The arg is optional because this doubles as trails' public accessor for the
-  // tracked count (Rails' affected_rows(result) is framework-internal and always
-  // passed the result); the port ignores it either way. executeMutation passes
-  // the perform_query result to mirror Rails' call site.
+  // The arg is optional because this is only trails' public accessor for the
+  // tracked count now — Rails' framework-internal `affected_rows(result)` call
+  // site (exec_delete/exec_update) has no analogue here: executeMutation returns
+  // the count as a local from _performQuery rather than re-reading the shared
+  // field through this port, which would re-open the concurrent-write race. The
+  // port ignores the arg either way (reads @last_affected_rows).
   affectedRows(result?: unknown): number {
     return sqliteAffectedRows.call(this, result);
   }

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -470,7 +470,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     const driverBinds = binds.map(_driverBind, this) as SqliteBinds;
     return Notifications.instrumentAsync("sql.active_record", payload, async () => {
       try {
-        return await this._performQuery(sql, driverBinds, payload);
+        return (await this._performQuery(sql, driverBinds, payload)).rows;
       } catch (e: any) {
         const translated = this._translateException(e, sql, binds);
         throw translated;
@@ -526,7 +526,11 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     sql: string,
     driverBinds: SqliteBinds,
     notificationPayload: Record<string, unknown>,
-  ): Promise<Record<string, unknown>[]> {
+  ): Promise<{
+    rows: Record<string, unknown>[];
+    affectedRows: number;
+    insertRowid: number | bigint;
+  }> {
     // Rails dirties in with_raw_connection's ensure (abstract_adapter.rb:1046),
     // gated only on materialize_transactions — NOT on read/write, and it runs
     // even when the query raises. execute/executeMutation (the only callers)
@@ -539,38 +543,47 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       // check_if_write_query uses (abstract-adapter.ts) — so the readonly guard
       // and the affected-rows gate can never disagree.
       const isWrite = this.isWriteQuery(sql);
+      let rows: Record<string, unknown>[];
+      // Default to the tracked counts so a non-write (BEGIN/COMMIT/read) returns
+      // the last write's values intact, as sqlite3_changes() does.
+      let affectedRows = this._lastAffectedRows;
+      let insertRowid = this._lastInsertRowid;
       // Reads take `.all()` (rows); everything else — writes (incl.
       // `INSERT … RETURNING`) and transaction-control — takes `.run()`, whose
       // RunResult carries the affected-row count and insert rowid ATOMICALLY.
       // Sourcing those from `.run()` (not a separate `SELECT changes()`) is
-      // essential: concurrent inserts (Promise.all) interleave at await points,
-      // and a follow-up `last_insert_rowid()` read would report another
+      // essential under concurrency: `Promise.all` inserts interleave at await
+      // points, so a follow-up `last_insert_rowid()` read would report another
       // statement's rowid. Gating on `!isWrite` also keeps a `SELECT`, which is
       // reader=true, on the `.all()` path; a write is never misread as a reader
       // because isWriteQuery classifies INSERT/UPDATE/DELETE/DDL as writes.
-      let rows: Record<string, unknown>[];
       if (stmt.reader && !isWrite) {
         rows = (await stmt.all(driverBinds)) as Record<string, unknown>[];
       } else {
         const result = await stmt.run(driverBinds);
-        // Only a write advances the counts (Rails' @last_affected_rows /
-        // last_insert_rowid); BEGIN/COMMIT/ROLLBACK/SAVEPOINT/RELEASE leave the
-        // last write's values intact. DDL takes this branch too and reports
-        // changes = 0 — a small deviation from Rails' sqlite3_changes(), which
-        // is preserved across DDL; matching that would need a per-statement
-        // handle read that isn't atomic under concurrency, and no caller reads
-        // affected_rows after a DDL (it is consumed right after its DML).
         if (isWrite) {
-          this._lastAffectedRows = Number(result.changes ?? 0);
-          this._lastInsertRowid = result.lastInsertRowid;
+          // DDL takes this branch too and reports changes = 0 — a small
+          // deviation from Rails' sqlite3_changes(), which is preserved across
+          // DDL; matching it would need a handle read that isn't atomic under
+          // concurrency, and no caller reads affected_rows after a DDL (it is
+          // consumed right after its DML).
+          affectedRows = Number(result.changes ?? 0);
+          insertRowid = result.lastInsertRowid;
         }
         rows = [];
       }
+      // Persist for the affected_rows() port / public accessor. The RETURNED
+      // locals — not these fields — are what executeMutation uses for its return
+      // value: reading `this._lastInsertRowid` back after the caller's await
+      // would race, since a concurrent write's _performQuery can overwrite it
+      // between this assignment and that read.
+      this._lastAffectedRows = affectedRows;
+      this._lastInsertRowid = insertRowid;
       // Rails' perform_query: `verified!` after @last_affected_rows, success
       // path only — a successful round-trip proves the connection is live.
       this.verifiedBang();
       notificationPayload.row_count = rows.length;
-      return rows;
+      return { rows, affectedRows, insertRowid };
     } finally {
       this.dirtyCurrentTransaction();
     }
@@ -687,18 +700,21 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     const driverBinds = binds.map(_driverBind, this) as SqliteBinds;
     return Notifications.instrumentAsync("sql.active_record", payload, async () => {
       try {
-        const result = await this._performQuery(sql, driverBinds, payload);
+        // Use the values RETURNED by _performQuery, not this._last* — those
+        // fields are shared and a concurrent write can overwrite them before
+        // this post-await continuation reads them (the Promise.all insert race).
+        const { affectedRows, insertRowid } = await this._performQuery(sql, driverBinds, payload);
         // perform_query reports the returned-row count (0 for a write); this
         // path has always reported affected rows, and subscribers rely on it.
-        payload.row_count = this._lastAffectedRows;
+        payload.row_count = affectedRows;
 
         // For INSERT, return the last inserted rowid
         if (sql.trimStart().toUpperCase().startsWith("INSERT")) {
-          return Number(this._lastInsertRowid);
+          return Number(insertRowid);
         }
 
         // For UPDATE/DELETE, return affected rows
-        return this.affectedRows(result);
+        return affectedRows;
       } catch (e: any) {
         const translated = this._translateException(e, sql, binds);
         throw translated;


### PR DESCRIPTION
## What

Rails' SQLite3 adapter has **one** SQL primitive, `perform_query`
(`sqlite3/database_statements.rb:78`), which branches internally on whether the
statement returns rows and sources affected rows from a separate handle read.
trails split that path in two — `execute` (`.all()`, rows) and `executeMutation`
(`.run()`, affected rows). That split is itself the deviation, and it's why DDL
can't flow through the public `execute`: better-sqlite3's `.all()` throws on a
statement with no result columns.

This gives the sqlite3 adapter a single `_performQuery` that both `execute` and
`executeMutation` delegate to.

## How the primitive works

- **Branch:** reads take `.all()` (rows); every write — including
  `INSERT … RETURNING` — and transaction-control take `.run()`. The guard is
  `stmt.reader && !isWrite`, where `isWrite` is the virtual `this.isWriteQuery`
  (the same predicate `check_if_write_query` dispatches through, so the readonly
  guard and the affected-rows gate can't disagree).
- **Affected rows / insert id** come from the `.run()` **RunResult** and are
  **returned** from `_performQuery` as `{ rows, affectedRows, insertRowid }`; the
  caller uses those locals. Both halves matter, because these paths hold no
  connection lock across awaits: (1) an earlier revision read the counts from a
  follow-up `SELECT changes(), last_insert_rowid()`, which a concurrent
  `Promise.all` insert's `.run()` could land between — replaced by the atomic
  RunResult; (2) even then, stashing the RunResult on `this._lastInsertRowid` and
  reading that field back *after* `await _performQuery` re-opened the same race
  (a concurrent write overwrites the shared field first), so the value is
  returned and read as a local, never re-read from `this`. `has-many-through`
  duplicate-id flake, fixed. Count assignment is gated on `isWrite`, so
  `BEGIN`/`COMMIT`/`SAVEPOINT`/`RELEASE` (reads in Rails' `READ_QUERY`) leave the
  last write's counts intact.
- **Dirtying** runs in a `finally`, mirroring Rails' `with_raw_connection`
  ensure (`abstract_adapter.rb:1046`): gated only on the materialize axis (both
  callers materialize unconditionally), not on read/write, and running even when
  the statement raises. So a plain `SELECT` in an open transaction dirties it,
  and a failed write still dirties.
- **`verified!`** (`verifiedBang`) fires on the success path after the counts,
  matching Rails' `perform_query`.
- **The readonly guard** folds into `isPreventingWrites()`, so `ReadOnlyError`
  reaches every statement via `check_if_write_query` rather than only
  `executeMutation`. `affected_rows` is wired to the existing this-typed port in
  `sqlite3/database-statements.ts` so api:compare coverage points at live code.

## Documented deviations from Rails' `perform_query`

- **RETURNING return contract.** Rails branches on `column_count.zero?`, so
  `INSERT … RETURNING` comes back as rows (`row_count = 1`). Here a RETURNING
  write takes `.run()` → `[]` (`row_count = 0`), so the id/count come from the
  RunResult atomically. Nothing calls `_performQuery`/`execute` expecting
  RETURNING rows: multi-column read-back goes through `internalExecQuery`
  (`.all()`), single-column through `executeMutation`'s rowid. Stated in the
  docstring.
- **DDL `affected_rows = 0`.** Rails' `sqlite3_changes()` is preserved across
  DDL; sourcing atomically means DDL reports the RunResult's `0`. Bounded — no
  caller reads `affected_rows` after a DDL (consumed right after its DML), and
  the atomic read can't distinguish DDL from a 0-row DML anyway. Documented
  inline.

## No query-cache change

DDL still routes via `executeMutation`, so the dirties-wiring and its nesting
guard are untouched; the `times: 1` expiry tests and the DDL-dirties test from
#4858 stay green. `execUpdate`/`execDelete` funnel through `executeMutation`
(confirmed by running them), so `execute` returning `[]` for a write doesn't
leak an array through the `execute`-casting definition in
`abstract/database-statements.ts`.

## Scope

sqlite3 only, per the story's own per-adapter sequencing (sqlite3 → postgresql →
mysql2 → DDL reroute). PG's `executeMutation` carries RETURNING-append and
savepoint machinery its `execute` lacks, and the ~26 `schema-statements.ts` DDL
sites can't reroute until all three adapters branch. Registered as stories
rather than fanned out:

- `unify-execute-mutation-into-perform-query-postgresql`
- `unify-execute-mutation-into-perform-query-mysql2` (deps: postgresql)
- `converge-ddl-through-execute-drop-dirty-guard` — un-blocked; its recorded
  blocker ("#4858 still OPEN") is stale (#4858 merged as `b9f5e876c`).
- `converge-vestigial-sqlite3-perform-query` — the unwired native-sync
  `performQuery` port in `sqlite3/database-statements.ts`.
- `sqlite-regex-driver-reader-misses-returning` — node-sqlite/expo compute
  `reader` from a leading-keyword regex, so `execute("INSERT … RETURNING")`
  returns `[]` there. Pre-existing in `internalExecQuery` on main; better-sqlite3
  (the only CI/live driver) reports the real column count. With writes now always
  taking `.run()`, this no longer affects the write path.

## Test

`sqlite3-adapter-perform-query.trails.test.ts` covers the branch, the RunResult
affected-rows source, `INSERT … RETURNING` id via `.run()`, the guard on both
entry points, and dirty-on-write / dirty-on-read / dirty-on-raise, plus a
concurrent-insert smoke test (a timing race can't be reliably reproduced with
bare inserts — the reliable guard is the `has-many-through` "should respect
table alias" integration test, which reaches it through model `.create`'s denser
interleaving). Also green: sqlite3 adapter suites, associations, autosave,
nested-attributes, query-cache,
query-cache-ddl-dirties, prevent-writes, bind-parameter, reconnection,
persistence, transactions, plus the `api:calls`, `api:calls:wide`, `api:pins`
ratchets.

Closes-story: unify-execute-mutation-into-perform-query

