### PR TITLE
fix(activesupport): compile CallbackObject to ObjectCall honouring chain scope

### DIFF
--- a/packages/activesupport/src/callbacks.test.ts
+++ b/packages/activesupport/src/callbacks.test.ts
@@ -7,7 +7,6 @@ import {
   runCallbacks,
   CallbacksMixin,
   CallTemplate,
-  CallbackSequence,
   throwAbort,
 } from "./callbacks.js";
 
@@ -182,39 +181,6 @@ describe("Callbacks", () => {
       expect(target.history).toEqual(["tweedle dum pre", "running", "tweedle dum post"]);
       // next() surfaces the block's return (Rails' `yield` inside the around).
       expect(target.result).toBe("running");
-    });
-
-    // Rails' CallbackObject#around(caller) { ... yield ... } compiles to
-    // CallTemplate::ObjectCall and dispatches `object.send(method, target, &block)` —
-    // the receiver is the object, the record is the first positional arg, and the
-    // continuation is the block. The method name is the callback's scope-join; with
-    // the default CallbackChain scope of [:kind] that is `around` (not `around_save`
-    // — the [:kind, :name] custom-scope shape), matching Rails' test_around_object.
-    // trails' setCallback resolves a CallbackObject to a plain around function, so
-    // drive invokeAround with an ObjectCall template directly to cover the
-    // object-dispatch threading (record first, block last).
-    it("test_around_object", () => {
-      const record: string[] = [];
-      const caller = {};
-      const obj = {
-        around(this: unknown, arg: object, next: () => unknown) {
-          record.push("around before");
-          expect(this).toBe(obj);
-          expect(arg).toBe(caller);
-          const v = next();
-          record.push("around after");
-          return v;
-        },
-      };
-      const seq = new CallbackSequence(null, new CallTemplate.ObjectCall(obj, "around"), null);
-
-      const result = seq.invokeAround({ target: caller, halted: false, value: undefined }, () => {
-        record.push("yielded");
-        return "block-result";
-      });
-
-      expect(record).toEqual(["around before", "yielded", "around after"]);
-      expect(result).toBe("block-result");
     });
   });
 
