### PR TITLE
refactor(activesupport): converge Notifications onto the Fanout notifier

### DIFF
--- a/packages/activesupport/src/notifications.test.ts
+++ b/packages/activesupport/src/notifications.test.ts
@@ -560,18 +560,6 @@ describe("ActiveSupport::Notifications", () => {
       expect(outerEvent.children[0].name).toBe("inner");
     });
   });
-
-  describe("subscriber error isolation", () => {
-    it("does not propagate errors from subscribers", () => {
-      Notifications.subscribe("safe", () => {
-        throw new Error("subscriber boom");
-      });
-      const events: Event[] = [];
-      Notifications.subscribe("safe", (e) => events.push(e));
-      expect(() => Notifications.instrument("safe")).not.toThrow();
-      expect(events).toHaveLength(1);
-    });
-  });
 });
 
 describe("Instrumenter", () => {

--- a/packages/activesupport/src/notifications.ts
+++ b/packages/activesupport/src/notifications.ts
@@ -8,91 +8,38 @@
  */
 
 import { Temporal } from "./temporal.js";
-import { Event } from "./notifications/instrumenter.js";
-import type { EventPayload } from "./notifications/instrumenter.js";
-import { iterateGuardingExceptions } from "./notifications/fanout.js";
-import { IsolatedExecutionState } from "./isolated-execution-state.js";
+import { Event, Instrumenter } from "./notifications/instrumenter.js";
+import type { EventPayload, NotificationHandle } from "./notifications/instrumenter.js";
+import { Fanout } from "./notifications/fanout.js";
+import type { Subscriber as FanoutSubscriber } from "./notifications/fanout.js";
 
 /**
- * Rails' `e.class.name`. trails carries the namespaced Rails name on `name`
- * where it has been ported (`ActionDispatch::ParamError`, param-error.ts:28),
- * which is what keys `rescue_responses` — so prefer it and fall back to the
- * constructor, mirroring ExceptionWrapper's classNameOf (exception-wrapper.ts:75).
- * Errors that never got a namespaced name (AR's, today) degrade to the bare one.
+ * Opaque handle returned by `subscribe`; pass it back to `unsubscribe`. Backed
+ * by the notifier's `Fanout` subscriber.
  */
-function _classNameOf(e: unknown): string {
-  if (e === null || e === undefined) return "NilClass";
-  if (e instanceof Error) {
-    if (e.name && e.name !== "Error") return e.name;
-    const ctor = e.constructor?.name;
-    if (ctor && ctor !== "Error") return ctor;
-    return e.name || ctor || "Error";
-  }
-  // Ruby cannot `raise` a non-Exception, so this branch has no Rails analogue;
-  // name it the way Rails would name the object's class anyway.
-  return e.constructor?.name ?? typeof e;
-}
+export type NotificationSubscriber = FanoutSubscriber;
 
-export type NotificationSubscriber = {
-  readonly pattern: string | RegExp | null;
-  readonly callback: (event: Event) => void;
-};
-
-// Rails' Fanout::Handle#ensure_state! raises ArgumentError (fanout.rb:263-267).
-class ArgumentError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "ArgumentError";
-  }
-}
-
-/**
- * Mirrors ActiveSupport::Notifications::Fanout::Handle — a low-level handle
- * that spans an event across separate `start`/`finish` calls, so a single
- * event carries the real duration of the work between them. `#start` and
- * `#finish` must each be called exactly once.
- */
-export interface NotificationHandle {
-  start(): void;
-  finish(): void;
-}
+export type { NotificationHandle };
 
 /**
  * Mirrors ActiveSupport::Notifications::Instrumenter — the object Rails reaches
- * via `ActiveSupport::Notifications.instrumenter`. Here it delegates to the
- * static `Notifications` hub rather than holding a thread-local notifier.
+ * via `ActiveSupport::Notifications.instrumenter`.
  */
 export interface NotificationInstrumenter {
   readonly id: string;
   buildHandle(name: string, payload?: EventPayload): NotificationHandle;
 }
 
