### PR TITLE
fix(validations): drop double-serialize in uniqueness build_relation

### DIFF
--- a/packages/activerecord/src/validations/uniqueness-validation.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.test.ts
@@ -223,16 +223,15 @@ describe("UniquenessValidationTest", () => {
     expect(await t.save()).toBe(true);
   });
 
-  // SKIPPED (story: unskip-content-uniqueness-shared-db-flake). These 5
-  // content-uniqueness tests validate `Reply.content` (a serialize-wrapped
-  // column) and hit a pre-existing shared-DB flake on CI: a just-persisted r1 is
-  // not seen by r2's uniqueness query (r1.isPersisted() passes; save() wrongly
-  // returns true) when co-scheduled in a fork worker that leaves the content
-  // serialize decorator unloaded (uniqueness.ts:408 decorated.coder falsy → the
-  // WHERE binds raw "hello world" instead of the stored "hello world\n"). Passes
-  // in isolation and in the full local suite; the identical signature has hit ≥6
-  // unrelated PRs. Un-skip + fix the decorator-loading/shared-DB fragility there.
-  it.skip("validate uniqueness with scope", async () => {
+  // These 5 content-uniqueness tests validate `Reply.content` (a serialize-
+  // wrapped column). They were skipped by #4738 as a suspected shared-DB flake,
+  // but the true cause was a deterministic double-serialize in build_relation
+  // (uniqueness.ts): it dumped the value through the coder AND the bind path
+  // re-dumped it via the arel table's decorated type, so r2's query looked for
+  // `"hello world\n\n"` and never matched r1's stored `"hello world\n"` — the
+  // collision was missed and `save()` wrongly returned true. Fixed by dropping
+  // the manual serialize (Rails lets `bind_attribute`/the type serialize once).
+  it("validate uniqueness with scope", async () => {
     Reply.validatesUniqueness("content", { scope: "parent_id" });
 
     const t = await Topic.create({ title: "I'm unique!" });
@@ -251,8 +250,8 @@ describe("UniquenessValidationTest", () => {
     expect(r3.isPersisted()).toBe(true);
   });
 
-  // SKIPPED: see unskip-content-uniqueness-shared-db-flake note above.
-  it.skip("validate uniqueness with aliases", async () => {
+  // Un-skipped: see the double-serialize note on "validate uniqueness with scope".
+  it("validate uniqueness with aliases", async () => {
     // Rails validates :new_content scope :new_parent_id (aliases of content /
     // parent_id, already declared on Reply).
     Reply.validatesUniqueness("newContent", { scope: "newParentId" });
@@ -275,8 +274,8 @@ describe("UniquenessValidationTest", () => {
     }).toThrow(ArgumentError);
   });
 
-  // SKIPPED: see unskip-content-uniqueness-shared-db-flake note above.
-  it.skip("validate uniqueness with object scope", async () => {
+  // Un-skipped: see the double-serialize note on "validate uniqueness with scope".
+  it("validate uniqueness with object scope", async () => {
     // Rails `scope: :topic` — scope by the belongs_to association name, which
     // resolve_attributes/scope_relation expand to the parent_id foreign key.
     Reply.validatesUniqueness("content", { scope: "topic" });
@@ -306,8 +305,8 @@ describe("UniquenessValidationTest", () => {
     }
   });
 
-  // SKIPPED: see unskip-content-uniqueness-shared-db-flake note above.
-  it.skip("validate uniqueness with composed attribute scope", async () => {
+  // Un-skipped: see the double-serialize note on "validate uniqueness with scope".
+  it("validate uniqueness with composed attribute scope", async () => {
     // Rails `ReplyWithTitleObject` validates content scoped to :title; the
     // dedicated subclass carries the validation so it does not perturb the
     // shared Reply/UniqueReply models.
@@ -332,8 +331,8 @@ describe("UniquenessValidationTest", () => {
     expect(await r2.save()).toBe(false);
   });
 
-  // SKIPPED: see unskip-content-uniqueness-shared-db-flake note above.
-  it.skip("validate uniqueness scoped to defining class", async () => {
+  // Un-skipped: see the double-serialize note on "validate uniqueness with scope".
+  it("validate uniqueness scoped to defining class", async () => {
     const t = await Topic.create({ title: "What, me worry?" });
 
     // UniqueReply / SillyUniqueReply carry the uniqueness validation (defined on

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -393,21 +393,13 @@ async function buildRelation(
   const typeObj =
     typeof klass.typeForAttribute === "function" ? klass.typeForAttribute(attribute) : null;
 
-  // Serialized columns (`serialize :content`) store the coder-dumped form, so
-  // the comparison must bind the serialized value — Rails produces it via the
-  // attribute type during `bind_attribute` and still flows it through
-  // `default_uniqueness_comparison`. The decorated (coder-wrapping) type lives
-  // on `attributeTypes()` (the base.ts `typeForAttribute` override returns the
-  // undecorated cast type), and on an STI subclass it is inherited via the
-  // replayed pending decorators. We serialize the value here and fall through to
-  // the comparison path below (rather than short-circuiting), so a serialized
-  // column with `case_sensitive:` still picks the right SQL comparison.
-  const decorated = klass.attributeTypes?.()?.[attribute] as
-    | { coder?: unknown; serialize?: (v: unknown) => unknown }
-    | undefined;
-  if (decorated?.coder && typeof decorated.serialize === "function") {
-    value = decorated.serialize(value);
-  }
+  // Serialized columns (`serialize :content`) store the coder-dumped form, but
+  // the value is NOT serialized here: the bind path below runs it through the
+  // attribute's (decorated, coder-wrapping) type, which the arel table resolves
+  // via `typeForAttribute` — so `buildBindAttribute` / `where` already emit the
+  // coder-dumped form. Serializing here too would double-dump (`"x\n"` →
+  // `"x\n\n"`) and never match the stored row. Mirrors Rails' `build_relation`,
+  // which hands the raw value to `bind_attribute` and lets the type serialize.
 
   // When the attribute supports unencrypted data alongside encrypted values, the
   // patched Relation#where (ExtendedDeterministicQueries) must receive a hash-style


### PR DESCRIPTION
## Summary

The 5 content-uniqueness tests in `uniqueness-validation.test.ts` validate
`Reply.content` — a `serialize`-wrapped column — and were `it.skip`ped by #4738
as a suspected shared-DB fork-scheduling flake. Investigating the un-skipped
tests reproduced the failure **deterministically** (locally, all adapters), so
it was never a flake.

## Root cause

`build_relation` (`validations/uniqueness.ts`) manually dumped the value
through the serialize coder (`value = decorated.serialize(value)`) **and** the
bind path (`predicateBuilder.buildBindAttribute` → the arel table's decorated
`typeForAttribute`) dumped it again. So for `content: "hello world"`:

- r1 persists `"hello world\n"` (one dump — correct).
- r2's uniqueness query binds `"hello world\n\n"` (two dumps) → matches no row →
  collision missed → `save()` wrongly returns `true` (the `expected true to be
  false` signature).

Confirmed via direct probe: `where({ content: "hello world\n" }).count()` → 0,
`where({ content: "hello world" }).count()` → matches, proving the query layer
already serializes once on its own.

Rails' `build_relation` never serializes by hand — it hands the raw value to
`bind_attribute` and lets the attribute type serialize exactly once. The trails
manual serialize was a deviation that only became harmful once the arel table's
`typeForAttribute` resolved the decorated (coder-wrapping) type.

## Fix

Drop the manual serialize; keep the bind path as the single serialization
point. Un-skip the 5 tests.

## Verification

- `uniqueness-validation.test.ts`: 54 passed, 2 skipped (the remaining 2 are
  PG-only `skipIf` cases), including the 5 un-skipped tests.
- `serialization.test.ts`: 9 passed.
- Adapter-independent (the bug is in value binding), so it holds across SQLite /
  PostgreSQL / MariaDB — CI confirms.

Closes-story: unskip-content-uniqueness-shared-db-flake
