### PR TITLE
refactor(test-compare): resolve helper expansion by enclosing scope

### DIFF
--- a/scripts/test-compare/extract-ruby-assertions.test.ts
+++ b/scripts/test-compare/extract-ruby-assertions.test.ts
@@ -191,6 +191,58 @@ describe("Ruby extractor assertion-count collection", () => {
     });
     expect(c["macro body"]).toBe(2);
   });
+
+  it("resolves a same-named helper to the caller's own class, not a sibling's", () => {
+    const counts = rubyAssertionCounts({
+      "cases/shadow_test.rb": `
+        class OneTest < ActiveSupport::TestCase
+          def check_row
+            assert_equal 1, a
+          end
+
+          def test_one
+            check_row
+          end
+        end
+
+        class ThreeTest < ActiveSupport::TestCase
+          def check_row
+            assert_equal 1, a
+            assert_equal 2, b
+            assert_equal 3, c
+          end
+
+          def test_three
+            check_row
+          end
+        end
+      `,
+    });
+    expect(counts["one"]).toBe(1);
+    expect(counts["three"]).toBe(3);
+  });
+
+  it("lets a class-local helper shadow a file-level one of the same name", () => {
+    const counts = rubyAssertionCounts({
+      "cases/outer_test.rb": `
+        def check_row
+          assert_equal 1, a
+        end
+
+        class InnerTest < ActiveSupport::TestCase
+          def check_row
+            assert_equal 1, a
+            assert_equal 2, b
+          end
+
+          def test_shadowed
+            check_row
+          end
+        end
+      `,
+    });
+    expect(counts["shadowed"]).toBe(2);
+  });
 });
 
 // Exercises the Ruby extractor's literal expected-VALUE capture (assertionValues)

--- a/scripts/test-compare/extract-ruby-assertions.test.ts
+++ b/scripts/test-compare/extract-ruby-assertions.test.ts
@@ -327,6 +327,38 @@ describe("Ruby extractor assertion-count collection", () => {
     // assertion and never expanded, so it cannot diverge either way.
     expect(counts["blocked"]).toBe(1);
   });
+
+  it("finds the includer of a nested module included by qualified constant", () => {
+    const counts = rubyAssertionCounts({
+      "cases/nested_mixin_test.rb": `
+        module SharedTests
+          module WithRoutingSharedTests
+            def test_reachable
+              check_route
+            end
+
+            def check_route
+              assert_equal 1, a
+              assert_equal 2, b
+            end
+          end
+        end
+
+        class WithRoutingTest < ActionDispatch::IntegrationTest
+          include SharedTests::WithRoutingSharedTests
+
+          def check_route
+            assert_equal 1, a
+          end
+        end
+      `,
+    });
+    // actionpack routing_assertions_test.rb includes a nested shared module by
+    // its QUALIFIED constant, so the includer is keyed
+    // "SharedTests::WithRoutingSharedTests" while the module's scope path is
+    // segmented — the includer must still be found and its override (1) win.
+    expect(counts["reachable"]).toBe(1);
+  });
 });
 
 // Exercises the Ruby extractor's literal expected-VALUE capture (assertionValues)

--- a/scripts/test-compare/extract-ruby-assertions.test.ts
+++ b/scripts/test-compare/extract-ruby-assertions.test.ts
@@ -295,6 +295,38 @@ describe("Ruby extractor assertion-count collection", () => {
     // branch -> leaf must pick the class-local leaf (2), not the file-level one.
     expect(counts["nested"]).toBe(2);
   });
+
+  it("prefers the including class's override over a mixin module's own helper", () => {
+    const counts = rubyAssertionCounts({
+      "cases/mro_test.rb": `
+        module SharedTests
+          def test_blocked
+            check_blocked { post :index }
+          end
+
+          def check_blocked
+            assert_nil session[:x], "still present"
+            assert_response :success
+          end
+        end
+
+        class UsingExceptionTest < ActionController::TestCase
+          include SharedTests
+
+          def check_blocked(&block)
+            assert_raises(SomeError, &block)
+          end
+        end
+      `,
+    });
+    // The module's tests run as instances of the including class, so Ruby's
+    // method lookup finds that class's check_blocked (1 assertion), not the
+    // module's own default (2). Same shape as actionpack's
+    // request_forgery_protection_test.rb, but with a helper whose name is not
+    // assert_*-prefixed — an assert_*-named override is counted as a single
+    // assertion and never expanded, so it cannot diverge either way.
+    expect(counts["blocked"]).toBe(1);
+  });
 });
 
 // Exercises the Ruby extractor's literal expected-VALUE capture (assertionValues)

