### PR TITLE
refactor(adapters): map Rails' username key onto the driver-native user

### DIFF
--- a/packages/activerecord/src/connection-adapters/adapter-args.test.ts
+++ b/packages/activerecord/src/connection-adapters/adapter-args.test.ts
@@ -92,23 +92,32 @@ describe("buildAdapterArg", () => {
       expect(config).toEqual({ uri: "mysql://h/db", advisoryLocks: false });
     });
 
-    it("remaps username to user when forwarding a URL with extra keys", () => {
+    it("forwards username under Rails' spelling when forwarding a URL with extra keys", () => {
+      // The credential is NOT remapped here: Rails maps it in the adapter
+      // constructor (postgresql_adapter.rb:326), so this layer must forward
+      // `username` untouched or it shadows that mapping entirely.
       const [config] = buildAdapterArg("mysql2", {
         adapter: "mysql2",
         url: "mysql://h/db",
         username: "alice",
       }) as [Record<string, unknown>];
-      expect(config).toEqual({ uri: "mysql://h/db", user: "alice" });
+      expect(config).toEqual({ uri: "mysql://h/db", username: "alice" });
     });
 
-    it("keeps an explicit user over username when forwarding a URL", () => {
+    it("forwards both username and user when forwarding a URL", () => {
+      // Precedence between the two is the constructor's call, not this
+      // layer's — Rails lets a truthy `username` overwrite `user`.
       const [config] = buildAdapterArg("postgresql", {
         adapter: "postgresql",
         url: "postgres://h/db",
         username: "alice",
         user: "bob",
       }) as [Record<string, unknown>];
-      expect(config).toEqual({ connectionString: "postgres://h/db", user: "bob" });
+      expect(config).toEqual({
+        connectionString: "postgres://h/db",
+        username: "alice",
+        user: "bob",
+      });
     });
 
     it("returns [config] hash when keyword config is given", () => {
@@ -120,7 +129,7 @@ describe("buildAdapterArg", () => {
       });
       expect(config).toMatchObject({
         database: "db",
-        user: "alice",
+        username: "alice",
         host: "localhost",
         port: 3307,
       });

--- a/packages/activerecord/src/connection-adapters/adapter-args.ts
+++ b/packages/activerecord/src/connection-adapters/adapter-args.ts
@@ -190,23 +190,23 @@ export function buildAdapterArg(
     // with the rest of the configuration hash. Forward the URL under the
     // adapter-specific connection key alongside the remaining options instead
     // of dropping them. Pure-URL configs (no extra keys) keep the `[url]` form.
-    const { adapter: _ua, url: _uu, username, ...urlRest } = configuration;
-    if (username === undefined && Object.keys(urlRest).length === 0) {
+    // `username` is deliberately NOT remapped here. Rails maps the credential
+    // inside the adapter constructor (postgresql_adapter.rb:326), so forward
+    // Rails' spelling untouched and let Mysql2Adapter/PostgreSQLAdapter apply
+    // the mapping with Ruby-truthiness precedence. Remapping here as well used
+    // to shadow the constructor entirely — this layer stripped `username`, so
+    // the constructor never saw it — and did so with the wrong precedence.
+    const { adapter: _ua, url: _uu, ...urlRest } = configuration;
+    if (Object.keys(urlRest).length === 0) {
       return [url];
-    }
-    // Apply the same `username` → `user` remap the discrete-field branch does,
-    // so callers passing `username` alongside a URL still reach the driver.
-    if (username !== undefined && urlRest.user === undefined) {
-      urlRest.user = username;
     }
     const urlKey = normalized === "postgresql" ? "connectionString" : "uri";
     return [{ ...urlRest, [urlKey]: url }];
   }
-  const { adapter: _a, url: _u, username, ...rest } = configuration;
+  // As in the URL branch above: `username` passes through under Rails'
+  // spelling and the adapter constructor maps it to the driver-native `user`.
+  const { adapter: _a, url: _u, ...rest } = configuration;
   const adapterConfig: Record<string, unknown> = { ...rest };
-  if (adapterConfig.user === undefined && username !== undefined) {
-    adapterConfig.user = username;
-  }
   // mysql2 uses `socketPath`; database.yml uses `socket`. Normalise here so
   // all callers benefit, not just the DatabaseTasks path.
   if (normalized === "mysql") {

--- a/packages/activerecord/src/connection-adapters/adapter-username-key.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/adapter-username-key.trails.test.ts
@@ -9,11 +9,12 @@
  *
  *     conn_params[:user] = conn_params.delete(:username) if conn_params[:username]
  *
- * so the precedence asserted here is Rails': a *present* `username` overwrites
- * `user` rather than deferring to it, and is always deleted from the hash.
- * Present, not JS-truthy — `conn_params = @config.compact` drops the nils
- * before the guard, and Ruby treats `""` as truthy, so a blank username maps
- * too.
+ * so the precedence asserted here is Rails': a *Ruby-truthy* `username`
+ * overwrites `user` rather than deferring to it, and is deleted from the hash.
+ * Ruby-truthy, not JS-truthy, and the two differ in both directions here: `""`
+ * is truthy in Ruby (so a blank username maps), while `false` is falsey and
+ * survives `@config.compact` (which drops only nils), so `username: false` is
+ * the one present value that does NOT map.
  *
  * For MySQL there is no Rails counterpart — Ruby's mysql2 gem reads `:username`
  * natively, so Rails passes the hash through untouched. The mapping is a
@@ -67,6 +68,16 @@ describe.each([
     const driverConfig = driverConfigFor({ ...BASE, username: "", user: "driver" });
     expect(driverConfig.user).toBe("");
     expect(driverConfig).not.toHaveProperty("username");
+  });
+
+  it("leaves an explicit user alone when username is false", () => {
+    // `false` is the one present value the guard rejects: `@config.compact`
+    // drops only nils, so `username: false` survives to line 326 and Ruby
+    // reads it as falsey. Verified against Ruby:
+    //   {username: false, user: "driver"}.compact
+    //     => {:username=>false, :user=>"driver"}  (mapping does not run)
+    const driverConfig = driverConfigFor({ ...BASE, username: false, user: "driver" });
+    expect(driverConfig.user).toBe("driver");
   });
 
   it("leaves user absent when neither key is given", () => {

--- a/packages/activerecord/src/connection-adapters/adapter-username-key.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/adapter-username-key.trails.test.ts
@@ -23,6 +23,7 @@
  */
 import { describe, expect, it } from "vitest";
 
+import { buildAdapterArg } from "./adapter-args.js";
 import { Mysql2Adapter } from "./mysql2-adapter.js";
 import { PostgreSQLAdapter } from "./postgresql-adapter.js";
 
@@ -82,6 +83,52 @@ describe.each([
 
   it("leaves user absent when neither key is given", () => {
     expect(driverConfigFor({ ...BASE })).not.toHaveProperty("user");
+  });
+});
+
+describe("through buildAdapterArg (the connection-handling path)", () => {
+  // Regression guard for the real failure mode: `connection-handling.ts:923`
+  // builds adapter args via `buildAdapterArg` and spreads them into the
+  // constructor. adapter-args.ts used to strip `username` and remap it itself,
+  // with the opposite precedence — so the constructor mapping never ran on the
+  // path users actually take, and unit tests that construct adapters directly
+  // could not see it. These go through the real path.
+  it("maps username to user for mysql2", () => {
+    const [config] = buildAdapterArg("mysql2", {
+      adapter: "mysql2",
+      database: "d",
+      username: "rails",
+    }) as [Record<string, unknown>];
+    expect(mysqlPoolConfig(config).user).toBe("rails");
+  });
+
+  it("maps username to user for postgresql", () => {
+    const [config] = buildAdapterArg("postgresql", {
+      adapter: "postgresql",
+      database: "d",
+      username: "rails",
+    }) as [Record<string, unknown>];
+    expect(pgClientOptions(config).user).toBe("rails");
+  });
+
+  it("lets username overwrite user end to end", () => {
+    const [config] = buildAdapterArg("postgresql", {
+      adapter: "postgresql",
+      database: "d",
+      username: "rails",
+      user: "driver",
+    }) as [Record<string, unknown>];
+    expect(pgClientOptions(config).user).toBe("rails");
+  });
+
+  it("keeps an explicit user when username is false end to end", () => {
+    const [config] = buildAdapterArg("mysql2", {
+      adapter: "mysql2",
+      database: "d",
+      username: false,
+      user: "driver",
+    }) as [Record<string, unknown>];
+    expect(mysqlPoolConfig(config).user).toBe("driver");
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/adapter-username-key.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/adapter-username-key.trails.test.ts
@@ -1,12 +1,21 @@
 /**
  * Rails' `database.yml` spells the credential `username`
- * (`database_configurations/hash_config.rb`), but the `mysql2` and `pg` drivers
- * both read the driver-native `user` — and both IGNORE unknown keys. Before the
- * adapters mapped the key, a Rails-spelled config hash connected as the OS user
- * instead of failing, silently.
+ * (`database_configurations/hash_config.rb`), while the Node `mysql2` and `pg`
+ * drivers read the driver-native `user` — and both IGNORE unknown keys. Unmapped,
+ * a Rails-spelled config hash connects as the OS user instead of failing.
  *
- * These are trails-only guards: Rails has no such translation because the Ruby
- * drivers take `username` directly.
+ * For PostgreSQL this mirrors a real Rails translation
+ * (`postgresql_adapter.rb:326`):
+ *
+ *     conn_params[:user] = conn_params.delete(:username) if conn_params[:username]
+ *
+ * so the precedence asserted here is Rails': a *truthy* `username` overwrites
+ * `user` rather than deferring to it, and is always deleted from the hash.
+ *
+ * For MySQL there is no Rails counterpart — Ruby's mysql2 gem reads `:username`
+ * natively, so Rails passes the hash through untouched. The mapping is a
+ * deviation forced by the Node driver; it follows the PostgreSQL semantics
+ * above so the two adapters agree.
  */
 import { describe, expect, it } from "vitest";
 
@@ -23,50 +32,58 @@ function pgClientOptions(config: Record<string, unknown>): Record<string, unknow
   return (adapter as unknown as { _pgClientOptions: Record<string, unknown> })._pgClientOptions;
 }
 
-describe("Mysql2Adapter credential key", () => {
+const BASE = { host: "127.0.0.1", database: "d" };
+
+describe.each([
+  ["Mysql2Adapter", mysqlPoolConfig],
+  ["PostgreSQLAdapter", pgClientOptions],
+])("%s credential key", (_name, driverConfigFor) => {
   it("maps Rails' username onto the driver's user", () => {
-    const poolConfig = mysqlPoolConfig({ host: "127.0.0.1", database: "d", username: "rails" });
-    expect(poolConfig.user).toBe("rails");
-    expect(poolConfig).not.toHaveProperty("username");
+    const driverConfig = driverConfigFor({ ...BASE, username: "rails" });
+    expect(driverConfig.user).toBe("rails");
+    expect(driverConfig).not.toHaveProperty("username");
   });
 
-  it("prefers an explicit user over username", () => {
-    const poolConfig = mysqlPoolConfig({
-      host: "127.0.0.1",
-      database: "d",
-      username: "rails",
-      user: "driver",
-    });
-    expect(poolConfig.user).toBe("driver");
-    expect(poolConfig).not.toHaveProperty("username");
+  it("passes an explicit user through untouched", () => {
+    const driverConfig = driverConfigFor({ ...BASE, user: "driver" });
+    expect(driverConfig.user).toBe("driver");
+  });
+
+  it("lets username overwrite an explicit user", () => {
+    // Rails' `if conn_params[:username]` overwrites unconditionally — it does
+    // not defer to a `user` already in the hash.
+    const driverConfig = driverConfigFor({ ...BASE, username: "rails", user: "driver" });
+    expect(driverConfig.user).toBe("rails");
+    expect(driverConfig).not.toHaveProperty("username");
+  });
+
+  it("ignores a blank username, mirroring Rails' truthiness guard", () => {
+    // `if conn_params[:username]` is falsy for "", so the key is left alone
+    // and `user` survives.
+    const driverConfig = driverConfigFor({ ...BASE, username: "", user: "driver" });
+    expect(driverConfig.user).toBe("driver");
   });
 
   it("leaves user absent when neither key is given", () => {
-    const poolConfig = mysqlPoolConfig({ host: "127.0.0.1", database: "d" });
-    expect(poolConfig).not.toHaveProperty("user");
+    expect(driverConfigFor({ ...BASE })).not.toHaveProperty("user");
   });
 });
 
-describe("PostgreSQLAdapter credential key", () => {
-  it("maps Rails' username onto the driver's user", () => {
-    const clientOptions = pgClientOptions({ host: "127.0.0.1", database: "d", username: "rails" });
-    expect(clientOptions.user).toBe("rails");
-    expect(clientOptions).not.toHaveProperty("username");
-  });
-
-  it("prefers an explicit user over username", () => {
-    const clientOptions = pgClientOptions({
-      host: "127.0.0.1",
-      database: "d",
-      username: "rails",
-      user: "driver",
-    });
-    expect(clientOptions.user).toBe("driver");
-    expect(clientOptions).not.toHaveProperty("username");
-  });
-
-  it("leaves user absent when neither key is given", () => {
-    const clientOptions = pgClientOptions({ host: "127.0.0.1", database: "d" });
-    expect(clientOptions).not.toHaveProperty("user");
+describe("retained config", () => {
+  // Rails maps `username` on the conn_params COPY and leaves `@config` alone
+  // (postgresql_adapter.rb:322 `conn_params = @config.compact`), so
+  // config-reading callers still see Rails' spelling. MySQLDatabaseTasks and
+  // PostgreSQLDatabaseTasks both depend on this — they read `username` off the
+  // config, not `user`.
+  it.each([
+    [
+      "Mysql2Adapter",
+      (c: Record<string, unknown>) => new Mysql2Adapter({ ...c, _fakeConnection: true } as never),
+    ],
+    ["PostgreSQLAdapter", (c: Record<string, unknown>) => new PostgreSQLAdapter(c as never)],
+  ])("%s keeps username in the config the driver mapping read from", (_name, build) => {
+    const adapter = build({ ...BASE, username: "rails" });
+    const config = (adapter as unknown as { _config: Record<string, unknown> })._config;
+    expect(config.username).toBe("rails");
   });
 });

--- a/packages/activerecord/src/connection-adapters/adapter-username-key.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/adapter-username-key.trails.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Rails' `database.yml` spells the credential `username`
+ * (`database_configurations/hash_config.rb`), but the `mysql2` and `pg` drivers
+ * both read the driver-native `user` — and both IGNORE unknown keys. Before the
+ * adapters mapped the key, a Rails-spelled config hash connected as the OS user
+ * instead of failing, silently.
+ *
+ * These are trails-only guards: Rails has no such translation because the Ruby
+ * drivers take `username` directly.
+ */
+import { describe, expect, it } from "vitest";
+
+import { Mysql2Adapter } from "./mysql2-adapter.js";
+import { PostgreSQLAdapter } from "./postgresql-adapter.js";
+
+function mysqlPoolConfig(config: Record<string, unknown>): Record<string, unknown> {
+  const adapter = new Mysql2Adapter({ ...config, _fakeConnection: true } as never);
+  return (adapter as unknown as { _poolConfig: Record<string, unknown> })._poolConfig;
+}
+
+function pgClientOptions(config: Record<string, unknown>): Record<string, unknown> {
+  const adapter = new PostgreSQLAdapter(config as never);
+  return (adapter as unknown as { _pgClientOptions: Record<string, unknown> })._pgClientOptions;
+}
+
+describe("Mysql2Adapter credential key", () => {
+  it("maps Rails' username onto the driver's user", () => {
+    const poolConfig = mysqlPoolConfig({ host: "127.0.0.1", database: "d", username: "rails" });
+    expect(poolConfig.user).toBe("rails");
+    expect(poolConfig).not.toHaveProperty("username");
+  });
+
+  it("prefers an explicit user over username", () => {
+    const poolConfig = mysqlPoolConfig({
+      host: "127.0.0.1",
+      database: "d",
+      username: "rails",
+      user: "driver",
+    });
+    expect(poolConfig.user).toBe("driver");
+    expect(poolConfig).not.toHaveProperty("username");
+  });
+
+  it("leaves user absent when neither key is given", () => {
+    const poolConfig = mysqlPoolConfig({ host: "127.0.0.1", database: "d" });
+    expect(poolConfig).not.toHaveProperty("user");
+  });
+});
+
+describe("PostgreSQLAdapter credential key", () => {
+  it("maps Rails' username onto the driver's user", () => {
+    const clientOptions = pgClientOptions({ host: "127.0.0.1", database: "d", username: "rails" });
+    expect(clientOptions.user).toBe("rails");
+    expect(clientOptions).not.toHaveProperty("username");
+  });
+
+  it("prefers an explicit user over username", () => {
+    const clientOptions = pgClientOptions({
+      host: "127.0.0.1",
+      database: "d",
+      username: "rails",
+      user: "driver",
+    });
+    expect(clientOptions.user).toBe("driver");
+    expect(clientOptions).not.toHaveProperty("username");
+  });
+
+  it("leaves user absent when neither key is given", () => {
+    const clientOptions = pgClientOptions({ host: "127.0.0.1", database: "d" });
+    expect(clientOptions).not.toHaveProperty("user");
+  });
+});

--- a/packages/activerecord/src/connection-adapters/adapter-username-key.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/adapter-username-key.trails.test.ts
@@ -9,8 +9,11 @@
  *
  *     conn_params[:user] = conn_params.delete(:username) if conn_params[:username]
  *
- * so the precedence asserted here is Rails': a *truthy* `username` overwrites
+ * so the precedence asserted here is Rails': a *present* `username` overwrites
  * `user` rather than deferring to it, and is always deleted from the hash.
+ * Present, not JS-truthy — `conn_params = @config.compact` drops the nils
+ * before the guard, and Ruby treats `""` as truthy, so a blank username maps
+ * too.
  *
  * For MySQL there is no Rails counterpart — Ruby's mysql2 gem reads `:username`
  * natively, so Rails passes the hash through untouched. The mapping is a
@@ -57,11 +60,13 @@ describe.each([
     expect(driverConfig).not.toHaveProperty("username");
   });
 
-  it("ignores a blank username, mirroring Rails' truthiness guard", () => {
-    // `if conn_params[:username]` is falsy for "", so the key is left alone
-    // and `user` survives.
+  it("maps a blank username, since Ruby treats an empty string as truthy", () => {
+    // `if conn_params[:username]` fires for "" — Ruby is falsy only for nil
+    // and false, and `@config.compact` has already dropped the nils. So a
+    // blank username still overwrites `user` rather than deferring to it.
     const driverConfig = driverConfigFor({ ...BASE, username: "", user: "driver" });
-    expect(driverConfig.user).toBe("driver");
+    expect(driverConfig.user).toBe("");
+    expect(driverConfig).not.toHaveProperty("username");
   });
 
   it("leaves user absent when neither key is given", () => {

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -11,6 +11,7 @@ import {
   type MysqlPreparedStatement,
 } from "./abstract-mysql-adapter.js";
 import { StringType, ImmutableStringType, BinaryData } from "@blazetrails/activemodel";
+import { isRubyTruthy } from "../ruby-truthy.js";
 import { TypeMap } from "../type/type-map.js";
 import * as Type from "../type.js";
 import { UnsignedInteger } from "../type/unsigned-integer.js";
@@ -554,15 +555,15 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // Rails-spelled hash connects as the OS user instead of failing.
     //
     // Semantics deliberately match the one place Rails DOES translate —
-    // postgresql_adapter.rb:326 — so both adapters agree: a PRESENT `username`
-    // (including "", which is truthy in Ruby) overwrites `user` and is always
-    // removed from the driver config.
+    // postgresql_adapter.rb:326 — so both adapters agree, down to the same
+    // `isRubyTruthy` guard: a Ruby-truthy `username` (including "") overwrites
+    // `user`, while `username: false` does not.
     const { username: railsUsername, ...mysqlDriverConfig } = mysqlConfig as typeof mysqlConfig & {
       username?: string;
     };
     this._poolConfig = {
       ...mysqlDriverConfig,
-      ...(railsUsername == null ? {} : { user: railsUsername }),
+      ...(isRubyTruthy(railsUsername) ? { user: railsUsername } : {}),
       flags: resolvedFlags,
       strict,
       waitTimeout,

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -547,8 +547,18 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         ? inputFlags
         : [...inputFlags, "FOUND_ROWS"]
       : ["FOUND_ROWS"];
+    // Rails' database.yml spells the credential `username`
+    // (database_configurations/hash_config.rb); the mysql2 driver reads `user`
+    // and ignores unknown keys, so a Rails-spelled hash would otherwise connect
+    // as the OS user instead of failing. Map it here. An explicit `user` wins.
+    const { username: railsUsername, ...mysqlDriverConfig } = mysqlConfig as typeof mysqlConfig & {
+      username?: string;
+    };
     this._poolConfig = {
-      ...mysqlConfig,
+      ...mysqlDriverConfig,
+      ...(mysqlDriverConfig.user === undefined && railsUsername !== undefined
+        ? { user: railsUsername }
+        : {}),
       flags: resolvedFlags,
       strict,
       waitTimeout,

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -547,18 +547,21 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         ? inputFlags
         : [...inputFlags, "FOUND_ROWS"]
       : ["FOUND_ROWS"];
-    // Rails' database.yml spells the credential `username`
-    // (database_configurations/hash_config.rb); the mysql2 driver reads `user`
-    // and ignores unknown keys, so a Rails-spelled hash would otherwise connect
-    // as the OS user instead of failing. Map it here. An explicit `user` wins.
+    // Deviation forced by the driver, NOT a port: Rails hands the config hash
+    // to Mysql2::Client untouched (mysql2_adapter.rb:24 `::Mysql2::Client.new(config)`)
+    // because the Ruby gem reads `:username` natively. Node's `mysql2` reads
+    // the driver-native `user` and ignores unknown keys, so an unmapped
+    // Rails-spelled hash connects as the OS user instead of failing.
+    //
+    // Semantics deliberately match the one place Rails DOES translate —
+    // postgresql_adapter.rb:326 — so both adapters agree: a truthy `username`
+    // overwrites `user`, and is always removed from the driver config.
     const { username: railsUsername, ...mysqlDriverConfig } = mysqlConfig as typeof mysqlConfig & {
       username?: string;
     };
     this._poolConfig = {
       ...mysqlDriverConfig,
-      ...(mysqlDriverConfig.user === undefined && railsUsername !== undefined
-        ? { user: railsUsername }
-        : {}),
+      ...(railsUsername ? { user: railsUsername } : {}),
       flags: resolvedFlags,
       strict,
       waitTimeout,

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -554,14 +554,15 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // Rails-spelled hash connects as the OS user instead of failing.
     //
     // Semantics deliberately match the one place Rails DOES translate —
-    // postgresql_adapter.rb:326 — so both adapters agree: a truthy `username`
-    // overwrites `user`, and is always removed from the driver config.
+    // postgresql_adapter.rb:326 — so both adapters agree: a PRESENT `username`
+    // (including "", which is truthy in Ruby) overwrites `user` and is always
+    // removed from the driver config.
     const { username: railsUsername, ...mysqlDriverConfig } = mysqlConfig as typeof mysqlConfig & {
       username?: string;
     };
     this._poolConfig = {
       ...mysqlDriverConfig,
-      ...(railsUsername ? { user: railsUsername } : {}),
+      ...(railsUsername == null ? {} : { user: railsUsername }),
       flags: resolvedFlags,
       strict,
       waitTimeout,

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -614,8 +614,18 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     const userGetTypeParser = (
       pgConfig.types as { getTypeParser?: (oid: number, format?: string) => unknown } | undefined
     )?.getTypeParser;
+    // Rails' database.yml spells the credential `username`
+    // (database_configurations/hash_config.rb); `pg` reads `user` and ignores
+    // unknown keys, so a Rails-spelled hash would otherwise connect as the OS
+    // user instead of failing. Map it here. An explicit `user` wins.
+    const { username: railsUsername, ...pgDriverConfig } = pgConfig as typeof pgConfig & {
+      username?: string;
+    };
     this._pgClientOptions = {
-      ...pgConfig,
+      ...pgDriverConfig,
+      ...(pgDriverConfig.user === undefined && railsUsername !== undefined
+        ? { user: railsUsername }
+        : {}),
       types: {
         getTypeParser(oid: number, format?: string): unknown {
           // Our Temporal parsers handle text-format for the 5 datetime OIDs.

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -614,18 +614,18 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     const userGetTypeParser = (
       pgConfig.types as { getTypeParser?: (oid: number, format?: string) => unknown } | undefined
     )?.getTypeParser;
-    // Rails' database.yml spells the credential `username`
-    // (database_configurations/hash_config.rb); `pg` reads `user` and ignores
-    // unknown keys, so a Rails-spelled hash would otherwise connect as the OS
-    // user instead of failing. Map it here. An explicit `user` wins.
+    // postgresql_adapter.rb:326 — "Map ActiveRecords param names to PGs."
+    //   conn_params[:user] = conn_params.delete(:username) if conn_params[:username]
+    // Note the semantics this ports: a present (truthy) `username` OVERWRITES
+    // any `user`, and is always deleted. Without it a Rails-spelled config
+    // hash connects as the OS user rather than failing, because `pg` reads the
+    // driver-native `user` and ignores unknown keys.
     const { username: railsUsername, ...pgDriverConfig } = pgConfig as typeof pgConfig & {
       username?: string;
     };
     this._pgClientOptions = {
       ...pgDriverConfig,
-      ...(pgDriverConfig.user === undefined && railsUsername !== undefined
-        ? { user: railsUsername }
-        : {}),
+      ...(railsUsername ? { user: railsUsername } : {}),
       types: {
         getTypeParser(oid: number, format?: string): unknown {
           // Our Temporal parsers handle text-format for the 5 datetime OIDs.

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -8,6 +8,7 @@ import {
   runLoadHooks,
 } from "@blazetrails/activesupport";
 import { sql as arelSql, Nodes, Visitors } from "@blazetrails/arel";
+import { isRubyTruthy } from "../ruby-truthy.js";
 import { Result } from "../result.js";
 import { HashLookupTypeMap } from "../type/hash-lookup-type-map.js";
 import { TypeMap } from "../type/type-map.js";
@@ -614,12 +615,14 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     const userGetTypeParser = (
       pgConfig.types as { getTypeParser?: (oid: number, format?: string) => unknown } | undefined
     )?.getTypeParser;
-    // postgresql_adapter.rb:326 — "Map ActiveRecords param names to PGs."
+    // postgresql_adapter.rb:322-326 — "Map ActiveRecords param names to PGs."
     //   conn_params = @config.compact
     //   conn_params[:user] = conn_params.delete(:username) if conn_params[:username]
-    // The guard is PRESENCE, not JS truthiness: `compact` has already dropped
-    // nils, and Ruby treats "" as truthy — so an empty `username` still maps
-    // and still overwrites any `user`. Without this mapping a Rails-spelled
+    // The guard is RUBY truthiness, which differs from JS in both directions:
+    // "" is truthy in Ruby (so a blank username maps and overwrites `user`),
+    // while `false` is falsy AND survives `compact` (which drops only nils),
+    // so `username: false` is the one present value that does NOT map.
+    // `isRubyTruthy` encodes exactly that. Without this mapping a Rails-spelled
     // config connects as the OS user rather than failing, because `pg` reads
     // the driver-native `user` and ignores unknown keys.
     const { username: railsUsername, ...pgDriverConfig } = pgConfig as typeof pgConfig & {
@@ -627,7 +630,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     };
     this._pgClientOptions = {
       ...pgDriverConfig,
-      ...(railsUsername == null ? {} : { user: railsUsername }),
+      ...(isRubyTruthy(railsUsername) ? { user: railsUsername } : {}),
       types: {
         getTypeParser(oid: number, format?: string): unknown {
           // Our Temporal parsers handle text-format for the 5 datetime OIDs.

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -615,17 +615,19 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       pgConfig.types as { getTypeParser?: (oid: number, format?: string) => unknown } | undefined
     )?.getTypeParser;
     // postgresql_adapter.rb:326 — "Map ActiveRecords param names to PGs."
+    //   conn_params = @config.compact
     //   conn_params[:user] = conn_params.delete(:username) if conn_params[:username]
-    // Note the semantics this ports: a present (truthy) `username` OVERWRITES
-    // any `user`, and is always deleted. Without it a Rails-spelled config
-    // hash connects as the OS user rather than failing, because `pg` reads the
-    // driver-native `user` and ignores unknown keys.
+    // The guard is PRESENCE, not JS truthiness: `compact` has already dropped
+    // nils, and Ruby treats "" as truthy — so an empty `username` still maps
+    // and still overwrites any `user`. Without this mapping a Rails-spelled
+    // config connects as the OS user rather than failing, because `pg` reads
+    // the driver-native `user` and ignores unknown keys.
     const { username: railsUsername, ...pgDriverConfig } = pgConfig as typeof pgConfig & {
       username?: string;
     };
     this._pgClientOptions = {
       ...pgDriverConfig,
-      ...(railsUsername ? { user: railsUsername } : {}),
+      ...(railsUsername == null ? {} : { user: railsUsername }),
       types: {
         getTypeParser(oid: number, format?: string): unknown {
           // Our Temporal parsers handle text-format for the 5 datetime OIDs.

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -10,6 +10,7 @@ import {
   Decryption as DecryptionError,
   Base as BaseEncryptionError,
 } from "./errors.js";
+import { isRubyTruthy } from "../ruby-truthy.js";
 import { NullEncryptor } from "./null-encryptor.js";
 import {
   normalizeEncoding as _normalizeEncoding,
@@ -30,12 +31,6 @@ export function setGlobalPreviousSchemesFn(fn: (scheme: Scheme) => Scheme[]): vo
 Configurable.onConfigure(() => {
   _globalPreviousVersion++;
 });
-
-// Mirrors Ruby truthiness for `@default &&`: only `nil` and `false` are falsey.
-// `""`, `0`, etc. are truthy in Ruby, so they still act as a present default.
-function isRubyTruthy(value: unknown): boolean {
-  return value !== null && value !== undefined && value !== false;
-}
 
 /**
  * An ActiveModel type that encrypts/decrypts attribute values. This is

--- a/packages/activerecord/src/ruby-truthy.ts
+++ b/packages/activerecord/src/ruby-truthy.ts
@@ -1,0 +1,17 @@
+/**
+ * Ruby truthiness, for ports of Ruby conditionals.
+ *
+ * This has no Rails counterpart — it's a language primitive we have to model
+ * explicitly because JS and Ruby disagree in both directions. In Ruby ONLY
+ * `nil` and `false` are falsey, so `""`, `0`, `NaN` and `[]` are all truthy;
+ * in JS the first three are falsy.
+ *
+ * Port any `if some_value` / `some_value && ...` guard through this rather
+ * than writing a bare JS truthiness check, which silently changes behavior for
+ * empty strings and zeroes.
+ *
+ * @internal
+ */
+export function isRubyTruthy(value: unknown): boolean {
+  return value !== null && value !== undefined && value !== false;
+}

--- a/packages/activerecord/src/test-helpers/template-global-setup.ts
+++ b/packages/activerecord/src/test-helpers/template-global-setup.ts
@@ -216,10 +216,16 @@ const mysqlAdapter: DbTemplateAdapter = {
 
     // Built from the config hash rather than a URL so a socket-configured run
     // (MYSQL_SOCK) reaches the driver — a URL cannot carry a socket path.
-    const { database: _adminDb, ...adminOpts } = driverConfig(settings);
+    // This connection is opened against the `mysql2` driver directly rather than
+    // through Mysql2Adapter, so it does not get the adapter's `username` → `user`
+    // mapping — spell the driver-native key here.
+    const { database: _adminDb, username, ...adminOpts } = driverConfig(settings);
     // CREATE DATABASE for all slots first (sequential — DDL against the same
     // server, DROP/CREATE must not race with themselves).
-    const admin = await mysql.createConnection(adminOpts as mysql.ConnectionOptions);
+    const admin = await mysql.createConnection({
+      ...adminOpts,
+      user: username,
+    } as mysql.ConnectionOptions);
     for (let slot = 1; slot <= n; slot++) {
       const slotDb = slot === 1 ? settings.database : `${settings.database}_${slot}`;
       await admin.query(`DROP DATABASE IF EXISTS \`${slotDb}\``);

--- a/packages/activerecord/src/test-helpers/test-connection-env.test.ts
+++ b/packages/activerecord/src/test-helpers/test-connection-env.test.ts
@@ -145,17 +145,16 @@ describe("test-connection-env", () => {
     expect(withDatabase(settings, "other")).toEqual({ ...settings, database: "other" });
   });
 
-  it("driverConfig emits both spellings of the credential and the socket", () => {
-    // Regression guard: DatabaseTasks reads Rails' `username`/`socket`, the
-    // drivers read `user`/`socketPath`, and both drivers IGNORE the key they
-    // don't know — so emitting one spelling connects as the OS user instead of
-    // failing. Caught as `Access denied for user ''` on the MySQL
-    // slot-provisioning path, which routes through DatabaseTasks.
+  it("driverConfig emits Rails' username and both spellings of the socket", () => {
+    // The credential is Rails' `username` alone — the adapters map it to the
+    // driver-native `user`. The socket still straddles: mysql2 reads
+    // `socketPath` and IGNORES `socket`, so emitting one spelling silently
+    // falls back to TCP instead of failing.
     const config = driverConfig(
       mysqlSettings(reader({ MYSQL_USER: "u", MYSQL_PASSWORD: "p", MYSQL_SOCK: "/tmp/m.sock" })),
     );
     expect(config.username).toBe("u");
-    expect(config.user).toBe("u");
+    expect(config).not.toHaveProperty("user");
     expect(config.socket).toBe("/tmp/m.sock");
     expect(config.socketPath).toBe("/tmp/m.sock");
   });

--- a/packages/activerecord/src/test-helpers/test-connection-env.ts
+++ b/packages/activerecord/src/test-helpers/test-connection-env.ts
@@ -185,22 +185,17 @@ export function mysqlSettings(read: EnvReader = getEnv): ServerSettings {
 
 /**
  * Translate {@link ServerSettings} into the key set a `configuration_hash` /
- * driver options object needs, straddling two naming conventions that disagree.
+ * driver options object needs.
  *
- * This is the single place that knows about the straddle:
+ * The credential is Rails' canonical `username` alone (as `database.yml` spells
+ * it): `MySQLDatabaseTasks#buildAdapterConfig` / `PostgreSQLDatabaseTasks` read
+ * it directly, and `Mysql2Adapter` / `PostgreSQLAdapter` map it to the
+ * driver-native `user` when building their driver config.
  *
- *   - **credential** — `MySQLDatabaseTasks#buildAdapterConfig` and
- *     `PostgreSQLDatabaseTasks` read Rails' canonical `username` (as
- *     `database.yml` spells it), while `Mysql2Adapter` / `PostgreSQLAdapter`
- *     forward the residual hash to the `mysql2` / `pg` drivers, which read the
- *     driver-native `user`.
- *   - **socket** — Rails' config key is `socket`; mysql2's driver option is
- *     `socketPath`.
- *
- * Emitting only one spelling of either fails *silently*: both drivers ignore
- * unknown keys, so a `username`-only config connects as the OS user rather than
- * raising (verified against a live server). Converging the adapters onto Rails'
- * spelling would let this collapse to one key each; that is its own story.
+ * The socket still straddles: Rails' config key is `socket`, while mysql2's
+ * driver option is `socketPath`. Emitting only one spelling fails *silently* —
+ * mysql2 ignores unknown keys, so a `socket`-only config falls back to TCP
+ * rather than raising.
  *
  * `password` and the socket keys are omitted when unset so the drivers apply
  * their own defaults — a literal `undefined` is not the same as absent.
@@ -211,7 +206,6 @@ export function driverConfig(settings: ServerSettings): Record<string, unknown> 
     host,
     port,
     username: user,
-    user,
     database,
     ...(password === undefined ? {} : { password }),
     ...(socket === undefined ? {} : { socket, socketPath: socket }),


### PR DESCRIPTION
Rails' `database.yml` spells the credential `username`
(`database_configurations/hash_config.rb`), and `MySQLDatabaseTasks` /
`PostgreSQLDatabaseTasks` already read it that way. But `Mysql2Adapter` and
`PostgreSQLAdapter` forwarded the residual config hash straight to the Node
`mysql2` / `pg` drivers, which read the driver-native `user` — and neither
driver errors on an unknown key. A Rails-spelled config therefore connected as
the **OS user** instead of failing, silently.

This was masked while the harness used a `UrlConfig` (each layer re-parsed the
credential out of the URL). The move to `HashConfig` surfaced it as
`Access denied for user ''@'...'` on the MySQL slot-provisioning path, worked
around by emitting *both* spellings from `driverConfig()`.

## PostgreSQL is a port, MySQL is a deviation

Worth stating explicitly, because the two adapters get the same code for
different reasons:

- **PostgreSQL** — Rails does this exact mapping, at
  `postgresql_adapter.rb:326`:
  ```ruby
  conn_params = @config.compact
  # Map ActiveRecords param names to PGs.
  conn_params[:user] = conn_params.delete(:username) if conn_params[:username]
  ```
  This PR ports that line, including its precedence: a **present `username`
  overwrites `user`** and is always deleted. It does *not* defer to a `user`
  already in the hash. The guard is *Ruby* truthiness, which differs from JS in
  both directions: `""` is truthy in Ruby so a blank `username` maps, while
  `false` is falsey **and** survives `compact` (which drops only nils), so
  `username: false` is the one present value that does not map. Both adapters
  share an `isRubyTruthy` helper — extracted here from
  `encrypted-attribute-type.ts`, where it already existed privately — so there
  is one definition of the guard rather than three.
- **MySQL** — Rails hands the hash to `Mysql2::Client.new(config)` untouched
  (`mysql2_adapter.rb:24`) because the Ruby gem reads `:username` natively.
  Node's `mysql2` does not, so the mapping here is a driver-forced deviation.
  It follows the PostgreSQL semantics above so the two adapters agree.

The retained `_config` is untouched by the mapping — Rails maps a *copy*
(`conn_params = @config.compact`), so `DatabaseTasks` still sees `username`.
Covered by a test.

## A second mapping already existed, and it won

Found in review. `adapter-args.ts:193-208` already remapped `username` → `user`,
on the path `connection-handling.ts:923` uses to build *every* adapter. It
stripped `username` before the config reached the constructor, so:

- the constructor mapping this PR added was **dead on the real path**, and
- `adapter-args` carried both defects the constructor fix corrected — an
  explicit `user` beat `username`, and `username: false` mapped.

Rails maps the credential inside the adapter constructor
(`postgresql_adapter.rb:326`), not in an arg builder, so the remap is removed
from `adapter-args.ts` and Rails' spelling is forwarded untouched. One mapping
site, in the Rails-faithful place.

Two `adapter-args` tests asserted the old behavior and are updated: the
credential now arrives at the constructor as `username`, and precedence is the
constructor's call. `buildAdapterArg` end-to-end coverage is added — the
direct-construction tests could not catch this, since they bypass the very
layer that was overriding them.

## Changes

- `Mysql2Adapter` / `PostgreSQLAdapter` map `username` → `user` when building
  their driver config.
- `adapter-args.ts` no longer remaps or strips the credential.
- `driverConfig()` in `test-helpers/test-connection-env.ts` drops the duplicated
  `user` emission and the straddle comment, keeping Rails' `username` alone. The
  socket straddle (`socket` / `socketPath`) is unchanged and still documented —
  it's a separate deviation.
- The MySQL slot-provisioning admin connection in `template-global-setup.ts`
  opens on the `mysql2` driver *directly* rather than through the adapter, so it
  doesn't get the mapping — it now spells `user` at that call site.

## Tests

New `adapter-username-key.trails.test.ts`, run against both adapters: `username`
maps to `user`; an explicit `user` passes through; `username` overwrites `user`;
a blank `username` still maps while `username: false` does not (Ruby
truthiness, verified against Ruby); neither key leaves `user` absent; and `_config` retains `username`. Built via the fake-connection /
lazy-connect paths, so no live server is needed.

## Follow-up registered

Rails also `compact`s, maps `database` → `dbname`, and `slice!`s `conn_params`
to valid PG keys (`postgresql_adapter.rb:322-331`). Those three are still
unported — latent rather than live, since `pg` ignores unknown keys, but it's
the same silent-ignore behavior that hid this bug. Registered as
`0025-fidelity-verification-tooling/port-pg-conn-params-mapping-and-allowlist`
rather than scope-creeping this PR.

## Note on a renamed test

`driverConfig emits both spellings of the credential and the socket` →
`driverConfig emits Rails' username and both spellings of the socket`. Harness
infra with no Rails counterpart (so not a `test:compare` anchor), and the old
name asserted exactly the behavior this PR removes.

## Not verified locally

No local MySQL/PG server (`ECONNREFUSED`), so the live-lane connection paths are
unverified here — CI's MySQL and PG jobs exercise them.

Closes-story: converge-adapters-onto-rails-username-key
