### PR TITLE
feat(api-compare): resolve alias arity through includes and superclasses

### DIFF
--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -1024,28 +1024,34 @@ class ApiExtractor
   # Public: invoked by `run` per package and by the extractor unit test.
   public def resolve_aliases!
     all = @classes.merge(@modules)
+    # Candidate table per (fqn, bucket): the bucket's own methods first, then —
+    # second resolution stage — the methods reachable through the ancestors the
+    # extractor recorded (`include`d modules and the superclass chain for
+    # instance methods, `extend`ed modules for class methods). `||=` keeps a
+    # same-bucket definition winning over any inherited one, mirroring Ruby's
+    # method lookup. Built once and reused across passes.
+    tables = {}
     all.each do |fqn, info|
       [:instanceMethods, :classMethods].each do |bucket|
-        methods = info[bucket]
         by_name = {}
-        methods.each { |m| by_name[m[:name]] ||= m }
-        # Second resolution stage: an alias whose target is not defined in this
-        # same bucket may still be reachable through the class's ancestors —
-        # `include`d modules (and inherited superclasses) supply instance
-        # methods, `extend`ed modules supply class methods. Fold those in as
-        # lower-priority candidates so the fixpoint below can use them, without
-        # ever shadowing a same-bucket definition.
-        ancestor_methods(fqn, info, bucket, all).each do |m|
-          by_name[m[:name]] ||= m
-        end
-        # Fixpoint: each non-breaking pass fills at least one previously-empty
-        # alias (filled aliases are skipped on later passes), so the count of
-        # unresolved aliases strictly decreases and the loop always terminates —
-        # no arbitrary iteration cap. Handles alias-of-an-alias chains
-        # regardless of source order.
-        loop do
-          changed = false
-          methods.each do |m|
+        info[bucket].each { |m| by_name[m[:name]] ||= m }
+        ancestor_methods(fqn, info, bucket, all).each { |m| by_name[m[:name]] ||= m }
+        tables[[fqn, bucket]] = by_name
+      end
+    end
+
+    # Fixpoint over ALL buckets at once, not per class: an alias may resolve to
+    # an alias in an ancestor that is itself still unresolved, so a single
+    # hash-ordered sweep would read an empty target and give up. Each
+    # non-breaking pass fills at least one previously-empty alias (filled
+    # aliases are skipped afterwards), so the unresolved count strictly
+    # decreases and the loop always terminates — no arbitrary iteration cap.
+    loop do
+      changed = false
+      all.each do |fqn, info|
+        [:instanceMethods, :classMethods].each do |bucket|
+          by_name = tables[[fqn, bucket]]
+          info[bucket].each do |m|
             next unless m[:notes] == "alias" && m[:alias_target]
             next unless m[:params].nil? || m[:params].empty?
             tgt = by_name[m[:alias_target]]
@@ -1053,9 +1059,14 @@ class ApiExtractor
             m[:params] = tgt[:params].map(&:dup)
             changed = true
           end
-          break unless changed
         end
-        methods.each { |m| m.delete(:alias_target) }
+      end
+      break unless changed
+    end
+
+    all.each_value do |info|
+      [:instanceMethods, :classMethods].each do |bucket|
+        info[bucket].each { |m| m.delete(:alias_target) }
       end
     end
   end

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -287,6 +287,12 @@ class ApiExtractor
     # `VALID_OPTIONS`-named symbol arrays per class FQN, expanded when a method
     # body passes the constant to `assert_valid_keys`. See collect_option_keys.
     @const_symbol_arrays = {}
+    # `include`/`extend` statements grouped per statement, keyed [fqn, :includes]
+    # / [fqn, :extends]. The flat `info[:includes]` the manifest emits loses
+    # statement boundaries, but Ruby's ancestor order needs them: a LATER
+    # `include` beats an earlier one, while within one `include A, B` the FIRST
+    # argument wins. Internal only — never emitted. See ancestor_methods.
+    @include_groups = {}
     # When true we're scanning a top-level umbrella file (e.g. active_record.rb)
     # one level above libPath. We only harvest module-level singleton config
     # (`singleton_class.attr_accessor` …) from it and redirect that config onto
@@ -808,9 +814,9 @@ class ApiExtractor
     target = @classes[fqn] || @modules[fqn]
     return unless target
 
-    extract_const_args(args).each do |mod_name|
-      target[:includes] << mod_name
-    end
+    names = extract_const_args(args)
+    names.each { |mod_name| target[:includes] << mod_name }
+    (@include_groups[[fqn, :includes]] ||= []) << names if names.any?
   end
 
   def process_include_from_arg_paren(args)
