### PR TITLE
fix(quoting): non-finite numeric string-quoting is PG-only

### DIFF
--- a/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
@@ -38,10 +38,15 @@ describe("MySQL quoting — quote", () => {
     expect(quote(BigInt("9007199254740993"))).toBe("9007199254740993");
   });
 
-  it("quotes non-finite numbers as strings", () => {
-    expect(quote(Number.POSITIVE_INFINITY)).toBe("'Infinity'");
-    expect(quote(Number.NEGATIVE_INFINITY)).toBe("'-Infinity'");
-    expect(quote(NaN)).toBe("'NaN'");
+  it("renders non-finite numbers bare (Rails' MySQL adapter has no non-finite override)", () => {
+    // Rails' MySQL adapter defines no `quote` override, so non-finite numbers
+    // fall through to the abstract `when Numeric then value.to_s`
+    // (abstract/quoting.rb:82) and render bare — only PostgreSQL string-quotes
+    // them (postgresql/quoting.rb:111-115). This is invalid SQL on MySQL, but it
+    // is exactly what Rails emits; trails converges rather than mirror PG here.
+    expect(quote(Number.POSITIVE_INFINITY)).toBe("Infinity");
+    expect(quote(Number.NEGATIVE_INFINITY)).toBe("-Infinity");
+    expect(quote(NaN)).toBe("NaN");
   });
 
   it("throws on Date — Date is no longer accepted", () => {

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -189,18 +189,15 @@ export function columnNameWithOrderMatcher(): RegExp {
  * `quote` runs the abstract `quote` and the MySQL-specific behaviour flows in
  * through the dispatched helpers (`quote_string`, `quoted_binary`,
  * `quoted_date`/`quoted_time`). We mirror that here: only the branches whose
- * dispatch the abstract `quote` doesn't thread through `this` (symbols, strings
- * — plus the trails-only non-finite guard) stay inline; the rest
+ * dispatch the abstract `quote` doesn't thread through `this` (symbols, strings)
+ * stay inline; the rest
  * delegates to {@link abstractQuote} with `this` threaded so the date/time
- * dispatch lands on MySQL's {@link quotedDate}. Booleans fall through to the
+ * dispatch lands on MySQL's {@link quotedDate}. Non-finite numbers fall through
+ * to the abstract `when Numeric then value.to_s` and render bare — Rails' MySQL
+ * adapter has no non-finite override (only PG does). Booleans fall through to the
  * abstract `"TRUE"`/`"FALSE"`; binds serialize to 1/0 via {@link castBoundValue}.
  */
 export function quote(this: QuotingDispatchHost, value: unknown): string {
-  // Non-finite numbers (±Infinity, NaN) have no MySQL literal — `String(Infinity)`
-  // produces the bareword `Infinity`, which MySQL parses as an identifier and
-  // throws "Unknown column 'Infinity'". Mirror PG's behavior and quote them as
-  // strings; MySQL coerces or rejects at the column-type boundary.
-  if (typeof value === "number" && !Number.isFinite(value)) return quoteString(String(value));
   if (typeof value === "symbol") {
     const desc = value.description;
     if (desc === undefined) throw new TypeError("Cannot quote a Symbol without a description");

--- a/packages/arel/src/visitors/default-quoter.ts
+++ b/packages/arel/src/visitors/default-quoter.ts
@@ -45,11 +45,11 @@ function isDateLike(value: unknown): value is { toISOString(): string } {
 
 function quoteScalar(this: ArelConnection, value: unknown): string {
   if (value === null || value === undefined) return "NULL";
-  if (typeof value === "number") {
-    // Non-finite numbers must be string-quoted; databases reject bare
-    // `Infinity` / `NaN` identifiers. PG accepts 'Infinity'::float8.
-    return Number.isFinite(value) ? String(value) : `'${String(value)}'`;
-  }
+  // Mirrors Rails' abstract `when Numeric then value.to_s` (abstract/quoting.rb:82):
+  // every number renders bare, including non-finite ones. Only PostgreSQL's adapter
+  // overrides this to string-quote non-finite values (postgresql/quoting.rb:111-115);
+  // postgresqlDefaultQuoter.quote layers that on top before delegating here.
+  if (typeof value === "number") return String(value);
   if (typeof value === "bigint") return String(value);
   if (typeof value === "boolean") return value ? this.quotedTrue() : this.quotedFalse();
   // Normalise all typed-array views to Uint8Array before handing off so
@@ -216,6 +216,12 @@ export const postgresqlDefaultQuoter: ArelConnection = {
   ...defaultQuoter,
 
   quote(value: unknown): string {
+    // Mirrors PostgreSQL::Quoting#quote (postgresql/quoting.rb:111-115): non-finite
+    // Numerics string-quote (`'Infinity'::float8`). This override is PG-only — the
+    // base/MySQL hosts emit them bare, per the abstract adapter.
+    if (typeof value === "number" && !Number.isFinite(value)) {
+      return `'${String(value)}'`;
+    }
     if (Array.isArray(value)) {
       // formatElement keeps #4867's fix alive on this path: a date element gets
       // the same `quoted_date` form the scalar path emits, mirroring Rails'

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -302,18 +302,19 @@ describe("the to_sql visitor", () => {
     expect(mgr.toSql()).toContain("VALUES (?)");
   });
 
-  it("string-quotes non-finite numbers in a ValuesList instead of emitting a bareword", () => {
-    // Databases reject `VALUES (Infinity)` because the unquoted identifier
-    // case-folds to a missing column; PG accepts `'Infinity'::float8`.
+  it("renders non-finite numbers bare in a ValuesList, matching the abstract adapter", () => {
+    // Rails' abstract `quote` emits `when Numeric then value.to_s`
+    // (abstract/quoting.rb:82), so the connection-less default visitor renders
+    // non-finite numbers bare. Only PostgreSQL's adapter string-quotes them.
     const mgr = new InsertManager(users);
     mgr.insert([[users.get("name"), Number.POSITIVE_INFINITY]]);
-    expect(mgr.toSql()).toContain("VALUES ('Infinity')");
+    expect(mgr.toSql()).toContain("VALUES (Infinity)");
     const mgr2 = new InsertManager(users);
     mgr2.insert([[users.get("name"), Number.NEGATIVE_INFINITY]]);
-    expect(mgr2.toSql()).toContain("VALUES ('-Infinity')");
+    expect(mgr2.toSql()).toContain("VALUES (-Infinity)");
     const mgr3 = new InsertManager(users);
     mgr3.insert([[users.get("name"), Number.NaN]]);
-    expect(mgr3.toSql()).toContain("VALUES ('NaN')");
+    expect(mgr3.toSql()).toContain("VALUES (NaN)");
   });
 
   describe("Nodes::UnionAll", () => {
@@ -2005,17 +2006,17 @@ describe("the to_sql visitor", () => {
         // Rails: Float has no `unboundable?`, so `attr.eq(Float::INFINITY)`
         // builds Casted(INFINITY) and renders `= Infinity` via `quote` →
         // `when Numeric then value.to_s` (abstract/quoting.rb:82), which is what
-        // the AR adapter path emits. The connection-less default quoter
-        // string-quotes non-finite numbers (default-quoter.ts:48-52) because
-        // bare `Infinity` is not valid SQL in every dialect.
-        expect(compile(id.eq(Infinity))).toBe('"users"."id" = \'Infinity\'');
-        expect(compile(id.gt(-Infinity))).toBe('"users"."id" > \'-Infinity\'');
-        expect(compile(id.in([1, Infinity, 2]))).toBe('"users"."id" IN (1, \'Infinity\', 2)');
+        // the abstract AR adapter path emits. The connection-less default quoter
+        // mirrors that and renders non-finite numbers bare; only PostgreSQL's
+        // adapter string-quotes them (postgresql/quoting.rb:111-115).
+        expect(compile(id.eq(Infinity))).toBe('"users"."id" = Infinity');
+        expect(compile(id.gt(-Infinity))).toBe('"users"."id" > -Infinity');
+        expect(compile(id.in([1, Infinity, 2]))).toBe('"users"."id" IN (1, Infinity, 2)');
       });
 
       it("Quoted wrapping INFINITY is bounded too (Quoted has no unboundable?)", () => {
         const eq = new Nodes.Equality(id, new Nodes.Quoted(Infinity));
-        expect(compile(eq)).toBe('"users"."id" = \'Infinity\'');
+        expect(compile(eq)).toBe('"users"."id" = Infinity');
       });
 
       it("bounded comparisons are unaffected", () => {


### PR DESCRIPTION
## Summary

Non-finite numeric string-quoting is **PostgreSQL-specific** in Rails. Only the PG adapter overrides the `Numeric` arm to emit `'#{value}'` (`postgresql/quoting.rb:111-115`); the SQLite3 adapter also overrides it (`sqlite3/quoting.rb:53-64`). MySQL has **no** such override, so it falls through to the abstract `when Numeric then value.to_s` (`abstract/quoting.rb:82`) and renders non-finite numbers **bare**.

Trails was mirroring the PG rule everywhere. This converges:

- **MySQL adapter** (`mysql/quoting.ts`) — drop the non-finite guard; falls through to the abstract bare rendering.
- **arel default-quoter** (`default-quoter.ts`) — `quoteScalar` stops string-quoting non-finite for the base/MySQL hosts; `postgresqlDefaultQuoter.quote` layers the PG-only string-quoting on top.
- **PG adapter** (`postgresql/quoting.ts`) — unchanged; correct.
- **SQLite3 adapter** — unchanged; Rails' sqlite3 adapter *does* override the Numeric arm, so string-quoting stays (the story's "confirm SQLite has no such branch" was mistaken — verified against `vendor/rails`).

The ratifying tests are re-pointed at Rails' actual output (bare `Infinity`/`-Infinity`/`NaN` for MySQL and the connection-less default visitor), not renamed away. PG and SQLite tests stay green.

## Testing

- `packages/arel/src/visitors/to-sql.test.ts` ✅ (288)
- `packages/activerecord/src/connection-adapters/mysql/quoting.test.ts` ✅ (44)
- `packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts` ✅ (57)
- `packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts` ✅ (43)

Closes-story: quote-non-finite-numerics-are-pg-only
