### PR TITLE
fix(query-cache): gate disabled on config, not nil max size

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -1468,17 +1468,17 @@ export class ConnectionPool implements ReapablePool {
  * public config type also accepts the documented "enabled"/"disabled"/
  * "unlimited" strings, which Rails would never see as raw values. Normalize
  * them so a pool configured with `queryCache: "disabled"` actually disables
- * storage instead of falling through to DEFAULT_MAX_SIZE. `"unlimited"` maps
- * to `Infinity` — a max size the Store never reaches, so it never evicts. That
- * mirrors Rails `query_cache: "unlimited"`, which (matching no `0/false/
- * Integer/nil` case) falls through to a `nil` (unbounded) max size.
+ * storage instead of falling through to DEFAULT_MAX_SIZE. `"unlimited"` passes
+ * through as-is: Rails' initializer case-matches it against no `0/false/Integer/
+ * nil` branch and falls through to a `nil` (unbounded) max size, and unlike
+ * `false` it does NOT mark the pool disabled (`db_config.query_cache == false`).
  */
-function normalizeQueryCacheConfig(raw: unknown): number | false | null | undefined {
-  if (raw === "disabled" || raw === false || raw === 0) return false;
-  if (raw === "unlimited") return Number.POSITIVE_INFINITY;
-  if (raw === "enabled" || raw === true || raw == null) return raw as null | undefined;
+function normalizeQueryCacheConfig(raw: unknown): number | false | null | "unlimited" {
+  if (raw === "disabled" || raw === false) return false;
+  if (raw === "unlimited") return "unlimited";
+  if (raw === "enabled" || raw === true || raw == null) return null;
   if (typeof raw === "number") return raw;
-  return undefined;
+  return null;
 }
 
 function isTransactionAware(conn: DatabaseAdapter): conn is TransactionAwareConnection {

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -1465,19 +1465,20 @@ export class ConnectionPool implements ReapablePool {
 /**
  * Map `DatabaseConfig#queryCache` to the shape ConnectionPoolConfiguration
  * expects. Rails' initializer case-matches on `0/false/Integer/nil`; trails'
- * public config type also accepts the documented "enabled"/"disabled"/
- * "unlimited" strings, which Rails would never see as raw values. Normalize
- * them so a pool configured with `queryCache: "disabled"` actually disables
- * storage instead of falling through to DEFAULT_MAX_SIZE. `"unlimited"` passes
- * through as-is: Rails' initializer case-matches it against no `0/false/Integer/
- * nil` branch and falls through to a `nil` (unbounded) max size, and unlike
- * `false` it does NOT mark the pool disabled (`db_config.query_cache == false`).
+ * public config type additionally documents the "enabled"/"disabled" string
+ * aliases, which Rails would never see as raw values. Only those two are
+ * translated ("disabled" → `false`, "enabled" → the `nil`/default branch);
+ * every other string is passed through untouched. Rails' `case
+ * db_config&.query_cache` has NO String branch, so any surviving string (e.g.
+ * `"unlimited"`, or a URL like `?query_cache=42` that stays the string `"42"`)
+ * falls through to a `nil` (unbounded) max size — NOT DEFAULT_SIZE — and, unlike
+ * `false`, does NOT mark the pool disabled (`db_config.query_cache == false`).
  */
-function normalizeQueryCacheConfig(raw: unknown): number | false | null | "unlimited" {
+function normalizeQueryCacheConfig(raw: unknown): number | false | null | string {
   if (raw === "disabled" || raw === false) return false;
-  if (raw === "unlimited") return "unlimited";
   if (raw === "enabled" || raw === true || raw == null) return null;
   if (typeof raw === "number") return raw;
+  if (typeof raw === "string") return raw;
   return null;
 }
 

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -224,14 +224,19 @@ export class ConnectionPoolConfiguration {
   private _queryCacheVersion = { value: 0 };
   private _pinnedCount = 0;
 
-  constructor(queryCacheConfig?: number | false | null | "unlimited") {
+  constructor(queryCacheConfig?: number | false | null | string) {
     // Mirrors Rails' `@query_cache_max_size = case db_config&.query_cache`
     // (`query_cache.rb:120-129`): `0`/`false` → nil, an Integer → itself, `nil`
-    // → DEFAULT_SIZE, and any other value (e.g. the "unlimited" string) falls
-    // through the case to nil (unbounded). A nil max size is NOT what marks a
-    // pool disabled — that gate is `db_config&.query_cache == false`.
+    // → DEFAULT_SIZE, and — since the case has no String branch — any string
+    // (e.g. "unlimited", or a `?query_cache=42` URL that stays the string "42")
+    // falls through to nil (unbounded). A nil max size is NOT what marks a pool
+    // disabled — that gate is `db_config&.query_cache == false`.
     this._queryCacheDisabled = queryCacheConfig === false;
-    if (queryCacheConfig === 0 || queryCacheConfig === false || queryCacheConfig === "unlimited") {
+    if (
+      queryCacheConfig === 0 ||
+      queryCacheConfig === false ||
+      typeof queryCacheConfig === "string"
+    ) {
       this._queryCacheMaxSize = null;
     } else if (typeof queryCacheConfig === "number") {
       this._queryCacheMaxSize = queryCacheConfig;

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -220,11 +220,18 @@ export interface QueryCacheHost extends DatabaseStatementsHost {
 export class ConnectionPoolConfiguration {
   private _threadQueryCaches = new QueryCacheRegistry();
   private _queryCacheMaxSize: number | null;
+  private _queryCacheDisabled: boolean;
   private _queryCacheVersion = { value: 0 };
   private _pinnedCount = 0;
 
-  constructor(queryCacheConfig?: number | false | null) {
-    if (queryCacheConfig === 0 || queryCacheConfig === false) {
+  constructor(queryCacheConfig?: number | false | null | "unlimited") {
+    // Mirrors Rails' `@query_cache_max_size = case db_config&.query_cache`
+    // (`query_cache.rb:120-129`): `0`/`false` → nil, an Integer → itself, `nil`
+    // → DEFAULT_SIZE, and any other value (e.g. the "unlimited" string) falls
+    // through the case to nil (unbounded). A nil max size is NOT what marks a
+    // pool disabled — that gate is `db_config&.query_cache == false`.
+    this._queryCacheDisabled = queryCacheConfig === false;
+    if (queryCacheConfig === 0 || queryCacheConfig === false || queryCacheConfig === "unlimited") {
       this._queryCacheMaxSize = null;
     } else if (typeof queryCacheConfig === "number") {
       this._queryCacheMaxSize = queryCacheConfig;
@@ -288,11 +295,13 @@ export class ConnectionPoolConfiguration {
 
   /**
    * Whether this pool's query cache is disabled by configuration
-   * (`db_config.query_cache == false`). The authoritative gate now lives in
-   * `QueryCache.run`, mirroring Rails' `next if pool.db_config&.query_cache == false`.
+   * (`db_config.query_cache == false`). Gates strictly on the config value, not
+   * on the max size being nil — Rails' `QueryCache.run` skips a pool with
+   * `next if pool.db_config&.query_cache == false`, and both `false` and
+   * `"unlimited"` leave the max size nil.
    */
   get queryCacheDisabled(): boolean {
-    return this._queryCacheMaxSize === null;
+    return this._queryCacheDisabled;
   }
 
   disableQueryCacheBang(): void {
@@ -318,7 +327,12 @@ export class ConnectionPoolConfiguration {
 
   get queryCache(): Store {
     return this._threadQueryCaches.computeIfAbsent(String(executionContextId()), () => {
-      return new Store(this._queryCacheVersion, this._queryCacheMaxSize ?? 0);
+      // A null max size is Rails' "unbounded" (nil) — the Store never evicts.
+      // trails' Store keys unboundedness off a number, so map nil to Infinity.
+      return new Store(
+        this._queryCacheVersion,
+        this._queryCacheMaxSize ?? Number.POSITIVE_INFINITY,
+      );
     });
   }
 

--- a/packages/activerecord/src/query-cache.test.ts
+++ b/packages/activerecord/src/query-cache.test.ts
@@ -74,8 +74,8 @@ function assertCache(
 // per-connection `Store`; trails' `Store` coalesces a disabled pool's `nil`
 // size to `0`, so the faithful value lives on the pool's cache config
 // (`@query_cache_max_size` in Rails). `false`/`0` → `null`, an Integer → that
-// integer, `nil` → the default size (100). trails represents Rails' "unbounded"
-// `nil` (the fall-through for a raw string like "unlimited") as `Infinity`.
+// integer, `nil` → the default size (100). Rails' fall-through for a raw string
+// like "unlimited" leaves it `nil` (unbounded), same as `false`/`0`.
 function poolQueryCacheMaxSize(pool: ConnectionPool): number | null {
   return (pool as unknown as { _cacheConfig: { _queryCacheMaxSize: number | null } })._cacheConfig
     ._queryCacheMaxSize;
@@ -233,12 +233,7 @@ describe("QueryCacheTest", () => {
     const mw = middleware(async () => {
       await Base.connectedTo({ role: "reading" }, async () => {
         assertCache("clean");
-        // Rails leaves `@max_size` nil (unbounded) for a raw string config;
-        // trails overloads null as "disabled" so represents unbounded as
-        // `Infinity` (converged by 0023-surfaced-deviations:
-        // query-cache-disabled-gate-on-config-not-maxsize, which will flip this
-        // assertion to null).
-        expect(poolQueryCacheMaxSize(Base.connectionPool())).toBe(Number.POSITIVE_INFINITY);
+        expect(poolQueryCacheMaxSize(Base.connectionPool())).toBeNull();
       });
     });
 


### PR DESCRIPTION
## What

Rails' `QueryCache.run` skips a pool with `db_config&.query_cache == false`
(`connection_adapters/abstract/query_cache.rb:39`), and its initializer
(`query_cache.rb:120-129`) leaves `@query_cache_max_size` **nil** for BOTH
`query_cache: false` and the fall-through `query_cache: "unlimited"` string.

trails instead overloaded `_queryCacheMaxSize === null` as "disabled". Because
null already meant disabled, `normalizeQueryCacheConfig` could not map
`"unlimited"` to the unbounded nil and mapped it to `Infinity`, forcing the
ported `cache is applied when config is string` test to assert `Infinity`
where Rails asserts nil.

## Change

- `ConnectionPoolConfiguration` now tracks `_queryCacheDisabled` separately,
  gated strictly on `queryCacheConfig === false` (Rails' `db_config&.query_cache
  == false`), and `queryCacheDisabled` returns it.
- Both `false` and `"unlimited"` leave `_queryCacheMaxSize` null; the
  per-context `Store` maps a null max size to `Infinity` (unbounded).
- `normalizeQueryCacheConfig` passes `"unlimited"` through to the constructor's
  fall-through path instead of pre-mapping it to `Infinity`.
- Flipped `cache is applied when config is string` to assert null, Rails-verbatim,
  and dropped the Infinity-deviation comment.

Tests: `query-cache.test.ts` passes (56 passed, 11 skipped).

Closes-story: query-cache-disabled-gate-on-config-not-maxsize