### PR TITLE
feat(has_one): generate awaitable set#{Name} accessor

### DIFF
--- a/packages/activerecord/src/associations/builder/has-one.ts
+++ b/packages/activerecord/src/associations/builder/has-one.ts
@@ -45,19 +45,6 @@ export class HasOne extends SingularAssociation {
     super.defineConstructors(mixin, name);
     if (!mixin || typeof mixin !== "object") return;
     const cap = name.charAt(0).toUpperCase() + name.slice(1);
-    // Ergonomic awaitable setter (`await firm.setAccount(x)` /
-    // `await firm.setAccount(null)`), the RFC-sanctioned alternative to the
-    // racy native `firm.account = x` property setter. A thin delegation to the
-    // association-level `writer`, whose has_one / has_one_through overrides run
-    // the Rails-faithful immediate replace/persist. Returns the `writer` promise
-    // so a failed replacement (`RecordNotSaved`) rejects at the call site.
-    Object.defineProperty(mixin, `set${cap}`, {
-      value: function (this: { association(n: string): any }, value: unknown) {
-        return this.association(name).writer(value);
-      },
-      writable: true,
-      configurable: true,
-    });
     // Redefine the `build#{name}` accessor to mirror Rails' synchronous
     // `set_new_record` → `replace` → `load_target`: materialize the current
     // target before the built record displaces it. The accessor returns a
@@ -114,6 +101,29 @@ export class HasOne extends SingularAssociation {
 
   static override defineWriters(mixin: object, name: string): void {
     if (!mixin || typeof mixin !== "object") return;
+    const cap = name.charAt(0).toUpperCase() + name.slice(1);
+    // Ergonomic awaitable setter (`await firm.setAccount(x)` /
+    // `await firm.setAccount(null)`), the RFC-sanctioned alternative to the
+    // racy native `firm.account = x` property setter defined below. Generated
+    // here — beside that setter, unconditionally (including polymorphic
+    // has_one) — rather than in `defineConstructors`, which Rails skips for
+    // polymorphic; the sugar must exist wherever the `=` setter does. A thin
+    // delegation to the association-level `writer`, whose has_one /
+    // has_one_through overrides run the Rails-faithful immediate replace/persist
+    // and whose returned promise rejects (`RecordNotSaved`) at the call site.
+    const setter = Object.getOwnPropertyDescriptor(mixin, `set${cap}`);
+    if (!setter || setter.configurable) {
+      Object.defineProperty(mixin, `set${cap}`, {
+        value: function (
+          this: { association(n: string): { writer(v: unknown): unknown } },
+          value: unknown,
+        ) {
+          return this.association(name).writer(value);
+        },
+        writable: true,
+        configurable: true,
+      });
+    }
     const existing = Object.getOwnPropertyDescriptor(mixin, name);
     if (existing && !existing.configurable) return;
     Object.defineProperty(mixin, name, {

--- a/packages/activerecord/src/associations/builder/has-one.ts
+++ b/packages/activerecord/src/associations/builder/has-one.ts
@@ -45,6 +45,19 @@ export class HasOne extends SingularAssociation {
     super.defineConstructors(mixin, name);
     if (!mixin || typeof mixin !== "object") return;
     const cap = name.charAt(0).toUpperCase() + name.slice(1);
+    // Ergonomic awaitable setter (`await firm.setAccount(x)` /
+    // `await firm.setAccount(null)`), the RFC-sanctioned alternative to the
+    // racy native `firm.account = x` property setter. A thin delegation to the
+    // association-level `writer`, whose has_one / has_one_through overrides run
+    // the Rails-faithful immediate replace/persist. Returns the `writer` promise
+    // so a failed replacement (`RecordNotSaved`) rejects at the call site.
+    Object.defineProperty(mixin, `set${cap}`, {
+      value: function (this: { association(n: string): any }, value: unknown) {
+        return this.association(name).writer(value);
+      },
+      writable: true,
+      configurable: true,
+    });
     // Redefine the `build#{name}` accessor to mirror Rails' synchronous
     // `set_new_record` → `replace` → `load_target`: materialize the current
     // target before the built record displaces it. The accessor returns a

--- a/packages/activerecord/src/associations/has-one-set-accessor-sugar.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-set-accessor-sugar.trails.test.ts
@@ -35,6 +35,7 @@ import { Ship } from "../test-helpers/models/ship.js";
 import { Member } from "../test-helpers/models/member.js";
 import { Club } from "../test-helpers/models/club.js";
 import { Membership, CurrentMembership } from "../test-helpers/models/membership.js";
+import { Sponsor } from "../test-helpers/models/sponsor.js";
 
 type Setter = { [k: string]: (value: Base | null) => Promise<void> };
 const set = (owner: unknown) => owner as Setter;
@@ -145,5 +146,28 @@ describe("has_one :through set#{Name} awaitable accessor", () => {
     await (member as unknown as { reload(): Promise<unknown> }).reload();
 
     expect((await readHasOne(member, "club"))?.id).toBe(newClub.id);
+  });
+});
+
+describe("polymorphic has_one set#{Name} awaitable accessor", () => {
+  // The `=` setter is defined unconditionally for polymorphic has_one, so the
+  // sugar must exist there too — even though `build#{Name}` / `create#{Name}`
+  // are skipped for polymorphic. Member#sponsor is a `has_one as: sponsorable`.
+  const { members } = fixtures(["members", "sponsors"]);
+
+  beforeAll(() => {
+    registerModel(Member);
+    registerModel(Sponsor);
+  });
+
+  it("persists the replacement, setting the polymorphic foreign key and type", async () => {
+    const member = members("groucho") as Base;
+    const sponsor = new Sponsor();
+
+    await set(member).setSponsor(sponsor);
+
+    expect(sponsor.isPersisted()).toBe(true);
+    expect(sponsor.sponsorable_id).toBe(Number((member as unknown as { id: number }).id));
+    expect(sponsor.sponsorable_type).toBe("Member");
   });
 });

--- a/packages/activerecord/src/associations/has-one-set-accessor-sugar.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-set-accessor-sugar.trails.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Trails-only surface: the generated `set#{Name}` awaitable accessor
+ * (`await firm.setAccount(x)` / `await member.setClub(x)`), the RFC 0068
+ * ergonomic alternative to the racy native `firm.account = x` property setter.
+ *
+ * It is a thin delegation to `association(name).writer(value)`, so it inherits
+ * the Rails-faithful immediate-persist replace path
+ * (`HasOneAssociation#writeImmediate/persistImmediate`, and the
+ * `HasOneThroughAssociation#writer` → `persistReplace` override for through).
+ * Rails reaches that path through the synchronous `=` setter, which in JS
+ * cannot await, so these assertions have no verbatim Rails test to mirror.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import {
+  registerModel,
+  enableSti,
+  registerSubclass,
+  RecordNotSaved,
+  RecordNotFound,
+  type Base,
+} from "../index.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+import {
+  Company,
+  Firm,
+  DependentFirm,
+  ExclusivelyDependentFirm,
+  RestrictedWithExceptionFirm,
+  RestrictedWithErrorFirm,
+  Client,
+} from "../test-helpers/models/company.js";
+import { Account } from "../test-helpers/models/account.js";
+import { Pirate } from "../test-helpers/models/pirate.js";
+import { Ship } from "../test-helpers/models/ship.js";
+import { Member } from "../test-helpers/models/member.js";
+import { Club } from "../test-helpers/models/club.js";
+import { Membership, CurrentMembership } from "../test-helpers/models/membership.js";
+
+type Setter = { [k: string]: (value: Base | null) => Promise<void> };
+const set = (owner: unknown) => owner as Setter;
+
+async function readHasOne(owner: Base, name: string): Promise<Base | null> {
+  return await (
+    owner as unknown as { association(n: string): { loadTarget(): Promise<Base | null> } }
+  )
+    .association(name)
+    .loadTarget();
+}
+
+describe("has_one set#{Name} awaitable accessor", () => {
+  const { companies, pirates } = fixtures(["companies", "accounts", "pirates", "ships"]);
+
+  beforeAll(() => {
+    registerModel(Company);
+    registerModel(Firm);
+    registerModel(DependentFirm);
+    registerModel(ExclusivelyDependentFirm);
+    registerModel(RestrictedWithExceptionFirm);
+    registerModel(RestrictedWithErrorFirm);
+    registerModel(Client);
+    registerModel(Account);
+    enableSti(Company);
+    registerSubclass(Firm);
+    registerSubclass(DependentFirm);
+    registerSubclass(ExclusivelyDependentFirm);
+    registerSubclass(RestrictedWithExceptionFirm);
+    registerSubclass(RestrictedWithErrorFirm);
+    registerSubclass(Client);
+    registerModel(Pirate);
+    registerModel(Ship);
+  });
+
+  it("persists the replacement immediately on a persisted owner", async () => {
+    const firm = (await Firm.find(1)) as Base;
+    const account = new Account({ credit_limit: 1000 });
+
+    await set(firm).setAccount(account);
+
+    // Immediate persist, not deferred to `firm.save()`.
+    expect(account.isPersisted()).toBe(true);
+    expect((await readHasOne(firm, "account"))?.id).toBe(account.id);
+  });
+
+  it("destroys the displaced dependent target inline, not at owner save", async () => {
+    const firm = companies("first_firm") as Base;
+    const oldAccountId = (await readHasOne(firm, "account"))?.id;
+
+    await set(firm).setAccount(new Account({ credit_limit: 5 }));
+
+    // No `firm.save()`: the dependent: :destroy removal already ran.
+    await expect(Account.find(oldAccountId)).rejects.toThrow(RecordNotFound);
+  });
+
+  it("nullifies the displaced dependent-nullify target inline", async () => {
+    const firm = companies("rails_core") as Base;
+    const oldAccountId = (await readHasOne(firm, "account"))?.id;
+
+    await set(firm).setAccount(new Account({ credit_limit: 5 }));
+
+    expect((await Account.find(oldAccountId)).firm_id).toBeNull();
+  });
+
+  it("clears the association when set to null", async () => {
+    const firm = companies("first_firm") as Base;
+    const oldAccountId = (await readHasOne(firm, "account"))?.id;
+
+    await set(firm).setAccount(null);
+
+    expect(await readHasOne(firm, "account")).toBeNull();
+    await expect(Account.find(oldAccountId)).rejects.toThrow(RecordNotFound);
+  });
+
+  it("rejects with RecordNotSaved when the new record fails to save", async () => {
+    const pirate = pirates("redbeard") as Base;
+    const newShip = new Ship();
+
+    let error: unknown;
+    try {
+      await set(pirate).setShip(newShip);
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeInstanceOf(RecordNotSaved);
+    expect((error as { record: unknown }).record).toBe(newShip);
+    expect(await readHasOne(pirate, "ship")).toBeNull();
+  });
+});
+
+describe("has_one :through set#{Name} awaitable accessor", () => {
+  const { members } = fixtures(["members", "clubs", "memberships"]);
+
+  beforeAll(() => {
+    registerModel(Member);
+    registerModel(Club);
+    enableSti(Membership);
+    registerModel(Membership);
+    registerModel(CurrentMembership);
+  });
+
+  it("replaces the through target immediately on a persisted owner", async () => {
+    const member = members("groucho") as Base;
+    const newClub = await Club.create({ name: "Marx Bros" });
+
+    await set(member).setClub(newClub);
+    await (member as unknown as { reload(): Promise<unknown> }).reload();
+
+    expect((await readHasOne(member, "club"))?.id).toBe(newClub.id);
+  });
+});


### PR DESCRIPTION
Adds the ergonomic awaitable `set#{Name}` accessor (e.g. `await firm.setAccount(x)` / `await member.setClub(x)`) sanctioned by RFC 0068, defined alongside `build#{Name}` / `create#{Name}` in `builder/has-one.ts`.

It is a THIN delegation to `this.association(name).writer(value)` — no new semantics. The association-level `writer` override handles has_one_through, so the same call works for both `has_one` and `has_one :through`. Returns the `writer` promise, so a failed replacement rejects (`RecordNotSaved`) at the call site.

No change to the native `=` setter.

## Tests

`has-one-set-accessor-sugar.trails.test.ts` (trails-only, since Rails reaches this path via the sync `=` setter): persisted-owner replace, dependent-destroy displaced inline, dependent-nullify displaced inline, nil assignment, through replace, and `RecordNotSaved` failure propagation.

Closes-story: awaitable-set-accessor-sugar