### PR TITLE
fix(associations): has_one create over an unloaded target detaches the prior row

### DIFF
--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -411,18 +411,30 @@ export class HasOneAssociation extends SingularAssociation {
     // `load_target` returns the already-cached target, so when the caller has
     // loaded it (`readHasOne` / preload), that OLD record is the one removed. Our
     // `replace`/`setNewRecord` are sync and cannot `await` that removal, so we run
-    // it here. Capture the loaded target BEFORE `super._createRecord`, which
+    // it here. Capture the displaced target BEFORE `super._createRecord`, which
     // builds the new record first — an invalid build (e.g. an inexistent foreign
     // key) must raise before any removal runs, exactly as Rails' `build_record`
-    // raises before `set_new_record`. An unloaded target is left to the property-
-    // setter displacement path (`queueWrite` flags), matching Rails' behaviour of
-    // only removing what `load_target` surfaces.
+    // raises before `set_new_record`.
     const displaced = this.loaded ? this.target : null;
+    const wasLoaded = this.loaded;
     const record = await super._createRecord(attributes, shouldRaise, block);
     // `super._createRecord` ran `setNewRecord` → `replace`, so `this.target` is
     // now the freshly created record; detach the displaced (previously attached)
     // one, matching `remove_target!` inside Rails' `replace`.
     await this.detachDisplacedTarget(displaced, record);
+    // When the target was never materialized, mirror Rails' `set_new_record` ->
+    // `replace(record, false)`, whose `load_target` runs AFTER
+    // `super._create_record` has saved the new row and removes `.first` of the
+    // now two FK-matching rows. Rails' singular load is an *unordered* `LIMIT 1`
+    // (`Association#find_target` -> `scope.to_a` then `Array#first`; our
+    // `doAsyncFindTarget` -> `loadHasOne` mirrors it with `take()`), so which row
+    // it returns is order-undefined — sometimes the OLD row (then removed),
+    // sometimes the freshly-created one (then nothing is detached). We reproduce
+    // that behaviour faithfully rather than inventing a deterministic order: run
+    // the same post-save load and detach the surfaced row only when it isn't the
+    // record just created. The build error still raises first, since
+    // `super._createRecord` has already run.
+    if (!wasLoaded && record) await this.detachUnloadedPriorRow(record);
     return record;
   }
 