--- a/scripts/test-compare/extract-ruby-assertions.test.ts
+++ b/scripts/test-compare/extract-ruby-assertions.test.ts
@@ -243,6 +243,58 @@ describe("Ruby extractor assertion-count collection", () => {
     });
     expect(counts["shadowed"]).toBe(2);
   });
+
+  it("still expands an unambiguous helper defined in an included module", () => {
+    const counts = rubyAssertionCounts({
+      "cases/mixin_test.rb": `
+        module RowAssertions
+          def check_row
+            assert_equal 1, a
+            assert_equal 2, b
+          end
+        end
+
+        class MixinTest < ActiveSupport::TestCase
+          include RowAssertions
+
+          def test_mixed_in
+            check_row
+          end
+        end
+      `,
+    });
+    // The def's scope path is ["RowAssertions"], which does not enclose the
+    // caller — but it is the file's only definition, so the pre-scope flat
+    // behavior is preserved and the mixin's asserts still fold in.
+    expect(counts["mixed in"]).toBe(2);
+  });
+
+  it("resolves a sub-helper from the calling helper's own class scope", () => {
+    const counts = rubyAssertionCounts({
+      "cases/nested_test.rb": `
+        def leaf
+          assert_equal 1, a
+        end
+
+        class NestedTest < ActiveSupport::TestCase
+          def leaf
+            assert_equal 1, a
+            assert_equal 2, b
+          end
+
+          def branch
+            leaf
+          end
+
+          def test_nested
+            branch
+          end
+        end
+      `,
+    });
+    // branch -> leaf must pick the class-local leaf (2), not the file-level one.
+    expect(counts["nested"]).toBe(2);
+  });
 });
 
 // Exercises the Ruby extractor's literal expected-VALUE capture (assertionValues)

--- a/scripts/test-compare/extract-ruby-tests.rb
+++ b/scripts/test-compare/extract-ruby-tests.rb
@@ -109,6 +109,9 @@ class TestExtractor
     @current_file = rel_path
     @current_filepath = filepath
     @describe_stack = []
+    # Enclosing class/module names only (the describe_stack also carries block
+    # descriptions) — the scope path helper resolution matches against.
+    @class_stack = []
     @test_cases = []
     @source_lines = source.lines
     @gate_stack = []
@@ -122,14 +125,17 @@ class TestExtractor
     @module_includes = {}
     @module_def_gates = {}
 
-    # Same-file non-assertion helper `def`s, keyed by name → body node, so a test
-    # that delegates its assertions to a helper (e.g. `test_copy_table`,
+    # Same-file non-assertion helper `def`s, keyed by name → list of definitions,
+    # so a test that delegates its assertions to a helper (e.g. `test_copy_table`,
     # `do_dump_index_tests_for_schema`) folds the helper's asserts into its count.
-    # The TS twin collects top-level functions (extract-ts-core.ts collectHelpers).
+    # The TS twin collects same-file functions (extract-ts-core.ts collectHelpers).
     # Pre-collected before walk() so a helper defined below its caller still
-    # resolves. File-scoped (not per-class) — a documented static approximation.
+    # resolves. SCOPE-AWARE: each definition records its enclosing class/module
+    # path and resolve_helper picks the innermost one visible from the call site,
+    # so two same-named helpers in different classes no longer collide. The TS
+    # twin resolves symmetrically, by innermost enclosing source range.
     @helper_defs = {}
-    collect_helper_defs(sexp)
+    collect_helper_defs(sexp, [])
 
     walk(sexp)
 
@@ -242,12 +248,14 @@ class TestExtractor
     return unless name
 
     @describe_stack.push(name)
+    @class_stack.push(name)
     # A class body always emits its `def test_*` directly (even a class nested
     # inside a module is a real test case), so suspend any module collection.
     prev = @module_collect
     @module_collect = nil
     walk_body(node[3] || node[2])
     @module_collect = prev
+    @class_stack.pop
     @describe_stack.pop
   end
 
