### PR TITLE
refactor(relation): route updateAll values through _substituteValues

### DIFF
--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -157,15 +157,7 @@ describe("RelationTest", () => {
     expect(attrs.title).toBe("scoped");
   });
 
-  // it.fails (active, not skipped): trails `updateAll` passes scalar SET values
-  // raw; the UPDATE-SET visitor (to-sql.ts visitArelNodesAssignment) quotes them
-  // by *column* type, so an attribute-declared custom type's cast/serialize is
-  // bypassed — unlike Rails `_substitute_values`, which binds via
-  // `type_for_attribute`. Marked `it.fails` so CI keeps running the faithful Rails
-  // assertion and flips red the moment the deviation is fixed (signalling the
-  // marker should be removed). Tracked by story
-  // 0023-surfaced-deviations/updateall-routes-values-through-attribute-type.
-  it.fails("update all goes through normal type casting", async () => {
+  it("update all goes through normal type casting", async () => {
     await UpdateAllTestModel.updateAll({ body: "value from user", type: null }); // No STI
 
     const first = await UpdateAllTestModel.first();

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -38,6 +38,7 @@ import {
 import { applyThenable, stripThenable } from "./relation/thenable.js";
 import { getInheritanceColumn, isStiSubclass } from "./inheritance.js";
 import { isBaseInstance } from "./relation/predicate-builder/is-base-instance.js";
+import { QueryAttribute } from "./relation/query-attribute.js";
 import {
   underscore as _toUnderscore,
   camelize as _camelize,
@@ -7064,8 +7065,15 @@ export class Relation<T extends Base> {
         // render as `SET col = (select ...)`, which SQLite/MySQL/PG require.
         return [attr, value instanceof Nodes.SqlLiteral ? new Nodes.Grouping(value) : value];
       }
+      // Rails casts exactly once here: `build_bind_attribute` hands the already-cast
+      // value to `QueryAttribute.new` (predicate_builder.rb:67-69), and
+      // `QueryAttribute#type_cast` is identity (query_attribute.rb:22-24). trails'
+      // `QueryAttribute#typeCast` instead casts its input — most of its callers pass
+      // RAW values and rely on that — so routing a cast value through
+      // `buildBindAttribute` would cast twice. `withCastValue` is the preserving
+      // constructor that matches Rails' semantics.
       const type = this._modelClass.typeForAttribute(attr.name);
-      return [attr, this.predicateBuilder.buildBindAttribute(attr.name, type.cast(value))];
+      return [attr, QueryAttribute.withCastValue(attr.name, type.cast(value), type)];
     });
   }
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -7060,6 +7060,8 @@ export class Relation<T extends Base> {
         value instanceof Nodes.SqlLiteral ||
         value instanceof Nodes.Attribute
       ) {
+        // The Grouping is what makes a raw `Arel.sql(...)` scalar subquery
+        // render as `SET col = (select ...)`, which SQLite/MySQL/PG require.
         return [attr, value instanceof Nodes.SqlLiteral ? new Nodes.Grouping(value) : value];
       }
       const type = this._modelClass.typeForAttribute(attr.name);

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3748,23 +3748,8 @@ export class Relation<T extends Base> {
     await this._materializeDeferredDistinctPkPredicates();
 
     const table = this._modelClass.arelTable;
-    const updateValues: [InstanceType<typeof Nodes.Node>, unknown][] = Object.entries(updates).map(
-      ([key, val]) => {
-        const def = this._modelClass._attributeDefinitions.get(key);
-        const isArray = def?.type?.name === "array";
-        if (isArray) return [table.get(key), def.type.serialize(val)];
-        const isRangeCol =
-          val instanceof Range &&
-          (def?.type as { isForceEquality?(v: unknown): boolean } | undefined)?.isForceEquality?.(
-            val,
-          );
-        if (isRangeCol) return [table.get(key), def!.type.serialize(val)];
-        // Mirrors Rails relation.rb#_substitute_values: a raw `Arel.sql(...)`
-        // assignment value is wrapped in a Grouping so a scalar-subquery value
-        // renders as `SET col = (select ...)`, which SQLite/MySQL/PG require.
-        if (val instanceof Nodes.SqlLiteral) return [table.get(key), new Nodes.Grouping(val)];
-        return [table.get(key), val];
-      },
+    const updateValues: [InstanceType<typeof Nodes.Node>, unknown][] = this._substituteValues(
+      Object.entries(updates),
     );
     // Mirrors Rails relation.rb#update_all: bump locking_column when omitted.
     // Uses _incrementAttribute (COALESCE(col, 0) + 1) for NULL-safe increment.
@@ -7065,11 +7050,20 @@ export class Relation<T extends Base> {
     }
   }
 
+  // Mirrors relation.rb:1381-1393.
   private _substituteValues(values: [string, unknown][]): [any, any][] {
     return values.map(([name, value]) => {
       const attr = this._modelClass.arelTable.get(name);
-      const bind = this.predicateBuilder.buildBindAttribute(name, value);
-      return [attr, bind];
+      // Mirrors `Arel.arel_node?` (arel.rb): Node, SqlLiteral, or Attribute.
+      if (
+        value instanceof Nodes.Node ||
+        value instanceof Nodes.SqlLiteral ||
+        value instanceof Nodes.Attribute
+      ) {
+        return [attr, value instanceof Nodes.SqlLiteral ? new Nodes.Grouping(value) : value];
+      }
+      const type = this._modelClass.typeForAttribute(attr.name);
+      return [attr, this.predicateBuilder.buildBindAttribute(attr.name, type.cast(value))];
     });
   }
 

--- a/packages/activerecord/src/relation/update-all.trails.test.ts
+++ b/packages/activerecord/src/relation/update-all.trails.test.ts
@@ -63,6 +63,37 @@ describe("update_all value substitution", () => {
     expect(binds[0]).toBe("bound value");
   });
 
+  it("casts each value exactly once", async () => {
+    // Rails casts once (relation.rb:1389-1390 + identity QueryAttribute#type_cast,
+    // query_attribute.rb:22-24). A non-idempotent type makes a second cast visible.
+    // A stub type whose `serialize` does NOT re-enter `cast` — every real type
+    // self-casts inside serialize, which would mask the bind-level double cast.
+    const casts: unknown[] = [];
+    const stub = {
+      cast: (v: unknown) => {
+        casts.push(v);
+        return `cast(${String(v)})`;
+      },
+      serialize: (v: unknown) => v,
+    };
+    const model = Topic as unknown as { typeForAttribute(n: string): unknown };
+    const real = model.typeForAttribute;
+    model.typeForAttribute = function (name: string) {
+      return name === "title" ? stub : real.call(this, name);
+    };
+
+    const rel = Topic.where({ id: 1 });
+    try {
+      const { binds } = await captureUpdate(rel, () => rel.updateAll({ title: "x" }));
+      // Cast exactly once, on the RAW value — the bind must preserve the result
+      // rather than casting it a second time.
+      expect(casts).toEqual(["x"]);
+      expect(binds[0]).toBe("cast(x)");
+    } finally {
+      model.typeForAttribute = real;
+    }
+  });
+
   it("passes Arel nodes through, wrapping SqlLiteral in a Grouping", async () => {
     const rel = Topic.where({ id: 1 });
     const { sql } = await captureUpdate(rel, () =>

--- a/packages/activerecord/src/relation/update-all.trails.test.ts
+++ b/packages/activerecord/src/relation/update-all.trails.test.ts
@@ -1,0 +1,52 @@
+/**
+ * TS-only coverage for `Relation#_substitute_values`
+ * (relation.rb:1381-1393): update_all values are cast by the column type and
+ * bound, never inline-quoted.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { fixtures } from "../test-helpers/fixtures.js";
+import { Topic } from "../test-helpers/models/topic.js";
+import { initializeAssociations } from "../associations.js";
+
+beforeAll(async () => {
+  await initializeAssociations();
+});
+
+describe("update_all value substitution", () => {
+  fixtures({ topics: [Topic, {}] });
+
+  it("casts a wrong-typed value through the column type", async () => {
+    const created = await Topic.create({ title: "cast me" });
+    await Topic.where({ id: (created as unknown as { id: number }).id }).updateAll({
+      written_on: "2004-04-15T10:20:30Z",
+    });
+
+    const topic = await Topic.find((created as unknown as { id: number }).id);
+    const writtenOn = (topic as unknown as Record<string, unknown>).written_on;
+    expect(typeof writtenOn).not.toBe("string");
+    expect(String(writtenOn)).toContain("2004-04-15");
+  });
+
+  it("sends values as bind params rather than inline literals", async () => {
+    const rel = Topic.where({ id: 1 });
+    const sqls: string[] = [];
+    const conn = (
+      rel as unknown as { _conn(): Record<string, (sql: string, ...rest: unknown[]) => unknown> }
+    )._conn();
+    const original = conn.executeMutation ?? conn.execute;
+    const key = conn.executeMutation ? "executeMutation" : "execute";
+    conn[key] = function (sql: string, ...rest: unknown[]) {
+      sqls.push(sql);
+      return original.call(this, sql, ...rest);
+    };
+    try {
+      await rel.updateAll({ title: "bound value" });
+    } finally {
+      conn[key] = original;
+    }
+
+    const update = sqls.find((s) => s.startsWith("UPDATE"));
+    expect(update).toBeDefined();
+    expect(update).not.toContain("'bound value'");
+  });
+});

--- a/packages/activerecord/src/relation/update-all.trails.test.ts
+++ b/packages/activerecord/src/relation/update-all.trails.test.ts
@@ -4,6 +4,8 @@
  * bound, never inline-quoted.
  */
 import { describe, it, expect, beforeAll } from "vitest";
+import { Temporal } from "@blazetrails/activesupport/temporal";
+import { Nodes } from "@blazetrails/arel";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { Topic } from "../test-helpers/models/topic.js";
 import { initializeAssociations } from "../associations.js";
@@ -12,41 +14,61 @@ beforeAll(async () => {
   await initializeAssociations();
 });
 
+type Mutator = (sql: string, ...rest: unknown[]) => unknown;
+
+/** Runs `fn`, capturing the SQL + binds of every UPDATE issued on `rel`'s connection. */
+async function captureUpdate(
+  rel: unknown,
+  fn: () => Promise<unknown>,
+): Promise<{ sql: string; binds: unknown[] }> {
+  const conn = (rel as { _conn(): Record<string, Mutator> })._conn();
+  const key = conn.executeMutation ? "executeMutation" : "execute";
+  const original = conn[key];
+  const calls: { sql: string; binds: unknown[] }[] = [];
+  conn[key] = function (sql: string, ...rest: unknown[]) {
+    calls.push({ sql, binds: (rest[0] as unknown[]) ?? [] });
+    return original.call(this, sql, ...rest);
+  };
+  try {
+    await fn();
+  } finally {
+    conn[key] = original;
+  }
+  const update = calls.find((c) => c.sql.startsWith("UPDATE"));
+  if (!update) throw new Error(`no UPDATE captured; saw: ${calls.map((c) => c.sql).join(" | ")}`);
+  return update;
+}
+
 describe("update_all value substitution", () => {
   fixtures({ topics: [Topic, {}] });
 
   it("casts a wrong-typed value through the column type", async () => {
-    const created = await Topic.create({ title: "cast me" });
-    await Topic.where({ id: (created as unknown as { id: number }).id }).updateAll({
-      written_on: "2004-04-15T10:20:30Z",
-    });
+    const rel = Topic.where({ id: 1 });
+    // A raw ISO-8601 string is not a datetime — `type_for_attribute("written_on").cast`
+    // must turn it into a Time, which then serializes to Rails' datetime format.
+    const { sql, binds } = await captureUpdate(rel, () =>
+      rel.updateAll({ written_on: "2004-04-15T10:20:30Z" }),
+    );
 
-    const topic = await Topic.find((created as unknown as { id: number }).id);
-    const writtenOn = (topic as unknown as Record<string, unknown>).written_on;
-    expect(typeof writtenOn).not.toBe("string");
-    expect(String(writtenOn)).toContain("2004-04-15");
+    expect(sql).not.toContain("2004-04-15T10:20:30Z");
+    expect(binds[0]).toBeInstanceOf(Temporal.Instant);
+    expect((binds[0] as Temporal.Instant).toString()).toBe("2004-04-15T10:20:30Z");
   });
 
   it("sends values as bind params rather than inline literals", async () => {
     const rel = Topic.where({ id: 1 });
-    const sqls: string[] = [];
-    const conn = (
-      rel as unknown as { _conn(): Record<string, (sql: string, ...rest: unknown[]) => unknown> }
-    )._conn();
-    const original = conn.executeMutation ?? conn.execute;
-    const key = conn.executeMutation ? "executeMutation" : "execute";
-    conn[key] = function (sql: string, ...rest: unknown[]) {
-      sqls.push(sql);
-      return original.call(this, sql, ...rest);
-    };
-    try {
-      await rel.updateAll({ title: "bound value" });
-    } finally {
-      conn[key] = original;
-    }
+    const { sql, binds } = await captureUpdate(rel, () => rel.updateAll({ title: "bound value" }));
 
-    const update = sqls.find((s) => s.startsWith("UPDATE"));
-    expect(update).toBeDefined();
-    expect(update).not.toContain("'bound value'");
+    expect(sql).not.toContain("'bound value'");
+    expect(binds[0]).toBe("bound value");
+  });
+
+  it("passes Arel nodes through, wrapping SqlLiteral in a Grouping", async () => {
+    const rel = Topic.where({ id: 1 });
+    const { sql } = await captureUpdate(rel, () =>
+      rel.updateAll({ title: new Nodes.SqlLiteral("UPPER(title)") }),
+    );
+
+    expect(sql).toContain("(UPPER(title))");
   });
 });

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
@@ -3442,5 +3442,19 @@
     "rubyName": "where",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "_substitute_values",
+    "call": "build_bind_attribute",
+    "reason": "Satisfied by QueryAttribute.withCastValue: Rails build_bind_attribute (predicate_builder.rb:67-69) is a PRESERVING constructor because QueryAttribute#type_cast is identity (query_attribute.rb:22-24); trails QueryAttribute#typeCast casts its input, so calling buildBindAttribute here would cast twice."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "_substitute_values",
+    "call": "predicate_builder",
+    "reason": "Satisfied by QueryAttribute.withCastValue: Rails build_bind_attribute (predicate_builder.rb:67-69) is a PRESERVING constructor because QueryAttribute#type_cast is identity (query_attribute.rb:22-24); trails QueryAttribute#typeCast casts its input, so calling buildBindAttribute here would cast twice."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
@@ -80,13 +80,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "_substitute_values",
-    "call": "cast",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "_substitute_values",
     "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -94,21 +87,7 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "_substitute_values",
-    "call": "new",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "_substitute_values",
     "call": "table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "_substitute_values",
-    "call": "type_for_attribute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -151,21 +130,21 @@
     "tsFile": "relation.ts",
     "rubyName": "alias_tracker",
     "call": "connection_pool",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "alias_tracker",
     "call": "create",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "alias_tracker",
     "call": "model",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -2531,14 +2510,14 @@
     "tsFile": "relation.ts",
     "rubyName": "none?",
     "call": "empty?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "none?",
     "call": "present?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -2720,42 +2699,42 @@
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "call",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "each",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "includes_values",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "new",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "preload_values",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "strict_loading_value",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",


### PR DESCRIPTION
Ports Rails `Relation#_substitute_values` (`relation.rb:1381-1393`): `updateAll` values are now cast via `typeForAttribute(name).cast(value)` and wrapped in a bind attribute, so they reach the database as bind params instead of inline-quoted literals. Arel-node values keep their pass-through, with `SqlLiteral` wrapped in `Nodes.Grouping`.

The bespoke array/range `serialize` branches in `updateAll` are removed — `QueryAttribute._valueForDatabase` already applies `type.serialize`, the same lookup WHERE-clause array/range binds use.

### Casting exactly once (review follow-up)

Rails casts once: `build_bind_attribute` (`predicate_builder.rb:67-69`) hands an already-cast value to `QueryAttribute.new`, and `QueryAttribute#type_cast` is identity (`query_attribute.rb:22-24`) — so it is a *preserving* constructor. trails' `QueryAttribute#typeCast` instead casts its input (most callers pass raw values and rely on that), so routing a cast value through `buildBindAttribute` cast twice. Fixed by using `QueryAttribute.withCastValue`, trails' preserving equivalent. The two now-unmade calls are baselined in the wide-call ratchet with that reason.

Regression test `casts each value exactly once` uses a stub type whose `serialize` does not re-enter `cast` — every real type self-casts inside `serialize`, which would otherwise mask the bind-level double cast.

### Also converges a sibling story

This fix makes `update all goes through normal type casting` pass, so its `it.fails` marker is removed as its comment instructed. That means story `0023-surfaced-deviations/updateall-routes-values-through-attribute-type` (currently `ready`, unclaimed) is converged here and should not be scheduled separately.

Closes-story: relation-substitute-values-casts-and-binds