### PR TITLE
fix(relation): leave string order fragments bare, matching Rails

### DIFF
--- a/packages/activerecord/src/associations/cascaded-eager-loading.test.ts
+++ b/packages/activerecord/src/associations/cascaded-eager-loading.test.ts
@@ -105,7 +105,7 @@ describe("CascadedEagerLoadingTest", () => {
     const authors = await Author.joins("posts")
       .eagerLoad("comments")
       .where({ posts: { tags_count: 1 } })
-      .order("id");
+      .order(Symbol.for("id"));
     await assertQueriesCount(0, false, () => {
       expect(authors).toHaveLength(3);
     });

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -1263,7 +1263,9 @@ describe("CalculationsTest", () => {
 
   it("ids with includes and non primary key order", async () => {
     const all = (await Company.all().order("id")).map((c) => Number(c.id));
-    const ids = (await Company.all().includes("contracts").order("id").ids()).map(Number);
+    const ids = (await Company.all().includes("contracts").order(Symbol.for("id")).ids()).map(
+      Number,
+    );
     expect(ids).toEqual(all);
   });
 
@@ -1302,8 +1304,10 @@ describe("CalculationsTest", () => {
   });
 
   it("ids with includes offset", async () => {
-    expect((await Topic.includes("replies").order("id").offset(4).ids()).map(Number)).toEqual([5]);
-    expect(await Topic.includes("replies").order("id").offset(5).ids()).toEqual([]);
+    expect(
+      (await Topic.includes("replies").order(Symbol.for("id")).offset(4).ids()).map(Number),
+    ).toEqual([5]);
+    expect(await Topic.includes("replies").order(Symbol.for("id")).offset(5).ids()).toEqual([]);
   });
 
   it("pluck with includes limit and empty result", async () => {
@@ -1312,10 +1316,12 @@ describe("CalculationsTest", () => {
   });
 
   it("pluck with includes offset", async () => {
-    expect((await Topic.includes("replies").order("id").offset(4).pluck("id")).map(Number)).toEqual(
-      [5],
+    expect(
+      (await Topic.includes("replies").order(Symbol.for("id")).offset(4).pluck("id")).map(Number),
+    ).toEqual([5]);
+    expect(await Topic.includes("replies").order(Symbol.for("id")).offset(5).pluck("id")).toEqual(
+      [],
     );
-    expect(await Topic.includes("replies").order("id").offset(5).pluck("id")).toEqual([]);
   });
 
   it("pluck with join", async () => {

--- a/packages/activerecord/src/finder.test.ts
+++ b/packages/activerecord/src/finder.test.ts
@@ -2096,10 +2096,7 @@ describe("FinderTest", () => {
   });
 
   it("include on unloaded relation with offset", async () => {
-    // Rails asserts /ORDER BY name ASC/; trails quotes the raw order string, so
-    // match the quoted `"customers"."name"` form the adapter emits.
-    const orderRe = new RegExp(`ORDER BY ${escapeRegExp(quoteTableName("customers.name"))} ASC`);
-    await assertQueriesMatch(orderRe, undefined, false, async () => {
+    await assertQueriesMatch(/ORDER BY name ASC/, undefined, false, async () => {
       expect(await Customer.offset(1).order("name ASC").include(customers("mary"))).toBe(true);
     });
   });
@@ -2193,10 +2190,7 @@ describe("FinderTest", () => {
   });
 
   it("member on unloaded relation with offset", async () => {
-    // Rails asserts /ORDER BY name ASC/; trails quotes the raw order string, so
-    // match the quoted `"customers"."name"` form the adapter emits.
-    const orderRe = new RegExp(`ORDER BY ${escapeRegExp(quoteTableName("customers.name"))} ASC`);
-    await assertQueriesMatch(orderRe, undefined, false, async () => {
+    await assertQueriesMatch(/ORDER BY name ASC/, undefined, false, async () => {
       expect(await Customer.offset(1).order("name ASC").member(customers("mary"))).toBe(true);
     });
   });

--- a/packages/activerecord/src/finder.test.ts
+++ b/packages/activerecord/src/finder.test.ts
@@ -320,7 +320,7 @@ describe("FinderTest", () => {
       undefined,
       false,
       async () => {
-        await Topic.order("updated_at").secondToLast();
+        await Topic.order(Symbol.for("updated_at")).secondToLast();
       },
     );
   });

--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -718,7 +718,7 @@ describe("RelationTest", () => {
   // load time: the main query carries the literal `author_id IN (<ids>)`, never
   // a LIMIT-bearing subquery, on every adapter.
   it("where with eager-loading limited collection relation subquery materializes distinct primary keys at load time", async () => {
-    const subquery = CanonAuthor.eagerLoad("posts").order("id").limit(2);
+    const subquery = CanonAuthor.eagerLoad("posts").order({ id: "asc" }).limit(2);
 
     let records: any[] = [];
     const queries = await captureSql(async () => {
@@ -751,7 +751,7 @@ describe("RelationTest", () => {
   // short-circuits as a contradiction (Rails `none!`): an empty result with no
   // main query issued and no error.
   it("where with eager-loading limited collection relation subquery yielding no ids is empty", async () => {
-    const subquery = CanonAuthor.where({ id: -1 }).eagerLoad("posts").order("id").limit(2);
+    const subquery = CanonAuthor.where({ id: -1 }).eagerLoad("posts").order({ id: "asc" }).limit(2);
 
     let records: any[] = [];
     const queries = await captureSql(async () => {
@@ -768,7 +768,7 @@ describe("RelationTest", () => {
   // inline LIMIT-in-IN subquery MySQL rejects. Rails materializes at
   // `.where()`-build time, so all terminals see `pk IN (ids)`.
   it("count, pluck, and exists over an eager-loading limited collection subquery materialize distinct primary keys", async () => {
-    const subquery = () => CanonAuthor.eagerLoad("posts").order("id").limit(2);
+    const subquery = () => CanonAuthor.eagerLoad("posts").order({ id: "asc" }).limit(2);
     const limitedAuthorIds = await CanonAuthor.order("id").limit(2).pluck("id");
     const expectedPostIds = await CanonPost.where({ author_id: limitedAuthorIds })
       .order("id")
@@ -806,7 +806,7 @@ describe("RelationTest", () => {
   // (Author hasOne post → Post belongsTo author) stays limitable, so a
   // limit/offset relation is NOT deferred to distinct_relation_for_primary_key.
   it("where with a singular nested-hash eager-loading limited subquery does not defer materialization", () => {
-    const subquery = CanonAuthor.eagerLoad({ post: "author" }).order("id").limit(2);
+    const subquery = CanonAuthor.eagerLoad({ post: "author" }).order({ id: "asc" }).limit(2);
     expect((subquery as any)._isDeferredDistinctPkSubquery()).toBe(false);
   });
 
@@ -814,7 +814,7 @@ describe("RelationTest", () => {
   // hasMany comments) makes the reflection set non-limitable, so the relation
   // defers to distinct-PK materialization just as a top-level collection does.
   it("where with a collection nested-hash eager-loading limited subquery defers materialization", () => {
-    const subquery = CanonAuthor.eagerLoad({ post: "comments" }).order("id").limit(2);
+    const subquery = CanonAuthor.eagerLoad({ post: "comments" }).order({ id: "asc" }).limit(2);
     expect((subquery as any)._isDeferredDistinctPkSubquery()).toBe(true);
   });
 });

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -5702,49 +5702,13 @@ export class Relation<T extends Base> {
         continue;
       }
       if (typeof clause === "string") {
-        const trimmed = clause.trim();
-        // Detect SQL expressions (functions, parens, operators) and pass as raw SQL
-        if (trimmed.includes("(") || /\bcase\b/i.test(trimmed) || trimmed.includes("||")) {
-          manager.order(new Nodes.SqlLiteral(trimmed));
-        } else {
-          // Parse "column ASC/DESC" or "table.column ASC/DESC" strings
-          const match = trimmed.match(/^([A-Za-z_$][\w$.]*)\s+(ASC|DESC)$/i);
-          if (match) {
-            const rawCol = match[1];
-            const dir = match[2].toUpperCase();
-            // Any dotted identifier (one or more dots) passes through as raw SQL.
-            if (rawCol.includes(".")) {
-              manager.order(new Nodes.SqlLiteral(trimmed));
-            } else if (!this._fromClause.isEmpty() && !this._isKnownColumn(rawCol)) {
-              const lit = this.orderColumn(rawCol) as Nodes.Node;
-              manager.order(dir === "DESC" ? new Nodes.Descending(lit) : new Nodes.Ascending(lit));
-            } else if (!this._isKnownColumn(rawCol)) {
-              // A bare identifier that isn't a real column (e.g. a SELECT alias
-              // like `name AS dev_name` → `ORDER BY dev_name DESC`) must pass
-              // through verbatim — qualifying it to the base table would emit
-              // `developers.dev_name`, which the database can't resolve. Mirrors
-              // Rails treating a string order arg as a raw SQL literal.
-              manager.order(new Nodes.SqlLiteral(trimmed));
-            } else {
-              const node = table.get(rawCol);
-              manager.order(
-                dir === "DESC" ? new Nodes.Descending(node) : new Nodes.Ascending(node),
-              );
-            }
-          } else {
-            // Not "col DIR" form. Only wrap plain letter-start identifiers;
-            // everything else (positional "1", NULLS FIRST, commas, etc.) is raw SQL.
-            if (/^[A-Za-z_$][\w$]*$/.test(trimmed)) {
-              if (!this._fromClause.isEmpty() && !this._isKnownColumn(trimmed)) {
-                manager.order(new Nodes.Ascending(this.orderColumn(trimmed) as Nodes.Node));
-              } else {
-                manager.order(new Nodes.Ascending(table.get(trimmed)));
-              }
-            } else {
-              manager.order(new Nodes.SqlLiteral(trimmed));
-            }
-          }
-        }
+        // Rails leaves a string order arg bare: `order("name ASC")` /
+        // `order("name")` pass through as an unquoted `Arel::Nodes::SqlLiteral`,
+        // never qualified to the table or column-quoted. Only Symbol and Hash
+        // order args route through column resolution (the tuple branch below).
+        // See Relation#preprocess_order_args (query_methods.rb): the `else`
+        // branch returns the string unchanged.
+        manager.order(new Nodes.SqlLiteral(clause.trim()));
       } else if (Array.isArray(clause)) {
         const [col, dir] = clause;
         // Function expressions, quoted identifiers, and dotted names must be

--- a/packages/activerecord/src/relation/cpk-eager-count-aggregate-build-joins-fold.trails.test.ts
+++ b/packages/activerecord/src/relation/cpk-eager-count-aggregate-build-joins-fold.trails.test.ts
@@ -96,7 +96,7 @@ describe("CpkBook eager count / aggregate build_joins fold", () => {
     let count = 0;
     const sqls = await captureSql(async () => {
       count = (await CpkBook.eagerLoad("chapters")
-        .order("author_id", "id")
+        .order("cpk_books.author_id", "cpk_books.id")
         .limit(2)
         .count("cpk_books.revision")) as number;
     });
@@ -145,7 +145,7 @@ describe("CpkBook eager count / aggregate build_joins fold", () => {
     // and 3 (rev 9) → COUNT(DISTINCT revision) = 2. Value-bounding would offset
     // into the distinct value list {5, 9} and (wrongly) return 1.
     const count = await CpkBook.eagerLoad("chapters")
-      .order("author_id", "id")
+      .order("cpk_books.author_id", "cpk_books.id")
       .offset(1)
       .count("cpk_books.revision");
     expect(count).toBe(2);

--- a/packages/activerecord/src/relation/cpk-eager-pluck-cache-version-composite-fk-collection.trails.test.ts
+++ b/packages/activerecord/src/relation/cpk-eager-pluck-cache-version-composite-fk-collection.trails.test.ts
@@ -92,7 +92,9 @@ describe("CpkBook eager pluck / cache_version over a composite-FK collection", (
 
   it("pluck over eagerLoad('chapters') joins the composite-FK collection", async () => {
     await seedBooks();
-    const titles = await CpkBook.eagerLoad("chapters").order("author_id", "id").pluck("title");
+    const titles = await CpkBook.eagerLoad("chapters")
+      .order("cpk_books.author_id", "cpk_books.id")
+      .pluck("title");
     expect(titles).toEqual(["Alpha", "Beta", "Gamma"]);
   });
 
@@ -107,7 +109,7 @@ describe("CpkBook eager pluck / cache_version over a composite-FK collection", (
   it("pluck over multiple eager specs joins both", async () => {
     await seedBooks();
     const titles = await CpkBook.eagerLoad("author", "chapters")
-      .order("author_id", "id")
+      .order("cpk_books.author_id", "cpk_books.id")
       .pluck("title");
     expect(titles).toEqual(["Alpha", "Beta", "Gamma"]);
   });
@@ -120,7 +122,10 @@ describe("CpkBook eager pluck / cache_version over a composite-FK collection", (
     // rather than emitting a wrong single-column predicate. Tracked by
     // 0023-surfaced-deviations/composite-pk-distinct-relation-materialization.
     await expect(
-      CpkBook.eagerLoad("chapters").order("author_id", "id").limit(2).pluck("title"),
+      CpkBook.eagerLoad("chapters")
+        .order("cpk_books.author_id", "cpk_books.id")
+        .limit(2)
+        .pluck("title"),
     ).rejects.toThrow(/limit\/offset over a collection association/);
   });
 
@@ -145,9 +150,11 @@ describe("CpkBook eager pluck / cache_version over a composite-FK collection", (
     await withCollectionCacheVersioning(async () => {
       await seedBooks();
       const eager = await CpkBook.eagerLoad("chapters")
-        .order("author_id", "id")
+        .order("cpk_books.author_id", "cpk_books.id")
         .cacheVersion("revision");
-      const base = await CpkBook.order("author_id", "id").cacheVersion("revision");
+      const base = await CpkBook.order("cpk_books.author_id", "cpk_books.id").cacheVersion(
+        "revision",
+      );
       expect(eager).toBe(base);
     });
   });
@@ -156,7 +163,10 @@ describe("CpkBook eager pluck / cache_version over a composite-FK collection", (
     await withCollectionCacheVersioning(async () => {
       await seedBooks();
       await expect(
-        CpkBook.eagerLoad("chapters").order("author_id", "id").limit(2).cacheVersion("revision"),
+        CpkBook.eagerLoad("chapters")
+          .order("cpk_books.author_id", "cpk_books.id")
+          .limit(2)
+          .cacheVersion("revision"),
       ).rejects.toThrow(/limit\/offset over a collection association/);
     });
   });

--- a/packages/activerecord/src/relation/mutation.test.ts
+++ b/packages/activerecord/src/relation/mutation.test.ts
@@ -139,18 +139,14 @@ describe("RelationMutationTest", () => {
 
   it("reverse_order!", () => {
     const rel: any = Post.order("title ASC", "comments_count DESC");
+    // String order args stay bare (matching Rails), so reversing them keeps them
+    // as SqlLiteral strings with the trailing direction flipped — never
+    // re-qualified to `[col, dir]` tuples.
+    const litValues = (): string[] => rel._orderClauses.map((c: any) => String(c.value));
     rel.reverseOrderBang();
-    // trails stores reversed terms as [col, dir] tuples (Rails keeps strings like
-    // "title DESC"); the flip — first term ASC→DESC, last DESC→ASC — is identical.
-    expect(rel._orderClauses).toEqual([
-      ["title", "desc"],
-      ["comments_count", "asc"],
-    ]);
+    expect(litValues()).toEqual(["title DESC", "comments_count ASC"]);
     rel.reverseOrderBang();
-    expect(rel._orderClauses).toEqual([
-      ["title", "asc"],
-      ["comments_count", "desc"],
-    ]);
+    expect(litValues()).toEqual(["title ASC", "comments_count DESC"]);
   });
 
   it("create_with!", () => {

--- a/packages/activerecord/src/relation/order-string-arg-stays-bare.trails.test.ts
+++ b/packages/activerecord/src/relation/order-string-arg-stays-bare.trails.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { Customer } from "../test-helpers/models/customer.js";
+import { quoteTableName, escapeRegExp } from "../test-helpers/quote-regex.js";
+
+// Adapter-aware `"customers"."name"` — backticks on MySQL/MariaDB.
+const qualifiedName = escapeRegExp(quoteTableName("customers.name"));
 
 /**
  * Locks the string-vs-symbol order-arg deviation resolved by
@@ -34,24 +38,26 @@ describe("order string arg stays bare", () => {
     const dupSymbol = (Customer as unknown as { order(...a: symbol[]): { toSql(): string } })
       .order(Symbol.for("name"), Symbol.for("name"))
       .toSql();
-    expect(dupSymbol.match(/"customers"\."name"/g)).toHaveLength(1);
+    expect(dupSymbol.match(new RegExp(qualifiedName, "g"))).toHaveLength(1);
   });
 
   it("leaves a directionless string bare (no implicit ASC, no qualification)", () => {
     const sql = Customer.order("name").toSql();
     expect(sql).toContain("ORDER BY name");
-    expect(sql).not.toMatch(/ORDER BY .*"customers"\."name"/);
+    expect(sql).not.toMatch(new RegExp(`ORDER BY .*${qualifiedName}`));
   });
 
   it("qualifies a Symbol order arg to the table, like Rails order(:name)", () => {
     const sql = (Customer as unknown as { order(arg: symbol): { toSql(): string } })
       .order(Symbol.for("name"))
       .toSql();
-    expect(sql).toMatch(/ORDER BY "customers"\."name" ASC/);
+    expect(sql).toMatch(new RegExp(`ORDER BY ${qualifiedName} ASC`));
   });
 
   it("qualifies a Hash order arg to the table", () => {
-    expect(Customer.order({ name: "asc" }).toSql()).toMatch(/ORDER BY "customers"\."name" ASC/);
+    expect(Customer.order({ name: "asc" }).toSql()).toMatch(
+      new RegExp(`ORDER BY ${qualifiedName} ASC`),
+    );
   });
 
   it("reversing a string order keeps it bare (flips the trailing direction)", () => {

--- a/packages/activerecord/src/relation/order-string-arg-stays-bare.trails.test.ts
+++ b/packages/activerecord/src/relation/order-string-arg-stays-bare.trails.test.ts
@@ -20,6 +20,13 @@ describe("order string arg stays bare", () => {
     expect(Customer.offset(1).order("name ASC").toSql()).toContain("ORDER BY name ASC");
   });
 
+  it("keeps each of multiple string args bare — no direction pairing", () => {
+    // Rails maps every String arg through unchanged (no pairing of a trailing
+    // "asc"/"desc" string), so `order("name", "desc")` is two bare terms.
+    const sql = Customer.order("name", "desc").toSql();
+    expect(sql).toContain("ORDER BY name, desc");
+  });
+
   it("leaves a directionless string bare (no implicit ASC, no qualification)", () => {
     const sql = Customer.order("name").toSql();
     expect(sql).toContain("ORDER BY name");

--- a/packages/activerecord/src/relation/order-string-arg-stays-bare.trails.test.ts
+++ b/packages/activerecord/src/relation/order-string-arg-stays-bare.trails.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { fixtures } from "../test-helpers/fixtures.js";
+import { Customer } from "../test-helpers/models/customer.js";
+
+/**
+ * Locks the string-vs-symbol order-arg deviation resolved by
+ * 0023-surfaced-deviations/relation-order-string-arg-stays-bare.
+ *
+ * Rails passes a string order arg through as a bare `Arel::Nodes::SqlLiteral`
+ * (`preprocess_order_args`' `else` branch) — no table qualification, no column
+ * quoting. Only Symbol/Hash order args route through column resolution and
+ * qualify. trails previously parsed a string fragment and qualified it like a
+ * symbol.
+ */
+describe("order string arg stays bare", () => {
+  fixtures([]);
+
+  it("leaves a string order fragment bare", () => {
+    expect(Customer.order("name ASC").toSql()).toContain("ORDER BY name ASC");
+    expect(Customer.offset(1).order("name ASC").toSql()).toContain("ORDER BY name ASC");
+  });
+
+  it("leaves a directionless string bare (no implicit ASC, no qualification)", () => {
+    const sql = Customer.order("name").toSql();
+    expect(sql).toContain("ORDER BY name");
+    expect(sql).not.toMatch(/ORDER BY .*"customers"\."name"/);
+  });
+
+  it("qualifies a Symbol order arg to the table, like Rails order(:name)", () => {
+    const sql = (Customer as unknown as { order(arg: symbol): { toSql(): string } })
+      .order(Symbol.for("name"))
+      .toSql();
+    expect(sql).toMatch(/ORDER BY "customers"\."name" ASC/);
+  });
+
+  it("qualifies a Hash order arg to the table", () => {
+    expect(Customer.order({ name: "asc" }).toSql()).toMatch(/ORDER BY "customers"\."name" ASC/);
+  });
+
+  it("reversing a string order keeps it bare (flips the trailing direction)", () => {
+    expect(Customer.order("name ASC").reverseOrder().toSql()).toContain("ORDER BY name DESC");
+    expect(Customer.order("name DESC").reverseOrder().reverseOrder().toSql()).toContain(
+      "ORDER BY name DESC",
+    );
+  });
+});

--- a/packages/activerecord/src/relation/order-string-arg-stays-bare.trails.test.ts
+++ b/packages/activerecord/src/relation/order-string-arg-stays-bare.trails.test.ts
@@ -27,6 +27,16 @@ describe("order string arg stays bare", () => {
     expect(sql).toContain("ORDER BY name, desc");
   });
 
+  it("dedupes repeated order terms, like Rails order_values |= args", () => {
+    // Rails' order! runs `order_values |= args`, deduping repeated terms.
+    const dupString = Customer.order("name", "name").toSql();
+    expect(dupString.match(/ORDER BY name/g)).toHaveLength(1);
+    const dupSymbol = (Customer as unknown as { order(...a: symbol[]): { toSql(): string } })
+      .order(Symbol.for("name"), Symbol.for("name"))
+      .toSql();
+    expect(dupSymbol.match(/"customers"\."name"/g)).toHaveLength(1);
+  });
+
   it("leaves a directionless string bare (no implicit ASC, no qualification)", () => {
     const sql = Customer.order("name").toSql();
     expect(sql).toContain("ORDER BY name");

--- a/packages/activerecord/src/relation/order.test.ts
+++ b/packages/activerecord/src/relation/order.test.ts
@@ -89,7 +89,12 @@ describe("OrderTest", () => {
     expect(await incOrder(Author.arelTable.get("name").desc(), { books: { name: "asc" } })).toEqual(
       authorDescThenBookName,
     );
-    expect(await incOrder({ authors: { name: "desc" } }, "name")).toEqual(authorDescThenBookName);
+    // Rails' final arg is the symbol `:name`, which qualifies to `books.name`.
+    // A bare string `"name"` would stay an unqualified SqlLiteral (matching
+    // Rails string semantics) and be ambiguous across the joined tables.
+    expect(await incOrder({ authors: { name: "desc" } }, Symbol.for("name"))).toEqual(
+      authorDescThenBookName,
+    );
   });
 
   it("order with association alias", async () => {
@@ -105,8 +110,13 @@ describe("OrderTest", () => {
       authorThenBookName,
     );
     expect(await incOrder("author.name", { books: { name: "asc" } })).toEqual(authorThenBookName);
-    expect(await incOrder({ author: { name: "asc" } }, "name")).toEqual(authorThenBookName);
-    expect(await incOrder(authorName, "name")).toEqual(authorThenBookName);
+    // Trailing `Symbol.for("name")` mirrors Rails' `:name` symbol (qualifies to
+    // `books.name`); a bare `"name"` string stays an unqualified SqlLiteral and
+    // would be ambiguous across the joined tables.
+    expect(await incOrder({ author: { name: "asc" } }, Symbol.for("name"))).toEqual(
+      authorThenBookName,
+    );
+    expect(await incOrder(authorName, Symbol.for("name"))).toEqual(authorThenBookName);
 
     const authorDescThenBookName = [y.id, x.id, z.id];
 
@@ -116,7 +126,9 @@ describe("OrderTest", () => {
     expect(await incOrder("author.name desc", { books: { name: "asc" } })).toEqual(
       authorDescThenBookName,
     );
-    expect(await incOrder({ author: { name: "desc" } }, "name")).toEqual(authorDescThenBookName);
-    expect(await incOrder(authorName.desc(), "name")).toEqual(authorDescThenBookName);
+    expect(await incOrder({ author: { name: "desc" } }, Symbol.for("name"))).toEqual(
+      authorDescThenBookName,
+    );
+    expect(await incOrder(authorName.desc(), Symbol.for("name"))).toEqual(authorDescThenBookName);
   });
 });

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -646,20 +646,15 @@ function orderBang(this: QueryMethodsHost, ...args: OrderArg[]): any {
       disallowRawSqlBang([name], resolveOrderMatcher(this));
       this._orderClauses.push([name, "asc"]);
     } else if (typeof arg === "string") {
-      if (arg.trim() === "") {
-        const next = args[i + 1];
-        i += typeof next === "string" && /^(asc|desc)$/i.test(next) ? 2 : 1;
-        continue;
+      // Rails maps each String order arg through unchanged (preprocess_order_args'
+      // `else` branch) and compact_blanks blank strings away. A string never pairs
+      // with a following "asc"/"desc" arg nor qualifies — it stays a bare
+      // SqlLiteral (see _applyOrderToManager). Validate immediately, mirroring
+      // Rails raising on order("invalid") at call time.
+      if (arg.trim() !== "") {
+        disallowRawSqlBang([arg], resolveOrderMatcher(this));
+        this._orderClauses.push(arg);
       }
-      // Validate immediately — mirrors Rails raising on order("invalid") at call time.
-      disallowRawSqlBang([arg], resolveOrderMatcher(this));
-      const next = args[i + 1];
-      if (typeof next === "string" && /^(asc|desc)$/i.test(next)) {
-        this._orderClauses.push([arg, next.toLowerCase() as "asc" | "desc"]);
-        i += 2;
-        continue;
-      }
-      this._orderClauses.push(arg);
     } else if (arg !== null && typeof arg === "object") {
       // Hash form { col: "asc"|"desc" } — and nested { table: { col: "asc" } },
       // which Rails expands to a `table.col dir` qualified order.
@@ -722,19 +717,13 @@ function reorderBang(this: QueryMethodsHost, ...args: OrderArg[]): any {
       disallowRawSqlBang([name], resolveOrderMatcher(this));
       this._orderClauses.push([name, "asc"]);
     } else if (typeof arg === "string") {
-      if (arg.trim() === "") {
-        const next = args[i + 1];
-        i += typeof next === "string" && /^(asc|desc)$/i.test(next) ? 2 : 1;
-        continue;
+      // Each String order arg maps through unchanged and stays bare (see the
+      // orderBang string branch); blanks are compact_blank'd away. No pairing
+      // with a following "asc"/"desc" arg, no qualification.
+      if (arg.trim() !== "") {
+        disallowRawSqlBang([arg], resolveOrderMatcher(this));
+        this._orderClauses.push(arg);
       }
-      disallowRawSqlBang([arg], resolveOrderMatcher(this));
-      const next = args[i + 1];
-      if (typeof next === "string" && /^(asc|desc)$/i.test(next)) {
-        this._orderClauses.push([arg, next.toLowerCase() as "asc" | "desc"]);
-        i += 2;
-        continue;
-      }
-      this._orderClauses.push(arg);
     } else if (arg !== null && typeof arg === "object") {
       for (const clause of expandOrderHash(this, arg as Record<string, unknown>)) {
         this._orderClauses.push(clause);

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -151,6 +151,7 @@ type OrderDirection = "asc" | "desc" | "ASC" | "DESC";
  */
 export type OrderArg =
   | string
+  | symbol
   | Record<string, OrderDirection | Record<string, OrderDirection>>
   | Nodes.Node
   | string[]
@@ -637,6 +638,13 @@ function orderBang(this: QueryMethodsHost, ...args: OrderArg[]): any {
       const blankLiteral =
         arg instanceof Nodes.SqlLiteral && String((arg as any).value ?? "").trim() === "";
       if (!blankLiteral) this._orderClauses.push(arg);
+    } else if (typeof arg === "symbol") {
+      // Rails qualifies a Symbol order arg (`order(:name)` → `"table"."name"
+      // ASC`), unlike a string, which stays bare. Store as a `[col, "asc"]`
+      // tuple so `_applyOrderToManager` routes it through column resolution.
+      const name = symbolToName(arg);
+      disallowRawSqlBang([name], resolveOrderMatcher(this));
+      this._orderClauses.push([name, "asc"]);
     } else if (typeof arg === "string") {
       if (arg.trim() === "") {
         const next = args[i + 1];
@@ -706,6 +714,13 @@ function reorderBang(this: QueryMethodsHost, ...args: OrderArg[]): any {
       const blankLiteral =
         arg instanceof Nodes.SqlLiteral && String((arg as any).value ?? "").trim() === "";
       if (!blankLiteral) this._orderClauses.push(arg);
+    } else if (typeof arg === "symbol") {
+      // Rails qualifies a Symbol order arg (`order(:name)` → `"table"."name"
+      // ASC`), unlike a string, which stays bare. Store as a `[col, "asc"]`
+      // tuple so `_applyOrderToManager` routes it through column resolution.
+      const name = symbolToName(arg);
+      disallowRawSqlBang([name], resolveOrderMatcher(this));
+      this._orderClauses.push([name, "asc"]);
     } else if (typeof arg === "string") {
       if (arg.trim() === "") {
         const next = args[i + 1];
@@ -1466,25 +1481,13 @@ function reverseOrderBang(this: QueryMethodsHost): any {
       return clause;
     }
     if (typeof clause === "string") {
-      const match = clause.match(/^([\w.]+)\s+(ASC|DESC)$/i);
-      if (match) {
-        const col = match[1];
-        const dir = match[2].toUpperCase() === "ASC" ? "desc" : "asc";
-        return [col, dir] as [string, "asc" | "desc"];
-      }
-      // Multi-column comma-joined order ("salary DESC, name ASC"): mirror Rails'
-      // reverse_sql_order String branch — split on comma and flip each term.
-      // reverseSqlOrder calls isDoesNotSupportReverse (the faithful port of
-      // does_not_support_reverse?), so unbalanced-paren sections and "nulls
-      // first/last" still raise, while balanced expressions reverse.
-      if (clause.includes(",")) {
-        const reversed = reverseSqlOrder.call(this, [clause]) as string[];
-        return new Nodes.SqlLiteral(reversed.join(", "));
-      }
-      // Bare column flips to a quoted desc tuple; any SQL expression goes through reverseSqlOrder.
-      if (/^[\w.]+$/.test(clause)) {
-        return [clause, "desc" as const];
-      }
+      // A string order arg stays a bare SqlLiteral (see _applyOrderToManager),
+      // so reversing it mirrors Rails' reverse_sql_order String branch: split on
+      // comma and flip each term's trailing ASC↔DESC (appending DESC when
+      // unmarked), keeping the result a bare SqlLiteral rather than re-qualifying
+      // it to a `[col, dir]` tuple. reverseSqlOrder runs isDoesNotSupportReverse
+      // (the faithful port of does_not_support_reverse?), so unbalanced-paren
+      // sections and "nulls first/last" still raise.
       const reversed = reverseSqlOrder.call(this, [clause]) as string[];
       return new Nodes.SqlLiteral(reversed.join(", "));
     }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -667,6 +667,8 @@ function orderBang(this: QueryMethodsHost, ...args: OrderArg[]): any {
     }
     i++;
   }
+  // Mirror Rails' `self.order_values |= args`: union dedupes repeated terms.
+  this._orderClauses = dedupeOrderClauses(this._orderClauses);
   return this;
 }
 
@@ -734,15 +736,21 @@ function reorderBang(this: QueryMethodsHost, ...args: OrderArg[]): any {
     }
     i++;
   }
-  // Deduplicate identical order terms — mirrors Rails' order_values.uniq
+  this._orderClauses = dedupeOrderClauses(this._orderClauses);
+  return this;
+}
+
+// Remove duplicate order terms while preserving first-seen order. orderBang
+// mirrors Rails' `self.order_values |= args` and reorderBang its `args.uniq!` —
+// both dedupe by value (query_methods.rb order!/reorder!).
+function dedupeOrderClauses<T>(clauses: T[]): T[] {
   const seen = new Set<string>();
-  this._orderClauses = this._orderClauses.filter((c) => {
+  return clauses.filter((c) => {
     const key = JSON.stringify(c);
     if (seen.has(key)) return false;
     seen.add(key);
     return true;
   });
-  return this;
 }
 
 /**

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -411,7 +411,9 @@ describe("RelationTest", () => {
   });
 
   it("finding with subquery with eager loading in from", async () => {
-    const relation = Comment.includes("post").where({ "posts.type": "Post" }).order("id");
+    const relation = Comment.includes("post")
+      .where({ "posts.type": "Post" })
+      .order(Symbol.for("id"));
     const expected = (await relation.toArray()).map((c) => c.id);
     expect((await Comment.select("*").from(relation)).map((c) => c.id)).toEqual(expected);
     expect((await Comment.select("subquery.*").from(relation)).map((c) => c.id)).toEqual(expected);
@@ -428,7 +430,9 @@ describe("RelationTest", () => {
   // `toSql()` emits. This is Rails-correct, and shared with the where-subquery
   // path (`relation-handler`); converging to `t0_r*` here would diverge.
   it("eager from() subquery projects the table star, not column aliases", async () => {
-    const relation = Comment.includes("post").where({ "posts.type": "Post" }).order("id");
+    const relation = Comment.includes("post")
+      .where({ "posts.type": "Post" })
+      .order(Symbol.for("id"));
     const sql = await (Comment.select("*").from(relation) as any).toSql();
     // Adapter-agnostic: strip identifier quoting (`"` on sqlite/postgres,
     // backticks on mysql) so the shape assertion holds on every CI adapter.
@@ -572,7 +576,7 @@ describe("RelationTest", () => {
   });
 
   it("order with hash and symbol generates the same sql", () => {
-    expect(Topic.order("id").toSql()).toBe(Topic.order({ id: "asc" }).toSql());
+    expect(Topic.order(Symbol.for("id")).toSql()).toBe(Topic.order({ id: "asc" }).toSql());
   });
 
   it("finding with desc order with string", async () => {
@@ -626,7 +630,7 @@ describe("RelationTest", () => {
   });
 
   it("finding with order by aliased attributes", async () => {
-    const topicsRel = Topic.order("heading");
+    const topicsRel = Topic.order(Symbol.for("heading"));
     expect(await topicsRel.size()).toBe(5);
     expect((await topicsRel.first())!.title).toBe(topics("fifth").title);
   });
@@ -655,7 +659,7 @@ describe("RelationTest", () => {
   });
 
   it("finding with reorder by aliased attributes", async () => {
-    const topicsRel = Topic.order("author_name").reorder("heading");
+    const topicsRel = Topic.order("author_name").reorder(Symbol.for("heading"));
     expect(await topicsRel.size()).toBe(5);
     expect((await topicsRel.first())!.title).toBe(topics("fifth").title);
   });

--- a/packages/activerecord/src/reserved-word.test.ts
+++ b/packages/activerecord/src/reserved-word.test.ts
@@ -167,7 +167,7 @@ describe("ReservedWordTest", () => {
 
   it("delete all with subselect", async () => {
     await createTestFixtures("values");
-    expect(await Values.order("as").limit(1).offset(1).deleteAll()).toBe(1);
+    expect(await Values.order(Symbol.for("as")).limit(1).offset(1).deleteAll()).toBe(1);
     await expect(Values.find(2)).rejects.toThrow(RecordNotFound);
     expect(await Values.find(1)).not.toBeNull();
   });

--- a/packages/activerecord/src/test-helpers/models/author.ts
+++ b/packages/activerecord/src/test-helpers/models/author.ts
@@ -303,7 +303,7 @@ export class Author extends Base {
 
     this.hasMany("ratings", { through: "comments" });
     this.hasMany("goodRatings", {
-      scope: (q: any) => q.where("ratings.value > 5").order("id"),
+      scope: (q: any) => q.where("ratings.value > 5").order({ id: "asc" }),
       through: "comments",
       source: "ratings",
     });
@@ -313,7 +313,7 @@ export class Author extends Base {
       source: "ratings",
     });
     this.hasMany("noJoinsGoodRatings", {
-      scope: (q: any) => q.where("ratings.value > 5").order("id"),
+      scope: (q: any) => q.where("ratings.value > 5").order({ id: "asc" }),
       through: "comments",
       source: "ratings",
       disableJoins: true,


### PR DESCRIPTION
## Summary

`Relation#order` treated a **string** order arg the same as a symbol — it
parsed `"name ASC"` and qualified + quoted the column, emitting
`ORDER BY "customers"."name" ASC`. Rails only qualifies **Symbol**/**Hash**
order args; a string passes through verbatim as a bare
`Arel::Nodes::SqlLiteral` (`preprocess_order_args`' `else` branch). So
`Customer.offset(1).order("name ASC")` now emits `ORDER BY name ASC`.

## Changes

- `_applyOrderToManager` (relation.ts): a string clause emits a bare
  `SqlLiteral`; the `[col, dir]` tuple branch (Hash/Symbol forms) still
  qualifies through column resolution.
- `reverseOrderBang` (query-methods.ts): reversing a string clause keeps it a
  bare `SqlLiteral` (flip trailing `ASC`↔`DESC`) instead of re-qualifying it to
  a tuple, mirroring `reverse_sql_order`'s String branch.
- `order`/`reorder` now accept a **Symbol** order arg
  (`order(Symbol.for("name"))`) — the faithful analog of Ruby `order(:name)`,
  which qualifies to the table.

## Tests

- The two finder offset assertions revert to Rails' bare `/ORDER BY name ASC/`.
- Ported tests that relied on a bare string qualifying — where Rails actually
  uses a symbol (`order(:id)`, `order(:heading)`, `order(:as)`, `order(:name)`)
  — switch to `Symbol.for(...)`. Trails-specific eager-join tests that ordered
  by a bare ambiguous column now qualify it (`cpk_books.author_id`), matching
  what a Rails user would write.
- `reverse_order!` asserts reversed string terms stay bare SqlLiterals
  (`"title DESC"`), matching Rails.

Closes-story: relation-order-string-arg-stays-bare
