### PR TITLE
refactor(quoting): require a host receiver on quoteTableName / quoteDefaultExpression

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -87,8 +87,8 @@ export function quoteColumnName(_columnName: string): string {
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting::ClassMethods#quote_table_name
  * (activerecord/.../abstract/quoting.rb L66 — `quote_column_name(table_name)`)
  */
-export function quoteTableName(this: QuotingDispatchHost | void, name: string): string {
-  if (this && typeof this === "object" && typeof this.quoteColumnName === "function") {
+export function quoteTableName(this: QuotingDispatchHost, name: string): string {
+  if (typeof this.quoteColumnName === "function") {
     return this.quoteColumnName(name);
   }
   return quoteColumnName(name);
@@ -249,7 +249,10 @@ export function quoteString(s: string): string {
  * Mirrors: ActiveRecord::ConnectionAdapters::Quoting#quote_table_name_for_assignment
  */
 export function quoteTableNameForAssignment(table: string, attr: string): string {
-  return quoteTableName(`${table}.${attr}`);
+  // `quoteTableName` requires a host receiver; this module-level helper has no
+  // adapter, so bind a bare host — dispatch falls to the throwing
+  // `quoteColumnName`, matching Rails' abstract behaviour.
+  return quoteTableName.call({}, `${table}.${attr}`);
 }
 
 /**
@@ -267,7 +270,7 @@ export function quoteTableNameForAssignment(table: string, attr: string): string
  * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#quote_default_expression
  */
 export function quoteDefaultExpression(
-  this: (QuotingDispatchHost & QuotingHost) | void,
+  this: QuotingDispatchHost & QuotingHost,
   value: unknown,
   column?: { sqlType?: string | null } | null,
 ): string {
@@ -288,7 +291,7 @@ export function quoteDefaultExpression(
   // returns the raw sqlType string and the value passes through unserialized.
   let serialized: unknown = value;
   if (column != null) {
-    const castType = lookupCastTypeFromColumn.call(this || undefined, {
+    const castType = lookupCastTypeFromColumn.call(this, {
       sqlType: column.sqlType ?? null,
     }) as { serialize?(v: unknown): unknown } | null;
     if (castType && typeof castType.serialize === "function") {
@@ -301,7 +304,7 @@ export function quoteDefaultExpression(
   // deliberately lacks. Falling straight to the module `quote` here would bypass
   // the dialect entirely and raise `can't quote Uint8Array` on a binary default.
   // Hosts without a `quote` (ABSTRACT_SCHEMA_QUOTER) keep the module helper.
-  return dispatchQuote(this || {}, serialized);
+  return dispatchQuote(this, serialized);
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3527,6 +3527,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         ? {
             array: isArray,
             sqlType: rawSqlType,
+            // Rails' uuid branch tests `column.type` (the AR type symbol), not
+            // sql_type, so forward it separately from `rawSqlType`.
+            type: col.type ?? null,
           }
         : null,
       lookup,

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3520,7 +3520,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         } | null;
       },
     };
-    return pgQuoteDefaultExpression(
+    return pgQuoteDefaultExpression.call(
+      this,
       value,
       col != null
         ? {

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
@@ -113,8 +113,8 @@ describe("PostgreSQL quoting", () => {
   });
 
   it("quotes a binary default through PG's quotedBinary", () => {
-    // Receiver-less: the fallback host must still reach the bytea escape form,
-    // not the abstract byte-string fallback. Cover both shapes that reach here —
+    // Binary self-dispatches through the host, so it must reach the bytea escape
+    // form, not the abstract byte-string fallback. Cover both shapes here —
     // the raw Uint8Array trails' BinaryType#serialize actually returns, and the
     // BinaryData Rails' Binary#serialize returns (activemodel/.../binary.rb:31).
     expect(quoteDefaultExpression.call(HOST, new Uint8Array([0x1f, 0x8b]))).toBe("'\\x1f8b'");
@@ -124,8 +124,9 @@ describe("PostgreSQL quoting", () => {
   });
 
   it("quotes a BC date default through PG's quotedDate", () => {
-    // Receiver-less: the fallback host must reach PG's BC-suffixing quotedDate
-    // (postgresql/quoting.rb:143), not the abstract formatter which drops " BC".
+    // Dates self-dispatch through the host, so they must reach PG's BC-suffixing
+    // quotedDate (postgresql/quoting.rb:143), not the abstract formatter which
+    // drops " BC".
     expect(quoteDefaultExpression.call(HOST, Temporal.PlainDate.from("-000043-03-15"))).toBe(
       "'0044-03-15 BC'",
     );
@@ -149,6 +150,26 @@ describe("PostgreSQL quoting", () => {
     };
     expect(quoteDefaultExpression.call(HOST, [], column, nullTypeMap)).toBe("'{}'");
     expect(quoteDefaultExpression.call(HOST, ["a", "b"], column, nullTypeMap)).toBe("'{a,b}'");
+  });
+
+  it("does not quote function default values for UUID columns", () => {
+    // Rails postgresql/quoting.rb:159-160. Both pgcrypto and uuid-ossp spellings
+    // are exercised (uuid_test.rb:16 picks between them by extension support).
+    const column = { type: "uuid", sqlType: "uuid" };
+    expect(quoteDefaultExpression.call(HOST, "gen_random_uuid()", column)).toBe(
+      "gen_random_uuid()",
+    );
+    expect(quoteDefaultExpression.call(HOST, "uuid_generate_v4()", column)).toBe(
+      "uuid_generate_v4()",
+    );
+    // A non-function string default on a uuid column is still quoted.
+    expect(quoteDefaultExpression.call(HOST, "11111111-1111-1111-1111-111111111111", column)).toBe(
+      "'11111111-1111-1111-1111-111111111111'",
+    );
+    // The branch is uuid-only — the same string on a text column is quoted.
+    expect(
+      quoteDefaultExpression.call(HOST, "gen_random_uuid()", { type: "text", sqlType: "text" }),
+    ).toBe("'gen_random_uuid()'");
   });
 
   it("does not apply array fallback when column.array is false", () => {

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
@@ -109,7 +109,7 @@ describe("PostgreSQL quoting", () => {
       },
     };
 
-    expect(quoteDefaultExpression(41, column, typeMap)).toBe("42");
+    expect(quoteDefaultExpression.call(HOST, 41, column, typeMap)).toBe("42");
   });
 
   it("quotes a binary default through PG's quotedBinary", () => {
@@ -117,14 +117,16 @@ describe("PostgreSQL quoting", () => {
     // not the abstract byte-string fallback. Cover both shapes that reach here —
     // the raw Uint8Array trails' BinaryType#serialize actually returns, and the
     // BinaryData Rails' Binary#serialize returns (activemodel/.../binary.rb:31).
-    expect(quoteDefaultExpression(new Uint8Array([0x1f, 0x8b]))).toBe("'\\x1f8b'");
-    expect(quoteDefaultExpression(new BinaryData(new Uint8Array([0x1f, 0x8b])))).toBe("'\\x1f8b'");
+    expect(quoteDefaultExpression.call(HOST, new Uint8Array([0x1f, 0x8b]))).toBe("'\\x1f8b'");
+    expect(quoteDefaultExpression.call(HOST, new BinaryData(new Uint8Array([0x1f, 0x8b])))).toBe(
+      "'\\x1f8b'",
+    );
   });
 
   it("quotes a BC date default through PG's quotedDate", () => {
     // Receiver-less: the fallback host must reach PG's BC-suffixing quotedDate
     // (postgresql/quoting.rb:143), not the abstract formatter which drops " BC".
-    expect(quoteDefaultExpression(Temporal.PlainDate.from("-000043-03-15"))).toBe(
+    expect(quoteDefaultExpression.call(HOST, Temporal.PlainDate.from("-000043-03-15"))).toBe(
       "'0044-03-15 BC'",
     );
   });
@@ -135,7 +137,7 @@ describe("PostgreSQL quoting", () => {
     // `array` must be present: the serialize branch is gated on `"array" in column`.
     const column = { sqlType: "bytea", array: false };
     const typeMap = { lookup: () => new BinaryType() };
-    expect(quoteDefaultExpression("ab", column, typeMap)).toBe("'\\x6162'");
+    expect(quoteDefaultExpression.call(HOST, "ab", column, typeMap)).toBe("'\\x6162'");
   });
 
   it("serializes array defaults via fallback OidArray when type map misses", () => {
@@ -145,8 +147,8 @@ describe("PostgreSQL quoting", () => {
         return null;
       },
     };
-    expect(quoteDefaultExpression([], column, nullTypeMap)).toBe("'{}'");
-    expect(quoteDefaultExpression(["a", "b"], column, nullTypeMap)).toBe("'{a,b}'");
+    expect(quoteDefaultExpression.call(HOST, [], column, nullTypeMap)).toBe("'{}'");
+    expect(quoteDefaultExpression.call(HOST, ["a", "b"], column, nullTypeMap)).toBe("'{a,b}'");
   });
 
   it("does not apply array fallback when column.array is false", () => {
@@ -157,7 +159,7 @@ describe("PostgreSQL quoting", () => {
       },
     };
     // A plain string value should still round-trip normally
-    expect(quoteDefaultExpression("hello", column, nullTypeMap)).toBe("'hello'");
+    expect(quoteDefaultExpression.call(HOST, "hello", column, nullTypeMap)).toBe("'hello'");
   });
 
   it("serializes array defaults through the type map", () => {
@@ -169,7 +171,7 @@ describe("PostgreSQL quoting", () => {
       },
     };
 
-    expect(quoteDefaultExpression(["a", "b"], column, typeMap)).toBe("'{a,b}'");
+    expect(quoteDefaultExpression.call(HOST, ["a", "b"], column, typeMap)).toBe("'{a,b}'");
   });
 
   it("serializes array defaults via an element subtype (per-element coercion)", () => {
@@ -184,7 +186,7 @@ describe("PostgreSQL quoting", () => {
         return { cast: (v: unknown) => v, serialize: (v: unknown) => Number(v) + 100 };
       },
     };
-    expect(quoteDefaultExpression([1, 2, 3], column, typeMap)).toBe("'{101,102,103}'");
+    expect(quoteDefaultExpression.call(HOST, [1, 2, 3], column, typeMap)).toBe("'{101,102,103}'");
   });
 
   it("passes raw array-literal string defaults through without scalar coercion", () => {
@@ -199,8 +201,8 @@ describe("PostgreSQL quoting", () => {
         return { serialize: (v: unknown) => Number(v) };
       },
     };
-    expect(quoteDefaultExpression("{}", column, typeMap)).toBe("'{}'");
-    expect(quoteDefaultExpression("{1,2,3}", column, typeMap)).toBe("'{1,2,3}'");
+    expect(quoteDefaultExpression.call(HOST, "{}", column, typeMap)).toBe("'{}'");
+    expect(quoteDefaultExpression.call(HOST, "{1,2,3}", column, typeMap)).toBe("'{1,2,3}'");
   });
 
   it("supports nested function calls up to 2 levels deep", () => {

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -152,7 +152,7 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
 }
 
 export function quoteDefaultExpression(
-  this: QuotingDispatchHost | void,
+  this: QuotingDispatchHost,
   value: unknown,
   column?: DefaultExpressionColumn | null,
   typeMap?: TypeMapLike | null,
@@ -196,11 +196,10 @@ export function quoteDefaultExpression(
       serialized = castType.serialize(value);
     }
   }
-  // `quote` requires a host receiver; thread our own so a receiver-less binary
-  // default reaches PG's bytea `quotedBinary` rather than the abstract
-  // byte-string fallback, and a date default reaches PG's BC-suffixing
-  // `quotedDate` (postgresql/quoting.rb:143) rather than the abstract format.
-  return quote.call(this || { quotedDate, quotedBinary }, serialized);
+  // Rails: `quote(value)` — self-dispatched, so a binary default reaches PG's
+  // bytea `quotedBinary` and a date default PG's BC-suffixing `quotedDate`
+  // (postgresql/quoting.rb:143) rather than the abstract formats.
+  return quote.call(this, serialized);
 }
 
 export function typeCast(this: QuotingDispatchHost, value: unknown): unknown {

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -167,6 +167,14 @@ export function quoteDefaultExpression(
     );
   }
   if (isSqlLiteral(value)) return value.value;
+  // Rails: `elsif column.type == :uuid && value.is_a?(String) && value.include?("()")`
+  // (postgresql/quoting.rb:159-160) — "Does not quote function default values
+  // for UUID columns", so `default: "gen_random_uuid()"` emits the bare call
+  // rather than the string literal `'gen_random_uuid()'`. Must precede the
+  // array/super paths, and matches `()` anywhere in the string as Rails does.
+  if (column?.type === "uuid" && typeof value === "string" && value.includes("()")) {
+    return value;
+  }
 
   let serialized: unknown = value;
   if (column != null && "array" in column) {

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
@@ -204,30 +204,36 @@ describe("SQLite3::Quoting", () => {
 
   describe("quoteDefaultExpression", () => {
     it("returns empty string for undefined", () => {
-      expect(quoteDefaultExpression(undefined)).toBe("");
+      expect(quoteDefaultExpression.call(HOST, undefined)).toBe("");
     });
 
     it("returns NULL for null", () => {
-      expect(quoteDefaultExpression(null)).toBe("NULL");
+      expect(quoteDefaultExpression.call(HOST, null)).toBe("NULL");
     });
 
     it("wraps function results in parens", () => {
-      expect(quoteDefaultExpression(() => "NOW()")).toBe("(NOW())");
+      expect(quoteDefaultExpression.call(HOST, () => "NOW()")).toBe("(NOW())");
     });
 
     it("returns non-function results as raw SQL", () => {
-      expect(quoteDefaultExpression(() => "CURRENT_TIMESTAMP")).toBe("CURRENT_TIMESTAMP");
+      expect(quoteDefaultExpression.call(HOST, () => "CURRENT_TIMESTAMP")).toBe(
+        "CURRENT_TIMESTAMP",
+      );
     });
 
     it("quotes a binary default through SQLite's quotedBinary", () => {
-      // Receiver-less: the fallback host must still reach the `x'..'` hex form,
-      // not the abstract byte-string fallback. Cover all three shapes that reach
-      // here — the `BinaryData` that `BinaryType#serialize` returns
+      // Binary self-dispatches through the host, so it must reach the `x'..'`
+      // hex form, not the abstract byte-string fallback. Cover all three shapes
+      // that reach here — the `BinaryData` that `BinaryType#serialize` returns
       // (activemodel/.../binary.rb:31), plus the raw `Uint8Array` and bare
       // `ArrayBuffer` a caller may hand to a migration default.
-      expect(quoteDefaultExpression(new Uint8Array([0xde, 0xad]))).toBe("x'dead'");
-      expect(quoteDefaultExpression(new Uint8Array([0xde, 0xad]).buffer)).toBe("x'dead'");
-      expect(quoteDefaultExpression(new BinaryData(new Uint8Array([0xde, 0xad])))).toBe("x'dead'");
+      expect(quoteDefaultExpression.call(HOST, new Uint8Array([0xde, 0xad]))).toBe("x'dead'");
+      expect(quoteDefaultExpression.call(HOST, new Uint8Array([0xde, 0xad]).buffer)).toBe(
+        "x'dead'",
+      );
+      expect(quoteDefaultExpression.call(HOST, new BinaryData(new Uint8Array([0xde, 0xad])))).toBe(
+        "x'dead'",
+      );
     });
   });
 

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -172,7 +172,7 @@ export function quotedBinary(value: Uint8Array | ArrayBuffer | BinaryData): stri
   return `x'${hex}'`;
 }
 
-export function quoteDefaultExpression(this: QuotingDispatchHost | void, value: unknown): string {
+export function quoteDefaultExpression(this: QuotingDispatchHost, value: unknown): string {
   if (value === undefined) return "";
   if (value === null) return "NULL";
   if (typeof value === "function") {
@@ -183,10 +183,10 @@ export function quoteDefaultExpression(this: QuotingDispatchHost | void, value: 
     if (/^\w+\(.*\)$/.test(str)) return `(${str})`;
     return str;
   }
-  // `quote` requires a host receiver; thread our own so date/time defaults reach
-  // SQLite's quotedDate / quotedTime overrides and binary defaults reach its
+  // Rails: `quote(value)` — self-dispatched, so date/time defaults reach
+  // SQLite's quotedDate / quotedTime overrides and binary defaults its
   // `x'..'` quotedBinary (the adapter binds `this`).
-  return quote.call(this || { quotedDate, quotedTime, quotedBinary }, value);
+  return quote.call(this, value);
 }
 
 export function typeCast(this: QuotingDispatchHost, value: unknown, bindsAsFloat = false): unknown {

--- a/packages/activerecord/src/quoting.test.ts
+++ b/packages/activerecord/src/quoting.test.ts
@@ -5,7 +5,7 @@ import {
   quote as quoteFn,
   quoteString,
   quoteColumnName,
-  quoteTableName,
+  quoteTableName as quoteTableNameFn,
   quoteTableNameForAssignment,
   quotedDate,
   quotedTime as quotedTimeFn,
@@ -21,11 +21,13 @@ import {
   columnNameWithOrderMatcher,
 } from "./connection-adapters/abstract/quoting.js";
 
-// `quote` / `typeCast` / `quotedTime` require a host receiver (no receiver-less
-// dispatch); bind an empty host so date/time values route through the abstract
-// module helpers.
+// `quote` / `typeCast` / `quotedTime` / `quoteTableName` require a host receiver
+// (no receiver-less dispatch); bind an empty host so date/time values route
+// through the abstract module helpers and table-name dispatch falls to the
+// throwing module-level `quoteColumnName`, as Rails' abstract layer does.
 const HOST = {};
 const quote = (value: unknown): string => quoteFn.call(HOST, value);
+const quoteTableName = (name: string): string => quoteTableNameFn.call(HOST, name);
 const typeCast = (value: unknown): unknown => typeCastFn.call(HOST, value);
 const quotedTime = (value: Temporal.PlainTime | Temporal.PlainDateTime): string =>
   quotedTimeFn.call(HOST, value);
@@ -123,7 +125,7 @@ describe("QuotingTest", () => {
   it("quote table name", () => {
     // Rails: abstract quote_table_name delegates to quote_column_name, which
     // raises NotImplementedError (quoting.rb L66).
-    expect(() => quoteTableName.call({}, "foo")).toThrow(NotImplementedError);
+    expect(() => quoteTableName("foo")).toThrow(NotImplementedError);
   });
 
   it("quote table name for assignment", () => {
@@ -141,10 +143,20 @@ describe("QuotingTest", () => {
   });
   it("quote table name calls quote column name", () => {
     // Rails overrides quote_column_name and asserts quote_table_name routes
-    // through it. trails has no module-level dispatch to monkey-patch, so the
-    // ported assertion verifies the delegation by its observable effect: the
-    // abstract quote_table_name surfaces quote_column_name's NotImplementedError.
-    expect(() => quoteTableName.call({}, "foo")).toThrow(NotImplementedError);
+    // through it. Now that a host receiver is required, that is directly
+    // expressible: bind a host whose quoteColumnName is a spy and assert the
+    // dispatch reaches it.
+    const calls: string[] = [];
+    const host = {
+      quoteColumnName(name: string): string {
+        calls.push(name);
+        return `[${name}]`;
+      },
+    };
+    expect(quoteTableNameFn.call(host, "foo")).toBe("[foo]");
+    expect(calls).toEqual(["foo"]);
+    // Without an override the abstract quote_column_name still raises.
+    expect(() => quoteTableName("foo")).toThrow(NotImplementedError);
   });
   it("quoted timestamp local", () => {
     setDefaultTimezone("local");

--- a/packages/activerecord/src/quoting.test.ts
+++ b/packages/activerecord/src/quoting.test.ts
@@ -123,7 +123,7 @@ describe("QuotingTest", () => {
   it("quote table name", () => {
     // Rails: abstract quote_table_name delegates to quote_column_name, which
     // raises NotImplementedError (quoting.rb L66).
-    expect(() => quoteTableName("foo")).toThrow(NotImplementedError);
+    expect(() => quoteTableName.call({}, "foo")).toThrow(NotImplementedError);
   });
 
   it("quote table name for assignment", () => {
@@ -144,7 +144,7 @@ describe("QuotingTest", () => {
     // through it. trails has no module-level dispatch to monkey-patch, so the
     // ported assertion verifies the delegation by its observable effect: the
     // abstract quote_table_name surfaces quote_column_name's NotImplementedError.
-    expect(() => quoteTableName("foo")).toThrow(NotImplementedError);
+    expect(() => quoteTableName.call({}, "foo")).toThrow(NotImplementedError);
   });
   it("quoted timestamp local", () => {
     setDefaultTimezone("local");

--- a/packages/activerecord/src/sql-default.test.ts
+++ b/packages/activerecord/src/sql-default.test.ts
@@ -57,46 +57,46 @@ describe("quote", () => {
 
 describe("quoteDefaultExpression", () => {
   it("returns empty string for undefined", () => {
-    expect(quoteDefaultExpression(undefined)).toBe("");
+    expect(quoteDefaultExpression.call({}, undefined)).toBe("");
   });
 
   it("returns DEFAULT NULL for null", () => {
-    expect(quoteDefaultExpression(null)).toBe("NULL");
+    expect(quoteDefaultExpression.call({}, null)).toBe("NULL");
   });
 
   it("returns DEFAULT TRUE/FALSE for booleans", () => {
-    expect(quoteDefaultExpression(true)).toBe("TRUE");
-    expect(quoteDefaultExpression(false)).toBe("FALSE");
+    expect(quoteDefaultExpression.call({}, true)).toBe("TRUE");
+    expect(quoteDefaultExpression.call({}, false)).toBe("FALSE");
   });
 
   it("returns unquoted numbers", () => {
-    expect(quoteDefaultExpression(42)).toBe("42");
+    expect(quoteDefaultExpression.call({}, 42)).toBe("42");
   });
 
   it("quotes regular strings", () => {
-    expect(quoteDefaultExpression("hello")).toBe("'hello'");
+    expect(quoteDefaultExpression.call({}, "hello")).toBe("'hello'");
   });
 
   it("passes through function return values as raw SQL", () => {
-    expect(quoteDefaultExpression(() => "CURRENT_TIMESTAMP")).toBe("CURRENT_TIMESTAMP");
+    expect(quoteDefaultExpression.call({}, () => "CURRENT_TIMESTAMP")).toBe("CURRENT_TIMESTAMP");
   });
 
   it("passes through function calls like now()", () => {
-    expect(quoteDefaultExpression(() => "now()")).toBe("now()");
+    expect(quoteDefaultExpression.call({}, () => "now()")).toBe("now()");
   });
 
   it("passes through SqlLiteral instances as raw SQL", () => {
-    expect(quoteDefaultExpression(new Nodes.SqlLiteral("CURRENT_TIMESTAMP"))).toBe(
+    expect(quoteDefaultExpression.call({}, new Nodes.SqlLiteral("CURRENT_TIMESTAMP"))).toBe(
       "CURRENT_TIMESTAMP",
     );
   });
 
   it("quotes plain string CURRENT_TIMESTAMP as a literal", () => {
-    expect(quoteDefaultExpression("CURRENT_TIMESTAMP")).toBe("'CURRENT_TIMESTAMP'");
+    expect(quoteDefaultExpression.call({}, "CURRENT_TIMESTAMP")).toBe("'CURRENT_TIMESTAMP'");
   });
 
   it("throws TypeError when function returns non-string/non-SqlLiteral", () => {
-    expect(() => quoteDefaultExpression(() => 123)).toThrow(TypeError);
-    expect(() => quoteDefaultExpression(() => undefined)).toThrow(TypeError);
+    expect(() => quoteDefaultExpression.call({}, () => 123)).toThrow(TypeError);
+    expect(() => quoteDefaultExpression.call({}, () => undefined)).toThrow(TypeError);
   });
 });

--- a/packages/activerecord/src/sql-default.test.ts
+++ b/packages/activerecord/src/sql-default.test.ts
@@ -2,13 +2,17 @@ import { describe, it, expect } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import {
   quote as quoteFn,
-  quoteDefaultExpression,
+  quoteDefaultExpression as quoteDefaultExpressionFn,
 } from "./connection-adapters/abstract/quoting.js";
 import { Nodes } from "@blazetrails/arel";
 
 // `quote` requires a host receiver (no receiver-less dispatch); bind an empty
 // host so date/time values route through the abstract module helpers.
 const quote = (value: unknown): string => quoteFn.call({}, value);
+// Likewise `quoteDefaultExpression` — an empty host has no `quote` override, so
+// values fall through to the abstract module quoting.
+const quoteDefaultExpression = (value: unknown, column?: { sqlType?: string | null } | null) =>
+  quoteDefaultExpressionFn.call({}, value, column);
 
 describe("quote", () => {
   it("returns NULL for null", () => {
@@ -57,46 +61,46 @@ describe("quote", () => {
 
 describe("quoteDefaultExpression", () => {
   it("returns empty string for undefined", () => {
-    expect(quoteDefaultExpression.call({}, undefined)).toBe("");
+    expect(quoteDefaultExpression(undefined)).toBe("");
   });
 
   it("returns DEFAULT NULL for null", () => {
-    expect(quoteDefaultExpression.call({}, null)).toBe("NULL");
+    expect(quoteDefaultExpression(null)).toBe("NULL");
   });
 
   it("returns DEFAULT TRUE/FALSE for booleans", () => {
-    expect(quoteDefaultExpression.call({}, true)).toBe("TRUE");
-    expect(quoteDefaultExpression.call({}, false)).toBe("FALSE");
+    expect(quoteDefaultExpression(true)).toBe("TRUE");
+    expect(quoteDefaultExpression(false)).toBe("FALSE");
   });
 
   it("returns unquoted numbers", () => {
-    expect(quoteDefaultExpression.call({}, 42)).toBe("42");
+    expect(quoteDefaultExpression(42)).toBe("42");
   });
 
   it("quotes regular strings", () => {
-    expect(quoteDefaultExpression.call({}, "hello")).toBe("'hello'");
+    expect(quoteDefaultExpression("hello")).toBe("'hello'");
   });
 
   it("passes through function return values as raw SQL", () => {
-    expect(quoteDefaultExpression.call({}, () => "CURRENT_TIMESTAMP")).toBe("CURRENT_TIMESTAMP");
+    expect(quoteDefaultExpression(() => "CURRENT_TIMESTAMP")).toBe("CURRENT_TIMESTAMP");
   });
 
   it("passes through function calls like now()", () => {
-    expect(quoteDefaultExpression.call({}, () => "now()")).toBe("now()");
+    expect(quoteDefaultExpression(() => "now()")).toBe("now()");
   });
 
   it("passes through SqlLiteral instances as raw SQL", () => {
-    expect(quoteDefaultExpression.call({}, new Nodes.SqlLiteral("CURRENT_TIMESTAMP"))).toBe(
+    expect(quoteDefaultExpression(new Nodes.SqlLiteral("CURRENT_TIMESTAMP"))).toBe(
       "CURRENT_TIMESTAMP",
     );
   });
 
   it("quotes plain string CURRENT_TIMESTAMP as a literal", () => {
-    expect(quoteDefaultExpression.call({}, "CURRENT_TIMESTAMP")).toBe("'CURRENT_TIMESTAMP'");
+    expect(quoteDefaultExpression("CURRENT_TIMESTAMP")).toBe("'CURRENT_TIMESTAMP'");
   });
 
   it("throws TypeError when function returns non-string/non-SqlLiteral", () => {
-    expect(() => quoteDefaultExpression.call({}, () => 123)).toThrow(TypeError);
-    expect(() => quoteDefaultExpression.call({}, () => undefined)).toThrow(TypeError);
+    expect(() => quoteDefaultExpression(() => 123)).toThrow(TypeError);
+    expect(() => quoteDefaultExpression(() => undefined)).toThrow(TypeError);
   });
 });


### PR DESCRIPTION
Extends the host-receiver requirement from PR #3892 to the two sibling dispatch
methods it left tolerating a receiver-less call.

Rails' `Quoting` defines `quote_table_name` and `quote_default_expression` as
self-dispatching instance methods (`quote_table_name` → `quote_column_name`,
`quote_default_expression` → `quote`), so a receiver is always present.

## Changes

- Drop `| void` on `quoteTableName` / `quoteDefaultExpression` in the abstract,
  PostgreSQL and SQLite ports — a receiver-less invocation is now a compile error.
- Replace the internal `this || {}` / `this || { quotedDate, quotedTime, quotedBinary }`
  fallbacks with the required receiver.
- Adapter-free callers bind a host explicitly: the module-level
  `quoteTableNameForAssignment` binds a bare host (dispatch still falls to the
  throwing `quoteColumnName`, matching Rails' abstract behaviour), and the PG
  adapter's `quoteDefaultExpression` override threads `this` into the dialect port.
- `ABSTRACT_SCHEMA_QUOTER`, the mysql schema-quoter and the sanitization
  `ABSTRACT_QUOTER` already invoke these as methods of their own object, so they
  are the dispatch host and needed no change.

## Why the removed fallbacks are not a behavior change

The dialect fallbacks only fired on a receiver-less call. Audited every runtime
caller of the two dialect ports:

- `postgresql/quoting.ts#quoteDefaultExpression` — sole production caller is the
  PG adapter's override, now `.call(this, ...)`, and the adapter carries
  `quotedDate` / `quotedBinary`.
- `sqlite3/quoting.ts#quoteDefaultExpression` — no production caller at all; the
  SQLite adapter's override delegates to `super` (the abstract adapter method).

So every surviving call already had a dialect-carrying host. Adapter-routed SQL
is byte-identical.

## Drive-by fidelity fix (from review)

Review surfaced that the PG `quoteDefaultExpression` port was missing Rails'
uuid branch — `column.type == :uuid && value.is_a?(String) && value.include?("()")`
returns the value unchanged (postgresql/quoting.rb:159-160, "Does not quote
function default values for UUID columns"). Without it, a uuid column with
`default: "gen_random_uuid()"` emitted the string literal `'gen_random_uuid()'`
instead of the bare call.

Ported at Rails' position (after the Proc/SqlLiteral arms, before array/super).
This also required plumbing: the PG adapter built its column shape with only
`array` and `sqlType`, dropping `type` — and the branch tests the AR type
symbol, not `sql_type`, so it could never have fired without forwarding it.

## Testing

- `pnpm typecheck` clean.
- 1636 tests green across all of `connection-adapters/`, plus the abstract
  quoting, sql-default and schema-definitions suites.
- `quote table name calls quote column name` is now a faithful port of the Rails
  test: with a receiver required, it binds a host whose `quoteColumnName` is a
  spy and asserts the dispatch reaches it, rather than inferring delegation from
  the raised `NotImplementedError` alone.
- New `does not quote function default values for UUID columns` covers both the
  pgcrypto and uuid-ossp spellings (uuid_test.rb:16 picks between them by
  extension support), a non-function uuid default, and a same-string text column
  to pin the branch as uuid-only.

Closes-story: require-host-receiver-quote-table-name-default-expression