### PR TITLE
fix(activerecord): guard belongs_to reader load against mid-flight FK reassignment

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1503,12 +1503,18 @@ export async function loadBelongsTo(
     : Array.isArray(foreignKey)
       ? foreignKey
       : [foreignKey];
-  const fkSnapshot: unknown[] = [];
   for (const fk of fkColsForCheck) {
     const v = record._readAttribute(fk);
     if (v === null || v === undefined) return null;
-    fkSnapshot.push(v);
   }
+  // The staleness key mirrors Rails' `stale_state`: the FK column(s), plus the
+  // `foreign_type` for a polymorphic belongs_to
+  // (belongs_to_polymorphic_association.rb:43-46), so a reassignment that keeps
+  // the same id but changes the target class is still detected below.
+  const staleCols = options.polymorphic
+    ? [...fkColsForCheck, options.foreignType ?? `${underscore(assocName)}_type`]
+    : fkColsForCheck;
+  const staleSnapshot = staleCols.map((col) => record._readAttribute(col));
 
   let result: Base | null;
   if (reflection) {
@@ -1564,11 +1570,11 @@ export async function loadBelongsTo(
   // await the validation chain, that window widened enough for the stale query
   // to resolve mid-save and `syncToAssociationInstance` clobber the
   // freshly-assigned holder target with the old record — dropping the FK change
-  // from `previousChanges`. If the owner's FK moved off the snapshot we queried,
-  // the fetched record is stale: leave the holder's newer target intact and
-  // return it instead of the stale row.
-  const fkMovedDuringLoad = fkColsForCheck.some(
-    (fk, i) => record._readAttribute(fk) !== fkSnapshot[i],
+  // from `previousChanges`. If the owner's stale key moved off the snapshot we
+  // queried, the fetched record is stale: leave the holder's newer target
+  // intact and return it instead of the stale row.
+  const fkMovedDuringLoad = staleCols.some(
+    (col, i) => record._readAttribute(col) !== staleSnapshot[i],
   );
   if (fkMovedDuringLoad) {
     const holder = record._associationInstances.get(assocName) as

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1503,9 +1503,11 @@ export async function loadBelongsTo(
     : Array.isArray(foreignKey)
       ? foreignKey
       : [foreignKey];
+  const fkSnapshot: unknown[] = [];
   for (const fk of fkColsForCheck) {
     const v = record._readAttribute(fk);
     if (v === null || v === undefined) return null;
+    fkSnapshot.push(v);
   }
 
   let result: Base | null;
@@ -1552,6 +1554,27 @@ export async function loadBelongsTo(
         [primaryKey as string]: record._readAttribute(foreignKey),
       });
     }
+  }
+
+  // Rails' `find_target` is synchronous, so it never observes the owner's
+  // foreign key change mid-load. Our loader awaits DB I/O: an in-flight reader
+  // query (e.g. `node.parent` accessed but never awaited) can still be pending
+  // when the caller synchronously reassigns the association
+  // (`node.parent = other`) with a new FK. Once RFC 0063 made `save` genuinely
+  // await the validation chain, that window widened enough for the stale query
+  // to resolve mid-save and `syncToAssociationInstance` clobber the
+  // freshly-assigned holder target with the old record — dropping the FK change
+  // from `previousChanges`. If the owner's FK moved off the snapshot we queried,
+  // the fetched record is stale: leave the holder's newer target intact and
+  // return it instead of the stale row.
+  const fkMovedDuringLoad = fkColsForCheck.some(
+    (fk, i) => record._readAttribute(fk) !== fkSnapshot[i],
+  );
+  if (fkMovedDuringLoad) {
+    const holder = record._associationInstances.get(assocName) as
+      | { isLoaded?: () => boolean; target?: Base | null }
+      | undefined;
+    if (holder?.isLoaded?.()) return holder.target ?? null;
   }
 
   // Set inverse_of: store reference back to the owner. Resolve via the

--- a/packages/activerecord/src/associations/belongs-to-associations.test.ts
+++ b/packages/activerecord/src/associations/belongs-to-associations.test.ts
@@ -1821,12 +1821,7 @@ describe("BelongsToAssociationsTest", () => {
     expect((await (lastComment as any).loadBelongsTo("post"))!.id).toBe(post.id);
   });
 
-  // SKIP (RFC 0063): flipping `save` to await the async validation chain
-  // reorders the `belongs_to touch: true` + autosave callbacks so the parent
-  // holder's target is reloaded stale before `saveBelongsToAssociation`
-  // propagates the FK, dropping `parent_id` from `previousChanges`. Tracked:
-  // 0063-async-validation-chain/fix-async-validation-touch-autosave-reorder.
-  it.skip("tracking change from one persisted record to another", async () => {
+  it("tracking change from one persisted record to another", async () => {
     const node = nodes("child_one_of_a");
     expect(node.parent).not.toBeNull();
     expect((node as any).parentChanged?.()).toBeFalsy();
@@ -1841,9 +1836,7 @@ describe("BelongsToAssociationsTest", () => {
     expect((node as any).parentPreviouslyChanged?.()).toBeTruthy();
   });
 
-  // SKIP (RFC 0063): same touch/autosave reorder as the test above. Tracked:
-  // 0063-async-validation-chain/fix-async-validation-touch-autosave-reorder.
-  it.skip("tracking change from persisted record to new record", async () => {
+  it("tracking change from persisted record to new record", async () => {
     const node = nodes("child_one_of_a");
     expect(node.parent).not.toBeNull();
 


### PR DESCRIPTION
## Summary

Fallout from RFC 0063 flipping `save` to genuinely `await` the validation
chain. An in-flight async `belongs_to` reader query (e.g. `node.parent`
accessed but never awaited) could resolve *after* the caller synchronously
reassigned the association (`node.parent = other`) and clobber the
freshly-assigned holder target via `syncToAssociationInstance`. With the
widened await window, that stale query now lands mid-`save`, reverting the
owner FK so the update chain's `changesApplied` snapshots an empty change set
and `parent_id` is dropped from `previousChanges`.

## Fix

In `loadBelongsTo`, snapshot the owner foreign key before issuing the query.
If the FK moved during the load (a concurrent synchronous reassignment won),
the fetched row is stale — return the holder's newer target instead of syncing
the old record onto the holder. Rails' `find_target` is synchronous and cannot
observe this race; our async loader must.

## Tests

Un-skips the two previously-red tracking tests (no renames):

- `tracking change from one persisted record to another`
- `tracking change from persisted record to new record`

Full `belongs-to-associations`, `has-one-associations`, `inverse-associations`,
`autosave-association`, and `dirty` suites pass locally. No sibling tests were
skipped for this reorder reason.

Closes-story: fix-async-validation-touch-autosave-reorder