### PR TITLE
fix(activerecord): dirties_query_cache clears all current-thread pools

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -252,6 +252,15 @@ export class ExecutorHooks {
     ExecutorHooks._getConnectionHandler = resolver;
   }
 
+  /**
+   * Resolves the current connection handler (lazily wired from `Base` in
+   * index.ts to avoid a module-level cycle), or `null` before it is wired.
+   * @internal
+   */
+  static connectionHandler(): ConnectionHandlerLike | null {
+    return ExecutorHooks._getConnectionHandler?.() ?? null;
+  }
+
   static run(): void {
     // noop — matches Rails
   }

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -10,6 +10,7 @@ import {
   executionContextId,
   registerContextExitHook,
 } from "./connection-pool/execution-context.js";
+import { ExecutorHooks } from "./connection-pool.js";
 
 /**
  * Matches the locking suffixes Rails refuses to cache (`SELECT ... FOR
@@ -553,6 +554,33 @@ function withWriteDirtyDepth(host: QueryCacheHost, original: () => unknown): unk
   return result;
 }
 
+/**
+ * Clear the query cache on every connection pool of the current thread,
+ * mirroring `ActiveRecord::Base.clear_query_caches_for_current_thread`, which
+ * Rails' `dirties_query_cache` decorator calls (query_cache.rb:24). A write
+ * under one role (`:writing`) must invalidate the caches of the current
+ * thread's *other* pools (`:reading`) too, so a subsequent read there does not
+ * return a stale row. Falls back to clearing the writing connection's own Store
+ * before the handler is wired (module bootstrap / standalone connections).
+ * @internal
+ */
+function clearCurrentThreadQueryCaches(host: QueryCacheHost): void {
+  const handler = ExecutorHooks.connectionHandler();
+  if (!handler) {
+    host._queryCache?.clear();
+    return;
+  }
+  // Mirror `each_connection_pool { pool.clear_query_cache }`: clear the pool's
+  // per-thread Store directly, NOT `pool.active_connection.clear_query_cache`.
+  // A pool whose connection is currently checked in still holds this thread's
+  // cached rows in its registry (they survive checkin, keyed by execution
+  // context), so a re-read after checkout would hit stale results unless the
+  // Store itself is cleared here.
+  handler.eachConnectionPool(null, (pool) => {
+    (pool as unknown as QueryCachePool).clearQueryCache?.();
+  });
+}
+
 /** @internal Reassign each named prototype slot to a cache-dirtying wrapper. */
 function wireDirties(
   base: { prototype: object },
@@ -576,7 +604,7 @@ function wireDirties(
       const dirtying =
         !!this._queryCache?.dirties && !(skipSchemaReflection && args.includes("SCHEMA"));
       if (dirtying) {
-        this._queryCache!.clear();
+        clearCurrentThreadQueryCaches(this);
         // Raise the write-dirty scope ONLY when this call is itself dirtying, so
         // the leaf `executeMutation` it funnels into defers (times: 1). A
         // non-dirtying call — cache off, `uncached(dirties: false)`, or a
@@ -696,7 +724,7 @@ export function dirtiesQueryCacheUnlessNested(
 
     proto[methodName] = function (this: QueryCacheHost, ...args: unknown[]) {
       if (this._queryCache?.dirties && (this._writeDirtyDepth ?? 0) === 0) {
-        this._queryCache.clear();
+        clearCurrentThreadQueryCaches(this);
       }
       return (original as (...a: unknown[]) => unknown).apply(this, args);
     };

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -184,22 +184,26 @@ export interface QueryCacheHost extends DatabaseStatementsHost {
   // Mixed in from the QueryCache module below. Dispatched through `this` (not
   // the module-level functions) so a per-connection override is honored, as in
   // Rails' `def connection.cache_notification_info`.
+  /** @internal */
   cacheNotificationInfo(
     sql: string,
     name: string | null | undefined,
     binds: unknown[],
   ): Record<string, unknown>;
+  /** @internal */
   cacheNotificationInfoResult(
     sql: string,
     name: string | null | undefined,
     binds: unknown[],
     result: Record<string, unknown>[],
   ): Record<string, unknown>;
+  /** @internal */
   lookupSqlCache(
     sql: string,
     name: string | null | undefined,
     binds: unknown[],
   ): Record<string, unknown>[] | undefined;
+  /** @internal */
   cacheSql(
     sql: string,
     name: string | null | undefined,
@@ -560,25 +564,31 @@ function withWriteDirtyDepth(host: QueryCacheHost, original: () => unknown): unk
  * Rails' `dirties_query_cache` decorator calls (query_cache.rb:24). A write
  * under one role (`:writing`) must invalidate the caches of the current
  * thread's *other* pools (`:reading`) too, so a subsequent read there does not
- * return a stale row. Falls back to clearing the writing connection's own Store
- * before the handler is wired (module bootstrap / standalone connections).
+ * return a stale row.
+ *
+ * Clear every handler pool's per-thread Store, then the host's own Store if it
+ * was not one of them: a standalone / NullPool adapter (`abstract-adapter.ts`)
+ * owns a local Store that `eachConnectionPool` never enumerates, so clearing
+ * only the handler pools would leave its own cached reads stale after a write.
+ * Dedup by Store identity so the writing connection — whose `_queryCache` IS
+ * its pool's per-thread Store — is cleared exactly once, preserving the
+ * `times: 1` collapse.
  * @internal
  */
 function clearCurrentThreadQueryCaches(host: QueryCacheHost): void {
-  const handler = ExecutorHooks.connectionHandler();
-  if (!handler) {
-    host._queryCache?.clear();
-    return;
-  }
   // Mirror `each_connection_pool { pool.clear_query_cache }`: clear the pool's
   // per-thread Store directly, NOT `pool.active_connection.clear_query_cache`.
   // A pool whose connection is currently checked in still holds this thread's
   // cached rows in its registry (they survive checkin, keyed by execution
   // context), so a re-read after checkout would hit stale results unless the
   // Store itself is cleared here.
-  handler.eachConnectionPool(null, (pool) => {
-    (pool as unknown as QueryCachePool).clearQueryCache?.();
+  const cleared = new Set<Store>();
+  ExecutorHooks.connectionHandler()?.eachConnectionPool(null, (pool) => {
+    const p = pool as unknown as QueryCachePool & { queryCache?: Store };
+    p.clearQueryCache?.();
+    if (p.queryCache) cleared.add(p.queryCache);
   });
+  if (host._queryCache && !cleared.has(host._queryCache)) host._queryCache.clear();
 }
 
 /** @internal Reassign each named prototype slot to a cache-dirtying wrapper. */

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -347,11 +347,14 @@ export function isShardSwappingProhibited(): boolean {
 }
 
 export function clearQueryCachesForCurrentThread(this: typeof Base): void {
+  // Mirror Rails' `each_connection_pool { pool.clear_query_cache }`
+  // (connection_handling.rb:258-260): clear the pool's per-thread Store
+  // directly, NOT `pool.active_connection.clear_query_cache`. A pool whose
+  // connection is currently checked in still holds this thread's cached rows
+  // in its registry (they survive checkin, keyed by execution context), so a
+  // re-read after checkout would hit stale results unless the Store is cleared.
   this.connectionHandler.eachConnectionPool(null, (pool) => {
-    const conn = pool.activeConnection;
-    if (conn && typeof (conn as any).clearQueryCache === "function") {
-      (conn as any).clearQueryCache();
-    }
+    (pool as unknown as { clearQueryCache?: () => void }).clearQueryCache?.();
   });
 }
 

--- a/packages/activerecord/src/query-cache.test.ts
+++ b/packages/activerecord/src/query-cache.test.ts
@@ -17,6 +17,7 @@ import { QueryCache } from "./query-cache.js";
 import { LogSubscriber } from "./log-subscriber.js";
 import { Notifications, Logger, type NotificationEvent } from "@blazetrails/activesupport";
 import type { ConnectionPool } from "./connection-adapters/abstract/connection-pool.js";
+import { inMemoryDb } from "./test-adapter.js";
 
 for (const m of [Task, Topic, Category, Post]) registerModel(m as never);
 
@@ -669,16 +670,39 @@ describe("QueryCacheTest", () => {
     await mw();
   });
 
-  it.skip("clear query cache is called on all connections", () => {
-    // TRACKED-PENDING-CONVERGENCE (0023-surfaced-deviations:
-    // query-cache-dirties-wiring-incomplete): a write under the :writing role
-    // must clear the query cache on ALL of the current thread's pools (Rails'
-    // `dirties_query_cache` decorator calls
-    // `ActiveRecord::Base.clear_query_caches_for_current_thread`,
-    // query_cache.rb:24). trails' decorator (abstract/query-cache.ts) clears
-    // only the writing connection's own Store, so the :reading pool's cache
-    // stays stale and the re-read returns the pre-write title. Un-skips once
-    // that story wires clearing across connections.
+  // Rails guards this with `unless in_memory_db?`: a separate :reading
+  // connection cannot see the :writing connection's committed rows on an
+  // in-memory SQLite database, so the cross-pool clear is unobservable there.
+  it.skipIf(inMemoryDb())("clear query cache is called on all connections", async () => {
+    // Establish a separate :reading pool against the same config, mirroring
+    // Rails' `establish_connection(db_config)` under `connected_to(:reading)`.
+    const dbConfig = Base.connectionPool().dbConfig;
+    await Base.connectedTo({ role: "reading" }, async () => {
+      await Base.establishConnection(dbConfig);
+    });
+
+    const mw = middleware(async () => {
+      let topic: Topic | null = null;
+      await Base.connectedTo({ role: "reading" }, async () => {
+        topic = await Topic.first();
+      });
+
+      expect(topic).not.toBeNull();
+
+      await Base.connectedTo({ role: "writing" }, async () => {
+        topic!.title = "Topic title";
+        await topic!.save();
+      });
+
+      expect(topic!.title).toBe("Topic title");
+
+      await Base.connectedTo({ role: "reading" }, async () => {
+        const fresh = await Topic.first();
+        expect(fresh!.title).toBe("Topic title");
+      });
+    });
+
+    await mw();
   });
 
   it.skip("query cache is enabled in threads with shared connection", () => {


### PR DESCRIPTION
## Summary

Rails' `dirties_query_cache` decorator calls
`ActiveRecord::Base.clear_query_caches_for_current_thread`, which iterates
`each_connection_pool { pool.clear_query_cache }` (`query_cache.rb:24`). trails'
decorator cleared only the writing connection's own `Store`, so a write under
the `:writing` role left the `:reading` pool's per-thread cache stale and a
re-read there returned the pre-write row.

## Changes

- Add a shared `clearCurrentThreadQueryCaches` helper in
  `connection-adapters/abstract/query-cache.ts` that resolves the connection
  handler (via the `ExecutorHooks` resolver already wired from `Base` in
  `index.ts`) and clears **every** current-thread pool's per-thread `Store`
  directly with `pool.clearQueryCache()` — mirroring
  `each_connection_pool { pool.clear_query_cache }`, not
  `pool.active_connection.clear_query_cache` (a checked-in pool still holds this
  thread's cached rows in its registry, so clearing via the active connection
  would miss them).
- Route both the generic dirties wiring and the `executeMutation` leaf through
  it, preserving the `_writeDirtyDepth` / `times: 1` single-logical-write
  collapse.
- Expose `ExecutorHooks.connectionHandler()` as the lazy resolver accessor.
- Un-skip `clear query cache is called on all connections` in
  `query-cache.test.ts`, guarded with `skipIf(inMemoryDb())` (mirroring Rails'
  `unless in_memory_db?`, since a separate `:reading` connection cannot see the
  `:writing` connection's committed rows on in-memory SQLite).

## Testing

- `pnpm vitest run packages/activerecord/src/query-cache.test.ts` (in-memory
  SQLite): 56 passed, 11 skipped.
- Same file against a file-based SQLite (`AR_TEST_WORKER_DB=...`): the un-skipped
  test passes, exercising the cross-pool clear.

Closes-story: query-cache-dirties-clears-all-current-thread-pools
