### PR TITLE
test(relations): un-skip 'to sql on eager join' using captureSql

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -780,10 +780,10 @@ describe("PreloaderTest", () => {
       { shippingLines: { discountApplications: "discount" } },
     ];
     const readDiscounts = (inv: Base) => {
-      const li = association(inv, "lineItems").target[0];
-      const sl = association(inv, "shippingLines").target[0];
-      expect(association(li, "discountApplications").target[0].discount).not.toBeNull();
-      expect(association(sl, "discountApplications").target[0].discount).not.toBeNull();
+      const li = (inv as any).association("lineItems").target[0];
+      const sl = (inv as any).association("shippingLines").target[0];
+      expect(li.association("discountApplications").target[0].discount).not.toBeNull();
+      expect(sl.association("discountApplications").target[0].discount).not.toBeNull();
     };
 
     // First preload: nothing loaded, so all five levels query —
@@ -1194,8 +1194,8 @@ describe("PreloaderTest", () => {
     // comes from availableRecords (assert_same → toBe), dave's is freshly loaded
     // (assert_equal → value equality).
     const reads = await captureSql(async () => {
-      expect(association(mary, "essayCategory").reader).toBe(tech);
-      expect((association(dave, "essayCategory").reader as any).id).toBe(general.id);
+      expect((mary as any).association("essayCategory").reader).toBe(tech);
+      expect((dave as any).association("essayCategory").reader.id).toBe(general.id);
     });
     expect(reads).toHaveLength(0);
   });

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -985,7 +985,7 @@ describe("RelationTest", () => {
         async () => {
           await Post.eagerLoad("lastComment").order("comments.id DESC");
         },
-        { includeSchema: false },
+        { includeSchema: false, rethrow: true },
       )
     )[0];
     const actual = Post.eagerLoad("lastComment").order("comments.id DESC").toSql();

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -985,7 +985,7 @@ describe("RelationTest", () => {
         async () => {
           await Post.eagerLoad("lastComment").order("comments.id DESC");
         },
-        { includeSchema: false, rethrow: true },
+        { includeSchema: false },
       )
     )[0];
     const actual = Post.eagerLoad("lastComment").order("comments.id DESC").toSql();

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -12,6 +12,7 @@ import { ArgumentError } from "@blazetrails/activemodel";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { adapterType } from "./test-adapter.js";
 import { sql as arelSql } from "@blazetrails/arel";
+import { captureSql } from "./testing/sql-capture.js";
 
 // Canonical models
 import {
@@ -978,10 +979,17 @@ describe("RelationTest", () => {
     expect(postWithLastComment.lastComment).toEqual(directLastComment);
   });
 
-  it.skip("to sql on eager join", () => {
-    // BLOCKED: relations — Rails uses capture_sql { ... }.first to get the actual SQL
-    // executed when loading, then asserts it equals to_sql. Trails has no capture_sql
-    // helper, so there is no way to verify toSql matches the executed query shape.
+  it("to sql on eager join", async () => {
+    const expected = (
+      await captureSql(
+        async () => {
+          await Post.eagerLoad("lastComment").order("comments.id DESC");
+        },
+        { includeSchema: false },
+      )
+    )[0];
+    const actual = Post.eagerLoad("lastComment").order("comments.id DESC").toSql();
+    expect(expected).toEqual(actual);
   });
 
   it("to sql on scoped proxy", async () => {

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -981,12 +981,9 @@ describe("RelationTest", () => {
 
   it("to sql on eager join", async () => {
     const expected = (
-      await captureSql(
-        async () => {
-          await Post.eagerLoad("lastComment").order("comments.id DESC");
-        },
-        { includeSchema: false },
-      )
+      await captureSql(async () => {
+        await Post.eagerLoad("lastComment").order("comments.id DESC");
+      })
     )[0];
     const actual = Post.eagerLoad("lastComment").order("comments.id DESC").toSql();
     expect(expected).toEqual(actual);

--- a/packages/activerecord/src/testing/sql-capture.test.ts
+++ b/packages/activerecord/src/testing/sql-capture.test.ts
@@ -15,15 +15,26 @@ function emitTrio(): void {
 }
 
 describe("captureSql", () => {
-  it("drops cached queries but keeps SCHEMA queries by default", async () => {
-    // Cached statements are always excluded (Rails SQLCounter parity); SCHEMA
-    // introspection is kept unless includeSchema is false.
-    expect(await captureSql(emitTrio)).toEqual(["LOAD", "INTROSPECT"]);
+  it("drops cached and SCHEMA queries by default", async () => {
+    // Rails' capture_sql defaults to include_schema: false and returns
+    // counter.log (test_case.rb:89), so SCHEMA introspection is dropped.
+    // Cached statements are always excluded (SQLCounter parity).
+    expect(await captureSql(emitTrio)).toEqual(["LOAD"]);
   });
 
-  it("drops SCHEMA and cached queries when includeSchema is false", async () => {
-    // Mirrors Rails' capture_sql(include_schema: false).
-    expect(await captureSql(emitTrio, { includeSchema: false })).toEqual(["LOAD"]);
+  it("keeps SCHEMA queries when includeSchema is true", async () => {
+    // Mirrors Rails' capture_sql(include_schema: true) -> counter.log_all.
+    expect(await captureSql(emitTrio, { includeSchema: true })).toEqual(["LOAD", "INTROSPECT"]);
+  });
+
+  it("propagates errors raised inside the block", async () => {
+    // Rails' capture_sql wraps a bare `yield` with no rescue, so a raising
+    // block must not be masked by the SQL already captured before it unwound.
+    await expect(
+      captureSql(() => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
   });
 });
 

--- a/packages/activerecord/src/testing/sql-capture.ts
+++ b/packages/activerecord/src/testing/sql-capture.ts
@@ -6,10 +6,9 @@
  * activerecord/test/cases/adapters/abstract_mysql_adapter/active_schema_test.rb:
  * the test monkey-patches `connection.execute` to instrument the SQL and
  * return it instead of running it.  We subscribe to the notification instead.
- * SQL strings are collected from the payload before any error propagates
- * (Notifications.instrumentAsync fires _notify in its finally block), so
- * errors from fn() are swallowed — matching Rails' stub-mode where execute
- * never throws.  Tables referenced in tests need not exist.
+ * Errors from fn() propagate, matching Rails' capture_sql (test_case.rb:90),
+ * which wraps a bare `yield` with no rescue.  In stub mode the statement never
+ * reaches the database, so tables referenced in tests need not exist.
  *
  * Usage:
  *   const sqls = await captureSql(() => adapter.addIndex("t", "c"));
@@ -85,15 +84,13 @@ function installExecuteStub(adapter: StubbableAdapter): () => void {
  * real `CREATE TABLE` / `CREATE INDEX` round-trips for pure SQL-assertion
  * tests (and the mysql:8 DDL cost they carry).
  *
- * Pass `{ rethrow: true }` when capturing SQL from a real query, so a failure
- * inside `fn` surfaces instead of being masked by the already-captured SQL.
  * @internal
  */
 export async function captureSql(
   fn: () => void | Promise<void>,
-  options: { includeSchema?: boolean; stub?: StubbableAdapter; rethrow?: boolean } = {},
+  options: { includeSchema?: boolean; stub?: StubbableAdapter } = {},
 ): Promise<string[]> {
-  const { includeSchema = true, stub, rethrow = false } = options;
+  const { includeSchema = true, stub } = options;
   const sqls: string[] = [];
   const sub = Notifications.subscribe("sql.active_record", (event: any) => {
     const payload = event.payload;
@@ -104,14 +101,13 @@ export async function captureSql(
     sqls.push(sql);
   });
   const restore = stub ? installExecuteStub(stub) : undefined;
+  // No catch: Rails' capture_sql wraps a bare `yield` in Notifications.subscribed
+  // (test_case.rb:90) with no rescue, so block errors propagate. Swallowing here
+  // would let captured-query tests assert green after the code under test raised,
+  // since the SQL is instrumented before the error unwinds. Stub mode keeps DDL
+  // off the database by stubbing execute, not by suppressing errors.
   try {
     await fn();
-  } catch (error) {
-    // Swallowing mirrors Rails stub-mode, where execute never throws. It is the
-    // wrong default for callers that capture SQL from a *real* query: the SQL is
-    // instrumented before the error propagates, so a query that raised would
-    // still yield its SQL and assert green. Those callers pass rethrow.
-    if (rethrow) throw error;
   } finally {
     restore?.();
     Notifications.unsubscribe(sub);

--- a/packages/activerecord/src/testing/sql-capture.ts
+++ b/packages/activerecord/src/testing/sql-capture.ts
@@ -74,9 +74,11 @@ function installExecuteStub(adapter: StubbableAdapter): () => void {
  * Runs `fn` and returns every SQL string emitted via `sql.active_record`
  * during its execution.  Subscription is cleaned up afterward.
  *
- * Cached statements are always dropped (Rails SQLCounter parity). Pass
- * `{ includeSchema: false }` to also drop `name: "SCHEMA"` introspection
- * queries, mirroring Rails' `capture_sql(include_schema: false)`.
+ * Cached statements are always dropped (Rails SQLCounter parity). `name: "SCHEMA"`
+ * introspection queries are dropped too, mirroring Rails'
+ * `capture_sql(include_schema: false)` (test_case.rb:89), which returns
+ * `counter.log` unless the caller opts in. Pass `{ includeSchema: true }` for
+ * Rails' `log_all` behaviour.
  *
  * Pass `{ stub: adapter }` to intercept the adapter's `execute`/
  * `executeMutation` so DDL is instrumented-and-returned without hitting the
@@ -90,7 +92,7 @@ export async function captureSql(
   fn: () => void | Promise<void>,
   options: { includeSchema?: boolean; stub?: StubbableAdapter } = {},
 ): Promise<string[]> {
-  const { includeSchema = true, stub } = options;
+  const { includeSchema = false, stub } = options;
   const sqls: string[] = [];
   const sub = Notifications.subscribe("sql.active_record", (event: any) => {
     const payload = event.payload;

--- a/packages/activerecord/src/testing/sql-capture.ts
+++ b/packages/activerecord/src/testing/sql-capture.ts
@@ -84,13 +84,16 @@ function installExecuteStub(adapter: StubbableAdapter): () => void {
  * DB — mirroring Rails' ActiveSchemaTest `setup` stub. This avoids issuing
  * real `CREATE TABLE` / `CREATE INDEX` round-trips for pure SQL-assertion
  * tests (and the mysql:8 DDL cost they carry).
+ *
+ * Pass `{ rethrow: true }` when capturing SQL from a real query, so a failure
+ * inside `fn` surfaces instead of being masked by the already-captured SQL.
  * @internal
  */
 export async function captureSql(
   fn: () => void | Promise<void>,
-  options: { includeSchema?: boolean; stub?: StubbableAdapter } = {},
+  options: { includeSchema?: boolean; stub?: StubbableAdapter; rethrow?: boolean } = {},
 ): Promise<string[]> {
-  const { includeSchema = true, stub } = options;
+  const { includeSchema = true, stub, rethrow = false } = options;
   const sqls: string[] = [];
   const sub = Notifications.subscribe("sql.active_record", (event: any) => {
     const payload = event.payload;
@@ -103,8 +106,12 @@ export async function captureSql(
   const restore = stub ? installExecuteStub(stub) : undefined;
   try {
     await fn();
-  } catch {
-    // intentional: mirrors Rails stub-mode where execute never throws
+  } catch (error) {
+    // Swallowing mirrors Rails stub-mode, where execute never throws. It is the
+    // wrong default for callers that capture SQL from a *real* query: the SQL is
+    // instrumented before the error propagates, so a query that raised would
+    // still yield its SQL and assert green. Those callers pass rethrow.
+    if (rethrow) throw error;
   } finally {
     restore?.();
     Notifications.unsubscribe(sub);


### PR DESCRIPTION
The `captureSql` helper already exists at `packages/activerecord/src/testing/sql-capture.ts`, so the only work left for this story was consuming it in the skipped test.

Ports `test_to_sql_on_eager_join` (`vendor/rails/activerecord/test/cases/relations_test.rb:754`): capture the SQL actually executed when loading `Post.eagerLoad("lastComment").order("comments.id DESC")` and assert it equals `toSql()`.

Consuming the helper surfaced two fidelity bugs in it, both caught in review.

## 1. captureSql swallowed errors

It had a bare `catch {}`. Because SQL is instrumented *before* an error unwinds, any captured-query test could assert green after the code under test raised. Rails' `capture_sql` wraps a bare `yield` in `Notifications.subscribed` with no rescue (`test_case.rb:90`). Errors now propagate unconditionally; stub mode still keeps DDL off the database by stubbing `execute`, which is the right mechanism.

This immediately exposed two tests in `associations.test.ts` passing on a masked `TypeError`: they called the imported `association(record, name)` helper, which returns a fresh un-hydrated proxy, so `.target[0]` was `undefined`. The discount/category assertions never executed, and the companion `expect(reads).toHaveLength(0)` passed vacuously because the throw meant no SQL was emitted. Fixed by reading through the record's own `.association(...)` method, matching the surrounding passing tests.

## 2. includeSchema defaulted to true

Rails' signature is `capture_sql(include_schema: false)`, returning `counter.log` unless the caller opts into `log_all` (`test_case.rb:89-98`) — our default was inverted. Our own sibling helper `testing/query-assertions.ts` already defaults `includeSchema = false`, so the two were inconsistent. Now defaulted to `false`, which also removes the need for `{ includeSchema: false }` in the new relation test, matching Rails' test verbatim. The two `transactions.test.ts` callers that want schema queries pass `{ includeSchema: true }` explicitly.

Both behaviours are now locked in by unit tests in `sql-capture.test.ts`, including a regression test that a raising block rejects rather than being masked.

## Verification

All 25 `captureSql` callers: 19 SQLite-runnable files green (1636 tests), plus the MySQL- and PG-gated adapter suites run locally against containers under `ARCONN=mysql2` / `ARCONN=postgresql`. Intermittent `1_need_quoting` failures there are a pre-existing collision between two adapter test files creating the same table in parallel; each passes when run alone against a fresh database.

Closes-story: relations-capture-sql-test-helper