### PR TITLE
refactor(validations): run uniqueness inline in valid?; delete async registry

### DIFF
--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -787,15 +787,37 @@ export class Model {
           const origErrors = r.errors;
           const tempErrors = new Errors(r);
           r.errors = tempErrors;
+          // Restore the real errors, then raise if the validator flagged
+          // anything. A DB-backed validator (uniqueness / associated) returns a
+          // Promise — its `errors.add` runs when that promise resolves, so we
+          // must await before inspecting `tempErrors`; otherwise strict would
+          // never fire for async validators (RFC 0063 made the chain async).
+          const settle = (): void => {
+            r.errors = origErrors;
+            if (tempErrors.any) {
+              throw new StrictValidationFailed(tempErrors.fullMessages.join(", "));
+            }
+          };
           let validateResult: unknown;
           try {
             validateResult = validator.validate(r);
-          } finally {
+          } catch (e) {
             r.errors = origErrors;
+            throw e;
           }
-          if (tempErrors.any) {
-            throw new StrictValidationFailed(tempErrors.fullMessages.join(", "));
+          if (
+            validateResult != null &&
+            typeof (validateResult as PromiseLike<void>).then === "function"
+          ) {
+            return Promise.resolve(validateResult as PromiseLike<void>).then(
+              () => settle(),
+              (e) => {
+                r.errors = origErrors;
+                throw e;
+              },
+            );
           }
+          settle();
           return validateResult as void;
         };
       } else {

--- a/packages/activerecord/README.md
+++ b/packages/activerecord/README.md
@@ -298,27 +298,24 @@ p.author; // Author (preloaded)
   [`src/strict-loading-sync-reader.test.ts`](src/strict-loading-sync-reader.test.ts)
   and the `loadBelongsTo` implementation in [`src/associations.ts`](src/associations.ts).
 
-### 3. `isValid()` is synchronous — but uniqueness/associated are async
+### 3. `isValid()` is async
 
-`record.isValid()` (Rails' `valid?`) is **synchronous** and returns a boolean.
-It runs all the synchronous validators (presence, length, numericality,
-absence, format, inclusion/exclusion, …) inline.
-
-But uniqueness and `validates_associated` need a DB round-trip, so they're
-**async**: they push a promise onto the record rather than blocking `isValid()`.
-That means a manual `isValid()` call returns _before_ those async validators
-have finished, so `record.errors` may not yet reflect them.
+`record.isValid()` (Rails' `valid?`) returns a `Promise<boolean>`. It runs the
+full validator chain inline — including the DB-backed `UniquenessValidator` and
+`validates_associated`, which issue their `SELECT`s and populate `errors` before
+the promise resolves. So `await record.isValid()` returns `false` on a
+uniqueness collision before any save, matching Rails' `valid?`.
 
 ```ts
-if (record.isValid()) { ... }   // sync validators only — uniqueness not yet resolved
+if (await record.isValid()) { ... }   // full chain, including uniqueness
 ```
 
-`save()` / `saveBang()` await the async validators for you — so the simplest
-correct pattern is to let `save` do the validating:
+`save()` / `saveBang()` run the same chain, so the simplest correct pattern is
+to let `save` do the validating:
 
 ```ts
 if (await record.save()) {
-  // runs sync + async validators, then persists
+  // runs the validation chain, then persists
   // saved
 } else {
   record.errors; // fully populated, including uniqueness
@@ -326,8 +323,7 @@ if (await record.save()) {
 ```
 
 See [`src/validations.ts`](src/validations.ts) (`isValid`) and
-[`src/validations/uniqueness.ts`](src/validations/uniqueness.ts) for the exact
-split, plus `_runAsyncValidations` in [`src/base.ts`](src/base.ts).
+[`src/validations/uniqueness.ts`](src/validations/uniqueness.ts).
 
 ### 4. Async everywhere else the DB is touched
 

--- a/packages/activerecord/src/associations/builder/belongs-to.ts
+++ b/packages/activerecord/src/associations/builder/belongs-to.ts
@@ -395,29 +395,27 @@ export class BelongsTo extends SingularAssociation {
 
       model.validatesPresenceOf(name, { message: "required", if: condition });
 
-      // The sync presence check above only fires when the FK is blank (Rails'
+      // The presence check above only fires when the FK is blank (Rails'
       // observable "must exist" for an unset association). When the FK IS
       // populated, Rails still reads the association — loading the target — and
-      // fails "must exist" if the row no longer exists. trails validations are
-      // synchronous and cannot load, so that case is deferred to the async
-      // validation pass (Base#_runAsyncValidations), which runs after the sync
-      // chain and is skipped on `save(validate: false)` just like Rails' valid?.
-      // It is gated by the same `railsRuns` condition so the false-config branch
-      // doesn't reload an already-persisted, unchanged FK (belongs_to_associations_test.rb
-      // "skips parent presence check if parent has not changed").
-      const klass = model as { _asyncValidations?: Array<unknown> };
-      if (!Object.prototype.hasOwnProperty.call(klass, "_asyncValidations")) {
-        klass._asyncValidations = [...(klass._asyncValidations ?? [])];
-      }
-      (klass._asyncValidations as Array<unknown>).push({
-        attribute: name,
-        options: {
-          belongsToExistence: true,
-          message: "required",
-          if: (record: any) => railsRuns(record) && foreignKeyPresent(record),
+      // fails "must exist" if the row no longer exists. Now that the validation
+      // chain is async (RFC 0063), that case runs as a normal validator that
+      // loads the target inline in `valid?`. It is gated by the same `railsRuns`
+      // condition so the false-config branch doesn't reload an already-persisted,
+      // unchanged FK (belongs_to_associations_test.rb "skips parent presence
+      // check if parent has not changed").
+      model.validate(
+        async (record: any) => {
+          let target: unknown = null;
+          if (typeof record.association === "function") {
+            target = await record.association(name).loadTarget();
+          }
+          if (target == null) {
+            record.errors.add(name, "blank", { message: "required" });
+          }
         },
-        declaringClass: model,
-      });
+        { if: (record: any) => railsRuns(record) && foreignKeyPresent(record) },
+      );
     }
   }
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -79,7 +79,6 @@ import {
   _setSuperIsValid,
   _setSuperValidates,
   type ValidationContextArg,
-  UniquenessValidator,
 } from "./validations.js";
 import * as _Validations from "./validations.js";
 import { encryptionHooks } from "./encryption-hooks.js";
@@ -116,7 +115,6 @@ import {
   beforeOrAroundCallbackSources,
   sanitizeForMassAssignment,
   isMassAssignmentEmpty,
-  shouldValidate,
 } from "@blazetrails/activemodel";
 import { SignedGlobalID as _SignedGlobalIDCtor } from "@blazetrails/globalid/signed-global-id";
 import {
@@ -674,23 +672,6 @@ function expandCallbackSourcesWithHelpers(
     }
   }
   return result;
-}
-
-/**
- * Mirror of the `on:` context guard that `setOptionsForCallback`
- * (activemodel/validations/callbacks.ts) installs onto sync validators:
- * `options[:on].intersect?(Array(o.validation_context))`. Deferred (async)
- * validators bypass the callback chain, so we re-apply the same intersection
- * here. No `on:` means the validator runs in every context.
- */
-function asyncValidationContextMatches(
-  context: string | string[] | null,
-  on: string | string[] | undefined,
-): boolean {
-  if (on == null) return true;
-  const onArr = Array.isArray(on) ? on : [on];
-  const ctxArr = Array.isArray(context) ? context : context == null ? [] : [context];
-  return onArr.some((o) => ctxArr.includes(o));
 }
 
 function _applyScopeAttributes(
@@ -3407,80 +3388,6 @@ export class Base extends Model {
   // signatures live on the merged `interface Base` at the bottom of this file.
 
   /**
-   * Run async validations (like uniqueness).
-   */
-  private async _runAsyncValidations(): Promise<boolean> {
-    const ctor = this.constructor as typeof Base;
-    const asyncValidators: Array<{ attribute: string; options: any; declaringClass?: any }> =
-      (ctor as any)._asyncValidations ?? [];
-
-    // The sync validation pass (performValidations) restores _validationContext
-    // to its prior value once it returns, so by the time we reach here it is
-    // null again. Recompute the effective context the same way isValid does so
-    // deferred validators honor on:/if:/unless: like Rails' callback chain.
-    const context = this._validationContext ?? defaultValidationContext.call(this);
-
-    for (const { attribute, options, declaringClass } of asyncValidators) {
-      if (!asyncValidationContextMatches(context, options.on)) continue;
-      if (!shouldValidate(this, options)) continue;
-      if (options.belongsToExistence) {
-        // Rails validates a required belongs_to on the association NAME, which
-        // reads the association — loading the target from the FK. A FK pointing
-        // at a deleted/nonexistent row loads nil and fails "must exist". trails'
-        // sync validator can't load an unloaded target, so the FK-present case
-        // is deferred here (the async pass, gated by validate:false exactly like
-        // Rails' valid?) where the target can be loaded and checked.
-        let target: unknown = null;
-        if (typeof this.association === "function") {
-          target = await (this.association(attribute) as any).loadTarget();
-        }
-        if (target == null) {
-          this.errors.add(attribute, "blank", { message: options.message ?? "required" });
-        }
-        continue;
-      }
-      // For an association attribute (`validates :event, uniqueness: true`), the
-      // presence check reads the underlying foreign key (Rails reads the
-      // association object; the FK carries the same value and avoids a lazy
-      // load). The error is still reported on the original attribute name.
-      const refl = (ctor as any)._reflectOnAssociation?.(attribute);
-      const valueAttr = refl
-        ? Array.isArray(refl.foreignKey)
-          ? refl.foreignKey[0]
-          : refl.foreignKey
-        : attribute;
-      const value = this.readAttribute(valueAttr);
-      // Rails' UniquenessValidator has no nil early-return — a nil value is
-      // checked as `IS NULL` (and the STI/scope filter usually makes it pass).
-      // Only allowNil/allowBlank short-circuit, matching EachValidator#validate's
-      // `value.nil? && allow_nil` / `value.blank? && allow_blank` guard.
-      if (value === undefined) continue;
-      if (value == null && options.allowNil === true) continue;
-      if (_isBlankValue(value) && options.allowBlank === true) continue;
-      const validator = new UniquenessValidator({
-        ...options,
-        attributes: attribute,
-        class: declaringClass ?? ctor,
-      });
-      validator.validateEach(this, attribute, value);
-    }
-
-    // Await per-instance async validation promises (pushed by UniquenessValidator.validateEach)
-    const instancePromises = (this as any)._asyncValidationPromises as
-      | Promise<unknown>[]
-      | undefined;
-    if (instancePromises?.length) {
-      try {
-        await Promise.all(instancePromises);
-      } finally {
-        (this as any)._asyncValidationPromises = [];
-      }
-    }
-
-    return this.errors.empty;
-  }
-
-  /**
    * Register a uniqueness validation.
    *
    * Mirrors: validates uniqueness: true
@@ -3493,20 +3400,6 @@ export class Base extends Model {
    * Mirrors: ActiveRecord::Validations::ClassMethods#validates_uniqueness_of
    */
   declare static validatesUniquenessOf: typeof _Validations.validatesUniquenessOf;
-
-  /**
-   * Clear all validators — including the deferred uniqueness validators kept off
-   * the synchronous validator chain in `_asyncValidations`. Rails'
-   * `clear_validators!` empties every validator on the class; without resetting
-   * `_asyncValidations` here, uniqueness declarations would leak across the
-   * `repair_validations(Topic, Reply)` boundary that test cases rely on.
-   */
-  static clearValidatorsBang(): void {
-    super.clearValidatorsBang();
-    if (Object.prototype.hasOwnProperty.call(this, "_asyncValidations")) {
-      (this as { _asyncValidations?: unknown[] })._asyncValidations = [];
-    }
-  }
 
   // save / saveBang extracted to persistence.ts; wired via include() below.
 

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -834,9 +834,6 @@ export async function save<T extends SaveRecord>(
     self._belongsToDefaultsApplied = false;
   }
   if (!validationsPassed) return false;
-  if (options?.validate !== false) {
-    if (!(await self._runAsyncValidations())) return false;
-  }
   // Mirrors ActiveRecord::Persistence#create_or_update: readonly raises first,
   // then `return false if destroyed?`. `save` returns false (it does not raise)
   // for a destroyed record; `save!` turns that false into

--- a/packages/activerecord/src/validations.ts
+++ b/packages/activerecord/src/validations.ts
@@ -125,34 +125,13 @@ export function _setSuperIsValid(fn: (context?: ValidationContextArg) => Promise
  * :update for persisted). Sets _validationContext for the duration
  * matching Rails' with_validation_context.
  *
- * TRACKED DEVIATION (pending convergence) — uniqueness is NOT run here.
- * Rails' `valid?` runs the full validation chain, including the DB-backed
- * `UniquenessValidator`, because Ruby's DB I/O is synchronous: `valid?`
- * issues the `SELECT 1 ... WHERE attr = ?` inline and returns `false` on a
- * collision. trails keeps the validation chain synchronous (`isValid`
- * returns a `boolean`, never a `Promise`) by design, so uniqueness — which
- * needs a DB round-trip — is registered into the deferred `_asyncValidations`
- * registry (see {@link validatesUniqueness}) and drained only at save time by
- * `Base#_runAsyncValidations` (awaited from persistence). Consequence:
- * `record.isValid()` can return `true` and then `save()`/`saveBang()` still
- * fail on a uniqueness collision.
- *
- * Convergence to Rails' observable `valid?` semantics would require an async
- * validation chain (`isValid` returning a `Promise`), which is barred by the
- * ratified sync-only-validations architecture: `isValid`/`valid?` return a
- * `boolean`, JS has no synchronous DB I/O, and an async `isValid` would ripple
- * through every synchronous caller. This deviation is therefore NOT a wontfix:
- * it is blocked-on-architecture, gated on that sync-only decision being
- * revisited (the same governing constraint behind the `async`-callback-on-sync
- * guard in `@blazetrails/activesupport`'s `callbacks.ts`). A standalone
- * convergence story is intentionally omitted because the only fix — making the
- * validation chain async — is the very thing that decision forbids; it would be
- * a no-op until/unless the architecture itself changes. If sync-only is ever
- * reconsidered, this and `async-validations-honor-validation-context` (the
- * sibling deviation on the same deferred path) become schedulable together.
- * Note Rails' own `valid?` uniqueness check is a TOCTOU race (the pre-check
- * and the INSERT aren't atomic), so the save-time-only behavior here is closer
- * to the concurrency-safe pattern — but it still diverges observably.
+ * Since the validation chain is async (RFC 0063), the DB-backed
+ * `UniquenessValidator` runs inline here like any other validator: `isValid`
+ * awaits the validate callback chain, which issues the
+ * `SELECT 1 ... WHERE attr = ?` existence check and populates `errors` on a
+ * collision — matching Rails' `valid?` (before any save). Uniqueness also
+ * honors the active validation context (`on: :create` etc.) because it now
+ * flows through the context-threaded callback chain.
  */
 export async function isValid(
   this: ValidationsHost,
@@ -330,11 +309,9 @@ export function validates(
   if (arRules.uniqueness) {
     const opts = arRules.uniqueness === true ? {} : (arRules.uniqueness as Record<string, unknown>);
     delete arRules.uniqueness;
-    // Uniqueness needs a DB round-trip, so it routes to the deferred
-    // _asyncValidations registry via validatesUniqueness rather than the
-    // synchronous validatesWith chain (matching Rails' UniquenessValidator).
-    // _runAsyncValidations honors the forwarded on/if/unless/strict guards, so
-    // they pass through unmodified.
+    // Uniqueness registers a UniquenessValidator via validatesUniqueness (which
+    // routes to validatesWith); its async validateEach runs the existence check
+    // inline in the async validation chain, honoring on/if/unless/strict.
     const { attributes: _attributes, ...uniqOpts } = buildOpts(opts) as Record<string, unknown>;
     validatesUniqueness.call(
       this,

--- a/packages/activerecord/src/validations/uniqueness-validation.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.test.ts
@@ -3,11 +3,10 @@
  *
  * Test names are chosen to match Ruby test names from the Rails test suite.
  *
- * Architectural note: trails keeps uniqueness validation off the synchronous
- * validator chain — it needs a DB round-trip, so it runs on `save`, not on the
- * sync `valid?`/`isValid()` pass (see base.ts `_runAsyncValidations`). Rails'
- * bodies assert via `record.valid?`; the faithful trails mirror drives the same
- * record through `save()` and reads `errors` after the deferred check runs.
+ * Since RFC 0063 made the validation chain async, uniqueness runs inline in
+ * `valid?`/`isValid()` like any other validator — `await record.isValid()`
+ * issues the existence check and returns `false` on a collision, matching
+ * Rails' `valid?` before any save.
  */
 import { describe, it, expect, beforeAll, afterEach } from "vitest";
 import { ArgumentError } from "@blazetrails/activemodel";
@@ -157,6 +156,7 @@ describe("UniquenessValidationTest", () => {
     expect(await t.save()).toBe(true);
 
     const t2 = new Topic({ title: "I'm uniqué!" });
+    expect(await t2.isValid()).toBe(false);
     expect(await t2.save()).toBe(false);
     expect(t2.errors.get("title")).toEqual(["has already been taken"]);
 
@@ -617,12 +617,14 @@ describe("UniquenessValidationTest", () => {
     expect(await t4.save()).toBe(true);
   });
 
-  it("validate uniqueness with non callable conditions is not supported", async () => {
-    Topic.validatesUniqueness("title", {
-      conditions: Topic.where({ approved: true }) as any,
-    });
-    const t = new Topic({ title: "test" });
-    await expect(t.save()).rejects.toThrow();
+  it("validate uniqueness with non callable conditions is not supported", () => {
+    // Rails instantiates the validator at declaration time (validates_with),
+    // so a non-callable :conditions raises immediately, not at save.
+    expect(() =>
+      Topic.validatesUniqueness("title", {
+        conditions: Topic.where({ approved: true }) as any,
+      }),
+    ).toThrow();
   });
 
   it("validate uniqueness with conditions with record arg", async () => {

--- a/packages/activerecord/src/validations/uniqueness-validation.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.test.ts
@@ -435,12 +435,25 @@ describe("UniquenessValidationTest", () => {
 
   it("validate uniqueness of with multiple attributes and array forms", async () => {
     // Rails' `validates_uniqueness_of(*attr_names)` arity: `_merge_attributes`
-    // flattens nested arrays and registers a deferred check per attribute, so a
-    // single call can guard several columns. (A string-column variant of the
-    // multi-attr form used by Rails' test_validate_case_insensitive_uniqueness;
-    // the integer `:parent_id` case-insensitive column that test also covers is
-    // asserted directly in "validate case insensitive uniqueness".)
+    // flattens nested arrays into one validator whose EachValidator loop guards
+    // each column, so a single call can guard several columns. (A string-column
+    // variant of the multi-attr form used by Rails'
+    // test_validate_case_insensitive_uniqueness; the integer `:parent_id`
+    // case-insensitive column that test also covers is asserted directly in
+    // "validate case insensitive uniqueness".)
     Topic.validatesUniquenessOf(["title"], "author_name");
+
+    // Rails registers ONE UniquenessValidator owning both attributes
+    // (validates_with UniquenessValidator, _merge_attributes(...)), so it
+    // de-dups to a single instance rather than one per attribute.
+    const uniqValidators = Topic.validators().filter(
+      (v) => (v as { kind?: string }).kind === "uniqueness",
+    );
+    expect(uniqValidators).toHaveLength(1);
+    expect((uniqValidators[0] as { attributes: readonly string[] }).attributes).toEqual([
+      "title",
+      "author_name",
+    ]);
 
     // Fixture topics(:first): title "The First Topic", author_name "David".
     const collideTitle = new Topic({ title: "The First Topic", author_name: "Someone Else" });

--- a/packages/activerecord/src/validations/uniqueness-validation.trails.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.trails.test.ts
@@ -1,0 +1,61 @@
+/**
+ * TS-only coverage for uniqueness validation that has no direct Rails test
+ * counterpart: since RFC 0063 made the validation chain async, uniqueness runs
+ * inside the context-threaded validate callback chain, so `on:` context options
+ * gate it exactly like any other validator (the sibling deviation
+ * `async-validations-honor-validation-context`).
+ */
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
+import { registerModel } from "../associations.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+import { Topic } from "../test-helpers/models/topic.js";
+
+describe("UniquenessValidationContextTest", () => {
+  fixtures(["topics"]);
+
+  beforeAll(() => {
+    registerModel("Topic", Topic);
+  });
+
+  afterEach(() => {
+    Topic.clearValidatorsBang();
+  });
+
+  it("uniqueness honors on: :create context", async () => {
+    Topic.validatesUniqueness("title", { on: "create" });
+
+    const first = await Topic.createBang({ title: "ctx-unique" });
+
+    // A brand-new record validates in the :create context, so the collision
+    // is caught.
+    const dup = new Topic({ title: "ctx-unique" });
+    expect(await dup.isValid()).toBe(false);
+    expect(dup.errors.get("title")).toEqual(["has already been taken"]);
+
+    // A persisted record validates in the :update context, where an `on: :create`
+    // validator does not fire — even though its title collides with itself's
+    // original value on a would-be duplicate.
+    const other = await Topic.createBang({ title: "ctx-other" });
+    other.writeAttribute("title", "ctx-unique");
+    expect(await other.isValid("update")).toBe(true);
+
+    void first;
+  });
+
+  it("uniqueness honors on: :update context", async () => {
+    Topic.validatesUniqueness("title", { on: "update" });
+
+    await Topic.createBang({ title: "upd-unique" });
+
+    // New record in :create context — the `on: :update` validator is skipped.
+    const created = new Topic({ title: "upd-unique" });
+    expect(await created.isValid("create")).toBe(true);
+
+    // Persisted record in :update context — the validator fires and catches the
+    // collision.
+    const persisted = await Topic.createBang({ title: "upd-other" });
+    persisted.writeAttribute("title", "upd-unique");
+    expect(await persisted.isValid("update")).toBe(false);
+    expect(persisted.errors.get("title")).toEqual(["has already been taken"]);
+  });
+});

--- a/packages/activerecord/src/validations/uniqueness-validation.trails.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.trails.test.ts
@@ -6,6 +6,7 @@
  * `async-validations-honor-validation-context`).
  */
 import { describe, it, expect, beforeAll, afterEach } from "vitest";
+import { StrictValidationFailed } from "@blazetrails/activemodel";
 import { registerModel } from "../associations.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { Topic } from "../test-helpers/models/topic.js";
@@ -54,5 +55,21 @@ describe("UniquenessValidationContextTest", () => {
     persisted.writeAttribute("title", "upd-unique");
     expect(await persisted.isValid("update")).toBe(false);
     expect(persisted.errors.get("title")).toEqual(["has already been taken"]);
+  });
+
+  it("strict: true raises StrictValidationFailed on a uniqueness collision", async () => {
+    // Rails leaves :strict in the validator options and forwards it to
+    // errors.add, which raises. In trails, validatesWith's (async-aware) strict
+    // wrapper awaits this DB-backed validator and raises StrictValidationFailed
+    // when it flags a collision.
+    Topic.validatesUniqueness("title", { strict: true });
+
+    await Topic.createBang({ title: "strict-dup" });
+
+    const dup = new Topic({ title: "strict-dup" });
+    await expect(dup.isValid()).rejects.toThrow(StrictValidationFailed);
+
+    const unique = new Topic({ title: "strict-unique" });
+    expect(await unique.isValid()).toBe(true);
   });
 });

--- a/packages/activerecord/src/validations/uniqueness-validation.trails.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.trails.test.ts
@@ -24,7 +24,7 @@ describe("UniquenessValidationContextTest", () => {
   it("uniqueness honors on: :create context", async () => {
     Topic.validatesUniqueness("title", { on: "create" });
 
-    const first = await Topic.createBang({ title: "ctx-unique" });
+    await Topic.createBang({ title: "ctx-unique" });
 
     // A brand-new record validates in the :create context, so the collision
     // is caught.
@@ -33,13 +33,10 @@ describe("UniquenessValidationContextTest", () => {
     expect(dup.errors.get("title")).toEqual(["has already been taken"]);
 
     // A persisted record validates in the :update context, where an `on: :create`
-    // validator does not fire — even though its title collides with itself's
-    // original value on a would-be duplicate.
+    // validator does not fire — even though its changed title now collides.
     const other = await Topic.createBang({ title: "ctx-other" });
     other.writeAttribute("title", "ctx-unique");
     expect(await other.isValid("update")).toBe(true);
-
-    void first;
   });
 
   it("uniqueness honors on: :update context", async () => {

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -175,10 +175,10 @@ export class UniquenessValidator extends EachValidator {
 
     const errorOpts: Record<string, unknown> = { value };
     if (opts?.message != null) errorOpts.message = opts.message;
-    // NOTE: `strict` currently never reaches here — validatesWith strips it and
-    // handles strict via its own (sync-only) wrapper, which does not raise for
-    // async validators. Tracked by the async-strict-validators-raise story
-    // (RFC 0063); Rails passes strict straight through to errors.add.
+    // `strict` does not arrive in options — validatesWith strips it and enforces
+    // it via its own wrapper (now async-aware, so it raises StrictValidationFailed
+    // for this async validator too). This line stays for parity with any caller
+    // that constructs the validator directly with a strict option.
     if (opts?.strict != null) errorOpts.strict = opts.strict;
 
     let [relation] = await buildRelation(modelClass, attribute, mapped, this.options);

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -73,21 +73,17 @@ export function validatesUniqueness(
 }
 
 /**
- * Register deferred uniqueness validations for one or more attributes,
- * delegating through `_mergeAttributes` so multiple / nested-array attr lists
- * (Rails' `*attr_names` arity) and the trailing options hash are normalized the
- * same way as the other `validates_*_of` helpers.
+ * Register a uniqueness validation for one or more attributes, delegating
+ * through `_mergeAttributes` so multiple / nested-array attr lists (Rails'
+ * `*attr_names` arity) and the trailing options hash are normalized the same
+ * way as the other `validates_*_of` helpers.
  *
  * Mirrors: ActiveRecord::Validations::ClassMethods#validates_uniqueness_of
- * (activerecord/lib/active_record/validations/uniqueness.rb:291-292).
- *
- * TRACKED DEVIATION (structural, behavior-preserving) — Rails registers a single
- * `validates_with UniquenessValidator, _merge_attributes(attr_names)`: one
- * validator instance owns the flattened `attributes` list. trails fans the
- * merged names into one `validatesWith(UniquenessValidator, { attributes: [a] })`
- * call each. `EachValidator#validate` loops `attributes.each` either way, so a
- * per-attribute registration produces the same per-attribute `validateEach`
- * calls (same count, same options, same errors) as Rails' single-validator loop.
+ * (activerecord/lib/active_record/validations/uniqueness.rb:291-292) —
+ * `validates_with UniquenessValidator, _merge_attributes(attr_names)`. Like
+ * Rails, this registers a SINGLE `UniquenessValidator` owning the flattened
+ * `attributes` list (its `EachValidator#validate` loops `attributes.each`), so
+ * `validators` de-dups to one instance rather than one per attribute.
  */
 export function validatesUniquenessOf(
   this: {
@@ -96,10 +92,12 @@ export function validatesUniquenessOf(
   },
   ...attrNames: unknown[]
 ): void {
-  const { attributes, ...options } = this._mergeAttributes(attrNames);
-  for (const attribute of attributes as string[]) {
-    validatesUniqueness.call(this, attribute, options);
-  }
+  const merged = this._mergeAttributes(attrNames);
+  // Validate options eagerly to match Rails' ArgumentError at declaration time
+  // (the constructor validates too, but validatesWith reaches it only after
+  // bucketing).
+  validateScopeOption(merged.scope);
+  this.validatesWith(UniquenessValidator, { ...merged, class: this });
 }
 
 export class UniquenessValidator extends EachValidator {

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -33,13 +33,23 @@ function validateScopeOption(scope: unknown): void {
 }
 
 /**
- * Register a deferred uniqueness validation to run on save (since uniqueness
- * requires a DB round-trip, it's kept off the synchronous validator chain).
+ * Register a uniqueness validation. Now that the AR/AM validation chain is
+ * async (RFC 0063), uniqueness runs inline in `valid?` like any other
+ * validator: it registers via `validates_with UniquenessValidator` and the
+ * validator's async `validateEach` issues the `SELECT 1 ... WHERE attr = ?`
+ * existence check, awaited by the validate callback chain.
+ *
+ * The declaring class is threaded through as the `:class` option so the
+ * validator reproduces Rails' `find_finder_class_for` (the existence query
+ * must target the class the validation was declared on — e.g. an abstract STI
+ * base — not the leaf subclass of the record being validated).
  *
  * Mirrors: ActiveRecord::Validations::ClassMethods#validates_uniqueness_of
  */
 export function validatesUniqueness(
-  this: unknown,
+  this: {
+    validatesWith(validatorClass: unknown, opts: Record<string, unknown>): void;
+  },
   attribute: string,
   options: {
     scope?: string | string[];
@@ -47,8 +57,6 @@ export function validatesUniqueness(
     conditions?: (this: any) => any;
     caseSensitive?: boolean;
     allowNil?: boolean;
-    // Context-guard keys honored by Base#_runAsyncValidations (it re-applies
-    // the on:/if:/unless: intersection that the sync callback chain installs).
     on?: string | string[];
     if?: unknown;
     unless?: unknown;
@@ -57,15 +65,11 @@ export function validatesUniqueness(
 ): void {
   // Validate options eagerly to match Rails' ArgumentError at declaration time.
   validateScopeOption(options.scope);
-  const klass = this as { _asyncValidations?: Array<unknown> };
-  if (!Object.prototype.hasOwnProperty.call(klass, "_asyncValidations")) {
-    klass._asyncValidations = [...(klass._asyncValidations ?? [])];
-  }
-  // Capture the declaring class so the deferred runner can reproduce Rails'
-  // `find_finder_class_for` (the existence query must target the class the
-  // validation was declared on — e.g. an abstract STI base — not the leaf
-  // subclass of the record being validated).
-  (klass._asyncValidations as Array<unknown>).push({ attribute, options, declaringClass: this });
+  this.validatesWith(UniquenessValidator, {
+    ...options,
+    attributes: [attribute],
+    class: this,
+  });
 }
 
 /**
@@ -79,23 +83,17 @@ export function validatesUniqueness(
  *
  * TRACKED DEVIATION (structural, behavior-preserving) — Rails registers a single
  * `validates_with UniquenessValidator, _merge_attributes(attr_names)`: one
- * validator instance owns the flattened `attributes` list, and
- * `EachValidator#validate` loops `attributes.each { |a| validate_each(record, a, value) }`
- * (activemodel/lib/active_model/validations/with.rb:88-104 →
- * each_validator.rb#validate). trails keeps uniqueness OFF the synchronous
- * validator chain in the `_asyncValidations` registry (the ratified sync-only
- * deviation documented on `isValid` in validations.ts), and that registry is
- * keyed by a single `attribute` per entry — `Base#_runAsyncValidations`
- * constructs one `UniquenessValidator` per entry and calls `validateEach` once,
- * never iterating a multi-attribute `attributes` array. So fanning the merged
- * names into one deferred entry each is the faithful equivalent: it produces the
- * same per-attribute `validateEach` calls (same count, same options, same
- * errors) as Rails' single-validator/`attributes.each` loop. Carrying them in
- * one entry would require teaching the deferred runner to loop `attributes`,
- * duplicating Rails' EachValidator loop in a different layer — out of scope here.
+ * validator instance owns the flattened `attributes` list. trails fans the
+ * merged names into one `validatesWith(UniquenessValidator, { attributes: [a] })`
+ * call each. `EachValidator#validate` loops `attributes.each` either way, so a
+ * per-attribute registration produces the same per-attribute `validateEach`
+ * calls (same count, same options, same errors) as Rails' single-validator loop.
  */
 export function validatesUniquenessOf(
-  this: { _mergeAttributes(attrNames: unknown[]): Record<string, unknown> },
+  this: {
+    _mergeAttributes(attrNames: unknown[]): Record<string, unknown>;
+    validatesWith(validatorClass: unknown, opts: Record<string, unknown>): void;
+  },
   ...attrNames: unknown[]
 ): void {
   const { attributes, ...options } = this._mergeAttributes(attrNames);
@@ -134,9 +132,29 @@ export class UniquenessValidator extends EachValidator {
     this._klass = options.class ?? null;
   }
 
-  validateEach(record: any, attribute: string, value: unknown): void {
-    // Mirror EachValidator#validate's allow_nil/allow_blank guard (the deferred
-    // runner calls validateEach directly, bypassing EachValidator#validate).
+  /**
+   * Rails' EachValidator#validate reads `record.read_attribute_for_validation`,
+   * which for an association returns the (loaded) associated object. trails'
+   * `readAttributeForValidation` deliberately does NOT lazy-load an unloaded
+   * association (to avoid strict-loading violations), so for an association
+   * attribute we read the underlying foreign-key scalar instead — build_relation
+   * reflects on the same attribute and compares the FK, matching Rails'
+   * observable existence check without triggering a load.
+   *
+   * @internal
+   */
+  protected override readAttributeForValidation(record: any, attribute: string): unknown {
+    const refl = record?.constructor?._reflectOnAssociation?.(attribute);
+    if (refl) {
+      const fk = Array.isArray(refl.foreignKey) ? refl.foreignKey[0] : refl.foreignKey;
+      return record.readAttribute(fk);
+    }
+    return super.readAttributeForValidation(record, attribute);
+  }
+
+  async validateEach(record: any, attribute: string, value: unknown): Promise<void> {
+    // Mirror EachValidator#validate's allow_nil/allow_blank guard (EachValidator
+    // already applies it, but validateEach is defensive against direct calls).
     if (value === undefined) return;
     const o = this.options as { allowNil?: unknown; allowBlank?: unknown };
     if (value == null && o.allowNil === true) return;
@@ -157,61 +175,52 @@ export class UniquenessValidator extends EachValidator {
 
     const opts = this.options as any;
 
-    let asyncValidations = record._asyncValidationPromises as Promise<unknown>[] | undefined;
-    if (!Array.isArray(asyncValidations)) {
-      asyncValidations = [];
-      record._asyncValidationPromises = asyncValidations;
-    }
-
     const errorOpts: Record<string, unknown> = { value };
     if (opts?.message != null) errorOpts.message = opts.message;
     if (opts?.strict != null) errorOpts.strict = opts.strict;
 
-    const validationPromise = (async () => {
-      let [relation] = await buildRelation(modelClass, attribute, mapped, this.options);
+    let [relation] = await buildRelation(modelClass, attribute, mapped, this.options);
 
-      if (record.isPersisted?.()) {
-        const pk = modelClass.primaryKey;
-        // Rails raises UnknownPrimaryKey rather than excluding the record by id
-        // when a persisted record's finder class has no primary key — there is
-        // no way to exclude the row itself from the existence check.
-        if (pk == null) {
-          throw new UnknownPrimaryKey(
-            modelClass,
-            "Cannot validate uniqueness for persisted record without primary key.",
-          );
-        }
-        if (Array.isArray(pk)) {
-          const dbVals = pk.map((col: string) =>
-            record._dirty?.attributeChanged(col)
-              ? record._dirty.attributeWas(col)
-              : record.readAttribute(col),
-          );
-          relation = relation.whereNot(pk, [dbVals]);
-        } else {
-          const dbVal = record._dirty?.attributeChanged(pk)
-            ? record._dirty.attributeWas(pk)
-            : record.readAttribute(pk);
-          relation = relation.whereNot({ [pk]: [dbVal] });
-        }
+    if (record.isPersisted?.()) {
+      const pk = modelClass.primaryKey;
+      // Rails raises UnknownPrimaryKey rather than excluding the record by id
+      // when a persisted record's finder class has no primary key — there is
+      // no way to exclude the row itself from the existence check.
+      if (pk == null) {
+        throw new UnknownPrimaryKey(
+          modelClass,
+          "Cannot validate uniqueness for persisted record without primary key.",
+        );
       }
-
-      relation = scopeRelation(record, relation, this.options);
-
-      if (opts?.conditions && typeof opts.conditions === "function") {
-        const conditioned =
-          opts.conditions.length === 0
-            ? opts.conditions.call(relation)
-            : opts.conditions.call(relation, record);
-        if (conditioned != null) relation = conditioned;
+      if (Array.isArray(pk)) {
+        const dbVals = pk.map((col: string) =>
+          record._dirty?.attributeChanged(col)
+            ? record._dirty.attributeWas(col)
+            : record.readAttribute(col),
+        );
+        relation = relation.whereNot(pk, [dbVals]);
+      } else {
+        const dbVal = record._dirty?.attributeChanged(pk)
+          ? record._dirty.attributeWas(pk)
+          : record.readAttribute(pk);
+        relation = relation.whereNot({ [pk]: [dbVal] });
       }
+    }
 
-      const exists = await relation.exists();
-      if (exists) {
-        record.errors.add(attribute, "taken", errorOpts);
-      }
-    })();
-    asyncValidations.push(validationPromise);
+    relation = scopeRelation(record, relation, this.options);
+
+    if (opts?.conditions && typeof opts.conditions === "function") {
+      const conditioned =
+        opts.conditions.length === 0
+          ? opts.conditions.call(relation)
+          : opts.conditions.call(relation, record);
+      if (conditioned != null) relation = conditioned;
+    }
+
+    const exists = await relation.exists();
+    if (exists) {
+      record.errors.add(attribute, "taken", errorOpts);
+    }
   }
 }
 

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -177,6 +177,10 @@ export class UniquenessValidator extends EachValidator {
 
     const errorOpts: Record<string, unknown> = { value };
     if (opts?.message != null) errorOpts.message = opts.message;
+    // NOTE: `strict` currently never reaches here — validatesWith strips it and
+    // handles strict via its own (sync-only) wrapper, which does not raise for
+    // async validators. Tracked by the async-strict-validators-raise story
+    // (RFC 0063); Rails passes strict straight through to errors.add.
     if (opts?.strict != null) errorOpts.strict = opts.strict;
 
     let [relation] = await buildRelation(modelClass, attribute, mapped, this.options);


### PR DESCRIPTION
With the AR/AM validation chain async (RFC 0063-async-validation-chain), uniqueness no longer needs the deferred `_asyncValidations` registry. `validatesUniqueness` now registers a normal `UniquenessValidator` via `validatesWith`, whose async `validateEach` issues the `SELECT 1 ... WHERE attr = ?` existence check inline in the context-threaded validate callback chain — matching Rails `UniquenessValidator`.

## Changes
- `validations/uniqueness.ts`: `validatesUniqueness` / `validatesUniquenessOf` route to `validatesWith(UniquenessValidator, ...)`; `validateEach` is now async and self-contained (no `_asyncValidationPromises`). `validatesUniquenessOf` registers a SINGLE validator owning the merged attributes list (Rails' `validates_with UniquenessValidator, _merge_attributes(attr_names)`), so `validators` de-dups to one instance. Added a `readAttributeForValidation` override so an association attribute reads its FK scalar without lazy-loading.
- `base.ts`: deleted `_runAsyncValidations`, the instance-promise drain, `asyncValidationContextMatches`, and the `clearValidatorsBang` STI-reset (super's clear now handles uniqueness like any validator).
- `persistence.ts`: dropped the save-time `_runAsyncValidations` call.
- `associations/builder/belongs-to.ts`: converted the deferred "must exist" existence check to a normal async validator.
- `activemodel/model.ts`: `validatesWith`'s strict wrapper now awaits async validators before inspecting its temp errors, so `strict: true` raises `StrictValidationFailed` for DB-backed validators (uniqueness / associated) again — the sync-only wrapper had silently stopped raising post-RFC-0063. Sync validators are unaffected.
- Uniqueness now honors validation context (`on: :create` etc.) — the sibling `async-validations-honor-validation-context` deviation is fixed because it flows through the context-threaded chain.

## Tests
- `uniqueness-validation.test.ts`: `await record.isValid()` returns `false` on a collision before save (Rails `valid?` parity); non-callable `:conditions` raises at declaration; multi-attribute `validatesUniquenessOf` de-dups to one validator instance.
- `uniqueness-validation.trails.test.ts`: `on: :create` / `on: :update` context coverage, plus `strict: true` raising `StrictValidationFailed` on a collision.
- All activemodel (565) + AR validation + belongs_to + transactions + autosave suites pass locally on SQLite; CI green.

`_asyncValidations` / `_runAsyncValidations` are deleted repo-wide (grep-gate zero in package src).

Closes-story: uniqueness-inline-delete-deferred-registry
Closes-story: async-strict-validators-raise