### PR TITLE
fix(associations): has_one create over a loaded target removes the prior record

### DIFF
--- a/packages/activerecord/src/associations/builder/has-one.ts
+++ b/packages/activerecord/src/associations/builder/has-one.ts
@@ -68,9 +68,24 @@ export class HasOne extends SingularAssociation {
           typeof assoc.needsTargetLoadForBuild === "function" &&
           assoc.needsTargetLoadForBuild()
         ) {
-          return assoc.loadTarget().then(() => assoc.build(...args));
+          return assoc.loadTarget().then((displaced: unknown) => {
+            const record = assoc.build(...args);
+            return assoc.detachDisplacedTarget(displaced, record).then(() => record);
+          });
         }
-        return assoc.build(...args);
+        // The target may already be loaded (so `needsTargetLoadForBuild` is
+        // false): Rails' `set_new_record` → `replace` still runs `remove_target!`
+        // on it, detaching the prior record (FK nullified / destroyed per
+        // `:dependent`). That removal needs an `await`, so return a Promise for
+        // the loaded-target case only — a new-record / no-target build keeps its
+        // synchronous return (the shape the STI-build tests assert).
+        const displaced =
+          typeof assoc.isLoaded === "function" && assoc.isLoaded() ? assoc.target : null;
+        const record = assoc.build(...args);
+        if (displaced && typeof assoc.detachDisplacedTarget === "function") {
+          return assoc.detachDisplacedTarget(displaced, record).then(() => record);
+        }
+        return record;
       },
       writable: true,
       configurable: true,

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -401,13 +401,15 @@ export class HasOneAssociation extends SingularAssociation {
     if (!displaced) return;
     if ((displaced as { isDestroyed?: () => boolean }).isDestroyed?.()) return;
     if (sameRecord(displaced, replacement)) return;
-    const currentTarget = this.target;
+    // Mirror Rails' `HasOneAssociation#replace`, where `self.target = record` runs
+    // only after the transaction block: if `remove_target!` raises (e.g. a failed
+    // nullify save, which restores the old record's owner attributes before
+    // raising — has_one_association.rb:102-108), the cached target stays the OLD
+    // record. So point the target at `displaced` across the removal and only
+    // promote the `replacement` on success — a throw leaves `displaced` cached.
     this.target = displaced;
-    try {
-      await removeTargetBang(this, (this.reflection.options.dependent as string) ?? "");
-    } finally {
-      this.target = currentTarget;
-    }
+    await removeTargetBang(this, (this.reflection.options.dependent as string) ?? "");
+    this.target = replacement;
   }
 
   protected override async doAsyncFindTarget(): Promise<Base | null> {

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -363,7 +363,38 @@ export class HasOneAssociation extends SingularAssociation {
     if (!(this.owner as { isPersisted?: () => boolean }).isPersisted?.()) {
       throw new RecordNotSaved("You cannot call create unless the parent is saved", this.owner);
     }
-    return super._createRecord(attributes, shouldRaise, block);
+    // Mirror Rails' `HasOneAssociation#replace` (has_one_association.rb:59-69),
+    // which `set_new_record` reaches via `replace(record, false)`: `remove_target!`
+    // detaches the currently associated record (FK nullified / destroyed per
+    // `:dependent`) whenever another record is being assigned. `replace`'s leading
+    // `load_target` returns the already-cached target, so when the caller has
+    // loaded it (`readHasOne` / preload), that OLD record is the one removed. Our
+    // `replace`/`setNewRecord` are sync and cannot `await` that removal, so we run
+    // it here. Capture the loaded target BEFORE `super._createRecord`, which
+    // builds the new record first — an invalid build (e.g. an inexistent foreign
+    // key) must raise before any removal runs, exactly as Rails' `build_record`
+    // raises before `set_new_record`. An unloaded target is left to the property-
+    // setter displacement path (`queueWrite` flags), matching Rails' behaviour of
+    // only removing what `load_target` surfaces.
+    const displaced = this.loaded ? this.target : null;
+    const record = await super._createRecord(attributes, shouldRaise, block);
+    // `super._createRecord` ran `setNewRecord` → `replace`, so `this.target` is
+    // now the freshly created record. Only the displaced (previously attached)
+    // record needs detaching, and only when the assignment actually changes it.
+    if (
+      displaced &&
+      !(displaced as { isDestroyed?: () => boolean }).isDestroyed?.() &&
+      !sameRecord(displaced, record)
+    ) {
+      const currentTarget = this.target;
+      this.target = displaced;
+      try {
+        await removeTargetBang(this, (this.reflection.options.dependent as string) ?? "");
+      } finally {
+        this.target = currentTarget;
+      }
+    }
+    return record;
   }
 
   protected override async doAsyncFindTarget(): Promise<Base | null> {

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -379,22 +379,35 @@ export class HasOneAssociation extends SingularAssociation {
     const displaced = this.loaded ? this.target : null;
     const record = await super._createRecord(attributes, shouldRaise, block);
     // `super._createRecord` ran `setNewRecord` → `replace`, so `this.target` is
-    // now the freshly created record. Only the displaced (previously attached)
-    // record needs detaching, and only when the assignment actually changes it.
-    if (
-      displaced &&
-      !(displaced as { isDestroyed?: () => boolean }).isDestroyed?.() &&
-      !sameRecord(displaced, record)
-    ) {
-      const currentTarget = this.target;
-      this.target = displaced;
-      try {
-        await removeTargetBang(this, (this.reflection.options.dependent as string) ?? "");
-      } finally {
-        this.target = currentTarget;
-      }
-    }
+    // now the freshly created record; detach the displaced (previously attached)
+    // one, matching `remove_target!` inside Rails' `replace`.
+    await this.detachDisplacedTarget(displaced, record);
     return record;
+  }
+
+  /**
+   * Detach the record displaced by a `create#{name}` / `build#{name}` over an
+   * already-**loaded** has_one target — the awaitable analog of the
+   * `remove_target!` Rails runs inside `HasOneAssociation#replace`
+   * (has_one_association.rb:69) whenever another record is assigned. Nullifies
+   * the displaced record's foreign key (or destroys/deletes it per
+   * `:dependent`). Our sync `replace`/`setNewRecord` cannot `await` that removal,
+   * so the async create/build accessors run it here after materializing the
+   * replacement. A no-op unless a *different*, non-destroyed record was loaded.
+   *
+   * @internal
+   */
+  async detachDisplacedTarget(displaced: Base | null, replacement: Base | null): Promise<void> {
+    if (!displaced) return;
+    if ((displaced as { isDestroyed?: () => boolean }).isDestroyed?.()) return;
+    if (sameRecord(displaced, replacement)) return;
+    const currentTarget = this.target;
+    this.target = displaced;
+    try {
+      await removeTargetBang(this, (this.reflection.options.dependent as string) ?? "");
+    } finally {
+      this.target = currentTarget;
+    }
   }
 
   protected override async doAsyncFindTarget(): Promise<Base | null> {

--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -548,6 +548,33 @@ describe("HasOneAssociationsTest", () => {
     expect((await readHasOne(firm, "account")).id).toBe(account.id);
   });
 
+  // Trails deviation guard (no Rails counterpart, RFC 0005-activerecord-gaps
+  // story has-one-loaded-target-create-missing-remove-target): Rails runs
+  // `remove_target!` inside `HasOneAssociation#replace` (has_one_association.rb:69)
+  // whenever another record is assigned — including the `create#{name}` path via
+  // `set_new_record`. Our sync `replace`/`setNewRecord` cannot `await` that
+  // removal, so `_createRecord` runs it. Load the target explicitly first (no
+  // property-setter assignment, so no displacement flag is set) and assert the
+  // prior row is detached the moment `createAccount` returns.
+  it("create over a loaded target nullifies the prior account", async () => {
+    const company = (await Company.create({ name: "NewCo" })) as any;
+    const original = await Account.create({ firm_id: Number(company.id), credit_limit: 50 });
+    const found = (await Company.find(company.id)) as any;
+    await readHasOne(found, "account");
+    const created = await found.createAccount({ credit_limit: 70 });
+    expect((await Account.find(original.id)).firm_id).toBeNull();
+    expect(await Account.where({ firm_id: Number(company.id) }).count()).toBe(1);
+    expect((await readHasOne(found, "account")).id).toBe(created.id);
+  });
+
+  it("create over a loaded target destroys the prior dependent account", async () => {
+    const firm = companies("first_firm") as any;
+    const originalId = (await readHasOne(firm, "account")).id;
+    const created = await firm.createAccount({ credit_limit: 70 });
+    await expect(Account.find(originalId)).rejects.toThrow(RecordNotFound);
+    expect((await readHasOne(firm, "account")).id).toBe(created.id);
+  });
+
   it("create when parent is new raises", async () => {
     const firm = new Firm();
     let error: unknown;

--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -575,6 +575,21 @@ describe("HasOneAssociationsTest", () => {
     expect((await readHasOne(firm, "account")).id).toBe(created.id);
   });
 
+  // Same root cause on the build path: `set_new_record` → `replace(record, false)`
+  // still runs `remove_target!` on the loaded target (has_one_association.rb:69),
+  // whose else-branch nullifies+saves the old row even though the new record is
+  // unsaved. Our sync `build` can't await, so the `build#{name}` accessor returns
+  // a Promise for the loaded-target case and detaches the prior row.
+  it("build over a loaded target nullifies the prior account", async () => {
+    const company = (await Company.create({ name: "BuildCo" })) as any;
+    const original = await Account.create({ firm_id: Number(company.id), credit_limit: 50 });
+    const found = (await Company.find(company.id)) as any;
+    await readHasOne(found, "account");
+    const built = await found.buildAccount({ credit_limit: 70 });
+    expect((await Account.find(original.id)).firm_id).toBeNull();
+    expect(built.isPersisted()).toBe(false);
+  });
+
   it("create when parent is new raises", async () => {
     const firm = new Firm();
     let error: unknown;


### PR DESCRIPTION
## Summary

Rails runs `remove_target!` inside `HasOneAssociation#replace`
(`has_one_association.rb:69`) whenever another record is assigned. Only the
`transaction_if` *wrapper* is gated on `save`; `remove_target!` itself is not, so
`set_new_record`'s `replace(record, false)` — reached by both `create#{name}` and
`build#{name}` — still detaches the previously attached record. Creating or
building over an already-**loaded** has_one target must therefore null the old
row's FK (or destroy/delete it per `:dependent`).

Our `replace`/`setNewRecord` are sync and cannot `await` that removal. This PR
adds an awaitable `detachDisplacedTarget` helper (wrapping the existing
`removeTargetBang`) and calls it from both async accessors:

- **`_createRecord`** captures the currently **loaded** target before delegating
  to `super._createRecord`, which builds the new record first — so an invalid
  build (e.g. an inexistent foreign key) still raises before any removal, exactly
  as Rails' `build_record` raises before `set_new_record`. After the child is
  built and saved, the displaced record is detached.
- **`build#{name}`** accessor: `needsTargetLoadForBuild` is false once a target
  is loaded, so that case falls through to the sync branch; it now returns a
  Promise (only when a target was loaded) that builds the record and detaches the
  prior one. New-record / no-target builds keep their synchronous return, so the
  STI-build tests are unaffected.

`replace`'s leading `load_target` returns the already-cached target, so it is the
caller-loaded OLD record that gets removed. The **unloaded `create`** case is left
as-is: the new row is already persisted by the time `set_new_record` runs, so a
fresh `load_target` there is ambiguous — the story scopes explicitly to the
already-loaded path (distinct from #4901's deferred-assignment displacement). The
unloaded `build` case *is* unambiguous (no row saved yet) and is covered by the
load-path branch.

## Tests

Three trails deviation guards in `has-one-associations.test.ts`, all loading the
target explicitly (no property-setter assignment, so no displacement flag is set):

- `create` nullify arm (`Company#account`): prior account's `firm_id` nulled,
  exactly one account remains attached when `createAccount` returns.
- `create` destroy arm (`Firm#account`): prior account destroyed.
- `build` nullify arm: prior account's `firm_id` nulled while the built record
  stays unsaved.

No regressions in the has_one / has_one_through / autosave / nested-attributes
suites.

Closes-story: has-one-loaded-target-create-missing-remove-target