@@ -259,7 +267,9 @@ class TestExtractor
     name = const_name(node[1])
     prev = @module_collect
     @module_collect = []
+    @class_stack.push(name) if name
     walk_body(node[2])
+    @class_stack.pop if name
     collected = @module_collect
     @module_collect = prev
     if name && !collected.empty?
@@ -877,7 +887,7 @@ class TestExtractor
   # which is what test:compare's assertion-count comparison needs (exact-count
   # parity with the Rails counterpart). See extract-ts-core.ts for the TS twin.
   def count_assertions(node)
-    count_assertions_expanded(node, [], 0)
+    count_assertions_expanded(node, [], 0, @class_stack.dup)
   end
 
   # Recursively count assertion calls, expanding self-calls (fcall/vcall/command,
@@ -886,7 +896,7 @@ class TestExtractor
   # expanded once per call site. `visiting` is the current recursion path (cycle
   # guard); `depth` is bounded by MAX_HELPER_DEPTH. Loops/`yield` are counted
   # statically (as written), not per runtime iteration — matching the TS side.
-  def count_assertions_expanded(node, visiting, depth)
+  def count_assertions_expanded(node, visiting, depth, scope)
     return 0 unless node.is_a?(Array)
 
     count = 0
@@ -894,10 +904,13 @@ class TestExtractor
     if name
       if assertion_method?(name)
         count += 1
-      elsif depth < MAX_HELPER_DEPTH && @helper_defs.key?(name) && !visiting.include?(name)
-        visiting.push(name)
-        count += count_assertions_expanded(@helper_defs[name], visiting, depth + 1)
-        visiting.pop
+      elsif depth < MAX_HELPER_DEPTH && !visiting.include?(name)
+        resolved = resolve_helper(name, scope)
+        if resolved
+          visiting.push(name)
+          count += count_assertions_expanded(resolved[0], visiting, depth + 1, resolved[1])
+          visiting.pop
+        end
       end
     elsif receiver_call_assertion?(node)
       # `x.must_equal y` / `sql.must_be_like %{…}` — receiver-form assertions
@@ -905,7 +918,7 @@ class TestExtractor
       count += 1
     end
 
-    node.each { |child| count += count_assertions_expanded(child, visiting, depth) if child.is_a?(Array) }
+    node.each { |child| count += count_assertions_expanded(child, visiting, depth, scope) if child.is_a?(Array) }
     count
   end
 
@@ -924,16 +937,47 @@ class TestExtractor
     node[3] && assertion_method?(ident_name(node[3]))
   end
 
-  # Collect every same-file `def name` → body node (node[3] is the bodystmt).
-  # Includes `test_*` methods too: a test method is itself a valid helper when
-  # another test delegates to it (e.g. `test_copy_table`).
-  def collect_helper_defs(node)
+  # Collect every same-file `def name` → { scope:, body: } (node[3] is the
+  # bodystmt), where `scope` is the enclosing class/module name path. Includes
+  # `test_*` methods too: a test method is itself a valid helper when another
+  # test delegates to it (e.g. `test_copy_table`).
+  def collect_helper_defs(node, scope)
     return unless node.is_a?(Array)
     if node[0] == :def
       name = ident_name(node[1])
-      @helper_defs[name] = node[3] if name && node[3]
+      if name && node[3]
+        (@helper_defs[name] ||= []) << { scope: scope, body: node[3] }
+      end
+    elsif node[0] == :class || node[0] == :module
+      name = const_name(node[1])
+      inner = name ? scope + [name] : scope
+      node.each { |child| collect_helper_defs(child, inner) if child.is_a?(Array) }
+      return
     end
-    node.each { |child| collect_helper_defs(child) if child.is_a?(Array) }
+    node.each { |child| collect_helper_defs(child, scope) if child.is_a?(Array) }
+  end
+
+  # The definition of `name` visible from a call site inside class/module path
+  # `scope` — the innermost enclosing definition wins, so a class-local helper
+  # shadows a file-level one of the same name. Returns [body, def_scope] or nil.
+  #
+  # When no enclosing definition exists, an UNAMBIGUOUS (single) definition
+  # elsewhere in the file still resolves: the old flat behavior, kept so a helper
+  # defined in a same-file `module` that the test class `include`s keeps folding
+  # in. Scope only disambiguates the genuinely colliding case — several
+  # same-named defs — which is the wrong-body risk this resolution removes.
+  # The TS twin (extract-ts-core.ts resolveHelper) falls back identically.
+  def resolve_helper(name, scope)
+    defs = @helper_defs[name] || []
+    return nil if defs.empty?
+
+    best = nil
+    defs.each do |d|
+      next unless scope[0, d[:scope].length] == d[:scope]
+      best = d if best.nil? || d[:scope].length > best[:scope].length
+    end
+    best ||= defs.first if defs.length == 1
+    best && [best[:body], best[:scope]]
   end
 
   # Raw (non-deduped) list of assertion *kind* tokens (method names) in a test
