### PR TITLE
docs(validations): remove sync-only validation prose after RFC 0063 async flip

### DIFF
--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -663,10 +663,11 @@ export class Model {
   ): void {
     const fn: CallbackFn = (record: object) => {
       // Return the underlying result so a Promise-returning validator flows
-      // into the callback runner, where strict-sync mode (on the `validate`
-      // event) throws instead of dropping it as an unhandled rejection.
-      // Validations are synchronous in trails — an async `validate` callback
-      // is an authoring bug; move the async work to before_save/after_save.
+      // into the callback runner, which awaits it (RFC 0063 made the validation
+      // chain async) rather than dropping it as an unhandled rejection. Most
+      // validators are synchronous like Rails; the exception is a DB-backed one
+      // such as `uniqueness`, whose existence check the awaited chain runs
+      // inline.
       const r = record as T & Record<string, unknown>;
       if (typeof methodOrFn === "function") {
         // Bind `this` to the record so block validators written as

--- a/packages/activerecord/README.md
+++ b/packages/activerecord/README.md
@@ -30,8 +30,8 @@ list, and design principles see the [root README](../../README.md).
 > The single biggest divergence: **JavaScript has no synchronous DB access**, so
 > nearly every method that touches the database is `async` and must be
 > `await`ed. The deviations below — the `Bang` suffix, async
-> singular-association loading, and the sync/async validation split — mostly
-> follow from that one fact.
+> singular-association loading, and the awaited (async) validation chain —
+> mostly follow from that one fact.
 
 ## Install
 

--- a/packages/activerecord/src/associations/builder/belongs-to.ts
+++ b/packages/activerecord/src/associations/builder/belongs-to.ts
@@ -299,13 +299,13 @@ export class BelongsTo extends SingularAssociation {
     // Mirrors Rails Associations::Builder::BelongsTo.add_default_callbacks:
     //   model.before_validation { |o| o.association(name).default(&default) }
     // so the defaulted target satisfies a presence validation on a required
-    // association. trails' validation chain is strictly synchronous while the
-    // default block may run an async finder (e.g. `() => Developer.first()`), so
-    // the awaited resolution actually runs in Base#_runBelongsToDefaults — an
-    // async pre-validation phase invoked from `save` before the chain. This
-    // before_validation callback fires `default` for the standalone `valid?`
-    // path; it's fire-and-forget because the sync chain cannot await it. On the
-    // save path the pre-pass already ran the block once and sets
+    // association. The default block may run an async finder (e.g.
+    // `() => Developer.first()`); on the save path the awaited resolution runs
+    // in Base#_runBelongsToDefaults — a pre-validation pass invoked from `save`
+    // before the chain. This before_validation callback fires `default` for the
+    // standalone `valid?` path; it's fire-and-forget (the pre-pass owns awaited
+    // resolution on the save path). On the save path the pre-pass already ran
+    // the block once and sets
     // `_belongsToDefaultsApplied`, so we skip here to keep the block at Rails'
     // exactly-once (belongs_to_association.rb:46-48) — re-running would invoke a
     // block that returned nil a second time.
@@ -361,9 +361,9 @@ export class BelongsTo extends SingularAssociation {
           : [reflection.foreignType ?? `${underscore(reflection.name)}_type`]
         : [];
 
-      // trails validations are synchronous (see CLAUDE.md) and cannot load an
-      // unloaded target, so we suppress the presence check when the FK is
-      // already populated — keeping `create({ parentId: id })` valid and
+      // The presence check reads the in-memory target and does not itself load
+      // an unloaded record, so we suppress it when the FK is already populated —
+      // keeping `create({ parentId: id })` valid and
       // matching Rails' observable behavior (where reading the association
       // loads the record from the FK).
       const foreignKeyPresent = (record: any): boolean => {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -3876,12 +3876,12 @@ export class Base extends Model {
    *
    * Rails registers the default on before_validation
    * (associations/builder/belongs_to.rb#add_default_callbacks) so a required
-   * association's presence validation sees the defaulted foreign key. trails'
-   * validation chain is strictly synchronous while a default block may be async
-   * (e.g. `() => Developer.first()`), so the async resolution runs here — an
-   * async pre-validation phase invoked from `save` — rather than inside the sync
-   * chain. The synchronous before_validation callback the builder registers
-   * still covers sync blocks and the standalone `valid?` path.
+   * association's presence validation sees the defaulted foreign key. A default
+   * block may be async (e.g. `() => Developer.first()`); on the save path its
+   * awaited resolution runs here — a pre-validation pass invoked from `save` —
+   * before the chain, so the FK is set once and marked applied. The
+   * before_validation callback the builder registers still covers the
+   * standalone `valid?` path.
    *
    * @internal
    */

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -2154,22 +2154,17 @@ describe("PersistenceTest", () => {
   );
 });
 
-// ==========================================================================
-// PersistenceTest — deviation tracked under RFC 0023-surfaced-deviations.
-//   * `update attribute in before validation respects callback chain` calls
-//     `update_attribute` (a DB write) from a `before_validation` callback.
-//     trails validations are sync-only, so an async `beforeValidation` throws
-//     "Async callback on sync chain". Tracked:
-//     rfcs/0023-surfaced-deviations/stories/async-before-validation-sync-chain.md
-// ==========================================================================
 describe("PersistenceTest", () => {
   const Topic = CanonicalTopic;
   fixtures(["topics"]);
 
-  it.skip("update attribute in before validation respects callback chain", async () => {
+  // `update_attribute` is a DB write, so the `before_validation` callback that
+  // calls it is async in trails; the RFC 0063 async validation chain awaits it
+  // (Rails' `set_author_name` is a plain sync method).
+  it("update attribute in before validation respects callback chain", async () => {
     let counter = 0;
     const callOnce = (record: any) => {
-      if (record.savedChangeToAuthorName()) counter += 1;
+      if (record.savedChangeToAuthor_name()) counter += 1;
     };
     class TrackingTopic extends Topic {
       static {
@@ -2181,7 +2176,7 @@ describe("PersistenceTest", () => {
           callOnce(this);
         });
         self.afterUpdate(function (this: any) {
-          if (this.savedChangeToAuthorName()) callOnce(this);
+          if (this.savedChangeToAuthor_name()) callOnce(this);
         });
       }
     }

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -871,7 +871,7 @@ export async function save<T extends SaveRecord>(
       // Validations#save { perform_validations; Persistence#save } }`
       // (transactions.rb:360, validations.rb:47), so `before_validation` runs
       // *inside* the transaction and *before* `valid?`. trails runs
-      // `performValidations` above (outside the transaction, line 778), so the
+      // `performValidations` above (outside the transaction), so the
       // deferred thunk's async body runs here — after the validators, not
       // before. Observable only when a record has BOTH a failing validation and
       // an aborting async `before_validation`: trails reports `errors.any`

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -819,11 +819,14 @@ export async function save<T extends SaveRecord>(
     await self._runBelongsToDefaults();
     self._belongsToDefaultsApplied = true;
   }
-  // A `before_validation` that needs async DB work (Rails runs it inside the
-  // save transaction — transactions_test.rb:714) can't await on trails' strict-
-  // sync validation chain, so such a callback defers its thunk here instead of
-  // running inline. Reset the queue before the chain populates it so a prior
-  // save that bailed at validation doesn't leak a stale thunk into this one.
+  // A `before_validation` that needs async DB work should run inside the save
+  // transaction (Rails wraps `super` in `with_transaction_returning_status` and
+  // `perform_validations` runs inside it — transactions.rb:360, validations.rb:47;
+  // transactions_test.rb:714). Trails runs `performValidations` before opening
+  // the save transaction, so such a callback defers its thunk here for `save` to
+  // drain inside the transaction instead of running it during validation. Reset
+  // the queue before the chain populates it so a prior save that bailed at
+  // validation doesn't leak a stale thunk into this one.
   self._beforeValidationSideEffects = [];
   let validationsPassed: boolean;
   try {

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -807,9 +807,9 @@ export async function save<T extends SaveRecord>(
   // Resolve `belongs_to ..., default:` blocks before validation. Rails registers
   // these on before_validation (builder/belongs_to.rb#add_default_callbacks) so a
   // required association's presence validation sees the defaulted FK. The block
-  // may be async (e.g. `() => Developer.first()`) and trails' validation chain is
-  // strictly synchronous, so we run it here — an async pre-validation phase —
-  // rather than inside the sync chain. Gated on `validate !== false`: Rails skips
+  // may be async (e.g. `() => Developer.first()`), so on the save path we resolve
+  // it here — a pre-validation pass — before running the chain. Gated on
+  // `validate !== false`: Rails skips
   // perform_validations (and thus every before_validation callback, including
   // this default) when `validate: false` (validations.rb:47-49), so the default
   // must not fire on that path. `_belongsToDefaultsApplied` then suppresses the
@@ -874,9 +874,10 @@ export async function save<T extends SaveRecord>(
       // an aborting async `before_validation`: trails reports `errors.any`
       // (validators already ran) where Rails reports none (abort halts first).
       // The four cancellation tests don't hit this (validations pass); the
-      // governing constraint is the strict-sync validation chain — see the
-      // Topic wiring and `validations.ts#isValid`. Tracked for convergence:
-      // RFC 0023 story `save-runs-validations-inside-transaction`.
+      // governing constraint is that `performValidations` runs outside the
+      // transaction — see the Topic wiring and `validations.ts#isValid`. Tracked
+      // for convergence: RFC 0023 story
+      // `save-runs-validations-inside-transaction`.
       const sideEffects = self._beforeValidationSideEffects as Array<() => unknown>;
       for (const thunk of sideEffects) {
         try {

--- a/packages/activerecord/src/test-helpers/models/topic.ts
+++ b/packages/activerecord/src/test-helpers/models/topic.ts
@@ -103,16 +103,14 @@ export class Topic extends Base {
     });
     // Rails registers these as plain synchronous method hooks
     // (`before_validation :before_validation_for_transaction`, etc. —
-    // all `def ...; end`). They MUST stay sync: `before_validation` runs on
-    // the strict-sync validation chain (ActiveModel `valid?`), which rejects
-    // a Promise-returning callback. The record arrives as the callback arg
-    // (not `this`), matching the `afterInitialize`/`setEmailAddress` hook below.
-    // Deferred rather than run inline: the cancellation test installs a
-    // `before_validation_for_transaction` that performs a DB write then
+    // all `def ...; end`), so we mirror them as sync. The record arrives as the
+    // callback arg (not `this`), matching the `afterInitialize`/`setEmailAddress`
+    // hook below. Deferred rather than run inline: the cancellation test installs
+    // a `before_validation_for_transaction` that performs a DB write then
     // `throw :abort`. Rails runs it inside the save transaction so the write
-    // rolls back, but trails' validation chain is strict-sync (can't await an
-    // async DB call). Enqueuing the thunk lets `save` await it inside the
-    // transaction. The default no-op hook is a harmless enqueued no-op.
+    // rolls back with it; enqueuing the thunk lets `save` await it inside the
+    // transaction rather than during the (pre-transaction) validation pass. The
+    // default no-op hook is a harmless enqueued no-op.
     this.beforeValidation((record: Topic) => {
       ((record as any)._beforeValidationSideEffects ??= []).push(() =>
         (record as any).beforeValidationForTransaction(),

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -615,9 +615,10 @@ describe("TransactionTest", () => {
   // before-filter. The canonical Topic `before_save_for_transaction` runs on the
   // async save-callback chain (the wrapper returns the hook's Promise so it is
   // awaited inside the save transaction). `before_validation_for_transaction`
-  // can't await on trails' strict-sync validation chain, so the Topic wrapper
-  // defers its thunk into `_beforeValidationSideEffects`, which `save` drains
-  // inside the transaction (persistence.ts). In both paths the `throw :abort`
+  // runs during `performValidations`, which trails invokes outside the save
+  // transaction, so the Topic wrapper defers its thunk into
+  // `_beforeValidationSideEffects`, which `save` drains inside the transaction
+  // (persistence.ts). In both paths the `throw :abort`
   // halts the save (status false → Rollback), rolling back `Book.create`.
   for (const filter of ["validation", "save"] as const) {
     const hook =

--- a/packages/activerecord/src/validations/association-validation.test.ts
+++ b/packages/activerecord/src/validations/association-validation.test.ts
@@ -8,11 +8,10 @@
  * with `clearValidatorsBang()` in `afterEach` (Topic, Reply, Interest) and
  * `repairValidations(...)` for the block-form cases.
  *
- * trails validations are synchronous, so where Rails appends in-memory
- * associated records (`t.replies << r`) we build them through the real
- * association (no insert on an unsaved/just-built target) or seed the
- * association cache — the behavior under test is the cascading `valid?`, not
- * collection persistence.
+ * Where Rails appends in-memory associated records (`t.replies << r`) we build
+ * them through the real association (no insert on an unsaved/just-built target)
+ * or seed the association cache — the behavior under test is the cascading
+ * `valid?`, not collection persistence.
  */
 import { afterEach, describe, expect, it } from "vitest";
 import { association } from "../associations.js";

--- a/packages/activerecord/src/validations/uniqueness-validation.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.test.ts
@@ -140,7 +140,7 @@ describe("UniquenessValidationTest", () => {
   });
 
   // Rails `repair_validations(Topic, Reply)` — clear validators (including the
-  // deferred uniqueness ones) added to Topic/Reply per test so they don't leak.
+  // uniqueness ones) added to Topic/Reply per test so they don't leak.
   afterEach(() => {
     Topic.clearValidatorsBang();
     Reply.clearValidatorsBang();

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -310,11 +310,12 @@ function isCoveredByUniqueIndex(
   _options: Record<string, unknown>,
 ): boolean {
   // Rails reads `klass.schema_cache.indexes(klass.table_name)` synchronously,
-  // but Trails' SchemaCache#indexes is async (requires a pool + I/O). Calling
-  // it from this synchronous validator path isn't safe. Conservatively return
-  // false so uniqueness always performs the existence check — correct, just
-  // skips the Rails optimization that drops a redundant SELECT when the DB
-  // already enforces uniqueness via a unique index.
+  // but Trails' SchemaCache#indexes is async (requires a pool + I/O) and this
+  // helper is synchronous. Conservatively return false so uniqueness always
+  // performs the existence check — correct, just skips the Rails optimization
+  // that drops a redundant SELECT when the DB already enforces uniqueness via a
+  // unique index. (The validation chain itself is async now, so awaiting the
+  // index lookup is a possible future optimization.)
   return false;
 }
 

--- a/packages/website/docs/guides/activemodel-rails-deviations.md
+++ b/packages/website/docs/guides/activemodel-rails-deviations.md
@@ -64,9 +64,9 @@ to a method) is accepted as a method-name string or a direct function
 (`packages/activemodel/src/callbacks.ts`), and because it awaits
 each handler, calling it is itself async.
 
-## Validations: sync signature, async reality
+## Validations: async chain
 
-`validates` / `validate` look the same:
+`validates` / `validate` are declared the same as Rails:
 
 ```ts
 import { Model } from "@blazetrails/activemodel";
@@ -78,14 +78,15 @@ class Post extends Model {
 }
 ```
 
-The deviation surfaces when a validator needs I/O. `uniqueness` is the
-canonical case (it has to hit the DB), and it lives in ActiveRecord, not
-ActiveModel, but ActiveModel is where the machinery that supports it
-lives. `isValid()` stays synchronous for back-compat with Rails'
-signature, and async validators push their `Promise`s onto
-`record._asyncValidationPromises` for the caller to await. `save()`
-awaits these automatically; bare `isValid()` callers have to do it
-themselves.
+The deviation is at the call site, not the declaration: Rails' `valid?`
+is synchronous, while trails' `isValid()` / `validate()` return a
+`Promise` and the whole validation callback chain is awaited (RFC 0063).
+This lets a validator that needs I/O run inline like any other. The
+canonical case is `uniqueness` — it has to hit the DB — which lives in
+ActiveRecord, not ActiveModel, but ActiveModel is where the machinery
+that supports it lives. Because the chain awaits, `isValid()` runs
+DB-backed validators before returning and `save()` sees the same result;
+there is no separate async-validator queue for callers to drain.
 
 See `packages/activerecord/src/validations/uniqueness.ts` for the
 pattern; ActiveModel contributes the validator registration and error
@@ -123,14 +124,14 @@ The cross-package conventions — [method casing](./index.md#method-casing),
 
 ## Summary
 
-| Area              | Rails                              | Trails                                                                   |
-| ----------------- | ---------------------------------- | ------------------------------------------------------------------------ |
-| Attribute methods | `method_missing` + `define_method` | Generated methods in `_generatedMethods`; index signature for reads      |
-| Dirty tracking    | Scattered ivars                    | `DirtyTracker` instance at `_dirtyTracker`                               |
-| Callbacks         | Blocks (`before_save do ... end`)  | Async-capable functions; `runCallbacks` is async                         |
-| Validations       | Synchronous                        | Sync signature; async validators collected on `_asyncValidationPromises` |
-| DSL sugar         | Block receivers                    | One `Proxy` in `Model.withOptions`                                       |
-| Serialization     | Eager map over ivars               | Same API, supports lazy attribute stores                                 |
+| Area              | Rails                              | Trails                                                                                                                 |
+| ----------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Attribute methods | `method_missing` + `define_method` | Generated methods in `_generatedMethods`; index signature for reads                                                    |
+| Dirty tracking    | Scattered ivars                    | `DirtyTracker` instance at `_dirtyTracker`                                                                             |
+| Callbacks         | Blocks (`before_save do ... end`)  | Async-capable functions; `runCallbacks` is async                                                                       |
+| Validations       | Synchronous                        | Async: `valid?`/`validate` return a `Promise`; the callback chain awaits DB-backed validators (e.g. uniqueness) inline |
+| DSL sugar         | Block receivers                    | One `Proxy` in `Model.withOptions`                                                                                     |
+| Serialization     | Eager map over ivars               | Same API, supports lazy attribute stores                                                                               |
 
 Cross-package deviations (mixins, method casing, bang methods, symbols/
 kwargs) live in the [guides index](./).

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -69,11 +69,11 @@ access through async drivers.
 
 ### Practical consequences
 
-- `if (user.valid?)` in Rails becomes `if (record.isValid())` in
-  Trails — still synchronous — **but** if any uniqueness validator
-  fired, you must `await` its pending promise before trusting
-  `record.errors`. `save()` does this for you; manual `isValid()`
-  callers don't get it for free. See
+- `if (user.valid?)` in Rails becomes `if (await record.isValid())` in
+  Trails — `isValid()` returns a `Promise` and the validation chain is
+  awaited, so DB-backed validators (like `uniqueness`) run inline and
+  `record.errors` is populated by the time it resolves. `save()` runs the
+  same chain. See
   `packages/activerecord/src/validations/uniqueness.ts`.
 - Sequencing matters. `user.posts.toArray()` and `user.posts.count()`
   are separate round-trips unless you preload. Accidentally awaiting
@@ -507,23 +507,23 @@ inside test setup/teardown.
 
 ## Summary
 
-| Area                     | Rails                                   | Trails                                            |
-| ------------------------ | --------------------------------------- | ------------------------------------------------- |
-| Finders / reads          | Sync                                    | Async (`await` required)                          |
-| Persistence              | Sync                                    | Async                                             |
-| Relation iteration       | `to_a`, `each` (sync)                   | `toArray()`, `for await`                          |
-| Transactions             | `transaction do ... end`                | `await transaction(async (tx) => { ... })`        |
-| Per-flow state           | `Thread.current`                        | `AsyncLocalStorage` via `getAsyncContext()`       |
-| Connection pool          | Thread-checkout model                   | Per-handler pools, per-query acquisition          |
-| Relation method dispatch | `method_missing`                        | `Proxy` wrapper (`wrapWithScopeProxy`)            |
-| Scopes                   | Generated via `define_singleton_method` | `_scopes` Map + delegation                        |
-| Enum bang methods        | Sync                                    | Async (`draftBang()` hits DB)                     |
-| Ranges                   | `Range`                                 | Plain `{ begin, end, excludeEnd }`                |
-| Numerics                 | `Integer`/`Float`/`BigDecimal`          | `number`/`bigint` only                            |
-| File / crypto access     | Direct stdlib                           | Pluggable adapters for browser support            |
-| Callbacks                | Ruby blocks                             | Async functions                                   |
-| Uniqueness validation    | Sync DB hit                             | Async, coordinated via `_asyncValidationPromises` |
-| Test fixtures            | YAML `test/fixtures/*.yml` + ERB        | Not ported; use factories or `Model.create`       |
+| Area                     | Rails                                   | Trails                                              |
+| ------------------------ | --------------------------------------- | --------------------------------------------------- |
+| Finders / reads          | Sync                                    | Async (`await` required)                            |
+| Persistence              | Sync                                    | Async                                               |
+| Relation iteration       | `to_a`, `each` (sync)                   | `toArray()`, `for await`                            |
+| Transactions             | `transaction do ... end`                | `await transaction(async (tx) => { ... })`          |
+| Per-flow state           | `Thread.current`                        | `AsyncLocalStorage` via `getAsyncContext()`         |
+| Connection pool          | Thread-checkout model                   | Per-handler pools, per-query acquisition            |
+| Relation method dispatch | `method_missing`                        | `Proxy` wrapper (`wrapWithScopeProxy`)              |
+| Scopes                   | Generated via `define_singleton_method` | `_scopes` Map + delegation                          |
+| Enum bang methods        | Sync                                    | Async (`draftBang()` hits DB)                       |
+| Ranges                   | `Range`                                 | Plain `{ begin, end, excludeEnd }`                  |
+| Numerics                 | `Integer`/`Float`/`BigDecimal`          | `number`/`bigint` only                              |
+| File / crypto access     | Direct stdlib                           | Pluggable adapters for browser support              |
+| Callbacks                | Ruby blocks                             | Async functions                                     |
+| Uniqueness validation    | Sync DB hit                             | Runs inline on the awaited (async) validation chain |
+| Test fixtures            | YAML `test/fixtures/*.yml` + ERB        | Not ported; use factories or `Model.create`         |
 
 If something in Rails surprises you with its absence here, the most
 common cause is: "it was synchronous in Ruby and the JavaScript

--- a/packages/website/docs/guides/idioms.md
+++ b/packages/website/docs/guides/idioms.md
@@ -136,10 +136,10 @@ if (await post.save()) {
 }
 ```
 
-`isValid()` stays synchronous for signature parity with Rails, but
-DB-backed validators (like `uniqueness`) push their promises onto
-`record._asyncValidationPromises` — `save()` awaits them for you;
-bare `isValid()` callers don't get that for free. See
+`isValid()` returns a `Promise` and the validation chain is awaited, so
+DB-backed validators (like `uniqueness`) run inline: `await record.isValid()`
+and `save()` both see the same result — there is no separate promise queue
+to drain. See
 [Rails deviations: async propagation](./index.md#async-propagation).
 
 ## Keyword args become one options object

--- a/packages/website/docs/guides/index.md
+++ b/packages/website/docs/guides/index.md
@@ -45,9 +45,8 @@ Every I/O call in Rails (DB, file system, crypto, HTTP) is synchronous.
 Every equivalent in JavaScript is async. That one fact propagates into
 finders, persistence, validations, callbacks, transactions, uniqueness
 checks, connection management, and even enum bang methods. `isValid()`
-stays synchronous for signature parity with Rails, but DB-backed
-validators (`uniqueness`) collect `Promise`s on
-`record._asyncValidationPromises` for the caller to await.
+returns a `Promise` and the validation chain is awaited, so DB-backed
+validators (`uniqueness`) run inline and callers just `await` the result.
 
 There is no synchronous escape hatch. Browsers and Node both expose DB
 access through async drivers.


### PR DESCRIPTION
## Summary

Cleanup + verification tail of RFC 0063-async-validation-chain. The async flip
(#4914) made the validation chain async — `isValid()` / `validate()` return a
`Promise` and the whole validation callback chain is awaited, so DB-backed
validators like `uniqueness` run inline (#4926). This PR removes the tree-wide
prose and guard comments that still described validations as *sync-only* or
documented the deferred-uniqueness / `_asyncValidationPromises` deviation as
current behavior.

## Changes

Comment-only (no code behavior change):
- `activemodel/src/model.ts` — `static validate()` no longer calls async
  validators an authoring bug; describes the awaited chain.
- `activerecord/src/associations/builder/belongs-to.ts`, `base.ts`,
  `persistence.ts` — drop the "validation chain is strictly synchronous"
  rationale for the `belongs_to default` pre-pass; describe it as a
  pre-validation pass that awaits async default blocks.
- `activerecord/src/persistence.ts` (side-effect drain) & `transactions.test.ts`
  — the governing constraint is that `performValidations` runs outside the save
  transaction, not sync-ness.
- `activerecord/src/test-helpers/models/topic.ts`,
  `validations/association-validation.test.ts`,
  `validations/uniqueness-validation.test.ts` — remove stale sync / "deferred
  uniqueness" claims.
- `activerecord/src/validations/uniqueness.ts` — clarify that
  `covered_by_unique_index?` is a *synchronous helper* (not the chain) returning
  `false`; note the async lookup is a future optimization.
- Docs (`website/docs/guides/*`): `activemodel-` / `activerecord-rails-deviations.md`,
  `idioms.md`, `index.md` — validations are async; removed all
  `_asyncValidationPromises` references.

Test (counted):
- Un-skipped `update attribute in before validation respects callback chain`
  (persistence.test.ts) — an async `before_validation` doing a DB write
  (`updateAttribute`) now runs on the awaited chain (Rails'
  `test_update_attribute_in_before_validation_respects_callback_chain`,
  persistence_test.rb:813).

## Verification

- Grep-gate **zero** for `_asyncValidations` / `_asyncValidationPromises`
  across `packages/`, `docs/`, `README.md`, `CONTRIBUTING.md`.
- No remaining prose claims validations are sync-only or documents the
  deferred-uniqueness deviation as current behavior.
- `test:compare` deltas (non-negative):
  - `validations_test.rb → validations.test.ts`: 45 ✓ (unchanged)
  - `uniqueness_validation_test.rb`: 55 ✓ (unchanged)
  - `persistence_test.rb`: 161 ✓ (**+1**, the un-skipped test)
- Local: validations + uniqueness + belongs-to + persistence suites pass;
  typecheck clean.

`docs/activerecord/` (frozen) contained no stale mentions — nothing to record.
The `activesupport/src/callbacks.ts` "Async callback on sync chain" strings are
the generic callback engine's `strict: "sync"` mode (used by `initialize`), not
validation-specific claims, so they are intentionally left untouched.

Closes-story: async-validations-docs-and-deviation-cleanup
