### PR TITLE
fix(query-cache): thread run's enabled pools into complete

### DIFF
--- a/packages/activerecord/src/query-cache.test.ts
+++ b/packages/activerecord/src/query-cache.test.ts
@@ -33,10 +33,11 @@ function middleware(app: () => unknown | Promise<unknown>): () => Promise<void> 
   // Resolve the pool list lazily on each run/complete so pools established
   // after the middleware is built (the multi-role `connected_to(role: :reading)`
   // tests) are included, mirroring Rails' `connection_pool_list(:all)`.
-  // (Rails threads run's enabled-pool result into complete so a disabled pool
-  // is never touched on complete; installExecutorHooks returns run's
-  // enabled-target list and threads it into complete for the same reason —
-  // mirroring the executor's per-execution hook_state.)
+  // (Rails threads run's return — the whole not-already-enabled receiver — into
+  // complete via the executor's per-execution hook_state, so complete acts on
+  // exactly the list this execution's run observed rather than re-resolving it;
+  // installExecutorHooks returns that list from run and threads it into
+  // complete for the same reason.)
   QueryCache.installExecutorHooks({ registerHook: (h) => (hook = h) }, () =>
     Base.connectionHandler.connectionPoolList("all"),
   );

--- a/packages/activerecord/src/query-cache.test.ts
+++ b/packages/activerecord/src/query-cache.test.ts
@@ -31,8 +31,8 @@ function middleware(app: () => unknown | Promise<unknown>): () => Promise<void> 
   // after the middleware is built (the multi-role `connected_to(role: :reading)`
   // tests) are included, mirroring Rails' `connection_pool_list(:all)`.
   // (Rails threads run's enabled-pool result into complete so a disabled pool
-  // is never touched on complete; trails re-resolves the full list — tracked by
-  // 0023-surfaced-deviations: query-cache-run-returns-enabled-pools-for-complete.)
+  // is never touched on complete; installExecutorHooks carries run's
+  // enabled-target list into complete for the same reason.)
   QueryCache.installExecutorHooks({ registerHook: (h) => (hook = h) }, () =>
     Base.connectionHandler.connectionPoolList("all"),
   );

--- a/packages/activerecord/src/query-cache.test.ts
+++ b/packages/activerecord/src/query-cache.test.ts
@@ -13,7 +13,7 @@ import { Post } from "./test-helpers/models/post.js";
 import { association } from "./associations.js";
 import { Rollback } from "./errors.js";
 import { assertQueriesCount, assertNoQueries } from "./testing/query-assertions.js";
-import { QueryCache } from "./query-cache.js";
+import { QueryCache, type QueryCacheCompleteTarget } from "./query-cache.js";
 import { LogSubscriber } from "./log-subscriber.js";
 import { Notifications, Logger, type NotificationEvent } from "@blazetrails/activesupport";
 import type { ConnectionPool } from "./connection-adapters/abstract/connection-pool.js";
@@ -26,22 +26,26 @@ for (const m of [Task, Topic, Category, Post]) registerModel(m as never);
 // wraps the block — enabling the query cache on every pool for the request and
 // disabling + clearing it afterward.
 function middleware(app: () => unknown | Promise<unknown>): () => Promise<void> {
-  let hook: { run(): void; complete(): void } | null = null;
+  let hook: {
+    run(): QueryCacheCompleteTarget[];
+    complete(pools: QueryCacheCompleteTarget[]): void;
+  } | null = null;
   // Resolve the pool list lazily on each run/complete so pools established
   // after the middleware is built (the multi-role `connected_to(role: :reading)`
   // tests) are included, mirroring Rails' `connection_pool_list(:all)`.
   // (Rails threads run's enabled-pool result into complete so a disabled pool
-  // is never touched on complete; installExecutorHooks carries run's
-  // enabled-target list into complete for the same reason.)
+  // is never touched on complete; installExecutorHooks returns run's
+  // enabled-target list and threads it into complete for the same reason —
+  // mirroring the executor's per-execution hook_state.)
   QueryCache.installExecutorHooks({ registerHook: (h) => (hook = h) }, () =>
     Base.connectionHandler.connectionPoolList("all"),
   );
   return async () => {
-    hook!.run();
+    const enabled = hook!.run();
     try {
       await app();
     } finally {
-      hook!.complete();
+      hook!.complete(enabled);
     }
   };
 }

