### PR TITLE
refactor(predicate-builder): unify type-resolution cascades; type positive equality bind

### DIFF
--- a/packages/activerecord/src/relation/predicate-builder.trails.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.trails.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
+import { IntegerType } from "@blazetrails/activemodel";
+import { Table } from "@blazetrails/arel";
 import { Company, Firm } from "../test-helpers/models/company.js";
+import { PredicateBuilder } from "./predicate-builder.js";
 
 // trails-specific regression guard (no Rails counterpart): Base.predicateBuilder
 // is now TableMetadata-backed, and that metadata is bound to the class. The memo
@@ -17,5 +20,28 @@ describe("Base.predicateBuilder STI memoization", () => {
     // Idempotent per class.
     expect(Company.predicateBuilder).toBe(companyPb);
     expect(Firm.predicateBuilder).toBe(firmPb);
+  });
+});
+
+// trails-specific regression guard (no Rails counterpart): Rails re-roots the
+// builder's `table` per association, so `build_bind_attribute` always sees the
+// right type caster. trails instead threads the attribute's own relation through
+// the shared type cascade — without it, a joined/aliased out-of-range equality
+// falls through to the identity fallback and silently binds a raw value the
+// column cannot hold, instead of collapsing to `1=0`.
+describe("PredicateBuilder positive-equality bind typing", () => {
+  it("types a joined/aliased equality bind via the relation type caster", () => {
+    const int8 = new IntegerType({ limit: 8 });
+    // Only the attribute's relation knows the column type; the builder's own
+    // table answers undefined, which is the identity-fallback trap.
+    const relation = { typeForAttribute: () => int8 };
+    const table = new Table("posts", { typeCaster: { typeForAttribute: () => undefined } });
+    const builder = new PredicateBuilder(table);
+    const attribute = Object.assign(table.get("author_id"), { relation });
+
+    const bind = builder.buildBindAttribute(attribute.name, 2n ** 63n, relation);
+    expect(bind.isUnboundable()).toBe(1);
+    // The narrow this.table-only lookup finds nothing → identity → not detected.
+    expect(builder.buildBindAttribute(attribute.name, 2n ** 63n).isUnboundable()).toBe(false);
   });
 });

--- a/packages/activerecord/src/relation/predicate-builder.trails.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.trails.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { IntegerType } from "@blazetrails/activemodel";
-import { Table } from "@blazetrails/arel";
+import { Table, Visitors } from "@blazetrails/arel";
 import { Company, Firm } from "../test-helpers/models/company.js";
 import { PredicateBuilder } from "./predicate-builder.js";
 