@@ -818,9 +824,9 @@ class ApiExtractor
     target = @classes[fqn] || @modules[fqn]
     return unless target
 
-    extract_const_args_from_paren(args).each do |mod_name|
-      target[:includes] << mod_name
-    end
+    names = extract_const_args_from_paren(args)
+    names.each { |mod_name| target[:includes] << mod_name }
+    (@include_groups[[fqn, :includes]] ||= []) << names if names.any?
   end
 
   def process_extend(args)
@@ -828,9 +834,9 @@ class ApiExtractor
     target = @classes[fqn] || @modules[fqn]
     return unless target
 
-    extract_const_args(args).each do |mod_name|
-      target[:extends] << mod_name
-    end
+    names = extract_const_args(args)
+    names.each { |mod_name| target[:extends] << mod_name }
+    (@include_groups[[fqn, :extends]] ||= []) << names if names.any?
   end
 
   def process_extend_from_arg_paren(args)
@@ -838,9 +844,9 @@ class ApiExtractor
     target = @classes[fqn] || @modules[fqn]
     return unless target
 
-    extract_const_args_from_paren(args).each do |mod_name|
-      target[:extends] << mod_name
-    end
+    names = extract_const_args_from_paren(args)
+    names.each { |mod_name| target[:extends] << mod_name }
+    (@include_groups[[fqn, :extends]] ||= []) << names if names.any?
   end
 
   # Is `recv` a `singleton_class` receiver — either the bare
@@ -1085,17 +1091,25 @@ class ApiExtractor
     seen[fqn] = true
 
     out = []
+    # Mixins BEFORE the superclass: Ruby inserts included modules between the
+    # class and its superclass, so an included override beats an inherited
+    # definition. Statement order is reversed (a later `include` wins) while
+    # names within one statement keep source order (`include A, B` puts A
+    # first) — the ancestor order `Module#include` actually produces.
+    mixin_key = bucket == :classMethods ? :extends : :includes
+    mixin_groups = @include_groups[[fqn, mixin_key]] || [info[mixin_key]]
+    mixin_groups.reverse_each do |group|
+      group.each do |mod_name|
+        found = lookup_ancestor(mod_name, fqn, all)
+        next unless found
+        out.concat(found[1][:instanceMethods])
+        out.concat(ancestor_methods(found[0], found[1], :instanceMethods, all, seen))
+      end
+    end
     sup = lookup_ancestor(info[:superclass], fqn, all)
     if sup
       out.concat(sup[1][bucket])
       out.concat(ancestor_methods(sup[0], sup[1], bucket, all, seen))
-    end
-    mixin_key = bucket == :classMethods ? :extends : :includes
-    info[mixin_key].each do |mod_name|
-      found = lookup_ancestor(mod_name, fqn, all)
-      next unless found
-      out.concat(found[1][:instanceMethods])
-      out.concat(ancestor_methods(found[0], found[1], :instanceMethods, all, seen))
     end
     out
   end
@@ -1107,15 +1121,25 @@ class ApiExtractor
   # finds `ActiveRecord::Delegation`.
   def lookup_ancestor(name, from_fqn, all)
     return nil unless name
-    name = name.sub(/\A::/, "")
-    return [name, all[name]] if all[name]
+    # Resolved lexically — innermost enclosing scope outwards, top level LAST.
+    # Checking `all[name]` up front would bind `include Delegation` inside
+    # `ActiveRecord::Relation` to a top-level `::Delegation` in preference to
+    # `ActiveRecord::Delegation`, which is the opposite of Ruby's rule.
+    #
+    # A leading `::` should strictly force the absolute lookup, but `const_name`
+    # normalizes `::Foo` to `Foo` before it reaches the recorded `includes`, so
+    # absoluteness isn't observable here; such a reference falls back to lexical
+    # order. Vendored Rails has no `include ::Foo` / `extend ::Foo` anywhere
+    # under `*/lib`, so nothing is misresolved today — teaching the extractor to
+    # preserve `::` would change emitted manifest values for every include and
+    # belongs in its own change.
     parts = from_fqn.split("::")
     while parts.any?
       candidate = (parts + [name]).join("::")
       return [candidate, all[candidate]] if all[candidate]
       parts.pop
     end
