### PR TITLE
refactor(postgresql): unify execute/executeMutation into one performQuery primitive

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter-perform-query.trails.test.ts
@@ -43,17 +43,16 @@ describeIfPg("PostgreSQLAdapterPerformQueryTest (trails)", () => {
     await expect(adapter.execute(`SELECT nick FROM pq`)).resolves.toEqual([{ nick: "a" }]);
   });
 
-  it("affectedRows reports the rows changed by the last write", async () => {
+  it("executeMutation sources affected rows through the affectedRows port", async () => {
     await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('a')`);
     await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('b')`);
+    await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('c')`);
 
-    expect(await adapter.executeMutation(`UPDATE pq SET nick = 'z'`)).toBe(2);
-    expect(adapter.affectedRows()).toBe(2);
-
-    // A read leaves the count alone — it tracks the last write, as
-    // affected_rows / @last_affected_rows does in Rails.
-    await adapter.execute(`SELECT * FROM pq`);
-    expect(adapter.affectedRows()).toBe(2);
+    // The count comes from the statement's own PG::Result (cmd_tuples), read
+    // via the affectedRows port — no cross-statement state.
+    expect(await adapter.executeMutation(`UPDATE pq SET nick = 'z' WHERE nick <> 'a'`)).toBe(2);
+    expect(await adapter.executeMutation(`UPDATE pq SET nick = 'y' WHERE nick = 'nope'`)).toBe(0);
+    expect(await adapter.executeMutation(`DELETE FROM pq`)).toBe(3);
   });
 
   it("executeMutation appends RETURNING id and returns the inserted id for a bare INSERT", async () => {
@@ -68,13 +67,6 @@ describeIfPg("PostgreSQLAdapterPerformQueryTest (trails)", () => {
   it("executeMutation returns the inserted id for an explicit INSERT ... RETURNING", async () => {
     const id = await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('a') RETURNING id`);
     expect(id).toBe(1);
-  });
-
-  it("executeMutation returns affected rows for UPDATE and DELETE", async () => {
-    await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('a')`);
-    await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('b')`);
-    expect(await adapter.executeMutation(`UPDATE pq SET nick = 'z'`)).toBe(2);
-    expect(await adapter.executeMutation(`DELETE FROM pq WHERE nick = 'z'`)).toBe(2);
   });
 
   it("errors when a write is routed through executeMutation while preventing writes", async () => {

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter-perform-query.trails.test.ts
@@ -8,7 +8,7 @@
  * shared branch, the affected-rows source, and that PG's RETURNING-append +
  * readonly guard survive the fold.
  */
-import { it, expect, beforeEach, afterEach } from "vitest";
+import { it, expect, beforeEach, afterEach, vi } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { ReadOnlyError } from "../../errors.js";
 
@@ -81,5 +81,18 @@ describeIfPg("PostgreSQLAdapterPerformQueryTest (trails)", () => {
   it("does not prevent a read routed through execute while preventing writes", async () => {
     preventWrites(adapter);
     await expect(adapter.execute(`SELECT * FROM pq`)).resolves.toEqual([]);
+  });
+
+  it("re-applies the session timezone on a reconnected session", async () => {
+    // update_typemap_for_default_timezone is guarded on @mapped_default_timezone
+    // (postgresql_adapter.rb:1094). A reconnect opens a fresh session at
+    // PostgreSQL's default timezone, so the cache must be cleared in
+    // configure_connection (:1112) or the guard would skip reconfiguring it.
+    await adapter.execute(`SELECT 1`); // maps the timezone for the first session
+    const spy = vi.spyOn(adapter, "reconfigureConnectionTimezone");
+    await adapter.reconnect(); // opens a fresh session; configure clears the cache
+    await adapter.execute(`SELECT 1`); // fresh session must re-apply the timezone
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter-perform-query.trails.test.ts
@@ -22,6 +22,7 @@ describeIfPg("PostgreSQLAdapterPerformQueryTest (trails)", () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await adapter.exec(`DROP TABLE IF EXISTS pq`);
     await adapter.close();
   });
@@ -93,6 +94,5 @@ describeIfPg("PostgreSQLAdapterPerformQueryTest (trails)", () => {
     await adapter.reconnect(); // opens a fresh session; configure clears the cache
     await adapter.execute(`SELECT 1`); // fresh session must re-apply the timezone
     expect(spy).toHaveBeenCalled();
-    spy.mockRestore();
   });
 });

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter-perform-query.trails.test.ts
@@ -1,0 +1,93 @@
+/**
+ * trails-only coverage for the unified `perform_query` primitive.
+ *
+ * Rails' PostgreSQL adapter has one SQL primitive, perform_query
+ * (postgresql/database_statements.rb:135), which both `execute` and
+ * `executeMutation` now delegate to; affected rows come from a separate
+ * `affected_rows` read rather than the statement result. These assert the
+ * shared branch, the affected-rows source, and that PG's RETURNING-append +
+ * readonly guard survive the fold.
+ */
+import { it, expect, beforeEach, afterEach } from "vitest";
+import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
+import { ReadOnlyError } from "../../errors.js";
+
+describeIfPg("PostgreSQLAdapterPerformQueryTest (trails)", () => {
+  let adapter: PostgreSQLAdapter;
+
+  beforeEach(async () => {
+    adapter = new PostgreSQLAdapter(PG_TEST_URL);
+    await adapter.exec(`DROP TABLE IF EXISTS pq`);
+    await adapter.exec(`CREATE TABLE pq (id serial primary key, nick character varying(255))`);
+  });
+
+  afterEach(async () => {
+    await adapter.exec(`DROP TABLE IF EXISTS pq`);
+    await adapter.close();
+  });
+
+  function preventWrites(a: PostgreSQLAdapter): void {
+    (a as PostgreSQLAdapter & { pool: { preventWrites?: boolean } }).pool = { preventWrites: true };
+  }
+
+  it("execute runs a non-row-returning statement and returns no rows", async () => {
+    // node-pg does not throw on a statement with no result columns, so DDL and a
+    // bare INSERT flow through the public `execute` and come back as [].
+    await expect(adapter.execute(`CREATE TABLE pq_ddl (id integer)`)).resolves.toEqual([]);
+    await adapter.execute(`DROP TABLE pq_ddl`);
+    await expect(adapter.execute(`INSERT INTO pq (nick) VALUES ('a')`)).resolves.toEqual([]);
+  });
+
+  it("execute still returns rows for a row-returning statement", async () => {
+    await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('a')`);
+    await expect(adapter.execute(`SELECT nick FROM pq`)).resolves.toEqual([{ nick: "a" }]);
+  });
+
+  it("affectedRows reports the rows changed by the last write", async () => {
+    await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('a')`);
+    await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('b')`);
+
+    expect(await adapter.executeMutation(`UPDATE pq SET nick = 'z'`)).toBe(2);
+    expect(adapter.affectedRows()).toBe(2);
+
+    // A read leaves the count alone — it tracks the last write, as
+    // affected_rows / @last_affected_rows does in Rails.
+    await adapter.execute(`SELECT * FROM pq`);
+    expect(adapter.affectedRows()).toBe(2);
+  });
+
+  it("executeMutation appends RETURNING id and returns the inserted id for a bare INSERT", async () => {
+    // use_insert_returning? is true, so a bare INSERT is rewritten to
+    // `... RETURNING id` and the first column of the first row is the id.
+    const id = await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('a')`);
+    expect(id).toBe(1);
+    const second = await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('b')`);
+    expect(second).toBe(2);
+  });
+
+  it("executeMutation returns the inserted id for an explicit INSERT ... RETURNING", async () => {
+    const id = await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('a') RETURNING id`);
+    expect(id).toBe(1);
+  });
+
+  it("executeMutation returns affected rows for UPDATE and DELETE", async () => {
+    await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('a')`);
+    await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('b')`);
+    expect(await adapter.executeMutation(`UPDATE pq SET nick = 'z'`)).toBe(2);
+    expect(await adapter.executeMutation(`DELETE FROM pq WHERE nick = 'z'`)).toBe(2);
+  });
+
+  it("errors when a write is routed through executeMutation while preventing writes", async () => {
+    // The guard lives in preprocess_query's check_if_write_query, so it reaches
+    // every write through the shared primitive.
+    preventWrites(adapter);
+    await expect(adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('a')`)).rejects.toThrow(
+      ReadOnlyError,
+    );
+  });
+
+  it("does not prevent a read routed through execute while preventing writes", async () => {
+    preventWrites(adapter);
+    await expect(adapter.execute(`SELECT * FROM pq`)).resolves.toEqual([]);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -107,6 +107,7 @@ import {
   suppressCompositePrimaryKey,
   castResult,
   performQuery,
+  affectedRows as pgAffectedRows,
   handleWarnings,
   returningColumnValues as pgReturningColumnValues,
 } from "./postgresql/database-statements.js";
@@ -367,6 +368,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   private _typeMap: HashLookupTypeMap | null = null;
   private _maxIdentifierLength: number | null = null;
   private _useInsertReturning = true;
+  /** @internal Rails' `@last_affected_rows`; read by the affected_rows port. */
+  _lastAffectedRows = 0;
   private _minMessages = "warning";
   // Memoized search path, backing Rails' @schema_search_path. Populated lazily
   // by schemaSearchPath() and updated by setSchemaSearchPath().
@@ -1729,28 +1732,64 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       try {
         return await this.withRawConnection({ allowRetry }, async (conn) => {
           const client = conn as unknown as pg.Client;
-          const queryResult = await this._runQuery(client, rewritten, bindArray);
-          // Mirrors Rails' raw_execute → verified! (database_statements.rb):
-          // a successful round-trip proves the connection is live, so mark it
-          // verified to skip the verify ping on the next withRawConnection.
-          this.verifiedBang();
-          // A multi-statement string (e.g. disable_referential_integrity's
-          // joined ALTERs) runs under the simple-query protocol, where node-pg
-          // returns one Result per statement. Mirror Rails' execute and surface
-          // the last command's result.
-          const result = Array.isArray(queryResult)
-            ? queryResult[queryResult.length - 1]
-            : queryResult;
-          const rows = result?.rows ?? [];
-          payload.row_count = rows.length;
-          this._flushWarnings(rewritten);
-          return rows;
+          const result = await this._performQuery(client, rewritten, bindArray, payload);
+          return result?.rows ?? [];
         });
       } catch (e: any) {
         const translated = this._translateException(e, rewritten, bindArray);
         throw translated;
       }
     });
+  }
+
+  /**
+   * The single SQL primitive: run a statement, mark the connection verified,
+   * flush warnings, record the affected-row count, and set the notification
+   * payload's row count — the shared body of `execute` and `executeMutation`,
+   * mirroring Rails' one `perform_query`. Returns the raw pg result (rows for a
+   * row-returning statement, `rowCount` for a write). Unlike sqlite, node-pg
+   * does not throw on a non-row-returning statement, so there is no branch on a
+   * driver throw — the read/write split lives in the callers' contracts
+   * (`execute` returns `.rows`, `executeMutation` sources affected rows through
+   * the `affectedRows` port).
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#perform_query
+   */
+  private async _performQuery(
+    client: pg.Client,
+    sql: string,
+    binds: unknown[],
+    payload: Record<string, unknown>,
+  ): Promise<pg.QueryResult> {
+    const queryResult = await this._runQuery(client, sql, binds);
+    // Mirrors Rails' perform_query → verified!: a successful round-trip proves
+    // the connection is live, so skip the verify ping on the next
+    // withRawConnection.
+    this.verifiedBang();
+    // A multi-statement string (e.g. disable_referential_integrity's joined
+    // ALTERs) runs under the simple-query protocol, where node-pg returns one
+    // Result per statement. Mirror Rails' execute and surface the last
+    // command's result.
+    const result = (
+      Array.isArray(queryResult) ? queryResult[queryResult.length - 1] : queryResult
+    ) as pg.QueryResult;
+    // Rails stashes the count on the result and reads it back via affected_rows;
+    // keep a last-affected-rows field so the port has a stable backing value.
+    this._lastAffectedRows = result ? pgAffectedRows(result) : 0;
+    payload.row_count = result?.rows?.length ?? 0;
+    this._flushWarnings(sql);
+    return result;
+  }
+
+  /**
+   * Rows affected by the most recent write. Mirrors Rails' `affected_rows`,
+   * wired to the existing this-less port so api:compare coverage points at
+   * live code.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#affected_rows
+   */
+  affectedRows(result?: pg.QueryResult): number {
+    return result ? pgAffectedRows(result) : this._lastAffectedRows;
   }
 
   /**
@@ -1812,19 +1851,20 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
                 await this._serializePinnedQuery(client, () =>
                   client.query(`SAVEPOINT "${spName}"`),
                 );
-              const result = await this._runQuery(client, withReturning, binds);
+              const result = await this._performQuery(client, withReturning, binds, payload);
               if (useSavepoint)
                 await this._serializePinnedQuery(client, () =>
                   client.query(`RELEASE SAVEPOINT "${spName}"`),
                 );
-              payload.row_count = result.rowCount ?? 0;
+              const affected = this.affectedRows(result);
+              payload.row_count = affected;
               if (result.rows.length > 1) {
-                return result.rowCount ?? result.rows.length;
+                return affected;
               }
               if (result.rows.length > 0) {
                 return result.rows[0][Object.keys(result.rows[0])[0]] as number;
               }
-              return result.rowCount ?? 0;
+              return affected;
             } catch (err) {
               // Cached-plan failures must propagate to the
               // transaction-retry machinery (Rails raises
@@ -1843,37 +1883,34 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
                 ).catch(() => {});
               }
               payload.sql = pgSql;
-              const result = await this._runQuery(client, pgSql, binds);
-              payload.row_count = result.rowCount ?? 0;
-              return result.rowCount ?? 0;
+              const result = await this._performQuery(client, pgSql, binds, payload);
+              const affected = this.affectedRows(result);
+              payload.row_count = affected;
+              return affected;
             }
           }
 
           // For INSERT with explicit RETURNING
           if (upper.startsWith("INSERT") && upper.includes("RETURNING")) {
-            const result = await this._runQuery(client, pgSql, binds);
-            payload.row_count = result.rowCount ?? 0;
+            const result = await this._performQuery(client, pgSql, binds, payload);
+            const affected = this.affectedRows(result);
+            payload.row_count = affected;
             if (result.rows.length > 0) {
               return result.rows[0][Object.keys(result.rows[0])[0]] as number;
             }
-            return result.rowCount ?? 0;
+            return affected;
           }
 
           // For UPDATE/DELETE, return affected rows
-          const result = await this._runQuery(client, pgSql, binds);
-          payload.row_count = result.rowCount ?? 0;
-          return result.rowCount ?? 0;
+          const result = await this._performQuery(client, pgSql, binds, payload);
+          const affected = this.affectedRows(result);
+          payload.row_count = affected;
+          return affected;
         });
       } catch (e: any) {
         const translated = this._translateException(e, pgSql, binds);
         throw translated;
       }
-      // Mirrors Rails' raw_execute → verified!: the block completed a live
-      // round-trip, so mark verified to skip the next withRawConnection's ping.
-      this.verifiedBang();
-      // Flush inside the instrumented callback so a raised SQLWarning is visible
-      // to instrumentation subscribers — mirrors handle_warnings inside perform_query.
-      this._flushWarnings(payload.sql as string);
       return rc!;
     });
     return m;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1789,6 +1789,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * live code.
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#affected_rows
+   * @internal
    */
   affectedRows(result?: pg.QueryResult): number {
     return result ? pgAffectedRows(result) : this._lastAffectedRows;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1773,8 +1773,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     const result = (
       Array.isArray(queryResult) ? queryResult[queryResult.length - 1] : queryResult
     ) as pg.QueryResult;
-    // Rails stashes the count on the result and reads it back via affected_rows;
-    // keep a last-affected-rows field so the port has a stable backing value.
+    // Record the affected-row count for the no-arg `affectedRows()` accessor.
+    // executeMutation instead passes the fresh `result` to the port (race-free,
+    // matching Rails' affected_rows(result) → cmd_tuples); this field is the
+    // stable backing for a later read after the statement returns.
     this._lastAffectedRows = result ? pgAffectedRows(result) : 0;
     payload.row_count = result?.rows?.length ?? 0;
     this._flushWarnings(sql);
@@ -1823,10 +1825,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       row_count: 0,
       transaction: txPublic.isOpen() ? txPublic : null,
     };
-    const m = await Notifications.instrumentAsync("sql.active_record", payload, async () => {
-      let rc: number;
+    return await Notifications.instrumentAsync("sql.active_record", payload, async () => {
       try {
-        rc = await this.withRawConnection(async (conn) => {
+        return await this.withRawConnection(async (conn) => {
           const client = conn as unknown as pg.Client;
           const upper = sql.trimStart().toUpperCase();
 
@@ -1911,9 +1912,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         const translated = this._translateException(e, pgSql, binds);
         throw translated;
       }
-      return rc!;
     });
-    return m;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -368,8 +368,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   private _typeMap: HashLookupTypeMap | null = null;
   private _maxIdentifierLength: number | null = null;
   private _useInsertReturning = true;
-  /** @internal Rails' `@last_affected_rows`; read by the affected_rows port. */
-  _lastAffectedRows = 0;
+  // Rails' @mapped_default_timezone: the timezone the session/typemap was last
+  // configured for. `null` until the first query configures it, matching Rails'
+  // nil start (postgresql_adapter.rb:1094).
+  private _mappedDefaultTimezone: "utc" | "local" | null = null;
   private _minMessages = "warning";
   // Memoized search path, backing Rails' @schema_search_path. Populated lazily
   // by schemaSearchPath() and updated by setSchemaSearchPath().
@@ -1761,6 +1763,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     binds: unknown[],
     payload: Record<string, unknown>,
   ): Promise<pg.QueryResult> {
+    // Rails' perform_query first syncs the timestamp typemap / session timezone
+    // when default_timezone changed (database_statements.rb:136 →
+    // update_typemap_for_default_timezone); guarded, so it's a no-op unless the
+    // timezone actually changed.
+    await this.updateTypemapForDefaultTimezone();
     const queryResult = await this._runQuery(client, sql, binds);
     // Mirrors Rails' perform_query → verified!: a successful round-trip proves
     // the connection is live, so skip the verify ping on the next
@@ -1773,26 +1780,22 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     const result = (
       Array.isArray(queryResult) ? queryResult[queryResult.length - 1] : queryResult
     ) as pg.QueryResult;
-    // Record the affected-row count for the no-arg `affectedRows()` accessor.
-    // executeMutation instead passes the fresh `result` to the port (race-free,
-    // matching Rails' affected_rows(result) → cmd_tuples); this field is the
-    // stable backing for a later read after the statement returns.
-    this._lastAffectedRows = result ? pgAffectedRows(result) : 0;
     payload.row_count = result?.rows?.length ?? 0;
     this._flushWarnings(sql);
     return result;
   }
 
   /**
-   * Rows affected by the most recent write. Mirrors Rails' `affected_rows`,
-   * wired to the existing this-less port so api:compare coverage points at
-   * live code.
+   * Rows affected by a write, read from its `PG::Result` (`cmd_tuples`).
+   * Wired to the existing this-less port so api:compare coverage points at live
+   * code. Unlike sqlite3, PG holds no `@last_affected_rows` state — the count is
+   * sourced strictly from the passed result, matching Rails.
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#affected_rows
    * @internal
    */
-  affectedRows(result?: pg.QueryResult): number {
-    return result ? pgAffectedRows(result) : this._lastAffectedRows;
+  affectedRows(result: pg.QueryResult): number {
+    return pgAffectedRows(result);
   }
 
   /**
@@ -4942,6 +4945,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * @internal
    */
   async reconfigureConnectionTimezone(): Promise<void> {
+    // Rails returns early when `variables["timezone"]` was set by the user
+    // (postgresql_adapter.rb:1005): configure_connection already applied it and
+    // it must never be overridden by the default_timezone SET below.
+    if (this._sessionVariables["timezone"]) return;
     const tz = getDefaultTimezone();
     // Off the withRawConnection loop. This runs as the first step of
     // performQuery (database-statements.ts), which is itself the block
@@ -5018,9 +5025,15 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * @internal
    */
   async updateTypemapForDefaultTimezone(): Promise<void> {
-    // node-pg uses custom type parsers registered at pool construction time
-    // via getTypeParser (see constructor). A timezone change only requires
-    // a session-level SET so subsequent result sets are interpreted correctly.
+    // Rails guards on `@mapped_default_timezone != default_timezone`
+    // (postgresql_adapter.rb:1094): reconfigure only when the timezone actually
+    // changed, so `perform_query` calling this per statement is a cheap no-op on
+    // the hot path. node-pg uses custom type parsers registered at pool
+    // construction time via getTypeParser (see constructor); a timezone change
+    // only requires a session-level SET so subsequent result sets decode right.
+    const tz = getDefaultTimezone();
+    if (this._mappedDefaultTimezone === tz) return;
+    this._mappedDefaultTimezone = tz;
     await this.reconfigureConnectionTimezone();
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -689,6 +689,13 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    */
   private async _maybeConfigureConnection(client: pg.Client): Promise<void> {
     if (this._connectionConfigured) return;
+    // Rails resets @mapped_default_timezone = nil while installing decoders in
+    // configure_connection (postgresql_adapter.rb:1112) so the next
+    // update_typemap_for_default_timezone re-applies the session timezone. This
+    // is a fresh physical session (reconnect/reset/discard cleared
+    // _connectionConfigured), which starts at PostgreSQL's default timezone, so
+    // the cache must be invalidated here or the guard would skip reconfiguring.
+    this._mappedDefaultTimezone = null;
     // Mirrors: set_standard_conforming_strings — required for correct quoting behaviour.
     await client.query("SET standard_conforming_strings = on");
     // Mirrors: SET intervalstyle — ISO 8601 so intervals parse cleanly.


### PR DESCRIPTION
## What

Rails' PostgreSQL adapter has **one** SQL primitive, `perform_query`
(`postgresql/database_statements.rb:135`), which branches internally on whether
the statement returns rows. trails split that into `execute` (rows) and
`executeMutation` (affected-rows / insert id). That split is itself the
deviation, and it's why DDL can't flow through the public `execute` the way
Rails' `schema_statements.rb` does.

This is the second of the per-adapter split (sqlite3 landed in #4893).

## How

Give the PG adapter a single private `_performQuery` that both `execute` and
`executeMutation` delegate to:

- runs `_runQuery`, marks the connection `verified!`, flushes warnings,
  surfaces the last statement of a multi-statement string, and sets
  `payload.row_count`.
- records the affected-row count in a new `_lastAffectedRows` field, sourced
  through the existing this-less `affectedRows` port in
  `postgresql/database-statements.ts` (wired, not re-copied — mirrors #4893's
  sqlite3 `affected_rows`).

`execute` returns `.rows`; `executeMutation` sources affected rows through the
`affectedRows` port rather than reading `result.rowCount` inline.

Unlike sqlite, node-pg does not throw on a non-row-returning statement, so
there's no branch on a driver throw — the read/write split lives in the
callers' contracts.

## Preserved exactly

- The RETURNING-append + SAVEPOINT (`_bt_ret_<n>`) fallback and the
  `payload.sql` rewrite, load-bearing for `execInsert`.
- The readonly-write guard (via `preprocessQuery` → `check_if_write_query`) and
  `materializeTransactions()`.

## Not in scope

DDL call sites are **not** rerouted — that's
`converge-ddl-through-execute-drop-dirty-guard`, which needs all three adapters
branching first.

## Test

New `postgresql-adapter-perform-query.trails.test.ts` covers the shared branch,
the affected-rows source, RETURNING-append for a bare INSERT, explicit
RETURNING, UPDATE/DELETE affected rows, and the readonly guard on both entry
points. Also green (`ARCONN=postgresql`): the PG exec-query, persistence,
prevent-writes, bind-parameter, query-cache, query-cache-ddl-dirties,
transactions, autosave-association, and nested-attributes suites.

Closes-story: unify-execute-mutation-into-perform-query-postgresql
