### PR TITLE
fix(has_one): displaced-record slot becomes an ordered collection

### DIFF
--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -26,8 +26,15 @@ export class HasOneAssociation extends SingularAssociation {
    * this removal synchronously inside `replace`; the JS property setter cannot
    * `await`, so we carry the displaced record forward to the single autosave
    * persistence path rather than running a parallel `persistReplace`.
+   *
+   * This is an *ordered collection*, not a single slot: a has_one owner can
+   * displace more than one persisted record before its `save()` drains the
+   * queue (`owner.x = b; owner.x = c` displaces both the original target and
+   * `b`). Rails removes each inline inside `replace`, so every displacement is
+   * accounted for; we accumulate them and remove all at save time, in
+   * displacement order.
    */
-  _displacedRecord: Base | null = null;
+  _displacedRecords: Base[] = [];
 
   /**
    * Set when a deferred assignment displaces an *unloaded* has_one on a persisted
@@ -46,7 +53,7 @@ export class HasOneAssociation extends SingularAssociation {
 
   override reset(): void {
     super.reset();
-    this._displacedRecord = null;
+    this._displacedRecords = [];
     this._removeDisplacedFromDb = false;
   }
 
@@ -65,24 +72,27 @@ export class HasOneAssociation extends SingularAssociation {
     const displaced = this.target;
     this.replace(record);
     if (!(this.owner as { isPersisted?: () => boolean }).isPersisted?.()) return;
-    // Reverting to the record already queued for removal cancels the removal
-    // (`owner.x = other; owner.x = original`).
-    if (this._displacedRecord && sameRecord(record, this._displacedRecord)) {
-      this._displacedRecord = null;
-      this._removeDisplacedFromDb = false;
-      return;
+    // Reverting to a record already queued for removal cancels *just its*
+    // removal (`owner.x = other; owner.x = original`) — remove only the reverted
+    // record from the pending set, leaving any other displacements intact.
+    if (record) {
+      const idx = this._displacedRecords.findIndex((r) => sameRecord(record, r));
+      if (idx !== -1) {
+        this._displacedRecords.splice(idx, 1);
+        return;
+      }
     }
     // Only a *persisted* displaced record has a row/foreign key to nullify. A
-    // transient in-memory target has none and must not clobber an
-    // already-recorded persisted displacement — `owner.x = newA; owner.x = newB`
-    // still has to nullify the original persisted row, not the un-saved `newA`.
+    // transient in-memory target has none and must not be queued — but it also
+    // must not clobber earlier persisted displacements, which the ordered
+    // collection preserves regardless.
     if (
       displaced &&
       (displaced as { isPersisted?: () => boolean }).isPersisted?.() &&
       !(displaced as { isDestroyed?: () => boolean }).isDestroyed?.() &&
       !sameRecord(displaced, record)
     ) {
-      this._displacedRecord = displaced;
+      this._displacedRecords.push(displaced);
     } else if (!wasLoaded && !displaced) {
       // The current target was never materialized, so we have no in-memory
       // displaced record — but a DB row keyed by the owner may exist. Rails'
@@ -167,9 +177,15 @@ export class HasOneAssociation extends SingularAssociation {
    * inside `HasOneAssociation#replace`.
    */
   async removeDisplaced(): Promise<void> {
-    let displaced = this._displacedRecord;
-    this._displacedRecord = null;
-    if (!displaced && this._removeDisplacedFromDb) {
+    // Drain the whole collection, removing each displaced record in
+    // displacement order (Rails removes each inline inside `replace`).
+    const queued = this._displacedRecords;
+    this._displacedRecords = [];
+    for (const record of queued) {
+      await this.removeOne(record);
+    }
+    let displaced: Base | null = null;
+    if (this._removeDisplacedFromDb) {
       // Unloaded property-setter replace: materialize the existing DB-associated
       // record now (the owner still keys the pre-replace row, since the new
       // target has not been persisted yet) so its `:dependent` remove runs.
@@ -190,7 +206,16 @@ export class HasOneAssociation extends SingularAssociation {
       }
       if (found && !sameRecord(found, savedTarget)) displaced = found;
     }
-    if (!displaced) return;
+    if (displaced) await this.removeOne(displaced);
+  }
+
+  /**
+   * Run `remove_target!` for a single displaced record, honoring the
+   * reflection's `:dependent` (delete/destroy/else-nullify). Temporarily sets
+   * `target` to the displaced record so `removeTargetBang` acts on it, then
+   * restores the current target.
+   */
+  private async removeOne(displaced: Base): Promise<void> {
     const currentTarget = this.target;
     this.target = displaced;
     try {
@@ -435,9 +460,31 @@ export class HasOneAssociation extends SingularAssociation {
    * memory), but the through override still honors it, and a create-path child
    * is already persisted, so the owner's next `autosaveHasOne` sees it unchanged
    * and does not re-save.
+   *
+   * `save = false` gates only `transaction_if(save)` (:68) and `if save &&
+   * !record.save` (:75) — `remove_target!` (:69) runs regardless, so building
+   * over an existing target still nullifies the displaced record's foreign key
+   * and clears its inverse. We run that in-memory half here and hand the
+   * displaced record to `removeDisplaced` (the owner's `autosaveHasOne`) for the
+   * DB half — `build` is synchronous and cannot await a save. Only a *persisted*
+   * displaced record has a row to remove, so a transient in-memory target is not
+   * queued (matching `queueWrite`).
    */
   protected override setNewRecord(record: Base): void {
+    const displaced = this.target;
+    const assigningAnother = !sameRecord(displaced, record);
     this.replace(record, false);
+    if (!displaced || !assigningAnother) return;
+    if ((displaced as { isPersisted?: () => boolean }).isPersisted?.() !== true) return;
+    if ((displaced as { isDestroyed?: () => boolean }).isDestroyed?.()) return;
+    const dependent = (this.reflection.options.dependent as string) ?? "";
+    if (dependent !== "delete" && dependent !== "destroy") {
+      // `remove_target!`'s else branch (:104-106) is synchronous in Rails; only
+      // its `target.save` (:108) needs an await, so do the memory half now.
+      this.nullifyOwnerAttributes(displaced);
+      this.removeInverseInstance(displaced);
+    }
+    this._displacedRecords.push(displaced);
   }
 
   private nullifyOwnerAttributes(record: Base): void {

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -72,20 +72,12 @@ export class HasOneAssociation extends SingularAssociation {
     const displaced = this.target;
     this.replace(record);
     if (!(this.owner as { isPersisted?: () => boolean }).isPersisted?.()) return;
-    // Reverting to a record already queued for removal cancels *just its*
-    // removal (`owner.x = other; owner.x = original`) — remove only the reverted
-    // record from the pending set, leaving any other displacements intact.
-    if (record) {
-      const idx = this._displacedRecords.findIndex((r) => sameRecord(record, r));
-      if (idx !== -1) {
-        this._displacedRecords.splice(idx, 1);
-        return;
-      }
-    }
-    // Only a *persisted* displaced record has a row/foreign key to nullify. A
-    // transient in-memory target has none and must not be queued — but it also
-    // must not clobber earlier persisted displacements, which the ordered
-    // collection preserves regardless.
+    // Rails `HasOneAssociation#replace` runs `remove_target!` on the current
+    // `target` for *every* assigning-another replacement (has_one_association.rb
+    // :64-84, :69) before `self.target = record`, so the record this assignment
+    // displaces must be queued regardless of whether the assignment also reverts
+    // an earlier displacement. Only a *persisted* displaced record has a
+    // row/foreign key to nullify; a transient in-memory target has none.
     if (
       displaced &&
       (displaced as { isPersisted?: () => boolean }).isPersisted?.() &&
@@ -101,6 +93,16 @@ export class HasOneAssociation extends SingularAssociation {
       // `:dependent` — the `else` branch nullifies the old FK even with no
       // `:dependent`. We defer that load to `removeDisplaced` at the owner's save.
       this._removeDisplacedFromDb = true;
+    }
+    // Reverting to a record already queued for removal cancels *just its*
+    // removal (`owner.x = other; owner.x = original`) — the now-target record no
+    // longer needs its FK nullified. This runs after the queue above so it only
+    // cancels the reverted record, never the one this same assignment displaced
+    // (which the push guard guarantees is a different record). Leaves every other
+    // pending displacement intact.
+    if (record) {
+      const idx = this._displacedRecords.findIndex((r) => sameRecord(record, r));
+      if (idx !== -1) this._displacedRecords.splice(idx, 1);
     }
   }
 

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -39,7 +39,7 @@ export class HasOneAssociation extends SingularAssociation {
   /**
    * Set when a deferred assignment displaces an *unloaded* has_one on a persisted
    * owner: at queue time the current target has not been materialized, so there
-   * is no in-memory `_displacedRecord` to remove — but a DB row keyed by the
+   * is no in-memory `_displacedRecords` entry to remove — but a DB row keyed by the
    * owner may still exist and must be removed (nullified, or per `:dependent`).
    * Rails loads the current target synchronously inside `replace`; the JS
    * property setter cannot `await`, so we defer the load to `removeDisplaced`,

--- a/packages/activerecord/src/associations/has-one-displaced-record-multi-slot.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-displaced-record-multi-slot.trails.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Trails-only: a has_one owner can displace more than one persisted record
+ * before its `save()` drains the queue. Rails has no queue — it removes each
+ * displaced record inline inside `HasOneAssociation#replace`
+ * (vendor/rails/activerecord/lib/active_record/associations/has_one_association.rb
+ * :59-85) — so there is no Rails test for this; the defect is specific to
+ * trails' deferral of the removal to save time (the JS property setter / sync
+ * `build` cannot await). These tests assert every displaced record is nullified,
+ * not just the last one.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { registerModel } from "../index.js";
+import { Pirate } from "../test-helpers/models/pirate.js";
+import { Ship } from "../test-helpers/models/ship.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+
+describe("HasOneDisplacedRecordMultiSlot", () => {
+  fixtures(["ships", "pirates"]);
+
+  beforeAll(() => {
+    registerModel(Pirate);
+    registerModel(Ship);
+  });
+
+  it("two persisted displacements via the writer path both get nullified", async () => {
+    const pirate = await Pirate.create({ catchphrase: "Arrr" });
+    const a = await Ship.create({ name: "A", pirate_id: pirate.id });
+    await pirate.loadHasOne("ship");
+    const b = await Ship.create({ name: "B" });
+    const c = await Ship.create({ name: "C" });
+
+    pirate.ship = b; // displaces the persisted A
+    pirate.ship = c; // displaces the persisted B; A must not be lost
+    await pirate.save();
+
+    expect((await Ship.find(a.id)).pirate_id).toBeNull();
+    expect((await Ship.find(b.id)).pirate_id).toBeNull();
+    expect((await Ship.find(c.id)).pirate_id).toBe(Number(pirate.id));
+  });
+
+  it("writer-then-build displacement both get nullified", async () => {
+    const pirate = await Pirate.create({ catchphrase: "Arrr" });
+    const a = await Ship.create({ name: "A", pirate_id: pirate.id });
+    await pirate.loadHasOne("ship");
+    const b = await Ship.create({ name: "B" });
+
+    pirate.ship = b; // displaces the persisted A (queueWrite)
+    const shipAssoc = pirate.association("ship") as unknown as {
+      build(attributes?: Record<string, unknown>): Ship | null;
+    };
+    const c = shipAssoc.build({ name: "C" }) as Ship; // displaces persisted B (setNewRecord)
+    await pirate.save();
+
+    expect((await Ship.find(a.id)).pirate_id).toBeNull();
+    expect((await Ship.find(b.id)).pirate_id).toBeNull();
+    expect(c.pirate_id).toBe(Number(pirate.id));
+    expect(c.isPersisted()).toBe(true);
+  });
+
+  it("reverting to a displaced record cancels only that record's removal", async () => {
+    const pirate = await Pirate.create({ catchphrase: "Arrr" });
+    const a = await Ship.create({ name: "A", pirate_id: pirate.id });
+    await pirate.loadHasOne("ship");
+    const b = await Ship.create({ name: "B" });
+
+    pirate.ship = b; // displaces the persisted A
+    pirate.ship = a; // reverts to A: cancels A's removal, displaces B
+    await pirate.save();
+
+    expect((await Ship.find(a.id)).pirate_id).toBe(Number(pirate.id));
+    expect((await Ship.find(b.id)).pirate_id).toBeNull();
+  });
+});

--- a/packages/activerecord/src/associations/has-one-displaced-record-multi-slot.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-displaced-record-multi-slot.trails.test.ts
@@ -70,4 +70,22 @@ describe("HasOneDisplacedRecordMultiSlot", () => {
     expect((await Ship.find(a.id)).pirate_id).toBe(Number(pirate.id));
     expect((await Ship.find(b.id)).pirate_id).toBeNull();
   });
+
+  it("reverting cancels only the re-assigned record, still removing what the revert displaces", async () => {
+    const pirate = await Pirate.create({ catchphrase: "Arrr" });
+    const a = await Ship.create({ name: "A", pirate_id: pirate.id });
+    await pirate.loadHasOne("ship");
+    const b = await Ship.create({ name: "B", pirate_id: pirate.id });
+    const c = await Ship.create({ name: "C", pirate_id: pirate.id });
+
+    pirate.ship = b; // displaces the persisted A
+    pirate.ship = c; // displaces b
+    pirate.ship = b; // reverts to b (cancels b's removal) but displaces c
+    await pirate.save();
+
+    // A and c both displaced and never reverted → nullified. b is the target.
+    expect((await Ship.find(a.id)).pirate_id).toBeNull();
+    expect((await Ship.find(c.id)).pirate_id).toBeNull();
+    expect((await Ship.find(b.id)).pirate_id).toBe(Number(pirate.id));
+  });
 });

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -349,8 +349,8 @@ export class HasOneThroughAssociation extends HasOneAssociation {
     //
     // We also clear the suppression sentinel we set on the through proxy's
     // duck-typed `_pendingReplace`: the base `HasOneAssociation#reset` clears
-    // only `_displacedRecord` (it never declares `_pendingReplace`, having
-    // converged onto `_displacedRecord` + `autosaveHasOne`), so without this the
+    // only `_displacedRecords` (it never declares `_pendingReplace`, having
+    // converged onto `_displacedRecords` + `autosaveHasOne`), so without this the
     // sentinel would linger and permanently make `autosaveHasOne` skip the
     // proxy — silently dropping any *later* independent write to
     // `owner.currentMembership` on this same instance. Runs before the `!pending`

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -531,7 +531,7 @@ async function autosaveHasOne(record: Base, assoc: AssociationDefinition): Promi
   // must NOT be inserted here — the through's own `persistReplace` reconciles
   // the existing DB row via `load_target` + `update`, and persisting it here
   // would duplicate that row. A plain `HasOneAssociation` never sets
-  // `_pendingReplace` itself (it converged onto `_displacedRecord` +
+  // `_pendingReplace` itself (it converged onto `_displacedRecords` +
   // `autosaveHasOne`), and the through association itself clears its marker
   // inside `persistThroughRecord` above, so a truthy marker on an instance with
   // no `persistThroughRecord` is unambiguously that suppression sentinel. Skip

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -501,7 +501,7 @@ async function autosaveHasOne(record: Base, assoc: AssociationDefinition): Promi
   // `!child` bail so assigning nil (`owner.account = null`) still removes it.
   if (
     typeof inst?.removeDisplaced === "function" &&
-    (inst?._displacedRecord || inst?._removeDisplacedFromDb)
+    ((inst?._displacedRecords?.length ?? 0) > 0 || inst?._removeDisplacedFromDb)
   ) {
     await inst.removeDisplaced();
   }


### PR DESCRIPTION
## What

`HasOneAssociation._displacedRecord` was a **single slot**, but a has_one owner can displace more than one persisted record before its `save()` drains the queue. The second displacement overwrote the first, so the first record's foreign key was never nullified:

```ts
pirate.ship = b; // displaces persisted A -> slot = A
pirate.ship = c; // displaces persisted B -> slot = B, A lost
await pirate.save();
// A.pirate_id still set; Rails nullified it at the first replace.
```

Rails has no queue — `HasOneAssociation#replace` runs `remove_target!` inline on every assignment (has_one_association.rb:59-85), so each displaced record is removed as it is displaced. trails defers because the JS property setter and sync `build` can't `await`; the deferral collapsed N displacements into one slot.

## Change

- `_displacedRecord` → ordered `_displacedRecords: Base[]`. Every persisted record displaced before `save()` is removed, in displacement order.
- `removeDisplaced()` drains the whole collection, running `removeTargetBang` per record with the reflection's `:dependent` (delete/destroy/else-nullify).
- The revert-cancel rule (`owner.x = other; owner.x = original`) now removes just the reverted record from the pending set, leaving other displacements intact.
- `setNewRecord` (the `build` path) queues onto the same collection, so writer-then-build displacements (both persisted) are both removed. This subsumes the single-slot version in the still-open #4899.
- The autosave guard (`autosave-association.ts`) checks emptiness, not truthiness — an empty array is truthy and would have fired `removeDisplaced` on every save.
- `reset()` clears the collection.

## Tests

New `has-one-displaced-record-multi-slot.trails.test.ts` (trails-only — Rails has no queue, so no Rails counterpart exists):
- two persisted displacements via the writer path both get nullified
- writer-then-build displacement (both persisted) both get nullified
- revert-cancel still cancels only the reverted record's removal

No regressions in the has_one, has_one_through, and autosave suites (347 passed).

Closes-story: has-one-displaced-record-multi-slot