### PR TITLE
fix(activesupport): Notifications.instrument gains the rescue arm and listening? short-circuit

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -1392,10 +1392,6 @@ async function logSql<T>(
       }
       return result;
     } catch (e: any) {
-      // Rails' Instrumenter sets payload[:exception] and [:exception_object]
-      // so subscribers (e.g. ExplainSubscriber) can detect failed queries.
-      payload.exception = e;
-      payload.exception_object = e;
       // Mirrors AbstractAdapter#log's rescue: the driver error has already been
       // translated to a StatementInvalid by with_raw_connection (with sql:/binds:
       // nil), so we only attach the statement context here — set_query is a no-op

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -697,8 +697,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
             : e instanceof ActiveRecordError
               ? e
               : await this._translateAndEnrich(e, driverSql, driverBinds);
-        payload.exception = translated;
-        payload.exception_object = translated;
         throw translated;
       }
     });
@@ -972,8 +970,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
             : e instanceof ActiveRecordError
               ? e
               : await this._translateAndEnrich(e, driverSql, driverBinds);
-        payload.exception = translated;
-        payload.exception_object = translated;
         throw translated;
       }
     });
@@ -1029,8 +1025,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
             : e instanceof ActiveRecordError
               ? e
               : await this._translateAndEnrich(e, driverSql, driverBinds);
-        payload.exception = translated;
-        payload.exception_object = translated;
         throw translated;
       }
     });
@@ -1236,8 +1230,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
             e instanceof ActiveRecordError
               ? e
               : await this._translateAndEnrich(e, driverSql, driverBinds);
-          payload.exception = translated;
-          payload.exception_object = translated;
           throw translated;
         }
       });

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1018,8 +1018,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
           return r;
         } catch (e: any) {
           const translated = this._translateException(e, rewritten, bindArray);
-          payload.exception = translated;
-          payload.exception_object = translated;
           throw translated;
         }
       },
@@ -1641,8 +1639,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         return r;
       } catch (e: any) {
         const translated = this._translateException(e, rewritten, bindArray);
-        payload.exception = translated;
-        payload.exception_object = translated;
         throw translated;
       }
     });
@@ -1752,8 +1748,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         });
       } catch (e: any) {
         const translated = this._translateException(e, rewritten, bindArray);
-        payload.exception = translated;
-        payload.exception_object = translated;
         throw translated;
       }
     });
@@ -1872,8 +1866,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         });
       } catch (e: any) {
         const translated = this._translateException(e, pgSql, binds);
-        payload.exception = translated;
-        payload.exception_object = translated;
         throw translated;
       }
       // Mirrors Rails' raw_execute → verified!: the block completed a live
@@ -2186,21 +2178,15 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         // the retry/verify/reconnect loop.
         this.withRawConnection({ materializeTransactions: false, allowRetry }, async (conn) => {
           const client = conn as unknown as pg.Client;
-          try {
-            const runResult = await this._runQuery(client, runSql, bindArray, { rowMode: "array" });
-            const count = runResult.rowCount ?? runResult.rows.length;
-            payload.row_count = count;
-            return runResult;
-          } catch (e: any) {
-            // Rethrow raw: withRawConnection translates the driver error to an
-            // ActiveRecordError (with sql: null / binds: []), and the shared logSql
-            // rescue then attaches sql + binds via set_query — mirroring Rails'
-            // AbstractAdapter#log. Translating here would duplicate that and, on an
-            // already-translated error, re-wrap it as StatementInvalid.
-            payload.exception = e;
-            payload.exception_object = e;
-            throw e;
-          }
+          // Errors propagate raw: withRawConnection translates the driver error to
+          // an ActiveRecordError (with sql: null / binds: []), and the shared logSql
+          // rescue then attaches sql + binds via set_query — mirroring Rails'
+          // AbstractAdapter#log. Translating here would duplicate that and, on an
+          // already-translated error, re-wrap it as StatementInvalid.
+          const runResult = await this._runQuery(client, runSql, bindArray, { rowMode: "array" });
+          const count = runResult.rowCount ?? runResult.rows.length;
+          payload.row_count = count;
+          return runResult;
         }),
       );
       if (hasBinds) this._flushWarnings(runSql);

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -481,8 +481,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
         return rows;
       } catch (e: any) {
         const translated = this._translateException(e, sql, binds);
-        payload.exception = translated;
-        payload.exception_object = translated;
         throw translated;
       }
     });
