### PR TITLE
fix(encryption): keep STI subclass encrypts declarations on the subclass

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1866,16 +1866,7 @@ export class Base extends Model {
    * Mirrors: ActiveRecord::Encryption.encrypts
    */
   static encrypts(...args: Array<string | EncryptsOptions>): void {
-    // Route through the STI base for the same reason `attribute()`
-    // does: Rails' `encrypts` lands on the shared attribute_types map.
-    // Without this, a subclass `encrypts()` would record pending
-    // encryptions on the subclass while the attribute def lives on
-    // the base — the type wrapper would never apply, or
-    // `applyPendingEncryptions` would fork `_attributeDefinitions` on
-    // the subclass and reintroduce the shadowing the STI-routing fix
-    // is trying to eliminate.
-    const target = isStiSubclass(this) ? getStiBase(this) : this;
-    encryptionHooks.encrypts(target, ...args);
+    encryptionHooks.encrypts(this, ...args);
   }
 
   /**

--- a/packages/activerecord/src/encrypted-attribute-sti.trails.test.ts
+++ b/packages/activerecord/src/encrypted-attribute-sti.trails.test.ts
@@ -1,0 +1,110 @@
+/**
+ * trails-only: `encrypts` declared on an STI subclass must wrap the cast type
+ * for that subclass only. Rails keeps this per-class (`encrypted_attributes` is
+ * a `class_attribute` and `_default_attributes` replays only the class's own
+ * pending decorators — see
+ * `activerecord/lib/active_record/encryption/encryptable_record.rb` and
+ * `activemodel/lib/active_model/attribute_registration.rb`), but `Base.encrypts`
+ * deliberately routed an STI subclass declaration to the STI base, so the base
+ * and every sibling subclass saw the `EncryptedAttributeType`.
+ *
+ * Mirrors the `normalizes` guard in `normalized-attribute.trails.test.ts`: the
+ * leak only reproduces when the SUBCLASS drives the first reflection of the STI
+ * table, so this file must own that first reflection — do not add a test above
+ * that reflects `Company` (or another subclass) first, or the guard silently
+ * stops guarding.
+ *
+ * Encrypts `description` rather than `name`: `name` is a restricted attribute
+ * (no dirty tracking), which would muddy the persistence round-trip below.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Company } from "./test-helpers/models/company.js";
+import { fixtures } from "./test-helpers/fixtures.js";
+import { EncryptedAttributeType } from "./encryption/encrypted-attribute-type.js";
+import {
+  configureEncryption,
+  snapshotEncryptionConfig,
+  restoreEncryptionConfig,
+} from "./encryption/test-helpers.js";
+
+class EncryptedCompany extends Company {}
+class OtherEncryptedCompany extends Company {}
+class ReflectedEncryptedCompany extends Company {}
+
+const defTypeFor = (klass: typeof Company, name: string) =>
+  (
+    klass as unknown as { _attributeDefinitions: Map<string, { type: unknown }> }
+  )._attributeDefinitions.get(name)!.type;
+
+const encryptedAttributesOf = (klass: typeof Company) =>
+  (klass as unknown as { _encryptedAttributes?: Set<string> })._encryptedAttributes ??
+  new Set<string>();
+
+describe("STI subclass encrypts", () => {
+  fixtures([]);
+
+  // Encryption must be configured before any declaration runs — buildScheme has
+  // no lazy fallback.
+  const snapshot = snapshotEncryptionConfig();
+  beforeAll(() => configureEncryption());
+  afterAll(() => restoreEncryptionConfig(snapshot));
+
+  it("does not leak the encrypted cast type onto the STI base or siblings", async () => {
+    // The subclass must drive the FIRST reflection of the STI table — that is
+    // the path that used to install the base's map as an own property.
+    await EncryptedCompany.loadSchema();
+    await Company.loadSchema();
+
+    EncryptedCompany.encrypts("description");
+
+    expect(defTypeFor(EncryptedCompany, "description")).toBeInstanceOf(EncryptedAttributeType);
+    expect(defTypeFor(Company, "description")).not.toBeInstanceOf(EncryptedAttributeType);
+    expect(defTypeFor(OtherEncryptedCompany, "description")).not.toBeInstanceOf(
+      EncryptedAttributeType,
+    );
+
+    expect(encryptedAttributesOf(EncryptedCompany)).toContain("description");
+    expect(encryptedAttributesOf(Company)).not.toContain("description");
+    expect(encryptedAttributesOf(OtherEncryptedCompany)).not.toContain("description");
+  });
+
+  it("encrypts at rest for the subclass while the base stores plaintext", async () => {
+    const secret = "a confidential description";
+
+    const encrypted = await EncryptedCompany.create({ name: "enc", description: secret });
+    const plain = await Company.create({ name: "plain", description: secret });
+
+    // Decrypts transparently on read-back through the declaring subclass.
+    expect((await EncryptedCompany.find(encrypted.id)).description).toBe(secret);
+    expect(encrypted.ciphertextFor("description")).not.toBe(secret);
+
+    // The base never had the decoration, so it round-trips plaintext — and the
+    // stored bytes really are plaintext, which is what the leak would have changed.
+    const reloadedPlain = await Company.find(plain.id);
+    expect(reloadedPlain.description).toBe(secret);
+    expect(reloadedPlain.encryptedAttribute("description")).toBe(false);
+  });
+
+  it("keeps the subclass decoration across a schema reset and re-reflection", async () => {
+    await ReflectedEncryptedCompany.loadSchema();
+    await Company.loadSchema();
+
+    ReflectedEncryptedCompany.encrypts("description");
+    expect(defTypeFor(ReflectedEncryptedCompany, "description")).toBeInstanceOf(
+      EncryptedAttributeType,
+    );
+
+    // Rails re-seeds `_default_attributes` from `columns_hash` and replays the
+    // pending-decorator chain on every rebuild, so reflection must not revert
+    // (or drop) the subclass's encrypted definition — it has to survive on the
+    // `_pendingEncryptions` replay buffer plus copy-on-write.
+    ReflectedEncryptedCompany.resetColumnInformation();
+    await Company.loadSchema();
+    await ReflectedEncryptedCompany.loadSchema();
+
+    expect(defTypeFor(ReflectedEncryptedCompany, "description")).toBeInstanceOf(
+      EncryptedAttributeType,
+    );
+    expect(defTypeFor(Company, "description")).not.toBeInstanceOf(EncryptedAttributeType);
+  });
+});

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -223,6 +223,10 @@ export function applyPendingEncryptions(klass: any): void {
   const pending: PendingEncryption[] | undefined = klass._pendingEncryptions;
   if (!pending || pending.length === 0) return;
 
+  // Copy-on-write so a subclass's pending encryption never mutates an inherited
+  // definitions map. The `decorateAttributes` path does its own copy-on-write
+  // (#4981); this still covers the plain-model branch of registerEncryptedType,
+  // which writes `_attributeDefinitions` directly.
   if (!Object.prototype.hasOwnProperty.call(klass, "_attributeDefinitions")) {
     klass._attributeDefinitions = new Map(klass._attributeDefinitions);
   }

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1123,12 +1123,23 @@ function reflectedTypeForColumn(
  * time in `columnsHash()` (filters the returned hash), but it cannot
  * retroactively remove a prototype accessor already defined on the
  * base — a consequence of TypeScript not having Ruby's method_missing.
- * Subclass `attribute()` and `encrypts()` calls route through the STI
- * base (see base.ts), so those specific flows don't create forked-map
- * shadowing. Other decorators that mutate `_attributeDefinitions`
- * directly on the calling class may still fork until they're routed
- * through the same shared owner — add them to the STI redirect list
- * in base.ts when they're introduced.
+ * Subclass `attribute()` calls route through the STI base (see base.ts),
+ * so that flow doesn't create forked-map shadowing.
+ *
+ * `encrypts()` does NOT: it is per-class, like `normalizes`. Rails mutates
+ * the receiver's `encrypted_attributes` `class_attribute` and calls
+ * `encrypt_attribute`/`decorate_attributes` on that class
+ * (encryption/encryptable_record.rb), and `_default_attributes` replays the
+ * superclass's modifications before only the class's own pending decorators
+ * (activemodel attribute_registration.rb). So a subclass `encrypts` must
+ * decorate the subclass alone.
+ *
+ * Per-class decorators are therefore EXPECTED to fork the map:
+ * `decorateAttributes` copy-on-writes it onto the calling class and
+ * `rebuildStiSubclassOverlay` keeps the subclass overlay in sync with the
+ * base. Do not add new decorators to the STI redirect list to avoid that
+ * fork — routing a per-class decorator to the base is what leaked the
+ * decorated type onto the base and its siblings.
  */
 function applyColumnsHash(
   host: SchemaHost,

--- a/packages/activerecord/src/sti-attribute-routing.test.ts
+++ b/packages/activerecord/src/sti-attribute-routing.test.ts
@@ -68,7 +68,7 @@ describe("STI subclass attribute() routing", () => {
     expect(Shape._attributeDefinitions.get("sides")?.type.name).toBe("integer");
   });
 
-  it("STI subclass encrypts() routes pending encryptions to the base", async () => {
+  it("STI subclass encrypts() stays on the subclass, unlike attribute()", async () => {
     const { isEncryptedAttribute } = await import("./encryption.js");
 
     class Animal extends Base {
@@ -80,22 +80,27 @@ describe("STI subclass attribute() routing", () => {
     }
     class Dog extends Animal {
       static {
-        // Pre-PR: encrypts() on subclass would add to Dog._pendingEncryptions
-        // while the attribute def lived on Animal — wrapper never applied.
-        // Post-PR: encrypts() also routes to the STI base.
         this.encrypts("name");
       }
     }
+    class Cat extends Animal {}
 
-    // Pending encryption is recorded on the base, not the subclass.
-    expect(Object.prototype.hasOwnProperty.call(Animal, "_pendingEncryptions")).toBe(true);
-    expect(Object.prototype.hasOwnProperty.call(Dog, "_pendingEncryptions")).toBe(false);
+    // Unlike `attribute()` (which writes to the shared base-owned map above),
+    // `encrypts` is per-class in Rails: `encrypted_attributes` is a
+    // `class_attribute` and `encrypt_attribute` calls `decorate_attributes` on
+    // the receiver, while `_default_attributes` replays the superclass's
+    // modifications first and then only the class's OWN pending decorators
+    // (encryption/encryptable_record.rb, activemodel attribute_registration.rb).
+    expect(Object.prototype.hasOwnProperty.call(Dog, "_pendingEncryptions")).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(Animal, "_pendingEncryptions")).toBe(false);
 
-    // Both classes observe the encrypted attribute via the shared map.
-    expect(isEncryptedAttribute(Animal, "name")).toBe(true);
+    // The declaring subclass encrypts; the base and its siblings do not.
     expect(isEncryptedAttribute(Dog, "name")).toBe(true);
-    // No fork on the subclass.
-    expect(Dog._attributeDefinitions).toBe(Animal._attributeDefinitions);
+    expect(isEncryptedAttribute(Animal, "name")).toBe(false);
+    expect(isEncryptedAttribute(Cat, "name")).toBe(false);
+
+    // Copy-on-write: the subclass no longer shares the base's definitions map.
+    expect(Dog._attributeDefinitions).not.toBe(Animal._attributeDefinitions);
   });
 
   it("subclass attribute survives schema reflection on the STI base (end-to-end)", async () => {


### PR DESCRIPTION
`Base.encrypts` deliberately routed an STI subclass declaration to the STI
base:

```ts
const target = isStiSubclass(this) ? getStiBase(this) : this;
```

Net effect: `encrypts` declared on one STI subclass wrapped the attribute type
on the STI **base**, so the base and every sibling subclass saw the
`EncryptedAttributeType` — a subclass opting one column into encryption
silently changed how the base and its siblings read and wrote that column.

Rails keeps this per-class: `encrypted_attributes` is a `class_attribute` and
`_default_attributes` replays only that class's own pending decorators
(`activerecord/lib/active_record/encryption/encryptable_record.rb`,
`activemodel/lib/active_model/attribute_registration.rb`).

The routing was a workaround for `applyPendingEncryptions` forking
`_attributeDefinitions` on the subclass and reintroducing shadowing. #4981
restored proper copy-on-write for an STI subclass's `_attributeDefinitions`,
and the durable declaration path already wraps types through
`decorateAttributes`, which honours it — so the routing is now dead weight.

## Verification

All three tests fail on `main` before the fix and pass after. The first fails
with exactly the leak described:

```
expected EncryptedAttributeType{ …(13) } to not be an instance of EncryptedAttributeType
```

Coverage goes beyond type identity deliberately:

- **Type isolation** — subclass wrapped; base and sibling untouched.
- **Behaviour at rest** — the subclass round-trips ciphertext (`ciphertextFor`
  is not the plaintext) while the base genuinely stores plaintext
  (`encryptedAttribute === false`). This is what the leak actually corrupted.
- **Replay** — the decoration survives `resetColumnInformation()` plus
  re-reflection, on the `_pendingEncryptions` buffer alone.

The test encrypts `description`, not `name`: `name` is a restricted attribute
with no dirty tracking, which would have muddied the persistence round-trip.

Green locally: full `encryption/` suite, `normalized-attribute.trails`,
`inheritance`, `attributes`, `model-schema`, `base` — 440 tests.

## Deliberately out of scope

I also tried removing the hand-rolled copy-on-write fork at the top of
`applyPendingEncryptions`, on the theory that #4981 made it redundant. I
reverted that: with the fork restored and only the routing fixed, the entire
encryption suite **and** the new guard pass identically, so nothing pins the
behaviour down in either direction and removing it would have been an
unverified change riding along. It stays, now with a comment explaining what
still depends on it, and the open question (including whether it should be
reconciled with `rebuildStiSubclassOverlay`'s revision bookkeeping) is filed as
`apply-pending-encryptions-hand-rolled-cow-vs-4981-overlay`.

Closes-story: sti-subclass-encrypts-routes-to-sti-base-leaking-type


## Review follow-up

`sti-attribute-routing.test.ts:71` asserted the old base-routing behavior
(`encrypts` on a subclass recording `_pendingEncryptions` on the STI base and
sharing the base's `_attributeDefinitions`) and failed against this change.
Confirmed and fixed rather than rebutted — the cited Rails source is right:
`encrypt_attribute` calls `decorate_attributes` on the receiver
(`encryption/encryptable_record.rb:84-95`) and
`apply_pending_attribute_modifications` replays the superclass's modifications
first and then only the class's own
(`activemodel/lib/active_model/attribute_registration.rb:81-88`).

The test now asserts the per-class behavior, and is renamed since its old name
described the removed routing. Renaming is safe here: `pnpm rails:find` returns
no mapping for it, so it is a trails-only invention test, not a Rails-matched
name that `test:compare` keys on.

Worth noting the updated assertion `Dog._attributeDefinitions !==
Animal._attributeDefinitions` is produced by the hand-rolled copy-on-write fork
in `applyPendingEncryptions` — independent evidence that reverting its removal
(above) was the right call.

This slipped through because my first verification pass picked test files by
directory rather than by symbol. Re-verified by grepping every test referencing
`encrypts(` / `_pendingEncryptions` / `_encryptedAttributes` /
`isEncryptedAttribute` and running all of them: 620 tests, plus 358 across the
STI and attribute suites.


### Second review round

`model-schema.ts:1126` still described subclass `encrypts()` as routing through
the STI base. Confirmed stale and fixed. The cited Rails source is right and
matches the first round: `encrypts` mutates the receiver's
`encrypted_attributes` and calls `encrypt_attribute`/`decorate_attributes` on
that class (`encryption/encryptable_record.rb:49-55`, `:84-95`), then
`_default_attributes` replays superclass modifications before only the class's
own pending decorators (`attribute_registration.rb:31-34`, `:81-88`).

The comment was stale in a second way the review did not name: its closing
advice was to add new decorators to the STI redirect list so they don't fork
the map. #4981 inverted that. `decorateAttributes` deliberately copy-on-writes
`_attributeDefinitions` onto the calling class
(`activemodel/src/attribute-registration.ts:191-193`) and
`rebuildStiSubclassOverlay` keeps the overlay in sync, so per-class decorators
are now *expected* to fork — routing one to the base is exactly the bug this PR
fixes. The note now says so, leaving only `attribute()` in the base-routing
bucket.

Comment-only change; re-ran model-schema, sti-attribute-routing, both STI
decorator guards, and inheritance. Also grepped for other stale references to
the removed routing across `packages/` and `docs/` — none outside this PR's own
test file, which uses past tense correctly.
