### PR TITLE
refactor(quoting): bare-literal quote_default_expression + cast-type serialize

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
@@ -118,6 +118,13 @@ describeIfSqlite("SQLite3AdapterTest", () => {
     expect(col?.default).toEqual("{}");
   });
 
+  // quote_default_expression serializes through the column's cast type exactly
+  // once (abstract/quoting.rb:161); a structured json default must not be
+  // double-encoded to `'"{}"'` by both a pre-serialize and `super`'s serialize.
+  it("quote default expression serializes a structured json default once", () => {
+    expect(adapter.quoteDefaultExpression({}, { sqlType: "json" })).toEqual("'{}'");
+  });
+
   it("exec insert", async () => {
     const id = await adapter.executeMutation(`INSERT INTO "items" ("name") VALUES ('test')`);
     expect(id).toBe(1);

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -816,18 +816,29 @@ export class AbstractAdapter implements Quoting {
     return this.quoteTableName(`${table}.${attr}`);
   }
 
-  quoteDefaultExpression(value: unknown, _column?: unknown): string {
+  quoteDefaultExpression(value: unknown, column?: unknown): string {
     if (value === undefined) return "";
     if (typeof value === "function") {
       const result = (value as () => unknown)();
-      if (typeof result === "string") return ` DEFAULT ${result}`;
-      if (isSqlLiteral(result)) return ` DEFAULT ${result.value}`;
+      if (typeof result === "string") return result;
+      if (isSqlLiteral(result)) return result.value;
       throw new TypeError(
         "quoteDefaultExpression expected function default to return a string or SqlLiteral",
       );
     }
-    if (isSqlLiteral(value)) return ` DEFAULT ${value.value}`;
-    return ` DEFAULT ${this.quote(value)}`;
+    if (isSqlLiteral(value)) return value.value;
+    // Rails: `value = lookup_cast_type(column.sql_type).serialize(value)`
+    // (abstract/quoting.rb:161) before quoting. Returns a bare literal — the
+    // ` DEFAULT ` keyword is owned by the caller (add_column_options!).
+    let serialized: unknown = value;
+    const sqlType = (column as { sqlType?: string | null } | undefined)?.sqlType;
+    if (sqlType) {
+      const castType = this.lookupCastTypeFromColumn({ sqlType }) as {
+        serialize?(v: unknown): unknown;
+      };
+      if (typeof castType?.serialize === "function") serialized = castType.serialize(value);
+    }
+    return this.quote(serialized);
   }
 
   quotedTrue(): string {

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -259,32 +259,49 @@ export function quoteTableNameForAssignment(table: string, attr: string): string
  * - A function: `() => "CURRENT_TIMESTAMP"` (mirrors Rails `-> { "CURRENT_TIMESTAMP" }`)
  * - An Arel SqlLiteral: `new SqlLiteral("CURRENT_TIMESTAMP")` (mirrors `Arel.sql(...)`)
  *
- * All other values are quoted as literals via `quote()`.
+ * Non-Proc values are serialized through the column's cast type before quoting
+ * (rb:161 `lookup_cast_type(column.sql_type).serialize(value)`), then quoted via
+ * `quote()`. The returned literal is **bare** — the ` DEFAULT ` keyword is owned
+ * by the caller (`add_column_options!`, `schema_creation.rb:150`), matching Rails.
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#quote_default_expression
  */
 export function quoteDefaultExpression(
-  this: QuotingDispatchHost | void,
+  this: (QuotingDispatchHost & QuotingHost) | void,
   value: unknown,
-  _column?: unknown,
+  column?: { sqlType?: string | null } | null,
 ): string {
   if (value === undefined) return "";
   if (typeof value === "function") {
     const result = (value as () => unknown)();
-    if (typeof result === "string") return ` DEFAULT ${result}`;
-    if (isSqlLiteral(result)) return ` DEFAULT ${result.value}`;
+    if (typeof result === "string") return result;
+    if (isSqlLiteral(result)) return result.value;
     throw new TypeError(
       "quoteDefaultExpression expected function default to return a string or SqlLiteral",
     );
   }
-  if (isSqlLiteral(value)) return ` DEFAULT ${value.value}`;
+  if (isSqlLiteral(value)) return value.value;
+  // Rails: `value = lookup_cast_type(column.sql_type).serialize(value)`
+  // (abstract/quoting.rb:161). Serialize only when the host exposes a cast type
+  // with a `serialize` — the adapter-free fallback (ABSTRACT_SCHEMA_QUOTER) and
+  // the mysql schema-quoter have no `lookupCastType`, so `lookupCastTypeFromColumn`
+  // returns the raw sqlType string and the value passes through unserialized.
+  let serialized: unknown = value;
+  if (column != null) {
+    const castType = lookupCastTypeFromColumn.call(this || undefined, {
+      sqlType: column.sqlType ?? null,
+    }) as { serialize?(v: unknown): unknown } | null;
+    if (castType && typeof castType.serialize === "function") {
+      serialized = castType.serialize(value);
+    }
+  }
   // Rails: `quote(value)` (abstract/quoting.rb:162) — self-dispatched, so a host
   // that overrides `quote` (the mysql schema-quoter binds the dialect's) gets its
   // own dialect quoting, including the raw-view branches the abstract `quote`
   // deliberately lacks. Falling straight to the module `quote` here would bypass
   // the dialect entirely and raise `can't quote Uint8Array` on a binary default.
   // Hosts without a `quote` (ABSTRACT_SCHEMA_QUOTER) keep the module helper.
-  return ` DEFAULT ${dispatchQuote(this || {}, value)}`;
+  return dispatchQuote(this || {}, serialized);
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -259,7 +259,7 @@ export class SchemaCreation {
         parts.push(`ALTER COLUMN ${col} DROP DEFAULT`);
       } else {
         parts.push(
-          `ALTER COLUMN ${col} SET${this.adapter.quoteDefaultExpression(change.defaultValue)}`,
+          `ALTER COLUMN ${col} SET DEFAULT ${this.adapter.quoteDefaultExpression(change.defaultValue)}`,
         );
       }
     }
@@ -346,10 +346,12 @@ export class SchemaCreation {
 
   addColumnOptions(sql: string, options: ColumnOptions): string {
     if (this.optionsIncludeDefault(options)) {
-      sql += this.adapter.quoteDefaultExpression(
+      // Rails: `sql << " DEFAULT #{quote_default_expression(...)}"`
+      // (schema_creation.rb:150) — the keyword lives here, not in the quoter.
+      sql += ` DEFAULT ${this.adapter.quoteDefaultExpression(
         options.default,
         (options as Record<string, unknown>)["column"],
-      );
+      )}`;
     }
     if (options.null === false) {
       sql += " NOT NULL";
@@ -371,7 +373,10 @@ export class SchemaCreation {
    * from `{ default: nil, null: false }`.
    */
   protected optionsIncludeDefault(options: ColumnOptions): boolean {
-    if (!("default" in options)) return false;
+    // `undefined` is trails' marker for an absent default (Rails has only
+    // `nil`); treat it as not-included so the ` DEFAULT ` keyword — now owned by
+    // this caller rather than the quoter — is not emitted with an empty literal.
+    if (!("default" in options) || options.default === undefined) return false;
     return !(options.null === false && options.default === null);
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -11,7 +11,7 @@ function makeStatements(adapterOverrides: Record<string, unknown> = {}) {
     adapterName: "sqlite" as const,
     quoteIdentifier: (n: string) => `"${n}"`,
     quoteTableName: (n: string) => `"${n}"`,
-    quoteDefaultExpression: (v: unknown) => ` DEFAULT ${v}`,
+    quoteDefaultExpression: (v: unknown) => `${v}`,
     execute: vi.fn().mockResolvedValue([]),
     executeMutation: vi.fn().mockResolvedValue(undefined),
     config: {},

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -550,7 +550,10 @@ export class SchemaStatements {
 
     if (this.adapterName === "mysql") {
       const nullable = options.null === false ? " NOT NULL" : "";
-      const defaultClause = this.adapter.quoteDefaultExpression(options.default);
+      const defaultClause =
+        options.default === undefined
+          ? ""
+          : ` DEFAULT ${this.adapter.quoteDefaultExpression(options.default)}`;
       await this.adapter.executeMutation(
         `ALTER TABLE ${table} MODIFY COLUMN ${col} ${sqlType}${nullable}${defaultClause}`,
       );
@@ -563,13 +566,16 @@ export class SchemaStatements {
       }
       if (options.default !== undefined) {
         clauses.push(
-          `ALTER COLUMN ${col} SET${this.adapter.quoteDefaultExpression(options.default)}`,
+          `ALTER COLUMN ${col} SET DEFAULT ${this.adapter.quoteDefaultExpression(options.default)}`,
         );
       }
       await this.adapter.executeMutation(`ALTER TABLE ${table} ${clauses.join(", ")}`);
     } else {
       const nullable = options.null === false ? " NOT NULL" : "";
-      const defaultClause = this.adapter.quoteDefaultExpression(options.default);
+      const defaultClause =
+        options.default === undefined
+          ? ""
+          : ` DEFAULT ${this.adapter.quoteDefaultExpression(options.default)}`;
       await this.adapter.executeMutation(
         `ALTER TABLE ${table} ALTER COLUMN ${col} TYPE ${sqlType}${nullable}${defaultClause}`,
       );
@@ -670,7 +676,7 @@ export class SchemaStatements {
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
     const clause = this.adapter.quoteDefaultExpression(defaultVal);
     await this.adapter.executeMutation(
-      `ALTER TABLE ${this._qi(tableName)} ALTER COLUMN ${this._qi(columnName)} SET${clause || " DEFAULT NULL"}`,
+      `ALTER TABLE ${this._qi(tableName)} ALTER COLUMN ${this._qi(columnName)} SET DEFAULT ${clause || "NULL"}`,
     );
   }
 
@@ -681,7 +687,7 @@ export class SchemaStatements {
     defaultValue?: unknown,
   ): Promise<void> {
     if (!allowNull && defaultValue !== undefined) {
-      const quoted = this.adapter.quoteDefaultExpression(defaultValue).replace(/^ DEFAULT /, "");
+      const quoted = this.adapter.quoteDefaultExpression(defaultValue);
       await this.adapter.executeMutation(
         `UPDATE ${this._qi(tableName)} SET ${this._qi(columnName)} = ${quoted} WHERE ${this._qi(columnName)} IS NULL`,
       );
@@ -2623,7 +2629,7 @@ export class SchemaStatements {
     if (newDefault == null) {
       return `ALTER COLUMN ${col} DROP DEFAULT`;
     }
-    return `ALTER COLUMN ${col} SET${this.adapter.quoteDefaultExpression(newDefault)}`;
+    return `ALTER COLUMN ${col} SET DEFAULT ${this.adapter.quoteDefaultExpression(newDefault)}`;
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -281,7 +281,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
     if (o.default == null && o.column.options.null === false) {
       sql += "DROP DEFAULT";
     } else {
-      sql += `SET${this.adapter.quoteDefaultExpression(o.default, o.column)}`;
+      sql += `SET DEFAULT ${this.adapter.quoteDefaultExpression(o.default, o.column)}`;
     }
     return sql;
   }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-quoter.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-quoter.test.ts
@@ -21,15 +21,13 @@ describe("mysqlSchemaQuoter", () => {
     // Uint8Array trails' BinaryType#serialize actually returns (which the
     // abstract `quote` alone would reject with "can't quote Uint8Array") and the
     // BinaryData Rails' Binary#serialize returns.
-    expect(q.quoteDefaultExpression(new Uint8Array([0xde, 0xad]))).toBe(" DEFAULT x'dead'");
-    expect(q.quoteDefaultExpression(new BinaryData(new Uint8Array([0xde, 0xad])))).toBe(
-      " DEFAULT x'dead'",
-    );
+    expect(q.quoteDefaultExpression(new Uint8Array([0xde, 0xad]))).toBe("x'dead'");
+    expect(q.quoteDefaultExpression(new BinaryData(new Uint8Array([0xde, 0xad])))).toBe("x'dead'");
   });
 
   it("quotes a binary default produced by BinaryType#serialize", () => {
     const q = mysqlSchemaQuoter();
-    expect(q.quoteDefaultExpression(new BinaryType().serialize("ab"))).toBe(" DEFAULT x'6162'");
+    expect(q.quoteDefaultExpression(new BinaryType().serialize("ab"))).toBe("x'6162'");
   });
 
   it("dispatches binary through a threaded host's quotedBinary override", () => {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.type-map.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.type-map.test.ts
@@ -98,12 +98,12 @@ describe("PostgreSQLAdapter#quoteDefaultExpression", () => {
     // Simulates a ColumnDefinition built by addColumn/changeColumn:
     // array lives on `.options`, sqlType is the `[]`-suffixed form.
     const columnDef = { sqlType: "integer[]", options: { array: true } };
-    expect(adapter.quoteDefaultExpression([1, 2, 3], columnDef)).toBe(" DEFAULT '{1,2,3}'");
+    expect(adapter.quoteDefaultExpression([1, 2, 3], columnDef)).toBe("'{1,2,3}'");
   });
 
   it("reads `array` from a live Column instance", () => {
     const column = { sqlType: "integer", array: true };
-    expect(adapter.quoteDefaultExpression([4, 5, 6], column)).toBe(" DEFAULT '{4,5,6}'");
+    expect(adapter.quoteDefaultExpression([4, 5, 6], column)).toBe("'{4,5,6}'");
   });
 
   it("normalizes `integer[]` sqlType so the integer subtype resolves", () => {
@@ -112,6 +112,6 @@ describe("PostgreSQLAdapter#quoteDefaultExpression", () => {
     // emitting the floats verbatim ('{1.7,2.3}'). IntegerType#serialize
     // truncates to integers, so '{1,2}' confirms the subtype lookup hit.
     const columnDef = { sqlType: "integer[]", options: { array: true } };
-    expect(adapter.quoteDefaultExpression([1.7, 2.3], columnDef)).toBe(" DEFAULT '{1,2}'");
+    expect(adapter.quoteDefaultExpression([1.7, 2.3], columnDef)).toBe("'{1,2}'");
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
@@ -109,7 +109,7 @@ describe("PostgreSQL quoting", () => {
       },
     };
 
-    expect(quoteDefaultExpression(41, column, typeMap)).toBe(" DEFAULT 42");
+    expect(quoteDefaultExpression(41, column, typeMap)).toBe("42");
   });
 
   it("quotes a binary default through PG's quotedBinary", () => {
@@ -117,17 +117,15 @@ describe("PostgreSQL quoting", () => {
     // not the abstract byte-string fallback. Cover both shapes that reach here —
     // the raw Uint8Array trails' BinaryType#serialize actually returns, and the
     // BinaryData Rails' Binary#serialize returns (activemodel/.../binary.rb:31).
-    expect(quoteDefaultExpression(new Uint8Array([0x1f, 0x8b]))).toBe(" DEFAULT '\\x1f8b'");
-    expect(quoteDefaultExpression(new BinaryData(new Uint8Array([0x1f, 0x8b])))).toBe(
-      " DEFAULT '\\x1f8b'",
-    );
+    expect(quoteDefaultExpression(new Uint8Array([0x1f, 0x8b]))).toBe("'\\x1f8b'");
+    expect(quoteDefaultExpression(new BinaryData(new Uint8Array([0x1f, 0x8b])))).toBe("'\\x1f8b'");
   });
 
   it("quotes a BC date default through PG's quotedDate", () => {
     // Receiver-less: the fallback host must reach PG's BC-suffixing quotedDate
     // (postgresql/quoting.rb:143), not the abstract formatter which drops " BC".
     expect(quoteDefaultExpression(Temporal.PlainDate.from("-000043-03-15"))).toBe(
-      " DEFAULT '0044-03-15 BC'",
+      "'0044-03-15 BC'",
     );
   });
 
@@ -137,7 +135,7 @@ describe("PostgreSQL quoting", () => {
     // `array` must be present: the serialize branch is gated on `"array" in column`.
     const column = { sqlType: "bytea", array: false };
     const typeMap = { lookup: () => new BinaryType() };
-    expect(quoteDefaultExpression("ab", column, typeMap)).toBe(" DEFAULT '\\x6162'");
+    expect(quoteDefaultExpression("ab", column, typeMap)).toBe("'\\x6162'");
   });
 
   it("serializes array defaults via fallback OidArray when type map misses", () => {
@@ -147,8 +145,8 @@ describe("PostgreSQL quoting", () => {
         return null;
       },
     };
-    expect(quoteDefaultExpression([], column, nullTypeMap)).toBe(" DEFAULT '{}'");
-    expect(quoteDefaultExpression(["a", "b"], column, nullTypeMap)).toBe(" DEFAULT '{a,b}'");
+    expect(quoteDefaultExpression([], column, nullTypeMap)).toBe("'{}'");
+    expect(quoteDefaultExpression(["a", "b"], column, nullTypeMap)).toBe("'{a,b}'");
   });
 
   it("does not apply array fallback when column.array is false", () => {
@@ -159,7 +157,7 @@ describe("PostgreSQL quoting", () => {
       },
     };
     // A plain string value should still round-trip normally
-    expect(quoteDefaultExpression("hello", column, nullTypeMap)).toBe(" DEFAULT 'hello'");
+    expect(quoteDefaultExpression("hello", column, nullTypeMap)).toBe("'hello'");
   });
 
   it("serializes array defaults through the type map", () => {
@@ -171,7 +169,7 @@ describe("PostgreSQL quoting", () => {
       },
     };
 
-    expect(quoteDefaultExpression(["a", "b"], column, typeMap)).toBe(" DEFAULT '{a,b}'");
+    expect(quoteDefaultExpression(["a", "b"], column, typeMap)).toBe("'{a,b}'");
   });
 
   it("serializes array defaults via an element subtype (per-element coercion)", () => {
@@ -186,7 +184,7 @@ describe("PostgreSQL quoting", () => {
         return { cast: (v: unknown) => v, serialize: (v: unknown) => Number(v) + 100 };
       },
     };
-    expect(quoteDefaultExpression([1, 2, 3], column, typeMap)).toBe(" DEFAULT '{101,102,103}'");
+    expect(quoteDefaultExpression([1, 2, 3], column, typeMap)).toBe("'{101,102,103}'");
   });
 
   it("passes raw array-literal string defaults through without scalar coercion", () => {
@@ -201,8 +199,8 @@ describe("PostgreSQL quoting", () => {
         return { serialize: (v: unknown) => Number(v) };
       },
     };
-    expect(quoteDefaultExpression("{}", column, typeMap)).toBe(" DEFAULT '{}'");
-    expect(quoteDefaultExpression("{1,2,3}", column, typeMap)).toBe(" DEFAULT '{1,2,3}'");
+    expect(quoteDefaultExpression("{}", column, typeMap)).toBe("'{}'");
+    expect(quoteDefaultExpression("{1,2,3}", column, typeMap)).toBe("'{1,2,3}'");
   });
 
   it("supports nested function calls up to 2 levels deep", () => {

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -160,13 +160,13 @@ export function quoteDefaultExpression(
   if (value === undefined) return "";
   if (typeof value === "function") {
     const result = (value as () => unknown)();
-    if (typeof result === "string") return ` DEFAULT ${result}`;
-    if (isSqlLiteral(result)) return ` DEFAULT ${result.value}`;
+    if (typeof result === "string") return result;
+    if (isSqlLiteral(result)) return result.value;
     throw new TypeError(
       "quoteDefaultExpression expected function default to return a string or SqlLiteral",
     );
   }
-  if (isSqlLiteral(value)) return ` DEFAULT ${value.value}`;
+  if (isSqlLiteral(value)) return value.value;
 
   let serialized: unknown = value;
   if (column != null && "array" in column) {
@@ -200,7 +200,7 @@ export function quoteDefaultExpression(
   // default reaches PG's bytea `quotedBinary` rather than the abstract
   // byte-string fallback, and a date default reaches PG's BC-suffixing
   // `quotedDate` (postgresql/quoting.rb:143) rather than the abstract format.
-  return ` DEFAULT ${quote.call(this || { quotedDate, quotedBinary }, serialized)}`;
+  return quote.call(this || { quotedDate, quotedBinary }, serialized);
 }
 
 export function typeCast(this: QuotingDispatchHost, value: unknown): unknown {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
@@ -237,7 +237,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
         // Mirrors Rails postgresql/schema_creation.rb:99 — pass column to
         // quote_default_expression so array/typeMap-aware serialization
         // is preserved on ALTER COLUMN SET DEFAULT.
-        sql += `, ALTER COLUMN ${quotedName} SET${this.adapter.quoteDefaultExpression(options["default"], column)}`;
+        sql += `, ALTER COLUMN ${quotedName} SET DEFAULT ${this.adapter.quoteDefaultExpression(options["default"], column)}`;
       }
     }
 
@@ -256,7 +256,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
     const action =
       o.default == null
         ? "DROP DEFAULT"
-        : `SET${this.adapter.quoteDefaultExpression(o.default, o.column)}`;
+        : `SET DEFAULT ${this.adapter.quoteDefaultExpression(o.default, o.column)}`;
     return `ALTER COLUMN ${col} ${action}`;
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -981,8 +981,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       );
     } else {
       const col = (await this.columns(tableName)).find((c) => c.name === columnName);
-      const clause = this.adapter.quoteDefaultExpression(defaultValue, col);
-      const expr = clause.startsWith(" DEFAULT ") ? clause.slice(" DEFAULT ".length) : clause;
+      const expr = this.adapter.quoteDefaultExpression(defaultValue, col);
       await this.adapter.executeMutation(
         `ALTER TABLE ${quotedTable} ALTER COLUMN ${quotedCol} SET DEFAULT ${expr}`,
       );
@@ -1045,8 +1044,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       // Rails guards the pre-ALTER UPDATE with `if column` — skip it when the
       // column can't be found rather than quoting against an undefined column.
       if (col) {
-        const clause = this.adapter.quoteDefaultExpression(defaultValue, col);
-        const expr = clause.startsWith(" DEFAULT ") ? clause.slice(" DEFAULT ".length) : clause;
+        const expr = this.adapter.quoteDefaultExpression(defaultValue, col);
         await this.adapter.executeMutation(
           `UPDATE ${quotedTable} SET ${quotedCol} = ${expr} WHERE ${quotedCol} IS NULL`,
         );

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1039,7 +1039,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
           "quoteDefaultExpression expected function default to return a string or SqlLiteral",
         );
       }
-      return /^\w+\(.*\)$/.test(str) ? ` DEFAULT (${str})` : ` DEFAULT ${str}`;
+      return /^\w+\(.*\)$/.test(str) ? `(${str})` : str;
     }
     const sqlType = (column as { sqlType?: string | null } | undefined)?.sqlType;
     return super.quoteDefaultExpression(this.serializeDefaultForColumn(value, sqlType), column);

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1025,10 +1025,13 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   // a Proc default that reads as a function call (`\A\w+\(.*\)\z`) is wrapped in
   // parentheses for SQLite DDL (`DEFAULT (ABS(RANDOM()))`); any other Proc result
   // (bare keyword expressions like CURRENT_TIMESTAMP, or an already-parenthesized
-  // expression) is emitted verbatim. Non-Proc values fall through to the abstract
-  // form. The Proc is invoked exactly once (Rails calls `value.call` once), so a
-  // proc with side effects is not double-evaluated. In Rails `SqlLiteral < String`,
-  // so a SqlLiteral result runs through the same `match?` regex — unwrap to its
+  // expression) is emitted verbatim. Non-Proc values fall through to `super`,
+  // which serializes through the column's cast type (abstract/quoting.rb:161) —
+  // so a structured `json` default (`default: {}`) is JSON-encoded to `{}` there,
+  // not pre-serialized here (which would double-encode via `super`'s serialize).
+  // The Proc is invoked exactly once (Rails calls `value.call` once), so a proc
+  // with side effects is not double-evaluated. In Rails `SqlLiteral < String`, so
+  // a SqlLiteral result runs through the same `match?` regex — unwrap to its
   // string and apply the same paren-wrap branch rather than special-casing it.
   override quoteDefaultExpression(value: unknown, column?: unknown): string {
     if (typeof value === "function") {
@@ -1041,8 +1044,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       }
       return /^\w+\(.*\)$/.test(str) ? `(${str})` : str;
     }
-    const sqlType = (column as { sqlType?: string | null } | undefined)?.sqlType;
-    return super.quoteDefaultExpression(this.serializeDefaultForColumn(value, sqlType), column);
+    return super.quoteDefaultExpression(value, column);
   }
 
   // Rails' abstract quote_default_expression serializes the value through the

--- a/packages/activerecord/src/sql-default.test.ts
+++ b/packages/activerecord/src/sql-default.test.ts
@@ -60,11 +60,11 @@ describe("quoteDefaultExpression", () => {
     expect(quoteDefaultExpression(undefined)).toBe("");
   });
 
-  it("returns bare NULL for null", () => {
+  it("returns DEFAULT NULL for null", () => {
     expect(quoteDefaultExpression(null)).toBe("NULL");
   });
 
-  it("returns bare TRUE/FALSE for booleans", () => {
+  it("returns DEFAULT TRUE/FALSE for booleans", () => {
     expect(quoteDefaultExpression(true)).toBe("TRUE");
     expect(quoteDefaultExpression(false)).toBe("FALSE");
   });

--- a/packages/activerecord/src/sql-default.test.ts
+++ b/packages/activerecord/src/sql-default.test.ts
@@ -60,39 +60,39 @@ describe("quoteDefaultExpression", () => {
     expect(quoteDefaultExpression(undefined)).toBe("");
   });
 
-  it("returns DEFAULT NULL for null", () => {
-    expect(quoteDefaultExpression(null)).toBe(" DEFAULT NULL");
+  it("returns bare NULL for null", () => {
+    expect(quoteDefaultExpression(null)).toBe("NULL");
   });
 
-  it("returns DEFAULT TRUE/FALSE for booleans", () => {
-    expect(quoteDefaultExpression(true)).toBe(" DEFAULT TRUE");
-    expect(quoteDefaultExpression(false)).toBe(" DEFAULT FALSE");
+  it("returns bare TRUE/FALSE for booleans", () => {
+    expect(quoteDefaultExpression(true)).toBe("TRUE");
+    expect(quoteDefaultExpression(false)).toBe("FALSE");
   });
 
   it("returns unquoted numbers", () => {
-    expect(quoteDefaultExpression(42)).toBe(" DEFAULT 42");
+    expect(quoteDefaultExpression(42)).toBe("42");
   });
 
   it("quotes regular strings", () => {
-    expect(quoteDefaultExpression("hello")).toBe(" DEFAULT 'hello'");
+    expect(quoteDefaultExpression("hello")).toBe("'hello'");
   });
 
   it("passes through function return values as raw SQL", () => {
-    expect(quoteDefaultExpression(() => "CURRENT_TIMESTAMP")).toBe(" DEFAULT CURRENT_TIMESTAMP");
+    expect(quoteDefaultExpression(() => "CURRENT_TIMESTAMP")).toBe("CURRENT_TIMESTAMP");
   });
 
   it("passes through function calls like now()", () => {
-    expect(quoteDefaultExpression(() => "now()")).toBe(" DEFAULT now()");
+    expect(quoteDefaultExpression(() => "now()")).toBe("now()");
   });
 
   it("passes through SqlLiteral instances as raw SQL", () => {
     expect(quoteDefaultExpression(new Nodes.SqlLiteral("CURRENT_TIMESTAMP"))).toBe(
-      " DEFAULT CURRENT_TIMESTAMP",
+      "CURRENT_TIMESTAMP",
     );
   });
 
   it("quotes plain string CURRENT_TIMESTAMP as a literal", () => {
-    expect(quoteDefaultExpression("CURRENT_TIMESTAMP")).toBe(" DEFAULT 'CURRENT_TIMESTAMP'");
+    expect(quoteDefaultExpression("CURRENT_TIMESTAMP")).toBe("'CURRENT_TIMESTAMP'");
   });
 
   it("throws TypeError when function returns non-string/non-SqlLiteral", () => {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-adapter.json
@@ -261,13 +261,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "quote_default_expression",
-    "call": "serialize",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
     "rubyName": "quoted_binary",
     "call": "quote_string",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/quoting.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/quoting.json
@@ -24,22 +24,8 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/quoting.ts",
     "rubyName": "quote_default_expression",
-    "call": "call",
-    "reason": "Rails' `value.call` invokes the Proc default; TS invokes it as `(value as () => unknown)()`, which has no `call` member. Previously matched only incidentally, by the `quote.call(...)` token that dispatchQuote replaced."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/quoting.ts",
-    "rubyName": "quote_default_expression",
     "call": "quote",
     "reason": "Satisfied via dispatchQuote, mirroring rb:162's bare `quote(value)` self-dispatch (host override, else the module helper) — same shape as the existing quote/quoted_date and quote/quoted_binary entries."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/quoting.ts",
-    "rubyName": "quote_default_expression",
-    "call": "serialize",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",


### PR DESCRIPTION
## Summary

Converges trails' `quoteDefaultExpression` onto Rails' abstract contract
(`abstract/quoting.rb:157-164`), closing a two-part divergence surfaced by
review of #4870.

1. **Serialize through the column's cast type.** The abstract standalone and
   the abstract-adapter method now mirror rb:161
   (`lookup_cast_type(column.sql_type).serialize(value)`) before quoting,
   instead of ignoring the column. Serialization only fires when the host
   exposes a `serialize`-bearing cast type, so the adapter-free
   `ABSTRACT_SCHEMA_QUOTER` and the mysql schema-quoter are unaffected.

2. **Bare-literal-out contract.** Abstract + PG + SQLite all return the **bare**
   quoted literal; the ` DEFAULT ` keyword is now owned by the callers
   (`add_column_options!` and the `ALTER COLUMN ... SET DEFAULT` sites), matching
   Rails' `schema_creation.rb:150`. Previously abstract/PG folded the prefix in
   while SQLite did not — the three are now consistent and substitutable.

`optionsIncludeDefault` treats an `undefined` default (trails' absence marker)
as not-included so the caller-owned prefix is never emitted with an empty
literal. The now-satisfied `quote_default_expression`/`serialize` (and the
incidentally-satisfied `/call`) wide-ratchet suppressions are dropped.

Emitted DDL is unchanged on all three adapters — this moves where the prefix
lives, not what is rendered.

## Testing

- Quoting/schema unit + DDL suites green on sqlite3 (PG/MySQL run in CI).
- `pnpm api:calls` and `pnpm api:calls:wide` ratchets pass.

Closes-story: quote-default-expression-serialize-and-default-prefix