### PR TITLE
fix(associations): has_one writer flushes deferred displacement before persisting

### DIFF
--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -173,6 +173,19 @@ export class HasOneAssociation extends SingularAssociation {
       // point of assignment, so run the pending remove now — while `record` is
       // still unsaved, the re-query resolves to the stale row unambiguously.
       if (this._removeDisplacedFromDb || this._displacedRecords.length > 0) {
+        // Reverting to a record already queued for removal cancels *its* removal
+        // (`owner.account = other; writer(original)`) — Rails' `replace` removes
+        // only the current `target`, never the record being assigned, and
+        // `queueWrite` mirrors the same same-record cancellation (:103-106). Drop
+        // the reverted record from the queue before draining so the flush does
+        // not nullify/destroy the very record `persistImmediate` is about to save.
+        // The `_removeDisplacedFromDb` path needs no equivalent guard: its
+        // re-query already skips a reverted DB row via `!sameRecord(found,
+        // savedTarget)` (savedTarget is the just-replaced `record`).
+        if (record) {
+          const idx = this._displacedRecords.findIndex((r) => sameRecord(record, r));
+          if (idx !== -1) this._displacedRecords.splice(idx, 1);
+        }
         await this.removeDisplaced();
       }
       if (displaced && !(displaced as any).isDestroyed?.() && !sameRecord(displaced, record)) {

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -162,6 +162,19 @@ export class HasOneAssociation extends SingularAssociation {
     save: boolean,
   ): Promise<void> {
     await transactionIf(this, save, async () => {
+      // Flush any displacement queued by an earlier deferred (property-setter)
+      // assignment to this same association before the new record is persisted.
+      // A prior `owner.child = a` on an *unloaded* has_one set
+      // `_removeDisplacedFromDb` (queueWrite, :95) but could not `await` the
+      // remove; if we persist `record` first, `removeDisplaced`'s FK re-query
+      // (:218) would match both the stale DB row and the freshly-saved `record`
+      // and pick whichever the DB yields first, leaving removal to depend on row
+      // order. Rails removes the displaced record inline inside `replace` at the
+      // point of assignment, so run the pending remove now — while `record` is
+      // still unsaved, the re-query resolves to the stale row unambiguously.
+      if (this._removeDisplacedFromDb || this._displacedRecords.length > 0) {
+        await this.removeDisplaced();
+      }
       if (displaced && !(displaced as any).isDestroyed?.() && !sameRecord(displaced, record)) {
         const currentTarget = this.target;
         this.target = displaced;

--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -625,6 +625,21 @@ describe("HasOneAssociationsTest", () => {
     expect((await readHasOne(firm, "account")).id).toBe(b.id);
   });
 
+  // Revert path: a sync `firm.account = other` queues `original` for removal,
+  // then `writer(original)` reassigns it. Rails' `replace` removes only the
+  // current target, never the record being assigned, and `queueWrite` mirrors
+  // that same-record cancellation (:103-106); the writer's deferred-flush must
+  // do the same, or it would destroy `original` right before persisting it.
+  it("writer reverting to a queued displaced record cancels its removal", async () => {
+    const firm = (await Firm.find(1)) as any;
+    const original = await readHasOne(firm, "account");
+    const originalId = original.id;
+    firm.account = new Account({ credit_limit: 60 });
+    await firm.association("account").writer(original);
+    expect((await readHasOne(firm, "account")).id).toBe(originalId);
+    expect((await Account.find(originalId)).firm_id).toBe(Number(firm.id));
+  });
+
   it("create when parent is new raises", async () => {
     const firm = new Firm();
     let error: unknown;

--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -607,9 +607,11 @@ describe("HasOneAssociationsTest", () => {
     const found = (await Company.find(company.id)) as any;
     expect(found.association("account").isLoaded()).toBe(false);
     found.account = new Account({ credit_limit: 60 });
-    await found.association("account").writer(new Account({ credit_limit: 70 }));
+    const b = new Account({ credit_limit: 70 });
+    await found.association("account").writer(b);
     expect((await Account.find(original.id)).firm_id).toBeNull();
     expect(await Account.where({ firm_id: Number(company.id) }).count()).toBe(1);
+    expect((await readHasOne(found, "account")).id).toBe(b.id);
   });
 
   it("writer over an unloaded displaced target destroys the prior dependent account", async () => {
@@ -617,8 +619,10 @@ describe("HasOneAssociationsTest", () => {
     const originalId = ((await Account.where({ firm_id: 1 }).first()) as any).id;
     expect(firm.association("account").isLoaded()).toBe(false);
     firm.account = new Account({ credit_limit: 60 });
-    await firm.association("account").writer(new Account({ credit_limit: 70 }));
+    const b = new Account({ credit_limit: 70 });
+    await firm.association("account").writer(b);
     await expect(Account.find(originalId)).rejects.toThrow(RecordNotFound);
+    expect((await readHasOne(firm, "account")).id).toBe(b.id);
   });
 
   it("create when parent is new raises", async () => {

--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -590,6 +590,37 @@ describe("HasOneAssociationsTest", () => {
     expect(built.isPersisted()).toBe(false);
   });
 
+  // Trails deviation guard (no Rails counterpart, RFC 0005-activerecord-gaps
+  // story has-one-unloaded-displacement-writer-window): a deferred
+  // `owner.account = a` on an *unloaded* has_one (the sync property setter runs
+  // `queueWrite`, which sets `_removeDisplacedFromDb` and calls `loadedBang`) is
+  // followed by the awaitable `writer(b)`. `writeImmediate` skips its leading
+  // `load_target` (the setter already loaded the slot), so the stale DB row is
+  // only removable via the deferred flag — `persistImmediate` must flush it
+  // before persisting `b`, or the owner's later `save` re-queries and picks
+  // whichever FK-matching row the DB yields first. Rails removes the displaced
+  // record inline inside `replace`, so assert the prior row is detached the
+  // moment `writer` returns, BEFORE the owner's save.
+  it("writer over an unloaded displaced target nullifies the prior account", async () => {
+    const company = (await Company.create({ name: "WriterCo" })) as any;
+    const original = await Account.create({ firm_id: Number(company.id), credit_limit: 50 });
+    const found = (await Company.find(company.id)) as any;
+    expect(found.association("account").isLoaded()).toBe(false);
+    found.account = new Account({ credit_limit: 60 });
+    await found.association("account").writer(new Account({ credit_limit: 70 }));
+    expect((await Account.find(original.id)).firm_id).toBeNull();
+    expect(await Account.where({ firm_id: Number(company.id) }).count()).toBe(1);
+  });
+
+  it("writer over an unloaded displaced target destroys the prior dependent account", async () => {
+    const firm = (await Firm.find(1)) as any;
+    const originalId = ((await Account.where({ firm_id: 1 }).first()) as any).id;
+    expect(firm.association("account").isLoaded()).toBe(false);
+    firm.account = new Account({ credit_limit: 60 });
+    await firm.association("account").writer(new Account({ credit_limit: 70 }));
+    await expect(Account.find(originalId)).rejects.toThrow(RecordNotFound);
+  });
+
   it("create when parent is new raises", async () => {
     const firm = new Firm();
     let error: unknown;


### PR DESCRIPTION
## Summary

A deferred `owner.child = a` on an **unloaded** has_one — the sync property
setter runs `queueWrite`, which sets `_removeDisplacedFromDb` and calls
`loadedBang` — followed by the awaitable `await owner.association("child").writer(b)`
left the stale DB row attached.

`writeImmediate` skips its leading `load_target` (the setter already loaded the
slot), so the in-memory `displaced` is the unsaved `a` and `persistImmediate`'s
`removeTargetBang` no-ops. `b` is persisted, and the old row's removal falls
through to the owner's `save`, whose FK re-query (`removeDisplaced`) now matches
two rows — the stale row and `b` — and picks whichever the DB yields first. If
it returns `b`, the `!sameRecord` guard cancels and the **old** row stays
attached. Masked on SQLite by row-ordering luck.

Same root cause as #4904 (the `create#{name}` window), on the awaitable writer
path #4904 left out of scope.

## Fix

Mirror Rails' `HasOneAssociation#replace` (`has_one_association.rb:66-84`),
which removes the displaced record inline at assignment. `persistImmediate` now
flushes any pending deferred displacement (`_removeDisplacedFromDb` /
`_displacedRecords`) via `removeDisplaced` **inside the transaction, before**
persisting the new record — so the re-query resolves to the stale row
unambiguously, regardless of DB row order.

## Tests

Two trails deviation guards in `has-one-associations.test.ts`, both asserting
the prior row is detached the moment `writer` returns — **before** the owner's
save (an assertion made only after the save passes even on unfixed code):

- nullify arm (`Company#account`): prior account's `firm_id` nulled, exactly
  one account remains.
- destroy arm (`Firm#account`): prior account destroyed.

Both fail on unfixed code regardless of DB ordering. No regressions in the
has_one / has_one_through / autosave suites.

Closes-story: has-one-unloaded-displacement-writer-window