### PR TITLE
feat(api-compare): honour leading :: as an absolute mixin/superclass reference

### DIFF
--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -241,6 +241,11 @@ describe("superclassesMatch", () => {
     expect(superclassesMatch(null, [], "Anything")).toBe(true);
   });
 
+  it("matches a `< ::Foo` absolute super against the plain ts name", () => {
+    // TS names never carry Ruby's absolute marker, so it is stripped first.
+    expect(superclassesMatch("::Binary", ["Binary"], "Cte")).toBe(true);
+  });
+
   it("flags ruby super with empty ts chain", () => {
     expect(superclassesMatch("Foo", [], "Anything")).toBe(false);
   });
@@ -691,6 +696,17 @@ describe("resolveModuleName", () => {
   it("passes through already-qualified names without consulting the map", () => {
     // Early return fires on "::" — byShort is irrelevant for pre-qualified names.
     expect(resolveModuleName("Foo::Bar", "Baz::Qux", new Map())).toEqual(["Foo::Bar"]);
+  });
+
+  it("strips a leading :: and resolves top-level, ignoring nearer candidates", () => {
+    // `include ::Foo` is absolute: it must not bind to the lexically nearer
+    // `Z::Foo` the unqualified form would pick.
+    const byShort = new Map([["Foo", ["Z::Foo", "Foo"]]]);
+    expect(resolveModuleName("::Foo", "Z::Bar", byShort)).toEqual(["Foo"]);
+  });
+
+  it("strips a leading :: from a qualified absolute name", () => {
+    expect(resolveModuleName("::Foo::Bar", "Baz::Qux", new Map())).toEqual(["Foo::Bar"]);
   });
 
   it("returns all candidates when context has no prefix match", () => {

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -554,6 +554,8 @@ export function superclassesMatch(
   tsChain: string[],
   tsName: string,
 ): boolean {
+  // `class X < ::Foo` records the absolute marker; TS names never carry it.
+  rubySuper = rubySuper?.replace(/^::/, "") ?? null;
   if (!rubySuper && tsChain.length === 0) return true;
   // Ruby builtins have no faithful TS superclass; accept whatever TS uses.
   if (rubySuper && RUBY_UNEXTENDABLE_BUILTINS.has(rubySuper)) return true;
@@ -621,6 +623,9 @@ export function resolveModuleName(
   contextFqn: string,
   moduleFqnByShort: Map<string, string[]>,
 ): string[] {
+  // A leading `::` is Ruby's absolute-reference marker, not a namespace
+  // qualifier: `include ::Foo` names top-level `Foo` regardless of context.
+  if (incName.startsWith("::")) return [incName.slice(2)];
   if (incName.includes("::")) return [incName];
   const candidates = moduleFqnByShort.get(incName);
   if (!candidates || candidates.length === 0) return [incName];

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -515,7 +515,7 @@ class ApiExtractor
     name = const_name(node[1])
     return unless name
 
-    superclass = const_name(node[2]) if node[2]
+    superclass = qualified_const_name(node[2]) if node[2]
 
     @namespace_stack.push(name)
     @visibility_stack.push(:public)
@@ -814,7 +814,7 @@ class ApiExtractor
     target = @classes[fqn] || @modules[fqn]
     return unless target
 
-    names = extract_const_args(args)
+    names = extract_const_args(args, keep_absolute: true)
     names.each { |mod_name| target[:includes] << mod_name }
     (@include_groups[[fqn, :includes]] ||= []) << names if names.any?
   end
@@ -824,7 +824,7 @@ class ApiExtractor
     target = @classes[fqn] || @modules[fqn]
     return unless target
 
-    names = extract_const_args_from_paren(args)
+    names = extract_const_args_from_paren(args, keep_absolute: true)
     names.each { |mod_name| target[:includes] << mod_name }
     (@include_groups[[fqn, :includes]] ||= []) << names if names.any?
   end
@@ -834,7 +834,7 @@ class ApiExtractor
     target = @classes[fqn] || @modules[fqn]
     return unless target
 
-    names = extract_const_args(args)
+    names = extract_const_args(args, keep_absolute: true)
     names.each { |mod_name| target[:extends] << mod_name }
     (@include_groups[[fqn, :extends]] ||= []) << names if names.any?
   end
@@ -844,7 +844,7 @@ class ApiExtractor
     target = @classes[fqn] || @modules[fqn]
     return unless target
 
-    names = extract_const_args_from_paren(args)
+    names = extract_const_args_from_paren(args, keep_absolute: true)
     names.each { |mod_name| target[:extends] << mod_name }
     (@include_groups[[fqn, :extends]] ||= []) << names if names.any?
   end
@@ -1121,18 +1121,19 @@ class ApiExtractor
   # finds `ActiveRecord::Delegation`.
   def lookup_ancestor(name, from_fqn, all)
     return nil unless name
+
+    # A leading `::` forces an absolute lookup: Ruby skips every lexical scope
+    # and resolves against the top level only, so `include ::Foo` inside
+    # `A::B` binds to `::Foo` even when `A::Foo` exists.
+    if name.start_with?("::")
+      absolute = name.delete_prefix("::")
+      return all[absolute] ? [absolute, all[absolute]] : nil
+    end
+
     # Resolved lexically — innermost enclosing scope outwards, top level LAST.
     # Checking `all[name]` up front would bind `include Delegation` inside
     # `ActiveRecord::Relation` to a top-level `::Delegation` in preference to
     # `ActiveRecord::Delegation`, which is the opposite of Ruby's rule.
-    #
-    # A leading `::` should strictly force the absolute lookup, but `const_name`
-    # normalizes `::Foo` to `Foo` before it reaches the recorded `includes`, so
-    # absoluteness isn't observable here; such a reference falls back to lexical
-    # order. Vendored Rails has no `include ::Foo` / `extend ::Foo` anywhere
-    # under `*/lib`, so nothing is misresolved today — teaching the extractor to
-    # preserve `::` would change emitted manifest values for every include and
-    # belongs in its own change.
     parts = from_fqn.split("::")
     while parts.any?
       candidate = (parts + [name]).join("::")
@@ -1909,28 +1910,53 @@ class ApiExtractor
     end
   end
 
-  def extract_const_args(args)
+  def extract_const_args(args, keep_absolute: false)
     results = []
     return results unless args.is_a?(Array)
-    traverse_for_consts(args, results)
+    traverse_for_consts(args, results, keep_absolute: keep_absolute)
     results
   end
 
-  def extract_const_args_from_paren(args)
+  def extract_const_args_from_paren(args, keep_absolute: false)
     results = []
     return results unless args.is_a?(Array)
-    traverse_for_consts(args, results)
+    traverse_for_consts(args, results, keep_absolute: keep_absolute)
     results
   end
 
-  def traverse_for_consts(node, results)
+  # `keep_absolute` preserves the leading `::` of an absolute reference
+  # (`include ::Foo`) so `lookup_ancestor` can honour Ruby's rule that `::`
+  # bypasses lexical scope. Off by default: other callers key into hashes of
+  # bare constant names and must keep seeing `Foo`.
+  def traverse_for_consts(node, results, keep_absolute: false)
     return unless node.is_a?(Array)
     case node[0]
     when :const_path_ref, :@const, :var_ref, :top_const_ref, :const_ref
-      name = const_name(node)
+      name = keep_absolute ? qualified_const_name(node) : const_name(node)
       results << name if name
     else
-      node.each { |child| traverse_for_consts(child, results) }
+      node.each { |child| traverse_for_consts(child, results, keep_absolute: keep_absolute) }
+    end
+  end
+
+  # `const_name` with a leading `::` restored when the reference was written
+  # absolutely — `::Foo` and `::A::B` both keep the marker; `A::B` does not.
+  def qualified_const_name(node)
+    name = const_name(node)
+    return nil unless name
+    absolute_const_ref?(node) ? "::#{name}" : name
+  end
+
+  # True when the leftmost element of a constant reference is `::`.
+  def absolute_const_ref?(node)
+    return false unless node.is_a?(Array)
+    case node[0]
+    when :top_const_ref, :top_const_path_ref
+      true
+    when :const_path_ref, :var_ref, :const_ref
+      absolute_const_ref?(node[1])
+    else
+      false
     end
   end
 

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -1947,11 +1947,16 @@ class ApiExtractor
     absolute_const_ref?(node) ? "::#{name}" : name
   end
 
-  # True when the leftmost element of a constant reference is `::`.
+  # True when the leftmost element of a constant reference is `::`. Ripper
+  # nests the qualifier leftwards, so `::A::B` is
+  # `const_path_ref(top_const_ref(A), B)` and the relative `A::B` is
+  # `const_path_ref(var_ref(A), B)` — recursing on node[1] separates them.
+  # (`:top_const_path_ref` is not a Ripper event; `Ripper::PARSER_EVENTS`
+  # defines only `:top_const_ref` and `:top_const_field`.)
   def absolute_const_ref?(node)
     return false unless node.is_a?(Array)
     case node[0]
-    when :top_const_ref, :top_const_path_ref
+    when :top_const_ref
       true
     when :const_path_ref, :var_ref, :const_ref
       absolute_const_ref?(node[1])

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -332,6 +332,52 @@ describe("Ruby extractor alias arity resolution", () => {
     expect(r["ActiveRecord::Relation#aka"].params).toEqual(["nested", "other"]);
   });
 
+  it("resolves a leading :: mixin against the top level, skipping lexical scope", () => {
+    // Ruby's `::` forces an absolute lookup, so `include ::Delegation` binds to
+    // top-level `Delegation` even though `ActiveRecord::Delegation` exists and
+    // would win for the unqualified `include Delegation` above.
+    const r = aliasParams({
+      "abs.rb": `
+        module Delegation
+          def target(top_level); end
+        end
+
+        module ActiveRecord
+          module Delegation
+            def target(nested, other); end
+          end
+
+          class Relation
+            include ::Delegation
+            alias :aka :target
+          end
+        end
+      `,
+    });
+    expect(r["ActiveRecord::Relation#aka"].params).toEqual(["top_level"]);
+  });
+
+  it("resolves a leading :: superclass against the top level", () => {
+    const r = aliasParams({
+      "abs_sup.rb": `
+        class Base
+          def target(top_level); end
+        end
+
+        module ActiveRecord
+          class Base
+            def target(nested, other); end
+          end
+
+          class Relation < ::Base
+            alias :aka :target
+          end
+        end
+      `,
+    });
+    expect(r["ActiveRecord::Relation#aka"].params).toEqual(["top_level"]);
+  });
+
   it("prefers a same-bucket definition over an inherited one", () => {
     const r = aliasParams({
       "shadow.rb": `

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -357,6 +357,63 @@ describe("Ruby extractor alias arity resolution", () => {
     expect(r["ActiveRecord::Relation#aka"].params).toEqual(["top_level"]);
   });
 
+  it("resolves a leading :: on a qualified mixin against the top level", () => {
+    // `::Outer::Mixin` is `const_path_ref(top_const_ref(Outer), Mixin)` — the
+    // `::` sits on the leftmost segment, so absoluteness must be detected
+    // through the qualifier nesting, not just on a bare `::Foo`.
+    const r = aliasParams({
+      "abs_path.rb": `
+        module Outer
+          module Mixin
+            def target(top_level); end
+          end
+        end
+
+        module ActiveRecord
+          module Outer
+            module Mixin
+              def target(nested, other); end
+            end
+          end
+
+          class Relation
+            include ::Outer::Mixin
+            alias :aka :target
+          end
+        end
+      `,
+    });
+    expect(r["ActiveRecord::Relation#aka"].params).toEqual(["top_level"]);
+  });
+
+  it("resolves a qualified mixin without :: lexically", () => {
+    // The same shape as above minus the `::` — `const_path_ref(var_ref(Outer),
+    // Mixin)` must still prefer the lexically nearer definition.
+    const r = aliasParams({
+      "rel_path.rb": `
+        module Outer
+          module Mixin
+            def target(top_level); end
+          end
+        end
+
+        module ActiveRecord
+          module Outer
+            module Mixin
+              def target(nested, other); end
+            end
+          end
+
+          class Relation
+            include Outer::Mixin
+            alias :aka :target
+          end
+        end
+      `,
+    });
+    expect(r["ActiveRecord::Relation#aka"].params).toEqual(["nested", "other"]);
+  });
+
   it("resolves a leading :: superclass against the top level", () => {
     const r = aliasParams({
       "abs_sup.rb": `


### PR DESCRIPTION
Ruby's leading `::` forces an absolute constant lookup, bypassing lexical scope. The extractor could not honour that: `const_name` normalized `::Foo` to `Foo` before the name reached `target[:includes]`, so absoluteness was not observable at `lookup_ancestor` — the limitation #4959 documented at the call site.

## Changes

**Ruby extractor** (`extract-ruby-api.rb`)

- `qualified_const_name` / `absolute_const_ref?` restore the leading `::` on mixin and superclass references. Ripper nests the qualifier leftwards — `::A::B` is `const_path_ref(top_const_ref(A), B)` and the relative `A::B` is `const_path_ref(var_ref(A), B)` — so recursing on `node[1]` separates the two.
- Opt-in via `keep_absolute:` on `traverse_for_consts`. The other caller (the `assert_valid_keys` const expansion) keys into a hash of bare constant names and must keep seeing `Foo`, so it is left on the old behaviour rather than being migrated.
- `lookup_ancestor` resolves a `::`-prefixed name against the top level only, skipping every lexical scope. Unqualified names keep today's innermost-outwards order.

**Comparer** (`compare.ts`) — consumers normalize the marker:

- `resolveModuleName` strips `::` and resolves top-level, rather than treating it as a namespace qualifier (its existing `incName.includes("::")` early return would otherwise have passed `::Foo` through as if pre-qualified).
- `superclassesMatch` strips it before matching against TS names, which never carry it.

## Verification

Test coverage fills the absolute/relative x bare/qualified matrix so the qualifier recursion is pinned in both directions, including the `include ::Foo` case removed as dead code in #4959, plus `class X < ::Foo` and unit tests for both TS-side normalizations. Extractor suite (28) and comparer suite (74) pass.

Inert on vendored Rails, which has no `include ::Foo` / `extend ::Foo` under any gem's `lib`: `api:compare` emits byte-identical manifests and unchanged totals (arity 7446/7627, inheritance 532/587, 11422/16975 methods). This is latent correctness for future vendored source.

One note for reviewers: a first pass also handled `:top_const_path_ref`. That is not a Ripper event — `Ripper::PARSER_EVENTS` defines only `:top_const_ref` and `:top_const_field` — so the branch was unreachable and has been dropped, with the reasoning recorded at the call site to stop it being re-added.

Closes-story: extractor-absolute-const-mixin-references
