### PR TITLE
refactor(arel): encode aliased join tables as TableAlias, not Table({as})

### DIFF
--- a/packages/activerecord/src/associations/alias-tracker.ts
+++ b/packages/activerecord/src/associations/alias-tracker.ts
@@ -3,7 +3,7 @@
  *
  * Mirrors: ActiveRecord::Associations::AliasTracker
  */
-import { Table, Nodes } from "@blazetrails/arel";
+import { Table, Nodes, type TableRef } from "@blazetrails/arel";
 import { maxIdentifierLength } from "../connection-adapters/abstract/database-limits.js";
 import type { Quoting } from "../connection-adapters/abstract/quoting-interface.js";
 
@@ -20,13 +20,9 @@ const DEFAULT_TABLE_ALIAS_LENGTH = maxIdentifierLength();
  * then `arel_table.alias(table_name) if arel_table.name != table_name`. (Not
  * `aliased_table_for`: this does none of that method's alias-count bookkeeping,
  * and its real port is `AliasTracker#aliasedTableFor` below.) Deriving from
- * `klass.arel_table` and aliasing is what keeps the caster, via `TableAlias`'s
- * delegation. trails cannot return a `TableAlias` here — the
- * JoinDependency plumbing that consumes these tables is typed on `Table` and
- * gates on `instanceof Table` (e.g. rebindTableReferences, join-dependency.ts),
- * which a `TableAlias` (a Binary node) silently fails — so an aliased table is
- * encoded as `Table(realName, { as })` and the caster is carried across by hand.
- * Converging that encoding onto `TableAlias` is tracked separately.
+ * `klass.arel_table` and aliasing produces a `TableAlias`, which delegates its
+ * type caster to the underlying real table (table_alias.rb:22-24) — so the
+ * caster rides across the alias for free, no hand-carried copy.
  *
  * @internal
  */
