### PR TITLE
fix(activesupport): Instrumenter#instrument yields the payload, not the Event

### DIFF
--- a/packages/activesupport/src/notifications.test.ts
+++ b/packages/activesupport/src/notifications.test.ts
@@ -609,13 +609,17 @@ describe("Instrumenter", () => {
   });
 
   it("tracks children for nested instrumentation", () => {
-    const notifier = { publish() {} };
+    const published: Event[] = [];
+    const notifier = {
+      publish(_name: string, event: Event) {
+        published.push(event);
+      },
+    };
     const inst = new Instrumenter(notifier);
-    let parentEvent: Event | undefined;
-    inst.instrument("parent", {}, (parent) => {
-      parentEvent = parent;
+    inst.instrument("parent", {}, () => {
       inst.instrument("child", {});
     });
+    const parentEvent = published.find((e) => e.name === "parent");
     expect(parentEvent!.children).toHaveLength(1);
     expect(parentEvent!.children[0].name).toBe("child");
   });

--- a/packages/activesupport/src/notifications/instrumenter.test.ts
+++ b/packages/activesupport/src/notifications/instrumenter.test.ts
@@ -125,40 +125,5 @@ describe("InstrumenterTest", () => {
       expect(notifier.finishes).toHaveLength(1);
       expect(notifier.finishes[0].name).toBe("no.block");
     });
-
-    it("record with exception", () => {
-      const notifier = buildNotifier();
-      const payload: Record<string, unknown> = {};
-      expect(() =>
-        new Instrumenter(notifier).instrument("crash", payload, () => {
-          throw new TypeError("Oopsies");
-        }),
-      ).toThrow("Oopsies");
-      expect(payload.exception).toEqual(["TypeError", "Oopsies"]);
-      expect((payload.exception_object as Error).message).toBe("Oopsies");
-      expect(notifier.finishes).toHaveLength(1);
-    });
-
-    it("instrumentAsync yields the payload for further modification", async () => {
-      const notifier = buildNotifier();
-      const payload: Record<string, unknown> = {};
-      await new Instrumenter(notifier).instrumentAsync("awesome", payload, async (p) => {
-        p.result = 1 + 1;
-      });
-      expect(payload.result).toBe(2);
-      expect(notifier.finishes[0].payload).toEqual({ result: 2 });
-    });
-
-    it("instrumentAsync with exception", async () => {
-      const notifier = buildNotifier();
-      const payload: Record<string, unknown> = {};
-      await expect(
-        new Instrumenter(notifier).instrumentAsync("crash", payload, async () => {
-          throw new RangeError("Oopsies");
-        }),
-      ).rejects.toThrow("Oopsies");
-      expect(payload.exception).toEqual(["RangeError", "Oopsies"]);
-      expect(payload.exception_object).toBeInstanceOf(RangeError);
-    });
   });
 });