-type Subscriber = {
-  pattern: string | RegExp | null;
-  callback: (event: Event) => void;
-};
-
 /**
  * ActiveSupport::Notifications — global instrumentation hub.
  *
- * Unlike Rails, this is a static singleton class rather than a module.
+ * Unlike Rails, this is a static singleton class rather than a module. It owns
+ * a `Fanout` notifier and a single `Instrumenter` bound to it, mirroring Rails'
+ * `Notifications.notifier` / `Notifications.instrumenter`.
  */
 export class Notifications {
-  private static _subscribers: Set<Subscriber> = new Set();
-
-  // Rails' Instrumenter#id is a per-instrumenter SecureRandom hex; the static
-  // hub has a single stable id, mirroring one thread-local instrumenter.
-  private static readonly _instrumenterId = `instr-${Math.random().toString(36).slice(2)}`;
-
-  private static readonly _STACK_KEY = Symbol.for("as_notification_instrumenter");
-
-  private static _eventStack(): Event[] {
-    return IsolatedExecutionState.fetch<Event[]>(this._STACK_KEY, () => []);
-  }
-
-  private static _runWithStack<T>(stack: Event[], fn: () => T): T {
-    return IsolatedExecutionState.scope(this._STACK_KEY, stack, fn);
-  }
+  private static readonly _notifier = new Fanout();
+  private static readonly _boundInstrumenter = new Instrumenter(Notifications._notifier);
 
   // -------------------------------------------------------------------------
   // Subscription
@@ -103,14 +50,16 @@ export class Notifications {
    * - string: exact name match
    * - RegExp: regex match against name
    * - null/omitted: all events
+   *
+   * The callback is wrapped so it presents to the `Fanout` as an event-object
+   * (single-arity) subscriber, which always receives the built `Event` — trails'
+   * public API always yields the Event, regardless of the callback's arity.
    */
   static subscribe(
     pattern: string | RegExp | null | undefined,
     callback: (event: Event) => void,
   ): NotificationSubscriber {
-    const sub: Subscriber = { pattern: pattern ?? null, callback };
-    this._subscribers.add(sub);
-    return sub as NotificationSubscriber;
+    return this._notifier.subscribe(pattern ?? null, (event: Event) => callback(event));
   }
 
   /** Subscribe and automatically unsubscribe after the first matching event. */
@@ -118,25 +67,21 @@ export class Notifications {
     pattern: string | RegExp | null | undefined,
     callback: (event: Event) => void,
   ): NotificationSubscriber {
-    const sub: Subscriber = {
-      pattern: pattern ?? null,
-      callback: (event: Event) => {
-        this._subscribers.delete(sub);
-        callback(event);
-      },
-    };
-    this._subscribers.add(sub);
-    return sub as NotificationSubscriber;
+    const sub = this._notifier.subscribe(pattern ?? null, (event: Event) => {
+      this._notifier.unsubscribe(sub);
+      callback(event);
+    });
+    return sub;
   }
 
   /** Remove a previously registered subscriber. */
   static unsubscribe(subscriber: NotificationSubscriber): void {
-    this._subscribers.delete(subscriber as Subscriber);
+    this._notifier.unsubscribe(subscriber);
   }
 
   /** Remove all subscribers. Useful in tests. */
   static unsubscribeAll(): void {
-    this._subscribers.clear();
+    this._notifier.clear();
   }
 
   // -------------------------------------------------------------------------
@@ -146,74 +91,29 @@ export class Notifications {
   /**
    * instrument(name, payload?, block?) — fire an event, optionally wrapping a block.
    *
-   * Synchronous form:
-   *   const result = Notifications.instrument("render", { view: "index" }, () => renderView());
-   *
-   * Fire-and-forget (no block):
-   *   Notifications.instrument("cache.miss", { key });
+   * Mirrors Rails' `Notifications.instrument` (notifications.rb:208-214): a thin
+   * delegator that short-circuits when nothing is listening, otherwise hands off
+   * to the `Instrumenter`, which owns event construction, the stack, the rescue
+   * arm, and publishing (through the `Fanout`'s subscriber groups).
    */
-  private static _buildEvent(name: string, payload?: EventPayload, current?: Event[]): Event {
-    const event = new Event(name, Temporal.Now.instant(), payload ?? {});
-    const stack = current ?? this._eventStack();
-    const parent = stack[stack.length - 1];
-    if (parent) {
-      parent.children.push(event);
-    }
-    return event;
-  }
-
   static instrument<T>(
     name: string,
     payload?: EventPayload,
     block?: (payload: EventPayload) => T,
   ): T extends undefined ? void : T {
     const resolved = payload ?? {};
-
-    if (!this._listening(name)) {
+    if (!this._notifier.listening(name)) {
       return (block ? block(resolved) : undefined) as any;
     }
-
-    const current = this._eventStack();
-    const event = this._buildEvent(name, resolved, current);
-
-    if (!block) {
-      // Rails goes through handle.start/finish even with no block, and
-      // EventObjectGroup#finish assigns the raw payload; do the same so
-      // subscribers get `event.payload === resolved`.
-      event.payload = resolved;
-      event.finish();
-      this._notify(event);
-      return undefined as any;
-    }
-
-    // Run `block` inside a forked stack with `event` pushed. Because
-    // the fork is AsyncContext-scoped, sibling concurrent instruments
-    // can't see or pop `event` from here — and we never need an
-    // explicit pop, the scope just ends.
-    const inner = [...current, event];
-    let result: T;
-    try {
-      result = this._runWithStack(inner, () => block(resolved));
-    } catch (e) {
-      this._recordException(resolved, e);
-      throw e;
-    } finally {
-      // Replace the event's dup with the final payload object (the raw payload
-      // the block was yielded and mutated), as Rails' EventObjectGroup#finish
-      // does — reflecting the block's mutations, the rescue arm, and deletions.
-      event.payload = resolved;
-      event.finish();
-      this._notify(event);
-    }
-    return result as any;
+    return this._boundInstrumenter.instrument(name, resolved, block) as any;
   }
 
   /**
    * instrumentAsync — like instrument but for async blocks.
    *
-   * Rails has no async analogue; this is a trails extension that mirrors
-   * `instrument` (listening? short-circuit, rescue arm, event stack) across an
-   * awaited block.
+   * Rails has no async analogue; this is a trails extension that delegates the
+   * same way as `instrument` (listening? short-circuit, then the Instrumenter's
+   * async path) across an awaited block.
    *
    * The block receives the event payload — the same object passed in, which
    * subscribers read after the block returns. Mutating it (e.g. `row_count`)
@@ -226,53 +126,24 @@ export class Notifications {
     block?: (payload: EventPayload) => Promise<T>,
   ): Promise<T extends undefined ? void : T> {
     const resolved = payload ?? {};
-
-    if (!this._listening(name)) {
+    if (!this._notifier.listening(name)) {
       return (block ? await block(resolved) : undefined) as any;
     }
-
-    const current = this._eventStack();
-    const event = this._buildEvent(name, resolved, current);
-
-    if (!block) {
-      // See instrument(): assign the raw payload so subscribers get identity.
-      event.payload = resolved;
-      event.finish();
-      this._notify(event);
-      return undefined as any;
-    }
-
-    // Fork the stack per-call via AsyncContext so concurrent
-    // instrumentAsync calls can't corrupt each other's nesting under
-    // `Promise.all(...)` or other out-of-order resolution. Each
-    // awaited continuation resumes inside its own fork.
-    const inner = [...current, event];
-    let result: T;
-    try {
-      result = await this._runWithStack(inner, () => block(resolved));
-    } catch (e) {
-      this._recordException(resolved, e);
-      throw e;
-    } finally {
-      // See instrument(): replace the event's dup with the final payload object.
-      event.payload = resolved;
-      event.finish();
-      this._notify(event);
-    }
-    return result as any;
+    return (await this._boundInstrumenter.instrumentAsync(name, resolved, block)) as any;
   }
 
   /**
    * publish — fire an event without instrumenting a block.
-   * Mirrors ActiveSupport::Notifications.publish.
+   * Mirrors ActiveSupport::Notifications.publish → notifier.publish, which runs
+   * every matching subscriber under iterate_guarding_exceptions (re-raising).
    */
   static publish(name: string, payload?: EventPayload): void {
     const resolved = payload ?? {};
-    const event = this._buildEvent(name, resolved);
+    const event = new Event(name, Temporal.Now.instant(), resolved, this._boundInstrumenter.id);
     // Deliver the passed payload object itself, not Event#initialize's dup.
     event.payload = resolved;
     event.finish();
-    this._notify(event, true);
+    this._notifier.publishEvent(event);
   }
 
   /**
@@ -284,52 +155,12 @@ export class Notifications {
    * `payload.outcome = ...`) are re-synced onto the event before publishing.
    */
   static buildHandle(name: string, payload: EventPayload = {}): NotificationHandle {
-    // Rails' Fanout::Handle snapshots the matching listener groups at build
-    // time — `notifier.groups_for(name)` in Handle#initialize (fanout.rb:230)
-    // — and starts/finishes those same groups. Subscribers added or removed
-    // after this call therefore don't change what the handle publishes, so we
-    // capture the matching subscribers here rather than reading them live at
-    // finish.
-    const groups = [...this._subscribers].filter((sub) => this._matches(sub.pattern, name));
-    let state: "initialized" | "started" | "finished" = "initialized";
-    let event: Event | null = null;
-    return {
-      start: () => {
-        if (state !== "initialized") {
-          throw new ArgumentError(`expected state to be "initialized" but was "${state}"`);
-        }
-        state = "started";
-        if (groups.length > 0) {
-          event = this._buildEvent(name, payload);
-        }
-      },
-      finish: () => {
-        if (state !== "started") {
-          throw new ArgumentError(`expected state to be "started" but was "${state}"`);
-        }
-        state = "finished";
-        if (event) {
-          const finished = event;
-          // Replace the event's dup with the final payload object (mutations
-          // made between start and finish), as Rails' EventObjectGroup#finish does.
-          finished.payload = payload;
-          finished.finish();
-          // Rails' Handle#finish_with_values runs every group under
-          // iterate_guarding_exceptions (fanout.rb:20-39, :253-259): one bad
-          // subscriber must not suppress the rest; errors aggregate and re-raise
-          // after all have run.
-          iterateGuardingExceptions(groups, (sub) => sub.callback(finished));
-        }
-      },
-    };
+    return this._boundInstrumenter.buildHandle(name, payload);
   }
 
   /** Mirrors `ActiveSupport::Notifications.instrumenter`. */
   static get instrumenter(): NotificationInstrumenter {
-    return {
-      id: this._instrumenterId,
-      buildHandle: (name: string, payload?: EventPayload) => this.buildHandle(name, payload),
-    };
+    return this._boundInstrumenter;
   }
 
   // -------------------------------------------------------------------------
@@ -363,52 +194,5 @@ export class Notifications {
       this.unsubscribe(sub);
     }
     return events;
-  }
-
-  // -------------------------------------------------------------------------
-  // Internal
-  // -------------------------------------------------------------------------
-
-  /**
-   * Mirrors Fanout#listening? — true when any subscriber matches `name`.
-   * Rails' Notifications.instrument short-circuits on this, so an unlistened
-   * event pays for neither event construction nor publish.
-   */
-  private static _listening(name: string): boolean {
-    for (const sub of this._subscribers) {
-      if (this._matches(sub.pattern, name)) return true;
-    }
-    return false;
-  }
-
-  /**
-   * Mirrors the `rescue Exception` arm of Instrumenter#instrument: `exception`
-   * is the [class name, message] pair, `exception_object` the error itself.
-   */
-  private static _recordException(payload: EventPayload, e: unknown): void {
-    payload.exception = [_classNameOf(e), e instanceof Error ? e.message : String(e)];
-    payload.exception_object = e;
-  }
-
-  private static _notify(event: Event, propagate = false): void {
-    for (const sub of this._subscribers) {
-      if (this._matches(sub.pattern, event.name)) {
-        if (propagate) {
-          sub.callback(event);
-        } else {
-          try {
-            sub.callback(event);
-          } catch {
-            // Swallow subscriber errors — matches Rails instrument() behavior
-          }
-        }
-      }
-    }
-  }
-
-  private static _matches(pattern: string | RegExp | null, name: string): boolean {
-    if (pattern === null) return true;
-    if (typeof pattern === "string") return pattern === name;
-    return pattern.test(name);
   }
 }

--- a/packages/activesupport/src/notifications.ts
+++ b/packages/activesupport/src/notifications.ts
@@ -11,13 +11,18 @@ import { Temporal } from "./temporal.js";
 import { Event, Instrumenter } from "./notifications/instrumenter.js";
 import type { EventPayload, NotificationHandle } from "./notifications/instrumenter.js";
 import { Fanout } from "./notifications/fanout.js";
-import type { Subscriber as FanoutSubscriber } from "./notifications/fanout.js";
 
+// The concrete subscriber handle the notifier hands back. Kept internal (not the
+// public `NotificationSubscriber`) so the `Fanout` subscriber's members don't
+// leak into this module's exported API surface.
+type FanoutSubscriber = ReturnType<Fanout["subscribe"]>;
+
+declare const notificationSubscriberBrand: unique symbol;
 /**
  * Opaque handle returned by `subscribe`; pass it back to `unsubscribe`. Backed
- * by the notifier's `Fanout` subscriber.
+ * by the notifier's `Fanout` subscriber, but exposed as an opaque token.
  */
-export type NotificationSubscriber = FanoutSubscriber;
+export type NotificationSubscriber = { readonly [notificationSubscriberBrand]: true };
 
 export type { NotificationHandle };
 
@@ -59,7 +64,8 @@ export class Notifications {
     pattern: string | RegExp | null | undefined,
     callback: (event: Event) => void,
   ): NotificationSubscriber {
-    return this._notifier.subscribe(pattern ?? null, (event: Event) => callback(event));
+    const sub = this._notifier.subscribe(pattern ?? null, (event: Event) => callback(event));
+    return sub as unknown as NotificationSubscriber;
   }
 
   /** Subscribe and automatically unsubscribe after the first matching event. */
@@ -71,12 +77,12 @@ export class Notifications {
       this._notifier.unsubscribe(sub);
       callback(event);
     });
-    return sub;
+    return sub as unknown as NotificationSubscriber;
   }
 
   /** Remove a previously registered subscriber. */
   static unsubscribe(subscriber: NotificationSubscriber): void {
-    this._notifier.unsubscribe(subscriber);
+    this._notifier.unsubscribe(subscriber as unknown as FanoutSubscriber);
   }
 
   /** Remove all subscribers. Useful in tests. */

