### PR TITLE
fix(associations): has_one_through build loads the through proxy, not the target join

### DIFF
--- a/packages/activerecord/src/associations/builder/has-one.ts
+++ b/packages/activerecord/src/associations/builder/has-one.ts
@@ -68,7 +68,14 @@ export class HasOne extends SingularAssociation {
           typeof assoc.needsTargetLoadForBuild === "function" &&
           assoc.needsTargetLoadForBuild()
         ) {
-          return assoc.loadTarget().then((displaced: unknown) => {
+          // `loadTargetForBuild` loads the direct-FK target for a plain has_one
+          // (the record `remove_target!` will detach), but a has_one_through
+          // overrides it to load the *through* proxy — Rails' has_one_through
+          // `replace` runs no `load_target`/`remove_target!` on the target; its
+          // `create_through_record` loads the through instead. The through's
+          // `detachDisplacedTarget` is a no-op, so the proxy passed as
+          // `displaced` here is inert.
+          return assoc.loadTargetForBuild().then((displaced: unknown) => {
             const record = assoc.build(...args);
             return assoc.detachDisplacedTarget(displaced, record).then(() => record);
           });

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -367,6 +367,22 @@ export class HasOneAssociation extends SingularAssociation {
     return this.findTargetNeeded();
   }
 
+  /**
+   * The load the `build#{name}` accessor awaits before constructing the new
+   * record. A direct-FK has_one loads its own target — Rails'
+   * `set_new_record` → `replace(record, false)` runs `load_target`
+   * (has_one_association.rb:59). A has_one_through overrides this: Rails'
+   * `HasOneThroughAssociation#replace` has NO `load_target`; its
+   * `create_through_record` loads the *through* proxy instead
+   * (has_one_through_association.rb:15-19), so the through must issue the
+   * join-model SELECT here, never a target SELECT.
+   *
+   * @internal
+   */
+  loadTargetForBuild(): Promise<unknown> {
+    return this.loadTarget();
+  }
+
   protected override replace(record: Base | null, _save = true): void {
     if (record) (this as any).raiseOnTypeMismatchBang(record);
     const assigningAnother = !sameRecord(this.target, record);

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -57,6 +57,44 @@ export class HasOneThroughAssociation extends HasOneAssociation {
   }
 
   /**
+   * Mirrors Rails' `HasOneThroughAssociation#create_through_record`, which
+   * loads the *through* proxy (`through_proxy.load_target`,
+   * has_one_through_association.rb:15-19) — NOT the target join. The base
+   * `HasOneAssociation` loads its own target for `build#{name}`, which for a
+   * through would issue a `clubs` SELECT Rails never runs while skipping the
+   * `memberships` SELECT it does. Override so the `build#{name}` accessor's
+   * pre-build load (gated by the inherited `needsTargetLoadForBuild`) reads
+   * the through proxy, then `constructThroughRecordInMemory` reconciles
+   * against the now-loaded join row (update-existing / build-when-absent),
+   * exactly as Rails' `create_through_record` does.
+   *
+   * @internal
+   */
+  override loadTargetForBuild(): Promise<unknown> {
+    const throughProxy = throughAssociation(this) as {
+      loadTarget?: () => unknown;
+    } | null;
+    return Promise.resolve(throughProxy?.loadTarget?.());
+  }
+
+  /**
+   * Rails' `HasOneThroughAssociation#replace` (has_one_through_association.rb:9-13)
+   * has NO `remove_target!` — displacing a through target is handled entirely by
+   * `create_through_record` mutating the join row (update / destroy), never by
+   * nullifying or destroying the *target* record's own foreign key (a through
+   * target has no FK back to the owner). The base `HasOneAssociation` runs
+   * `remove_target!` on the displaced target; inheriting that would wrongly
+   * nullify/destroy the previously-associated end record. Override to a no-op so
+   * the `build#{name}` / `create#{name}` accessors leave displacement to the
+   * through's own `createThroughRecord` / `persistReplace`.
+   *
+   * @internal
+   */
+  override async detachDisplacedTarget(): Promise<void> {
+    // no-op — see JSDoc
+  }
+
+  /**
    * The deferred (non-awaitable) property-setter / mass-assignment path. The
    * base `queueWrite` records a displaced record for the direct-FK autosave to
    * remove, but a through routes displacement through the join model

--- a/packages/activerecord/src/associations/has-one-through-build.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-through-build.trails.test.ts
@@ -64,4 +64,26 @@ describe("HasOneThroughBuildTrails", () => {
     expect(built.isNewRecord()).toBe(true);
     expect(member.association("club").target).toBe(built);
   });
+
+  it("buildClub then save reconciles the existing join row without duplicating it", async () => {
+    const member = members("groucho");
+    // Scope the join-row count to this member — a shared parallel DB races a
+    // global CurrentMembership.count against concurrent fixture reloads.
+    const joinCount = async (): Promise<number> =>
+      (await CurrentMembership.where({ member_id: member.id }).count()) as number;
+    const before = await joinCount();
+
+    const newClub = await (
+      member as unknown as { buildClub(attrs: Record<string, unknown>): Promise<Club> }
+    ).buildClub({ name: "Brand New Club" });
+    await member.save();
+
+    // Rails' create_through_record `update`s the loaded join row rather than
+    // inserting a second one — the count is unchanged and the through now
+    // points at the freshly-persisted club.
+    expect(await joinCount()).toBe(before);
+    expect(newClub.isPersisted()).toBe(true);
+    await member.association("club").reload();
+    expect((member.association("club").target as Club | null)?.id).toBe(newClub.id);
+  });
 });

--- a/packages/activerecord/src/associations/has-one-through-build.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-through-build.trails.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Trails-only assertion pinning the query SHAPE of `build#{name}` on an
+ * UNLOADED has_one_through with a persisted owner.
+ *
+ * Rails' `HasOneThroughAssociation#replace` has no `load_target`; its
+ * `create_through_record` (has_one_through_association.rb:15-19) loads the
+ * *through* proxy instead. So `member.buildClub(...)` must issue the
+ * join-model (`memberships`) SELECT and NEVER the target-join (`clubs INNER
+ * JOIN memberships`) SELECT that a direct-FK has_one's `load_target` would
+ * run. No Rails test pins this shape — the has_one_through /
+ * has_one_through_disable_joins / nested_attributes suites all pass both with
+ * and without the fix (an `assert_queries_count` alone matches both). Hence a
+ * dedicated shape assertion here.
+ */
+import { describe, it, expect } from "vitest";
+import { registerModel, enableSti } from "../index.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+import { Notifications, NotificationEvent } from "@blazetrails/activesupport";
+import { SQLCounter, type SqlPayload } from "../testing/query-assertions.js";
+import { Member } from "../test-helpers/models/member.js";
+import { Club } from "../test-helpers/models/club.js";
+import { Membership, CurrentMembership } from "../test-helpers/models/membership.js";
+
+describe("HasOneThroughBuildTrails", () => {
+  const { members } = fixtures(["members", "clubs", "memberships"]);
+
+  registerModel(Member);
+  registerModel(Club);
+  enableSti(Membership);
+  registerModel(Membership);
+  registerModel(CurrentMembership);
+
+  it("buildClub on an unloaded through loads the through proxy, not the target join", async () => {
+    const member = members("groucho");
+    expect(member.association("club").isLoaded()).toBe(false);
+
+    const counter = new SQLCounter();
+    const sub = Notifications.subscribe("sql.active_record", (event: NotificationEvent) => {
+      counter.call(event.name, event.transactionId, event.payload as SqlPayload);
+    });
+
+    let built: Club;
+    try {
+      built = await (
+        member as unknown as { buildClub(attrs: Record<string, unknown>): Promise<Club> }
+      ).buildClub({ name: "New Club" });
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+
+    const queries = counter.log;
+
+    // No `clubs INNER JOIN memberships` target load — Rails never issues it.
+    expect(queries.some((q) => /clubs/i.test(q) && /inner join/i.test(q))).toBe(false);
+    expect(queries.some((q) => /clubs/i.test(q))).toBe(false);
+
+    // Exactly the through-proxy load, as `create_through_record` runs.
+    const membershipLoads = queries.filter((q) => /from\s+["'`]?memberships/i.test(q));
+    expect(membershipLoads.length).toBe(1);
+
+    // The built target is the freshly-built new club, reconciled onto the
+    // existing (loaded) join row.
+    expect(built).toBeInstanceOf(Club);
+    expect(built.isNewRecord()).toBe(true);
+    expect(member.association("club").target).toBe(built);
+  });
+});


### PR DESCRIPTION
## Summary

`member.buildClub(...)` on an **unloaded has_one_through** issued a `clubs`
SELECT that Rails never issues, while skipping the `memberships` SELECT that
Rails does issue.

Rails' `HasOneThroughAssociation#replace` has **no** `load_target` — its
`create_through_record` (has_one_through_association.rb:15-19) loads the
**through** proxy instead:

```ruby
through_proxy  = through_association
through_record = through_proxy.load_target
```

The base `HasOneAssociation`'s `build#{name}` accessor (builder/has-one.ts)
pre-issues its own `load_target` (Rails has_one_association.rb:59). A through
inherited that, so `build_club` ran `SELECT clubs.* FROM clubs INNER JOIN
memberships …` (a target load Rails never does) and never touched
`memberships`.

## Fix

Route the accessor's pre-build load through a new overridable
`loadTargetForBuild()` hook (has-one-association.ts):

- Base `HasOneAssociation` loads its own target — unchanged.
- `HasOneThroughAssociation` overrides it to load the **through proxy**, so the
  accessor issues the `memberships` SELECT and no `clubs` SELECT, then
  `constructThroughRecordInMemory` reconciles against the now-loaded join row —
  exactly as `create_through_record` does.

A merely-neutralized override (`return false`) would trade one divergence for
another (zero queries vs Rails' one), so it is not sufficient. Because
`assert_queries_count` alone passes both with and without the fix (confirmed:
all has_one_through / disable_joins / nested_attributes suites are green both
ways), a trails-only assertion pins the query **shape**, not just the count.

## Testing

- New `has-one-through-build.trails.test.ts` — pins: no `clubs` SELECT, exactly
  one `memberships` SELECT, built target is the reconciled new club. Verified it
  fails on the pre-fix behavior.
- No `.then` callers depend on `build#{name}` returning a Promise for a through.
- Green: has-one-through-associations, has-one-through-disable-joins-associations,
  nested-attributes (×3).

Closes-story: has-one-through-build-skips-target-load