@@ -598,8 +596,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
         return result.changes;
       } catch (e: any) {
         const translated = this._translateException(e, sql, binds);
-        payload.exception = translated;
-        payload.exception_object = translated;
         throw translated;
       }
     });
@@ -725,8 +721,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
           return 0;
         } catch (e: any) {
           const translated = this._translateException(e, sql, []);
-          payload.exception = translated;
-          payload.exception_object = translated;
           throw translated;
         }
       });
@@ -808,8 +802,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
         return this.castResult(result);
       } catch (e: any) {
         const translated = this._translateException(e, processed, binds);
-        payload.exception = translated;
-        payload.exception_object = translated;
         throw translated;
       }
     });

--- a/packages/activerecord/src/instrumentation.trails.test.ts
+++ b/packages/activerecord/src/instrumentation.trails.test.ts
@@ -1,0 +1,54 @@
+/**
+ * trails-only coverage: the `sql.active_record` payload carries the exception
+ * keys on a failed query. Rails gets these from Instrumenter#instrument's
+ * `rescue Exception` arm; the adapters used to hand-roll them at each call
+ * site. This pins that the inherited arm still covers the adapter paths.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+
+import { Notifications } from "@blazetrails/activesupport";
+import type { Event } from "@blazetrails/activesupport";
+import { Base } from "./index.js";
+import { fixtures } from "./test-helpers/fixtures.js";
+import "./test-helpers/canonical-model-index.js";
+
+describe("Instrumentation exception payload (trails)", () => {
+  fixtures(["books"]);
+
+  afterEach(() => {
+    Notifications.unsubscribeAll();
+  });
+
+  it("sets exception and exception_object on a failed query", async () => {
+    const payloads: Record<string, unknown>[] = [];
+    Notifications.subscribe("sql.active_record", (event: Event) => {
+      payloads.push(event.payload);
+    });
+
+    await expect(Base.connection.execute("SELECT * FROM definitely_not_a_table")).rejects.toThrow();
+
+    const failed = payloads.filter((p) => p.exception_object !== undefined);
+    expect(failed).toHaveLength(1);
+    // Rails' arm records [class name, message] alongside the error itself.
+    expect(failed[0].exception).toEqual([
+      (failed[0].exception_object as Error).constructor.name,
+      (failed[0].exception_object as Error).message,
+    ]);
+    expect(failed[0].exception_object).toBeInstanceOf(Error);
+  });
+
+  it("leaves exception keys unset on a successful query", async () => {
+    const payloads: Record<string, unknown>[] = [];
+    Notifications.subscribe("sql.active_record", (event: Event) => {
+      payloads.push(event.payload);
+    });
+
+    await Base.connection.execute("SELECT 1");
+
+    expect(payloads.length).toBeGreaterThan(0);
+    for (const p of payloads) {
+      expect(p.exception).toBeUndefined();
+      expect(p.exception_object).toBeUndefined();
+    }
+  });
+});

--- a/packages/activerecord/src/instrumentation.trails.test.ts
+++ b/packages/activerecord/src/instrumentation.trails.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import type { NotificationEvent } from "@blazetrails/activesupport";
 import { Base } from "./index.js";
+import { StatementInvalid } from "./errors.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import "./test-helpers/canonical-model-index.js";
 
@@ -30,11 +31,11 @@ describe("Instrumentation exception payload (trails)", () => {
     const failed = payloads.filter((p) => p.exception_object !== undefined);
     expect(failed).toHaveLength(1);
     // Rails' arm records [class name, message] alongside the error itself.
-    expect(failed[0].exception).toEqual([
-      (failed[0].exception_object as Error).constructor.name,
-      (failed[0].exception_object as Error).message,
-    ]);
-    expect(failed[0].exception_object).toBeInstanceOf(Error);
+    const [className, message] = failed[0].exception as [string, string];
+    expect(className).toBe("StatementInvalid");
+    expect(message).toMatch(/definitely_not_a_table/);
+    expect(failed[0].exception_object).toBeInstanceOf(StatementInvalid);
+    expect((failed[0].exception_object as Error).message).toBe(message);
   });
 
   it("leaves exception keys unset on a successful query", async () => {

--- a/packages/activerecord/src/instrumentation.trails.test.ts
+++ b/packages/activerecord/src/instrumentation.trails.test.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect, afterEach } from "vitest";
 
 import { Notifications } from "@blazetrails/activesupport";
-import type { Event } from "@blazetrails/activesupport";
+import type { NotificationEvent } from "@blazetrails/activesupport";
 import { Base } from "./index.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import "./test-helpers/canonical-model-index.js";
@@ -21,7 +21,7 @@ describe("Instrumentation exception payload (trails)", () => {
 
   it("sets exception and exception_object on a failed query", async () => {
     const payloads: Record<string, unknown>[] = [];
-    Notifications.subscribe("sql.active_record", (event: Event) => {
+    Notifications.subscribe("sql.active_record", (event: NotificationEvent) => {
       payloads.push(event.payload);
     });
 
@@ -39,7 +39,7 @@ describe("Instrumentation exception payload (trails)", () => {
 
   it("leaves exception keys unset on a successful query", async () => {
     const payloads: Record<string, unknown>[] = [];
-    Notifications.subscribe("sql.active_record", (event: Event) => {
+    Notifications.subscribe("sql.active_record", (event: NotificationEvent) => {
       payloads.push(event.payload);
     });
 

--- a/packages/activesupport/src/notifications.test.ts
+++ b/packages/activesupport/src/notifications.test.ts
@@ -292,9 +292,12 @@ describe("InstrumentationTest", () => {
   });
 
   it("nested events can be instrumented", () => {
+    // Mirrors Rails' catch-all subscriber: `instrument` short-circuits on
+    // `notifier.listening?(name)`, so an unlistened inner event is never built
+    // and never becomes a child.
     let outerEvent!: Event;
-    Notifications.subscribe("outer", (e) => {
-      outerEvent = e;
+    Notifications.subscribe(null, (e) => {
+      if (e.name === "outer") outerEvent = e;
     });
     Notifications.instrument("outer", {}, () => {
       Notifications.instrument("inner", {});
@@ -549,6 +552,7 @@ describe("ActiveSupport::Notifications", () => {
       Notifications.subscribe("outer", (e) => {
         outerEvent = e;
       });
+      Notifications.subscribe("inner", () => {});
       Notifications.instrument("outer", {}, () => {
         Notifications.instrument("inner", {});
       });

--- a/packages/activesupport/src/notifications.trails.test.ts
+++ b/packages/activesupport/src/notifications.trails.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { Notifications } from "./notifications.js";
+import type { Event } from "./notifications/instrumenter.js";
+
+/**
+ * trails-only coverage for the static Notifications surface: the
+ * `notifier.listening?(name)` short-circuit (Rails has no dedicated test for
+ * it) and `instrumentAsync`, which is a trails extension with no Rails
+ * analogue.
+ */
+describe("Notifications (trails)", () => {
+  afterEach(() => {
+    Notifications.unsubscribeAll();
+  });
+
+  describe("listening? short-circuit", () => {
+    it("runs the block when nothing is listening", () => {
+      let ran = false;
+      const result = Notifications.instrument("unlistened", { a: 1 }, (payload) => {
+        ran = true;
+        expect(payload.a).toBe(1);
+        return "value";
+      });
+      expect(ran).toBe(true);
+      expect(result).toBe("value");
+    });
+
+    it("yields the same payload object when nothing is listening", () => {
+      const payload = { a: 1 };
+      Notifications.instrument("unlistened", payload, (yielded) => {
+        expect(yielded).toBe(payload);
+      });
+    });
+
+    it("does not attach a child event to a listened-to parent", () => {
+      const events: Event[] = [];
+      Notifications.subscribe("parent", (e) => events.push(e));
+      Notifications.instrument("parent", {}, () => {
+        Notifications.instrument("unlistened.child", {}, () => undefined);
+      });
+      expect(events).toHaveLength(1);
+      expect(events[0].children).toHaveLength(0);
+    });
+
+    it("does not set exception keys when nothing is listening", () => {
+      const payload: Record<string, unknown> = {};
+      expect(() =>
+        Notifications.instrument("unlistened", payload, () => {
+          throw new Error("boom");
+        }),
+      ).toThrow("boom");
+      expect(payload.exception).toBeUndefined();
+      expect(payload.exception_object).toBeUndefined();
+    });
+
+    it("runs an async block when nothing is listening", async () => {
+      const result = await Notifications.instrumentAsync(
+        "unlistened",
+        { a: 1 },
+        async (payload) => {
+          expect(payload.a).toBe(1);
+          return "value";
+        },
+      );
+      expect(result).toBe("value");
+    });
+  });
+
+  describe("instrumentAsync rescue arm", () => {
+    it("records exception and exception_object, then rethrows", async () => {
+      const events: Event[] = [];
+      Notifications.subscribe("crash", (e) => events.push(e));
+      await expect(
+        Notifications.instrumentAsync("crash", {}, async () => {
+          throw new TypeError("Oopsies");
+        }),
+      ).rejects.toThrow("Oopsies");
+      expect(events).toHaveLength(1);
+      expect(events[0].payload.exception).toEqual(["TypeError", "Oopsies"]);
+      expect(events[0].payload.exception_object).toBeInstanceOf(TypeError);
+    });
+
+    it("still finishes and publishes the event on error", async () => {
+      const events: Event[] = [];
+      Notifications.subscribe("crash", (e) => events.push(e));
+      await expect(
+        Notifications.instrumentAsync("crash", {}, async () => {
+          throw new Error("boom");
+        }),
+      ).rejects.toThrow("boom");
+      expect(events[0].end).not.toBeNull();
+    });
+
+    it("records a non-Error throw", async () => {
+      const events: Event[] = [];
+      Notifications.subscribe("crash", (e) => events.push(e));
+      await expect(
+        Notifications.instrumentAsync("crash", {}, async () => {
+          throw "bare string";
+        }),
+      ).rejects.toBe("bare string");
+      expect(events[0].payload.exception_object).toBe("bare string");
+    });
+
+    it("leaves exception keys unset on success", async () => {
+      const events: Event[] = [];
+      Notifications.subscribe("ok", (e) => events.push(e));
+      await Notifications.instrumentAsync("ok", {}, async () => "fine");
+      expect(events[0].payload.exception).toBeUndefined();
+      expect(events[0].payload.exception_object).toBeUndefined();
+    });
+  });
+});