@@ -1475,55 +1441,60 @@ describe("RunSpecificCallbackTest", () => {
 });
 
 describe("UsingObjectTest", () => {
-  it("save", () => {
-    const target = { log: [] as string[] };
-    defineCallbacks(target, "save");
-    const callbackObj = { before: (t: any) => t.log.push("obj-before") };
-    setCallback(target, "save", "before", (t: any) => callbackObj.before(t));
-    runCallbacks(target, "save");
-    expect(target.log).toContain("obj-before");
+  // Rails' CallbackObject (callbacks_test.rb:707): the method dispatched depends
+  // on the chain scope. Default scope [:kind] calls `before`/`around`;
+  // scope [:kind, :name] calls `beforeSave`.
+  const callbackObject = () => ({
+    before(caller: { record: string[] }): void {
+      caller.record.push("before");
+    },
+    beforeSave(caller: { record: string[] }): void {
+      caller.record.push("before save");
+    },
+    around(caller: { record: string[] }, next: () => unknown): void {
+      caller.record.push("around before");
+      next();
+      caller.record.push("around after");
+    },
   });
-  it("before object", () => {
-    const target = { log: [] as string[] };
-    defineCallbacks(target, "save");
-    const obj = { before: (t: any) => t.log.push("before-obj") };
-    setCallback(target, "save", "before", (t: any) => obj.before(t));
-    runCallbacks(target, "save");
-    expect(target.log).toContain("before-obj");
-  });
-  it("around object", () => {
-    const target = { log: [] as string[] };
-    defineCallbacks(target, "save");
-    const obj = {
-      around: (t: any, next: () => void) => {
-        t.log.push("around-pre");
-        next();
-        t.log.push("around-post");
-      },
-    };
-    setCallback(target, "save", "around", (t: any, next: () => void) => obj.around(t, next));
-    runCallbacks(target, "save", () => target.log.push("body"));
-    expect(target.log).toEqual(["around-pre", "body", "around-post"]);
-  });
-  it("customized object", () => {
-    const target = { log: [] as string[], custom: true };
-    defineCallbacks(target, "save");
-    const obj = {
-      before: (t: any) => {
-        if (t.custom) t.log.push("custom");
-      },
-    };
-    setCallback(target, "save", "before", (t: any) => obj.before(t));
-    runCallbacks(target, "save");
-    expect(target.log).toContain("custom");
-  });
-  it("block result is returned", () => {
-    const target = { result: "" };
-    defineCallbacks(target, "save");
-    runCallbacks(target, "save", () => {
-      target.result = "done";
+
+  const usingObjectBefore = () => {
+    const u = { record: [] as string[] };
+    defineCallbacks(u, "save");
+    setCallback(u, "save", "before", callbackObject());
+    return u;
+  };
+  const usingObjectAround = () => {
+    const u = { record: [] as string[] };
+    defineCallbacks(u, "save");
+    setCallback(u, "save", "around", callbackObject());
+    return u;
+  };
+  const customScopeObject = () => {
+    const u = { record: [] as string[] };
+    defineCallbacks(u, "save", { scope: ["kind", "name"] });
+    setCallback(u, "save", "before", callbackObject());
+    return u;
+  };
+  const save = (u: { record: string[] }) =>
+    runCallbacks(u, "save", () => {
+      u.record.push("yielded");
     });
-    expect(target.result).toBe("done");
+
+  it("test_before_object", () => {
+    const u = usingObjectBefore();
+    save(u);
+    expect(u.record).toEqual(["before", "yielded"]);
+  });
+  it("test_around_object", () => {
+    const u = usingObjectAround();
+    save(u);
+    expect(u.record).toEqual(["around before", "yielded", "around after"]);
+  });
+  it("test_customized_object", () => {
+    const u = customScopeObject();
+    save(u);
+    expect(u.record).toEqual(["before save", "yielded"]);
   });
 });
 
@@ -1981,29 +1952,29 @@ describe("Callbacks — async propagation", () => {
 });
 
 describe("CallbackObject dispatch", () => {
-  it("before — calls beforeSave on the object", () => {
+  it("before — calls the object's before method", () => {
     const target = { log: [] as string[] };
     defineCallbacks(target, "save");
-    const obj = { beforeSave: (t: typeof target) => t.log.push("before-obj") };
+    const obj = { before: (t: typeof target) => t.log.push("before-obj") };
     setCallback(target, "save", "before", obj);
     runCallbacks(target, "save");
     expect(target.log).toEqual(["before-obj"]);
   });
 
-  it("after — calls afterSave on the object", () => {
+  it("after — calls the object's after method", () => {
     const target = { log: [] as string[] };
     defineCallbacks(target, "save");
-    const obj = { afterSave: (t: typeof target) => t.log.push("after-obj") };
+    const obj = { after: (t: typeof target) => t.log.push("after-obj") };
     setCallback(target, "save", "after", obj);
     runCallbacks(target, "save");
     expect(target.log).toEqual(["after-obj"]);
   });
 
-  it("around — calls aroundSave with target and proceed", () => {
+  it("around — calls the object's around method with target and proceed", () => {
     const target = { log: [] as string[] };
     defineCallbacks(target, "save");
     const obj = {
-      aroundSave: (t: typeof target, next: () => void) => {
+      around: (t: typeof target, next: () => void) => {
         t.log.push("around-pre");
         next();
         t.log.push("around-post");
@@ -2014,11 +1985,13 @@ describe("CallbackObject dispatch", () => {
     expect(target.log).toEqual(["around-pre", "body", "around-post"]);
   });
 
-  it("missing method throws at registration time", () => {
-    const target = {};
-    defineCallbacks(target, "save");
-    const obj = { afterSave: () => {} };
-    expect(() => setCallback(target, "save", "before", obj)).toThrow(/beforeSave/);
+  it("custom scope dispatches the kind+name method", () => {
+    const target = { log: [] as string[] };
+    defineCallbacks(target, "save", { scope: ["kind", "name"] });
+    const obj = { beforeSave: (t: typeof target) => t.log.push("before-save-obj") };
+    setCallback(target, "save", "before", obj);
+    runCallbacks(target, "save");
+    expect(target.log).toEqual(["before-save-obj"]);
   });
 
   it("object method called with correct this binding", () => {
@@ -2026,7 +1999,7 @@ describe("CallbackObject dispatch", () => {
     defineCallbacks(target, "save");
     const obj = {
       label: "my-obj",
-      beforeSave(t: typeof target) {
+      before(t: typeof target) {
         t.log.push(this.label);
       },
     };
@@ -2039,7 +2012,7 @@ describe("CallbackObject dispatch", () => {
     const target = { log: [] as string[] };
     defineCallbacks(target, "save");
     setCallback(target, "save", "before", (t: typeof target) => t.log.push("fn1"));
-    setCallback(target, "save", "before", { beforeSave: (t: typeof target) => t.log.push("obj") });
+    setCallback(target, "save", "before", { before: (t: typeof target) => t.log.push("obj") });
     setCallback(target, "save", "before", (t: typeof target) => t.log.push("fn2"));
     runCallbacks(target, "save");
     expect(target.log).toEqual(["fn1", "obj", "fn2"]);
@@ -2049,7 +2022,7 @@ describe("CallbackObject dispatch", () => {
     const target = { log: [] as string[] };
     defineCallbacks(target, "save");
     const obj = {
-      beforeSave: async (t: typeof target) => {
+      before: async (t: typeof target) => {
         await Promise.resolve();
         t.log.push("async-obj");
       },
@@ -2065,7 +2038,7 @@ describe("CallbackObject dispatch", () => {
     class Model extends CallbacksMixin() {}
     Model.defineCallbacks("save");
     const log: string[] = [];
-    Model.beforeCallback("save", { beforeSave: () => log.push("mixin-obj") });
+    Model.beforeCallback("save", { before: () => log.push("mixin-obj") });
     const inst = new Model();
     (inst as any).runCallbacks("save");
     expect(log).toEqual(["mixin-obj"]);
@@ -2075,7 +2048,7 @@ describe("CallbackObject dispatch", () => {
     class Model extends CallbacksMixin() {}
     Model.defineCallbacks("save");
     const log: string[] = [];
-    Model.afterCallback("save", { afterSave: () => log.push("after-mixin") });
+    Model.afterCallback("save", { after: () => log.push("after-mixin") });
     const inst = new Model();
     (inst as any).runCallbacks("save");
     expect(log).toEqual(["after-mixin"]);
@@ -2084,7 +2057,7 @@ describe("CallbackObject dispatch", () => {
   it("skipCallback removes object-form callback by original reference", () => {
     const target = { log: [] as string[] };
     defineCallbacks(target, "save");
-    const obj = { beforeSave: (t: typeof target) => t.log.push("obj") };
+    const obj = { before: (t: typeof target) => t.log.push("obj") };
     setCallback(target, "save", "before", obj);
     setCallback(target, "save", "before", (t: typeof target) => t.log.push("fn"));
     skipCallback(target, "save", "before", obj);
@@ -2095,7 +2068,7 @@ describe("CallbackObject dispatch", () => {
   it("skipCallback matches object by reference after chain inheritance clone", () => {
     const parent = { log: [] as string[] };
     defineCallbacks(parent, "save");
-    const obj = { beforeSave: (t: typeof parent) => t.log.push("obj") };
+    const obj = { before: (t: typeof parent) => t.log.push("obj") };
     setCallback(parent, "save", "before", obj);
 
     // simulate inheritance: getCallbackChains copies the chain when a child prototype is used
@@ -2110,7 +2083,7 @@ describe("CallbackObject dispatch", () => {
     Model.defineCallbacks("save");
     const log: string[] = [];
     Model.aroundCallback("save", {
-      aroundSave: (_: unknown, next: () => void) => {
+      around: (_: unknown, next: () => void) => {
         log.push("pre");
         next();
         log.push("post");

--- a/packages/activesupport/src/callbacks.test.ts
+++ b/packages/activesupport/src/callbacks.test.ts
@@ -2002,6 +2002,16 @@ describe("CallbackObject dispatch", () => {
     expect(target.log).toEqual(["before-save-obj"]);
   });
 
+  it("missing scoped method raises when the chain runs", () => {
+    // Rails ObjectCall dispatches `receiver.send(method, target)`, which raises
+    // NoMethodError when the scoped method is absent — no silent no-op. Default
+    // scope calls `before`, so an object providing only `beforeSave` has no match.
+    const target = { log: [] as string[] };
+    defineCallbacks(target, "save");
+    setCallback(target, "save", "before", { beforeSave: () => {} });
+    expect(() => runCallbacks(target, "save")).toThrow(/before/);
+  });
+
   it("object method called with correct this binding", () => {
     const target = { log: [] as string[] };
     defineCallbacks(target, "save");

--- a/packages/activesupport/src/callbacks.test.ts
+++ b/packages/activesupport/src/callbacks.test.ts
@@ -1481,20 +1481,28 @@ describe("UsingObjectTest", () => {
       u.record.push("yielded");
     });
 
-  it("test_before_object", () => {
+  it("before object", () => {
     const u = usingObjectBefore();
     save(u);
     expect(u.record).toEqual(["before", "yielded"]);
   });
-  it("test_around_object", () => {
+  it("around object", () => {
     const u = usingObjectAround();
     save(u);
     expect(u.record).toEqual(["around before", "yielded", "around after"]);
   });
-  it("test_customized_object", () => {
+  it("customized object", () => {
     const u = customScopeObject();
     save(u);
     expect(u.record).toEqual(["before save", "yielded"]);
+  });
+  it("block result is returned", () => {
+    const target = { result: "" };
+    defineCallbacks(target, "save");
+    runCallbacks(target, "save", () => {
+      target.result = "done";
+    });
+    expect(target.result).toBe("done");
   });
 });
 

--- a/packages/activesupport/src/callbacks.test.ts
+++ b/packages/activesupport/src/callbacks.test.ts
@@ -2026,6 +2026,26 @@ describe("CallbackObject dispatch", () => {
     expect(target.log).toEqual(["my-obj"]);
   });
 
+  it("around object method reads object state via this", () => {
+    // Rails dispatches the around ObjectCall as `receiver.send(method, target, &block)`,
+    // binding `self` to the callback object. A JS member invocation
+    // (`receiver[method](...)`) binds `this === receiver` the same way, so a
+    // method-style around can read its own object state.
+    const target = { log: [] as string[] };
+    defineCallbacks(target, "save");
+    const obj = {
+      label: "around-obj",
+      around(t: typeof target, next: () => void) {
+        t.log.push(`${this.label}-pre`);
+        next();
+        t.log.push(`${this.label}-post`);
+      },
+    };
+    setCallback(target, "save", "around", obj);
+    runCallbacks(target, "save", () => target.log.push("body"));
+    expect(target.log).toEqual(["around-obj-pre", "body", "around-obj-post"]);
+  });
+
   it("mixed chain: function + object + function all run", () => {
     const target = { log: [] as string[] };
     defineCallbacks(target, "save");

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -72,47 +72,24 @@ export type AnyCallback<T extends object = object> =
   | AroundCallback<T>;
 
 /**
- * Object form for callbacks. Mirrors activemodel's object-callback dispatch.
- * The object must implement a method named after the kind and event:
- * `beforeSave`, `afterSave`, or `aroundSave` for an event named `"save"`.
+ * Object form for callbacks. Mirrors Rails' object-callback dispatch: the object
+ * compiles to a {@link ObjectCall} CallTemplate whose method name is the
+ * callback's `currentScopes().join` (camelCased). With the default chain scope
+ * `[:kind]` the object must implement the bare kind method — `before`, `after`,
+ * or `around`; with `scope: ["kind", "name"]` it implements `beforeSave`,
+ * `afterSave`, or `aroundSave` for an event named `"save"`.
  *
  * @example
  * ```ts
  * const logger = {
- *   beforeSave(record: MyModel) { console.log("saving", record); },
- *   afterSave(record: MyModel)  { console.log("saved",  record); },
+ *   before(record: MyModel) { console.log("saving", record); },
+ *   after(record: MyModel)  { console.log("saved",  record); },
  * };
  * setCallback(target, "save", "before", logger);
  * setCallback(target, "save", "after",  logger);
  * ```
  */
 export type CallbackObject = { [key: string]: unknown };
-
-/**
- * Resolves an object-form callback to a plain function, matching the Rails
- * activemodel `resolveCallback` dispatch. Throws if the required method
- * (e.g. `beforeSave` for kind=before, name=save) is absent.
- * @internal
- */
-function resolveCallbackObject<T extends object>(
-  obj: CallbackObject,
-  kind: CallbackKind,
-  name: string,
-): AnyCallback<T> {
-  const camelName = name.charAt(0).toUpperCase() + name.slice(1);
-  const methodName = `${kind}${camelName}`;
-  const method = obj[methodName] as ((...args: any[]) => unknown) | undefined;
-  if (typeof method !== "function") {
-    throw new Error(
-      `Callback object must implement ${methodName} (for kind="${kind}", name="${name}")`,
-    );
-  }
-  if (kind === "around") {
-    return ((target: T, proceed: () => void | Promise<void>) =>
-      method.call(obj, target, proceed)) as AroundCallback<T>;
-  }
-  return ((target: T) => method.call(obj, target)) as BeforeCallback<T> | AfterCallback<T>;
-}
 
 export interface RunCallbacksOptions {
   /** If "sync", throw when any callback or block returns a Promise. */
@@ -217,9 +194,14 @@ export class ObjectCall implements CallTemplate {
   makeLambda(): (target: object, value: unknown) => unknown {
     const ot = this.target;
     const m = this.methodName;
+    // Rails ObjectCall#make_lambda: `(@override_target || target).send(@method_name, target)`
+    // — `send` binds `self` to the receiver, so call with `this` = receiver.
     return (target: object) => {
       const receiver = (ot ?? target) as Record<string, unknown>;
-      return (receiver[m] as ((arg: object) => unknown) | undefined)?.(target);
+      return (receiver[m] as ((this: unknown, arg: object) => unknown) | undefined)?.call(
+        receiver,
+        target,
+      );
     };
   }
 
@@ -228,7 +210,10 @@ export class ObjectCall implements CallTemplate {
     const m = this.methodName;
     return (target: object) => {
       const receiver = (ot ?? target) as Record<string, unknown>;
-      return !(receiver[m] as ((arg: object) => unknown) | undefined)?.(target);
+      return !(receiver[m] as ((this: unknown, arg: object) => unknown) | undefined)?.call(
+        receiver,
+        target,
+      );
     };
   }
 
@@ -364,14 +349,14 @@ export class Before {
   readonly userCallback: (target: object, value: unknown) => unknown;
   readonly userConditions: Array<(target: object, value: unknown) => boolean>;
   readonly terminator: ((target: object, fn: () => unknown) => boolean) | false | undefined;
-  readonly filter: AnyCallback | string | symbol;
+  readonly filter: AnyCallback | string | symbol | CallbackObject;
   readonly name: string;
 
   constructor(
     userCallback: (target: object, value: unknown) => unknown,
     userConditions: Array<(target: object, value: unknown) => boolean>,
     chainConfig: { terminator?: ((target: object, fn: () => unknown) => boolean) | false },
-    filter: AnyCallback | string | symbol = "",
+    filter: AnyCallback | string | symbol | CallbackObject = "",
     name: string = "",
   ) {
     this.userCallback = userCallback;
@@ -584,7 +569,7 @@ export class Around {
 export class Callback {
   kind: CallbackKind;
   name: string;
-  readonly filter: AnyCallback | string | symbol;
+  readonly filter: AnyCallback | string | symbol | CallbackObject;
   readonly options: CallbackOptions;
   readonly chainConfig: DefineCallbacksOptions;
   /** Preserved when registered via a CallbackObject so skipCallback can match by original reference. */
@@ -594,7 +579,7 @@ export class Callback {
 
   constructor(
     name: string,
-    filter: AnyCallback | string | symbol,
+    filter: AnyCallback | string | symbol | CallbackObject,
     kind: CallbackKind,
     options: CallbackOptions = {},
     chainConfig: DefineCallbacksOptions = {},
@@ -695,6 +680,12 @@ export class Callback {
       throw new Error(
         `Passing string to define a callback is not supported: ${String(this.filter)}`,
       );
+    } else if (typeof this.filter === "object" && this.filter !== null) {
+      // Rails CallTemplate.build: an object filter compiles to
+      // ObjectCall.new(filter, current_scopes.join("_").to_sym) — the dispatched
+      // method is the callback's scope-join, so the default `[:kind]` scope calls
+      // `around`/`before`/`after` and `scope: [:kind, :name]` calls `aroundSave`.
+      callTemplate = new ObjectCall(this.filter, this.objectCallMethodName());
     } else {
       callTemplate = new MethodCall(this.filter as PropertyKey);
     }
@@ -722,6 +713,16 @@ export class Callback {
     return scope.map((s) =>
       s === "kind" ? String(this.kind) : String((this as Record<string, unknown>)[s]),
     );
+  }
+
+  /**
+   * The object-callback method name — Rails' `current_scopes.join("_").to_sym`,
+   * camelCased for TS. Default scope `[:kind]` → `around`/`before`/`after`;
+   * `scope: [:kind, :name]` → `aroundSave`/`beforeSave`.
+   */
+  private objectCallMethodName(): string {
+    const [head, ...rest] = this.currentScopes();
+    return head + rest.map((s) => s.charAt(0).toUpperCase() + s.slice(1)).join("");
   }
 }
 
@@ -1339,11 +1340,12 @@ export namespace Callbacks {
     if (!chain) {
       throw new Error(`No callback chain "${name}" defined. Call defineCallbacks first.`);
     }
+    // Rails hands the callback object straight to Callback.build, which compiles
+    // it to an ObjectCall honouring the chain scope — no function-wrapping.
     const isObj = typeof callback === "object" && callback !== null;
-    const resolved = isObj ? resolveCallbackObject<T>(callback, kind, name) : callback;
     const entry = new Callback(
       name,
-      resolved as AnyCallback,
+      callback as AnyCallback | CallbackObject,
       kind,
       options as CallbackOptions,
       chain.config,

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -191,38 +191,32 @@ export class ObjectCall implements CallTemplate {
     return [this.target ?? target, block, this.methodName, target];
   }
 
+  // Rails ObjectCall#make_lambda: `(@override_target || target).send(@method_name, target)`
+  // — `send` binds `self` to the receiver and raises NoMethodError when the scoped
+  // method is absent. Dispatch directly (no optional chaining) so a missing method
+  // throws rather than silently no-opping.
+  private send(receiver: Record<string, unknown>, target: object): unknown {
+    const method = receiver[this.methodName];
+    if (typeof method !== "function") {
+      throw new TypeError(
+        `undefined method '${this.methodName}' for callback object (kind/scope mismatch)`,
+      );
+    }
+    return (method as (this: unknown, arg: object) => unknown).call(receiver, target);
+  }
+
   makeLambda(): (target: object, value: unknown) => unknown {
     const ot = this.target;
-    const m = this.methodName;
-    // Rails ObjectCall#make_lambda: `(@override_target || target).send(@method_name, target)`
-    // — `send` binds `self` to the receiver, so call with `this` = receiver.
-    return (target: object) => {
-      const receiver = (ot ?? target) as Record<string, unknown>;
-      return (receiver[m] as ((this: unknown, arg: object) => unknown) | undefined)?.call(
-        receiver,
-        target,
-      );
-    };
+    return (target: object) => this.send((ot ?? target) as Record<string, unknown>, target);
   }
 
   invertedLambda(): (target: object, value: unknown) => boolean {
     const ot = this.target;
-    const m = this.methodName;
-    return (target: object) => {
-      const receiver = (ot ?? target) as Record<string, unknown>;
-      return !(receiver[m] as ((this: unknown, arg: object) => unknown) | undefined)?.call(
-        receiver,
-        target,
-      );
-    };
+    return (target: object) => !this.send((ot ?? target) as Record<string, unknown>, target);
   }
 
   make(instance: object, _value: unknown): unknown {
-    const t = (this.target ?? instance) as Record<string, unknown>;
-    return (t[this.methodName] as ((this: unknown, arg: object) => unknown) | undefined)?.call(
-      t,
-      instance,
-    );
+    return this.send((this.target ?? instance) as Record<string, unknown>, instance);
   }
 }
 
@@ -1535,6 +1529,7 @@ export function CallbacksMixin<TBase extends new (...args: any[]) => object>(Bas
     // A hook invoked every time a before callback is halted. Overridable in
     // implementors (Rails: ActiveSupport::Callbacks#halted_callback_hook) to
     // provide better debugging/logging. Default is a no-op.
+    /** @internal */
     haltedCallbackHook(_filter: unknown, _name: string): void {}
   }
 


### PR DESCRIPTION
## Summary

trails' `setCallback` resolved a `CallbackObject` through `resolveCallbackObject`, wrapping it into a plain function keyed `${kind}${CamelName}` (e.g. `aroundSave`) that compiled to `InstanceExec`. As a result the `ObjectCall` `CallTemplate` and the object-dispatch branch of `CallbackSequence.invokeAround` were **dead in production** and diverged from Rails.

Now, matching Rails `CallTemplate.build`, an object filter compiles to `ObjectCall(filter, currentScopes().join)`:

- default scope `[:kind]` dispatches the bare `around` / `before` / `after` method,
- `scope: ["kind", "name"]` dispatches `aroundSave` / `beforeSave`, etc.

## Changes

- `Callback.compiled` compiles a `CallbackObject` to an `ObjectCall` honouring the chain's `scope` via `currentScopes()` (new `objectCallMethodName` helper, camelCased scope-join).
- Removed `resolveCallbackObject`'s function-wrapping deviation; `setCallback` hands the object straight to `Callback`.
- Fixed `ObjectCall`'s before/after `makeLambda`/`invertedLambda` to bind `this` to the receiver (Rails `send` semantics).
- Ported Rails `test_before_object`, `test_around_object`, `test_customized_object` through the public `setCallback` API; updated the trails-specific `CallbackObject dispatch` coverage to the canonical (default-scope, bare-method) shape.

## Testing

- `pnpm vitest run packages/activesupport/src/callbacks.test.ts packages/activesupport/src/callbacks.trails.test.ts` — 139 passing
- `pnpm vitest run packages/activemodel/src/callbacks.test.ts` — 59 passing (activemodel keeps its own resolver, unaffected)
- tsc + eslint clean

Closes-story: callback-object-compiles-to-objectcall