### PR TITLE
refactor(relation): converge name delegate from method to property reader

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -327,6 +327,19 @@ type JoinClauseSpec = {
  */
 const EMPTY_VALUE_ARRAY: readonly never[] = Object.freeze([]);
 
+declare const relationNameBrand: unique symbol;
+
+/**
+ * Return type of {@link Relation.name} — a *supertype* of `string`
+ * (`string | { [relationNameBrand]: never }`). The runtime value is always a
+ * plain string (the model class name); the brand member is phantom and never
+ * present at runtime. Widening past `string` is deliberate: it keeps `name` off
+ * the structural surface so `Relation` does not satisfy `{ name: string }` (see
+ * `Relation#name`), while remaining a supertype of `string` so string literals
+ * stay assignable to it at call sites.
+ */
+export type RelationName = string | { readonly [relationNameBrand]: never };
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Relation<T extends Base> {
   /**
@@ -6257,19 +6270,25 @@ export class Relation<T extends Base> {
 
   /**
    * `delegate :name, to: :model` (relation/delegation.rb:106) — the model
-   * class name.
+   * class name. Exposed as a property reader (`relation.name`, no parens),
+   * matching Rails' calling convention.
    *
-   * Exposed as a method (not a `get name(): string`) deliberately: a
-   * string-typed `name` getter would make the structurally-typed `Relation`
-   * satisfy the ubiquitous `{ name: string }` object shape, which silently
-   * flips `Array#reduce` accumulator inference — e.g.
+   * The declared return type is {@link RelationName} — a *supertype* of
+   * `string` (`string | RelationNameBrand`), not plain `string`. The runtime
+   * value is always the model-class-name string, but the widened static type is
+   * deliberate: a plain-`string` `name` getter would make the structurally
+   * typed `Relation` satisfy the ubiquitous `{ name: string }` object shape,
+   * which silently flips `Array#reduce` accumulator inference — e.g.
    * `[{ name }, …].reduce((memo, param) => memo.where(param), Model.unscoped())`
    * would resolve the `reduce(cb, initial: T): T` overload with `T = { name }`
    * (since `Relation` would be assignable to the element type) instead of the
-   * generic `reduce<U>(cb, initial: U): U` with `U = Relation`. A method-typed
-   * `name` is not assignable to `{ name: string }`, so inference stays correct.
+   * generic `reduce<U>(cb, initial: U): U` with `U = Relation`. Because
+   * `RelationName` is not assignable to `string`, `Relation` is not assignable
+   * to `{ name: string }`, so inference stays correct; because it is a
+   * *supertype* of `string`, a string literal is still assignable to it, so
+   * `expect(relation.name).toBe("Comment")` type-checks at the call site.
    */
-  name(): string {
+  get name(): RelationName {
     return this.model.name;
   }
 
@@ -7664,12 +7683,13 @@ export interface Relation<T extends Base>
 // DelegationMethods carries getters (connection/primaryKey/tableName) and
 // generic/T-returning methods, so its surface is declared explicitly here rather
 // than via Included<> (which drops accessors and erases the generics).
-// NB: `name` (`delegate :name, to: :model`) is intentionally NOT a getter here —
-// a string-typed `name` accessor would make `Relation` structurally satisfy the
-// ubiquitous `{ name: string }` shape and flip `Array#reduce` accumulator
-// inference, so it lives as a class-body method (`name(): string`) on Relation
-// instead. `slice` (`to: :records`) is likewise a class-body method (its
-// signature must stay override-compatible with `CollectionProxy#slice`).
+// NB: `name` (`delegate :name, to: :model`) is a getter typed to return
+// `RelationName` (a supertype of `string`), NOT plain `string` — a plain-string
+// `name` accessor would make `Relation` structurally satisfy the ubiquitous
+// `{ name: string }` shape and flip `Array#reduce` accumulator inference. See
+// the `get name()` doc comment for the full rationale. `slice` (`to: :records`)
+// is a class-body method (its signature must stay override-compatible with
+// `CollectionProxy#slice`).
 export interface Relation<T extends Base> {
   each(fn: (record: T, index: number) => void): Promise<T[]>;
   join(separator?: string): Promise<string>;

--- a/packages/activerecord/src/relation/delegation.test.ts
+++ b/packages/activerecord/src/relation/delegation.test.ts
@@ -612,7 +612,7 @@ describe("DelegationTest", () => {
     });
 
     it("delegates name to the model class name", () => {
-      expect(Comment.all().name()).toBe("Comment");
+      expect(Comment.all().name).toBe("Comment");
     });
   }); // DelegationNamedMethods
 });