--- a/packages/activesupport/src/notifications/instrumenter.test.ts
+++ b/packages/activesupport/src/notifications/instrumenter.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { Notifications } from "../notifications.js";
-import { Event } from "./instrumenter.js";
+import { Event, Instrumenter } from "./instrumenter.js";
 import { Temporal } from "../temporal.js";
 
 describe("InstrumenterTest", () => {
@@ -84,5 +84,81 @@ describe("InstrumenterTest", () => {
       }),
     ).toThrow("boom");
     expect(events).toHaveLength(1);
+  });
+
+  describe("Instrumenter", () => {
+    const buildNotifier = () => {
+      const finishes: Event[] = [];
+      return {
+        finishes,
+        publish(_name: string, event: Event) {
+          finishes.push(event);
+        },
+      };
+    };
+
+    it("instrument", () => {
+      const notifier = buildNotifier();
+      let called = false;
+      new Instrumenter(notifier).instrument("foo", { foo: {} }, () => {
+        called = true;
+      });
+      expect(called).toBe(true);
+    });
+
+    it("instrument yields the payload for further modification", () => {
+      const notifier = buildNotifier();
+      const result = new Instrumenter(notifier).instrument(
+        "awesome",
+        {},
+        (p) => (p.result = 1 + 1),
+      );
+      expect(result).toBe(2);
+      expect(notifier.finishes).toHaveLength(1);
+      expect(notifier.finishes[0].name).toBe("awesome");
+      expect(notifier.finishes[0].payload).toEqual({ result: 2 });
+    });
+
+    it("instrument works without a block", () => {
+      const notifier = buildNotifier();
+      new Instrumenter(notifier).instrument("no.block", { foo: {} });
+      expect(notifier.finishes).toHaveLength(1);
+      expect(notifier.finishes[0].name).toBe("no.block");
+    });
+
+    it("record with exception", () => {
+      const notifier = buildNotifier();
+      const payload: Record<string, unknown> = {};
+      expect(() =>
+        new Instrumenter(notifier).instrument("crash", payload, () => {
+          throw new TypeError("Oopsies");
+        }),
+      ).toThrow("Oopsies");
+      expect(payload.exception).toEqual(["TypeError", "Oopsies"]);
+      expect((payload.exception_object as Error).message).toBe("Oopsies");
+      expect(notifier.finishes).toHaveLength(1);
+    });
+
+    it("instrumentAsync yields the payload for further modification", async () => {
+      const notifier = buildNotifier();
+      const payload: Record<string, unknown> = {};
+      await new Instrumenter(notifier).instrumentAsync("awesome", payload, async (p) => {
+        p.result = 1 + 1;
+      });
+      expect(payload.result).toBe(2);
+      expect(notifier.finishes[0].payload).toEqual({ result: 2 });
+    });
+
+    it("instrumentAsync with exception", async () => {
+      const notifier = buildNotifier();
+      const payload: Record<string, unknown> = {};
+      await expect(
+        new Instrumenter(notifier).instrumentAsync("crash", payload, async () => {
+          throw new RangeError("Oopsies");
+        }),
+      ).rejects.toThrow("Oopsies");
+      expect(payload.exception).toEqual(["RangeError", "Oopsies"]);
+      expect(payload.exception_object).toBeInstanceOf(RangeError);
+    });
   });
 });

--- a/packages/activesupport/src/notifications/instrumenter.test.ts
+++ b/packages/activesupport/src/notifications/instrumenter.test.ts
@@ -3,38 +3,46 @@ import { Notifications } from "../notifications.js";
 import { Event, Instrumenter } from "./instrumenter.js";
 import { Temporal } from "../temporal.js";
 
