### PR TITLE
fix(activesupport): Instrumenter routes through a raw-payload handle so Event#dup is faithful

### DIFF
--- a/packages/activesupport/src/notifications.trails.test.ts
+++ b/packages/activesupport/src/notifications.trails.test.ts
@@ -231,5 +231,25 @@ describe("Notifications (trails)", () => {
 
       expect(events[0].payload).toBe(payload);
     });
+
+    it("publishes the same payload object with no block", () => {
+      const events: Event[] = [];
+      Notifications.subscribe("ident", (e) => events.push(e));
+
+      const payload = { a: 1 };
+      Notifications.instrument("ident", payload);
+
+      expect(events[0].payload).toBe(payload);
+    });
+
+    it("publish delivers the same payload object", () => {
+      const events: Event[] = [];
+      Notifications.subscribe("ident", (e) => events.push(e));
+
+      const payload = { a: 1 };
+      Notifications.publish("ident", payload);
+
+      expect(events[0].payload).toBe(payload);
+    });
   });
 });

--- a/packages/activesupport/src/notifications.trails.test.ts
+++ b/packages/activesupport/src/notifications.trails.test.ts
@@ -203,4 +203,33 @@ describe("Notifications (trails)", () => {
       expect(() => handle.start()).toThrow(/expected state to be "initialized"/);
     });
   });
+
+  // Rails' EventObjectGroup#finish assigns `@event.payload = payload` after
+  // Event#initialize dup'd it (fanout.rb:166-178), so the published event
+  // reflects the final payload object exactly — including keys the block deleted.
+  describe("payload is replaced at finish, not merged", () => {
+    it("reflects a key the block deleted", () => {
+      const events: Event[] = [];
+      Notifications.subscribe("del", (e) => events.push(e));
+
+      Notifications.instrument("del", { stale: true }, (payload) => {
+        delete payload.stale;
+      });
+
+      expect(events).toHaveLength(1);
+      expect("stale" in events[0].payload).toBe(false);
+    });
+
+    it("publishes the same payload object the block was yielded", () => {
+      const events: Event[] = [];
+      Notifications.subscribe("ident", (e) => events.push(e));
+
+      const payload = { a: 1 };
+      Notifications.instrument("ident", payload, (yielded) => {
+        expect(yielded).toBe(payload);
+      });
+
+      expect(events[0].payload).toBe(payload);
+    });
+  });
 });

