### PR TITLE
fix(associations): has_one set_new_record removes the displaced record

### DIFF
--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -430,34 +430,75 @@ export class HasOneAssociation extends SingularAssociation {
     // it here. Capture the loaded target BEFORE `super._createRecord`, which
     // builds the new record first — an invalid build (e.g. an inexistent foreign
     // key) must raise before any removal runs, exactly as Rails' `build_record`
-    // raises before `set_new_record`. An unloaded target is left to the property-
-    // setter displacement path (`queueWrite` flags), matching Rails' behaviour of
-    // only removing what `load_target` surfaces.
+    // raises before `set_new_record`.
+    //
+    // When the target was never materialized, Rails' `load_target` (:62) still
+    // surfaces and removes the existing DB row, so sample `needsLoad` here
+    // (`replace`/`setNewRecord` flip `loaded` via `loadedBang`) and let
+    // `detachDisplacedTarget` issue the find *after* `super` — after, because the
+    // find must not precede `build_record`'s `UnknownAttributeError` for a bogus
+    // reflection `foreign_key`.
     const displaced = this.loaded ? this.target : null;
+    const needsLoad = displaced === null && this.findTargetNeeded();
     const record = await super._createRecord(attributes, shouldRaise, block);
     // `super._createRecord` ran `setNewRecord` → `replace`, so `this.target` is
     // now the freshly created record; detach the displaced (previously attached)
     // one, matching `remove_target!` inside Rails' `replace`.
-    await this.detachDisplacedTarget(displaced, record);
+    await this.detachDisplacedTarget(displaced, record, needsLoad);
     return record;
   }
 
   /**
    * Detach the record displaced by a `create#{name}` / `build#{name}` over an
-   * already-**loaded** has_one target — the awaitable analog of the
-   * `remove_target!` Rails runs inside `HasOneAssociation#replace`
-   * (has_one_association.rb:69) whenever another record is assigned. Nullifies
-   * the displaced record's foreign key (or destroys/deletes it per
-   * `:dependent`). Our sync `replace`/`setNewRecord` cannot `await` that removal,
-   * so the async create/build accessors run it here after materializing the
-   * replacement. A no-op unless a *different*, non-destroyed record was loaded.
+   * existing has_one target — the awaitable analog of the `remove_target!` Rails
+   * runs inside `HasOneAssociation#replace` (has_one_association.rb:69) whenever
+   * another record is assigned. Nullifies the displaced record's foreign key (or
+   * destroys/deletes it per `:dependent`). Our sync `replace`/`setNewRecord`
+   * cannot `await` that removal, so the async create/build accessors run it here
+   * after materializing the replacement.
+   *
+   * `displaced` is the target the caller had loaded, if any. When it is null but
+   * `needsLoad` is set — a `create#{name}` on a freshly-found owner whose target
+   * was never materialized — Rails' `load_target` (:62) would still surface and
+   * remove the existing DB row, so query for it now (after `super`, per the note
+   * in `_createRecord`). The new record is already persisted, so the un-ordered
+   * `LIMIT 1` may return either row; a `sameRecord(found, replacement)` match
+   * reproduces Rails' two-row outcome (find the new row → `assigning_another_
+   * record` false → `remove_target!` skipped). A no-op unless a *different*,
+   * non-destroyed record is in play.
    *
    * @internal
    */
