### PR TITLE
test(associations): cover scoped source through composite-PK non-HABTM model with mixed predicate

### DIFF
--- a/packages/activerecord/src/associations/through-association-scope-composite-pk.trails.test.ts
+++ b/packages/activerecord/src/associations/through-association-scope-composite-pk.trails.test.ts
@@ -30,14 +30,17 @@ registerModel([CpkOrder, CpkOrderTag, CpkTag]);
 
 // A MIXED predicate referencing both the through table (`cpk_order_tags`) and
 // the source table (`cpk_tags`) in one node, on a scoped source through the
-// composite-PK `Cpk::OrderTag`. `cpk_order_tags.attached_reason` is NULL in the
-// fixtures, so the predicate reduces to `cpk_tags.name = 'Loyal customer'`.
+// composite-PK `Cpk::OrderTag`. BOTH halves must resolve for the query to parse:
+// `cpk_order_tags.order_id` lives on the through table, `cpk_tags.name` on the
+// source table. If the composite-PK bypass orphaned this onto the source-only
+// preload stage (which never joins `cpk_order_tags`), the through-table column
+// would raise `no such column`. `order_1` is tagged both `Loyal customer` and
+// `Digital product`; the source-table half narrows the result to the latter.
 CpkOrder.hasMany("tagsWithMixedCondition", {
   className: "CpkTag",
   through: "orderTags",
   source: "tag",
-  scope: (rel) =>
-    rel.where("cpk_order_tags.attached_reason = 'x' OR cpk_tags.name = 'Loyal customer'"),
+  scope: (rel) => rel.where("cpk_order_tags.order_id > 0 AND cpk_tags.name = 'Digital product'"),
 });
 
 interface ThroughScopeProbe {
@@ -62,10 +65,11 @@ describe("Preloader::ThroughAssociation#through_scope composite-PK through", () 
     const order = cpkOrders("cpk_groceries_order_1");
     const loader = throughLoader([order], "tagsWithMixedCondition");
     const sql = (loader as unknown as ThroughScopeProbe)._buildThroughScope().toSql();
-    // Both the through-table and source-table columns are referenced in one
-    // predicate, and the source is eager-JOINed so both resolve in one query.
-    expect(sql).toContain("cpk_order_tags");
-    expect(sql).toContain("cpk_tags");
+    // The whole mixed predicate rides the through query (both column references
+    // are the verbatim raw-SQL string, adapter-quoting-independent), and the
+    // source is eager-JOINed so `cpk_tags.name` resolves alongside it — one query.
+    expect(sql).toContain("cpk_order_tags.order_id > 0");
+    expect(sql).toContain("cpk_tags.name = 'Digital product'");
     expect(sql).toMatch(/JOIN .*cpk_tags/);
   });
 
@@ -76,6 +80,8 @@ describe("Preloader::ThroughAssociation#through_scope composite-PK through", () 
       id: order.readAttribute("id"),
     }).preload("tagsWithMixedCondition");
     const tags = (row.association("tagsWithMixedCondition").target ?? []) as CpkTag[];
-    expect(tags.map((t) => t.name)).toEqual(["Loyal customer"]);
+    // Both predicate halves resolved in one JOINed query: the through-table half
+    // did not raise, and the source-table half narrowed order_1's two tags to one.
+    expect(tags.map((t) => t.name)).toEqual(["Digital product"]);
   });
 });

