### PR TITLE
fix(enum): raise on friendly-alias/sibling collision within one enum

### DIFF
--- a/packages/activerecord/src/enum.trails.test.ts
+++ b/packages/activerecord/src/enum.trails.test.ts
@@ -68,7 +68,9 @@ describe("Enum name conflict detection", () => {
   // label's friendly alias and a sibling label's generated predicate/bang.
   // The camelCase friendly-alias surface is trails-specific: `"api-key"`
   // camelizes to `apiKey` → `isApiKey`, which also is `api_key`'s main
-  // predicate, defining `isApiKey` twice.
+  // predicate, defining `isApiKey` twice. Because both share the one
+  // `_enum_methods_module`, Rails reports `source: "another enum"`
+  // (enum.rb:302-310, 388-395), not the default "Active Record".
   it("raises when a friendly alias collides with a sibling label within one enum", () => {
     expect(() => {
       class Klass extends Base {
@@ -77,8 +79,7 @@ describe("Enum name conflict detection", () => {
           this.enum("status", { "api-key": 0, api_key: 1 });
         }
       }
-      new Klass();
-    }).toThrow(/already defined/);
+    }).toThrow(/already defined by another enum/);
   });
 
   // Rails runs the `?`/`!` `detect_enum_conflict!` calls *only* inside

--- a/packages/activerecord/src/enum.trails.test.ts
+++ b/packages/activerecord/src/enum.trails.test.ts
@@ -62,6 +62,25 @@ describe("Enum name conflict detection", () => {
     }).toThrow(/already defined by another enum/);
   });
 
