### PR TITLE
fix(activemodel): detect permitted as a getter in sanitizeForMassAssignment

### DIFF
--- a/packages/actionpack/src/action-controller/controller/parameters/mass-assignment-empty.test.ts
+++ b/packages/actionpack/src/action-controller/controller/parameters/mass-assignment-empty.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Model } from "@blazetrails/activemodel";
+import { Model, ForbiddenAttributesError } from "@blazetrails/activemodel";
 import { Parameters } from "../../metal/strong-parameters.js";
 
 // A real ActionController::Parameters stores its data in a private field and
@@ -39,6 +39,28 @@ describe("MassAssignmentEmptyParametersTest", () => {
     expect(new Parameters({ name: "Bob" }).empty).toBe(false);
     expect(
       () => new Account(new Parameters({ name: "Bob" }) as unknown as Record<string, unknown>),
-    ).toThrow();
+    ).toThrow(ForbiddenAttributesError);
+  });
+});
+
+// `sanitize_for_mass_assignment` guards on `respond_to?(:permitted?)`. Real
+// Parameters exposes `permitted` as a boolean getter rather than a method, so
+// these exercise the ForbiddenAttributesProtection contract against the actual
+// class it mirrors — not a duck-typed stand-in whose `permitted` is callable
+// (that variant is covered in activemodel's attribute-assignment.test.ts).
+describe("ParametersForbiddenAttributesTest", () => {
+  it("forbidden attributes cannot be used for mass assignment", () => {
+    const params = new Parameters({ name: "Bob" });
+    expect(params.permitted).toBe(false);
+    expect(() => new Account(params as unknown as Record<string, unknown>)).toThrow(
+      ForbiddenAttributesError,
+    );
+  });
+
+  it("permitted attributes can be used for mass assignment", () => {
+    const params = new Parameters({ name: "Bob" }).permitAll();
+    expect(params.permitted).toBe(true);
+    const record = new Account(params as unknown as Record<string, unknown>);
+    expect(record.readAttribute("name")).toBe("Bob");
   });
 });

--- a/packages/activemodel/src/attribute-assignment.ts
+++ b/packages/activemodel/src/attribute-assignment.ts
@@ -7,17 +7,6 @@ interface PermittedAttributes {
   toH?(): Record<string, unknown>;
 }
 