+// Rails' TestNotifier collects the start/finish calls; trails' notifier surface
+// is a single publish, so `finishes` collects the published events.
+const buildNotifier = () => {
+  const finishes: Event[] = [];
+  return {
+    finishes,
+    publish(_name: string, event: Event) {
+      finishes.push(event);
+    },
+  };
+};
+
 describe("InstrumenterTest", () => {
   afterEach(() => {
     Notifications.unsubscribeAll();
   });
 
   it("instrument", () => {
-    let fired = false;
-    Notifications.subscribe("foo.bar", () => {
-      fired = true;
+    const notifier = buildNotifier();
+    let called = false;
+    new Instrumenter(notifier).instrument("foo", { foo: {} }, () => {
+      called = true;
     });
-    Notifications.instrument("foo.bar", {});
-    expect(fired).toBe(true);
+    expect(called).toBe(true);
   });
 
   it("instrument yields the payload for further modification", () => {
-    let received: Record<string, unknown> = {};
-    Notifications.subscribe("foo", (e) => {
-      received = e.payload;
-    });
-    Notifications.instrument("foo", { key: "original" }, (payload) => {
-      payload.added = "modified";
-    });
-    expect(received.key).toBe("original");
-    expect(received.added).toBe("modified");
+    const notifier = buildNotifier();
+    const result = new Instrumenter(notifier).instrument("awesome", {}, (p) => (p.result = 1 + 1));
+    expect(result).toBe(2);
+    expect(notifier.finishes).toHaveLength(1);
+    expect(notifier.finishes[0].name).toBe("awesome");
+    expect(notifier.finishes[0].payload).toEqual({ result: 2 });
   });
 
   it("instrument works without a block", () => {
-    const events: Event[] = [];
-    Notifications.subscribe("foo", (e) => events.push(e));
-    Notifications.instrument("foo", { x: 1 });
-    expect(events).toHaveLength(1);
-    expect(events[0].end).toBeInstanceOf(Temporal.Instant);
+    const notifier = buildNotifier();
+    new Instrumenter(notifier).instrument("no.block", { foo: {} });
+    expect(notifier.finishes).toHaveLength(1);
+    expect(notifier.finishes[0].name).toBe("no.block");
   });
 
   it("start", () => {
@@ -84,46 +92,5 @@ describe("InstrumenterTest", () => {
       }),
     ).toThrow("boom");
     expect(events).toHaveLength(1);
-  });
-
-  describe("Instrumenter", () => {
-    const buildNotifier = () => {
-      const finishes: Event[] = [];
-      return {
-        finishes,
-        publish(_name: string, event: Event) {
-          finishes.push(event);
-        },
-      };
-    };
-
-    it("instrument", () => {
-      const notifier = buildNotifier();
-      let called = false;
-      new Instrumenter(notifier).instrument("foo", { foo: {} }, () => {
-        called = true;
-      });
-      expect(called).toBe(true);
-    });
-
-    it("instrument yields the payload for further modification", () => {
-      const notifier = buildNotifier();
-      const result = new Instrumenter(notifier).instrument(
-        "awesome",
-        {},
-        (p) => (p.result = 1 + 1),
-      );
-      expect(result).toBe(2);
-      expect(notifier.finishes).toHaveLength(1);
-      expect(notifier.finishes[0].name).toBe("awesome");
-      expect(notifier.finishes[0].payload).toEqual({ result: 2 });
-    });
-
-    it("instrument works without a block", () => {
-      const notifier = buildNotifier();
-      new Instrumenter(notifier).instrument("no.block", { foo: {} });
-      expect(notifier.finishes).toHaveLength(1);
-      expect(notifier.finishes[0].name).toBe("no.block");
-    });
   });
 });

--- a/packages/activesupport/src/notifications/instrumenter.trails.test.ts
+++ b/packages/activesupport/src/notifications/instrumenter.trails.test.ts
@@ -1,0 +1,67 @@
+// TS-only surface: Rails has no async instrument, and no test for
+// Instrumenter#instrument's rescue arm (its test_record_with_exception covers
+// Event#record, which trails' Event does not implement).
+import { describe, expect, it } from "vitest";
+import { Event, Instrumenter } from "./instrumenter.js";
+
+const buildNotifier = () => {
+  const finishes: Event[] = [];
+  return {
+    finishes,
+    publish(_name: string, event: Event) {
+      finishes.push(event);
+    },
+  };
+};
+
+describe("Instrumenter (trails)", () => {
+  it("instrument records the exception on the payload and re-raises", () => {
+    const notifier = buildNotifier();
+    const payload: Record<string, unknown> = {};
+    expect(() =>
+      new Instrumenter(notifier).instrument("crash", payload, () => {
+        throw new TypeError("Oopsies");
+      }),
+    ).toThrow("Oopsies");
+    expect(payload.exception).toEqual(["TypeError", "Oopsies"]);
+    expect((payload.exception_object as Error).message).toBe("Oopsies");
+    expect(notifier.finishes).toHaveLength(1);
+  });
+
+  // JS can throw a non-Error; Ruby cannot, so `e.class.name` has no analogue
+  // here and the fallback is what keeps payload[:exception] a [name, message]
+  // pair regardless of what was thrown.
+  it("instrument names a thrown non-Error without a constructor", () => {
+    const notifier = buildNotifier();
+    const payload: Record<string, unknown> = {};
+    expect(() =>
+      new Instrumenter(notifier).instrument("crash", payload, () => {
+        throw null;
+      }),
+    ).toThrow();
+    expect(payload.exception).toEqual(["Error", "null"]);
+    expect(payload.exception_object).toBeNull();
+  });
+
+  it("instrumentAsync yields the payload for further modification", async () => {
+    const notifier = buildNotifier();
+    const payload: Record<string, unknown> = {};
+    await new Instrumenter(notifier).instrumentAsync("awesome", payload, async (p) => {
+      p.result = 1 + 1;
+    });
+    expect(payload.result).toBe(2);
+    expect(notifier.finishes[0].payload).toEqual({ result: 2 });
+  });
+
+  it("instrumentAsync records the exception on the payload and re-raises", async () => {
+    const notifier = buildNotifier();
+    const payload: Record<string, unknown> = {};
+    await expect(
+      new Instrumenter(notifier).instrumentAsync("crash", payload, async () => {
+        throw new RangeError("Oopsies");
+      }),
+    ).rejects.toThrow("Oopsies");
+    expect(payload.exception).toEqual(["RangeError", "Oopsies"]);
+    expect(payload.exception_object).toBeInstanceOf(RangeError);
+  });
+});

--- a/packages/activesupport/src/notifications/instrumenter.trails.test.ts
+++ b/packages/activesupport/src/notifications/instrumenter.trails.test.ts
@@ -34,11 +34,17 @@ describe("Instrumenter (trails)", () => {
   it("instrument names a thrown non-Error without a constructor", () => {
     const notifier = buildNotifier();
     const payload: Record<string, unknown> = {};
-    expect(() =>
+    // Asserting the thrown value itself, not just toThrow(): a falsy throw is
+    // exactly where "did it re-raise?" and "did it swallow?" look alike.
+    let thrown: unknown = "nothing was thrown";
+    try {
       new Instrumenter(notifier).instrument("crash", payload, () => {
         throw null;
-      }),
-    ).toThrow();
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeNull();
     expect(payload.exception).toEqual(["Error", "null"]);
     expect(payload.exception_object).toBeNull();
   });

--- a/packages/activesupport/src/notifications/instrumenter.ts
+++ b/packages/activesupport/src/notifications/instrumenter.ts
@@ -48,8 +48,8 @@ export class Event {
   }
 }
 
-// Rails' `rescue Exception` arm: [e.class.name, e.message] plus the raw error,
-// so subscribers can detect a failed event.
+// Rails' `rescue Exception` arm — subscribers (e.g. ExplainSubscriber) key off
+// these to detect a failed event.
 function _recordException(payload: EventPayload, e: unknown): void {
   const error = e as { constructor?: { name?: string }; message?: unknown };
   payload.exception = [error?.constructor?.name ?? "Error", String(error?.message ?? e)];

--- a/packages/activesupport/src/notifications/instrumenter.ts
+++ b/packages/activesupport/src/notifications/instrumenter.ts
@@ -107,6 +107,12 @@ export class Instrumenter {
     }
   }
 
+  // Rails' #instrument never builds an Event — it hands the raw payload to a
+  // Fanout handle, so subscribers see the block's mutations (that is how
+  // payload[:exception] reaches them). trails routes it through an Event, which
+  // works only because Event holds the payload by reference. Rails' Event#dups
+  // it (instrumenter.rb:105); converging that dup without first moving this path
+  // off Event would silently hide the exception keys from subscribers.
   private _push(name: string, payload: EventPayload): Event {
     const event = new Event(name, Temporal.Now.instant(), payload, this.id);
     const parent = this._stack[this._stack.length - 1];

--- a/packages/activesupport/src/notifications/instrumenter.ts
+++ b/packages/activesupport/src/notifications/instrumenter.ts
@@ -48,6 +48,14 @@ export class Event {
   }
 }
 
+// Rails' `rescue Exception` arm: [e.class.name, e.message] plus the raw error,
+// so subscribers can detect a failed event.
+function _recordException(payload: EventPayload, e: unknown): void {
+  const error = e as { constructor?: { name?: string }; message?: unknown };
+  payload.exception = [error?.constructor?.name ?? "Error", String(error?.message ?? e)];
+  payload.exception_object = e;
+}
+
 export class Instrumenter {
   private _notifier: { publish(name: string, event: Event): void };
   private _stack: Event[] = [];
@@ -58,58 +66,59 @@ export class Instrumenter {
     this.id = generateTransactionId();
   }
 
+  /**
+   * The block receives the payload — the same object passed in, which
+   * subscribers read after the block returns. Mutating it is how a caller
+   * reports back into the notification, mirroring Rails' `yield payload`.
+   */
   instrument<T = void>(
     name: string,
-    payloadOrFn?: EventPayload | ((event: Event) => T),
-    fn?: (event: Event) => T,
+    payload: EventPayload = {},
+    fn?: (payload: EventPayload) => T,
   ): T {
-    let payload: EventPayload = {};
-    let callback = fn;
-    if (typeof payloadOrFn === "function") {
-      callback = payloadOrFn;
-    } else if (payloadOrFn) {
-      payload = payloadOrFn;
-    }
-    const event = new Event(name, Temporal.Now.instant(), payload, this.id);
-    const parent = this._stack[this._stack.length - 1];
-    if (parent) parent.children.push(event);
-    this._stack.push(event);
+    const event = this._push(name, payload);
 
     try {
-      if (callback) return callback(event);
+      if (fn) return fn(payload);
       return undefined as unknown as T;
+    } catch (e) {
+      _recordException(payload, e);
+      throw e;
     } finally {
-      this._stack.pop();
-      event.finish();
-      this._notifier.publish(name, event);
+      this._pop(event);
     }
   }
 
   async instrumentAsync<T = void>(
     name: string,
-    payloadOrFn?: EventPayload | ((event: Event) => Promise<T>),
-    fn?: (event: Event) => Promise<T>,
+    payload: EventPayload = {},
+    fn?: (payload: EventPayload) => Promise<T>,
   ): Promise<T> {
-    let payload: EventPayload = {};
-    let callback = fn;
-    if (typeof payloadOrFn === "function") {
-      callback = payloadOrFn;
-    } else if (payloadOrFn) {
-      payload = payloadOrFn;
+    const event = this._push(name, payload);
+
+    try {
+      if (fn) return await fn(payload);
+      return undefined as unknown as T;
+    } catch (e) {
+      _recordException(payload, e);
+      throw e;
+    } finally {
+      this._pop(event);
     }
+  }
+
+  private _push(name: string, payload: EventPayload): Event {
     const event = new Event(name, Temporal.Now.instant(), payload, this.id);
     const parent = this._stack[this._stack.length - 1];
     if (parent) parent.children.push(event);
     this._stack.push(event);
+    return event;
+  }
 
-    try {
-      if (callback) return await callback(event);
-      return undefined as unknown as T;
-    } finally {
-      this._stack.pop();
-      event.finish();
-      this._notifier.publish(name, event);
-    }
+  private _pop(event: Event): void {
+    this._stack.pop();
+    event.finish();
+    this._notifier.publish(event.name, event);
   }
 }
 


### PR DESCRIPTION
Rails' `ActiveSupport::Notifications::Instrumenter#instrument` yields the
**payload** (`vendor/rails/activesupport/lib/active_support/notifications/instrumenter.rb:56-67`)
and its `rescue Exception` arm records the error on that payload before
re-raising. trails' instance `Instrumenter` yielded the `Event` instead, and
never set the exception keys.

## Changes

- `Instrumenter#instrument` / `#instrumentAsync` now yield the payload.
- Ported the `rescue Exception` arm: `payload.exception = [name, message]` and
  `payload.exception_object = e`, matching Rails' shape.
- Dropped the trails-invented `payloadOrFn` callback-as-2nd-arg overload — Rails
  has no analogue, and payload now occupies Rails' positional slot.
- Factored the shared push/pop of the event stack out of the two methods.
- Ported the three `instrument` tests of `InstrumenterTest` onto the
  `Instrumenter` instance (see follow-up 5).

## Notes

- **No double-set of the exception keys.** The AR adapters that hand-roll
  `payload.exception` go through the *static* `Notifications.instrumentAsync`,
  which this PR does not touch.
- One trails-only test in `notifications.test.ts` ("tracks children for nested
  instrumentation") read the yielded `Event`; it now observes the same event via
  the notifier, which is what subscribers actually see.

## Test-coverage accounting (read this before trusting the row)

The `instrumenter_test.rb` row reads **9/9 matched, 0 wrong-describe, 0 TS-only
extras**, but that number overstates reality and I am not claiming it as clean:

- **3 are real ports** — the `instrument` tests this PR rewrote, now driving
  `instrumenter.instrument` against a TestNotifier equivalent.
- **6 are false positives** — `start` :48, `finish` :55, `record` :62, `record
  yields the payload for further modification` :69, `record works without a
  block` :76, `record with exception` :83. They carry Rails' names but drive the
  static `Notifications.instrument` + `subscribe`. Rails' `test_start`/`test_finish`
  (`instrumenter_test.rb:53-63`) call `instrumenter.start`/`finish`; `test_record*`
  (`:65-104`) call `new_event` then `event.record`. trails' `Instrumenter` has no
  `start`, no `finish`, no `new_event`, and `Event` has no `record` — so those six
  report coverage of methods that do not exist.

Left out of this PR for LOC, and filed as
`port-instrumenter-start-finish-record-tests` (RFC 0023). Note deleting them
would drop matched by 6 (`14448 → 14442`) — correcting false positives reads as
a negative delta, which the story calls out so the gate is judged with context.

## Review follow-ups

1. **`record with exception` mis-mapped** — the faithful instrument-with-exception
   test moved to `instrumenter.trails.test.ts`. Correction: the stale `record with
   exception` at `:83` is a *separate* mis-port and is still present — it belongs to
   the six above, not to this fix. My earlier "fixed" was half-right.
2. **Async tests are a TS-only surface** — fixed, moved to the trails-only file.
3. **`Event` payload-by-reference vs Rails' `.dup`** — noted in code, filed as
   `converge-instrumenter-event-payload-dup` (RFC 0023). Rails' `#instrument` never
   builds an `Event`: it hands the **raw payload** to a Fanout handle
   (`fanout.rb:233,245,250`), which is how `payload[:exception]` reaches
   `ExplainSubscriber`. Rails' `.dup` (`instrumenter.rb:105`) is on the `new_event` /
   `Event#record` path trails does not implement. Two divergences cancel; converging
   the `.dup` alone would silently hide the exception keys.
4. **`"Error"` fallback reachability** — reachable via `throw null` / `throw
   undefined`; JS (unlike Ruby) can throw a non-`Error`. Pinned by a test.
5. **Duplicate names shadowing the ports** — fixed. `normPath` (`test-compare.ts:114`)
   matches on `[...ancestors, description]`, so ports under an extra
   `describe("Instrumenter")` could never match `InstrumenterTest > test_instrument`.
   The extra level is gone and the three ports replace the mis-ports in place. Static
   coverage lives in `notifications.test.ts` under `InstrumentationTest`, per Rails'
   `notifications_test.rb`.
6. **Static/instance divergence** — filed
   `converge-static-notifications-instrument-delegates` (RFC 0023). Rails'
   `Notifications.instrument` (`notifications.rb:208-214`) is a thin delegator owning
   no timing, stack, or rescue arm, short-circuiting on `notifier.listening?`; trails'
   static reimplements all of it. ~151 call sites use that path, and its missing rescue
   arm is why ~16 adapter sites hand-roll the exception keys.
7. **`toThrow()` on a falsy throw** — good catch, and it is not ambiguous: I probed
   vitest directly, and no-arg `toThrow()` passes on `throw null` while failing on a
   non-throwing function. But it was pinning little, so the test now captures the
   thrown value and asserts `expect(thrown).toBeNull()` — which additionally pins that
   the rescue arm preserves identity, like Rails' `raise e`.

## Rebased onto #4892 (one deliberate conflict resolution)

#4892 landed while this was in review and edited the same test. It strengthened
`InstrumenterTest > instrument yields the payload for further modification` in place
so the static-driven test actually mutated the payload; this PR **replaces** that test
with the faithful port driving `instrumenter.instrument` against a TestNotifier. I
resolved in favour of this PR's version, so #4892's edit to that one test is gone.

That is not a revert of #4892's intent: its static payload-yield assertion lives on
main in `notifications.test.ts:265` under `InstrumentationTest` (verified against
`origin/main`), which is where Rails' `notifications_test.rb` covers the static API.
Keeping the static test here as well would only re-shadow the `InstrumenterTest`
mapping — the exact problem review point 5 identified. No other hunk conflicted.

## Tests

`instrumenter.test.ts` ports `InstrumenterTest`'s three `instrument` tests against a
TestNotifier equivalent, including a yield test that mutates the payload and asserts
the notifier observes it. TS-only coverage (both exception arms, the non-`Error`
throw, async) lives in `notifications/instrumenter.trails.test.ts`.

82 passed across the affected files (rebased onto `7ca49e74d`). Overall test:compare matched unchanged at
`14448/21663`; api:compare unchanged (`11416/16975`, arity `7438/7619`).

The `instrumenter_test.rb` row prints **9/9 matched, 0 TS-only extras**, but do not
take that at face value: it is **3 real ports + 6 false positives** that match by
name only, tracked by `port-instrumenter-start-finish-record-tests` (RFC 0023). See
the Test-coverage accounting section above for the breakdown.

Closes-story: converge-instrumenter-yield-payload