@@ -949,7 +993,7 @@ class TestExtractor
   def collect_assertion_kinds(node)
     kinds = []
     values = []
-    collect_assertion_kinds_expanded(node, kinds, values, [], 0, nil)
+    collect_assertion_kinds_expanded(node, kinds, values, [], 0, nil, @class_stack.dup)
     [kinds, values]
   end
 
@@ -963,7 +1007,7 @@ class TestExtractor
   # expected value without moving the (lockstep-critical) recording site. The
   # `:command` (`assert_equal 5, foo`) and `:command_call` (`foo.must_equal 5`)
   # forms carry their args on the node directly (node[2] / node[4]).
-  def collect_assertion_kinds_expanded(node, results, values, visiting, depth, pending_args)
+  def collect_assertion_kinds_expanded(node, results, values, visiting, depth, pending_args, scope)
     return unless node.is_a?(Array)
 
     name = self_call_name(node)
@@ -975,10 +1019,13 @@ class TestExtractor
         results << name
         args = node[0] == :command ? node[2] : pending_args
         values << literal_token(expected_arg(args, name))
-      elsif depth < MAX_HELPER_DEPTH && @helper_defs.key?(name) && !visiting.include?(name)
-        visiting.push(name)
-        collect_assertion_kinds_expanded(@helper_defs[name], results, values, visiting, depth + 1, nil)
-        visiting.pop
+      elsif depth < MAX_HELPER_DEPTH && !visiting.include?(name)
+        resolved = resolve_helper(name, scope)
+        if resolved
+          visiting.push(name)
+          collect_assertion_kinds_expanded(resolved[0], results, values, visiting, depth + 1, nil, resolved[1])
+          visiting.pop
+        end
       end
     elsif receiver_call_assertion?(node)
       # `x.must_equal y` / `x.must_equal(y)` — receiver-form assertions (never
@@ -996,11 +1043,11 @@ class TestExtractor
     # callee (node[1]) so the value is available at the recording site, then
     # recurse the args normally. Every other node recurses its children unchanged.
     if node[0] == :method_add_arg && node[1].is_a?(Array) && %i[fcall call].include?(node[1][0])
-      collect_assertion_kinds_expanded(node[1], results, values, visiting, depth, node[2])
-      collect_assertion_kinds_expanded(node[2], results, values, visiting, depth, nil)
+      collect_assertion_kinds_expanded(node[1], results, values, visiting, depth, node[2], scope)
+      collect_assertion_kinds_expanded(node[2], results, values, visiting, depth, nil, scope)
     else
       node.each do |child|
-        collect_assertion_kinds_expanded(child, results, values, visiting, depth, nil) if child.is_a?(Array)
+        collect_assertion_kinds_expanded(child, results, values, visiting, depth, nil, scope) if child.is_a?(Array)
       end
     end
   end

--- a/scripts/test-compare/extract-ruby-tests.rb
+++ b/scripts/test-compare/extract-ruby-tests.rb
@@ -990,7 +990,14 @@ class TestExtractor
   # classes. Searching the includer first reproduces that lookup; the module
   # itself stays in the chain as the fallback (its default definition).
   def lookup_scopes(scope)
-    includer = @module_includers[scope.last]
+    return [scope] if scope.empty?
+
+    # A nested module is `include`d by its QUALIFIED constant
+    # (`include RoutingAssertionsSharedTests::WithRoutingSharedTests` —
+    # actionpack routing_assertions_test.rb), which is how the includer is
+    # keyed; an include from within the enclosing scope names it bare. Try the
+    # qualified path first, then the bare name.
+    includer = @module_includers[scope.join("::")] || @module_includers[scope.last]
     includer && includer != scope ? [includer, scope] : [scope]
   end
 