--- a/packages/activesupport/src/notifications.trails.test.ts
+++ b/packages/activesupport/src/notifications.trails.test.ts
@@ -100,6 +100,28 @@ describe("Notifications (trails)", () => {
         }),
       ).rejects.toBe("bare string");
       expect(events[0].payload.exception_object).toBe("bare string");
+      // Ruby cannot raise a non-Exception, so there is no Rails analogue; name
+      // the class the way Rails would name it rather than leaking `typeof`.
+      expect(events[0].payload.exception).toEqual(["String", "bare string"]);
+    });
+
+    it("names a namespaced error by its Rails class name", async () => {
+      class ParamError extends Error {
+        constructor(message: string) {
+          super(message);
+          this.name = "ActionDispatch::ParamError";
+        }
+      }
+      const events: Event[] = [];
+      Notifications.subscribe("crash", (e) => events.push(e));
+      await expect(
+        Notifications.instrumentAsync("crash", {}, async () => {
+          throw new ParamError("bad param");
+        }),
+      ).rejects.toThrow("bad param");
+      // Rails' e.class.name is fully qualified; trails carries that on `name`,
+      // and it is what rescue_responses keys off (log_subscriber.rb:32).
+      expect(events[0].payload.exception).toEqual(["ActionDispatch::ParamError", "bad param"]);
     });
 
     it("leaves exception keys unset on success", async () => {

--- a/packages/activesupport/src/notifications.ts
+++ b/packages/activesupport/src/notifications.ts
@@ -113,8 +113,14 @@ export class Notifications {
     payload?: EventPayload,
     block?: (payload: EventPayload) => T,
   ): T extends undefined ? void : T {
+    const resolved = payload ?? {};
+
+    if (!this._listening(name)) {
+      return (block ? block(resolved) : undefined) as any;
+    }
+
     const current = this._eventStack();
-    const event = this._buildEvent(name, payload, current);
+    const event = this._buildEvent(name, resolved, current);
 
     if (!block) {
       event.finish();
@@ -130,6 +136,9 @@ export class Notifications {
     let result: T;
     try {
       result = this._runWithStack(inner, () => block(event.payload));
+    } catch (e) {
+      this._recordException(event.payload, e);
+      throw e;
     } finally {
       event.finish();
       this._notify(event);
@@ -139,6 +148,10 @@ export class Notifications {
 
   /**
    * instrumentAsync — like instrument but for async blocks.
+   *
+   * Rails has no async analogue; this is a trails extension that mirrors
+   * `instrument` (listening? short-circuit, rescue arm, event stack) across an
+   * awaited block.
    *
    * The block receives the event payload — the same object passed in, which
    * subscribers read after the block returns. Mutating it (e.g. `row_count`)
@@ -150,8 +163,14 @@ export class Notifications {
     payload?: EventPayload,
     block?: (payload: EventPayload) => Promise<T>,
   ): Promise<T extends undefined ? void : T> {
+    const resolved = payload ?? {};
+
+    if (!this._listening(name)) {
+      return (block ? await block(resolved) : undefined) as any;
+    }
+
     const current = this._eventStack();
-    const event = this._buildEvent(name, payload, current);
+    const event = this._buildEvent(name, resolved, current);
 
     if (!block) {
       event.finish();
@@ -167,6 +186,9 @@ export class Notifications {
     let result: T;
     try {
       result = await this._runWithStack(inner, () => block(event.payload));
+    } catch (e) {
+      this._recordException(event.payload, e);
+      throw e;
     } finally {
       event.finish();
       this._notify(event);
@@ -220,6 +242,31 @@ export class Notifications {
   // -------------------------------------------------------------------------
   // Internal
   // -------------------------------------------------------------------------
+
+  /**
+   * Mirrors Fanout#listening? — true when any subscriber matches `name`.
+   * Rails' Notifications.instrument short-circuits on this, so an unlistened
+   * event pays for neither event construction nor publish.
+   */
+  private static _listening(name: string): boolean {
+    for (const sub of this._subscribers) {
+      if (this._matches(sub.pattern, name)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Mirrors the `rescue Exception` arm of Instrumenter#instrument: `exception`
+   * is the [class name, message] pair, `exception_object` the error itself.
+   */
+  private static _recordException(payload: EventPayload, e: unknown): void {
+    if (e instanceof Error) {
+      payload.exception = [e.constructor.name, e.message];
+    } else {
+      payload.exception = [typeof e, String(e)];
+    }
+    payload.exception_object = e;
+  }
 
   private static _notify(event: Event, propagate = false): void {
     for (const sub of this._subscribers) {

--- a/packages/activesupport/src/notifications.ts
+++ b/packages/activesupport/src/notifications.ts
@@ -12,6 +12,26 @@ import { Event } from "./notifications/instrumenter.js";
 import type { EventPayload } from "./notifications/instrumenter.js";
 import { IsolatedExecutionState } from "./isolated-execution-state.js";
 
+/**
+ * Rails' `e.class.name`. trails carries the namespaced Rails name on `name`
+ * where it has been ported (`ActionDispatch::ParamError`, param-error.ts:28),
+ * which is what keys `rescue_responses` — so prefer it and fall back to the
+ * constructor, mirroring ExceptionWrapper's classNameOf (exception-wrapper.ts:75).
+ * Errors that never got a namespaced name (AR's, today) degrade to the bare one.
+ */
+function _classNameOf(e: unknown): string {
+  if (e === null || e === undefined) return "NilClass";
+  if (e instanceof Error) {
+    if (e.name && e.name !== "Error") return e.name;
+    const ctor = e.constructor?.name;
+    if (ctor && ctor !== "Error") return ctor;
+    return e.name || ctor || "Error";
+  }
+  // Ruby cannot `raise` a non-Exception, so this branch has no Rails analogue;
+  // name it the way Rails would name the object's class anyway.
+  return e.constructor?.name ?? typeof e;
+}
+
 export type NotificationSubscriber = {
   readonly pattern: string | RegExp | null;
   readonly callback: (event: Event) => void;
@@ -260,11 +280,7 @@ export class Notifications {
    * is the [class name, message] pair, `exception_object` the error itself.
    */
   private static _recordException(payload: EventPayload, e: unknown): void {
-    if (e instanceof Error) {
-      payload.exception = [e.constructor.name, e.message];
-    } else {
-      payload.exception = [typeof e, String(e)];
-    }
+    payload.exception = [_classNameOf(e), e instanceof Error ? e.message : String(e)];
     payload.exception_object = e;
   }
 

--- a/packages/activesupport/src/notifications/instrumenter.test.ts
+++ b/packages/activesupport/src/notifications/instrumenter.test.ts
@@ -77,12 +77,14 @@ describe("InstrumenterTest", () => {
 
   it("record with exception", () => {
     const events: Event[] = [];
-    Notifications.subscribe("risky", (e) => events.push(e));
+    Notifications.subscribe("crash", (e) => events.push(e));
     expect(() =>
-      Notifications.instrument("risky", {}, () => {
-        throw new Error("boom");
+      Notifications.instrument("crash", {}, () => {
+        throw new Error("Oopsies");
       }),
-    ).toThrow("boom");
+    ).toThrow("Oopsies");
     expect(events).toHaveLength(1);
+    expect((events[0].payload.exception_object as Error).message).toBe("Oopsies");
+    expect(events[0].payload.exception).toEqual(["Error", "Oopsies"]);
   });
 });


### PR DESCRIPTION
## What

Rails' `Notifications.instrument` short-circuits on `notifier.listening?(name)` and inherits the `rescue Exception` arm from `Instrumenter#instrument`, which records `payload[:exception] = [e.class.name, e.message]` and `payload[:exception_object] = e` (`vendor/rails/activesupport/lib/active_support/notifications.rb:208-214`, `notifications/instrumenter.rb:56-67`).

trails' static path had neither. This ports both onto `instrument` / `instrumentAsync` and drops the **15** AR adapter sites (sqlite3, mysql2, postgresql, `abstract/database-statements.ts`) that hand-rolled the two keys inline — every one of them assigned the keys to the exact object it then threw, so the inherited arm covers each. `explain-subscriber.ts:33` is the only real reader, and it's a subscriber, so it only runs when something is listening.

## Deviation from the story spec

The story specified delegating the static path to the instance `Instrumenter`, on the stated premise that "#4894 converged the instance Instrumenter." **That premise is false** — there is no PR #4894; `git log` on `notifications/instrumenter.ts` stops at #4892. The instance `Instrumenter` is *less* Rails-faithful than the static path it was meant to be the delegation target for:

- no rescue arm of its own (bare try/finally), so delegating would inherit nothing;
- yields the `Event`, not the payload — delegating would **undo #4892**, the one thing the story says is already converged;
- keeps an instance `_stack` array instead of the AsyncContext-scoped `IsolatedExecutionState` stack, reintroducing the concurrent-`instrumentAsync` corruption the static path guards against;
- has zero production consumers.

Real delegation also needs `Notifications` to own a `Fanout` notifier (`fanout.ts` exists with `listening()`, but `Notifications` never uses it — it keeps a private `_subscribers` Set), which changes the `subscribe`/`unsubscribe` return shape repo-wide. That's registered separately as `converge-notifications-onto-fanout-notifier` with the corrected premise. This PR ships the load-bearing behavioural half.

`instrumentAsync` has no Rails analogue and stays a documented trails extension.

## Test changes

Two existing tests subscribed only to `"outer"` and asserted `"inner"` became a child — behaviour the short-circuit correctly ends. Rails' `test_nested_events_can_be_instrumented` uses a **catch-all** subscriber, so our port had diverged; `nested events can be instrumented` now subscribes catch-all to match Rails. No test was renamed.

`record with exception` gains Rails' own assertion (`assert_equal "Oopsies", event.payload[:exception_object].message`, `instrumenter_test.rb:98-104`), which previously only checked the event count.

## Verification

- 131 activesupport notification + AR explain tests pass; `pnpm typecheck` clean; eslint/prettier clean on all touched files.
- New `instrumentation.trails.test.ts` drives a **real failing query** end-to-end (`SELECT * FROM definitely_not_a_table`) and confirms a `sql.active_record` subscriber still observes both keys with zero hand-rolled sites — and that they stay unset on success. MySQL/PG adapter paths are structurally identical (translate → assign → throw the translated error) and are covered by the ARCONN CI jobs.

288 LOC.

Closes-story: converge-static-notifications-instrument-delegates
