### PR TITLE
fix(activerecord): propagate strict-loading violations from the destroy belongs_to preload

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -65,7 +65,12 @@ import {
   defineDynamicSelectReaders,
   subclassFromAttributesForNew,
 } from "./inheritance.js";
-import { NotImplementedError, RecordNotFound, StaleObjectError } from "./errors.js";
+import {
+  NotImplementedError,
+  RecordNotFound,
+  StaleObjectError,
+  StrictLoadingViolationError,
+} from "./errors.js";
 import {
   AutosaveAssociation,
   reload as _autosaveReload,
@@ -3857,11 +3862,16 @@ export class Base extends Model {
         } else {
           await assoc.loadTarget();
         }
-      } catch {
-        // An unregistered target class, missing FK row, strict-loading
-        // violation, or transient DB error must not abort the destroy. Resolve
-        // the association to `null` so a sync callback that reads it sees `null`
-        // rather than trails' async-reader Promise.
+      } catch (err) {
+        // A strict-loading violation is the record's own configuration talking:
+        // Rails raises when a destroy callback dereferences an unloaded
+        // association on a `strict_loading` record (association.rb#load_target),
+        // so it must propagate rather than be papered over with `null`.
+        if (err instanceof StrictLoadingViolationError) throw err;
+        // An unregistered target class, missing FK row, or transient DB error
+        // must not abort the destroy. Resolve the association to `null` so a
+        // sync callback that reads it sees `null` rather than trails'
+        // async-reader Promise.
         assoc?.setTarget?.(null);
       }
     }

--- a/packages/activerecord/src/strict-loading-sync-reader.test.ts
+++ b/packages/activerecord/src/strict-loading-sync-reader.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, it, expect, beforeAll } from "vitest";
 import { registerModel, StrictLoadingViolationError } from "./index.js";
+import { resetCallbacks } from "./callbacks.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { Developer } from "./test-helpers/models/developer.js";
 import { Ship } from "./test-helpers/models/ship.js";
@@ -117,6 +118,21 @@ describe("strict loading — sync singular reader (Phase R.3)", () => {
     expect(() => (ship as any).developer).not.toThrow();
     expect(((ship as any).developer as Developer).id).toBe(developers("david").id);
     expect(assoc.loaded).toBe(true);
+  });
+
+  it("strict loading raises when a before_destroy callback reads an unloaded belongs_to", async () => {
+    const ship = await Ship.create({ name: "Destroy Ship", developer_id: developers("david").id });
+    ship.strictLoadingBang();
+    let readDeveloper: unknown;
+    await resetCallbacks(Ship, "destroy", async () => {
+      Ship.beforeDestroy((r: any) => {
+        readDeveloper = r.developer;
+      });
+      await expect(ship.destroy()).rejects.toThrow(StrictLoadingViolationError);
+      // The destroy aborted in the preload, before the callback chain ran.
+      expect(readDeveloper).toBeUndefined();
+      expect(await Ship.findBy({ id: ship.id })).not.toBeNull();
+    });
   });
 
   it("ships fixture is linked to developer in the ships fixture", () => {


### PR DESCRIPTION
`Base#_preloadBelongsToForDestroyCallbacks` materializes a record's
`belongs_to` targets before the destroy callback chain runs, so a sync
`before_destroy`/`around_destroy` callback can read them. The load was
best-effort: *any* `loadTarget()` error resolved the association to `null`.

That swallow also covered `StrictLoadingViolationError`. In Rails, reading a
`strict_loading` record's unloaded `belongs_to` inside a destroy callback
raises (`associations/association.rb#load_target`); trails silently resolved it
to `null` and completed the destroy.

Now `StrictLoadingViolationError` is rethrown. The other cases the swallow
exists for — an unregistered target class and a missing FK row — still resolve
to `null`, so CPK destroys are unaffected. Under
`action_on_strict_loading_violation = "log"` nothing is thrown, so that mode
still preloads as before.

Verified the new test is red on `main` and green with the fix. Also ran
`strict-loading*`, `callbacks`, `habtm-destroy-order`, `persistence`,
`primary-keys`, and the composite-PK belongs_to suites — all pass.

Closes-story: strict-loading-violation-suppressed-in-destroy-belongs-to-preload