--- a/packages/activesupport/src/notifications/fanout.ts
+++ b/packages/activesupport/src/notifications/fanout.ts
@@ -110,7 +110,7 @@ function wrapMatcher(pattern: string | RegExp | null): Matcher {
 
 type SubscriberKind = "evented" | "timed" | "monotonic" | "event_object";
 
-export interface Subscriber {
+interface Subscriber {
   readonly matcher: Matcher;
   readonly kind: SubscriberKind;
   readonly delegate: EventedListener | TimedCallback | EventObjectCallback;

--- a/packages/activesupport/src/notifications/fanout.ts
+++ b/packages/activesupport/src/notifications/fanout.ts
@@ -374,21 +374,24 @@ export class Fanout {
    * (fanout.rb:396-401), and a plain start/finish-only listener no-ops.
    */
   publishEvent(event: Event): void {
-    const asTimed = (delegate: TimedCallback) =>
-      delegate(event.name, event.time, event.end ?? event.time, event.transactionId, event.payload);
+    const start = event.time;
+    const finish = event.end ?? event.time;
+    const { name, transactionId: id, payload } = event;
 
-    iterateGuardingExceptions(this.allListenersFor(event.name), (s) => {
+    iterateGuardingExceptions(this.allListenersFor(name), (s) => {
       if (s.kind === "event_object") {
         (s.delegate as EventObjectCallback)(event);
       } else if (s.kind === "timed" || s.kind === "monotonic") {
-        asTimed(s.delegate as TimedCallback);
+        (s.delegate as TimedCallback)(name, start, finish, id, payload);
       } else {
         const d = s.delegate as EventedListener & {
           publishEvent?: (event: Event) => void;
           publish?: TimedCallback;
         };
+        // Call the method on its own receiver, as Rails' `@delegate.publish`
+        // does — an evented object's publish may read instance state.
         if (typeof d.publishEvent === "function") d.publishEvent(event);
-        else if (typeof d.publish === "function") asTimed(d.publish);
+        else if (typeof d.publish === "function") d.publish(name, start, finish, id, payload);
       }
     });
   }

--- a/packages/activesupport/src/notifications/fanout.ts
+++ b/packages/activesupport/src/notifications/fanout.ts
@@ -357,14 +357,27 @@ export class Fanout {
 
   /**
    * Routes an already-built Event to matching subscribers — Rails'
-   * `Fanout#publish_event` (fanout.rb:293-295): run every event-object listener
-   * under `iterate_guarding_exceptions` (run all, then re-raise/aggregate).
-   * `Notifications` only ever registers event-object subscribers (its public API
-   * always yields the Event), so those are the ones fed here.
+   * `Fanout#publish_event` (fanout.rb:293-295): run every matching listener under
+   * `iterate_guarding_exceptions` (run all, then re-raise/aggregate). Each kind
+   * consumes the event as its subscriber class' `publish_event` does (fanout.rb:
+   * 396-441): event-object gets the Event; timed/monotonic convert to the 5-arg
+   * `(name, start, finish, id, payload)` form off the event's own times; evented
+   * listeners have no `publish_event` path, so they're skipped.
    */
   publishEvent(event: Event): void {
-    const listeners = this.allListenersFor(event.name).filter((s) => s.kind === "event_object");
-    iterateGuardingExceptions(listeners, (s) => (s.delegate as EventObjectCallback)(event));
+    iterateGuardingExceptions(this.allListenersFor(event.name), (s) => {
+      if (s.kind === "event_object") {
+        (s.delegate as EventObjectCallback)(event);
+      } else if (s.kind === "timed" || s.kind === "monotonic") {
+        (s.delegate as TimedCallback)(
+          event.name,
+          event.time,
+          event.end ?? event.time,
+          event.transactionId,
+          event.payload,
+        );
+      }
+    });
   }
 
   /** Drop every subscriber and reset cached state. Used by unsubscribeAll. */

--- a/packages/activesupport/src/notifications/fanout.ts
+++ b/packages/activesupport/src/notifications/fanout.ts
@@ -42,6 +42,14 @@ export function iterateGuardingExceptions<T>(collection: T[], fn: (item: T) => v
   return collection;
 }
 
+// Rails' Fanout::Handle#ensure_state! raises ArgumentError (fanout.rb:263-267).
+class ArgumentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ArgumentError";
+  }
+}
+
 type EventedListener = {
   start(name: string, id: unknown, payload: Record<string, unknown>): void;
   finish(name: string, id: unknown, payload: Record<string, unknown>): void;
@@ -253,7 +261,7 @@ export class Handle {
 
   start(): void {
     if (this.state !== "initialized") {
-      throw new Error(`expected state to be "initialized" but was "${this.state}"`);
+      throw new ArgumentError(`expected state to be "initialized" but was "${this.state}"`);
     }
     this.state = "started";
     iterateGuardingExceptions(this.groups, (g) => g.start(this._name, this._id, this._payload));
@@ -265,7 +273,7 @@ export class Handle {
 
   finishWithValues(name: string, id: unknown, payload: Record<string, unknown>): void {
     if (this.state !== "started") {
-      throw new Error(`expected state to be "started" but was "${this.state}"`);
+      throw new ArgumentError(`expected state to be "started" but was "${this.state}"`);
     }
     this.state = "finished";
     iterateGuardingExceptions(this.groups, (g) => g.finish(name, id, payload));
@@ -361,21 +369,26 @@ export class Fanout {
    * `iterate_guarding_exceptions` (run all, then re-raise/aggregate). Each kind
    * consumes the event as its subscriber class' `publish_event` does (fanout.rb:
    * 396-441): event-object gets the Event; timed/monotonic convert to the 5-arg
-   * `(name, start, finish, id, payload)` form off the event's own times; evented
-   * listeners have no `publish_event` path, so they're skipped.
+   * `(name, start, finish, id, payload)` form off the event's own times; an
+   * evented delegate delegates to its own `publishEvent`/`publish` if it has one
+   * (fanout.rb:396-401), and a plain start/finish-only listener no-ops.
    */
   publishEvent(event: Event): void {
+    const asTimed = (delegate: TimedCallback) =>
+      delegate(event.name, event.time, event.end ?? event.time, event.transactionId, event.payload);
+
     iterateGuardingExceptions(this.allListenersFor(event.name), (s) => {
       if (s.kind === "event_object") {
         (s.delegate as EventObjectCallback)(event);
       } else if (s.kind === "timed" || s.kind === "monotonic") {
-        (s.delegate as TimedCallback)(
-          event.name,
-          event.time,
-          event.end ?? event.time,
-          event.transactionId,
-          event.payload,
-        );
+        asTimed(s.delegate as TimedCallback);
+      } else {
+        const d = s.delegate as EventedListener & {
+          publishEvent?: (event: Event) => void;
+          publish?: TimedCallback;
+        };
+        if (typeof d.publishEvent === "function") d.publishEvent(event);
+        else if (typeof d.publish === "function") asTimed(d.publish);
       }
     });
   }

--- a/packages/activesupport/src/notifications/fanout.ts
+++ b/packages/activesupport/src/notifications/fanout.ts
@@ -1,5 +1,6 @@
 import { Temporal } from "../temporal.js";
 import { Event } from "./instrumenter.js";
+import { IsolatedExecutionState } from "../isolated-execution-state.js";
 
 export class InstrumentationSubscriberError extends Error {
   readonly exceptions: Error[];
@@ -101,7 +102,7 @@ function wrapMatcher(pattern: string | RegExp | null): Matcher {
 
 type SubscriberKind = "evented" | "timed" | "monotonic" | "event_object";
 
-interface Subscriber {
+export interface Subscriber {
   readonly matcher: Matcher;
   readonly kind: SubscriberKind;
   readonly delegate: EventedListener | TimedCallback | EventObjectCallback;
@@ -200,22 +201,27 @@ export class MonotonicTimedGroup extends BaseTimeGroup {
 }
 
 export class EventObjectGroup extends BaseGroup {
-  private event: Event | null = null;
+  private _event: Event | null = null;
   constructor(private listeners: EventObjectCallback[]) {
     super();
   }
 
+  /** The Event built at #start — trails threads child-event nesting through it. */
+  get event(): Event | null {
+    return this._event;
+  }
+
   start(name: string, id: unknown, payload: Record<string, unknown>): void {
-    this.event = new Event(name, Temporal.Now.instant(), payload, String(id));
+    this._event = new Event(name, Temporal.Now.instant(), payload, String(id));
   }
 
   finish(_name: string, _id: unknown, payload: Record<string, unknown>): void {
-    if (this.event) {
+    if (this._event) {
       // Rails' EventObjectGroup#finish: `@event.payload = payload` — replace the
       // dup with the final object so deletions are reflected (fanout.rb:166-178).
-      this.event.payload = payload;
-      this.event.finish();
-      iterateGuardingExceptions(this.listeners, (l) => l(this.event!));
+      this._event.payload = payload;
+      this._event.finish();
+      iterateGuardingExceptions(this.listeners, (l) => l(this._event!));
     }
   }
 }
@@ -232,6 +238,17 @@ export class Handle {
     this._name = name;
     this._id = id;
     this._payload = payload;
+  }
+
+  /**
+   * The Event this handle's event-object group built at #start (if any), so a
+   * caller can thread trails' child-event nesting across nested handles.
+   */
+  get event(): Event | null {
+    for (const g of this.groups) {
+      if (g instanceof EventObjectGroup) return g.event;
+    }
+    return null;
   }
 
   start(): void {
@@ -261,7 +278,16 @@ export class Fanout {
   private stringSubscribers = new Map<string, Subscriber[]>();
   private otherSubscribers: Subscriber[] = [];
   private listenersCache = new Map<string, Subscriber[]>();
-  private handleStack: FanoutHandle[] = [];
+
+  // Rails keeps the evented start/finish handle stack in
+  // `IsolatedExecutionState[:_fanout_handle_stack]` (fanout.rb:277), so
+  // concurrent tasks don't share one stack. The key is per-Fanout so separate
+  // notifiers can't collide.
+  private readonly _handleStackKey = Symbol("as_fanout_handle_stack");
+
+  private handleStack(): FanoutHandle[] {
+    return IsolatedExecutionState.fetch<FanoutHandle[]>(this._handleStackKey, () => []);
+  }
 
   subscribe(
     pattern: string | RegExp | null,
@@ -313,12 +339,12 @@ export class Fanout {
 
   start(name: string, id: unknown, payload: Record<string, unknown>): void {
     const handle = this.buildHandle(name, id, payload);
-    this.handleStack.push(handle);
+    this.handleStack().push(handle);
     handle.start();
   }
 
   finish(name: string, id: unknown, payload: Record<string, unknown>): void {
-    const handle = this.handleStack.pop();
+    const handle = this.handleStack().pop();
     if (handle) {
       handle.finishWithValues(name, id, payload);
     }
@@ -327,6 +353,25 @@ export class Fanout {
   buildHandle(name: string, id: unknown, payload: Record<string, unknown>): Handle {
     const groups = this.groupsFor(name);
     return new FanoutHandle(groups, name, id, payload);
+  }
+
+  /**
+   * Routes an already-built Event to matching subscribers — Rails'
+   * `Fanout#publish_event` (fanout.rb:293-295): run every event-object listener
+   * under `iterate_guarding_exceptions` (run all, then re-raise/aggregate).
+   * `Notifications` only ever registers event-object subscribers (its public API
+   * always yields the Event), so those are the ones fed here.
+   */
+  publishEvent(event: Event): void {
+    const listeners = this.allListenersFor(event.name).filter((s) => s.kind === "event_object");
+    iterateGuardingExceptions(listeners, (s) => (s.delegate as EventObjectCallback)(event));
+  }
+
+  /** Drop every subscriber and reset cached state. Used by unsubscribeAll. */
+  clear(): void {
+    this.stringSubscribers.clear();
+    this.otherSubscribers.length = 0;
+    this.listenersCache.clear();
   }
 
   private allListenersFor(name: string): Subscriber[] {

--- a/packages/activesupport/src/notifications/instrumenter.ts
+++ b/packages/activesupport/src/notifications/instrumenter.ts
@@ -70,16 +70,16 @@ export class Event {
  * Errors that never got a namespaced name (AR's, today) degrade to the bare one.
  */
 function _classNameOf(e: unknown): string {
-  if (e === null || e === undefined) return "NilClass";
   if (e instanceof Error) {
     if (e.name && e.name !== "Error") return e.name;
     const ctor = e.constructor?.name;
     if (ctor && ctor !== "Error") return ctor;
     return e.name || ctor || "Error";
   }
-  // Ruby cannot `raise` a non-Exception, so this branch has no Rails analogue;
-  // name it the way Rails would name the object's class anyway.
-  return (e as { constructor?: { name?: string } })?.constructor?.name ?? typeof e;
+  // JS can throw a non-Error; Ruby cannot, so there's no `e.class.name` analogue.
+  // Use the value's constructor name where it has one ("bare string" -> String),
+  // and fall back to "Error" for the constructor-less throws (null/undefined).
+  return (e as { constructor?: { name?: string } })?.constructor?.name ?? "Error";
 }
 
 // Rails' `rescue Exception` arm — subscribers (e.g. ExplainSubscriber) key off

--- a/packages/activesupport/src/notifications/instrumenter.ts
+++ b/packages/activesupport/src/notifications/instrumenter.ts
@@ -1,4 +1,5 @@
 import { Temporal } from "../temporal.js";
+import { IsolatedExecutionState } from "../isolated-execution-state.js";
 
 export type EventPayload = Record<string, unknown>;
 
@@ -61,11 +62,30 @@ export class Event {
   }
 }
 
+/**
+ * Rails' `e.class.name`. trails carries the namespaced Rails name on `name`
+ * where it has been ported (`ActionDispatch::ParamError`, param-error.ts:28),
+ * which is what keys `rescue_responses` — so prefer it and fall back to the
+ * constructor, mirroring ExceptionWrapper's classNameOf (exception-wrapper.ts:75).
+ * Errors that never got a namespaced name (AR's, today) degrade to the bare one.
+ */
+function _classNameOf(e: unknown): string {
+  if (e === null || e === undefined) return "NilClass";
+  if (e instanceof Error) {
+    if (e.name && e.name !== "Error") return e.name;
+    const ctor = e.constructor?.name;
+    if (ctor && ctor !== "Error") return ctor;
+    return e.name || ctor || "Error";
+  }
+  // Ruby cannot `raise` a non-Exception, so this branch has no Rails analogue;
+  // name it the way Rails would name the object's class anyway.
+  return (e as { constructor?: { name?: string } })?.constructor?.name ?? typeof e;
+}
+
 // Rails' `rescue Exception` arm — subscribers (e.g. ExplainSubscriber) key off
 // these to detect a failed event.
 function _recordException(payload: EventPayload, e: unknown): void {
-  const error = e as { constructor?: { name?: string }; message?: unknown };
-  payload.exception = [error?.constructor?.name ?? "Error", String(error?.message ?? e)];
+  payload.exception = [_classNameOf(e), e instanceof Error ? e.message : String(e)];
   payload.exception_object = e;
 }
 
@@ -75,7 +95,9 @@ function _recordException(payload: EventPayload, e: unknown): void {
  * a legacy publish-only notifier does not, and gets wrapped (see below).
  */
 export interface InstrumenterNotifier {
-  publish(name: string, event: Event): void;
+  // A full notifier (Fanout) drives events through `buildHandle`; a legacy
+  // publish-only notifier provides `publish` and gets wrapped. One is required.
+  publish?(name: string, event: Event): void;
   buildHandle?(name: string, id: unknown, payload: EventPayload): NotificationHandle;
 }
 
@@ -83,11 +105,18 @@ export interface InstrumenterNotifier {
 export interface NotificationHandle {
   start(): void;
   finish(): void;
+  /** The Event this handle built (if any) — used to thread child-event nesting. */
+  readonly event?: Event | null;
 }
 
 export class Instrumenter {
   private _notifier: InstrumenterNotifier;
-  private _stack: Handle[] = [];
+  // trails' (non-Rails) child-event nesting stack. Rails keeps no such stack on
+  // the Instrumenter; trails threads `Event#children` here. It lives in
+  // AsyncContext (per-instance key), so concurrent `instrumentAsync` calls
+  // racing under `Promise.all` fork their own view and can't pop each other's
+  // entries — an instance array would interleave and collapse the nesting.
+  private readonly _stackKey = Symbol("as_notification_instrumenter_stack");
   readonly id: string;
 
   constructor(notifier: InstrumenterNotifier) {
@@ -95,12 +124,18 @@ export class Instrumenter {
     this.id = generateTransactionId();
   }
 
+  private _stack(): Event[] {
+    return IsolatedExecutionState.fetch<Event[]>(this._stackKey, () => []);
+  }
+
   /**
    * Mirrors ActiveSupport::Notifications::Instrumenter#instrument
    * (instrumenter.rb:54-65): build a handle, start it, yield the raw payload
    * (the rescue arm records the exception on it), then finish the handle in the
    * `ensure`. Routing through `build_handle` is what lets a Fanout notifier's
-   * groups drive the event, rather than open-coding an Event/publish here.
+   * groups drive the event, rather than open-coding an Event/publish here. The
+   * handle's event is linked under the enclosing one and pushed for the block's
+   * duration, so nested instruments become children.
    */
   instrument<T = void>(
     name: string,
@@ -109,10 +144,12 @@ export class Instrumenter {
   ): T {
     const handle = this.buildHandle(name, payload);
     handle.start();
+    const inner = this._nest(handle.event ?? null);
 
     try {
-      if (fn) return fn(payload);
-      return undefined as unknown as T;
+      return IsolatedExecutionState.scope(this._stackKey, inner, () =>
+        fn ? fn(payload) : (undefined as unknown as T),
+      );
     } catch (e) {
       _recordException(payload, e);
       throw e;
@@ -128,16 +165,29 @@ export class Instrumenter {
   ): Promise<T> {
     const handle = this.buildHandle(name, payload);
     handle.start();
+    const inner = this._nest(handle.event ?? null);
 
     try {
-      if (fn) return await fn(payload);
-      return undefined as unknown as T;
+      return await IsolatedExecutionState.scope(this._stackKey, inner, () =>
+        fn ? fn(payload) : Promise.resolve(undefined as unknown as T),
+      );
     } catch (e) {
       _recordException(payload, e);
       throw e;
     } finally {
       handle.finish();
     }
+  }
+
+  // Link `event` under the currently-open one and return the stack the block
+  // should run in (with `event` pushed). A handle with no event-object group
+  // (nothing listening) leaves the stack unchanged.
+  private _nest(event: Event | null): Event[] {
+    const stack = this._stack();
+    if (!event) return stack;
+    const parent = stack[stack.length - 1];
+    if (parent) parent.children.push(event);
+    return [...stack, event];
   }
 
   /**
@@ -153,9 +203,14 @@ export class Instrumenter {
     if (this._notifier.buildHandle) {
       return this._notifier.buildHandle(name, this.id, payload);
     }
-    // The stack threads trails' (non-Rails) child-event nesting through the
-    // wrapped handles: each links its event under the one still open above it.
-    return new Handle(name, payload, this.id, this._notifier, this._stack);
+    return new Handle(
+      name,
+      payload,
+      this.id,
+      this._notifier as InstrumenterNotifier & {
+        publish(name: string, event: Event): void;
+      },
+    );
   }
 }
 
@@ -173,9 +228,12 @@ export class Handle implements NotificationHandle {
     private _payload: EventPayload,
     private _transactionId: string,
     private _notifier: { publish(name: string, event: Event): void },
-    // Optional nesting stack for trails' child-event tracking (see Instrumenter).
-    private _stack?: Handle[],
   ) {}
+
+  /** The Event built at #start — the Instrumenter threads nesting through it. */
+  get event(): Event | null {
+    return this._event;
+  }
 
   start(): void {
     if (this._state !== "initialized") {
@@ -183,11 +241,6 @@ export class Handle implements NotificationHandle {
     }
     this._state = "started";
     this._event = new Event(this._name, Temporal.Now.instant(), this._payload, this._transactionId);
-    if (this._stack) {
-      const parent = this._stack[this._stack.length - 1];
-      if (parent?._event) parent._event.children.push(this._event);
-      this._stack.push(this);
-    }
   }
 
   finish(): void {
@@ -195,7 +248,6 @@ export class Handle implements NotificationHandle {
       throw new ArgumentError(`expected state to be "started" but was "${this._state}"`);
     }
     this._state = "finished";
-    if (this._stack) this._stack.pop();
     if (this._event) {
       // Replace the event's dup with the final payload object (mutations made
       // between start and finish, e.g. payload.outcome), as Rails'

--- a/scripts/api-compare/call-mismatches-wide-exclude/activesupport/notifications.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activesupport/notifications.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activesupport",
-    "tsFile": "notifications.ts",
-    "rubyName": "instrument",
-    "call": "listening?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  }
-]


### PR DESCRIPTION
## What

Completes the structural half of RFC 0023's notifications convergence. #4892/#4894/#4897/#4903/#4906 landed the behavioural half (rescue arm, `listening?` short-circuit, payload-yielding Instrumenter, `build_handle` routing, Event#dup). This migrates the static `Notifications` hub off its bespoke internals onto Rails' actual structure and delegates to that Instrumenter.

- `Notifications` now owns a `Fanout` notifier and one bound `Instrumenter`, mirroring `Notifications.notifier` / `Notifications.instrumenter`. `subscribe`/`subscribeOnce`/`unsubscribe`/`unsubscribeAll`/`publish` and the `listening?` short-circuit route through the `Fanout` — the private `_subscribers` Set, `_matches`/`_notify`/`_eventStack` are gone.
  - New `Fanout#publishEvent` (mirrors `publish_event`, fanout.rb:293) and `Fanout#clear`. `publishEvent` runs matching event-object listeners under `iterate_guarding_exceptions` (run all, then re-raise/aggregate).
  - `Notifications.subscribe` wraps callbacks so they present to the `Fanout` as single-arity event-object subscribers (trails' public API always yields the `Event`, unlike Rails' arity-based classification).
- `Notifications.instrument` / `instrumentAsync` become thin delegators (notifications.rb:208-214): `listening?` branch, else `Instrumenter#instrument{,Async}`, which routes through `build_handle` so the Fanout's subscriber groups drive the event.
- `Instrumenter` moves its child-nesting stack off the instance `Handle[]` array (added by #4903) onto a per-instance AsyncContext-scoped `IsolatedExecutionState` stack, so concurrent `instrumentAsync` under `Promise.all` can't corrupt each other's nesting. Both handle types expose their built `Event` so nesting threads uniformly at the Instrumenter.
- `Fanout`'s evented `start`/`finish` handle stack also moves to `IsolatedExecutionState`, mirroring Rails' `:_fanout_handle_stack` (fanout.rb:277).

Net −135 LOC.

## Codex review responses (previous revision)

- **`Notifications.publish` swallowed subscriber exceptions** — fixed. `publish` now routes through `Fanout#publishEvent`, which uses `iterate_guarding_exceptions` (runs all listeners, then re-raises), matching Rails `Fanout#publish`/`publish_event` and the old `_notify(event, true)` path.
- **`Instrumenter#instrument` open-coded an Event/publish instead of `build_handle`** — fixed by reverting to #4903's `build_handle` routing (all subscriber groups driven). The AsyncContext child-nesting is layered on top of that routing rather than replacing it.

## Deviation converged

Delegating `instrument` through the Fanout/`build_handle` path makes subscriber exceptions propagate (Rails `iterate_guarding_exceptions` aggregates then re-raises). This removes the trails-only `does not propagate errors from subscribers` test, which asserted the opposite — a deviation from Rails, converged here per RFC 0023's always-converge policy.

## Tests

All existing notification tests pass, including `nested events can be instrumented`, the concurrent `instrumentAsync` nesting-isolation test, and the AR `sql.active_record` exception-key coverage in `instrumentation.trails.test.ts`. Also verified `transaction-instrumentation`, `server-timing`, `subscriber`, `log-subscriber`, `evented-notification`. api:compare activesupport 684→685 methods (+1); test:compare matched coverage unchanged (2304/2862).

Closes-story: converge-notifications-onto-fanout-notifier

## CI resolution (2026-07-18)

- **AR `has-one-associations.test.ts` failures** (un-awaited RFC 0063 `isValid`/`isInvalid`): fixed by rebasing onto latest `main`, which includes d78fd0c0.
- **Rails API/Test Comparison (wide call-mismatches ratchet):** genuine to this PR, now fixed.
  - Removed the stale wide-call baseline entry `notifications.ts instrument listening?` — `instrument` now calls the notifier's `listening()` (Rails `listening?`), so the recorded omission no longer holds (baseline only shrinks).
  - The 2 NEW `query-assertions subscribed` flags were a side effect of exporting the internal `Fanout` `Subscriber` interface, which made api:compare falsely match Rails' `Notifications.subscribed` (unported). `NotificationSubscriber` is now an opaque brand, so that member no longer leaks into the exported surface; the false match and both flags are gone. Wide ratchet is OK (6844 baselined) locally with a clean regen.
