### PR TITLE
refactor(mysql2): unify execute/executeMutation into one performQuery primitive

### DIFF
--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter-perform-query.trails.test.ts
@@ -1,0 +1,95 @@
+/**
+ * trails-only coverage for the unified `perform_query` primitive.
+ *
+ * Rails' Mysql2 adapter has one SQL primitive, perform_query
+ * (mysql2/database_statements.rb:41), which both `execute` and
+ * `executeMutation` now delegate to; affected rows come from a separate
+ * `affected_rows` read (backed by `_affectedRowsBeforeWarnings`) rather than
+ * the statement result. These assert the shared branch, the affected-rows
+ * source, the insert-id path (MySQL 8 has no INSERT ... RETURNING, so the id
+ * comes from the driver's `insertId`), and that the readonly guard survives the
+ * fold on both entry points.
+ */
+import { it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  describeIfMysql,
+  Mysql2Adapter,
+  MYSQL_TEST_URL,
+} from "../abstract-mysql-adapter/test-helper.js";
+import { ReadOnlyError } from "../../errors.js";
+
+describeIfMysql("Mysql2AdapterPerformQueryTest (trails)", () => {
+  let adapter: Mysql2Adapter;
+
+  beforeEach(async () => {
+    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
+    await adapter.exec(`DROP TABLE IF EXISTS pq`);
+    await adapter.exec(
+      `CREATE TABLE pq (id bigint NOT NULL AUTO_INCREMENT PRIMARY KEY, nick varchar(255))`,
+    );
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await adapter.exec(`DROP TABLE IF EXISTS pq`);
+    await adapter.close();
+  });
+
+  function preventWrites(a: Mysql2Adapter): void {
+    (a as Mysql2Adapter & { pool: { preventWrites?: boolean } }).pool = { preventWrites: true };
+  }
+
+  it("execute runs a non-row-returning statement and returns no rows", async () => {
+    // mysql2 returns a ResultSetHeader (no rows array) for DDL and a bare
+    // INSERT, so both flow through the public `execute` and come back as [].
+    await expect(adapter.execute(`CREATE TABLE pq_ddl (id integer)`)).resolves.toEqual([]);
+    await adapter.execute(`DROP TABLE pq_ddl`);
+    await expect(adapter.execute(`INSERT INTO pq (nick) VALUES ('a')`)).resolves.toEqual([]);
+  });
+
+  it("execute still returns rows for a row-returning statement", async () => {
+    await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('a')`);
+    await expect(adapter.execute(`SELECT nick FROM pq`)).resolves.toEqual([{ nick: "a" }]);
+  });
+
+  it("executeMutation sources affected rows through the affectedRows port", async () => {
+    await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('a')`);
+    await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('b')`);
+    await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('c')`);
+
+    // The count comes from _affectedRowsBeforeWarnings, recorded by
+    // perform_query and read back via the affectedRows port.
+    expect(await adapter.executeMutation(`UPDATE pq SET nick = 'z' WHERE nick <> 'a'`)).toBe(2);
+    expect(await adapter.executeMutation(`UPDATE pq SET nick = 'y' WHERE nick = 'nope'`)).toBe(0);
+    expect(await adapter.executeMutation(`DELETE FROM pq`)).toBe(3);
+  });
+
+  it("executeMutation returns the driver insert id for a bare INSERT", async () => {
+    // MySQL 8 has no INSERT ... RETURNING; the id comes from the driver's
+    // insertId on the ResultSetHeader.
+    const id = await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('a')`);
+    expect(id).toBe(1);
+    const second = await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('b')`);
+    expect(second).toBe(2);
+  });
+
+  it("executeMutation returns affected rows for a multi-row INSERT", async () => {
+    expect(await adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('a'), ('b'), ('c')`)).toBe(
+      3,
+    );
+  });
+
+  it("errors when a write is routed through executeMutation while preventing writes", async () => {
+    // The guard lives in preprocess_query's check_if_write_query, so it reaches
+    // every write through the shared primitive.
+    preventWrites(adapter);
+    await expect(adapter.executeMutation(`INSERT INTO pq (nick) VALUES ('a')`)).rejects.toThrow(
+      ReadOnlyError,
+    );
+  });
+
+  it("does not prevent a read routed through execute while preventing writes", async () => {
+    preventWrites(adapter);
+    await expect(adapter.execute(`SELECT * FROM pq`)).resolves.toEqual([]);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -40,6 +40,7 @@ import { Result } from "../result.js";
 import { ForeignKeyDefinition } from "./abstract/schema-definitions.js";
 import { ExplainPrettyPrinter } from "./mysql/explain-pretty-printer.js";
 import {
+  affectedRows as mysql2AffectedRows,
   buildColumnTypes,
   castResult as mysql2CastResult,
   performQuery as mysql2PerformQuery,
@@ -288,6 +289,13 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * Updated by {@link _syncDatabaseTimezone} from the perform-query path.
    */
   databaseTimezone: "utc" | "local" = "utc";
+
+  /**
+   * Rows affected by the most recent write, recorded by {@link _performQuery}.
+   * Rails takes the statement result in `affected_rows` and ignores it, reading
+   * `@affected_rows` (set inside `perform_query`) instead — this is that field.
+   */
+  _affectedRowsBeforeWarnings = 0;
 
   /**
    * Refresh {@link databaseTimezone} from the global default. Called from
@@ -920,6 +928,51 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   /**
+   * The single SQL primitive `execute` / `executeMutation` delegate to: track
+   * the prepared statement, run the statement through the shared array-mode
+   * `performQuery` seam (which records the affected-row count in
+   * `_affectedRowsBeforeWarnings`), fetch warnings, and set the notification
+   * payload's row count. Returns the raw `{ rows, fields, affectedRows,
+   * insertId }` — `execute` rebuilds row objects from it, `executeMutation`
+   * reads the affected rows / insert id. mysql2 hands back a ResultSetHeader
+   * (with `affectedRows` / `insertId`) rather than rows for a non-row-returning
+   * statement, so the read/write split is which shape came back, not a driver
+   * throw.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements#perform_query
+   */
+  private async _performQuery(
+    conn: mysql.Connection,
+    driverSql: string,
+    binds: unknown[],
+    driverBinds: unknown[],
+    payload: Record<string, unknown>,
+  ): Promise<Mysql2RawResult> {
+    // Track the SQL in our statement pool first so LRU eviction sends
+    // COM_STMT_CLOSE (via unprepare) when we exceed `statement_limit`.
+    const prepare = this._shouldPrepare(binds);
+    if (prepare) this._trackPrepared(conn, driverSql);
+    const raw = await mysql2PerformQuery.call(this as any, conn, driverSql, binds, driverBinds, {
+      prepare,
+    });
+    payload.row_count = raw.rows?.length ?? 0;
+    await this._handleWarningsOn(conn, driverSql);
+    return raw;
+  }
+
+  /**
+   * Rows affected by the most recent write. Rails takes the statement result
+   * and ignores it, reading `@affected_rows` instead — wired to the this-less
+   * port so api:compare's `affected_rows` coverage points at reachable code.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::Mysql2::DatabaseStatements#affected_rows
+   * @internal
+   */
+  affectedRows(rawResult: Mysql2RawResult): number {
+    return mysql2AffectedRows.call(this as any, rawResult);
+  }
+
+  /**
    * Execute a SELECT query and return rows. Wrapped in a
    * `sql.active_record` notification — mirrors Rails'
    * `AbstractAdapter#log` so LogSubscriber / ExplainSubscriber /
@@ -951,33 +1004,19 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       try {
         return await this.withRawConnection({ allowRetry }, async (conn) => {
           const mysqlConn = conn as unknown as mysql.Connection;
-          // Use server-side prepared statements when enabled and binds
-          // are present — matches PR #589's preparedStatements toggle.
-          // Track the SQL in our statement pool first so LRU eviction
-          // sends COM_STMT_CLOSE (via unprepare) when we exceed
-          // `statement_limit`.
-          const prepare = this._shouldPrepare(binds);
-          if (prepare) this._trackPrepared(mysqlConn, driverSql);
-          const [rows, rowFields] = prepare
-            ? await mysqlConn.execute(driverSql, driverBinds as any[])
-            : await mysqlConn.query(driverSql, driverBinds);
-          // Unwrap nested result sets from CALL (see execQuery for the full
-          // comment). Use rowFields[0] as the fields.empty? discriminator.
-          let r: Record<string, unknown>[];
-          if (Array.isArray(rowFields) && Array.isArray(rowFields[0])) {
-            r = (rows as unknown[])[0] as Record<string, unknown>[];
-          } else if (
-            Array.isArray(rowFields) &&
-            rowFields[0] === undefined &&
-            Array.isArray(rows)
-          ) {
-            r = [];
-          } else {
-            r = Array.isArray(rows) ? (rows as Record<string, unknown>[]) : [];
-          }
-          payload.row_count = r.length;
-          await this._handleWarningsOn(mysqlConn, driverSql);
-          return r;
+          const raw = await this._performQuery(mysqlConn, driverSql, binds, driverBinds, payload);
+          // A non-row-returning statement (DML passed to execute) has null rows.
+          // Rebuild hash-keyed row objects from the array-mode positional rows +
+          // field descriptors `perform_query` returns — the same objects a
+          // non-array-mode driver query would have produced (duplicate column
+          // names collapse either way).
+          if (raw.rows == null) return [];
+          const names = raw.fields.map((f) => f.name);
+          return raw.rows.map((row) => {
+            const obj: Record<string, unknown> = {};
+            for (let i = 0; i < names.length; i++) obj[names[i]] = row[i];
+            return obj;
+          });
         });
       } catch (e: any) {
         const translated =
@@ -1014,25 +1053,23 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       try {
         return await this.withRawConnection(async (conn) => {
           const mysqlConn = conn as unknown as mysql.Connection;
-          const prepare = this._shouldPrepare(binds);
-          if (prepare) this._trackPrepared(mysqlConn, driverSql);
-          const [result] = prepare
-            ? await mysqlConn.execute(driverSql, driverBinds as any[])
-            : await mysqlConn.query(driverSql, driverBinds);
-          const info = result as mysql.ResultSetHeader;
-          payload.row_count = info.affectedRows ?? 0;
-          await this._handleWarningsOn(mysqlConn, driverSql);
+          const raw = await this._performQuery(mysqlConn, driverSql, binds, driverBinds, payload);
+          // Source affected rows through the `affected_rows` port (reads the
+          // `_affectedRowsBeforeWarnings` field `perform_query` set) rather than
+          // off the statement result, mirroring Rails' `affected_rows`.
+          const affected = this.affectedRows(raw);
+          payload.row_count = affected;
 
           // For INSERT, return the last inserted ID (or affected rows for multi-row)
           if (sql.trimStart().toUpperCase().startsWith("INSERT")) {
-            if (info.affectedRows > 1) {
-              return info.affectedRows;
+            if (affected > 1) {
+              return affected;
             }
-            return info.insertId;
+            return raw.insertId ?? 0;
           }
 
           // For UPDATE/DELETE, return affected rows
-          return info.affectedRows;
+          return affected;
         });
       } catch (e: any) {
         const translated =

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -952,10 +952,16 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // COM_STMT_CLOSE (via unprepare) when we exceed `statement_limit`.
     const prepare = this._shouldPrepare(binds);
     if (prepare) this._trackPrepared(conn, driverSql);
+    // Hand the payload to the port so it records both keys the way Rails'
+    // perform_query does (database_statements.rb:97-98):
+    // `affected_rows = @affected_rows_before_warnings` and
+    // `row_count = result&.size || 0` — the latter is 0 for a non-row-returning
+    // statement (mysql2 hands back a header, not a result set), so a write's
+    // row_count stays 0 and its count is reported only via affected_rows.
     const raw = await mysql2PerformQuery.call(this as any, conn, driverSql, binds, driverBinds, {
       prepare,
+      notificationPayload: payload,
     });
-    payload.row_count = raw.rows?.length ?? 0;
     await this._handleWarningsOn(conn, driverSql);
     return raw;
   }
@@ -1056,9 +1062,10 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
           const raw = await this._performQuery(mysqlConn, driverSql, binds, driverBinds, payload);
           // Source affected rows through the `affected_rows` port (reads the
           // `_affectedRowsBeforeWarnings` field `perform_query` set) rather than
-          // off the statement result, mirroring Rails' `affected_rows`.
+          // off the statement result, mirroring Rails' `affected_rows`. The
+          // notification payload's `row_count` is left as `perform_query` set it
+          // (0 for a write) — Rails reports the count only via `affected_rows`.
           const affected = this.affectedRows(raw);
-          payload.row_count = affected;
 
           // For INSERT, return the last inserted ID (or affected rows for multi-row)
           if (sql.trimStart().toUpperCase().startsWith("INSERT")) {

--- a/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
@@ -38,6 +38,10 @@ export interface Mysql2RawResult {
   rows: unknown[][] | null;
   fields: Mysql2FieldDescriptor[];
   affectedRows: number;
+  // The driver's `insertId` from a non-row-returning statement's
+  // ResultSetHeader — 0/undefined for a SELECT. Sourced by `execInsert`'s write
+  // path (mysql2_adapter.rb's `last_inserted_id`).
+  insertId?: number;
 }
 
 /**
@@ -264,12 +268,14 @@ export async function performQuery(
   let rows: unknown[][] | null = null;
   let fieldList: Mysql2FieldDescriptor[] = [];
   let affectedRows = 0;
+  let insertId: number | undefined;
   if (Array.isArray(result)) {
     rows = result as unknown[][];
     fieldList = (fields ?? []) as unknown as Mysql2FieldDescriptor[];
     affectedRows = rows.length;
   } else {
     affectedRows = result.affectedRows ?? 0;
+    insertId = result.insertId;
   }
 
   this._affectedRowsBeforeWarnings = affectedRows;
@@ -282,7 +288,7 @@ export async function performQuery(
   this.verified?.();
   this.handleWarnings?.(sql);
 
-  return { rows, fields: fieldList, affectedRows };
+  return { rows, fields: fieldList, affectedRows, insertId };
 }
 
 /**


### PR DESCRIPTION
## What

Rails' Mysql2 adapter has **one** SQL primitive, `perform_query`
(`mysql2/database_statements.rb:41`), which branches internally on whether the
statement returns rows. trails split that into `execute` (rows) and
`executeMutation` (affected-rows / insert id). That split is the deviation, and
it's why DDL can't flow through the public `execute` the way Rails'
`schema_statements.rb` does.

Third of the per-adapter split (sqlite3 #4893, postgresql #4939).

## How

`execute` and `executeMutation` now delegate to a single private `_performQuery`
that:

- tracks the prepared statement, runs the statement through the existing shared
  array-mode `performQuery` seam (which records the affected-row count in
  `_affectedRowsBeforeWarnings`), fetches warnings, and sets the notification
  payload's row count.
- `execute` rebuilds hash-keyed row objects from the array-mode positional rows
  + field descriptors (the same objects a non-array-mode driver query produced).
- `executeMutation` sources affected rows through the `affectedRows` port
  (reading the `_affectedRowsBeforeWarnings` field, mirroring Rails'
  `affected_rows`) and the insert id from the driver's ResultSetHeader — MySQL 8
  has no `INSERT ... RETURNING`, so the id comes from `insertId`. The
  `performQuery` port now also surfaces `insertId`.

mysql2 returns a ResultSetHeader (with `affectedRows` / `insertId`) rather than
rows for a non-row-returning statement, so the read/write split is which shape
came back, not a driver throw.

## Preserved

- The readonly-write guard (via `preprocessQuery` → `check_if_write_query`) and
  `materializeTransactions()`.
- `withRawConnection` already mirrors Rails' `dirty_current_transaction` ensure,
  so no sqlite3-style dirty handling is needed here.

## Not in scope

DDL call sites are **not** rerouted — that's
`converge-ddl-through-execute-drop-dirty-guard`, which needs all three adapters
branching first.

## Test

New `mysql2-adapter-perform-query.trails.test.ts` covers the shared branch, the
affected-rows source, the driver insert-id path (bare + multi-row INSERT),
UPDATE/DELETE affected rows, and the readonly guard on both entry points. Also
green (`ARCONN=mysql2`): the mysql2 adapter mirror + trails suites,
internal-execute-cast-result, persistence, bind-parameter, transactions, and
query-cache.

Closes-story: unify-execute-mutation-into-perform-query-mysql2