@@ -34,15 +30,15 @@ export function aliasedArelTableFor(
   klass: { arelTable?: Table; tableName?: string } | null | undefined,
   tableName: string,
   effectiveName?: string,
-): Table {
+): TableRef {
   const sqlName = effectiveName ?? tableName;
-  const base = klass?.arelTable;
-  // No klass (polymorphic): nothing to source a caster from.
-  if (!base) return new Table(tableName, { as: effectiveName });
+  // No klass (polymorphic): nothing to source a caster from, so build a bare
+  // table on the real name and alias it exactly as Rails' `arel_table.alias`.
+  const base = klass?.arelTable ?? new Table(tableName);
   // `base.name` is the real table. Rails aliases it to whatever name the join
   // must answer to (table_metadata.rb:44) and keeps the caster either way.
   if (sqlName === base.name) return base;
-  return new Table(base.name, { as: sqlName, typeCaster: base.typeCaster, klass: base.klass });
+  return base.alias(sqlName);
 }
 
 /**
@@ -56,7 +52,7 @@ export function aliasedArelTableForReflection(
   reflection: { klass?: unknown; isPolymorphic?: () => boolean } | null | undefined,
   tableName: string,
   effectiveName?: string,
-): Table {
+): TableRef {
   const klass = reflection?.isPolymorphic?.() ? null : (reflection?.klass as never);
   return aliasedArelTableFor(klass, tableName, effectiveName);
 }

--- a/packages/activerecord/src/associations/join-dependency-through-aliasing.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-through-aliasing.test.ts
@@ -13,7 +13,7 @@ import { Base, registerModel } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { Associations } from "../associations.js";
 import { JoinDependency } from "./join-dependency.js";
-import { Nodes, Table } from "@blazetrails/arel";
+import { Nodes, Table, tableRealName, tableSqlName, type TableRef } from "@blazetrails/arel";
 
 describe("JoinDependency#_addThroughAssociation real-table-name reuse", () => {
   // Ride the boot-laid canonical `Base.connection` (single-pool test model)
@@ -95,10 +95,10 @@ describe("JoinDependency#_addThroughAssociation real-table-name reuse", () => {
     // Rails names the collision `{plural_name}_{owner_table}` (root link, no _join).
     expect(node!.effectiveSqlName).toBe("jdt_comments_jdt_authors");
 
-    // Target aliased
-    const targetTable = (node!.arelJoin as Nodes.OuterJoin).left as Table;
-    expect(targetTable.name).toBe("jdt_comments");
-    expect(targetTable.tableAlias).toBe("jdt_comments_jdt_authors");
+    // Target aliased — Rails encodes this as a `TableAlias` over the real table.
+    const targetTable = (node!.arelJoin as Nodes.OuterJoin).left as TableRef;
+    expect(tableRealName(targetTable)).toBe("jdt_comments");
+    expect(tableSqlName(targetTable)).toBe("jdt_comments_jdt_authors");
 
     // Through still uses real name
     const throughNode = jd.nodes.find(
@@ -249,8 +249,8 @@ describe("JoinDependency#_addThroughAssociation real-table-name reuse", () => {
     // Lazily consume references; the free reference name renames the target.
     jd.joinConstraints([], (jd as any)._aliasTracker, ["jdtComments"]);
     expect(target.effectiveSqlName).toBe("jdtComments");
-    expect((target.arelTable as Table).name).toBe("jdt_comments");
-    expect((target.arelTable as Table).tableAlias).toBe("jdtComments");
+    expect(tableRealName(target.arelTable as TableRef)).toBe("jdt_comments");
+    expect(tableSqlName(target.arelTable as TableRef)).toBe("jdtComments");
 
     // The intermediate `_through_` link is internal and never reference-aliased.
     const throughNode = jd.nodes.find((n) => n.assocName.includes("_through_"))!;

--- a/packages/activerecord/src/associations/join-dependency-walk.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-walk.test.ts
@@ -10,7 +10,7 @@ import { Base, registerModel } from "../index.js";
 import { clearReflectionsCache } from "../reflection.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { JoinDependency } from "./join-dependency.js";
-import { Nodes } from "@blazetrails/arel";
+import { Nodes, tableRealName, tableSqlName, type TableRef } from "@blazetrails/arel";
 
 describe("JoinDependency walk() deduplication", () => {
   // Ride the boot-laid canonical `Base.connection` (single-pool test model)
@@ -192,14 +192,14 @@ describe("JoinDependency walk() deduplication", () => {
     // The ON predicate must NOT reference "comments" for the parent side —
     // that's jd2's un-aliased name. It should reference jd1's alias (e.g. "t2").
     const jd1ReviewsJoin = joins.find((j) => {
-      const table = (j as Nodes.OuterJoin).left;
-      const alias = (table as any).tableAlias;
-      const name = (table as any).name;
-      return name === "comments" && alias && alias !== "comments";
+      const table = (j as Nodes.OuterJoin).left as TableRef;
+      const realName = tableRealName(table);
+      const alias = tableSqlName(table);
+      return realName === "comments" && alias !== "comments";
     }) as Nodes.OuterJoin | undefined;
     expect(jd1ReviewsJoin).toBeDefined();
 
-    const jd1ReviewsAlias = (jd1ReviewsJoin!.left as any).tableAlias;
+    const jd1ReviewsAlias = tableSqlName(jd1ReviewsJoin!.left as TableRef);
     expect(referencedTables).toContain(jd1ReviewsAlias);
     expect(referencedTables).toContain("likes");
     expect(referencedTables).not.toContain("comments");

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -17,7 +17,7 @@ import {
   camelize as _camelize,
   singularize as _singularize,
 } from "@blazetrails/activesupport";
-import { Table, Nodes } from "@blazetrails/arel";
+import { Table, Nodes, tableSqlName, type TableRef } from "@blazetrails/arel";
 import { modelRegistry, isAssociationCached } from "../associations.js";
 import { _reflectOnAssociation } from "../reflection.js";
 import { getInheritanceColumn, isStiSubclass } from "../inheritance.js";
@@ -104,9 +104,9 @@ function getModelColumns(modelClass: any): string[] {
 export class Aliases {
   private _aliasCache: Map<JoinPart | null, Map<string, string>>;
   private _allColumns: AliasMap[];
-  private _tables: Array<{ node: JoinPart | null; table: Table; columns: AliasMap[] }>;
+  private _tables: Array<{ node: JoinPart | null; table: TableRef; columns: AliasMap[] }>;
 
-  constructor(tables: Array<{ node: JoinPart | null; table: Table; columns: AliasMap[] }>) {
+  constructor(tables: Array<{ node: JoinPart | null; table: TableRef; columns: AliasMap[] }>) {
     this._aliasCache = new Map();
     this._allColumns = [];
     this._tables = tables;
@@ -179,7 +179,7 @@ export class JoinDependency {
    */
   private _joinedTables: Map<
     string,
