### PR TITLE
fix(collection-proxy): rebase stale new-owner seed for proxy-invoked mutation terminals

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -843,6 +843,68 @@ describe("CollectionProxy — mutated finder requery on stale new-owner seed", (
   });
 });
 
+// The mutation terminals invoked on the PROXY itself (not a spawned relation)
+// route through `Relation`'s implementations with `this` = the proxy — and
+// `deleteAll`'s diverged branch calls `super.deleteAll()` on the proxy — so
+// they hit the base `_isEmptyRelation()` chokepoint on the proxy. The
+// `CollectionProxy#_isEmptyRelation` override rebases the stale new-owner
+// `1=0` seed there, giving the mutation side the same rebase reads already
+// get through `_finderScope`.
+describe("CollectionProxy — mutation terminals invoked on the proxy itself on stale new-owner seed", () => {
+  fixtures(["authors", "posts"]);
+
+  it("resolves the persisted FK on updateAll/updateCounters invoked on the proxy after save", async () => {
+    const author = new Author({ name: "Proxy Mutation One" });
+    const posts = association<Post>(author, "posts") as any;
+
+    await author.save();
+    const authorId = author.id as number;
+    const mine = await Post.create({ title: "mine", body: "1", author_id: authorId });
+    // A post belonging to a DIFFERENT author proves the rebuilt scope still
+    // constrains to this owner's FK, not a bare `updateAll` over the table.
+    const otherAuthor = await Author.create({ name: "Someone Else" });
+    const theirs = await Post.create({ title: "theirs", body: "2", author_id: otherAuthor.id });
+
+    expect(await posts.updateCounters({ tags_count: 1 })).toBe(1);
+    expect((await Post.find(mine.id)).tags_count).toBe(1);
+    expect((await Post.find(theirs.id)).tags_count).toBe(0);
+
+    expect(await posts.updateAll({ body: "updated" })).toBe(1);
+    expect((await Post.find(mine.id)).body).toBe("updated");
+    expect((await Post.find(theirs.id)).body).toBe("2");
+  });
+
+  it("resolves the persisted FK on the diverged deleteAll branch invoked on the proxy after save", async () => {
+    const author = new Author({ name: "Proxy Mutation Two" });
+    const posts = association<Post>(author, "posts") as any;
+    // Diverge the proxy in place while the owner is new so its base is the
+    // stale `1=0` seed and `deleteAll` takes the `super.deleteAll()` branch.
+    posts.whereBang({ title: "drop" });
+
+    await author.save();
+    const authorId = author.id as number;
+    const dropped = await Post.create({ title: "drop", body: "1", author_id: authorId });
+    const kept = await Post.create({ title: "keep", body: "2", author_id: authorId });
+
+    expect(await posts.deleteAll()).toBe(1);
+    expect(await Post.where({ author_id: authorId }).pluck("id")).toEqual([kept.id]);
+    expect(await Post.exists(dropped.id)).toBe(false);
+  });
+
+  it("resolves the persisted FK on touchAll invoked on the proxy after save", async () => {
+    const ship = new Ship({ name: "Proxy Mutation Three" });
+    const parts = association<ShipPart>(ship, "parts") as any;
+
+    await ship.save();
+    const shipId = ship.id as number;
+    const stale = "2000-01-01T00:00:00Z";
+    const mast = await ShipPart.create({ name: "mast", ship_id: shipId, updated_at: stale });
+
+    expect(await parts.touchAll()).toBe(1);
+    expect(String((await ShipPart.find(mast.id)).updated_at)).not.toBe(stale);
+  });
+});
+
 // The in-memory `CollectionProxy#find` path (loaded `inverse_of` collection,
 // scanned in memory) must emit the identical not-found message as the SQL
 // `performFind` path — Rails routes both through

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -748,6 +748,40 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   /**
+   * The none-short-circuit chokepoint (see `Relation#_isEmptyRelation`), overridden
+   * so mutation terminals invoked on the PROXY itself resolve a stale new-owner
+   * `1=0` seed once the owner is saved. `updateAll`/`touchAll`/`updateCounters`
+   * have no `CollectionProxy` override — they run `Relation`'s with `this` = the
+   * proxy — and `deleteAll`'s diverged branch calls `super.deleteAll()` on the
+   * proxy; all reach this before building SQL. Rebasing here (mirroring the
+   * `AssociationRelation` override) gives the mutation side the same rebase that
+   * reads already get through `_finderScope`, from one place.
+   */
+  _isEmptyRelation(): boolean {
+    this._maybeRebaseProxySeed();
+    return super._isEmptyRelation();
+  }
+
+  /**
+   * @internal Rebase this proxy in place when it still carries a stale new-owner
+   * `1=0` seed and the owner has since been saved (so `scope()` resolves a real
+   * FK). Mirrors `_finderScope`'s rebase, but mutates `this` — a mutation
+   * terminal runs against the proxy's own relation state, so the resolved FK
+   * must land there. Clears the seed marker so it runs exactly once.
+   */
+  private _maybeRebaseProxySeed(): void {
+    if (!this._seededNoneNewOwner) return;
+    const fresh = this.scope() as unknown as { _isNone: boolean };
+    if (fresh._isNone) return;
+    rebaseNewOwnerSeed(
+      this as unknown as Parameters<typeof rebaseNewOwnerSeed>[0],
+      fresh as unknown,
+      this._seedWherePredicates,
+    );
+    this._seededNoneNewOwner = false;
+  }
+
+  /**
    * Shared execution core for `toArray()` and `load()`. Routes both the
    * unmutated and mutated (whereBang / orderBang / ...) proxy through a
    * single `loadHasMany` call. When the proxy state has diverged from the

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -6304,13 +6304,8 @@ export class Relation<T extends Base> {
    * (`owner.things.where(...)`) resolves the persisted FK once the owner is
    * saved — mirroring Rails' CollectionProxy delegating every query to
    * `association.scope`, rather than each terminal carrying its own rebase hook.
-   *
-   * Note the scope of that override: `CollectionProxy` extends `Relation`, not
-   * `AssociationRelation`, and does not override this, so mutation terminals
-   * invoked on the PROXY itself (`owner.things.updateAll(...)`) still see the
-   * raw `_isNone`. Reads dodge this via `CollectionProxy#_finderScope`; the
-   * mutation side has no equivalent. Tracked by the
-   * `rebase-new-owner-seed-for-collection-proxy-mutations` story.
+   * `CollectionProxy` overrides this too, so mutation terminals invoked on the
+   * PROXY itself (`owner.things.updateAll(...)`) rebase the same way.
    *
    * @internal
    */


