### PR TITLE
perf(activerecord): memoize _returningColumnsForInsert per-class

### DIFF
--- a/packages/activerecord/src/model-schema-returning-columns.trails.test.ts
+++ b/packages/activerecord/src/model-schema-returning-columns.trails.test.ts
@@ -1,0 +1,62 @@
+/**
+ * trails-only: Rails memoizes @_returning_columns_for_insert per-class
+ * (model_schema.rb:437) and clears it in reload_schema_from_cache
+ * (model_schema.rb:554). There is no upstream test for the memo itself, so
+ * these guard the caching + invalidation contract.
+ */
+import { describe, it, expect } from "vitest";
+import { Base } from "./index.js";
+import { fixtures } from "./test-helpers/fixtures.js";
+
+describe("_returningColumnsForInsert memoization", () => {
+  fixtures([]);
+
+  class Topic extends Base {}
+
+  // Both are mixed in via `this`-typed statics, so they are not on the
+  // Base class type; narrow to just the surface these tests drive.
+  const schemaHost = Topic as unknown as {
+    _returningColumnsForInsert(connection: {
+      returnValueAfterInsert(column: { name: string }): boolean;
+    }): string[];
+    resetColumnInformation(): void;
+  };
+
+  it("computes the auto-populated filter only once per class", async () => {
+    await Topic.loadSchema();
+    let calls = 0;
+    const connection = {
+      returnValueAfterInsert(column: { name: string }) {
+        calls += 1;
+        return column.name === "id";
+      },
+    };
+
+    expect(schemaHost._returningColumnsForInsert(connection)).toEqual(["id"]);
+    const first = calls;
+    expect(first).toBeGreaterThan(0);
+
+    expect(schemaHost._returningColumnsForInsert(connection)).toEqual(["id"]);
+    expect(calls).toBe(first);
+  });
+
+  it("recomputes after resetColumnInformation", async () => {
+    await Topic.loadSchema();
+    let calls = 0;
+    const connection = {
+      returnValueAfterInsert(column: { name: string }) {
+        calls += 1;
+        return column.name === "id";
+      },
+    };
+
+    schemaHost._returningColumnsForInsert(connection);
+    const first = calls;
+
+    schemaHost.resetColumnInformation();
+    await Topic.loadSchema();
+
+    expect(schemaHost._returningColumnsForInsert(connection)).toEqual(["id"]);
+    expect(calls).toBeGreaterThan(first);
+  });
+});

--- a/packages/activerecord/src/model-schema-returning-columns.trails.test.ts
+++ b/packages/activerecord/src/model-schema-returning-columns.trails.test.ts
@@ -59,4 +59,50 @@ describe("_returningColumnsForInsert memoization", () => {
     expect(schemaHost._returningColumnsForInsert(connection)).toEqual(["id"]);
     expect(calls).toBeGreaterThan(first);
   });
+
+  it("resetting a base clears a descendant's memo", async () => {
+    class Reply extends Topic {}
+    const sub = Reply as unknown as typeof schemaHost;
+
+    // Clear first: Topic is describe-scoped and earlier tests memoized on it,
+    // which Reply would otherwise inherit through the prototype chain — the
+    // descendant would never compute its OWN memo and this test would be
+    // vacuous.
+    schemaHost.resetColumnInformation();
+    await Reply.loadSchema();
+
+    let calls = 0;
+    const connection = {
+      returnValueAfterInsert(column: { name: string }) {
+        calls += 1;
+        return column.name === "id";
+      },
+    };
+
+    sub._returningColumnsForInsert(connection);
+    const afterSubMemo = calls;
+    // The descendant really did compute (and now owns) a memo of its own.
+    expect(afterSubMemo).toBeGreaterThan(0);
+    expect(Object.prototype.hasOwnProperty.call(Reply, "_returningColumnsForInsertCache")).toBe(
+      true,
+    );
+    sub._returningColumnsForInsert(connection);
+    expect(calls).toBe(afterSubMemo);
+
+    // Resetting the BASE leaves the descendant's own `_columns` in place — a
+    // pre-existing, memo-independent trails divergence (Rails'
+    // reload_schema_from_cache recurses through `subclasses`, model_schema.rb
+    // :553-569, while trails' resetColumnInformation clears only `this`).
+    // This pins the property that makes the memo safe on top of that gap: the
+    // memoized value never differs from a fresh compute over the columns the
+    // class currently sees, so a stale memo is only ever as stale as the
+    // `_columns` behind it — exactly what the pre-memo code, recomputing from
+    // those same stale columns, already returned.
+    schemaHost.resetColumnInformation();
+    await Reply.loadSchema();
+
+    const memoized = sub._returningColumnsForInsert(connection);
+    Reflect.deleteProperty(Reply, "_returningColumnsForInsertCache");
+    expect(memoized).toEqual(sub._returningColumnsForInsert(connection));
+  });
 });

