### PR TITLE
refactor(activerecord): drop PG quoting's boolean-literal extras

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
@@ -34,11 +34,8 @@ describe("PostgreSQL quoting", () => {
   it("inherits abstract boolean SQL literals", () => {
     // Rails PG overrides none of quoted_true/quoted_false/unquoted_true/
     // unquoted_false — it inherits "TRUE"/"FALSE" and bare true/false from
-    // active_record/connection_adapters/abstract/quoting.rb:166-180. Pin the
-    // inherited values through PG's own quote/typeCast rather than through
-    // re-exports, so the dispatch itself is what's under test: inheriting the
-    // abstract pair (not MySQL/SQLite's 1/0) is why encode_array emits
-    // '{true}'.
+    // abstract/quoting.rb:166-180. Inheriting that pair (not MySQL/SQLite's
+    // 1/0) is why encode_array emits '{true}'.
     expect(quote(true)).toBe("TRUE");
     expect(quote(false)).toBe("FALSE");
     expect(typeCast(true)).toBe(true);

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
@@ -16,8 +16,6 @@ import {
   quoteDefaultExpression,
   quotedBinary,
   quotedDate,
-  quotedFalse,
-  quotedTrue,
   quoteSchemaName,
   quoteTableNameForAssignment,
   typeCast as typeCastFn,
@@ -34,10 +32,18 @@ const typeCast = (value: unknown): unknown => typeCastFn.call(HOST, value);
 
 describe("PostgreSQL quoting", () => {
   it("inherits abstract boolean SQL literals", () => {
-    // Rails PG does not override quoted_true/quoted_false — it inherits
-    // "TRUE"/"FALSE" from active_record/connection_adapters/abstract/quoting.rb:166.
-    expect(quotedTrue()).toBe("TRUE");
-    expect(quotedFalse()).toBe("FALSE");
+    // Rails PG overrides none of quoted_true/quoted_false/unquoted_true/
+    // unquoted_false — it inherits "TRUE"/"FALSE" and bare true/false from
+    // active_record/connection_adapters/abstract/quoting.rb:166-180. Pin the
+    // inherited values through PG's own quote/typeCast rather than through
+    // re-exports, so the dispatch itself is what's under test: inheriting the
+    // abstract pair (not MySQL/SQLite's 1/0) is why encode_array emits
+    // '{true}'.
+    expect(quote(true)).toBe("TRUE");
+    expect(quote(false)).toBe("FALSE");
+    expect(typeCast(true)).toBe(true);
+    expect(typeCast(false)).toBe(false);
+    expect(quote(new ArrayData(new OidArray(stringSubtype), [true, false]))).toBe("'{true,false}'");
   });
 
   it("type casts binary data to a Buffer for node-postgres bytea binding", () => {

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
@@ -36,6 +36,11 @@ describe("PostgreSQL quoting", () => {
     // unquoted_false — it inherits "TRUE"/"FALSE" and bare true/false from
     // abstract/quoting.rb:166-180. Inheriting that pair (not MySQL/SQLite's
     // 1/0) is why encode_array emits '{true}'.
+    //
+    // These pin the values, not the dispatch: abstract/quoting.ts:112,175-176
+    // call the module-level quotedTrue/unquotedTrue, where Rails self-dispatches
+    // (quoting.rb:77-78, 98-99), so an override here would not be caught. That
+    // gap is the type-casted-binds-payload-self-dispatch story's to close.
     expect(quote(true)).toBe("TRUE");
     expect(quote(false)).toBe("FALSE");
     expect(typeCast(true)).toBe(true);

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -2,6 +2,10 @@
  * PostgreSQL quoting — PostgreSQL-specific value and identifier quoting.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::Quoting
+ *
+ * No boolean-literal methods here: Rails' PostgreSQL::Quoting defines none
+ * either, inheriting the abstract pair (quoting.rb:166-180) — which is why
+ * encode_array emits '{true}', not MySQL/SQLite's '{1}'. Don't re-add them.
  */
 
 import { BinaryData } from "@blazetrails/activemodel";
@@ -44,10 +48,6 @@ const PG_INT64_MAX = BigInt("9223372036854775807");
 export const quotingConfig = {
   raiseIntWiderThan64Bit: true,
 };
-
-// This module defines no boolean-literal methods: Rails' PostgreSQL::Quoting
-// defines none either, inheriting the abstract pair (quoting.rb:166-180) — which
-// is why encode_array emits '{true}', not MySQL/SQLite's '{1}'. Don't re-add them.
 
 export interface BinaryBind {
   value: string;

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -45,10 +45,9 @@ export const quotingConfig = {
   raiseIntWiderThan64Bit: true,
 };
 
-// Rails' PostgreSQL::Quoting overrides none of the boolean literal methods —
-// it inherits "TRUE"/"FALSE" and bare true/false from abstract/quoting.rb:166-180.
-// That inheritance is why encode_array emits '{true}' rather than MySQL/SQLite's
-// '{1}'.
+// No boolean-literal methods here: Rails' PostgreSQL::Quoting defines none,
+// inheriting the abstract pair (quoting.rb:166-180) — which is why encode_array
+// emits '{true}', not MySQL/SQLite's '{1}'. Don't re-add them.
 export interface Quoting {
   quoteTableName(name: string): string;
   quoteColumnName(name: string): string;

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -8,8 +8,6 @@ import { BinaryData } from "@blazetrails/activemodel";
 import {
   quote as abstractQuote,
   quotedDate as abstractQuotedDate,
-  quotedFalse as abstractQuotedFalse,
-  quotedTrue as abstractQuotedTrue,
   typeCast as abstractTypeCast,
   type QuotingDispatchHost,
 } from "../abstract/quoting.js";
@@ -47,11 +45,11 @@ export const quotingConfig = {
   raiseIntWiderThan64Bit: true,
 };
 
+// Rails' PostgreSQL::Quoting overrides none of the boolean literal methods —
+// it inherits "TRUE"/"FALSE" and bare true/false from abstract/quoting.rb:166-180.
+// That inheritance is why encode_array emits '{true}' rather than MySQL/SQLite's
+// '{1}'.
 export interface Quoting {
-  quotedTrue(): string;
-  unquotedTrue(): boolean;
-  quotedFalse(): string;
-  unquotedFalse(): boolean;
   quoteTableName(name: string): string;
   quoteColumnName(name: string): string;
   quoteString(value: string): string;
@@ -71,22 +69,6 @@ export interface DefaultExpressionColumn {
 
 export interface TypeMapLike {
   lookup(sqlType: string): { serialize?(value: unknown): unknown } | null;
-}
-
-export function quotedTrue(): string {
-  return abstractQuotedTrue();
-}
-
-export function unquotedTrue(): boolean {
-  return true;
-}
-
-export function quotedFalse(): string {
-  return abstractQuotedFalse();
-}
-
-export function unquotedFalse(): boolean {
-  return false;
 }
 
 export function quoteTableName(name: string): string {

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -45,15 +45,9 @@ export const quotingConfig = {
   raiseIntWiderThan64Bit: true,
 };
 
-// No boolean-literal methods here: Rails' PostgreSQL::Quoting defines none,
-// inheriting the abstract pair (quoting.rb:166-180) — which is why encode_array
-// emits '{true}', not MySQL/SQLite's '{1}'. Don't re-add them.
-export interface Quoting {
-  quoteTableName(name: string): string;
-  quoteColumnName(name: string): string;
-  quoteString(value: string): string;
-  quoteBinaryColumn(value: Buffer): string;
-}
+// This module defines no boolean-literal methods: Rails' PostgreSQL::Quoting
+// defines none either, inheriting the abstract pair (quoting.rb:166-180) — which
+// is why encode_array emits '{true}', not MySQL/SQLite's '{1}'. Don't re-add them.
 
 export interface BinaryBind {
   value: string;


### PR DESCRIPTION
Rails' `PostgreSQL::Quoting` defines **none** of `quoted_true` / `quoted_false` /
`unquoted_true` / `unquoted_false`. Only `abstract/quoting.rb:166-180` (`"TRUE"` /
bare `true` / `"FALSE"` / bare `false`), `mysql/quoting.rb:72-78` and
`sqlite3/quoting.rb:83-97` define them. PG inherits the abstract pair — and that
inheritance is precisely why PG's `encode_array` emits `'{true}'` rather than
MySQL/SQLite's `'{1}'`.

Our `postgresql/quoting.ts` declared all four on its `Quoting` interface and
exported them. Two problems, both addressed here:

1. **Extra methods vs Rails** — they inflated the api:compare surface with names
   Rails does not define on this class.
2. **`unquotedTrue`/`unquotedFalse` re-implemented the abstract body** (`return
   true`) instead of delegating like their `quoted_*` neighbours did
   (`abstractQuotedTrue()`), so they would have silently stopped tracking a
   change to the abstract pair.

With the four gone, `export interface Quoting` had **zero consumers** — every
`Quoting` type reference in the repo resolves to `abstract/quoting-interface.ts`,
which `quoting-interface.test.ts` already pins on `AbstractAdapter`. Rails has no
per-adapter `Quoting` *type* either (its `module Quoting` is the method container,
not a contract), so it was a trails invention left dead by this cleanup and is
removed too. Typecheck passes without it.

## Verification

- **No production caller.** `postgresql-adapter.ts` imports twelve symbols from
  this module (`quote`, `typeCast`, `quoteTableName`, `quotedDate`,
  `quotedBinary`, …) and none of these four. `AbstractAdapter` already supplies
  the pair at `abstract-adapter.ts:832-846`, so the PG adapter resolves it via
  inheritance today — deleting is behaviour-neutral. The only caller was
  `quoting.test.ts`.
- **The test pins the inherited values, not the dispatch.** `abstract/quoting.ts:112`
  and `:175-176` call the *module-level* `quotedTrue`/`unquotedTrue`, whereas Rails
  self-dispatches (`abstract/quoting.rb:77-78`, `:98-99`) — so these assertions
  would pass even if PG overrode the pair. The values are still the right thing to
  pin (scalar `TRUE`/`FALSE`, bare `true`/`false`, and the `'{true,false}'` array
  form that depends on the inherited pair). Closing the self-dispatch gap belongs
  to the `type-casted-binds-payload-self-dispatch` story: converging one producer
  in isolation flips SQLite's `1` to `1n`, so it needs the coordinated sweep, not a
  drive-by here.
- **PG-only, as intended.** `mysql/quoting.ts` defines `unquotedTrue`/
  `unquotedFalse` only (matching `mysql/quoting.rb`, which does not override
  `quoted_*`), and `sqlite3/quoting.ts` defines all four (matching
  `sqlite3/quoting.rb`). Both are legitimate and untouched.
- **Deltas non-negative**, measured against `origin/main`:
  - api:compare — `connection_adapters/postgresql/quoting.rb` 23/23 **100%**; the
    file's extras drop **5 moved → 1 moved**; overall unchanged at
    `11416/16975 (67.3%)`.
  - test:compare — unchanged at `14448/21663 (66.7%)`.
- Typecheck, `lint:deps`, and the affected suites (`postgresql/quoting.test.ts`,
  `quoting-interface.test.ts`, `quoting.test.ts` — 91 tests) pass.

Fidelity / dead-code cleanup, not a bug fix — scoped and reviewed as such.

Closes-story: drop-pg-quoting-boolean-literal-extras