### PR TITLE
test(postgresql): raise timeout for contention-prone 'dumping schemas' case

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -665,7 +665,9 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(output).not.toMatch(/createSchema\("public"\)/);
       expect(output).toMatch(/createSchema\("test_schema"\)/);
       expect(output).toMatch(/createSchema\("test_schema2"\)/);
-    });
+      // Timeout raised above vitest's 5s default: a full pg schema dump is heavy
+      // enough to cross it under parallel-fork contention (Rails has no such budget).
+    }, 30_000);
   });
 
   describe("SchemaForeignKeyTest", () => {

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -665,8 +665,11 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(output).not.toMatch(/createSchema\("public"\)/);
       expect(output).toMatch(/createSchema\("test_schema"\)/);
       expect(output).toMatch(/createSchema\("test_schema2"\)/);
-      // Timeout raised above vitest's 5s default: a full pg schema dump is heavy
-      // enough to cross it under parallel-fork contention (Rails has no such budget).
+      // Timeout raised above vitest's 5s default: even with the /./ filter above
+      // skipping per-table introspection, this case has repeatedly crossed 5s under
+      // parallel-fork contention and passed on rerun. Rails' test_dumping_schemas
+      // (schema_test.rb:530) is plain minitest with no per-test budget, so the 5s
+      // ceiling is a harness artifact, not behavior we are meant to hold to.
     }, 30_000);
   });
 


### PR DESCRIPTION
`PostgreSQLAdapter > SchemaTest > dumping schemas` recurrently exceeds vitest's
default 5000ms per-test timeout under parallel-fork contention — e.g. PR #3870
postgres-tests run 27951669218 at forks=8 (1 failed / 460 passed), which passed
on a plain rerun, plus the same isolated 5s timeout in a forks=4 sweep during
that PR. It is a timeout-budget flake, not a shared-table collision.

Raise the per-test timeout to 30s for this case only.

Why a timeout bump rather than reducing dump work: the case already passes `/./`
as the ignore filter (matching Rails' `dump_all_table_schema(/./)`), so it emits
only the createSchema lines and skips all per-table introspection — there is no
dump work left to trim without diverging from Rails.

Rails' counterpart, `test_dumping_schemas` at
`activerecord/test/cases/adapters/postgresql/schema_test.rb:530`, is plain
minitest with no per-test timeout, so the 5s ceiling is a vitest artifact rather
than a budget we are meant to hold to.

`dumpAllTableSchema` has exactly one call site in this file, so no sibling test
carries the same exposure. Test name unchanged (test:compare matching).

Closes-story: schema-dumping-schemas-timeout-flake