--- a/packages/activerecord/src/associations/through-association-scope-composite-pk.trails.test.ts
+++ b/packages/activerecord/src/associations/through-association-scope-composite-pk.trails.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Preloader::ThroughAssociation#through_scope — scoped source through a
+ * composite-PK, non-HABTM through model.
+ *
+ * A trails-only pin (no canonical association routes a scoped source through a
+ * composite-PK non-HABTM model): `Cpk::Order has_many :tags, through:
+ * :order_tags` routes through `Cpk::OrderTag`, whose table `cpk_order_tags` has
+ * a DB-level composite primary key `[:order_id, :tag_id]`. The source
+ * (`belongs_to :tag`) is to-one, so `through_scope` takes Rails' single-query
+ * JOIN branch: the FULL reflection-scope `where_clause` is copied onto the
+ * through query and the source (`cpk_tags`) is eager-JOINed.
+ *
+ * `Relation#_eagerLoadBypassesJoinDependency` used to degrade ANY composite-PK
+ * base's eager load to preload — which would orphan the copied source-table
+ * predicate onto a query that never joins `cpk_tags` (`no such column`). It now
+ * bypasses a composite-PK base only for the LIMIT+collection `_materializeLimitedIds`
+ * path, so this unlimited through-preload JOIN materializes like Rails and a
+ * MIXED predicate spanning BOTH the through table (`cpk_order_tags`) and the
+ * source table (`cpk_tags`) — which no two-step split can resolve — is answered
+ * in one JOINed query.
+ */
+import { describe, it, expect } from "vitest";
+import { registerModel } from "../index.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+import { Preloader } from "./preloader.js";
+import { ThroughAssociation } from "./preloader/through-association.js";
+import { CpkOrder, CpkOrderTag, CpkTag } from "../test-helpers/models/cpk.js";
+
+registerModel([CpkOrder, CpkOrderTag, CpkTag]);
+
+// A MIXED predicate referencing both the through table (`cpk_order_tags`) and
+// the source table (`cpk_tags`) in one node, on a scoped source through the
+// composite-PK `Cpk::OrderTag`. `cpk_order_tags.attached_reason` is NULL in the
+// fixtures, so the predicate reduces to `cpk_tags.name = 'Loyal customer'`.
+CpkOrder.hasMany("tagsWithMixedCondition", {
+  className: "CpkTag",
+  through: "orderTags",
+  source: "tag",
+  scope: (rel) =>
+    rel.where("cpk_order_tags.attached_reason = 'x' OR cpk_tags.name = 'Loyal customer'"),
+});
+
+interface ThroughScopeProbe {
+  _buildThroughScope(): { toSql(): string };
+}
+
+describe("Preloader::ThroughAssociation#through_scope composite-PK through", () => {
+  const { cpkOrders } = fixtures(["cpkOrders", "cpkTags", "cpkOrderTags"]);
+
+  function throughLoader(owners: CpkOrder[], name: string): ThroughAssociation {
+    const loaders = new Preloader({
+      records: owners,
+      associations: [name],
+      associateByDefault: false,
+    }).loaders;
+    const loader = loaders.find((l) => l instanceof ThroughAssociation);
+    if (!loader) throw new Error("expected a ThroughAssociation loader");
+    return loader;
+  }
+
+  it("JOINs the source and copies a mixed through+source predicate onto the composite-PK through query", () => {
+    const order = cpkOrders("cpk_groceries_order_1");
+    const loader = throughLoader([order], "tagsWithMixedCondition");
+    const sql = (loader as unknown as ThroughScopeProbe)._buildThroughScope().toSql();
+    // Both the through-table and source-table columns are referenced in one
+    // predicate, and the source is eager-JOINed so both resolve in one query.
+    expect(sql).toContain("cpk_order_tags");
+    expect(sql).toContain("cpk_tags");
+    expect(sql).toMatch(/JOIN .*cpk_tags/);
+  });
+
+  it("preloads a scoped source through a composite-PK model without orphaning the source predicate", async () => {
+    const order = cpkOrders("cpk_groceries_order_1");
+    const [row] = await CpkOrder.where({
+      shop_id: order.shop_id,
+      id: order.readAttribute("id"),
+    }).preload("tagsWithMixedCondition");
+    const tags = (row.association("tagsWithMixedCondition").target ?? []) as CpkTag[];
+    expect(tags.map((t) => t.name)).toEqual(["Loyal customer"]);
+  });
+});


### PR DESCRIPTION
## What

Adds coverage for a **scoped source through a composite-PK, non-HABTM through
model** with a predicate spanning both the through and source tables — the
latent-fidelity case tracked by this story.

`Cpk::Order has_many :tags, through: :order_tags` routes through `Cpk::OrderTag`
(`cpk_order_tags`, DB composite PK `[order_id, tag_id]`). The source
(`belongs_to :tag`) is to-one, so `through_scope` takes Rails' single-query JOIN
branch: the full reflection-scope `where_clause` is copied onto the through
query and `cpk_tags` is eager-JOINed. A MIXED predicate referencing both
`cpk_order_tags` and `cpk_tags` in one node — which no two-step split can
resolve — is answered in that one JOINed query.

## Why this is test-only

The behavioural fix landed in #4917
(`converge-through-preload-source-join`), which this story built on. As merged,
#4917 narrowed `Relation#_eagerLoadBypassesJoinDependency` directly — a
composite-PK base now bypasses the eager JoinDependency **only** for the
LIMIT+collection `_materializeLimitedIds` path (keeping `preloading has_many
with cpk` green), so an unlimited composite-PK through-preload JOINs like Rails.
Because #4917 achieved this by narrowing the bypass rather than by adding a
degraded `_throughQueryJoinsSource()` branch, there was **no degraded branch or
`&& this._throughQueryJoinsSource()` guard left to delete** (acceptance
criteria 1 and 2 were satisfied on merge of #4917). The only remaining
deliverable is the coverage this PR adds (acceptance criterion 3); no eager,
CPK-eager, HABTM, through, nested-through, or through-scope suite regresses
(criterion 4) since no product code changes.

No canonical association routes a scoped source through a composite-PK non-HABTM
model, so this is a `*.trails.test.ts` using canonical CPK models + a bespoke
mixed-predicate scope.

Closes-story: close-composite-pk-through-eager-bypass-for-scoped-source
