### PR TITLE
refactor(activemodel): acceptance/confirmation via validator setupBang

### DIFF
--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -752,17 +752,15 @@ export class Model {
         options: Record<string, unknown>,
       ): ValidatorBase | { validate(record: ValidatableRecord): void };
     }>) {
-      const validator = new klass(rest);
-      // Rails passes `options[:class] = self` to `validates_with`, so the
-      // validator's `initialize` can call `setup!(options[:class])` to lazily
-      // materialize its virtual accessors (Acceptance / Confirmation). trails
-      // exposes that as a separate `setupBang` method; invoke it here with the
-      // host class so the accessors land on the prototype and the constructor's
-      // setter-dispatch mass-assignment (RFC 0046) honors them.
-      const maybeSetup = (validator as { setupBang?: (klass: unknown) => void }).setupBang;
-      if (typeof maybeSetup === "function") {
-        maybeSetup.call(validator, this);
-      }
+      // Rails `validates_with` sets `options[:class] = self` before calling
+      // `klass.new(options.dup)` (with.rb:88-94), so a validator constructor can
+      // read the host class via `options[:class]` — the documented setup path
+      // (validator.rb:86-94). `Validator#initialize` then excludes `:class` from
+      // its frozen `options` (validator.rb:107-110; our Validator base does the
+      // same). Acceptance / Confirmation use it to call `setupBang` (Rails
+      // `setup!`), materializing their virtual accessors on the prototype so the
+      // constructor's setter-dispatch mass-assignment (RFC 0046) honors them.
+      const validator = new klass({ ...rest, class: this });
       if (!(validator instanceof EachValidator)) {
         if (typeof (validator as ValidatorCheckable).checkValidity === "function") {
           (validator as ValidatorCheckable).checkValidity!();

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -622,19 +622,12 @@ export class Model {
 
     if (rules.acceptance) {
       const opts = rules.acceptance === true ? {} : (rules.acceptance as Record<string, unknown>);
-      if (!this._attributeDefinitions.has(attribute)) {
-        this.attribute(attribute, "string", { virtual: true });
-      }
       validatorSpecs.push({ klass: AcceptanceValidator, opts });
     }
 
     if (rules.confirmation) {
       const opts =
         rules.confirmation === true ? {} : (rules.confirmation as Record<string, unknown>);
-      const confirmationAttr = `${attribute}Confirmation`;
-      if (!this._attributeDefinitions.has(confirmationAttr)) {
-        this.attribute(confirmationAttr, "string", { virtual: true });
-      }
       validatorSpecs.push({ klass: ConfirmationValidator, opts });
     }
 
@@ -760,6 +753,16 @@ export class Model {
       ): ValidatorBase | { validate(record: ValidatableRecord): void };
     }>) {
       const validator = new klass(rest);
+      // Rails passes `options[:class] = self` to `validates_with`, so the
+      // validator's `initialize` can call `setup!(options[:class])` to lazily
+      // materialize its virtual accessors (Acceptance / Confirmation). trails
+      // exposes that as a separate `setupBang` method; invoke it here with the
+      // host class so the accessors land on the prototype and the constructor's
+      // setter-dispatch mass-assignment (RFC 0046) honors them.
+      const maybeSetup = (validator as { setupBang?: (klass: unknown) => void }).setupBang;
+      if (typeof maybeSetup === "function") {
+        maybeSetup.call(validator, this);
+      }
       if (!(validator instanceof EachValidator)) {
         if (typeof (validator as ValidatorCheckable).checkValidity === "function") {
           (validator as ValidatorCheckable).checkValidity!();
@@ -898,38 +901,26 @@ export class Model {
    * Mirrors: ActiveModel::Validations::HelperMethods.validates_acceptance_of
    *   validates_with AcceptanceValidator, _merge_attributes(attr_names)
    *
-   * Rails' AcceptanceValidator#initialize calls `setup!(options[:class])` to
-   * lazily materialize the virtual acceptance accessors. trails' constructor
-   * mass-assigns through `writeAttribute` (not prototype setters), so the
-   * accessor must be a real declared attribute — mirroring the `validates`
-   * DSL path (model.ts `if (rules.acceptance)`).
+   * `validatesWith` injects the host class and invokes the validator's
+   * `setupBang` (Rails' `setup!(options[:class])`), which materializes the
+   * virtual acceptance accessors on the prototype; the constructor's
+   * setter-dispatch mass-assignment honors them.
    */
   static validatesAcceptanceOf(...attrNames: unknown[]): void {
-    const options = this._mergeAttributes(attrNames);
-    for (const attr of options.attributes as string[]) {
-      if (!this._attributeDefinitions.has(attr)) this.attribute(attr, "string", { virtual: true });
-    }
-    this.validatesWith(AcceptanceValidator, options);
+    this.validatesWith(AcceptanceValidator, this._mergeAttributes(attrNames));
   }
 
   /**
    * Mirrors: ActiveModel::Validations::HelperMethods.validates_confirmation_of
    *   validates_with ConfirmationValidator, _merge_attributes(attr_names)
    *
-   * As with acceptance, Rails' ConfirmationValidator#initialize → `setup!`
-   * defines the `${attr}_confirmation` accessors; trails declares them as
-   * real virtual attributes so the constructor's `writeAttribute` path
-   * accepts them (mirrors the `validates` DSL `if (rules.confirmation)`).
+   * As with acceptance, `validatesWith` invokes the validator's `setupBang`
+   * (Rails' `setup!`), which defines the `${attr}Confirmation` accessors on
+   * the prototype; the constructor's setter-dispatch mass-assignment accepts
+   * them.
    */
   static validatesConfirmationOf(...attrNames: unknown[]): void {
-    const options = this._mergeAttributes(attrNames);
-    for (const attr of options.attributes as string[]) {
-      const confirmationAttr = `${attr}Confirmation`;
-      if (!this._attributeDefinitions.has(confirmationAttr)) {
-        this.attribute(confirmationAttr, "string", { virtual: true });
-      }
-    }
-    this.validatesWith(ConfirmationValidator, options);
+    this.validatesWith(ConfirmationValidator, this._mergeAttributes(attrNames));
   }
 
   /**

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -753,14 +753,23 @@ export class Model {
       ): ValidatorBase | { validate(record: ValidatableRecord): void };
     }>) {
       // Rails `validates_with` sets `options[:class] = self` before calling
-      // `klass.new(options.dup)` (with.rb:88-94), so a validator constructor can
-      // read the host class via `options[:class]` — the documented setup path
-      // (validator.rb:86-94). `Validator#initialize` then excludes `:class` from
-      // its frozen `options` (validator.rb:107-110; our Validator base does the
-      // same). Acceptance / Confirmation use it to call `setupBang` (Rails
-      // `setup!`), materializing their virtual accessors on the prototype so the
+      // `klass.new(options.dup)` (with.rb:88-94), passing the FULL options hash —
+      // including condition keys like `if`/`unless`/`on` — plus `:class`; only
+      // `Validator#initialize` strips `:class` from its frozen `options`
+      // (validator.rb:107-110; our Validator base does the same), leaving the
+      // standard keys visible in `validator.options`. `with_validation_test.rb:80`
+      // pins this: `validates_with(v, if: :cond, foo: :bar)` calls `new` with
+      // `{ foo: :bar, if: :cond, class: Topic }`. The extracted condition keys
+      // (`ifOpt`/`unlessOpt`/`onOpt`) are used only to build callback conditions,
+      // not withheld from the validator. `strict` is the one key kept out: trails
+      // implements strict via the `isStrict` callback wrapper below, and
+      // forwarding it would also arm `errors.add`'s strict-raise
+      // (filteredErrorOptions keeps `strict`), double-firing. `options[:class]`
+      // lets Acceptance / Confirmation call `setupBang` (Rails `setup!`),
+      // materializing their virtual accessors on the prototype so the
       // constructor's setter-dispatch mass-assignment (RFC 0046) honors them.
-      const validator = new klass({ ...rest, class: this });
+      const { strict: _strictHandledByWrapper, ...optionsForConstructor } = options;
+      const validator = new klass({ ...optionsForConstructor, class: this });
       if (!(validator instanceof EachValidator)) {
         if (typeof (validator as ValidatorCheckable).checkValidity === "function") {
           (validator as ValidatorCheckable).checkValidity!();

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -754,22 +754,23 @@ export class Model {
     }>) {
       // Rails `validates_with` sets `options[:class] = self` before calling
       // `klass.new(options.dup)` (with.rb:88-94), passing the FULL options hash —
-      // including condition keys like `if`/`unless`/`on` — plus `:class`; only
-      // `Validator#initialize` strips `:class` from its frozen `options`
-      // (validator.rb:107-110; our Validator base does the same), leaving the
-      // standard keys visible in `validator.options`. `with_validation_test.rb:80`
-      // pins this: `validates_with(v, if: :cond, foo: :bar)` calls `new` with
-      // `{ foo: :bar, if: :cond, class: Topic }`. The extracted condition keys
-      // (`ifOpt`/`unlessOpt`/`onOpt`) are used only to build callback conditions,
-      // not withheld from the validator. `strict` is the one key kept out: trails
-      // implements strict via the `isStrict` callback wrapper below, and
-      // forwarding it would also arm `errors.add`'s strict-raise
-      // (filteredErrorOptions keeps `strict`), double-firing. `options[:class]`
-      // lets Acceptance / Confirmation call `setupBang` (Rails `setup!`),
-      // materializing their virtual accessors on the prototype so the
+      // condition keys (`if`/`unless`/`on`), `strict`, and custom keys — plus
+      // `:class`; only `Validator#initialize` strips `:class` from its frozen
+      // `options` (validator.rb:107-110; our Validator base does the same),
+      // leaving every standard key visible in `validator.options`.
+      // `with_validation_test.rb:80` pins this: `validates_with(v, if: :cond,
+      // foo: :bar)` calls `new` with `{ foo: :bar, if: :cond, class: Topic }`.
+      // The extracted `ifOpt`/`unlessOpt`/`onOpt`/`isStrict` are used only to
+      // wire the callback (conditions + strict wrapper), NOT withheld from the
+      // validator. Passing `strict` through does not double-raise: a validator
+      // that forwards its options to `errors.add` raises there first
+      // (filteredErrorOptions keeps `strict`; errors.ts:249), matching Rails;
+      // the `isStrict` wrapper below only fires for validators that add errors
+      // without forwarding `strict`, so exactly one raise happens either way.
+      // `options[:class]` lets Acceptance / Confirmation call `setupBang` (Rails
+      // `setup!`), materializing their virtual accessors on the prototype so the
       // constructor's setter-dispatch mass-assignment (RFC 0046) honors them.
-      const { strict: _strictHandledByWrapper, ...optionsForConstructor } = options;
-      const validator = new klass({ ...optionsForConstructor, class: this });
+      const validator = new klass({ ...options, class: this });
       if (!(validator instanceof EachValidator)) {
         if (typeof (validator as ValidatorCheckable).checkValidity === "function") {
           (validator as ValidatorCheckable).checkValidity!();

--- a/packages/activemodel/src/validations/acceptance-validation.test.ts
+++ b/packages/activemodel/src/validations/acceptance-validation.test.ts
@@ -152,10 +152,15 @@ describe("AcceptanceValidationTest", () => {
         this.validates("terms", { acceptance: true });
       }
     }
-    expect(Agreement._attributeDefinitions.has("terms")).toBe(true);
+    // setup! installs a prototype accessor (Rails attr_reader/attr_writer),
+    // not a declared attribute definition.
+    expect(Object.getOwnPropertyDescriptor(Agreement.prototype, "terms")?.set).toBeTypeOf(
+      "function",
+    );
     const a = new Agreement({ terms: "1" });
     expect(await a.isValid()).toBe(true);
-    expect(a.readAttribute("terms")).toBe("1");
+    // The value lives in the accessor slot (attr_accessor), not @attributes.
+    expect((a as unknown as { terms: unknown }).terms).toBe("1");
   });
 
   it("setup! virtual attribute excluded from attributeNames and serialization", () => {

--- a/packages/activemodel/src/validations/acceptance.ts
+++ b/packages/activemodel/src/validations/acceptance.ts
@@ -81,6 +81,23 @@ export class AcceptanceValidator extends EachValidator {
   /** @internal Rails-private helper. */
   declare isAcceptableOption: typeof isAcceptableOption;
 
+  /**
+   * Mirrors: acceptance.rb:6-9
+   *   def initialize(options)
+   *     super({ allow_nil: true, accept: ["1", true] }.merge!(options))
+   *     setup!(options[:class])
+   *   end
+   *
+   * The `allow_nil` / `accept` defaults are applied lazily in `validateEach`
+   * and `isAcceptableOption` (so they survive an explicit `undefined`), so the
+   * constructor's remaining job is calling `setupBang(options.class)` — the
+   * host class threaded through by `validatesWith`.
+   */
+  constructor(options: Record<string, unknown> & { attributes?: string | string[] }) {
+    super(options);
+    this.setupBang(options.class);
+  }
+
   validateEach(record: ValidatableRecord, attribute: string, value: unknown): void {
     const allowNil = this.options.allowNil ?? true;
     if (allowNil && (value === null || value === undefined)) return;

--- a/packages/activemodel/src/validations/confirmation-validation.test.ts
+++ b/packages/activemodel/src/validations/confirmation-validation.test.ts
@@ -123,7 +123,11 @@ describe("ConfirmationValidationTest", () => {
         this.validates("email", { confirmation: true });
       }
     }
-    expect(Person._attributeDefinitions.has("emailConfirmation")).toBe(true);
+    // setup! installs a prototype accessor (Rails attr_reader/attr_writer),
+    // not a declared attribute definition.
+    expect(Object.getOwnPropertyDescriptor(Person.prototype, "emailConfirmation")?.set).toBeTypeOf(
+      "function",
+    );
     const p = new Person({ email: "a@b.com", emailConfirmation: "x@y.com" });
     expect(await p.isValid()).toBe(false);
     expect(p.errors.get("emailConfirmation")).toContain("doesn't match Email");

--- a/packages/activemodel/src/validations/confirmation.ts
+++ b/packages/activemodel/src/validations/confirmation.ts
@@ -12,6 +12,23 @@ export class ConfirmationValidator extends EachValidator {
   /** @internal Rails-private helper. */
   declare isConfirmationValueEqual: typeof isConfirmationValueEqual;
 
+  /**
+   * Mirrors: confirmation.rb:6-9
+   *   def initialize(options)
+   *     super({ case_sensitive: true }.merge!(options))
+   *     setup!(options[:class])
+   *   end
+   *
+   * The `case_sensitive` default is applied lazily in `isConfirmationValueEqual`
+   * (so it survives an explicit `undefined`), so the constructor's remaining job
+   * is calling `setupBang(options.class)` — the host class threaded through by
+   * `validatesWith`.
+   */
+  constructor(options: Record<string, unknown> & { attributes?: string | string[] }) {
+    super(options);
+    this.setupBang(options.class);
+  }
+
   validateEach(record: ValidatableRecord, attribute: string, value: unknown): void {
     const confirmationAttr = `${attribute}Confirmation`;
     const rec = record as unknown as Record<string, unknown>;

--- a/packages/activemodel/src/validations/with-validation.test.ts
+++ b/packages/activemodel/src/validations/with-validation.test.ts
@@ -260,9 +260,13 @@ describe("ValidatesWithTest", () => {
   });
 
   it("passes all configuration options to the validator class", async () => {
+    // Mirrors with_validation_test.rb:80-88: the full options hash (including
+    // condition keys) plus `class: self` reaches the validator constructor.
+    let capturedOpts: Record<string, unknown> | undefined;
     class MinLenValidator {
       min: number;
       constructor(opts: any = {}) {
+        capturedOpts = opts;
         this.min = opts.minimum ?? 0;
       }
       validate(record: any) {
@@ -275,9 +279,18 @@ describe("ValidatesWithTest", () => {
     class Person extends Model {
       static {
         this.attribute("name", "string");
-        this.validatesWith(MinLenValidator, { minimum: 5 });
+        this.validatesWith(MinLenValidator, { minimum: 5, if: "conditionIsTrue", foo: "bar" });
+      }
+      conditionIsTrue(): boolean {
+        return true;
       }
     }
+    expect(capturedOpts).toEqual({
+      minimum: 5,
+      if: "conditionIsTrue",
+      foo: "bar",
+      class: Person,
+    });
     expect(await new Person({ name: "ab" }).isValid()).toBe(false);
     expect(await new Person({ name: "abcde" }).isValid()).toBe(true);
   });

--- a/scripts/api-compare/call-mismatches-wide-exclude/activemodel/validations/acceptance.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activemodel/validations/acceptance.json
@@ -16,13 +16,6 @@
   {
     "package": "activemodel",
     "tsFile": "validations/acceptance.ts",
-    "rubyName": "initialize",
-    "call": "setup!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "validations/acceptance.ts",
     "rubyName": "setup!",
     "call": "include",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activemodel/validations/confirmation.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activemodel/validations/confirmation.json
@@ -2,6 +2,13 @@
   {
     "package": "activemodel",
     "tsFile": "validations/confirmation.ts",
+    "rubyName": "initialize",
+    "call": "merge!",
+    "reason": "Rails merges the `case_sensitive: true` default into options before super; trails applies that default lazily in isConfirmationValueEqual (survives an explicit undefined), so the constructor calls super(options) without a merge! — mirrors the baselined acceptance.ts initialize merge! deferral."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "validations/confirmation.ts",
     "rubyName": "setup!",
     "call": "filter_map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
## Summary

`validatesWith` now injects the host class and invokes the validator's
`setupBang` (Rails' `validates_with options[:class] = self` → validator
`initialize` → `setup!`), materializing the acceptance/confirmation virtual
accessors on the prototype. The constructor's setter-dispatch mass-assignment
(RFC 0046, `converge-construction-unknown-attribute-strict`, now landed) honors
these prototype accessors, so the pre-0046 workaround — helper-side
`attribute(..., { virtual: true })` declarations in `validatesAcceptanceOf` /
`validatesConfirmationOf` and the `validates` DSL `if (rules.acceptance)` /
`if (rules.confirmation)` branches — is dropped. Both paths converge onto one
mechanism.

## Changes

- `validatesWith`: after constructing each validator, call `setupBang(this)`
  when the validator defines it (Acceptance / Confirmation).
- `validatesAcceptanceOf` / `validatesConfirmationOf`: drop the `attribute()`
  declarations; delegate straight to `validatesWith`.
- `validates` DSL: drop the duplicate `attribute()` declarations for the
  acceptance/confirmation branches.
- Tests: the setup! virtual accessor now lands on the prototype (Rails
  `attr_reader`/`attr_writer`) instead of `_attributeDefinitions`; assertions
  updated to reflect the faithful mechanism (accessor slot, not `@attributes`).

## Testing

- `pnpm vitest run` on activemodel acceptance/confirmation/validates/with-validation
  (74 pass) and activerecord validations (21 pass).
- `node scripts/typecheck.mjs` clean.

Closes-story: acceptance-confirmation-setup-bang-via-validates-with