### PR DESCRIPTION
## What

Mutation terminals invoked on the `CollectionProxy` itself — `updateAll` /
`touchAll` / `updateCounters`, and `deleteAll`'s diverged `super.deleteAll()`
branch — ran `Relation`'s implementations with `this` = the proxy, so they hit
the base `_isEmptyRelation()` chokepoint's raw `_isNone`. A proxy spawned off a
NEW owner carries the stale `1=0` seed; those terminals affected 0 rows even
after the owner was saved and its FK resolved.

```ts
const author = new Author({ name: "Gap" });
const posts = author.posts;        // proxy, seed collapsed to 1=0
await author.save();
await Post.create({ title: "GG", author_id: author.id });
await posts.updateAll({ body: "H" });      // was 0 → now 1
await posts.updateCounters({ tags_count: 1 }); // was 0 → now 1
```

## Fix

Override `CollectionProxy#_isEmptyRelation()` to rebase the stale seed onto the
live association scope **in place**, mirroring the `AssociationRelation`
override and reusing the `_finderScope()` rebase machinery
(`rebaseNewOwnerSeed`). This is a single mechanism at the shared chokepoint —
no per-terminal hooks — so the mutation side gets the same rebase reads already
get via `_finderScope`. Drops the now-stale "Note the scope of that override"
caveat in `Relation#_isEmptyRelation`.

## Tests

Regression tests in `collection-proxy.test.ts` for the proxy-invoked mutation
terminals (has_many): `updateAll`/`updateCounters`, the diverged `deleteAll`
branch, and `touchAll` (via `ship.parts`), alongside the existing
spawned-relation tests.

Closes-story: rebase-new-owner-seed-for-collection-proxy-mutations
