### PR TITLE
fix(arel): to-sql dispatches only Temporal types with a Ruby analogue

### DIFF
--- a/packages/arel/src/temporal-tag.ts
+++ b/packages/arel/src/temporal-tag.ts
@@ -3,9 +3,11 @@
  * Temporal checks structural rather than pulling the namespace into arel's
  * runtime imports — arel has no activesupport dependency at runtime.
  *
- * Shared by the visitors so the tag-shape knowledge lives in one place; each
- * caller maps the tag to its own Rails analogue (to-sql dispatches on
- * supported-vs-unsupported, dot labels leaf nodes with a Ruby class name).
+ * Answers only "is this a Temporal value, and which one" — the tag-to-Rails-class
+ * mapping is `temporalClassName` below, which every caller shares. This stays
+ * separate because recognizing a Temporal and having a Ruby analogue are
+ * different questions: `Duration` answers here but not there, which is how
+ * to-sql keeps an unmapped Temporal out of its `toISOString` duck-type.
  *
  * @internal
  */

--- a/packages/arel/src/temporal-tag.ts
+++ b/packages/arel/src/temporal-tag.ts
@@ -14,3 +14,38 @@ export function temporalTag(v: unknown): string | null {
   const tag = (v as Record<symbol, unknown>)[Symbol.toStringTag];
   return typeof tag === "string" && tag.startsWith("Temporal.") ? tag : null;
 }
+
+/** @internal */
+export type TemporalClassName = "Date" | "DateTime" | "Time";
+
+/**
+ * The Ruby class each Temporal type stands in for. Temporal is this codebase's
+ * Time/Date analogue, so these values have a visitable Rails ancestor
+ * (`visit_Date` / `visit_DateTime` / `visit_Time`) and dispatch onto it.
+ *
+ * Deliberately a whitelist, not a `startsWith("Temporal.")` catch-all: the
+ * Temporal types absent here (`Duration`, `PlainYearMonth`, `PlainMonthDay`)
+ * have NO visitable Rails ancestor — Rails defines no visitor for
+ * `ActiveSupport::Duration`, which is a plain `Object` subclass rather than a
+ * `Numeric` — so Rails raises on them at visitor.rb:39 and so must we.
+ *
+ * @internal
+ */
+const TEMPORAL_CLASS_NAMES: Readonly<Record<string, TemporalClassName>> = {
+  "Temporal.PlainDate": "Date",
+  "Temporal.PlainDateTime": "DateTime",
+  "Temporal.Instant": "Time",
+  "Temporal.ZonedDateTime": "Time",
+  "Temporal.PlainTime": "Time",
+};
+
+/**
+ * The Ruby class Rails would dispatch `v` on, or `null` when `v` is not a
+ * Temporal value or is one with no Ruby analogue.
+ *
+ * @internal
+ */
+export function temporalClassName(v: unknown): TemporalClassName | null {
+  const tag = temporalTag(v);
+  return tag === null ? null : (TEMPORAL_CLASS_NAMES[tag] ?? null);
+}

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -4,34 +4,9 @@ import { Table } from "../table.js";
 import { Visitor, type NodeCtor } from "./visitor.js";
 import { PlainString } from "../collectors/plain-string.js";
 import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
-import { temporalTag } from "../temporal-tag.js";
+import { temporalClassName } from "../temporal-tag.js";
 
 type AppendableCollector = { append(s: string): unknown; value: string };