-    nil
+    all[name] ? [name, all[name]] : nil
   end
 
   # `class_attribute`/`cattr_accessor`/`mattr_accessor` (and their reader/writer

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -1023,11 +1023,21 @@ class ApiExtractor
   # reaches the manifest.
   # Public: invoked by `run` per package and by the extractor unit test.
   public def resolve_aliases!
-    (@classes.values + @modules.values).each do |info|
+    all = @classes.merge(@modules)
+    all.each do |fqn, info|
       [:instanceMethods, :classMethods].each do |bucket|
         methods = info[bucket]
         by_name = {}
         methods.each { |m| by_name[m[:name]] ||= m }
+        # Second resolution stage: an alias whose target is not defined in this
+        # same bucket may still be reachable through the class's ancestors —
+        # `include`d modules (and inherited superclasses) supply instance
+        # methods, `extend`ed modules supply class methods. Fold those in as
+        # lower-priority candidates so the fixpoint below can use them, without
+        # ever shadowing a same-bucket definition.
+        ancestor_methods(fqn, info, bucket, all).each do |m|
+          by_name[m[:name]] ||= m
+        end
         # Fixpoint: each non-breaking pass fills at least one previously-empty
         # alias (filled aliases are skipped on later passes), so the count of
         # unresolved aliases strictly decreases and the loop always terminates —
@@ -1048,6 +1058,53 @@ class ApiExtractor
         methods.each { |m| m.delete(:alias_target) }
       end
     end
+  end
+
+  # Methods an alias in `fqn`'s `bucket` can resolve against beyond its own
+  # bucket, walking the ancestors the extractor recorded. For instance methods
+  # that's the superclass chain plus each `include`d module's instance methods
+  # (a module's own `include` is followed transitively); for class methods it's
+  # the superclass chain plus each `extend`ed module's INSTANCE methods, since
+  # `extend Foo` promotes Foo's instance methods to singleton methods.
+  # Ancestors outside the package simply aren't in `all`, so their aliases stay
+  # empty-param — best-effort, exactly as before.
+  def ancestor_methods(fqn, info, bucket, all, seen = nil)
+    seen ||= {}
+    return [] if seen[fqn]
+    seen[fqn] = true
+
+    out = []
+    sup = lookup_ancestor(info[:superclass], fqn, all)
+    if sup
+      out.concat(sup[1][bucket])
+      out.concat(ancestor_methods(sup[0], sup[1], bucket, all, seen))
+    end
+    mixin_key = bucket == :classMethods ? :extends : :includes
+    info[mixin_key].each do |mod_name|
+      found = lookup_ancestor(mod_name, fqn, all)
+      next unless found
+      out.concat(found[1][:instanceMethods])
+      out.concat(ancestor_methods(found[0], found[1], :instanceMethods, all, seen))
+    end
+    out
+  end
+
+  # Resolve a `class X < Sup` / `include Mod` constant reference written inside
+  # `from_fqn` to a recorded `[fqn, info]`. Tries the name as an absolute FQN
+  # first, then as relative to each enclosing lexical scope (Ruby's own constant
+  # lookup order), so `include Delegation` inside `ActiveRecord::Relation`
+  # finds `ActiveRecord::Delegation`.
+  def lookup_ancestor(name, from_fqn, all)
+    return nil unless name
+    name = name.sub(/\A::/, "")
+    return [name, all[name]] if all[name]
+    parts = from_fqn.split("::")
+    while parts.any?
+      candidate = (parts + [name]).join("::")
+      return [candidate, all[candidate]] if all[candidate]
+      parts.pop
+    end
+    nil
   end
 
   # `class_attribute`/`cattr_accessor`/`mattr_accessor` (and their reader/writer

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -197,6 +197,30 @@ describe("Ruby extractor alias arity resolution", () => {
     expect(r["Pkg::Relation#to_a"]).toMatchObject({ params: ["limit"], notes: "alias" });
   });
 
