### PR TITLE
fix(attribute-methods): resolve attribute aliases in static hasAttribute

### DIFF
--- a/packages/activemodel/src/attribute-methods.ts
+++ b/packages/activemodel/src/attribute-methods.ts
@@ -655,27 +655,39 @@ export function resolveAliasName(host: AttributeMethodHost, name: string): strin
 }
 
 /**
- * Trails-only convention bridge for `resolveAliasName`.
+ * `resolveAliasName` plus the trails-only camelCase-key bridge, resolved
+ * against a caller-supplied attribute set.
  *
  * Trails stores alias KEYS camelCase (`newName`, `commentsCount`) while derived
  * names — counter-cache columns, DB column names — are snake_case (`new_name`,
  * `comments_count`). Rails needs no such bridge: its alias keys are already in
- * the same convention as its column names, so a plain
- * `attribute_aliases[attr_name]` hit suffices.
+ * the same convention as its column names, so the plain
+ * `attribute_aliases[attr_name] || attr_name` step suffices everywhere it uses
+ * one (attribute_methods.rb:316-319, read.rb:31-34, write.rb:31-34).
  *
- * This is a *fallback* and deliberately NOT folded into `resolveAliasName`.
- * Callers must first establish that `name` is not itself a real attribute of
- * the relevant set, because the camelized key is a guess: a record loaded with
- * a projected `comments_count` (say `SELECT COUNT(*) AS comments_count`) owns
- * that name outright and must never be redirected to an unrelated
- * `commentsCount` alias. Which set is "relevant" differs by caller — the class
- * attribute set for `has_attribute?` at class level, the loaded `@attributes`
- * at instance level (attribute_methods.rb:316-319) — so the check belongs at
- * the call site, not here.
+ * Because the camelized key is a *guess*, it is applied only after `present`
+ * has been consulted: a name the relevant set already owns — a record loaded
+ * with a projected `SELECT COUNT(*) AS comments_count`, say — must never be
+ * redirected to an unrelated `commentsCount` alias. `present` is the set that
+ * defines ownership for the calling surface: the class attribute set for
+ * class-level `has_attribute?`, the loaded `@attributes` for the instance form
+ * and for `read_attribute` / `write_attribute`.
+ *
+ * Rails applies one identical resolution step across all of those surfaces, so
+ * trails routes them all through this single function — sharing the bridge
+ * keeps them coherent, i.e. never `has_attribute?` true while `read_attribute`
+ * returns nil for the same name.
  *
  * @internal
  */
