### PR TITLE
fix(relation): spawn honors already_in_scope? instead of always cloning

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -251,6 +251,7 @@ import * as _AssocInstance from "./associations/instance-methods.js";
 import { argumentError } from "./relation/query-methods.js";
 import {
   ScopeRegistry,
+  scopeRegistry as _scopeRegistry,
   scopeAttributes,
   defaultScopeOverride as _defaultScopeOverride,
   populateWithCurrentScopeAttributes as _populateWithCurrentScopeAttributes,
@@ -2243,6 +2244,11 @@ export class Base extends Model {
   static get currentScope(): any | null {
     return ScopeRegistry.currentScope(this);
   }
+
+  /**
+   * Mirrors: ActiveRecord::Scoping::ClassMethods#scope_registry
+   */
+  static scopeRegistry = _scopeRegistry;
 
   // -- Finders (class methods) --
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -7015,9 +7015,9 @@ export class Relation<T extends Base> {
     this._seedWherePredicates = [...source._seedWherePredicates];
     // `_delegateToModel` is deliberately NOT copied: Rails' `initialize_copy`
     // (relation.rb:97-100) ends in `reset`, which clears `@delegate_to_model`.
-    // Carrying it onto clones would make every chained call inside a scope body
-    // "already in scope", so `where(a).where(b)` would spawn `model.all` and
-    // silently drop `a`.
+    // Carrying it onto clones would let derived relations report "already in
+    // scope" whenever a current scope is installed, so a chained `where` would
+    // spawn `model.all` and discard the values accumulated so far.
   }
 
   /** @internal */

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -474,6 +474,10 @@ export class Relation<T extends Base> {
   // Tri-state (Rails `@values.fetch(:skip_query_cache, nil)`): `undefined` = unset.
   private _skipQueryCache: boolean | undefined = undefined;
   private _loaded = false;
+  // Rails `@delegate_to_model` (relation.rb:90) — true only while a scope body
+  // runs via `_exec_scope`, which is what makes `already_in_scope?` (and hence
+  // `spawn`'s `model.all` branch) reachable at all.
+  private _delegateToModel = false;
   private _records: T[] = [];
   /**
    * Per-record loader block, run on each freshly instantiated record BEFORE
@@ -2080,6 +2084,7 @@ export class Relation<T extends Base> {
    */
   reset(): this {
     this._loaded = false;
+    this._delegateToModel = false;
     this._records = [];
     this._cacheKeys = undefined;
     this._cacheVersions = undefined;
@@ -6601,10 +6606,16 @@ export class Relation<T extends Base> {
     const registry = ScopeRegistry.instance();
 
     // Rails: global_scope? && all_queries == false → raise.
-    if (registry.globalCurrentScope(modelClass, true) && allQueries === false) {
+    if (this.isGlobalScope(registry) && allQueries === false) {
       throw new ArgumentError(
         "Scoping is set to apply to all queries and cannot be unset in a nested block.",
       );
+    }
+
+    // Rails: `elsif already_in_scope?(registry) then yield` — the receiver is
+    // already installed as the current scope, so re-installing it is a no-op.
+    if (this._isAlreadyInScope(registry)) {
+      return await callback();
     }
 
     const prev = registry.currentScope(modelClass, true);
@@ -7002,6 +7013,11 @@ export class Relation<T extends Base> {
     this._skipQueryCache = source._skipQueryCache;
     this._seededNoneNewOwner = source._seededNoneNewOwner;
     this._seedWherePredicates = [...source._seedWherePredicates];
+    // `_delegateToModel` is deliberately NOT copied: Rails' `initialize_copy`
+    // (relation.rb:97-100) ends in `reset`, which clears `@delegate_to_model`.
+    // Carrying it onto clones would make every chained call inside a scope body
+    // "already in scope", so `where(a).where(b)` would spawn `model.all` and
+    // silently drop `a`.
   }
 
   /** @internal */
@@ -7011,8 +7027,24 @@ export class Relation<T extends Base> {
     return wrapWithScopeProxy(rel);
   }
 
-  _execScope(fn: (...args: unknown[]) => unknown, ...args: unknown[]): Relation<T> {
-    return (fn.call(this, ...args) || this) as Relation<T>;
+  /**
+   * Run a named-scope body with this relation as the receiver.
+   *
+   * Rails `instance_exec`s the body against the relation; trails scope bodies
+   * instead take the relation as their first argument, so it is passed
+   * explicitly here — the `|| self` fallback and the scope-registry threading
+   * are otherwise identical.
+   *
+   * Mirrors: ActiveRecord::Relation#_exec_scope
+   */
+  _execScope(fn: (rel: Relation<T>, ...args: unknown[]) => unknown, ...args: unknown[]): unknown {
+    this._delegateToModel = true;
+    const registry = ScopeRegistry.instance();
+    try {
+      return this._scoping(null, registry, () => fn(this, ...args) || this);
+    } finally {
+      this._delegateToModel = false;
+    }
   }
 
   protected loadRecords(records: T[]): void {
@@ -7020,8 +7052,12 @@ export class Relation<T extends Base> {
     this._loaded = true;
   }
 
-  private isAlreadyInScope(registry: any): boolean {
-    return !!registry?.currentScope?.(this._modelClass, true);
+  // Mirrors relation.rb:1337-1339 — the `@delegate_to_model` guard is what
+  // narrows this to "receiver is the current scope inside a scope body";
+  // without it every relation under any `scoping {}` block would qualify.
+  /** @internal */
+  _isAlreadyInScope(registry: any): boolean {
+    return this._delegateToModel && !!registry?.currentScope?.(this._modelClass, true);
   }
 
   private isGlobalScope(registry: any): boolean {

--- a/packages/activerecord/src/relation/delegation.ts
+++ b/packages/activerecord/src/relation/delegation.ts
@@ -734,7 +734,10 @@ export function wrapWithScopeProxy<T extends object>(rel: T): T {
       if (modelClass._scopes.has(prop)) {
         return (...args: any[]) => {
           const scopeFn = modelClass._scopes.get(prop)!;
-          const result = scopeFn(target, ...args);
+          // Rails named.rb:175 — `all._exec_scope(*args, &body)`, not a bare
+          // call: `_exec_scope` is what marks the relation delegate-to-model
+          // and nils the current scope for the duration of the body.
+          const result = target._execScope(scopeFn, ...args);
           const extensions = modelClass._scopeExtensions?.get(prop);
           if (extensions && result && typeof result === "object") {
             // Register the extension as a module on the relation (mirrors Ruby's

--- a/packages/activerecord/src/relation/spawn-already-in-scope.trails.test.ts
+++ b/packages/activerecord/src/relation/spawn-already-in-scope.trails.test.ts
@@ -3,12 +3,14 @@
 // (spawn_methods.rb:9-11), and `already_in_scope?` is
 // `@delegate_to_model && registry.current_scope(model, true)`
 // (relation.rb:1337-1339). `@delegate_to_model` is set only for the duration of
-// `_exec_scope`, i.e. while a named-scope body runs.
+// `_exec_scope` (relation.rb:552-558), i.e. while a named-scope body runs.
 //
-// No Rails test names this branch directly, so these are trails tests pinning
-// the port: that the flag is scoped to the scope body, that clones do not
-// inherit it (Rails' `initialize_copy` ends in `reset`), and that chaining
-// inside a scope body still accumulates conditions.
+// No Rails test names this branch, and it is not reachable through ordinary
+// named-scope use: `_exec_scope` nils the current scope for the duration of the
+// body, so `@delegate_to_model` and a non-nil current scope do not normally
+// coincide. These trails tests therefore establish the precondition explicitly
+// (via the real scope registry) and drive `spawn()` itself, so the `model.all`
+// arm is actually executed rather than merely present.
 import { describe, test, expect } from "vitest";
 import { registerModel } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
@@ -18,11 +20,16 @@ registerModel([Post]);
 
 /** The relation internals these tests reach into. */
 interface ScopeInternals {
-  _isAlreadyInScope(registry: { currentScope(): unknown }): boolean;
+  _isAlreadyInScope(registry: ScopeRegistryLike): boolean;
   _clone(): ScopeInternals;
   spawn(): ScopeInternals;
   where(conditions: Record<string, unknown>): ScopeInternals;
   toSql(): Promise<string>;
+}
+
+interface ScopeRegistryLike {
+  currentScope(model: unknown, skipInherited?: boolean): unknown;
+  setCurrentScope(model: unknown, scope: unknown): void;
 }
 
 type ScopeBody = (rel: ScopeInternals) => unknown;
@@ -30,6 +37,7 @@ type ScopeBody = (rel: ScopeInternals) => unknown;
 const model = Post as unknown as {
   scope(name: string, body: ScopeBody): void;
   where(conditions: Record<string, unknown>): ScopeInternals;
+  scopeRegistry(): ScopeRegistryLike;
 };
 
 /** Define a named scope and immediately invoke it. */
@@ -38,45 +46,81 @@ function defineAndCallScope(name: string, body: ScopeBody): unknown {
   return (Post as unknown as Record<string, () => unknown>)[name]();
 }
 
-/** A stand-in registry whose current scope is always `rel`. */
-const registryFor = (rel: ScopeInternals) => ({ currentScope: () => rel });
+/** Run `fn` with `scope` installed as the model's current scope. */
+function withCurrentScope<R>(scope: unknown, fn: (registry: ScopeRegistryLike) => R): R {
+  const registry = model.scopeRegistry();
+  const previous = registry.currentScope(Post, true);
+  registry.setCurrentScope(Post, scope);
+  try {
+    return fn(registry);
+  } finally {
+    registry.setCurrentScope(Post, previous ?? null);
+  }
+}
 
 describe("SpawnAlreadyInScopeTest", () => {
   fixtures(["posts"]);
 
-  test("spawn outside a scope body clones", async () => {
+  test("spawn outside a scope body clones the receiver", async () => {
     const rel = model.where({ type: "Post" });
     const spawned = rel.spawn();
+
     expect(spawned).not.toBe(rel);
     expect(await spawned.toSql()).toEqual(await rel.toSql());
   });
 
-  test("scope body relation is already in scope only while the body runs", () => {
-    let insideFlag: boolean | undefined;
-    let bodyRelation: ScopeInternals | undefined;
+  test("spawn inside a scope body re-derives model.all instead of cloning", async () => {
+    // The discriminating case: the current scope is a *different* relation from
+    // the receiver. `clone` would keep the receiver's `title` condition;
+    // `model.all` re-derives from the current scope and carries `type` instead.
+    const currentScope = model.where({ type: "SpecialPost" });
+    let spawned: ScopeInternals | undefined;
 
-    const scoped = defineAndCallScope("titledSomething", (rel) => {
-      bodyRelation = rel;
-      insideFlag = rel._isAlreadyInScope(registryFor(rel));
-      return rel.where({ title: "Welcome to the weblog" });
+    defineAndCallScope("spawnsInsideBody", (rel) => {
+      withCurrentScope(currentScope, () => {
+        // Drive spawn on `rel` itself, which `_execScope` marked
+        // delegate-to-model — a clone would not carry the flag.
+        spawned = rel.spawn();
+      });
+      return rel;
     });
 
-    expect(insideFlag).toBe(true);
-    // The flag is cleared once `_execScope` returns.
-    expect(bodyRelation!._isAlreadyInScope(registryFor(bodyRelation!))).toBe(false);
-    expect(scoped).toBeDefined();
+    // `spawn` re-derived `model.all` (the current scope) rather than cloning
+    // the receiver, so it carries the current scope's condition.
+    expect(await spawned!.toSql()).toMatch(/SpecialPost/);
   });
 
-  test("chaining inside a scope body accumulates conditions", async () => {
-    const scoped = defineAndCallScope("chainedInBody", (rel) =>
-      rel.where({ type: "Post" }).where({ title: "Welcome to the weblog" }),
-    ) as ScopeInternals;
+  test("already in scope requires both the flag and a current scope", () => {
+    const outside = model.where({ type: "Post" });
+    // Flag unset (not in a scope body) — a current scope alone is not enough.
+    withCurrentScope(outside, (registry) => {
+      expect(outside._isAlreadyInScope(registry)).toBe(false);
+    });
 
-    // If `_delegateToModel` leaked onto clones, the second `where` would spawn
-    // `model.all` and drop the first condition.
-    const sql = await scoped.toSql();
-    expect(sql).toMatch(/type/);
-    expect(sql).toMatch(/title/);
+    let flagWithoutScope: boolean | undefined;
+    let flagWithScope: boolean | undefined;
+    let flagAfterBody: boolean | undefined;
+    let bodyRelation: ScopeInternals | undefined;
+
+    defineAndCallScope("checksBothConditions", (rel) => {
+      bodyRelation = rel;
+      const registry = model.scopeRegistry();
+      // `_exec_scope` nils the current scope, so the flag alone is not enough.
+      flagWithoutScope = rel._isAlreadyInScope(registry);
+      withCurrentScope(rel, (reg) => {
+        flagWithScope = rel._isAlreadyInScope(reg);
+      });
+      return rel;
+    });
+
+    withCurrentScope(bodyRelation, (registry) => {
+      flagAfterBody = bodyRelation!._isAlreadyInScope(registry);
+    });
+
+    expect(flagWithoutScope).toBe(false);
+    expect(flagWithScope).toBe(true);
+    // The flag is cleared once `_execScope` returns.
+    expect(flagAfterBody).toBe(false);
   });
 
   test("clones do not inherit the delegate-to-model flag", () => {
@@ -84,10 +128,28 @@ describe("SpawnAlreadyInScopeTest", () => {
 
     defineAndCallScope("clonedInBody", (rel) => {
       const cloned = rel._clone();
-      clonedFlag = cloned._isAlreadyInScope(registryFor(cloned));
+      withCurrentScope(cloned, (registry) => {
+        clonedFlag = cloned._isAlreadyInScope(registry);
+      });
       return rel;
     });
 
+    // Rails' `initialize_copy` ends in `reset`, which clears the flag. If it
+    // leaked, a derived relation would report "already in scope" whenever a
+    // current scope is installed, and spawn would discard its own values.
     expect(clonedFlag).toBe(false);
+  });
+
+  // A plain composition sanity check on the `_execScope` rewiring — it does not
+  // discriminate the clone-flag leak, since `_exec_scope` nils the current scope
+  // for the duration of the body (the test above covers the leak).
+  test("chaining inside a scope body accumulates conditions", async () => {
+    const scoped = defineAndCallScope("chainedInBody", (rel) =>
+      rel.where({ type: "Post" }).where({ title: "Welcome to the weblog" }),
+    ) as ScopeInternals;
+
+    const sql = await scoped.toSql();
+    expect(sql).toMatch(/type/);
+    expect(sql).toMatch(/title/);
   });
 });

--- a/packages/activerecord/src/relation/spawn-already-in-scope.trails.test.ts
+++ b/packages/activerecord/src/relation/spawn-already-in-scope.trails.test.ts
@@ -1,0 +1,93 @@
+// Rails' `SpawnMethods#spawn` is
+// `already_in_scope?(model.scope_registry) ? model.all : clone`
+// (spawn_methods.rb:9-11), and `already_in_scope?` is
+// `@delegate_to_model && registry.current_scope(model, true)`
+// (relation.rb:1337-1339). `@delegate_to_model` is set only for the duration of
+// `_exec_scope`, i.e. while a named-scope body runs.
+//
+// No Rails test names this branch directly, so these are trails tests pinning
+// the port: that the flag is scoped to the scope body, that clones do not
+// inherit it (Rails' `initialize_copy` ends in `reset`), and that chaining
+// inside a scope body still accumulates conditions.
+import { describe, test, expect } from "vitest";
+import { registerModel } from "../index.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+import { Post } from "../test-helpers/models/post.js";
+
+registerModel([Post]);
+
+/** The relation internals these tests reach into. */
+interface ScopeInternals {
+  _isAlreadyInScope(registry: { currentScope(): unknown }): boolean;
+  _clone(): ScopeInternals;
+  spawn(): ScopeInternals;
+  where(conditions: Record<string, unknown>): ScopeInternals;
+  toSql(): Promise<string>;
+}
+
+type ScopeBody = (rel: ScopeInternals) => unknown;
+
+const model = Post as unknown as {
+  scope(name: string, body: ScopeBody): void;
+  where(conditions: Record<string, unknown>): ScopeInternals;
+};
+
+/** Define a named scope and immediately invoke it. */
+function defineAndCallScope(name: string, body: ScopeBody): unknown {
+  model.scope(name, body);
+  return (Post as unknown as Record<string, () => unknown>)[name]();
+}
+
+/** A stand-in registry whose current scope is always `rel`. */
+const registryFor = (rel: ScopeInternals) => ({ currentScope: () => rel });
+
+describe("SpawnAlreadyInScopeTest", () => {
+  fixtures(["posts"]);
+
+  test("spawn outside a scope body clones", async () => {
+    const rel = model.where({ type: "Post" });
+    const spawned = rel.spawn();
+    expect(spawned).not.toBe(rel);
+    expect(await spawned.toSql()).toEqual(await rel.toSql());
+  });
+
+  test("scope body relation is already in scope only while the body runs", () => {
+    let insideFlag: boolean | undefined;
+    let bodyRelation: ScopeInternals | undefined;
+
+    const scoped = defineAndCallScope("titledSomething", (rel) => {
+      bodyRelation = rel;
+      insideFlag = rel._isAlreadyInScope(registryFor(rel));
+      return rel.where({ title: "Welcome to the weblog" });
+    });
+
+    expect(insideFlag).toBe(true);
+    // The flag is cleared once `_execScope` returns.
+    expect(bodyRelation!._isAlreadyInScope(registryFor(bodyRelation!))).toBe(false);
+    expect(scoped).toBeDefined();
+  });
+
+  test("chaining inside a scope body accumulates conditions", async () => {
+    const scoped = defineAndCallScope("chainedInBody", (rel) =>
+      rel.where({ type: "Post" }).where({ title: "Welcome to the weblog" }),
+    ) as ScopeInternals;
+
+    // If `_delegateToModel` leaked onto clones, the second `where` would spawn
+    // `model.all` and drop the first condition.
+    const sql = await scoped.toSql();
+    expect(sql).toMatch(/type/);
+    expect(sql).toMatch(/title/);
+  });
+
+  test("clones do not inherit the delegate-to-model flag", () => {
+    let clonedFlag: boolean | undefined;
+
+    defineAndCallScope("clonedInBody", (rel) => {
+      const cloned = rel._clone();
+      clonedFlag = cloned._isAlreadyInScope(registryFor(cloned));
+      return rel;
+    });
+
+    expect(clonedFlag).toBe(false);
+  });
+});

--- a/packages/activerecord/src/relation/spawn-methods.ts
+++ b/packages/activerecord/src/relation/spawn-methods.ts
@@ -9,15 +9,22 @@ import { argumentError } from "./query-methods.js";
 
 interface SpawnRelation<T = unknown> {
   _clone(): T;
+  _isAlreadyInScope(registry: unknown): boolean;
+  _modelClass: { all(): T; scopeRegistry(): unknown };
 }
 
 /**
  * Create a fresh copy of this relation.
  *
- * Mirrors: ActiveRecord::SpawnMethods#spawn
+ * Mirrors: ActiveRecord::SpawnMethods#spawn —
+ * `already_in_scope?(model.scope_registry) ? model.all : clone`. Inside a scope
+ * body the receiver *is* the model's current scope, so Rails re-derives it with
+ * `model.all` (which re-applies the default scope) rather than cloning.
  */
 export function performSpawn<T extends SpawnRelation<T>>(this: T): T {
-  return this._clone();
+  return this._isAlreadyInScope(this._modelClass.scopeRegistry())
+    ? this._modelClass.all()
+    : this._clone();
 }
 
 /**

--- a/packages/activerecord/src/relation/spawn-methods.ts
+++ b/packages/activerecord/src/relation/spawn-methods.ts
@@ -17,9 +17,14 @@ interface SpawnRelation<T = unknown> {
  * Create a fresh copy of this relation.
  *
  * Mirrors: ActiveRecord::SpawnMethods#spawn —
- * `already_in_scope?(model.scope_registry) ? model.all : clone`. Inside a scope
- * body the receiver *is* the model's current scope, so Rails re-derives it with
- * `model.all` (which re-applies the default scope) rather than cloning.
+ * `already_in_scope?(model.scope_registry) ? model.all : clone`. When the
+ * receiver is the model's current scope *and* is running as a scope body, the
+ * relation is re-derived from `model.all` rather than cloned.
+ *
+ * Note the `model.all` arm does not fire during ordinary named-scope use:
+ * `_exec_scope` nils the current scope for the body's duration, so the two
+ * conditions of `already_in_scope?` do not normally coincide. It is kept for
+ * fidelity with `spawn_methods.rb:9-11`.
  */
 export function performSpawn<T extends SpawnRelation<T>>(this: T): T {
   return this._isAlreadyInScope(this._modelClass.scopeRegistry())

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
@@ -184,13 +184,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "already_in_scope?",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "any?",
     "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -2860,20 +2853,6 @@
     "tsFile": "relation.ts",
     "rubyName": "scope_for_create",
     "call": "to_s",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "scoping",
-    "call": "already_in_scope?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "scoping",
-    "call": "global_scope?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {


### PR DESCRIPTION
Rails' `SpawnMethods#spawn` is
`already_in_scope?(model.scope_registry) ? model.all : clone`
(`spawn_methods.rb:9-11`). trails' `performSpawn` was unconditionally
`this._clone()` — there was no scope-registry / `already_in_scope?` check at
all.

Surfaced while converging `merge` onto the single `Merger#merge` path (#4767):
`merge` is `spawn.merge!`, so `merge` inside a scoping block cloned the current
scope rather than re-deriving `model.all`.

## What changed

- **`_delegateToModel`** (`relation.rb:90`) — the ivar `already_in_scope?`
  actually gates on. Set only for the duration of `_exec_scope`, cleared in
  `reset`, and deliberately **not** copied by `_copyStateFrom`: Rails'
  `initialize_copy` (`relation.rb:97-100`) ends in `reset`.
- **`_execScope`** now threads the scope registry (`_scoping(null, registry)`)
  and sets/clears the flag, and named-scope bodies route through it
  (`named.rb:175` — `all._exec_scope(*args, &body)`) instead of being invoked
  bare in `relation/delegation.ts`.
- **`_isAlreadyInScope`** gains the `@delegate_to_model` guard
  (`relation.rb:1337-1339`). Without it, every relation under any `scoping {}`
  block would have qualified.
- **`Relation#scoping`** gains the `already_in_scope? -> yield` branch
  (`relation.rb:545`).
- **`Base.scopeRegistry`** wired as a class method
  (`Scoping::ClassMethods#scope_registry`); `scoping.ts` already exported it.

## Reachability — please read before reviewing the tests

I instrumented the new `model.all` arm and ran the 949 relation + scoping
tests: **it fired 0 times.** The branch is not reachable through ordinary
named-scope use, because `_exec_scope` nils the current scope for the duration
of the body — so `@delegate_to_model` and a non-nil current scope do not
normally coincide. As far as I can tell the same is true in Rails; this reads
as a vestigial-but-real branch that trails should still mirror.

It *is* reachable and correct when the precondition holds, which I verified
directly. The tests therefore establish that precondition explicitly through
the real scope registry and call `spawn()` itself, rather than asserting the
flag against a mock — an earlier revision of this PR did the latter, which
looked green while never executing the new code.

## Tests

New `relation/spawn-already-in-scope.trails.test.ts` (trails-side: no Rails test
names this branch). Each assertion was checked to **fail** when its
corresponding change is reverted:

| Test | Fails when reverted |
| --- | --- |
| `spawn inside a scope body re-derives model.all instead of cloning` | `performSpawn` → unconditional `_clone()` |
| `clones do not inherit the delegate-to-model flag` | `_copyStateFrom` copies `_delegateToModel` |

The discriminating case makes the current scope a *different* relation than the
receiver, so `model.all` and `clone` produce different SQL.
`chaining inside a scope body accumulates conditions` is a plain composition
sanity check on the `_execScope` rewiring — it does **not** discriminate the
clone-flag leak, and is commented as such.

Locally: `relation/` + `scoping/` 915 passed, `associations/` 1838 passed,
0 failed. `api:compare` exits 0 (data layer 7471/7474).

## CI note

`Preflight` and `Rails API/Test Comparison` are currently red from the ongoing
GitHub API outage, not this diff — both jobs shell out to `gh api` under
`set -euo pipefail` and are getting HTTP 503 (the 503 body appears inline in the
api-compare log). The Preflight step that fails is the commit-message
attribution scan; running that job's own regex over this PR's commits locally
finds no match. Worth a re-run once the API recovers.

Closes-story: spawn-honors-already-in-scope-registry