-/**
- * Reads a params-like wrapper's `permitted?`. The real
- * `ActionController::Parameters` exposes it as a boolean GETTER
- * (strong-parameters.ts:113), while duck-typed wrappers may expose a method —
- * Ruby draws no such distinction, so both must answer here.
- */
-function readPermitted(attrs: PermittedAttributes): boolean {
-  const permitted = attrs.permitted;
-  return typeof permitted === "function" ? permitted.call(attrs) : Boolean(permitted);
-}
-
 export function assignAttributes(model: AttributeAssignment, newAttributes: unknown): void {
   assertHashAttributes(newAttributes);
 
@@ -26,57 +15,6 @@ export function assignAttributes(model: AttributeAssignment, newAttributes: unkn
 
   const sanitized = sanitizeForMassAssignment(attrs);
   _assignAttributes(model, sanitized);
-}
-
-/**
- * The mass-assignment empty-bag guard shared by every entry point that runs
- * `sanitize_for_mass_assignment` before per-key dispatch (the `Model`
- * constructor, `Model#assignAttributes`, and the ActiveRecord `Base`
- * constructor).
- *
- * Mirrors ActiveModel::AttributeAssignment#assign_attributes'
- * `return if new_attributes.empty?` (attribute_assignment.rb:32). A params-like
- * wrapper (the `ActionController::Parameters` analogue) delegates `empty?` to
- * its private parameter store (strong_parameters.rb:250) — so counting the
- * wrapper's own `Object.keys` reads its instance fields (`parameters`,
- * `_permitted`), NOT its parameter count, and an EMPTY unpermitted wrapper
- * would wrongly read as non-empty and proceed into sanitization instead of
- * being a no-op. Consult the wrapper's `empty` when present; a plain hash has
- * no such delegate, so it falls through to the key count.
- *
- * @internal Rails-private helper.
- */
-export function isMassAssignmentEmpty(attrs: object): boolean {
-  if (isParamsLikeWrapper(attrs)) {
-    const empty = (attrs as { empty?: unknown }).empty;
-    if (typeof empty === "boolean") return empty;
-  }
-  return Object.keys(attrs).length === 0;
-}
-
-/**
- * A non-plain object duck-typing the `ActionController::Parameters` surface —
- * the trails analogue of Rails' params wrapper, distinct from a plain hash whose
- * own keys ARE its contents. Single source of truth for wrapper recognition on
- * the mass-assignment path: `isHashLike` admits it as hash-like, and
- * `isMassAssignmentEmpty` consults its `empty` (so a plain hash that happens to
- * carry an `empty: <boolean>` attribute is unaffected).
- *
- * For the real ActionController::Parameters, `permitted` is a boolean getter
- * (strong-parameters.ts:113), not a method, so the probe tests key presence
- * rather than callability — the non-plain-prototype gate above is what keeps a
- * plain hash with a literal `permitted` key from being mistaken for a wrapper.
- */
-function isParamsLikeWrapper(attrs: object): boolean {
-  const proto = Object.getPrototypeOf(attrs);
-  if (proto === Object.prototype || proto === null) return false;
-  const wrapper = attrs as PermittedAttributes;
-  return "permitted" in wrapper || typeof wrapper.toH === "function";
-}
-
-export interface AttributeAssignment {
-  writeAttribute(name: string, value: unknown): void;
-  attributeWriterMissing?(name: string, value: unknown): void;
 }
 
 export function attributeWriterMissing(
@@ -125,6 +63,68 @@ export function _assignAttribute(model: AttributeAssignment, key: string, value:
   }
 }
 
+export interface AttributeAssignment {
+  writeAttribute(name: string, value: unknown): void;
+  attributeWriterMissing?(name: string, value: unknown): void;
+}
+
+/**
+ * Reads a params-like wrapper's `permitted?`. The real
+ * `ActionController::Parameters` exposes it as a boolean GETTER
+ * (strong-parameters.ts:113), while duck-typed wrappers may expose a method —
+ * Ruby draws no such distinction, so both must answer here.
+ */
+function readPermitted(attrs: PermittedAttributes): boolean {
+  const permitted = attrs.permitted;
+  return typeof permitted === "function" ? permitted.call(attrs) : Boolean(permitted);
+}
+
+/**
+ * The mass-assignment empty-bag guard shared by every entry point that runs
+ * `sanitize_for_mass_assignment` before per-key dispatch (the `Model`
+ * constructor, `Model#assignAttributes`, and the ActiveRecord `Base`
+ * constructor).
+ *
+ * Mirrors ActiveModel::AttributeAssignment#assign_attributes'
+ * `return if new_attributes.empty?` (attribute_assignment.rb:32). A params-like
+ * wrapper (the `ActionController::Parameters` analogue) delegates `empty?` to
+ * its private parameter store (strong_parameters.rb:250) — so counting the
+ * wrapper's own `Object.keys` reads its instance fields (`parameters`,
+ * `_permitted`), NOT its parameter count, and an EMPTY unpermitted wrapper
+ * would wrongly read as non-empty and proceed into sanitization instead of
+ * being a no-op. Consult the wrapper's `empty` when present; a plain hash has
+ * no such delegate, so it falls through to the key count.
+ *
+ * @internal Rails-private helper.
+ */
+export function isMassAssignmentEmpty(attrs: object): boolean {
+  if (isParamsLikeWrapper(attrs)) {
+    const empty = (attrs as { empty?: unknown }).empty;
+    if (typeof empty === "boolean") return empty;
+  }
+  return Object.keys(attrs).length === 0;
+}
+
+/**
+ * A non-plain object duck-typing the `ActionController::Parameters` surface —
+ * the trails analogue of Rails' params wrapper, distinct from a plain hash whose
+ * own keys ARE its contents. Single source of truth for wrapper recognition on
+ * the mass-assignment path: `isHashLike` admits it as hash-like, and
+ * `isMassAssignmentEmpty` consults its `empty` (so a plain hash that happens to
+ * carry an `empty: <boolean>` attribute is unaffected).
+ *
+ * For the real ActionController::Parameters, `permitted` is a boolean getter
+ * (strong-parameters.ts:113), not a method, so the probe tests key presence
+ * rather than callability — the non-plain-prototype gate above is what keeps a
+ * plain hash with a literal `permitted` key from being mistaken for a wrapper.
+ */
+function isParamsLikeWrapper(attrs: object): boolean {
+  const proto = Object.getPrototypeOf(attrs);
+  if (proto === Object.prototype || proto === null) return false;
+  const wrapper = attrs as PermittedAttributes;
+  return "permitted" in wrapper || typeof wrapper.toH === "function";
+}
+
 /** @internal Rails-private helper. */
 export function sanitizeForMassAssignment(
   attributes: Record<string, unknown>,
@@ -135,11 +135,9 @@ export function sanitizeForMassAssignment(
   // unwrap via `to_h` so the caller iterates a plain hash, not the wrapper.
   // Rails calls `attributes.to_h` unconditionally; a permitted params object is
   // expected to respond to it (a malformed one would NoMethodError there too).
-  // `permitted` is a boolean getter on the real Parameters, so probing for a
-  // function here would silently skip the whole guard for the exact class this
-  // mirrors. Gate on wrapper-hood + key presence instead, which keeps a plain
-  // hash carrying a literal `permitted` key out (Ruby's Hash does not
-  // `respond_to?(:permitted?)` either).
+  // The wrapper-hood conjunct is what stands in for `respond_to?`: it keeps a
+  // plain hash carrying a literal `permitted` key out of the guard, since
+  // Ruby's Hash does not `respond_to?(:permitted?)` either.
   if (isParamsLikeWrapper(attrs) && "permitted" in attrs) {
     if (!readPermitted(attrs)) {
       throw new ForbiddenAttributesError();

--- a/packages/activemodel/src/attribute-assignment.ts
+++ b/packages/activemodel/src/attribute-assignment.ts
@@ -119,6 +119,11 @@ export function isMassAssignmentEmpty(attrs: object): boolean {
  * plain hash with a literal `permitted` key from being mistaken for a wrapper.
  */
 function isParamsLikeWrapper(attrs: object): boolean {
+  // `where`/`exists` funnel raw primitives through sanitizeForMassAssignment, and
+  // `Object.getPrototypeOf` box-coerces them (so a number clears the plain-object
+  // gate below) while `in` throws on them outright. A primitive is never a params
+  // wrapper — reject before either check.
+  if (typeof attrs !== "object" || attrs === null) return false;
   const proto = Object.getPrototypeOf(attrs);
   if (proto === Object.prototype || proto === null) return false;
   const wrapper = attrs as PermittedAttributes;

--- a/packages/activemodel/src/attribute-assignment.ts
+++ b/packages/activemodel/src/attribute-assignment.ts
@@ -3,8 +3,19 @@ import { UnknownAttributeError } from "./errors.js";
 import { MissingAttributeError } from "./attribute-methods.js";
 
 interface PermittedAttributes {
-  permitted?(): boolean;
+  permitted?: boolean | (() => boolean);
   toH?(): Record<string, unknown>;
+}
+
+/**
+ * Reads a params-like wrapper's `permitted?`. The real
+ * `ActionController::Parameters` exposes it as a boolean GETTER
+ * (strong-parameters.ts:113), while duck-typed wrappers may expose a method —
+ * Ruby draws no such distinction, so both must answer here.
+ */
+function readPermitted(attrs: PermittedAttributes): boolean {
+  const permitted = attrs.permitted;
+  return typeof permitted === "function" ? permitted.call(attrs) : Boolean(permitted);
 }
 
 export function assignAttributes(model: AttributeAssignment, newAttributes: unknown): void {
@@ -52,16 +63,15 @@ export function isMassAssignmentEmpty(attrs: object): boolean {
  * carry an `empty: <boolean>` attribute is unaffected).
  *
  * For the real ActionController::Parameters, `permitted` is a boolean getter
- * (strong-parameters.ts:113), not a method, so `toH` is the load-bearing check
- * that admits it here; the `permitted` function-probe covers other duck-typed
- * wrappers. (sanitizeForMassAssignment has the same permitted-as-function
- * assumption — tracked in `sanitize-mass-assignment-permitted-getter`.)
+ * (strong-parameters.ts:113), not a method, so the probe tests key presence
+ * rather than callability — the non-plain-prototype gate above is what keeps a
+ * plain hash with a literal `permitted` key from being mistaken for a wrapper.
  */
 function isParamsLikeWrapper(attrs: object): boolean {
   const proto = Object.getPrototypeOf(attrs);
   if (proto === Object.prototype || proto === null) return false;
   const wrapper = attrs as PermittedAttributes;
-  return typeof wrapper.permitted === "function" || typeof wrapper.toH === "function";
+  return "permitted" in wrapper || typeof wrapper.toH === "function";
 }
 
 export interface AttributeAssignment {
@@ -125,8 +135,13 @@ export function sanitizeForMassAssignment(
   // unwrap via `to_h` so the caller iterates a plain hash, not the wrapper.
   // Rails calls `attributes.to_h` unconditionally; a permitted params object is
   // expected to respond to it (a malformed one would NoMethodError there too).
-  if (typeof attrs.permitted === "function") {
-    if (!attrs.permitted()) {
+  // `permitted` is a boolean getter on the real Parameters, so probing for a
+  // function here would silently skip the whole guard for the exact class this
+  // mirrors. Gate on wrapper-hood + key presence instead, which keeps a plain
+  // hash carrying a literal `permitted` key out (Ruby's Hash does not
+  // `respond_to?(:permitted?)` either).
+  if (isParamsLikeWrapper(attrs) && "permitted" in attrs) {
+    if (!readPermitted(attrs)) {
       throw new ForbiddenAttributesError();
     }
     return attrs.toH!();

--- a/packages/activerecord/src/forbidden-attributes-protection.trails.test.ts
+++ b/packages/activerecord/src/forbidden-attributes-protection.trails.test.ts
@@ -1,0 +1,55 @@
+/**
+ * TS-only extras for strong-parameters protection — no counterpart in
+ * activerecord/test/cases/forbidden_attributes_protection_test.rb, which covers
+ * construction, `create_with`, and `where` but never `#update` / `#update!`.
+ *
+ * Rails' `#update` / `#update!` delegate to `assign_attributes` inside the
+ * transaction (persistence.rb:563-579), which runs the empty-bag guard and
+ * `sanitize_for_mass_assignment` (attribute_assignment.rb:32-34). trails
+ * replaces only `_assign_attributes` with a raw writeAttribute loop (to keep
+ * original error classes), so these lock in that the guards Rails runs BEFORE
+ * that loop still apply — otherwise an un-permitted params object mass-assigns
+ * through `update` unchecked.
+ */
+import { describe, it, expect } from "vitest";
+import { ForbiddenAttributesError } from "@blazetrails/activemodel";
+// Side-effect: registers the Relation constructor on Base.
+import "./index.js";
+import { Person } from "./test-helpers/models/person.js";
+import { fixtures } from "./test-helpers/fixtures.js";
+import { ProtectedParams } from "./test-helpers/protected-params.js";
+
+describe("ForbiddenAttributesProtectionUpdateTest", () => {
+  fixtures(["people"]);
+
+  it("forbidden attributes cannot be used for update", async () => {
+    const person = await Person.first();
+    await expect(person!.update(new ProtectedParams({ first_name: "Guille" }))).rejects.toThrow(
+      ForbiddenAttributesError,
+    );
+  });
+
+  it("forbidden attributes cannot be used for update!", async () => {
+    const person = await Person.first();
+    await expect(person!.updateBang(new ProtectedParams({ first_name: "Guille" }))).rejects.toThrow(
+      ForbiddenAttributesError,
+    );
+  });
+
+  it("permitted attributes can be used for update", async () => {
+    const person = await Person.first();
+    await person!.update(new ProtectedParams({ first_name: "Guille" }).permit());
+
+    expect(person!.readAttribute("first_name")).toBe("Guille");
+    await person!.reload();
+    expect(person!.readAttribute("first_name")).toBe("Guille");
+  });
+
+  it("empty forbidden params still save without raising", async () => {
+    // Rails' `assign_attributes` returns before sanitizing on an empty bag, so
+    // an empty (always un-permitted) params object is an assignment no-op —
+    // but `save` still runs inside the transaction.
+    const person = await Person.first();
+    await expect(person!.update(new ProtectedParams({}))).resolves.toBe(true);
+  });
+});

--- a/packages/activerecord/src/forbidden-attributes-protection.trails.test.ts
+++ b/packages/activerecord/src/forbidden-attributes-protection.trails.test.ts
@@ -45,6 +45,17 @@ describe("ForbiddenAttributesProtectionUpdateTest", () => {
     expect(person!.readAttribute("first_name")).toBe("Guille");
   });
 
+  it("forbidden attributes raise before the locking-column guard", async () => {
+    // trails adds a locking-column guard that Rails has no counterpart for. It
+    // must not preempt the sanitizer: Rails' #update runs `assign_attributes`
+    // (and so `sanitize_for_mass_assignment`) before anything else, so an
+    // un-permitted wrapper is rejected on permission, not on its contents.
+    const person = await Person.first();
+    await expect(
+      person!.update(new ProtectedParams({ lock_version: 1, first_name: "Guille" })),
+    ).rejects.toThrow(ForbiddenAttributesError);
+  });
+
   it("empty forbidden params still save without raising", async () => {
     // Rails' `assign_attributes` returns before sanitizing on an empty bag, so
     // an empty (always un-permitted) params object is an assignment no-op —

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -603,10 +603,17 @@ function assertLockingColumnNotExplicitly(
  *
  * `isMassAssignmentEmpty` rather than `Object.keys(attrs).length` because a
  * params wrapper's own keys are its instance fields, not its contents.
+ *
+ * The trails-local locking guard runs on the SANITIZED hash, after the
+ * sanitizer. Rails' #update does only `assign_attributes` before saving
+ * (persistence.rb:563-579), so nothing may preempt ForbiddenAttributesError;
+ * and on the raw wrapper the guard inspects a params object's instance fields
+ * rather than its contents, so it silently missed `lock_version` there anyway.
  */
 async function assignUpdateAttributes(self: any, attrs: Record<string, unknown>): Promise<void> {
   if (isMassAssignmentEmpty(attrs)) return;
   const sanitized = sanitizeForMassAssignment(attrs);
+  assertLockingColumnNotExplicitly(self, sanitized);
   const pending: Promise<void>[] = [];
   for (const [key, value] of Object.entries(sanitized)) {
     const p = assignUpdateAttribute(self, key, value);
@@ -666,7 +673,6 @@ export async function update<T extends UpdateRecord>(
   attrs: Record<string, unknown>,
 ): Promise<boolean | undefined> {
   assertHashAttributes(attrs);
-  assertLockingColumnNotExplicitly(this, attrs);
   const self = this as any;
   return withTransactionReturningStatus.call(self, async () => {
     // Rails' #update delegates to `assign_attributes`, which iterates setters
@@ -700,7 +706,6 @@ export async function updateBang<T extends UpdateRecord>(
   attrs: Record<string, unknown>,
 ): Promise<true | undefined> {
   assertHashAttributes(attrs);
-  assertLockingColumnNotExplicitly(this, attrs);
   const self = this as any;
   return withTransactionReturningStatus.call(self, async () => {
     // See update(): raw loop preserves original error classes (matches Rails,

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -13,6 +13,7 @@ import {
   SerializeCastValue,
   runAfterCallbacksOnProto,
   assertHashAttributes,
+  isMassAssignmentEmpty,
 } from "@blazetrails/activemodel";
 import { InsertManager, UpdateManager, DeleteManager, Table as ArelTable } from "@blazetrails/arel";
 import {
@@ -593,6 +594,27 @@ function assertLockingColumnNotExplicitly(
  * setter so records are built / marked-for-destruction in memory before save.
  * @internal
  */
+/**
+ * The `assign_attributes` prelude shared by `#update` and `#update!`: the
+ * empty-bag guard and `sanitize_for_mass_assignment`
+ * (attribute_assignment.rb:32-34), then the raw per-key loop that stands in for
+ * `_assign_attributes` (see update() for why the loop is raw rather than a call
+ * to Base#assignAttributes).
+ *
+ * `isMassAssignmentEmpty` rather than `Object.keys(attrs).length` because a
+ * params wrapper's own keys are its instance fields, not its contents.
+ */
+async function assignUpdateAttributes(self: any, attrs: Record<string, unknown>): Promise<void> {
+  if (isMassAssignmentEmpty(attrs)) return;
+  const sanitized = sanitizeForMassAssignment(attrs);
+  const pending: Promise<void>[] = [];
+  for (const [key, value] of Object.entries(sanitized)) {
+    const p = assignUpdateAttribute(self, key, value);
+    if (p) pending.push(p);
+  }
+  if (pending.length) await Promise.all(pending);
+}
+
 function assignUpdateAttribute(self: any, key: string, value: unknown): Promise<void> | void {
   const configs = self.constructor?._nestedAttributeConfigs as
     | { associationName: string }[]
@@ -657,12 +679,14 @@ export async function update<T extends UpdateRecord>(
     // through their setter (assignUpdateAttribute). A column with a custom writer
     // would be missed; none exist today. TODO: unify on `public_send`-equivalent
     // setter dispatch if/when a custom column writer is introduced.
-    const pending: Promise<void>[] = [];
-    for (const [key, value] of Object.entries(attrs)) {
-      const p = assignUpdateAttribute(self, key, value);
-      if (p) pending.push(p);
-    }
-    if (pending.length) await Promise.all(pending);
+    //
+    // The raw loop replaces only `_assign_attributes`; the empty-bag guard and
+    // `sanitize_for_mass_assignment` that `assign_attributes` runs first
+    // (attribute_assignment.rb:32-34) still apply, or an unpermitted params
+    // wrapper would mass-assign here unchecked. Rails runs both INSIDE the
+    // transaction, so they stay inside this block. An empty bag skips only the
+    // assignment — `save` still runs, as in Rails.
+    await assignUpdateAttributes(self, attrs);
     return self.save() as Promise<boolean | undefined>;
   }) as Promise<boolean | undefined>;
 }
@@ -681,13 +705,9 @@ export async function updateBang<T extends UpdateRecord>(
   return withTransactionReturningStatus.call(self, async () => {
     // See update(): raw loop preserves original error classes (matches Rails,
     // avoids Base#assignAttributes's AttributeAssignmentError wrap); nested
-    // attribute writers still route through their setter.
-    const pending: Promise<void>[] = [];
-    for (const [key, value] of Object.entries(attrs)) {
-      const p = assignUpdateAttribute(self, key, value);
-      if (p) pending.push(p);
-    }
-    if (pending.length) await Promise.all(pending);
+    // attribute writers still route through their setter, and the empty-bag +
+    // sanitize guards from `assign_attributes` run first.
+    await assignUpdateAttributes(self, attrs);
     return self.saveBang() as Promise<true | undefined>;
   }) as Promise<true | undefined>;
 }


### PR DESCRIPTION
## Problem

`sanitizeForMassAssignment` gated the ForbiddenAttributesProtection unwrap on
`typeof attrs.permitted === "function"`. But the real trails
`ActionController::Parameters.permitted` (`strong-parameters.ts:113`) is a boolean
**getter**, not a method — `typeof` on it is `"boolean"`, never `"function"`.

Consequence: passing an unpermitted `Parameters` to mass-assignment did **not**
raise `ForbiddenAttributesError` and was **not** unwrapped via `toH`; the raw
wrapper flowed straight into `_assignAttributes`. ForbiddenAttributesProtection
was defeated for the exact class it mirrors.

Pre-existing (surfaced in review of #4529).

## 1 — The getter probe (activemodel)

Gate on params-wrapper-hood plus `"permitted" in attrs`, reading the value through
a helper that accepts either a getter or a method — mirroring Ruby's
`respond_to?(:permitted?)`, which draws no such distinction. The non-plain-prototype
gate in `isParamsLikeWrapper` keeps a plain hash carrying a literal `permitted` key
from being mistaken for a wrapper (Ruby's `Hash` doesn't `respond_to?(:permitted?)`
either). That helper now also rejects primitives up front: `where`/`exists` funnel
raw primitives through the sanitizer, `Object.getPrototypeOf` box-coerces them past
the plain-object gate, and `in` throws on them — the old property-access probe was
safe on primitives only by accident.

## 2 — `#update` / `#update!` never sanitized at all (activerecord)

Found in review. They called `assertHashAttributes` and then iterated
`Object.entries(attrs)` directly, never reaching the sanitizer — **independent of**
the getter bug: even the method-style `ProtectedParams` stub mass-assigned through
`update` unchecked.

Rails delegates to `assign_attributes` inside the transaction
(`persistence.rb:563-579`), which runs the empty-bag guard and
`sanitize_for_mass_assignment` (`attribute_assignment.rb:32-34`) before
`_assign_attributes`. trails had replaced the *whole* delegation with a raw
writeAttribute loop; that loop is deliberate (it preserves original error classes
instead of `Base#assignAttributes`'s `AttributeAssignmentError` wrap), so this
restores only the **prelude**. Both guards run inside the transaction where Rails
runs them, and an empty bag skips assignment while still saving.

## 3 — Locking guard preempted the sanitizer

Also found in review. trails has a locking-column guard with no Rails counterpart
(added in #684, untested) that ran *before* assignment, so
`update(params(lock_version: 1))` raised `lock_version cannot be updated explicitly`
instead of `ForbiddenAttributesError`. Rails' `#update` does only
`assign_attributes` before saving, so nothing may preempt the sanitizer.

It was also wrong on its own terms: reading own enumerable props off a raw wrapper
means a real `Parameters`' *private fields*, so it never saw `lock_version` there.
Now runs on the sanitized hash — fixing both precedence and the missed check. The
guard itself is kept as-is.

## Why this hid

Rails' own `ProtectedParams` stub (`test/support/stubs/strong_parameters.rb`) defines
`permitted?` as a **method**, and trails' port faithfully mirrors that — so the AR
suite never exercised the getter shape. The stub is left alone (changing it would
diverge from Rails); real-`Parameters` coverage is added where the real class lives.

## Tests

**actionpack** (real `Parameters`, getter shape), Rails-named: `forbidden attributes
cannot be used for mass assignment`, `permitted attributes can be used for mass
assignment`. The sibling `non-empty Parameters proceeds past the empty-bag guard`
test carried a comment explaining it asserted a bare `.toThrow()` *because* of this
divergence; it now asserts `ForbiddenAttributesError` and the comment is retired.

**activerecord** — `forbidden-attributes-protection.trails.test.ts` (`.trails.`
because Rails' 16-test file covers construction/`create_with`/`where` but never
`#update`): update/update! rejection, permitted unwrap, locking-guard precedence,
and the empty-bag still-saves case.

Verified non-vacuous: the rejection tests fail on `origin/main`, pass here.

## Gates

- **Rails fidelity** — `forbidden_attributes_protection.rb:24-28`,
  `attribute_assignment.rb:28-34`, `persistence.rb:563-579`.
- **No stubs.**
- **api:compare / test:compare** — `14473/21663` and `11422/16975`, both unchanged
  against baseline. **Delta 0.**
- 542 tests green across persistence / locking / nested-attributes / base /
  forbidden-attributes.

Closes-story: sanitize-mass-assignment-permitted-getter