-export function resolveAliasNameBridged(host: AttributeMethodHost, name: string): string {
-  const aliases = host._attributeAliases;
-  return aliases?.[name] ?? aliases?.[camelize(name, "lower")] ?? name;
+export function resolveAliasNameIn(
+  host: AttributeMethodHost,
+  present: { has(name: string): boolean } | undefined,
+  name: string,
+): string {
+  const aliases = host?._attributeAliases;
+  const exact = aliases?.[name];
+  if (exact !== undefined) return exact;
+  if (present?.has(name)) return name;
+  return aliases?.[camelize(name, "lower")] ?? name;
 }

--- a/packages/activemodel/src/attribute-methods.ts
+++ b/packages/activemodel/src/attribute-methods.ts
@@ -650,10 +650,17 @@ export function defineDirtyAttributeMethods(prototype: object, attrName: string)
  */
 export function resolveAliasName(host: AttributeMethodHost, name: string): string {
   const aliases = host._attributeAliases;
-  // Rails: `attribute_aliases[attr_name] || attr_name`. Trails stores alias
-  // keys camelCase (`newName`, `commentsCount`) while callers often pass the
-  // snake_case column name (`new_name`, `comments_count`), so normalize the
-  // lookup key — Rails gets this for free because its alias keys are already
-  // in the same convention as its column names.
-  return aliases?.[name] ?? aliases?.[camelize(name, "lower")] ?? name;
+  // Rails: `attribute_aliases[attr_name] || attr_name`.
+  const exact = aliases?.[name];
+  if (exact !== undefined) return exact;
+
+  // Trails stores alias keys camelCase (`newName`, `commentsCount`) while
+  // callers often pass the snake_case column name (`new_name`,
+  // `comments_count`); Rails needs no such bridge because its alias keys are
+  // already in the same convention as its column names. Defer to a real
+  // attribute of that exact name first, so a model that happens to own BOTH a
+  // `new_name` column and an unrelated `newName` alias still resolves
+  // `new_name` to its own column, the way Rails would.
+  if (host._attributeDefinitions?.has(name)) return name;
+  return aliases?.[camelize(name, "lower")] ?? name;
 }

--- a/packages/activemodel/src/attribute-methods.ts
+++ b/packages/activemodel/src/attribute-methods.ts
@@ -649,18 +649,33 @@ export function defineDirtyAttributeMethods(prototype: object, attrName: string)
  * the same key whether the caller passed `nickname` or `name`.
  */
 export function resolveAliasName(host: AttributeMethodHost, name: string): string {
-  const aliases = host._attributeAliases;
-  // Rails: `attribute_aliases[attr_name] || attr_name`.
-  const exact = aliases?.[name];
-  if (exact !== undefined) return exact;
+  // Rails: `attribute_aliases[attr_name] || attr_name`. Exact lookup only —
+  // read/write paths must not second-guess the name the caller supplied.
+  return host._attributeAliases?.[name] ?? name;
+}
 
-  // Trails stores alias keys camelCase (`newName`, `commentsCount`) while
-  // callers often pass the snake_case column name (`new_name`,
-  // `comments_count`); Rails needs no such bridge because its alias keys are
-  // already in the same convention as its column names. Defer to a real
-  // attribute of that exact name first, so a model that happens to own BOTH a
-  // `new_name` column and an unrelated `newName` alias still resolves
-  // `new_name` to its own column, the way Rails would.
-  if (host._attributeDefinitions?.has(name)) return name;
-  return aliases?.[camelize(name, "lower")] ?? name;
+/**
+ * Trails-only convention bridge for `resolveAliasName`.
+ *
+ * Trails stores alias KEYS camelCase (`newName`, `commentsCount`) while derived
+ * names — counter-cache columns, DB column names — are snake_case (`new_name`,
+ * `comments_count`). Rails needs no such bridge: its alias keys are already in
+ * the same convention as its column names, so a plain
+ * `attribute_aliases[attr_name]` hit suffices.
+ *
+ * This is a *fallback* and deliberately NOT folded into `resolveAliasName`.
+ * Callers must first establish that `name` is not itself a real attribute of
+ * the relevant set, because the camelized key is a guess: a record loaded with
+ * a projected `comments_count` (say `SELECT COUNT(*) AS comments_count`) owns
+ * that name outright and must never be redirected to an unrelated
+ * `commentsCount` alias. Which set is "relevant" differs by caller — the class
+ * attribute set for `has_attribute?` at class level, the loaded `@attributes`
+ * at instance level (attribute_methods.rb:316-319) — so the check belongs at
+ * the call site, not here.
+ *
+ * @internal
+ */
+export function resolveAliasNameBridged(host: AttributeMethodHost, name: string): string {
+  const aliases = host._attributeAliases;
+  return aliases?.[name] ?? aliases?.[camelize(name, "lower")] ?? name;
 }

--- a/packages/activemodel/src/attribute-methods.ts
+++ b/packages/activemodel/src/attribute-methods.ts
@@ -7,6 +7,8 @@
  * In TS, the exported functions use `this: AttributeMethodHost` so they can
  * be assigned directly to Model's static side — no delegation wrappers needed.
  */
+import { camelize } from "@blazetrails/activesupport";
+
 export interface AttributeMethods {
   hasAttribute(name: string): boolean;
   attributePresent(name: string): boolean;
@@ -647,6 +649,11 @@ export function defineDirtyAttributeMethods(prototype: object, attrName: string)
  * the same key whether the caller passed `nickname` or `name`.
  */
 export function resolveAliasName(host: AttributeMethodHost, name: string): string {
-  const aliased = host._attributeAliases?.[name];
-  return aliased ?? name;
+  const aliases = host._attributeAliases;
+  // Rails: `attribute_aliases[attr_name] || attr_name`. Trails stores alias
+  // keys camelCase (`newName`, `commentsCount`) while callers often pass the
+  // snake_case column name (`new_name`, `comments_count`), so normalize the
+  // lookup key — Rails gets this for free because its alias keys are already
+  // in the same convention as its column names.
+  return aliases?.[name] ?? aliases?.[camelize(name, "lower")] ?? name;
 }

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -11,7 +11,7 @@ export {
   MissingAttributeError,
   AttributeMethodPattern,
   resolveAliasName,
-  resolveAliasNameBridged,
+  resolveAliasNameIn,
   AttrNames,
   defineDirtyAttributeMethods,
 } from "./attribute-methods.js";

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -11,6 +11,7 @@ export {
   MissingAttributeError,
   AttributeMethodPattern,
   resolveAliasName,
+  resolveAliasNameBridged,
   AttrNames,
   defineDirtyAttributeMethods,
 } from "./attribute-methods.js";

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -68,6 +68,7 @@ import {
   attributeMethodAffix,
   aliasAttribute,
   resolveAliasName,
+  resolveAliasNameIn,
   undefineAttributeMethods,
   attributeMissing,
   attributeAliases,
@@ -1669,8 +1670,10 @@ export class Model {
 
   readAttribute(name: string): unknown {
     // Rails resolves alias_attribute names in `read_attribute`
-    // (attribute_aliases[name] || name); `_read_attribute` skips it.
-    const resolved = resolveAliasName(this.constructor as typeof Model, name);
+    // (attribute_aliases[name] || name, read.rb:31-34); `_read_attribute`
+    // skips it. Resolved against the loaded attribute set so the trails
+    // camelCase-key bridge cannot displace a name the record already owns.
+    const resolved = resolveAliasNameIn(this.constructor as typeof Model, this._attributes, name);
     if (!this._attributes.has(resolved)) {
       return null;
     }
@@ -1712,8 +1715,10 @@ export class Model {
 
   writeAttribute(name: string, value: unknown): void {
     // Alias-resolve on the public write path; aliased writes land on the
-    // canonical attribute's dirty state (Rails `write_attribute`).
-    const resolved = resolveAliasName(this.constructor as typeof Model, name);
+    // canonical attribute's dirty state (Rails `write_attribute`,
+    // write.rb:31-34). Resolved against the loaded attribute set to stay
+    // coherent with `readAttribute` / `hasAttribute`.
+    const resolved = resolveAliasNameIn(this.constructor as typeof Model, this._attributes, name);
     this._writeAttribute(resolved, value);
   }
 
@@ -1790,8 +1795,8 @@ export class Model {
    */
   hasAttribute(name: string): boolean {
     const ctor = this.constructor as typeof Model;
-    const resolved = resolveAliasName(ctor, name);
-    return ctor._attributeDefinitions.has(resolved);
+    const defs = ctor._attributeDefinitions;
+    return defs.has(resolveAliasNameIn(ctor, defs, name));
   }
 
   /**

--- a/packages/activerecord/src/attribute-methods.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods.trails.test.ts
@@ -111,6 +111,24 @@ describe("AttributeMethodsTest (trails)", () => {
     expect(t.readAttribute("newName")).toBe("a");
   });
 
+  it("resolves the camelCase bridge identically for has/read/write", () => {
+    // Rails runs one identical alias step in has_attribute?
+    // (attribute_methods.rb:316-319), read_attribute (read.rb:31-34) and
+    // write_attribute (write.rb:31-34). The trails bridge must be shared by all
+    // three, or an attribute can report present while reads return nil.
+    class Topic extends Base {
+      static {
+        this.attribute("legacy_comments_count", "integer");
+        this.aliasAttribute("commentsCount", "legacy_comments_count");
+      }
+    }
+    const t = Topic.instantiate({ legacy_comments_count: 7 });
+    expect(t.hasAttribute("comments_count")).toBe(true);
+    expect(t.readAttribute("comments_count")).toBe(7);
+    t.writeAttribute("comments_count", 9);
+    expect(t.readAttribute("legacy_comments_count")).toBe(9);
+  });
+
   it("prefers a loaded attribute over the camelCase alias bridge", () => {
     // Rails' instance has_attribute? checks the loaded @attributes
     // (attribute_methods.rb:316-319), which can hold names the class does not
@@ -127,6 +145,10 @@ describe("AttributeMethodsTest (trails)", () => {
     expect(t.hasAttribute("comments_count")).toBe(true);
     expect(t.readAttribute("comments_count")).toBe(42);
     expect(t.readAttribute("commentsCount")).toBe(7);
+    // The write path must agree with the read path about which one it means.
+    t.writeAttribute("comments_count", 43);
+    expect(t.readAttribute("comments_count")).toBe(43);
+    expect(t.readAttribute("legacy_comments_count")).toBe(7);
   });
 
   it("readonly attributes are not updated after create", async () => {

--- a/packages/activerecord/src/attribute-methods.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods.trails.test.ts
@@ -94,10 +94,10 @@ describe("AttributeMethodsTest (trails)", () => {
     expect(Topic.hasAttribute("replies_count")).toBe(false);
   });
 
-  it("prefers a real attribute over the camelCase alias bridge", () => {
-    // The snake_case bridge must not hijack a name the model really owns: with
-    // both a real `new_name` column and an unrelated `newName` alias, Rails
-    // resolves `new_name` to its own column, so trails must too.
+  it("prefers a real class attribute over the camelCase alias bridge", () => {
+    // The bridge must not hijack a name the model really owns: with both a real
+    // `new_name` column and an unrelated `newName` alias, Rails resolves
+    // `new_name` to its own column, so trails must too.
     class Topic extends Base {
       static {
         this.attribute("name", "string");
@@ -105,9 +105,28 @@ describe("AttributeMethodsTest (trails)", () => {
         this.aliasAttribute("newName", "name");
       }
     }
+    expect(Topic.hasAttribute("new_name")).toBe(true);
     const t = new Topic({ name: "a", new_name: "b" });
     expect(t.readAttribute("new_name")).toBe("b");
     expect(t.readAttribute("newName")).toBe("a");
+  });
+
+  it("prefers a loaded attribute over the camelCase alias bridge", () => {
+    // Rails' instance has_attribute? checks the loaded @attributes
+    // (attribute_methods.rb:316-319), which can hold names the class does not
+    // declare — a projected `SELECT COUNT(*) AS comments_count`, say. Such a
+    // name must resolve to the loaded value, not to an unrelated
+    // `commentsCount` alias, so the bridge has to run after the exact lookup.
+    class Topic extends Base {
+      static {
+        this.attribute("legacy_comments_count", "integer");
+        this.aliasAttribute("commentsCount", "legacy_comments_count");
+      }
+    }
+    const t = Topic.instantiate({ legacy_comments_count: 7, comments_count: 42 });
+    expect(t.hasAttribute("comments_count")).toBe(true);
+    expect(t.readAttribute("comments_count")).toBe(42);
+    expect(t.readAttribute("commentsCount")).toBe(7);
   });
 
   it("readonly attributes are not updated after create", async () => {

--- a/packages/activerecord/src/attribute-methods.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods.trails.test.ts
@@ -78,6 +78,38 @@ describe("AttributeMethodsTest (trails)", () => {
     expect(t.hasAttribute("missing")).toBe(false);
   });
 
+  it("resolves snake_case lookups against camelCase alias keys", () => {
+    // Trails stores alias keys camelCase while derived names (counter-cache
+    // columns, DB column names) are snake_case; Rails needs no such bridge
+    // because its alias keys already match its column naming.
+    class Topic extends Base {
+      static {
+        this.attribute("legacy_comments_count", "integer");
+        this.aliasAttribute("commentsCount", "legacy_comments_count");
+      }
+    }
+    expect(Topic.hasAttribute("commentsCount")).toBe(true);
+    expect(Topic.hasAttribute("comments_count")).toBe(true);
+    expect(Topic.hasAttribute("legacy_comments_count")).toBe(true);
+    expect(Topic.hasAttribute("replies_count")).toBe(false);
+  });
+
+  it("prefers a real attribute over the camelCase alias bridge", () => {
+    // The snake_case bridge must not hijack a name the model really owns: with
+    // both a real `new_name` column and an unrelated `newName` alias, Rails
+    // resolves `new_name` to its own column, so trails must too.
+    class Topic extends Base {
+      static {
+        this.attribute("name", "string");
+        this.attribute("new_name", "string");
+        this.aliasAttribute("newName", "name");
+      }
+    }
+    const t = new Topic({ name: "a", new_name: "b" });
+    expect(t.readAttribute("new_name")).toBe("b");
+    expect(t.readAttribute("newName")).toBe("a");
+  });
+
   it("readonly attributes are not updated after create", async () => {
     // Rails raises ReadonlyAttributeError on a persisted-record write to an
     // attr_readonly column (readonly_attributes.rb line 49). The test name's

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -4,7 +4,11 @@
  * Mirrors: ActiveRecord::AttributeMethods
  */
 import { isBlank } from "@blazetrails/activesupport";
-import { MissingAttributeError, resolveAliasName } from "@blazetrails/activemodel";
+import {
+  MissingAttributeError,
+  resolveAliasName,
+  resolveAliasNameBridged,
+} from "@blazetrails/activemodel";
 import { formatForInspect as _formatForInspect } from "./attribute-inspection.js";
 import {
   attributeForInspect as _attrForInspect,
@@ -80,15 +84,16 @@ interface AttributeAccessorHost {
  * Mirrors: ActiveRecord::AttributeMethods#has_attribute?
  */
 export function hasAttribute(this: AttributeRecord, name: string): boolean {
-  // Rails `has_attribute?` resolves attribute_aliases before hitting the
-  // attribute set (active_record/attribute_methods.rb).
-  const resolved = resolveAliasName(
-    (this as unknown as { constructor: unknown }).constructor as Parameters<
-      typeof resolveAliasName
-    >[0],
-    name,
-  );
-  return this._attributes.has(resolved);
+  // Rails: `attr_name = self.class.attribute_aliases[attr_name] || attr_name`
+  // then `@attributes.key?(attr_name)` (attribute_methods.rb:316-319).
+  const ctor = (this as unknown as { constructor: unknown }).constructor as Parameters<
+    typeof resolveAliasName
+  >[0];
+  if (this._attributes.has(resolveAliasName(ctor, name))) return true;
+  // Trails-only camelCase alias-key bridge. Applied last, so a name the loaded
+  // attribute set actually owns — e.g. a projected `comments_count` — is never
+  // redirected to an unrelated `commentsCount` alias.
+  return this._attributes.has(resolveAliasNameBridged(ctor, name));
 }
 
 /**

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -4,11 +4,7 @@
  * Mirrors: ActiveRecord::AttributeMethods
  */
 import { isBlank } from "@blazetrails/activesupport";
-import {
-  MissingAttributeError,
-  resolveAliasName,
-  resolveAliasNameBridged,
-} from "@blazetrails/activemodel";
+import { MissingAttributeError, resolveAliasNameIn } from "@blazetrails/activemodel";
 import { formatForInspect as _formatForInspect } from "./attribute-inspection.js";
 import {
   attributeForInspect as _attrForInspect,
@@ -79,6 +75,29 @@ interface AttributeAccessorHost {
 }
 
 /**
+ * Instance-level alias resolution, resolved against the record's loaded
+ * attribute set.
+ *
+ * Rails runs one identical `attribute_aliases[name] || name` step in
+ * `has_attribute?` (attribute_methods.rb:316-319), `read_attribute`
+ * (read.rb:31-34) and `write_attribute` (write.rb:31-34). Trails needs an extra
+ * camelCase-key bridge on top (see `resolveAliasNameIn`), so all three route
+ * through here rather than resolving independently — otherwise the bridge could
+ * report an attribute present while reads and writes went somewhere else.
+ *
+ * @internal
+ */
+export function recordAliasName(
+  record: { _attributes?: { has(name: string): boolean } },
+  name: string,
+): string {
+  const ctor = (record as unknown as { constructor: unknown }).constructor as Parameters<
+    typeof resolveAliasNameIn
+  >[0];
+  return resolveAliasNameIn(ctor, record._attributes, name);
+}
+
+/**
  * Check whether an attribute exists on a record.
  *
  * Mirrors: ActiveRecord::AttributeMethods#has_attribute?
@@ -86,14 +105,7 @@ interface AttributeAccessorHost {
 export function hasAttribute(this: AttributeRecord, name: string): boolean {
   // Rails: `attr_name = self.class.attribute_aliases[attr_name] || attr_name`
   // then `@attributes.key?(attr_name)` (attribute_methods.rb:316-319).
-  const ctor = (this as unknown as { constructor: unknown }).constructor as Parameters<
-    typeof resolveAliasName
-  >[0];
-  if (this._attributes.has(resolveAliasName(ctor, name))) return true;
-  // Trails-only camelCase alias-key bridge. Applied last, so a name the loaded
-  // attribute set actually owns — e.g. a projected `comments_count` — is never
-  // redirected to an unrelated `commentsCount` alias.
-  return this._attributes.has(resolveAliasNameBridged(ctor, name));
+  return this._attributes.has(recordAliasName(this, name));
 }
 
 /**
@@ -633,18 +645,14 @@ export function attributeForInspect(this: InstanceMethodHost, attr: string): str
   return _attrForInspect.call(this as any, attr);
 }
 
-/** Mirrors: ActiveRecord::AttributeMethods#read_attribute */
+/** Mirrors: ActiveRecord::AttributeMethods#read_attribute (read.rb:31-34) */
 export function readAttribute(this: InstanceMethodHost, name: string): unknown {
-  const aliases = (this.constructor as any)?._attributeAliases ?? {};
-  const resolved = (aliases[name] as string | undefined) ?? name;
-  return this._readAttribute(resolved);
+  return this._readAttribute(recordAliasName(this, name));
 }
 
-/** Mirrors: ActiveRecord::AttributeMethods#write_attribute */
+/** Mirrors: ActiveRecord::AttributeMethods#write_attribute (write.rb:31-34) */
 export function writeAttribute(this: InstanceMethodHost, name: string, value: unknown): void {
-  const aliases = (this.constructor as any)?._attributeAliases ?? {};
-  const resolved = (aliases[name] as string | undefined) ?? name;
-  _writeAttribute.call(this as any, resolved, value);
+  _writeAttribute.call(this as any, recordAliasName(this, name), value);
 }
 
 /** Mirrors: ActiveRecord::AttributeMethods#query_attribute */

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -23,6 +23,7 @@ import { fixtures } from "./test-helpers/fixtures.js";
 import { withTimezoneConfig } from "./test-helper.js";
 import { IntegerType, Type } from "@blazetrails/activemodel";
 import { CpkBook } from "./test-helpers/models/cpk.js";
+import { Company as CanonicalCompany } from "./test-helpers/models/company.js";
 
 vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
 
@@ -2089,6 +2090,26 @@ describe("BasicsTest", () => {
     const p = await Post.create({ title: "saved" });
     const d = p.dup();
     expect(d.isNewRecord()).toBe(true);
+  });
+
+  it("has attribute", async () => {
+    await CanonicalCompany.loadSchema();
+    expect(CanonicalCompany.hasAttribute("id")).toBe(true);
+    expect(CanonicalCompany.hasAttribute("type")).toBe(true);
+    expect(CanonicalCompany.hasAttribute("name")).toBe(true);
+    expect(CanonicalCompany.hasAttribute("new_name")).toBe(true);
+    expect(CanonicalCompany.hasAttribute("metadata")).toBe(true);
+    expect(CanonicalCompany.hasAttribute("lastname")).toBe(false);
+    expect(CanonicalCompany.hasAttribute("age")).toBe(false);
+
+    const company = CanonicalCompany.new();
+    expect(company.hasAttribute("id")).toBe(true);
+    expect(company.hasAttribute("type")).toBe(true);
+    expect(company.hasAttribute("name")).toBe(true);
+    expect(company.hasAttribute("new_name")).toBe(true);
+    expect(company.hasAttribute("metadata")).toBe(true);
+    expect(company.hasAttribute("lastname")).toBe(false);
+    expect(company.hasAttribute("age")).toBe(false);
   });
 
   it("bignum", async () => {

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1,7 +1,7 @@
 import type { Base } from "./base.js";
 import { Nodes, sql as arelSql } from "@blazetrails/arel";
 import { pluralize, underscore } from "@blazetrails/activesupport";
-import { resolveAliasNameBridged } from "@blazetrails/activemodel";
+import { resolveAliasNameIn } from "@blazetrails/activemodel";
 import {
   Attribute,
   AttributeSetBuilder,
@@ -231,11 +231,9 @@ export function columnNames(this: typeof Base): string[] {
  */
 export function hasAttributeDefinition(this: typeof Base, name: string): boolean {
   // Rails: `attr_name = attribute_aliases[attr_name] || attr_name`
-  // (attribute_methods.rb:256) before checking `attribute_types`. A real
-  // attribute of that exact name wins over the trails camelCase bridge.
-  const attrName = String(name);
-  if (this._attributeDefinitions.has(attrName)) return true;
-  return this._attributeDefinitions.has(resolveAliasNameBridged(this as never, attrName));
+  // (attribute_methods.rb:256) before checking `attribute_types`.
+  const defs = this._attributeDefinitions;
+  return defs.has(resolveAliasNameIn(this as never, defs, String(name)));
 }
 
 /**

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1,6 +1,7 @@
 import type { Base } from "./base.js";
 import { Nodes, sql as arelSql } from "@blazetrails/arel";
 import { pluralize, underscore } from "@blazetrails/activesupport";
+import { resolveAliasName } from "@blazetrails/activemodel";
 import {
   Attribute,
   AttributeSetBuilder,
@@ -229,7 +230,9 @@ export function columnNames(this: typeof Base): string[] {
  * Mirrors: ActiveRecord::ModelSchema::ClassMethods#has_attribute?
  */
 export function hasAttributeDefinition(this: typeof Base, name: string): boolean {
-  return this._attributeDefinitions.has(name);
+  // Rails: `attr_name = attribute_aliases[attr_name] || attr_name`
+  // (attribute_methods.rb:256) before checking `attribute_types`.
+  return this._attributeDefinitions.has(resolveAliasName(this as never, String(name)));
 }
 
 /**

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1,7 +1,7 @@
 import type { Base } from "./base.js";
 import { Nodes, sql as arelSql } from "@blazetrails/arel";
 import { pluralize, underscore } from "@blazetrails/activesupport";
-import { resolveAliasName } from "@blazetrails/activemodel";
+import { resolveAliasNameBridged } from "@blazetrails/activemodel";
 import {
   Attribute,
   AttributeSetBuilder,
@@ -231,8 +231,11 @@ export function columnNames(this: typeof Base): string[] {
  */
 export function hasAttributeDefinition(this: typeof Base, name: string): boolean {
   // Rails: `attr_name = attribute_aliases[attr_name] || attr_name`
-  // (attribute_methods.rb:256) before checking `attribute_types`.
-  return this._attributeDefinitions.has(resolveAliasName(this as never, String(name)));
+  // (attribute_methods.rb:256) before checking `attribute_types`. A real
+  // attribute of that exact name wins over the trails camelCase bridge.
+  const attrName = String(name);
+  if (this._attributeDefinitions.has(attrName)) return true;
+  return this._attributeDefinitions.has(resolveAliasNameBridged(this as never, attrName));
 }
 
 /**

--- a/packages/activerecord/src/readonly-attributes.ts
+++ b/packages/activerecord/src/readonly-attributes.ts
@@ -1,5 +1,5 @@
 import type { Base } from "./base.js";
-import { Model, MissingAttributeError, resolveAliasName } from "@blazetrails/activemodel";
+import { Model, MissingAttributeError, resolveAliasNameIn } from "@blazetrails/activemodel";
 import { ActiveRecordError } from "./errors.js";
 import { raiseOnAssignToAttrReadonly, setRaiseOnAssignToAttrReadonly } from "./ar-config.js";
 
@@ -121,7 +121,7 @@ export function writeAttribute(this: Base, name: string, value: unknown): void {
   // Rails' `write_attribute` resolves `attribute_aliases[name]` before the
   // chain runs, so HasReadonlyAttributes' check sees the canonical name and
   // writing via an alias cannot bypass readonly enforcement.
-  let canonical = resolveAliasName(ctor, String(name));
+  let canonical = resolveAliasNameIn(ctor, this._attributes, String(name));
   // Rails `write_attribute` remaps the `id` literal to the primary key before
   // `write_from_user` (write.rb:35: `name = @primary_key if name == "id" &&
   // @primary_key`), where `@primary_key` is `klass.primary_key` (core.rb:844).

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -491,15 +491,8 @@ export class AbstractReflection {
     const iwucc = this.inverseWhichUpdatesCounterCache();
     if (iwucc && asConcrete(iwucc).options?.counterCache) {
       const col = this.counterCacheColumn();
-      // Rails' class-level `has_attribute?` resolves attribute aliases
-      // (attribute_methods.rb:256) before checking `attribute_types`. Trails'
-      // static `hasAttribute` does not, so resolve the derived counter column
-      // (e.g. comments_count) through the owner's aliases first — the canonical
-      // posts table stores it as `legacy_comments_count`
-      // (aliasAttribute("commentsCount", "legacy_comments_count")).
       const owner = this._concrete().activeRecord as any;
-      const resolved = col ? resolveAliasedColumn(owner, col) : col;
-      if (resolved && owner?.hasAttribute?.(resolved)) return true;
+      if (col && owner?.hasAttribute?.(col)) return true;
     }
     return false;
   }


### PR DESCRIPTION
## Summary

Rails' class-level `has_attribute?` resolves attribute aliases before checking
the attribute set ([attribute_methods.rb:254-258][r1]):

```ruby
def has_attribute?(attr_name)
  attr_name = attr_name.to_s
  attr_name = attribute_aliases[attr_name] || attr_name
  attribute_types.key?(attr_name)
end
```

Trails' static `hasAttribute` was a bare membership check, so
`Post.hasAttribute("comments_count")` returned `false` even though
`aliasAttribute("commentsCount", "legacy_comments_count")` makes it a valid
alias. Every caller passing a possibly-aliased name got a false negative and had
to remember to pre-resolve.

## Where the fix landed, and why

Trails stores alias KEYS camelCase (`newName`, `commentsCount`) while callers
pass the snake_case column name (`new_name`, `comments_count`), so a faithful
port has to bridge the two conventions. Two candidate layers:

**Declaration time** — have `aliasAttribute` register both key spellings, so
`resolveAliasName` could stay a literal `aliases[name] ?? name`. Rejected:
`generateAliasAttributes` (attribute-methods.ts:465) *enumerates*
`_attributeAliases` to define accessors, so a synthetic key would invent a
public `post.comments_count` accessor that Rails never defines — trading a false
negative for a fidelity regression in the public surface.

**Lookup time** — chosen, via a single shared resolver.

`resolveAliasName` stays the exact Rails one-liner for paths that must not
second-guess a supplied name. The bridge lives in `resolveAliasNameIn`, which
takes the attribute set that defines *ownership* for the calling surface:

```ts
resolveAliasNameIn(host, present, name)
//  exact alias hit -> target        (Rails)
//  present.has(name) -> name        (never displace an owned name)
//  camelized alias hit -> target    (trails bridge)
```

Rails runs one identical `attribute_aliases[name] || name` step across
`has_attribute?` (attribute_methods.rb:254-258, :316-319), `read_attribute`
(read.rb:31-34) and `write_attribute` (write.rb:31-34), so trails routes all of
them through this one function — `present` being `_attributeDefinitions` at
class level and the loaded `@attributes` at instance level. Sharing it is what
keeps the surface coherent; bridging a subset produces an attribute that reports
present but reads back nil.

The public entry points are not the ones the module layout suggests, and all are
covered: `Base#readAttribute`/`#writeAttribute` come from `Model` (activemodel),
and the public `writeAttribute` is `ReadonlyAttributes`'.

With that, both levels resolve aliases and the manual `resolveAliasedColumn`
pre-resolution in `AbstractReflection#hasCachedCounter` (added by #4845) becomes
redundant and is removed.

### Deliberately not in scope

~11 `resolveAliasName(` sites remain exact-only in `model.ts` — dirty tracking
(`attributeWas`, `attributeChange`), `readAttributeBeforeTypeCast`. Same root
cause and same fix shape, but each needs its own `present`-set decision, and
this PR is already 148 LOC across 7 files with a review cycle open. Registered as
`0023-surfaced-deviations/alias-bridge-remaining-resolve-sites`.

`resolveAliasedColumn` (reflection.ts) is **retained**: its remaining caller in
the associations counter-update path uses it for real column-name resolution on
the SQL write path, not as a `hasAttribute` workaround. Collapsing it onto
`resolveAliasName` is now a pure dedup, left for a follow-up.

## Tests

- Ports `base_test.rb:1600` `test_has_attribute` verbatim — it covers exactly
  this case, since Rails' `Company` declares `alias_attribute :new_name, :name`
  and asserts both the class and instance forms. Both failed before this change.
- Four trails-only invariants in `attribute-methods.trails.test.ts` (no Rails
  counterpart, since Rails has no convention split): the snake_case→camelCase
  bridge; has/read/write coherence; and precedence guards for both the class
  attribute set and the loaded attribute set. Each guard was verified
  load-bearing by reverting it and confirming the corresponding test fails.

## Verification

- 3614 tests across the full activemodel package plus activerecord base /
  attribute-methods / model-schema / reflection / counter-cache / column-alias /
  timestamp-alias-resolution / readonly / enum / insert-all / dirty / core /
  integration / encryption / associations / persistence / serialization pass,
  no regressions.
- `pnpm typecheck` clean.

## Review follow-ups (Codex)

**Round 1 — bridge applied too broadly.** The first revision folded the bridge
into the shared `resolveAliasName`, which the read/write paths also use, and the
precedence guard checked `_attributeDefinitions` — the *class* set, which holds
no projected attributes. A record loaded with `SELECT COUNT(*) AS comments_count`
was redirected to an unrelated `commentsCount` alias. Reproduced (read `7`, not
`42`) and fixed by making the guard set explicit per surface.

**Round 2 — bridge applied too narrowly.** Scoping it to instance `hasAttribute`
alone left `hasAttribute` true while `readAttribute` returned nil for the same
name. Reproduced, and fixed by routing all of has/read/write through the single
`resolveAliasNameIn`, per Rails using one identical step for all three. Locked in
by the coherence test.

[r1]: https://github.com/rails/rails/blob/main/activerecord/lib/active_record/attribute_methods.rb

Closes-story: static-hasattribute-resolves-aliases
