### PR TITLE
test(activesupport): cover method-name and object around dispatch in invokeAround

### DIFF
--- a/packages/activesupport/src/callbacks.test.ts
+++ b/packages/activesupport/src/callbacks.test.ts
@@ -7,6 +7,7 @@ import {
   runCallbacks,
   CallbacksMixin,
   CallTemplate,
+  CallbackSequence,
   throwAbort,
 } from "./callbacks.js";
 
@@ -153,6 +154,64 @@ describe("Callbacks", () => {
       runCallbacks(target, "save", () => target.log.push("block"));
 
       expect(target.log).toEqual(["around-pre", "block", "after", "around-post"]);
+    });
+  });
+
+  describe("around dispatch shapes (method-name & object)", () => {
+    // Rails covers a Symbol-filter around callback via AroundPersonResult#tweedle_dum
+    // (`@result = yield`), which compiles to CallTemplate::MethodCall and dispatches
+    // `target.send(method, &block)` — the continuation is threaded as the block.
+    it("test_save_around", () => {
+      const tweedleDum = Symbol("tweedleDum");
+      const target: any = { history: [] as string[], result: null };
+      target[tweedleDum] = function (this: any, next: () => unknown) {
+        this.history.push("tweedle dum pre");
+        this.result = next();
+        this.history.push("tweedle dum post");
+      };
+      defineCallbacks(target, "save");
+      // A Symbol filter is the method-name branch; a function would compile to
+      // InstanceExec instead. Cast past the AnyCallback type as tests do elsewhere.
+      setCallback(target, "save", "around", tweedleDum as any);
+
+      runCallbacks(target, "save", () => {
+        target.history.push("running");
+        return "running";
+      });
+
+      expect(target.history).toEqual(["tweedle dum pre", "running", "tweedle dum post"]);
+      // next() surfaces the block's return (Rails' `yield` inside the around).
+      expect(target.result).toBe("running");
+    });
+
+    // Rails' CallbackObject#around(caller) { ... yield ... } compiles to
+    // CallTemplate::ObjectCall and dispatches `object.send(method, target, &block)` —
+    // the receiver is the object, the record is the first positional arg, and the
+    // continuation is the block. trails' setCallback resolves a CallbackObject to a
+    // plain around function, so drive invokeAround with an ObjectCall template
+    // directly to cover the object-dispatch threading (record first, block last).
+    it("test_around_object", () => {
+      const record: string[] = [];
+      const caller = {};
+      const obj = {
+        aroundSave(this: unknown, arg: object, next: () => unknown) {
+          record.push("around before");
+          expect(this).toBe(obj);
+          expect(arg).toBe(caller);
+          const v = next();
+          record.push("around after");
+          return v;
+        },
+      };
+      const seq = new CallbackSequence(null, new CallTemplate.ObjectCall(obj, "aroundSave"), null);
+
+      const result = seq.invokeAround({ target: caller, halted: false, value: undefined }, () => {
+        record.push("yielded");
+        return "block-result";
+      });
+
+      expect(record).toEqual(["around before", "yielded", "around after"]);
+      expect(result).toBe("block-result");
     });
   });
 

--- a/packages/activesupport/src/callbacks.test.ts
+++ b/packages/activesupport/src/callbacks.test.ts
@@ -187,14 +187,17 @@ describe("Callbacks", () => {
     // Rails' CallbackObject#around(caller) { ... yield ... } compiles to
     // CallTemplate::ObjectCall and dispatches `object.send(method, target, &block)` —
     // the receiver is the object, the record is the first positional arg, and the
-    // continuation is the block. trails' setCallback resolves a CallbackObject to a
-    // plain around function, so drive invokeAround with an ObjectCall template
-    // directly to cover the object-dispatch threading (record first, block last).
+    // continuation is the block. The method name is the callback's scope-join; with
+    // the default CallbackChain scope of [:kind] that is `around` (not `around_save`
+    // — the [:kind, :name] custom-scope shape), matching Rails' test_around_object.
+    // trails' setCallback resolves a CallbackObject to a plain around function, so
+    // drive invokeAround with an ObjectCall template directly to cover the
+    // object-dispatch threading (record first, block last).
     it("test_around_object", () => {
       const record: string[] = [];
       const caller = {};
       const obj = {
-        aroundSave(this: unknown, arg: object, next: () => unknown) {
+        around(this: unknown, arg: object, next: () => unknown) {
           record.push("around before");
           expect(this).toBe(obj);
           expect(arg).toBe(caller);
@@ -203,7 +206,7 @@ describe("Callbacks", () => {
           return v;
         },
       };
-      const seq = new CallbackSequence(null, new CallTemplate.ObjectCall(obj, "aroundSave"), null);
+      const seq = new CallbackSequence(null, new CallTemplate.ObjectCall(obj, "around"), null);
 
       const result = seq.invokeAround({ target: caller, halted: false, value: undefined }, () => {
         record.push("yielded");


### PR DESCRIPTION
## What

`CallbackSequence.invokeAround` dispatches an around callback via `expand_call_template` + `send`-with-block across three CallTemplate shapes: `instanceExec` (InstanceExec0/1/2), `call` (ProcCall), and the method-name branch (`MethodCall` / `ObjectCall` — `receiver[method](...args, block)`). Only the `instanceExec` shape was exercised by tests, leaving the method-name and object-dispatch branches — where the continuation is threaded as the trailing positional arg — uncovered.

## Tests added

- `test_save_around` — a Symbol-filter around callback (Rails `AroundPersonResult#tweedle_dum`, `@result = yield`) compiling to `MethodCall`, asserting pre/yield/post ordering and that `next()` returns the block value.
- `test_around_object` — drives `invokeAround` with an `ObjectCall` template (`aroundSave`) to cover the object-dispatch threading (receiver is the object, record first, continuation last).

No production code changes; test-only.

Closes-story: cover-method-name-around-dispatch