### PR TITLE
feat(relation): touchAll accepts time: option matching Rails touch_all

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -129,6 +129,8 @@ import {
 import { BatchEnumerator } from "./relation/batches/batch-enumerator.js";
 import {
   touchAttributesWithTime,
+  parseTouchAllArgs,
+  type TouchAllArgs,
   parseCounterCacheTouch,
   type CounterCacheTouchOption,
 } from "./timestamp.js";
@@ -3947,7 +3949,8 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#touch_all
    */
-  async touchAll(...names: string[]): Promise<number> {
+  async touchAll(...args: TouchAllArgs): Promise<number> {
+    const { names, time } = parseTouchAllArgs(args);
     // No `none?` guard here: Rails' touch_all (relation.rb:969-971) is a bare
     // `update_all model.touch_attributes_with_time(...)` and inherits the
     // `return 0 if @none` from update_all (relation.rb:592). Delegating rather
@@ -3958,7 +3961,7 @@ export class Relation<T extends Base> {
     // (e.g. Developer.updated_at → legacy_updated_at). Route through updateAll
     // so optimistic locking (lock_version increment) is applied — mirrors Rails
     // touch_all which calls update_all internally (relation.rb).
-    const touchUpdates = touchAttributesWithTime.call(this._modelClass, ...names, undefined);
+    const touchUpdates = touchAttributesWithTime.call(this._modelClass, ...names, time);
     const updates: Record<string, unknown> = {};
     for (const [col, time] of Object.entries(touchUpdates)) {
       updates[col] = new Nodes.Quoted(time);

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3963,8 +3963,8 @@ export class Relation<T extends Base> {
     // touch_all which calls update_all internally (relation.rb).
     const touchUpdates = touchAttributesWithTime.call(this._modelClass, ...names, time);
     const updates: Record<string, unknown> = {};
-    for (const [col, time] of Object.entries(touchUpdates)) {
-      updates[col] = new Nodes.Quoted(time);
+    for (const [col, touchedAt] of Object.entries(touchUpdates)) {
+      updates[col] = new Nodes.Quoted(touchedAt);
     }
 
     // Deviation: Rails passes the empty hash straight to update_all, which

--- a/packages/activerecord/src/relation/batches/batch-enumerator.ts
+++ b/packages/activerecord/src/relation/batches/batch-enumerator.ts
@@ -9,13 +9,14 @@
  */
 
 import { applyThenable } from "../thenable.js";
+import type { TouchAllArgs } from "../../timestamp.js";
 
 interface BatchRelation {
   toArray(): Promise<any[]>;
   deleteAll(): Promise<number>;
   updateAll(updates: Record<string, unknown>): Promise<number>;
   destroyAll(): Promise<any[]>;
-  touchAll?(...names: string[]): Promise<number>;
+  touchAll?(...args: TouchAllArgs): Promise<number>;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -109,11 +110,11 @@ export class BatchEnumerator<T extends BatchRelation> {
     return total;
   }
 
-  async touchAll(...names: string[]): Promise<number> {
+  async touchAll(...args: TouchAllArgs): Promise<number> {
     let total = 0;
     for await (const batchRelation of this) {
       if (typeof batchRelation.touchAll === "function") {
-        total += await batchRelation.touchAll(...names);
+        total += await batchRelation.touchAll(...args);
       }
     }
     return total;

--- a/packages/activerecord/src/relation/update-all.test.ts
+++ b/packages/activerecord/src/relation/update-all.test.ts
@@ -251,9 +251,7 @@ describe("UpdateAllTest", () => {
     const previouslyCreatedAt = developer.legacy_created_at;
     const previouslyUpdatedAt = developer.legacy_updated_at;
     const newTime = instant("2015-02-16T04:54:00Z");
-    vi.useFakeTimers({ now: newTime.epochMilliseconds });
-    await Developer.where({ name: "David" }).touchAll("created_at");
-    vi.useRealTimers();
+    await Developer.where({ name: "David" }).touchAll("created_at", { time: newTime });
     await developer.reload();
 
     expect(epochMs(developer.legacy_created_at)).not.toBe(epochMs(previouslyCreatedAt));

--- a/packages/activerecord/src/timestamp.ts
+++ b/packages/activerecord/src/timestamp.ts
@@ -242,8 +242,8 @@ async function touchRow(this: Base, touchCols: string[], now: Temporal.Instant):
  *
  * Mirrors: ActiveRecord::Base.touch_all
  */
-export async function touchAll(this: typeof Base, ...names: string[]): Promise<number> {
-  return this.all().touchAll(...names);
+export async function touchAll(this: typeof Base, ...args: TouchAllArgs): Promise<number> {
+  return this.all().touchAll(...args);
 }
 
 // ---------------------------------------------------------------------------
@@ -274,6 +274,23 @@ interface TimestampInstanceHost {
   id?: unknown;
   recordTimestamps?: boolean;
   constructor: TimestampHost & { recordTimestamps: boolean; partialUpdates?: boolean };
+}
+
+/**
+ * Argument list for `touch_all(*names, time: nil)`. Ruby's trailing keyword
+ * becomes an optional trailing options object in TS.
+ */
+export type TouchAllArgs = (string | { time?: Temporal.Instant })[];
+
+export function parseTouchAllArgs(args: TouchAllArgs): {
+  names: string[];
+  time: Temporal.Instant | undefined;
+} {
+  const last = args[args.length - 1];
+  if (last !== undefined && typeof last !== "string") {
+    return { names: args.slice(0, -1) as string[], time: last.time };
+  }
+  return { names: args as string[], time: undefined };
 }
 
 export function touchAttributesWithTime(

--- a/packages/activerecord/src/timestamp.ts
+++ b/packages/activerecord/src/timestamp.ts
@@ -280,7 +280,9 @@ interface TimestampInstanceHost {
  * Argument list for `touch_all(*names, time: nil)`. Ruby's trailing keyword
  * becomes an optional trailing options object in TS.
  */
-export type TouchAllArgs = (string | { time?: Temporal.Instant })[];
+export type TouchAllOptions = { time?: Temporal.Instant };
+
+export type TouchAllArgs = string[] | [...names: string[], options: TouchAllOptions];
 
 export function parseTouchAllArgs(args: TouchAllArgs): {
   names: string[];


### PR DESCRIPTION
Rails' `Relation#touch_all(*names, time: nil)` accepts an explicit time; trails' `touchAll` always passed `undefined`. Wires `time:` through to `touchAttributesWithTime` via a shared `TouchAllArgs` / `parseTouchAllArgs` helper (also threaded through `Timestamp.touchAll` and `BatchEnumerator#touchAll`).

Restores the "touch all with given time" test to the literal Rails form, dropping the `vi.useFakeTimers` workaround.

Closes-story: relation-touch-all-time-option