--- a/packages/activesupport/src/notifications.ts
+++ b/packages/activesupport/src/notifications.ts
@@ -177,6 +177,10 @@ export class Notifications {
     const event = this._buildEvent(name, resolved, current);
 
     if (!block) {
+      // Rails goes through handle.start/finish even with no block, and
+      // EventObjectGroup#finish assigns the raw payload; do the same so
+      // subscribers get `event.payload === resolved`.
+      event.payload = resolved;
       event.finish();
       this._notify(event);
       return undefined as any;
@@ -231,6 +235,8 @@ export class Notifications {
     const event = this._buildEvent(name, resolved, current);
 
     if (!block) {
+      // See instrument(): assign the raw payload so subscribers get identity.
+      event.payload = resolved;
       event.finish();
       this._notify(event);
       return undefined as any;
@@ -261,7 +267,10 @@ export class Notifications {
    * Mirrors ActiveSupport::Notifications.publish.
    */
   static publish(name: string, payload?: EventPayload): void {
-    const event = this._buildEvent(name, payload);
+    const resolved = payload ?? {};
+    const event = this._buildEvent(name, resolved);
+    // Deliver the passed payload object itself, not Event#initialize's dup.
+    event.payload = resolved;
     event.finish();
     this._notify(event, true);
   }

--- a/packages/activesupport/src/notifications.ts
+++ b/packages/activesupport/src/notifications.ts
@@ -189,11 +189,15 @@ export class Notifications {
     const inner = [...current, event];
     let result: T;
     try {
-      result = this._runWithStack(inner, () => block(event.payload));
+      result = this._runWithStack(inner, () => block(resolved));
     } catch (e) {
-      this._recordException(event.payload, e);
+      this._recordException(resolved, e);
       throw e;
     } finally {
+      // Event#initialize dup'd the payload; re-sync the block's mutations (and
+      // the rescue arm's) onto that copy before publishing, as Rails' Fanout
+      // EventObjectGroup does. The block mutates the raw payload it was yielded.
+      Object.assign(event.payload, resolved);
       event.finish();
       this._notify(event);
     }
@@ -239,11 +243,14 @@ export class Notifications {
     const inner = [...current, event];
     let result: T;
     try {
-      result = await this._runWithStack(inner, () => block(event.payload));
+      result = await this._runWithStack(inner, () => block(resolved));
     } catch (e) {
-      this._recordException(event.payload, e);
+      this._recordException(resolved, e);
       throw e;
     } finally {
+      // See instrument(): re-sync the raw payload's mutations onto the event's
+      // dup before publishing.
+      Object.assign(event.payload, resolved);
       event.finish();
       this._notify(event);
     }
@@ -265,8 +272,8 @@ export class Notifications {
    * `ActiveSupport::Notifications.instrumenter.build_handle`. The returned
    * handle records the event's start at `#start` and finishes + publishes it at
    * `#finish`, so `event.duration` covers the whole span (not just the publish
-   * call). The payload is held by reference: mutations made between `#start`
-   * and `#finish` (e.g. `payload.outcome = ...`) are visible to subscribers.
+   * call). Mutations made between `#start` and `#finish` (e.g.
+   * `payload.outcome = ...`) are re-synced onto the event before publishing.
    */
   static buildHandle(name: string, payload: EventPayload = {}): NotificationHandle {
     // Rails' Fanout::Handle snapshots the matching listener groups at build
@@ -295,6 +302,9 @@ export class Notifications {
         state = "finished";
         if (event) {
           const finished = event;
+          // Event#initialize dup'd the payload; re-sync mutations made between
+          // start and finish onto that copy before delivering.
+          Object.assign(finished.payload, payload);
           finished.finish();
           // Rails' Handle#finish_with_values runs every group under
           // iterate_guarding_exceptions (fanout.rb:20-39, :253-259): one bad

--- a/packages/activesupport/src/notifications.ts
+++ b/packages/activesupport/src/notifications.ts
@@ -194,10 +194,10 @@ export class Notifications {
       this._recordException(resolved, e);
       throw e;
     } finally {
-      // Event#initialize dup'd the payload; re-sync the block's mutations (and
-      // the rescue arm's) onto that copy before publishing, as Rails' Fanout
-      // EventObjectGroup does. The block mutates the raw payload it was yielded.
-      Object.assign(event.payload, resolved);
+      // Replace the event's dup with the final payload object (the raw payload
+      // the block was yielded and mutated), as Rails' EventObjectGroup#finish
+      // does — reflecting the block's mutations, the rescue arm, and deletions.
+      event.payload = resolved;
       event.finish();
       this._notify(event);
     }
@@ -248,9 +248,8 @@ export class Notifications {
       this._recordException(resolved, e);
       throw e;
     } finally {
-      // See instrument(): re-sync the raw payload's mutations onto the event's
-      // dup before publishing.
-      Object.assign(event.payload, resolved);
+      // See instrument(): replace the event's dup with the final payload object.
+      event.payload = resolved;
       event.finish();
       this._notify(event);
     }
@@ -302,9 +301,9 @@ export class Notifications {
         state = "finished";
         if (event) {
           const finished = event;
-          // Event#initialize dup'd the payload; re-sync mutations made between
-          // start and finish onto that copy before delivering.
-          Object.assign(finished.payload, payload);
+          // Replace the event's dup with the final payload object (mutations
+          // made between start and finish), as Rails' EventObjectGroup#finish does.
+          finished.payload = payload;
           finished.finish();
           // Rails' Handle#finish_with_values runs every group under
           // iterate_guarding_exceptions (fanout.rb:20-39, :253-259): one bad

--- a/packages/activesupport/src/notifications/fanout.ts
+++ b/packages/activesupport/src/notifications/fanout.ts
@@ -211,7 +211,9 @@ export class EventObjectGroup extends BaseGroup {
 
   finish(_name: string, _id: unknown, payload: Record<string, unknown>): void {
     if (this.event) {
-      Object.assign(this.event.payload, payload);
+      // Rails' EventObjectGroup#finish: `@event.payload = payload` — replace the
+      // dup with the final object so deletions are reflected (fanout.rb:166-178).
+      this.event.payload = payload;
       this.event.finish();
       iterateGuardingExceptions(this.listeners, (l) => l(this.event!));
     }

--- a/packages/activesupport/src/notifications/instrumenter.trails.test.ts
+++ b/packages/activesupport/src/notifications/instrumenter.trails.test.ts
@@ -112,4 +112,30 @@ describe("Instrumenter (trails)", () => {
     expect(handle).toBe(delegated);
     expect(calls).toEqual([["span", instrumenter.id]]);
   });
+
+  it("instrument routes through the notifier's build_handle", () => {
+    // Rails' #instrument is build_handle → start → yield → finish
+    // (instrumenter.rb:54-65), so a notifier that builds handles drives the
+    // event through them rather than a separate publish path.
+    const order: string[] = [];
+    const notifier = {
+      publish() {
+        order.push("publish");
+      },
+      buildHandle(_name: string, _id: unknown) {
+        return {
+          start() {
+            order.push("start");
+          },
+          finish() {
+            order.push("finish");
+          },
+        };
+      },
+    };
+    new Instrumenter(notifier).instrument("span", {}, () => {
+      order.push("block");
+    });
+    expect(order).toEqual(["start", "block", "finish"]);
+  });
 });

--- a/packages/activesupport/src/notifications/instrumenter.ts
+++ b/packages/activesupport/src/notifications/instrumenter.ts
@@ -87,7 +87,7 @@ export interface NotificationHandle {
 
 export class Instrumenter {
   private _notifier: InstrumenterNotifier;
-  private _stack: Event[] = [];
+  private _stack: Handle[] = [];
   readonly id: string;
 
   constructor(notifier: InstrumenterNotifier) {
@@ -96,16 +96,19 @@ export class Instrumenter {
   }
 
   /**
-   * The block receives the payload — the same object passed in, which
-   * subscribers read after the block returns. Mutating it is how a caller
-   * reports back into the notification, mirroring Rails' `yield payload`.
+   * Mirrors ActiveSupport::Notifications::Instrumenter#instrument
+   * (instrumenter.rb:54-65): build a handle, start it, yield the raw payload
+   * (the rescue arm records the exception on it), then finish the handle in the
+   * `ensure`. Routing through `build_handle` is what lets a Fanout notifier's
+   * groups drive the event, rather than open-coding an Event/publish here.
    */
   instrument<T = void>(
     name: string,
     payload: EventPayload = {},
     fn?: (payload: EventPayload) => T,
   ): T {
-    const event = this._push(name, payload);
+    const handle = this.buildHandle(name, payload);
+    handle.start();
 
     try {
       if (fn) return fn(payload);
@@ -114,7 +117,7 @@ export class Instrumenter {
       _recordException(payload, e);
       throw e;
     } finally {
-      this._pop(event, payload);
+      handle.finish();
     }
   }
 
@@ -123,7 +126,8 @@ export class Instrumenter {
     payload: EventPayload = {},
     fn?: (payload: EventPayload) => Promise<T>,
   ): Promise<T> {
-    const event = this._push(name, payload);
+    const handle = this.buildHandle(name, payload);
+    handle.start();
 
     try {
       if (fn) return await fn(payload);
@@ -132,7 +136,7 @@ export class Instrumenter {
       _recordException(payload, e);
       throw e;
     } finally {
-      this._pop(event, payload);
+      handle.finish();
     }
   }
 
@@ -149,25 +153,9 @@ export class Instrumenter {
     if (this._notifier.buildHandle) {
       return this._notifier.buildHandle(name, this.id, payload);
     }
-    return new Handle(name, payload, this.id, this._notifier);
-  }
-
-  private _push(name: string, payload: EventPayload): Event {
-    const event = new Event(name, Temporal.Now.instant(), payload, this.id);
-    const parent = this._stack[this._stack.length - 1];
-    if (parent) parent.children.push(event);
-    this._stack.push(event);
-    return event;
-  }
-
-  private _pop(event: Event, payload: EventPayload): void {
-    this._stack.pop();
-    // Rails' EventObjectGroup#finish replaces the event's dup with the final
-    // payload object, so the block's mutations (and the rescue arm's, and any
-    // deletions) are reflected exactly.
-    event.payload = payload;
-    event.finish();
-    this._notifier.publish(event.name, event);
+    // The stack threads trails' (non-Rails) child-event nesting through the
+    // wrapped handles: each links its event under the one still open above it.
+    return new Handle(name, payload, this.id, this._notifier, this._stack);
   }
 }
 
@@ -185,6 +173,8 @@ export class Handle implements NotificationHandle {
     private _payload: EventPayload,
     private _transactionId: string,
     private _notifier: { publish(name: string, event: Event): void },
+    // Optional nesting stack for trails' child-event tracking (see Instrumenter).
+    private _stack?: Handle[],
   ) {}
 
   start(): void {
@@ -193,6 +183,11 @@ export class Handle implements NotificationHandle {
     }
     this._state = "started";
     this._event = new Event(this._name, Temporal.Now.instant(), this._payload, this._transactionId);
+    if (this._stack) {
+      const parent = this._stack[this._stack.length - 1];
+      if (parent?._event) parent._event.children.push(this._event);
+      this._stack.push(this);
+    }
   }
 
   finish(): void {
@@ -200,6 +195,7 @@ export class Handle implements NotificationHandle {
       throw new ArgumentError(`expected state to be "started" but was "${this._state}"`);
     }
     this._state = "finished";
+    if (this._stack) this._stack.pop();
     if (this._event) {
       // Replace the event's dup with the final payload object (mutations made
       // between start and finish, e.g. payload.outcome), as Rails'

--- a/packages/activesupport/src/notifications/instrumenter.ts
+++ b/packages/activesupport/src/notifications/instrumenter.ts
@@ -22,7 +22,9 @@ export class Event {
   readonly name: string;
   readonly time: Temporal.Instant;
   end: Temporal.Instant | null;
-  readonly payload: EventPayload;
+  // Writable, mirroring Rails' `attr_accessor :payload`: the event is built with
+  // a dup, then finish replaces it with the final payload object (below).
+  payload: EventPayload;
   readonly transactionId: string;
   readonly children: Event[];
 
@@ -35,10 +37,9 @@ export class Event {
     this.name = name;
     this.time = start;
     this.end = null;
-    // Rails' Event#initialize does `@payload = payload.dup` (a shallow copy).
-    // The event holds a snapshot; sites that mutate the source payload after
-    // construction (the rescue arm, an outcome set before finish) re-sync it
-    // onto this copy before publishing — as Fanout's EventObjectGroup does.
+    // Rails' Event#initialize does `@payload = payload.dup` (a shallow copy):
+    // the event holds a snapshot until finish replaces it with the final
+    // payload object (Fanout's EventObjectGroup#finish: `@event.payload = payload`).
     this.payload = { ...payload };
     this.transactionId = transactionId ?? generateTransactionId();
     this.children = [];
@@ -161,10 +162,10 @@ export class Instrumenter {
 
   private _pop(event: Event, payload: EventPayload): void {
     this._stack.pop();
-    // Event#initialize dup'd the payload at _push; re-sync the block's and the
-    // rescue arm's mutations onto that copy before publishing, as Rails' Fanout
-    // EventObjectGroup does at finish.
-    Object.assign(event.payload, payload);
+    // Rails' EventObjectGroup#finish replaces the event's dup with the final
+    // payload object, so the block's mutations (and the rescue arm's, and any
+    // deletions) are reflected exactly.
+    event.payload = payload;
     event.finish();
     this._notifier.publish(event.name, event);
   }
@@ -173,7 +174,7 @@ export class Instrumenter {
 /**
  * Mirrors ActiveSupport::Notifications::Fanout::Handle — builds the Event at
  * `#start` (so its start time is the real start of the work) and publishes it
- * at `#finish`, re-syncing any payload mutations made in between.
+ * at `#finish`, replacing the event's payload with the final object first.
  */
 export class Handle implements NotificationHandle {
   private _state: "initialized" | "started" | "finished" = "initialized";
@@ -200,10 +201,10 @@ export class Handle implements NotificationHandle {
     }
     this._state = "finished";
     if (this._event) {
-      // Event#initialize dup'd the payload at #start; re-sync mutations made
-      // between start and finish (e.g. payload.outcome) onto that copy before
-      // publishing, as Rails' Fanout EventObjectGroup does.
-      Object.assign(this._event.payload, this._payload);
+      // Replace the event's dup with the final payload object (mutations made
+      // between start and finish, e.g. payload.outcome), as Rails'
+      // EventObjectGroup#finish does.
+      this._event.payload = this._payload;
       this._event.finish();
       this._notifier.publish(this._event.name, this._event);
     }

--- a/packages/activesupport/src/notifications/instrumenter.ts
+++ b/packages/activesupport/src/notifications/instrumenter.ts
@@ -35,7 +35,11 @@ export class Event {
     this.name = name;
     this.time = start;
     this.end = null;
-    this.payload = payload;
+    // Rails' Event#initialize does `@payload = payload.dup` (a shallow copy).
+    // The event holds a snapshot; sites that mutate the source payload after
+    // construction (the rescue arm, an outcome set before finish) re-sync it
+    // onto this copy before publishing — as Fanout's EventObjectGroup does.
+    this.payload = { ...payload };
     this.transactionId = transactionId ?? generateTransactionId();
     this.children = [];
   }
@@ -109,7 +113,7 @@ export class Instrumenter {
       _recordException(payload, e);
       throw e;
     } finally {
-      this._pop(event);
+      this._pop(event, payload);
     }
   }
 
@@ -127,7 +131,7 @@ export class Instrumenter {
       _recordException(payload, e);
       throw e;
     } finally {
-      this._pop(event);
+      this._pop(event, payload);
     }
   }
 
@@ -147,12 +151,6 @@ export class Instrumenter {
     return new Handle(name, payload, this.id, this._notifier);
   }
 
-  // Rails' #instrument never builds an Event — it hands the raw payload to a
-  // Fanout handle, so subscribers see the block's mutations (that is how
-  // payload[:exception] reaches them). trails routes it through an Event, which
-  // works only because Event holds the payload by reference. Rails' Event#dups
-  // it (instrumenter.rb:105); converging that dup without first moving this path
-  // off Event would silently hide the exception keys from subscribers.
   private _push(name: string, payload: EventPayload): Event {
     const event = new Event(name, Temporal.Now.instant(), payload, this.id);
     const parent = this._stack[this._stack.length - 1];
@@ -161,8 +159,12 @@ export class Instrumenter {
     return event;
   }
 
-  private _pop(event: Event): void {
+  private _pop(event: Event, payload: EventPayload): void {
     this._stack.pop();
+    // Event#initialize dup'd the payload at _push; re-sync the block's and the
+    // rescue arm's mutations onto that copy before publishing, as Rails' Fanout
+    // EventObjectGroup does at finish.
+    Object.assign(event.payload, payload);
     event.finish();
     this._notifier.publish(event.name, event);
   }
@@ -171,7 +173,7 @@ export class Instrumenter {
 /**
  * Mirrors ActiveSupport::Notifications::Fanout::Handle — builds the Event at
  * `#start` (so its start time is the real start of the work) and publishes it
- * at `#finish`, off the payload held by reference.
+ * at `#finish`, re-syncing any payload mutations made in between.
  */
 export class Handle implements NotificationHandle {
   private _state: "initialized" | "started" | "finished" = "initialized";
@@ -198,6 +200,10 @@ export class Handle implements NotificationHandle {
     }
     this._state = "finished";
     if (this._event) {
+      // Event#initialize dup'd the payload at #start; re-sync mutations made
+      // between start and finish (e.g. payload.outcome) onto that copy before
+      // publishing, as Rails' Fanout EventObjectGroup does.
+      Object.assign(this._event.payload, this._payload);
       this._event.finish();
       this._notifier.publish(this._event.name, this._event);
     }

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -42330,13 +42330,6 @@
   },
   {
     "package": "activesupport",
-    "tsFile": "notifications/instrumenter.ts",
-    "rubyName": "instrument",
-    "call": "build_handle",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activesupport",
     "tsFile": "number-helper/number-to-currency-converter.ts",
     "rubyName": "convert",
     "call": "to_s",


### PR DESCRIPTION
## What

Rails' `Event#initialize` does `@payload = payload.dup` (`vendor/rails/activesupport/lib/active_support/notifications/instrumenter.rb:112`). The event holds a *snapshot*; the Fanout groups re-sync the final payload onto it at finish (`EventObjectGroup#finish` → `Object.assign`, already faithful in `fanout.ts`). trails' `Event` instead held the payload **by reference**, so converging the `.dup` in isolation would have hidden the keys the rescue arm sets (`payload.exception` / `payload.exception_object`) and other post-build mutations (`row_count`, transaction `outcome`) from subscribers — the coupling flagged in review of #4894.

## Changes

- Converge `Event#initialize` to `this.payload = { ...payload }` (Rails' shallow `.dup`).
- Re-sync `Object.assign(event.payload, payload)` at every publish site that mutates the source payload *after* building the event — the instance `Instrumenter._pop`, its `build_handle` `Handle#finish`, and the static `Notifications` `instrument` / `instrumentAsync` / `buildHandle` paths. This mirrors what Fanout's `EventObjectGroup` already does.
- The static `instrument` path now yields the **raw** payload (as Rails does) rather than the event's copy, so closure-style callers (e.g. `sql.active_record`'s `row_count`, which mutates its own payload object and ignores the yielded arg) land on the object that gets re-synced.

## Notes

- **Rebased onto #4906.** That PR (merged) added `Instrumenter#build_handle` and converged `TransactionInstrumenter` onto it — which resolved the Codex review comment on the earlier revision of this PR and made my prior `transaction.ts` edit obsolete. This revision drops that edit; the `build_handle` `Handle` is instead made dup-safe via the same re-sync. `#4906` did **not** touch `Event#initialize`, so the dup convergence — this story's core — is still landed here.
- **`Event#record` / `new_event` not ported.** They are Rails' alternate build-an-Event entry point (`instrumenter.rb:132-143`), unused by trails; porting empty bodies would add unused surface.

## Tests

No new tests — the existing `notifications/instrumenter.trails.test.ts` exception-key assertions, plus AR's `instrumentation`, `transaction-instrumentation`, and `log-subscriber` suites, are the regression surface. 212 passed across the affected activesupport + activerecord suites. api:compare `11418/16975` and test:compare `14448/21663` — both non-negative vs main.

Closes-story: converge-instrumenter-event-payload-dup


## Review response (2)

**Codex — `Object.assign` re-sync preserves keys the block deleted.** Fixed, and the reviewer is right: Rails' `EventObjectGroup#finish` does `@event.payload = payload` (`fanout.rb:166-178`) — it *replaces* the dup with the final object, so deletions and the exact final object are reflected. I switched every finish site (instance `Instrumenter`, its `build_handle` `Handle`, the static `instrument`/`buildHandle` paths, and Fanout's `EventObjectGroup`, which had the same latent bug) from `Object.assign` to `event.payload = payload`, and made `Event#payload` writable to match Rails' `attr_accessor :payload`. Added trails coverage for the deletion and object-identity semantics (`notifications.trails.test.ts`).


## Review response (3)

**Codex — `Instrumenter#instrument` open-codes `_push`/publish and ignores a `buildHandle`-capable notifier.** Fixed — this is the story's acceptance criterion #1. `instrument` / `instrumentAsync` now do `this.buildHandle(name, payload).start()` → yield the raw payload → `finish()` in the `ensure`, mirroring Rails (`instrumenter.rb:54-65`, `:78-80`), so a Fanout notifier's `build_handle` drives the event instead of a separate publish path. trails' non-Rails child-event nesting is preserved by threading the instrumenter's stack into the wrapped `Handle` (each event links under the one still open above it); a notifier that supplies its own `build_handle` drives its own handle, as in Rails. Added coverage that `instrument` invokes the notifier's `build_handle` (`instrumenter.trails.test.ts`).


## Review response (4)

**Codex — no-block static `instrument` paths publish the dup, losing `event.payload === payload`.** Fixed. The no-block branches of static `instrument` / `instrumentAsync` (and `publish`, which had the same dup-introduced regression) now assign `event.payload = resolved` before delivery, matching Rails running `handle.start`/`ensure handle.finish` even with no block (`instrumenter.rb:54-65`) and `EventObjectGroup#finish`'s `@event.payload = payload` (`fanout.rb:172-174`). The instance `Instrumenter` no-block path already had identity (it routes through the handle, whose `finish` assigns the payload). Added coverage for no-block `instrument` and `publish` payload identity.