-    { aliased: Table; effectiveName: string; terminated: boolean }
+    { aliased: TableRef; effectiveName: string; terminated: boolean }
   > = new Map();
   constructor(baseModel: typeof Base, joinType?: typeof Nodes.InnerJoin | typeof Nodes.OuterJoin) {
     this._baseModel = baseModel;
@@ -790,7 +790,7 @@ export class JoinDependency {
       resolvedTable = lEffective;
     } else {
       const lt = l.table;
-      resolvedTable = typeof lt === "string" ? lt : (lt.tableAlias ?? lt.name);
+      resolvedTable = typeof lt === "string" ? lt : tableSqlName(lt);
     }
     r.table = resolvedTable;
     if (originalTable === resolvedTable) return;
@@ -893,7 +893,7 @@ export class JoinDependency {
     // `walk`/`joinConstraints` still memoizes its shared chain tails.
     if (joinType === Nodes.OuterJoin && !this._joinedTables.has(chainKey)) {
       this._joinedTables.set(chainKey, {
-        aliased: child.arelTable as Table,
+        aliased: child.arelTable as TableRef,
         effectiveName: child.effectiveSqlName,
         terminated: true,
       });
@@ -929,7 +929,7 @@ export class JoinDependency {
     const tableName = child.tableName;
     const aliased = aliasedArelTableForReflection(child.reflection, tableName, newName);
     const foreignTable =
-      (parent.arelTable as Table) ??
+      (parent.arelTable as TableRef) ??
       aliasedArelTableForReflection(child.reflection, child.tableName);
     const joinAssoc = new JoinAssociation(child.reflection);
     const joins = joinAssoc.joinConstraints(
@@ -946,7 +946,7 @@ export class JoinDependency {
     // name): a name-rebind can't tell the two sides apart, so it is skipped (FK
     // already correct; a scoped self-join's scope predicate stays un-rebound — a
     // pre-existing limitation).
-    const parentEffName = foreignTable.tableAlias ?? foreignTable.name;
+    const parentEffName = tableSqlName(foreignTable);
     if (newName !== tableName && parentEffName !== tableName) {
       const on = (arelJoin as any).right as Nodes.On;
       if (on instanceof Nodes.On) {
@@ -981,10 +981,10 @@ export class JoinDependency {
     group.resolved = true;
     const chainLen = group.reflection.chain.length;
     const foreignTable =
-      (parent.arelTable as Table) ??
+      (parent.arelTable as TableRef) ??
       aliasedArelTableFor(group.chainTables[0].model as never, group.chainTables[0].tableName);
     const joinAssoc = new JoinAssociation(group.reflection);
-    const resolvedByIdx: Array<{ effectiveName: string; aliased: Table }> = new Array(chainLen);
+    const resolvedByIdx: Array<{ effectiveName: string; aliased: TableRef }> = new Array(chainLen);
     const joins = joinAssoc.joinConstraints(
       foreignTable,
       group.parentModel,
@@ -1160,7 +1160,7 @@ export class JoinDependency {
   private _addStiConstraintArel(
     predicate: Nodes.Node,
     model: typeof Base,
-    arelTable: Table,
+    arelTable: TableRef,
   ): Nodes.Node {
     const inheritanceCol = getInheritanceColumn(model);
     if (inheritanceCol && isStiSubclass(model)) {
@@ -1429,7 +1429,7 @@ export class JoinDependency {
       node: JoinPart,
       columns: string[],
       tableIndex: number,
-    ): { node: JoinPart; table: Table; columns: AliasMap[] } => ({
+    ): { node: JoinPart; table: TableRef; columns: AliasMap[] } => ({
       node,
       table: node.arelTable!,
       columns: columns.map((column, columnIndex) => ({
@@ -1633,7 +1633,7 @@ export class JoinDependency {
     // `ThroughJoinGroup` carries the chain metadata so emit resolves every link's
     // alias against the shared AliasTracker and rebuilds + redistributes the joins.
     const chainTables: Array<{
-      table: Table;
+      table: TableRef;
       tableName: string;
       tableIndex: number;
       tableAlias: string;
@@ -1767,7 +1767,7 @@ export interface ThroughJoinGroup {
 function rebindTableReferences(
   node: Nodes.Node,
   fromTableName: string,
-  toTable: Table,
+  toTable: TableRef,
 ): Nodes.Node {
   if (node instanceof Nodes.Attribute) {
     const rel = node.relation;
@@ -1779,7 +1779,10 @@ function rebindTableReferences(
     // query (bumping on collision), so an alias can never equal a sibling join's
     // real table name — and this rebind only walks one join's ON (its own table
     // plus its grandchildren), not the whole FROM list.
-    if (rel instanceof Table && (rel.tableAlias ?? rel.name) === fromTableName) {
+    if (
+      (rel instanceof Table || rel instanceof Nodes.TableAlias) &&
+      tableSqlName(rel) === fromTableName
+    ) {
       return toTable.get(node.name);
     }
     return node;

--- a/packages/activerecord/src/associations/join-dependency/join-association.ts
+++ b/packages/activerecord/src/associations/join-dependency/join-association.ts
@@ -9,7 +9,7 @@
  */
 
 import type { Base } from "../../base.js";
-import { Table, Nodes } from "@blazetrails/arel";
+import { Nodes, relationName, tableSqlName, type TableRef } from "@blazetrails/arel";
 import type { AbstractReflection } from "../../reflection.js";
 import { JoinPart } from "./join-part.js";
 import { aliasedArelTableForReflection, type AliasTracker } from "../alias-tracker.js";
@@ -18,12 +18,12 @@ type JoinType = typeof Nodes.InnerJoin | typeof Nodes.OuterJoin;
 type TableResolver = (
   reflection: AbstractReflection,
   remainingChain: AbstractReflection[],
-) => [Table, boolean];
+) => [TableRef, boolean];
 
 export class JoinAssociation extends JoinPart {
   readonly reflection: AbstractReflection;
-  private _table: Table | null = null;
-  readonly tables: Table[] = [];
+  private _table: TableRef | null = null;
+  readonly tables: TableRef[] = [];
   /**
    * Extra join sources contributed by the association scope's own `joins(...)`
    * (Rails `joins.concat arel.join_sources`). Kept separate from the per-chain
@@ -52,13 +52,14 @@ export class JoinAssociation extends JoinPart {
   get table(): string {
     const t = this._table;
     if (!t) return this.reflection.tableName;
-    return t.tableAlias ?? t.name;
+    return tableSqlName(t);
   }
 
   set table(value: string) {
-    this._table = aliasedArelTableForReflection(this.reflection, this.reflection.tableName, value);
-    if (!this.tables.some((t) => (t.tableAlias ?? t.name) === value)) {
-      this.tables.push(this._table);
+    const table = aliasedArelTableForReflection(this.reflection, this.reflection.tableName, value);
+    this._table = table;
+    if (!this.tables.some((t) => tableSqlName(t) === value)) {
+      this.tables.push(table);
     }
   }
 
@@ -86,20 +87,20 @@ export class JoinAssociation extends JoinPart {
    * Mirrors: ActiveRecord::Associations::JoinDependency::JoinAssociation#join_constraints
    */
   joinConstraints(
-    foreignTable: Table,
+    foreignTable: TableRef,
     foreignKlass: typeof Base,
     joinType: JoinType,
     aliasTracker?: AliasTracker,
     resolveTable?: TableResolver,
   ): Nodes.Node[] {
     const joins: Nodes.Node[] = [];
-    const chain: [AbstractReflection, Table][] = [];
+    const chain: [AbstractReflection, TableRef][] = [];
 
     const reflectionChain = this.reflection.chain;
 
     for (let index = 0; index < reflectionChain.length; index++) {
       const refl = reflectionChain[index];
-      let table: Table;
+      let table: TableRef;
       let terminated = false;
 
       if (resolveTable) {
@@ -109,7 +110,7 @@ export class JoinAssociation extends JoinPart {
       }
 
       if (!this._table) this._table = table;
-      if (!this.tables.some((t) => (t.tableAlias ?? t.name) === (table.tableAlias ?? table.name))) {
+      if (!this.tables.some((t) => tableSqlName(t) === tableSqlName(table))) {
         this.tables.push(table);
       }
 
@@ -159,7 +160,7 @@ export class JoinAssociation extends JoinPart {
       if (nodes instanceof Nodes.And) {
         const remaining: Nodes.Node[] = [];
         for (const child of nodes.children) {
-          if (!nodeReferencesTable(child, table.tableAlias ?? table.name)) {
+          if (!nodeReferencesTable(child, tableSqlName(table))) {
             others.push(child);
           } else {
             remaining.push(child);
@@ -273,7 +274,7 @@ function nodeReferencesTable(node: Nodes.Node, tableName: string): boolean {
   node.fetchAttribute((attr: Nodes.Node) => {
     if (attr instanceof Nodes.Attribute) {
       const rel = attr.relation;
-      if ((rel.tableAlias ?? rel.name) === tableName) {
+      if (relationName(rel.tableAlias ?? rel.name) === tableName) {
         found = true;
         return false;
       }

--- a/packages/activerecord/src/associations/join-dependency/join-part.ts
+++ b/packages/activerecord/src/associations/join-dependency/join-part.ts
@@ -8,7 +8,7 @@
  */
 
 import type { Base } from "../../base.js";
-import type { Table, Nodes } from "@blazetrails/arel";
+import type { TableRef, Nodes } from "@blazetrails/arel";
 import type { ThroughJoinGroup } from "../join-dependency.js";
 
 export abstract class JoinPart {
@@ -23,7 +23,7 @@ export abstract class JoinPart {
    * the way Rails' JoinPart#table does — no separate index-keyed table map.
    * @internal
    */
-  arelTable: Table | null = null;
+  arelTable: TableRef | null = null;
   columns: string[] = [];
   assocName = "";
   assocType: "hasMany" | "hasOne" | "belongsTo" = "hasMany";
@@ -55,7 +55,7 @@ export abstract class JoinPart {
     if (children) this.children.push(...children);
   }
 
-  abstract get table(): Table | string;
+  abstract get table(): TableRef | string;
 
   /**
    * Mirrors Rails' `delegate :table_name, :column_names, :primary_key,

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -10,7 +10,7 @@ import {
   demodulize,
   foreignKey as deriveForeignKey,
 } from "@blazetrails/activesupport";
-import { Table } from "@blazetrails/arel";
+import { Table, type TableRef } from "@blazetrails/arel";
 import { _correctNames } from "./associations.js";
 import { joinTableName } from "./migration/join-table.js";
 import { rubyInspectArray } from "./relation/ruby-inspect.js";
@@ -265,7 +265,7 @@ export class AbstractReflection {
     return [this];
   }
 
-  buildScope(table?: Table, _predicateBuilder?: any, klass?: typeof Base): any {
+  buildScope(table?: TableRef, _predicateBuilder?: any, klass?: typeof Base): any {
     // Rails: `Relation.create(klass, table:, predicate_builder:)` — a genuinely
     // bare relation. Default scope and the STI `type_condition` are layered on
     // later by `klassJoinScope` (scope_for_association) and `joinScope`, so the
@@ -274,7 +274,7 @@ export class AbstractReflection {
     return target._buildBareRelation?.(table) ?? target.all();
   }
 
-  joinScope(table: Table, foreignTable: Table, foreignKlass: typeof Base): any {
+  joinScope(table: TableRef, foreignTable: TableRef, foreignKlass: typeof Base): any {
     let scope = this.klassJoinScope(table);
 
     const typeCol = this._concrete().type;
@@ -312,7 +312,7 @@ export class AbstractReflection {
     return scope;
   }
 
-  joinScopes(table: Table, predicateBuilder?: any, klass?: typeof Base, record?: any): any[] {
+  joinScopes(table: TableRef, predicateBuilder?: any, klass?: typeof Base, record?: any): any[] {
     if (this.scope) {
       const rel = this.buildScope(table, predicateBuilder, klass);
       const result = this._concrete().scopeFor?.(rel, record) ?? this.scope(rel);
@@ -321,7 +321,7 @@ export class AbstractReflection {
     return [];
   }
 
-  klassJoinScope(table?: Table, predicateBuilder?: any): any {
+  klassJoinScope(table?: TableRef, predicateBuilder?: any): any {
     // Rails: `klass.scope_for_association(build_scope(table, predicate_builder))`.
     // `build_scope` is a bare relation (no default scope, no STI); the STI
     // `type_condition` is added by `joinScope`, qualified by the join's table.
@@ -1792,7 +1792,7 @@ export class ThroughReflection extends AbstractReflection {
     return this.delegateReflection.scopeFor(relation, owner);
   }
 
-  joinScopes(table: Table, predicateBuilder?: any, klass?: typeof Base, record?: any): any[] {
+  joinScopes(table: TableRef, predicateBuilder?: any, klass?: typeof Base, record?: any): any[] {
     const sourceScopes =
       this.sourceReflection?.joinScopes(table, predicateBuilder, klass, record) ?? [];
     return [...sourceScopes, ...super.joinScopes(table, predicateBuilder, klass, record)];
@@ -2105,7 +2105,7 @@ export class PolymorphicReflection extends AbstractReflection {
     return (this._reflection as any).scopeFor?.(relation, owner) ?? relation;
   }
 
-  joinScopes(table: Table, predicateBuilder?: any, klass?: typeof Base, record?: any): any[] {
+  joinScopes(table: TableRef, predicateBuilder?: any, klass?: typeof Base, record?: any): any[] {
     const scopes = super.joinScopes(table, predicateBuilder, klass, record);
     if (!(this._previousReflection as any).isThroughReflection?.()) {
       const prevScopes =

--- a/packages/arel/src/index.ts
+++ b/packages/arel/src/index.ts
@@ -1,4 +1,5 @@
 export { Table } from "./table.js";
+export { type TableRef, tableSqlName, tableRealName } from "./table-ref.js";
 export * as Nodes from "./nodes/index.js";
 export * as Visitors from "./visitors/index.js";
 export * as Collectors from "./collectors/index.js";

--- a/packages/arel/src/table-ref.ts
+++ b/packages/arel/src/table-ref.ts
@@ -1,0 +1,28 @@
+import { Table } from "./table.js";
+import { TableAlias } from "./nodes/table-alias.js";
+import { relationName } from "./attributes/attribute.js";
+
+/**
+ * A table reference that can appear in a JOIN's FROM/ON position: either a plain
+ * `Arel::Table` or an `Arel::Nodes::TableAlias` wrapping one. Rails treats the
+ * two uniformly — `aliased_table_for` returns `arel_table.alias(name)` (a
+ * `TableAlias`) when aliased and the bare `Table` otherwise — so the join
+ * plumbing that consumes these must accept both.
+ */
+export type TableRef = Table | TableAlias;
+
+/**
+ * The SQL name a table answers to in FROM/ON: its alias when aliased, else the
+ * real table name. Mirrors Rails' uniform `relation.table_alias || relation.name`
+ * read, which works across both `Arel::Table` and `Arel::Nodes::TableAlias`.
+ */
+export function tableSqlName(rel: TableRef): string {
+  if (rel instanceof TableAlias) return relationName(rel.tableAlias);
+  return rel.tableAlias ?? rel.name;
+}
+
+/** The underlying real table name, ignoring any alias. */
+export function tableRealName(rel: TableRef): string {
+  if (rel instanceof TableAlias) return rel.tableName;
+  return rel.name;
+}

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -33,11 +33,10 @@ export class Table extends Node {
   readonly name: string;
   readonly tableAlias: string | null;
   readonly klass?: TableKlass;
-  /** Rails: `private attr_reader :type_caster` (table.rb:115). Readable here so
-   *  an aliased copy of a table can inherit it — trails encodes an aliased table
-   *  as `Table(name, { as })` where Rails wraps in a caster-delegating TableAlias.
-   *  @internal */
-  readonly typeCaster: unknown;
+  /** Rails: `private attr_reader :type_caster` (table.rb:115). An aliased table
+   *  is a `TableAlias` wrapping this one and delegates its caster back here
+   *  (table_alias.rb:22-24), so no external reader is needed. */
+  private readonly typeCaster: unknown;
 
   constructor(name: string, options?: { as?: string; klass?: TableKlass; typeCaster?: unknown }) {
     super();


### PR DESCRIPTION
## What

Converge the encoding of an aliased join table onto `Arel::Nodes::TableAlias`, matching Rails, and drop the hand-carried type-caster copy #4889 needed to work around the old encoding.

Rails' `aliased_table_for` returns `arel_table.alias(name)` — a `TableAlias` that delegates `type_for_attribute` to the underlying real table (`table_alias.rb:22-24`), so the caster rides across the alias for free. trails had instead encoded it as `Table(realName, { as })` and copied `typeCaster`/`klass` by hand, because the JoinDependency plumbing was typed on `Table` and gated on `instanceof Table` — which a `TableAlias` (a `Binary` node) silently fails.

## Changes

- New `TableRef = Table | TableAlias` type plus `tableSqlName` / `tableRealName` helpers in `@blazetrails/arel`. The effective SQL name (alias when aliased, else real name) and the real table name are now read through one helper instead of `.tableAlias ?? .name`, which changed meaning between the two node types.
- `aliasedArelTableFor` collapses to `base.alias(sqlName)` (Rails `alias_tracker.rb:64` / `table_metadata.rb:44`); the `typeCaster`/`klass` copy is gone.
- JoinDependency plumbing (`join-dependency.ts`, `join-association.ts`, `join-part.ts`) and `Reflection#joinScope`/`joinScopes`/`buildScope` widened to `TableRef`; the `rebindTableReferences` `instanceof Table` gate now also accepts `TableAlias`.
- `Table#typeCaster` reverts to `private` — nothing outside the node reads it now.
- The 3 structural tests the story flagged stay green; only their arel-shape reads were updated to the `TableAlias` encoding (no test-name changes).

## Testing

- `join-dependency-walk.test.ts` and `join-dependency-through-aliasing.test.ts` (incl. the 3 named tests) pass.
- Full `associations/` suite: 1880 passed, 36 skipped.

Closes-story: arel-aliased-join-tables-should-be-tablealias
