### PR TITLE
refactor(activerecord): route PG quotedBinary through shared toBytes

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -345,12 +345,8 @@ export function unquotedFalse(): boolean {
  * raw views — so an implementation has to accept that union to be callable
  * either way.
  *
- * The abstract, MySQL and SQLite `quotedBinary` route through this. PG's
- * hand-rolls the unwrap instead and omits `ArrayBuffer` from its signature, so
- * a direct `pgQuotedBinary(dataView)` raises where the other two hex it —
- * unreachable via `quote` (which normalises views first) and via PG's own
- * adapter override (which handles `ArrayBuffer` separately). Converging it is
- * story `pg-quoted-binary-route-through-tobytes` (RFC 0023).
+ * The abstract, MySQL, SQLite and PostgreSQL `quotedBinary` all route through
+ * this, so every adapter accepts the same union.
  *
  * @internal
  */
@@ -457,10 +453,8 @@ export function isSqlLiteral(value: unknown): value is { value: string } {
  * Takes `unknown` rather than `BinaryData`: the rb:83 branch passes a
  * `BinaryData`, but the abstract view branch passes normalized bytes and
  * SQLite's bare-`ArrayBuffer` branch dispatches the buffer itself. The
- * abstract/MySQL/SQLite `quotedBinary` normalise all three through
- * {@link toBytes} (PG's exception is noted there — it is unreachable from this
- * dispatch, which only sees a raw `ArrayBuffer` from SQLite's branch, with a
- * SQLite host).
+ * abstract/MySQL/SQLite/PostgreSQL `quotedBinary` all normalise these through
+ * {@link toBytes}.
  * @internal
  */
 export function dispatchQuotedBinary(host: QuotingDispatchHost, value: unknown): string {

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -97,9 +97,8 @@ export function quoteString(value: string): string {
  * Mirrors: MySQL::Quoting#quoted_binary (`x'#{value.hex}'`, mysql/quoting.rb:80).
  * Rails' signature takes the `Type::Binary::Data` itself, so accept it alongside
  * the raw views our `quote` unwraps to — a Rails-shaped call then works here too.
- * Shares {@link toBytes} with the abstract and SQLite overrides, so those three
- * accept the same union (PG's hand-rolls the unwrap — exception noted on
- * `toBytes`). A latin1 `string` stays supported on top: Ruby's `Data#hex` reads
+ * Shares {@link toBytes} with the abstract, SQLite and PostgreSQL overrides, so
+ * all accept the same union. A latin1 `string` stays supported on top: Ruby's `Data#hex` reads
  * a byte String, and callers here pass the JS stand-in for one. PG accepts one
  * too; SQLite's override rejects it.
  */

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4186,10 +4186,18 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    */
   override quotedBinary(value: unknown): string {
     // Rails passes the `Type::Binary::Data` itself; our `quote` unwraps to bytes
-    // before dispatching, so accept both and this stays callable Rails-shaped.
-    if (value instanceof BinaryData || value instanceof Uint8Array) return pgQuotedBinary(value);
-    if (value instanceof ArrayBuffer) return pgQuotedBinary(new Uint8Array(value));
-    if (typeof value === "string") return pgQuotedBinary(value);
+    // before dispatching. Rails has a single quoted_binary with no adapter-layer
+    // narrowing (postgresql/quoting.rb:152), so delegate the whole union
+    // pgQuotedBinary's toBytes accepts — any ArrayBuffer view, a bare
+    // ArrayBuffer, BinaryData, or a latin1 string — rather than re-narrowing.
+    if (
+      value instanceof BinaryData ||
+      ArrayBuffer.isView(value) ||
+      value instanceof ArrayBuffer ||
+      typeof value === "string"
+    ) {
+      return pgQuotedBinary(value);
+    }
     throw new TypeError(
       `quotedBinary expects Uint8Array, ArrayBuffer, Buffer, string, or BinaryData; got ${
         value === null ? "null" : typeof value

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
@@ -239,6 +239,18 @@ describe("PostgreSQL quoting", () => {
     expect(quotedBinary("ab")).toBe("'\\x6162'");
   });
 
+  it("quotedBinary hexes an ArrayBuffer view like MySQL/SQLite do", () => {
+    // Routed through the shared toBytes: a DataView (non-Uint8Array view) hexes
+    // its own bytes rather than raising inside escapeBytea's Buffer.from.
+    const buffer = new Uint8Array([0x1f, 0x8b]).buffer;
+    expect(quotedBinary(new DataView(buffer))).toBe("'\\x1f8b'");
+  });
+
+  it("quotedBinary hexes a bare ArrayBuffer like MySQL/SQLite do", () => {
+    const buffer = new Uint8Array([0x1f, 0x8b]).buffer;
+    expect(quotedBinary(buffer)).toBe("'\\x1f8b'");
+  });
+
   it("quote(Uint8Array) emits a bytea hex literal via quotedBinary", () => {
     // byte 0x8b (> 0x7f) must not be corrupted to the UTF-8 replacement
     // character sequence EF BF BD — regression for the String(buffer) path

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -12,6 +12,7 @@ import { BinaryData } from "@blazetrails/activemodel";
 import {
   quote as abstractQuote,
   quotedDate as abstractQuotedDate,
+  toBytes,
   typeCast as abstractTypeCast,
   type QuotingDispatchHost,
 } from "../abstract/quoting.js";
@@ -104,9 +105,16 @@ export function quoteSchemaName(schemaName: string): string {
  * quotes, never nil. Rails' signature takes the `Type::Binary::Data` itself
  * (`postgresql/quoting.rb:152`), so accept it alongside the raw views our
  * `quote` unwraps to — a Rails-shaped call then works here too.
+ *
+ * Routes its byte union through the shared {@link toBytes}, as the abstract,
+ * MySQL and SQLite overrides do. `toBytes` returns `null` for a latin1 `string`,
+ * so the string branch stays ordered after it — PG's `escapeBytea` accepts one.
  */
-export function quotedBinary(value: Buffer | Uint8Array | string | BinaryData): string {
-  return `'${escapeBytea(value instanceof BinaryData ? value.bytes : value)}'`;
+export function quotedBinary(
+  value: Buffer | ArrayBufferView | ArrayBuffer | string | BinaryData,
+): string {
+  const bytes = toBytes(value);
+  return bytes ? `'${escapeBytea(bytes)}'` : `'${escapeBytea(value as string)}'`;
 }
 
 export function quote(this: QuotingDispatchHost, value: unknown): string {


### PR DESCRIPTION
## What

PostgreSQL's `quotedBinary` hand-rolled its `BinaryData` unwrap
(`value instanceof BinaryData ? value.bytes : value`) and omitted `ArrayBuffer`
from its signature, so a direct `pgQuotedBinary(dataView)` raised inside
`escapeBytea`'s `Buffer.from` where MySQL and SQLite hex the view. #4870's
`b7ff8301d` moved MySQL onto the shared `toBytes` normaliser for exactly this
reason; PG was the remaining hold-out (a uniformity gap on a public surface, not
a live bug — `quote` normalises views first and PG's adapter override covers
`ArrayBuffer` on its own branch).

## Changes

- Route PG's `quotedBinary` byte union through the shared `toBytes`, keeping the
  latin1 `string` branch ordered after it (`toBytes` returns `null` for strings,
  and PG's `escapeBytea` accepts one).
- Drop the now-stale exception paragraph from `toBytes`' doc and the two doc
  cross-references (`dispatchQuotedBinary`, MySQL `quotedBinary`) that asserted
  PG hand-rolls.
- Add tests: `pgQuotedBinary(dataView)` and `pgQuotedBinary(arrayBuffer)` hex the
  same bytes MySQL/SQLite do.

Closes-story: pg-quoted-binary-route-through-tobytes