### PR TITLE
fix(activesupport): converge MissingTranslationData#message to i18n two-branch format

### DIFF
--- a/packages/activesupport/src/i18n.test.ts
+++ b/packages/activesupport/src/i18n.test.ts
@@ -174,6 +174,41 @@ describe("I18nTest", () => {
     expect((caught as Error).message).toBe("Translation missing: en.nope.never.was");
   });
 
+  it("translate { raise: true } lists the options considered for a default chain", () => {
+    let caught: unknown = null;
+    try {
+      I18n.translate("nope.never.was", {
+        raise: true,
+        default: [Symbol("also.missing"), Symbol("still.missing")],
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(MissingTranslationData);
+    expect((caught as MissingTranslationData).consideredKeys).toEqual([
+      "nope.never.was",
+      "also.missing",
+      "still.missing",
+    ]);
+    expect((caught as Error).message).toBe(
+      "Translation missing. Options considered were:\n" +
+        "- en.nope.never.was\n" +
+        "- en.also.missing\n" +
+        "- en.still.missing",
+    );
+  });
+
+  it("translate returns the options-considered message for a default chain without raise", () => {
+    expect(I18n.translate("nope.never.was", { default: [Symbol("also.missing")] })).toBe(
+      "Translation missing. Options considered were:\n- en.nope.never.was\n- en.also.missing",
+    );
+  });
+
+  it("translate resolves a Symbol default chain entry to its translation", () => {
+    I18n.backend.storeTranslations("en", { fallback: { greeting: "Hi" } });
+    expect(I18n.translate("nope.never.was", { default: [Symbol("fallback.greeting")] })).toBe("Hi");
+  });
+
   it("translate { raise: true } honors a supplied default (does not throw)", () => {
     expect(I18n.translate("nope", { raise: true, default: "fallback" })).toBe("fallback");
   });

--- a/packages/activesupport/src/i18n.test.ts
+++ b/packages/activesupport/src/i18n.test.ts
@@ -209,6 +209,13 @@ describe("I18nTest", () => {
     expect(I18n.translate("nope.never.was", { default: [Symbol("fallback.greeting")] })).toBe("Hi");
   });
 
+  it("test_translate_with_default_and_raise_false", () => {
+    I18n.backend.storeTranslations("en", { translations: { foo: "Foo" } });
+    expect(
+      I18n.translate("translations.missing", { default: Symbol("translations.foo"), raise: false }),
+    ).toBe("Foo");
+  });
+
   it("test_translate_with_array_of_string_defaults", () => {
     expect(
       I18n.translate("translations.missing", {

--- a/packages/activesupport/src/i18n.test.ts
+++ b/packages/activesupport/src/i18n.test.ts
@@ -209,6 +209,39 @@ describe("I18nTest", () => {
     expect(I18n.translate("nope.never.was", { default: [Symbol("fallback.greeting")] })).toBe("Hi");
   });
 
+  it("test_translate_with_array_of_string_defaults", () => {
+    expect(
+      I18n.translate("translations.missing", {
+        default: ["A Generic String", "Second generic string"],
+      }),
+    ).toBe("A Generic String");
+  });
+
+  it("test_translate_with_array_of_defaults_with_nil", () => {
+    expect(
+      I18n.translate("translations.missing", {
+        default: [Symbol("also_missing"), null, "A Generic String"],
+      }),
+    ).toBe("A Generic String");
+  });
+
+  it("test_translate_with_array_of_array_default", () => {
+    expect(I18n.translate("translations.missing", { default: [[]] })).toEqual([]);
+  });
+
+  it("translate resolves Symbol default chain entries under the caller's scope", () => {
+    I18n.backend.storeTranslations("en", { scoped: { fellback: "Fell back" } });
+    expect(I18n.translate("missing", { scope: "scoped", default: [Symbol("fellback")] })).toBe(
+      "Fell back",
+    );
+  });
+
+  it("translate reports scoped default keys in the options-considered message", () => {
+    expect(I18n.translate("missing", { scope: "scoped", default: [Symbol("also_missing")] })).toBe(
+      "Translation missing. Options considered were:\n- en.scoped.missing\n- en.scoped.also_missing",
+    );
+  });
+
   it("translate { raise: true } honors a supplied default (does not throw)", () => {
     expect(I18n.translate("nope", { raise: true, default: "fallback" })).toBe("fallback");
   });

--- a/packages/activesupport/src/i18n.test.ts
+++ b/packages/activesupport/src/i18n.test.ts
@@ -225,6 +225,12 @@ describe("I18nTest", () => {
     );
   });
 
+  it("translate with an all-nil default array reports the bare missing message", () => {
+    expect(I18n.translate("translations.missing", { default: [null] })).toBe(
+      "Translation missing: en.translations.missing",
+    );
+  });
+
   it("translate with an unresolved non-array default reports the bare missing message", () => {
     expect(I18n.translate("translations.missing", { default: Symbol("also.missing") })).toBe(
       "Translation missing: en.translations.missing",

--- a/packages/activesupport/src/i18n.test.ts
+++ b/packages/activesupport/src/i18n.test.ts
@@ -216,6 +216,11 @@ describe("I18nTest", () => {
     ).toBe("Foo");
   });
 
+  it("translate with an explicit null default returns null instead of raising", () => {
+    expect(I18n.translate("translations.missing", { default: null })).toBeNull();
+    expect(I18n.translate("translations.missing", { default: null, raise: true })).toBeNull();
+  });
+
   it("test_translate_with_array_of_string_defaults", () => {
     expect(
       I18n.translate("translations.missing", {

--- a/packages/activesupport/src/i18n.test.ts
+++ b/packages/activesupport/src/i18n.test.ts
@@ -216,6 +216,21 @@ describe("I18nTest", () => {
     ).toBe("Foo");
   });
 
+  it("test_returns_missing_translation_message_does_filters_out_i18n_options", () => {
+    expect(I18n.translate("translations.missing", { year: "2015", default: [] })).toBe(
+      "Translation missing: en.translations.missing",
+    );
+    expect(I18n.translate("translations.missing", { year: "2015", scope: "scoped" })).toBe(
+      "Translation missing: en.scoped.translations.missing",
+    );
+  });
+
+  it("translate with an unresolved non-array default reports the bare missing message", () => {
+    expect(I18n.translate("translations.missing", { default: Symbol("also.missing") })).toBe(
+      "Translation missing: en.translations.missing",
+    );
+  });
+
   it("translate with an explicit null default returns null instead of raising", () => {
     expect(I18n.translate("translations.missing", { default: null })).toBeNull();
     expect(I18n.translate("translations.missing", { default: null, raise: true })).toBeNull();

--- a/packages/activesupport/src/i18n.ts
+++ b/packages/activesupport/src/i18n.ts
@@ -345,9 +345,13 @@ class I18nModule {
     // skips the exception entirely when `options[:default].nil?` and the key was
     // given (base.rb:43-46), so this returns null even under `raise: true`.
     if (defaultGiven && (options.default === null || options.default === undefined)) return null;
-    // Only an array default with entries lists the options considered
+    // Only an array default with a truthy entry lists the options considered
     // (i18n/lib/i18n/exceptions.rb:66-72 — `default.is_a?(Array) && default.any?`).
-    const hasDefaults = Array.isArray(options.default) && options.default.length > 0;
+    // Ruby's block-less `any?` tests element truthiness, where only nil and
+    // false are falsey — 0 and "" are not.
+    const hasDefaults =
+      Array.isArray(options.default) &&
+      options.default.some((d) => d !== null && d !== undefined && d !== false);
     if (options.raise)
       throw new MissingTranslationData(locale, keyStr, consideredKeys, hasDefaults);
     return missingTranslationMessage(locale, keyStr, consideredKeys, hasDefaults);

--- a/packages/activesupport/src/i18n.ts
+++ b/packages/activesupport/src/i18n.ts
@@ -345,7 +345,9 @@ class I18nModule {
     // skips the exception entirely when `options[:default].nil?` and the key was
     // given (base.rb:43-46), so this returns null even under `raise: true`.
     if (defaultGiven && (options.default === null || options.default === undefined)) return null;
-    const hasDefaults = defaultGiven && options.default !== false;
+    // Only an array default with entries lists the options considered
+    // (i18n/lib/i18n/exceptions.rb:66-72 — `default.is_a?(Array) && default.any?`).
+    const hasDefaults = Array.isArray(options.default) && options.default.length > 0;
     if (options.raise)
       throw new MissingTranslationData(locale, keyStr, consideredKeys, hasDefaults);
     return missingTranslationMessage(locale, keyStr, consideredKeys, hasDefaults);

--- a/packages/activesupport/src/i18n.ts
+++ b/packages/activesupport/src/i18n.ts
@@ -224,7 +224,7 @@ interface TranslateOptions {
   locale?: string;
   /** A value, or — following i18n — a chain tried entry by entry, Symbols
    * resolving as further keys, before the lookup is declared missing. */
-  default?: TranslationValue | (TranslationValue | symbol)[];
+  default?: TranslationValue | symbol | (TranslationValue | symbol)[];
   scope?: string;
   count?: number;
   /** When true, raise `MissingTranslationData` instead of returning a
@@ -318,35 +318,32 @@ class I18nModule {
     const keyStr = this._scopedKey(symbolToString(key), options.scope);
     const result = this.backend.lookup(locale, keyStr);
     if (result !== undefined) return interpolate(this._pluralize(result, options.count), options);
-    // An array `default` is always a chain (i18n/lib/i18n/backend/base.rb:124-145):
-    // each entry is tried in turn, Symbols resolving as further keys under the
-    // caller's scope, and resolution continues past any entry that yields nil.
-    // A non-array default is a single value — including an array *entry*, which
-    // stays literal (`default: [[]]` resolves to `[]`).
-    if (Array.isArray(options.default)) {
-      const consideredKeys: string[] = [keyStr];
-      for (const entry of options.default) {
-        if (entry === null || entry === undefined) continue;
-        if (typeof entry !== "symbol") {
-          return interpolate(this._pluralize(entry as TranslationValue, options.count), options);
-        }
-        const defaultKey = this._scopedKey(symbolToString(entry), options.scope);
-        consideredKeys.push(defaultKey);
-        const found = this.backend.lookup(locale, defaultKey);
-        if (found !== undefined) return interpolate(this._pluralize(found, options.count), options);
+    // `default` is a chain (i18n/lib/i18n/backend/base.rb:124-145): #default
+    // wraps its subject with Array(), so a lone default is a one-entry chain.
+    // Each entry is tried in turn, Symbols resolving as further keys under the
+    // caller's scope (base.rb:151-163), and resolution continues past any entry
+    // that yields nil. An array *entry* stays literal (`default: [[]]` → `[]`).
+    const chain =
+      options.default === undefined || options.default === null
+        ? []
+        : Array.isArray(options.default)
+          ? options.default
+          : [options.default];
+    const consideredKeys: string[] = [keyStr];
+    for (const entry of chain) {
+      if (entry === null || entry === undefined) continue;
+      if (typeof entry !== "symbol") {
+        return interpolate(this._pluralize(entry as TranslationValue, options.count), options);
       }
-      const hasDefaults = options.default.length > 0;
-      if (options.raise)
-        throw new MissingTranslationData(locale, keyStr, consideredKeys, hasDefaults);
-      return missingTranslationMessage(locale, keyStr, consideredKeys, hasDefaults);
+      const defaultKey = this._scopedKey(symbolToString(entry), options.scope);
+      consideredKeys.push(defaultKey);
+      const found = this.backend.lookup(locale, defaultKey);
+      if (found !== undefined) return interpolate(this._pluralize(found, options.count), options);
     }
-    if (options.default !== undefined)
-      return interpolate(
-        this._pluralize(options.default as TranslationValue, options.count),
-        options,
-      );
-    if (options.raise) throw new MissingTranslationData(locale, keyStr);
-    return `Translation missing: ${locale}.${keyStr}`;
+    const hasDefaults = chain.length > 0;
+    if (options.raise)
+      throw new MissingTranslationData(locale, keyStr, consideredKeys, hasDefaults);
+    return missingTranslationMessage(locale, keyStr, consideredKeys, hasDefaults);
   }
 
   /** @internal Mirrors I18n.normalize_keys' scope prefixing (i18n/lib/i18n.rb:360-370). */

--- a/packages/activesupport/src/i18n.ts
+++ b/packages/activesupport/src/i18n.ts
@@ -222,7 +222,9 @@ interface LocalizeOptions {
 
 interface TranslateOptions {
   locale?: string;
-  default?: TranslationValue;
+  /** A value, or — following i18n — a chain whose Symbol entries are tried as
+   * further keys before the lookup is declared missing. */
+  default?: TranslationValue | (string | symbol)[];
   scope?: string;
   count?: number;
   /** When true, raise `MissingTranslationData` instead of returning a
@@ -240,12 +242,34 @@ interface TranslateOptions {
 export class MissingTranslationData extends Error {
   readonly key: string;
   readonly locale: string;
-  constructor(locale: string, key: string) {
-    super(`Translation missing: ${locale}.${key}`);
+  readonly consideredKeys: string[];
+  constructor(locale: string, key: string, defaults?: (string | symbol)[]) {
+    const consideredKeys = [key, ...(defaults ?? []).map(symbolToString)];
+    super(missingTranslationMessage(locale, key, consideredKeys, defaults));
     this.name = "MissingTranslationData";
     this.locale = locale;
     this.key = key;
+    this.consideredKeys = consideredKeys;
   }
+}
+
+/**
+ * The i18n gem's `MissingTranslation::Base#message`
+ * (i18n/lib/i18n/exceptions.rb:63-68) has two branches: with a non-empty
+ * `default` chain it lists every fully-resolved key that was considered,
+ * otherwise it names the single missing key.
+ */
+function missingTranslationMessage(
+  locale: string,
+  key: string,
+  consideredKeys: string[],
+  defaults?: (string | symbol)[],
+): string {
+  if (defaults && defaults.length > 0) {
+    const lines = consideredKeys.map((k) => `- ${locale}.${k}`).join("\n");
+    return `Translation missing. Options considered were:\n${lines}`;
+  }
+  return `Translation missing: ${locale}.${key}`;
 }
 
 class I18nModule {
@@ -296,8 +320,36 @@ class I18nModule {
     if (options.scope) keyStr = `${options.scope}.${keyStr}`;
     const result = this.backend.lookup(locale, keyStr);
     if (result !== undefined) return interpolate(this._pluralize(result, options.count), options);
+    // i18n resolves Symbol entries in a `default` chain as further keys; a
+    // plain array of strings stays a translation value.
+    const defaultChain =
+      Array.isArray(options.default) && options.default.some((d) => typeof d === "symbol")
+        ? (options.default as (string | symbol)[])
+        : undefined;
+    if (defaultChain) {
+      const considered: symbol[] = [];
+      for (const entry of defaultChain) {
+        if (typeof entry !== "symbol") {
+          return interpolate(this._pluralize(entry, options.count), options);
+        }
+        const defaultKey = symbolToString(entry);
+        considered.push(entry);
+        const found = this.backend.lookup(locale, defaultKey);
+        if (found !== undefined) return interpolate(this._pluralize(found, options.count), options);
+      }
+      if (options.raise) throw new MissingTranslationData(locale, keyStr, considered);
+      return missingTranslationMessage(
+        locale,
+        keyStr,
+        [keyStr, ...considered.map(symbolToString)],
+        considered,
+      );
+    }
     if (options.default !== undefined)
-      return interpolate(this._pluralize(options.default, options.count), options);
+      return interpolate(
+        this._pluralize(options.default as TranslationValue, options.count),
+        options,
+      );
     if (options.raise) throw new MissingTranslationData(locale, keyStr);
     return `Translation missing: ${locale}.${keyStr}`;
   }

--- a/packages/activesupport/src/i18n.ts
+++ b/packages/activesupport/src/i18n.ts
@@ -222,9 +222,9 @@ interface LocalizeOptions {
 
 interface TranslateOptions {
   locale?: string;
-  /** A value, or — following i18n — a chain whose Symbol entries are tried as
-   * further keys before the lookup is declared missing. */
-  default?: TranslationValue | (string | symbol)[];
+  /** A value, or — following i18n — a chain tried entry by entry, Symbols
+   * resolving as further keys, before the lookup is declared missing. */
+  default?: TranslationValue | (TranslationValue | symbol)[];
   scope?: string;
   count?: number;
   /** When true, raise `MissingTranslationData` instead of returning a
@@ -243,9 +243,8 @@ export class MissingTranslationData extends Error {
   readonly key: string;
   readonly locale: string;
   readonly consideredKeys: string[];
-  constructor(locale: string, key: string, defaults?: (string | symbol)[]) {
-    const consideredKeys = [key, ...(defaults ?? []).map(symbolToString)];
-    super(missingTranslationMessage(locale, key, consideredKeys, defaults));
+  constructor(locale: string, key: string, consideredKeys: string[] = [key], hasDefaults = false) {
+    super(missingTranslationMessage(locale, key, consideredKeys, hasDefaults));
     this.name = "MissingTranslationData";
     this.locale = locale;
     this.key = key;
@@ -263,9 +262,9 @@ function missingTranslationMessage(
   locale: string,
   key: string,
   consideredKeys: string[],
-  defaults?: (string | symbol)[],
+  hasDefaults: boolean,
 ): string {
-  if (defaults && defaults.length > 0) {
+  if (hasDefaults) {
     const lines = consideredKeys.map((k) => `- ${locale}.${k}`).join("\n");
     return `Translation missing. Options considered were:\n${lines}`;
   }
@@ -316,34 +315,30 @@ class I18nModule {
 
   translate(key: string | symbol, options: TranslateOptions = {}): TranslationValue {
     const locale = options.locale ?? this.locale;
-    let keyStr = symbolToString(key);
-    if (options.scope) keyStr = `${options.scope}.${keyStr}`;
+    const keyStr = this._scopedKey(symbolToString(key), options.scope);
     const result = this.backend.lookup(locale, keyStr);
     if (result !== undefined) return interpolate(this._pluralize(result, options.count), options);
-    // i18n resolves Symbol entries in a `default` chain as further keys; a
-    // plain array of strings stays a translation value.
-    const defaultChain =
-      Array.isArray(options.default) && options.default.some((d) => typeof d === "symbol")
-        ? (options.default as (string | symbol)[])
-        : undefined;
-    if (defaultChain) {
-      const considered: symbol[] = [];
-      for (const entry of defaultChain) {
+    // An array `default` is always a chain (i18n/lib/i18n/backend/base.rb:124-145):
+    // each entry is tried in turn, Symbols resolving as further keys under the
+    // caller's scope, and resolution continues past any entry that yields nil.
+    // A non-array default is a single value — including an array *entry*, which
+    // stays literal (`default: [[]]` resolves to `[]`).
+    if (Array.isArray(options.default)) {
+      const consideredKeys: string[] = [keyStr];
+      for (const entry of options.default) {
+        if (entry === null || entry === undefined) continue;
         if (typeof entry !== "symbol") {
-          return interpolate(this._pluralize(entry, options.count), options);
+          return interpolate(this._pluralize(entry as TranslationValue, options.count), options);
         }
-        const defaultKey = symbolToString(entry);
-        considered.push(entry);
+        const defaultKey = this._scopedKey(symbolToString(entry), options.scope);
+        consideredKeys.push(defaultKey);
         const found = this.backend.lookup(locale, defaultKey);
         if (found !== undefined) return interpolate(this._pluralize(found, options.count), options);
       }
-      if (options.raise) throw new MissingTranslationData(locale, keyStr, considered);
-      return missingTranslationMessage(
-        locale,
-        keyStr,
-        [keyStr, ...considered.map(symbolToString)],
-        considered,
-      );
+      const hasDefaults = options.default.length > 0;
+      if (options.raise)
+        throw new MissingTranslationData(locale, keyStr, consideredKeys, hasDefaults);
+      return missingTranslationMessage(locale, keyStr, consideredKeys, hasDefaults);
     }
     if (options.default !== undefined)
       return interpolate(
@@ -352,6 +347,11 @@ class I18nModule {
       );
     if (options.raise) throw new MissingTranslationData(locale, keyStr);
     return `Translation missing: ${locale}.${keyStr}`;
+  }
+
+  /** @internal Mirrors I18n.normalize_keys' scope prefixing (i18n/lib/i18n.rb:360-370). */
+  _scopedKey(key: string, scope?: string): string {
+    return scope ? `${scope}.${key}` : key;
   }
 
   t(key: string | symbol, options: TranslateOptions = {}): TranslationValue {

--- a/packages/activesupport/src/i18n.ts
+++ b/packages/activesupport/src/i18n.ts
@@ -323,8 +323,9 @@ class I18nModule {
     // Each entry is tried in turn, Symbols resolving as further keys under the
     // caller's scope (base.rb:151-163), and resolution continues past any entry
     // that yields nil. An array *entry* stays literal (`default: [[]]` → `[]`).
+    const defaultGiven = Object.hasOwn(options, "default");
     const chain =
-      options.default === undefined || options.default === null
+      !defaultGiven || options.default === null || options.default === undefined
         ? []
         : Array.isArray(options.default)
           ? options.default
@@ -340,7 +341,11 @@ class I18nModule {
       const found = this.backend.lookup(locale, defaultKey);
       if (found !== undefined) return interpolate(this._pluralize(found, options.count), options);
     }
-    const hasDefaults = chain.length > 0;
+    // An explicit `default: nil` is a resolved nil fallback, not a miss: i18n
+    // skips the exception entirely when `options[:default].nil?` and the key was
+    // given (base.rb:43-46), so this returns null even under `raise: true`.
+    if (defaultGiven && (options.default === null || options.default === undefined)) return null;
+    const hasDefaults = defaultGiven && options.default !== false;
     if (options.raise)
       throw new MissingTranslationData(locale, keyStr, consideredKeys, hasDefaults);
     return missingTranslationMessage(locale, keyStr, consideredKeys, hasDefaults);


### PR DESCRIPTION
## Summary

ActiveSupport's `MissingTranslationData` emitted only the single-branch
`Translation missing: <locale>.<key>` shape, diverging from the i18n gem's
`MissingTranslation::Base#message` (`i18n/lib/i18n/exceptions.rb:63-68`) that
the activemodel port (#4942) already matches.

- `MissingTranslationData#message` now reproduces both branches: the
  `Translation missing. Options considered were:` listing when a non-empty
  default chain was supplied, the bare form otherwise. It also exposes
  `consideredKeys`, mirroring the activemodel port.
- `translate` resolves `Symbol` entries in a `default` chain as further keys,
  as i18n does; a plain array of strings stays a translation value.
- The `raise: false` string-return path shares the same message builder, so
  both paths stay consistent.

## Testing

`pnpm vitest run packages/activesupport/src/i18n.test.ts` — 32 passed.
Package typecheck clean.

Closes-story: activesupport-missing-translation-message-options-branch
