### PR TITLE
fix(model-schema): stop STI subclass type decorations leaking onto the base

### DIFF
--- a/packages/activemodel/src/attribute-registration.test.ts
+++ b/packages/activemodel/src/attribute-registration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Model, Types, ValueType } from "./index.js";
+import { Model, Types, ValueType, isDecoratorReplay, replayOwnPendingDecorators } from "./index.js";
 
 describe("AttributeRegistrationTest", () => {
   it("attributes can be registered", () => {
@@ -373,5 +373,29 @@ describe("AttributeRegistrationTest", () => {
     Base.attribute("new_attr", "integer", { default: 7 });
 
     expect((Leaf as any)._defaultAttributes().getAttribute("new_attr").value).toBe(7);
+  });
+
+  it("replaying pending decorators establishes decorator-replay context", () => {
+    // Mirrors ActiveModel::AttributeRegistration::PendingDecorator#apply_to,
+    // which is what makes `isDecoratorReplay()` true. Decorators gated on replay
+    // context (enum's undeclared-type check) change behavior without this.
+    const seen: boolean[] = [];
+    class MyModel extends Model {
+      static {
+        this.attribute("title", "string");
+        this.decorateAttributes(["title"], (_name, type) => {
+          seen.push(isDecoratorReplay());
+          return type;
+        });
+      }
+    }
+
+    const defs = new Map(
+      (MyModel as unknown as { _attributeDefinitions: Map<string, never> })._attributeDefinitions,
+    );
+    seen.length = 0;
+    replayOwnPendingDecorators(MyModel as never, defs as never);
+
+    expect(seen).toEqual([true]);
   });
 });

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -400,6 +400,37 @@ function collectPendingModifications(cls: AttributeHostInternals): PendingModifi
 // ---------------------------------------------------------------------------
 
 /**
+ * Replay a class's OWN pending decorators onto a definitions map.
+ *
+ * Rails rebuilds `_default_attributes` from `columns_hash` and then replays the
+ * pending-modification chain every time
+ * (ActiveModel::AttributeRegistration#_default_attributes), so a decoration
+ * declared on a class survives schema reflection/reload. AR's STI reflection
+ * rebuilds a subclass's `_attributeDefinitions` from the base map, which drops
+ * decorations unless they are replayed — this is that replay, restricted to the
+ * class's OWN decorators because inherited ones are already baked into the base
+ * map by `decorateAttributes`' immediate apply.
+ *
+ * @internal
+ */
+export function replayOwnPendingDecorators(
+  cls: AttributeHostInternals,
+  defs: Map<string, { name: string; type: Type }>,
+): void {
+  if (!Object.prototype.hasOwnProperty.call(cls, "_pendingAttributeModifications")) return;
+  for (const mod of cls._pendingAttributeModifications as PendingModification[]) {
+    if (!(mod instanceof PendingDecorator)) continue;
+    const targets = mod.names ?? Array.from(defs.keys());
+    for (const name of targets) {
+      const def = defs.get(name);
+      if (!def) continue;
+      const newType = mod.decorator(name, def.type, cls);
+      if (newType) defs.set(name, { ...def, type: newType });
+    }
+  }
+}
+
+/**
  * Push a type declaration onto the pending-modification queue.
  * Called internally by attribute() implementations.
  *

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -109,6 +109,25 @@ export function isDecoratorReplay(): boolean {
   return _decoratorReplayDepth > 0;
 }
 
+/**
+ * Run `fn` in decorator-replay context, so `isDecoratorReplay()` reports true.
+ *
+ * Mirrors: the replay performed by
+ * ActiveModel::AttributeRegistration::PendingDecorator#apply_to. Every path that
+ * replays a pending decorator MUST go through this, or decorators gated on
+ * replay context (notably enum's undeclared-type check) silently change behavior.
+ *
+ * @internal
+ */
+function inDecoratorReplay<T>(fn: () => T): T {
+  _decoratorReplayDepth++;
+  try {
+    return fn();
+  } finally {
+    _decoratorReplayDepth--;
+  }
+}
+
 /** @internal Rails-private helper. */
 export class PendingDecorator implements PendingModification {
   constructor(
@@ -121,13 +140,7 @@ export class PendingDecorator implements PendingModification {
     const targets = this.names ?? attributeSet.keys();
     for (const name of targets) {
       const existing = attributeSet.getAttribute(name);
-      _decoratorReplayDepth++;
-      let newType: Type;
-      try {
-        newType = this.decorator(name, existing.type, host);
-      } finally {
-        _decoratorReplayDepth--;
-      }
+      const newType = inDecoratorReplay(() => this.decorator(name, existing.type, host));
       if (newType) {
         attributeSet.set(name, existing.withType(newType));
       }
@@ -424,7 +437,10 @@ export function replayOwnPendingDecorators(
     for (const name of targets) {
       const def = defs.get(name);
       if (!def) continue;
-      const newType = mod.decorator(name, def.type, cls);
+      // Same replay context Rails' PendingDecorator#apply_to establishes — this
+      // IS a replay of the pending chain, so decorators gated on
+      // `isDecoratorReplay()` must run here too.
+      const newType = inDecoratorReplay(() => mod.decorator(name, def.type, cls));
       if (newType) defs.set(name, { ...def, type: newType });
     }
   }

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -35,6 +35,7 @@ export {
   applyPendingAttributeModifications,
   isDecoratorReplay,
   pushPendingDecorator,
+  replayOwnPendingDecorators,
   resetDefaultAttributes,
   registerWithSuperclass,
 } from "./attribute-registration.js";

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1354,6 +1354,11 @@ export class Base extends Model {
       state._schemaLoadPromise = undefined;
       throw e;
     }
+    // An STI subclass INHERITS the base's `_schemaLoadPromise`, so it awaits the
+    // base's load and `applyColumnsHash` never runs with this subclass as the
+    // originating host. Re-sync its overlay here, or a subclass that forked
+    // `_attributeDefinitions` stays pinned to pre-reflection definitions.
+    ModelSchema.syncStiSubclassAttributeDefinitions(this as never);
   }
 
   /**

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1201,11 +1201,7 @@ function applyColumnsHash(
         const existing = baseDefs.get(name);
         const subIsUser = (def.userProvided ?? true) === true;
         const baseIsUser = existing ? (existing.userProvided ?? true) === true : false;
-        // `def !== existing` marks an entry the subclass actually declared or
-        // decorated (untouched entries are copied by reference from the base),
-        // so a subclass-only decoration survives even though both sides are
-        // schema-sourced (`userProvided === false`).
-        if (!existing || def !== existing || (subIsUser && !baseIsUser)) {
+        if (!existing || (subIsUser && !baseIsUser)) {
           overlay.set(name, def);
         }
       }

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -7,6 +7,7 @@ import {
   AttributeSetCoder,
   typeRegistry,
   defineDirtyAttributeMethods,
+  replayOwnPendingDecorators,
   type Type,
 } from "@blazetrails/activemodel";
 import {
@@ -886,8 +887,92 @@ export function resetColumnInformation(this: SchemaHost): void {
  * For a full async reflection (fetching from the adapter if the cache
  * isn't populated), call `Base.loadSchema()` (base.ts).
  */
+/**
+ * Rebuild an STI subclass's `_attributeDefinitions` as a per-subclass OVERLAY
+ * over the base's freshly reflected map.
+ *
+ * Rails keeps attribute types per class: `_default_attributes` is memoized per
+ * class, seeded from `columns_hash`, and then replays that class's own pending
+ * modifications (ActiveModel::AttributeRegistration#_default_attributes,
+ * ActiveRecord::Attributes). So a subclass `normalizes` / `attribute` must not
+ * reach the base or its siblings, and must survive a reflection/reload.
+ *
+ * Only applies when the subclass actually forked its map. A subclass that never
+ * declared anything must keep INHERITING the base map: installing the base map
+ * as an own property of the subclass fools the copy-on-write guard in
+ * `decorateAttributes` (`hasOwnProperty(this, "_attributeDefinitions")`), so a
+ * later `normalizes` would decorate the base's definitions in place.
+ */
+function rebuildStiSubclassOverlay(sub: SchemaHost, base: SchemaHost): void {
+  const baseDefs = base._attributeDefinitions;
+  const subDefs = sub._attributeDefinitions;
+  if (
+    !(baseDefs instanceof Map) ||
+    !(subDefs instanceof Map) ||
+    subDefs === baseDefs ||
+    !Object.prototype.hasOwnProperty.call(sub, "_attributeDefinitions")
+  ) {
+    return;
+  }
+
+  const overlay = new Map(baseDefs);
+  // Precedence: subclass user-provided entries win over base non-user entries;
+  // otherwise the (reflected) base entry wins.
+  for (const [name, def] of subDefs) {
+    const existing = baseDefs.get(name);
+    const subIsUser = (def.userProvided ?? true) === true;
+    const baseIsUser = existing ? (existing.userProvided ?? true) === true : false;
+    if (!existing || (subIsUser && !baseIsUser)) {
+      overlay.set(name, def);
+    }
+  }
+  // Seeding from the base map drops subclass decorations — a `normalizes`d
+  // schema column is `userProvided: false` on BOTH sides, so the precedence rule
+  // above cannot carry it. Rails re-applies the pending-decorator chain on every
+  // rebuild for exactly this reason; replay the subclass's own decorators so the
+  // decoration survives reflection and reload.
+  replayOwnPendingDecorators(sub as never, overlay);
+  sub._attributeDefinitions = overlay;
+}
+
+/**
+ * Re-sync a subclass overlay whose base has been re-reflected since it was
+ * built. `_schemaLoaded` lives on the STI base, so `loadSchema` early-returns on
+ * the subclass and would otherwise leave the overlay pinned to stale (or, after
+ * a `resetColumnInformation`, missing) definitions.
+ *
+ * Cheap key-coverage check first so the hot early-return path doesn't allocate.
+ */
+export function syncStiSubclassAttributeDefinitions(host: SchemaHost): void {
+  if (!isStiSubclass(host)) return;
+  syncStiSubclassOverlay(host, getStiBase(host) as SchemaHost);
+}
+
+function syncStiSubclassOverlay(sub: SchemaHost, base: SchemaHost): void {
+  const baseDefs = base._attributeDefinitions;
+  const subDefs = sub._attributeDefinitions;
+  if (!(baseDefs instanceof Map) || !(subDefs instanceof Map) || subDefs === baseDefs) return;
+  if (!Object.prototype.hasOwnProperty.call(sub, "_attributeDefinitions")) return;
+  let covered = true;
+  for (const name of baseDefs.keys()) {
+    if (!subDefs.has(name)) {
+      covered = false;
+      break;
+    }
+  }
+  if (covered) return;
+  rebuildStiSubclassOverlay(sub, base);
+}
+
 export function loadSchema(this: SchemaHost): void {
-  if (this._schemaLoaded) return;
+  if (this._schemaLoaded) {
+    // `_schemaLoaded` lives on the STI base, so a subclass inherits it and
+    // returns here even when the base was reset and re-reflected since the
+    // subclass built its overlay. Re-sync first, or the overlay stays pinned to
+    // the pre-reset definitions forever.
+    syncStiSubclassAttributeDefinitions(this);
+    return;
+  }
 
   // Rails ModelSchema#load_schema!: `raise TableNotSpecified unless table_name`.
   // Rails' `table_name` is nil for an abstract class; ours computes an inferred
@@ -1178,41 +1263,8 @@ function applyColumnsHash(
   const reflectedColumnNames = Object.keys(hash).filter((n) => !ignored.has(n));
   encryptionHooks.requireOriginalColumnsAfterReflection?.(host, reflectedColumnNames);
 
-  // STI: if the subclass previously forked _attributeDefinitions (via
-  // attribute()/decorateAttributes()/normalizes()/encrypts()), keep that fork
-  // as a per-subclass OVERLAY over the freshly reflected base map instead of
-  // merging it back into the shared map. Rails keeps subclass declarations and
-  // type decorations per-class (`_default_attributes` is memoized per class and
-  // replays only that class's own pending modifications), so a `normalizes` /
-  // `encrypts` on one STI subclass must not decorate the base or its siblings.
-  // Precedence: subclass user-provided entries win over base non-user entries;
-  // otherwise the (reflected) base entry wins.
   if (originatingHost && originatingHost !== host) {
-    const baseDefs = host._attributeDefinitions;
-    const subDefs = originatingHost._attributeDefinitions;
-    if (
-      baseDefs instanceof Map &&
-      subDefs instanceof Map &&
-      subDefs !== baseDefs &&
-      Object.prototype.hasOwnProperty.call(originatingHost, "_attributeDefinitions")
-    ) {
-      const overlay = new Map(baseDefs);
-      for (const [name, def] of subDefs) {
-        const existing = baseDefs.get(name);
-        const subIsUser = (def.userProvided ?? true) === true;
-        const baseIsUser = existing ? (existing.userProvided ?? true) === true : false;
-        if (!existing || (subIsUser && !baseIsUser)) {
-          overlay.set(name, def);
-        }
-      }
-      originatingHost._attributeDefinitions = overlay;
-    }
-    // No `else` assignment: when the subclass never forked, it must keep
-    // INHERITING the base map. Installing the base map as an own property of
-    // the subclass fools the copy-on-write guard in `decorateAttributes`
-    // (`hasOwnProperty(this, "_attributeDefinitions")`), so a later
-    // `normalizes` / `encrypts` on the subclass would decorate the base's
-    // definitions in place — the leak this branch used to cause.
+    rebuildStiSubclassOverlay(originatingHost, host);
     encryptionHooks.applyPendingEncryptions(originatingHost);
     // Recompute the reflected column set against the subclass's own
     // `ignoredColumns` — an STI subclass may ignore a different set than its

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -539,6 +539,15 @@ interface SchemaHost {
   _attributesBuilder?: any;
   _schemaLoaded?: boolean;
   _virtualAttributesReconciled?: boolean;
+  /**
+   * Bumped whenever this class's reflected attribute definitions are
+   * invalidated or rebuilt. STI subclasses stamp the value they last synced
+   * their overlay against, mirroring Rails' `reset_column_information`
+   * invalidating the class AND its descendants (model_schema.rb).
+   */
+  _schemaRevision?: number;
+  /** Base `_schemaRevision` this subclass's overlay was built from. @internal */
+  _stiOverlaySyncedAt?: number;
   connection: any;
   prototype: Record<string, unknown>;
   superclass?: SchemaHost;
@@ -855,6 +864,11 @@ export function resetColumnInformation(this: SchemaHost): void {
   this._attributesBuilder = undefined;
   this._schemaLoaded = false;
   this._virtualAttributesReconciled = false;
+  // Invalidate every STI subclass overlay built from the pre-reset definitions.
+  // The defs Map below is mutated IN PLACE, so neither map identity nor key
+  // coverage can detect that a subclass's overlay is stale — only this counter
+  // can. Mirrors Rails resetting the class and its descendants.
+  this._schemaRevision = (this._schemaRevision ?? 0) + 1;
   (this as SchemaHost & { _cachedDefaultAttributes?: unknown })._cachedDefaultAttributes = null;
   (this as SchemaHost & { _schemaLoadPromise?: Promise<void> })._schemaLoadPromise = undefined;
   // Mirrors Rails reset_column_information's
@@ -903,7 +917,13 @@ export function resetColumnInformation(this: SchemaHost): void {
  * `decorateAttributes` (`hasOwnProperty(this, "_attributeDefinitions")`), so a
  * later `normalizes` would decorate the base's definitions in place.
  */
+const rebuildingOverlays = new WeakSet<object>();
+
 function rebuildStiSubclassOverlay(sub: SchemaHost, base: SchemaHost): void {
+  // Replaying a decorator can re-enter schema loading — the enum decorator calls
+  // `columnForAttribute`, which calls `loadSchema`, which syncs overlays. Without
+  // this guard that cycle recurses until the stack blows.
+  if (rebuildingOverlays.has(sub as object)) return;
   const baseDefs = base._attributeDefinitions;
   const subDefs = sub._attributeDefinitions;
   if (
@@ -931,8 +951,16 @@ function rebuildStiSubclassOverlay(sub: SchemaHost, base: SchemaHost): void {
   // above cannot carry it. Rails re-applies the pending-decorator chain on every
   // rebuild for exactly this reason; replay the subclass's own decorators so the
   // decoration survives reflection and reload.
-  replayOwnPendingDecorators(sub as never, overlay);
+  // Stamp and install BEFORE replaying: a decorator that re-enters `loadSchema`
+  // must see the fresh overlay and a synced stamp, not recurse into another rebuild.
   sub._attributeDefinitions = overlay;
+  sub._stiOverlaySyncedAt = base._schemaRevision ?? 0;
+  rebuildingOverlays.add(sub as object);
+  try {
+    replayOwnPendingDecorators(sub as never, overlay);
+  } finally {
+    rebuildingOverlays.delete(sub as object);
+  }
 }
 
 /**
@@ -941,7 +969,10 @@ function rebuildStiSubclassOverlay(sub: SchemaHost, base: SchemaHost): void {
  * the subclass and would otherwise leave the overlay pinned to stale (or, after
  * a `resetColumnInformation`, missing) definitions.
  *
- * Cheap key-coverage check first so the hot early-return path doesn't allocate.
+ * Staleness is detected by `_schemaRevision`, not by inspecting the maps: a
+ * reset mutates the base's definitions Map IN PLACE, so map identity is stable,
+ * and a re-reflection can change a column's type/default while leaving the key
+ * set identical — so key coverage would wrongly report the overlay as fresh.
  */
 export function syncStiSubclassAttributeDefinitions(host: SchemaHost): void {
   if (!isStiSubclass(host)) return;
@@ -953,14 +984,12 @@ function syncStiSubclassOverlay(sub: SchemaHost, base: SchemaHost): void {
   const subDefs = sub._attributeDefinitions;
   if (!(baseDefs instanceof Map) || !(subDefs instanceof Map) || subDefs === baseDefs) return;
   if (!Object.prototype.hasOwnProperty.call(sub, "_attributeDefinitions")) return;
-  let covered = true;
-  for (const name of baseDefs.keys()) {
-    if (!subDefs.has(name)) {
-      covered = false;
-      break;
-    }
-  }
-  if (covered) return;
+  // Own-property check: a subclass that never synced would otherwise INHERIT a
+  // stamp through the prototype chain and wrongly skip its first rebuild.
+  const stamped = Object.prototype.hasOwnProperty.call(sub, "_stiOverlaySyncedAt")
+    ? sub._stiOverlaySyncedAt
+    : undefined;
+  if (stamped === (base._schemaRevision ?? 0)) return;
   rebuildStiSubclassOverlay(sub, base);
 }
 
@@ -1262,6 +1291,10 @@ function applyColumnsHash(
   // `columnNames()` partial-load path — are the source of truth here.
   const reflectedColumnNames = Object.keys(hash).filter((n) => !ignored.has(n));
   encryptionHooks.requireOriginalColumnsAfterReflection?.(host, reflectedColumnNames);
+
+  // Reflection may change a column's metadata/type/default without changing the
+  // key set, so bump before rebuilding overlays from the new definitions.
+  host._schemaRevision = (host._schemaRevision ?? 0) + 1;
 
   if (originatingHost && originatingHost !== host) {
     rebuildStiSubclassOverlay(originatingHost, host);

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1179,12 +1179,14 @@ function applyColumnsHash(
   encryptionHooks.requireOriginalColumnsAfterReflection?.(host, reflectedColumnNames);
 
   // STI: if the subclass previously forked _attributeDefinitions (via
-  // attribute()/decorateAttributes()/encrypts()), carry its entries
-  // into the shared base map before unifying references — naive
-  // reassignment would silently discard subclass-declared attributes.
-  // Precedence: subclass user-provided entries win over base non-user
-  // entries; otherwise base wins (Rails' STI shares attribute_types,
-  // but subclass declarations extend it).
+  // attribute()/decorateAttributes()/normalizes()/encrypts()), keep that fork
+  // as a per-subclass OVERLAY over the freshly reflected base map instead of
+  // merging it back into the shared map. Rails keeps subclass declarations and
+  // type decorations per-class (`_default_attributes` is memoized per class and
+  // replays only that class's own pending modifications), so a `normalizes` /
+  // `encrypts` on one STI subclass must not decorate the base or its siblings.
+  // Precedence: subclass user-provided entries win over base non-user entries;
+  // otherwise the (reflected) base entry wins.
   if (originatingHost && originatingHost !== host) {
     const baseDefs = host._attributeDefinitions;
     const subDefs = originatingHost._attributeDefinitions;
@@ -1194,16 +1196,27 @@ function applyColumnsHash(
       subDefs !== baseDefs &&
       Object.prototype.hasOwnProperty.call(originatingHost, "_attributeDefinitions")
     ) {
+      const overlay = new Map(baseDefs);
       for (const [name, def] of subDefs) {
         const existing = baseDefs.get(name);
         const subIsUser = (def.userProvided ?? true) === true;
         const baseIsUser = existing ? (existing.userProvided ?? true) === true : false;
-        if (!existing || (subIsUser && !baseIsUser)) {
-          baseDefs.set(name, def);
+        // `def !== existing` marks an entry the subclass actually declared or
+        // decorated (untouched entries are copied by reference from the base),
+        // so a subclass-only decoration survives even though both sides are
+        // schema-sourced (`userProvided === false`).
+        if (!existing || def !== existing || (subIsUser && !baseIsUser)) {
+          overlay.set(name, def);
         }
       }
+      originatingHost._attributeDefinitions = overlay;
     }
-    originatingHost._attributeDefinitions = baseDefs;
+    // No `else` assignment: when the subclass never forked, it must keep
+    // INHERITING the base map. Installing the base map as an own property of
+    // the subclass fools the copy-on-write guard in `decorateAttributes`
+    // (`hasOwnProperty(this, "_attributeDefinitions")`), so a later
+    // `normalizes` / `encrypts` on the subclass would decorate the base's
+    // definitions in place — the leak this branch used to cause.
     encryptionHooks.applyPendingEncryptions(originatingHost);
     // Recompute the reflected column set against the subclass's own
     // `ignoredColumns` — an STI subclass may ignore a different set than its

--- a/packages/activerecord/src/normalized-attribute.trails.test.ts
+++ b/packages/activerecord/src/normalized-attribute.trails.test.ts
@@ -6,6 +6,12 @@
  * `_attributeDefinitions` map as an OWN property of the subclass, which fooled
  * the copy-on-write guard in `decorateAttributes` — so the subclass decoration
  * landed on the base's definitions and leaked to sibling subclasses.
+ *
+ * The leak only reproduces when the SUBCLASS drives the first reflection of the
+ * STI table (that is the path that installs the base map as an own property), so
+ * this file must own that first reflection — do not add a test above that
+ * reflects `Company` (or another subclass) first, or the guard silently stops
+ * guarding.
  */
 import { describe, it, expect } from "vitest";
 import { Company } from "./test-helpers/models/company.js";
@@ -13,6 +19,13 @@ import { fixtures } from "./test-helpers/fixtures.js";
 
 class NormalizedCompany extends Company {}
 class OtherCompany extends Company {}
+
+const defTypeFor = (klass: typeof Company, name: string) =>
+  (
+    klass as unknown as {
+      _attributeDefinitions: Map<string, { type: { cast(v: unknown): unknown } }>;
+    }
+  )._attributeDefinitions.get(name)!.type;
 
 describe("STI subclass normalizes", () => {
   fixtures([]);
@@ -25,16 +38,9 @@ describe("STI subclass normalizes", () => {
       typeof name === "string" ? name.trim().toUpperCase() : name,
     );
 
-    const defTypeFor = (klass: typeof Company) =>
-      (
-        klass as unknown as {
-          _attributeDefinitions: Map<string, { type: { cast(v: unknown): unknown } }>;
-        }
-      )._attributeDefinitions.get("name")!.type;
-
-    expect(defTypeFor(NormalizedCompany).cast("  acme  ")).toBe("ACME");
-    expect(defTypeFor(Company).cast("  acme  ")).toBe("  acme  ");
-    expect(defTypeFor(OtherCompany).cast("  acme  ")).toBe("  acme  ");
+    expect(defTypeFor(NormalizedCompany, "name").cast("  acme  ")).toBe("ACME");
+    expect(defTypeFor(Company, "name").cast("  acme  ")).toBe("  acme  ");
+    expect(defTypeFor(OtherCompany, "name").cast("  acme  ")).toBe("  acme  ");
 
     expect(NormalizedCompany.new({ name: "  acme  " }).name).toBe("ACME");
     expect(Company.new({ name: "  acme  " }).name).toBe("  acme  ");

--- a/packages/activerecord/src/normalized-attribute.trails.test.ts
+++ b/packages/activerecord/src/normalized-attribute.trails.test.ts
@@ -19,6 +19,7 @@ import { fixtures } from "./test-helpers/fixtures.js";
 
 class NormalizedCompany extends Company {}
 class OtherCompany extends Company {}
+class ReloadedCompany extends Company {}
 
 const defTypeFor = (klass: typeof Company, name: string) =>
   (
@@ -44,5 +45,25 @@ describe("STI subclass normalizes", () => {
 
     expect(NormalizedCompany.new({ name: "  acme  " }).name).toBe("ACME");
     expect(Company.new({ name: "  acme  " }).name).toBe("  acme  ");
+  });
+
+  it("keeps the subclass decoration across a schema reset and re-reflection", async () => {
+    await ReloadedCompany.loadSchema();
+    await Company.loadSchema();
+
+    ReloadedCompany.normalizes("name", (name: unknown) =>
+      typeof name === "string" ? name.trim().toUpperCase() : name,
+    );
+    expect(defTypeFor(ReloadedCompany, "name").cast("  acme  ")).toBe("ACME");
+
+    // Rails re-seeds `_default_attributes` from `columns_hash` and replays the
+    // pending-decorator chain on every rebuild, so reflection must not revert
+    // (or drop) the subclass's decorated definition.
+    ReloadedCompany.resetColumnInformation();
+    await Company.loadSchema();
+    await ReloadedCompany.loadSchema();
+
+    expect(defTypeFor(ReloadedCompany, "name").cast("  acme  ")).toBe("ACME");
+    expect(defTypeFor(Company, "name").cast("  acme  ")).toBe("  acme  ");
   });
 });

--- a/packages/activerecord/src/normalized-attribute.trails.test.ts
+++ b/packages/activerecord/src/normalized-attribute.trails.test.ts
@@ -1,0 +1,42 @@
+/**
+ * trails-only: `normalizes` declared on an STI subclass must decorate only that
+ * subclass's attribute types. Rails keeps this per-class (`normalized_attributes`
+ * is a `class_attribute` and `_default_attributes` replays only the class's own
+ * pending decorators), but trails' STI reflection installed the base's shared
+ * `_attributeDefinitions` map as an OWN property of the subclass, which fooled
+ * the copy-on-write guard in `decorateAttributes` — so the subclass decoration
+ * landed on the base's definitions and leaked to sibling subclasses.
+ */
+import { describe, it, expect } from "vitest";
+import { Company } from "./test-helpers/models/company.js";
+import { fixtures } from "./test-helpers/fixtures.js";
+
+class NormalizedCompany extends Company {}
+class OtherCompany extends Company {}
+
+describe("STI subclass normalizes", () => {
+  fixtures([]);
+
+  it("does not leak the decorated cast type onto the STI base or siblings", async () => {
+    await NormalizedCompany.loadSchema();
+    await Company.loadSchema();
+
+    NormalizedCompany.normalizes("name", (name: unknown) =>
+      typeof name === "string" ? name.trim().toUpperCase() : name,
+    );
+
+    const defTypeFor = (klass: typeof Company) =>
+      (
+        klass as unknown as {
+          _attributeDefinitions: Map<string, { type: { cast(v: unknown): unknown } }>;
+        }
+      )._attributeDefinitions.get("name")!.type;
+
+    expect(defTypeFor(NormalizedCompany).cast("  acme  ")).toBe("ACME");
+    expect(defTypeFor(Company).cast("  acme  ")).toBe("  acme  ");
+    expect(defTypeFor(OtherCompany).cast("  acme  ")).toBe("  acme  ");
+
+    expect(NormalizedCompany.new({ name: "  acme  " }).name).toBe("ACME");
+    expect(Company.new({ name: "  acme  " }).name).toBe("  acme  ");
+  });
+});

--- a/packages/activerecord/src/normalized-attribute.trails.test.ts
+++ b/packages/activerecord/src/normalized-attribute.trails.test.ts
@@ -20,6 +20,7 @@ import { fixtures } from "./test-helpers/fixtures.js";
 class NormalizedCompany extends Company {}
 class OtherCompany extends Company {}
 class ReloadedCompany extends Company {}
+class RefreshedCompany extends Company {}
 
 const defTypeFor = (klass: typeof Company, name: string) =>
   (
@@ -65,5 +66,25 @@ describe("STI subclass normalizes", () => {
 
     expect(defTypeFor(ReloadedCompany, "name").cast("  acme  ")).toBe("ACME");
     expect(defTypeFor(Company, "name").cast("  acme  ")).toBe("  acme  ");
+  });
+
+  it("refreshes a subclass overlay whose key set is unchanged after a base reset", async () => {
+    await RefreshedCompany.loadSchema();
+    await Company.loadSchema();
+
+    // Fork an overlay covering every reflected column.
+    RefreshedCompany.normalizes("description", (value: unknown) => value);
+    const defsOf = (klass: typeof Company) =>
+      (klass as unknown as { _attributeDefinitions: Map<string, object> })._attributeDefinitions;
+    expect([...defsOf(Company).keys()].every((k) => defsOf(RefreshedCompany).has(k))).toBe(true);
+
+    // Rails' reset_column_information invalidates the class AND its descendants,
+    // so a subclass must not keep an old overlay merely because it still covers
+    // every key — reflection can change a column's type/default in place.
+    Company.resetColumnInformation();
+    await Company.loadSchema();
+    await RefreshedCompany.loadSchema();
+
+    expect(defsOf(RefreshedCompany).get("name")).toBe(defsOf(Company).get("name"));
   });
 });


### PR DESCRIPTION
An STI subclass that reflected schema had the base's shared `_attributeDefinitions` map installed as an **own** property of the subclass, which fooled the copy-on-write guard in `decorateAttributes` (`hasOwnProperty(this, "_attributeDefinitions")`). A later `normalizes` on the subclass therefore decorated the **base's** definitions in place, leaking the cast type onto the STI base and every sibling subclass.

Rails keeps this per-class: `normalized_attributes` is a `class_attribute` and `_default_attributes` is memoized per class, replaying only that class's own pending decorators.

## The fix

- Don't install the base map as an own property when the subclass never forked — leave it **inherited**, so copy-on-write works as intended.
- When the subclass *did* fork, keep it as a per-subclass **overlay** over the reflected base map instead of merging it back into the shared map.

## Verification

`normalized-attribute.trails.test.ts` fails on `origin/main` (`expected 'ACME' to be '  acme  '` — the base's definition got decorated) and passes here. The test asserts on `_attributeDefinitions` directly, because `Model.new` / `typeForAttribute` resolve through the per-class `attribute_types` and are already clean — the leak is only observable on the definitions map that column building and defaults read.

Reflection order matters: the leak only reproduces when the **subclass** drives the first reflection of the STI table. An earlier version of this test added a second case that reflected `Company` first and silently disarmed the guard, so the file carries a comment warning against adding a test above it.

Green: `normalized-attribute`, `inheritance`, `attributes`, `model-schema`, `dirty`, `base`, `enum`, `serialization`, `sti/`, `schema-dumper`, `persistence`, `timestamp`, the full `activemodel` package, the full `encryption/` suite, and `relations/` + `associations/` + `validations/` — 5,400+ tests.

## Codex review follow-up (fixed)

Codex flagged that rebuilding the overlay from the base drops a subclass decoration: a `normalizes`d schema column is `userProvided: false` on **both** sides, so the precedence rule can't carry it. Confirmed — and it was worse than reported. After a reset + re-reflection the subclass's definition was **absent entirely**, not merely reverted:

```
PROBE before  sub: ACME      base:   acme
PROBE after   sub: <absent>  base:   acme
```

Two causes, both fixed:

1. **No decorator replay.** Rails re-seeds `_default_attributes` from `columns_hash` and replays the pending-decorator chain on every rebuild. Added `replayOwnPendingDecorators` (activemodel) and replay the subclass's *own* decorators onto the rebuilt overlay — own-only, since inherited decorators are already baked into the base map by `decorateAttributes`' immediate apply.
2. **The overlay was never rebuilt at all.** Both `_schemaLoaded` and `_schemaLoadPromise` live on the STI base, so a subclass early-returns from `loadSchema` and `applyColumnsHash` never runs with it as originating host — the overlay stayed pinned to pre-reset definitions forever. Both early-return paths now re-sync (guarded by a cheap key-coverage check so the hot path doesn't allocate).

Second regression test added; both tests fail on `origin/main` and pass here.

An earlier revision of this PR carried a `def !== existing` clause that would have partly masked cause 1. I'd dropped it as speculative because my probe only covered *pre*-reflection `normalizes` (which never touches the def map). Codex's case — decorate *then* re-reflect — was the one I hadn't probed. The replay is the principled version of that clause.

## Second Codex review follow-up (fixed)

Codex flagged that the key-coverage staleness check keeps a subclass overlay when the table has the same column names but changed reflected metadata/type/defaults. Correct — and the weakness was worse than a proxy being imprecise: `resetColumnInformation` mutates the base's definitions Map **in place**, so map identity is stable too. Neither the key set nor the map reference can detect that invalidation happened.

- Track `_schemaRevision` on the base, bumped on reset and on reflection; stamp each subclass overlay with the revision it was built from, and rebuild on mismatch. Mirrors Rails' `reset_column_information` invalidating the class **and its descendants** (model_schema.rb:523, :553).
- The stamp check is own-property guarded, or a subclass would inherit a stamp through the prototype chain and skip its first rebuild.
- Third regression test added, using Codex's exact repro (`Company.resetColumnInformation()` with an overlay that still covers every key). It fails against the previous commit with `expected { name: 'name', …(5) } to be { name: 'name', …(5) }` — two structurally identical defs that are different objects, i.e. the stale copy.

**Reentrancy bug caught while fixing this:** replaying the enum decorator calls `columnForAttribute` → `loadSchema` → overlay sync → replay, recursing until the stack blew (`RangeError` in `dirty.test.ts`). The overlay is now installed and stamped *before* replaying, with a `WeakSet` guard so a re-entering decorator sees the fresh overlay instead of triggering another rebuild. This was latent in the previous commit and only surfaced in a file I hadn't run — the sweep is correspondingly wider now.

## Third Codex review follow-up (fixed)

Codex flagged that `replayOwnPendingDecorators` called the decorator directly, bypassing the replay-depth wrapper in `PendingDecorator#applyTo`, so `isDecoratorReplay()` was `false` during replay — diverging from Rails' `PendingDecorator#apply_to` and silently changing behavior for decorators gated on replay context (enum's undeclared-type check, enum.rb:240).

Fixed by extracting `inDecoratorReplay()` and routing **both** replay paths through it, so there is a single implementation of the context rather than a second one that drifts. Added a unit test pinning it; against the previous commit it fails with `expected [ false ] to deeply equal [ true ]`.

Worth noting this interacts with the reentrancy guard from the previous round: with replay context now correctly `true`, enum's check *does* run during overlay replay and re-enters `loadSchema` — which is exactly the cycle the `WeakSet` guard handles. Both are needed; the guard alone would have masked the divergence, and the divergence alone would have hidden the recursion.

## Scope notes

- **`encrypts` is deliberately excluded.** The story suggested the fix would generalize, but `Base.encrypts` (base.ts:1863) *intentionally* routes STI subclasses to the STI base — a documented workaround for the very shadowing this PR removes. So `encrypts` on an STI subclass still decorates the base (verified by probe). Unwinding that changes encryption semantics and touches the encryption suite, so it is registered separately as `sti-subclass-encrypts-routes-to-sti-base-leaking-type` rather than fanned out here.

Closes-story: sti-subclass-normalizes-shared-attribute-definitions-leak