+  // Rails defines each special-char label's friendly alias immediately through
+  // `_enum_methods_module` (enum.rb:273-275), so `detect_enum_conflict!`
+  // (enum.rb:302-310, 381-384) catches a same-enum collision between one
+  // label's friendly alias and a sibling label's generated predicate/bang.
+  // The camelCase friendly-alias surface is trails-specific: `"api-key"`
+  // camelizes to `apiKey` → `isApiKey`, which also is `api_key`'s main
+  // predicate, defining `isApiKey` twice.
+  it("raises when a friendly alias collides with a sibling label within one enum", () => {
+    expect(() => {
+      class Klass extends Base {
+        static _tableName = "books";
+        static {
+          this.enum("status", { "api-key": 0, api_key: 1 });
+        }
+      }
+      new Klass();
+    }).toThrow(/already defined/);
+  });
+
   // Rails runs the `?`/`!` `detect_enum_conflict!` calls *only* inside
   // `if instance_methods` (enum.rb:303-311), so a second enum that opts out of
   // instance methods can reuse a value-method name a prior enum generated — no

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -709,8 +709,17 @@ export function _enum(
     // `instance_methods: false` must not raise on a predicate-name collision it
     // will never generate.
     if (instanceMethodsEnabled) {
-      if (definedNames.has(predicateName)) raiseConflictError.call(this, attribute, predicateName);
-      if (definedNames.has(bangName)) raiseConflictError.call(this, attribute, bangName);
+      // `definedNames` models Rails' `_enum_methods_module`: every
+      // `define_enum_methods` call within a single `_enum` defines into that one
+      // module, so an intra-enum collision (a later label reusing an earlier
+      // label's predicate/bang — including its friendly alias) hits
+      // `method_defined_within?(method_name, _enum_methods_module, Module)` and
+      // reports `source: "another enum"` (enum.rb:302-310, 388-395), not the
+      // default "Active Record".
+      if (definedNames.has(predicateName))
+        raiseConflictError.call(this, attribute, predicateName, { source: "another enum" });
+      if (definedNames.has(bangName))
+        raiseConflictError.call(this, attribute, bangName, { source: "another enum" });
       definedNames.add(predicateName);
       definedNames.add(bangName);
       // Instance value methods (predicate/bang) only conflict with *dangerous*
@@ -752,9 +761,12 @@ export function _enum(
         // already-defined method within the *same* enum (enum.rb:273-275,
         // 302-310, 381-384). Mirror the main-label branch: check and record
         // `fp`/`friendlyBang` in `definedNames` so one label's friendly alias
-        // colliding with a sibling label's generated predicate/bang raises.
-        if (definedNames.has(fp)) raiseConflictError.call(this, attribute, fp);
-        if (definedNames.has(friendlyBang)) raiseConflictError.call(this, attribute, friendlyBang);
+        // colliding with a sibling label's generated predicate/bang raises with
+        // `source: "another enum"` (module membership, per the main-label note).
+        if (definedNames.has(fp))
+          raiseConflictError.call(this, attribute, fp, { source: "another enum" });
+        if (definedNames.has(friendlyBang))
+          raiseConflictError.call(this, attribute, friendlyBang, { source: "another enum" });
         definedNames.add(fp);
         definedNames.add(friendlyBang);
         if (dangerousMethods.has(fp)) raiseConflictError.call(this, attribute, fp);

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -747,6 +747,16 @@ export function _enum(
         notScopeName: notFriendlyName,
       } = enumMethodNamesFor(friendlyName);
       if (instanceMethodsEnabled) {
+        // Rails defines each friendly alias immediately through
+        // `_enum_methods_module`, so `detect_enum_conflict!` catches an
+        // already-defined method within the *same* enum (enum.rb:273-275,
+        // 302-310, 381-384). Mirror the main-label branch: check and record
+        // `fp`/`friendlyBang` in `definedNames` so one label's friendly alias
+        // colliding with a sibling label's generated predicate/bang raises.
+        if (definedNames.has(fp)) raiseConflictError.call(this, attribute, fp);
+        if (definedNames.has(friendlyBang)) raiseConflictError.call(this, attribute, friendlyBang);
+        definedNames.add(fp);
+        definedNames.add(friendlyBang);
         if (dangerousMethods.has(fp)) raiseConflictError.call(this, attribute, fp);
         if (enumMethodNames.has(fp))
           raiseConflictError.call(this, attribute, fp, { source: "another enum" });


### PR DESCRIPTION
## What

The `_enum` conflict-detection pass's friendly-alias branch
(`packages/activerecord/src/enum.ts`) checked a special-char label's
friendly-alias predicate/bang (`fp`, `friendlyBang`) against `dangerousMethods`
and the cross-enum `enumMethodNames` set, but — unlike the main-label branch —
never added them to the per-enum `definedNames` set, nor checked membership
there.

Consequence: within a **single** enum, one label's friendly alias could
silently collide with a later label's generated method without raising. E.g.
`{ "api-key": 0, api_key: 1 }` — `"api-key"` camelizes to `apiKey` → `isApiKey`,
and `api_key`'s main predicate is also `isApiKey`. The pass defined `isApiKey`
twice; Rails raises on the second.

## Fix

Mirror the main-label branch: check `definedNames.has(fp/friendlyBang)` and
raise, then `definedNames.add(...)`. Matches Rails' per-alias
`detect_enum_conflict!` via `_enum_methods_module` (enum.rb:273-275, 302-310,
381-384).

**Source is `"another enum"`, not `"Active Record"`.** `definedNames` models
Rails' `_enum_methods_module`: every `define_enum_methods` call within one
`_enum` defines into that single module, so an intra-enum collision hits
`method_defined_within?(method_name, _enum_methods_module, Module)` and reports
`source: "another enum"` (enum.rb:302-310, 388-395). The collision in the
`{ "api-key": 0, api_key: 1 }` case actually surfaces on the second label's
main predicate (`isApiKey`) reusing the first label's friendly alias, so this
correction is applied to **both** the main-label and friendly-alias branches
(the pre-existing main-label `definedNames` raise had the same divergence).

## Tests

Added a trails-specific case (the camelCase alias surface has no Rails
enum_test.rb counterpart) asserting `{ "api-key": 0, api_key: 1 }` raises with
`/already defined by another enum/`. Full `enum.test.ts` +
`enum.trails.test.ts` green; `api:compare` green for `enum.rb`.

Closes-story: enum-friendly-alias-intra-enum-conflict