### PR TITLE
fix(enum): widen defineEnum options to match _enum surface

### DIFF
--- a/packages/activerecord/dx-tests/declare-patterns.test-d.ts
+++ b/packages/activerecord/dx-tests/declare-patterns.test-d.ts
@@ -176,6 +176,25 @@ class Article extends Base {
   }
 }
 
+// `defineEnum`'s options match `_enum`'s full surface (prefix/suffix/scopes/
+// instanceMethods/validate/default) — no `as any` needed for a supported
+// option. Compile-only: never invoked.
+export function _defineEnumOptionsTypecheck(): void {
+  defineEnum(
+    Article,
+    "status",
+    { draft: 0, published: 1 },
+    {
+      prefix: true,
+      suffix: "state",
+      scopes: false,
+      instanceMethods: false,
+      validate: true,
+      default: "draft",
+    },
+  );
+}
+
 // --- Temporal attribute typing ---
 import { Temporal } from "@blazetrails/activesupport/temporal";
 class Event extends Base {

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -213,14 +213,7 @@ export function defineEnum(
   modelClass: typeof Base,
   attribute: string,
   valuesInput: string[] | Record<string, string | number | boolean | null>,
-  options?: {
-    prefix?: boolean | string;
-    suffix?: boolean | string;
-    scopes?: boolean;
-    instanceMethods?: boolean;
-    validate?: boolean | Record<string, unknown>;
-    default?: unknown;
-  },
+  options?: EnumMacroOptions,
 ): void {
   _enum.call(modelClass, attribute, valuesInput, options);
 }
@@ -477,6 +470,23 @@ export class EnumMethods {
 }
 
 /**
+ * Options accepted by the `enum` macro and its `defineEnum` alias.
+ *
+ * Mirrors the keyword arguments of `ActiveRecord::Enum#enum`
+ * (`prefix:`, `suffix:`, `scopes:`, `instance_methods:`, `validate:`,
+ * `default:`). Shared by `enumMethod`, `_enum`, and `defineEnum` so the three
+ * entry points cannot drift out of sync.
+ */
+export interface EnumMacroOptions {
+  prefix?: boolean | string;
+  suffix?: boolean | string;
+  scopes?: boolean;
+  instanceMethods?: boolean;
+  validate?: boolean | Record<string, unknown>;
+  default?: unknown;
+}
+
+/**
  * Public `enum` macro. Validates then delegates to the private `_enum` impl.
  *
  * `_enum` is the single enum entry point: it defines `is{Name}()` predicates,
@@ -491,14 +501,7 @@ export function enumMethod(
   this: typeof Base,
   name: string,
   values: string[] | Record<string, EnumValue>,
-  options?: {
-    prefix?: boolean | string;
-    suffix?: boolean | string;
-    scopes?: boolean;
-    instanceMethods?: boolean;
-    validate?: boolean | Record<string, unknown>;
-    default?: unknown;
-  },
+  options?: EnumMacroOptions,
 ): void {
   _enum.call(this, name, values, options);
 }
@@ -520,14 +523,7 @@ export function _enum(
   this: typeof import("./base.js").Base,
   name: string,
   values: string[] | Record<string, string | number | boolean | null>,
-  options?: {
-    prefix?: boolean | string;
-    suffix?: boolean | string;
-    scopes?: boolean;
-    instanceMethods?: boolean;
-    validate?: boolean | Record<string, unknown>;
-    default?: unknown;
-  },
+  options?: EnumMacroOptions,
 ): void {
   if (values == null) throw new ArgumentError(`${String(name)} enum values must not be nil`);
   assertValidEnumDefinitionValues(values);

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -213,7 +213,14 @@ export function defineEnum(
   modelClass: typeof Base,
   attribute: string,
   valuesInput: string[] | Record<string, string | number | boolean | null>,
-  options?: { prefix?: boolean | string; suffix?: boolean | string },
+  options?: {
+    prefix?: boolean | string;
+    suffix?: boolean | string;
+    scopes?: boolean;
+    instanceMethods?: boolean;
+    validate?: boolean | Record<string, unknown>;
+    default?: unknown;
+  },
 ): void {
   _enum.call(modelClass, attribute, valuesInput, options);
 }

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -142,6 +142,7 @@ export {
   setRunAfterTransactionCallbacksInOrderDefined,
 } from "./ar-config.js";
 export { defineEnum, readEnumValue, castEnumValue } from "./enum.js";
+export type { EnumMacroOptions } from "./enum.js";
 export {
   enableSti,
   getInheritanceColumn,


### PR DESCRIPTION
`defineEnum` delegates to `_enum` but typed its `options` parameter as `{ prefix, suffix }` only, so `scopes`/`instanceMethods`/`validate`/`default` were type errors at call sites despite working at runtime — the sibling of the narrowness PR #4890 fixed for the public `enum` macro (which had spawned 25 `as any` casts).

Rather than paste a third divergent copy of the option shape, this extracts one exported `EnumMacroOptions` interface (mirroring `ActiveRecord::Enum#enum`'s keyword args) and shares it across all three entry points — `enumMethod`, `_enum`, and `defineEnum` — so they can no longer drift out of sync, which is what produced this bug.

- No call site needed an `as any` cast (grep confirms none existed); a compile-only positive assertion in `declare-patterns.test-d.ts` exercises the widened options under the type checker.
- `pnpm typecheck` clean.
- type-virtualization fixtures 07/14/18/19 still pass (81/81).

Closes-story: widen-define-enum-options-to-match-enum