### PR TITLE
test(has_one): await async isValid/isInvalid in failure-path assertions

### DIFF
--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -830,7 +830,7 @@ describe("HasOneAssociationsTest", () => {
     expect(newShip.isEqual(ships("black_pearl"))).toBe(false);
     expect((await readHasOne(pirate, "ship")).isEqual(newShip)).toBe(true);
     expect(newShip.isNewRecord()).toBe(true);
-    expect(newShip.isInvalid()).toBe(true);
+    expect(await newShip.isInvalid()).toBe(true);
     expect(origShip.pirate_id).toBeNull();
     expect(origShip.changed).toBe(false); // check it was saved
   });
@@ -841,7 +841,7 @@ describe("HasOneAssociationsTest", () => {
 
     const newShip = await pirate.createDependentShip();
     expect(newShip.isNewRecord()).toBe(true);
-    expect(newShip.isInvalid()).toBe(true);
+    expect(await newShip.isInvalid()).toBe(true);
     expect(origShip.isDestroyed()).toBe(true);
   });
 
@@ -870,7 +870,7 @@ describe("HasOneAssociationsTest", () => {
     const currentShip = await readHasOne(pirate, "ship");
     currentShip.name = null;
 
-    expect(currentShip.isValid()).toBe(false);
+    expect(await currentShip.isValid()).toBe(false);
     let error: any;
     try {
       await pirate.association("ship").writer(ships("interceptor"));


### PR DESCRIPTION
## Summary

The "Active Record MariaDB Tests (1)" job was red on `main` @a00347c0. The
failure was not adapter-specific — three `has_one` failure-path tests added in
#4832 asserted `isInvalid()`/`isValid()` **synchronously**:

```ts
expect(newShip.isInvalid()).toBe(true);
expect(currentShip.isValid()).toBe(false);
```

But `isValid`/`isInvalid` return `Promise<boolean>` (RFC 0063 async
validations), so the un-awaited Promise compared unequal to the boolean
literal and the assertions failed on every adapter. Added the missing `await`.

## Test plan

- `pnpm vitest run packages/activerecord/src/associations/has-one-associations.test.ts` — 95 passed (sqlite)
- Same file with `ARCONN=mysql2` against MariaDB/MySQL — 95 passed

Closes-story: red-a00347c0