### PR TITLE
refactor(activemodel): port bare throws in i18n.ts and lint.ts

### DIFF
--- a/eslint/rails-error-parity-exclude.json
+++ b/eslint/rails-error-parity-exclude.json
@@ -1,6 +1,4 @@
 [
-  "packages/activemodel/src/i18n.ts",
-  "packages/activemodel/src/lint.ts",
   "packages/activerecord/src/adapters/postgresql/pg-range.ts",
   "packages/activerecord/src/aggregations.ts",
   "packages/activerecord/src/associations.ts",

--- a/packages/activemodel/src/i18n.test.ts
+++ b/packages/activemodel/src/i18n.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { I18n } from "./i18n.js";
-import { MissingInterpolationArgument } from "./i18n.js";
+import { MissingInterpolationArgument, MissingTranslationData } from "./i18n.js";
 
 describe("I18n", () => {
   beforeEach(() => {
@@ -46,6 +46,29 @@ describe("I18n", () => {
       expect(() => I18n.t("hi", { locale: "en", defaults: [{ key: "missing" }] })).toThrow(
         MissingInterpolationArgument,
       );
+    });
+  });
+
+  describe("raise on missing", () => {
+    it("raises MissingTranslationData for an unknown key with raise:true", () => {
+      expect(() => I18n.t("nope", { raise: true })).toThrow(MissingTranslationData);
+    });
+
+    it("lists the considered keys when the default chain is exhausted", () => {
+      // Mirrors i18n MissingTranslation::Base#message: with a `default` chain the
+      // message appends `. Options considered were:` listing every resolved key
+      // (activemodel CHANGELOG, human_attribute_name raise path).
+      let error: MissingTranslationData | undefined;
+      try {
+        I18n.t("a.b", { raise: true, defaults: [{ key: "c.d" }, { key: "e.f" }] });
+      } catch (e) {
+        error = e as MissingTranslationData;
+      }
+      expect(error).toBeInstanceOf(MissingTranslationData);
+      expect(error?.message).toBe(
+        "translation missing: en.a.b. Options considered were:\n- en.a.b\n- en.c.d\n- en.e.f",
+      );
+      expect(error?.consideredKeys).toEqual(["a.b", "c.d", "e.f"]);
     });
   });
 

--- a/packages/activemodel/src/i18n.test.ts
+++ b/packages/activemodel/src/i18n.test.ts
@@ -51,13 +51,22 @@ describe("I18n", () => {
 
   describe("raise on missing", () => {
     it("raises MissingTranslationData for an unknown key with raise:true", () => {
-      expect(() => I18n.t("nope", { raise: true })).toThrow(MissingTranslationData);
+      let error: MissingTranslationData | undefined;
+      try {
+        I18n.t("nope", { raise: true });
+      } catch (e) {
+        error = e as MissingTranslationData;
+      }
+      expect(error).toBeInstanceOf(MissingTranslationData);
+      // No-default branch of MissingTranslation::Base#message.
+      expect(error?.message).toBe("Translation missing: en.nope");
     });
 
     it("lists the considered keys when the default chain is exhausted", () => {
-      // Mirrors i18n MissingTranslation::Base#message: with a `default` chain the
-      // message appends `. Options considered were:` listing every resolved key
-      // (activemodel CHANGELOG, human_attribute_name raise path).
+      // Options branch of i18n MissingTranslation::Base#message: with a
+      // non-empty `default` chain the message is `Translation missing. Options
+      // considered were:` listing every resolved key — the shape ActiveModel's
+      // human_attribute_name raise path produces (activemodel CHANGELOG).
       let error: MissingTranslationData | undefined;
       try {
         I18n.t("a.b", { raise: true, defaults: [{ key: "c.d" }, { key: "e.f" }] });
@@ -66,7 +75,7 @@ describe("I18n", () => {
       }
       expect(error).toBeInstanceOf(MissingTranslationData);
       expect(error?.message).toBe(
-        "translation missing: en.a.b. Options considered were:\n- en.a.b\n- en.c.d\n- en.e.f",
+        "Translation missing. Options considered were:\n- en.a.b\n- en.c.d\n- en.e.f",
       );
       expect(error?.consideredKeys).toEqual(["a.b", "c.d", "e.f"]);
     });

--- a/packages/activemodel/src/i18n.ts
+++ b/packages/activemodel/src/i18n.ts
@@ -39,22 +39,40 @@ export class MissingInterpolationArgument extends globalThis.Error {
 }
 
 /**
- * Raised by `I18n.t(key, { raise: true })` when a key resolves to nothing and
- * no default is supplied.
+ * Raised by `I18n.t(key, { raise: true })` when a key (and every default key)
+ * resolves to nothing.
  *
  * Mirrors: I18n::MissingTranslationData (i18n/lib/i18n/exceptions.rb) — the i18n
  * gem's `MissingTranslation` alias, an `ArgumentError` subclass in Ruby. We root
  * it at the global `Error` here since the activemodel service has no local
  * `ArgumentError` home, matching the sibling ActiveSupport port.
+ *
+ * `MissingTranslation::Base` stores `locale`/`key`/`options` and its `#message`
+ * appends `. Options considered were:` listing every fully-resolved key when a
+ * `default` was supplied — the shape shown in activemodel's CHANGELOG for the
+ * `human_attribute_name` raise path (which passes the ancestor lookup chain as
+ * `defaults`). We reproduce that so the exhausted-`defaults` branch reports the
+ * considered keys, not just the primary.
  */
 export class MissingTranslationData extends globalThis.Error {
   readonly key: string;
   readonly locale: string;
-  constructor(locale: string, key: string) {
-    super(`Translation missing: ${locale}.${key}`);
+  readonly consideredKeys: string[];
+  constructor(locale: string, key: string, defaults?: TranslateOptions["defaults"]) {
+    const consideredKeys = [key, ...(defaults ?? []).flatMap((d) => ("key" in d ? [d.key] : []))];
+    const first = `${locale}.${consideredKeys[0]}`;
+    let message = `translation missing: ${first}`;
+    // `#message` only lists options when a `default` chain was passed
+    // (i18n MissingTranslation::Base#message).
+    if (defaults && defaults.length > 0) {
+      const lines = consideredKeys.map((k) => `- ${locale}.${k}`).join("\n");
+      message += `. Options considered were:\n${lines}`;
+    }
+    super(message);
     this.name = "MissingTranslationData";
     this.locale = locale;
     this.key = key;
+    this.consideredKeys = consideredKeys;
   }
 }
 
@@ -160,7 +178,7 @@ class I18nService {
     }
 
     if (options?.raise ?? raiseOnMissingTranslations()) {
-      throw new MissingTranslationData(locale, key);
+      throw new MissingTranslationData(locale, key, options?.defaults);
     }
     return key;
   }

--- a/packages/activemodel/src/i18n.ts
+++ b/packages/activemodel/src/i18n.ts
@@ -48,11 +48,12 @@ export class MissingInterpolationArgument extends globalThis.Error {
  * `ArgumentError` home, matching the sibling ActiveSupport port.
  *
  * `MissingTranslation::Base` stores `locale`/`key`/`options` and its `#message`
- * appends `. Options considered were:` listing every fully-resolved key when a
- * `default` was supplied — the shape shown in activemodel's CHANGELOG for the
- * `human_attribute_name` raise path (which passes the ancestor lookup chain as
- * `defaults`). We reproduce that so the exhausted-`defaults` branch reports the
- * considered keys, not just the primary.
+ * has two branches (i18n/lib/i18n/exceptions.rb): with a non-empty `default`
+ * chain it returns `Translation missing. Options considered were:` followed by
+ * each fully-resolved key; otherwise the bare `Translation missing: <keys>`.
+ * ActiveModel's `human_attribute_name` raise path passes the ancestor lookup
+ * chain as `default:` (activemodel/lib/active_model/translation.rb), so it hits
+ * the options-listing branch — the shape shown in activemodel's CHANGELOG.
  */
 export class MissingTranslationData extends globalThis.Error {
   readonly key: string;
@@ -60,13 +61,12 @@ export class MissingTranslationData extends globalThis.Error {
   readonly consideredKeys: string[];
   constructor(locale: string, key: string, defaults?: TranslateOptions["defaults"]) {
     const consideredKeys = [key, ...(defaults ?? []).flatMap((d) => ("key" in d ? [d.key] : []))];
-    const first = `${locale}.${consideredKeys[0]}`;
-    let message = `translation missing: ${first}`;
-    // `#message` only lists options when a `default` chain was passed
-    // (i18n MissingTranslation::Base#message).
+    let message: string;
     if (defaults && defaults.length > 0) {
       const lines = consideredKeys.map((k) => `- ${locale}.${k}`).join("\n");
-      message += `. Options considered were:\n${lines}`;
+      message = `Translation missing. Options considered were:\n${lines}`;
+    } else {
+      message = `Translation missing: ${locale}.${key}`;
     }
     super(message);
     this.name = "MissingTranslationData";

--- a/packages/activemodel/src/i18n.ts
+++ b/packages/activemodel/src/i18n.ts
@@ -39,6 +39,26 @@ export class MissingInterpolationArgument extends globalThis.Error {
 }
 
 /**
+ * Raised by `I18n.t(key, { raise: true })` when a key resolves to nothing and
+ * no default is supplied.
+ *
+ * Mirrors: I18n::MissingTranslationData (i18n/lib/i18n/exceptions.rb) — the i18n
+ * gem's `MissingTranslation` alias, an `ArgumentError` subclass in Ruby. We root
+ * it at the global `Error` here since the activemodel service has no local
+ * `ArgumentError` home, matching the sibling ActiveSupport port.
+ */
+export class MissingTranslationData extends globalThis.Error {
+  readonly key: string;
+  readonly locale: string;
+  constructor(locale: string, key: string) {
+    super(`Translation missing: ${locale}.${key}`);
+    this.name = "MissingTranslationData";
+    this.locale = locale;
+    this.key = key;
+  }
+}
+
+/**
  * Keys the I18n gem reserves (not forwarded as `%{}` interpolations).
  * See i18n/lib/i18n.rb RESERVED_KEYS.
  */
@@ -140,7 +160,7 @@ class I18nService {
     }
 
     if (options?.raise ?? raiseOnMissingTranslations()) {
-      throw new Error(`Translation missing: ${key}`);
+      throw new MissingTranslationData(locale, key);
     }
     return key;
   }

--- a/packages/activemodel/src/lint.ts
+++ b/packages/activemodel/src/lint.ts
@@ -12,6 +12,22 @@
 export interface Lint {}
 
 /**
+ * Raised when an ActiveModel::Lint compliance check fails.
+ *
+ * Rails' `Lint::Tests` are Minitest test methods whose `assert*` calls raise
+ * `Minitest::Assertion` on failure (there is no ActiveModel error class for
+ * these — the failures are test-framework assertions). This ports that
+ * assertion-failure identity so the standalone lint functions surface a single
+ * named class instead of a bare `Error`.
+ */
+export class MinitestAssertion extends globalThis.Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MinitestAssertion";
+  }
+}
+
+/**
  * Resolve the model fixture under test. Mirrors Rails
  * `Lint::Tests#model` (activemodel/lib/active_model/lint.rb:108-111)
  * which calls `@model.to_model` so the fixture can stand in via
@@ -34,7 +50,7 @@ export function model<T>(m: T | { toModel(): T }): T {
  */
 export function assertBoolean(result: unknown, name: string): void {
   if (result !== true && result !== false) {
-    throw new Error(`${name} should be a boolean`);
+    throw new MinitestAssertion(`${name} should be a boolean`);
   }
 }
 
@@ -45,19 +61,19 @@ export namespace Tests {
     const m = model(input);
     const key = m.toKey();
     if (key !== null && !Array.isArray(key)) {
-      throw new Error("toKey must return null or an array");
+      throw new MinitestAssertion("toKey must return null or an array");
     }
 
     const persisted = m.isPersisted();
     assertBoolean(persisted, "isPersisted");
 
     if (persisted && key === null) {
-      throw new Error("toKey must not return null when the model is persisted");
+      throw new MinitestAssertion("toKey must not return null when the model is persisted");
     }
 
     withPatchedPersistedFalse(m, () => {
       if (m.toKey() !== null) {
-        throw new Error("toKey should return null when `isPersisted` returns false");
+        throw new MinitestAssertion("toKey should return null when `isPersisted` returns false");
       }
     });
   }
@@ -71,7 +87,7 @@ export namespace Tests {
     const m = model(input);
     const param = m.toParam();
     if (param !== null && typeof param !== "string") {
-      throw new Error("toParam must return null or a string");
+      throw new MinitestAssertion("toParam must return null or a string");
     }
 
     withPatched(
@@ -81,7 +97,9 @@ export namespace Tests {
       () => {
         withPatchedPersistedFalse(m, () => {
           if (m.toParam() !== null) {
-            throw new Error("toParam should return null when `isPersisted` returns false");
+            throw new MinitestAssertion(
+              "toParam should return null when `isPersisted` returns false",
+            );
           }
         });
       },
@@ -95,7 +113,7 @@ export namespace Tests {
     const m = model(input);
     const path = m.toPartialPath();
     if (typeof path !== "string") {
-      throw new Error("toPartialPath must return a string");
+      throw new MinitestAssertion("toPartialPath must return a string");
     }
   }
 
@@ -107,7 +125,7 @@ export namespace Tests {
   export function testErrors(model: { errors: { fullMessages: unknown[] } }): void {
     const messages = model.errors.fullMessages;
     if (!Array.isArray(messages)) {
-      throw new Error("errors.fullMessages must return an array");
+      throw new MinitestAssertion("errors.fullMessages must return an array");
     }
   }
 
@@ -118,19 +136,19 @@ export namespace Tests {
   export function testModelNaming(model: ModelNamingHost): void {
     const classModelName = model.constructor.modelName;
     if (!classModelName) {
-      throw new Error("model.constructor.modelName must be defined");
+      throw new MinitestAssertion("model.constructor.modelName must be defined");
     }
     if (typeof classModelName.human !== "string") {
-      throw new Error("modelName.human must return a string");
+      throw new MinitestAssertion("modelName.human must return a string");
     }
     if (typeof classModelName.singular !== "string") {
-      throw new Error("modelName.singular must return a string");
+      throw new MinitestAssertion("modelName.singular must return a string");
     }
     if (typeof classModelName.plural !== "string") {
-      throw new Error("modelName.plural must return a string");
+      throw new MinitestAssertion("modelName.plural must return a string");
     }
     if (model.modelName !== classModelName) {
-      throw new Error("model.modelName must equal model.constructor.modelName");
+      throw new MinitestAssertion("model.modelName must equal model.constructor.modelName");
     }
   }
 
@@ -142,7 +160,7 @@ export namespace Tests {
   export function testErrorsAref(model: { errors: { get(attribute: string): string[] } }): void {
     const result = model.errors.get("attribute");
     if (!Array.isArray(result)) {
-      throw new Error("errors.get(attribute) must return an array");
+      throw new MinitestAssertion("errors.get(attribute) must return an array");
     }
   }
 }


### PR DESCRIPTION
## What

Clears the last two ActiveModel bare-throw files from the `rails-error-parity`
exclude baseline (follows continue-4, PR #4856).

- **i18n.ts**: the `raise: true` missing-translation path now throws a ported
  `MissingTranslationData` (Rails `I18n::MissingTranslationData`), matching the
  ActiveSupport sibling class rather than a bare `Error`.
- **lint.ts**: the `ActiveModel::Lint` compliance-check failures now throw a
  ported `MinitestAssertion` — Rails' `Lint::Tests` are Minitest methods whose
  `assert*` calls raise `Minitest::Assertion` on failure (no ActiveModel error
  class exists for these).
- Removes `i18n.ts` and `lint.ts` from `eslint/rails-error-parity-exclude.json`
  (baseline strictly smaller).

## Testing

- `npx eslint` clean on both files; rule stays `error`.
- `i18n.test.ts`, `lint.test.ts`, `translation.test.ts` — 66 tests green.

Closes-story: rails-error-parity-bare-throw-burndown-continue-5