### PR TITLE
refactor(pg): converge quote_default_expression array branch onto lookupCastTypeFromColumn

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3489,6 +3489,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
           sqlType?: string | null;
           type?: string;
           array?: boolean;
+          oid?: number | null;
+          fmod?: number | null;
           options?: { array?: boolean };
         }
       | undefined;
@@ -3498,23 +3500,30 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     // DEFAULT paths (live Column) both fire the array branch.
     const isArray = col?.array === true || col?.options?.array === true;
     const rawSqlType = col?.sqlType ?? col?.type ?? null;
-    // Rails' lookup_cast_type_from_column normalizes formatted SQL types
-    // (`integer` → `int4`, `numeric(10,2)` → `numeric`) before consulting
-    // the OID-keyed type map. The CastTypeLookup passed to
-    // pgQuoteDefaultExpression delegates to it so element subtypes
-    // resolve instead of falling back to ValueType.
     const self = this;
     const lookup = {
-      lookupCastTypeFromColumn(col: { sqlType?: string | null }): {
-        serialize?(v: unknown): unknown;
-      } | null {
-        // Strip a trailing `[]` so an array column's sqlType (e.g.
-        // `integer[]` from ColumnDefinition.typeToSql) resolves to the
-        // element typname. `lookupCastTypeFromColumn` (Rails
-        // postgresql/quoting.rb:162) does the normalizeFormatType +
-        // FORMAT_TYPE_ALIASES lookup, but deliberately preserves `[]` for
-        // the type-casting path, so the strip happens here at the call site.
-        const base = (col.sqlType ?? "").replace(/\[\]\s*$/, "");
+      lookupCastTypeFromColumn(c: {
+        sqlType?: string | null;
+        oid?: number | null;
+        fmod?: number | null;
+      }): { serialize?(v: unknown): unknown } | null {
+        // A live Column carries an OID, so hand it straight through: Rails
+        // keys the lookup on (oid, fmod, sql_type) (quoting.rb:191), and for
+        // an array column that OID resolves to OID::Array(subtype) — an
+        // array-aware type whose serialize returns ArrayData, which
+        // quoteDefaultExpression handles directly.
+        if (c.oid != null) {
+          return self.lookupCastTypeFromColumn(c) as {
+            serialize?(v: unknown): unknown;
+          } | null;
+        }
+        // No OID means a ColumnDefinition from a DDL path, whose sqlType is
+        // the `[]`-suffixed form typeToSql emitted (`integer[]`). Strip it so
+        // the element typname resolves — normalizeFormatType deliberately
+        // preserves `[]` for the type-casting path, so the strip belongs
+        // here at the call site rather than in the shared helper. The
+        // element subtype is then wrapped in OidArray downstream.
+        const base = (c.sqlType ?? "").replace(/\[\]\s*$/, "");
         return self.lookupCastTypeFromColumn({ sqlType: base }) as {
           serialize?(v: unknown): unknown;
         } | null;
@@ -3527,6 +3536,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         ? {
             array: isArray,
             sqlType: rawSqlType,
+            oid: col.oid ?? null,
+            fmod: col.fmod ?? null,
             // Rails' uuid branch tests `column.type` (the AR type symbol), not
             // sql_type, so forward it separately from `rawSqlType`.
             type: col.type ?? null,

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3500,22 +3500,22 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     const rawSqlType = col?.sqlType ?? col?.type ?? null;
     // Rails' lookup_cast_type_from_column normalizes formatted SQL types
     // (`integer` → `int4`, `numeric(10,2)` → `numeric`) before consulting
-    // the OID-keyed type map. Mirror that here so the TypeMapLike passed
-    // to pgQuoteDefaultExpression resolves element subtypes instead of
-    // falling back to ValueType.
-    const tm = this.typeMap;
+    // the OID-keyed type map. The CastTypeLookup passed to
+    // pgQuoteDefaultExpression delegates to it so element subtypes
+    // resolve instead of falling back to ValueType.
+    const self = this;
     const lookup = {
-      lookup(sqlType: string): { serialize?(v: unknown): unknown } | null {
+      lookupCastTypeFromColumn(col: { sqlType?: string | null }): {
+        serialize?(v: unknown): unknown;
+      } | null {
         // Strip a trailing `[]` so an array column's sqlType (e.g.
         // `integer[]` from ColumnDefinition.typeToSql) resolves to the
-        // element typname via normalizeFormatType + FORMAT_TYPE_ALIASES.
-        // normalizeFormatType deliberately preserves `[]` for the
-        // type-casting path, so the strip happens here at the call site.
-        // Forward the original (`[]`-stripped) sqlType as the third arg
-        // so registerClassWithLimit/Precision factories can recover
-        // limit/precision/scale from `numeric(10,2)` etc.
-        const base = sqlType.replace(/\[\]\s*$/, "");
-        return tm.lookup(normalizeFormatType(base), -1, base) as {
+        // element typname. `lookupCastTypeFromColumn` (Rails
+        // postgresql/quoting.rb:162) does the normalizeFormatType +
+        // FORMAT_TYPE_ALIASES lookup, but deliberately preserves `[]` for
+        // the type-casting path, so the strip happens here at the call site.
+        const base = (col.sqlType ?? "").replace(/\[\]\s*$/, "");
+        return self.lookupCastTypeFromColumn({ sqlType: base }) as {
           serialize?(v: unknown): unknown;
         } | null;
       },

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.type-map.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.type-map.test.ts
@@ -107,7 +107,7 @@ describe("PostgreSQLAdapter#quoteDefaultExpression", () => {
   });
 
   it("normalizes `integer[]` sqlType so the integer subtype resolves", () => {
-    // If normalization were missing, `tm.lookup("integer[]")` would
+    // If normalization were missing, the `integer[]` lookup would
     // miss and the element subtype would fall back to ValueType,
     // emitting the floats verbatim ('{1.7,2.3}'). IntegerType#serialize
     // truncates to integers, so '{1,2}' confirms the subtype lookup hit.

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.type-map.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.type-map.test.ts
@@ -114,4 +114,36 @@ describe("PostgreSQLAdapter#quoteDefaultExpression", () => {
     const columnDef = { sqlType: "integer[]", options: { array: true } };
     expect(adapter.quoteDefaultExpression([1.7, 2.3], columnDef)).toBe("'{1,2}'");
   });
+
+  it("resolves a live column's cast type by oid/fmod, not by formatted name", () => {
+    // Rails keys lookup_cast_type_from_column on (oid, fmod, sql_type)
+    // (postgresql/quoting.rb:191). Registering a distinguishable type under
+    // an OID whose sqlType would otherwise resolve elsewhere proves the OID
+    // wins: `numeric` by name is a decimal, so `'99'` can only come from the
+    // OID-registered type.
+    adapter.typeMap.registerType(918_273, {
+      serialize: () => "99",
+    } as never);
+    const column = { oid: 918_273, fmod: -1, sqlType: "numeric", array: false };
+    expect(adapter.quoteDefaultExpression(1.5, column)).toBe("'99'");
+  });
+
+  it("forwards fmod so precision-carrying types resolve", () => {
+    // fmod is how numeric(10,2) recovers its precision/scale; dropping it
+    // would silently hand the factory -1.
+    let seen: number | undefined;
+    adapter.typeMap.registerType(918_274, {
+      serialize: (v: unknown) => v,
+    } as never);
+    const spy = vi.spyOn(adapter.typeMap, "fetch").mockImplementation(((
+      _oid: number,
+      fmod: number,
+    ) => {
+      seen = fmod;
+      return { serialize: (v: unknown) => v };
+    }) as never);
+    adapter.quoteDefaultExpression("x", { oid: 918_274, fmod: 655_366, sqlType: "numeric" });
+    expect(seen).toBe(655_366);
+    spy.mockRestore();
+  });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
@@ -103,8 +103,8 @@ describe("PostgreSQL quoting", () => {
   it("serializes defaults for any PostgreSQL column, not only array columns", () => {
     const column = { sqlType: "integer", array: false };
     const typeMap = {
-      lookup(sqlType: string) {
-        expect(sqlType).toBe("integer");
+      lookupCastTypeFromColumn(col: { sqlType?: string | null }) {
+        expect(col.sqlType).toBe("integer");
         return { serialize: (value: unknown) => Number(value) + 1 };
       },
     };
@@ -137,14 +137,14 @@ describe("PostgreSQL quoting", () => {
     // serialize emits must still reach PG's bytea form.
     // `array` must be present: the serialize branch is gated on `"array" in column`.
     const column = { sqlType: "bytea", array: false };
-    const typeMap = { lookup: () => new BinaryType() };
+    const typeMap = { lookupCastTypeFromColumn: () => new BinaryType() };
     expect(quoteDefaultExpression.call(HOST, "ab", column, typeMap)).toBe("'\\x6162'");
   });
 
   it("serializes array defaults via fallback OidArray when type map misses", () => {
     const column = { sqlType: "text[]", array: true };
     const nullTypeMap = {
-      lookup() {
+      lookupCastTypeFromColumn() {
         return null;
       },
     };
@@ -175,7 +175,7 @@ describe("PostgreSQL quoting", () => {
   it("does not apply array fallback when column.array is false", () => {
     const column = { sqlType: "text", array: false };
     const nullTypeMap = {
-      lookup() {
+      lookupCastTypeFromColumn() {
         return null;
       },
     };
@@ -187,7 +187,7 @@ describe("PostgreSQL quoting", () => {
     const arrayType = new OidArray(stringSubtype);
     const column = { sqlType: "text[]", array: true };
     const typeMap = {
-      lookup() {
+      lookupCastTypeFromColumn() {
         return { serialize: (value: unknown) => new ArrayData(arrayType, value as unknown[]) };
       },
     };
@@ -199,11 +199,11 @@ describe("PostgreSQL quoting", () => {
     // Mirrors Rails postgresql/quoting.rb:161-163 where
     // lookup_cast_type_from_column returns OID::Array(IntegerType) and
     // serialize walks each element through Integer#serialize. Trails'
-    // TypeMapLike returns the element subtype here; quoteDefaultExpression
+    // CastTypeLookup returns the element subtype here; quoteDefaultExpression
     // must wrap it in OidArray so per-element casting fires.
     const column = { sqlType: "integer", array: true };
     const typeMap = {
-      lookup() {
+      lookupCastTypeFromColumn() {
         return { cast: (v: unknown) => v, serialize: (v: unknown) => Number(v) + 100 };
       },
     };
@@ -218,7 +218,7 @@ describe("PostgreSQL quoting", () => {
     // pass-through; mirror that here.
     const column = { sqlType: "integer", array: true };
     const typeMap = {
-      lookup() {
+      lookupCastTypeFromColumn() {
         return { serialize: (v: unknown) => Number(v) };
       },
     };

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -59,6 +59,12 @@ export interface DefaultExpressionColumn {
   sqlType?: string | null;
   type?: string | null;
   array?: boolean;
+  // Rails' lookup_cast_type_from_column keys on (oid, fmod, sql_type)
+  // (postgresql/quoting.rb:191), so a live Column's OID and type modifier
+  // must survive the trip here — the formatted-name fallback is only for
+  // ColumnDefinitions, which have neither.
+  oid?: number | null;
+  fmod?: number | null;
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -61,8 +61,15 @@ export interface DefaultExpressionColumn {
   array?: boolean;
 }
 
-export interface TypeMapLike {
-  lookup(sqlType: string): { serialize?(value: unknown): unknown } | null;
+/**
+ * The `lookup_cast_type_from_column` surface `quote_default_expression`'s
+ * array branch needs (postgresql/quoting.rb:161-163), narrowed to what the
+ * branch actually uses.
+ */
+export interface CastTypeLookup {
+  lookupCastTypeFromColumn(column: DefaultExpressionColumn): {
+    serialize?(value: unknown): unknown;
+  } | null;
 }
 
 export function quoteTableName(name: string): string {
@@ -155,7 +162,7 @@ export function quoteDefaultExpression(
   this: QuotingDispatchHost,
   value: unknown,
   column?: DefaultExpressionColumn | null,
-  typeMap?: TypeMapLike | null,
+  castTypeLookup?: CastTypeLookup | null,
 ): string {
   if (value === undefined) return "";
   if (typeof value === "function") {
@@ -178,12 +185,11 @@ export function quoteDefaultExpression(
 
   let serialized: unknown = value;
   if (column != null && "array" in column) {
-    const sqlType = column.sqlType ?? column.type ?? null;
-    const castType = sqlType ? typeMap?.lookup(sqlType) : null;
+    const castType = castTypeLookup?.lookupCastTypeFromColumn(column) ?? null;
     if (column.array === true && globalThis.Array.isArray(value)) {
       // Rails routes JS arrays through OID::Array.serialize so each
       // element is cast by the element subtype before quoting. Trails'
-      // TypeMapLike permits two shapes: an already-array-aware type
+      // CastTypeLookup permits two shapes: an already-array-aware type
       // (serialize returns ArrayData) or the element subtype. Run
       // serialize first; if ArrayData, use it. Otherwise wrap the
       // original value in OidArray(subtype) for per-element coercion.

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { SchemaCreation } from "./schema-creation.js";
+import { quoteDefaultExpression } from "./quoting.js";
 import { ExclusionConstraintDefinition, UniqueConstraintDefinition } from "./schema-definitions.js";
 import {
   ForeignKeyDefinition,
@@ -109,6 +110,22 @@ describe("PostgreSQL SchemaCreation", () => {
     expect(
       s().visitChangeColumnDefaultDefinition(new ChangeColumnDefaultDefinition(col, "v")),
     ).toContain("SET DEFAULT");
+  });
+
+  it("visitChangeColumnDefaultDefinition: uuid function default stays bare", () => {
+    // postgresql/quoting.rb:159-160 — a `()`-bearing string default on a
+    // uuid column must reach the DDL as a call, not as `'uuid_generate_v4()'`.
+    const col = new ColumnDefinition("id", "uuid");
+    // The shared stub fakes quoteDefaultExpression; this branch lives in
+    // the real one, so wire that in.
+    const host = s();
+    host.adapter.quoteDefaultExpression = (v: unknown, c: unknown) =>
+      quoteDefaultExpression.call(null as never, v, c as never);
+    expect(
+      host.visitChangeColumnDefaultDefinition(
+        new ChangeColumnDefaultDefinition(col, "uuid_generate_v4()"),
+      ),
+    ).toBe('ALTER COLUMN "id" SET DEFAULT uuid_generate_v4()');
   });
 
   it("visitChangeColumnDefinition: ALTER COLUMN TYPE", () => {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql/quoting.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql/quoting.json
@@ -18,14 +18,7 @@
     "tsFile": "connection-adapters/postgresql/quoting.ts",
     "rubyName": "quote_default_expression",
     "call": "include?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/quoting.ts",
-    "rubyName": "quote_default_expression",
-    "call": "lookup_cast_type_from_column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Vetted: ported as `value.includes(\"()\")` (quoting.rb:159). Ruby `include?` maps to the TS candidates `include`/`isInclude`, which JS strings do not have \u2014 `String#includes` is the exact equivalent."
   },
   {
     "package": "activerecord",


### PR DESCRIPTION
> **Scope changed after rebase.** This PR originally ported the uuid function-default branch. That branch landed independently in #4958 while this sat, so it has been dropped here — what remains is the *other* half of the story: converging the array branch onto `lookup_cast_type_from_column`.

Rails' PostgreSQL `quote_default_expression` array branch calls `lookup_cast_type_from_column(column)` (`postgresql/quoting.rb:161-163`); trails threaded a bespoke `typeMap.lookup(sqlType)` closure instead.

## Changes

- `TypeMapLike { lookup(sqlType) }` → `CastTypeLookup { lookupCastTypeFromColumn(column) }`, and the adapter's closure now delegates to its real `lookupCastTypeFromColumn`. Behavior-identical: that method's `oid == null` path is exactly the `typeMap.lookup(normalizeFormatType(sqlType), -1, sqlType)` the closure was inlining. The `[]`-strip stays at the call site, since `normalizeFormatType` deliberately preserves `[]` for the type-casting path.
- Forward the live column's `oid`/`fmod` through `CastTypeLookup`/`DefaultExpressionColumn`, so reflected PG columns resolve via the exact OID/fmod cast type as Rails does (`quoting.rb:191`) rather than the formatted-name fallback. The `[]`-strip now applies only to the OID-less `ColumnDefinition` path, where it is genuinely needed.
- Drop the now-satisfied `quote_default_expression`/`lookup_cast_type_from_column` wide-call exclude entry (ratchet: 6840 → 6839 baselined).
- Add a DDL-level regression test for the uuid branch: `visitChangeColumnDefaultDefinition` emits `ALTER COLUMN "id" SET DEFAULT uuid_generate_v4()`. #4958 covers the branch at the quoting-unit level; this covers the schema-creation wiring that threads `o.column` into it, which was untested.

## Note on the remaining `include?` exclude entry

Not name-satisfiable: `rubyMethodToTs("include?")` yields `isInclude`/`include`, neither of which exists on a JS string. The port uses `value.includes("()")`, the exact equivalent. The entry is kept but re-worded from the RFC 0047 boilerplate to a vetted reason.

`pnpm api:calls:wide` is green.

Closes-story: pg-quote-default-expression-uuid-fn-branch
