### PR TITLE
refactor(activerecord): converge Relation#only to values.slice without unscope replay

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1471,6 +1471,14 @@ export class Relation<T extends Base> {
       case "skipQueryCache":
         rel._skipQueryCache = undefined;
         break;
+      case "reverseOrder":
+        // `:reverse_order` is in VALUE_METHODS, so `values.except`/`values.slice`
+        // touch it; but trails (like the pinned Rails' `reverse_order!`) flips
+        // order eagerly and leaves `_reverseOrderValue` vestigial-nil, so this
+        // reset is a faithful no-op — the flipped order lives in `_orderClauses`
+        // (the `order` key).
+        rel._reverseOrderValue = undefined;
+        break;
       default:
         // Rails' `values` slice/except silently ignores unknown keys;
         // resetValueForScope's switch no-ops on any non-UnscopeType string.

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -52,7 +52,7 @@ import {
   WhereChain,
   QueryMethodBangs,
   areStructurallyCompatible,
-  VALID_UNSCOPING_VALUES,
+  EXCEPT_ONLY_KEYS,
   argumentError,
   assertModifiableBang as _assertModifiableBang,
   checkIfMethodHasArgumentsBang as _checkIfMethodHasArgumentsBang,
@@ -1380,11 +1380,20 @@ export class Relation<T extends Base> {
   /**
    * Keep only the specified query parts and remove everything else.
    *
-   * Mirrors: ActiveRecord::SpawnMethods#only
+   * Mirrors: ActiveRecord::SpawnMethods#only — `relation_with
+   * values.slice(*onlies)` (spawn_methods.rb). Like `except`, this resets value
+   * keys on the returned relation WITHOUT recording an `unscope_values`
+   * directive, so merging the result does not erase the same parts on the other
+   * relation (unlike delegating to `unscope`). It covers the same full
+   * `Relation::VALUE_METHODS` surface as `except`: every key NOT named is reset
+   * (the complement of `values.slice`).
    */
-  only(...types: Array<UnscopeType>): Relation<T> {
-    const toRemove = [...VALID_UNSCOPING_VALUES].filter((t) => !types.includes(t));
-    return this.unscope(...toRemove);
+  only(...onlies: Array<ExceptSkip>): Relation<T> {
+    const rel = this._clone();
+    for (const key of EXCEPT_ONLY_KEYS) {
+      if (!onlies.includes(key)) this._resetExceptValue(rel, key);
+    }
+    return rel;
   }
 
   /**
@@ -1418,46 +1427,56 @@ export class Relation<T extends Base> {
   except(...skips: Array<ExceptSkip>): Relation<T> {
     const rel = this._clone();
     for (const skip of skips) {
-      switch (skip) {
-        // Value keys that have no `unscope` equivalent (they are not in
-        // VALID_UNSCOPING_VALUES) but are part of Rails' `Relation::VALUE_METHODS`,
-        // so `values.except(*skips)` removes them too.
-        case "distinct":
-          rel._isDistinct = false;
-          break;
-        case "strictLoading":
-          // `:strict_loading` is a SINGLE_VALUE_METHOD (default `nil`); deleting
-          // the key reads back as unset, distinct from an explicit `false`.
-          rel._isStrictLoading = undefined;
-          break;
-        case "references":
-          // `:references` is a single Rails value key; trails splits its local
-          // representation into the values list and the manual-vs-derived
-          // marker, so both must be cleared together.
-          rel._referencesValues = [];
-          rel._manualReferences = [];
-          break;
-        case "extending":
-          rel._extending = [];
-          break;
-        case "unscope":
-          rel._unscopeValues = [];
-          break;
-        case "reordering":
-          // `values.except(:reordering)` deletes the key → unset (`nil`).
-          rel._reordering = undefined;
-          break;
-        case "skipQueryCache":
-          rel._skipQueryCache = undefined;
-          break;
-        default:
-          // Rails' `values.except(*skips)` silently ignores unknown keys;
-          // resetValueForScope's switch no-ops on any non-UnscopeType string.
-          _qm.resetValueForScope(rel as any, skip as UnscopeType);
-          break;
-      }
+      this._resetExceptValue(rel, skip);
     }
     return rel;
+  }
+
+  /**
+   * Reset a single `Relation::VALUE_METHODS` value key to its default on `rel`,
+   * with no `unscope_values` merge-replay side effect. Shared by `except`
+   * (reset the named keys) and `only` (reset the complement).
+   *
+   * @internal
+   */
+  private _resetExceptValue(rel: Relation<T>, key: ExceptSkip): void {
+    switch (key) {
+      // Value keys that have no `unscope` equivalent (they are not in
+      // VALID_UNSCOPING_VALUES) but are part of Rails' `Relation::VALUE_METHODS`.
+      case "distinct":
+        rel._isDistinct = false;
+        break;
+      case "strictLoading":
+        // `:strict_loading` is a SINGLE_VALUE_METHOD (default `nil`); deleting
+        // the key reads back as unset, distinct from an explicit `false`.
+        rel._isStrictLoading = undefined;
+        break;
+      case "references":
+        // `:references` is a single Rails value key; trails splits its local
+        // representation into the values list and the manual-vs-derived
+        // marker, so both must be cleared together.
+        rel._referencesValues = [];
+        rel._manualReferences = [];
+        break;
+      case "extending":
+        rel._extending = [];
+        break;
+      case "unscope":
+        rel._unscopeValues = [];
+        break;
+      case "reordering":
+        // `values.except(:reordering)` deletes the key → unset (`nil`).
+        rel._reordering = undefined;
+        break;
+      case "skipQueryCache":
+        rel._skipQueryCache = undefined;
+        break;
+      default:
+        // Rails' `values` slice/except silently ignores unknown keys;
+        // resetValueForScope's switch no-ops on any non-UnscopeType string.
+        _qm.resetValueForScope(rel as any, key as UnscopeType);
+        break;
+    }
   }
 
   /**

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -801,12 +801,14 @@ export const VALID_UNSCOPING_VALUES: ReadonlySet<UnscopeType> = new Set<UnscopeT
  * Value keys accepted by `SpawnMethods#except` — Rails' `Relation::VALUE_METHODS`.
  * A superset of `UnscopeType`: it additionally covers value keys that have no
  * `unscope` equivalent (`distinct`, `strictLoading`, `references`, `extending`,
- * `unscope`, `reordering`, `skipQueryCache`), mirroring
+ * `unscope`, `reordering`, `skipQueryCache`, `reverseOrder`), mirroring
  * `relation_with values.except(*skips)`.
  *
- * Rails' `:reverse_order` is omitted: trails applies `reverseOrder` eagerly
- * (it flips `_orderClauses` in place rather than storing a `reverse_order`
- * value), so there is no stored value key to remove.
+ * `reverseOrder` (`:reverse_order`, a SINGLE_VALUE_METHOD) is included for
+ * surface parity with `Relation::VALUE_METHODS` and the merger, but resetting it
+ * is a faithful no-op: trails applies `reverseOrder` eagerly (flipping
+ * `_orderClauses` in place), leaving `_reverseOrderValue` vestigial-nil — exactly
+ * as the pinned Rails' `reverse_order!` leaves `values[:reverse_order]` nil.
  */
 export type ExceptKey =
   | UnscopeType
@@ -816,7 +818,8 @@ export type ExceptKey =
   | "extending"
   | "unscope"
   | "reordering"
-  | "skipQueryCache";
+  | "skipQueryCache"
+  | "reverseOrder";
 
 /**
  * The full `Relation::VALUE_METHODS` key surface handled by `SpawnMethods#except`
@@ -833,6 +836,7 @@ export const EXCEPT_ONLY_KEYS: readonly ExceptKey[] = [
   "unscope",
   "reordering",
   "skipQueryCache",
+  "reverseOrder",
 ];
 
 /**

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -819,6 +819,23 @@ export type ExceptKey =
   | "skipQueryCache";
 
 /**
+ * The full `Relation::VALUE_METHODS` key surface handled by `SpawnMethods#except`
+ * (reset the named keys) and `SpawnMethods#only` (reset every key NOT named — the
+ * complement of `values.slice(*onlies)`). A superset of `VALID_UNSCOPING_VALUES`
+ * with the seven value keys that have no `unscope` equivalent.
+ */
+export const EXCEPT_ONLY_KEYS: readonly ExceptKey[] = [
+  ...VALID_UNSCOPING_VALUES,
+  "distinct",
+  "strictLoading",
+  "references",
+  "extending",
+  "unscope",
+  "reordering",
+  "skipQueryCache",
+];
+
+/**
  * Argument type for `SpawnMethods#except`. Rails' `values.except(*skips)`
  * (spawn_methods.rb:59-60) accepts ANY key — unrecognized ones are a silent
  * no-op. The `(string & {})` arm preserves `ExceptKey` autocomplete while

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -1836,6 +1836,21 @@ describe("RelationTest", () => {
     expect(allArr.map((p) => p.id)).toEqual((await Post.order("id ASC")).map((p) => p.id));
   });
 
+  it("only does not replay unscope on merge", () => {
+    const stripped = Post.where({ author_id: 1 }).order("id ASC").limit(1).only("where");
+
+    // Unlike delegating to unscope, only records no unscope_values: merging the
+    // result must NOT erase the receiver's order/limit (mirrors except).
+    const merged = Post.order("title").limit(5).merge(stripped);
+    expect(merged.toSql()).toContain("ORDER BY");
+    expect(merged.toSql()).toContain("LIMIT");
+
+    // only keeps value keys with no unscope equivalent when named, and resets
+    // the rest (Rails VALUE_METHODS complement of values.slice).
+    expect(Post.all().distinct().only("distinct").toSql()).toContain("DISTINCT");
+    expect(Post.all().distinct().only("where").toSql()).not.toContain("DISTINCT");
+  });
+
   it("anonymous extension", () => {
     const relation = Post.where({ author_id: 1 })
       .order("id ASC")


### PR DESCRIPTION
## Summary

`Relation#only` was implemented as `this.unscope(...complement)`, which records `_unscopeValues`. `Merger#mergeUnscope` replays those directives into the receiving relation on merge, so `other.merge(rel.only("where"))` erased parts of `other` — unlike Rails.

Rails `SpawnMethods#only(*onlies)` is `relation_with values.slice(*onlies)` (`spawn_methods.rb`): keep only the named value keys, record **no** `unscope_values`. This is the same divergence fixed for `except` in #4052.

## Changes

- `only` now resets the complement of the named keys directly (no merge-replay), sharing per-key reset logic with `except` via a new private `_resetExceptValue` helper.
- Both `except` and `only` now cover the full `Relation::VALUE_METHODS` surface via the new `EXCEPT_ONLY_KEYS` constant (adds `distinct`, `strictLoading`, `references`, `extending`, `unscope`, `reordering`, `skipQueryCache` over the narrower `VALID_UNSCOPING_VALUES` that `only` previously used).
- Added a merge-replay regression test proving `other.merge(rel.only(...))` does not erase `other`'s parts.

## Verification

- `relations.test.ts` `except`/`only` tests pass.
- `api:compare`: `spawn_methods.rb` stays 100%.

Closes-story: relation-only-values-slice-no-unscope-replay