+  it("resolves an alias whose mixin target is itself an unresolved alias", () => {
+    // The host's alias points at `to_ary`, which is itself only an alias inside
+    // the module. Resolution must not depend on the module happening to be
+    // visited before the host — hence the global fixpoint rather than a
+    // per-class sweep. `zz_` sorts the module after the host to make a
+    // hash-order-dependent implementation fail here.
+    const r = aliasParams({
+      "chain.rb": `
+        module Pkg
+          class Relation
+            include ZzDelegation
+            alias :to_a :to_ary
+          end
+
+          module ZzDelegation
+            def records(limit, offset); end
+            alias :to_ary :records
+          end
+        end
+      `,
+    });
+    expect(r["Pkg::Relation#to_a"].params).toEqual(["limit", "offset"]);
+  });
+
   it("resolves a target inherited from a superclass", () => {
     const r = aliasParams({
       "sup.rb": `
@@ -247,7 +271,7 @@ describe("Ruby extractor alias arity resolution", () => {
     expect(r["Owner#aka"].params).toEqual(["right", "also"]);
   });
 
-  it("leaves an alias empty when its target is outside the package", () => {
+  it("leaves an alias empty when its ancestors are outside the package", () => {
     const r = aliasParams({
       "out.rb": `
         class Orphan < SomeGem::Base

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -254,6 +254,84 @@ describe("Ruby extractor alias arity resolution", () => {
     expect(r["Host#create"].params).toEqual(["scope", "opts"]);
   });
 
+  it("prefers an included module's method over the superclass's", () => {
+    // Ruby inserts included modules between the class and its superclass, so
+    // `Mixin#target` wins over `Parent#target`.
+    const r = aliasParams({
+      "order.rb": `
+        class Parent
+          def target(from_superclass); end
+        end
+
+        module Mixin
+          def target(from_mixin, extra); end
+        end
+
+        class Child < Parent
+          include Mixin
+          alias :aka :target
+        end
+      `,
+    });
+    expect(r["Child#aka"].params).toEqual(["from_mixin", "extra"]);
+  });
+
+  it("prefers the last `include` statement, but the first name within one", () => {
+    // ancestors == [Host, Late, EarlyA, EarlyB]: a later `include` beats an
+    // earlier one, while `include EarlyA, EarlyB` puts EarlyA ahead of EarlyB.
+    const r = aliasParams({
+      "ancestry.rb": `
+        module EarlyA
+          def target(early_a); end
+        end
+        module EarlyB
+          def target(early_b); end
+        end
+        module Late
+          def target(late); end
+        end
+
+        class Host
+          include EarlyA, EarlyB
+          include Late
+          alias :aka :target
+        end
+
+        class Sibling
+          include EarlyA, EarlyB
+          alias :aka :target
+        end
+      `,
+    });
+    expect(r["Host#aka"].params).toEqual(["late"]);
+    expect(r["Sibling#aka"].params).toEqual(["early_a"]);
+  });
+
+  it("resolves an unqualified mixin lexically before the top level", () => {
+    // The ActiveRecord::Relation case: `include Delegation` inside
+    // `ActiveRecord::Relation` must find `ActiveRecord::Delegation`, not a
+    // top-level `::Delegation`.
+    const r = aliasParams({
+      "lex.rb": `
+        module Delegation
+          def target(top_level); end
+        end
+
+        module ActiveRecord
+          module Delegation
+            def target(nested, other); end
+          end
+
+          class Relation
+            include Delegation
+            alias :aka :target
+          end
+        end
+      `,
+    });
+    expect(r["ActiveRecord::Relation#aka"].params).toEqual(["nested", "other"]);
+  });
+
   it("prefers a same-bucket definition over an inherited one", () => {
     const r = aliasParams({
       "shadow.rb": `

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -179,6 +179,86 @@ describe("Ruby extractor alias arity resolution", () => {
     expect(r["Encoding#dump"]).toMatchObject({ params: ["value", "options"], notes: "alias" });
   });
 
+  it("resolves a target defined in an included module", () => {
+    const r = aliasParams({
+      "mix.rb": `
+        module Pkg
+          module Delegation
+            def to_ary(limit = nil); end
+          end
+
+          class Relation
+            include Delegation
+            alias :to_a :to_ary
+          end
+        end
+      `,
+    });
+    expect(r["Pkg::Relation#to_a"]).toMatchObject({ params: ["limit"], notes: "alias" });
+  });
+
+  it("resolves a target inherited from a superclass", () => {
+    const r = aliasParams({
+      "sup.rb": `
+        class Parent
+          def compute(a, b); end
+        end
+
+        class Child < Parent
+          alias :calc :compute
+        end
+      `,
+    });
+    expect(r["Child#calc"].params).toEqual(["a", "b"]);
+  });
+
+  it("resolves a class-method target through `extend`", () => {
+    const r = aliasParams({
+      "ext.rb": `
+        module Builders
+          def build(scope, opts = {}); end
+        end
+
+        class Host
+          extend Builders
+          class << self
+            alias_method :create, :build
+          end
+        end
+      `,
+    });
+    expect(r["Host#create"].params).toEqual(["scope", "opts"]);
+  });
+
+  it("prefers a same-bucket definition over an inherited one", () => {
+    const r = aliasParams({
+      "shadow.rb": `
+        module Mixin
+          def target(wrong); end
+        end
+
+        class Owner
+          include Mixin
+          def target(right, also); end
+          alias :aka :target
+        end
+      `,
+    });
+    expect(r["Owner#aka"].params).toEqual(["right", "also"]);
+  });
+
+  it("leaves an alias empty when its target is outside the package", () => {
+    const r = aliasParams({
+      "out.rb": `
+        class Orphan < SomeGem::Base
+          include SomeGem::Mixin
+          alias :local :elsewhere
+        end
+      `,
+    });
+    expect(r["Orphan#local"]).toMatchObject({ params: [], notes: "alias", hasAliasTarget: false });
+  });
+
   it("follows an alias chain (alias of an alias)", () => {
     const r = aliasParams({
       "c.rb": `


### PR DESCRIPTION
`resolve_aliases!` previously copied an alias target's param list only when the target was defined in the SAME class/module bucket. Aliases whose target arrives via `include`/`extend` of a mixin, or by inheritance, stayed empty-param (`params: []`) and could false-flag the advisory arity check against a faithful TS delegator.

## What changed

- **Ancestor resolution stage.** Alias targets now also resolve against the ancestors the extractor already records: `include`d modules and the superclass chain for instance methods, `extend`ed modules' *instance* methods for class methods (`extend Foo` promotes them to singleton methods). Mixins are followed transitively, with cycle protection.
- **Ruby's real ancestor order.** Own bucket first, then included modules, then the superclass chain — so an included override beats an inherited definition. Within the mixins, a later `include` statement wins while `include A, B` puts A first; the extractor tracks statement groups internally to preserve that distinction (the manifest's emitted `includes` value is unchanged).
- **Lexical constant lookup.** Unqualified mixin names resolve innermost-scope-outwards with the top level tried LAST, so `include Delegation` inside `ActiveRecord::Relation` binds to `ActiveRecord::Delegation` rather than a top-level `::Delegation`.
- **Global fixpoint.** Resolution iterates over every bucket at once rather than per class. A per-class sweep could read an ancestor's alias before that alias was itself resolved, permanently leaving the dependent alias empty — and whether it did depended on hash iteration order.
- Out-of-package ancestors (another gem's source) simply aren't in the table, so those aliases stay empty — best-effort, exactly as before.

## Measured effect

Four activerecord aliases that previously extracted as zero-arity now carry their real params — all via the inherited/mixin path this PR adds:

```
ActiveRecord::ConnectionAdapters::Mysql2Adapter#reset!    [] -> [restore_transactions]
ActiveRecord::ConnectionAdapters::SQLite3Adapter#reset!   [] -> [restore_transactions]
ActiveRecord::ConnectionAdapters::TrilogyAdapter#reset!   [] -> [restore_transactions]
Arel::Nodes::UnqualifiedColumn#attribute=                 [] -> [value]
```

(The `reset!` cases alias `reconnect!`, inherited from `AbstractAdapter` — the story's exact scenario.)

**No regression:** `api:compare` before and after produces an identical `arity-mismatches.json` (181 mismatches, overall arity 7443/7624) once the timestamp is excluded. Today's four fixes are latent false-flags removed rather than counter movement.

## Review round 2 (Codex)

**Ancestor ordering** — fixed, as described above. Tracking statement groups was necessary because a flat reverse would get `include A, B` backwards.

**Lexical constant lookup** — fixed for the actionable half (unqualified names, above).

The leading-`::` half is *not* implemented, deliberately: `const_name` normalizes `::Foo` to `Foo` before it reaches the recorded `includes`, so absoluteness is not observable at `lookup_ancestor` at all. I wrote that branch, found its test failing, and traced the cause rather than forcing it green. Vendored Rails contains **zero** `include ::Foo` / `extend ::Foo` under any `*/lib`, so nothing is misresolved today. Preserving `::` would change emitted manifest values for every include across all packages — its own change, not this one. The limitation is documented at the call site.

## Tests

Nine cases in `extract-ruby-api.test.ts` pin: mixin-target alias, superclass-inherited target, `extend`ed class-method target, an alias whose mixin target is *itself* an unresolved alias (ordered to fail a hash-order-dependent implementation), included-module-beats-superclass, last-`include`-wins vs first-name-within-a-statement, lexical-before-top-level, same-bucket shadowing precedence, and out-of-package ancestors staying empty.

Closes-story: resolve-alias-arity-through-includes
