### PR TITLE
fix(adapters): classify severed-connection query errors as retryable ConnectionFailed

### DIFF
--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -128,6 +128,14 @@ function sleep(ms: number): Promise<void> {
 // non-SQLite adapter.
 async function remoteDisconnect(conn: DatabaseAdapter): Promise<void> {
   if (adapterType === "postgres") {
+    // Rails: `connection.verify! if raw_connection.status == PG::CONNECTION_BAD`
+    // — a previous non-retryable query may have left the raw connection dead;
+    // reconnect it before provoking a fresh disconnect. node-pg exposes no
+    // `status`, so probe liveness (activePredicate issues a no-op `;`) and
+    // verify!/reconnect when it is not queryable.
+    if (!(await activePredicate(conn))) {
+      await conn.verifyBang();
+    }
     const raw = (
       conn as unknown as {
         _rawConnectionForTest(): { query(sql: string): Promise<unknown> } | null;
@@ -921,26 +929,30 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
     expect(connection.active).toBe(true);
   });
 
-  itBlocked("querying a 'clean' long-failed connection restores and succeeds", async () => {
-    await remoteDisconnect(connection);
+  it.skipIf(!remoteSupported)(
+    "querying a 'clean' long-failed connection restores and succeeds",
+    async () => {
+      await remoteDisconnect(connection);
 
-    connection.cleanBang(); // this simulates a fresh checkout from the pool
+      connection.cleanBang(); // this simulates a fresh checkout from the pool
 
-    // Backdate last activity to simulate a connection we haven't used in a while
-    (connection as unknown as { _lastActivity: number })._lastActivity = Date.now() - 5 * 60 * 1000;
+      // Backdate last activity to simulate a connection we haven't used in a while
+      (connection as unknown as { _lastActivity: number })._lastActivity =
+        Date.now() - 5 * 60 * 1000;
 
-    // Clean did not verify / fix the connection
-    expect(await activePredicate(connection)).toBe(false);
+      // Clean did not verify / fix the connection
+      expect(await activePredicate(connection)).toBe(false);
 
-    // Because the connection hasn't been verified since checkout, and the
-    // query cannot safely be retried, the connection is verified before
-    // querying.
-    await Post.deleteAll();
+      // Because the connection hasn't been verified since checkout, and the
+      // query cannot safely be retried, the connection is verified before
+      // querying.
+      await Post.deleteAll();
 
-    expect(connection.active).toBe(true);
-  });
+      expect(connection.active).toBe(true);
+    },
+  );
 
-  itBlocked(
+  it.skipIf(!remoteSupported)(
     "querying a 'clean' recently-used but now-failed connection skips verification",
     async () => {
       await remoteDisconnect(connection);
@@ -957,7 +969,7 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
     },
   );
 
-  itBlocked(
+  it.skipIf(!remoteSupported)(
     "quoting a string on a 'clean' failed connection will not prevent reconnecting",
     async () => {
       await remoteDisconnect(connection);
@@ -978,34 +990,40 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
     },
   );
 
-  itBlocked("querying after a failed non-retryable query restores and succeeds", async () => {
-    await Post.first(); // Connection verified (and prepared statement pool populated)
+  it.skipIf(!remoteSupported)(
+    "querying after a failed non-retryable query restores and succeeds",
+    async () => {
+      await Post.first(); // Connection verified (and prepared statement pool populated)
 
-    await remoteDisconnect(connection);
+      await remoteDisconnect(connection);
 
-    await expect(
-      connection.execute("INSERT INTO posts(title, body) VALUES ('foo', 'bar')"),
-    ).rejects.toBeInstanceOf(ConnectionFailed);
+      await expect(
+        connection.execute("INSERT INTO posts(title, body) VALUES ('foo', 'bar')"),
+      ).rejects.toBeInstanceOf(ConnectionFailed);
 
-    expect(await Post.first()).toBeTruthy(); // Verifying causes a reconnect and the query succeeds
-    expect(connection.active).toBe(true);
-  });
+      expect(await Post.first()).toBeTruthy(); // Verifying causes a reconnect and the query succeeds
+      expect(connection.active).toBe(true);
+    },
+  );
 
-  itBlocked("idempotent SELECT queries are retried and result in a reconnect", async () => {
-    await Post.first();
+  it.skipIf(!remoteSupported)(
+    "idempotent SELECT queries are retried and result in a reconnect",
+    async () => {
+      await Post.first();
 
-    await remoteDisconnect(connection);
+      await remoteDisconnect(connection);
 
-    expect(await Post.first()).toBeTruthy();
-    expect(connection.active).toBe(true);
+      expect(await Post.first()).toBeTruthy();
+      expect(connection.active).toBe(true);
 
-    await remoteDisconnect(connection);
+      await remoteDisconnect(connection);
 
-    expect(await Post.where({ id: [1, 2] }).first()).toBeTruthy();
-    expect(connection.active).toBe(true);
-  });
+      expect(await Post.where({ id: [1, 2] }).first()).toBeTruthy();
+      expect(connection.active).toBe(true);
+    },
+  );
 
-  itBlocked(
+  it.skipIf(!remoteSupported)(
     "#find and #find_by queries with known attributes are retried and result in a reconnect",
     async () => {
       await Post.first();
@@ -1022,7 +1040,7 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
     },
   );
 
-  itBlocked("queries containing SQL fragments are not retried", async () => {
+  it.skipIf(!remoteSupported)("queries containing SQL fragments are not retried", async () => {
     await Post.first();
 
     await remoteDisconnect(connection);
@@ -1048,7 +1066,7 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
     expect(await activePredicate(connection)).toBe(false);
   });
 
-  itBlocked("queries containing SQL functions are not retried", async () => {
+  it.skipIf(!remoteSupported)("queries containing SQL functions are not retried", async () => {
     await Post.first();
 
     await remoteDisconnect(connection);
@@ -1104,24 +1122,27 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
     },
   );
 
-  itBlocked("dirty transaction cannot be restored after remote disconnection", async () => {
-    let invocations = 0;
-    await expect(
-      Post.transaction(async () => {
-        invocations += 1;
-        await Post.deleteAll();
-        await remoteDisconnect(connection);
-        await Post.count();
-      }),
-    ).rejects.toBeInstanceOf(ConnectionFailed);
+  it.skipIf(!remoteSupported)(
+    "dirty transaction cannot be restored after remote disconnection",
+    async () => {
+      let invocations = 0;
+      await expect(
+        Post.transaction(async () => {
+          invocations += 1;
+          await Post.deleteAll();
+          await remoteDisconnect(connection);
+          await Post.count();
+        }),
+      ).rejects.toBeInstanceOf(ConnectionFailed);
 
-    expect(invocations).toBe(1); // the whole transaction block is not retried
+      expect(invocations).toBe(1); // the whole transaction block is not retried
 
-    // After the (outermost) transaction block failed, the connection is ready
-    // to reconnect on next use, but hasn't done so yet.
-    expect(await activePredicate(connection)).toBe(false);
-    expect((await Post.count()) as number).toBeGreaterThan(0);
-  });
+      // After the (outermost) transaction block failed, the connection is ready
+      // to reconnect on next use, but hasn't done so yet.
+      expect(await activePredicate(connection)).toBe(false);
+      expect((await Post.count()) as number).toBeGreaterThan(0);
+    },
+  );
 
   it("can reconnect and retry queries under limit when retry deadline is set", async () => {
     let attempts = 0;
@@ -1162,7 +1183,7 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
     });
   });
 
-  itBlocked("#execute is retryable", async () => {
+  it.skipIf(!remoteSupported)("#execute is retryable", async () => {
     const connectionIdSql =
       adapterType === "mysql" ? "SELECT CONNECTION_ID()" : "SELECT pg_backend_pid()";
     const connId = (await connection.execQuery(connectionIdSql)).rows[0][0];

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -711,12 +711,26 @@ describeIfPg("PostgreSQLAdapter", () => {
       const pid = (pidRows[0] as { pid: number }).pid;
       // Terminate this backend from a separate connection. After the single
       // persistent client's backend is gone, the next query on it surfaces a
-      // connection error that translates to ConnectionNotEstablished — rather
-      // than transparently retrying (allowRetry defaults to false).
+      // connection error that translates to a retryable connection error —
+      // rather than transparently retrying (allowRetry defaults to false).
+      //
+      // DEVIATION (node-pg): Rails asserts ConnectionNotEstablished here, but
+      // only because its test explicitly pre-sends a query with the raw libpq
+      // connection to flip PG::Connection#status to CONNECTION_BAD, forcing the
+      // "no connection to the server" message that translate_exception maps to
+      // ConnectionNotEstablished (postgresql_adapter.rb:801-821). Without that
+      // libpq-status trick — which the pure-JS node-pg driver has no analogue
+      // for — the natural post-terminate query surfaces node-pg's single
+      // "Client has encountered a connection error and is not queryable" string,
+      // indistinguishable from a mid-query sever. trails maps that query-path
+      // connection error to the retryable ConnectionFailed (see
+      // postgresql-adapter.ts _translateException). Both are retryable
+      // connection errors (retryable_connection_error? covers each), so the
+      // reconnect-on-next-use behavior is unchanged.
       await withSecondAdapter(PG_TEST_URL, async (adapter2) => {
         await adapter2.execute(`SELECT pg_terminate_backend(${pid})`);
       });
-      await expect(adapter.execute("SELECT 1")).rejects.toBeInstanceOf(ConnectionNotEstablished);
+      await expect(adapter.execute("SELECT 1")).rejects.toBeInstanceOf(ConnectionFailed);
     });
 
     it("reload type map for newly defined types", async () => {

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -202,18 +202,25 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     );
   }
 
-  // No verifyBang override: now that the sync `active` getter reflects real
-  // connection state, a never-connected adapter reports inactive and flows
-  // through the inherited base `verifyBang` (abstract-adapter.ts) exactly like
-  // any other inactive adapter — `_unconfiguredConnection` promotion when the
-  // deprecated raw-connection was stashed (mysql2's `_isFakeConnection` path),
-  // otherwise `reconnectBang({ restoreTransactions: true })` with its retry
-  // loop. This mirrors Rails' `verify!` (abstract_adapter.rb:759), which gates
-  // the `attempt_configure_connection`-only shortcut on `@unconfigured_connection`
-  // and routes a genuinely fresh (`@raw_connection == nil`) adapter through the
-  // full retry-capable `reconnect!` — there is no separate "never connected"
-  // shortcut. `Mysql2Adapter#reconnect` closes a nil `_client` as a no-op, so the
-  // full path costs nothing extra on a fresh adapter and gains connect retries.
+  // Mirrors Rails' `verify!` (abstract_adapter.rb:759), which decides whether to
+  // reconnect by calling `active?` — a real `mysql_ping` on the raw connection.
+  // trails' sync `active` getter is optimistic (it reports the cached
+  // `_activeState`, unchanged by a remote disconnect the adapter hasn't yet
+  // observed), so the inherited base `verifyBang` — which gates on that sync
+  // getter — would no-op on a socket the server has already severed
+  // (`wait_timeout`, server-side `KILL`). Probe with the async ping first
+  // (`activeAsync`, the analogue of Rails' `active?`) so the cached state
+  // reflects reality, then delegate to the inherited flow: base `verifyBang`
+  // now sees `active === false` and drives `reconnectBang({ restoreTransactions:
+  // true })` (or the `_unconfiguredConnection` promotion for the fake-connection
+  // stash). A never-connected/fake/closed adapter skips the ping and flows
+  // straight through the base logic, exactly as before.
+  override async verifyBang(): Promise<void> {
+    if (this._client !== null && !this._permanentlyClosed && !this._isFakeConnection) {
+      await this.activeAsync();
+    }
+    await super.verifyBang();
+  }
 
   // Single persistent connection — mirrors Rails' @raw_connection. Unified onto
   // the inherited base `_connection` slot rather than a parallel field: Rails
@@ -611,7 +618,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     sql: string,
     name?: string | null,
     binds?: unknown[],
-    options?: { prepare?: boolean },
+    options?: { prepare?: boolean; allowRetry?: boolean },
   ): Promise<Result> {
     return this.internalExecQuery(sql, name, binds, options);
   }
@@ -620,7 +627,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     sql: string,
     name?: string | null,
     binds?: unknown[],
-    options?: { prepare?: boolean },
+    options?: { prepare?: boolean; allowRetry?: boolean },
   ): Promise<Result> {
     sql = this.preprocessQuery(sql);
     this._syncDatabaseTimezone();
@@ -638,58 +645,66 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     };
     return Notifications.instrumentAsync("sql.active_record", payload, async () => {
       try {
-        return await this.withRawConnection(async (conn) => {
-          const mysqlConn = conn as unknown as mysql.Connection;
-          const prepare = options?.prepare ?? this._shouldPrepare(binds ?? []);
-          if (prepare) this._trackPrepared(mysqlConn, driverSql);
-          // Request array-mode rows so duplicate column names
-          // (e.g. `SELECT 1 AS a, 2 AS a`) survive: object-keyed rows would
-          // collapse the second `a` onto the first. This mirrors Rails, whose
-          // `configure_connection` sets `query_options[:as] = :array`
-          // (mysql2_adapter.rb:159), making `raw_result.to_a` positional — so
-          // cast_result builds the Result from `result.fields` + positional rows.
-          const [rawResult, rawFields] = prepare
-            ? await mysqlConn.execute(
-                { sql: driverSql, rowsAsArray: true } as any,
-                driverBinds as any[],
-              )
-            : await mysqlConn.query({ sql: driverSql, rowsAsArray: true } as any, driverBinds);
-          // Unwrap mysql2's nested CALL/multi-result sets to the single result
-          // set Rails' cast_result reads (the same seam internalExecute uses).
-          // `fields` are the field descriptors for the returned rows — present
-          // whenever a SELECT projected columns, even at zero rows matched.
-          const { result, fields } = unwrapMultiResult(
-            rawResult,
-            rawFields as mysql.FieldPacket[] | undefined,
-          );
-          // DML results in a ResultSetHeader (no rows array); SELECT results
-          // in an array of positional row arrays. Return empty Result for DML
-          // to avoid throwing on INSERT/UPDATE/DELETE passed to execQuery.
-          if (!Array.isArray(result)) {
-            payload.row_count = result.affectedRows ?? 0;
+        // Thread allowRetry (Rails' select_all → internal_exec_query
+        // `allow_retry: preparable`) into withRawConnection so idempotent SELECTs
+        // retry+reconnect after a severed connection, while raw-SQL-fragment
+        // reads (allowRetry false) surface the connection error. Mirrors PG's
+        // internalExecQuery (postgresql-adapter.ts).
+        return await this.withRawConnection(
+          { allowRetry: options?.allowRetry ?? false },
+          async (conn) => {
+            const mysqlConn = conn as unknown as mysql.Connection;
+            const prepare = options?.prepare ?? this._shouldPrepare(binds ?? []);
+            if (prepare) this._trackPrepared(mysqlConn, driverSql);
+            // Request array-mode rows so duplicate column names
+            // (e.g. `SELECT 1 AS a, 2 AS a`) survive: object-keyed rows would
+            // collapse the second `a` onto the first. This mirrors Rails, whose
+            // `configure_connection` sets `query_options[:as] = :array`
+            // (mysql2_adapter.rb:159), making `raw_result.to_a` positional — so
+            // cast_result builds the Result from `result.fields` + positional rows.
+            const [rawResult, rawFields] = prepare
+              ? await mysqlConn.execute(
+                  { sql: driverSql, rowsAsArray: true } as any,
+                  driverBinds as any[],
+                )
+              : await mysqlConn.query({ sql: driverSql, rowsAsArray: true } as any, driverBinds);
+            // Unwrap mysql2's nested CALL/multi-result sets to the single result
+            // set Rails' cast_result reads (the same seam internalExecute uses).
+            // `fields` are the field descriptors for the returned rows — present
+            // whenever a SELECT projected columns, even at zero rows matched.
+            const { result, fields } = unwrapMultiResult(
+              rawResult,
+              rawFields as mysql.FieldPacket[] | undefined,
+            );
+            // DML results in a ResultSetHeader (no rows array); SELECT results
+            // in an array of positional row arrays. Return empty Result for DML
+            // to avoid throwing on INSERT/UPDATE/DELETE passed to execQuery.
+            if (!Array.isArray(result)) {
+              payload.row_count = result.affectedRows ?? 0;
+              await this._handleWarningsOn(mysqlConn, driverSql);
+              return new Result([], []);
+            }
+            payload.row_count = result.length;
             await this._handleWarningsOn(mysqlConn, driverSql);
-            return new Result([], []);
-          }
-          payload.row_count = result.length;
-          await this._handleWarningsOn(mysqlConn, driverSql);
-          // Build the Result from the field descriptors plus the positional
-          // (array-mode) rows, mirroring Rails' `cast_result`: columns come
-          // from `result.fields` and rows from `result.to_a`. This preserves
-          // duplicate column names and keeps the column set when zero rows
-          // matched (the field descriptors are present whenever a SELECT
-          // projected columns).
-          const fieldList = (fields ?? []) as unknown as Mysql2FieldDescriptor[];
-          const names = fieldList.map((f) => f.name);
-          if (names.length === 0) return Result.empty();
-          // Report column_types from the field descriptors (numeric/decimal
-          // families) so extra/computed select columns deserialize to the
-          // faithful trails type — a BigDecimal for NEWDECIMAL rather than the
-          // raw "1.1" driver string. Mirrors the PostgreSQL adapter's
-          // cast_result; node-mysql2 (decimalNumbers:false) has no driver-level
-          // BigDecimal cast, so the adapter reports the type map itself.
-          const columnTypes = buildColumnTypes(fieldList, (t) => this.lookupCastType(t));
-          return new Result(names, result as unknown[][], columnTypes);
-        });
+            // Build the Result from the field descriptors plus the positional
+            // (array-mode) rows, mirroring Rails' `cast_result`: columns come
+            // from `result.fields` and rows from `result.to_a`. This preserves
+            // duplicate column names and keeps the column set when zero rows
+            // matched (the field descriptors are present whenever a SELECT
+            // projected columns).
+            const fieldList = (fields ?? []) as unknown as Mysql2FieldDescriptor[];
+            const names = fieldList.map((f) => f.name);
+            if (names.length === 0) return Result.empty();
+            // Report column_types from the field descriptors (numeric/decimal
+            // families) so extra/computed select columns deserialize to the
+            // faithful trails type — a BigDecimal for NEWDECIMAL rather than the
+            // raw "1.1" driver string. Mirrors the PostgreSQL adapter's
+            // cast_result; node-mysql2 (decimalNumbers:false) has no driver-level
+            // BigDecimal cast, so the adapter reports the type map itself.
+            const columnTypes = buildColumnTypes(fieldList, (t) => this.lookupCastType(t));
+            return new Result(names, result as unknown[][], columnTypes);
+          },
+        );
       } catch (e: any) {
         const translated =
           e instanceof MismatchedForeignKey
@@ -914,6 +929,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     sql: string,
     binds: unknown[] = [],
     name: string = "SQL",
+    { allowRetry = false }: { allowRetry?: boolean } = {},
   ): Promise<Record<string, unknown>[]> {
     sql = this.preprocessQuery(sql);
     this._syncDatabaseTimezone();
@@ -933,7 +949,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     };
     return Notifications.instrumentAsync("sql.active_record", payload, async () => {
       try {
-        return await this.withRawConnection(async (conn) => {
+        return await this.withRawConnection({ allowRetry }, async (conn) => {
           const mysqlConn = conn as unknown as mysql.Connection;
           // Use server-side prepared statements when enabled and binds
           // are present — matches PR #589's preparedStatements toggle.
@@ -2148,6 +2164,17 @@ function isMysql2ConnectionError(e: unknown): boolean {
   const errno = (e as { errno?: number }).errno;
   if (typeof errno === "number" && errno > 0) return false;
   const code = (e as { code?: string }).code;
+  // The node-mysql2 driver's client-side "Can't add new command when
+  // connection is in closed state" error (base/connection.js#_addCommandClosedState)
+  // carries no `code`/`errno`. It fires when the socket was severed out from
+  // under the adapter (e.g. a `wait_timeout` remote disconnect), the analogue
+  // of Rails' Mysql2::Error::ConnectionError. Without this the raw driver error
+  // surfaces untranslated instead of the retryable ConnectionFailed. Match on
+  // the message: the `fatal` flag is stripped by the time the error reaches
+  // translation (it is re-wrapped in the withRawConnection retry path).
+  if (/add new command when connection is in closed state/i.test(e.message)) {
+    return true;
+  }
   return (
     code === "PROTOCOL_CONNECTION_LOST" ||
     code === "PROTOCOL_ENQUEUE_AFTER_QUIT" ||

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2036,6 +2036,32 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     );
   }
 
+  /**
+   * Whether a node-pg connection error indicates the connection was already
+   * closed *before* the query was sent — i.e. the query definitely never ran.
+   * These are node-pg's analogues of the messages Rails' translate_exception
+   * routes to ConnectionNotEstablished rather than ConnectionFailed
+   * (postgresql_adapter.rb:801-818 — `connection is closed` /
+   * `no connection to the server`, and the pg-internal, pre-send PG::ConnectionBad
+   * whose libpq message lacks the trailing newline). node-pg raises these when
+   * the client rejected the query because `end()` was called or the client was
+   * closed — as opposed to "Client has encountered a connection error" / socket
+   * severs, where the server may already have executed part or all of the query.
+   */
+  private static _isConnectionClosedBeforeSend(err: unknown): boolean {
+    const msg =
+      typeof (err as { message?: string })?.message === "string"
+        ? (err as { message: string }).message
+        : "";
+    if (!msg) return false;
+    return (
+      msg.includes("client has already ended") ||
+      /client was closed/i.test(msg) ||
+      /connection is closed/i.test(msg) ||
+      /no connection to the server/i.test(msg)
+    );
+  }
+
   // Mirrors: DatabaseStatements#exec_restart_db_transaction (database_statements.rb:83)
   async execRestartDbTransaction(): Promise<void> {
     this._cancelAnyRunningQuery();
@@ -4276,21 +4302,29 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
           // "Client has encountered a connection error", …) surfaces here as a
           // generic Error or non-DatabaseError. This is the query path
           // (_translateException runs inside execute/execQuery, after the query
-          // was dispatched), so it is the analogue of Rails'
-          // translate_exception (postgresql_adapter.rb:801-821) splitting a
-          // libpq PG::ConnectionBad whose message ends with "\n" into
-          // ConnectionFailed — "the server may have already executed part or all
-          // of the query". node-pg is pure JS with no libpq layer, so it cannot
-          // reproduce Rails' newline signal that separates a libpq failure from a
-          // pg-internal (pre-send) ConnectionBad; every severed-connection error
-          // on the query path surfaces the SAME "Client has encountered a
-          // connection error and is not queryable" string. We map it to the
-          // retryable ConnectionFailed so idempotent queries retry+reconnect and
-          // non-retryable queries raise a connection error rather than a raw
-          // driver error, matching Rails' remote-disconnect behavior. (Connect
-          // path failures still surface as ConnectionNotEstablished — see
-          // newClient.)
+          // was dispatched), so it mirrors Rails' translate_exception
+          // (postgresql_adapter.rb:801-818), which splits connection errors:
+          //   - "connection is closed" / "no connection to the server", and the
+          //     pre-send pg-internal PG::ConnectionBad → ConnectionNotEstablished
+          //     (the query definitely never ran).
+          //   - a libpq PG::ConnectionBad whose message ends with "\n" →
+          //     ConnectionFailed ("the server may have already executed part or
+          //     all of the query").
+          // We preserve ConnectionNotEstablished for node-pg's pre-send/closed
+          // analogues (see _isConnectionClosedBeforeSend). The remaining
+          // live-socket severs map to the retryable ConnectionFailed so
+          // idempotent queries retry+reconnect and non-retryable queries raise a
+          // connection error rather than a raw driver error, matching Rails'
+          // remote-disconnect behavior. node-pg has no libpq layer, so it cannot
+          // reproduce Rails' newline signal for the ambiguous server-sever case
+          // ("Client has encountered a connection error and is not queryable" is
+          // emitted identically whether the socket died mid-send or just before);
+          // that residual case takes ConnectionFailed. (Connect-path failures
+          // still surface as ConnectionNotEstablished — see newClient.)
           if (PostgreSQLAdapter._isConnectionError(e)) {
+            if (PostgreSQLAdapter._isConnectionClosedBeforeSend(e)) {
+              return new ConnectionNotEstablished(msg, { cause });
+            }
             return new ConnectionFailed(msg, { sql, binds, cause });
           }
           // Only wrap node-postgres `DatabaseError`s. The SQLSTATE

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4311,20 +4311,25 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
           //     ConnectionFailed ("the server may have already executed part or
           //     all of the query").
           // We preserve ConnectionNotEstablished for node-pg's pre-send/closed
-          // analogues (see _isConnectionClosedBeforeSend). The remaining
-          // live-socket severs map to the retryable ConnectionFailed so
-          // idempotent queries retry+reconnect and non-retryable queries raise a
-          // connection error rather than a raw driver error, matching Rails'
-          // remote-disconnect behavior. node-pg has no libpq layer, so it cannot
-          // reproduce Rails' newline signal for the ambiguous server-sever case
-          // ("Client has encountered a connection error and is not queryable" is
-          // emitted identically whether the socket died mid-send or just before);
-          // that residual case takes ConnectionFailed. (Connect-path failures
-          // still surface as ConnectionNotEstablished — see newClient.)
+          // analogues (see _isConnectionClosedBeforeSend). Rails matches these
+          // messages directly, ahead of the PG::ConnectionBad split, so this
+          // check runs FIRST — some of its messages ("connection is closed",
+          // "no connection to the server", "client was closed") are not in
+          // _isConnectionError's set and would otherwise fall through as raw
+          // Errors. The remaining live-socket severs map to the retryable
+          // ConnectionFailed so idempotent queries retry+reconnect and
+          // non-retryable queries raise a connection error rather than a raw
+          // driver error, matching Rails' remote-disconnect behavior. node-pg
+          // has no libpq layer, so it cannot reproduce Rails' newline signal for
+          // the ambiguous server-sever case ("Client has encountered a
+          // connection error and is not queryable" is emitted identically
+          // whether the socket died mid-send or just before); that residual case
+          // takes ConnectionFailed. (Connect-path failures still surface as
+          // ConnectionNotEstablished — see newClient.)
+          if (PostgreSQLAdapter._isConnectionClosedBeforeSend(e)) {
+            return new ConnectionNotEstablished(msg, { cause });
+          }
           if (PostgreSQLAdapter._isConnectionError(e)) {
-            if (PostgreSQLAdapter._isConnectionClosedBeforeSend(e)) {
-              return new ConnectionNotEstablished(msg, { cause });
-            }
             return new ConnectionFailed(msg, { sql, binds, cause });
           }
           // Only wrap node-postgres `DatabaseError`s. The SQLSTATE

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4273,19 +4273,25 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
           return new ConnectionNotEstablished(msg, { cause });
         default:
           // A severed connection (08xxx, "Connection terminated", pg's
-          // "Client has encountered a connection error", …) surfaces as a
-          // generic Error or non-DatabaseError; map it to ConnectionNotEstablished
-          // so callers see the lost connection rather than a raw driver error.
-          //
-          // Rails' translate_exception (postgresql_adapter.rb:801-821) additionally
-          // splits a libpq PG::ConnectionBad whose message ends with "\n" into
-          // ConnectionFailed (vs ConnectionNotEstablished for the pg-internal case).
-          // That distinction is a libpq PQerrorMessage artifact; node-pg is pure JS
-          // with no libpq layer and doesn't carry the pg-internal/libpq split, so
-          // there is no reliable signal to reproduce it — every severed-connection
-          // error maps to ConnectionNotEstablished here.
+          // "Client has encountered a connection error", …) surfaces here as a
+          // generic Error or non-DatabaseError. This is the query path
+          // (_translateException runs inside execute/execQuery, after the query
+          // was dispatched), so it is the analogue of Rails'
+          // translate_exception (postgresql_adapter.rb:801-821) splitting a
+          // libpq PG::ConnectionBad whose message ends with "\n" into
+          // ConnectionFailed — "the server may have already executed part or all
+          // of the query". node-pg is pure JS with no libpq layer, so it cannot
+          // reproduce Rails' newline signal that separates a libpq failure from a
+          // pg-internal (pre-send) ConnectionBad; every severed-connection error
+          // on the query path surfaces the SAME "Client has encountered a
+          // connection error and is not queryable" string. We map it to the
+          // retryable ConnectionFailed so idempotent queries retry+reconnect and
+          // non-retryable queries raise a connection error rather than a raw
+          // driver error, matching Rails' remote-disconnect behavior. (Connect
+          // path failures still surface as ConnectionNotEstablished — see
+          // newClient.)
           if (PostgreSQLAdapter._isConnectionError(e)) {
-            return new ConnectionNotEstablished(msg, { cause });
+            return new ConnectionFailed(msg, { sql, binds, cause });
           }
           // Only wrap node-postgres `DatabaseError`s. The SQLSTATE
           // 5-char shape alone isn't enough — Node system errors like


### PR DESCRIPTION
## Summary

A severed connection now surfaces the retryable `ConnectionFailed` on the query
path for both PostgreSQL and MySQL/MariaDB, matching Rails' remote-disconnect
behavior: idempotent queries retry+reconnect, non-retryable queries raise a
connection error rather than a raw driver error.

### PostgreSQL
`_translateException` now splits query-path connection errors the way Rails'
`translate_exception` does (postgresql_adapter.rb:801-818):
- node-pg's **pre-send / already-closed** messages (`client has already ended`,
  `client was closed`, `connection is closed`, `no connection to the server`) —
  the query definitely never ran — keep `ConnectionNotEstablished` (Rails'
  non-newline `PG::ConnectionBad` case).
- the **live-socket sever** takes the retryable `ConnectionFailed` (Rails' libpq
  newline case, "the server may have already executed part or all of the query").

node-pg is pure JS with no libpq layer, so for the ambiguous server-sever it
cannot reproduce Rails' newline signal — `pg_terminate_backend` and
`remote_disconnect` both emit the identical `Client has encountered a connection
error and is not queryable`, which is a live-socket sever → `ConnectionFailed`.
The connect path still raises `ConnectionNotEstablished` (`newClient`). The
`pg_terminate` unit test is reconciled with a documented note (Rails only reaches
`ConnectionNotEstablished` there via a libpq `send_query` pre-send trick that
node-pg has no analogue for).

### MySQL/MariaDB
- `isMysql2ConnectionError` recognizes the driver's client-side "Can't add new
  command when connection is in closed state" error → `ConnectionFailed`.
- `execute`/`execQuery` thread `allowRetry` into `withRawConnection` so
  idempotent reads retry+reconnect (raw-SQL-fragment reads still surface the
  error).
- `verifyBang` probes with a real ping (`activeAsync`, the analogue of Rails'
  `active?`) so a remote disconnect the optimistic sync `active` getter missed
  is detected and reconnected.

### Tests
Un-skips the `AdapterConnectionTest` cases blocked on these divergences; they
pass verbatim on PG and MySQL/MariaDB (24 on PG, 23 on MySQL — "active
transaction is restored" stays PG-gated for a separate divergence). The
`remoteDisconnect` helper gains Rails' `verify! if CONNECTION_BAD` step so a
prior non-retryable failure reconnects before the next disconnect is provoked.

Closes-story: adapter-connection-failure-error-classification