--- a/scripts/test-compare/extract-ruby-tests.rb
+++ b/scripts/test-compare/extract-ruby-tests.rb
@@ -137,6 +137,14 @@ class TestExtractor
     @helper_defs = {}
     collect_helper_defs(sexp, [])
 
+    # module name → scope path of the FIRST class that `include`s it. A module's
+    # tests are emitted once and attributed to the first includer (see
+    # process_include / flush_collected_modules), so that class is the one whose
+    # method overrides Ruby's lookup would actually run for those tests.
+    # Pre-collected because a module body is walked before the later `include`.
+    @module_includers = {}
+    collect_module_includers(sexp, [])
+
     walk(sexp)
 
     flush_collected_modules
@@ -957,9 +965,41 @@ class TestExtractor
     node.each { |child| collect_helper_defs(child, scope) if child.is_a?(Array) }
   end
 
+  # Record the first class to `include` each module, keyed module name → the
+  # including class's scope path. Mirrors process_include's first-include-wins
+  # rule, which flush_collected_modules already uses for gates.
+  def collect_module_includers(node, scope)
+    return unless node.is_a?(Array)
+    if node[0] == :class || node[0] == :module
+      name = const_name(node[1])
+      inner = name ? scope + [name] : scope
+      node.each { |child| collect_module_includers(child, inner) if child.is_a?(Array) }
+      return
+    elsif node[0] == :command && ident_name(node[1]) == "include"
+      mod = const_name_from_args(node[2])
+      @module_includers[mod] ||= scope if mod && !scope.empty?
+    end
+    node.each { |child| collect_module_includers(child, scope) if child.is_a?(Array) }
+  end
+
+  # Scope paths to search, in Ruby method-resolution order, for a call made from
+  # `scope`. A test defined in a mixin module runs as an instance of the class
+  # that `include`s it, so that class's overrides win over the module's own defs
+  # — e.g. actionpack's request_forgery_protection_test.rb, where
+  # RequestForgeryProtectionTests#assert_blocked is overridden by both including
+  # classes. Searching the includer first reproduces that lookup; the module
+  # itself stays in the chain as the fallback (its default definition).
+  def lookup_scopes(scope)
+    includer = @module_includers[scope.last]
+    includer && includer != scope ? [includer, scope] : [scope]
+  end
+
   # The definition of `name` visible from a call site inside class/module path
   # `scope` — the innermost enclosing definition wins, so a class-local helper
   # shadows a file-level one of the same name. Returns [body, def_scope] or nil.
+  #
+  # Scopes are searched in Ruby method-resolution order (see lookup_scopes), so
+  # an including class's override beats a mixin module's own definition.
   #
   # When no enclosing definition exists, an UNAMBIGUOUS (single) definition
   # elsewhere in the file still resolves: the old flat behavior, kept so a helper
@@ -971,13 +1011,20 @@ class TestExtractor
     defs = @helper_defs[name] || []
     return nil if defs.empty?
 
-    best = nil
-    defs.each do |d|
-      next unless scope[0, d[:scope].length] == d[:scope]
-      best = d if best.nil? || d[:scope].length > best[:scope].length
+    lookup_scopes(scope).each do |lookup|
+      best = nil
+      defs.each do |d|
+        next unless lookup[0, d[:scope].length] == d[:scope]
+        best = d if best.nil? || d[:scope].length > best[:scope].length
+      end
+      next unless best
+
+      # Resolved through an includer: keep searching from that class's scope so
+      # nested helper calls also see its overrides.
+      return [best[:body], lookup == scope ? best[:scope] : lookup]
     end
-    best ||= defs.first if defs.length == 1
-    best && [best[:body], best[:scope]]
+
+    defs.length == 1 ? [defs.first[:body], defs.first[:scope]] : nil
   end
 
   # Raw (non-deduped) list of assertion *kind* tokens (method names) in a test

