### PR TITLE
fix(store): return null (not undefined) from store accessor dirty methods

### DIFF
--- a/packages/activerecord/src/store.test.ts
+++ b/packages/activerecord/src/store.test.ts
@@ -106,10 +106,8 @@ describe("StoreTest", () => {
   it("new record and no accessors changes", () => {
     const user = new AdminUser();
     expect((user as any).colorChanged()).toBe(false);
-    // trails: colorWas/colorChange return undefined (not null) when the attribute
-    // has never been set; Rails returns nil. Tracked for convergence.
-    // expect((user as any).colorWas()).toBeNull();
-    // expect((user as any).colorChange()).toBeNull();
+    expect((user as any).colorWas()).toBeNull();
+    expect((user as any).colorChange()).toBeNull();
 
     user.color = "red";
     expect((user as any).colorChanged()).toBe(true);
@@ -170,7 +168,7 @@ describe("StoreTest", () => {
     expect((john as any).partner_nameChanged()).toBe(true);
 
     await john.save();
-    expect((john as any).partner_nameChange()).toBeUndefined();
+    expect((john as any).partner_nameChange()).toBeNull();
     expect((john as any).savedChangeToPartner_name()).toBe(true);
     expect((john as any).savedChangeToPartner_nameValues()).toEqual(["Dallas", "Lena"]);
     expect((john as any).partner_nameBeforeLastSave()).toBe("Dallas");
@@ -182,7 +180,7 @@ describe("StoreTest", () => {
     expect((john as any).enableFriendRequestsChanged()).toBe(true);
 
     await john.save();
-    expect((john as any).enableFriendRequestsChange()).toBeUndefined();
+    expect((john as any).enableFriendRequestsChange()).toBeNull();
     expect((john as any).savedChangeToEnableFriendRequests()).toBe(true);
     expect((john as any).savedChangeToEnableFriendRequestsValues()).toEqual([null, true]);
     (john as any).enableFriendRequests = false;

--- a/packages/activerecord/src/store.ts
+++ b/packages/activerecord/src/store.ts
@@ -416,12 +416,12 @@ function defineStoreAccessorDirtyMethods(
     return dig(prev, key) !== dig(next, key);
   });
   define(`${accessorName}Change`, function (this) {
-    if (!this.attributeChanged(storeAttribute)) return undefined;
+    if (!this.attributeChanged(storeAttribute)) return null;
     const [prev, next] = this.changes[storeAttribute] ?? [undefined, undefined];
     return [dig(prev, key) ?? null, dig(next, key) ?? null];
   });
   define(`${accessorName}Was`, function (this) {
-    if (!this.attributeChanged(storeAttribute)) return undefined;
+    if (!this.attributeChanged(storeAttribute)) return null;
     const [prev] = this.changes[storeAttribute] ?? [undefined];
     return dig(prev, key) ?? null;
   });
@@ -434,12 +434,12 @@ function defineStoreAccessorDirtyMethods(
     return dig(prev, key) !== dig(next, key);
   });
   define(`savedChangeTo${cap}Values`, function (this) {
-    if (!this.savedChangeToAttribute?.(storeAttribute)) return undefined;
+    if (!this.savedChangeToAttribute?.(storeAttribute)) return null;
     const [prev, next] = this.savedChanges?.[storeAttribute] ?? [undefined, undefined];
     return [dig(prev, key) ?? null, dig(next, key) ?? null];
   });
   define(`${accessorName}BeforeLastSave`, function (this) {
-    if (!this.savedChangeToAttribute?.(storeAttribute)) return undefined;
+    if (!this.savedChangeToAttribute?.(storeAttribute)) return null;
     const [prev] = this.savedChanges?.[storeAttribute] ?? [undefined];
     return dig(prev, key) ?? null;
   });


### PR DESCRIPTION
Rails' store accessor dirty helpers (`*_was`, `*_change`, `saved_change_to_*`,
`*_before_last_save`) return `nil` when there is no recorded change; ours
returned `undefined`. Converged on `null`.

- `store.ts`: the five no-change early returns now return `null`.
- `store.test.ts`: un-commented the `colorWas()` / `colorChange()` nil
  assertions in "new record and no accessors changes"; updated the two
  `toBeUndefined()` assertions in the saved-changes tests to `toBeNull()`
  (Rails asserts `assert_not`, i.e. nil).

`vendor/rails/activerecord/test/cases/store_test.rb:96,155,166`.

All 50 tests in `store.test.ts` pass.

Closes-story: store-accessor-dirty-was-change-returns-null-not-undefined