@@ -451,6 +463,36 @@ export class HasOneAssociation extends SingularAssociation {
     this.target = displaced;
     await removeTargetBang(this, (this.reflection.options.dependent as string) ?? "");
     this.target = replacement;
+  }
+
+  /**
+   * Detach the prior DB row after a `create#{name}` over an *unloaded* target —
+   * the analog of the `remove_target!` Rails runs inside
+   * `HasOneAssociation#replace` when `set_new_record`'s `load_target` (evaluated
+   * AFTER the new child is saved) surfaces the previously associated row. The new
+   * record is already `super._createRecord`-persisted and cached as the target,
+   * so we clear the cache and re-issue the (unordered `LIMIT 1`) load to see what
+   * Rails' `load_target` would — then detach it per `:dependent` only if it isn't
+   * the freshly-created record. Restores the cached new target around the query,
+   * matching Rails' `self.target = record` after `replace`'s block.
+   *
+   * @internal
+   */
+  private async detachUnloadedPriorRow(record: Base): Promise<void> {
+    const savedTarget = this.target;
+    const savedLoaded = this.loaded;
+    this.target = null;
+    this.loaded = false;
+    let found: Base | null = null;
+    try {
+      found = await this.doAsyncFindTarget();
+    } finally {
+      this.target = savedTarget;
+      this.loaded = savedLoaded;
+    }
+    if (found && !sameRecord(found, record)) {
+      await this.detachDisplacedTarget(found, record);
+    }
   }
 
   protected override async doAsyncFindTarget(): Promise<Base | null> {

--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -590,6 +590,37 @@ describe("HasOneAssociationsTest", () => {
     expect(built.isPersisted()).toBe(false);
   });
 
+  // Trails deviation guard (no Rails counterpart, RFC 0005-activerecord-gaps
+  // story has-one-unloaded-target-create-missing-remove-target): follow-up to
+  // the loaded-target guards above. Here the target is *never* materialized — a
+  // bare `createAccount` on a freshly-found owner. Rails' `set_new_record` ->
+  // `replace(record, false)` runs `load_target` AFTER the new row is saved and
+  // removes `.first` of the two FK-matching rows. That singular load is an
+  // *unordered* `LIMIT 1` (`Association#find_target` -> `scope.to_a` then
+  // `Array#first`), so which row it detaches is order-undefined in Rails; we
+  // replicate the same post-save load faithfully (via `detachUnloadedPriorRow`)
+  // rather than inventing a deterministic order. On the sqlite test adapter the
+  // unordered `LIMIT 1` returns the lowest-rowid OLD row, so it is detached here.
+  it("create over an unloaded target nullifies the prior account", async () => {
+    const company = (await Company.create({ name: "UnloadedNullifyCo" })) as any;
+    const original = await Account.create({ firm_id: Number(company.id), credit_limit: 50 });
+    const found = (await Company.find(company.id)) as any;
+    const created = await found.createAccount({ credit_limit: 70 });
+    expect((await Account.find(original.id)).firm_id).toBeNull();
+    expect(await Account.where({ firm_id: Number(company.id) }).count()).toBe(1);
+    expect((await readHasOne(found, "account")).id).toBe(created.id);
+  });
+
+  it("create over an unloaded target destroys the prior dependent account", async () => {
+    const firm = (await Firm.create({ name: "UnloadedDestroyFirm" })) as any;
+    const original = await Account.create({ firm_id: Number(firm.id), credit_limit: 50 });
+    const found = (await Firm.find(firm.id)) as any;
+    const created = await found.createAccount({ credit_limit: 70 });
+    await expect(Account.find(original.id)).rejects.toThrow(RecordNotFound);
+    expect(await Account.where({ firm_id: Number(firm.id) }).count()).toBe(1);
+    expect((await readHasOne(found, "account")).id).toBe(created.id);
+  });
+
   it("create when parent is new raises", async () => {
     const firm = new Firm();
     let error: unknown;


### PR DESCRIPTION
## Summary

Follow-up to #4904 (has_one create over a **loaded** target). Rails runs
`remove_target!` inside `HasOneAssociation#replace` (has_one_association.rb:69)
whenever another record is assigned — including the `create#{name}` path via
`set_new_record` → `replace(record, false)`. That `replace`'s `load_target`
runs **after** `super._create_record` has already saved the new row, then
removes `.first` of the now two FK-matching rows. Rails' singular load is an
*unordered* `LIMIT 1` (`Association#find_target` → `scope.to_a` then
`Array#first`), so which row it detaches is order-undefined at the SQL level.

PR #4904 deliberately scoped its create fix to the already-**loaded** target
(`displaced = this.loaded ? this.target : null`), so a bare `createChild()`
over an **unloaded** existing DB row left both rows attached.

## Change

Adds `detachUnloadedPriorRow`: after `super._createRecord` saves the new child,
re-issue the same post-save load (via `doAsyncFindTarget`, which mirrors Rails'
unordered `take()`) and detach the surfaced row per `:dependent` **only when it
isn't the freshly-created record** — faithfully replicating Rails' behaviour
rather than inventing a deterministic order (owner sign-off: fidelity is the
goal). The build error still raises first, since `super._createRecord` has
already run, so the inexistent-FK test is unaffected.

On the sqlite test adapter the unordered `LIMIT 1` returns the lowest-rowid OLD
row (as it does in practice on MySQL/PG too), so it is the one detached.

## Tests

Two trails guards (no Rails counterpart) for the bare unloaded `createAccount`
path — target never materialized, no property-setter assignment:

- nullify arm (`Company#account`): prior account's `firm_id` nulled, exactly one
  account attached.
- destroy arm (`Firm#account`): prior dependent account destroyed.

No regressions in has_one / has_one_through / autosave / nested-attributes.

Closes-story: has-one-unloaded-target-create-missing-remove-target