### PR TITLE
fix(reflection): accept a nil name in create and honor pluralizeTableNames

### DIFF
--- a/packages/activerecord/src/reflection.trails.test.ts
+++ b/packages/activerecord/src/reflection.trails.test.ts
@@ -324,6 +324,28 @@ describe("ReflectionTest", () => {
     expect(reflection.pluralName).toBe("");
   });
 
+  it("nil name derivations coerce like Ruby to_s, not to the string null", () => {
+    // Rails stores `@name = name` but every string derivation interpolates or
+    // calls to_s (reflection.rb:453, :821-825, :829), so nil yields the
+    // empty-name forms. JS template strings would render "null" instead.
+    class NilDerivOwner extends Base {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    registerModel("NilDerivOwner", NilDerivOwner);
+
+    const hasMany = create("hasMany", null, null, {}, NilDerivOwner);
+    expect(hasMany.className).toBe("");
+
+    const belongsTo = create("belongsTo", null, null, {}, NilDerivOwner);
+    expect(belongsTo.className).toBe("");
+    expect(belongsTo.foreignKey).toBe("_id");
+
+    const poly = create("belongsTo", null, null, { polymorphic: true }, NilDerivOwner);
+    expect(poly.foreignType).toBe("_type");
+  });
+
   it("plural_name honors pluralize_table_names", () => {
     // Rails: active_record.pluralize_table_names ? name.to_s.pluralize : name.to_s
     // (reflection.rb:395). We previously pluralized unconditionally.

--- a/packages/activerecord/src/reflection.trails.test.ts
+++ b/packages/activerecord/src/reflection.trails.test.ts
@@ -15,6 +15,7 @@ import {
   belongsToCounterCacheColumn,
   counterCacheColumnOption,
   resolveAliasedColumn,
+  create,
 } from "./reflection.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 
@@ -306,5 +307,40 @@ describe("ReflectionTest", () => {
     expect(resolveAliasedColumn(model, "comments_count")).toBe("legacy_comments_count");
     expect(resolveAliasedColumn(model, "replies_count")).toBe("replies_count");
     expect(resolveAliasedColumn(undefined, "comments_count")).toBe("comments_count");
+  });
+
+  it("create accepts a nil name without a cast", () => {
+    // Rails' Reflection.create tolerates a nil name (reflection_test.rb:126).
+    // TS-only guard: the signature must admit null so callers need no cast.
+    class NilNameOwner extends Base {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    registerModel("NilNameOwner", NilNameOwner);
+    const reflection = create("hasMany", null, null, {}, NilNameOwner);
+    expect(reflection.name).toBeNull();
+    // Ruby's `nil.to_s.pluralize` is "", not a raise.
+    expect(reflection.pluralName).toBe("");
+  });
+
+  it("plural_name honors pluralize_table_names", () => {
+    // Rails: active_record.pluralize_table_names ? name.to_s.pluralize : name.to_s
+    // (reflection.rb:395). We previously pluralized unconditionally.
+    class PluralOwner extends Base {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    class SingularOwner extends Base {
+      static pluralizeTableNames = false;
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    registerModel("PluralOwner", PluralOwner);
+    registerModel("SingularOwner", SingularOwner);
+    expect(create("hasMany", "comment", null, {}, PluralOwner).pluralName).toBe("comments");
+    expect(create("hasMany", "comment", null, {}, SingularOwner).pluralName).toBe("comment");
   });
 });

--- a/packages/activerecord/src/reflection.trails.test.ts
+++ b/packages/activerecord/src/reflection.trails.test.ts
@@ -346,6 +346,28 @@ describe("ReflectionTest", () => {
     expect(poly.foreignType).toBe("_type");
   });
 
+  it("nil name through-source inference coerces like Ruby to_s", () => {
+    // Rails: options[:source] ? [options[:source]] : [name.to_s.singularize, name].uniq
+    // (reflection.rb:1109) — the singular candidate is coerced, the second is
+    // the raw name. singularize(null) would otherwise throw or infer wrongly.
+    class NilThroughOwner extends Base {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    registerModel("NilThroughOwner", NilThroughOwner);
+
+    const through = create(
+      "hasMany",
+      null,
+      null,
+      { through: "nilThroughs" },
+      NilThroughOwner,
+    ) as ThroughReflection;
+    expect(through.sourceReflectionNames()).toEqual(["", null]);
+    expect(() => through.source).not.toThrow();
+  });
+
   it("plural_name honors pluralize_table_names", () => {
     // Rails: active_record.pluralize_table_names ? name.to_s.pluralize : name.to_s
     // (reflection.rb:395). We previously pluralized unconditionally.

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -585,17 +585,21 @@ export class MacroReflection extends AbstractReflection {
   private _klassCacheGeneration = -1;
 
   constructor(
-    name: string,
+    name: string | null,
     scope: ((...args: any[]) => any) | null,
     options: Record<string, unknown>,
     activeRecord: typeof Base,
   ) {
     super();
-    this.name = name;
+    // Rails' `name` is a Symbol that callers always supply, but
+    // `Reflection.create` itself tolerates nil (reflection_test.rb:126). The
+    // field stays typed `string` because every real association path sets it;
+    // the nil case is confined to this assignment.
+    this.name = name as string;
     this._scope = scope;
     this.options = this.normalizeOptions(options);
     this.activeRecord = activeRecord;
-    this.pluralName = pluralize(name);
+    this.pluralName = activeRecord.pluralizeTableNames ? pluralize(name ?? "") : (name ?? "");
   }
 
   equals(other: unknown): boolean {
@@ -784,7 +788,7 @@ export class AssociationReflection extends MacroReflection {
   private _activeRecordPrimaryKeyCache: string | string[] | null = null;
 
   constructor(
-    name: string,
+    name: string | null,
     scope: ((...args: any[]) => any) | null,
     options: Record<string, unknown>,
     activeRecord: typeof Base,
@@ -2217,7 +2221,7 @@ export class ColumnReflection {
 function reflectionClassFor(
   macro: string,
 ): new (
-  name: string,
+  name: string | null,
   scope: ((...args: any[]) => any) | null,
   options: Record<string, unknown>,
   activeRecord: typeof Base,
@@ -2241,21 +2245,21 @@ function reflectionClassFor(
  */
 export function create(
   macro: Exclude<MacroType, "composedOf">,
-  name: string,
+  name: string | null,
   scope: ((...args: any[]) => any) | null,
   options: Record<string, unknown>,
   activeRecord: typeof Base,
 ): AssociationReflection | ThroughReflection;
 export function create(
   macro: "composedOf",
-  name: string,
+  name: string | null,
   scope: ((...args: any[]) => any) | null,
   options: Record<string, unknown>,
   activeRecord: typeof Base,
 ): AggregateReflection;
 export function create(
   macro: MacroType,
-  name: string,
+  name: string | null,
   scope: ((...args: any[]) => any) | null,
   options: Record<string, unknown>,
   activeRecord: typeof Base,

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -703,7 +703,7 @@ export class MacroReflection extends AbstractReflection {
       // (reflection.rb:495-508). Match AssociationReflection#computeClass so
       // callers rescuing only NameError treat both paths uniformly.
       throw new NameError(
-        `Model '${lookupName}' not found in registry (for '${this.name}' on ${this.activeRecord.name})`,
+        `Model '${lookupName}' not found in registry (for '${this.nameString}' on ${this.activeRecord.name})`,
       );
     }
     return resolved;
@@ -1170,7 +1170,7 @@ export class AssociationReflection extends MacroReflection {
     //   klass.cached_find_by_statement(key, &block)
     // The compiled statement is memoized on the *target* class, keyed by this
     // reflection (plus the owner's polymorphic type when applicable).
-    let key = `assocScope:${this.activeRecord.name}#${this.name}`;
+    let key = `assocScope:${this.activeRecord.name}#${this.nameString}`;
     if (this.isPolymorphic()) {
       key += `:${owner?._readAttribute?.(this.foreignType)}`;
     }
@@ -1204,7 +1204,7 @@ export class AssociationReflection extends MacroReflection {
     // Rails checks scope.arity == 0 because it uses instance_exec for the relation.
     if (this.scope.length > 1) {
       throw new ArgumentError(
-        `The association scope '${this.name}' is instance dependent (the scope ` +
+        `The association scope '${this.nameString}' is instance dependent (the scope ` +
           `block takes more than one argument). Eager loading instance dependent scopes is not supported.`,
       );
     }
@@ -1316,7 +1316,7 @@ export class AssociationReflection extends MacroReflection {
           if (resolved) {
             if (!(resolved as any)._isActiveRecordBase) {
               throw new ArgumentError(
-                `The ${candidate} model class for the ${this.activeRecord.name}#${this.name} association is not an ActiveRecord::Base subclass.`,
+                `The ${candidate} model class for the ${this.activeRecord.name}#${this.nameString} association is not an ActiveRecord::Base subclass.`,
               );
             }
             return resolved;
@@ -1331,12 +1331,12 @@ export class AssociationReflection extends MacroReflection {
       // error check_validity! callers rescue); the subclass guard below raises
       // ArgumentError, which must propagate. reflection.rb:495-508.
       throw new NameError(
-        `Model '${simpleName}' not found in registry (for '${this.name}' on ${this.activeRecord.name})`,
+        `Model '${simpleName}' not found in registry (for '${this.nameString}' on ${this.activeRecord.name})`,
       );
     }
     if (!(resolved as any)._isActiveRecordBase) {
       throw new ArgumentError(
-        `The ${simpleName} model class for the ${this.activeRecord.name}#${this.name} association is not an ActiveRecord::Base subclass.`,
+        `The ${simpleName} model class for the ${this.activeRecord.name}#${this.nameString} association is not an ActiveRecord::Base subclass.`,
       );
     }
     return resolved;
@@ -1575,6 +1575,11 @@ export class ThroughReflection extends AbstractReflection {
     return this.delegateReflection.name;
   }
 
+  /** Ruby's `name.to_s` — see MacroReflection#nameString. */
+  private get nameString(): string {
+    return this.name ?? "";
+  }
+
   get macro(): MacroType {
     return this.delegateReflection.macro;
   }
@@ -1721,14 +1726,14 @@ export class ThroughReflection extends AbstractReflection {
     const throughRef = this.throughReflection;
     if (throughRef) {
       try {
-        const singular = singularize(this.name);
+        const singular = singularize(this.nameString);
         if (throughRef.klass._reflectOnAssociation(singular)) return singular;
         if (throughRef.klass._reflectOnAssociation(this.name)) return this.name;
       } catch {
         /* klass resolution may fail */
       }
     }
-    return this._delegate.isCollection() ? singularize(this.name) : this.name;
+    return this._delegate.isCollection() ? singularize(this.nameString) : this.name;
   }
 
   get sourceReflection(): AssociationReflection | ThroughReflection | null {
@@ -1885,7 +1890,7 @@ export class ThroughReflection extends AbstractReflection {
 
   sourceReflectionNames(): string[] {
     if (this.options.source) return [this.options.source as string];
-    const singular = singularize(this.name);
+    const singular = singularize(this.nameString);
     const names = [singular, this.name];
     return [...new Set(names)];
   }
@@ -1908,7 +1913,7 @@ export class ThroughReflection extends AbstractReflection {
     }
 
     try {
-      const singular = singularize(this.name);
+      const singular = singularize(this.nameString);
       const candidates = [...new Set([singular, this.name])];
       const matching = candidates.filter((n) => throughRef.klass._reflectOnAssociation(n) != null);
 

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -602,6 +602,16 @@ export class MacroReflection extends AbstractReflection {
     this.pluralName = activeRecord.pluralizeTableNames ? pluralize(name ?? "") : (name ?? "");
   }
 
+  /**
+   * Ruby's `name.to_s` — nil renders as "". Rails stores `@name = name` but
+   * every string derivation goes through interpolation or `to_s`
+   * (reflection.rb:453, :821-825, :829), so a nil name yields "" / "_id" /
+   * "_type" rather than the literal "null" JS template strings would produce.
+   */
+  protected get nameString(): string {
+    return this.name ?? "";
+  }
+
   equals(other: unknown): boolean {
     if (this === other) return true;
     if (!(other instanceof (this.constructor as typeof MacroReflection))) return false;
@@ -627,7 +637,7 @@ export class MacroReflection extends AbstractReflection {
 
   get className(): string {
     if (this.options.className) return this.options.className as string;
-    return camelize(singularize(this.name));
+    return camelize(singularize(this.nameString));
   }
 
   get klass(): typeof Base {
@@ -716,7 +726,7 @@ export class MacroReflection extends AbstractReflection {
    * Derives class name from association name. Used by `className` getter.
    */
   protected deriveClassName(): string {
-    return camelize(this.name);
+    return camelize(this.nameString);
   }
 
   private normalizeOptions(options: Record<string, unknown>): Record<string, unknown> {
@@ -803,7 +813,7 @@ export class AssociationReflection extends MacroReflection {
       const macro = new.target.name.replace(/Reflection$/, "");
       const macroName = macro.charAt(0).toLowerCase() + macro.slice(1);
       throw new ConfigurationError(
-        `Setting \`queryConstraints:\` option on \`${activeRecord.name}.${macroName} :${name}\` ` +
+        `Setting \`queryConstraints:\` option on \`${activeRecord.name}.${macroName} :${name ?? ""}\` ` +
           `is not allowed. To get the same behavior, use the \`foreignKey\` option instead.`,
       );
     }
@@ -848,7 +858,7 @@ export class AssociationReflection extends MacroReflection {
   }
 
   private deriveForeignKey(inferFromInverseOf = true): string {
-    if (this.belongsTo()) return `${underscore(this.name)}_id`;
+    if (this.belongsTo()) return `${underscore(this.nameString)}_id`;
     if (this.options.as) return `${underscore(this.options.as as string)}_id`;
     if (this.options.inverseOf && inferFromInverseOf) {
       const inv = this.inverseOf();
@@ -908,7 +918,9 @@ export class AssociationReflection extends MacroReflection {
   get foreignType(): string | null {
     if (!this.options.polymorphic && !this.options.as) return null;
     if (this.belongsTo())
-      return (this.options.foreignType as string | undefined) ?? `${underscore(this.name)}_type`;
+      return (
+        (this.options.foreignType as string | undefined) ?? `${underscore(this.nameString)}_type`
+      );
     if (this.options.as) {
       return (
         (this.options.foreignType as string | undefined) ??
@@ -1337,9 +1349,9 @@ export class AssociationReflection extends MacroReflection {
   get className(): string {
     if (this.options.className) return this.options.className as string;
     if (this.isCollection()) {
-      return camelize(singularize(this.name));
+      return camelize(singularize(this.nameString));
     }
-    return camelize(this.name);
+    return camelize(this.nameString);
   }
 
   /** @internal */


### PR DESCRIPTION
Rails' `Reflection.create` tolerates a nil `name` (`vendor/rails/activerecord/test/cases/reflection_test.rb:126`), but our port typed `name` as `string`, so expressing that call required a cast.

## Changes

- Widen `name` to `string | null` on the three `create` overloads + implementation, the `reflectionClassFor` constructor signature, and the `MacroReflection` / `AssociationReflection` constructors.
- `MacroReflection#pluralName` computed `pluralize(name)` unconditionally. That silently yielded `null` on a nil name and ignored `pluralize_table_names`. Rails (`reflection.rb:395`) does `active_record.pluralize_table_names ? name.to_s.pluralize : name.to_s` — now mirrored, so a nil name gives `""` (Ruby's `nil.to_s`).
- Two regression tests in `reflection.trails.test.ts`. Both were verified to fail against the parent commit — the nil-name test caught `pluralName` returning `null` instead of `""`.

## Why the `name` field stays `string`

The constructor *parameters* are widened, but the `name` field is not. I measured this: widening `MacroReflection#name` to `string | null` produces 15 downstream type errors in `reflection.ts` alone (foreign-key derivation, join-key computation, index expressions). Since every real association path supplies a name, the nil case is confined to one documented assignment rather than pushed onto ~13 call sites as null-checks Rails doesn't have. Callers need no cast, which is the acceptance criterion.

## On the eager-`pluralName` question

Ruled out — not a divergence. `plural_name` is declared on `MacroReflection` and computed eagerly in its `initialize` in Rails too (`reflection.rb:386-396`). The story context pointed at `reflection.rb:517`, which is `AssociationReflection#initialize`; that method does not define `plural_name`. Our placement was already faithful. The only real bug there was the missing `pluralize_table_names` check, fixed above.

## Scope note

The acceptance criteria also ask to remove the `null as unknown as string` cast from `reflection.test.ts`. **That cast is not on `main`** — it arrives with #4973, which is still open. Rewriting that test here would put this PR in direct conflict with #4973 over the same test body, so `reflection.test.ts` is untouched. This PR removes the *need* for the cast; #4973 can drop it on rebase.

Reflection suites green: 77 passed, 4 pre-existing skips.

## Review follow-up (Codex)

Fixed. Widening the signature made the name-derived branches reachable with nil, and they rendered it as the literal `"null"` via JS template strings. Coercion is now centralized in a protected `nameString` getter (Ruby `name.to_s`), applied to `className`, `deriveClassName`, `foreignKey`, `foreignType`, and the `queryConstraints` error message — giving `""` / `"_id"` / `"_type"` / `:` as Rails does (`reflection.rb:453`, `:821-825`, `:829`).

One site deliberately **not** changed: `AggregateReflection#mapping`. Rails uses the raw `name` there with no `to_s` (`reflection.rb:482`, `options[:mapping] || [name, name]`), so our `[[name, name]]` already matches — coercing it would have introduced a divergence.

Covered by a new test verified to fail against the parent commit.

## Review follow-up 2 (Codex)

Fixed, and this time audited exhaustively instead of patching only the flagged lines.

The through-source bug was real and worse than cosmetic: `singularize(null)` returned `null`, so `[...new Set([singular, name])]` collapsed to `[null]` and dropped the singular candidate outright — a source-inference divergence. Rails uses `name.to_s.singularize` for that candidate and the raw `name` for the second (`reflection.rb:1109`); `ThroughReflection` now has its own `nameString` and mirrors that split. Also routed the remaining `this.name` string interpolations through it.

Full audit of the 22 remaining raw `this.name` uses — all are raw in Rails too, so all are deliberately unchanged:

| Use | Rails basis |
| --- | --- |
| storage, `nameString` getter, `equals` identity | `@name = name` |
| `AggregateReflection#mapping` | `options[:mapping] \|\| [name, name]` (`:482`) — no `to_s` |
| second through-source candidate, `indexOf`, dictionary filter | raw symbol used as lookup key |
| values passed **into** error constructors | Rails passes the symbol; formatting happens inside the error |

Rule now consistent: every *string derivation* coerces via `nameString`; every *raw-value* use stays raw.

Verified against the parent commit (new test failed with `[null]` vs `["", null]`). Suites: reflection + all of `associations/` — 2033 tests green.

Closes-story: reflection-create-accepts-nil-name