--- a/packages/activerecord/src/query-cache.trails.test.ts
+++ b/packages/activerecord/src/query-cache.trails.test.ts
@@ -10,6 +10,7 @@ import { fixtures } from "./test-helpers/fixtures.js";
 import { Base } from "./base.js";
 import { Task } from "./test-helpers/models/task.js";
 import { Notifications, type NotificationEvent } from "@blazetrails/activesupport";
+import { QueryCache } from "./query-cache.js";
 
 registerModel(Task as never);
 
@@ -119,5 +120,68 @@ describe("cacheNotificationInfo payload (trails)", () => {
     const cached = payloads.filter((p) => p.cached);
     expect(cached.length).toBe(1);
     expect(cached[0].name).toBeUndefined();
+  });
+});
+
+// Covers the run→complete pool threading (0023-surfaced-deviations:
+// query-cache-run-returns-enabled-pools-for-complete). Rails' `QueryCache.run`
+// returns the pools it enabled and the executor threads that exact list into
+// `complete(pools)`, so a pool skipped by `run` is never touched by `complete`.
+describe("run returns enabled targets for complete (trails)", () => {
+  class FakeTarget {
+    queryCacheEnabled = false;
+    disabled: boolean;
+    enabledCount = 0;
+    disabledCount = 0;
+    clearedCount = 0;
+    constructor(disabledByConfig = false) {
+      this.disabled = disabledByConfig;
+    }
+    get queryCacheDisabled(): boolean {
+      return this.disabled;
+    }
+    enableQueryCacheBang(): void {
+      this.enabledCount++;
+      this.queryCacheEnabled = true;
+    }
+    disableQueryCacheBang(): void {
+      this.disabledCount++;
+      this.queryCacheEnabled = false;
+    }
+    clearQueryCache(): void {
+      this.clearedCount++;
+    }
+  }
+
+  it("run returns only the targets it enabled", () => {
+    const enabled = new FakeTarget();
+    const configDisabled = new FakeTarget(true);
+    const alreadyEnabled = new FakeTarget();
+    alreadyEnabled.queryCacheEnabled = true;
+
+    const result = QueryCache.run([enabled, configDisabled, alreadyEnabled]);
+
+    expect(result).toEqual([enabled]);
+    expect(enabled.enabledCount).toBe(1);
+    expect(configDisabled.enabledCount).toBe(0);
+    expect(alreadyEnabled.enabledCount).toBe(0);
+  });
+
+  it("complete only disables/clears the pools run enabled", () => {
+    const enabled = new FakeTarget();
+    const configDisabled = new FakeTarget(true);
+    let hook: { run(): void; complete(): void } | null = null;
+    QueryCache.installExecutorHooks({ registerHook: (h) => (hook = h) }, () => [
+      enabled,
+      configDisabled,
+    ]);
+
+    hook!.run();
+    hook!.complete();
+
+    expect(enabled.disabledCount).toBe(1);
+    expect(enabled.clearedCount).toBe(1);
+    expect(configDisabled.disabledCount).toBe(0);
+    expect(configDisabled.clearedCount).toBe(0);
   });
 });

