### PR TITLE
feat(notifications): build_handle spans the transaction event

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -9,11 +9,10 @@ import {
 } from "../../errors.js";
 import {
   Notifications,
-  NotificationEvent,
   getAsyncContext,
   type AsyncContext,
+  type NotificationHandle,
 } from "@blazetrails/activesupport";
-import { Temporal } from "@blazetrails/activesupport/temporal";
 import { beforeCommittedOnAllRecords } from "../../ar-config.js";
 
 /**
@@ -154,7 +153,7 @@ export class TransactionInstrumenter {
   private _started = false;
   private _basePayload: Record<string, unknown>;
   private _payload: Record<string, unknown> | null = null;
-  private _event: NotificationEvent | null = null;
+  private _handle: NotificationHandle | null = null;
 
   constructor(payload: Record<string, unknown> = {}) {
     this._basePayload = payload;
@@ -168,12 +167,15 @@ export class TransactionInstrumenter {
 
     Notifications.instrument("start_transaction.active_record", this._basePayload);
 
+    // Mirror Rails: a handle spans the transaction so the published event's
+    // duration covers start→finish, and the outcome mutated into the payload
+    // before finish reaches subscribers (transaction.rb:90-107).
     this._payload = { ...this._basePayload };
-    this._event = new NotificationEvent(
+    this._handle = Notifications.instrumenter.buildHandle(
       "transaction.active_record",
-      Temporal.Now.instant(),
       this._payload,
     );
+    this._handle.start();
   }
 
   finish(outcome: string): void {
@@ -185,16 +187,8 @@ export class TransactionInstrumenter {
     if (this._payload) {
       this._payload.outcome = outcome;
     }
-    if (this._event) {
-      this._event.finish();
-      // Publish with the finished event's payload including timing and outcome.
-      // Ideally we'd publish the Event instance directly (like Rails' handle.finish),
-      // but Notifications.publish creates a new Event. The payload carries the
-      // outcome; duration can be derived from the event's time/end if needed.
-      Notifications.publish("transaction.active_record", {
-        ...this._event.payload,
-        duration: this._event.duration,
-      });
+    if (this._handle) {
+      this._handle.finish();
     }
   }
 }

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -370,7 +370,11 @@ export {
   Wrapper as InstrumenterWrapper,
 } from "./notifications/instrumenter.js";
 export type { EventPayload } from "./notifications/instrumenter.js";
-export type { NotificationSubscriber } from "./notifications.js";
+export type {
+  NotificationSubscriber,
+  NotificationHandle,
+  NotificationInstrumenter,
+} from "./notifications.js";
 export {
   Fanout,
   InstrumentationSubscriberError,

--- a/packages/activesupport/src/notifications.trails.test.ts
+++ b/packages/activesupport/src/notifications.trails.test.ts
@@ -161,6 +161,22 @@ describe("Notifications (trails)", () => {
       }).not.toThrow();
     });
 
+    it("snapshots the subscribers at build time, not at finish", () => {
+      // Rails' Fanout::Handle captures groups_for(name) in initialize
+      // (fanout.rb:230): a subscriber added after build_handle sees nothing.
+      const early: Event[] = [];
+      const late: Event[] = [];
+      Notifications.subscribe("span", (e) => early.push(e));
+
+      const handle = Notifications.buildHandle("span", {});
+      handle.start();
+      Notifications.subscribe("span", (e) => late.push(e));
+      handle.finish();
+
+      expect(early).toHaveLength(1);
+      expect(late).toHaveLength(0);
+    });
+
     it("raises when start/finish are called out of order", () => {
       Notifications.subscribe("span", () => {});
       const handle = Notifications.buildHandle("span", {});

--- a/packages/activesupport/src/notifications.trails.test.ts
+++ b/packages/activesupport/src/notifications.trails.test.ts
@@ -132,4 +132,41 @@ describe("Notifications (trails)", () => {
       expect(events[0].payload.exception_object).toBeUndefined();
     });
   });
+
+  // Mirrors ActiveSupport::Notifications.instrumenter.build_handle — the
+  // low-level primitive TransactionInstrumenter spans a transaction with.
+  describe("buildHandle", () => {
+    it("publishes one event spanning start→finish, off the mutated payload", () => {
+      const events: Event[] = [];
+      Notifications.subscribe("span", (e) => events.push(e));
+
+      const payload: Record<string, unknown> = { a: 1 };
+      const handle = Notifications.instrumenter.buildHandle("span", payload);
+      handle.start();
+      // Subscribers must see mutations made between start and finish.
+      payload.outcome = "done";
+      handle.finish();
+
+      expect(events).toHaveLength(1);
+      expect(events[0].name).toBe("span");
+      expect(events[0].payload.outcome).toBe("done");
+      expect(events[0].end).not.toBeNull();
+    });
+
+    it("skips building an event when nothing is listening", () => {
+      const handle = Notifications.buildHandle("unlistened", {});
+      expect(() => {
+        handle.start();
+        handle.finish();
+      }).not.toThrow();
+    });
+
+    it("raises when start/finish are called out of order", () => {
+      Notifications.subscribe("span", () => {});
+      const handle = Notifications.buildHandle("span", {});
+      expect(() => handle.finish()).toThrow(/expected state to be "started"/);
+      handle.start();
+      expect(() => handle.start()).toThrow(/expected state to be "initialized"/);
+    });
+  });
 });

--- a/packages/activesupport/src/notifications.trails.test.ts
+++ b/packages/activesupport/src/notifications.trails.test.ts
@@ -177,6 +177,24 @@ describe("Notifications (trails)", () => {
       expect(late).toHaveLength(0);
     });
 
+    it("runs every snapshot subscriber even when one throws, then re-raises", () => {
+      // Rails' Handle#finish_with_values guards each group
+      // (iterate_guarding_exceptions, fanout.rb:20-39): a throwing subscriber
+      // must not stop the ones after it.
+      const ran: string[] = [];
+      Notifications.subscribe("span", () => ran.push("a"));
+      Notifications.subscribe("span", () => {
+        ran.push("b");
+        throw new Error("boom");
+      });
+      Notifications.subscribe("span", () => ran.push("c"));
+
+      const handle = Notifications.buildHandle("span", {});
+      handle.start();
+      expect(() => handle.finish()).toThrow("boom");
+      expect(ran).toEqual(["a", "b", "c"]);
+    });
+
     it("raises when start/finish are called out of order", () => {
       Notifications.subscribe("span", () => {});
       const handle = Notifications.buildHandle("span", {});

--- a/packages/activesupport/src/notifications.ts
+++ b/packages/activesupport/src/notifications.ts
@@ -10,6 +10,7 @@
 import { Temporal } from "./temporal.js";
 import { Event } from "./notifications/instrumenter.js";
 import type { EventPayload } from "./notifications/instrumenter.js";
+import { iterateGuardingExceptions } from "./notifications/fanout.js";
 import { IsolatedExecutionState } from "./isolated-execution-state.js";
 
 /**
@@ -293,9 +294,13 @@ export class Notifications {
         }
         state = "finished";
         if (event) {
-          event.finish();
-          // Propagate subscriber errors (like publish), over the snapshot.
-          for (const sub of groups) sub.callback(event);
+          const finished = event;
+          finished.finish();
+          // Rails' Handle#finish_with_values runs every group under
+          // iterate_guarding_exceptions (fanout.rb:20-39, :253-259): one bad
+          // subscriber must not suppress the rest; errors aggregate and re-raise
+          // after all have run.
+          iterateGuardingExceptions(groups, (sub) => sub.callback(finished));
         }
       },
     };

--- a/packages/activesupport/src/notifications.ts
+++ b/packages/activesupport/src/notifications.ts
@@ -37,6 +37,35 @@ export type NotificationSubscriber = {
   readonly callback: (event: Event) => void;
 };
 
+// Rails' Fanout::Handle#ensure_state! raises ArgumentError (fanout.rb:263-267).
+class ArgumentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ArgumentError";
+  }
+}
+
+/**
+ * Mirrors ActiveSupport::Notifications::Fanout::Handle — a low-level handle
+ * that spans an event across separate `start`/`finish` calls, so a single
+ * event carries the real duration of the work between them. `#start` and
+ * `#finish` must each be called exactly once.
+ */
+export interface NotificationHandle {
+  start(): void;
+  finish(): void;
+}
+
+/**
+ * Mirrors ActiveSupport::Notifications::Instrumenter — the object Rails reaches
+ * via `ActiveSupport::Notifications.instrumenter`. Here it delegates to the
+ * static `Notifications` hub rather than holding a thread-local notifier.
+ */
+export interface NotificationInstrumenter {
+  readonly id: string;
+  buildHandle(name: string, payload?: EventPayload): NotificationHandle;
+}
+
 type Subscriber = {
   pattern: string | RegExp | null;
   callback: (event: Event) => void;
@@ -49,6 +78,10 @@ type Subscriber = {
  */
 export class Notifications {
   private static _subscribers: Set<Subscriber> = new Set();
+
+  // Rails' Instrumenter#id is a per-instrumenter SecureRandom hex; the static
+  // hub has a single stable id, mirroring one thread-local instrumenter.
+  private static readonly _instrumenterId = `instr-${Math.random().toString(36).slice(2)}`;
 
   private static readonly _STACK_KEY = Symbol.for("as_notification_instrumenter");
 
@@ -224,6 +257,48 @@ export class Notifications {
     const event = this._buildEvent(name, payload);
     event.finish();
     this._notify(event, true);
+  }
+
+  /**
+   * buildHandle(name, payload) — mirrors
+   * `ActiveSupport::Notifications.instrumenter.build_handle`. The returned
+   * handle records the event's start at `#start` and finishes + publishes it at
+   * `#finish`, so `event.duration` covers the whole span (not just the publish
+   * call). The payload is held by reference: mutations made between `#start`
+   * and `#finish` (e.g. `payload.outcome = ...`) are visible to subscribers.
+   */
+  static buildHandle(name: string, payload: EventPayload = {}): NotificationHandle {
+    let state: "initialized" | "started" | "finished" = "initialized";
+    let event: Event | null = null;
+    return {
+      start: () => {
+        if (state !== "initialized") {
+          throw new ArgumentError(`expected state to be "initialized" but was "${state}"`);
+        }
+        state = "started";
+        if (this._listening(name)) {
+          event = this._buildEvent(name, payload);
+        }
+      },
+      finish: () => {
+        if (state !== "started") {
+          throw new ArgumentError(`expected state to be "started" but was "${state}"`);
+        }
+        state = "finished";
+        if (event) {
+          event.finish();
+          this._notify(event, true);
+        }
+      },
+    };
+  }
+
+  /** Mirrors `ActiveSupport::Notifications.instrumenter`. */
+  static get instrumenter(): NotificationInstrumenter {
+    return {
+      id: this._instrumenterId,
+      buildHandle: (name: string, payload?: EventPayload) => this.buildHandle(name, payload),
+    };
   }
 
   // -------------------------------------------------------------------------

--- a/packages/activesupport/src/notifications.ts
+++ b/packages/activesupport/src/notifications.ts
@@ -268,6 +268,13 @@ export class Notifications {
    * and `#finish` (e.g. `payload.outcome = ...`) are visible to subscribers.
    */
   static buildHandle(name: string, payload: EventPayload = {}): NotificationHandle {
+    // Rails' Fanout::Handle snapshots the matching listener groups at build
+    // time — `notifier.groups_for(name)` in Handle#initialize (fanout.rb:230)
+    // — and starts/finishes those same groups. Subscribers added or removed
+    // after this call therefore don't change what the handle publishes, so we
+    // capture the matching subscribers here rather than reading them live at
+    // finish.
+    const groups = [...this._subscribers].filter((sub) => this._matches(sub.pattern, name));
     let state: "initialized" | "started" | "finished" = "initialized";
     let event: Event | null = null;
     return {
@@ -276,7 +283,7 @@ export class Notifications {
           throw new ArgumentError(`expected state to be "initialized" but was "${state}"`);
         }
         state = "started";
-        if (this._listening(name)) {
+        if (groups.length > 0) {
           event = this._buildEvent(name, payload);
         }
       },
@@ -287,7 +294,8 @@ export class Notifications {
         state = "finished";
         if (event) {
           event.finish();
-          this._notify(event, true);
+          // Propagate subscriber errors (like publish), over the snapshot.
+          for (const sub of groups) sub.callback(event);
         }
       },
     };

--- a/packages/activesupport/src/notifications/fanout.ts
+++ b/packages/activesupport/src/notifications/fanout.ts
@@ -15,7 +15,7 @@ export class InstrumentationSubscriberError extends Error {
 }
 
 /** @internal */
-export function iterateGuardingExceptions<T>(collection: T[], fn: (item: T) => void): void {
+export function iterateGuardingExceptions<T>(collection: T[], fn: (item: T) => void): T[] {
   let exceptions: Error[] | null = null;
 
   for (const item of collection) {
@@ -36,6 +36,9 @@ export function iterateGuardingExceptions<T>(collection: T[], fn: (item: T) => v
     }
     throw new InstrumentationSubscriberError(flat);
   }
+
+  // Rails' iterate_guarding_exceptions returns the collection (fanout.rb:41).
+  return collection;
 }
 
 type EventedListener = {

--- a/packages/activesupport/src/notifications/fanout.ts
+++ b/packages/activesupport/src/notifications/fanout.ts
@@ -15,7 +15,7 @@ export class InstrumentationSubscriberError extends Error {
 }
 
 /** @internal */
-function iterateGuardingExceptions<T>(collection: T[], fn: (item: T) => void): void {
+export function iterateGuardingExceptions<T>(collection: T[], fn: (item: T) => void): void {
   let exceptions: Error[] | null = null;
 
   for (const item of collection) {

--- a/packages/activesupport/src/notifications/instrumenter.trails.test.ts
+++ b/packages/activesupport/src/notifications/instrumenter.trails.test.ts
@@ -70,4 +70,27 @@ describe("Instrumenter (trails)", () => {
     expect(payload.exception).toEqual(["RangeError", "Oopsies"]);
     expect(payload.exception_object).toBeInstanceOf(RangeError);
   });
+
+  // build_handle is the low-level primitive TransactionInstrumenter spans a
+  // transaction with; it publishes one event carrying payload mutations made
+  // between start and finish.
+  it("buildHandle publishes one event spanning start→finish", () => {
+    const notifier = buildNotifier();
+    const payload: Record<string, unknown> = { a: 1 };
+    const handle = new Instrumenter(notifier).buildHandle("span", payload);
+    handle.start();
+    payload.outcome = "done";
+    handle.finish();
+    expect(notifier.finishes).toHaveLength(1);
+    expect(notifier.finishes[0].name).toBe("span");
+    expect(notifier.finishes[0].payload.outcome).toBe("done");
+    expect(notifier.finishes[0].end).not.toBeNull();
+  });
+
+  it("buildHandle raises when start/finish are called out of order", () => {
+    const handle = new Instrumenter(buildNotifier()).buildHandle("span", {});
+    expect(() => handle.finish()).toThrow(/expected state to be "started"/);
+    handle.start();
+    expect(() => handle.start()).toThrow(/expected state to be "initialized"/);
+  });
 });

--- a/packages/activesupport/src/notifications/instrumenter.trails.test.ts
+++ b/packages/activesupport/src/notifications/instrumenter.trails.test.ts
@@ -93,4 +93,23 @@ describe("Instrumenter (trails)", () => {
     handle.start();
     expect(() => handle.start()).toThrow(/expected state to be "initialized"/);
   });
+
+  // Rails' Instrumenter#build_handle delegates to the notifier when it can build
+  // handles (instrumenter.rb:78-80), only falling back to the LegacyHandle
+  // wrapper for publish-only notifiers (instrumenter.rb:13-15).
+  it("buildHandle delegates to a notifier that can build handles", () => {
+    const delegated = { start() {}, finish() {} };
+    const calls: Array<[string, unknown]> = [];
+    const notifier = {
+      publish() {},
+      buildHandle(name: string, id: unknown) {
+        calls.push([name, id]);
+        return delegated;
+      },
+    };
+    const instrumenter = new Instrumenter(notifier);
+    const handle = instrumenter.buildHandle("span", {});
+    expect(handle).toBe(delegated);
+    expect(calls).toEqual([["span", instrumenter.id]]);
+  });
 });

--- a/packages/activesupport/src/notifications/instrumenter.ts
+++ b/packages/activesupport/src/notifications/instrumenter.ts
@@ -2,6 +2,14 @@ import { Temporal } from "../temporal.js";
 
 export type EventPayload = Record<string, unknown>;
 
+// Rails' Fanout::Handle#ensure_state! raises ArgumentError (fanout.rb:263-267).
+class ArgumentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ArgumentError";
+  }
+}
+
 let _txCounter = 0;
 function generateTransactionId(): string {
   return `tx-${Date.now()}-${(++_txCounter).toString(36)}`;
@@ -107,6 +115,16 @@ export class Instrumenter {
     }
   }
 
+  /**
+   * Mirrors ActiveSupport::Notifications::Instrumenter#build_handle
+   * (instrumenter.rb:78-80). Returns a handle that records the event's start at
+   * `#start` and publishes it at `#finish`, so a single event carries the span
+   * between the two calls. `#start`/`#finish` must each be called exactly once.
+   */
+  buildHandle(name: string, payload: EventPayload = {}): Handle {
+    return new Handle(name, payload, this.id, this._notifier);
+  }
+
   // Rails' #instrument never builds an Event — it hands the raw payload to a
   // Fanout handle, so subscribers see the block's mutations (that is how
   // payload[:exception] reaches them). trails routes it through an Event, which
@@ -125,6 +143,42 @@ export class Instrumenter {
     this._stack.pop();
     event.finish();
     this._notifier.publish(event.name, event);
+  }
+}
+
+/**
+ * Mirrors ActiveSupport::Notifications::Fanout::Handle — builds the Event at
+ * `#start` (so its start time is the real start of the work) and publishes it
+ * at `#finish`, off the payload held by reference.
+ */
+export class Handle {
+  private _state: "initialized" | "started" | "finished" = "initialized";
+  private _event: Event | null = null;
+
+  constructor(
+    private _name: string,
+    private _payload: EventPayload,
+    private _transactionId: string,
+    private _notifier: { publish(name: string, event: Event): void },
+  ) {}
+
+  start(): void {
+    if (this._state !== "initialized") {
+      throw new ArgumentError(`expected state to be "initialized" but was "${this._state}"`);
+    }
+    this._state = "started";
+    this._event = new Event(this._name, Temporal.Now.instant(), this._payload, this._transactionId);
+  }
+
+  finish(): void {
+    if (this._state !== "started") {
+      throw new ArgumentError(`expected state to be "started" but was "${this._state}"`);
+    }
+    this._state = "finished";
+    if (this._event) {
+      this._event.finish();
+      this._notifier.publish(this._event.name, this._event);
+    }
   }
 }
 

--- a/packages/activesupport/src/notifications/instrumenter.ts
+++ b/packages/activesupport/src/notifications/instrumenter.ts
@@ -64,12 +64,28 @@ function _recordException(payload: EventPayload, e: unknown): void {
   payload.exception_object = e;
 }
 
+/**
+ * The notifier an Instrumenter publishes through. A full notifier (Fanout)
+ * additionally exposes `buildHandle`, which snapshots the listener groups;
+ * a legacy publish-only notifier does not, and gets wrapped (see below).
+ */
+export interface InstrumenterNotifier {
+  publish(name: string, event: Event): void;
+  buildHandle?(name: string, id: unknown, payload: EventPayload): NotificationHandle;
+}
+
+/** The low-level start/finish handle returned by `buildHandle`. */
+export interface NotificationHandle {
+  start(): void;
+  finish(): void;
+}
+
 export class Instrumenter {
-  private _notifier: { publish(name: string, event: Event): void };
+  private _notifier: InstrumenterNotifier;
   private _stack: Event[] = [];
   readonly id: string;
 
-  constructor(notifier: { publish(name: string, event: Event): void }) {
+  constructor(notifier: InstrumenterNotifier) {
     this._notifier = notifier;
     this.id = generateTransactionId();
   }
@@ -117,11 +133,17 @@ export class Instrumenter {
 
   /**
    * Mirrors ActiveSupport::Notifications::Instrumenter#build_handle
-   * (instrumenter.rb:78-80). Returns a handle that records the event's start at
-   * `#start` and publishes it at `#finish`, so a single event carries the span
-   * between the two calls. `#start`/`#finish` must each be called exactly once.
+   * (instrumenter.rb:78-80): `@notifier.build_handle(name, @id, payload)`. A
+   * full notifier (Fanout) builds the handle itself, snapshotting its listener
+   * groups (fanout.rb:230, :322-324); a legacy publish-only notifier has no
+   * `build_handle`, so — like Rails' `LegacyHandle::Wrapper` (instrumenter.rb:
+   * 13-15, 20-47) — we wrap it in a Handle that builds the Event at start and
+   * publishes it at finish. `#start`/`#finish` must each be called exactly once.
    */
-  buildHandle(name: string, payload: EventPayload = {}): Handle {
+  buildHandle(name: string, payload: EventPayload = {}): NotificationHandle {
+    if (this._notifier.buildHandle) {
+      return this._notifier.buildHandle(name, this.id, payload);
+    }
     return new Handle(name, payload, this.id, this._notifier);
   }
 
@@ -151,7 +173,7 @@ export class Instrumenter {
  * `#start` (so its start time is the real start of the work) and publishes it
  * at `#finish`, off the payload held by reference.
  */
-export class Handle {
+export class Handle implements NotificationHandle {
   private _state: "initialized" | "started" | "finished" = "initialized";
   private _event: Event | null = null;
 

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -42177,6 +42177,20 @@
   {
     "package": "activesupport",
     "tsFile": "notifications/fanout.ts",
+    "rubyName": "iterate_guarding_exceptions",
+    "call": "each",
+    "reason": "Idiomatic translation: Ruby `collection.each` is a TS `for...of` loop. Surfaced when the helper was exported for reuse by Notifications.buildHandle (#4906)."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "notifications/fanout.ts",
+    "rubyName": "iterate_guarding_exceptions",
+    "call": "first",
+    "reason": "Idiomatic translation: Ruby `exceptions.first` is TS index access `flat[0]`. Surfaced when the helper was exported for reuse by Notifications.buildHandle (#4906)."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "notifications/fanout.ts",
     "rubyName": "all_listeners_for",
     "call": "select",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
## What

Rails' `TransactionInstrumenter` spans a transaction with a handle
(`ActiveSupport::Notifications.instrumenter.build_handle`), so the single
published `transaction.active_record` event carries the real start→finish span:
`event.duration` covers the transaction and the outcome mutated into the payload
before `finish` reaches subscribers (`transaction.rb:90-107`).

trails diverged: it built a `NotificationEvent` at `start()` but never started
it through the notifier, then at `finish()` called `Notifications.publish(...)`,
which builds a **fresh** event at publish time. The published event's real
timing was the publish call; the true duration was only stuffed into the
payload. The old code comment already acknowledged this.

## Changes

- Add `Instrumenter#buildHandle` and a `Handle` class (builds the `Event` at
  `start`, publishes at `finish`, off the payload held by reference), mirroring
  `instrumenter.rb:78-80` and `Fanout::Handle`. `ensure_state!` raises
  `ArgumentError` like Rails (`fanout.rb:263-267`).
- Expose the static analogue `Notifications.instrumenter` /
  `Notifications.buildHandle` that Rails reaches via
  `ActiveSupport::Notifications.instrumenter.build_handle`.
- Rewire `TransactionInstrumenter#start`/`#finish` to start/finish the handle
  instead of building a `NotificationEvent` + `Notifications.publish`. Drop the
  `duration`-in-payload workaround; `event.duration` now covers the transaction.
- trails-only unit coverage for both handle surfaces.

`transaction-instrumentation.test.ts` (21 tests) keeps passing.

Closes-story: converge-transaction-instrumenter-build-handle