--- a/packages/activerecord/src/relation/delegation.trails.test.ts
+++ b/packages/activerecord/src/relation/delegation.trails.test.ts
@@ -177,3 +177,36 @@ describe("generated relation methods — remaining delegate-class carriers", () 
     }
   });
 });
+
+describe("name delegate — property-reader typing invariant", () => {
+  // `delegate :name, to: :model` is a Rails property reader (`relation.name`,
+  // no parens). It is typed to return `RelationName` — a *supertype* of `string`
+  // — rather than plain `string` on purpose: a plain-string `name` getter would
+  // make the structurally typed `Relation` satisfy `{ name: string }`, flipping
+  // `Array#reduce` accumulator inference (`relations.test.ts` "find all with
+  // multiple should use and"). These assertions pin both halves of that
+  // invariant at compile time so a future regression fails loudly here.
+
+  it("reads as a getter returning the model class name (no parens)", () => {
+    expect(Comment.all().name).toBe("Comment");
+  });
+
+  it("keeps Relation off the `{ name: string }` structural surface (reduce guard)", () => {
+    const rel = Comment.all();
+    // If `name` were typed `string`, `rel` would be assignable to
+    // `{ name: string }` and this assignment would compile — flipping reduce
+    // inference. The `@ts-expect-error` is load-bearing: regressing the getter
+    // to `string` makes the directive unused, which is itself a type error.
+    // @ts-expect-error Relation must NOT be assignable to { name: string }
+    const structural: { name: string } = rel;
+    void structural;
+  });
+
+  it("stays a supertype of `string` so string literals remain assignable at call sites", () => {
+    // The other half: `RelationName` must accept a plain string, so
+    // `expect(relation.name).toBe("Comment")` type-checks without a cast.
+    const rel = Comment.all();
+    const name: typeof rel.name = "Comment";
+    expect(name).toBe("Comment");
+  });
+});


### PR DESCRIPTION
## What

`delegate :name, to: :model` (`relation/delegation.rb:106`) is a **property reader** in Rails — callers write `relation.name` (no parens). trails deliberately exposed it as a method (`name(): string`) because a plain-`string` `name` getter makes the structurally-typed `Relation` satisfy the ubiquitous `{ name: string }` shape, which flips `Array#reduce` accumulator inference (breaking `relations.test.ts` "find all with multiple should use and").

This converges the calling convention to Rails: `name` is now a **getter**, typed to return `RelationName` — a *supertype* of `string` (`string | brand`):

- Not assignable to `string` ⇒ `Relation` still does **not** satisfy `{ name: string }` ⇒ reduce inference stays correct.
- A supertype of `string` ⇒ string literals remain assignable to it ⇒ `expect(relation.name).toBe("Comment")` still type-checks without a cast.

The runtime value is unchanged (the model class name string).

## Self-enforcing guard

`delegation.trails.test.ts` adds compile-time assertions pinning both halves of the invariant: a `@ts-expect-error` proving `Relation` is not assignable to `{ name: string }`, and a positive assignment proving a string literal is assignable to `RelationName`. Regressing the getter back to plain `string` makes the `@ts-expect-error` directive unused — itself a type error — so the deviation's rationale can't silently rot. Verified: flipping the return type to `string` fails typecheck at both the guard and the original `relations.test.ts` reduce site.

## Verification

- `relations.test.ts` "find all with multiple should use and" — green (reduce inference preserved).
- `delegation.test.ts` "delegates name to the model class name" — updated to `relation.name` (no parens), green.
- `delegation.trails.test.ts` — 3 new type-invariant tests green.
- `pnpm typecheck` — clean.
- api:compare `relation.rb` stays at 100%, no arity regression on `name`.

Closes-story: relation-name-delegate-getter-not-method