### PR TITLE
fix(activerecord): converge ignored-column attribute-set semantics onto Rails' value-keyed model

### DIFF
--- a/packages/activerecord/src/base.trails.test.ts
+++ b/packages/activerecord/src/base.trails.test.ts
@@ -284,3 +284,45 @@ describe("BasicsTest (trails)", () => {
     expect(exists).toBe(true);
   });
 });
+
+// Rails removes ignored columns from `columns_hash` entirely, so their values
+// never enter `@attributes` even when a raw `SELECT *` / find_by_sql row carries
+// them (model_schema.rb `columns_hash.except(*ignored_columns)`). trails now
+// mirrors this in writeDatabaseRow: a plain ignored column absent from
+// `_attributeDefinitions` is dropped on load, while a column ignored yet still
+// declared via `attribute()` (Rails' AttributedDeveloper) survives and casts.
+describe("ignored columns absent from the instance attribute set (trails)", () => {
+  fixtures([]);
+
+  it("a plain ignored column loaded via SELECT * never enters the attribute set", async () => {
+    class Topic extends Base {
+      static tableName = "topics";
+      static {
+        this.ignoredColumns = ["author_name"];
+      }
+    }
+    await Base.connection.execute("INSERT INTO topics (title, author_name) VALUES ('hi', 'bob')");
+    const [topic] = await Topic.findBySql("SELECT * FROM topics");
+    const keys = [
+      ...(topic as unknown as { _attributes: { keys(): Iterable<string> } })._attributes.keys(),
+    ];
+    expect(keys).not.toContain("author_name");
+    expect(
+      (topic as unknown as { readAttribute(n: string): unknown }).readAttribute("author_name"),
+    ).toBeNull();
+    expect("author_name" in topic).toBe(false);
+  });
+
+  it("an ignored column still declared via attribute() loads and casts on SELECT *", async () => {
+    const { AttributedDeveloper } = await import("./test-helpers/models/developer.js");
+    const dev = await AttributedDeveloper.create();
+    await dev.updateColumn("name", "name");
+    const loaded = await AttributedDeveloper.where({ id: dev.id }).select("*").first();
+    // `name` is ignored yet declared via `attribute()`, so writeDatabaseRow keeps
+    // it in the attribute set and it casts through DeveloperName (unlike a plain
+    // ignored column, which is dropped).
+    expect((loaded as unknown as { readAttribute(n: string): unknown }).readAttribute("name")).toBe(
+      "Developer: name",
+    );
+  });
+});

--- a/packages/activerecord/src/base.trails.test.ts
+++ b/packages/activerecord/src/base.trails.test.ts
@@ -285,16 +285,18 @@ describe("BasicsTest (trails)", () => {
   });
 });
 