--- a/scripts/test-compare/extract-ts-assertions.test.ts
+++ b/scripts/test-compare/extract-ts-assertions.test.ts
@@ -158,6 +158,55 @@ describe("TS extractor assertion-count collection", () => {
     `;
     expect(tsAssertionCounts(src)["lookalikes"]).toBe(1);
   });
+
+  it("resolves a same-named helper to the caller's own suite, not a sibling's", () => {
+    const src = `
+      describe("a", () => {
+        function checkRow() {
+          expect(a).toEqual(1);
+        }
+        it("one", () => {
+          checkRow();
+        });
+      });
+      describe("b", () => {
+        function checkRow() {
+          expect(a).toEqual(1);
+          expect(b).toEqual(2);
+          expect(c).toEqual(3);
+        }
+        it("three", () => {
+          checkRow();
+        });
+      });
+    `;
+    const counts = tsAssertionCounts(src);
+    expect(counts["one"]).toBe(1);
+    expect(counts["three"]).toBe(3);
+  });
+
+  it("lets a suite-local helper shadow a file-level one of the same name", () => {
+    const src = `
+      function checkRow() {
+        expect(a).toEqual(1);
+      }
+      describe("inner", () => {
+        function checkRow() {
+          expect(a).toEqual(1);
+          expect(b).toEqual(2);
+        }
+        it("shadowed", () => {
+          checkRow();
+        });
+      });
+      it("outer", () => {
+        checkRow();
+      });
+    `;
+    const counts = tsAssertionCounts(src);
+    expect(counts["shadowed"]).toBe(2);
+    expect(counts["outer"]).toBe(1);
+  });
 });
 
 /** Index a file's extracted tests by description → assertionKinds. */

--- a/scripts/test-compare/extract-ts-assertions.test.ts
+++ b/scripts/test-compare/extract-ts-assertions.test.ts
@@ -207,6 +207,47 @@ describe("TS extractor assertion-count collection", () => {
     expect(counts["shadowed"]).toBe(2);
     expect(counts["outer"]).toBe(1);
   });
+
+  it("still expands an unambiguous helper defined in a sibling scope", () => {
+    const src = `
+      describe("defs", () => {
+        function checkRow() {
+          expect(a).toEqual(1);
+          expect(b).toEqual(2);
+        }
+      });
+      describe("use", () => {
+        it("sibling", () => {
+          checkRow();
+        });
+      });
+    `;
+    // Nothing lexically encloses the call, but the single definition is
+    // unambiguous — the pre-scope flat behavior is preserved.
+    expect(tsAssertionCounts(src)["sibling"]).toBe(2);
+  });
+
+  it("resolves a sub-helper from the calling helper's own scope", () => {
+    const src = `
+      function leaf() {
+        expect(a).toEqual(1);
+      }
+      describe("outer", () => {
+        function leaf() {
+          expect(a).toEqual(1);
+          expect(b).toEqual(2);
+        }
+        function branch() {
+          leaf();
+        }
+        it("nested", () => {
+          branch();
+        });
+      });
+    `;
+    // branch() -> leaf() must pick the suite-local leaf (2), not the file one.
+    expect(tsAssertionCounts(src)["nested"]).toBe(2);
+  });
 });
 
 /** Index a file's extracted tests by description → assertionKinds. */

--- a/scripts/test-compare/extract-ts-core.ts
+++ b/scripts/test-compare/extract-ts-core.ts
@@ -36,37 +36,80 @@ function isAssertionCallee(name: string): boolean {
 const MAX_HELPER_DEPTH = 5;
 
 /**
- * Map of same-file non-assertion helper functions — any `function` declaration
- * and any `const foo = (...) => …` / `= function …`, at ANY nesting depth (the
- * walk descends the whole file, not just top-level statements) — to their body
- * node, so a test that delegates its assertions to a helper (e.g. `testCopyTable`)
- * has the helper's asserts folded into its count. The Ruby twin collects
- * same-file `def`s the same way (extract-ruby-tests.rb `collect_helper_defs`).
- *
- * Static and name-keyed on a FLAT map (no lexical-scope tracking) — this mirrors
- * the Ruby side's file-scoped (not per-class) approximation. Consequences:
- * receiver calls (`obj.foo()`) and runtime-dispatched helpers are out of scope,
- * and two same-named helpers in different suites collide (last definition wins),
- * so a call could fold in the wrong body. Acceptable for a report-only count on
- * real test files, where helper names are effectively file-unique.
+ * One same-file helper definition: its body plus the source range of the
+ * lexical scope (the enclosing block / describe callback body, or the file)
+ * that the declaration is visible in.
  */
-type HelperMap = Map<string, ts.Node>;
+interface HelperDef {
+  body: ts.Node;
+  scopeStart: number;
+  scopeEnd: number;
+}
+
+/**
+ * Same-file non-assertion helper functions — any `function` declaration and any
+ * `const foo = (...) => …` / `= function …`, at ANY nesting depth (the walk
+ * descends the whole file, not just top-level statements) — keyed by name, so a
+ * test that delegates its assertions to a helper (e.g. `testCopyTable`) has the
+ * helper's asserts folded into its count. The Ruby twin collects same-file
+ * `def`s the same way (extract-ruby-tests.rb `collect_helper_defs`).
+ *
+ * Resolution is SCOPE-AWARE: each name maps to every definition of it, and
+ * {@link resolveHelper} picks the innermost one whose scope range contains the
+ * call site. Two same-named helpers in different `describe` suites therefore no
+ * longer collide — each suite's tests expand their own. The Ruby side resolves
+ * symmetrically, by innermost enclosing class/module rather than source range.
+ *
+ * Still static: receiver calls (`obj.foo()`) and runtime-dispatched helpers are
+ * out of scope, which is fine for a report-only count.
+ */
+type HelperMap = Map<string, HelperDef[]>;
 
 function collectHelpers(sourceFile: ts.SourceFile): HelperMap {
   const helpers: HelperMap = new Map();
-  const walk = (n: ts.Node) => {
+  const add = (name: string, body: ts.Node, scope: ts.Node) => {
+    const defs = helpers.get(name) ?? [];
+    defs.push({ body, scopeStart: scope.pos, scopeEnd: scope.end });
+    helpers.set(name, defs);
+  };
+  const walk = (n: ts.Node, scope: ts.Node) => {
     if (ts.isFunctionDeclaration(n) && n.name && n.body) {
-      helpers.set(n.name.text, n.body);
+      add(n.name.text, n.body, scope);
     } else if (ts.isVariableDeclaration(n) && ts.isIdentifier(n.name) && n.initializer) {
       const init = n.initializer;
       if ((ts.isArrowFunction(init) || ts.isFunctionExpression(init)) && init.body) {
-        helpers.set(n.name.text, init.body);
+        add(n.name.text, init.body, scope);
       }
     }
-    ts.forEachChild(n, walk);
+    const inner = ts.isBlock(n) || ts.isModuleBlock(n) || ts.isCaseBlock(n) ? n : scope;
+    ts.forEachChild(n, (c) => walk(c, inner));
   };
-  walk(sourceFile);
+  walk(sourceFile, sourceFile);
   return helpers;
+}
+
+/**
+ * The helper definition of `name` visible from a call site at position `pos` —
+ * the innermost enclosing scope wins, so a suite-local helper shadows a
+ * file-level one of the same name.
+ *
+ * When nothing lexically encloses the call site, an UNAMBIGUOUS (single)
+ * definition elsewhere in the file still resolves: the old flat behavior, kept
+ * so a helper reached across sibling scopes (the TS analogue of Ruby's
+ * `include`d-module helpers) keeps folding in. Scope only disambiguates the
+ * genuinely colliding case — several same-named definitions — which is exactly
+ * the wrong-body risk this resolution exists to remove.
+ */
+function resolveHelper(helpers: HelperMap, name: string, pos: number): ts.Node | null {
+  const defs = helpers.get(name);
+  if (!defs || defs.length === 0) return null;
+  let best: HelperDef | null = null;
+  for (const def of defs) {
+    if (pos < def.scopeStart || pos > def.scopeEnd) continue;
+    if (!best || def.scopeStart > best.scopeStart) best = def;
+  }
+  if (best) return best.body;
+  return defs.length === 1 ? defs[0].body : null;
 }
 
 /**
@@ -89,10 +132,13 @@ function countAssertions(
       const name = n.expression.text;
       if (isAssertionCallee(name)) {
         count++;
-      } else if (depth < MAX_HELPER_DEPTH && helpers.has(name) && !visiting.has(name)) {
-        visiting.add(name);
-        count += countAssertions(helpers.get(name)!, helpers, depth + 1, visiting);
-        visiting.delete(name);
+      } else if (depth < MAX_HELPER_DEPTH && !visiting.has(name)) {
+        const body = resolveHelper(helpers, name, n.pos);
+        if (body) {
+          visiting.add(name);
+          count += countAssertions(body, helpers, depth + 1, visiting);
+          visiting.delete(name);
+        }
       }
     }
     ts.forEachChild(n, walk);
@@ -217,12 +263,15 @@ function collectAssertionKinds(
             kinds.push(name);
             values.push(helperCalleeValue(name, n.arguments));
           }
-        } else if (depth < MAX_HELPER_DEPTH && helpers.has(name) && !visiting.has(name)) {
-          visiting.add(name);
-          const sub = collectAssertionKinds(helpers.get(name)!, helpers, depth + 1, visiting);
-          kinds.push(...sub.kinds);
-          values.push(...sub.values);
-          visiting.delete(name);
+        } else if (depth < MAX_HELPER_DEPTH && !visiting.has(name)) {
+          const body = resolveHelper(helpers, name, n.pos);
+          if (body) {
+            visiting.add(name);
+            const sub = collectAssertionKinds(body, helpers, depth + 1, visiting);
+            kinds.push(...sub.kinds);
+            values.push(...sub.values);
+            visiting.delete(name);
+          }
         }
       }
     }


### PR DESCRIPTION
Follow-up from #4390. Both extractors resolved same-file helper calls through a
FLAT, name-keyed map with no lexical-scope tracking, so two same-named helpers
in different suites/classes collided (last definition won) and a test could fold
in the wrong helper body's assertion count. Reviewers flagged this twice as the
residual risk.

## What changed

Each helper name now maps to *all* its definitions, and resolution picks the
innermost one visible from the call site:

- **TS** (`extract-ts-core.ts`): each definition records the source range of its
  enclosing scope (block / describe callback / file); `resolveHelper` picks the
  innermost range containing the call site.
- **Ruby** (`extract-ruby-tests.rb`): each `def` records its enclosing
  class/module name path; `resolve_helper` picks the longest path that is a
  prefix of the caller's scope.

Both walk the call site's own scope on recursive expansion, so a helper body's
internal calls resolve from *its* scope, not the original test's.

### Mixin helpers follow Ruby's method lookup

A test defined in a mixin module runs as an instance of the class that
`include`s it, so that class's overrides win. Ruby resolution therefore
pre-collects module → first including class (mirroring the first-include-wins
rule `flush_collected_modules` already uses for gates) and searches that
class's scope before the module's own. A nested module is included by its
QUALIFIED constant (`include RoutingAssertionsSharedTests::WithRoutingSharedTests`),
so the includer is matched on the qualified path first, then the bare name.
TS needs no equivalent — `describe` blocks have no method lookup.

### Fallback keeps mixins working

When nothing lexically encloses the call site, an **unambiguous** (single)
definition elsewhere in the file still resolves — the old flat behavior. This
keeps Ruby helpers defined in a same-file `module` that the test class
`include`s folding in, and the TS analogue across sibling scopes. Scope only
disambiguates the genuinely colliding case (several same-named defs), which is
exactly the wrong-body risk this exists to remove.

## Verification

`pnpm test:compare` totals are **byte-identical** before and after:

```
Overall: 14473/21663 tests (66.8%) (1162 skipped, 169 wrong describe,
22 gate-mismatch, 2018 assertion-count-mismatch, 3998 assertion-kind-mismatch,
183 assertion-value-mismatch, 4017 extra) | 747/1020 files | 209 misplaced
```

So the accepted approximation was in fact collision-free on today's corpus (the
audit half of the acceptance criteria) — and it is now structurally guaranteed
rather than incidental.

Eight new extractor unit tests, symmetric across TS and Ruby:

| Case | On `main` |
| --- | --- |
| Same-named helper in a sibling suite/class | **fails** (folds wrong body) |
| Suite-local helper shadowing a file-level one | **fails** (TS) |
| Unambiguous helper in a sibling scope / included module still expands | passes (pins fallback) |
| Sub-helper resolved from the calling helper's own scope | passes (pins nesting) |
| Including class's override beats the mixin module's helper | **fails** (folds module default) |
| Nested module included by qualified constant finds its includer | **fails** (folds module default) |

Five of them fail against `main`'s flat resolution, so they are real
regression tests rather than restatements of current behavior; the rest pin
the behavior this change deliberately preserves.

All 123 `scripts/test-compare` tests pass. Report-only; no CI gate added.

Closes-story: scope-aware-helper-expansion-resolution
