### PR TITLE
refactor(associations): converge through-preload source join onto includes/references for every source kind

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -2677,6 +2677,17 @@ function createHabtmJoinModel(
   JoinModel._tableName = joinTableName;
   JoinModel.primaryKey = [ownerFk, targetFk];
 
+  // The composite PK above is a trails affordance (Rails' HABTM join model has
+  // no primary key) that only supports delete/destroy's PK-based WHERE. It must
+  // NOT force the composite-PK eager-load bypass in `_eagerLoadBypassesJoinDependency`:
+  // an `includes(<source belongsTo>).references(...)` on this join model is a
+  // plain single-column belongs_to JOIN the JoinDependency handles fine (parent
+  // dedup keys off the composite PK in `instantiateFromRows`). Marking it here
+  // lets the through-preloader's source join run as Rails' eager LEFT OUTER JOIN
+  // rather than degrading to preload (which would orphan a copied source-table
+  // predicate onto an unjoined table).
+  (JoinModel as { _isHabtmJoinModel?: boolean })._isHabtmJoinModel = true;
+
   // Carry the declaring model's Ruby module path onto the anonymous join model
   // so its source `belongsTo` resolves an unqualified target class name
   // (e.g. "Article") namespace-relative to the owner (→ "Publisher::Article").

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -2677,17 +2677,6 @@ function createHabtmJoinModel(
   JoinModel._tableName = joinTableName;
   JoinModel.primaryKey = [ownerFk, targetFk];
 
-  // The composite PK above is a trails affordance (Rails' HABTM join model has
-  // no primary key) that only supports delete/destroy's PK-based WHERE. It must
-  // NOT force the composite-PK eager-load bypass in `_eagerLoadBypassesJoinDependency`:
-  // an `includes(<source belongsTo>).references(...)` on this join model is a
-  // plain single-column belongs_to JOIN the JoinDependency handles fine (parent
-  // dedup keys off the composite PK in `instantiateFromRows`). Marking it here
-  // lets the through-preloader's source join run as Rails' eager LEFT OUTER JOIN
-  // rather than degrading to preload (which would orphan a copied source-table
-  // predicate onto an unjoined table).
-  (JoinModel as { _isHabtmJoinModel?: boolean })._isHabtmJoinModel = true;
-
   // Carry the declaring model's Ruby module path onto the anonymous join model
   // so its source `belongsTo` resolves an unqualified target class name
   // (e.g. "Article") namespace-relative to the owner (→ "Publisher::Article").

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -1193,6 +1193,7 @@ export class JoinDependency {
   ): {
     parents: any[];
     associations: Map<unknown, Map<string, any[]>>;
+    parentKeys: Map<any, unknown>;
   } {
     const joinRoot = this._joinRoot;
     const aliases = this.aliases();
@@ -1236,7 +1237,18 @@ export class JoinDependency {
     }
 
     const parentList = [...parents.values()];
-    return { parents: parentList, associations: this._collectAssociations(parents) };
+    // Reverse index: each parent record → the RAW aliased dedup key it was
+    // stored under (the same `_keyFor` key `_collectAssociations` uses). The
+    // eager inverse-cache loop must look `associations` up by this raw key, not
+    // by re-reading the instantiated record's (deserialized) PK, which can
+    // diverge from the raw row value on adapters that deserialize PK columns.
+    const parentKeys = new Map<any, unknown>();
+    for (const [key, parent] of parents) parentKeys.set(parent, key);
+    return {
+      parents: parentList,
+      associations: this._collectAssociations(parents),
+      parentKeys,
+    };
   }
 
   /**

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -587,6 +587,18 @@ export class ThroughAssociation extends Association {
         // `_getSourcePreloaders`, which keeps them for this case). Rails never
         // reaches here — it always JOINs — so this is trails' faithful
         // degradation of the same `through_scope` where-copy.
+        //
+        // Residual capability gap: a single predicate that references BOTH the
+        // through table AND the source table can't be resolved by either stage
+        // (the through query joins only the through table; the source query only
+        // the source table), so it stays on the source stage and errors — the
+        // same inherent limitation as the long-standing collection `twoStep`
+        // split, since no two-step decomposition can span two never-joined
+        // tables. The faithful fix is closing the composite-PK eager bypass so
+        // this whole branch collapses to Rails' single JOIN; tracked by story
+        // `close-composite-pk-through-eager-bypass-for-scoped-source` (RFC 0054).
+        // Unreachable in the canonical suite today (no scoped source routes
+        // through a composite-PK non-HABTM model).
         const throughTable = this._throughTableName();
         const throughOnly =
           throughTable != null
@@ -641,12 +653,28 @@ export class ThroughAssociation extends Association {
           scope = scope.references(sourceRefl.klass.tableName);
         }
 
-        // joins!(source => joins) / left_outer_joins!(source => …) (rb:132-137).
+        // joins!(source_reflection.name => joins) (rb:132-134): Rails applies the
+        // whole flattened `values[:joins]` bucket ONCE, nested under the source
+        // reflection name. trails splits that bucket into `_namedInnerJoins`
+        // (symbol association joins) and `_joinValues` (raw string / Arel-node
+        // joins), so their UNION is Rails' single `values[:joins]` — applied here
+        // exactly once. A raw string / Arel join anywhere in the FLATTENED chain
+        // scope raises `ConfigurationError` in Rails (`JoinDependency` rejects the
+        // bogus association name symbolized from the raw string), regardless of
+        // the collection/nested strategy — nesting it under the source reflection
+        // name makes trails' join builder raise identically. This branch is
+        // already gated on the flattened `where_clause` being non-empty (the same
+        // `elsif !reflection_scope.where_clause.empty?` gate, rb:117), so matching
+        // Rails means raising here too — a raw join declared only on a deeper
+        // sub-chain link is NOT deferred to its own recursive stage (verified
+        // against a live Rails nested-through repro).
         const nestedRawJoinValues: any[] = reflScope?._joinValues ?? [];
         const nestedJoins: any[] = reflScope?._namedInnerJoins ?? [];
         if (nestedRawJoinValues.length > 0 || nestedJoins.length > 0) {
           scope = scope.joins({ [sourceName]: [...nestedRawJoinValues, ...nestedJoins] });
         }
+
+        // left_outer_joins!(source_reflection.name => left_outer_joins) (rb:136-137).
         const nestedLeftOuter: any[] = reflScope?._leftOuterJoinsValues ?? [];
         if (nestedLeftOuter.length > 0) {
           scope = scope.leftOuterJoins({ [sourceName]: nestedLeftOuter });
@@ -659,23 +687,6 @@ export class ThroughAssociation extends Association {
         if (orderClauses.length > 0 || rawOrderClauses.length > 0) {
           scope._orderClauses = [...scope._orderClauses, ...orderClauses];
           scope._rawOrderClauses = [...scope._rawOrderClauses, ...rawOrderClauses];
-        }
-
-        // A raw string / Arel-node join anywhere in the FLATTENED chain scope
-        // (`.joins("INNER JOIN …")`, held in `_joinValues`) raises
-        // `ConfigurationError` in Rails regardless of the collection/nested
-        // strategy — `through_scope` passes the whole flattened `values[:joins]`
-        // to `joins!(source_reflection.name => joins)` (rb:132-134) and
-        // `JoinDependency` rejects the bogus association name. This branch is
-        // already gated on the flattened `where_clause` being non-empty (the
-        // same `elsif !reflection_scope.where_clause.empty?` gate, rb:117), so
-        // matching Rails means raising here too — a raw join declared only on a
-        // deeper sub-chain link is NOT deferred to its own recursive stage
-        // (verified against a live Rails nested-through repro). Nest it under the
-        // source reflection name so trails' join builder raises identically.
-        const rawJoinValues: any[] = reflScope?._joinValues ?? [];
-        if (rawJoinValues.length > 0) {
-          scope = scope.joins({ [sourceRefl.name]: [...rawJoinValues] });
         }
       }
     }

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -527,20 +527,13 @@ export class ThroughAssociation extends Association {
    * resolves in ONE query with no per-predicate table attribution. The
    * JoinDependency instantiates distinct parents by primary key, so a to-many
    * source no longer fans the middle records out, and a to-one source (e.g. a
-   * HABTM's belongs_to on the anonymous `HABTM_*` join model) joins the same way
-   * — the composite-PK eager bypass that previously forced a plain
-   * `leftOuterJoins` there is lifted (see `_isHabtmJoinModel`). `disable_joins`
-   * and polymorphic `source_type` keep their own paths.
-   *
-   * This is a faithful `through_scope` port; the only residual deviation is
-   * orthogonal and lives in `Relation#_eagerLoadBypassesJoinDependency`: for a
-   * composite-PK, NON-HABTM through model, trails' eager path degrades to preload
-   * (Rails always JOINs), so the `includes!`/`references!` here would not
-   * actually JOIN and a copied source-table predicate would orphan. That case is
-   * unreachable in the canonical suite (no scoped source routes through such a
-   * model) and is tracked for convergence by story
-   * `close-composite-pk-through-eager-bypass-for-scoped-source` (RFC 0054) — the
-   * fix belongs in the eager JOIN builder, not in a non-Rails branch here.
+   * HABTM's belongs_to on the anonymous `HABTM_*` join model) joins the same way.
+   * The through query carries no LIMIT/OFFSET, so its composite-PK base
+   * (HABTM join model, or a real composite-PK through model) applies the eager
+   * JoinDependency — `Relation#_eagerLoadBypassesJoinDependency` bypasses a
+   * composite PK only on the LIMIT+collection `_materializeLimitedIds` path,
+   * which this query never takes. `disable_joins` and polymorphic `source_type`
+   * keep their own paths.
    */
   private _buildThroughScope(): any {
     const throughRefl = this._throughReflection;

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -227,13 +227,7 @@ export class ThroughAssociation extends Association {
     const strategy = this._throughScopeStrategy();
     if (strategy !== "nested" && this._reflectionScope != null) {
       sourceScope = this._reflectionScope._clone();
-      if (strategy === "join" && this._throughQueryJoinsSource()) {
-        // The through query copied the FULL where_clause and eager-JOINed the
-        // source, so the source query re-applies NO predicates. When the through
-        // query could NOT join the source (a composite-PK non-HABTM through model
-        // bypasses the eager JoinDependency), fall through to keep the
-        // source-table predicates here instead — they never reached the through
-        // query (see `_buildThroughScope`).
+      if (strategy === "join") {
         sourceScope._whereClause = new WhereClause([]);
       } else {
         const throughTable = this._throughTableName();
@@ -537,6 +531,16 @@ export class ThroughAssociation extends Association {
    * — the composite-PK eager bypass that previously forced a plain
    * `leftOuterJoins` there is lifted (see `_isHabtmJoinModel`). `disable_joins`
    * and polymorphic `source_type` keep their own paths.
+   *
+   * This is a faithful `through_scope` port; the only residual deviation is
+   * orthogonal and lives in `Relation#_eagerLoadBypassesJoinDependency`: for a
+   * composite-PK, NON-HABTM through model, trails' eager path degrades to preload
+   * (Rails always JOINs), so the `includes!`/`references!` here would not
+   * actually JOIN and a copied source-table predicate would orphan. That case is
+   * unreachable in the canonical suite (no scoped source routes through such a
+   * model) and is tracked for convergence by story
+   * `close-composite-pk-through-eager-bypass-for-scoped-source` (RFC 0054) — the
+   * fix belongs in the eager JOIN builder, not in a non-Rails branch here.
    */
   private _buildThroughScope(): any {
     const throughRefl = this._throughReflection;
@@ -576,38 +580,7 @@ export class ThroughAssociation extends Association {
       // where_clause onto the through query and JOIN the source reflection so
       // every referenced column resolves in this single query.
       const sourceRefl = this._sourceReflection;
-      if (sourceRefl && !this._throughQueryJoinsSource()) {
-        // trails can't apply the eager JoinDependency for this through query (a
-        // composite-PK non-HABTM through model bypasses it, degrading to
-        // preload), so `includes!(source)` would NOT actually JOIN the source.
-        // Copying the FULL where_clause here would then orphan the source-table
-        // predicates onto an unjoined table. Instead copy ONLY the
-        // through-table-only predicates (to constrain the intermediate rows); the
-        // source-table predicates ride the recursive source stage (see
-        // `_getSourcePreloaders`, which keeps them for this case). Rails never
-        // reaches here — it always JOINs — so this is trails' faithful
-        // degradation of the same `through_scope` where-copy.
-        //
-        // Residual capability gap: a single predicate that references BOTH the
-        // through table AND the source table can't be resolved by either stage
-        // (the through query joins only the through table; the source query only
-        // the source table), so it stays on the source stage and errors — the
-        // same inherent limitation as the long-standing collection `twoStep`
-        // split, since no two-step decomposition can span two never-joined
-        // tables. The faithful fix is closing the composite-PK eager bypass so
-        // this whole branch collapses to Rails' single JOIN; tracked by story
-        // `close-composite-pk-through-eager-bypass-for-scoped-source` (RFC 0054).
-        // Unreachable in the canonical suite today (no scoped source routes
-        // through a composite-PK non-HABTM model).
-        const throughTable = this._throughTableName();
-        const throughOnly =
-          throughTable != null
-            ? whereClause.predicates.filter((p: any) => predicateIsThroughOnly(p, throughTable))
-            : [];
-        if (throughOnly.length > 0) {
-          scope._whereClause = new WhereClause([...scope._whereClause.predicates, ...throughOnly]);
-        }
-      } else if (sourceRefl) {
+      if (sourceRefl) {
         // Mirror Rails' `through_scope` eager-load branch exactly for EVERY
         // source kind (to-one, collection, nested through).
         // Copy the FULL reflection-scope where_clause and `includes!(source)` +
@@ -694,32 +667,6 @@ export class ThroughAssociation extends Association {
     // cascade_strict_loading: a strict-loading preload scope propagates to the
     // through query so intermediate records inherit the constraint (rb:145).
     return this._cascadeStrictLoading(scope);
-  }
-
-  /**
-   * Whether the through query will ACTUALLY eager-JOIN the source reflection
-   * when `_buildThroughScope` issues `includes!(source)`/`references!`. It does
-   * unless trails' eager path bypasses the JoinDependency for the through model
-   * (`Relation#_eagerLoadBypassesJoinDependency`): a composite-PK base degrades
-   * to preload — EXCEPT the anonymous `HABTM_*` join model, whose composite PK is
-   * a delete-only affordance flagged `_isHabtmJoinModel`. Rails has no such
-   * bypass (it always JOINs), so this is false only for trails' capability gap:
-   * a composite-PK, non-HABTM through model. In that case the where-copy must
-   * degrade (see `_buildThroughScope` / `_getSourcePreloaders`) rather than
-   * orphan source-table predicates on an unjoined through query.
-   * @internal
-   */
-  private _throughQueryJoinsSource(): boolean {
-    const throughRefl = this._throughReflection;
-    if (!throughRefl) return false;
-    let throughKlass: typeof Base;
-    try {
-      throughKlass = throughRefl.klass;
-    } catch {
-      return false;
-    }
-    const pk = (throughKlass as any).primaryKey;
-    return !(Array.isArray(pk) && !(throughKlass as any)._isHabtmJoinModel);
   }
 
   /** @internal */

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -227,7 +227,13 @@ export class ThroughAssociation extends Association {
     const strategy = this._throughScopeStrategy();
     if (strategy !== "nested" && this._reflectionScope != null) {
       sourceScope = this._reflectionScope._clone();
-      if (strategy === "join") {
+      if (strategy === "join" && this._throughQueryJoinsSource()) {
+        // The through query copied the FULL where_clause and eager-JOINed the
+        // source, so the source query re-applies NO predicates. When the through
+        // query could NOT join the source (a composite-PK non-HABTM through model
+        // bypasses the eager JoinDependency), fall through to keep the
+        // source-table predicates here instead — they never reached the through
+        // query (see `_buildThroughScope`).
         sourceScope._whereClause = new WhereClause([]);
       } else {
         const throughTable = this._throughTableName();
@@ -570,7 +576,26 @@ export class ThroughAssociation extends Association {
       // where_clause onto the through query and JOIN the source reflection so
       // every referenced column resolves in this single query.
       const sourceRefl = this._sourceReflection;
-      if (sourceRefl) {
+      if (sourceRefl && !this._throughQueryJoinsSource()) {
+        // trails can't apply the eager JoinDependency for this through query (a
+        // composite-PK non-HABTM through model bypasses it, degrading to
+        // preload), so `includes!(source)` would NOT actually JOIN the source.
+        // Copying the FULL where_clause here would then orphan the source-table
+        // predicates onto an unjoined table. Instead copy ONLY the
+        // through-table-only predicates (to constrain the intermediate rows); the
+        // source-table predicates ride the recursive source stage (see
+        // `_getSourcePreloaders`, which keeps them for this case). Rails never
+        // reaches here — it always JOINs — so this is trails' faithful
+        // degradation of the same `through_scope` where-copy.
+        const throughTable = this._throughTableName();
+        const throughOnly =
+          throughTable != null
+            ? whereClause.predicates.filter((p: any) => predicateIsThroughOnly(p, throughTable))
+            : [];
+        if (throughOnly.length > 0) {
+          scope._whereClause = new WhereClause([...scope._whereClause.predicates, ...throughOnly]);
+        }
+      } else if (sourceRefl) {
         // Mirror Rails' `through_scope` eager-load branch exactly for EVERY
         // source kind (to-one, collection, nested through).
         // Copy the FULL reflection-scope where_clause and `includes!(source)` +
@@ -658,6 +683,32 @@ export class ThroughAssociation extends Association {
     // cascade_strict_loading: a strict-loading preload scope propagates to the
     // through query so intermediate records inherit the constraint (rb:145).
     return this._cascadeStrictLoading(scope);
+  }
+
+  /**
+   * Whether the through query will ACTUALLY eager-JOIN the source reflection
+   * when `_buildThroughScope` issues `includes!(source)`/`references!`. It does
+   * unless trails' eager path bypasses the JoinDependency for the through model
+   * (`Relation#_eagerLoadBypassesJoinDependency`): a composite-PK base degrades
+   * to preload — EXCEPT the anonymous `HABTM_*` join model, whose composite PK is
+   * a delete-only affordance flagged `_isHabtmJoinModel`. Rails has no such
+   * bypass (it always JOINs), so this is false only for trails' capability gap:
+   * a composite-PK, non-HABTM through model. In that case the where-copy must
+   * degrade (see `_buildThroughScope` / `_getSourcePreloaders`) rather than
+   * orphan source-table predicates on an unjoined through query.
+   * @internal
+   */
+  private _throughQueryJoinsSource(): boolean {
+    const throughRefl = this._throughReflection;
+    if (!throughRefl) return false;
+    let throughKlass: typeof Base;
+    try {
+      throughKlass = throughRefl.klass;
+    } catch {
+      return false;
+    }
+    const pk = (throughKlass as any).primaryKey;
+    return !(Array.isArray(pk) && !(throughKlass as any)._isHabtmJoinModel);
   }
 
   /** @internal */

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -518,20 +518,19 @@ export class ThroughAssociation extends Association {
    * `Preloader::ThroughAssociation#through_scope`
    * (vendor/rails/activerecord/lib/active_record/associations/preloader/through_association.rb:104-146).
    *
-   * For a to-one, non-through source this is Rails' single-query strategy: the
-   * whole reflection-scope `where_clause` is copied onto the through query and
-   * the source reflection is JOINed (Rails `includes!`/`references!`, a LEFT
-   * OUTER JOIN), so every column — through-table, source-table, or a
-   * scope-joined nested table — resolves in ONE query with no per-predicate
-   * table attribution.
-   *
-   * A collection (has_many) source or a nested (through) source can't be JOINed
-   * without fanning the through rows out (trails collects raw rows; Rails' eager
-   * JoinDependency dedups by PK), so those keep the two-step: only the
-   * reflection scope's through-table predicates are copied here (to constrain
-   * the intermediate rows), and the source / sub-chain predicates and order ride
-   * the recursive source-preloader stage (see `_getSourcePreloaders`).
-   * `disable_joins` and polymorphic `source_type` keep their own paths.
+   * When the reflection scope carries a where-clause, EVERY source kind (to-one
+   * belongs_to/has_one, collection has_many, or nested through) takes the SAME
+   * Rails-faithful branch: the whole reflection-scope `where_clause` is copied
+   * onto the through query and the source reflection is eager-loaded via
+   * `includes!`/`references!` (a LEFT OUTER JOIN through the JoinDependency), so
+   * every column — through-table, source-table, or a scope-joined nested table —
+   * resolves in ONE query with no per-predicate table attribution. The
+   * JoinDependency instantiates distinct parents by primary key, so a to-many
+   * source no longer fans the middle records out, and a to-one source (e.g. a
+   * HABTM's belongs_to on the anonymous `HABTM_*` join model) joins the same way
+   * — the composite-PK eager bypass that previously forced a plain
+   * `leftOuterJoins` there is lifted (see `_isHabtmJoinModel`). `disable_joins`
+   * and polymorphic `source_type` keep their own paths.
    */
   private _buildThroughScope(): any {
     const throughRefl = this._throughReflection;
@@ -571,73 +570,9 @@ export class ThroughAssociation extends Association {
       // where_clause onto the through query and JOIN the source reflection so
       // every referenced column resolves in this single query.
       const sourceRefl = this._sourceReflection;
-      const strategy = this._throughScopeStrategy();
-      if (sourceRefl && strategy === "join") {
-        scope._whereClause = new WhereClause([
-          ...scope._whereClause.predicates,
-          ...whereClause.predicates,
-        ]);
-        const sourceName = sourceRefl.name;
-        const nestedJoins: any[] = reflScope?._namedInnerJoins ?? [];
-        const nestedLeftOuter: any[] = reflScope?._leftOuterJoinsValues ?? [];
-        // Raw string / Arel-node joins the reflection scope carries in its own
-        // `_joinValues` bucket (`.joins("INNER JOIN …")` or `.joins(<Arel node>)`).
-        // Rails passes the scope's FULL `joins_values` — symbols AND raw strings
-        // / Arel nodes — to `joins!(source_reflection.name => joins)`
-        // (rb:132-134). `JoinDependency.walk_tree` symbolizes a raw string into a
-        // bogus association name and `find_reflection` raises
-        // `ActiveRecord::ConfigurationError` — real Rails raises on preload here,
-        // it does not silently carry the raw join. Nesting it under the source
-        // reflection name makes trails' join builder raise the same error.
-        // Read from the FLATTENED `reflection_scope` (`join_scopes.inject(&:merge!)`,
-        // preloader/association.rb:290): Rails nests the whole flattened
-        // `values[:joins]` — sub-chain raw joins included — so a raw join
-        // declared on a deeper link in a nested chain raises here too.
-        const nestedRawJoinValues: any[] = reflScope?._joinValues ?? [];
-
-        // Rails `includes!(source_reflection.name => values[:includes])` (bare
-        // when the scope has no `.includes`) + `references!(...)` promotes to a
-        // LEFT OUTER JOIN of the source reflection and its nested includes
-        // (rb:120-124). trails carries the scope's explicit `.includes`
-        // (`_includesAssociations`) the same way — nested under the source
-        // reflection — so a has_one-through scope like
-        // `includes(:category).where(categories: { … })` joins `categories` on
-        // this through query and the predicate resolves. `.left_joins(source =>
-        // nested)` (`_leftOuterJoinsValues`) is carried likewise. Carried
-        // unconditionally here: `_throughScopeStrategy` already diverted the only
-        // unsafe case (a collection target whose scope reaches a to-many nested
-        // table) to the two-step, so nothing copied here references an unjoined
-        // table.
-        const nestedIncludes: any[] = reflScope?._includesAssociations ?? [];
-        const nestedOuter = [...nestedLeftOuter, ...nestedIncludes];
-        if (nestedOuter.length > 0) {
-          scope = scope.leftOuterJoins({ [sourceName]: nestedOuter });
-        } else {
-          scope = scope.leftOuterJoins(sourceName);
-        }
-
-        // joins!(source_reflection.name => joins): symbol-association joins are
-        // carried as an inner join; raw string / Arel joins raise as above.
-        if (nestedRawJoinValues.length > 0) {
-          scope = scope.joins({ [sourceName]: [...nestedRawJoinValues] });
-        }
-        if (nestedJoins.length > 0) {
-          scope = scope.joins({ [sourceName]: nestedJoins });
-        }
-
-        // Rails carries `order` only when `scope.eager_loading?` (rb:140). In
-        // this branch Rails always `includes!(source)` + `references!(...)`, so
-        // `eager_loading?` is true whenever the branch runs — our source join
-        // above is the analogue, so carry the order unconditionally here.
-        const orderClauses: any[] = reflScope?._orderClauses ?? [];
-        const rawOrderClauses: string[] = reflScope?._rawOrderClauses ?? [];
-        if (orderClauses.length > 0 || rawOrderClauses.length > 0) {
-          scope._orderClauses = [...scope._orderClauses, ...orderClauses];
-          scope._rawOrderClauses = [...scope._rawOrderClauses, ...rawOrderClauses];
-        }
-      } else if (sourceRefl) {
-        // Collection source/target ("twoStep") or nested through source
-        // ("nested"): mirror Rails' `through_scope` eager-load branch exactly.
+      if (sourceRefl) {
+        // Mirror Rails' `through_scope` eager-load branch exactly for EVERY
+        // source kind (to-one, collection, nested through).
         // Copy the FULL reflection-scope where_clause and `includes!(source)` +
         // `references!(source.table_name)`, promoting the source reflection to a
         // LEFT OUTER JOIN eager-load on this through query. Unlike a bare

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2773,8 +2773,13 @@ export class Relation<T extends Base> {
       inverseMap.set(assoc.name, assoc.options?.inverseOf);
     }
 
+    const basePkCols = Array.isArray(basePk) ? basePk : [basePk];
     for (const parent of parents) {
-      const pk = parent.readAttribute(basePk);
+      // Key the same way `JoinDependency#_keyFor` seeds the associations map:
+      // a single-column PK keys on the bare value, a composite PK (e.g. an
+      // anonymous HABTM join model) on the null-joined tuple.
+      const pkVals = basePkCols.map((c) => parent.readAttribute(c));
+      const pk = pkVals.length === 1 ? pkVals[0] : pkVals.join(" ");
       const assocs = associations.get(pk);
       for (const node of jd.nodes) {
         // Skip intermediate through nodes and nested nodes (handled in instantiateFromRows).
@@ -3103,7 +3108,12 @@ export class Relation<T extends Base> {
    */
   private _eagerLoadBypassesJoinDependency(): boolean {
     const basePk = (this._modelClass as any).primaryKey ?? "id";
-    return Array.isArray(basePk) || this._ctes.length > 0 || !this._fromClause.isEmpty();
+    // An anonymous HABTM join model carries a composite PK only as a delete/
+    // destroy affordance (Rails' join model has none); its eager source join is a
+    // plain single-column belongs_to the JoinDependency handles, so it does NOT
+    // take the composite-PK bypass — see `_isHabtmJoinModel` in associations.ts.
+    const compositePkBypass = Array.isArray(basePk) && !(this._modelClass as any)._isHabtmJoinModel;
+    return compositePkBypass || this._ctes.length > 0 || !this._fromClause.isEmpty();
   }
 
   /**

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3111,15 +3111,21 @@ export class Relation<T extends Base> {
     // A composite-PK base IS eager-JOINable: `JoinDependency.instantiateFromRows`
     // dedups parents by the composite key. The one composite-PK path trails can't
     // emit is the limited-ids subquery (`_materializeLimitedIds` /
-    // `columns_for_distinct`), which projects the pk as a single column — so
-    // bypass a composite PK ONLY when a LIMIT/OFFSET forces that path. Every other
-    // composite-PK eager load (notably the through-preloader's own unlimited
-    // `includes(source).references(...)` query) applies the JoinDependency, so a
-    // scoped source through a composite-PK model JOINs like Rails. Rails always
-    // applies the JoinDependency; the LIMIT+composite gap is trails' remaining
-    // capability gap (tracked for convergence — see RFC 0054).
+    // `columns_for_distinct`), which projects the pk as a single column. Rails
+    // only takes that `distinct_relation_for_primary_key` path for a limit/offset
+    // over NON-limitable (collection) reflections (finder_methods.rb:463-488), so
+    // bypass a composite PK only in exactly that case — mirroring the narrower
+    // `hasLimit && jd hasMany` guard the eager execute path already applies. A
+    // composite-PK `includes(:belongs_to)` (limitable) with a limit still JOINs,
+    // as does the through-preloader's own unlimited `includes(source)` query, so
+    // a scoped source through a composite-PK model JOINs like Rails. The
+    // LIMIT+collection+composite gap is trails' remaining capability gap (tracked
+    // for convergence — see RFC 0054).
     const hasLimitOrOffset = this._limitValue !== null || this._offsetValue !== null;
-    const compositePkBypass = Array.isArray(basePk) && hasLimitOrOffset;
+    const compositePkBypass =
+      Array.isArray(basePk) &&
+      hasLimitOrOffset &&
+      !this._applyJoinDependencyIsLimitable(this._deferredDistinctPkEagerSpecs());
     return compositePkBypass || this._ctes.length > 0 || !this._fromClause.isEmpty();
   }
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3108,11 +3108,18 @@ export class Relation<T extends Base> {
    */
   private _eagerLoadBypassesJoinDependency(): boolean {
     const basePk = (this._modelClass as any).primaryKey ?? "id";
-    // An anonymous HABTM join model carries a composite PK only as a delete/
-    // destroy affordance (Rails' join model has none); its eager source join is a
-    // plain single-column belongs_to the JoinDependency handles, so it does NOT
-    // take the composite-PK bypass — see `_isHabtmJoinModel` in associations.ts.
-    const compositePkBypass = Array.isArray(basePk) && !(this._modelClass as any)._isHabtmJoinModel;
+    // A composite-PK base IS eager-JOINable: `JoinDependency.instantiateFromRows`
+    // dedups parents by the composite key. The one composite-PK path trails can't
+    // emit is the limited-ids subquery (`_materializeLimitedIds` /
+    // `columns_for_distinct`), which projects the pk as a single column — so
+    // bypass a composite PK ONLY when a LIMIT/OFFSET forces that path. Every other
+    // composite-PK eager load (notably the through-preloader's own unlimited
+    // `includes(source).references(...)` query) applies the JoinDependency, so a
+    // scoped source through a composite-PK model JOINs like Rails. Rails always
+    // applies the JoinDependency; the LIMIT+composite gap is trails' remaining
+    // capability gap (tracked for convergence — see RFC 0054).
+    const hasLimitOrOffset = this._limitValue !== null || this._offsetValue !== null;
+    const compositePkBypass = Array.isArray(basePk) && hasLimitOrOffset;
     return compositePkBypass || this._ctes.length > 0 || !this._fromClause.isEmpty();
   }
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2756,7 +2756,7 @@ export class Relation<T extends Base> {
       record_count: rows.length,
       class_name: this._modelClass.baseClass.name,
     };
-    const { parents, associations } = Notifications.instrument(
+    const { parents, associations, parentKeys } = Notifications.instrument(
       "instantiation.active_record",
       eagerPayload,
       () =>
@@ -2773,13 +2773,13 @@ export class Relation<T extends Base> {
       inverseMap.set(assoc.name, assoc.options?.inverseOf);
     }
 
-    const basePkCols = Array.isArray(basePk) ? basePk : [basePk];
     for (const parent of parents) {
-      // Key the same way `JoinDependency#_keyFor` seeds the associations map:
-      // a single-column PK keys on the bare value, a composite PK (e.g. an
-      // anonymous HABTM join model) on the null-joined tuple.
-      const pkVals = basePkCols.map((c) => parent.readAttribute(c));
-      const pk = pkVals.length === 1 ? pkVals[0] : pkVals.join(" ");
+      // Look `associations` up by the SAME raw aliased key `instantiateFromRows`
+      // stored the parent under — not by re-reading the instantiated record's
+      // PK, which is deserialized and can diverge from the raw row value (e.g.
+      // bigint / composite HABTM keys), missing the lookup and skipping inverse
+      // caching.
+      const pk = parentKeys.get(parent);
       const assocs = associations.get(pk);
       for (const node of jd.nodes) {
         // Skip intermediate through nodes and nested nodes (handled in instantiateFromRows).


### PR DESCRIPTION
## Summary

Converges the through-preloader's `_buildThroughScope` onto a **single
Rails-exact `through_scope` branch**: when the reflection scope carries a
where-clause, copy the full `where_clause` onto the through query and eager-load
the source reflection via `includes!`/`references!` for every source kind — to-one
`belongs_to`/`has_one`, collection `has_many`, or nested through
(`through_association.rb:117-141`). This deletes the trails-only two-mode split
where a to-one source (e.g. a HABTM's `belongs_to`) fell back to a plain
`leftOuterJoins`.

The to-one fallback existed only because the source join bypassed the eager
JoinDependency: the through query's base is a composite-PK model (the anonymous
`HABTM_*` join model, whose composite PK is a trails delete/destroy affordance —
Rails' join model has none), and `_eagerLoadBypassesJoinDependency` degraded ALL
composite-PK eager loads to preload, orphaning the copied source-table predicate
(`no such column: developers.name`).

## Changes

- **Close the composite-PK eager bypass for this path.** Narrow
  `_eagerLoadBypassesJoinDependency` so a composite-PK base bypasses the
  JoinDependency ONLY when a LIMIT/OFFSET forces the limited-ids subquery
  (`_materializeLimitedIds`, the one composite-PK path trails can't yet emit — it
  projects the pk as a single column). The through query has no LIMIT, so it now
  applies the JoinDependency and JOINs the source like Rails — for the HABTM join
  model AND any real composite-PK through model. `instantiateFromRows` already
  dedups parents by the composite key.
- `instantiateFromRows` returns a `parentKeys` map (record → raw dedup key) and
  the eager inverse-cache loop looks `associations` up by that raw key instead of
  re-reading the instantiated record's deserialized PK (which can diverge on
  bigint / composite keys).
- Apply the reflection scope's `values[:joins]` bucket exactly once (trails'
  `_joinValues` + `_namedInnerJoins` union), matching Rails' single
  `joins!(source_reflection.name => joins)`.

## Remaining composite-PK gap (tracked)

The only composite-PK eager path still degrading to preload is the
LIMIT+collection limited-ids subquery (`preloading has_many with cpk`), because
`_materializeLimitedIds` / `_distinctSelectForLimitedIds` project the pk as a
single column. That is orthogonal to the through-preload convergence and tracked
by RFC 0054 story `close-composite-pk-through-eager-bypass-for-scoped-source`
(teach the limited-ids subquery composite keys, then drop the LIMIT guard).

## Testing

- `preloading has many through with custom scope` (the reproducer) now exercises
  the eager JOIN path and passes.
- No regression: eager, CPK-eager, HABTM, has_many/has_one-through,
  nested-through (all variants), through-association-scope, composite-key, and
  preloader (incl. raw-join scope) suites all green.

Closes-story: converge-through-preload-to-one-source-includes-eager-load