### PR TITLE
fix(relation): reverseOrder() raises IrreversibleOrderError on no-PK table

### DIFF
--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -849,4 +849,22 @@ describe("inspect wrapper class name", () => {
     expect(relation.isLoaded).toBe(false);
     expect(relation.inspect()).toBe("#<ActiveRecord::Relation [...]>");
   });
+
+  // reverse_sql_order's empty-order branch has two outcomes; the no-PK raise is
+  // covered by Rails' test_default_reverse_order_on_table_without_primary_key in
+  // relations.test.ts. This guards the other half, which has no like-named Rails
+  // test: a PK-bearing table falls back to ORDER BY <pk> DESC. Before the
+  // reverseOrderBang fix, an empty order was a silent no-op and emitted no
+  // ORDER BY at all.
+  it("defaults an unordered reverseOrder to the primary key descending", () => {
+    expect(CanonPost.all().reverseOrder().toSql()).toContain("ORDER BY");
+    expect(CanonPost.all().reverseOrder().toSql()).toMatch(/ORDER BY .*\bid\b.* DESC/i);
+  });
+
+  // compact_blank: a blank string order is rejected before the reverse, so the
+  // relation still falls back to the primary-key default rather than trying to
+  // flip "" into " DESC".
+  it("treats a blank string order as no order when reversing", () => {
+    expect(CanonPost.order("").reverseOrder().toSql()).toMatch(/ORDER BY .*\bid\b.* DESC/i);
+  });
 });

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1467,7 +1467,16 @@ function optimizerHintsBang(this: QueryMethodsHost, ...hints: string[]): any {
 }
 
 function reverseOrderBang(this: QueryMethodsHost): any {
-  this._orderClauses = this._orderClauses.map((clause) => {
+  // Rails hands the whole (compact_blank'd) order list to reverse_sql_order, so an
+  // empty order falls into its default branch: ORDER BY <pk> DESC, or an
+  // IrreversibleOrderError when the table has no primary key. Mapping over the
+  // clauses here skips that branch entirely, so delegate the empty case.
+  const clauses = this._orderClauses.filter((clause) => clause !== null && clause !== undefined);
+  if (clauses.length === 0) {
+    this._orderClauses = reverseSqlOrder.call(this, []) as typeof this._orderClauses;
+    return this;
+  }
+  this._orderClauses = clauses.map((clause) => {
     if (clause instanceof Nodes.Node) {
       // Arel::Nodes::SqlLiteral is a String subclass in Rails, so reverse_sql_order
       // reverses it via the `when String` branch (flip trailing ASC↔DESC), not .desc.

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1471,7 +1471,14 @@ function reverseOrderBang(this: QueryMethodsHost): any {
   // empty order falls into its default branch: ORDER BY <pk> DESC, or an
   // IrreversibleOrderError when the table has no primary key. Mapping over the
   // clauses here skips that branch entirely, so delegate the empty case.
-  const clauses = this._orderClauses.filter((clause) => clause !== null && clause !== undefined);
+  // Rails' compact_blank is reject(&:blank?). activesupport's isBlank is not a
+  // substitute here: it reports a key-less object as blank, but Ruby's blank? is
+  // false for an Arel node (it has no #empty?), so routing clauses through it
+  // would drop every Ordering. Only nil/blank-string clauses are blank in this
+  // list; nodes and [col, dir] tuples never are.
+  const clauses = this._orderClauses.filter(
+    (clause) => clause != null && !(typeof clause === "string" && /^\s*$/.test(clause)),
+  );
   if (clauses.length === 0) {
     this._orderClauses = reverseSqlOrder.call(this, []) as typeof this._orderClauses;
     return this;

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -570,9 +570,8 @@ describe("RelationTest", () => {
     );
   });
 
-  it.skip("default reverse order on table without primary key", () => {
-    // BLOCKED: relations — reverseOrder() on a no-PK table should raise IrreversibleOrderError;
-    // Trails' reverseOrder() doesn't check for a missing primary key yet
+  it("default reverse order on table without primary key", () => {
+    expect(() => Edge.all().reverseOrder()).toThrow(IrreversibleOrderError);
   });
 
   it("order with hash and symbol generates the same sql", () => {
@@ -2046,7 +2045,7 @@ describe("RelationTest", () => {
   });
 
   it("reverse order with reorder nil removes the order", () => {
-    const sql = Topic.order("title").reorder(null).reverseOrder().toSql();
+    const sql = Topic.order("title").reverseOrder().reorder(null).toSql();
     expect(sql).not.toContain("ORDER BY");
   });
 


### PR DESCRIPTION
`Relation#reverseOrder()` on a table with no primary key silently produced SQL with no `ORDER BY` instead of raising `IrreversibleOrderError`.

## Root cause

`reverseOrderBang` mapped over `_orderClauses`, so an **empty** order array was a silent no-op — it never reached `reverseSqlOrder`'s empty-order branch, which already had the correct logic. Rails' `reverse_order!` hands the whole `compact_blank`'d list to `reverse_sql_order`, so the empty case is handled there.

`vendor/rails/activerecord/lib/active_record/relation/query_methods.rb:1502,2016`

That branch has **two** outcomes, and both were dead:

| order | table | before | after (= Rails) |
|---|---|---|---|
| empty | has PK | *no `ORDER BY`* | `ORDER BY <pk> DESC` |
| empty | no PK (`Edge`) | *no `ORDER BY`* | raises `IrreversibleOrderError` |

## Changes

- `reverseOrderBang` filters blanks and delegates the empty case to `reverseSqlOrder`.
- Blank filtering follows Rails' `compact_blank` (`reject(&:blank?)`) — nil and blank strings only. Deliberately **not** activesupport's `isBlank`, which reports a key-less object as blank; Ruby's `blank?` is false for an Arel node (no `#empty?`), so routing clauses through it would drop every `Ordering`.
- Un-skips `default reverse order on table without primary key`.
- Adds trails-side coverage for the PK-bearing half in `relation.trails.test.ts`. It has no like-named Rails test, so it does not get an invented Rails name.
- Corrects `reverse order with reorder nil removes the order` to mirror Rails' call order — Rails is `.order(:title).reverse_order.reorder(nil)` (reorder **last**); the trails port had `reorder(null)` first, which only passed because `reverseOrder()` was a no-op on an empty order.

## Testing

921 passed across `relations`, `relation`, `relation.trails`, `finder`, `view`, `relation-scoping`, `default-scoping`, `batches`. `.last()` routes through `reverseOrder`, so no-PK views were the main fallout risk — `view.test.ts` is clean.

38 insertions / 5 deletions.

Closes-story: relations-reverse-order-no-pk