### PR TITLE
fix(query-cache): Store max size nullable for unbounded, not Infinity sentinel

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -28,13 +28,13 @@ const DEFAULT_MAX_SIZE = 100;
  */
 export class Store {
   private _map = new Map<string, Record<string, unknown>[]>();
-  private _maxSize: number;
+  private _maxSize: number | null;
   private _version: { value: number } | null;
   private _currentVersion: number;
   enabled = false;
   dirties = true;
 
-  constructor(version: { value: number } | null = null, maxSize: number = DEFAULT_MAX_SIZE) {
+  constructor(version: { value: number } | null = null, maxSize: number | null = DEFAULT_MAX_SIZE) {
     this._maxSize = maxSize;
     this._version = version;
     this._currentVersion = version?.value ?? 0;
@@ -87,11 +87,7 @@ export class Store {
     }
 
     return compute().then((result) => {
-      if (this._maxSize <= 0) {
-        // maxSize of 0 or negative disables caching — return without storing
-        return result;
-      }
-      if (this._map.size >= this._maxSize) {
+      if (this._maxSize != null && this._map.size >= this._maxSize) {
         const firstKey = this._map.keys().next().value;
         if (firstKey !== undefined) this._map.delete(firstKey);
       }
@@ -332,12 +328,7 @@ export class ConnectionPoolConfiguration {
 
   get queryCache(): Store {
     return this._threadQueryCaches.computeIfAbsent(String(executionContextId()), () => {
-      // A null max size is Rails' "unbounded" (nil) — the Store never evicts.
-      // trails' Store keys unboundedness off a number, so map nil to Infinity.
-      return new Store(
-        this._queryCacheVersion,
-        this._queryCacheMaxSize ?? Number.POSITIVE_INFINITY,
-      );
+      return new Store(this._queryCacheVersion, this._queryCacheMaxSize);
     });
   }
 

--- a/packages/activerecord/src/query-cache.trails.test.ts
+++ b/packages/activerecord/src/query-cache.trails.test.ts
@@ -11,6 +11,7 @@ import { Base } from "./base.js";
 import { Task } from "./test-helpers/models/task.js";
 import { Notifications, type NotificationEvent } from "@blazetrails/activesupport";
 import { QueryCache } from "./query-cache.js";
+import { Store } from "./connection-adapters/abstract/query-cache.js";
 
 registerModel(Task as never);
 
@@ -221,5 +222,39 @@ describe("run returns not-already-enabled targets for complete (trails)", () => 
     expect(innerState).toEqual([inner]);
     expect(outer.disabledCount).toBe(1);
     expect(inner.disabledCount).toBe(1);
+  });
+});
+
+// Rails' "query cache lru eviction" test drives `@max_size` through a public
+// per-connection setter that trails does not expose (it stays skipped in the
+// mirrored file). These construct the Store directly to pin the eviction gate
+// `@max_size && @map.size >= @max_size` (query_cache.rb:75): a null max size is
+// unbounded (never evicts), an integer caps the map and evicts the oldest.
+describe("Store max size eviction gate (trails)", () => {
+  const fill = async (store: Store, keys: string[]): Promise<void> => {
+    for (const key of keys) {
+      await store.computeIfAbsent(key, () => Promise.resolve([{ key }]));
+    }
+  };
+
+  it("a null max size is unbounded and never evicts", async () => {
+    const store = new Store(null, null);
+    store.enabled = true;
+    await fill(
+      store,
+      Array.from({ length: 200 }, (_, i) => `k${i}`),
+    );
+    expect(store.size).toBe(200);
+  });
+
+  it("an integer max size caps the map and evicts the oldest entry", async () => {
+    const store = new Store(null, 2);
+    store.enabled = true;
+    await fill(store, ["a", "b", "c"]);
+    expect(store.size).toBe(2);
+    // "a" was the oldest and gets shifted out; "b"/"c" remain.
+    expect(store.get("a")).toBeUndefined();
+    expect(store.get("b")).toEqual([{ key: "b" }]);
+    expect(store.get("c")).toEqual([{ key: "c" }]);
   });
 });


### PR DESCRIPTION
## What

Rails' `QueryCache::Store` (`query_cache.rb:34-92`) holds a **nullable**
`@max_size`: `nil` means unbounded, and eviction gates on
`@max_size && @map.size >= @max_size` (`:75`). trails typed `_maxSize` as a
plain `number`, treated `<= 0` as "disable storage", and had no native
representation of unbounded. PR #4932 papered over the gap at the call site by
mapping a null pool max size to `Number.POSITIVE_INFINITY`.

This aligns the Store's shape with Rails:

- `Store#_maxSize` becomes `number | null` (null = unbounded).
- Eviction gates on `this._maxSize != null && this._map.size >= this._maxSize`;
  the `<= 0` sentinel is dropped.
- `get queryCache()` passes `_queryCacheMaxSize` straight through, removing the
  `?? Number.POSITIVE_INFINITY` shim.

Existing `query-cache.test.ts` assertions stay Rails-verbatim (null for
false/unlimited, integer for a sized config).

Closes-story: query-cache-store-max-size-nullable-not-infinity