-// Rails removes ignored columns from `columns_hash` entirely, so their values
-// never enter `@attributes` even when a raw `SELECT *` / find_by_sql row carries
-// them (model_schema.rb `columns_hash.except(*ignored_columns)`). trails now
-// mirrors this in writeDatabaseRow: a plain ignored column absent from
-// `_attributeDefinitions` is dropped on load, while a column ignored yet still
-// declared via `attribute()` (Rails' AttributedDeveloper) survives and casts.
-describe("ignored columns absent from the instance attribute set (trails)", () => {
+// Rails removes ignored columns only from schema/default `attribute_types`
+// (`columns_hash.except(*ignored_columns)`), NOT from a raw result row: a
+// `SELECT *` that projects an ignored column still lands it in `@attributes`
+// (LazyAttributeSet keys off `values`), so `read_attribute` returns it and
+// `method_missing` responds to the accessor (`@attributes.key?` → true).
+// A load that does not project the column leaves its slot uninitialized, so
+// `key?` is false. These guard the trails analogs (dynamic reader install +
+// narrow-to-uninitialized) against regressing to a schema-membership gate.
+describe("ignored columns follow Rails' value-keyed attribute set (trails)", () => {
   fixtures([]);
 
-  it("a plain ignored column loaded via SELECT * never enters the attribute set", async () => {
+  it("a plain ignored column projected by a raw SELECT * is readable and responds", async () => {
     class Topic extends Base {
       static tableName = "topics";
       static {
@@ -303,26 +305,52 @@ describe("ignored columns absent from the instance attribute set (trails)", () =
     }
     await Base.connection.execute("INSERT INTO topics (title, author_name) VALUES ('hi', 'bob')");
     const [topic] = await Topic.findBySql("SELECT * FROM topics");
-    const keys = [
-      ...(topic as unknown as { _attributes: { keys(): Iterable<string> } })._attributes.keys(),
-    ];
-    expect(keys).not.toContain("author_name");
+    // Rails: values-keyed @attributes ⇒ read_attribute returns it, and
+    // method_missing responds (the trails dynamic reader).
     expect(
       (topic as unknown as { readAttribute(n: string): unknown }).readAttribute("author_name"),
-    ).toBeNull();
-    expect("author_name" in topic).toBe(false);
+    ).toBe("bob");
+    expect((topic as unknown as Record<string, unknown>).author_name).toBe("bob");
+    expect("author_name" in topic).toBe(true);
   });
 
-  it("an ignored column still declared via attribute() loads and casts on SELECT *", async () => {
+  it("an ignored column not projected by the query leaves an uninitialized slot", async () => {
+    class Topic extends Base {
+      static tableName = "topics";
+      static {
+        this.ignoredColumns = ["author_name"];
+      }
+    }
+    await Base.connection.execute("INSERT INTO topics (title, author_name) VALUES ('hi', 'bob')");
+    // The default select drops ignored columns, so the row never carries it —
+    // Rails' key? is false and no accessor responds.
+    const topic = (await Topic.first())!;
+    expect("author_name" in topic).toBe(false);
+    expect([
+      ...(topic as unknown as { _attributes: { keys(): Iterable<string> } })._attributes.keys(),
+    ]).not.toContain("author_name");
+  });
+
+  it("an ignored column still declared via attribute() casts and responds on SELECT *", async () => {
     const { AttributedDeveloper } = await import("./test-helpers/models/developer.js");
     const dev = await AttributedDeveloper.create();
     await dev.updateColumn("name", "name");
     const loaded = await AttributedDeveloper.where({ id: dev.id }).select("*").first();
-    // `name` is ignored yet declared via `attribute()`, so writeDatabaseRow keeps
-    // it in the attribute set and it casts through DeveloperName (unlike a plain
-    // ignored column, which is dropped).
+    // Rails asserts `loaded.name == "Developer: name"` (base_test.rb): the
+    // projected value casts through DeveloperName and the accessor responds.
+    expect((loaded as unknown as Record<string, unknown>).name).toBe("Developer: name");
     expect((loaded as unknown as { readAttribute(n: string): unknown }).readAttribute("name")).toBe(
       "Developer: name",
     );
+  });
+
+  it("a declared-then-ignored column not projected does not respond after reload", async () => {
+    const { AttributedDeveloper } = await import("./test-helpers/models/developer.js");
+    const dev = await AttributedDeveloper.create();
+    await dev.updateColumn("name", "name");
+    await dev.reload();
+    // reload's default select omits the ignored column, so its declared slot
+    // narrows to uninitialized — Rails' key? is false, no accessor responds.
+    expect("name" in dev).toBe(false);
   });
 });

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -63,6 +63,7 @@ import {
   ensureProperType as _ensureProperType,
   narrowToProjectedColumns,
   defineDynamicSelectReaders,
+  writeDatabaseRow,
   subclassFromAttributesForNew,
 } from "./inheritance.js";
 import { NotImplementedError, RecordNotFound, StaleObjectError } from "./errors.js";
@@ -2977,14 +2978,13 @@ export class Base extends Model {
     // set's column type (when the adapter reported one) to cast them — mirrors
     // Rails' `instantiate(record, column_types)` slice in find_by_sql /
     // JoinDependency#instantiate.
-    for (const [key, value] of Object.entries(row)) {
-      const override = overrideTypes?.[key];
-      if (override) {
-        record._attributes.overrideFromDatabase(key, value, override);
-      } else {
-        record._attributes.writeFromDatabase(key, value, columnTypes?.[key]);
-      }
-    }
+    writeDatabaseRow(
+      this as unknown as typeof Base,
+      record as unknown as Base,
+      row,
+      columnTypes,
+      overrideTypes,
+    );
     // A SELECT that projects only a subset of columns yields a row with just
     // those keys, so hasAttribute() must reflect what was loaded rather than
     // the full schema. Mirrors Rails' attributes_builder narrowing (see

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -63,7 +63,6 @@ import {
   ensureProperType as _ensureProperType,
   narrowToProjectedColumns,
   defineDynamicSelectReaders,
-  writeDatabaseRow,
   subclassFromAttributesForNew,
 } from "./inheritance.js";
 import { NotImplementedError, RecordNotFound, StaleObjectError } from "./errors.js";
@@ -2978,13 +2977,14 @@ export class Base extends Model {
     // set's column type (when the adapter reported one) to cast them — mirrors
     // Rails' `instantiate(record, column_types)` slice in find_by_sql /
     // JoinDependency#instantiate.
-    writeDatabaseRow(
-      this as unknown as typeof Base,
-      record as unknown as Base,
-      row,
-      columnTypes,
-      overrideTypes,
-    );
+    for (const [key, value] of Object.entries(row)) {
+      const override = overrideTypes?.[key];
+      if (override) {
+        record._attributes.overrideFromDatabase(key, value, override);
+      } else {
+        record._attributes.writeFromDatabase(key, value, columnTypes?.[key]);
+      }
+    }
     // A SELECT that projects only a subset of columns yields a row with just
     // those keys, so hasAttribute() must reflect what was loaded rather than
     // the full schema. Mirrors Rails' attributes_builder narrowing (see

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -554,48 +554,6 @@ export function findStiClass(baseClass: typeof Base, typeName: string): typeof B
 }
 
 /**
- * Write a database row into a freshly-allocated record's attribute set,
- * dropping ignored columns that a `SELECT *` (or raw `find_by_sql`) row can
- * carry. Rails builds `@attributes` from `columns_hash.except(*ignored_columns)`
- * (model_schema.rb), so a plain ignored column never enters the attribute set —
- * `@attributes.key?("<ignored>")` is false. `applyColumnsHash` already removes a
- * schema-sourced ignored column's definition, so an ignored key absent from
- * `_attributeDefinitions` is exactly a plain ignored column and is skipped here.
- * A column ignored yet still explicitly declared via `attribute()` (Rails'
- * `AttributedDeveloper`, which keeps `name` in `attribute_types`) survives in
- * `_attributeDefinitions`, so its value still loads and casts through the
- * declared type.
- *
- * @internal
- */
-export function writeDatabaseRow(
-  klass: typeof Base,
-  record: Base,
-  row: Record<string, unknown>,
-  columnTypes?: Record<string, { deserialize(value: unknown): unknown }>,
-  overrideTypes?: Record<string, { deserialize(value: unknown): unknown }>,
-): void {
-  const ignored = new Set(
-    (klass as unknown as { _ignoredColumns?: string[] })._ignoredColumns ?? [],
-  );
-  const defs = (klass as unknown as { _attributeDefinitions: Map<string, unknown> })
-    ._attributeDefinitions;
-  const attrs = record._attributes as {
-    writeFromDatabase(key: string, value: unknown, type?: unknown): void;
-    overrideFromDatabase(key: string, value: unknown, type: unknown): void;
-  };
-  for (const [key, value] of Object.entries(row)) {
-    if (ignored.has(key) && !defs.has(key)) continue;
-    const override = overrideTypes?.[key];
-    if (override) {
-      attrs.overrideFromDatabase(key, value, override);
-    } else {
-      attrs.writeFromDatabase(key, value, columnTypes?.[key]);
-    }
-  }
-}
-
-/**
  * Narrow a freshly-hydrated record's attribute set to the columns actually
  * returned by the query, so `hasAttribute()` reflects a projected SELECT.
  *
@@ -629,6 +587,18 @@ export function narrowToProjectedColumns(
   const pkSet = new Set(Array.isArray(pk) ? pk : pk != null ? [pk] : []);
   const rowKeys = new Set(Object.keys(row));
   const narrowable = klass.columnNames().filter((c) => !pkSet.has(c) && !rowKeys.has(c));
+  // An ignored column is dropped from columnNames(), so a `new` record's seeded
+  // default for a still-declared-and-ignored attribute (Rails' AttributedDeveloper
+  // `name`) would otherwise survive narrowing as an initialized value. Rails
+  // leaves it uninitialized after a load that didn't project it — its
+  // `_default_attributes` entry is `Attribute.uninitialized`, so
+  // `@attributes.key?` is false. Uninitialize any ignored column the row did not
+  // carry so a narrowed reload matches; an ignored column present in a raw
+  // `SELECT *` row (in rowKeys) is untouched and keeps its loaded value.
+  const ignoredColumns = (klass as unknown as { _ignoredColumns?: string[] })._ignoredColumns ?? [];
+  for (const c of ignoredColumns) {
+    if (!pkSet.has(c) && !rowKeys.has(c)) narrowable.push(c);
+  }
   // Hot path: a full SELECT projects every column, so there is nothing to
   // narrow — skip the attribute-set scan entirely.
   if (narrowable.length === 0) return;
@@ -668,7 +638,6 @@ const SELECT_ALIAS_READERS = Symbol.for("activerecord.selectAliasReaders");
  */
 export function defineDynamicSelectReaders(record: Base): void {
   const attrs = (record as any)._attributes as { keys(): Iterable<string> };
-  const klass = record.constructor as typeof Base;
   const rec = record as unknown as Record<string | symbol, unknown>;
   const installed = (rec[SELECT_ALIAS_READERS] as Set<string> | undefined) ?? new Set<string>();
   // Drop readers whose alias no longer appears in the fresh attribute set
@@ -682,26 +651,19 @@ export function defineDynamicSelectReaders(record: Base): void {
       }
     }
   }
-  // Hot path: every declared attribute (a real column, and also an ignored
-  // column still declared via `attribute()`) is a known attribute, so only keys
-  // absent from _attributeDefinitions can be bare select aliases. A full
-  // `SELECT *` load projects only declared columns, so this loop finds nothing to
-  // install and never walks the prototype chain — mirrors
-  // narrowToProjectedColumns' own full-projection early-out.
-  //
-  // Gating on _attributeDefinitions (not columnNames(), which drops ignored
-  // columns) is still required even though writeDatabaseRow now keeps plain
-  // ignored columns out of the attribute set: a column ignored yet still declared
-  // via `attribute()` (Rails' AttributedDeveloper) has no DB column and stays in
-  // the attribute set as its declared default, so it is present in
-  // `_attributeDefinitions` but absent from columnNames(). Gating on columnNames()
-  // would mistake it for a bare select alias and install an accessor for it —
-  // regressing base.test.ts's `"secret" in u` expectation.
-  const definedAttrs = (klass as unknown as { _attributeDefinitions: Map<string, unknown> })
-    ._attributeDefinitions;
+  // Install a reader for every loaded attribute key that has no accessor on the
+  // prototype chain. `attrs.keys()` is initialized-only (Rails' `key?` gate), so
+  // a full `SELECT *` of ordinary columns — all of which carry prototype
+  // accessors — finds nothing to install and never walks the chain past the
+  // hasProtoMember check. This covers Rails' method_missing reaching `key?` for
+  // BOTH a bare select alias and an ignored column whose value a raw `SELECT *`
+  // actually projected (`AttributedDeveloper#name` → "Developer: name"): Rails
+  // makes both respond via `attribute_missing`. narrowToProjectedColumns has
+  // already uninitialized any ignored column the row did not carry, so a narrowed
+  // reload leaves its declared-but-ignored default out of `keys()` and no reader
+  // is installed — matching Rails' `key?` being false for that uninitialized slot.
   const proto = Object.getPrototypeOf(record) as object;
   for (const name of attrs.keys()) {
-    if (definedAttrs.has(name)) continue;
     if (installed.has(name)) continue;
     if (Object.prototype.hasOwnProperty.call(record, name)) continue;
     // A non-column key can still resolve to a real method or an aliased
@@ -773,7 +735,14 @@ function directInstantiate(
   // decrypt and raw DB representations (e.g. an enum's integer `0`) are accepted
   // — mirrors the non-STI Base._instantiate path. Building via `new klass(row)`
   // instead ran every column through the user cast, which rejects raw DB values.
-  writeDatabaseRow(klass, record, row, columnTypes, overrideTypes);
+  for (const [key, value] of Object.entries(row)) {
+    const override = overrideTypes?.[key];
+    if (override) {
+      record._attributes.overrideFromDatabase(key, value, override);
+    } else {
+      record._attributes.writeFromDatabase(key, value, columnTypes?.[key]);
+    }
+  }
   narrowToProjectedColumns(klass, record, row, overrideTypes);
   defineDynamicSelectReaders(record);
   record._newRecord = false;

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -554,6 +554,48 @@ export function findStiClass(baseClass: typeof Base, typeName: string): typeof B
 }
 
 /**
+ * Write a database row into a freshly-allocated record's attribute set,
+ * dropping ignored columns that a `SELECT *` (or raw `find_by_sql`) row can
+ * carry. Rails builds `@attributes` from `columns_hash.except(*ignored_columns)`
+ * (model_schema.rb), so a plain ignored column never enters the attribute set —
+ * `@attributes.key?("<ignored>")` is false. `applyColumnsHash` already removes a
+ * schema-sourced ignored column's definition, so an ignored key absent from
+ * `_attributeDefinitions` is exactly a plain ignored column and is skipped here.
+ * A column ignored yet still explicitly declared via `attribute()` (Rails'
+ * `AttributedDeveloper`, which keeps `name` in `attribute_types`) survives in
+ * `_attributeDefinitions`, so its value still loads and casts through the
+ * declared type.
+ *
+ * @internal
+ */
+export function writeDatabaseRow(
+  klass: typeof Base,
+  record: Base,
+  row: Record<string, unknown>,
+  columnTypes?: Record<string, { deserialize(value: unknown): unknown }>,
+  overrideTypes?: Record<string, { deserialize(value: unknown): unknown }>,
+): void {
+  const ignored = new Set(
+    (klass as unknown as { _ignoredColumns?: string[] })._ignoredColumns ?? [],
+  );
+  const defs = (klass as unknown as { _attributeDefinitions: Map<string, unknown> })
+    ._attributeDefinitions;
+  const attrs = record._attributes as {
+    writeFromDatabase(key: string, value: unknown, type?: unknown): void;
+    overrideFromDatabase(key: string, value: unknown, type: unknown): void;
+  };
+  for (const [key, value] of Object.entries(row)) {
+    if (ignored.has(key) && !defs.has(key)) continue;
+    const override = overrideTypes?.[key];
+    if (override) {
+      attrs.overrideFromDatabase(key, value, override);
+    } else {
+      attrs.writeFromDatabase(key, value, columnTypes?.[key]);
+    }
+  }
+}
+
+/**
  * Narrow a freshly-hydrated record's attribute set to the columns actually
  * returned by the query, so `hasAttribute()` reflects a projected SELECT.
  *
@@ -641,13 +683,20 @@ export function defineDynamicSelectReaders(record: Base): void {
     }
   }
   // Hot path: every declared attribute (a real column, and also an ignored
-  // column) is a known attribute, so only keys absent from _attributeDefinitions
-  // can be bare select aliases. A full `SELECT *` load projects only declared
-  // columns, so this loop finds nothing to install and never walks the prototype
-  // chain — mirrors narrowToProjectedColumns' own full-projection early-out.
+  // column still declared via `attribute()`) is a known attribute, so only keys
+  // absent from _attributeDefinitions can be bare select aliases. A full
+  // `SELECT *` load projects only declared columns, so this loop finds nothing to
+  // install and never walks the prototype chain — mirrors
+  // narrowToProjectedColumns' own full-projection early-out.
+  //
   // Gating on _attributeDefinitions (not columnNames(), which drops ignored
-  // columns) keeps an ignored column — declared but accessor-less — from being
-  // mistaken for a select alias.
+  // columns) is still required even though writeDatabaseRow now keeps plain
+  // ignored columns out of the attribute set: a column ignored yet still declared
+  // via `attribute()` (Rails' AttributedDeveloper) has no DB column and stays in
+  // the attribute set as its declared default, so it is present in
+  // `_attributeDefinitions` but absent from columnNames(). Gating on columnNames()
+  // would mistake it for a bare select alias and install an accessor for it —
+  // regressing base.test.ts's `"secret" in u` expectation.
   const definedAttrs = (klass as unknown as { _attributeDefinitions: Map<string, unknown> })
     ._attributeDefinitions;
   const proto = Object.getPrototypeOf(record) as object;
@@ -724,14 +773,7 @@ function directInstantiate(
   // decrypt and raw DB representations (e.g. an enum's integer `0`) are accepted
   // — mirrors the non-STI Base._instantiate path. Building via `new klass(row)`
   // instead ran every column through the user cast, which rejects raw DB values.
-  for (const [key, value] of Object.entries(row)) {
-    const override = overrideTypes?.[key];
-    if (override) {
-      record._attributes.overrideFromDatabase(key, value, override);
-    } else {
-      record._attributes.writeFromDatabase(key, value, columnTypes?.[key]);
-    }
-  }
+  writeDatabaseRow(klass, record, row, columnTypes, overrideTypes);
   narrowToProjectedColumns(klass, record, row, overrideTypes);
   defineDynamicSelectReaders(record);
   record._newRecord = false;


### PR DESCRIPTION
## Background (Codex review addressed)

The first cut of this PR filtered ignored columns out of a raw result row on
load. A Codex review correctly flagged that as a deviation: Rails does **not**
filter `values`. `columns_hash.except(*ignored_columns)` only strips ignored
columns from schema/default `attribute_types`; a raw `SELECT *` that projects an
ignored column still lands it in `@attributes` (`LazyAttributeSet` keys off
`values`), and `@attributes.key?` is true whenever that slot is **initialized**
(`attribute_set/builder.rb:31-38, 60-64`). `method_missing` reaches the same
`key?` gate, so Rails even responds to the accessor
(`attribute_methods.rb:507-543`). That row-filtering approach is reverted.

## The actual divergence

trails-main already matches Rails for a plain ignored column loaded via raw
`SELECT *` (present, readable, accessor responds). The real gap was a
**declared-then-ignored** column (Rails' `AttributedDeveloper#name`, which keeps
`name` in `attribute_types`):

| | Rails | trails-main |
|---|---|---|
| `SELECT *` load → `record.name` | `"Developer: name"` | `undefined` ✗ |
| `SELECT *` load → `"name" in record` | true | false ✗ |
| `read_attribute("name")` | `"Developer: name"` | `"Developer: name"` ✓ |
| narrowed reload → `"name" in record` | false | false ✓ |

trails skips the accessor at method-generation time and
`defineDynamicSelectReaders` gated on `_attributeDefinitions`, so a value that
*was* loaded still got no reader.

## How

- **`defineDynamicSelectReaders`** installs a reader for every loaded
  (initialized) attribute key lacking a prototype accessor — dropping the
  `_attributeDefinitions` short-circuit. `_attributes.keys()` is already
  initialized-only (mirrors Rails' `key?`), so ordinary `SELECT *` columns (which
  carry accessors) still install nothing. This covers Rails' `method_missing` →
  `attribute_missing` for both a bare select alias and a projected ignored column.
- **`narrowToProjectedColumns`** uninitializes any ignored column the row did not
  carry, matching Rails' uninitialized `_default_attributes` slot — so a narrowed
  reload keeps `"secret" in u` false while a raw `SELECT *` that projected the
  column keeps its loaded, cast value.

## Tests

Four guard cases in `base.trails.test.ts` pin the Rails-faithful behavior:
projected plain ignored column is readable and responds; un-projected ignored
column leaves an uninitialized slot; declared-then-ignored casts and responds on
`SELECT *`; declared-then-ignored does not respond after a narrowed reload.

Closes-story: ignored-columns-absent-from-instance-attributes