### PR TITLE
fix(sqlite): classify INSERT ... RETURNING as row-returning on regex drivers

### DIFF
--- a/packages/activerecord/src/sqlite/expo-sqlite.ts
+++ b/packages/activerecord/src/sqlite/expo-sqlite.ts
@@ -9,6 +9,7 @@ import {
   type SqliteOpenConfig,
   type SqliteStatement,
 } from "../sqlite-adapter.js";
+import { statementIsReader } from "./statement-reader.js";
 
 // Minimal subset of the expo-sqlite public API used by this driver.
 // Kept inline so typecheck passes without installing the optional package.
@@ -68,15 +69,6 @@ function expandBinds(binds: SqliteBinds | undefined): unknown[] | Record<string,
 }
 
 /** @internal */
-function isReader(sql: string): boolean {
-  const upper = sql.trimStart().toUpperCase();
-  return (
-    /^(SELECT|WITH|EXPLAIN|VALUES|TABLE)\b/.test(upper) ||
-    (/^PRAGMA\b/.test(upper) && !upper.includes("="))
-  );
-}
-
-/** @internal */
 class ExpoSqliteStatement implements SqliteStatement {
   readonly reader: boolean;
 
@@ -84,7 +76,7 @@ class ExpoSqliteStatement implements SqliteStatement {
     private readonly stmt: ExpoSQLiteStatement,
     sql: string,
   ) {
-    this.reader = isReader(sql);
+    this.reader = statementIsReader(sql);
   }
 
   async run(binds?: SqliteBinds): Promise<RunResult> {

--- a/packages/activerecord/src/sqlite/node-sqlite.ts
+++ b/packages/activerecord/src/sqlite/node-sqlite.ts
@@ -12,6 +12,7 @@ import {
   type SyncSqliteConnection,
   type SyncSqliteStatement,
 } from "../sqlite-adapter.js";
+import { statementIsReader } from "./statement-reader.js";
 import { resolveUriDatabasePath } from "./sqlite-uri.js";
 
 // Soft-load: Node 22.5+ only. Sync via createRequire so the module stays sync.
@@ -40,11 +41,17 @@ class NodeSqliteStatement implements SqliteStatement, SyncSqliteStatement {
 
   constructor(private readonly stmt: import("node:sqlite").StatementSync) {
     stmt.setAllowBareNamedParameters(true); // allow { name: val } to bind $name
-    const sql = stmt.sourceSQL.trimStart().toUpperCase();
-    // PRAGMA without `=` returns rows; PRAGMA with `=` is a write. Matches better-sqlite3.
-    this.reader =
-      /^(SELECT|WITH|EXPLAIN|VALUES|TABLE)\b/.test(sql) ||
-      (/^PRAGMA\b/.test(sql) && !sql.includes("="));
+    // Rails branches .all()/.run() on stmt.column_count.zero?; node:sqlite exposes
+    // the same information via columns(). Using it (rather than a leading-keyword
+    // regex) is what makes `INSERT ... RETURNING` classify as row-returning.
+    // Older node:sqlite builds throw from columns() on a non-reader statement.
+    let columnCount: number;
+    try {
+      columnCount = stmt.columns().length;
+    } catch {
+      columnCount = 0;
+    }
+    this.reader = columnCount > 0 || statementIsReader(stmt.sourceSQL);
   }
 
   private call<T>(method: string, binds: SqliteBinds | undefined): T {

--- a/packages/activerecord/src/sqlite/node-sqlite.ts
+++ b/packages/activerecord/src/sqlite/node-sqlite.ts
@@ -12,7 +12,6 @@ import {
   type SyncSqliteConnection,
   type SyncSqliteStatement,
 } from "../sqlite-adapter.js";
-import { statementIsReader } from "./statement-reader.js";
 import { resolveUriDatabasePath } from "./sqlite-uri.js";
 
 // Soft-load: Node 22.5+ only. Sync via createRequire so the module stays sync.
@@ -42,16 +41,9 @@ class NodeSqliteStatement implements SqliteStatement, SyncSqliteStatement {
   constructor(private readonly stmt: import("node:sqlite").StatementSync) {
     stmt.setAllowBareNamedParameters(true); // allow { name: val } to bind $name
     // Rails branches .all()/.run() on stmt.column_count.zero?; node:sqlite exposes
-    // the same information via columns(). Using it (rather than a leading-keyword
-    // regex) is what makes `INSERT ... RETURNING` classify as row-returning.
-    // Older node:sqlite builds throw from columns() on a non-reader statement.
-    let columnCount: number;
-    try {
-      columnCount = stmt.columns().length;
-    } catch {
-      columnCount = 0;
-    }
-    this.reader = columnCount > 0 || statementIsReader(stmt.sourceSQL);
+    // the same count via columns(). Using it rather than a leading-keyword regex
+    // is what makes `INSERT ... RETURNING` classify as row-returning.
+    this.reader = stmt.columns().length > 0;
   }
 
   private call<T>(method: string, binds: SqliteBinds | undefined): T {

--- a/packages/activerecord/src/sqlite/statement-reader.test.ts
+++ b/packages/activerecord/src/sqlite/statement-reader.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
 import type { SqliteConnection, SqliteDriver } from "../sqlite-adapter.js";
+import type { AbstractSQLite3Adapter } from "../connection-adapters/sqlite3-adapter.js";
+import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
+import { LibSQLAdapter } from "../connection-adapters/libsql-adapter.js";
+import { NodeSQLiteAdapter } from "../connection-adapters/node-sqlite-adapter.js";
 import { statementIsReader } from "./statement-reader.js";
 import { betterSqlite3Driver } from "./better-sqlite3.js";
 import { libsqlDriver } from "./libsql.js";
@@ -48,6 +52,37 @@ describe.each(drivers)("SqliteStatement#reader — %s", (_name, driver, availabl
       expect(rows[0]?.["id"]).toBe(1);
     } finally {
       await conn.close();
+    }
+  });
+});
+
+const adapters: [string, () => AbstractSQLite3Adapter, boolean][] = [
+  ["better-sqlite3", () => new BetterSQLite3Adapter(":memory:"), true],
+  ["libsql", () => new LibSQLAdapter(":memory:"), true],
+  ["node-sqlite", () => new NodeSQLiteAdapter(":memory:"), isNodeSqliteAvailable],
+];
+
+// `execute` (via `_performQuery`) still drops RETURNING rows on EVERY driver,
+// because that path gates rows on `stmt.reader && !isWriteQuery(sql)` — a
+// trails invention; Rails branches on `column_count.zero?` alone. Removing the
+// isWrite gate would cost `executeMutation` the atomic RunResult rowid that PR
+// 4893 introduced, so it is tracked separately as
+// sqlite-perform-query-iswrite-gate-drops-returning-rows.
+describe.each(adapters)("SQLite3Adapter RETURNING rows — %s", (_name, build, available) => {
+  it.skipIf(!available)("internalExecQuery returns the RETURNING rows", async () => {
+    const adapter = build();
+    try {
+      await adapter.execute("CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL)");
+
+      const result = await adapter.internalExecQuery(
+        "INSERT INTO widgets (name) VALUES ('gear') RETURNING id, name",
+      );
+      expect(result.columns).toEqual(["id", "name"]);
+      expect(result.rows).toHaveLength(1);
+      expect(result.rows[0]?.[1]).toBe("gear");
+    } finally {
+      await adapter.execute('DROP TABLE IF EXISTS "widgets"');
+      await adapter.close();
     }
   });
 });

--- a/packages/activerecord/src/sqlite/statement-reader.test.ts
+++ b/packages/activerecord/src/sqlite/statement-reader.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import type { SqliteConnection, SqliteDriver } from "../sqlite-adapter.js";
+import { statementIsReader } from "./statement-reader.js";
+import { betterSqlite3Driver } from "./better-sqlite3.js";
+import { libsqlDriver } from "./libsql.js";
+import { isNodeSqliteAvailable, nodeSqliteDriver } from "./node-sqlite.js";
+
+describe("statementIsReader", () => {
+  it("classifies plain writes as non-readers", () => {
+    expect(statementIsReader("INSERT INTO widgets (name) VALUES ('a')")).toBe(false);
+    expect(statementIsReader("UPDATE widgets SET name = 'a'")).toBe(false);
+    expect(statementIsReader("PRAGMA foreign_keys = ON")).toBe(false);
+  });
+
+  it("classifies RETURNING writes as readers", () => {
+    expect(statementIsReader("INSERT INTO widgets (name) VALUES ('a') RETURNING id")).toBe(true);
+    expect(statementIsReader("  delete from widgets returning id")).toBe(true);
+    expect(statementIsReader("UPDATE widgets SET name = 'b' RETURNING id, name")).toBe(true);
+  });
+
+  it("still classifies queries and read PRAGMAs as readers", () => {
+    expect(statementIsReader("SELECT 1")).toBe(true);
+    expect(statementIsReader("PRAGMA foreign_keys")).toBe(true);
+  });
+});
+
+const drivers: [string, SqliteDriver, boolean][] = [
+  ["better-sqlite3", betterSqlite3Driver, true],
+  ["libsql", libsqlDriver, true],
+  ["node-sqlite", nodeSqliteDriver, isNodeSqliteAvailable],
+];
+
+describe.each(drivers)("SqliteStatement#reader — %s", (_name, driver, available) => {
+  it.skipIf(!available)("reports INSERT ... RETURNING as row-returning", async () => {
+    const conn: SqliteConnection = await driver.open({ database: ":memory:" });
+    try {
+      const create = await conn.prepare(
+        "CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL)",
+      );
+      await create.run();
+
+      const stmt = await conn.prepare("INSERT INTO widgets (name) VALUES (?) RETURNING id, name");
+      expect(stmt.reader).toBe(true);
+
+      const rows = (await stmt.all(["sprocket"])) as Record<string, unknown>[];
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.["name"]).toBe("sprocket");
+      expect(rows[0]?.["id"]).toBe(1);
+    } finally {
+      await conn.close();
+    }
+  });
+});

--- a/packages/activerecord/src/sqlite/statement-reader.ts
+++ b/packages/activerecord/src/sqlite/statement-reader.ts
@@ -1,0 +1,21 @@
+/**
+ * Row-returning classification for drivers that cannot report a prepared
+ * statement's real column count.
+ *
+ * Rails branches `.all()` vs `.run()` on `stmt.column_count.zero?`
+ * (sqlite3/database_statements.rb). Drivers that expose column metadata
+ * (better-sqlite3, libsql, node:sqlite) should use that directly; this
+ * keyword approximation exists only for drivers that expose nothing
+ * (expo-sqlite). A write with a RETURNING clause has a nonzero column count
+ * in SQLite, so it must classify as a reader too.
+ *
+ * @internal
+ */
+export function statementIsReader(sql: string): boolean {
+  const upper = sql.trimStart().toUpperCase();
+  return (
+    /^(SELECT|WITH|EXPLAIN|VALUES|TABLE)\b/.test(upper) ||
+    (/^(INSERT|UPDATE|DELETE|REPLACE)\b/.test(upper) && /\bRETURNING\b/.test(upper)) ||
+    (/^PRAGMA\b/.test(upper) && !upper.includes("="))
+  );
+}


### PR DESCRIPTION
`SqliteStatement#reader` is the signal both `internalExecQuery` and the unified
`_performQuery` branch on to pick `.all()` (rows) vs `.run()` (no rows),
mirroring Rails' `stmt.column_count.zero?`
(`sqlite3/database_statements.rb:79-112`).

`node-sqlite.ts` and `expo-sqlite.ts` derived `reader` from a leading-keyword
regex (`/^(SELECT|WITH|EXPLAIN|VALUES|TABLE)\b/`). An `INSERT ... RETURNING`
matches none of those, so it was classified as non-row-returning and its rows
were dropped. CI runs better-sqlite3 only (which delegates `reader` to the
driver's real column count), so this was invisible in the matrix.

## Changes

- **`node-sqlite.ts`**: `reader` now comes from the prepared statement's real
  column count via `stmt.columns().length` — the direct analogue of Rails'
  `column_count`. I probed every statement shape (`SELECT`, CTE, `VALUES`,
  `EXPLAIN`, read/write `PRAGMA`, DDL, `BEGIN`, and RETURNING writes) and
  `columns()` matches `column_count` in all of them, and only throws on SQL
  that `prepare()` already rejects — so no keyword fallback is needed here.
- **`expo-sqlite.ts`**: expo exposes no column metadata, so it keeps a keyword
  approximation, now extracted to `statement-reader.ts` and extended to
  recognise a `RETURNING` clause on INSERT/UPDATE/DELETE/REPLACE.
- better-sqlite3 and libsql already delegate `reader` to the driver's real
  column count; the new tests pin that.

## Scope: one AC is deliberately deferred

Writing the adapter-level test surfaced a **second, independent bug** that this
PR does not fix. `_performQuery` gates rows on:

```ts
if (stmt.reader && !isWrite) { rows = await stmt.all(...) } else { rows = [] }
```

Rails branches on `column_count.zero?` **alone** — the `!isWrite` conjunct is a
trails invention. Because a RETURNING write is a write, `execute()` returns `[]`
on **every** driver, better-sqlite3 included. Correcting `reader` cannot fix it.

Removing that conjunct is not a one-liner: the gate exists so writes take
`.run()`, whose `RunResult` supplies `changes`/`lastInsertRowid` **atomically** —
PR #4893 added it precisely because a separate awaited `last_insert_rowid()`
races under `Promise.all`. `executeMutation` returns that rowid for a
single-column `INSERT ... RETURNING id`, so rerouting it to `.all()` would
regress #4893. A correct fix likely needs a connection-level `changes` /
`lastInsertRowid` accessor on `SqliteConnection`, which doesn't exist yet.

Rather than risk that regression inside this story, it is registered as
`0023-surfaced-deviations/sqlite-perform-query-iswrite-gate-drops-returning-rows`
with the full analysis, and the test file carries a comment pointing at it.

So of the story's ACs: driver `reader` correctness ✅, driver-parameterized
tests ✅, `internalExecQuery` returns RETURNING rows on every driver ✅,
`_performQuery` ❌ (deferred, as above).

## Tests

`sqlite/statement-reader.test.ts`:
- unit coverage of the keyword helper (writes, RETURNING writes, reads/PRAGMA);
- `describe.each` over better-sqlite3 / libsql / node-sqlite asserting
  `INSERT ... RETURNING` reports `reader === true` and `all()` yields the rows;
- adapter-level `describe.each` over `BetterSQLite3Adapter` / `LibSQLAdapter` /
  `NodeSQLiteAdapter` asserting `internalExecQuery` returns the RETURNING rows
  and columns.

Verified load-bearing: reverting the node-sqlite driver change to the old regex
fails exactly the node-sqlite `internalExecQuery` test and no others.

Closes-story: sqlite-regex-driver-reader-misses-returning