--- a/packages/activerecord/src/query-cache.trails.test.ts
+++ b/packages/activerecord/src/query-cache.trails.test.ts
@@ -170,18 +170,47 @@ describe("run returns enabled targets for complete (trails)", () => {
   it("complete only disables/clears the pools run enabled", () => {
     const enabled = new FakeTarget();
     const configDisabled = new FakeTarget(true);
-    let hook: { run(): void; complete(): void } | null = null;
-    QueryCache.installExecutorHooks({ registerHook: (h) => (hook = h) }, () => [
+    let hook: {
+      run(): FakeTarget[];
+      complete(pools: FakeTarget[]): void;
+    } | null = null;
+    QueryCache.installExecutorHooks({ registerHook: (h) => (hook = h as never) }, () => [
       enabled,
       configDisabled,
     ]);
 
-    hook!.run();
-    hook!.complete();
+    const state = hook!.run();
+    hook!.complete(state);
 
     expect(enabled.disabledCount).toBe(1);
     expect(enabled.clearedCount).toBe(1);
     expect(configDisabled.disabledCount).toBe(0);
     expect(configDisabled.clearedCount).toBe(0);
+  });
+
+  it("threads each execution's own run result to its complete", () => {
+    // Rails keeps per-execution hook_state and passes run's return to complete
+    // as an argument (execution_wrapper.rb:25-37): overlapping/nested executions
+    // must not clobber each other's enabled-pool list. Interleave two runs
+    // against different pool sets before either completes.
+    const outer = new FakeTarget();
+    const inner = new FakeTarget();
+    let pools: FakeTarget[] = [outer];
+    let hook: {
+      run(): FakeTarget[];
+      complete(pools: FakeTarget[]): void;
+    } | null = null;
+    QueryCache.installExecutorHooks({ registerHook: (h) => (hook = h as never) }, () => pools);
+
+    const outerState = hook!.run(); // enables outer
+    pools = [inner];
+    const innerState = hook!.run(); // enables inner
+    hook!.complete(innerState);
+    hook!.complete(outerState);
+
+    expect(outerState).toEqual([outer]);
+    expect(innerState).toEqual([inner]);
+    expect(outer.disabledCount).toBe(1);
+    expect(inner.disabledCount).toBe(1);
   });
 });

--- a/packages/activerecord/src/query-cache.trails.test.ts
+++ b/packages/activerecord/src/query-cache.trails.test.ts
@@ -124,10 +124,13 @@ describe("cacheNotificationInfo payload (trails)", () => {
 });
 
 // Covers the run→complete pool threading (0023-surfaced-deviations:
-// query-cache-run-returns-enabled-pools-for-complete). Rails' `QueryCache.run`
-// returns the pools it enabled and the executor threads that exact list into
-// `complete(pools)`, so a pool skipped by `run` is never touched by `complete`.
-describe("run returns enabled targets for complete (trails)", () => {
+// query-cache-run-returns-enabled-pools-for-complete). Ruby's `Array#each`
+// returns its receiver, so Rails' `QueryCache.run` returns the whole
+// `reject(&:query_cache_enabled)` array — config-disabled pools included — and
+// the executor threads that exact list into `complete(pools)`. The point of
+// the fix is that `complete` acts on the list *run* observed, not one it
+// re-resolves independently.
+describe("run returns not-already-enabled targets for complete (trails)", () => {
   class FakeTarget {
     queryCacheEnabled = false;
     disabled: boolean;
@@ -153,7 +156,7 @@ describe("run returns enabled targets for complete (trails)", () => {
     }
   }
 
-  it("run returns only the targets it enabled", () => {
+  it("run returns the not-already-enabled targets without enabling config-disabled ones", () => {
     const enabled = new FakeTarget();
     const configDisabled = new FakeTarget(true);
     const alreadyEnabled = new FakeTarget();
@@ -161,13 +164,16 @@ describe("run returns enabled targets for complete (trails)", () => {
 
     const result = QueryCache.run([enabled, configDisabled, alreadyEnabled]);
 
-    expect(result).toEqual([enabled]);
+    // Mirrors Rails' `reject(&:query_cache_enabled)` receiver: the already
+    // enabled pool is dropped, the config-disabled pool stays in the returned
+    // list (it is `next`-skipped, not rejected) but is never enabled.
+    expect(result).toEqual([enabled, configDisabled]);
     expect(enabled.enabledCount).toBe(1);
     expect(configDisabled.enabledCount).toBe(0);
     expect(alreadyEnabled.enabledCount).toBe(0);
   });
 
-  it("complete only disables/clears the pools run enabled", () => {
+  it("complete disables/clears every target run returned, config-disabled included", () => {
     const enabled = new FakeTarget();
     const configDisabled = new FakeTarget(true);
     let hook: {
@@ -182,10 +188,13 @@ describe("run returns enabled targets for complete (trails)", () => {
     const state = hook!.run();
     hook!.complete(state);
 
+    // Rails threads run's whole receiver into complete, so disable!/clear run
+    // on the config-disabled pool too — inert (it was never enabled) but a
+    // faithful mirror of query_cache.rb:44-49.
     expect(enabled.disabledCount).toBe(1);
     expect(enabled.clearedCount).toBe(1);
-    expect(configDisabled.disabledCount).toBe(0);
-    expect(configDisabled.clearedCount).toBe(0);
+    expect(configDisabled.disabledCount).toBe(1);
+    expect(configDisabled.clearedCount).toBe(1);
   });
 
   it("threads each execution's own run result to its complete", () => {

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -84,18 +84,25 @@ export class QueryCache {
 
   /**
    * Enable query cache on all provided pools/adapters, skipping those whose
-   * cache is already enabled or disabled by configuration.
+   * cache is already enabled or disabled by configuration. Returns the targets
+   * it actually enabled so `complete` can be threaded exactly those — a pool
+   * skipped by `run` (already enabled, or `query_cache: false`) is therefore
+   * never disabled/cleared by `complete`.
    * Called at the start of a request/execution context.
    *
    * Mirrors: ActiveRecord::QueryCache.run
    * (`each_connection_pool.reject(&:query_cache_enabled).each { next if
-   * pool.db_config&.query_cache == false; pool.enable_query_cache! }`)
+   * pool.db_config&.query_cache == false; pool.enable_query_cache! }`), whose
+   * return value the executor threads into `complete(pools)`.
    */
-  static run(targets: QueryCacheRunTarget[]): void {
+  static run<T extends QueryCacheRunTarget>(targets: T[]): T[] {
+    const enabled: T[] = [];
     for (const target of targets) {
       if (target.queryCacheEnabled || target.queryCacheDisabled) continue;
       target.enableQueryCacheBang();
+      enabled.push(target);
     }
+    return enabled;
   }
 
   /**
@@ -127,13 +134,19 @@ export class QueryCache {
     if (!executor) return;
     const resolve = typeof targets === "function" ? targets : () => targets;
 
-    // Mirrors Rails' ExecutorHooks module with static run/complete
+    // Mirrors Rails' ExecutorHooks module with static run/complete. Rails'
+    // executor threads `run`'s return value into `complete(pools)` as its
+    // state; we carry the enabled-target list across the two static calls so
+    // `complete` only touches the pools `run` enabled (never a config-disabled
+    // pool `run` skipped).
     class ExecutorHooks {
+      static enabledTargets: (QueryCacheRunTarget & QueryCacheCompleteTarget)[] = [];
       static run() {
-        QueryCache.run(resolve());
+        ExecutorHooks.enabledTargets = QueryCache.run(resolve());
       }
       static complete() {
-        QueryCache.complete(resolve());
+        QueryCache.complete(ExecutorHooks.enabledTargets);
+        ExecutorHooks.enabledTargets = [];
       }
     }
 

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -93,7 +93,12 @@ export class QueryCache {
    * Mirrors: ActiveRecord::QueryCache.run
    * (`each_connection_pool.reject(&:query_cache_enabled).each { next if
    * pool.db_config&.query_cache == false; pool.enable_query_cache! }`), whose
-   * return value the executor threads into `complete(pools)`.
+   * return value the executor threads into `complete(pools)`. Rails' block
+   * returns the rejected array (config-disabled pools included, since
+   * `disable_query_cache!`/`clear_query_cache` no-op there); we return only the
+   * enabled subset because in trails `clearQueryCache` on an unenabled pool
+   * still lazily instantiates its `Store` (and bumps the version when pinned),
+   * so leaving config-disabled pools untouched is behaviorally meaningful here.
    */
   static run<T extends QueryCacheRunTarget>(targets: T[]): T[] {
     const enabled: T[] = [];

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -130,7 +130,10 @@ export class QueryCache {
    */
   static installExecutorHooks(
     executor?: {
-      registerHook(hook: { run(): void; complete(): void }): void;
+      registerHook(hook: {
+        run(): (QueryCacheRunTarget & QueryCacheCompleteTarget)[];
+        complete(pools: QueryCacheCompleteTarget[]): void;
+      }): void;
     },
     targets:
       | (QueryCacheRunTarget & QueryCacheCompleteTarget)[]
@@ -140,18 +143,18 @@ export class QueryCache {
     const resolve = typeof targets === "function" ? targets : () => targets;
 
     // Mirrors Rails' ExecutorHooks module with static run/complete. Rails'
-    // executor threads `run`'s return value into `complete(pools)` as its
-    // state; we carry the enabled-target list across the two static calls so
-    // `complete` only touches the pools `run` enabled (never a config-disabled
-    // pool `run` skipped).
+    // executor keeps per-execution `hook_state` and passes `run`'s return value
+    // as the argument to `complete` (execution_wrapper.rb:25-37, :145-148), so
+    // `run` returns the enabled-pool list and `complete` receives it — no
+    // shared state that a nested/overlapping execution could clobber. `complete`
+    // then only touches the pools `run` enabled (never a config-disabled pool
+    // `run` skipped).
     class ExecutorHooks {
-      static enabledTargets: (QueryCacheRunTarget & QueryCacheCompleteTarget)[] = [];
-      static run() {
-        ExecutorHooks.enabledTargets = QueryCache.run(resolve());
+      static run(): (QueryCacheRunTarget & QueryCacheCompleteTarget)[] {
+        return QueryCache.run(resolve());
       }
-      static complete() {
-        QueryCache.complete(ExecutorHooks.enabledTargets);
-        ExecutorHooks.enabledTargets = [];
+      static complete(pools: QueryCacheCompleteTarget[]): void {
+        QueryCache.complete(pools);
       }
     }
 

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -83,31 +83,31 @@ export class QueryCache {
   }
 
   /**
-   * Enable query cache on all provided pools/adapters, skipping those whose
-   * cache is already enabled or disabled by configuration. Returns the targets
-   * it actually enabled so `complete` can be threaded exactly those — a pool
-   * skipped by `run` (already enabled, or `query_cache: false`) is therefore
-   * never disabled/cleared by `complete`.
+   * Enable query cache on all provided pools/adapters that are not already
+   * enabled, skipping (without enabling) those disabled by configuration.
+   * Returns the not-already-enabled targets — the receiver of Rails' `each`,
+   * config-disabled pools included — so the executor can thread that exact list
+   * into `complete`.
    * Called at the start of a request/execution context.
    *
    * Mirrors: ActiveRecord::QueryCache.run
    * (`each_connection_pool.reject(&:query_cache_enabled).each { next if
-   * pool.db_config&.query_cache == false; pool.enable_query_cache! }`), whose
-   * return value the executor threads into `complete(pools)`. Rails' block
-   * returns the rejected array (config-disabled pools included, since
-   * `disable_query_cache!`/`clear_query_cache` no-op there); we return only the
-   * enabled subset because in trails `clearQueryCache` on an unenabled pool
-   * still lazily instantiates its `Store` (and bumps the version when pinned),
-   * so leaving config-disabled pools untouched is behaviorally meaningful here.
+   * pool.db_config&.query_cache == false; pool.enable_query_cache! }`). Ruby's
+   * `Array#each` returns its receiver, so `run` returns the whole
+   * `reject(&:query_cache_enabled)` array (including the config-disabled pools
+   * `next` skips over), and the executor threads it into `complete(pools)`.
+   * `complete` disabling/clearing a config-disabled pool is inert in Rails
+   * exactly as in trails — `disable_query_cache!` re-disables an already-off
+   * cache and `clear_query_cache` only bumps the version when pinned
+   * (query_cache.rb:164-190) — so we mirror Rails rather than pre-filter.
    */
   static run<T extends QueryCacheRunTarget>(targets: T[]): T[] {
-    const enabled: T[] = [];
-    for (const target of targets) {
-      if (target.queryCacheEnabled || target.queryCacheDisabled) continue;
+    const notAlreadyEnabled = targets.filter((target) => !target.queryCacheEnabled);
+    for (const target of notAlreadyEnabled) {
+      if (target.queryCacheDisabled) continue;
       target.enableQueryCacheBang();
-      enabled.push(target);
     }
-    return enabled;
+    return notAlreadyEnabled;
   }
 
   /**
@@ -145,10 +145,10 @@ export class QueryCache {
     // Mirrors Rails' ExecutorHooks module with static run/complete. Rails'
     // executor keeps per-execution `hook_state` and passes `run`'s return value
     // as the argument to `complete` (execution_wrapper.rb:25-37, :145-148), so
-    // `run` returns the enabled-pool list and `complete` receives it — no
-    // shared state that a nested/overlapping execution could clobber. `complete`
-    // then only touches the pools `run` enabled (never a config-disabled pool
-    // `run` skipped).
+    // `run` returns its not-already-enabled receiver and `complete` receives
+    // that exact list — no shared state a nested/overlapping execution could
+    // clobber, and `complete` acts only on the pools this execution's `run`
+    // observed rather than re-resolving the list independently.
     class ExecutorHooks {
       static run(): (QueryCacheRunTarget & QueryCacheCompleteTarget)[] {
         return QueryCache.run(resolve());


### PR DESCRIPTION
## Summary

The real divergence surfaced by PR #4850: trails' `installExecutorHooks`
re-resolved the pool list independently in `run` and in `complete`, so
`complete` acted on a *different* list than `run` observed (pools established or
torn down between the two calls). Rails instead threads `run`'s return value
into `complete(pools)` via the executor's per-execution `hook_state`
(`execution_wrapper.rb:25-37`, `:145-148`), so `complete` sees exactly what
`run` saw.

## Changes

- `QueryCache.run` returns its receiver — the whole
  `reject(&:query_cache_enabled)` list, config-disabled pools included, matching
  Ruby's `Array#each` return (`query_cache.rb:37-41`).
- `installExecutorHooks` registers a hook whose `run()` returns that list and
  whose `complete(pools)` receives it as an argument (no shared class state that
  a nested/overlapping execution could clobber) — mirroring Rails' per-execution
  `hook_state`.
- Focused trails unit tests: `run`'s receiver contents, `complete` acting on
  exactly that list, and a nested/overlapping-execution test proving each
  execution threads its own `run` result.

### Note on config-disabled pools

An earlier revision pre-filtered `run` to only the pools it enabled, on the
belief that `complete` touching a `query_cache: false` pool was a trails-only
side effect. That was wrong: Rails' pool-side `clear_query_cache` bumps the
version only when pinned and `disable_query_cache!` re-disables an already-off
cache (`query_cache.rb:164-190`) — identical to trails — and Rails still returns
config-disabled pools to `complete`. So this PR mirrors Rails rather than
pre-filtering. The ported `cache is not applied when config is false` test
passes unchanged.

## Verification

- `pnpm vitest run packages/activerecord/src/query-cache.test.ts` — 56 passed
- `pnpm vitest run packages/activerecord/src/query-cache.trails.test.ts` — 7 passed
- Pre-commit `tsc --build` + project typecheck clean

Closes-story: query-cache-run-returns-enabled-pools-for-complete