### PR TITLE
fix(activerecord): flush deferred has_one displacement before _createRecord

### DIFF
--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -409,9 +409,7 @@ export class HasOneAssociation extends SingularAssociation {
     // here, while this insert's own FK-matching row does not exist yet: deferring
     // to the owner's save leaves `removeDisplaced`'s FK re-query choosing between
     // two matching rows, and the old row survives if it picks the new one.
-    if (this._displacedRecord || this._removeDisplacedFromDb) {
-      await this.removeDisplaced();
-    }
+    await this.removeDisplaced();
     return super._createRecord(attributes, shouldRaise, block);
   }
 

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -404,11 +404,11 @@ export class HasOneAssociation extends SingularAssociation {
     if (!(this.owner as { isPersisted?: () => boolean }).isPersisted?.()) {
       throw new RecordNotSaved("You cannot call create unless the parent is saved", this.owner);
     }
-    // A displacement queued by the sync property setter is still pending: Rails'
-    // `replace` would already have removed the old record before `create_#{name}`
-    // ran. Flush it here, while this insert's own FK-matching row does not exist
-    // yet — deferring to the owner's save would leave `removeDisplaced`'s FK
-    // re-query picking between two matching rows, and the old row could survive.
+    // Rails' `replace` has already removed the displaced record by the time
+    // `create_#{name}` runs; our sync property setter can only queue it. Flush it
+    // here, while this insert's own FK-matching row does not exist yet: deferring
+    // to the owner's save leaves `removeDisplaced`'s FK re-query choosing between
+    // two matching rows, and the old row survives if it picks the new one.
     if (this._displacedRecord || this._removeDisplacedFromDb) {
       await this.removeDisplaced();
     }

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -404,6 +404,14 @@ export class HasOneAssociation extends SingularAssociation {
     if (!(this.owner as { isPersisted?: () => boolean }).isPersisted?.()) {
       throw new RecordNotSaved("You cannot call create unless the parent is saved", this.owner);
     }
+    // A displacement queued by the sync property setter is still pending: Rails'
+    // `replace` would already have removed the old record before `create_#{name}`
+    // ran. Flush it here, while this insert's own FK-matching row does not exist
+    // yet — deferring to the owner's save would leave `removeDisplaced`'s FK
+    // re-query picking between two matching rows, and the old row could survive.
+    if (this._displacedRecord || this._removeDisplacedFromDb) {
+      await this.removeDisplaced();
+    }
     return super._createRecord(attributes, shouldRaise, block);
   }
 

--- a/packages/activerecord/src/associations/has-one-unloaded-displacement-create-window.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-unloaded-displacement-create-window.trails.test.ts
@@ -1,0 +1,55 @@
+/**
+ * trails-only regression (no Rails counterpart).
+ *
+ * Rails' `HasOneAssociation#replace` (has_one_association.rb:66-84) removes the
+ * displaced record synchronously at assignment, so by the time `create_account`
+ * runs the old row is already detached — the window this file covers cannot
+ * exist there. The JS property setter cannot `await`, so `queueWrite` defers the
+ * removal to the owner's save. When the has_one was *unloaded* at assignment
+ * there is no in-memory `_displacedRecord`, only `_removeDisplacedFromDb`, and
+ * the removal is resolved by an FK re-query at save time. A `createAccount()` in
+ * between inserts a second FK-matching row, so that re-query could return the
+ * just-created account, trip `removeDisplaced`'s `!sameRecord(found, savedTarget)`
+ * guard, and leave the *old* account attached — the outcome then depended on DB
+ * row ordering. `_createRecord` now flushes the pending displacement before its
+ * insert, restoring Rails' ordering.
+ */
+import { describe, it, expect } from "vitest";
+import { Company } from "../test-helpers/models/company.js";
+import { Account } from "../test-helpers/models/account.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+
+// The generated `create#{name}` accessor is not surfaced on the model's declared
+// type, so name its shape here rather than casting the record to `any`.
+interface CreatesAccount {
+  createAccount(attributes: Record<string, unknown>): Promise<Account | null>;
+}
+
+describe("has_one unloaded displacement followed by create", () => {
+  fixtures(["companies", "accounts"]);
+
+  it("detaches the prior DB account when create_account follows an unloaded displacement", async () => {
+    const company = await Company.create({ name: "37signals" });
+    const original = await Account.create({ firm_id: company.id, credit_limit: 50 });
+
+    // Re-find the company so its `account` association is unloaded: the deferred
+    // setter then records `_removeDisplacedFromDb` with no in-memory target.
+    const reloaded = await Company.find(company.id);
+    reloaded.account = Account.new({ credit_limit: 60 });
+
+    const createAccount = (reloaded as Company & CreatesAccount).createAccount;
+    const created = (await createAccount.call(reloaded, { credit_limit: 70 })) as Account;
+
+    // Rails has already detached the old account by the time `create_account`
+    // returns. Asserting here — before the owner's save — pins the ordering
+    // rather than the luck of which FK-matching row the save-time re-query
+    // happens to see first.
+    expect((await Account.find(original.id)).firm_id).toBeNull();
+
+    await reloaded.save();
+
+    expect((await Account.find(original.id)).firm_id).toBeNull();
+    expect((await Account.find(created.id)).firm_id).toBe(company.id);
+    expect(await Account.where({ firm_id: company.id }).count()).toBe(1);
+  });
+});

--- a/packages/activerecord/src/associations/has-one-unloaded-displacement-create-window.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-unloaded-displacement-create-window.trails.test.ts
@@ -19,8 +19,7 @@ import { Company } from "../test-helpers/models/company.js";
 import { Account } from "../test-helpers/models/account.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 
-// The generated `create#{name}` accessor is not surfaced on the model's declared
-// type, so name its shape here rather than casting the record to `any`.
+// The generated `create#{name}` accessor is not on the model's declared type.
 interface CreatesAccount {
   createAccount(attributes: Record<string, unknown>): Promise<Account | null>;
 }
@@ -37,8 +36,8 @@ describe("has_one unloaded displacement followed by create", () => {
     const reloaded = await Company.find(company.id);
     reloaded.account = Account.new({ credit_limit: 60 });
 
-    const createAccount = (reloaded as Company & CreatesAccount).createAccount;
-    const created = (await createAccount.call(reloaded, { credit_limit: 70 })) as Account;
+    const owner = reloaded as Company & CreatesAccount;
+    const created = (await owner.createAccount({ credit_limit: 70 })) as Account;
 
     // Rails has already detached the old account by the time `create_account`
     // returns. Asserting here — before the owner's save — pins the ordering


### PR DESCRIPTION
## Problem

A deferred `owner.child = x` on an **unloaded** has_one sets
`_removeDisplacedFromDb`: there is no in-memory target to record, but a DB row
keyed by the owner may exist, so the removal is deferred to the owner's save,
where `removeDisplaced` re-queries by foreign key.

If `owner.createChild()` runs before that save, `_createRecord` inserts a
*second* FK-matching row. The save-time re-query then returns whichever row the
DB yields first; if it returns the just-created child, `removeDisplaced`'s
`!sameRecord(found, savedTarget)` guard cancels and the **old** row stays
attached. Which row won depended on DB ordering.

Rails has no such window: `HasOneAssociation#replace`
(`has_one_association.rb:66-84`) removes the old row synchronously at
assignment, so it is already detached before `create_#{name}` runs. The root
cause here is that the JS property setter cannot `await`, forcing `queueWrite`
to defer.

## Fix

`_createRecord` is async and already guards that the owner is persisted, so it
is the right place to restore Rails' ordering: flush any pending displacement
there, before the insert — while this create's own FK-matching row does not
exist yet, so the re-query is unambiguous.

## Testing

New trails-only regression (no Rails counterpart — the window cannot exist
there): `has-one-unloaded-displacement-create-window.trails.test.ts`, riding the
canonical `companies`/`accounts` tables and the real `Company`/`Account` models.

It asserts the old account is detached **immediately after `createAccount()`,
before the owner's save**. That ordering is what the fix guarantees and is
deterministic; asserting only after the save passes even without the fix,
because SQLite happens to return the old row first — exactly the row-ordering
luck this story is about. Verified the test fails on the unfixed code
(`expected 16 to be null`) and passes with it.

No regressions: `has-one-associations`, `has-one-through-associations`, and
`autosave-association` all green (347 passed, 11 skipped).

## Review responses

**1. `setNewRecord` omits `remove_target!` — loaded-target create path.**
Confirmed, and the reading of rb:69 is correct: only the `transaction_if`
wrapper is gated on `save`, so `replace(record, false)` still detaches. Probed
it — `await c.loadHasOne("account")` then `c.createAccount({...})` leaves the old
`firm_id` set and an attached count of 2.

Filing rather than fixing here, because it is a **different defect with a
different root cause**: no setter is involved, no displacement flag is set, and
the convergence belongs in `replace`/`setNewRecord` (which are sync and cannot
await) rather than on the deferred-assignment paths this story scopes. Fixing
only the create path inside `_createRecord` would leave the shared
`setNewRecord` deviation in place while making it look converged. Registered as
`has-one-loaded-target-create-missing-remove-target` (0005-activerecord-gaps)
with the rb:69 citation, the probe, and the follow-up to trim the note below.

Agreed the doc comment was asserting a gap as a convergence — that part is fixed
here: has-one-association.ts:438-448 now carries an explicit KNOWN GAP note
citing rb:69 and the story, so the next reader is not misled.

**2. Ordering vs Rails — did I intend to move the `_displacedRecord` arm too?**
Yes, intentional. Rails removes the displaced record inside `create_#{name}`
(via `set_new_record` → `replace` → `remove_target!`); before this PR our
`_displacedRecord` arm deferred it all the way to the owner's *next save*, which
is strictly **later** than Rails. Moving it into `_createRecord` brings it back
inside the create call, so both arms converge. The remaining before-vs-after-
insert difference is not observable: Rails' `_create_record` calls
`set_new_record` unconditionally after `record.save`, so the old row is detached
by the time `create_#{name}` returns whether or not the insert succeeded — same
as here. Gating on `_removeDisplacedFromDb` alone would have left the
`_displacedRecord` arm at its pre-PR, less-faithful timing.

**3. Guard is redundant.** Correct — removed. `_createRecord` now calls
`await this.removeDisplaced()` unconditionally and relies on its self-no-op.

## Gates

- api:compare delta **0** (measured against `origin/main`, not assumed): data
  layer 7472/7474, 407/407 files.
- test:compare delta **0**: 14448/21663, 747/1020 files.
- No stubs.

## Review responses — round 2

**1. Through-path create-window.** Probed it. The **conclusion is right that the
through path is broken, but the mechanism described is not**, and it is not a
create-window at all — so I filed it on what it actually is rather than as
described.

- *`_pendingReplace.record` goes stale:* **not reproduced.** The `inMemory` arm
  is not a no-op for `_pendingReplace` — it updates `record` at
  has-one-through-association.ts:273-278, and the comment at :245-248 spells out
  why a stale record there would be a bug. Probed:
  `member.club = A; await member.createClub({ name: "B" })` leaves
  `_pendingReplace.record` pointing at **B**, and `member.club` reads back **B**
  after save. `setNewRecord` → `replace(created, false)` does take the `inMemory`
  arm, but that arm updates the queued record.
- *What is actually broken:* over an **unloaded** has_one_through, a second join
  row is INSERTED instead of the existing one being UPDATED. Rails does
  `through_record.update(attributes)`
  (`has_one_through_association.rb:29-38`); we leak a duplicate, so the stale
  join to the old target survives and `owner.child` depends on row ordering.
- *Why it is not this PR's window:* `create` is irrelevant. Given a member with
  an existing `Membership` to club OLD, re-found so the through is unloaded:

  | sequence | join rows | stale OLD join present |
  | --- | --- | --- |
  | `m.club = A; await m.save()` | 2 | yes |
  | `m.club = A; await m.createClub({...}); await m.save()` | 2 | yes |
  | `await m.createClub({...}); await m.save()` | 2 | yes |

  The setter-only row leaks identically with no `create` in sight, so this is not
  the create-window #4901 fixes. Confirmed the inherited flush correctly no-ops
  on through (`queueWrite` sets neither flag), as noted in the review.

  Filed as `has-one-through-unloaded-displacement-duplicate-join`
  (0005-activerecord-gaps) with the rb:29-38 citation, the probe table, and a
  sequencing note against the `hasChangesToSave` story below.

Agreed the PR body should not have implied the "Rails has no such window"
reasoning stops at the direct has_one — the follow-ups list below now names the
through gap explicitly.

**2. Is the cited story slug real?** Yes — verified, not assumed:
`rfcs/0005-activerecord-gaps/stories/has-one-loaded-target-create-missing-remove-target.md`,
`status: ready`, with full `## Context` (rb:69 citation + the probe) and
`## Acceptance criteria`. It is committed and on the tasks repo's `origin/main`
(commit `f27d4ac61`), so it is visible outside this worktree — a review worktree
without the `tasks` symlink would not see it locally, but it is filed. Same for
`has-one-unloaded-displacement-writer-window` (`c8219b18e`).

**Drive-by (`hasChangesToSave` getter called as `?.()`).** Confirmed real:
`hasChangesToSave` is a getter on `Model.prototype` (base.ts:5178), so `?.()`
throws once it is truthy. Already tracked by
`has-changes-to-save-getter-called-as-method` (status `in-progress`) — not
duplicating it. Noted in the new through story that it sits on that exact path
and should be sequenced first, since it may change which `replace` branch runs.

## Rebased onto main (2026-07-16)

Rebased onto `origin/main` to clear a merge conflict. The conflict was in the
`setNewRecord` doc comment: **#4902** ("displaced-record slot becomes an ordered
collection") landed on main and rewrote `setNewRecord` to run `remove_target!`'s
in-memory half and queue the displaced record — i.e. it converged the
loaded-target gap this PR's round-1 comment 1 had documented as a KNOWN GAP.
Resolution: took main's version and **dropped the now-obsolete KNOWN GAP note**;
the deferred-assignment `_createRecord` flush this PR adds is unchanged and sits
cleanly atop main's `_displacedRecords` collection. Re-probed after the rebase:
the loaded-target create path now detaches the old row at the owner's save
(nullify arm, count 1). The residual create-time-vs-save-time timing is tracked
by the follow-up story below (now claimed as **#4904**). Diff is still the same
6-line flush + test; all four suites green (348 passed, 11 skipped).

## Known follow-ups (registered, not fixed here)

- `has-one-loaded-target-create-missing-remove-target` — round 1, comment 1; converged at owner-save by #4902, residual timing claimed as #4904.
- `has-one-through-unloaded-displacement-duplicate-join` — round 2, comment 1.
- `has-one-unloaded-displacement-writer-window` — the same window on the
  awaitable `writer` path, currently masked by SQLite row ordering.
- `has-changes-to-save-getter-called-as-method` — pre-existing, already
  in-progress; covers the drive-by.

Closes-story: has-one-unloaded-displacement-create-window

