### PR TITLE
fix(activerecord): has_one replace removes displaced target on a new owner

### DIFF
--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -122,19 +122,30 @@ export class HasOneAssociation extends SingularAssociation {
     // transaction.
     const changed = !sameRecord(displaced, record) || record?.hasChangesToSave === true;
     this.replace(record);
-    if (changed && (this.owner as { isPersisted?: () => boolean }).isPersisted?.()) {
-      return this.persistImmediate(record, displaced);
+    if (changed) {
+      // Rails: `save &&= owner.persisted?` — a new owner does not gate the block
+      // itself, only the new record's save. The displaced record's removal still
+      // runs (in-memory nullify + `remove_inverse_instance`); `remove_target!`'s
+      // own `target.persisted? && owner.persisted?` gate skips its DB save.
+      const save = (this.owner as { isPersisted?: () => boolean }).isPersisted?.() === true;
+      return this.persistImmediate(record, displaced, save);
     }
   }
 
   /**
-   * The awaitable immediate-persist body for assignment to a *saved* owner —
-   * Rails' `HasOneAssociation#replace` transaction (has_one_association.rb:59-77):
-   * remove the displaced record, then re-derive the foreign key and save the new
-   * record. `replace` has already set the in-memory target/inverse.
+   * The awaitable immediate-persist body for `HasOneAssociation#replace`'s
+   * transaction (has_one_association.rb:64-77): remove the displaced record,
+   * then re-derive the foreign key and save the new record. `replace` has
+   * already set the in-memory target/inverse. `save` is Rails' post-`&&=` flag:
+   * false for a non-persisted owner, which both skips the transaction and gates
+   * the new record's save.
    */
-  private async persistImmediate(record: Base | null, displaced: Base | null): Promise<void> {
-    await transactionIf(this, true, async () => {
+  private async persistImmediate(
+    record: Base | null,
+    displaced: Base | null,
+    save: boolean,
+  ): Promise<void> {
+    await transactionIf(this, save, async () => {
       if (displaced && !(displaced as any).isDestroyed?.() && !sameRecord(displaced, record)) {
         const currentTarget = this.target;
         this.target = displaced;
@@ -144,9 +155,10 @@ export class HasOneAssociation extends SingularAssociation {
           this.target = currentTarget;
         }
       }
-      if (record && typeof (record as any).save === "function") {
+      if (record) {
         this.setOwnerAttributes(record);
         this.setInverseInstance(record);
+        if (!save || typeof (record as any).save !== "function") return;
         const saved = await (record as any).save();
         if (!saved) {
           this.nullifyOwnerAttributes(record);

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -158,9 +158,7 @@ export class HasOneAssociation extends SingularAssociation {
       if (record) {
         this.setOwnerAttributes(record);
         this.setInverseInstance(record);
-        if (!save || typeof (record as any).save !== "function") return;
-        const saved = await (record as any).save();
-        if (!saved) {
+        if (save && !(await record.save())) {
           this.nullifyOwnerAttributes(record);
           if (displaced) this.setOwnerAttributes(displaced);
           throw new RecordNotSaved(

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -117,16 +117,20 @@ export class HasOneAssociation extends SingularAssociation {
     if (!this.loaded) await this.loadTarget();
     const displaced = this.target;
     // Mirror Rails `replace`'s `assigning_another_record || has_changes_to_save?`
-    // gate: only touch the DB when the assignment actually changes something, so
-    // a no-op re-assignment (e.g. `writer(null)` with no target) opens no
-    // transaction.
+    // gate (:64-65): only touch the DB when the assignment actually changes
+    // something, so a no-op re-assignment (e.g. `writer(null)` with no target)
+    // opens no transaction. `hasChangesToSave` is a getter, read (not called)
+    // per #4900. The `?.` stands in for Rails' `return target unless
+    // load_target || record` (:62): with both sides nil `sameRecord` is true
+    // and this short-circuits to undefined, which is falsy — exactly where
+    // Rails would have returned.
     const changed = !sameRecord(displaced, record) || record?.hasChangesToSave === true;
     this.replace(record);
     if (changed) {
-      // Rails: `save &&= owner.persisted?` — a new owner does not gate the block
-      // itself, only the new record's save. The displaced record's removal still
-      // runs (in-memory nullify + `remove_inverse_instance`); `remove_target!`'s
-      // own `target.persisted? && owner.persisted?` gate skips its DB save.
+      // Rails: `save &&= owner.persisted?` (:66) — a new owner does not gate the
+      // block itself, only `transaction_if` (:68) and `record.save` (:75).
+      // `remove_target!` (:69) runs regardless; its own
+      // `target.persisted? && owner.persisted?` gate (:108) skips the DB save.
       const save = (this.owner as { isPersisted?: () => boolean }).isPersisted?.() === true;
       return this.persistImmediate(record, displaced, save);
     }
@@ -134,11 +138,11 @@ export class HasOneAssociation extends SingularAssociation {
 
   /**
    * The awaitable immediate-persist body for `HasOneAssociation#replace`'s
-   * transaction (has_one_association.rb:64-77): remove the displaced record,
-   * then re-derive the foreign key and save the new record. `replace` has
-   * already set the in-memory target/inverse. `save` is Rails' post-`&&=` flag:
-   * false for a non-persisted owner, which both skips the transaction and gates
-   * the new record's save.
+   * transaction (has_one_association.rb:68-81): remove the displaced record
+   * (:69), then re-derive the foreign key and save the new record (:71-80).
+   * `replace` has already set the in-memory target/inverse. `save` is Rails'
+   * post-`&&=` flag (:66): false for a non-persisted owner, which both skips
+   * the transaction (:68) and gates the new record's save (:75).
    */
   private async persistImmediate(
     record: Base | null,

--- a/packages/activerecord/src/associations/has-one-nonpersisted-owner-replace.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-nonpersisted-owner-replace.trails.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Rails' `HasOneAssociation#replace` (has_one_association.rb:64-84) does
+ * `save &&= owner.persisted?` and then `transaction_if(save)` — with `save`
+ * false the block still runs, so `remove_target!` fires for the displaced
+ * record; only `record.save` is gated. `remove_target!`'s else branch in turn
+ * gates the displaced record's *DB* save on `target.persisted? &&
+ * owner.persisted?` (:108), so a new-record owner gets the in-memory nullify
+ * plus `remove_inverse_instance` and no writes at all.
+ *
+ * trails-specific: Rails reaches this through the sync `pirate.ship = x`
+ * setter, which in JS cannot await; the awaitable `association(name).writer`
+ * is the trails-only surface that exercises the same code path, so these
+ * assertions have no verbatim Rails test to mirror.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { registerModel } from "../index.js";
+import type { HasOneAssociation } from "./has-one-association.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+import { Pirate } from "../test-helpers/models/pirate.js";
+import { Ship } from "../test-helpers/models/ship.js";
+import { assertNoQueriesMatch } from "../testing/query-assertions.js";
+
+describe("has_one replace on a non-persisted owner", () => {
+  fixtures(["ships", "pirates"]);
+
+  beforeAll(async () => {
+    registerModel(Pirate);
+    registerModel(Ship);
+    await Pirate.loadSchema();
+    await Ship.loadSchema();
+  });
+
+  it("removes the displaced target in memory without saving", async () => {
+    const persistedPirate = await Pirate.create({ catchphrase: "Arrr" });
+    const oldShip = await Ship.create({
+      name: "old ship",
+      pirate_id: Number(persistedPirate.id),
+    });
+
+    // A new-record owner carrying the same primary key: `foreign_key_present?`
+    // is true, so `load_target` still materializes the displaced DB row.
+    const newPirate = new Pirate({ id: Number(persistedPirate.id) });
+    expect(newPirate.isPersisted()).toBe(false);
+
+    const displaced = (await newPirate.association("ship").loadTarget()) as Ship;
+    expect(Number(displaced.id)).toBe(Number(oldShip.id));
+    expect(await displaced.association("pirate").loadTarget()).toBe(newPirate);
+
+    const newShip = new Ship({ name: "new ship" });
+    await assertNoQueriesMatch(/UPDATE |INSERT |DELETE /i, false, async () => {
+      await (newPirate.association("ship") as HasOneAssociation).writer(newShip);
+    });
+
+    expect(displaced.readAttribute("pirate_id")).toBeNull();
+    expect(displaced.association("pirate").target).toBeNull();
+    expect(newPirate.association("ship").target).toBe(newShip);
+    expect(newShip.isNewRecord()).toBe(true);
+
+    // The nullify is in-memory only: the DB row still points at the pirate.
+    const reloadedOld = await Ship.find(oldShip.id);
+    expect(reloadedOld.readAttribute("pirate_id")).toBe(Number(persistedPirate.id));
+  });
+});

--- a/packages/activerecord/src/associations/has-one-nonpersisted-owner-replace.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-nonpersisted-owner-replace.trails.test.ts
@@ -1,11 +1,16 @@
 /**
- * Rails' `HasOneAssociation#replace` (has_one_association.rb:64-84) does
- * `save &&= owner.persisted?` and then `transaction_if(save)` — with `save`
- * false the block still runs, so `remove_target!` fires for the displaced
- * record; only `record.save` is gated. `remove_target!`'s else branch in turn
- * gates the displaced record's *DB* save on `target.persisted? &&
- * owner.persisted?` (:108), so a new-record owner gets the in-memory nullify
- * plus `remove_inverse_instance` and no writes at all.
+ * Rails' `HasOneAssociation#replace` (has_one_association.rb:59-85) does
+ * `save &&= owner.persisted?` (:66) and then `transaction_if(save)` (:68) —
+ * with `save` false the block still runs, so `remove_target!` (:69) fires for
+ * the displaced record; only `record.save` (:75) is gated. `remove_target!`'s
+ * else branch (:104-115) in turn gates the displaced record's *DB* save on
+ * `target.persisted? && owner.persisted?` (:108), so a new-record owner gets
+ * the in-memory nullify plus `remove_inverse_instance` and no writes at all.
+ *
+ * Its `:destroy` branch (:99-103) gates only on `target.persisted?` (:101) —
+ * no `owner.persisted?` — so a `dependent: :destroy` has_one on a new-record
+ * owner *does* issue a real DELETE, outside any transaction. That asymmetry
+ * between the two branches is Rails', and both are pinned below.
  *
  * trails-specific: Rails reaches this through the sync `pirate.ship = x`
  * setter, which in JS cannot await; the awaitable `association(name).writer`
@@ -16,16 +21,19 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { registerModel } from "../index.js";
 import type { HasOneAssociation } from "./has-one-association.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { Pirate } from "../test-helpers/models/pirate.js";
+import { DestructivePirate, Pirate } from "../test-helpers/models/pirate.js";
 import { Ship } from "../test-helpers/models/ship.js";
+import { Developer } from "../test-helpers/models/developer.js";
 import { assertNoQueriesMatch } from "../testing/query-assertions.js";
 
 describe("has_one replace on a non-persisted owner", () => {
-  fixtures(["ships", "pirates"]);
+  fixtures(["ships", "pirates", "developers"]);
 
   beforeAll(async () => {
     registerModel(Pirate);
+    registerModel(DestructivePirate);
     registerModel(Ship);
+    registerModel(Developer);
     await Pirate.loadSchema();
     await Ship.loadSchema();
   });
@@ -59,5 +67,48 @@ describe("has_one replace on a non-persisted owner", () => {
     // The nullify is in-memory only: the DB row still points at the pirate.
     const reloadedOld = await Ship.find(oldShip.id);
     expect(reloadedOld.readAttribute("pirate_id")).toBe(Number(persistedPirate.id));
+  });
+
+  // Rails' :65 gate is `assigning_another_record || record.has_changes_to_save?`
+  // — re-assigning the *same* record still saves it when it has unsaved
+  // changes. `hasChangesToSave` is a getter, so the `typeof … === "function"`
+  // guard this replaced made that half of the gate unreachable.
+  it("saves a re-assigned same record that has unsaved changes", async () => {
+    const pirate = await Pirate.create({ catchphrase: "Arrr" });
+    const ship = await Ship.create({ name: "old name", pirate_id: Number(pirate.id) });
+
+    const loaded = (await pirate.association("ship").loadTarget()) as Ship;
+    loaded.name = "new name";
+    expect(loaded.hasChangesToSave).toBe(true);
+
+    await (pirate.association("ship") as HasOneAssociation).writer(loaded);
+
+    const reloaded = await Ship.find(ship.id);
+    expect(reloaded.name).toBe("new name");
+  });
+
+  it("destroys the displaced target on a dependent destroy has_one", async () => {
+    const persistedPirate = await DestructivePirate.create({ catchphrase: "Arrr" });
+    const oldShip = await Ship.create({
+      name: "doomed ship",
+      pirate_id: Number(persistedPirate.id),
+    });
+
+    const newPirate = new DestructivePirate({ id: Number(persistedPirate.id) });
+    expect(newPirate.isPersisted()).toBe(false);
+
+    const displaced = (await newPirate.association("dependentShip").loadTarget()) as Ship;
+    expect(Number(displaced.id)).toBe(Number(oldShip.id));
+
+    const newShip = new Ship({ name: "new ship" });
+    await (newPirate.association("dependentShip") as HasOneAssociation).writer(newShip);
+
+    // `remove_target!`'s :destroy branch gates only on `target.persisted?`
+    // (:101), not on `owner.persisted?` — so unlike the nullify branch above,
+    // a new-record owner really does destroy the displaced row.
+    expect(displaced.isDestroyed()).toBe(true);
+    expect(await Ship.findBy({ id: oldShip.id })).toBeNull();
+    // The new record is still unsaved: `save` is false, so :75 never runs.
+    expect(newShip.isNewRecord()).toBe(true);
   });
 });


### PR DESCRIPTION
Follow-up discovered during review of #4832.

## Problem

`HasOneAssociation#writeImmediate` branched the *entire* displaced-record removal on `owner.isPersisted()`: only a persisted owner routed through `persistImmediate` (which runs `remove_target!` + save); a non-persisted owner fell through to a bare `replace(record)` that never removed the displaced target. This predates #4832 (confirmed against `origin/main`).

Rails' `HasOneAssociation#replace` (`has_one_association.rb:59-85`) does `save &&= owner.persisted?` (`:66`) and then `transaction_if(save)` (`:68`) — with `save` false the block **still runs**, so `remove_target!` fires (`:69`); only `record.save` is gated (`:75`). `remove_target!`'s else branch (`:104-115`) itself gates the displaced record's DB save on `target.persisted? && owner.persisted?` (`:108`), so on a new owner it performs the in-memory nullify + `remove_inverse_instance` and skips the save.

Reachable when a new-record owner has its PK set (`Pirate.new({ id: 42 })`), where `foreignKeyPresent` is true and `loadTarget` can materialize a real displaced row. trails left it attached; Rails nullifies its FK in memory and clears the inverse.

## Changes

**1. `save` gate (the story).** `writeImmediate` now computes `save = owner.isPersisted()` (Rails' `:66`) and always calls `persistImmediate` when the assignment changes something, passing `save` through to `transactionIf` (`:68`) and the new record's save gate (`:75`). `removeTargetBang` already had the correct `target.persisted? && owner.persisted?` DB gate (`:108`), so a new owner gets the in-memory nullify + `removeInverseInstance` and issues no writes.

**2. Getter fix — now landed separately by #4900.** This PR originally also revived a dead `has_changes_to_save?` gate. #4900 (merged) swept that getter-vs-method bug across all association sites, including this file, and added a lint rule. After rebasing onto it, that line is identical to `main`, so this PR's diff is now just the `save`-gating fix. Left here for context:

The `has_changes_to_save?` half of Rails' `:65` gate was **unreachable** before #4900:

```ts
typeof (record as any)?.hasChangesToSave === "function" && (record as any).hasChangesToSave()
```

`hasChangesToSave` is a **getter** on `Model.prototype`, not a method — `base.ts:5178` documents this explicitly ("getters on Model.prototype; wiring via `include()` replaces the getter descriptor with a data property and breaks behavior. Category A"). So `typeof` yields `"boolean"`, never `"function"`, and the clause was always false. Consequence: re-assigning the *same* record with unsaved changes skipped the save entirely, where Rails saves it. Now reads the getter. Pinned by a new test that fails on `main` with `expected 'old name' to be 'new name'`.

## Testing

New `has-one-nonpersisted-owner-replace.trails.test.ts` — a `.trails.` file because Rails reaches this through the sync `pirate.ship = x` setter, which in JS cannot await; the awaitable `association(name).writer` is the trails-only surface, so there is no verbatim Rails test to mirror.

All three cases are genuine regression tests — each fails against `origin/main`'s `has-one-association.ts` and passes with the fix:

| Case | Failure on `main` |
| --- | --- |
| nullify branch on a new owner | `expected 959118196 to be null` |
| same-record re-assign with unsaved changes | `expected 'old name' to be 'new name'` |
| `dependent: :destroy` on a new owner | `expected false to be true` |

The `:destroy` case pins an asymmetry worth calling out: `remove_target!`'s `:destroy` branch gates only on `target.persisted?` (`:101`), **not** `owner.persisted?`, so a `dependent: :destroy` has_one on a new-record owner does issue a real DELETE outside any transaction. That is Rails' behavior (`:99-103`), and it is a behavior change this PR introduces — `main` issued no writes at all on this path. Both branches are now pinned.

No regressions: 517 passed / 11 skipped across the has_one, has_one_through, has_one_through_disable_joins, autosave, and nested-attributes suites.

## Parity

Zero delta on both, and non-negative by construction:

- **api:compare** — no methods added or removed. All three ratchets pass: `call-mismatches: OK (19 baselined)`, `wide call-mismatches: OK (6846 baselined)`, `body-pins: OK`.
- **test:compare** — unaffected; the new file is a `.trails.test.ts` with no Rails counterpart, so it is not mapped.

## Follow-up filed

Neither is fixed here, kept scoped per the one-story-per-PR rule.

**1. `set_new_record` has the same gap on the `build` path.** Rails' `set_new_record` (`:91-93`) is `replace(record, false)`, and `false` only gates `transaction_if` and `record.save` — `remove_target!` at `:69` still runs. trails' `setNewRecord` calls the in-memory-only `replace` and never removes the displaced target. Confirmed by probe against this branch: after `build`, the displaced ship keeps `pirate_id: 959118196` and its inverse is still set.

Registered as `0005-activerecord-gaps/has-one-set-new-record-displaced-removal`.

**2. The dead-getter bug has five live siblings.** `get hasChangesToSave(): boolean` is at `activemodel/src/model.ts:1952`, and `base.ts:5178` marks it Category A (never wired via `include()`), so *every* call-site treatment of it is wrong. Four are the same silently-dead `typeof … === "function"` gate fixed here — `collection-association.ts:678`, `has-many-through-association.ts:138` and `:596`, `collection-proxy.ts:4165`.

The fifth **raises**. `has-one-through-association.ts:148` reads `(record as any)?.hasChangesToSave?.()`; optional-call short-circuits only on null/undefined, so a boolean getter value hits `false?.()`. Verified by probe — a persisted owner re-assigning the same record to a `has_one_through` (`Member.hasOne("club", { through: "currentMembership" })`) raises:

```
TypeError: record?.hasChangesToSave is not a function
```

`tsc` cannot see any of this behind the `as any` casts, which is how it hid at multiple sites at once. **Fixed by #4900** (merged), which swept 10 sites and added the `no-getter-called-as-method` lint rule so it cannot reappear. This branch is rebased onto that merge.

Closes-story: has-one-nonpersisted-owner-replace-removal

