### PR TITLE
refactor(has_one): retire the dead _removeDisplacedFromDb flag and port replace's early return

### DIFF
--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -18,46 +18,8 @@ import { polymorphicName } from "../inheritance.js";
  * Mirrors: ActiveRecord::Associations::HasOneAssociation
  */
 export class HasOneAssociation extends SingularAssociation {
-  /**
-   * The record(s) displaced by the sync `build#{name}` / `create#{name}` path
-   * (`setNewRecord`) on a *persisted* owner — recorded there and removed
-   * (FK-nullified/destroyed per `:dependent`) by the owner's `save`-time has_one
-   * autosave callback (`autosaveHasOne` → `removeDisplaced`). Rails does this
-   * removal synchronously inside `replace`; the sync builder cannot `await`, so
-   * we carry the displaced record forward to the single autosave persistence
-   * path rather than running a parallel `persistReplace`.
-   *
-   * The property setter no longer feeds this queue: on a persisted owner it
-   * throws (RFC 0068), so only the build/create path can enqueue here.
-   *
-   * This is an *ordered collection*, not a single slot: repeated builds can
-   * displace more than one persisted record before `save()` drains the queue.
-   * Rails removes each inline inside `replace`, so every displacement is
-   * accounted for; we accumulate them and remove all at save time, in
-   * displacement order.
-   */
-  _displacedRecords: Base[] = [];
-
-  /**
-   * Was set when a deferred property-setter assignment displaced an *unloaded*
-   * has_one on a persisted owner (the DB row keyed by the owner still needed
-   * removal). That path is now a throw (RFC 0068), so this field is never set
-   * to `true` any more; the drain branch in `removeDisplaced` is inert. Kept
-   * (rather than removed here) because the whole deferred-displacement machinery
-   * — this field, `_displacedRecords`, `removeDisplaced`, the `autosaveHasOne`
-   * drain — is retired together in a later RFC 0068 story once no caller can
-   * reach the deferral.
-   */
-  _removeDisplacedFromDb = false;
-
   constructor(owner: Base, definition: AssociationDefinition) {
     super(owner, definition);
-  }
-
-  override reset(): void {
-    super.reset();
-    this._displacedRecords = [];
-    this._removeDisplacedFromDb = false;
   }
 
   /**
@@ -124,14 +86,19 @@ export class HasOneAssociation extends SingularAssociation {
     // be nullified/removed, rather than silently orphaning it.
     if (!this.loaded) await this.loadTarget();
     const displaced = this.target;
+    // Rails: `return target unless load_target || record` (has_one_association
+    // .rb:61) — with nothing loaded and nothing being assigned there is no work,
+    // and crucially no `self.target =`, so the association stays UNLOADED. The
+    // sync `queueWrite` path could not await the load, so this was previously
+    // approximated by the `changed` gate below, which still fell through to
+    // `replace(null)` and marked the association loaded.
+    if (!displaced && !record) return;
     // Mirror Rails `replace`'s `assigning_another_record || has_changes_to_save?`
     // gate (:64-65): only touch the DB when the assignment actually changes
     // something, so a no-op re-assignment (e.g. `writer(null)` with no target)
     // opens no transaction. `hasChangesToSave` is a getter, read (not called)
-    // per #4900. The `?.` stands in for Rails' `return target unless
-    // load_target || record` (:62): with both sides nil `sameRecord` is true
-    // and this short-circuits to undefined, which is falsy — exactly where
-    // Rails would have returned.
+    // per #4900. The `?.` is now just nil-safety on `record`; Rails' `return
+    // target unless load_target || record` is ported as the early return above.
     const changed = !sameRecord(displaced, record) || record?.hasChangesToSave === true;
     if (changed) {
       // Rails: `save &&= owner.persisted?` (:66) — a new owner does not gate the
@@ -186,61 +153,6 @@ export class HasOneAssociation extends SingularAssociation {
     // repeat of the in-transaction work) and, for `record === null`, clears the
     // inverse on the now-removed displaced record.
     this.replace(record);
-  }
-
-  /**
-   * Remove the record displaced by a deferred assignment to a persisted owner.
-   * Called by the has_one autosave callback (`autosaveHasOne`) before persisting
-   * the new target — the deferred analog of the `remove_target!` Rails runs
-   * inside `HasOneAssociation#replace`.
-   */
-  async removeDisplaced(): Promise<void> {
-    // Drain the whole collection, removing each displaced record in
-    // displacement order (Rails removes each inline inside `replace`).
-    const queued = this._displacedRecords;
-    this._displacedRecords = [];
-    for (const record of queued) {
-      await this.removeOne(record);
-    }
-    let displaced: Base | null = null;
-    if (this._removeDisplacedFromDb) {
-      // Unloaded property-setter replace: materialize the existing DB-associated
-      // record now (the owner still keys the pre-replace row, since the new
-      // target has not been persisted yet) so its `:dependent` remove runs.
-      // Mirrors Rails' synchronous `load_target` inside `replace`. `replace`
-      // already cached the new (unsaved) target, so clear it around the find to
-      // force a DB query instead of returning that cached record.
-      this._removeDisplacedFromDb = false;
-      const savedTarget = this.target;
-      const savedLoaded = this.loaded;
-      this.target = null;
-      this.loaded = false;
-      let found: Base | null = null;
-      try {
-        found = await this.doAsyncFindTarget();
-      } finally {
-        this.target = savedTarget;
-        this.loaded = savedLoaded;
-      }
-      if (found && !sameRecord(found, savedTarget)) displaced = found;
-    }
-    if (displaced) await this.removeOne(displaced);
-  }
-
-  /**
-   * Run `remove_target!` for a single displaced record, honoring the
-   * reflection's `:dependent` (delete/destroy/else-nullify). Temporarily sets
-   * `target` to the displaced record so `removeTargetBang` acts on it, then
-   * restores the current target.
-   */
-  private async removeOne(displaced: Base): Promise<void> {
-    const currentTarget = this.target;
-    this.target = displaced;
-    try {
-      await removeTargetBang(this, (this.reflection.options.dependent as string) ?? "");
-    } finally {
-      this.target = currentTarget;
-    }
   }
 
   /**
@@ -544,11 +456,10 @@ export class HasOneAssociation extends SingularAssociation {
    * `save = false` gates only `transaction_if(save)` (:68) and `if save &&
    * !record.save` (:75) — `remove_target!` (:69) runs regardless, so building
    * over an existing target still nullifies the displaced record's foreign key
-   * and clears its inverse. We run that in-memory half here and hand the
-   * displaced record to `removeDisplaced` (the owner's `autosaveHasOne`) for the
-   * DB half — `build` is synchronous and cannot await a save. Only a *persisted*
-   * displaced record has a row to remove, so a transient in-memory target is not
-   * queued (matching `queueWrite`).
+   * and clears its inverse. We run that in-memory half here; the DB half runs in
+   * the awaitable `build#{name}` / `create#{name}` accessors via
+   * `detachDisplacedTarget`, which is the real port of `remove_target!` inside
+   * `replace`. `setNewRecord` itself is synchronous and cannot await a save.
    */
   protected override setNewRecord(record: Base): void {
     const displaced = this.target;
@@ -564,7 +475,6 @@ export class HasOneAssociation extends SingularAssociation {
       this.nullifyOwnerAttributes(displaced);
       this.removeInverseInstance(displaced);
     }
-    this._displacedRecords.push(displaced);
   }
 
   private nullifyOwnerAttributes(record: Base): void {

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -86,12 +86,15 @@ export class HasOneAssociation extends SingularAssociation {
     // be nullified/removed, rather than silently orphaning it.
     if (!this.loaded) await this.loadTarget();
     const displaced = this.target;
-    // Rails: `return target unless load_target || record` (has_one_association
-    // .rb:61) — with nothing loaded and nothing being assigned there is no work,
-    // and crucially no `self.target =`, so the association stays UNLOADED. The
-    // sync `queueWrite` path could not await the load, so this was previously
-    // approximated by the `changed` gate below, which still fell through to
-    // `replace(null)` and marked the association loaded.
+    // Rails: `return target unless load_target || record`
+    // (has_one_association.rb:61) — nothing associated and nothing being
+    // assigned means no work, so return before the gate and before
+    // `self.target = record`. Note this does NOT leave the association
+    // unloaded: `load_target` calls `loaded!` unconditionally
+    // (association.rb:192), as does the `loadTarget()` above. The old code
+    // reached the same end state by falling through to a `replace(null)` that
+    // happened to be a no-op with a null target; this ports the structure Rails
+    // actually has rather than relying on that coincidence.
     if (!displaced && !record) return;
     // Mirror Rails `replace`'s `assigning_another_record || has_changes_to_save?`
     // gate (:64-65): only touch the DB when the assignment actually changes

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -18,8 +18,39 @@ import { polymorphicName } from "../inheritance.js";
  * Mirrors: ActiveRecord::Associations::HasOneAssociation
  */
 export class HasOneAssociation extends SingularAssociation {
+  /**
+   * The record(s) displaced by the sync `build#{name}` / `create#{name}` path
+   * (`setNewRecord`) on a *persisted* owner — recorded there and removed
+   * (FK-nullified/destroyed per `:dependent`) by the owner's `save`-time has_one
+   * autosave callback (`autosaveHasOne` → `removeDisplaced`). Rails does this
+   * removal synchronously inside `replace`; the sync builder cannot `await`, so
+   * we carry the displaced record forward to the single autosave persistence
+   * path rather than running a parallel `persistReplace`.
+   *
+   * The property setter no longer feeds this queue: on a persisted owner it
+   * throws (RFC 0068). The remaining producer is the *synchronous* build path —
+   * `setNewRecord`, reached via `assoc.build()` from nested attributes
+   * (nested-attributes.ts) as well as the `build#{name}` / `create#{name}`
+   * accessors. Rails runs `remove_target!`'s persisted nullify save inline
+   * (has_one_association.rb:108); a sync JS builder cannot await it, so the
+   * queue carries it to the owner's save. This is why the queue could NOT be
+   * retired wholesale with the deferred setter (RFC 0068).
+   *
+   * This is an *ordered collection*, not a single slot: repeated builds can
+   * displace more than one persisted record before `save()` drains the queue.
+   * Rails removes each inline inside `replace`, so every displacement is
+   * accounted for; we accumulate them and remove all at save time, in
+   * displacement order.
+   */
+  _displacedRecords: Base[] = [];
+
   constructor(owner: Base, definition: AssociationDefinition) {
     super(owner, definition);
+  }
+
+  override reset(): void {
+    super.reset();
+    this._displacedRecords = [];
   }
 
   /**
@@ -89,12 +120,9 @@ export class HasOneAssociation extends SingularAssociation {
     // Rails: `return target unless load_target || record`
     // (has_one_association.rb:61) — nothing associated and nothing being
     // assigned means no work, so return before the gate and before
-    // `self.target = record`. Note this does NOT leave the association
-    // unloaded: `load_target` calls `loaded!` unconditionally
-    // (association.rb:192), as does the `loadTarget()` above. The old code
-    // reached the same end state by falling through to a `replace(null)` that
-    // happened to be a no-op with a null target; this ports the structure Rails
-    // actually has rather than relying on that coincidence.
+    // `self.target = record`. This does NOT leave the association unloaded:
+    // `load_target` calls `loaded!` unconditionally (association.rb:192), as
+    // does the `loadTarget()` above.
     if (!displaced && !record) return;
     // Mirror Rails `replace`'s `assigning_another_record || has_changes_to_save?`
     // gate (:64-65): only touch the DB when the assignment actually changes
@@ -156,6 +184,38 @@ export class HasOneAssociation extends SingularAssociation {
     // repeat of the in-transaction work) and, for `record === null`, clears the
     // inverse on the now-removed displaced record.
     this.replace(record);
+  }
+
+  /**
+   * Remove the record displaced by a deferred assignment to a persisted owner.
+   * Called by the has_one autosave callback (`autosaveHasOne`) before persisting
+   * the new target — the deferred analog of the `remove_target!` Rails runs
+   * inside `HasOneAssociation#replace`.
+   */
+  async removeDisplaced(): Promise<void> {
+    // Drain the whole collection, removing each displaced record in
+    // displacement order (Rails removes each inline inside `replace`).
+    const queued = this._displacedRecords;
+    this._displacedRecords = [];
+    for (const record of queued) {
+      await this.removeOne(record);
+    }
+  }
+
+  /**
+   * Run `remove_target!` for a single displaced record, honoring the
+   * reflection's `:dependent` (delete/destroy/else-nullify). Temporarily sets
+   * `target` to the displaced record so `removeTargetBang` acts on it, then
+   * restores the current target.
+   */
+  private async removeOne(displaced: Base): Promise<void> {
+    const currentTarget = this.target;
+    this.target = displaced;
+    try {
+      await removeTargetBang(this, (this.reflection.options.dependent as string) ?? "");
+    } finally {
+      this.target = currentTarget;
+    }
   }
 
   /**
@@ -459,10 +519,11 @@ export class HasOneAssociation extends SingularAssociation {
    * `save = false` gates only `transaction_if(save)` (:68) and `if save &&
    * !record.save` (:75) — `remove_target!` (:69) runs regardless, so building
    * over an existing target still nullifies the displaced record's foreign key
-   * and clears its inverse. We run that in-memory half here; the DB half runs in
-   * the awaitable `build#{name}` / `create#{name}` accessors via
-   * `detachDisplacedTarget`, which is the real port of `remove_target!` inside
-   * `replace`. `setNewRecord` itself is synchronous and cannot await a save.
+   * and clears its inverse. We run that in-memory half here and hand the
+   * displaced record to `removeDisplaced` (the owner's `autosaveHasOne`) for the
+   * DB half — `build` is synchronous and cannot await a save. Only a *persisted*
+   * displaced record has a row to remove, so a transient in-memory target is not
+   * queued (matching `queueWrite`).
    */
   protected override setNewRecord(record: Base): void {
     const displaced = this.target;
@@ -478,6 +539,7 @@ export class HasOneAssociation extends SingularAssociation {
       this.nullifyOwnerAttributes(displaced);
       this.removeInverseInstance(displaced);
     }
+    this._displacedRecords.push(displaced);
   }
 
   private nullifyOwnerAttributes(record: Base): void {

--- a/packages/activerecord/src/associations/has-one-set-accessor-sugar.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-set-accessor-sugar.trails.test.ts
@@ -171,3 +171,31 @@ describe("polymorphic has_one set#{Name} awaitable accessor", () => {
     expect(sponsor.sponsorable_type).toBe("Member");
   });
 });
+
+describe("has_one replace with no loaded target and no record", () => {
+  // Rails' `return target unless load_target || record`
+  // (has_one_association.rb:61): assigning nil to a has_one with nothing
+  // associated returns early, before the `assigning_another_record ||
+  // has_changes_to_save?` gate and before `self.target = record`. Note the
+  // association still ends up LOADED — Rails' `load_target` calls `loaded!`
+  // unconditionally (association.rb:192) — so the early return is about doing
+  // no work, not about staying unloaded.
+  const { companies } = fixtures(["companies", "accounts"]);
+
+  beforeAll(() => {
+    registerModel(Firm);
+    registerModel(Account);
+  });
+
+  it("is a no-op that leaves the association empty", async () => {
+    void companies;
+    const firm = (await Firm.create({ name: "no account" })) as Base;
+
+    await set(firm).setAccount(null);
+
+    expect(await (firm as unknown as { account: Promise<Base | null> }).account).toBe(null);
+    expect(await Account.where({ firm_id: (firm as unknown as { id: number }).id }).count()).toBe(
+      0,
+    );
+  });
+});

--- a/packages/activerecord/src/associations/has-one-set-accessor-sugar.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-set-accessor-sugar.trails.test.ts
@@ -10,7 +10,7 @@
  * Rails reaches that path through the synchronous `=` setter, which in JS
  * cannot await, so these assertions have no verbatim Rails test to mirror.
  */
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, vi } from "vitest";
 import {
   registerModel,
   enableSti,
@@ -176,23 +176,30 @@ describe("has_one replace with no loaded target and no record", () => {
   // Rails' `return target unless load_target || record`
   // (has_one_association.rb:61): assigning nil to a has_one with nothing
   // associated returns early, before the `assigning_another_record ||
-  // has_changes_to_save?` gate and before `self.target = record`. Note the
-  // association still ends up LOADED — Rails' `load_target` calls `loaded!`
-  // unconditionally (association.rb:192) — so the early return is about doing
-  // no work, not about staying unloaded.
-  const { companies } = fixtures(["companies", "accounts"]);
+  // has_changes_to_save?` gate and before `self.target = record`.
+  //
+  // The association still ends up LOADED either way — `load_target` calls
+  // `loaded!` unconditionally (association.rb:192) — and a `replace(null)` over
+  // a null target is itself a no-op, so the end state is identical with or
+  // without the early return. The only way to pin the ported structure is to
+  // assert `replace` is never reached, which is what this does.
+  fixtures(["companies", "accounts"]);
 
   beforeAll(() => {
     registerModel(Firm);
     registerModel(Account);
   });
 
-  it("is a no-op that leaves the association empty", async () => {
-    void companies;
+  it("returns before reaching replace, leaving the association empty", async () => {
     const firm = (await Firm.create({ name: "no account" })) as Base;
+    const assoc = (
+      firm as unknown as { association(n: string): { replace(r: unknown): void } }
+    ).association("account");
+    const replace = vi.spyOn(assoc, "replace");
 
     await set(firm).setAccount(null);
 
+    expect(replace).not.toHaveBeenCalled();
     expect(await (firm as unknown as { account: Promise<Base | null> }).account).toBe(null);
     expect(await Account.where({ firm_id: (firm as unknown as { id: number }).id }).count()).toBe(
       0,

--- a/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Trails-only surface: the deferred removal of a has_one record displaced by
+ * the *synchronous* build path.
+ *
+ * Rails' `HasOneAssociation#set_new_record` -> `replace(record, false)` runs
+ * `remove_target!` inline (has_one_association.rb:68-69, 91-92), including the
+ * persisted nullify `target.save` at :108. A synchronous JS builder cannot
+ * await that write, so `setNewRecord` performs only the in-memory half and
+ * queues the displaced record on `_displacedRecords`; the owner's
+ * `autosaveHasOne` drains it via `removeDisplaced` at save time.
+ *
+ * The awaitable `build#{Name}` / `create#{Name}` accessors do the DB half
+ * inline instead (`detachDisplacedTarget`), but `assoc.build()` — which nested
+ * attributes calls directly (nested-attributes.ts) — does NOT go through those
+ * accessors. That is why the queue survives RFC 0068's awaitable setter: the
+ * setter stopped feeding it, the sync build path did not.
+ *
+ * Rails' own `test_should_replace_an_existing_record_if_there_is_no_id`
+ * (nested_attributes_test.rb:288) asserts only in-memory state and never saves
+ * the owner, so it does not cover the displaced row — hence this trails-only
+ * guard rather than a change to the mirrored test.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { registerModel, type Base } from "../index.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+import { Pirate } from "../test-helpers/models/pirate.js";
+import { Ship } from "../test-helpers/models/ship.js";
+
+describe("has_one displacement via the synchronous build path", () => {
+  fixtures(["pirates", "ships"]);
+
+  beforeAll(() => {
+    registerModel(Pirate);
+    registerModel(Ship);
+  });
+
+  it("nullifies the displaced row when nested attributes replace a loaded child", async () => {
+    const pirate = (await Pirate.create({ catchphrase: "Aye" })) as Base;
+    const displaced = (await Ship.create({
+      name: "Nights Dirty Lightning",
+      pirate_id: (pirate as unknown as { id: number }).id,
+    })) as Base;
+
+    // Load the association so `setNewRecord` sees a loaded, persisted target —
+    // the case where Rails' `remove_target!` has a row to nullify.
+    await (pirate as unknown as { ship: Promise<Base | null> }).ship;
+
+    (pirate as unknown as { shipAttributes: unknown }).shipAttributes = {
+      name: "Davy Jones Gold Dagger",
+    };
+    await pirate.save();
+
+    const reloaded = (await Ship.find((displaced as unknown as { id: number }).id)) as Base;
+    expect((reloaded as unknown as { pirate_id: number | null }).pirate_id).toBe(null);
+  });
+});

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -399,11 +399,10 @@ export class HasOneThroughAssociation extends HasOneAssociation {
     // Rails' `load_target` returning the same object on an already-loaded proxy.
     //
     // We also clear the suppression sentinel we set on the through proxy's
-    // duck-typed `_pendingReplace`: the base `HasOneAssociation` never declares
-    // `_pendingReplace` (its displacement runs inline in the awaitable
-    // `replace`/`detachDisplacedTarget` paths), so its `reset` does not clear the
-    // sentinel — without this it would linger and permanently make
-    // `autosaveHasOne` skip the
+    // duck-typed `_pendingReplace`: the base `HasOneAssociation#reset` clears
+    // only `_displacedRecords` (it never declares `_pendingReplace`, having
+    // converged onto `_displacedRecords` + `autosaveHasOne`), so without this the
+    // sentinel would linger and permanently make `autosaveHasOne` skip the
     // proxy — silently dropping any *later* independent write to
     // `owner.currentMembership` on this same instance. Runs before the `!pending`
     // early return so a reverted build (which nulls `this._pendingReplace`) can't

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -399,10 +399,11 @@ export class HasOneThroughAssociation extends HasOneAssociation {
     // Rails' `load_target` returning the same object on an already-loaded proxy.
     //
     // We also clear the suppression sentinel we set on the through proxy's
-    // duck-typed `_pendingReplace`: the base `HasOneAssociation#reset` clears
-    // only `_displacedRecords` (it never declares `_pendingReplace`, having
-    // converged onto `_displacedRecords` + `autosaveHasOne`), so without this the
-    // sentinel would linger and permanently make `autosaveHasOne` skip the
+    // duck-typed `_pendingReplace`: the base `HasOneAssociation` never declares
+    // `_pendingReplace` (its displacement runs inline in the awaitable
+    // `replace`/`detachDisplacedTarget` paths), so its `reset` does not clear the
+    // sentinel — without this it would linger and permanently make
+    // `autosaveHasOne` skip the
     // proxy — silently dropping any *later* independent write to
     // `owner.currentMembership` on this same instance. Runs before the `!pending`
     // early return so a reverted build (which nulls `this._pendingReplace`) can't

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -313,8 +313,8 @@ export function validOptions(): string[] {
 // Post-commit flush for association instances that still queue a deferred
 // `_pendingReplace` — collection associations (has_many / HABTM,
 // CollectionAssociation#persistReplace). Neither singular has_one path relies on
-// this any more: the direct has_one converged onto
-// `autosaveHasOne` -> `removeDisplaced`, and has_one *through* onto
+// this any more: the direct has_one persists inline via the awaitable
+// `writer`/`build`/`create` paths, and has_one *through* converged onto
 // `autosaveHasOne` -> `persistThroughRecord` (Rails' `save_has_one_association`
 // through arm), both of which run during the save and clear their markers, so by
 // the time this runs post-commit those singular markers are already null and the
@@ -493,19 +493,6 @@ async function _insertCollectionRecordFallback(
 async function autosaveHasOne(record: Base, assoc: AssociationDefinition): Promise<boolean> {
   const inst = _loadedAssociation(record, assoc.name);
 
-  // A deferred (non-awaitable) assignment to a persisted owner
-  // (`owner.account = b` via the property setter / mass-assignment) records the
-  // displaced record so this single autosave path — not a parallel
-  // `persistReplace` — nullifies/destroys it, mirroring the `remove_target!`
-  // Rails runs synchronously inside `HasOneAssociation#replace`. Runs before the
-  // `!child` bail so assigning nil (`owner.account = null`) still removes it.
-  if (
-    typeof inst?.removeDisplaced === "function" &&
-    ((inst?._displacedRecords?.length ?? 0) > 0 || inst?._removeDisplacedFromDb)
-  ) {
-    await inst.removeDisplaced();
-  }
-
   // Rails `save_has_one_association`'s `through_reflection` arm persists the
   // join side of a has_one *through* (build/update/destroy via
   // `createThroughRecord`) — the analog of Rails' assignment-time
@@ -531,8 +518,8 @@ async function autosaveHasOne(record: Base, assoc: AssociationDefinition): Promi
   // must NOT be inserted here — the through's own `persistReplace` reconciles
   // the existing DB row via `load_target` + `update`, and persisting it here
   // would duplicate that row. A plain `HasOneAssociation` never sets
-  // `_pendingReplace` itself (it converged onto `_displacedRecords` +
-  // `autosaveHasOne`), and the through association itself clears its marker
+  // `_pendingReplace` itself (its displacement runs inline in the awaitable
+  // `replace`/`detachDisplacedTarget` paths), and the through clears its marker
   // inside `persistThroughRecord` above, so a truthy marker on an instance with
   // no `persistThroughRecord` is unambiguously that suppression sentinel. Skip
   // the end-record persistence; the through owns the join row.

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -313,8 +313,8 @@ export function validOptions(): string[] {
 // Post-commit flush for association instances that still queue a deferred
 // `_pendingReplace` — collection associations (has_many / HABTM,
 // CollectionAssociation#persistReplace). Neither singular has_one path relies on
-// this any more: the direct has_one persists inline via the awaitable
-// `writer`/`build`/`create` paths, and has_one *through* converged onto
+// this any more: the direct has_one converged onto
+// `autosaveHasOne` -> `removeDisplaced`, and has_one *through* onto
 // `autosaveHasOne` -> `persistThroughRecord` (Rails' `save_has_one_association`
 // through arm), both of which run during the save and clear their markers, so by
 // the time this runs post-commit those singular markers are already null and the
@@ -493,6 +493,16 @@ async function _insertCollectionRecordFallback(
 async function autosaveHasOne(record: Base, assoc: AssociationDefinition): Promise<boolean> {
   const inst = _loadedAssociation(record, assoc.name);
 
+  // A deferred (non-awaitable) assignment to a persisted owner
+  // (`owner.account = b` via the property setter / mass-assignment) records the
+  // displaced record so this single autosave path — not a parallel
+  // `persistReplace` — nullifies/destroys it, mirroring the `remove_target!`
+  // Rails runs synchronously inside `HasOneAssociation#replace`. Runs before the
+  // `!child` bail so assigning nil (`owner.account = null`) still removes it.
+  if (typeof inst?.removeDisplaced === "function" && (inst?._displacedRecords?.length ?? 0) > 0) {
+    await inst.removeDisplaced();
+  }
+
   // Rails `save_has_one_association`'s `through_reflection` arm persists the
   // join side of a has_one *through* (build/update/destroy via
   // `createThroughRecord`) — the analog of Rails' assignment-time
@@ -518,8 +528,8 @@ async function autosaveHasOne(record: Base, assoc: AssociationDefinition): Promi
   // must NOT be inserted here — the through's own `persistReplace` reconciles
   // the existing DB row via `load_target` + `update`, and persisting it here
   // would duplicate that row. A plain `HasOneAssociation` never sets
-  // `_pendingReplace` itself (its displacement runs inline in the awaitable
-  // `replace`/`detachDisplacedTarget` paths), and the through clears its marker
+  // `_pendingReplace` itself (it converged onto `_displacedRecords` +
+  // `autosaveHasOne`), and the through association itself clears its marker
   // inside `persistThroughRecord` above, so a truthy marker on an instance with
   // no `persistThroughRecord` is unambiguously that suppression sentinel. Skip
   // the end-record persistence; the through owns the join row.


### PR DESCRIPTION
## The story's premise does not hold — scope corrected

This story asked to retire the has_one deferred-displacement machinery
wholesale, on the premise that with the persisted-owner `=` setter throwing
(#4949) nothing can reach it. **That premise is wrong in two places**, so this
PR ships the part that is genuinely dead and explains the part that is not.

Codex review caught the second one after I had already removed it. Credit where
due — it was a real regression, verified by baselining against `main`.

### 1. `queueWrite` is NOT displacement machinery (kept)

The story asks for zero grep hits on `queueWrite`. It is not part of the
deferral — it is the sync writer dispatch RFC 0068 *itself created* (throw on a
persisted owner, in-memory replace on a new one). Live callers beyond the native
setter: `attribute-assignment.ts` (mass-assignment), `collection-proxy.ts` and
`has-many-through-association.ts` (through-inverse builders). Deleting it breaks
mass-assignment.

### 2. `_displacedRecords` + the autosave drain are load-bearing (kept)

The story says the DB half of `remove_target!` now runs via the create/build
accessors' `detachDisplacedTarget`. That is true **only for the awaitable
`build#{Name}` / `create#{Name}` accessors**. Nested attributes calls
`assoc.build()` directly (`nested-attributes.ts:772`), reaching `setNewRecord`
without going through those accessors.

Rails runs `remove_target!`'s persisted nullify save **inline**
(`has_one_association.rb:91-92, 108`), reached from nested attributes via
`build_#{association_name}` (`nested_attributes.rb:434, 450-452`). A synchronous
JS builder cannot await that write — which is exactly why the queue existed. With
it removed, a nested-attributes replacement of a loaded persisted child was
nullified in memory only and the old row stayed attached in the DB.

Verified rather than argued:

| | repro result |
|---|---|
| `main` | passes (`pirate_id` → `null`) |
| queue removed | **fails** (`pirate_id` → `959118196`) |

### What this PR actually retires

- `_removeDisplacedFromDb` and its inert branch in `removeDisplaced`. This one
  *is* genuinely dead: it was only ever set by the deferred property-setter
  assignment over an unloaded target, which #4949 turned into a throw.
- Ports Rails' `return target unless load_target || record`
  (`has_one_association.rb:61`) into `writeImmediate`, which the sync path could
  not express.

Net: **+109 / −43**, not the ~350 LOC deletion the story projected.

### Note on the early return

It is a **structural fidelity port, not a behavior change**. The story asks that
`replace(null)` on a never-loaded association "return without marking it loaded";
that is not achievable and not Rails — `load_target` calls `loaded!`
unconditionally (`association.rb:192`), *before* the early return in Rails' own
`replace`. With a null target the old fall-through `replace(null)` was itself a
no-op, so the end state is identical. The test pins it by spying on `replace`,
the only observable difference.

### Tests

New trails-only guard: `has-one-sync-build-displacement.trails.test.ts`. Rails'
own `test_should_replace_an_existing_record_if_there_is_no_id`
(`nested_attributes_test.rb:288`) asserts only in-memory state and never saves
the owner, so the displaced row is uncovered upstream too — hence a trails-only
guard rather than touching the mirrored test.

Both new tests were **mutation-verified**: each was confirmed to fail when the
code it guards is removed, then pass when restored.

Full sweep — entire `associations/` directory + `autosave-association` +
`nested-attributes`: **2216 passed, 0 failed** (80 files).

## Review response: double-removal on the awaited build path

Second Codex comment reports that `setNewRecord` queues a record the awaitable
`build#{Name}` accessor has already removed via `detachDisplacedTarget`, risking
a re-run of `:destroy`/`:delete` against a frozen record.

**The mechanism is real; the consequence and the attribution are not.** Measured,
not argued:

| `dependent:` | queued | already removed? | second removal |
|---|---|---|---|
| `destroy` | 1 | yes (`isDestroyed` true) | **skipped** — `removeTargetBang`'s `target.isPersisted()` guard (`has-one-association.ts:647`) |
| `delete` | 1 | yes (row gone) | redundant `DELETE`, affects 0 rows, no error |

No frozen-record error is reachable: Rails freezes on `delete`/`destroy`
(`persistence.rb:439-459`), but our `destroy` arm is gated on `isPersisted()` and
our `delete` arm tolerates the no-op.

**And this PR did not introduce it.** I baselined both files against `main`:
`queued = 1 | destroyed = true`, `SAVE OK` — byte-identical on `main` and this
branch. Neither `setNewRecord`'s enqueue nor `builder/has-one.ts` is touched
here; the enqueue in this diff is `main`'s code, restored verbatim after the
first review round.

So I've left it out of scope rather than widen a PR that has already changed
shape once, and registered it instead:
`0068-awaitable-has-one-setter/has-one-displaced-record-removed-twice-on-awaited-build`
— with the measurements, the Rails citation, and a warning that the queue must
survive any fix because the sync `assoc.build()` path depends on it.

Happy to fold it in here instead if you'd rather — it's a small change — but it
is a pre-existing efficiency bug, not a regression from this PR.

### Follow-up

The remaining machinery cannot be retired until the sync `assoc.build()` path
has an awaitable equivalent for nested attributes. Happy to register that as a
new story if you agree with the read.

Closes-story: retire-has-one-displacement-machinery