-  async detachDisplacedTarget(displaced: Base | null, replacement: Base | null): Promise<void> {
+  async detachDisplacedTarget(
+    displaced: Base | null,
+    replacement: Base | null,
+    needsLoad = false,
+  ): Promise<void> {
+    if (!displaced && needsLoad) {
+      const savedTarget = this.target;
+      const savedLoaded = this.loaded;
+      this.target = null;
+      this.loaded = false;
+      try {
+        displaced = await this.doAsyncFindTarget();
+      } finally {
+        this.target = savedTarget;
+        this.loaded = savedLoaded;
+      }
+      if (displaced && sameRecord(displaced, replacement)) displaced = null;
+    }
     if (!displaced) return;
     if ((displaced as { isDestroyed?: () => boolean }).isDestroyed?.()) return;
     if (sameRecord(displaced, replacement)) return;
+    // `setNewRecord` (reached via `super._createRecord` / `assoc.build`) already
+    // queued this same record onto `_displacedRecords` for the owner's next
+    // `save()`. We remove it here and now, so drop the queued duplicate — else
+    // `autosaveHasOne` → `removeDisplaced` would run `removeOne` on it a second
+    // time (a redundant nullify UPDATE, or a re-entrant `:destroy` on a frozen
+    // record via `preloadDestroyInverseBelongsTo`). The sync `assoc.build` path,
+    // which never reaches `detachDisplacedTarget`, keeps relying on that queue.
+    const queuedIdx = this._displacedRecords.findIndex((r) => sameRecord(r, displaced));
+    if (queuedIdx !== -1) this._displacedRecords.splice(queuedIdx, 1);
     // Mirror Rails' `HasOneAssociation#replace`, where `self.target = record` runs
     // only after the transaction block: if `remove_target!` raises (e.g. a failed
     // nullify save, which restores the old record's owner attributes before
@@ -544,25 +585,42 @@ export class HasOneAssociation extends SingularAssociation {
    * over an existing target still nullifies the displaced record's foreign key
    * and clears its inverse. We run that in-memory half here and hand the
    * displaced record to `removeDisplaced` (the owner's `autosaveHasOne`) for the
-   * DB half — `build` is synchronous and cannot await a save. Only a *persisted*
-   * displaced record has a row to remove, so a transient in-memory target is not
-   * queued (matching `queueWrite`).
+   * DB half — `build` is synchronous and cannot await a save.
+   *
+   * The queue gate is branch-dependent, because `owner.persisted?` appears in
+   * exactly one place in `remove_target!` — the else branch's save at `:108`:
+   *
+   *   - else / `:nullify` / `:destroyAsync` / `:restrict*` queue only when
+   *     `target.persisted? && owner.persisted?` (the two `:108` conjuncts,
+   *     evaluated at *replace* time). Deferring re-reads them at *save* time, by
+   *     which point a new-record owner has become persisted — queueing would
+   *     write a nullification Rails never performs (it nullifies the FK in memory
+   *     inline and never saves the displaced row).
+   *   - `:delete` / `:destroy` queue unconditionally: `:delete` runs even on an
+   *     unpersisted target (:97-98) and `:destroy` re-checks `target.persisted?`
+   *     in `removeOne` (:99-103); neither consults the owner.
    */
   protected override setNewRecord(record: Base): void {
     const displaced = this.target;
     const assigningAnother = !sameRecord(displaced, record);
     this.replace(record, false);
     if (!displaced || !assigningAnother) return;
-    if ((displaced as { isPersisted?: () => boolean }).isPersisted?.() !== true) return;
     if ((displaced as { isDestroyed?: () => boolean }).isDestroyed?.()) return;
     const dependent = (this.reflection.options.dependent as string) ?? "";
-    if (dependent !== "delete" && dependent !== "destroy") {
-      // `remove_target!`'s else branch (:104-106) is synchronous in Rails; only
-      // its `target.save` (:108) needs an await, so do the memory half now.
-      this.nullifyOwnerAttributes(displaced);
-      this.removeInverseInstance(displaced);
+    if (dependent === "delete" || dependent === "destroy") {
+      this._displacedRecords.push(displaced);
+      return;
     }
-    this._displacedRecords.push(displaced);
+    // `remove_target!`'s else branch (:104-106) is synchronous in Rails; only
+    // its `target.save` (:108) needs an await, so do the memory half now.
+    this.nullifyOwnerAttributes(displaced);
+    this.removeInverseInstance(displaced);
+    if (
+      displaced.isPersisted() &&
+      (this.owner as { isPersisted?: () => boolean }).isPersisted?.()
+    ) {
+      this._displacedRecords.push(displaced);
+    }
   }
 
   private nullifyOwnerAttributes(record: Base): void {

--- a/packages/activerecord/src/associations/has-one-set-new-record-displaced.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-set-new-record-displaced.trails.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Trails-only coverage for the `build#{name}` half of Rails'
+ * `HasOneAssociation#set_new_record` → `replace(record, false)`
+ * (vendor/rails/activerecord/lib/active_record/associations/has_one_association.rb:59-93).
+ *
+ * The `false` gates only `transaction_if(save)` (:68) and `if save &&
+ * !record.save` (:75); `remove_target!` (:69) runs regardless, so building a new
+ * has_one over an existing target nullifies the displaced record's foreign key
+ * and clears its inverse in memory. Rails has no dedicated test for this — it
+ * falls out of `replace` — so the assertions live here rather than in the
+ * name-matched has_one_associations_test.rb port.
+ */
+import { describe, it, expect } from "vitest";
+import { fixtures } from "../test-helpers/use-fixtures.js";
+import type { Base } from "../base.js";
+import { Pirate, DestructivePirate } from "../test-helpers/models/pirate.js";
+import { Ship } from "../test-helpers/models/ship.js";
+import { Member } from "../test-helpers/models/member.js";
+import { Club } from "../test-helpers/models/club.js";
+import { RecordNotFound } from "../index.js";
+import { UnknownAttributeError } from "@blazetrails/activemodel";
+import { assertQueriesCount } from "../testing/query-assertions.js";
+
+/** `build#{name}` returns a Promise only on the `load_target` path. */
+type ShipBuilder = Pirate & {
+  buildShip(attributes: Record<string, unknown>): Ship | Promise<Ship>;
+};
+
+const inverseTarget = (ship: Ship): unknown => ship.association("pirate").target;
+
+/** The deferred-removal queue drained by the owner's `autosaveHasOne`. */
+const displacedQueue = (owner: Base, name = "ship"): Base[] =>
+  (owner.association(name) as unknown as { _displacedRecords: Base[] })._displacedRecords;
+
+describe("HasOneAssociation#setNewRecord displaced removal", () => {
+  fixtures(["pirates", "ships", "members", "clubs", "memberships", "memberTypes", "developers"]);
+
+  it("build nullifies the displaced record in memory", async () => {
+    const pirate = (await Pirate.create({ catchphrase: "Arrr" })) as ShipBuilder;
+    const original = await Ship.create({ name: "Black Pearl", pirate_id: pirate.id });
+
+    const displaced = await pirate.loadHasOne("ship");
+    expect(displaced?.id).toBe(original.id);
+
+    await pirate.buildShip({ name: "brand new" });
+
+    expect(displaced?.pirate_id).toBeNull();
+    expect(inverseTarget(displaced as Ship)).toBeNull();
+  });
+
+  it("build loads an unloaded target before displacing it", async () => {
+    const pirate = await Pirate.create({ catchphrase: "Arrr" });
+    const original = await Ship.create({ name: "Black Pearl", pirate_id: pirate.id });
+
+    // No preceding load: `build#{name}` must issue Rails' leading `load_target`
+    // (:62) itself, or the existing row is silently orphaned.
+    const found = (await Pirate.find(pirate.id)) as ShipBuilder;
+    await found.buildShip({ name: "brand new" });
+    await found.save();
+
+    expect((await Ship.find(original.id)).pirate_id).toBeNull();
+  });
+
+  it("build over a new-record owner leaves no displaced record", async () => {
+    const pirate = Pirate.new({ catchphrase: "Arrr" }) as ShipBuilder;
+    const first = await pirate.buildShip({ name: "first" });
+    const second = await pirate.buildShip({ name: "second" });
+
+    expect(second.name).toBe("second");
+    // `first.pirate_id` is already null here whatever `set_new_record` does —
+    // `replace`'s `set_owner_attributes` copied the id-less owner's nil pk into
+    // it during the first build — so only the inverse clear is load-bearing.
+    expect(inverseTarget(first)).toBeNull();
+    expect(displacedQueue(pirate)).toHaveLength(0);
+  });
+
+  it("create removes the displaced record without waiting for the owner's save", async () => {
+    const pirate = (await Pirate.create({ catchphrase: "Arrr" })) as ShipBuilder;
+    const original = await Ship.create({ name: "Black Pearl", pirate_id: pirate.id });
+    await pirate.loadHasOne("ship");
+
+    // Unlike the sync `build`, `_create_record` can await, and Rails runs
+    // `remove_target!` inline inside it (`set_new_record` after `record.save`,
+    // singular_association.rb) — so the row must already be nullified here, with
+    // no `pirate.save()`.
+    await (
+      pirate as unknown as { createShip(a: Record<string, unknown>): Promise<Ship> }
+    ).createShip({ name: "brand new" });
+
+    expect((await Ship.find(original.id)).pirate_id).toBeNull();
+    // detachDisplacedTarget removed it now, so it must not stay queued for a
+    // second removal at the owner's next save.
+    expect(displacedQueue(pirate)).toHaveLength(0);
+    await pirate.save();
+    expect((await Ship.find(original.id)).pirate_id).toBeNull();
+  });
+
+  it("build over a loaded dependent destroy target does not re-destroy at save", async () => {
+    const pirate = await DestructivePirate.create({ catchphrase: "Arrr" });
+    const original = await Ship.create({ name: "Doomed", pirate_id: pirate.id });
+    await (
+      pirate as unknown as { loadHasOne(n: "dependentShip"): Promise<Ship | null> }
+    ).loadHasOne("dependentShip");
+
+    // The build accessor detaches (destroys) the loaded target immediately. The
+    // record must not also stay on `_displacedRecords`, or `pirate.save()` would
+    // re-enter removeTargetBang(:destroy) on the now-frozen record.
+    await (
+      pirate as unknown as { buildDependentShip(a: Record<string, unknown>): Promise<Ship> }
+    ).buildDependentShip({ name: "replacement" });
+
+    await expect(Ship.find(original.id)).rejects.toThrow(RecordNotFound);
+    expect(displacedQueue(pirate, "dependentShip")).toHaveLength(0);
+    // The second drain must not throw on the frozen, already-destroyed record.
+    await pirate.save();
+  });
+
+  it("create loads an unloaded target before displacing it", async () => {
+    const pirate = await Pirate.create({ catchphrase: "Arrr" });
+    const original = await Ship.create({ name: "Black Pearl", pirate_id: pirate.id });
+
+    // No preceding load, and no `build#{name}` accessor to pre-issue the SELECT:
+    // `_createRecord` must run Rails' leading `load_target` (:62) itself, or the
+    // existing row is silently orphaned. The removal is inline, so no `save()`.
+    const found = (await Pirate.find(pirate.id)) as unknown as {
+      createShip(a: Record<string, unknown>): Promise<Ship>;
+    };
+    await found.createShip({ name: "brand new" });
+
+    expect((await Ship.find(original.id)).pirate_id).toBeNull();
+  });
+
+  it("create that fails to build the record leaves the displaced record alone", async () => {
+    const pirate = await Pirate.create({ catchphrase: "Arrr" });
+    const original = await Ship.create({ name: "Black Pearl", pirate_id: pirate.id });
+
+    // Rails reaches `remove_target!` only via `set_new_record`, which runs after
+    // `build_record` (singular_association.rb) — so a `build_record` that raises
+    // removes nothing. The deferred load must not fire here either.
+    const found = (await Pirate.find(pirate.id)) as unknown as {
+      createShip(a: Record<string, unknown>): Promise<Ship>;
+    };
+    await expect(found.createShip({ bogus_column: 1 })).rejects.toThrow(UnknownAttributeError);
+
+    expect((await Ship.find(original.id)).pirate_id).toBe(Number(pirate.id));
+  });
+
+  it("build over a new-record owner destroys a dependent destroy displaced record", async () => {
+    const keeper = await DestructivePirate.create({ catchphrase: "Keeper" });
+    const doomed = await Ship.create({ name: "Doomed", pirate_id: keeper.id });
+
+    // `remove_target!`'s `:destroy` arm (:99-103) gates on `target.persisted?`
+    // alone — `owner.persisted?` lives only in the else branch (:108) — so a
+    // new-record owner still destroys the displaced ship.
+    const pirate = DestructivePirate.new({ catchphrase: "Arrr" });
+    (pirate as unknown as { dependentShip: Ship | null }).dependentShip = doomed;
+    (
+      pirate.association("dependentShip") as unknown as { build(a: Record<string, unknown>): Ship }
+    ).build({ name: "replacement" });
+    await pirate.save();
+
+    await expect(Ship.find(doomed.id)).rejects.toThrow(RecordNotFound);
+  });
+
+  it("build over a new-record owner does not nullify a persisted ship in the database", async () => {
+    const other = await Pirate.create({ catchphrase: "Other" });
+    const existing = await Ship.create({ name: "Interceptor", pirate_id: other.id });
+
+    // `remove_target!` evaluates `owner.persisted?` (:108) at replace time, so a
+    // new-record owner nullifies in memory only. Deferring the DB half must not
+    // resurrect it once `save()` makes the owner persisted.
+    const pirate = Pirate.new({ catchphrase: "Arrr" }) as ShipBuilder;
+    pirate.ship = existing;
+    await pirate.buildShip({ name: "brand new" });
+    await pirate.save();
+
+    expect((await Ship.find(existing.id)).pirate_id).toBe(Number(other.id));
+  });
+
+  it("build does not clobber a displacement already queued by the writer", async () => {
+    const pirate = (await Pirate.create({ catchphrase: "Arrr" })) as ShipBuilder;
+    const original = await Ship.create({ name: "Black Pearl", pirate_id: pirate.id });
+    await pirate.loadHasOne("ship");
+
+    // The property setter queues `original` for removal; the unsaved `interim`
+    // then displaced by `buildShip` has no row and must not take its place.
+    pirate.ship = Ship.new({ name: "interim" });
+    await pirate.buildShip({ name: "brand new" });
+    await pirate.save();
+
+    expect((await Ship.find(original.id)).pirate_id).toBeNull();
+  });
+
+  it("build on a has_one_through does not remove the displaced record", async () => {
+    const member = await Member.create({ name: "Joe" });
+    const oldClub = await Club.create({ name: "Old Club" });
+    await (member.association("club") as unknown as { writer(v: Club): Promise<void> }).writer(
+      oldClub,
+    );
+    await member.save();
+
+    // `HasOneThroughAssociation#replace` (has_one_through_association.rb:10-13)
+    // is `create_through_record` + `self.target = record` — no `remove_target!`.
+    // A through's displaced record is reconciled by the join row, so the
+    // inherited `set_new_record` removal must not reach it.
+    const refetched = await Member.find(member.id);
+    const loaded = await (
+      refetched as unknown as { loadHasOne(n: "club"): Promise<Club | null> }
+    ).loadHasOne("club");
+    expect(loaded?.id).toBe(oldClub.id);
+
+    (refetched.association("club") as unknown as { build(a: Record<string, unknown>): Club }).build(
+      {
+        name: "Final",
+      },
+    );
+
+    // The removal would write a `club_id` a Club has no business owning, marking
+    // it dirty and queueing it for a save the owner's autosave then performs.
+    expect((loaded as unknown as { hasChangesToSave: boolean }).hasChangesToSave).toBe(false);
+    expect(
+      (refetched.association("club") as unknown as { _displacedRecords: Club[] })._displacedRecords,
+    ).toHaveLength(0);
+  });
+
+  it("create on a has_one_through does not load or remove the displaced record", async () => {
+    const member = await Member.create({ name: "Joe" });
+    const oldClub = await Club.create({ name: "Old Club" });
+    await (member.association("club") as unknown as { writer(v: Club): Promise<void> }).writer(
+      oldClub,
+    );
+    await member.save();
+
+    // `_createRecord` drains the displaced queue itself, so a through must opt
+    // out there too — not just in `setNewRecord`. Otherwise the drain issues a
+    // `load_target` Rails never performs for a through (whose `replace`
+    // reconciles the join row) and hands the old club to `removeTargetBang`,
+    // which nullifies a foreign key `Club` does not own. Only the INSERT and the
+    // join-row reconcile SELECT should run, inside the savepoint pair — the
+    // fifth query would be the `clubs` re-find.
+    const refetched = await Member.find(member.id);
+    await assertQueriesCount(4, false, async () => {
+      await (
+        refetched.association("club") as unknown as {
+          create(a: Record<string, unknown>): Promise<Club>;
+        }
+      ).create({ name: "New Club" });
+    });
+  });
+});

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -95,6 +95,21 @@ export class HasOneThroughAssociation extends HasOneAssociation {
   }
 
   /**
+   * `HasOneAssociation#setNewRecord` queues the displaced target onto
+   * `_displacedRecords` for the owner's next `save()` to remove — the deferred
+   * counterpart of the `detachDisplacedTarget` opt-out above, and wrong for a
+   * through for the same reason: Rails' `HasOneThroughAssociation#replace`
+   * (has_one_through_association.rb:9-13) has no `remove_target!`, so the sync
+   * `assoc.build` path (reached from the `build#{name}` accessor) must not queue
+   * the end record for a direct-FK nullify it doesn't own. Restore the bare base
+   * `replace(record, false)`, which for a through routes to its own `replace` and
+   * leaves displacement to `createThroughRecord`.
+   */
+  protected override setNewRecord(record: Base): void {
+    this.replace(record, false);
+  }
+
+  /**
    * The deferred (non-awaitable) property-setter / mass-assignment path. The
    * base `queueWrite` records a displaced record for the direct-FK autosave to
    * remove, but a through routes displacement through the join model


### PR DESCRIPTION
**Narrowed** after this story landed on `main` in pieces — #4902 (build displaced
removal + `_displacedRecords` collection), #4904 (create over a *loaded* target,
via `detachDisplacedTarget`), and #4905 (has_one_through build loads the through
proxy + the through `detachDisplacedTarget` create opt-out). This PR is the
remaining delta — four residual divergences from Rails, each verified to fail
against current `main`. Reconciled with the landed `detachDisplacedTarget`
architecture (no duplicate overrides).

## 1. `create<Name>` over an *unloaded* target orphaned the row

#4904 detaches only a pre-loaded target (`displaced = this.loaded ? this.target :
null`). Rails' `load_target` (:62) inside `replace` surfaces and removes the
existing DB row even when the caller never materialized it. So `_createRecord`
samples `needsLoad` *before* `super` (`replace`/`setNewRecord` flip `loaded` via
`loadedBang`) and `detachDisplacedTarget` issues the find *after* `super` —
after, because `build_record` must raise `UnknownAttributeError` for a bogus
reflection `foreign_key` before any query, or `create_with_inexistent_foreign_key
_failing` regresses. The new record's row already carries the FK, so the
un-ordered `LIMIT 1` may return either row; a `sameRecord(found, replacement)`
match reproduces Rails' own two-row outcome (find the new row →
`assigning_another_record` false → `remove_target!` skipped).

## 2. `has_one_through` still leaked on the *build* path

#4905 closed the through *create* path (its `detachDisplacedTarget` no-op) but
`build` still inherits the base `setNewRecord`, which queues the displaced end
record onto `_displacedRecords` for a direct-FK nullify a through target doesn't
own (Rails' `HasOneThroughAssociation#replace`, `has_one_through_association.rb:9-13`,
has no `remove_target!`). Override `setNewRecord` to a bare `replace`, matching
the create-path opt-out already on `main`.

## 3. New-record-owner gate (corrects #4902)

`main`'s `setNewRecord` gates the whole removal on `displaced.isPersisted()` then
queues unconditionally — so a **new-record owner** building over a persisted
displaced record queued it and nullified its row at `save()` time. Rails'
`remove_target!` gates the *save* on `target.persisted? && owner.persisted?`
(`:108`), evaluated at replace time, so a new-record owner nullifies the FK **in
memory only**. The gate is now branch-dependent: else/`:nullify`/`:destroyAsync`/
`:restrict*` queue only when both `:108` conjuncts hold; `:delete`/`:destroy`
queue unconditionally (neither consults the owner). New evidence for revisiting
#4902: `has_one_association.rb:108` plus a test that fails on `main`.

## 4. Double-removal after a detach (queue leftover)

`setNewRecord` queues the displaced record, but the `build<Name>` accessor and
`_createRecord` also call `detachDisplacedTarget`, which removes it immediately —
leaving a stale queue entry that `removeDisplaced` would remove a second time at
the owner's next `save()` (a redundant nullify, or a re-entrant `:destroy` on a
frozen record). `detachDisplacedTarget` now splices the entry it removes. The sync
`assoc.build` path, which never reaches `detachDisplacedTarget`, still relies on
the queue, so the `setNewRecord` push stays.

## Tests

Twelve cases in `has-one-set-new-record-displaced.trails.test.ts` (trails-only —
Rails has no dedicated test; this falls out of `replace`). The four residuals each
fail against current `main`; the rest guard the landed `build`/`create` behaviour.
#4902's multi-slot suite and #4904/#4905's tests still pass.

No regressions across has_one, has_one_through, has_one_through_disable_joins,
autosave, nested_attributes, inverse_associations, and the multi-slot suite (628
passing).

The earlier follow-up (`member.buildClub` on an unloaded through) landed as #4905,
so the previous "known limitation" note is resolved. Review of this rebase noted
one remaining coverage gap in #4905's landed code — no test pins the query *shape*
of the build-through accessor path — filed as `has-one-through-build-accessor-query-shape`
(RFC 0005); not a blocker for this diff.

Closes-story: has-one-set-new-record-displaced-removal