-
-/**
- * The Ruby class each Temporal type stands in for. Temporal is this codebase's
- * Time/Date analogue, so these values have a visitable Rails ancestor
- * (`visit_Date` / `visit_DateTime` / `visit_Time`, dot.rb:200-202) and must not
- * fall through to `visit`'s TypeError.
- *
- * Deliberately a whitelist, not a `startsWith("Temporal.")` catch-all: the
- * Temporal types absent here (`Duration`, `PlainYearMonth`, `PlainMonthDay`)
- * have NO visitable Rails ancestor — dot.rb defines no visitor for
- * `ActiveSupport::Duration`, which is a plain `Object` subclass rather than a
- * `Numeric` — so Rails raises on them at visitor.rb:39 and so must we.
- */
-const TEMPORAL_CLASS_NAMES: Readonly<Record<string, "Date" | "DateTime" | "Time">> = {
-  "Temporal.PlainDate": "Date",
-  "Temporal.PlainDateTime": "DateTime",
-  "Temporal.Instant": "Time",
-  "Temporal.ZonedDateTime": "Time",
-  "Temporal.PlainTime": "Time",
-};
-
-function temporalClassName(v: unknown): "Date" | "DateTime" | "Time" | null {
-  const tag = temporalTag(v);
-  return tag === null ? null : (TEMPORAL_CLASS_NAMES[tag] ?? null);
-}
 
 function isAppendableCollector(c: unknown): c is AppendableCollector {
   if (typeof c !== "object" || c === null) return false;

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -590,7 +590,7 @@ describe("the to_sql visitor", () => {
       it("dispatches a bare Temporal on its Rails analogue", () => {
         // Temporal is the Time analogue, so an Instant must reach visit_Time
         // (`alias :visit_Time :unsupported`, to_sql.rb:844) and a PlainDate
-        // visit_Date (to_sql.rb:837) — not the generic no-handler tail.
+        // visit_Date (to_sql.rb:836) — not the generic no-handler tail.
         // Temporal exposes no toISOString, so the tag is what routes them.
         const v = new Visitors.ToSql();
         const seen: string[] = [];
@@ -651,7 +651,7 @@ describe("the to_sql visitor", () => {
 
       it("dispatches a bare Temporal.PlainDateTime on visit_DateTime", () => {
         // PlainDateTime is the DateTime analogue (`alias :visit_DateTime
-        // :unsupported`, to_sql.rb:836), not the Time one.
+        // :unsupported`, to_sql.rb:837), not the Time one.
         const v = new Visitors.ToSql();
         const seen: string[] = [];
         const spy = Object.create(v) as Record<string, unknown> & { compile(n: unknown): string };

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -623,6 +623,53 @@ describe("the to_sql visitor", () => {
         expect(seen).toEqual(["Time", "Date"]);
       });
 
+      it("does not dispatch a Temporal without a Rails analogue on visit_Time", () => {
+        // Duration/PlainYearMonth/PlainMonthDay have no visitable Rails
+        // ancestor: to_sql.rb defines no visit_ActiveSupport_Duration and
+        // ActiveSupport::Duration is a plain Object subclass, not a Numeric
+        // (duration.rb:14), so Rails finds no handler (visitor.rb:39). They
+        // must reach that same tail, not be mislabelled as a Ruby Time.
+        const v = new Visitors.ToSql();
+        const spy = Object.create(v) as Record<string, unknown> & { compile(n: unknown): string };
+        spy.visitTime = () => {
+          throw new Error("visit_Time must not be reached");
+        };
+        spy.visitDate = () => {
+          throw new Error("visit_Date must not be reached");
+        };
+        const attr = new Table("users").get("id");
+        for (const value of [
+          Temporal.Duration.from({ hours: 1 }),
+          Temporal.PlainYearMonth.from("2026-04"),
+          Temporal.PlainMonthDay.from("04-30"),
+        ]) {
+          expect(() =>
+            spy.compile(new Nodes.Equality(attr, value as unknown as Nodes.NodeOrValue)),
+          ).toThrow(Visitors.UnsupportedVisitError);
+        }
+      });
+
+      it("dispatches a bare Temporal.PlainDateTime on visit_DateTime", () => {
+        // PlainDateTime is the DateTime analogue (`alias :visit_DateTime
+        // :unsupported`, to_sql.rb:836), not the Time one.
+        const v = new Visitors.ToSql();
+        const seen: string[] = [];
+        const spy = Object.create(v) as Record<string, unknown> & { compile(n: unknown): string };
+        spy.visitDateTime = () => {
+          seen.push("DateTime");
+          throw new Visitors.UnsupportedVisitError("x");
+        };
+        expect(() =>
+          spy.compile(
+            new Nodes.Equality(
+              new Table("users").get("id"),
+              Temporal.PlainDateTime.from("2026-04-30T12:34:56") as unknown as Nodes.NodeOrValue,
+            ),
+          ),
+        ).toThrow(Visitors.UnsupportedVisitError);
+        expect(seen).toEqual(["DateTime"]);
+      });
+
       it("raises for a bare Temporal but still renders it wrapped", () => {
         // A bare Temporal raises; wrapped in Quoted it routes through quote()
         // (to_sql.rb:87-90) and still inlines, which is the only shape any AR

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -17,7 +17,7 @@ import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 export { UnsupportedVisitError };
 
 import { defaultQuoter } from "./default-quoter.js";
-import { temporalTag } from "../temporal-tag.js";
+import { temporalClassName, temporalTag, type TemporalClassName } from "../temporal-tag.js";
 export type { ArelConnection } from "./connection.js";
 import type { ArelConnection } from "./connection.js";
 
@@ -73,24 +73,26 @@ function isPlainObject(v: unknown): boolean {
   return proto === Object.prototype || proto === null;
 }
 
-// The analogue of Ruby's Date, which Rails aliases to `unsupported`
-// (to_sql.rb:837). Temporal.PlainDate is the only wall-clock-date type here.
-function isDateOnly(v: unknown): boolean {
-  return temporalTag(v) === "Temporal.PlainDate";
-}
-
-// The analogue of Ruby's Time (to_sql.rb:844, also aliased to `unsupported`).
-// Temporal is the Time analogue in this codebase, and Temporal types expose no
-// `toISOString`, so they must be matched on their tag; a JS Date (or any
-// toISOString duck-type) is an instant-in-time and maps here too.
-function isTimeLike(v: unknown): boolean {
-  if (temporalTag(v) !== null) return !isDateOnly(v);
-  return (
+// The Ruby class Rails would dispatch a date/time value on, all three of which
+// Rails aliases to `unsupported` (to_sql.rb:836-844). Temporal is the Time/Date
+// analogue in this codebase and Temporal types expose no `toISOString`, so they
+// match on their tag via the shared whitelist; a JS Date (or any toISOString
+// duck-type) is an instant-in-time and maps to Time.
+//
+// Only the whitelisted tags answer: `Duration`, `PlainYearMonth` and
+// `PlainMonthDay` have no Ruby analogue and so fall through to the same
+// no-visitable-ancestor path an arbitrary object takes, rather than being
+// mislabelled as a Time.
+function dateTimeClassName(v: unknown): TemporalClassName | null {
+  const temporalClass = temporalClassName(v);
+  if (temporalClass !== null) return temporalClass;
+  if (temporalTag(v) !== null) return null;
+  const isInstantDuckType =
     typeof v === "object" &&
     v !== null &&
     "toISOString" in v &&
-    typeof (v as { toISOString: unknown }).toISOString === "function"
-  );
+    typeof (v as { toISOString: unknown }).toISOString === "function";
+  return isInstantDuckType ? "Time" : null;
 }
 
 // Rails' UnsupportedVisitError message interpolates `object.class.name`
@@ -2113,8 +2115,14 @@ export class ToSql extends Visitor {
       return v ? this.visitTrueClass(v, collector) : this.visitFalseClass(v, collector);
     }
     if (typeof v === "symbol") return this.visitSymbol(v, collector);
-    if (isDateOnly(v)) return this.visitDate(v, collector);
-    if (isTimeLike(v)) return this.visitTime(v, collector);
+    switch (dateTimeClassName(v)) {
+      case "Date":
+        return this.visitDate(v, collector);
+      case "DateTime":
+        return this.visitDateTime(v, collector);
+      case "Time":
+        return this.visitTime(v, collector);
+    }
     if (isPlainObject(v)) return this.visitHash(v, collector);
     // Rails dispatches on the object's actual class (visitor.rb:29-30), so an
     // arbitrary object never reaches visit_Hash — it finds no handler and


### PR DESCRIPTION
Surfaced by review of #4884, which converged the identical shape in `Dot`; `to-sql.ts:98` was raised there and deferred as out of scope.

`isTimeLike` treated **any** Temporal tag that was not `Temporal.PlainDate` as
time-like, so `visitNodeOrValue` routed `Temporal.Duration`,
`Temporal.PlainYearMonth` and `Temporal.PlainMonthDay` to `visit_Time`.

Rails has no such catch-all. `Visitor#visit` (`visitor.rb:27-41`) dispatches on
`object.class` and walks `object.class.ancestors`; `to_sql.rb` defines no
`visit_ActiveSupport_Duration`, and `ActiveSupport::Duration` is a plain
`Object` subclass (`duration.rb:14` — only the nested `Scalar` is a `Numeric`),
so no ancestor answers and Rails raises at `visitor.rb:39`.

## Why it matters (the error itself is unchanged)

Worth being precise, since it narrows the story's framing: `unsupported`
interpolates the *value's* class (`to_sql.rb:828-830`), not the visitor's name, so
a `Duration` already reported `Unsupported argument type: Duration` on `main`.
Verified by probe — the raised error is byte-identical before and after.

The bug is therefore latent rather than user-visible today: it is *which*
`visit_*` method receives the value. `visit_Time` only raises because the base
class aliases it to `unsupported`; a `ToSql` subclass that overrides `visit_Time`
to actually render a time would silently render a `Duration` as one. That is the
regression this closes, and it is what the spied tests pin.

## Change

`TEMPORAL_CLASS_NAMES` moves out of `dot.ts` to sit beside `temporalTag` in
`packages/arel/src/temporal-tag.ts`, exposed as `temporalClassName`. Both
visitors now share the one whitelist instead of keeping a second, looser copy.
`to-sql` dispatches on it, so the three analogue-less types fall through to the
same no-visitable-ancestor tail an arbitrary object already takes.

`PlainDateTime` now reaches `visit_DateTime` (`to_sql.rb:837`) rather than
`visit_Time`, matching dot's mapping; both alias to `unsupported`, so the
observable error is unchanged. `Instant` / `ZonedDateTime` / `PlainTime` still
reach `visit_Time` (`rb:844`), `PlainDate` still reaches `visit_Date` (`rb:836`),
and the JS-`Date` `toISOString` duck-type still maps to Time.

## Out of scope

Trails raises `UnsupportedVisitError` at that tail where Rails raises
`TypeError, "Cannot visit ..."`. That divergence is pre-existing for *every*
unhandled object and belongs to `arel-visit-dispatches-raw-classes-like-rails`,
which retires `visitNodeOrValue` wholesale. This PR only stops `Duration` from
jumping the queue into `visit_Time`.

## Verification

- `pnpm vitest run packages/arel/src/visitors/{to-sql,dot}.test.ts` — 336 pass.
- api:compare `11416/16975` on both `origin/main` and this branch — delta **0**.
- test:compare matched `14448/21663` on both — delta **0** (TS-only extra
  4006 → 4008: the two new tests, sitting beside the existing TS-only sibling
  `dispatches a bare Temporal on its Rails analogue`; Rails has no Temporal, so
  there is no Rails test to match).

Closes-story: arel-tosql-temporal-catchall-misclassifies-duration