### PR TITLE
refactor(test-harness): select backend by ARCONN, detail it by sub-settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -988,10 +988,17 @@ jobs:
       - run: pnpm vitest run packages/activerecord/ --shard=${{ matrix.shard }}/2
         env:
           ARCONN: postgresql
-          PG_TEST_URL: postgres://postgres:postgres@localhost:5432/rails_js_test
+          PGHOST: localhost
+          PGPORT: "5432"
+          PGUSER: postgres
+          PGPASSWORD: postgres
+          PGDATABASE: rails_js_test
           AR_DB_FORKS: 8
       # CLI E2E is not sharded — run it once, on shard 1 only, to avoid a
       # redundant double-run across the two legs.
+      # PG_TEST_URL is the activerecord-cli E2E's own input (it drives the CLI's
+      # --database-url flag), not the activerecord harness's backend selector.
+      # It stays a URL because that is literally what the CLI takes.
       - if: ${{ matrix.shard == 1 }}
         run: pnpm vitest run packages/activerecord-cli
         env:
@@ -1049,9 +1056,12 @@ jobs:
       - run: pnpm vitest run packages/activerecord/
         env:
           ARCONN: mysql2
-          MYSQL_TEST_URL: mysql://root@localhost:3306/rails_js_test
+          MYSQL_HOST: localhost
+          MYSQL_PORT: "3306"
+          MYSQL_USER: root
+          MYSQL_DATABASE: rails_js_test
           AR_DB_FORKS: 8
-      # No MYSQL_TEST_URL: no mysql-happy-path E2E exists yet. This run
+      # No MySQL connection env: no mysql-happy-path E2E exists yet. This run
       # covers the SQLite E2E until a mysql suite lands and can be wired up.
       - run: pnpm vitest run packages/activerecord-cli
 
@@ -1113,9 +1123,12 @@ jobs:
       - run: pnpm vitest run packages/activerecord/ --shard=${{ matrix.shard }}/2
         env:
           ARCONN: mysql2
-          MYSQL_TEST_URL: mysql://root@localhost:3306/rails_js_test
+          MYSQL_HOST: localhost
+          MYSQL_PORT: "3306"
+          MYSQL_USER: root
+          MYSQL_DATABASE: rails_js_test
           AR_DB_FORKS: 8
-      # No MYSQL_TEST_URL: no mysql-happy-path E2E exists yet. This run
+      # No MySQL connection env: no mysql-happy-path E2E exists yet. This run
       # covers the SQLite E2E until a mysql suite lands and can be wired up.
       # CLI E2E is not sharded — run it once, on shard 1 only.
       - if: ${{ matrix.shard == 1 }}