--- a/packages/activerecord/src/model-schema-returning-columns.trails.test.ts
+++ b/packages/activerecord/src/model-schema-returning-columns.trails.test.ts
@@ -22,6 +22,38 @@ describe("_returningColumnsForInsert memoization", () => {
     resetColumnInformation(): void;
   };
 
+  it("does not let a subclass reuse the base's memo", () => {
+    // Ruby class instance variables are NOT inherited, so Rails' `||=` on
+    // @_returning_columns_for_insert is genuinely per-class (model_schema.rb
+    // :436-443). A plain JS static read walks the prototype chain, so without
+    // an own-property check a subclass would hand back the base's list.
+    //
+    // Pinned with a sentinel memo rather than two real tables on purpose: a
+    // base/subclass pair on different tables ALSO mis-answers here because
+    // loading the base clobbers the subclass's `_columns`, which reproduces
+    // with the memo entirely disabled and so is a separate pre-existing bug.
+    // A sentinel isolates the prototype-chain read this test is about.
+    class Parent extends Base {
+      static tableName = "topics";
+    }
+    class Child extends Parent {}
+    const sentinel = ["LEAKED_FROM_BASE"];
+    (
+      Parent as unknown as { _returningColumnsForInsertCache?: string[] }
+    )._returningColumnsForInsertCache = sentinel;
+
+    const connection = {
+      returnValueAfterInsert: (column: { name: string }) => column.name === "id",
+    };
+    const child = Child as unknown as typeof schemaHost;
+
+    expect(child._returningColumnsForInsert(connection)).not.toEqual(sentinel);
+    expect(
+      (Parent as unknown as { _returningColumnsForInsertCache?: string[] })
+        ._returningColumnsForInsertCache,
+    ).toBe(sentinel);
+  });
+
   it("computes the auto-populated filter only once per class", async () => {
     await Topic.loadSchema();
     let calls = 0;

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -599,20 +599,20 @@ export function _returningColumnsForInsert(
   // reflected Column objects implement; the synthesized column-hash fallback (used
   // before the schema cache is warm) holds plain shapes, so skip those — they
   // carry no auto-increment metadata and the PK fallback below covers them.
-  // Rails memoizes into @_returning_columns_for_insert (a per-class ivar), cleared
-  // by reload_schema_from_cache. Check own-property so an STI subclass doesn't
-  // inherit the base's memo through the prototype chain.
-  if (Object.prototype.hasOwnProperty.call(this, "_returningColumnsForInsertCache")) {
-    const memo = this._returningColumnsForInsertCache;
-    if (memo !== undefined) return memo;
-  }
+  // Rails memoizes into @_returning_columns_for_insert (a per-class ivar,
+  // model_schema.rb:437) and clears it in reload_schema_from_cache; the `||=`
+  // is mirrored here, with the clear in resetColumnInformation (which is what
+  // trails' reloadSchemaFromCache delegates to).
+  const memo = this._returningColumnsForInsertCache;
+  if (memo !== undefined) return memo;
   const cols = columns.call(this) as { name: string; isAutoPopulated?: unknown }[];
+  const memoize = (value: string[]): string[] => (this._returningColumnsForInsertCache = value);
   const autoPopulated = cols
     .filter(
       (c) => typeof c.isAutoPopulated === "function" && connection.returnValueAfterInsert?.(c),
     )
     .map((c) => c.name);
-  if (autoPopulated.length > 0) return (this._returningColumnsForInsertCache = autoPopulated);
+  if (autoPopulated.length > 0) return memoize(autoPopulated);
   // PK fallback. Restrict to columns that actually exist on the table: Rails
   // reflects `primary_key` as nil for a table without that column (e.g. an
   // id-less HABTM join table whose model still defaults `primary_key` to "id"),
@@ -621,7 +621,7 @@ export function _returningColumnsForInsert(
   const colNames = new Set(cols.map((c) => c.name));
   const pk = this.primaryKey;
   const pkArr = Array.isArray(pk) ? pk : pk ? [pk] : [];
-  return (this._returningColumnsForInsertCache = pkArr.filter((p) => colNames.has(p)));
+  return memoize(pkArr.filter((p) => colNames.has(p)));
 }
 
 export function resetSequenceName(this: SchemaHost): void {

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -532,6 +532,7 @@ interface SchemaHost {
   _defaultAttributes(): { deepDup(): { toHash(): Record<string, unknown> } };
   _columnsHash?: Record<string, unknown>;
   _columns?: any[];
+  _returningColumnsForInsertCache?: string[];
   _attributesBuilder?: any;
   _schemaLoaded?: boolean;
   _virtualAttributesReconciled?: boolean;
@@ -598,13 +599,20 @@ export function _returningColumnsForInsert(
   // reflected Column objects implement; the synthesized column-hash fallback (used
   // before the schema cache is warm) holds plain shapes, so skip those — they
   // carry no auto-increment metadata and the PK fallback below covers them.
+  // Rails memoizes into @_returning_columns_for_insert (a per-class ivar), cleared
+  // by reload_schema_from_cache. Check own-property so an STI subclass doesn't
+  // inherit the base's memo through the prototype chain.
+  if (Object.prototype.hasOwnProperty.call(this, "_returningColumnsForInsertCache")) {
+    const memo = this._returningColumnsForInsertCache;
+    if (memo !== undefined) return memo;
+  }
   const cols = columns.call(this) as { name: string; isAutoPopulated?: unknown }[];
   const autoPopulated = cols
     .filter(
       (c) => typeof c.isAutoPopulated === "function" && connection.returnValueAfterInsert?.(c),
     )
     .map((c) => c.name);
-  if (autoPopulated.length > 0) return autoPopulated;
+  if (autoPopulated.length > 0) return (this._returningColumnsForInsertCache = autoPopulated);
   // PK fallback. Restrict to columns that actually exist on the table: Rails
   // reflects `primary_key` as nil for a table without that column (e.g. an
   // id-less HABTM join table whose model still defaults `primary_key` to "id"),
@@ -613,7 +621,7 @@ export function _returningColumnsForInsert(
   const colNames = new Set(cols.map((c) => c.name));
   const pk = this.primaryKey;
   const pkArr = Array.isArray(pk) ? pk : pk ? [pk] : [];
-  return pkArr.filter((p) => colNames.has(p));
+  return (this._returningColumnsForInsertCache = pkArr.filter((p) => colNames.has(p)));
 }
 
 export function resetSequenceName(this: SchemaHost): void {
@@ -812,6 +820,7 @@ export function resetColumnInformation(this: SchemaHost): void {
       "_schemaLoaded",
       "_cachedDefaultAttributes",
       "_virtualAttributesReconciled",
+      "_returningColumnsForInsertCache",
     ]) {
       if (Object.prototype.hasOwnProperty.call(this, key)) Reflect.deleteProperty(this, key);
     }
@@ -834,6 +843,7 @@ export function resetColumnInformation(this: SchemaHost): void {
   }
   this._columnsHash = undefined;
   this._columns = undefined;
+  this._returningColumnsForInsertCache = undefined;
   this._attributesBuilder = undefined;
   this._schemaLoaded = false;
   this._virtualAttributesReconciled = false;

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -599,12 +599,17 @@ export function _returningColumnsForInsert(
   // reflected Column objects implement; the synthesized column-hash fallback (used
   // before the schema cache is warm) holds plain shapes, so skip those — they
   // carry no auto-increment metadata and the PK fallback below covers them.
-  // Rails memoizes into @_returning_columns_for_insert (a per-class ivar,
-  // model_schema.rb:437) and clears it in reload_schema_from_cache; the `||=`
-  // is mirrored here, with the clear in resetColumnInformation (which is what
-  // trails' reloadSchemaFromCache delegates to).
-  const memo = this._returningColumnsForInsertCache;
-  if (memo !== undefined) return memo;
+  // Rails memoizes into @_returning_columns_for_insert (model_schema.rb:437)
+  // and clears it in reload_schema_from_cache; the `||=` is mirrored here, with
+  // the clear in resetColumnInformation (what trails' reloadSchemaFromCache
+  // delegates to). Ruby class instance variables are NOT inherited, so that
+  // memo is genuinely per-class -- hence the own-property check: a plain static
+  // read walks the JS prototype chain and would hand a subclass on a different
+  // table the base's list.
+  if (Object.prototype.hasOwnProperty.call(this, "_returningColumnsForInsertCache")) {
+    const memo = this._returningColumnsForInsertCache;
+    if (memo !== undefined) return memo;
+  }
   const cols = columns.call(this) as { name: string; isAutoPopulated?: unknown }[];
   const memoize = (value: string[]): string[] => (this._returningColumnsForInsertCache = value);
   const autoPopulated = cols


### PR DESCRIPTION
Rails memoizes `@_returning_columns_for_insert` per-class (vendored v8.0.2 `activerecord/lib/active_record/model_schema.rb:437`, the `||=` block) and clears it in `reload_schema_from_cache` (`model_schema.rb:554`). trails' `_returningColumnsForInsert` recomputed the `autoPopulated` filter over `columns()` on every call — once per INSERT since #4111.

## Changes

- Memoize into `_returningColumnsForInsertCache` (added to `SchemaHost`), assigned on both return paths. The read is an own-property check so an STI subclass does not inherit the base's memo through the prototype chain.
- `resetColumnInformation` clears it on both branches: added to the STI delete-key loop and set to `undefined` in the base path.
- trails-only tests (no upstream counterpart for the memo itself): the filter runs once per class, and recomputes after `resetColumnInformation`.

No behavior change — same columns returned, just computed once.

Closes-story: returning-columns-for-insert-memoize
