### PR TITLE
feat(activesupport): port Notifications.monotonicSubscribe/subscribed/publishEvent

### DIFF
--- a/packages/activerecord/src/testing/query-assertions.ts
+++ b/packages/activerecord/src/testing/query-assertions.ts
@@ -64,14 +64,13 @@ export async function assertQueriesCount(
   fn: () => void | Promise<void>,
 ): Promise<void> {
   const counter = new SQLCounter();
-  const sub = Notifications.subscribe("sql.active_record", (event: NotificationEvent) => {
-    counter.call(event.name, event.transactionId, event.payload as SqlPayload);
-  });
-  try {
-    await fn();
-  } finally {
-    Notifications.unsubscribe(sub);
-  }
+  await Notifications.subscribed(
+    (event: NotificationEvent) => {
+      counter.call(event.name, event.transactionId, event.payload as SqlPayload);
+    },
+    "sql.active_record",
+    fn,
+  );
   const queries = includeSchema ? counter.logAll : counter.log;
   if (count !== undefined) {
     if (queries.length !== count) {
@@ -111,14 +110,13 @@ export async function assertQueriesMatch(
   fn: () => void | Promise<void>,
 ): Promise<void> {
   const counter = new SQLCounter();
-  const sub = Notifications.subscribe("sql.active_record", (event: NotificationEvent) => {
-    counter.call(event.name, event.transactionId, event.payload as SqlPayload);
-  });
-  try {
-    await fn();
-  } finally {
-    Notifications.unsubscribe(sub);
-  }
+  await Notifications.subscribed(
+    (event: NotificationEvent) => {
+      counter.call(event.name, event.transactionId, event.payload as SqlPayload);
+    },
+    "sql.active_record",
+    fn,
+  );
   const queries = includeSchema ? counter.logAll : counter.log;
   // Reset lastIndex before each test (and after) to mirror Ruby Regexp#=== (always stateless).
   const matched = queries.filter((q) => {

--- a/packages/activesupport/src/notifications.test.ts
+++ b/packages/activesupport/src/notifications.test.ts
@@ -75,7 +75,7 @@ describe("TimedAndMonotonicTimedSubscriberTest", () => {
 
   it("monotonic subscribe", () => {
     const events: Event[] = [];
-    Notifications.subscribe("monotonic.event", (e) => events.push(e));
+    Notifications.monotonicSubscribe("monotonic.event", (e) => events.push(e));
     Notifications.instrument("monotonic.event", {});
     expect(events[0].duration).toBeGreaterThanOrEqual(0);
   });
@@ -101,20 +101,36 @@ describe("BuildHandleTest", () => {
 });
 
 describe("SubscribedTest", () => {
-  it("subscribed", () => {
-    const events = Notifications.collectEvents("subscribed.event", () => {
-      Notifications.instrument("subscribed.event", { x: 1 });
+  it("subscribed", async () => {
+    const name = "foo";
+    const name2 = name + name;
+    const events: string[] = [];
+    const callback = (e: Event) => events.push(e.name);
+    await Notifications.subscribed(callback, name, () => {
+      Notifications.instrument(name);
+      Notifications.instrument(name2);
+      Notifications.instrument(name);
     });
-    expect(events).toHaveLength(1);
-    expect(events[0].payload.x).toBe(1);
+    expect(events).toEqual([name, name]);
+
+    Notifications.instrument(name);
+    expect(events).toEqual([name, name]);
   });
 
-  it("subscribed all messages", () => {
-    const events = Notifications.collectEvents(null, () => {
-      Notifications.instrument("alpha");
-      Notifications.instrument("beta");
+  it("subscribed all messages", async () => {
+    const name = "foo";
+    const name2 = name + name;
+    const events: string[] = [];
+    const callback = (e: Event) => events.push(e.name);
+    await Notifications.subscribed(callback, null, () => {
+      Notifications.instrument(name);
+      Notifications.instrument(name2);
+      Notifications.instrument(name);
     });
-    expect(events.length).toBeGreaterThanOrEqual(2);
+    expect(events).toEqual([name, name2, name]);
+
+    Notifications.instrument(name);
+    expect(events).toEqual([name, name2, name]);
   });
 
   it("subscribing to instrumentation while inside it", () => {

--- a/packages/activesupport/src/notifications.test.ts
+++ b/packages/activesupport/src/notifications.test.ts
@@ -74,10 +74,14 @@ describe("TimedAndMonotonicTimedSubscriberTest", () => {
   });
 
   it("monotonic subscribe", () => {
-    const events: Event[] = [];
-    Notifications.monotonicSubscribe("monotonic.event", (e) => events.push(e));
+    let classOfStarted: string | undefined;
+    let classOfFinished: string | undefined;
+    Notifications.monotonicSubscribe("monotonic.event", (_name, started, finished) => {
+      classOfStarted = typeof started;
+      classOfFinished = typeof finished;
+    });
     Notifications.instrument("monotonic.event", {});
-    expect(events[0].duration).toBeGreaterThanOrEqual(0);
+    expect([classOfStarted, classOfFinished]).toEqual(["number", "number"]);
   });
 });
 
@@ -122,7 +126,7 @@ describe("SubscribedTest", () => {
     const name2 = name + name;
     const events: string[] = [];
     const callback = (e: Event) => events.push(e.name);
-    await Notifications.subscribed(callback, null, () => {
+    await Notifications.subscribed(callback, () => {
       Notifications.instrument(name);
       Notifications.instrument(name2);
       Notifications.instrument(name);

--- a/packages/activesupport/src/notifications.trails.test.ts
+++ b/packages/activesupport/src/notifications.trails.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { Notifications } from "./notifications.js";
+import { Event as EventClass } from "./notifications/instrumenter.js";
 import type { Event } from "./notifications/instrumenter.js";
+import { Temporal } from "./temporal.js";
 
 /**
  * trails-only coverage for the static Notifications surface: the
@@ -250,6 +252,19 @@ describe("Notifications (trails)", () => {
       Notifications.publish("ident", payload);
 
       expect(events[0].payload).toBe(payload);
+    });
+
+    it("publishEvent routes a prebuilt event to matching subscribers", () => {
+      const received: Event[] = [];
+      Notifications.subscribe("prebuilt", (e) => received.push(e));
+
+      const event = new EventClass("prebuilt", Temporal.Now.instant(), { b: 2 }, "id-1");
+      event.finish();
+      Notifications.publishEvent(event);
+
+      expect(received).toHaveLength(1);
+      expect(received[0].name).toBe("prebuilt");
+      expect(received[0].payload.b).toBe(2);
     });
   });
 });

--- a/packages/activesupport/src/notifications.ts
+++ b/packages/activesupport/src/notifications.ts
@@ -27,6 +27,26 @@ export type NotificationSubscriber = { readonly [notificationSubscriberBrand]: t
 export type { NotificationHandle };
 
 /**
+ * A subscriber callback. Mirrors the two block shapes Rails accepts (see
+ * `ActiveSupport::Notifications.subscribe`): a single-arity block receives the
+ * built `Event`, while the five-arity block receives `(name, start, finish, id,
+ * payload)`. The notifier classifies by arity, so `monotonic` subscribers must
+ * be the five-arity form to see monotonic (`number`) start/finish times.
+ */
+export type NotificationCallback =
+  | ((event: Event) => void)
+  | ((
+      name: string,
+      start: Temporal.Instant | number,
+      finish: Temporal.Instant | number,
+      id: string,
+      payload: EventPayload,
+    ) => void);
+
+/** The listener shape the underlying `Fanout` notifier accepts. */
+type FanoutListener = Parameters<Fanout["subscribe"]>[1];
+
+/**
  * Mirrors ActiveSupport::Notifications::Instrumenter — the object Rails reaches
  * via `ActiveSupport::Notifications.instrumenter`.
  */
@@ -71,32 +91,58 @@ export class Notifications {
   /**
    * monotonicSubscribe — like `subscribe`, but the notifier records the event's
    * start/finish in monotonic time instead of wall-clock time. Mirrors
-   * `ActiveSupport::Notifications.monotonic_subscribe` (notifications.rb:~248):
-   * `notifier.subscribe(pattern, callback, monotonic: true)`.
+   * `ActiveSupport::Notifications.monotonic_subscribe` (notifications.rb:254):
+   * `notifier.subscribe(pattern, callback, monotonic: true)`. The callback is
+   * forwarded with its arity intact (not wrapped) so a five-arity subscriber is
+   * classified as monotonic-timed and receives `number` start/finish times.
    */
   static monotonicSubscribe(
     pattern: string | RegExp | null | undefined,
-    callback: (event: Event) => void,
+    callback: NotificationCallback,
   ): NotificationSubscriber {
-    const sub = this._notifier.subscribe(pattern ?? null, (event: Event) => callback(event), true);
+    const sub = this._notifier.subscribe(pattern ?? null, callback as FanoutListener, true);
     return sub as unknown as NotificationSubscriber;
   }
 
   /**
    * subscribed — subscribe, run `block`, then unsubscribe in a `finally`.
-   * Mirrors `ActiveSupport::Notifications.subscribed` (notifications.rb:~256):
-   * `subscribe`, `yield`, `ensure unsubscribe`. Unlike Rails, `block` may be
+   * Mirrors `ActiveSupport::Notifications.subscribed` (notifications.rb:258):
+   * `subscribe`, `yield`, `ensure unsubscribe`. `pattern` defaults to all events
+   * (Rails' `pattern = nil`), so it may be omitted. Unlike Rails, `block` may be
    * async and its result is awaited/returned.
    */
-  static async subscribed<T>(
-    callback: (event: Event) => void,
+  static subscribed<T>(
+    callback: NotificationCallback,
+    block: () => T | Promise<T>,
+    options?: { monotonic?: boolean },
+  ): Promise<T>;
+  static subscribed<T>(
+    callback: NotificationCallback,
     pattern: string | RegExp | null | undefined,
     block: () => T | Promise<T>,
-    options: { monotonic?: boolean } = {},
+    options?: { monotonic?: boolean },
+  ): Promise<T>;
+  static async subscribed<T>(
+    callback: NotificationCallback,
+    patternOrBlock: string | RegExp | null | undefined | (() => T | Promise<T>),
+    blockOrOptions?: (() => T | Promise<T>) | { monotonic?: boolean },
+    maybeOptions?: { monotonic?: boolean },
   ): Promise<T> {
+    let pattern: string | RegExp | null;
+    let block: () => T | Promise<T>;
+    let options: { monotonic?: boolean };
+    if (typeof patternOrBlock === "function") {
+      pattern = null;
+      block = patternOrBlock;
+      options = (blockOrOptions as { monotonic?: boolean } | undefined) ?? {};
+    } else {
+      pattern = patternOrBlock ?? null;
+      block = blockOrOptions as () => T | Promise<T>;
+      options = maybeOptions ?? {};
+    }
     const sub = this._notifier.subscribe(
-      pattern ?? null,
-      (event: Event) => callback(event),
+      pattern,
+      callback as FanoutListener,
       options.monotonic ?? false,
     );
     try {

--- a/packages/activesupport/src/notifications.ts
+++ b/packages/activesupport/src/notifications.ts
@@ -68,6 +68,44 @@ export class Notifications {
     return sub as unknown as NotificationSubscriber;
   }
 
+  /**
+   * monotonicSubscribe — like `subscribe`, but the notifier records the event's
+   * start/finish in monotonic time instead of wall-clock time. Mirrors
+   * `ActiveSupport::Notifications.monotonic_subscribe` (notifications.rb:~248):
+   * `notifier.subscribe(pattern, callback, monotonic: true)`.
+   */
+  static monotonicSubscribe(
+    pattern: string | RegExp | null | undefined,
+    callback: (event: Event) => void,
+  ): NotificationSubscriber {
+    const sub = this._notifier.subscribe(pattern ?? null, (event: Event) => callback(event), true);
+    return sub as unknown as NotificationSubscriber;
+  }
+
+  /**
+   * subscribed — subscribe, run `block`, then unsubscribe in a `finally`.
+   * Mirrors `ActiveSupport::Notifications.subscribed` (notifications.rb:~256):
+   * `subscribe`, `yield`, `ensure unsubscribe`. Unlike Rails, `block` may be
+   * async and its result is awaited/returned.
+   */
+  static async subscribed<T>(
+    callback: (event: Event) => void,
+    pattern: string | RegExp | null | undefined,
+    block: () => T | Promise<T>,
+    options: { monotonic?: boolean } = {},
+  ): Promise<T> {
+    const sub = this._notifier.subscribe(
+      pattern ?? null,
+      (event: Event) => callback(event),
+      options.monotonic ?? false,
+    );
+    try {
+      return await block();
+    } finally {
+      this._notifier.unsubscribe(sub);
+    }
+  }
+
   /** Subscribe and automatically unsubscribe after the first matching event. */
   static subscribeOnce(
     pattern: string | RegExp | null | undefined,
@@ -149,6 +187,15 @@ export class Notifications {
     // Deliver the passed payload object itself, not Event#initialize's dup.
     event.payload = resolved;
     event.finish();
+    this._notifier.publishEvent(event);
+  }
+
+  /**
+   * publishEvent — route an already-built `Event` to matching subscribers.
+   * Mirrors `ActiveSupport::Notifications.publish_event` (notifications.rb:~204):
+   * `notifier.publish_event(event)`.
+   */
+  static publishEvent(event: Event): void {
     this._notifier.publishEvent(event);
   }
 

--- a/packages/activesupport/src/notifications.ts
+++ b/packages/activesupport/src/notifications.ts
@@ -96,11 +96,25 @@ export class Notifications {
    * forwarded with its arity intact (not wrapped) so a five-arity subscriber is
    * classified as monotonic-timed and receives `number` start/finish times.
    */
+  static monotonicSubscribe(callback: NotificationCallback): NotificationSubscriber;
   static monotonicSubscribe(
     pattern: string | RegExp | null | undefined,
     callback: NotificationCallback,
+  ): NotificationSubscriber;
+  static monotonicSubscribe(
+    patternOrCallback: string | RegExp | null | undefined | NotificationCallback,
+    maybeCallback?: NotificationCallback,
   ): NotificationSubscriber {
-    const sub = this._notifier.subscribe(pattern ?? null, callback as FanoutListener, true);
+    let pattern: string | RegExp | null;
+    let callback: NotificationCallback;
+    if (typeof patternOrCallback === "function") {
+      pattern = null;
+      callback = patternOrCallback;
+    } else {
+      pattern = patternOrCallback ?? null;
+      callback = maybeCallback!;
+    }
+    const sub = this._notifier.subscribe(pattern, callback as FanoutListener, true);
     return sub as unknown as NotificationSubscriber;
   }
 


### PR DESCRIPTION
Ports the three Rails module-level shortcuts on `ActiveSupport::Notifications` left unported by #4913 (converged `Notifications` onto `Fanout`):

- `monotonicSubscribe(pattern, callback)` — routes through `Fanout.subscribe(..., monotonic = true)`, mirroring `notifications.rb` `monotonic_subscribe`.
- `subscribed(callback, pattern?, block, { monotonic })` — subscribes, runs the block, and unsubscribes in a `finally` (Rails' subscribe/yield/ensure-unsubscribe). `block` may be async; its result is awaited and returned.
- `publishEvent(event)` — delegates to `Fanout.publishEvent` (added in #4913 but never exposed on the module).

Also migrates the inlined subscribe/try-finally/unsubscribe pattern in `query-assertions.ts` onto `Notifications.subscribed`.

`NotificationSubscriber` stays opaque — the internal `Fanout` `Subscriber` type is not re-exported. Tests match Rails names (`monotonic subscribe`, `subscribed`, `subscribed all messages`).

Closes-story: port-notifications-module-subscribed-monotonic