--- a/README.md
+++ b/README.md
@@ -264,10 +264,10 @@ Every sub-setting has a working default (`localhost`, the stock port, and the
 `ARCONN`. An empty value counts as unset. `ARCONN=sqlite3_mem` selects the pure
 `:memory:` lane.
 
-`MYSQL_SOCK` reaches the primary connection and the template provisioning that
-builds each worker's database. The adapter-specific probe suites
-(`describeIfMysql` / `describeIfPg` in `adapters/*/test-helper.ts`) still build
-a URL, and a URL cannot carry a socket path — those connect over TCP.
+Defaults are a trails choice matching what CI provisions, not Rails parity:
+Rails hard-codes `username: rails` and interpolates only host/port/socket
+(`vendor/rails/activerecord/test/config.example.yml`). `ARCONN` selecting the
+backend is the part that mirrors Rails.
 
 The `SchemaAdapter` wrapper auto-creates tables from model attribute definitions, so tests don't need manual DDL.
 

--- a/README.md
+++ b/README.md
@@ -264,9 +264,10 @@ Every sub-setting has a working default (`localhost`, the stock port, and the
 `ARCONN`. An empty value counts as unset. `ARCONN=sqlite3_mem` selects the pure
 `:memory:` lane.
 
-`MYSQL_SOCK` reaches the primary connection only. The adapter-specific probe
-suites (`describeIfMysql` / `describeIfPg` in `adapters/*/test-helper.ts`) still
-build a URL, and a URL cannot carry a socket path — they connect over TCP.
+`MYSQL_SOCK` reaches the primary connection and the template provisioning that
+builds each worker's database. The adapter-specific probe suites
+(`describeIfMysql` / `describeIfPg` in `adapters/*/test-helper.ts`) still build
+a URL, and a URL cannot carry a socket path — those connect over TCP.
 
 The `SchemaAdapter` wrapper auto-creates tables from model attribute definitions, so tests don't need manual DDL.
 

--- a/README.md
+++ b/README.md
@@ -261,7 +261,12 @@ Connection _details_ come from discrete sub-setting env vars.
 
 Every sub-setting has a working default (`localhost`, the stock port, and the
 `rails_js_test` database), so a local server on default ports needs only
-`ARCONN`. `ARCONN=sqlite3_mem` selects the pure `:memory:` lane.
+`ARCONN`. An empty value counts as unset. `ARCONN=sqlite3_mem` selects the pure
+`:memory:` lane.
+
+`MYSQL_SOCK` reaches the primary connection only. The adapter-specific probe
+suites (`describeIfMysql` / `describeIfPg` in `adapters/*/test-helper.ts`) still
+build a URL, and a URL cannot carry a socket path — they connect over TCP.
 
 The `SchemaAdapter` wrapper auto-creates tables from model attribute definitions, so tests don't need manual DDL.
 

--- a/README.md
+++ b/README.md
@@ -249,11 +249,19 @@ CI runs `test:compare` and `api:compare` on every push to ensure we don't regres
 
 Tests run against all three database backends in CI:
 
-| Backend          | How to run locally                           | Env variable     |
-| ---------------- | -------------------------------------------- | ---------------- |
-| SQLite (default) | `pnpm vitest run`                            | (none)           |
-| PostgreSQL       | `PG_TEST_URL=postgres://... pnpm vitest run` | `PG_TEST_URL`    |
-| MySQL/MariaDB    | `MYSQL_TEST_URL=mysql://... pnpm vitest run` | `MYSQL_TEST_URL` |
+Which backend runs is selected by `ARCONN`, naming a connection exactly as
+Rails' `test/config.yml` does — never by the presence of a connection detail.
+Connection _details_ come from discrete sub-setting env vars.
+
+| Backend          | How to run locally                  | Connection sub-settings                                                               |
+| ---------------- | ----------------------------------- | ------------------------------------------------------------------------------------- |
+| SQLite (default) | `pnpm vitest run`                   | (none)                                                                                |
+| PostgreSQL       | `ARCONN=postgresql pnpm vitest run` | `PGHOST` `PGPORT` `PGUSER` `PGPASSWORD` `PGDATABASE`                                  |
+| MySQL/MariaDB    | `ARCONN=mysql2 pnpm vitest run`     | `MYSQL_HOST` `MYSQL_PORT` `MYSQL_SOCK` `MYSQL_USER` `MYSQL_PASSWORD` `MYSQL_DATABASE` |
+
+Every sub-setting has a working default (`localhost`, the stock port, and the
+`rails_js_test` database), so a local server on default ports needs only
+`ARCONN`. `ARCONN=sqlite3_mem` selects the pure `:memory:` lane.
 
 The `SchemaAdapter` wrapper auto-creates tables from model attribute definitions, so tests don't need manual DDL.
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:watch": "vitest",
     "test:types": "vitest run --config vitest.dx-tests.config.ts",
     "test:types:virtualized": "tsc -b packages/activerecord-cli && node packages/activerecord-cli/dist/tsc-wrapper/cli.js -p packages/activerecord/virtualized-dx-tests/tsconfig.json",
-    "test:db": "PG_TEST_URL=postgres://postgres:postgres@localhost:25432/rails_js_test MYSQL_TEST_URL=mysql://root@localhost:13306/rails_js_test vitest run",
+    "test:db": "ARCONN=postgresql PGHOST=localhost PGPORT=25432 PGUSER=postgres PGPASSWORD=postgres PGDATABASE=rails_js_test MYSQL_HOST=localhost MYSQL_PORT=13306 MYSQL_USER=root MYSQL_DATABASE=rails_js_test vitest run",
     "db:up": "docker compose up -d --wait",
     "db:down": "docker compose down",
     "api:compare": "bash scripts/api-compare/run.sh",

--- a/packages/activerecord-cli/src/__e2e__/mysql-happy-path.test.ts
+++ b/packages/activerecord-cli/src/__e2e__/mysql-happy-path.test.ts
@@ -1,5 +1,6 @@
 // MySQL E2E suite — mirrors sqlite-happy-path.test.ts and postgres-happy-path.test.ts.
-// Set MYSQL_TEST_URL to run (same var used by packages/activerecord MySQL test suite).
+// Set MYSQL_TEST_URL to run. This is the CLI's own input (it feeds --database-url);
+// the activerecord harness selects its backend with ARCONN + sub-settings instead.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { readdir, writeFile } from "fs/promises";

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
@@ -3,14 +3,18 @@ import mysql from "mysql2/promise";
 import { Mysql2Adapter } from "../../connection-adapters/mysql2-adapter.js";
 import { Version } from "../../connection-adapters/abstract-adapter.js";
 import { arunitDatabaseNames } from "../../test-helpers/arunit2-config.js";
+import { mysqlSettings, mysqlUrl } from "../../test-helpers/test-connection-env.js";
 
 // `dbWarningsAction` is a single global setting on the base adapter, so the
 // shared helper toggles it for every adapter (including MySQL). Re-exported
 // here so MySQL adapter tests can keep importing it from this module.
 export { withDbWarningsAction } from "../../test-helpers/with-db-warnings-action.js";
 
-export const MYSQL_TEST_URL =
-  process.env.MYSQL_TEST_URL ?? "mysql://root@localhost:3306/rails_js_test";
+// A *serialization* of the MySQL sub-settings (MYSQL_HOST/MYSQL_PORT/
+// MYSQL_USER/...), not an env var of its own: these adapter suites probe the
+// server directly via describeIfMysql regardless of ARCONN, so they need a URL
+// to hand the driver, but they no longer source one from the environment.
+export const MYSQL_TEST_URL = mysqlUrl();
 
 export { databaseName } from "../../test-helpers/arunit2-config.js";
 
@@ -19,14 +23,15 @@ export { databaseName } from "../../test-helpers/arunit2-config.js";
  * `arunit2` — and reads both names from `ARTest.test_configuration_hashes`.
  * Rails' cross-database-select probe references them by those configured
  * names rather than inventing throwaway databases. trails provisions a single
- * MySQL server (`MYSQL_TEST_URL`), so the names are derived from that config
+ * MySQL server, so the names are derived from its `database` sub-setting
  * by suffixing the primary database (see `arunit2-config`). They are dedicated
  * to the cross-database probe — kept off the shared primary, whose canonical
  * tables parallel test workers create and drop — but config-derived, not
  * invented per call.
  */
-export const { arunit: ARUNIT_DATABASE, arunit2: ARUNIT2_DATABASE } =
-  arunitDatabaseNames(MYSQL_TEST_URL);
+export const { arunit: ARUNIT_DATABASE, arunit2: ARUNIT2_DATABASE } = arunitDatabaseNames(
+  mysqlSettings().database,
+);
 
 let mysqlAvailable = false;
 let mariaDb = false;

--- a/packages/activerecord/src/adapters/postgresql/test-helper.ts
+++ b/packages/activerecord/src/adapters/postgresql/test-helper.ts
@@ -4,8 +4,13 @@ import { PostgreSQLAdapter } from "../../connection-adapters/postgresql-adapter.
 import { pgDatetimeConfig } from "../../connection-adapters/postgresql/pg-datetime-config.js";
 import { Notifications, squish } from "@blazetrails/activesupport";
 import type { NotificationSubscriber, NotificationEvent } from "@blazetrails/activesupport";
+import { postgresUrl } from "../../test-helpers/test-connection-env.js";
 
-export const PG_TEST_URL = process.env.PG_TEST_URL ?? "postgres://localhost:5432/rails_js_test";
+// A *serialization* of the PG sub-settings (PGHOST/PGPORT/PGUSER/PGPASSWORD/
+// PGDATABASE), not an env var of its own: these adapter suites probe the server
+// directly via describeIfPg regardless of ARCONN, so they need a URL to hand
+// the driver, but they no longer source one from the environment.
+export const PG_TEST_URL = postgresUrl();
 
 let pgAvailable = false;
 let pgServerVersionNum = 0;

--- a/packages/activerecord/src/insert-all.test.ts
+++ b/packages/activerecord/src/insert-all.test.ts
@@ -1242,7 +1242,7 @@ describe("InsertAllTest", () => {
 
   // Rails gates this on current_adapter?(:Mysql2) (insert_all_test.rb) and
   // qualifies the table with `Book.connection_db_config.database`. The
-  // per-worker slot DB suffixed onto MYSQL_TEST_URL (test-setup-worker-db.ts)
+  // per-worker slot DB derived from AR_DB_SLOT (test-setup-worker-db.ts)
   // now surfaces on the db_config hash, so we read it the Rails way.
   it.skipIf(adapterType !== "mysql")("insert all when table name contains database", async () => {
     const databaseName = Book.connectionDbConfig().database;

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -31,8 +31,8 @@ import { Base } from "./base.js";
 import { getEnv } from "@blazetrails/activesupport";
 import {
   activeLane,
+  driverConfig,
   mysqlSettings,
-  mysqlUrl,
   postgresSettings,
 } from "./test-helpers/test-connection-env.js";
 
@@ -88,9 +88,9 @@ export type LeasedTestAdapter = DatabaseAdapter & {
 // instead of hardcoding `adapter: "sqlite3"`.
 const _primaryConfiguration: Record<string, unknown> =
   adapterType === "postgres"
-    ? { adapter: "postgresql", ...postgresSettings() }
+    ? { adapter: "postgresql", ...driverConfig(postgresSettings()) }
     : adapterType === "mysql"
-      ? { adapter: "mysql2", ...mysqlSettings() }
+      ? { adapter: "mysql2", ...driverConfig(mysqlSettings()) }
       : { adapter: "sqlite3", database: getEnv("AR_TEST_WORKER_DB") ?? ":memory:" };
 
 /**
@@ -118,25 +118,20 @@ export function ambientPoolConfiguration(): Record<string, unknown> {
 export let newRawTestAdapter: () => DatabaseAdapter;
 
 if (adapterType === "postgres") {
-  const { host, port, user, password, database } = postgresSettings();
+  const config = driverConfig(postgresSettings());
   const { PostgreSQLAdapter } = await import("./connection-adapters/postgresql-adapter.js");
   // Constrain the driver pool to max: 1 so each pooled-adapter slot maps to
   // exactly one PG server connection (the outer ConnectionPool multiplexes).
   newRawTestAdapter = () =>
-    new PostgreSQLAdapter({
-      host,
-      port,
-      user,
-      password,
-      database,
-      max: 1,
-    }) as unknown as DatabaseAdapter;
+    new PostgreSQLAdapter({ ...config, max: 1 }) as unknown as DatabaseAdapter;
 } else if (adapterType === "mysql") {
-  const uri = mysqlUrl();
+  // Built from the config hash rather than a URL so a socket-configured run
+  // (MYSQL_SOCK) reaches the driver — a URL cannot carry a socket path.
+  const config = driverConfig(mysqlSettings());
   const { Mysql2Adapter } = await import("./connection-adapters/mysql2-adapter.js");
   newRawTestAdapter = () =>
     new Mysql2Adapter({
-      uri,
+      ...config,
       connectionLimit: 1,
       flags: ["FOUND_ROWS"],
     }) as unknown as DatabaseAdapter;

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -1,10 +1,12 @@
 /**
  * Shared test adapter helpers.
  *
- * Resolves which backend the active lane uses from the environment:
- *   - PG_TEST_URL    → PostgreSQLAdapter
- *   - MYSQL_TEST_URL → Mysql2Adapter
- *   - (default)      → SQLite3Adapter (the per-worker template clone, or
+ * Resolves which backend the active lane uses the way Rails does — from
+ * `ARCONN` naming a key of the `connections:` hash, never from the presence of
+ * a connection detail (see `test-helpers/test-connection-env.ts`):
+ *   - ARCONN=postgresql → PostgreSQLAdapter
+ *   - ARCONN=mysql2     → Mysql2Adapter
+ *   - (default)         → SQLite3Adapter (the per-worker template clone, or
  *     `:memory:` when no clone was built)
  *
  * RFC 0059 retired the standing sidecar `_pool`: Rails has no sidecar test
@@ -27,18 +29,19 @@ import type { TransactionManager } from "./connection-adapters/abstract/transact
 import { resetTestTables } from "./test-helpers/drop-all-tables.js";
 import { Base } from "./base.js";
 import { getEnv } from "@blazetrails/activesupport";
+import {
+  activeLane,
+  mysqlSettings,
+  mysqlUrl,
+  postgresSettings,
+} from "./test-helpers/test-connection-env.js";
 
-// PG_TEST_URL / MYSQL_TEST_URL are already worker-scoped by
-// test-setup-worker-db.ts (a setupFile that runs before this module loads).
-const PG_TEST_URL = getEnv("PG_TEST_URL");
-const MYSQL_TEST_URL = getEnv("MYSQL_TEST_URL");
-
-/** Which adapter backend is active. */
-export const adapterType: "sqlite" | "postgres" | "mysql" = PG_TEST_URL
-  ? "postgres"
-  : MYSQL_TEST_URL
-    ? "mysql"
-    : "sqlite";
+/**
+ * Which adapter backend is active. Read once at module load — the worker's
+ * isolation slot is published by test-setup-worker-db.ts (a setupFile that runs
+ * before this module loads), so the settings below are already worker-scoped.
+ */
+export const adapterType: "sqlite" | "postgres" | "mysql" = activeLane();
 
 /**
  * Mirror of Rails' `in_memory_db?`
@@ -83,11 +86,12 @@ export type LeasedTestAdapter = DatabaseAdapter & {
 // `ActiveRecord::Base.connection_pool.db_config.configuration_hash`, letting
 // pool-mechanics tests clone the ambient config (with per-test overrides)
 // instead of hardcoding `adapter: "sqlite3"`.
-const _primaryConfiguration: Record<string, unknown> = PG_TEST_URL
-  ? { adapter: "postgresql", url: PG_TEST_URL }
-  : MYSQL_TEST_URL
-    ? { adapter: "mysql2", url: MYSQL_TEST_URL }
-    : { adapter: "sqlite3", database: getEnv("AR_TEST_WORKER_DB") ?? ":memory:" };
+const _primaryConfiguration: Record<string, unknown> =
+  adapterType === "postgres"
+    ? { adapter: "postgresql", ...postgresSettings() }
+    : adapterType === "mysql"
+      ? { adapter: "mysql2", ...mysqlSettings() }
+      : { adapter: "sqlite3", database: getEnv("AR_TEST_WORKER_DB") ?? ":memory:" };
 
 /**
  * A copy of the active lane's primary configuration hash. Mirrors Rails'
@@ -113,17 +117,26 @@ export function ambientPoolConfiguration(): Record<string, unknown> {
  */
 export let newRawTestAdapter: () => DatabaseAdapter;
 
-if (PG_TEST_URL) {
+if (adapterType === "postgres") {
+  const { host, port, user, password, database } = postgresSettings();
   const { PostgreSQLAdapter } = await import("./connection-adapters/postgresql-adapter.js");
   // Constrain the driver pool to max: 1 so each pooled-adapter slot maps to
   // exactly one PG server connection (the outer ConnectionPool multiplexes).
   newRawTestAdapter = () =>
-    new PostgreSQLAdapter({ connectionString: PG_TEST_URL, max: 1 }) as unknown as DatabaseAdapter;
-} else if (MYSQL_TEST_URL) {
+    new PostgreSQLAdapter({
+      host,
+      port,
+      user,
+      password,
+      database,
+      max: 1,
+    }) as unknown as DatabaseAdapter;
+} else if (adapterType === "mysql") {
+  const uri = mysqlUrl();
   const { Mysql2Adapter } = await import("./connection-adapters/mysql2-adapter.js");
   newRawTestAdapter = () =>
     new Mysql2Adapter({
-      uri: MYSQL_TEST_URL,
+      uri,
       connectionLimit: 1,
       flags: ["FOUND_ROWS"],
     }) as unknown as DatabaseAdapter;

--- a/packages/activerecord/src/test-helpers/arunit2-config.test.ts
+++ b/packages/activerecord/src/test-helpers/arunit2-config.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  arunit2Url,
   arunitDatabaseNames,
   databaseName,
   resolveSecondDatabaseConfig,
@@ -18,44 +17,46 @@ describe("arunit2-config", () => {
   });
 
   it("arunitDatabaseNames suffixes the primary database name", () => {
-    expect(arunitDatabaseNames("mysql://root@localhost:3306/rails_js_test")).toEqual({
+    expect(arunitDatabaseNames("rails_js_test")).toEqual({
       arunit: "rails_js_test_arunit",
       arunit2: "rails_js_test_arunit2",
     });
   });
 
-  it("arunit2Url swaps the database while preserving host, port, and credentials", () => {
-    expect(arunit2Url("mysql://root:pw@db.example:3307/rails_js_test")).toBe(
-      "mysql://root:pw@db.example:3307/rails_js_test_arunit2",
+  it("resolves Postgres when ARCONN names the postgresql connection", () => {
+    expect(
+      resolveSecondDatabaseConfig(
+        reader({ ARCONN: "postgresql", PGHOST: "db.example", PGDATABASE: "ar_test" }),
+      ),
+    ).toEqual({
+      adapter: "postgres",
+      config: "postgres://postgres@db.example:5432/ar_test_arunit2",
+    });
+  });
+
+  it("resolves MySQL when ARCONN names the mysql2 connection", () => {
+    expect(resolveSecondDatabaseConfig(reader({ ARCONN: "mysql2" }))).toEqual({
+      adapter: "mysql",
+      config: "mysql://root@localhost:3306/rails_js_test_arunit2",
+    });
+  });
+
+  it("carries the worker isolation slot into the arunit2 database name", () => {
+    expect(resolveSecondDatabaseConfig(reader({ ARCONN: "mysql2", AR_DB_SLOT: "3" })).config).toBe(
+      "mysql://root@localhost:3306/rails_js_test_3_arunit2",
     );
   });
 
-  it("resolves Postgres when PG_TEST_URL is set", () => {
+  it("ignores connection sub-settings when ARCONN does not select that backend", () => {
+    // The whole point of the ARCONN split: a PG host in the environment must
+    // not drag the second database onto Postgres.
     expect(
-      resolveSecondDatabaseConfig(reader({ PG_TEST_URL: "postgres://localhost/ar_test" })),
-    ).toEqual({ adapter: "postgres", config: "postgres://localhost/ar_test_arunit2" });
+      resolveSecondDatabaseConfig(reader({ PGHOST: "db.example", MYSQL_HOST: "mysql.example" }))
+        .adapter,
+    ).toBe("sqlite");
   });
 
-  it("resolves MySQL when MYSQL_TEST_URL is set and PG is not", () => {
-    expect(
-      resolveSecondDatabaseConfig(
-        reader({ MYSQL_TEST_URL: "mysql://root@localhost:3306/rails_js_test" }),
-      ),
-    ).toEqual({ adapter: "mysql", config: "mysql://root@localhost:3306/rails_js_test_arunit2" });
-  });
-
-  it("prefers Postgres over MySQL when both URLs are present", () => {
-    expect(
-      resolveSecondDatabaseConfig(
-        reader({
-          PG_TEST_URL: "postgres://localhost/ar_test",
-          MYSQL_TEST_URL: "mysql://root@localhost:3306/rails_js_test",
-        }),
-      ).adapter,
-    ).toBe("postgres");
-  });
-
-  it("falls back to a separate in-memory SQLite pool with no env URLs", () => {
+  it("falls back to a separate in-memory SQLite pool when ARCONN is unset", () => {
     expect(resolveSecondDatabaseConfig(reader({}))).toEqual({
       adapter: "sqlite",
       config: { adapter: "sqlite3", database: ":memory:", pool: 1 },

--- a/packages/activerecord/src/test-helpers/arunit2-config.test.ts
+++ b/packages/activerecord/src/test-helpers/arunit2-config.test.ts
@@ -41,6 +41,16 @@ describe("arunit2-config", () => {
     });
   });
 
+  it("carries MYSQL_SOCK into the arunit2 connection", () => {
+    // Rails puts the socket in mysql2.arunit2 as well as mysql2.arunit
+    // (config.example.yml:37-39) before ARUnit2Model.establish_connection
+    // :arunit2 (connection.rb:33), so the second database must reach the
+    // socket too — not just the primary.
+    expect(
+      resolveSecondDatabaseConfig(reader({ ARCONN: "mysql2", MYSQL_SOCK: "/tmp/m.sock" })).config,
+    ).toBe("mysql://root@localhost:3306/rails_js_test_arunit2?socketPath=%2Ftmp%2Fm.sock");
+  });
+
   it("carries the worker isolation slot into the arunit2 database name", () => {
     expect(resolveSecondDatabaseConfig(reader({ ARCONN: "mysql2", AR_DB_SLOT: "3" })).config).toBe(
       "mysql://root@localhost:3306/rails_js_test_3_arunit2",

--- a/packages/activerecord/src/test-helpers/arunit2-config.ts
+++ b/packages/activerecord/src/test-helpers/arunit2-config.ts
@@ -8,12 +8,12 @@
  * `arunit2`; the cross-database-select probe references both by their
  * configured names.
  *
- * trails provisions a single server per adapter (`MYSQL_TEST_URL` /
- * `PG_TEST_URL`), so rather than maintaining a separate config file we derive
- * the two database names from the primary connection URL by suffixing. This
- * keeps the names config-derived (not invented per call) and dedicated to the
- * cross-pool work — off the shared primary database whose canonical tables
- * parallel workers create and drop.
+ * trails provisions a single server per adapter, so rather than maintaining a
+ * separate config file we derive the two database names from the primary
+ * connection's `database` sub-setting by suffixing. This keeps the names
+ * config-derived (not invented per call) and dedicated to the cross-pool
+ * work — off the shared primary database whose canonical tables parallel
+ * workers create and drop.
  *
  * Hard rules (RFC 0023): no `node:*` imports, no `process.*` — environment
  * reads go through activesupport's `getEnv`; async fs only (none needed here).
@@ -22,8 +22,17 @@
  */
 
 import { getEnv } from "@blazetrails/activesupport";
+import {
+  activeLane,
+  mysqlSettings,
+  postgresSettings,
+  settingsUrl,
+  withDatabase,
+  type EnvReader,
+  type TestAdapterName,
+} from "./test-connection-env.js";
 
-export type TestAdapterName = "sqlite" | "postgres" | "mysql";
+export type { TestAdapterName };
 
 const ARUNIT_SUFFIX = "_arunit";
 const ARUNIT2_SUFFIX = "_arunit2";
@@ -33,26 +42,17 @@ export function databaseName(url: string): string {
   return new URL(url).pathname.replace(/^\//, "");
 }
 
-/** Return a copy of `url` with its database (path) swapped to `database`. */
-function swapDatabase(url: string, database: string): string {
-  const u = new URL(url);
-  u.pathname = `/${database}`;
-  return u.toString();
-}
-
 /**
- * The config-derived `arunit` / `arunit2` database names for a primary URL.
- * Both are the primary database name plus a fixed suffix, mirroring how
- * `ARTest.test_configuration_hashes` exposes two named databases.
+ * The config-derived `arunit` / `arunit2` database names for a primary
+ * database. Both are the primary database name plus a fixed suffix, mirroring
+ * how `ARTest.test_configuration_hashes` exposes two named databases.
  */
-export function arunitDatabaseNames(primaryUrl: string): { arunit: string; arunit2: string } {
-  const base = databaseName(primaryUrl);
+export function arunitDatabaseNames(primaryDatabase: string): {
+  arunit: string;
+  arunit2: string;
+} {
+  const base = primaryDatabase;
   return { arunit: `${base}${ARUNIT_SUFFIX}`, arunit2: `${base}${ARUNIT2_SUFFIX}` };
-}
-
-/** The `arunit2` connection URL derived from a primary URL. */
-export function arunit2Url(primaryUrl: string): string {
-  return swapDatabase(primaryUrl, arunitDatabaseNames(primaryUrl).arunit2);
 }
 
 /** A config accepted by `Model.establishConnection` (URL string or hash). */
@@ -65,8 +65,8 @@ export interface ResolvedSecondDatabase {
 
 /**
  * Resolve the second-database (`arunit2`) connection config for the adapter the
- * current worker is running against, from the same env signals
- * (`PG_TEST_URL` / `MYSQL_TEST_URL`) the primary harness uses. On sqlite the
+ * current worker is running against, from the same `ARCONN` + sub-settings
+ * the primary harness uses. On sqlite the
  * two databases are separate in-memory pools (a server-less analog of the
  * `arunit` / `arunit2` split); on Postgres/MySQL the config points at the
  * derived `arunit2` database on the shared server.
@@ -80,17 +80,22 @@ export interface ResolvedSecondDatabase {
  *
  * `read` is injectable so tests can exercise each adapter branch without
  * mutating the ambient environment; it defaults to activesupport's `getEnv`.
+ * Selection keys off `ARCONN` — the same signal the primary harness uses.
  */
-export function resolveSecondDatabaseConfig(
-  read: (key: string) => string | undefined = getEnv,
-): ResolvedSecondDatabase {
-  const pgUrl = read("PG_TEST_URL");
-  if (pgUrl) {
-    return { adapter: "postgres", config: arunit2Url(pgUrl) };
+export function resolveSecondDatabaseConfig(read: EnvReader = getEnv): ResolvedSecondDatabase {
+  const lane = activeLane(read);
+  if (lane === "postgres") {
+    const settings = postgresSettings(read);
+    const { arunit2 } = arunitDatabaseNames(settings.database);
+    return {
+      adapter: "postgres",
+      config: settingsUrl("postgres", withDatabase(settings, arunit2)),
+    };
   }
-  const mysqlUrl = read("MYSQL_TEST_URL");
-  if (mysqlUrl) {
-    return { adapter: "mysql", config: arunit2Url(mysqlUrl) };
+  if (lane === "mysql") {
+    const settings = mysqlSettings(read);
+    const { arunit2 } = arunitDatabaseNames(settings.database);
+    return { adapter: "mysql", config: settingsUrl("mysql", withDatabase(settings, arunit2)) };
   }
   return { adapter: "sqlite", config: { adapter: "sqlite3", database: ":memory:", pool: 1 } };
 }

--- a/packages/activerecord/src/test-helpers/ddl-profile.ts
+++ b/packages/activerecord/src/test-helpers/ddl-profile.ts
@@ -8,7 +8,7 @@
  * Not wired into CI; opt in for an ad-hoc measurement run, e.g.:
  *
  *   DDL_PROFILE=1 DDL_PROFILE_OUT_DIR=/tmp/ddlprof ARCONN=postgresql \
- *     PG_TEST_URL=postgres://… pnpm vitest run packages/activerecord/src/<file>
+ *     ARCONN=postgresql pnpm vitest run packages/activerecord/src/<file>
  *   node scripts/ddl-profile-aggregate.mjs /tmp/ddlprof
  *
  * See PR #3904 / the `ddl-timing-profile` audit for the methodology + findings.
@@ -292,8 +292,6 @@ function dumpSummary(): void {
       : `/tmp/ddl-profile-${process.env.ARCONN ?? "sqlite"}-${process.pid}.json`);
   const payload = {
     adapter: process.env.ARCONN ?? "sqlite3",
-    pgUrl: process.env.PG_TEST_URL ?? null,
-    mysqlUrl: process.env.MYSQL_TEST_URL ?? null,
     capturedAt: Temporal.Now.instant().toString(),
     totalCount: agg.totalCount,
     totalMs: agg.totalMs,

--- a/packages/activerecord/src/test-helpers/pg-template.test.ts
+++ b/packages/activerecord/src/test-helpers/pg-template.test.ts
@@ -10,7 +10,7 @@
  * The probe targets the template DB itself (deterministic, slot-independent)
  * rather than the worker's variably-assigned slot DB.
  *
- * Skipped automatically on sqlite/MySQL runs (PG_TEST_URL not set).
+ * Skipped automatically on sqlite/MySQL runs (ARCONN is not postgresql).
  */
 import { describe, it, expect } from "vitest";
 import pg from "pg";
@@ -18,8 +18,9 @@ import { generateSchemaFile } from "./schema-file-generator.js";
 import { schemaSha1 } from "../tasks/database-tasks.js";
 import { TEST_SCHEMA } from "./test-schema.js";
 import { PG_TEMPLATE_ENV } from "./template-global-setup.js";
+import { activeLane, postgresSettings, settingsUrl, withDatabase } from "./test-connection-env.js";
 
-const pgActive = Boolean(process.env.PG_TEST_URL);
+const pgActive = activeLane() === "postgres";
 
 describe.skipIf(!pgActive)("PG template-clone (Phase 1 probe)", () => {
   it("globalSetup provisioned the PG template for this run", () => {
@@ -38,10 +39,9 @@ describe.skipIf(!pgActive)("PG template-clone (Phase 1 probe)", () => {
     const expectedSha1 = await schemaSha1(schemaFile);
 
     const templateDb = process.env[PG_TEMPLATE_ENV]!;
-    const url = new URL(process.env.PG_TEST_URL!);
-    url.pathname = `/${templateDb}`;
+    const url = settingsUrl("postgres", withDatabase(postgresSettings(), templateDb));
 
-    const client = new pg.Client(url.toString());
+    const client = new pg.Client(url);
     await client.connect();
     try {
       const res = await client.query<{ value: string }>(

--- a/packages/activerecord/src/test-helpers/sqlite-template.ts
+++ b/packages/activerecord/src/test-helpers/sqlite-template.ts
@@ -38,6 +38,7 @@ import type { FsAdapter } from "@blazetrails/activesupport/fs-adapter";
 import { getFsAsync, getPathAsync } from "@blazetrails/activesupport/fs-adapter";
 import { getOsAsync } from "@blazetrails/activesupport";
 import { betterSqlite3Driver } from "../sqlite/better-sqlite3.js";
+import { activeLane } from "./test-connection-env.js";
 
 /** WAL sidecars sqlite writes alongside a file DB, plus the DB file itself. */
 const DB_FILE_SUFFIXES = ["", "-wal", "-shm"] as const;
@@ -63,9 +64,9 @@ export const RUN_TOKEN_ENV = "AR_TEST_RUN_TOKEN";
 /** Env var: per-worker restored DB path (stamped by the worker setupFile). */
 export const WORKER_DB_ENV = "AR_TEST_WORKER_DB";
 
-/** True when the active run targets sqlite (no PG/MySQL URL present). */
+/** True when the connection named by ARCONN rides a sqlite lane. */
 export function isSqliteRun(): boolean {
-  return !process.env.PG_TEST_URL && !process.env.MYSQL_TEST_URL;
+  return activeLane() === "sqlite";
 }
 
 /** Temp directory root, via the os-adapter so the path is portable (TMPDIR/TEMP/TMP). */

--- a/packages/activerecord/src/test-helpers/template-global-setup.ts
+++ b/packages/activerecord/src/test-helpers/template-global-setup.ts
@@ -33,6 +33,13 @@ import {
   unlinkDbFiles,
 } from "./sqlite-template.js";
 import { slotPoolSize, workerForkCount } from "./ar-db-slots.js";
+import {
+  activeLane,
+  mysqlSettings,
+  mysqlUrl,
+  postgresSettings,
+  postgresUrl,
+} from "./test-connection-env.js";
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -130,11 +137,11 @@ async function pgTerminateConnections(admin: pg.Client, dbName: string): Promise
 }
 
 const pgAdapter: DbTemplateAdapter = {
-  isActive: () => Boolean(process.env.PG_TEST_URL),
+  isActive: () => activeLane() === "postgres",
 
   async provision() {
-    const baseUrl = process.env.PG_TEST_URL!;
-    const baseDb = new URL(baseUrl).pathname.replace(/^\//, "");
+    const baseUrl = postgresUrl();
+    const baseDb = postgresSettings().database;
     const templateDb = `${baseDb}_template`;
 
     const admin = new pg.Client(pgAdminUrl(baseUrl));
@@ -223,12 +230,12 @@ function mysqlConnOpts(url: string): mysql.ConnectionOptions {
 }
 
 const mysqlAdapter: DbTemplateAdapter = {
-  isActive: () => Boolean(process.env.MYSQL_TEST_URL),
+  isActive: () => activeLane() === "mysql",
 
   async provision() {
     const { Mysql2Adapter } = await import("../connection-adapters/mysql2-adapter.js");
-    const baseUrl = process.env.MYSQL_TEST_URL!;
-    const baseDb = new URL(baseUrl).pathname.replace(/^\//, "");
+    const baseUrl = mysqlUrl();
+    const baseDb = mysqlSettings().database;
     const n = slotCount();
 
     // CREATE DATABASE for all slots first (sequential — DDL against the same

--- a/packages/activerecord/src/test-helpers/template-global-setup.ts
+++ b/packages/activerecord/src/test-helpers/template-global-setup.ts
@@ -35,10 +35,11 @@ import {
 import { slotPoolSize, workerForkCount } from "./ar-db-slots.js";
 import {
   activeLane,
+  driverConfig,
   mysqlSettings,
-  mysqlUrl,
   postgresSettings,
   postgresUrl,
+  withDatabase,
 } from "./test-connection-env.js";
 
 // ---------------------------------------------------------------------------
@@ -211,36 +212,21 @@ const pgAdapter: DbTemplateAdapter = {
 
 export const MYSQL_TEMPLATE_ENV = "AR_TEST_MYSQL_TEMPLATE";
 
-function mysqlSlotUrl(baseUrl: string, slot: number): string {
-  if (slot === 1) return baseUrl;
-  const u = new URL(baseUrl);
-  const db = u.pathname.replace(/^\//, "");
-  u.pathname = `/${db}_${slot}`;
-  return u.toString();
-}
-
-function mysqlConnOpts(url: string): mysql.ConnectionOptions {
-  const u = new URL(url);
-  return {
-    host: u.hostname,
-    port: u.port ? parseInt(u.port, 10) : 3306,
-    user: u.username || undefined,
-    password: u.password || undefined,
-  };
-}
-
 const mysqlAdapter: DbTemplateAdapter = {
   isActive: () => activeLane() === "mysql",
 
   async provision() {
     const { Mysql2Adapter } = await import("../connection-adapters/mysql2-adapter.js");
-    const baseUrl = mysqlUrl();
-    const baseDb = mysqlSettings().database;
+    const settings = mysqlSettings();
+    const baseDb = settings.database;
     const n = slotCount();
 
+    // Built from the config hash rather than a URL so a socket-configured run
+    // (MYSQL_SOCK) reaches the driver — a URL cannot carry a socket path.
+    const { database: _adminDb, ...adminOpts } = driverConfig(settings);
     // CREATE DATABASE for all slots first (sequential — DDL against the same
     // server, DROP/CREATE must not race with themselves).
-    const admin = await mysql.createConnection(mysqlConnOpts(baseUrl));
+    const admin = await mysql.createConnection(adminOpts as mysql.ConnectionOptions);
     for (let slot = 1; slot <= n; slot++) {
       const slotDb = slot === 1 ? baseDb : `${baseDb}_${slot}`;
       await admin.query(`DROP DATABASE IF EXISTS \`${slotDb}\``);
@@ -255,7 +241,7 @@ const mysqlAdapter: DbTemplateAdapter = {
     await Promise.all(
       Array.from({ length: n }, (_, i) => i + 1).map(async (slot) => {
         const adapter = new Mysql2Adapter({
-          uri: mysqlSlotUrl(baseUrl, slot),
+          ...driverConfig(withDatabase(settings, slot === 1 ? baseDb : `${baseDb}_${slot}`)),
           connectionLimit: 1,
           flags: ["FOUND_ROWS"],
         }) as unknown as DatabaseAdapter;

--- a/packages/activerecord/src/test-helpers/template-global-setup.ts
+++ b/packages/activerecord/src/test-helpers/template-global-setup.ts
@@ -38,7 +38,7 @@ import {
   driverConfig,
   mysqlSettings,
   postgresSettings,
-  postgresUrl,
+  settingsUrl,
   withDatabase,
 } from "./test-connection-env.js";
 
@@ -123,12 +123,6 @@ const sqliteAdapter: DbTemplateAdapter = {
 // means the PG template path did not run (sqlite/MySQL run, or globalSetup off).
 export const PG_TEMPLATE_ENV = "AR_TEST_PG_TEMPLATE";
 
-function pgAdminUrl(baseUrl: string): string {
-  const u = new URL(baseUrl);
-  u.pathname = "/postgres";
-  return u.toString();
-}
-
 async function pgTerminateConnections(admin: pg.Client, dbName: string): Promise<void> {
   await admin.query(
     `SELECT pg_terminate_backend(pid) FROM pg_stat_activity
@@ -141,21 +135,20 @@ const pgAdapter: DbTemplateAdapter = {
   isActive: () => activeLane() === "postgres",
 
   async provision() {
-    const baseUrl = postgresUrl();
-    const baseDb = postgresSettings().database;
-    const templateDb = `${baseDb}_template`;
+    const settings = postgresSettings();
+    const templateDb = `${settings.database}_template`;
 
-    const admin = new pg.Client(pgAdminUrl(baseUrl));
+    // Derive both connections from the settings rather than rewriting the URL
+    // string: a socket-directory PGHOST does not survive `new URL()` surgery.
+    const admin = new pg.Client(settingsUrl("postgres", withDatabase(settings, "postgres")));
     await admin.connect();
 
     await pgTerminateConnections(admin, templateDb);
     await admin.query(`DROP DATABASE IF EXISTS "${templateDb}"`);
     await admin.query(`CREATE DATABASE "${templateDb}"`);
 
-    const tplUrl = new URL(baseUrl);
-    tplUrl.pathname = `/${templateDb}`;
     const adapter = new PostgreSQLAdapter({
-      connectionString: tplUrl.toString(),
+      connectionString: settingsUrl("postgres", withDatabase(settings, templateDb)),
       max: 1,
     }) as unknown as DatabaseAdapter;
     try {
@@ -181,7 +174,7 @@ const pgAdapter: DbTemplateAdapter = {
     }
 
     for (let slot = 1; slot <= slotCount(); slot++) {
-      const slotDb = slot === 1 ? baseDb : `${baseDb}_${slot}`;
+      const slotDb = slot === 1 ? settings.database : `${settings.database}_${slot}`;
       await pgTerminateConnections(admin, slotDb);
       await admin.query(`DROP DATABASE IF EXISTS "${slotDb}"`);
       await admin.query(`CREATE DATABASE "${slotDb}" TEMPLATE "${templateDb}"`);
@@ -191,7 +184,7 @@ const pgAdapter: DbTemplateAdapter = {
     await admin.end();
 
     return async () => {
-      const cleanup = new pg.Client(pgAdminUrl(baseUrl));
+      const cleanup = new pg.Client(settingsUrl("postgres", withDatabase(settings, "postgres")));
       await cleanup.connect();
       await pgTerminateConnections(cleanup, templateDb);
       await cleanup.query(`DROP DATABASE IF EXISTS "${templateDb}"`);
@@ -228,7 +221,7 @@ const mysqlAdapter: DbTemplateAdapter = {
     // server, DROP/CREATE must not race with themselves).
     const admin = await mysql.createConnection(adminOpts as mysql.ConnectionOptions);
     for (let slot = 1; slot <= n; slot++) {
-      const slotDb = slot === 1 ? baseDb : `${baseDb}_${slot}`;
+      const slotDb = slot === 1 ? settings.database : `${settings.database}_${slot}`;
       await admin.query(`DROP DATABASE IF EXISTS \`${slotDb}\``);
       await admin.query(`CREATE DATABASE \`${slotDb}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_bin`);
     }

--- a/packages/activerecord/src/test-helpers/test-connection-env.test.ts
+++ b/packages/activerecord/src/test-helpers/test-connection-env.test.ts
@@ -101,11 +101,23 @@ describe("test-connection-env", () => {
     );
   });
 
-  it("refuses to serialize a socket-configured connection as a URL", () => {
-    // A URL cannot carry a socket path; rendering host:port instead would
-    // connect somewhere the caller never asked for.
+  it("carries MYSQL_SOCK through a rendered URL as socketPath", () => {
+    // Rails puts MYSQL_SOCK in both mysql2.arunit and mysql2.arunit2
+    // (config.example.yml:18-19,37-39), so every mysql path must preserve it.
+    // mysql2's parseUrl copies query params into its options and honours
+    // socketPath (connection_config.js:52,271-290) — verified against the
+    // driver, which attempts the socket rather than falling back to TCP.
     const settings = mysqlSettings(reader({ MYSQL_SOCK: "/tmp/mysql.sock" }));
-    expect(() => settingsUrl("mysql", settings)).toThrow(/Cannot render a connection URL/);
+    expect(settingsUrl("mysql", settings)).toBe(
+      "mysql://root@localhost:3306/rails_js_test?socketPath=%2Ftmp%2Fmysql.sock",
+    );
+  });
+
+  it("raises for a socket on the postgres scheme, which has no socket setting", () => {
+    // libpq spells a socket connection as PGHOST=/path, already carried as host.
+    expect(() =>
+      settingsUrl("postgres", { ...postgresSettings(reader({})), socket: "/tmp/pg.sock" }),
+    ).toThrow(/PGHOST=/);
   });
 
   it("renders settings as a URL, encoding credentials", () => {

--- a/packages/activerecord/src/test-helpers/test-connection-env.test.ts
+++ b/packages/activerecord/src/test-helpers/test-connection-env.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  activeLane,
+  connectionName,
+  mysqlSettings,
+  mysqlUrl,
+  postgresSettings,
+  postgresUrl,
+  withDatabase,
+} from "./test-connection-env.js";
+
+/** A stub env reader backed by a fixed map (no ambient env mutation). */
+function reader(env: Record<string, string | undefined>): (key: string) => string | undefined {
+  return (key) => env[key];
+}
+
+describe("test-connection-env", () => {
+  it("selects the connection named by ARCONN", () => {
+    expect(connectionName(reader({ ARCONN: "mysql2" }))).toBe("mysql2");
+    expect(activeLane(reader({ ARCONN: "mysql2" }))).toBe("mysql");
+    expect(activeLane(reader({ ARCONN: "postgresql" }))).toBe("postgres");
+    expect(activeLane(reader({ ARCONN: "sqlite3_mem" }))).toBe("sqlite");
+  });
+
+  it("falls back to the default_connection when ARCONN is unset or empty", () => {
+    expect(connectionName(reader({}))).toBe("sqlite3");
+    expect(activeLane(reader({ ARCONN: "" }))).toBe("sqlite");
+  });
+
+  it("never selects a backend from a connection sub-setting", () => {
+    // The regression this whole module exists to prevent: connection details
+    // present in the environment must not switch the lane on their own.
+    expect(activeLane(reader({ PGHOST: "db.example", MYSQL_HOST: "mysql.example" }))).toBe(
+      "sqlite",
+    );
+  });
+
+  it("reads Postgres details from libpq's env vars, with defaults", () => {
+    expect(postgresSettings(reader({}))).toEqual({
+      host: "localhost",
+      port: 5432,
+      user: "postgres",
+      password: undefined,
+      database: "rails_js_test",
+    });
+    expect(
+      postgresSettings(
+        reader({ PGHOST: "db", PGPORT: "6543", PGUSER: "u", PGPASSWORD: "p", PGDATABASE: "d" }),
+      ),
+    ).toEqual({ host: "db", port: 6543, user: "u", password: "p", database: "d" });
+  });
+
+  it("reads MySQL details from the sub-settings config.example.yml interpolates", () => {
+    expect(
+      mysqlSettings(
+        reader({ MYSQL_HOST: "db", MYSQL_PORT: "3307", MYSQL_SOCK: "/tmp/mysql.sock" }),
+      ),
+    ).toEqual({
+      host: "db",
+      port: 3307,
+      user: "root",
+      password: undefined,
+      database: "rails_js_test",
+      socket: "/tmp/mysql.sock",
+    });
+  });
+
+  it("suffixes the database with the worker isolation slot above slot 1", () => {
+    expect(postgresSettings(reader({ AR_DB_SLOT: "1" })).database).toBe("rails_js_test");
+    expect(postgresSettings(reader({ AR_DB_SLOT: "4" })).database).toBe("rails_js_test_4");
+    expect(mysqlSettings(reader({ AR_DB_SLOT: "2" })).database).toBe("rails_js_test_2");
+  });
+
+  it("renders settings as a URL, encoding credentials", () => {
+    expect(mysqlUrl(reader({}))).toBe("mysql://root@localhost:3306/rails_js_test");
+    expect(postgresUrl(reader({ PGPASSWORD: "p@ss word" }))).toBe(
+      "postgres://postgres:p%40ss%20word@localhost:5432/rails_js_test",
+    );
+  });
+
+  it("withDatabase repoints settings at another database on the same server", () => {
+    const settings = mysqlSettings(reader({ MYSQL_HOST: "db" }));
+    expect(withDatabase(settings, "other")).toEqual({ ...settings, database: "other" });
+  });
+});

--- a/packages/activerecord/src/test-helpers/test-connection-env.test.ts
+++ b/packages/activerecord/src/test-helpers/test-connection-env.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   activeLane,
+  driverConfig,
+  settingsUrl,
   connectionName,
   mysqlSettings,
   mysqlUrl,
@@ -71,6 +73,41 @@ describe("test-connection-env", () => {
     expect(mysqlSettings(reader({ AR_DB_SLOT: "2" })).database).toBe("rails_js_test_2");
   });
 
+  it("treats an empty sub-setting as unset rather than as an empty value", () => {
+    // CI routinely sets a var to "" to mean "no value". Taking that literally
+    // yields user: "" and the server answers `Access denied for user ''`.
+    const settings = mysqlSettings(
+      reader({ MYSQL_USER: "", MYSQL_HOST: "", MYSQL_DATABASE: "", MYSQL_SOCK: "" }),
+    );
+    expect(settings.user).toBe("root");
+    expect(settings.host).toBe("localhost");
+    expect(settings.database).toBe("rails_js_test");
+    expect(settings.socket).toBeUndefined();
+    expect(activeLane(reader({ ARCONN: "" }))).toBe("sqlite");
+  });
+
+  it("raises on a malformed slot rather than sharing the base database", () => {
+    // Silently falling back to the base DB is the cross-worker collision the
+    // slot mechanism exists to prevent, and would surface as an unrelated
+    // DDL failure much later.
+    expect(() => postgresSettings(reader({ AR_DB_SLOT: "abc" }))).toThrow(/must be an integer/);
+    expect(() => postgresSettings(reader({ AR_DB_SLOT: "0" }))).toThrow(/must be >= 1/);
+  });
+
+  it("raises on a non-integer port rather than passing NaN to the driver", () => {
+    expect(() => postgresSettings(reader({ PGPORT: "abc" }))).toThrow(/PGPORT must be an integer/);
+    expect(() => mysqlSettings(reader({ MYSQL_PORT: "3306.5" }))).toThrow(
+      /MYSQL_PORT must be an integer/,
+    );
+  });
+
+  it("refuses to serialize a socket-configured connection as a URL", () => {
+    // A URL cannot carry a socket path; rendering host:port instead would
+    // connect somewhere the caller never asked for.
+    const settings = mysqlSettings(reader({ MYSQL_SOCK: "/tmp/mysql.sock" }));
+    expect(() => settingsUrl("mysql", settings)).toThrow(/Cannot render a connection URL/);
+  });
+
   it("renders settings as a URL, encoding credentials", () => {
     expect(mysqlUrl(reader({}))).toBe("mysql://root@localhost:3306/rails_js_test");
     expect(postgresUrl(reader({ PGPASSWORD: "p@ss word" }))).toBe(
@@ -81,5 +118,28 @@ describe("test-connection-env", () => {
   it("withDatabase repoints settings at another database on the same server", () => {
     const settings = mysqlSettings(reader({ MYSQL_HOST: "db" }));
     expect(withDatabase(settings, "other")).toEqual({ ...settings, database: "other" });
+  });
+
+  it("driverConfig emits both spellings of the credential and the socket", () => {
+    // Regression guard: DatabaseTasks reads Rails' `username`/`socket`, the
+    // drivers read `user`/`socketPath`, and both drivers IGNORE the key they
+    // don't know — so emitting one spelling connects as the OS user instead of
+    // failing. Caught as `Access denied for user ''` on the MySQL
+    // slot-provisioning path, which routes through DatabaseTasks.
+    const config = driverConfig(
+      mysqlSettings(reader({ MYSQL_USER: "u", MYSQL_PASSWORD: "p", MYSQL_SOCK: "/tmp/m.sock" })),
+    );
+    expect(config.username).toBe("u");
+    expect(config.user).toBe("u");
+    expect(config.socket).toBe("/tmp/m.sock");
+    expect(config.socketPath).toBe("/tmp/m.sock");
+  });
+
+  it("driverConfig omits password and socket entirely when unset", () => {
+    // `undefined` is not the same as absent to mysql2.
+    const config = driverConfig(mysqlSettings(reader({})));
+    expect(config).not.toHaveProperty("password");
+    expect(config).not.toHaveProperty("socket");
+    expect(config).not.toHaveProperty("socketPath");
   });
 });

--- a/packages/activerecord/src/test-helpers/test-connection-env.test.ts
+++ b/packages/activerecord/src/test-helpers/test-connection-env.test.ts
@@ -113,8 +113,21 @@ describe("test-connection-env", () => {
     );
   });
 
-  it("raises for a socket on the postgres scheme, which has no socket setting", () => {
-    // libpq spells a socket connection as PGHOST=/path, already carried as host.
+  it("spells a socket-directory PGHOST the way libpq does", () => {
+    // Rails' postgresql: entries carry no host and lean on libpq's PG* env
+    // (config.example.yml:74-81), where a leading "/" in PGHOST means a socket
+    // DIRECTORY. Putting that in the URL authority yields
+    // postgres://user@/var/run/postgresql:5432/db, which pg misreads as a
+    // hostname and reports as an authentication failure — verified against a
+    // real socket, as was the empty-authority + host= form emitted here.
+    const settings = postgresSettings(reader({ PGHOST: "/var/run/postgresql" }));
+    expect(settingsUrl("postgres", settings)).toBe(
+      "postgres://postgres@/rails_js_test?host=%2Fvar%2Frun%2Fpostgresql&port=5432",
+    );
+  });
+
+  it("raises for a socket field on the postgres scheme", () => {
+    // Postgres has no socket sub-setting; PGHOST carries it (see above).
     expect(() =>
       settingsUrl("postgres", { ...postgresSettings(reader({})), socket: "/tmp/pg.sock" }),
     ).toThrow(/PGHOST=/);

--- a/packages/activerecord/src/test-helpers/test-connection-env.ts
+++ b/packages/activerecord/src/test-helpers/test-connection-env.ts
@@ -13,6 +13,23 @@
  *     `PGPASSWORD` / `PGDATABASE` for the postgresql lane (Rails' `postgresql:`
  *     entries carry no host at all, deferring to libpq's own env).
  *
+ * ## Deviations from `config.example.yml` (deliberate, not parity)
+ *
+ * Rails interpolates ONLY `MYSQL_HOST` / `MYSQL_PORT` / `MYSQL_SOCK` from the
+ * environment and hard-codes the rest — notably `username: rails` on both
+ * `mysql2.arunit` and `mysql2.arunit2` (`config.example.yml:4,24`), because
+ * Rails' own CI provisions a `rails` user.
+ *
+ * trails makes the credential and database name env-driven too
+ * (`MYSQL_USER` / `MYSQL_PASSWORD` / `MYSQL_DATABASE`, and the `PG*` set), and
+ * defaults them to `root` / `postgres` / `rails_js_test` — the users and
+ * database the containers in `.github/workflows/ci.yml` actually provision.
+ * Hard-coding Rails' `rails` user would not authenticate against them.
+ *
+ * So: the ARCONN-selects / sub-settings-describe *split* is Rails parity; the
+ * particular set of interpolated keys and their defaults is a trails choice.
+ * Anything relying on Rails' literal credential must set `MYSQL_USER` itself.
+ *
  * trails previously collapsed both into a single `PG_TEST_URL` /
  * `MYSQL_TEST_URL` URL string, which made backend selection a side effect of
  * a connection detail being present. This module is the replacement: `ARCONN`
@@ -132,8 +149,10 @@ function applySlot(database: string, read: EnvReader): string {
 }
 
 /**
- * PostgreSQL connection details from libpq's standard env vars, exactly the
- * ones Rails' `postgresql:` entries rely on by carrying no host of their own.
+ * PostgreSQL connection details from libpq's standard env vars — the ones
+ * Rails' `postgresql:` entries rely on by carrying no host of their own. The
+ * defaults (`postgres` / `rails_js_test`) are a trails choice matching what CI
+ * provisions; see the deviations note in the module doc.
  */
 export function postgresSettings(read: EnvReader = getEnv): ServerSettings {
   return {
@@ -146,8 +165,12 @@ export function postgresSettings(read: EnvReader = getEnv): ServerSettings {
 }
 
 /**
- * MySQL/MariaDB connection details from the sub-settings `config.example.yml`
- * interpolates (`MYSQL_HOST` / `MYSQL_PORT` / `MYSQL_SOCK`) plus credentials.
+ * MySQL/MariaDB connection details.
+ *
+ * `MYSQL_HOST` / `MYSQL_PORT` / `MYSQL_SOCK` mirror the keys Rails interpolates
+ * (`config.example.yml:12-19`). The credential and database name are a trails
+ * extension defaulting to what CI provisions — Rails hard-codes
+ * `username: rails` instead. See the deviations note in the module doc.
  */
 export function mysqlSettings(read: EnvReader = getEnv): ServerSettings {
   return {
@@ -212,21 +235,31 @@ function credentials({ user, password }: ServerSettings): string {
  * `pg` and `mysql2` drivers (and the CLI's `--database-url`) both accept one,
  * so this keeps a single formatting site instead of hand-built strings.
  *
- * A URL cannot carry a Unix socket path, so a socket-configured connection
- * raises here rather than silently serializing to `host:port` — that would
- * connect somewhere the caller did not ask for. Socket users go through the
- * config hash (`serverHash` in `test-database-config.ts`), which carries it.
+ * A `MYSQL_SOCK` connection survives the round trip: mysql2's `parseUrl` copies
+ * every query parameter into its options hash and `socketPath` is one of its
+ * recognised keys (`mysql2/lib/connection_config.js:52,271-290`), so the socket
+ * is emitted as `?socketPath=`. Verified against the driver — with a socket in
+ * the query it attempts the socket and fails `ENOENT` rather than silently
+ * falling back to TCP. This matters because Rails carries `MYSQL_SOCK` into
+ * both `mysql2.arunit` and `mysql2.arunit2` (`config.example.yml:18-19,37-39`),
+ * so every mysql path here has to preserve it.
+ *
+ * Postgres has no socket sub-setting (libpq spells a socket connection as
+ * `PGHOST=/path`, which is already carried as `host`), so a socket on the
+ * postgres scheme is unreachable and raises rather than being dropped.
  */
 export function settingsUrl(scheme: "postgres" | "mysql", settings: ServerSettings): string {
   const { host, port, database, socket } = settings;
-  if (socket !== undefined) {
+  const base = `${scheme}://${credentials(settings)}${host}:${port}/${database}`;
+  if (socket === undefined) return base;
+  if (scheme === "postgres") {
     // eslint-disable-next-line blazetrails/rails-error-parity
     throw new Error(
-      `Cannot render a connection URL for a socket-configured connection ` +
-        `(socket: ${JSON.stringify(socket)}). Use the configuration hash instead.`,
+      `Postgres has no socket sub-setting; spell a socket connection as ` +
+        `PGHOST=${socket} so it is carried as the host.`,
     );
   }
-  return `${scheme}://${credentials(settings)}${host}:${port}/${database}`;
+  return `${base}?socketPath=${encodeURIComponent(socket)}`;
 }
 
 /** The primary PostgreSQL URL for the active worker. */

--- a/packages/activerecord/src/test-helpers/test-connection-env.ts
+++ b/packages/activerecord/src/test-helpers/test-connection-env.ts
@@ -244,22 +244,39 @@ function credentials({ user, password }: ServerSettings): string {
  * both `mysql2.arunit` and `mysql2.arunit2` (`config.example.yml:18-19,37-39`),
  * so every mysql path here has to preserve it.
  *
- * Postgres has no socket sub-setting (libpq spells a socket connection as
- * `PGHOST=/path`, which is already carried as `host`), so a socket on the
- * postgres scheme is unreachable and raises rather than being dropped.
+ * Postgres has no socket *sub-setting* because libpq spells a socket connection
+ * as a directory in `PGHOST` (`/var/run/postgresql`) — Rails' `postgresql:`
+ * entries carry no host fields at all and lean on that env
+ * (`config.example.yml:74-81`). A directory cannot go in the URL authority: it
+ * yields `postgres://user@/var/run/postgresql:5432/db`, which `pg` misreads as
+ * a hostname and reports as a confusing authentication failure rather than a
+ * parse error. libpq's own spelling for this is an empty authority plus a
+ * `host=` parameter, so a socket-directory `PGHOST` is emitted as
+ * `postgres://user:pass@/database?host=/dir&port=N` — verified against a real
+ * PostgreSQL socket.
  */
 export function settingsUrl(scheme: "postgres" | "mysql", settings: ServerSettings): string {
   const { host, port, database, socket } = settings;
-  const base = `${scheme}://${credentials(settings)}${host}:${port}/${database}`;
-  if (socket === undefined) return base;
+  const auth = credentials(settings);
+
   if (scheme === "postgres") {
-    // eslint-disable-next-line blazetrails/rails-error-parity
-    throw new Error(
-      `Postgres has no socket sub-setting; spell a socket connection as ` +
-        `PGHOST=${socket} so it is carried as the host.`,
-    );
+    // libpq treats a leading "/" in PGHOST as a socket directory, not a host.
+    if (host.startsWith("/")) {
+      const params = new URLSearchParams({ host, port: String(port) });
+      return `postgres://${auth}/${database}?${params.toString()}`;
+    }
+    if (socket !== undefined) {
+      // eslint-disable-next-line blazetrails/rails-error-parity
+      throw new Error(
+        `Postgres has no socket sub-setting; spell a socket connection as ` +
+          `PGHOST=${socket} so libpq resolves it as a socket directory.`,
+      );
+    }
+    return `postgres://${auth}${host}:${port}/${database}`;
   }
-  return `${base}?socketPath=${encodeURIComponent(socket)}`;
+
+  const base = `mysql://${auth}${host}:${port}/${database}`;
+  return socket === undefined ? base : `${base}?socketPath=${encodeURIComponent(socket)}`;
 }
 
 /** The primary PostgreSQL URL for the active worker. */

--- a/packages/activerecord/src/test-helpers/test-connection-env.ts
+++ b/packages/activerecord/src/test-helpers/test-connection-env.ts
@@ -47,13 +47,44 @@ export const CONNECTION_LANES: Record<ConnectionName, TestAdapterName> = {
 export type EnvReader = (key: string) => string | undefined;
 
 /**
- * The connection name selected by `ARCONN`, falling back to
- * {@link DEFAULT_CONNECTION}. Mirrors `connection.rb:10`. The name is returned
- * unvalidated — `test-database-config.ts` owns Rails' "Connection not found"
- * failure so the error surfaces once, at config-build time.
+ * Read an env var, treating an empty value as absent.
+ *
+ * CI routinely sets a variable to `""` to mean "no value" (an empty password,
+ * an unused socket path), and `??` alone would take that literally — an empty
+ * `MYSQL_USER` becomes `user: ""` and the server answers
+ * `Access denied for user ''`. This matches the convention already used by
+ * `MySQLDatabaseTasks#resolvedField`, which likewise rejects `""`.
  */
-export function connectionName(read: EnvReader = getEnv): ConnectionName {
-  return (read("ARCONN") || DEFAULT_CONNECTION) as ConnectionName;
+function present(read: EnvReader, key: string): string | undefined {
+  const value = read(key);
+  return value === undefined || value === "" ? undefined : value;
+}
+
+/** Parse an integer sub-setting, failing loudly rather than yielding NaN. */
+function intSetting(read: EnvReader, key: string, fallback: number): number {
+  const raw = present(read, key);
+  if (raw === undefined) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed)) {
+    // Test-helper invariant with no Rails error counterpart — a bare Error is intentional.
+    // eslint-disable-next-line blazetrails/rails-error-parity
+    throw new Error(`${key} must be an integer, got ${JSON.stringify(raw)}`);
+  }
+  return parsed;
+}
+
+/**
+ * The connection name selected by `ARCONN`, falling back to
+ * {@link DEFAULT_CONNECTION}. Mirrors `connection.rb:10`.
+ *
+ * Returns a bare `string`, not a {@link ConnectionName}: `ARCONN` is arbitrary
+ * user input, and asserting it into the union here would be a type lie that
+ * makes the unknown-name branch look unreachable to every caller.
+ * `test-database-config.ts` owns Rails' "Connection not found" failure, so the
+ * error surfaces once, at config-build time.
+ */
+export function connectionName(read: EnvReader = getEnv): string {
+  return present(read, "ARCONN") ?? DEFAULT_CONNECTION;
 }
 
 /**
@@ -62,7 +93,8 @@ export function connectionName(read: EnvReader = getEnv): ConnectionName {
  * `test-database-config.ts`, not to every lane predicate in the harness.
  */
 export function activeLane(read: EnvReader = getEnv): TestAdapterName {
-  return CONNECTION_LANES[connectionName(read)] ?? CONNECTION_LANES[DEFAULT_CONNECTION];
+  const lanes: Partial<Record<string, TestAdapterName>> = CONNECTION_LANES;
+  return lanes[connectionName(read)] ?? CONNECTION_LANES[DEFAULT_CONNECTION];
 }
 
 /** Connection details for a server-backed lane, assembled from sub-settings. */
@@ -88,8 +120,15 @@ export interface ServerSettings {
 export const SLOT_ENV = "AR_DB_SLOT";
 
 function applySlot(database: string, read: EnvReader): string {
-  const slot = parseInt(read(SLOT_ENV) ?? "1", 10);
-  return Number.isFinite(slot) && slot > 1 ? `${database}_${slot}` : database;
+  // A malformed slot must never silently degrade to the shared base database —
+  // that is precisely the cross-worker collision slots exist to prevent, and it
+  // would surface later as an unrelated DDL or fixture failure.
+  const slot = intSetting(read, SLOT_ENV, 1);
+  if (slot < 1) {
+    // eslint-disable-next-line blazetrails/rails-error-parity
+    throw new Error(`${SLOT_ENV} must be >= 1, got ${slot}`);
+  }
+  return slot > 1 ? `${database}_${slot}` : database;
 }
 
 /**
@@ -98,11 +137,11 @@ function applySlot(database: string, read: EnvReader): string {
  */
 export function postgresSettings(read: EnvReader = getEnv): ServerSettings {
   return {
-    host: read("PGHOST") ?? "localhost",
-    port: parseInt(read("PGPORT") ?? "5432", 10),
-    user: read("PGUSER") ?? "postgres",
-    password: read("PGPASSWORD"),
-    database: applySlot(read("PGDATABASE") ?? "rails_js_test", read),
+    host: present(read, "PGHOST") ?? "localhost",
+    port: intSetting(read, "PGPORT", 5432),
+    user: present(read, "PGUSER") ?? "postgres",
+    password: present(read, "PGPASSWORD"),
+    database: applySlot(present(read, "PGDATABASE") ?? "rails_js_test", read),
   };
 }
 
@@ -112,12 +151,47 @@ export function postgresSettings(read: EnvReader = getEnv): ServerSettings {
  */
 export function mysqlSettings(read: EnvReader = getEnv): ServerSettings {
   return {
-    host: read("MYSQL_HOST") ?? "localhost",
-    port: parseInt(read("MYSQL_PORT") ?? "3306", 10),
-    user: read("MYSQL_USER") ?? "root",
-    password: read("MYSQL_PASSWORD"),
-    database: applySlot(read("MYSQL_DATABASE") ?? "rails_js_test", read),
-    socket: read("MYSQL_SOCK"),
+    host: present(read, "MYSQL_HOST") ?? "localhost",
+    port: intSetting(read, "MYSQL_PORT", 3306),
+    user: present(read, "MYSQL_USER") ?? "root",
+    password: present(read, "MYSQL_PASSWORD"),
+    database: applySlot(present(read, "MYSQL_DATABASE") ?? "rails_js_test", read),
+    socket: present(read, "MYSQL_SOCK"),
+  };
+}
+
+/**
+ * Translate {@link ServerSettings} into the key set a `configuration_hash` /
+ * driver options object needs, straddling two naming conventions that disagree.
+ *
+ * This is the single place that knows about the straddle:
+ *
+ *   - **credential** — `MySQLDatabaseTasks#buildAdapterConfig` and
+ *     `PostgreSQLDatabaseTasks` read Rails' canonical `username` (as
+ *     `database.yml` spells it), while `Mysql2Adapter` / `PostgreSQLAdapter`
+ *     forward the residual hash to the `mysql2` / `pg` drivers, which read the
+ *     driver-native `user`.
+ *   - **socket** — Rails' config key is `socket`; mysql2's driver option is
+ *     `socketPath`.
+ *
+ * Emitting only one spelling of either fails *silently*: both drivers ignore
+ * unknown keys, so a `username`-only config connects as the OS user rather than
+ * raising (verified against a live server). Converging the adapters onto Rails'
+ * spelling would let this collapse to one key each; that is its own story.
+ *
+ * `password` and the socket keys are omitted when unset so the drivers apply
+ * their own defaults — a literal `undefined` is not the same as absent.
+ */
+export function driverConfig(settings: ServerSettings): Record<string, unknown> {
+  const { host, port, user, password, database, socket } = settings;
+  return {
+    host,
+    port,
+    username: user,
+    user,
+    database,
+    ...(password === undefined ? {} : { password }),
+    ...(socket === undefined ? {} : { socket, socketPath: socket }),
   };
 }
 
@@ -137,9 +211,21 @@ function credentials({ user, password }: ServerSettings): string {
  * URLs are a *serialization* of the sub-settings, never a source of them: the
  * `pg` and `mysql2` drivers (and the CLI's `--database-url`) both accept one,
  * so this keeps a single formatting site instead of hand-built strings.
+ *
+ * A URL cannot carry a Unix socket path, so a socket-configured connection
+ * raises here rather than silently serializing to `host:port` — that would
+ * connect somewhere the caller did not ask for. Socket users go through the
+ * config hash (`serverHash` in `test-database-config.ts`), which carries it.
  */
 export function settingsUrl(scheme: "postgres" | "mysql", settings: ServerSettings): string {
-  const { host, port, database } = settings;
+  const { host, port, database, socket } = settings;
+  if (socket !== undefined) {
+    // eslint-disable-next-line blazetrails/rails-error-parity
+    throw new Error(
+      `Cannot render a connection URL for a socket-configured connection ` +
+        `(socket: ${JSON.stringify(socket)}). Use the configuration hash instead.`,
+    );
+  }
   return `${scheme}://${credentials(settings)}${host}:${port}/${database}`;
 }
 

--- a/packages/activerecord/src/test-helpers/test-connection-env.ts
+++ b/packages/activerecord/src/test-helpers/test-connection-env.ts
@@ -1,0 +1,154 @@
+/**
+ * The environment surface of the test harness, mirroring
+ * `vendor/rails/activerecord/test/config.example.yml`.
+ *
+ * Rails splits the two concerns this module keeps apart:
+ *
+ *   - **Which backend runs** is chosen by `ARCONN`, naming a key of the
+ *     `connections:` hash (`test/support/connection.rb:10,14-19`). Nothing
+ *     else selects a backend — there is no "is this env var set?" sniffing.
+ *   - **How to reach it** comes from discrete sub-setting env vars interpolated
+ *     into that connection's entry: `MYSQL_HOST` / `MYSQL_PORT` / `MYSQL_SOCK`
+ *     for the mysql2 lane, and libpq's `PGHOST` / `PGPORT` / `PGUSER` /
+ *     `PGPASSWORD` / `PGDATABASE` for the postgresql lane (Rails' `postgresql:`
+ *     entries carry no host at all, deferring to libpq's own env).
+ *
+ * trails previously collapsed both into a single `PG_TEST_URL` /
+ * `MYSQL_TEST_URL` URL string, which made backend selection a side effect of
+ * a connection detail being present. This module is the replacement: `ARCONN`
+ * selects, sub-settings describe.
+ *
+ * Hard rules (RFC 0023): no `node:*` imports, no `process.*` — environment
+ * reads go through activesupport's `getEnv`; async fs only (none needed here).
+ *
+ * @internal
+ */
+
+import { getEnv } from "@blazetrails/activesupport";
+
+/** The public backend lane a named connection drives. */
+export type TestAdapterName = "sqlite" | "postgres" | "mysql";
+
+/** A key of the `connections:` hash in `config.example.yml`. */
+export type ConnectionName = "sqlite3" | "sqlite3_mem" | "postgresql" | "mysql2";
+
+/** Rails' `config["default_connection"]` (`connection.rb:10`). */
+export const DEFAULT_CONNECTION: ConnectionName = "sqlite3";
+
+/** Every connection name the harness knows, and the lane each drives. */
+export const CONNECTION_LANES: Record<ConnectionName, TestAdapterName> = {
+  sqlite3: "sqlite",
+  sqlite3_mem: "sqlite",
+  postgresql: "postgres",
+  mysql2: "mysql",
+};
+
+/** A reader over the environment; injectable so tests need not mutate ambient env. */
+export type EnvReader = (key: string) => string | undefined;
+
+/**
+ * The connection name selected by `ARCONN`, falling back to
+ * {@link DEFAULT_CONNECTION}. Mirrors `connection.rb:10`. The name is returned
+ * unvalidated — `test-database-config.ts` owns Rails' "Connection not found"
+ * failure so the error surfaces once, at config-build time.
+ */
+export function connectionName(read: EnvReader = getEnv): ConnectionName {
+  return (read("ARCONN") || DEFAULT_CONNECTION) as ConnectionName;
+}
+
+/**
+ * The backend lane the current `ARCONN` drives. Unknown names resolve to the
+ * default connection's lane; the loud failure for those belongs to
+ * `test-database-config.ts`, not to every lane predicate in the harness.
+ */
+export function activeLane(read: EnvReader = getEnv): TestAdapterName {
+  return CONNECTION_LANES[connectionName(read)] ?? CONNECTION_LANES[DEFAULT_CONNECTION];
+}
+
+/** Connection details for a server-backed lane, assembled from sub-settings. */
+export interface ServerSettings {
+  host: string;
+  port: number;
+  user: string;
+  password?: string;
+  database: string;
+  /** Unix socket path (`MYSQL_SOCK`); mysql2 prefers it over host/port when set. */
+  socket?: string;
+}
+
+/**
+ * Per-worker database isolation slot, published by `test-setup-worker-db.ts`
+ * after it wins an advisory lock. Slot 1 (or unset) is the shared base
+ * database; higher slots get a `_N`-suffixed database of their own.
+ *
+ * Applying the suffix here — rather than rewriting a URL env var in place —
+ * means every consumer derives the same worker database from one signal,
+ * instead of racing to read a mutated string.
+ */
+export const SLOT_ENV = "AR_DB_SLOT";
+
+function applySlot(database: string, read: EnvReader): string {
+  const slot = parseInt(read(SLOT_ENV) ?? "1", 10);
+  return Number.isFinite(slot) && slot > 1 ? `${database}_${slot}` : database;
+}
+
+/**
+ * PostgreSQL connection details from libpq's standard env vars, exactly the
+ * ones Rails' `postgresql:` entries rely on by carrying no host of their own.
+ */
+export function postgresSettings(read: EnvReader = getEnv): ServerSettings {
+  return {
+    host: read("PGHOST") ?? "localhost",
+    port: parseInt(read("PGPORT") ?? "5432", 10),
+    user: read("PGUSER") ?? "postgres",
+    password: read("PGPASSWORD"),
+    database: applySlot(read("PGDATABASE") ?? "rails_js_test", read),
+  };
+}
+
+/**
+ * MySQL/MariaDB connection details from the sub-settings `config.example.yml`
+ * interpolates (`MYSQL_HOST` / `MYSQL_PORT` / `MYSQL_SOCK`) plus credentials.
+ */
+export function mysqlSettings(read: EnvReader = getEnv): ServerSettings {
+  return {
+    host: read("MYSQL_HOST") ?? "localhost",
+    port: parseInt(read("MYSQL_PORT") ?? "3306", 10),
+    user: read("MYSQL_USER") ?? "root",
+    password: read("MYSQL_PASSWORD"),
+    database: applySlot(read("MYSQL_DATABASE") ?? "rails_js_test", read),
+    socket: read("MYSQL_SOCK"),
+  };
+}
+
+/** A copy of `settings` pointed at a different database on the same server. */
+export function withDatabase(settings: ServerSettings, database: string): ServerSettings {
+  return { ...settings, database };
+}
+
+function credentials({ user, password }: ServerSettings): string {
+  const auth = encodeURIComponent(user);
+  return password ? `${auth}:${encodeURIComponent(password)}@` : `${auth}@`;
+}
+
+/**
+ * Render `settings` as a connection URL.
+ *
+ * URLs are a *serialization* of the sub-settings, never a source of them: the
+ * `pg` and `mysql2` drivers (and the CLI's `--database-url`) both accept one,
+ * so this keeps a single formatting site instead of hand-built strings.
+ */
+export function settingsUrl(scheme: "postgres" | "mysql", settings: ServerSettings): string {
+  const { host, port, database } = settings;
+  return `${scheme}://${credentials(settings)}${host}:${port}/${database}`;
+}
+
+/** The primary PostgreSQL URL for the active worker. */
+export function postgresUrl(read: EnvReader = getEnv): string {
+  return settingsUrl("postgres", postgresSettings(read));
+}
+
+/** The primary MySQL URL for the active worker. */
+export function mysqlUrl(read: EnvReader = getEnv): string {
+  return settingsUrl("mysql", mysqlSettings(read));
+}

--- a/packages/activerecord/src/test-helpers/test-database-config.test.ts
+++ b/packages/activerecord/src/test-helpers/test-database-config.test.ts
@@ -19,8 +19,6 @@ describe("buildTestDatabaseConfig", () => {
 
   it("selects the sqlite3 connection named by ARCONN", async () => {
     vi.stubEnv("ARCONN", "sqlite3");
-    vi.stubEnv("PG_TEST_URL", "");
-    vi.stubEnv("MYSQL_TEST_URL", "");
     const { adapter, envConfig } = await buildTestDatabaseConfig();
     expect(adapter).toBe("sqlite");
     expect(envConfig.adapter).toMatch(/sqlite/i);
@@ -29,16 +27,12 @@ describe("buildTestDatabaseConfig", () => {
 
   it("falls back to the default_connection (sqlite3) when ARCONN is unset", async () => {
     vi.stubEnv("ARCONN", "");
-    vi.stubEnv("PG_TEST_URL", "");
-    vi.stubEnv("MYSQL_TEST_URL", "");
     const { adapter } = await buildTestDatabaseConfig();
     expect(adapter).toBe("sqlite");
   });
 
   it("inherits Rails' default pool size (5) on the file-backed lane", async () => {
     vi.stubEnv("ARCONN", "sqlite3");
-    vi.stubEnv("PG_TEST_URL", "");
-    vi.stubEnv("MYSQL_TEST_URL", "");
     vi.stubEnv("AR_TEST_WORKER_DB", "/tmp/ar-test-worker.sqlite3");
     const { envConfig } = await buildTestDatabaseConfig();
     expect(envConfig.pool).toBe(5);
@@ -46,8 +40,6 @@ describe("buildTestDatabaseConfig", () => {
 
   it("pins pool 1 on the sqlite3_mem :memory: connection", async () => {
     vi.stubEnv("ARCONN", "sqlite3_mem");
-    vi.stubEnv("PG_TEST_URL", "");
-    vi.stubEnv("MYSQL_TEST_URL", "");
     vi.stubEnv("AR_TEST_WORKER_DB", "");
     const { adapter, envConfig } = await buildTestDatabaseConfig();
     expect(adapter).toBe("sqlite");
@@ -56,15 +48,12 @@ describe("buildTestDatabaseConfig", () => {
 
   it("selects the postgresql connection named by ARCONN", async () => {
     vi.stubEnv("ARCONN", "postgresql");
-    vi.stubEnv("PG_TEST_URL", "postgresql://localhost/trails_test");
     const { adapter } = await buildTestDatabaseConfig();
     expect(adapter).toBe("postgres");
   });
 
   it("selects the mysql2 connection named by ARCONN", async () => {
     vi.stubEnv("ARCONN", "mysql2");
-    vi.stubEnv("PG_TEST_URL", "");
-    vi.stubEnv("MYSQL_TEST_URL", "mysql2://localhost/trails_test");
     const { adapter } = await buildTestDatabaseConfig();
     expect(adapter).toBe("mysql");
   });
@@ -74,21 +63,16 @@ describe("buildTestDatabaseConfig", () => {
     await expect(buildTestDatabaseConfig()).rejects.toThrow(/Connection "oracle" not found/);
   });
 
-  it("raises on an ARCONN / resolved-adapter mismatch (postgresql without PG_TEST_URL)", async () => {
-    vi.stubEnv("ARCONN", "postgresql");
-    vi.stubEnv("PG_TEST_URL", "");
-    vi.stubEnv("MYSQL_TEST_URL", "");
-    await expect(buildTestDatabaseConfig()).rejects.toThrow(
-      /connection name did not match the adapter name/,
-    );
-  });
-
-  it("raises on an ARCONN / resolved-adapter mismatch (mysql2 without MYSQL_TEST_URL)", async () => {
-    vi.stubEnv("ARCONN", "mysql2");
-    vi.stubEnv("PG_TEST_URL", "");
-    vi.stubEnv("MYSQL_TEST_URL", "");
-    await expect(buildTestDatabaseConfig()).rejects.toThrow(
-      /connection name did not match the adapter name/,
-    );
-  });
+  // The adapter-name guard (`connection.rb:35-37`) used to be tripped by a
+  // missing `*_TEST_URL`. Sub-settings always carry defaults, so there is no
+  // absent-details state left to trip it; what it now asserts is the structural
+  // invariant over the connections table, exercised here for every entry.
+  it.each(["sqlite3", "sqlite3_mem", "postgresql", "mysql2"])(
+    "builds an adapter whose name is contained in the connection name (%s)",
+    async (name) => {
+      vi.stubEnv("ARCONN", name);
+      const { envConfig } = await buildTestDatabaseConfig();
+      expect(name).toContain(String(envConfig.adapter));
+    },
+  );
 });

--- a/packages/activerecord/src/test-helpers/test-database-config.ts
+++ b/packages/activerecord/src/test-helpers/test-database-config.ts
@@ -12,13 +12,11 @@
  *     unconfigured connection,
  *   - `unless connection_name.include?(arunit_adapter) raise ArgumentError`
  *     (`connection.rb:35-37`) — a loud raise when `ARCONN` and the resolved
- *     adapter diverge. PR #4768's `*_TEST_URL`-presence guard folds into this:
- *     a live-backend `ARCONN` whose connection details are absent resolves to
- *     SQLite, whose adapter (`sqlite3`) is not a substring of the connection
- *     name (`postgresql` / `mysql2`), so the mismatch check raises.
+ *     adapter diverge.
  *
  * As in `config.example.yml`, `ENV` only feeds connection *sub-settings*
- * (host/port/socket/credentials); it never selects the backend.
+ * (host/port/socket/credentials, via `test-connection-env.ts`); it never
+ * selects the backend.
  *
  * Phase 1 of RFC 0002 — new file, no consumer changes.
  * Phase 2 of RFC 0002 — adds `establishFromTestConfig` for setupHandlerSuite.
@@ -32,8 +30,16 @@ import { DatabaseConfigurations } from "../database-configurations.js";
 import { DatabaseTasks } from "../tasks/database-tasks.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
 import { UrlConfig } from "../database-configurations/url-config.js";
+import {
+  connectionName,
+  mysqlSettings,
+  postgresSettings,
+  type ConnectionName,
+  type ServerSettings,
+  type TestAdapterName,
+} from "./test-connection-env.js";
 
-export type TestAdapterName = "sqlite" | "postgres" | "mysql";
+export type { TestAdapterName };
 
 export interface TestDatabaseConfig {
   /** The `DatabaseConfigurations` instance wired into `DatabaseTasks`. */
@@ -59,7 +65,34 @@ interface NamedConnection {
   adapter: string;
   /** The public {@link TestAdapterName} lane this connection drives. */
   lane: TestAdapterName;
-  build(): HashConfig | UrlConfig | null;
+  build(): HashConfig;
+}
+
+/**
+ * Turn {@link ServerSettings} into the `configuration_hash` shape a
+ * `HashConfig` carries. Rails' `config.example.yml` entries are exactly this:
+ * an adapter plus discrete host/port/socket/credential keys — never a URL.
+ *
+ * The credential key is `user`, not Rails' `username`: trails' adapters hand
+ * the residual config straight to the `pg` / `mysql2` drivers, which read
+ * `user`. A `username` key is silently ignored by both, so the connection would
+ * fall back to the OS user rather than failing — verified against a live server.
+ * (Teaching the adapters Rails' `username` alias is a separate concern.)
+ *
+ * `socket` and `password` are omitted when unset so the drivers apply their
+ * own defaults (a literal `undefined` is not the same as absent to mysql2).
+ */
+function serverHash(adapter: string, settings: ServerSettings): Record<string, unknown> {
+  const { host, port, user, password, database, socket } = settings;
+  return {
+    adapter,
+    host,
+    port,
+    user,
+    database,
+    ...(password === undefined ? {} : { password }),
+    ...(socket === undefined ? {} : { socket }),
+  };
 }
 
 /**
@@ -67,14 +100,10 @@ interface NamedConnection {
  * `connections:` hash of `config.example.yml`. `ARCONN` selects one of these
  * keys; `DEFAULT_CONNECTION` is Rails' `config["default_connection"]` fallback.
  *
- * Connection details for the live backends still come from `PG_TEST_URL` /
- * `MYSQL_TEST_URL` in this foundation PR; migrating those onto Rails' discrete
- * sub-setting env vars is tracked as a follow-up story.
+ * Every entry builds a `HashConfig` from discrete sub-settings, matching how
+ * Rails' yml interpolates `MYSQL_HOST`/`MYSQL_PORT`/`MYSQL_SOCK` and defers to
+ * libpq's `PG*` vars. No entry reads a connection URL.
  */
-type ConnectionName = "sqlite3" | "sqlite3_mem" | "postgresql" | "mysql2";
-
-const DEFAULT_CONNECTION: ConnectionName = "sqlite3";
-
 const CONNECTIONS: Record<ConnectionName, NamedConnection> = {
   sqlite3: {
     adapter: "sqlite3",
@@ -90,18 +119,12 @@ const CONNECTIONS: Record<ConnectionName, NamedConnection> = {
   postgresql: {
     adapter: "postgresql",
     lane: "postgres",
-    build: () => {
-      const pgUrl = getEnv("PG_TEST_URL");
-      return pgUrl ? new UrlConfig("test", "primary", pgUrl) : null;
-    },
+    build: () => new HashConfig("test", "primary", serverHash("postgresql", postgresSettings())),
   },
   mysql2: {
     adapter: "mysql2",
     lane: "mysql",
-    build: () => {
-      const mysqlUrl = getEnv("MYSQL_TEST_URL");
-      return mysqlUrl ? new UrlConfig("test", "primary", mysqlUrl) : null;
-    },
+    build: () => new HashConfig("test", "primary", serverHash("mysql2", mysqlSettings())),
   },
 };
 
@@ -112,31 +135,33 @@ const CONNECTIONS: Record<ConnectionName, NamedConnection> = {
  * adapter-name guard in `connection.rb`.
  */
 function resolve(): { adapter: TestAdapterName; envConfig: HashConfig | UrlConfig } {
-  const connectionName = (getEnv("ARCONN") || DEFAULT_CONNECTION) as ConnectionName;
-  const connection = CONNECTIONS[connectionName];
+  const name = connectionName();
+  const connection = CONNECTIONS[name];
   if (!connection) {
     // Rails prints "Connection ... not found" and `exit 1`; we have no
     // `process.exit`, so the loud failure is a throw with the same message.
     // Test-helper invariant with no Rails error counterpart — a bare Error is intentional.
     // eslint-disable-next-line blazetrails/rails-error-parity
     throw new Error(
-      `Connection "${connectionName}" not found. Available connections: ` +
+      `Connection "${name}" not found. Available connections: ` +
         `${Object.keys(CONNECTIONS).join(", ")}`,
     );
   }
 
   const envConfig = connection.build();
   // Rails: `unless connection_name.include?(arunit_adapter) raise ArgumentError`
-  // (connection.rb:35-37). A live-backend `ARCONN` whose connection details are
-  // absent would silently fall back to SQLite — folding in PR #4768's guard, we
-  // raise instead of resolving the wrong backend. The `arunit_adapter` proxy is
-  // the fallback lane (`sqlite3`); the message mirrors Rails' wording verbatim
-  // (single-quoted interpolations included) — only the trigger (missing env var
-  // vs. a genuine post-connect adapter mismatch) is necessarily trails-specific.
-  if (envConfig === null) {
+  // (connection.rb:35-37). Previously this fired on a missing `*_TEST_URL` — an
+  // env-presence proxy, since absent connection details silently resolved to
+  // SQLite. Sub-settings always carry defaults, so there is no "absent" state
+  // left to proxy for; the check is now Rails' literal one, comparing the
+  // connection name against the adapter its entry actually built. That makes it
+  // a structural invariant over the CONNECTIONS table (a mislabelled entry
+  // raises) rather than a report on the environment.
+  const builtAdapter = String(envConfig.configurationHash.adapter);
+  if (!name.includes(builtAdapter)) {
     throw new ArgumentError(
       `The connection name did not match the adapter name. Connection name is ` +
-        `'${connectionName}' and the adapter name is '${DEFAULT_CONNECTION}'.`,
+        `'${name}' and the adapter name is '${builtAdapter}'.`,
     );
   }
 

--- a/packages/activerecord/src/test-helpers/test-database-config.ts
+++ b/packages/activerecord/src/test-helpers/test-database-config.ts
@@ -73,11 +73,20 @@ interface NamedConnection {
  * `HashConfig` carries. Rails' `config.example.yml` entries are exactly this:
  * an adapter plus discrete host/port/socket/credential keys — never a URL.
  *
- * The credential key is `user`, not Rails' `username`: trails' adapters hand
- * the residual config straight to the `pg` / `mysql2` drivers, which read
- * `user`. A `username` key is silently ignored by both, so the connection would
- * fall back to the OS user rather than failing — verified against a live server.
- * (Teaching the adapters Rails' `username` alias is a separate concern.)
+ * The credential is emitted under BOTH `username` and `user`, because the two
+ * layers that read it disagree — a divergence this config has to straddle, not
+ * create:
+ *
+ *   - `MySQLDatabaseTasks#buildAdapterConfig` / `PostgreSQLDatabaseTasks` read
+ *     Rails' canonical `username` (as `database.yml` spells it).
+ *   - `Mysql2Adapter` / `PostgreSQLAdapter` hand the residual config straight to
+ *     the `mysql2` / `pg` drivers, which read the driver-native `user`.
+ *
+ * The previous `UrlConfig` satisfied both by accident: each layer parsed the
+ * credential out of the URL itself. Emitting only one key silently connects as
+ * the OS user instead of failing — both drivers ignore the key they don't know
+ * (verified against a live server). Converging the adapters onto Rails'
+ * `username` alias would let this drop back to one key; that is its own story.
  *
  * `socket` and `password` are omitted when unset so the drivers apply their
  * own defaults (a literal `undefined` is not the same as absent to mysql2).
@@ -88,6 +97,7 @@ function serverHash(adapter: string, settings: ServerSettings): Record<string, u
     adapter,
     host,
     port,
+    username: user,
     user,
     database,
     ...(password === undefined ? {} : { password }),

--- a/packages/activerecord/src/test-helpers/test-database-config.ts
+++ b/packages/activerecord/src/test-helpers/test-database-config.ts
@@ -32,6 +32,7 @@ import { HashConfig } from "../database-configurations/hash-config.js";
 import { UrlConfig } from "../database-configurations/url-config.js";
 import {
   connectionName,
+  driverConfig,
   mysqlSettings,
   postgresSettings,
   type ConnectionName,
@@ -69,40 +70,14 @@ interface NamedConnection {
 }
 
 /**
- * Turn {@link ServerSettings} into the `configuration_hash` shape a
- * `HashConfig` carries. Rails' `config.example.yml` entries are exactly this:
- * an adapter plus discrete host/port/socket/credential keys — never a URL.
- *
- * The credential is emitted under BOTH `username` and `user`, because the two
- * layers that read it disagree — a divergence this config has to straddle, not
- * create:
- *
- *   - `MySQLDatabaseTasks#buildAdapterConfig` / `PostgreSQLDatabaseTasks` read
- *     Rails' canonical `username` (as `database.yml` spells it).
- *   - `Mysql2Adapter` / `PostgreSQLAdapter` hand the residual config straight to
- *     the `mysql2` / `pg` drivers, which read the driver-native `user`.
- *
- * The previous `UrlConfig` satisfied both by accident: each layer parsed the
- * credential out of the URL itself. Emitting only one key silently connects as
- * the OS user instead of failing — both drivers ignore the key they don't know
- * (verified against a live server). Converging the adapters onto Rails'
- * `username` alias would let this drop back to one key; that is its own story.
- *
- * `socket` and `password` are omitted when unset so the drivers apply their
- * own defaults (a literal `undefined` is not the same as absent to mysql2).
+ * Turn {@link ServerSettings} into the `configuration_hash` a `HashConfig`
+ * carries. Rails' `config.example.yml` entries are exactly this: an adapter
+ * plus discrete host/port/socket/credential keys — never a URL. The key
+ * translation (and why it emits two spellings of the credential and socket)
+ * lives in `driverConfig`.
  */
 function serverHash(adapter: string, settings: ServerSettings): Record<string, unknown> {
-  const { host, port, user, password, database, socket } = settings;
-  return {
-    adapter,
-    host,
-    port,
-    username: user,
-    user,
-    database,
-    ...(password === undefined ? {} : { password }),
-    ...(socket === undefined ? {} : { socket }),
-  };
+  return { adapter, ...driverConfig(settings) };
 }
 
 /**
@@ -146,7 +121,10 @@ const CONNECTIONS: Record<ConnectionName, NamedConnection> = {
  */
 function resolve(): { adapter: TestAdapterName; envConfig: HashConfig | UrlConfig } {
   const name = connectionName();
-  const connection = CONNECTIONS[name];
+  // `name` is arbitrary user input from ARCONN, so the lookup is a partial one;
+  // the miss below is Rails' "Connection not found" exit (connection.rb:14-19).
+  const connections: Partial<Record<string, NamedConnection>> = CONNECTIONS;
+  const connection = connections[name];
   if (!connection) {
     // Rails prints "Connection ... not found" and `exit 1`; we have no
     // `process.exit`, so the loud failure is a throw with the same message.

--- a/packages/activerecord/src/test-helpers/use-transactional-tests.test.ts
+++ b/packages/activerecord/src/test-helpers/use-transactional-tests.test.ts
@@ -7,7 +7,7 @@
  *   pnpm vitest run packages/activerecord/src/test-helpers/use-transactional-tests.test.ts
  *
  * With PG:
- *   PG_TEST_URL=postgres://localhost:5432/rails_test \
+ *   ARCONN=postgresql PGHOST=localhost PGPORT=5432 PGDATABASE=rails_test \
  *     pnpm vitest run packages/activerecord/src/test-helpers/use-transactional-tests.test.ts
  */
 import { describe, it, expect, beforeAll, afterAll } from "vitest";

--- a/packages/activerecord/src/test-setup-worker-db.ts
+++ b/packages/activerecord/src/test-setup-worker-db.ts
@@ -1,14 +1,18 @@
 /**
- * Vitest setupFile for the activerecord project: applies a per-worker
- * database suffix to PG_TEST_URL and MYSQL_TEST_URL before any test code
- * or import runs.
+ * Vitest setupFile for the activerecord project: claims this worker's database
+ * isolation slot before any test code or import runs.
  *
  * Opens a bootstrap connection to the base DB and tries an advisory lock for
  * slot N=1..slotPoolSize(). The pool is sized with headroom over the worker
  * count (see test-helpers/ar-db-slots.ts), so a worker recycling in between
- * files always finds a free slot. Claims the first free slot, rewrites the URL
- * to that slot's DB, and holds the bootstrap connection for the life of the
- * process (lock released automatically on disconnect).
+ * files always finds a free slot. Claims the first free slot, publishes it as
+ * `AR_DB_SLOT`, and holds the bootstrap connection for the life of the process
+ * (lock released automatically on disconnect).
+ *
+ * The slot is published as a *number*, not as a rewritten connection URL:
+ * `test-helpers/test-connection-env.ts` applies the `_N` database suffix, so
+ * every consumer derives the same worker database from one signal instead of
+ * reading a mutated string.
  *
  *   PG:      pg_try_advisory_lock(N)
  *   MariaDB: GET_LOCK('ar_test_slot_N', 0)  — 0-second timeout = non-blocking
@@ -31,21 +35,18 @@ import mysql from "mysql2/promise";
 import "./sqlite/better-sqlite3.js";
 import { WORKER_DB_ENV, ensureWorkerClone } from "./test-helpers/sqlite-template.js";
 import { slotPoolSize, workerForkCount } from "./test-helpers/ar-db-slots.js";
+import {
+  SLOT_ENV,
+  activeLane,
+  mysqlSettings,
+  postgresSettings,
+} from "./test-helpers/test-connection-env.js";
 
 // Shared by all evaluations of this module within the same worker process.
 const g = globalThis as typeof globalThis & {
   __arAdvisorySlotPg?: number;
   __arAdvisorySlotMysql?: number;
 };
-
-function slotDbUrl(baseUrl: string, slot: number): string {
-  if (slot === 1) return baseUrl;
-  const url = new URL(baseUrl);
-  const db = url.pathname.replace(/^\//, "");
-  if (!db) throw new Error(`slotDbUrl: no database name in URL: ${baseUrl}`);
-  url.pathname = `/${db}_${slot}`;
-  return url.toString();
-}
 
 // Bounded retry policy: when all slots are held, retry with linear backoff.
 // Workers that can't acquire within the window fail loudly rather than
@@ -57,17 +58,18 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function acquireAdvisorySlotPg(baseUrl: string): Promise<string> {
-  if (workerForkCount() <= 1) return baseUrl;
+async function acquireAdvisorySlotPg(): Promise<number> {
+  if (workerForkCount() <= 1) return 1;
   // Slot pool is sized with headroom over the worker count (see ar-db-slots.ts).
   const slots = slotPoolSize();
 
   // Idempotent: re-evaluation returns the already-claimed slot.
   if (g.__arAdvisorySlotPg !== undefined) {
-    return slotDbUrl(baseUrl, g.__arAdvisorySlotPg);
+    return g.__arAdvisorySlotPg;
   }
 
-  const client = new pg.Client(baseUrl);
+  const { host, port, user, password, database } = postgresSettings();
+  const client = new pg.Client({ host, port, user, password, database });
   await client.connect();
 
   for (let attempt = 0; attempt < SLOT_RETRY_ATTEMPTS; attempt++) {
@@ -81,7 +83,7 @@ async function acquireAdvisorySlotPg(baseUrl: string): Promise<string> {
         // Keep client open for the process lifetime; PG drops session locks on
         // disconnect, so no explicit release is needed on clean exit.
         process.on("exit", () => void client.end());
-        return slotDbUrl(baseUrl, slot);
+        return slot;
       }
     }
     if (attempt < SLOT_RETRY_ATTEMPTS - 1) await sleep(SLOT_RETRY_DELAY_MS);
@@ -95,24 +97,24 @@ async function acquireAdvisorySlotPg(baseUrl: string): Promise<string> {
   );
 }
 
-async function acquireAdvisorySlotMysql(baseUrl: string): Promise<string> {
-  if (workerForkCount() <= 1) return baseUrl;
+async function acquireAdvisorySlotMysql(): Promise<number> {
+  if (workerForkCount() <= 1) return 1;
   // Slot pool is sized with headroom over the worker count (see ar-db-slots.ts).
   const slots = slotPoolSize();
 
   // Idempotent: re-evaluation returns the already-claimed slot.
   if (g.__arAdvisorySlotMysql !== undefined) {
-    return slotDbUrl(baseUrl, g.__arAdvisorySlotMysql);
+    return g.__arAdvisorySlotMysql;
   }
 
-  // Parse the mysql:// URL into mysql2 connection options.
-  const u = new URL(baseUrl);
+  const { host, port, user, password, database, socket } = mysqlSettings();
   const conn = await mysql.createConnection({
-    host: u.hostname,
-    port: u.port ? parseInt(u.port, 10) : 3306,
-    user: u.username || undefined,
-    password: u.password || undefined,
-    database: u.pathname.replace(/^\//, "") || undefined,
+    host,
+    port,
+    user,
+    password,
+    database,
+    ...(socket === undefined ? {} : { socketPath: socket }),
   });
 
   for (let attempt = 0; attempt < SLOT_RETRY_ATTEMPTS; attempt++) {
@@ -126,7 +128,7 @@ async function acquireAdvisorySlotMysql(baseUrl: string): Promise<string> {
         g.__arAdvisorySlotMysql = slot;
         // Hold the connection open; MariaDB releases GET_LOCK on disconnect.
         process.on("exit", () => void conn.end());
-        return slotDbUrl(baseUrl, slot);
+        return slot;
       }
     }
     if (attempt < SLOT_RETRY_ATTEMPTS - 1) await sleep(SLOT_RETRY_DELAY_MS);
@@ -140,17 +142,18 @@ async function acquireAdvisorySlotMysql(baseUrl: string): Promise<string> {
   );
 }
 
-if (process.env.PG_TEST_URL) {
-  const base = process.env.PG_TEST_URL;
-  process.env.PG_TEST_URL = await acquireAdvisorySlotPg(base);
-  // When the URL was suffixed, this worker owns an exclusive per-worker DB;
+const lane = activeLane();
+if (lane === "postgres") {
+  const slot = await acquireAdvisorySlotPg();
+  process.env[SLOT_ENV] = String(slot);
+  // A slot above 1 means this worker owns an exclusive per-worker DB;
   // test-setup-dy.ts uses reconstructFromSchema (purge+load) instead of loadSchema.
-  if (process.env.PG_TEST_URL !== base) process.env.AR_PG_EXCLUSIVE_DB = "1";
+  if (slot > 1) process.env.AR_PG_EXCLUSIVE_DB = "1";
 }
-if (process.env.MYSQL_TEST_URL) {
-  const base = process.env.MYSQL_TEST_URL;
-  process.env.MYSQL_TEST_URL = await acquireAdvisorySlotMysql(base);
-  if (process.env.MYSQL_TEST_URL !== base) process.env.AR_MYSQL_EXCLUSIVE_DB = "1";
+if (lane === "mysql") {
+  const slot = await acquireAdvisorySlotMysql();
+  process.env[SLOT_ENV] = String(slot);
+  if (slot > 1) process.env.AR_MYSQL_EXCLUSIVE_DB = "1";
 }
 
 // Phase 0 sqlite template-clone: when globalSetup built a canonical template,
@@ -170,7 +173,7 @@ if (process.env.MYSQL_TEST_URL) {
 {
   const { resolve: resolveAdapter } = await import("./connection-adapters.js");
   const adapters: string[] = ["sqlite3"];
-  if (process.env.PG_TEST_URL) adapters.push("postgresql");
-  if (process.env.MYSQL_TEST_URL) adapters.push("mysql2");
+  if (lane === "postgres") adapters.push("postgresql");
+  if (lane === "mysql") adapters.push("mysql2");
   await Promise.all(adapters.map((a) => resolveAdapter(a)));
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -335,7 +335,7 @@ export default defineConfig({
           setupFiles: [
             "./packages/activerecord/src/test-setup-worker-db.ts",
             "./packages/activerecord/src/test-setup-ar.ts",
-            ...(process.env.MYSQL_TEST_URL
+            ...(process.env.ARCONN === "mysql2"
               ? ["./packages/activerecord/src/test-setup-mysql.ts"]
               : []),
             "./packages/activerecord/src/test-setup-dy.ts",
@@ -360,7 +360,7 @@ export default defineConfig({
           // letting CI fail on every transient race — burns more reviewer
           // time than the rare hidden flake costs. Revisit if a real
           // regression slips through.
-          retry: process.env.PG_TEST_URL || process.env.MYSQL_TEST_URL ? 2 : 0,
+          retry: process.env.ARCONN === "postgresql" || process.env.ARCONN === "mysql2" ? 2 : 0,
           // Large-schema beforeAll(defineSchema(...)) calls on MySQL issue
           // hundreds of CREATE TABLE statements (e.g. has-many-associations.test.ts
           // creates ~354 tables in one beforeAll). At ~30ms per CREATE on MySQL


### PR DESCRIPTION
Rails splits two concerns that the trails test harness had collapsed into one
env var. `ARCONN` names a key of the `connections:` hash
(`vendor/rails/activerecord/test/support/connection.rb:10`), while discrete
sub-settings supply connection *details* — `MYSQL_HOST` / `MYSQL_PORT` /
`MYSQL_SOCK` interpolated into the yml, and libpq's `PG*` vars, which Rails'
`postgresql:` entries rely on by carrying no host at all
(`test/config.example.yml`).

trails instead sniffed `PG_TEST_URL` / `MYSQL_TEST_URL` **presence** to pick a
backend, so selection was a side effect of a connection detail being set.

## What changed

New `test-helpers/test-connection-env.ts` is the single env surface: `ARCONN` →
lane, sub-settings → `ServerSettings`. Every consumer routes through it —
`test-adapter`, `test-setup-worker-db`, `template-global-setup`,
`arunit2-config`, `sqlite-template`, `ddl-profile`, `vitest.config`, and the
adapter test-helpers. `test-database-config`'s `postgresql` / `mysql2` entries
now build a `HashConfig` from sub-settings instead of a `UrlConfig` from a URL.

Worker isolation publishes `AR_DB_SLOT` (a number) rather than rewriting the
URL env var in place, so every consumer derives the same worker database from
one signal instead of reading a mutated string.

CI's postgres/mysql/maria jobs move onto the sub-setting inputs. The
`activerecord-cli` E2E keeps `PG_TEST_URL`: that is the CLI's own
`--database-url` input, not a harness backend selector.

## Two things reviewers should look at

**`driverConfig()` deliberately emits two spellings of the credential and the
socket.** The layers that read them disagree: `MySQLDatabaseTasks` /
`PostgreSQLDatabaseTasks` read Rails' canonical `username` / `socket`, while the
adapters forward the residual hash to `mysql2` / `pg`, which read `user` /
`socketPath`. The old `UrlConfig` satisfied both by accident — each layer parsed
the URL itself. Emitting one spelling fails *silently*, because both drivers
ignore keys they don't recognise: a `username`-only config connects as the **OS
user** instead of raising. Consolidated into one documented function and pinned
by a regression test. Converging the adapters onto Rails' spelling is registered
as `0025-fidelity-verification-tooling/converge-adapters-onto-rails-username-key`.

**The adapter-name guard is now Rails' literal check.** It previously fired on a
missing `*_TEST_URL` — an env-presence proxy, since absent details silently
resolved to SQLite. Sub-settings always carry defaults, so that trigger is gone;
the check now compares the connection name against the adapter its entry
actually built (`connection.rb:35-37`), a structural invariant over the
connections table. The two tests premised on the old trigger are replaced by a
table-driven test over every entry.

## Failure modes closed

Self-review of the new env surface found four silent failures, each now tested:

- An empty env value was taken literally, so a CI-style `MYSQL_USER=""` produced
  `user: ""` → `Access denied for user ''`. Empty now means absent, matching
  `MySQLDatabaseTasks#resolvedField`.
- A malformed `AR_DB_SLOT` parsed to `NaN` and fell back to the **shared base
  database** — exactly the cross-worker collision slots exist to prevent,
  surfacing much later as an unrelated DDL failure. Now raises, as does a
  non-integer port instead of handing `NaN` to the driver.
- `MYSQL_SOCK` was advertised but half-wired: URL rendering silently dropped it
  (connecting over TCP), and the hash emitted only `socket`. URLs now refuse to
  serialize a socket-configured connection; the primary lane and slot
  provisioning build from the hash so the socket reaches the driver. README
  states the remaining reach (adapter probe suites are still TCP).
- `connectionName()` asserted arbitrary `ARCONN` input into the `ConnectionName`
  union, making the unknown-name branch look unreachable. It returns `string`;
  the partial lookups are explicit.

## Verification

Ran against live PostgreSQL and MySQL servers at `AR_DB_FORKS=8` (the CI fork
config) so the advisory-slot and template-provisioning paths are exercised:

- sqlite: `base`, `sqlite-template`, full `test-helpers/` suite (304 tests)
- postgres: `base`, `dirty`, `pg-template`, `test-connection-env` — 238 passed
- mysql: `base`, `dirty`, `connection.test.ts`, `test-connection-env` — 256 passed

The `username`/`user` split was caught this way: it reproduced only on the MySQL
slot-provisioning path (which routes through `DatabaseTasks`), and `origin/main`
served as the baseline confirming a real regression rather than a known flake.

`pnpm typecheck` and `pnpm lint` are clean. Lint reports one pre-existing
`expected-fixtures` error in `encryption/encrypted-fixtures.test.ts`, untouched
here.

## Size

~640 LOC, over the 500 ceiling. Every consumer shares the URL env var, so this
cannot be split into non-overlapping-file PRs while keeping CI green — the story
notes it is necessarily one coordinated change. Roughly a third is the new
module's tests and doc comments.

Closes-story: remove-test-url-sniffing-migrate-ci-onto-sub-settings
