### PR TITLE
feat(pg): compact and allowlist connection params before handing config to pg

### DIFF
--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -557,6 +557,12 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     const { username: railsUsername, ...mysqlDriverConfig } = mysqlConfig as typeof mysqlConfig & {
       username?: string;
     };
+    // No compact/allowlist here, unlike PostgreSQLAdapter (which mirrors
+    // postgresql_adapter.rb:322-331). Rails hands mysql2 the residual config
+    // hash verbatim — `::Mysql2::Client.new(config)` (mysql2_adapter.rb:24-25)
+    // — with no `compact` and no `slice!`, so passing the residual hash through
+    // IS the faithful port. The `username` remap above is a separate,
+    // driver-forced deviation and does not imply an allowlist belongs here.
     this._poolConfig = {
       ...mysqlDriverConfig,
       ...(isRubyTruthy(railsUsername) ? { user: railsUsername } : {}),

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.conn-params.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.conn-params.test.ts
@@ -35,6 +35,30 @@ describe("PostgreSQLAdapter conn_params", () => {
     expect(options).not.toHaveProperty("hsot");
   });
 
+  it("forwards every driver-native param it is given", () => {
+    const options = clientOptions({
+      user: "alice",
+      password: "s3cret",
+      database: "trails_test",
+      host: "localhost",
+      port: 5432,
+      application_name: "trails",
+      connectionTimeoutMillis: 100,
+      ssl: false,
+    });
+
+    expect(options).toMatchObject({
+      user: "alice",
+      password: "s3cret",
+      database: "trails_test",
+      host: "localhost",
+      port: 5432,
+      application_name: "trails",
+      connectionTimeoutMillis: 100,
+      ssl: false,
+    });
+  });
+
   it("drops undefined-valued params so pg applies its own defaults", () => {
     const options = clientOptions({
       database: "trails_test",

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.conn-params.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.conn-params.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Mirrors Rails' PostgreSQLAdapter#initialize conn_params handling
+ * (postgresql_adapter.rb:322-331): `@config.compact` followed by
+ * `conn_params.slice!(*valid_conn_param_keys)`. The node-pg equivalent of
+ * libpq's `PG::Connection.conndefaults_hash.keys` is the `pg.ClientConfig`
+ * interface — see PostgreSQLAdapter.VALID_CONN_PARAM_KEYS.
+ */
+import { describe, expect, it } from "vitest";
+
+import { PostgreSQLAdapter } from "./postgresql-adapter.js";
+
+function clientOptions(config: Record<string, unknown>): Record<string, unknown> {
+  const adapter = new PostgreSQLAdapter(config as never);
+  return (adapter as unknown as { _pgClientOptions: Record<string, unknown> })._pgClientOptions;
+}
+
+describe("PostgreSQLAdapter conn_params", () => {
+  it("forwards only valid pg connection params", () => {
+    const options = clientOptions({
+      adapter: "postgresql",
+      database: "trails_test",
+      host: "localhost",
+      pool: 5,
+      checkoutTimeout: 5,
+      migrationsPaths: "db/migrate",
+      hsot: "typo",
+    });
+
+    expect(options.database).toBe("trails_test");
+    expect(options.host).toBe("localhost");
+    expect(options).not.toHaveProperty("adapter");
+    expect(options).not.toHaveProperty("pool");
+    expect(options).not.toHaveProperty("checkoutTimeout");
+    expect(options).not.toHaveProperty("migrationsPaths");
+    expect(options).not.toHaveProperty("hsot");
+  });
+
+  it("drops undefined-valued params so pg applies its own defaults", () => {
+    const options = clientOptions({
+      database: "trails_test",
+      password: undefined,
+      host: null,
+    });
+
+    expect(options.database).toBe("trails_test");
+    expect(options).not.toHaveProperty("password");
+    expect(options).not.toHaveProperty("host");
+  });
+
+  it("keeps database rather than renaming it to dbname", () => {
+    const options = clientOptions({ database: "trails_test" });
+
+    expect(options.database).toBe("trails_test");
+    expect(options).not.toHaveProperty("dbname");
+  });
+});

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.conn-params.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.conn-params.test.ts
@@ -7,6 +7,7 @@
  */
 import { describe, expect, it } from "vitest";
 
+import { buildAdapterArg } from "./adapter-args.js";
 import { PostgreSQLAdapter } from "./postgresql-adapter.js";
 
 function clientOptions(config: Record<string, unknown>): Record<string, unknown> {
@@ -106,5 +107,31 @@ describe("PostgreSQLAdapter conn_params", () => {
 
     expect(options.database).toBe("trails_test");
     expect(options).not.toHaveProperty("dbname");
+  });
+
+  // Direct construction bypasses adapter-args, which is what hid the #4964
+  // username bug: unit tests went green while every real connection was
+  // broken. Assert the slice through the path connection-handling actually
+  // uses (buildAdapterArg -> constructor spread).
+  describe("through buildAdapterArg (the connection-handling path)", () => {
+    it("slices the residual database.yml hash the arg builder forwards", () => {
+      const [config] = buildAdapterArg("postgresql", {
+        adapter: "postgresql",
+        database: "trails_test",
+        username: "alice",
+        pool: 5,
+        checkoutTimeout: 5,
+        migrationsPaths: "db/migrate",
+      });
+      const options = clientOptions(config as Record<string, unknown>);
+
+      expect(options.user).toBe("alice");
+      expect(options.database).toBe("trails_test");
+      expect(options.host).toBe("localhost");
+      expect(options).not.toHaveProperty("username");
+      expect(options).not.toHaveProperty("pool");
+      expect(options).not.toHaveProperty("checkoutTimeout");
+      expect(options).not.toHaveProperty("migrationsPaths");
+    });
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.conn-params.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.conn-params.test.ts
@@ -71,6 +71,36 @@ describe("PostgreSQLAdapter conn_params", () => {
     expect(options).not.toHaveProperty("host");
   });
 
+  it("maps username onto user before slicing", () => {
+    const options = clientOptions({ username: "alice", database: "trails_test" });
+
+    expect(options.user).toBe("alice");
+    expect(options).not.toHaveProperty("username");
+  });
+
+  it("lets a truthy username overwrite an explicit user", () => {
+    // Ruby truthiness: "" is truthy, so a blank username still overwrites.
+    expect(clientOptions({ username: "alice", user: "bob" }).user).toBe("alice");
+    expect(clientOptions({ username: "", user: "bob" }).user).toBe("");
+    expect(clientOptions({ username: false, user: "bob" }).user).toBe("bob");
+  });
+
+  it("forwards driver params that @types/pg omits", () => {
+    // pg/lib/connection-parameters.js:82,103 and pg/lib/client.js:75,86 read
+    // these even though the published ClientConfig interface lacks them.
+    const options = clientOptions({
+      binary: true,
+      replication: "database",
+      enableChannelBinding: true,
+    });
+
+    expect(options).toMatchObject({
+      binary: true,
+      replication: "database",
+      enableChannelBinding: true,
+    });
+  });
+
   it("keeps database rather than renaming it to dbname", () => {
     const options = clientOptions({ database: "trails_test" });
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -417,21 +417,18 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    *   1. `conn_params = @config.compact` — drop absent values so node-pg
    *      applies its own defaults.
    *   2. `conn_params[:user] = conn_params.delete(:username) if conn_params[:username]`
-   *      — map the AR param name onto the driver's.
+   *      — map the AR param name onto the driver's. Applied by the CALLER
+   *      (shared `isRubyTruthy` guard, #4964); this helper receives the
+   *      already-mapped hash.
    *   3. `conn_params.slice!(*valid_conn_param_keys)` — forward only keys the
    *      driver understands, so Rails-native keys (`adapter`, `pool`,
    *      `checkoutTimeout`, `migrationsPaths`, ...) and typo'd driver keys are
    *      dropped here rather than silently ignored by the driver.
    *
-   * Steps 2 and 3 are fused into one pass so the ordering cannot be got wrong:
-   * slicing first would drop `username` before it could be renamed, and node-pg
-   * would then connect as the OS user instead of failing (`user` is what
-   * `ConnectionParameters` reads; unknown keys are ignored).
-   *
-   * The `if conn_params[:username]` guard is RUBY truthiness, which differs
-   * from JS in both directions: `""` is truthy in Ruby (a blank username maps
-   * and overwrites `user`), while `false` is falsy, so `username: false` is the
-   * one present value that does NOT map.
+   * The order is load-bearing: slicing before the mapping would drop `username`
+   * before it could be renamed, and node-pg would then connect as the OS user
+   * instead of failing (`user` is what `ConnectionParameters` reads; unknown
+   * keys are ignored). The call site therefore slices the mapped hash.
    * @internal
    */
   private static _sliceValidConnParams(config: Record<string, unknown>): pg.ClientConfig {
@@ -440,13 +437,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       // Ruby's `compact` drops nil; both `undefined` and `null` are the JS
       // spelling of an absent value in a database.yml-shaped config.
       if (value === undefined || value === null) continue;
-      if (key === "username") continue;
       if (!PostgreSQLAdapter.VALID_CONN_PARAM_KEYS.has(key)) continue;
       sliced[key] = value;
-    }
-    const username = config.username;
-    if (username !== undefined && username !== null && username !== false) {
-      sliced.user = username;
     }
     return sliced as pg.ClientConfig;
   }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -354,6 +354,65 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       });
     }
   }
+  /**
+   * The node-pg analogue of `PG::Connection.conndefaults_hash.keys + [:requiressl]`
+   * (postgresql_adapter.rb:330-331). libpq's conndefaults enumerates the keywords
+   * libpq itself accepts; node-pg does not talk to libpq, so its accepted keyword
+   * set is the `ClientConfig` interface (`@types/pg` index.d.ts, `interface
+   * ClientConfig`) as consumed by `pg.Client` (pg/lib/client.js constructor and
+   * `ConnectionParameters`). This list mirrors that interface exactly.
+   *
+   * `database` is deliberately NOT renamed to Rails' `dbname`: Rails renames
+   * because libpq's keyword is `dbname`, whereas node-pg's keyword IS `database`
+   * (ConnectionParameters reads `config.database`) and it has no `dbname` key at
+   * all. Renaming would drop the database name. This is an intentional
+   * divergence from postgresql_adapter.rb:326.
+   * @internal
+   */
+  private static readonly VALID_CONN_PARAM_KEYS: ReadonlySet<string> = new Set([
+    "user",
+    "database",
+    "password",
+    "port",
+    "host",
+    "connectionString",
+    "keepAlive",
+    "stream",
+    "statement_timeout",
+    "ssl",
+    "query_timeout",
+    "lock_timeout",
+    "keepAliveInitialDelayMillis",
+    "idle_in_transaction_session_timeout",
+    "application_name",
+    "fallback_application_name",
+    "connectionTimeoutMillis",
+    "types",
+    "options",
+    "client_encoding",
+  ]);
+
+  /**
+   * Mirrors `conn_params = @config.compact` + `conn_params.slice!(*valid_conn_param_keys)`
+   * (postgresql_adapter.rb:322, 331): drop `undefined`-valued keys so node-pg
+   * applies its own defaults, then forward only keys node-pg understands.
+   * Rails-native keys (`adapter`, `pool`, `checkoutTimeout`, `migrationsPaths`,
+   * ...) and typo'd driver keys are dropped rather than silently ignored by the
+   * driver.
+   * @internal
+   */
+  private static _sliceValidConnParams(config: Record<string, unknown>): pg.ClientConfig {
+    const sliced: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(config)) {
+      // Ruby's `compact` drops nil; both `undefined` and `null` are the JS
+      // spelling of an absent value in a database.yml-shaped config.
+      if (value === undefined || value === null) continue;
+      if (!PostgreSQLAdapter.VALID_CONN_PARAM_KEYS.has(key)) continue;
+      sliced[key] = value;
+    }
+    return sliced as pg.ClientConfig;
+  }
+
   private _pgClientOptions: pg.ClientConfig | null = null;
   // Non-null when a transaction is open on _rawConnection. Always equals
   // _rawConnection while set — kept as a field for legibility of the
@@ -624,9 +683,14 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     const { username: railsUsername, ...pgDriverConfig } = pgConfig as typeof pgConfig & {
       username?: string;
     };
+    // The slice runs on the ALREADY-MAPPED hash, matching Rails' order
+    // (postgresql_adapter.rb:325 then :331): slicing first would drop
+    // `username` before it could be renamed.
     this._pgClientOptions = {
-      ...pgDriverConfig,
-      ...(isRubyTruthy(railsUsername) ? { user: railsUsername } : {}),
+      ...PostgreSQLAdapter._sliceValidConnParams({
+        ...pgDriverConfig,
+        ...(isRubyTruthy(railsUsername) ? { user: railsUsername } : {}),
+      }),
       types: {
         getTypeParser(oid: number, format?: string): unknown {
           // Our Temporal parsers handle text-format for the 5 datetime OIDs.

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -358,9 +358,22 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * The node-pg analogue of `PG::Connection.conndefaults_hash.keys + [:requiressl]`
    * (postgresql_adapter.rb:330-331). libpq's conndefaults enumerates the keywords
    * libpq itself accepts; node-pg does not talk to libpq, so its accepted keyword
-   * set is the `ClientConfig` interface (`@types/pg` index.d.ts, `interface
-   * ClientConfig`) as consumed by `pg.Client` (pg/lib/client.js constructor and
-   * `ConnectionParameters`). This list mirrors that interface exactly.
+   * set is every key `pg.Client` actually reads. That is derived from the
+   * pinned pg@8.20 SOURCE, not from `@types/pg`: the published `ClientConfig`
+   * interface is narrower than the driver, omitting `binary`, `replication`,
+   * `enableChannelBinding`, `connection` and `Promise`. Slicing against the
+   * types would silently reject params node-pg accepts — the same silent-drop
+   * failure this allowlist exists to prevent. The two read sites are:
+   *   - `pg/lib/connection-parameters.js:63-127` — user, database, password,
+   *     port, host, binary, options, ssl, client_encoding, replication,
+   *     application_name, fallback_application_name, statement_timeout,
+   *     lock_timeout, idle_in_transaction_session_timeout, query_timeout,
+   *     connectionTimeoutMillis, keepAlive, keepAliveInitialDelayMillis
+   *     (plus `connectionString`, which it parses).
+   *   - `pg/lib/client.js:62-99` — Promise, types, enableChannelBinding,
+   *     connection, stream, binary, connectionTimeoutMillis.
+   * `Promise` and `connection` are deprecated in pg@9 but accepted today;
+   * Rails slices against what the driver accepts, so they stay in.
    *
    * `database` is deliberately NOT renamed to Rails' `dbname`: Rails renames
    * because libpq's keyword is `dbname`, whereas node-pg's keyword IS `database`
@@ -390,19 +403,35 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     "types",
     "options",
     "client_encoding",
+    "binary",
+    "replication",
+    "enableChannelBinding",
+    "connection",
+    "Promise",
   ]);
 
   /**
-   * Mirrors `conn_params = @config.compact` + `conn_params.slice!(*valid_conn_param_keys)`
-   * (postgresql_adapter.rb:322, 331): drop `undefined`-valued keys so node-pg
-   * applies its own defaults, then forward only keys node-pg understands.
-   * Rails-native keys (`adapter`, `pool`, `checkoutTimeout`, `migrationsPaths`,
-   * ...) and typo'd driver keys are dropped rather than silently ignored by the
-   * driver.
+   * Mirrors the whole `conn_params` pipeline of `PostgreSQLAdapter#initialize`
+   * (postgresql_adapter.rb:322-331), in Rails' order:
    *
-   * Order matters and matches Rails: the AR-to-PG name mapping
-   * (`username` -> `user`, postgresql_adapter.rb:325) must run BEFORE this
-   * slice, or the Rails-spelled key is dropped before it can be renamed.
+   *   1. `conn_params = @config.compact` — drop absent values so node-pg
+   *      applies its own defaults.
+   *   2. `conn_params[:user] = conn_params.delete(:username) if conn_params[:username]`
+   *      — map the AR param name onto the driver's.
+   *   3. `conn_params.slice!(*valid_conn_param_keys)` — forward only keys the
+   *      driver understands, so Rails-native keys (`adapter`, `pool`,
+   *      `checkoutTimeout`, `migrationsPaths`, ...) and typo'd driver keys are
+   *      dropped here rather than silently ignored by the driver.
+   *
+   * Steps 2 and 3 are fused into one pass so the ordering cannot be got wrong:
+   * slicing first would drop `username` before it could be renamed, and node-pg
+   * would then connect as the OS user instead of failing (`user` is what
+   * `ConnectionParameters` reads; unknown keys are ignored).
+   *
+   * The `if conn_params[:username]` guard is RUBY truthiness, which differs
+   * from JS in both directions: `""` is truthy in Ruby (a blank username maps
+   * and overwrites `user`), while `false` is falsy, so `username: false` is the
+   * one present value that does NOT map.
    * @internal
    */
   private static _sliceValidConnParams(config: Record<string, unknown>): pg.ClientConfig {
@@ -411,8 +440,13 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       // Ruby's `compact` drops nil; both `undefined` and `null` are the JS
       // spelling of an absent value in a database.yml-shaped config.
       if (value === undefined || value === null) continue;
+      if (key === "username") continue;
       if (!PostgreSQLAdapter.VALID_CONN_PARAM_KEYS.has(key)) continue;
       sliced[key] = value;
+    }
+    const username = config.username;
+    if (username !== undefined && username !== null && username !== false) {
+      sliced.user = username;
     }
     return sliced as pg.ClientConfig;
   }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -399,6 +399,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * Rails-native keys (`adapter`, `pool`, `checkoutTimeout`, `migrationsPaths`,
    * ...) and typo'd driver keys are dropped rather than silently ignored by the
    * driver.
+   *
+   * Order matters and matches Rails: the AR-to-PG name mapping
+   * (`username` -> `user`, postgresql_adapter.rb:325) must run BEFORE this
+   * slice, or the Rails-spelled key is dropped before it can be renamed.
    * @internal
    */
   private static _sliceValidConnParams(config: Record<string, unknown>): pg.ClientConfig {


### PR DESCRIPTION
Ports Rails' `conn_params` handling in `PostgreSQLAdapter#initialize` (`vendor/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:322-331`).

- **compact** (`postgresql_adapter.rb:322`): `undefined`/`null`-valued keys are dropped so node-pg applies its own defaults. `false` survives, matching Ruby's `compact` (which drops only `nil`).
- **`username` -> `user`** (`postgresql_adapter.rb:325`): supplied by #4964 (now merged) via the shared `isRubyTruthy` guard. This PR feeds its output into the slice, preserving Rails' map-then-slice order.
- **allowlist** (`slice!`, `postgresql_adapter.rb:330-331`): only valid node-pg connection keys are forwarded. libpq's `PG::Connection.conndefaults_hash.keys` has no direct node-pg analogue — node-pg does not use libpq — so the equivalent accepted-keyword set is derived from the pinned **pg@8.20 source**, not `@types/pg`: `connection-parameters.js:63-127` plus the `client.js:62-99` constructor reads. `@types/pg`'s `ClientConfig` is narrower than the driver (it omits `binary`, `replication`, `enableChannelBinding`, `connection`, `Promise`), so slicing against the types would have silently rejected params node-pg accepts.
- **`database` -> `dbname`**: intentionally NOT ported, documented inline. Rails renames because libpq's keyword is `dbname`; node-pg's keyword *is* `database` and it has no `dbname` key at all, so renaming would drop the database name.

Tests cover: every driver-native key is forwarded (positive control), an unknown/Rails-only key is not (`adapter`, `pool`, `checkoutTimeout`, `migrationsPaths`, plus a typo'd driver key), an explicit `undefined` is dropped, and `database` is not renamed.

### Interaction with #4964

Rebased onto #4964, which merged the `username` -> `user` mapping into both adapter constructors. The conflict was in the shared construction site and is resolved by keeping #4964's mapping as the single source and slicing its output — `_sliceValidConnParams` receives the already-mapped hash. My branch's duplicate inline remap was deleted. Order is load-bearing (`postgresql_adapter.rb:325` then `:331`): slicing first would drop `username` before it could be renamed, and node-pg would then connect as the OS user rather than failing.

Per the lesson #4964 paid three review rounds for — direct adapter construction bypasses `adapter-args`, so unit tests go green while production breaks — there is also a test through the real `buildAdapterArg` -> constructor path, not just direct construction.

### Mysql2Adapter assessment: no allowlist

Rails hands mysql2 the residual hash verbatim — `::Mysql2::Client.new(config)` (`mysql2_adapter.rb:24-25`) — with no `compact` and no `slice!`. Passing the residual hash through is therefore the faithful port. Recorded as an inline comment at the `_poolConfig` construction site.

Closes-story: port-pg-conn-params-mapping-and-allowlist