@@ -30,18 +30,29 @@ describe("Base.predicateBuilder STI memoization", () => {
 // falls through to the identity fallback and silently binds a raw value the
 // column cannot hold, instead of collapsing to `1=0`.
 describe("PredicateBuilder positive-equality bind typing", () => {
-  it("types a joined/aliased equality bind via the relation type caster", () => {
-    const int8 = new IntegerType({ limit: 8 });
-    // Only the attribute's relation knows the column type; the builder's own
-    // table answers undefined, which is the identity-fallback trap.
-    const relation = { typeForAttribute: () => int8 };
-    const table = new Table("posts", { typeCaster: { typeForAttribute: () => undefined } });
-    const builder = new PredicateBuilder(table);
-    const attribute = Object.assign(table.get("author_id"), { relation });
+  const int8 = new IntegerType({ limit: 8 });
+  const OUT_OF_RANGE = 2n ** 63n;
 
-    const bind = builder.buildBindAttribute(attribute.name, 2n ** 63n, relation);
-    expect(bind.isUnboundable()).toBe(1);
-    // The narrow this.table-only lookup finds nothing → identity → not detected.
-    expect(builder.buildBindAttribute(attribute.name, 2n ** 63n).isUnboundable()).toBe(false);
+  // Only the attribute's relation knows the column type. The builder's own
+  // table answers undefined — the identity-fallback trap the narrow
+  // `this.table`-only lookup used to fall into.
+  const buildJoinedEquality = (value: unknown) => {
+    const table = new Table("posts", {
+      typeCaster: { typeForAttribute: () => undefined },
+    });
+    const builder = new PredicateBuilder(table);
+    const joined = new Table("authors", { typeCaster: { typeForAttribute: () => int8 } });
+    return builder.build(joined.get("id"), value);
+  };
+
+  it("collapses a joined out-of-range equality to 1=0", () => {
+    const sql = new Visitors.ToSql().compile(buildJoinedEquality(OUT_OF_RANGE));
+    expect(sql).toBe("1=0");
+  });
+
+  it("leaves an in-range joined equality as a bound predicate", () => {
+    const [sql, binds] = new Visitors.ToSql().compileWithBinds(buildJoinedEquality(7n));
+    expect(sql).not.toContain("1=0");
+    expect(binds).toHaveLength(1);
   });
 });

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -11,6 +11,7 @@ import { Substitute } from "../statement-cache.js";
 import { PolymorphicArrayValue } from "./predicate-builder/polymorphic-array-value.js";
 import { argumentError } from "./query-methods.js";
 import { Connection as TypeCasterConnection } from "../type-caster/connection.js";
+import { attributeRelationOf } from "./predicate-builder/attribute-relation.js";
 
 interface BoundType {
   cast?(x: unknown): unknown;
@@ -22,11 +23,6 @@ type TypeCandidate = (BoundType & { isForceEquality?(v: unknown): boolean }) | n
 
 interface TypeCaster {
   typeForAttribute?(name: string): TypeCandidate;
-}
-
-/** The typeCaster-bearing relation an Arel attribute was resolved against. */
-function attributeRelationOf(attribute: Nodes.Attribute): unknown {
-  return (attribute as unknown as { relation?: unknown }).relation;
 }
 
 const IDENTITY_CAST_TYPE = {
@@ -132,27 +128,49 @@ export class PredicateBuilder {
   }
 
   /**
-   * The single type-resolution cascade every bind-building path shares:
-   * the attribute's own relation typeCaster (covers joined/aliased tables),
-   * then the predicate builder's table/model context, then the arel table.
-   * Yields each candidate (including misses) so callers that need to probe
-   * every level — `_buildForceEqualityOrNull`'s `isForceEquality?` scan — can
-   * walk the same order as callers that just want the first hit.
+   * The single type-resolution cascade every bind-building path shares: the
+   * attribute's own relation typeCaster (covers joined/aliased tables), then
+   * the predicate builder's table/model context, then the arel table. Returns
+   * the first candidate `accept` approves.
+   *
+   * `accept` is what lets the force-equality scan share this cascade: it probes
+   * every level for `isForceEquality?(value)` rather than stopping at the first
+   * type that merely exists. Each level is evaluated lazily and only until
+   * `accept` is satisfied — the arel-table leg throws on a caster-less table,
+   * so it must stay unreached when an earlier level answers.
+   *
+   * Written as a straight-line cascade rather than a generator or a lookup
+   * array on purpose: positive single-value equality is the hottest path in the
+   * builder, and this runs once per `where` value — no iterator or closure
+   * allocation per call.
    *
    * @internal
    */
-  private *_typeLookups(columnName: string, relation?: unknown): Generator<TypeCandidate> {
-    yield (relation as TypeCaster | undefined)?.typeForAttribute?.(columnName);
-    yield (this._tableContext as TypeCaster | null)?.typeForAttribute?.(columnName);
-    yield this.table.typeForAttribute(columnName) as TypeCandidate;
+  private _resolveTypeBy(
+    columnName: string,
+    relation: unknown,
+    accept: (type: TypeCandidate) => boolean,
+  ): TypeCandidate {
+    const relationType = (relation as TypeCaster | undefined)?.typeForAttribute?.(columnName);
+    if (accept(relationType)) return relationType;
+    const contextType = (this._tableContext as TypeCaster | null)?.typeForAttribute?.(columnName);
+    if (accept(contextType)) return contextType;
+    const tableType = this.table.typeForAttribute(columnName) as TypeCandidate;
+    if (accept(tableType)) return tableType;
+    return undefined;
   }
 
-  /** First hit of the {@link _typeLookups} cascade, or undefined. */
+  /**
+   * First existing type in the cascade, or undefined.
+   *
+   * Note this is byte-compatible with the old `this.table`-only lookup for
+   * plain (non-joined) columns: `table.get(col).relation` IS `this.table`, so
+   * the first leg answers with exactly the type the narrow lookup would have
+   * returned. The extra levels only come into play for joined/aliased
+   * attributes, which is precisely where the narrow lookup was wrong.
+   */
   private resolveColumnType(columnName: string, relation?: unknown): TypeCandidate {
-    for (const type of this._typeLookups(columnName, relation)) {
-      if (type) return type;
-    }
-    return undefined;
+    return this._resolveTypeBy(columnName, relation, Boolean);
   }
 
   buildFromHash(
@@ -776,23 +794,24 @@ export class PredicateBuilder {
    */
   private _buildForceEqualityOrNull(attribute: Nodes.Attribute, value: unknown): Nodes.Node | null {
     type CastLike = { cast(v: unknown): unknown; serialize(v: unknown): unknown };
-    for (const t of this._typeLookups(attribute.name, attributeRelationOf(attribute))) {
-      if (t?.isForceEquality?.(value)) {
-        // Rails (`predicate_builder.rb#build`) emits a bind for force-equality
-        // types: `attribute.eq(build_bind_attribute(attribute.name, value))`. The
-        // bind value (e.g. a `Range`) serializes to its pg literal string via the
-        // adapter's `typeCast` in the bind path (`type_casted_binds`).
-        //
-        // Construct the bind with the SAME type object that made the branch true
-        // (`table.type(attribute.name)` in Rails). A joined/aliased range attribute
-        // may be typed on `attribute.relation` / `_tableContext` but not on
-        // `this.table`, so deferring to `buildBindAttribute`'s `this.table` lookup
-        // would bind through the identity type and skip `RangeType#serialize`.
-        const castType = t.cast && t.serialize ? (t as CastLike) : IDENTITY_CAST_TYPE;
-        return attribute.eq(new QueryAttribute(attribute.name, value, castType));
-      }
-    }
-    return null;
+    const forcing = this._resolveTypeBy(
+      attribute.name,
+      attributeRelationOf(attribute),
+      (type) => type?.isForceEquality?.(value) === true,
+    );
+    if (!forcing) return null;
+    // Rails (`predicate_builder.rb#build`) emits a bind for force-equality
+    // types: `attribute.eq(build_bind_attribute(attribute.name, value))`. The
+    // bind value (e.g. a `Range`) serializes to its pg literal string via the
+    // adapter's `typeCast` in the bind path (`type_casted_binds`).
+    //
+    // Construct the bind with the SAME type object that made the branch true
+    // (`table.type(attribute.name)` in Rails) rather than re-resolving — the
+    // cascade level that reported `force_equality?` is not necessarily the one
+    // a fresh first-hit lookup would return, and binding through the wrong type
+    // would skip e.g. `RangeType#serialize`.
+    const castType = forcing.cast && forcing.serialize ? (forcing as CastLike) : IDENTITY_CAST_TYPE;
+    return attribute.eq(new QueryAttribute(attribute.name, value, castType));
   }
 
   static references(conditions: string[] | Record<string, unknown>): Nodes.SqlLiteral[] {

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -17,6 +17,23 @@ interface BoundType {
   serialize?(x: unknown): unknown;
 }
 
+/** A type as the cascade sees it — any level may answer null/undefined. */
+type TypeCandidate = (BoundType & { isForceEquality?(v: unknown): boolean }) | null | undefined;
+
+interface TypeCaster {
+  typeForAttribute?(name: string): TypeCandidate;
+}
+
+/** The typeCaster-bearing relation an Arel attribute was resolved against. */
+function attributeRelationOf(attribute: Nodes.Attribute): unknown {
+  return (attribute as unknown as { relation?: unknown }).relation;
+}
+
+const IDENTITY_CAST_TYPE = {
+  cast: (v: unknown) => v,
+  serialize: (v: unknown) => v,
+};
+
 /**
  * Converts hash conditions ({ name: "dean", age: 30 }) into
  * Arel predicate nodes. Used by Relation to build WHERE clauses.
@@ -66,8 +83,7 @@ export class PredicateBuilder {
    * equality/negation single-value paths, and handles non-numeric out-of-range
    * bounds (e.g. custom types) type-agnostically.
    *
-   * Callers pass the type from {@link resolveBoundType} (not the narrower
-   * `this.table`-only lookup `buildBindAttribute` uses) so sign detection uses
+   * Callers pass the type from {@link resolveBoundType} so sign detection uses
    * the same type as the accompanying cast — otherwise a joined/aliased bound
    * could be detected against the wrong (or identity) type.
    */
@@ -82,8 +98,7 @@ export class PredicateBuilder {
 
   /**
    * Builds a QueryAttribute bind for a bound using {@link resolveBoundType}'s
-   * relation/context/table cascade rather than `buildBindAttribute`'s narrower
-   * `this.table`-only lookup. Used by the negation path so a joined/aliased
+   * relation/context/table cascade. Used by the negation path so a joined/aliased
    * out-of-range bound is typed correctly (and thus detected as unboundable →
    * `1=1`) instead of falling through to the identity fallback and silently
    * binding a raw value the column can't hold.
@@ -97,7 +112,7 @@ export class PredicateBuilder {
     value: unknown,
     type: BoundType | undefined,
   ): QueryAttribute {
-    const castType = (type ?? { cast: (v: unknown) => v, serialize: (v: unknown) => v }) as {
+    const castType = (type ?? IDENTITY_CAST_TYPE) as {
       cast(v: unknown): unknown;
       serialize(v: unknown): unknown;
     };
@@ -111,17 +126,33 @@ export class PredicateBuilder {
    * Rails' `build_bind_attribute` gets for free via `table.type(column_name)`.
    */
   private resolveBoundType(attribute: Nodes.Attribute): BoundType | undefined {
-    const attrRelation = (attribute as unknown as { relation?: unknown }).relation;
-    const attrType = (
-      attrRelation as { typeForAttribute?(n: string): BoundType | null } | undefined
-    )?.typeForAttribute?.(attribute.name);
-    if (attrType) return attrType;
-    const ctx = this._tableContext as {
-      typeForAttribute?(n: string): BoundType | null;
-    } | null;
-    const ctxType = ctx?.typeForAttribute?.(attribute.name);
-    if (ctxType) return ctxType;
-    return this.table.typeForAttribute(attribute.name) as BoundType | undefined;
+    return this.resolveColumnType(attribute.name, attributeRelationOf(attribute)) as
+      | BoundType
+      | undefined;
+  }
+
+  /**
+   * The single type-resolution cascade every bind-building path shares:
+   * the attribute's own relation typeCaster (covers joined/aliased tables),
+   * then the predicate builder's table/model context, then the arel table.
+   * Yields each candidate (including misses) so callers that need to probe
+   * every level — `_buildForceEqualityOrNull`'s `isForceEquality?` scan — can
+   * walk the same order as callers that just want the first hit.
+   *
+   * @internal
+   */
+  private *_typeLookups(columnName: string, relation?: unknown): Generator<TypeCandidate> {
+    yield (relation as TypeCaster | undefined)?.typeForAttribute?.(columnName);
+    yield (this._tableContext as TypeCaster | null)?.typeForAttribute?.(columnName);
+    yield this.table.typeForAttribute(columnName) as TypeCandidate;
+  }
+
+  /** First hit of the {@link _typeLookups} cascade, or undefined. */
+  private resolveColumnType(columnName: string, relation?: unknown): TypeCandidate {
+    for (const type of this._typeLookups(columnName, relation)) {
+      if (type) return type;
+    }
+    return undefined;
   }
 
   buildFromHash(
@@ -629,7 +660,9 @@ export class PredicateBuilder {
     // tuple lists allocation-light.
     const attrs = cols.map((c) => this.resolveColumn(c));
     const groupings: Nodes.Node[] = validTuples.map((tuple) => {
-      const eqs = attrs.map((attr, i) => attr.eq(this.buildBindAttribute(attr.name, tuple[i])));
+      const eqs = attrs.map((attr, i) =>
+        attr.eq(this.buildBindAttribute(attr.name, tuple[i], attributeRelationOf(attr))),
+      );
       return new Nodes.Grouping(new Nodes.And(eqs));
     });
     if (groupings.length === 1) return groupings[0];
@@ -668,12 +701,19 @@ export class PredicateBuilder {
     this.handlers.unshift([klass, handler]);
   }
 
-  buildBindAttribute(columnName: string, value: unknown): QueryAttribute {
-    const type = this.table.typeForAttribute(columnName) as
-      | { cast(v: unknown): unknown; serialize(v: unknown): unknown }
-      | undefined;
-    const castType = type ?? { cast: (v: unknown) => v, serialize: (v: unknown) => v };
-    return new QueryAttribute(columnName, value, castType);
+  /**
+   * Rails' `build_bind_attribute(column_name, value)`. The optional `relation`
+   * is the trails-side stand-in for Rails re-rooting `table` per association:
+   * a joined/aliased column is typed on the attribute's own relation, so
+   * without it an out-of-range equality would bind a raw value through the
+   * identity fallback instead of collapsing to `1=0`.
+   */
+  buildBindAttribute(columnName: string, value: unknown, relation?: unknown): QueryAttribute {
+    return this.queryAttributeWithType(
+      columnName,
+      value,
+      this.resolveColumnType(columnName, relation) ?? undefined,
+    );
   }
 
   resolveArelAttribute(
@@ -736,25 +776,7 @@ export class PredicateBuilder {
    */
   private _buildForceEqualityOrNull(attribute: Nodes.Attribute, value: unknown): Nodes.Node | null {
     type CastLike = { cast(v: unknown): unknown; serialize(v: unknown): unknown };
-    type TypeLike =
-      | ({ isForceEquality?(v: unknown): boolean } & Partial<CastLike>)
-      | null
-      | undefined;
-    const lookups = [
-      () => {
-        const rel = (attribute as unknown as { relation?: unknown }).relation;
-        return (rel as { typeForAttribute?(n: string): TypeLike } | undefined)?.typeForAttribute?.(
-          attribute.name,
-        );
-      },
-      () =>
-        (
-          this._tableContext as { typeForAttribute?(n: string): TypeLike } | null
-        )?.typeForAttribute?.(attribute.name),
-      () => this.table.typeForAttribute(attribute.name) as TypeLike,
-    ];
-    for (const lookup of lookups) {
-      const t = lookup();
+    for (const t of this._typeLookups(attribute.name, attributeRelationOf(attribute))) {
       if (t?.isForceEquality?.(value)) {
         // Rails (`predicate_builder.rb#build`) emits a bind for force-equality
         // types: `attribute.eq(build_bind_attribute(attribute.name, value))`. The
@@ -766,10 +788,7 @@ export class PredicateBuilder {
         // may be typed on `attribute.relation` / `_tableContext` but not on
         // `this.table`, so deferring to `buildBindAttribute`'s `this.table` lookup
         // would bind through the identity type and skip `RangeType#serialize`.
-        const castType =
-          t.cast && t.serialize
-            ? (t as CastLike)
-            : { cast: (v: unknown) => v, serialize: (v: unknown) => v };
+        const castType = t.cast && t.serialize ? (t as CastLike) : IDENTITY_CAST_TYPE;
         return attribute.eq(new QueryAttribute(attribute.name, value, castType));
       }
     }

--- a/packages/activerecord/src/relation/predicate-builder/attribute-relation.ts
+++ b/packages/activerecord/src/relation/predicate-builder/attribute-relation.ts
@@ -1,0 +1,14 @@
+import { Nodes } from "@blazetrails/arel";
+
+/**
+ * The typeCaster-bearing relation an Arel attribute was resolved against.
+ *
+ * Lives in its own module so both `PredicateBuilder` and the handlers it
+ * constructs can reach for the relation the same way without an import cycle.
+ * It is the trails stand-in for Rails re-rooting `PredicateBuilder#table` per
+ * association: a joined/aliased column's type caster hangs off the attribute's
+ * relation, not off the builder's own table.
+ */
+export function attributeRelationOf(attribute: Nodes.Attribute): unknown {
+  return (attribute as unknown as { relation?: unknown }).relation;
+}

--- a/packages/activerecord/src/relation/predicate-builder/basic-object-handler.ts
+++ b/packages/activerecord/src/relation/predicate-builder/basic-object-handler.ts
@@ -13,17 +13,24 @@ import { Nodes } from "@blazetrails/arel";
  */
 export class BasicObjectHandler {
   private _predicateBuilder: {
-    buildBindAttribute(columnName: string, value: unknown): unknown;
+    buildBindAttribute(columnName: string, value: unknown, relation?: unknown): unknown;
   };
 
   constructor(predicateBuilder: {
-    buildBindAttribute(columnName: string, value: unknown): unknown;
+    buildBindAttribute(columnName: string, value: unknown, relation?: unknown): unknown;
   }) {
     this._predicateBuilder = predicateBuilder;
   }
 
   call(attribute: Nodes.Attribute, value: unknown): Nodes.Node {
-    const bind = this._predicateBuilder.buildBindAttribute(attribute.name, value);
+    // Pass the attribute's own relation so a joined/aliased column resolves
+    // through the full type cascade — Rails gets this for free because it
+    // re-roots `table` per association before building the bind.
+    const bind = this._predicateBuilder.buildBindAttribute(
+      attribute.name,
+      value,
+      (attribute as unknown as { relation?: unknown }).relation,
+    );
     return attribute.eq(bind);
   }
 

--- a/packages/activerecord/src/relation/predicate-builder/basic-object-handler.ts
+++ b/packages/activerecord/src/relation/predicate-builder/basic-object-handler.ts
@@ -1,4 +1,5 @@
 import { Nodes } from "@blazetrails/arel";
+import { attributeRelationOf } from "./attribute-relation.js";
 
 /**
  * Handles basic scalar values (strings, numbers, booleans) in where
@@ -29,7 +30,7 @@ export class BasicObjectHandler {
     const bind = this._predicateBuilder.buildBindAttribute(
       attribute.name,
       value,
-      (attribute as unknown as { relation?: unknown }).relation,
+      attributeRelationOf(attribute),
     );
     return attribute.eq(bind);
   }

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder.json
@@ -32,7 +32,7 @@
     "tsFile": "relation/predicate-builder.ts",
     "rubyName": "build_bind_attribute",
     "call": "table",
-    "reason": "Satisfied via a different path (story unify-predicate-builder-type-resolution-cascades): Rails' build_bind_attribute reads `table.type(column_name)` inline. trails unified the three duplicate type-resolution cascades into _resolveTypeBy, whose final leg IS `this.table.typeForAttribute(columnName)` \u2014 so the `table` read still happens on every call, one frame down. The name-based wide gate only inspects the Rails-mapped method body, so it cannot follow the shared resolver."
+    "reason": "Adapted through the shared type cascade (story unify-predicate-builder-type-resolution-cascades): Rails' build_bind_attribute reads `table.type(column_name)` inline and unconditionally (predicate_builder.rb:67-68). trails resolves the same type through _resolveTypeBy, a shared relation -> _tableContext -> this.table cascade that returns the first level to answer, so `this.table` is the fallback leg rather than an unconditional read. This is equivalent for plain columns because `table.get(col).relation` IS `this.table`, so the relation leg returns exactly what Rails' inline read would; for joined/aliased attributes an earlier level intentionally answers first, which is the divergence this story exists to introduce (Rails gets the same effect by re-rooting PredicateBuilder#table per association, which trails cannot do). Either way the wide gate is name-based and inspects only the Rails-mapped method body, so it cannot see the read in the shared resolver."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder.json
@@ -31,6 +31,13 @@
     "package": "activerecord",
     "tsFile": "relation/predicate-builder.ts",
     "rubyName": "build_bind_attribute",
+    "call": "table",
+    "reason": "Satisfied via a different path (story unify-predicate-builder-type-resolution-cascades): Rails' build_bind_attribute reads `table.type(column_name)` inline. trails unified the three duplicate type-resolution cascades into _resolveTypeBy, whose final leg IS `this.table.typeForAttribute(columnName)` \u2014 so the `table` read still happens on every call, one frame down. The name-based wide gate only inspects the Rails-mapped method body, so it cannot follow the shared resolver."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/predicate-builder.ts",
+    "rubyName": "build_bind_attribute",
     "call": "type",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -214,14 +221,14 @@
     "tsFile": "relation/predicate-builder.ts",
     "rubyName": "handler_for",
     "call": "detect",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/predicate-builder.ts",
     "rubyName": "handler_for",
     "call": "last",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body \u2014 these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",


### PR DESCRIPTION
`PredicateBuilder` had three near-duplicate column-type resolution cascades:
`resolveBoundType`, `_buildForceEqualityOrNull`'s inline `lookups` array, and
`buildBindAttribute`'s narrow `this.table`-only lookup.

## What changed

They now collapse into one shared `_resolveTypeBy(columnName, relation, accept)`
cascade — relation → `_tableContext` → `this.table` — returning the first
candidate `accept` approves. `resolveColumnType` passes `Boolean` for the
first-hit callers; `_buildForceEqualityOrNull` passes an `isForceEquality?`
predicate so it probes every level, as it did before, and still binds with the
exact type object that matched rather than re-resolving.

`buildBindAttribute` keeps its Rails-faithful `(columnName, value)` signature
and gains an optional third `relation` argument — the trails stand-in for Rails
re-rooting `table` per association. `BasicObjectHandler` threads the attribute's
relation through, so the positive single-value equality path is typed by the
same cascade the range/negation paths use: a joined/aliased out-of-range
equality now collapses to `1=0` (the visitor already does this once the bind
answers `isUnboundable`) instead of silently binding a raw value the column
cannot hold.

`attributeRelationOf` lives in its own module so the builder and the handlers it
constructs share it without an import cycle.

## No regression

Non-joined scalar equality is unchanged by construction: `table.get(col).relation`
IS `this.table`, so the first leg returns exactly what the narrow lookup returned.
The extra levels only engage for joined/aliased attributes — precisely where the
narrow lookup was wrong.

The cascade is written straight-line rather than as a generator or lookup array:
positive equality is the hottest path in the builder and runs once per `where`
value, so this avoids per-call iterator/closure allocation. Level evaluation stays
lazy — the arel-table leg throws on a caster-less table and must stay unreached
when an earlier level answers.

## Tests

`packages/activerecord/src/relation/`, `finder.test.ts`, and
`packages/activerecord/src/associations` — 118 files, 2927 passing.

New trails-side guards assert the acceptance criterion at the SQL level: a joined
out-of-range equality compiles to `1=0`, and an in-range one still compiles to a
bound predicate. Verified to fail when the relation threading is reverted.

Closes-story: unify-predicate-builder-type-resolution-cascades


## One wide-call baseline entry

CI's wide call-set gate flagged `build_bind_attribute` -> `table` as a new
mismatch. That is a real consequence of this diff, not a flake.

Rails reads `table.type(column_name)` inline and unconditionally
(`predicate_builder.rb:67-68`). trails now resolves the same type through
`_resolveTypeBy`, a shared relation -> `_tableContext` -> `this.table` cascade
that returns the first level to answer — so `this.table` is the fallback leg,
not an unconditional read. For plain columns this is equivalent, because
`table.get(col).relation` IS `this.table` and the relation leg returns exactly
what Rails' inline read would; for joined/aliased attributes an earlier level
intentionally answers first, which is the divergence this story exists to
introduce (Rails achieves the same by re-rooting `PredicateBuilder#table` per
association, which trails cannot do). Either way the gate is name-based and
inspects only the Rails-mapped method body, so it cannot see the read in the
shared resolver.

Baselined with that reason rather than the bulk RFC 0047 boilerplate. Note
`build_bind_attribute` -> `type` was already baselined for this method before
this PR.

All four api-compare gates (narrow ratchet, body pins, wide ratchet, privates)
pass locally.
