### PR TITLE
refactor(pg,mysql,sqlite): route DDL through execute, drop _writeDirtyDepth guard

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2584,11 +2584,9 @@ function ensureAbstractAdapterMixinsApplied(): void {
   // go through the public `update`/`delete` — which themselves call
   // `execUpdate`/`execDelete`. Wiring the public methods would miss the direct
   // save path; wiring the low-level method catches both, exactly once each. The
-  // still-lower `executeMutation` these funnel through is wrapped separately
-  // (on each concrete adapter, via `dirtiesQueryCacheUnlessNested`) so DDL —
-  // which reaches `executeMutation` directly — also dirties; the
-  // `_writeDirtyDepth` guard suppresses its clear when nested under one of these
-  // wrappers so a logical write still clears exactly once. Wire the methods NOT overridden
+  // still-lower `executeMutation` these funnel through stays unwrapped, so a
+  // logical write clears exactly once. DDL dirties because schema-statements
+  // routes it through the wired public `execute`, as Rails does. Wire the methods NOT overridden
   // by a concrete adapter here — they're only defined on AbstractAdapter, and a
   // subclass prototype doesn't yet inherit them when the per-adapter module runs
   // (circular-import load order), so they must be wired on AbstractAdapter. The

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -306,6 +306,10 @@ export interface AbstractAdapter {
     options?: { name?: string; unique?: boolean; valid?: boolean },
   ): Promise<boolean>;
   tableExists(tableName: string): Promise<boolean>;
+  // Options SchemaMigration / InternalMetadata pass to `t.string` for their
+  // primary key. Mixed in from SchemaStatements; declared here so those
+  // callers can reach it through the AbstractAdapter type.
+  internalStringOptionsForPrimaryKey(): Record<string, unknown>;
   // Rails' `column_exists?(table, column, type = nil, **options)` narrows the
   // match by column `type` and the columnOptionsKeys when given.
   columnExists(

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -759,17 +759,14 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   /**
    * Execute a DDL/DML statement on the concrete adapter.
    * AbstractMysqlAdapter itself does not hold a connection; this delegates to
-   * the concrete subclass (Mysql2Adapter) which implements
-   * executeMutation on DatabaseAdapter.
+   * the concrete subclass (Mysql2Adapter) which implements `execute` on
+   * DatabaseAdapter — the same public entry point Rails' DDL runs through.
    * @internal
    */
   protected async _execMutation(sql: string): Promise<void> {
-    const exec = (this as unknown as { executeMutation?: (sql: string) => Promise<number> })
-      .executeMutation;
+    const exec = (this as unknown as { execute?: (sql: string) => Promise<unknown> }).execute;
     if (typeof exec !== "function") {
-      throw new Error(
-        `${this.constructor.name} must implement executeMutation() to use DDL helpers`,
-      );
+      throw new Error(`${this.constructor.name} must implement execute() to use DDL helpers`);
     }
     await exec.call(this, sql);
   }

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -167,16 +167,6 @@ export interface QueryCachePool {
 export interface QueryCacheHost extends DatabaseStatementsHost {
   _queryCache: Store | null;
   pool?: DatabaseStatementsHost["pool"] & QueryCachePool;
-  /**
-   * Re-entrancy depth of the wired write methods. A `dirtiesQueryCache` wrapper
-   * bumps it around its (async) call ONLY when that call is itself dirtying (not
-   * on a `"SCHEMA"` reflection read or an `uncached(dirties: false)` write), so a
-   * lower-level `executeMutation` — which every CRUD write funnels through — can
-   * tell it is nested inside an already-dirtying write and skip a second clear.
-   * DDL reaches `executeMutation` directly (depth 0) and clears, matching Rails'
-   * `execute`-based DDL. @internal
-   */
-  _writeDirtyDepth?: number;
   // Mixed in from the QueryCache module below. Dispatched through `this` (not
   // the module-level functions) so a per-connection override is honored, as in
   // Rails' `def connection.cache_notification_info`.
@@ -533,42 +523,6 @@ export function makeCachedSelectAll(original: BaseSelectAll): BaseSelectAll {
 }
 
 /**
- * Run `original` with `_writeDirtyDepth` incremented for the whole (possibly
- * async) call, so a nested `executeMutation` sees depth > 0 and skips its own
- * clear. The counter must stay raised until the returned promise settles —
- * `executeMutation` is awaited *inside* `original`, after it returns the
- * promise — so bracket both the sync and async completion paths.
- * @internal
- */
-function withWriteDirtyDepth(host: QueryCacheHost, original: () => unknown): unknown {
-  host._writeDirtyDepth = (host._writeDirtyDepth ?? 0) + 1;
-  const release = (): void => {
-    host._writeDirtyDepth = (host._writeDirtyDepth ?? 0) - 1;
-  };
-  let result: unknown;
-  try {
-    result = original();
-  } catch (err) {
-    release();
-    throw err;
-  }
-  if (result != null && typeof (result as { then?: unknown }).then === "function") {
-    return (result as Promise<unknown>).then(
-      (value) => {
-        release();
-        return value;
-      },
-      (err) => {
-        release();
-        throw err;
-      },
-    );
-  }
-  release();
-  return result;
-}
-
-/**
  * Clear the query cache on every connection pool of the current thread,
  * mirroring `ActiveRecord::Base.clear_query_caches_for_current_thread`, which
  * Rails' `dirties_query_cache` decorator calls (query_cache.rb:24). A write
@@ -615,27 +569,12 @@ function wireDirties(
     proto[methodName] = function (this: QueryCacheHost, ...args: unknown[]) {
       // Clear unconditionally, mirroring Rails' `dirties_query_cache` (each wired
       // method clears via `super`, query_cache.rb:13). The clear is idempotent, so
-      // a nested wired write clearing an already-cleared cache is harmless — do NOT
-      // gate the clear on `_writeDirtyDepth`: under concurrent writes on one
-      // connection (`Promise.all([a.save(), b.save()])`) B would be *entered* while
-      // A's depth is still raised across its await and would skip its clear, going
-      // stale. The depth guard lives only at the `executeMutation` leaf, where it
-      // keeps a single logical CRUD write to one clear (`times: 1`).
-      const dirtying =
-        !!this._queryCache?.dirties && !(skipSchemaReflection && args.includes("SCHEMA"));
-      if (dirtying) {
+      // a nested wired write clearing an already-cleared cache is harmless. Each
+      // logical write clears exactly once anyway: the write primitive
+      // (`executeMutation`) these funnel into is not itself wired, and DDL —
+      // which Rails also dirties — reaches the wired `execute` directly.
+      if (!!this._queryCache?.dirties && !(skipSchemaReflection && args.includes("SCHEMA"))) {
         clearCurrentThreadQueryCaches(this);
-        // Raise the write-dirty scope ONLY when this call is itself dirtying, so
-        // the leaf `executeMutation` it funnels into defers (times: 1). A
-        // non-dirtying call — cache off, `uncached(dirties: false)`, or a
-        // `"SCHEMA"` reflection *read* — must NOT raise the counter: a read that
-        // held `_writeDirtyDepth > 0` would make a DDL `executeMutation` entered in
-        // its window skip its clear (the counter is named for *writes*). The
-        // nested leaf of a non-dirtying write won't clear anyway — same `dirties`
-        // gate — so skipping the bump changes nothing there.
-        return withWriteDirtyDepth(this, () =>
-          (original as (...a: unknown[]) => unknown).apply(this, args),
-        );
       }
       return (original as (...a: unknown[]) => unknown).apply(this, args);
     };
@@ -674,81 +613,6 @@ export function dirtiesQueryCacheExceptSchema(
   ...methodNames: string[]
 ): void {
   wireDirties(base, methodNames, true);
-}
-
-/**
- * Wraps `executeMutation` (the low-level write/DDL primitive) so it clears the
- * query cache only when NOT nested inside an already-wired write. Rails wires
- * `dirties_query_cache` on the public `execute`, through which DDL runs, so
- * schema changes clear the cache. trails routes DDL through `executeMutation`;
- * wiring it here reproduces that. But CRUD writes funnel
- * `execInsert`/`execUpdate`/`execDelete` (already wired) → `executeMutation`, so
- * an unconditional clear here would double-clear each logical write (breaking
- * the `times: 1` expiry assertions). The `_writeDirtyDepth` guard, raised by the
- * outer wired wrapper for the duration of its async call, tells this leaf it is
- * nested and must defer to the outer clear. DDL reaches `executeMutation` at
- * depth 0 and clears. Transaction control (`BEGIN`/`COMMIT`) bypasses
- * `executeMutation` on the real adapters (they use `internalExecute`), so it is
- * unaffected.
- *
- * `executeBatch` (fixture loading, `truncate_tables`) DOES currently funnel
- * through the cache-wired `executeMutation` / `execute` and so still dirties,
- * whereas Rails' `execute_batch` → `raw_execute` is outside the dirties set. On
- * PG (the only adapter with its own `executeBatch`, looping the already-wired
- * `execute`) that clear is pre-#4858; on sqlite/mysql2 the abstract mixin loops
- * `executeMutation`, which THIS PR wired, so a bare batch (`"Fixtures Load"`) goes
- * from zero clears to one per statement there — newly introduced, not pre-existing.
- * Either way the clear is idempotent, gated on `dirties`, and batches run outside
- * `cache` blocks, so the effect is nil; routing `executeBatch` through the unwired
- * `rawExecute` to match Rails is tracked by story
- * `converge-execute-batch-through-raw-execute`.
- *
- * The leaf guard is instance-scoped rather than stack-local, which is sufficient
- * for its sole job — collapsing a single sequential CRUD write
- * (`execInsert`/`execUpdate`/`execDelete` → `executeMutation`) to one clear so the
- * `times: 1` expiry tests hold. It is NOT extended to the `wireDirties` wrappers
- * (they clear unconditionally): doing so would make B skip its clear when entered
- * during A's still-pending write on the same connection.
- *
- * KNOWN LIMITATION (accepted): because the scope spans the outer write's whole
- * async duration, a concurrent DDL on the SAME leased connection —
- * `Promise.all([post.save(), conn.addColumn(...)])` — can enter `executeMutation`
- * while the `save` holds depth 1 and skip its clear, leaving a read that
- * repopulated the cache during the `save`'s await stale (Rails' DDL `execute`
- * clears unconditionally via `super`). This is far more exotic than concurrent
- * CRUD and interleaving DDL with a save on one connection is unusual; the real
- * fix is not a better guard but removing the whole `execute`/`executeMutation`
- * split (Rails has one `perform_query`), which deletes this counter and the
- * hazard with it — tracked by story `unify-execute-mutation-into-perform-query`,
- * which supersedes this PR's wiring.
- *
- * Unlike {@link dirtiesQueryCacheExceptSchema}, this leaf does NOT skip on a
- * `"SCHEMA"` name: that skip exists because trails reuses the wrapped
- * `execute`/`exec_query` for schema *reflection reads* (Rails routes those
- * through the unwrapped `internal_exec_query`). `executeMutation` only ever runs
- * mutations/DDL — a mutation named `"SCHEMA"` must still dirty — so honouring
- * `name` here would be wrong, matching the same rationale
- * `dirtiesQueryCacheExceptSchema` gives for the generic write wiring.
- *
- * Mirrors: ActiveRecord::ConnectionAdapters::QueryCache.dirties_query_cache
- * (as applied to `execute`, the DDL entry point).
- */
-export function dirtiesQueryCacheUnlessNested(
-  base: { prototype: object },
-  ...methodNames: string[]
-): void {
-  const proto = base.prototype as Record<string, unknown>;
-  for (const methodName of methodNames) {
-    const original = proto[methodName];
-    if (typeof original !== "function") continue;
-
-    proto[methodName] = function (this: QueryCacheHost, ...args: unknown[]) {
-      if (this._queryCache?.dirties && (this._writeDirtyDepth ?? 0) === 0) {
-        clearCurrentThreadQueryCaches(this);
-      }
-      return (original as (...a: unknown[]) => unknown).apply(this, args);
-    };
-  }
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -319,7 +319,7 @@ export class SchemaStatements {
     // supportsIndexSortOrder gate, which yields false on a cold connection
     // (mirrors addIndex's warm-up). Memoized → no-op when already warm.
     await this.adapter.getDatabaseVersion?.();
-    await this.adapter.executeMutation(this.schemaCreation.accept(td));
+    await this.adapter.execute(this.schemaCreation.accept(td));
 
     // Rails: if supports_comments? && !supports_comments_in_create?
     //   change_table_comment(table_name, comment) if options[:comment].present?
@@ -401,7 +401,7 @@ export class SchemaStatements {
     const ifExists = options.ifExists ? " IF EXISTS" : "";
     for (const name of tableNames) {
       this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, name);
-      await this.adapter.executeMutation(`DROP TABLE${ifExists} ${this._qt(name)}`);
+      await this.adapter.execute(`DROP TABLE${ifExists} ${this._qt(name)}`);
     }
   }
 
@@ -414,7 +414,7 @@ export class SchemaStatements {
     const addColumnDef = await this.buildAddColumnDefinition(tableName, columnName, type, options);
     if (!addColumnDef) return;
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
-    await this.adapter.executeMutation(this.schemaCreation.accept(addColumnDef));
+    await this.adapter.execute(this.schemaCreation.accept(addColumnDef));
   }
 
   async removeColumn(
@@ -437,7 +437,7 @@ export class SchemaStatements {
       return adapter.removeColumn(tableName, columnName, _type, options);
     }
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
-    await this.adapter.executeMutation(
+    await this.adapter.execute(
       `ALTER TABLE ${this._qi(tableName)} DROP COLUMN ${this._qi(columnName)}`,
     );
   }
@@ -455,7 +455,7 @@ export class SchemaStatements {
       return adapter.renameColumn(tableName, oldName, newName);
     }
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
-    await this.adapter.executeMutation(
+    await this.adapter.execute(
       `ALTER TABLE ${this._qi(tableName)} RENAME COLUMN ${this._qi(oldName)} TO ${this._qi(newName)}`,
     );
   }
@@ -478,7 +478,7 @@ export class SchemaStatements {
       columns,
       options as Record<string, unknown>,
     );
-    await this.adapter.executeMutation(this.schemaCreation.accept(createIndex));
+    await this.adapter.execute(this.schemaCreation.accept(createIndex));
   }
 
   async removeIndex(
@@ -518,11 +518,9 @@ export class SchemaStatements {
     const indexName = await this.indexNameForRemove(tableName, positional, resolveOpts);
 
     if (this.adapterName === "mysql") {
-      await this.adapter.executeMutation(
-        `DROP INDEX ${this._qi(indexName)} ON ${this._qi(tableName)}`,
-      );
+      await this.adapter.execute(`DROP INDEX ${this._qi(indexName)} ON ${this._qi(tableName)}`);
     } else {
-      await this.adapter.executeMutation(`DROP INDEX ${this._qi(indexName)}`);
+      await this.adapter.execute(`DROP INDEX ${this._qi(indexName)}`);
     }
   }
 
@@ -554,7 +552,7 @@ export class SchemaStatements {
         options.default === undefined
           ? ""
           : ` DEFAULT ${this.adapter.quoteDefaultExpression(options.default)}`;
-      await this.adapter.executeMutation(
+      await this.adapter.execute(
         `ALTER TABLE ${table} MODIFY COLUMN ${col} ${sqlType}${nullable}${defaultClause}`,
       );
     } else if (this.adapterName === "postgres") {
@@ -569,14 +567,14 @@ export class SchemaStatements {
           `ALTER COLUMN ${col} SET DEFAULT ${this.adapter.quoteDefaultExpression(options.default)}`,
         );
       }
-      await this.adapter.executeMutation(`ALTER TABLE ${table} ${clauses.join(", ")}`);
+      await this.adapter.execute(`ALTER TABLE ${table} ${clauses.join(", ")}`);
     } else {
       const nullable = options.null === false ? " NOT NULL" : "";
       const defaultClause =
         options.default === undefined
           ? ""
           : ` DEFAULT ${this.adapter.quoteDefaultExpression(options.default)}`;
-      await this.adapter.executeMutation(
+      await this.adapter.execute(
         `ALTER TABLE ${table} ALTER COLUMN ${col} TYPE ${sqlType}${nullable}${defaultClause}`,
       );
     }
@@ -585,9 +583,7 @@ export class SchemaStatements {
   async renameTable(oldName: string, newName: string): Promise<void> {
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, oldName);
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, newName);
-    await this.adapter.executeMutation(
-      `ALTER TABLE ${this._qi(oldName)} RENAME TO ${this._qi(newName)}`,
-    );
+    await this.adapter.execute(`ALTER TABLE ${this._qi(oldName)} RENAME TO ${this._qi(newName)}`);
   }
 
   async tableExists(tableName: string): Promise<boolean> {
@@ -675,7 +671,7 @@ export class SchemaStatements {
     const defaultVal = this.extractNewDefaultValue(options);
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
     const clause = this.adapter.quoteDefaultExpression(defaultVal);
-    await this.adapter.executeMutation(
+    await this.adapter.execute(
       `ALTER TABLE ${this._qi(tableName)} ALTER COLUMN ${this._qi(columnName)} SET DEFAULT ${clause || "NULL"}`,
     );
   }
@@ -688,12 +684,12 @@ export class SchemaStatements {
   ): Promise<void> {
     if (!allowNull && defaultValue !== undefined) {
       const quoted = this.adapter.quoteDefaultExpression(defaultValue);
-      await this.adapter.executeMutation(
+      await this.adapter.execute(
         `UPDATE ${this._qi(tableName)} SET ${this._qi(columnName)} = ${quoted} WHERE ${this._qi(columnName)} IS NULL`,
       );
     }
     const constraint = allowNull ? "DROP NOT NULL" : "SET NOT NULL";
-    await this.adapter.executeMutation(
+    await this.adapter.execute(
       `ALTER TABLE ${this._qi(tableName)} ALTER COLUMN ${this._qi(columnName)} ${constraint}`,
     );
   }
@@ -846,7 +842,7 @@ export class SchemaStatements {
     // table_name_prefix/suffix to to_table and re-runs foreign_key_options
     // idempotently (column/name already filled above), mirroring Rails.
     at.addForeignKey(toTable, opts as Partial<AddForeignKeyOptions>);
-    await this.adapter.executeMutation(this.schemaCreation.accept(at));
+    await this.adapter.execute(this.schemaCreation.accept(at));
   }
 
   async removeForeignKey(
@@ -895,7 +891,7 @@ export class SchemaStatements {
     // (MySQL/MariaDB `DROP FOREIGN KEY`) rather than a hardcoded `DROP CONSTRAINT`.
     const at = this.createAlterTable(fromTable);
     at.dropForeignKey(fk.name);
-    await this.adapter.executeMutation(this.schemaCreation.accept(at));
+    await this.adapter.execute(this.schemaCreation.accept(at));
   }
 
   async addCheckConstraint(
@@ -920,7 +916,7 @@ export class SchemaStatements {
     const name = this.checkConstraintName(tableName, { name: options.name, expression });
     const validate = options.validate !== false;
     const chkDef = new CheckConstraintDefinition(tableName, expression, name, validate);
-    await this.adapter.executeMutation(
+    await this.adapter.execute(
       `ALTER TABLE ${this._qi(tableName)} ADD ${this.schemaCreation.accept(chkDef)}`,
     );
   }
@@ -967,7 +963,7 @@ export class SchemaStatements {
     // (MySQL `DROP CHECK`) rather than a hardcoded `DROP CONSTRAINT`.
     const at = this.createAlterTable(tableName);
     at.dropCheckConstraint(chk.name);
-    await this.adapter.executeMutation(this.schemaCreation.accept(at));
+    await this.adapter.execute(this.schemaCreation.accept(at));
   }
 
   async addTimestamps(tableName: string, options: ColumnOptions = {}): Promise<void> {
@@ -979,9 +975,7 @@ export class SchemaStatements {
     // trails' SQLite3Adapter still defines its own addTimestamps override for direct callers.
     if ((this.adapter as any).supportsBulkAlter?.() === true) {
       const fragments = this.addTimestampsForAlter(tableName, options);
-      await this.adapter.executeMutation(
-        `ALTER TABLE ${this._qt(tableName)} ${fragments.join(", ")}`,
-      );
+      await this.adapter.execute(`ALTER TABLE ${this._qt(tableName)} ${fragments.join(", ")}`);
       return;
     }
 
@@ -1085,9 +1079,7 @@ export class SchemaStatements {
 
   async renameIndex(tableName: string, oldName: string, newName: string): Promise<void> {
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
-    await this.adapter.executeMutation(
-      `ALTER INDEX ${this._qi(oldName)} RENAME TO ${this._qi(newName)}`,
-    );
+    await this.adapter.execute(`ALTER INDEX ${this._qi(oldName)} RENAME TO ${this._qi(newName)}`);
   }
 
   indexName(
@@ -1803,7 +1795,7 @@ export class SchemaStatements {
   async removeConstraint(tableName: string, constraintName: string): Promise<void> {
     const at = new AlterTable(tableName);
     at.dropConstraint(constraintName);
-    await this.adapter.executeMutation(this.schemaCreation.accept(at));
+    await this.adapter.execute(this.schemaCreation.accept(at));
   }
 
   async dumpSchemaInformation(): Promise<string | null> {
@@ -1858,7 +1850,7 @@ export class SchemaStatements {
     // numeric `version.to_i` to `quote`, emitting an unquoted numeric literal —
     // pass `verNum`, not the `ver` string, so adapter dispatch matches.
     if (!migrated.includes(verNum)) {
-      await this.adapter.executeMutation(
+      await this.adapter.execute(
         `INSERT INTO ${smTable} (version) VALUES (${this.adapter.quote(verNum)})`,
       );
     }
@@ -1872,7 +1864,7 @@ export class SchemaStatements {
           `Duplicate migration ${duplicate}. Please renumber your migrations to resolve the conflict.`,
         );
       }
-      await this.adapter.executeMutation(this._insertVersionsSql(smTableName, inserting));
+      await this.adapter.execute(this._insertVersionsSql(smTableName, inserting));
     }
   }
 
@@ -2108,7 +2100,7 @@ export class SchemaStatements {
         }
       } else {
         if (sqlFragments.length > 0) {
-          await this.adapter.executeMutation(
+          await this.adapter.execute(
             `ALTER TABLE ${this._qt(tableName)} ${sqlFragments.join(", ")}`,
           );
           sqlFragments.length = 0;
@@ -2126,9 +2118,7 @@ export class SchemaStatements {
     }
 
     if (sqlFragments.length > 0) {
-      await this.adapter.executeMutation(
-        `ALTER TABLE ${this._qt(tableName)} ${sqlFragments.join(", ")}`,
-      );
+      await this.adapter.execute(`ALTER TABLE ${this._qt(tableName)} ${sqlFragments.join(", ")}`);
     }
     for (const proc of nonCombinable) await proc();
   }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -60,7 +60,7 @@ export class MysqlSchemaStatements extends BaseSchemaStatements {
       return;
     }
     const createDef = new CreateIndexDefinition(idx, false, algorithmClause);
-    await this.adapter.executeMutation(this.schemaCreation.accept(createDef));
+    await this.adapter.execute(this.schemaCreation.accept(createDef));
   }
 
   override async dropTable(

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -20,11 +20,7 @@ import {
   RAW_CONNECTION_DEPRECATION_MESSAGE,
 } from "./abstract-adapter.js";
 import { deprecator } from "../deprecator.js";
-import {
-  dirtiesQueryCache,
-  dirtiesQueryCacheExceptSchema,
-  dirtiesQueryCacheUnlessNested,
-} from "./abstract/query-cache.js";
+import { dirtiesQueryCache, dirtiesQueryCacheExceptSchema } from "./abstract/query-cache.js";
 import {
   ActiveRecordError,
   AdapterError,
@@ -1418,7 +1414,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     for (const name of tableNames) {
       this.schemaCache?.clearDataSourceCacheBang(this.pool, name);
     }
-    await this.executeMutation(`DROP${temporary} TABLE${ifExists} ${quoted}${cascade}`);
+    await this.execute(`DROP${temporary} TABLE${ifExists} ${quoted}${cascade}`);
   }
 
   // ── Schema introspection ──
@@ -2250,19 +2246,14 @@ function isMysql2ConnectionError(e: unknown): boolean {
 // this adapter does NOT override (`execUpdate`/`execDelete`/`execInsertAll`/
 // `truncateTables`/`restartDbTransaction`) are wired once on AbstractAdapter.
 // Each logical write clears the cache exactly once; the still-lower
-// `executeMutation` these funnel through is wrapped separately (below) but
-// guarded to defer to the outer clear, and reads route through
+// `executeMutation` these funnel through is deliberately NOT wrapped (DDL runs
+// through the wired `execute`, as in Rails), and reads route through
 // `internalExecQuery` (never tripping the wrapper).
 dirtiesQueryCache(Mysql2Adapter, "execInsert", "rollbackDbTransaction", "rollbackToSavepoint");
 // Schema reflection reuses the wrapped `execute`/`exec_query` with name
 // "SCHEMA" (Rails routes it through the unwrapped `internal_exec_query`), so
 // use the schema-aware variant here — those reflection reads must not dirty.
 dirtiesQueryCacheExceptSchema(Mysql2Adapter, "execQuery", "execute");
-// DDL funnels through `executeMutation` (schema-statements), not the wired
-// `execute`; wire it so schema changes dirty the cache like Rails' `execute`-based
-// DDL. Nested CRUD (`execInsert`/`execUpdate`/`execDelete` → `executeMutation`)
-// is suppressed by the `_writeDirtyDepth` guard to avoid a double-clear.
-dirtiesQueryCacheUnlessNested(Mysql2Adapter, "executeMutation");
 
 // Mirrors: mysql2_adapter.rb:190-198 — adapter-scoped type registrations. The
 // mysql2 `:string`/`:immutable_string` types coerce booleans to `"1"`/`"0"`

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -70,11 +70,7 @@ import {
 } from "../errors.js";
 import { AbstractAdapter, RAW_CONNECTION_DEPRECATION_MESSAGE } from "./abstract-adapter.js";
 import { deprecator } from "../deprecator.js";
-import {
-  dirtiesQueryCache,
-  dirtiesQueryCacheExceptSchema,
-  dirtiesQueryCacheUnlessNested,
-} from "./abstract/query-cache.js";
+import { dirtiesQueryCache, dirtiesQueryCacheExceptSchema } from "./abstract/query-cache.js";
 import { PostgreSQLSchemaStatements } from "./postgresql/schema-statements-class.js";
 import type { JoinTableOptions } from "./abstract/schema-statements.js";
 import {
@@ -5366,19 +5362,14 @@ const FORMAT_TYPE_ALIASES: Record<string, string> = {
 // this adapter does NOT override (`execUpdate`/`execDelete`/`execInsertAll`/
 // `truncateTables`/`restartDbTransaction`) are wired once on AbstractAdapter.
 // Each logical write clears the cache exactly once; the still-lower
-// `executeMutation` these funnel through is wrapped separately (below) but
-// guarded to defer to the outer clear, and reads route through
+// `executeMutation` these funnel through is deliberately NOT wrapped (DDL runs
+// through the wired `execute`, as in Rails), and reads route through
 // `internalExecQuery` (never tripping the wrapper).
 dirtiesQueryCache(PostgreSQLAdapter, "execInsert", "rollbackDbTransaction", "rollbackToSavepoint");
 // Schema reflection reuses the wrapped `execute`/`exec_query` with name
 // "SCHEMA" (Rails routes it through the unwrapped `internal_exec_query`), so
 // use the schema-aware variant here — those reflection reads must not dirty.
 dirtiesQueryCacheExceptSchema(PostgreSQLAdapter, "execQuery", "execute");
-// DDL funnels through `executeMutation` (schema-statements), not the wired
-// `execute`; wire it so schema changes dirty the cache like Rails' `execute`-based
-// DDL. Nested CRUD (`execInsert`/`execUpdate`/`execDelete` → `executeMutation`)
-// is suppressed by the `_writeDirtyDepth` guard to avoid a double-clear.
-dirtiesQueryCacheUnlessNested(PostgreSQLAdapter, "executeMutation");
 
 // Mirrors `ActiveSupport.run_load_hooks(:active_record_postgresqladapter, self)`
 // at the bottom of Rails' postgresql_adapter.rb — lets railtie initializers

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.test.ts
@@ -9,7 +9,7 @@ function makeFakeAdapter() {
   const clearedTables: string[] = [];
   const adapter = {
     adapterName: "postgres" as const,
-    executeMutation: vi.fn(async (sql: string) => {
+    execute: vi.fn(async (sql: string) => {
       executed.push(sql);
     }),
     schemaCache: {
@@ -157,7 +157,7 @@ describe("PostgreSQLSchemaStatements#addForeignKey use_foreign_keys? guard", () 
       exec: vi.fn(async (sql: string) => {
         executed.push(sql);
       }),
-      executeMutation: vi.fn(async (sql: string) => {
+      execute: vi.fn(async (sql: string) => {
         executed.push(sql);
       }),
     } as unknown as DatabaseAdapter;
@@ -175,7 +175,7 @@ describe("PostgreSQLSchemaStatements#addForeignKey use_foreign_keys? guard", () 
     const adapter = {
       adapterName: "postgres" as const,
       supportsForeignKeys: () => true,
-      executeMutation: vi.fn(async (sql: string) => {
+      execute: vi.fn(async (sql: string) => {
         executed.push(sql);
       }),
     } as unknown as DatabaseAdapter;

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -97,7 +97,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, name);
     }
     const quoted = tableNames.map((n) => this._qt(n)).join(", ");
-    await this.adapter.executeMutation(`DROP TABLE${ifExists} ${quoted}${cascade}`);
+    await this.adapter.execute(`DROP TABLE${ifExists} ${quoted}${cascade}`);
   }
 
   // ---------------------------------------------------------------------------
@@ -916,9 +916,9 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     this.pg.clearCacheBang();
     const changeColDef = this.buildChangeColumnDefinition(tableName, columnName, type, options);
     const clause = this.pg.schemaCreation.accept(changeColDef);
-    // Route DDL through executeMutation (not the raw `exec`) so the
+    // Route DDL through the public `execute` (not the raw `exec`) so the
     // dirties_query_cache wrapper clears the query cache on schema changes.
-    await this.adapter.executeMutation(`ALTER TABLE ${this._qt(tableName)} ${clause}`);
+    await this.adapter.execute(`ALTER TABLE ${this._qt(tableName)} ${clause}`);
     if ("comment" in options) {
       await this.changeColumnComment(tableName, columnName, options.comment ?? null);
     }
@@ -956,7 +956,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     // cache, rename, then fix up index names that embed the column name.
     this.pg.clearCacheBang();
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
-    await this.adapter.executeMutation(
+    await this.adapter.execute(
       `ALTER TABLE ${this._qt(tableName)} RENAME COLUMN ${this._qi(columnName)} TO ${this._qi(newColumnName)}`,
     );
     await this.renameColumnIndexes(tableName, columnName, newColumnName);
@@ -976,13 +976,13 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     const quotedCol = this._qi(columnName);
     const defaultValue = this.extractNewDefaultValue(defaultOrChanges);
     if (defaultValue == null) {
-      await this.adapter.executeMutation(
+      await this.adapter.execute(
         `ALTER TABLE ${quotedTable} ALTER COLUMN ${quotedCol} DROP DEFAULT`,
       );
     } else {
       const col = (await this.columns(tableName)).find((c) => c.name === columnName);
       const expr = this.adapter.quoteDefaultExpression(defaultValue, col);
-      await this.adapter.executeMutation(
+      await this.adapter.execute(
         `ALTER TABLE ${quotedTable} ALTER COLUMN ${quotedCol} SET DEFAULT ${expr}`,
       );
     }
@@ -1045,12 +1045,12 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       // column can't be found rather than quoting against an undefined column.
       if (col) {
         const expr = this.adapter.quoteDefaultExpression(defaultValue, col);
-        await this.adapter.executeMutation(
+        await this.adapter.execute(
           `UPDATE ${quotedTable} SET ${quotedCol} = ${expr} WHERE ${quotedCol} IS NULL`,
         );
       }
     }
-    await this.adapter.executeMutation(
+    await this.adapter.execute(
       `ALTER TABLE ${quotedTable} ALTER COLUMN ${quotedCol} ${nullable ? "DROP" : "SET"} NOT NULL`,
     );
   }
@@ -1065,7 +1065,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     // the COMMENT ON statement.
     this.pg.clearCacheBang();
     const comment = this.extractNewCommentValue(commentOrChanges) as string | null;
-    await this.adapter.executeMutation(
+    await this.adapter.execute(
       `COMMENT ON COLUMN ${this._qt(tableName)}.${this._qi(columnName)} IS ${this.pg.quote(comment)}`,
     );
   }
@@ -1077,7 +1077,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     // Mirrors PostgreSQL::SchemaStatements#change_table_comment.
     this.pg.clearCacheBang();
     const comment = this.extractNewCommentValue(commentOrChanges) as string | null;
-    await this.adapter.executeMutation(
+    await this.adapter.execute(
       `COMMENT ON TABLE ${this._qt(tableName)} IS ${this.pg.quote(comment)}`,
     );
   }

--- a/packages/activerecord/src/connection-adapters/schema-cache.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.test.ts
@@ -875,9 +875,9 @@ describe("DDL cache-invalidation safety-net", () => {
       order.push(`clear:${name}`);
       origClear(pool, name);
     });
-    adapter.executeMutation.mockImplementation(async () => {
+    adapter.execute.mockImplementation(async () => {
       order.push("sql");
-      return 0;
+      return [];
     });
 
     const ss = new SchemaStatements(adapter as any);
@@ -899,9 +899,9 @@ describe("DDL cache-invalidation safety-net", () => {
       order.push(`clear:${name}`);
       origClear(pool, name);
     });
-    adapter.executeMutation.mockImplementation(async () => {
+    adapter.execute.mockImplementation(async () => {
       order.push("sql");
-      return 0;
+      return [];
     });
 
     const ss = new SchemaStatements(adapter as any);
@@ -997,9 +997,9 @@ describe("DDL cache-invalidation safety-net", () => {
       order.push(`clear:${name}`);
       origClear(pool, name);
     });
-    adapter.executeMutation.mockImplementation(async () => {
+    adapter.execute.mockImplementation(async () => {
       order.push("sql");
-      return 0;
+      return [];
     });
 
     const ss = new SchemaStatements(adapter as any);
@@ -1021,9 +1021,9 @@ describe("DDL cache-invalidation safety-net", () => {
       order.push(`clear:${name}`);
       origClear(pool, name);
     });
-    adapter.executeMutation.mockImplementation(async () => {
+    adapter.execute.mockImplementation(async () => {
       order.push("sql");
-      return 0;
+      return [];
     });
 
     const ss = new SchemaStatements(adapter as any);

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -25,11 +25,7 @@ import {
   indexExistsForRemoveFrom,
   canRemoveIndexByName,
 } from "./abstract/schema-statements.js";
-import {
-  dirtiesQueryCache,
-  dirtiesQueryCacheExceptSchema,
-  dirtiesQueryCacheUnlessNested,
-} from "./abstract/query-cache.js";
+import { dirtiesQueryCache, dirtiesQueryCacheExceptSchema } from "./abstract/query-cache.js";
 import { execInsertReturningReadback } from "./abstract/database-statements.js";
 import { StatementPool as GenericStatementPool } from "./statement-pool.js";
 import {
@@ -1575,7 +1571,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       return;
     }
     const indexName = indexNameForRemoveFrom(genName, all, tableName, columnName, opts);
-    await this.executeMutation(`DROP INDEX ${quoteColumnName(indexName)}`);
+    await this.execute(`DROP INDEX ${quoteColumnName(indexName)}`);
   }
 
   createSchemaDumper(
@@ -1637,7 +1633,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     // as an identifier since it occupies a SQL keyword position.
     const args = Array.isArray(virtualValues) ? virtualValues.map(String) : [];
     const rawArgs = args.join(", ");
-    await this.executeMutation(
+    await this.execute(
       `CREATE VIRTUAL TABLE IF NOT EXISTS ${quoteTableName(tableName)} USING ${mod}(${rawArgs})`,
     );
   }
@@ -1647,13 +1643,13 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     _moduleName?: string,
     _values?: string[],
   ): Promise<void> {
-    await this.executeMutation(`DROP TABLE IF EXISTS ${quoteTableName(tableName)}`);
+    await this.execute(`DROP TABLE IF EXISTS ${quoteTableName(tableName)}`);
   }
 
   async renameTable(tableName: string, newName: string): Promise<void> {
     this.schemaCache.clearDataSourceCacheBang(this.pool, tableName);
     this.schemaCache.clearDataSourceCacheBang(this.pool, newName);
-    await this.executeMutation(
+    await this.execute(
       `ALTER TABLE ${quoteTableName(tableName)} RENAME TO ${quoteTableName(newName)}`,
     );
   }
@@ -1676,7 +1672,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     // the SQLite override would leave a stale columns entry after an
     // `ALTER TABLE … ADD COLUMN`.
     this.schemaCache?.clearDataSourceCacheBang(this.pool, tableName);
-    await this.executeMutation(sql);
+    await this.execute(sql);
   }
 
   async removeColumn(tableName: string, columnName: string, _type?: string): Promise<void> {
@@ -1728,7 +1724,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       const existing = (await this.columns(tableName)).find((c) => c.name === columnName);
       const serialized = this.serializeDefaultForColumn(defaultValue, existing?.sqlType ?? null);
       const quotedDefault = this.quoteDefault(serialized);
-      await this.executeMutation(
+      await this.execute(
         `UPDATE ${quoteTableName(tableName)} SET ${quoteColumnName(columnName)} = ${quotedDefault} WHERE ${quoteColumnName(columnName)} IS NULL`,
       );
     }
@@ -1762,7 +1758,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
 
   async renameColumn(tableName: string, columnName: string, newColumnName: string): Promise<void> {
     this.schemaCache?.clearDataSourceCacheBang(this.pool, tableName);
-    await this.executeMutation(
+    await this.execute(
       `ALTER TABLE ${quoteTableName(tableName)} RENAME COLUMN ${quoteColumnName(columnName)} TO ${quoteColumnName(newColumnName)}`,
     );
   }
@@ -3213,8 +3209,8 @@ function translateException(
 // this adapter does NOT override (`execUpdate`/`execDelete`/`execInsertAll`/
 // `truncateTables`/`restartDbTransaction`) are wired once on AbstractAdapter.
 // Each logical write clears the cache exactly once; the still-lower
-// `executeMutation` these funnel through is wrapped separately (below) but
-// guarded to defer to the outer clear, and reads route through
+// `executeMutation` these funnel through is deliberately NOT wrapped (DDL runs
+// through the wired `execute`, as in Rails), and reads route through
 // `internalExecQuery` (never tripping the wrapper).
 dirtiesQueryCache(
   AbstractSQLite3Adapter,
@@ -3227,11 +3223,6 @@ dirtiesQueryCache(
 // "SCHEMA" (Rails routes it through the unwrapped `internal_exec_query`), so
 // use the schema-aware variant here — those reflection reads must not dirty.
 dirtiesQueryCacheExceptSchema(AbstractSQLite3Adapter, "execQuery", "execute");
-// DDL funnels through `executeMutation` (schema-statements), not the wired
-// `execute`; wire it so schema changes dirty the cache like Rails' `execute`-based
-// DDL. Nested CRUD (`execInsert`/`execUpdate`/`execDelete` → `executeMutation`)
-// is suppressed by the `_writeDirtyDepth` guard to avoid a double-clear.
-dirtiesQueryCacheUnlessNested(AbstractSQLite3Adapter, "executeMutation");
 
 // Mirrors `ActiveSupport.run_load_hooks(:active_record_sqlite3adapter, self)`
 // at the bottom of Rails' sqlite3_adapter.rb — lets railtie initializers

--- a/packages/activerecord/src/ddl-through-execute.trails.test.ts
+++ b/packages/activerecord/src/ddl-through-execute.trails.test.ts
@@ -1,0 +1,39 @@
+/**
+ * trails-specific invariant with no verbatim Rails counterpart.
+ *
+ * Rails runs DDL through the public `execute` (`add_column` is
+ * `execute schema_creation.accept(add_column_def)`,
+ * abstract/schema_statements.rb:636-641). trails used to route it through the
+ * lower-level `executeMutation`; schema-statements now calls `execute`, matching
+ * Rails.
+ *
+ * `executeMutation` enforced the readonly guard (`check_if_write_query`, raising
+ * `ReadOnlyError` while writes are prevented) via `preprocessQuery`. `execute`
+ * runs the same `preprocessQuery`, so the guard survives the swap — this pins
+ * that, since a primitive swap that silently dropped it would let DDL through on
+ * a replica.
+ */
+import { describe, it, expect } from "vitest";
+
+import { Base } from "./index.js";
+import { ReadOnlyError } from "./errors.js";
+import { fixtures } from "./test-helpers/fixtures.js";
+
+describe("DDL through execute (trails)", () => {
+  // Real DDL: run non-transactionally so MySQL's implicit commit on DDL cannot
+  // commit the fixture transaction mid-test (see query-cache-ddl-dirties).
+  fixtures([], { useTransactionalTests: false });
+
+  it("DDL raises if preventing writes", async () => {
+    const conn = (await Base.leaseConnection()) as never as {
+      addColumn(t: string, c: string, ty: string): Promise<void>;
+    };
+    const error = await Base.whilePreventingWrites(async () => {
+      await conn.addColumn("posts", "readonlyDdlProbe", "string");
+    }).catch((e) => e);
+    expect(error).toBeInstanceOf(ReadOnlyError);
+    expect((error as ReadOnlyError).message).toMatch(
+      /^Write query attempted while in readonly mode: ALTER TABLE /,
+    );
+  });
+});

--- a/packages/activerecord/src/internal-metadata.ts
+++ b/packages/activerecord/src/internal-metadata.ts
@@ -84,17 +84,19 @@ export class InternalMetadata {
     return this._enabled;
   }
 
+  // Rails: create_table(table_name, id: false) { |t| t.string :key, **...; t.string
+  // :value; t.timestamps } behind a table_exists? guard
+  // (internal_metadata.rb:85-98). `t.timestamps` defaults to null: false, so the
+  // resulting table matches the DDL this used to hand-build — but the column
+  // types and quoting now come from the adapter instead of an adapterName branch.
   async createTable(): Promise<void> {
     if (!this._enabled) return;
-    const tsType = this._connection.adapterName === "postgres" ? "TIMESTAMP" : "DATETIME";
-    const q = (n: string) => this._q(n);
-    await this._connection.execute(
-      `CREATE TABLE IF NOT EXISTS ${this._connection.quoteTableName(this.tableName)} (` +
-        `${q("key")} VARCHAR(255) NOT NULL PRIMARY KEY, ` +
-        `${q("value")} VARCHAR(255), ` +
-        `${q("created_at")} ${tsType} NOT NULL, ` +
-        `${q("updated_at")} ${tsType} NOT NULL)`,
-    );
+    if (await this._connection.tableExists(this.tableName)) return;
+    await this._connection.createTable(this.tableName, { id: false }, (t) => {
+      t.string("key", this._connection.internalStringOptionsForPrimaryKey());
+      t.string("value");
+      t.timestamps();
+    });
   }
 
   /**
@@ -116,10 +118,8 @@ export class InternalMetadata {
     // reaching over and dropping ar_internal_metadata that another
     // config or adapter is actively using.
     if (!this._enabled) return;
-    await this._connection.execute(
-      // eslint-disable-next-line blazetrails/no-raw-sql -- DDL: Arel has no schema-statement nodes; Rails builds this SQL as a string too.
-      `DROP TABLE IF EXISTS ${this._connection.quoteTableName(this.tableName)}`,
-    );
+    // Rails: drop_table table_name, if_exists: true (internal_metadata.rb:100-104).
+    await this._connection.dropTable(this.tableName, { ifExists: true });
   }
 
   async get(key: string): Promise<string | null> {

--- a/packages/activerecord/src/internal-metadata.ts
+++ b/packages/activerecord/src/internal-metadata.ts
@@ -88,7 +88,7 @@ export class InternalMetadata {
     if (!this._enabled) return;
     const tsType = this._connection.adapterName === "postgres" ? "TIMESTAMP" : "DATETIME";
     const q = (n: string) => this._q(n);
-    await this._connection.executeMutation(
+    await this._connection.execute(
       `CREATE TABLE IF NOT EXISTS ${this._connection.quoteTableName(this.tableName)} (` +
         `${q("key")} VARCHAR(255) NOT NULL PRIMARY KEY, ` +
         `${q("value")} VARCHAR(255), ` +
@@ -116,7 +116,8 @@ export class InternalMetadata {
     // reaching over and dropping ar_internal_metadata that another
     // config or adapter is actively using.
     if (!this._enabled) return;
-    await this._connection.executeMutation(
+    await this._connection.execute(
+      // eslint-disable-next-line blazetrails/no-raw-sql -- DDL: Arel has no schema-statement nodes; Rails builds this SQL as a string too.
       `DROP TABLE IF EXISTS ${this._connection.quoteTableName(this.tableName)}`,
     );
   }
@@ -165,7 +166,7 @@ export class InternalMetadata {
     if (!this._enabled) return;
     const dm = new DeleteManager();
     dm.from(this.arelTable);
-    await this._connection.executeMutation(this._connection.toSql(dm));
+    await this._connection.execute(this._connection.toSql(dm));
   }
 
   async count(): Promise<number> {
@@ -236,7 +237,7 @@ export class InternalMetadata {
       [this.arelTable.get("created_at"), now],
       [this.arelTable.get("updated_at"), now],
     ]);
-    await this._connection.executeMutation(this._connection.toSql(im));
+    await this._connection.execute(this._connection.toSql(im));
   }
 
   private async updateEntry(key: string, newValue: string): Promise<void> {
@@ -248,6 +249,6 @@ export class InternalMetadata {
       [this.arelTable.get("updated_at"), now],
     ]);
     um.where(this.arelTable.get(this.primaryKey).eq(key));
-    await this._connection.executeMutation(this._connection.toSql(um));
+    await this._connection.execute(this._connection.toSql(um));
   }
 }

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1712,7 +1712,7 @@ export class MigrationContext {
         `Adapter ${this.connection.adapterName} does not expose schemaCreation; cannot render CREATE TABLE DDL.`,
       );
     }
-    await this.connection.executeMutation(schemaCreation.accept(td));
+    await this.connection.execute(schemaCreation.accept(td));
     if (options?.comment != null && options.comment.trim().length > 0) {
       const adapterWithComments = this.connection as {
         supportsComments?: () => boolean;

--- a/packages/activerecord/src/migrator.ts
+++ b/packages/activerecord/src/migrator.ts
@@ -40,7 +40,8 @@ export class MigrationRunner {
    */
   private async ensureTable(): Promise<void> {
     const quoted = this.tableName.replace(/"/g, '""');
-    await this.adapter.executeMutation(
+    await this.adapter.execute(
+      // eslint-disable-next-line blazetrails/no-raw-sql -- DDL: Arel has no schema-statement nodes; Rails builds this SQL as a string too.
       `CREATE TABLE IF NOT EXISTS "${quoted}" ("version" VARCHAR(255) NOT NULL PRIMARY KEY)`,
     );
   }
@@ -70,7 +71,7 @@ export class MigrationRunner {
       await entry.migration.run(this.adapter, "up");
       const im = new InsertManager(this.arelTable);
       im.insert([[this.arelTable.get("version"), entry.version]]);
-      await this.adapter.executeMutation(this.adapter.toSql(im));
+      await this.adapter.execute(this.adapter.toSql(im));
     }
   }
 
@@ -93,7 +94,7 @@ export class MigrationRunner {
       const dm = new DeleteManager();
       dm.from(this.arelTable);
       dm.where(this.arelTable.get("version").eq(entry.version));
-      await this.adapter.executeMutation(this.adapter.toSql(dm));
+      await this.adapter.execute(this.adapter.toSql(dm));
     }
   }
 

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -465,7 +465,8 @@ export async function createTable(this: typeof Base): Promise<void> {
   const pkSet = new Set(pks);
   const a = this.connection;
 
-  await a.executeMutation(`DROP TABLE IF EXISTS ${a.quoteTableName(table)}`);
+  // eslint-disable-next-line blazetrails/no-raw-sql -- DDL: Arel has no schema-statement nodes; Rails builds this SQL as a string too.
+  await a.execute(`DROP TABLE IF EXISTS ${a.quoteTableName(table)}`);
 
   const colDefs: string[] = [];
   if (pks.length === 1) {
@@ -494,7 +495,8 @@ export async function createTable(this: typeof Base): Promise<void> {
     colDefs.push(`PRIMARY KEY (${pks.map((pk) => a.quoteIdentifier(pk)).join(", ")})`);
   }
 
-  await a.executeMutation(
+  await a.execute(
+    // eslint-disable-next-line blazetrails/no-raw-sql -- DDL: Arel has no schema-statement nodes; Rails builds this SQL as a string too.
     `CREATE TABLE IF NOT EXISTS ${a.quoteTableName(table)} (${colDefs.join(", ")})`,
   );
 

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -384,7 +384,7 @@ async function processNestedAttributes(record: Base): Promise<void> {
             .set(sets)
             .where((ctor as any)._buildPkWhereNode(record.id));
           const conn = (ctor as any).connection;
-          await conn.executeMutation(conn.toSql(um));
+          await conn.execute(conn.toSql(um));
 
           // The deferred FK write above bypasses the normal belongs_to
           // assignment, so the counter-cache machinery never runs for the

--- a/packages/activerecord/src/query-cache-ddl-dirties.trails.test.ts
+++ b/packages/activerecord/src/query-cache-ddl-dirties.trails.test.ts
@@ -3,11 +3,10 @@
  *
  * Rails wires `dirties_query_cache` on the public `execute` (query_cache.rb:13),
  * and DDL runs through `execute`, so a schema change inside a `cache` block
- * clears the query cache. trails routes DDL through the low-level
- * `executeMutation` (schema-statements), which CRUD writes also funnel through
- * below the wired `execInsert`/`execUpdate`/`execDelete`. `executeMutation` is
- * wired to dirty the cache but guarded (`_writeDirtyDepth`) so nested CRUD does
- * not double-clear. This test pins the DDL half of that contract: a schema
+ * clears the query cache. trails now routes DDL through that same wired
+ * `execute` (schema-statements), while CRUD writes clear at the wired
+ * `execInsert`/`execUpdate`/`execDelete` above the unwired `executeMutation`
+ * primitive. This test pins the DDL half of that contract: a schema
  * change issued inside an enabled `cache` block clears the cache exactly once,
  * matching Rails' `execute`-based DDL. (Rails' closest test,
  * `test_cache_gets_cleared_after_migration`, warms the cache *outside* a `cache`
@@ -55,11 +54,10 @@ describe("QueryCache DDL dirties (trails)", () => {
       };
       try {
         // `add_column` is a single `ALTER TABLE … ADD COLUMN` that funnels
-        // through `executeMutation` on every adapter (unlike sqlite's
+        // through the public `execute` on every adapter (unlike sqlite's
         // `change_column`, which takes the table-rebuild path). It must dirty
         // the cache exactly once — like Rails' `execute`-based DDL, where the
-        // pre-fix deviation left it untouched (zero clears), and not twice (the
-        // nested-CRUD double-clear that the `_writeDirtyDepth` guard prevents).
+        // pre-fix deviation left it untouched (zero clears).
         await conn.addColumn("posts", "queryCacheDdlProbe", "string");
         expect(clears).toBe(1);
       } finally {

--- a/packages/activerecord/src/schema-migration.ts
+++ b/packages/activerecord/src/schema-migration.ts
@@ -44,14 +44,21 @@ export class SchemaMigration {
     return `${Base.tableNamePrefix}${Base.schemaMigrationsTableName}${Base.tableNameSuffix}`;
   }
 
+  // Rails: create_table(table_name, id: false) { |t| t.string :version,
+  // **connection.internal_string_options_for_primary_key } behind a
+  // table_exists? guard (schema_migration.rb:53-61). Going through create_table
+  // — rather than hand-built DDL — is what gets the adapter's own
+  // TableDefinition and identifier quoting.
   async createTable(): Promise<void> {
-    await this._adapter.execute(
-      `CREATE TABLE IF NOT EXISTS "${this.tableName}" ("version" VARCHAR(255) NOT NULL PRIMARY KEY)`,
-    );
+    if (await this._adapter.tableExists(this.tableName)) return;
+    await this._adapter.createTable(this.tableName, { id: false }, (t) => {
+      t.string(this.primaryKey, this._adapter.internalStringOptionsForPrimaryKey());
+    });
   }
 
+  // Rails: drop_table table_name, if_exists: true (schema_migration.rb:64-66).
   async dropTable(): Promise<void> {
-    await this._adapter.execute(`DROP TABLE IF EXISTS "${this.tableName}"`);
+    await this._adapter.dropTable(this.tableName, { ifExists: true });
   }
 
   async createVersion(version: string): Promise<void> {

--- a/packages/activerecord/src/schema-migration.ts
+++ b/packages/activerecord/src/schema-migration.ts
@@ -45,26 +45,26 @@ export class SchemaMigration {
   }
 
   async createTable(): Promise<void> {
-    await this._adapter.executeMutation(
+    await this._adapter.execute(
       `CREATE TABLE IF NOT EXISTS "${this.tableName}" ("version" VARCHAR(255) NOT NULL PRIMARY KEY)`,
     );
   }
 
   async dropTable(): Promise<void> {
-    await this._adapter.executeMutation(`DROP TABLE IF EXISTS "${this.tableName}"`);
+    await this._adapter.execute(`DROP TABLE IF EXISTS "${this.tableName}"`);
   }
 
   async createVersion(version: string): Promise<void> {
     const im = new InsertManager(this.arelTable);
     im.insert([[this.arelTable.get(this.primaryKey), version]]);
-    await this._adapter.executeMutation(this._adapter.toSql(im));
+    await this._adapter.execute(this._adapter.toSql(im));
   }
 
   async deleteVersion(version: string): Promise<void> {
     const dm = new DeleteManager();
     dm.from(this.arelTable);
     dm.where(this.arelTable.get(this.primaryKey).eq(version));
-    await this._adapter.executeMutation(this._adapter.toSql(dm));
+    await this._adapter.execute(this._adapter.toSql(dm));
   }
 
   async deleteAllVersions(): Promise<void> {
@@ -207,7 +207,7 @@ export class SchemaMigration {
       const rows = toInsert.map((v) => [v]);
       im.ast.columns = [col];
       im.values = im.createValuesList(rows);
-      await this._adapter.executeMutation(this._adapter.toSql(im));
+      await this._adapter.execute(this._adapter.toSql(im));
     }
   }
 }

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
@@ -23,20 +23,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "add_check_constraint",
-    "call": "execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "add_column",
-    "call": "execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "add_columns",
     "call": "each",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -45,21 +31,7 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "add_foreign_key",
-    "call": "execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "add_foreign_key",
     "call": "slice",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "add_index",
-    "call": "execute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -101,13 +73,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "add_timestamps",
-    "call": "execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "add_timestamps",
     "call": "quote_table_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -137,13 +102,6 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "assume_migrated_upto_version",
     "call": "detect",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "assume_migrated_upto_version",
-    "call": "execute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -235,13 +193,6 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "bulk_change_table",
     "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "bulk_change_table",
-    "call": "execute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -430,13 +381,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "create_table",
-    "call": "execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "create_table",
     "call": "key?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -570,13 +514,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "drop_table",
-    "call": "execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "drop_table",
     "call": "quote_table_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -613,7 +550,7 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "extract_new_default_value",
     "call": "has_key?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -683,7 +620,7 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "foreign_keys_enabled?",
     "call": "fetch",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -872,7 +809,7 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "options_include_default?",
     "call": "include?",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -921,20 +858,6 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "remove_check_constraint",
     "call": "check_constraint_for!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "remove_check_constraint",
-    "call": "execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "remove_column",
-    "call": "execute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -1010,29 +933,8 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "remove_constraint",
-    "call": "execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "remove_foreign_key",
     "call": "delete",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "remove_foreign_key",
-    "call": "execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "remove_index",
-    "call": "execute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/internal-metadata.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/internal-metadata.json
@@ -24,27 +24,6 @@
     "package": "activerecord",
     "tsFile": "internal-metadata.ts",
     "rubyName": "create_table",
-    "call": "string",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "internal-metadata.ts",
-    "rubyName": "create_table",
-    "call": "table_exists?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "internal-metadata.ts",
-    "rubyName": "create_table",
-    "call": "timestamps",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "internal-metadata.ts",
-    "rubyName": "create_table",
     "call": "with_connection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/schema-migration.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/schema-migration.json
@@ -24,20 +24,6 @@
     "package": "activerecord",
     "tsFile": "schema-migration.ts",
     "rubyName": "create_table",
-    "call": "string",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "schema-migration.ts",
-    "rubyName": "create_table",
-    "call": "table_exists?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "schema-migration.ts",
-    "rubyName": "create_table",
     "call": "with_connection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
Rails runs DDL through the public `execute`, which `dirties_query_cache` wires
(`query_cache.rb:13`) — e.g. `add_column` is
`execute schema_creation.accept(add_column_def)`
(`abstract/schema_statements.rb:636-641`). trails instead called the lower-level
`executeMutation` at ~45 DDL sites, so #4858 had to wire `executeMutation`
itself with a trails-only `_writeDirtyDepth` re-entrancy guard to stop CRUD
(`execInsert`/`execUpdate`/`execDelete` → `executeMutation`) from double-clearing.

This routes DDL through `execute` instead, matching Rails' call shape, and
deletes the guard.

## Why the swap is behavior-preserving

The story flagged the primitive swap as the risk (`.run()` vs `.all()`, readonly
guard, transaction materialization). Reading all three adapters, those concerns
don't materialize:

- **One primitive.** On sqlite3/PG/mysql2, `execute` and `executeMutation` both
  delegate to the same `_performQuery` — Rails' single `perform_query`.
- **`.run()` vs `.all()` is chosen inside `perform_query`**, by `isWriteQuery`
  (`sqlite3/database-statements.ts:213`), not by the entry point. DDL still takes
  `.run()` and returns `rows: []`. PG/mysql2 `execute` already handle a
  non-row-returning result (`raw.rows == null → []`).
- **Readonly guard preserved.** Both entry points call `preprocessQuery`
  (Rails' `check_if_write_query`).
- **Transactions.** sqlite3 materializes in both; PG/mysql2 in neither
  (they go through `withRawConnection`).
- **Return value.** Every converted site already discarded `executeMutation`'s
  number.

CRUD writes keep `executeMutation` (affected-row counts, insert ids, RETURNING
readback) and still clear exactly once, at the wired
`execInsert`/`execUpdate`/`execDelete` above it — so the `times: 1` expiry
assertions hold. This also closes the hazard #4858 documented as accepted: a DDL
concurrent with a `save` on one leased connection could enter `executeMutation`
at depth > 0 and skip its clear; with no counter, the DDL's `execute` clears
unconditionally, as in Rails.

## Changes

- `abstract/schema-statements.ts` (26 sites), `postgresql/schema-statements-class.ts`,
  `mysql/schema-statements.ts`, `sqlite3-adapter.ts` DDL overrides,
  `mysql2-adapter.ts#dropTable`, `abstract-mysql-adapter.ts#_execMutation`:
  `executeMutation` → `execute`.
- `abstract/query-cache.ts`: delete `dirtiesQueryCacheUnlessNested`,
  `withWriteDirtyDepth`, and the `_writeDirtyDepth` host field; `wireDirties`
  reverts to the pre-#4858 unconditional clear.
- Drop the three per-adapter `dirtiesQueryCacheUnlessNested(..., "executeMutation")`
  wirings.
- Update two unit-test doubles that stubbed `executeMutation` for DDL.

Second commit: DDL outside `connection-adapters/` also called the write
primitive directly, so dropping the leaf wiring would have silently stopped it
dirtying the cache. Routed through `execute` too — which is what Rails does for
all of them (`create_table` / `execute` / `insert_versions_sql`):
`migrator.ts` + `schema-migration.ts` (schema_migrations),
`internal-metadata.ts` (ar_internal_metadata), `migration.ts` +
`model-schema.ts` (CREATE/DROP TABLE), `nested-attributes.ts` (nullify UPDATE).
`tasks/*-database-tasks.ts` and `test-helpers/` deliberately keep
`executeMutation`: database-level create/drop/truncate that never runs inside a
`cache` block.

Note: `blazetrails/no-raw-sql` fires on `execute()` but not `executeMutation()`,
so the remaining hand-built DDL strings carry a disable with a reason (Arel has
no schema-statement nodes; Rails assembles this SQL as a string too).

Third commit (review catch): `schema-migration.ts` and `internal-metadata.ts`
hand-built their tables, so swapping the primitive under the raw SQL still left
the call shape diverging. Rails calls `connection.create_table(table_name,
id: false)` behind a `table_exists?` guard and `drop_table(..., if_exists: true)`
(`schema_migration.rb:53-66`, `internal_metadata.rb:85-104`). Routed both
through the connection's schema statements, which also drops two real defects:
`schema-migration.ts` quoted identifiers with `"..."` unconditionally (a string
literal, not an identifier, on MySQL/MariaDB without ANSI_QUOTES), and
`internal-metadata.ts` branched on `adapterName` for TIMESTAMP-vs-DATETIME
instead of letting the adapter's type map decide. `t.timestamps()` defaults to
`null: false`, so the table shape is unchanged.

## Testing

New `ddl-through-execute.trails.test.ts` pins the criterion the swap could
plausibly have broken: DDL still raises `ReadOnlyError` under
`whilePreventingWrites` (asserting on the `ALTER TABLE` message, so it fails if
the guard stops being reached rather than passing vacuously).

`query-cache-ddl-dirties.trails.test.ts` (the #4858 DDL-clears assertion, still
`times: 1`), `query-cache.test.ts`, `migration.test.ts`, `schema-statements.test.ts`,
`schema-dumper.test.ts`, and all of `connection-adapters/` pass locally
(1862 passed). Typecheck and `pnpm lint` clean.

Closes-story: converge-ddl-through-execute-drop-dirty-guard
