### PR TITLE
fix(relation): drop invented composite-PK raise in reverseSqlOrder

### DIFF
--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -12,6 +12,8 @@ import { Nodes, Table as ArelTable } from "@blazetrails/arel";
 import { Base } from "./index.js";
 import { registerModel, modelRegistry } from "./associations.js";
 import { performMerge } from "./relation/spawn-methods.js";
+import { reverseSqlOrder } from "./relation/query-methods.js";
+import { CpkOrder } from "./test-helpers/models/cpk.js";
 import { AssociationRelation } from "./association-relation.js";
 
 import { fixtures } from "./test-helpers/fixtures.js";
@@ -859,6 +861,18 @@ describe("inspect wrapper class name", () => {
   it("defaults an unordered reverseOrder to the primary key descending", () => {
     expect(CanonPost.all().reverseOrder().toSql()).toContain("ORDER BY");
     expect(CanonPost.all().reverseOrder().toSql()).toMatch(/ORDER BY .*\bid\b.* DESC/i);
+  });
+
+  // A composite primary key is an Array, which is truthy in Rails'
+  // `return [table[primary_key].desc] if primary_key` guard, so it takes the
+  // same default-order path as a scalar PK rather than raising. trails used to
+  // invent an IrreversibleOrderError here.
+  it("defaults an unordered reverseOrder to a composite primary key descending", () => {
+    const clauses = reverseSqlOrder.call(CpkOrder.all() as any, []);
+    expect(clauses).toHaveLength(1);
+    const ordering = clauses[0] as InstanceType<typeof Nodes.Descending>;
+    expect(ordering).toBeInstanceOf(Nodes.Descending);
+    expect((ordering.expr as any).name).toEqual(["shop_id", "id"]);
   });
 
   // compact_blank: a blank string order is rejected before the reverse, so the

--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -867,12 +867,26 @@ describe("inspect wrapper class name", () => {
   // `return [table[primary_key].desc] if primary_key` guard, so it takes the
   // same default-order path as a scalar PK rather than raising. trails used to
   // invent an IrreversibleOrderError here.
+  //
+  // Note the resulting SQL is a *broken* column reference in Rails too:
+  // `Arel::Table#[]` builds `Attribute.new(table, name)` for any name
+  // (arel/table.rb:82) and `visit_Arel_Attributes_Attribute` hands it to the
+  // adapter's `quote_column_name`, which stringifies the Array. So Rails emits
+  // `"cpk_orders"."[\"shop_id\", \"id\"]"` and we emit
+  // `"cpk_orders"."shop_id,id"` — same shape, differing only by Ruby's
+  // `Array#to_s` vs JS's. Both fail at the database. Reproducing that is the
+  // point: the deviation being fixed is the *raise*, and converging the
+  // stringification would mean inventing formatting Rails never specified.
   it("defaults an unordered reverseOrder to a composite primary key descending", () => {
     const clauses = reverseSqlOrder.call(CpkOrder.all() as any, []);
     expect(clauses).toHaveLength(1);
     const ordering = clauses[0] as InstanceType<typeof Nodes.Descending>;
     expect(ordering).toBeInstanceOf(Nodes.Descending);
     expect((ordering.expr as any).name).toEqual(["shop_id", "id"]);
+
+    // End-to-end: builds rather than raising.
+    expect(CpkOrder.all().reverseOrder().toSql()).toContain(`ORDER BY`);
+    expect(CpkOrder.all().reverseOrder().toSql()).toMatch(/ORDER BY .*shop_id.*id.* DESC/i);
   });
 
   // compact_blank: a blank string order is rejected before the reverse, so the

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1985,13 +1985,10 @@ export function isDoesNotSupportReverse(order: string): boolean {
 export function reverseSqlOrder(this: QueryMethodsHost, orderQuery: unknown[]): unknown[] {
   if (orderQuery.length === 0) {
     const pk = (this as any)._modelClass?.primaryKey;
+    // Rails guards on `if primary_key` alone: a composite primary key is an
+    // Array, which is truthy, so it takes the same `table[primary_key].desc`
+    // path as a scalar one. The raise is reserved for a nil primary key.
     if (pk) {
-      if (Array.isArray(pk)) {
-        throw new IrreversibleOrderError(
-          "Relation has no current order and table has a composite primary key; cannot determine default reverse order",
-        );
-      }
-      const table: any = (this as any)._modelClass?.arelTable;
       const modelClass: any = (this as any)._modelClass;
       const arelTable =
         modelClass?.arelTable ??


### PR DESCRIPTION
Rails' `reverse_sql_order` guards its empty-order branch on `if primary_key` alone (`query_methods.rb:2016`). A composite primary key is an Array — truthy — so Rails takes the `table[primary_key].desc` path and never reaches the raise, which is reserved for a **nil** primary key (the no-PK table case fixed in #4957).

trails invented an extra raise, plus its message text, for the composite case, so `CpkOrder.all().reverseOrder()` raised `IrreversibleOrderError` where Rails returns an ordered relation. The branch was dormant before #4957, which stopped `reverseOrderBang` short-circuiting on an empty order.

## The resulting SQL is broken in Rails too — deliberately reproduced

Worth stating up front, since it looks like a bug this PR introduces. Verified against vendored Arel: `Table#[]` builds `Attribute.new(table, name)` for *any* name (`arel/table.rb:82`), and `visit_Arel_Attributes_Attribute` (`to_sql.rb:746`) hands it to the adapter's `quote_column_name`, which stringifies it (`sqlite3/quoting.rb:45` — `name.to_s`).

So for an Array PK both Rails and trails emit an invalid column reference, differing only by `Array#to_s`:

| | ORDER BY |
|---|---|
| Rails | `"cpk_orders"."[\"shop_id\", \"id\"]" DESC` |
| trails (this PR) | `"cpk_orders"."shop_id,id" DESC` |

Both fail at the database. Reproducing that is the point: **the deviation being fixed is the raise**, not the SQL. Converging the stringification would mean inventing a formatting rule Rails never specified, and the string is an artifact of Ruby's `Array#to_s`, not of AR semantics. Confirmed by probe that the relation *builds* rather than throwing — so this is a genuine behavior change, not a relocated failure.

## Tests

- Composite-PK path on the canonical `CpkOrder` model: asserts the `Descending` node over an Attribute whose name is `["shop_id", "id"]`, plus end-to-end `toSql()` (which would catch a regression back to throwing).
- The no-PK raise still covered by `test_default_reverse_order_on_table_without_primary_key` (`relations.test.ts:575`) — verified passing.

Also removes an unused `const table` left over in the same block.

Closes-story: reverse-sql-order-composite-pk-invented-raise
