### PR TITLE
feat(validations): converge UniquenessValidator#covered_by_unique_index?

### DIFF
--- a/packages/activerecord/src/validations/uniqueness-validation.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.test.ts
@@ -8,13 +8,14 @@
  * issues the existence check and returns `false` on a collision, matching
  * Rails' `valid?` before any save.
  */
-import { describe, it, expect, beforeAll, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { makeRange } from "@blazetrails/activesupport";
 import { Base } from "../index.js";
 import { registerModel } from "../associations.js";
 import { registerSubclass } from "../inheritance.js";
 import { adapterType } from "../test-adapter.js";
+import { assertQueriesCount, assertNoQueries } from "../testing/query-assertions.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { Topic } from "../test-helpers/models/topic.js";
 import { Reply, UniqueReply, SillyUniqueReply } from "../test-helpers/models/reply.js";
@@ -740,42 +741,70 @@ describe("UniquenessValidationTest", () => {
 });
 
 describe("UniquenessValidationWithIndexTest", () => {
-  fixtures(["topics"]);
+  fixtures(["topics"], { useTransactionalTests: false });
 
-  afterEach(() => {
-    Topic.clearValidatorsBang();
+  beforeAll(() => {
+    registerModel("Topic", Topic);
+    registerModel("Event", Event);
+    registerModel("Keyboard", Keyboard);
   });
 
-  // The Rails counterparts assert query *counts* against a unique index (an
-  // index-aware skip optimization trails does not model). The converted bodies
-  // verify the same uniqueness behavior the index protects.
+  beforeEach(async () => {
+    // Rails' `@connection.schema_cache.clear!` — the index list for `topics` must
+    // go cold between tests so each test's freshly added index is reflected.
+    const connection = Base.connection;
+    connection.schemaCache.clearDataSourceCacheBang(connection.pool ?? connection, "topics");
+    await Topic.deleteAll();
+    await Event.deleteAll();
+  });
+
+  afterEach(async () => {
+    Topic.clearValidatorsBang();
+    await Base.connection.removeIndex("topics", { name: "topics_index", ifExists: true });
+  });
 
   it("new record", async () => {
     Topic.validatesUniqueness("title");
+    await Base.connection.addIndex("topics", "title", { unique: true, name: "topics_index" });
+
     const t = new Topic({ title: "abc" });
-    expect(await t.save()).toBe(true);
+    await assertQueriesCount(1, false, async () => {
+      await t.isValid();
+    });
   });
 
   it("changing non unique attribute", async () => {
     Topic.validatesUniqueness("title");
+    await Base.connection.addIndex("topics", "title", { unique: true, name: "topics_index" });
+
     const t = await Topic.createBang({ title: "abc" });
     t.writeAttribute("author_name", "John");
-    expect(await t.save()).toBe(true);
+    await assertNoQueries(false, async () => {
+      await t.isValid();
+    });
   });
 
   it("changing unique attribute", async () => {
     Topic.validatesUniqueness("title");
-    await Topic.createBang({ title: "abc" });
-    const t = await Topic.createBang({ title: "original" });
-    t.writeAttribute("title", "abc");
-    expect(await t.save()).toBe(false);
+    await Base.connection.addIndex("topics", "title", { unique: true, name: "topics_index" });
+
+    const t = await Topic.createBang({ title: "abc" });
+    t.writeAttribute("title", "abc v2");
+    await assertQueriesCount(1, false, async () => {
+      await t.isValid();
+    });
   });
 
   it("changing non unique attribute and unique attribute is nil", async () => {
     Topic.validatesUniqueness("title");
-    const t = await Topic.createBang({ title: null });
+    await Base.connection.addIndex("topics", "title", { unique: true, name: "topics_index" });
+
+    const t = await Topic.createBang({});
+    expect(t.readAttribute("title")).toBeNull();
     t.writeAttribute("author_name", "John");
-    expect(await t.save()).toBe(true);
+    await assertQueriesCount(1, false, async () => {
+      await t.isValid();
+    });
   });
 
   it("conditions", async () => {
@@ -784,57 +813,95 @@ describe("UniquenessValidationWithIndexTest", () => {
         return this.whereNot({ author_name: null });
       },
     });
-    const t = await Topic.createBang({ title: "abc", author_name: "John" });
+    await Base.connection.addIndex("topics", "title", { unique: true, name: "topics_index" });
+
+    const t = await Topic.createBang({ title: "abc" });
     t.writeAttribute("title", "abc v2");
-    expect(await t.save()).toBe(true);
+    await assertQueriesCount(1, false, async () => {
+      await t.isValid();
+    });
   });
 
   it("case sensitive", async () => {
     Topic.validatesUniqueness("title", { caseSensitive: true });
-    await Topic.createBang({ title: "abc" });
-    const t2 = new Topic({ title: "abc" });
-    expect(await t2.save()).toBe(false);
-    const t3 = new Topic({ title: "ABC" });
-    expect(await t3.save()).toBe(true);
+    await Base.connection.addIndex("topics", "title", { unique: true, name: "topics_index" });
+
+    const t = await Topic.createBang({ title: "abc" });
+    t.writeAttribute("title", "abc v2");
+    await assertQueriesCount(1, false, async () => {
+      await t.isValid();
+    });
   });
 
-  it("partial index", async () => {
+  it.skipIf(adapterType === "mysql")("partial index", async () => {
     Topic.validatesUniqueness("title");
-    await Topic.createBang({ title: "abc", approved: true });
-    const t2 = new Topic({ title: "abc", approved: false });
-    expect(await t2.save()).toBe(false);
+    await Base.connection.addIndex("topics", "title", {
+      unique: true,
+      where: "approved",
+      name: "topics_index",
+    });
+
+    const t = await Topic.createBang({ title: "abc" });
+    t.writeAttribute("author_name", "John");
+    await assertQueriesCount(1, false, async () => {
+      await t.isValid();
+    });
   });
 
   it("non unique index", async () => {
     Topic.validatesUniqueness("title");
-    await Topic.createBang({ title: "abc" });
-    const t2 = new Topic({ title: "abc" });
-    expect(await t2.save()).toBe(false);
+    await Base.connection.addIndex("topics", "title", { name: "topics_index" });
+
+    const t = await Topic.createBang({ title: "abc" });
+    t.writeAttribute("author_name", "John");
+    await assertQueriesCount(1, false, async () => {
+      await t.isValid();
+    });
   });
 
   it("scope", async () => {
     Topic.validatesUniqueness("title", { scope: "author_name" });
-    await Topic.createBang({ title: "abc", author_name: "John" });
+    await Base.connection.addIndex("topics", ["author_name", "title"], {
+      unique: true,
+      name: "topics_index",
+    });
 
-    const t2 = new Topic({ title: "abc", author_name: "Amy" });
-    expect(await t2.save()).toBe(true);
+    const t = await Topic.createBang({ title: "abc", author_name: "John" });
+    t.writeAttribute("content", "hello world");
+    await assertNoQueries(false, async () => {
+      await t.isValid();
+    });
 
-    const t3 = new Topic({ title: "abc", author_name: "John" });
-    expect(await t3.save()).toBe(false);
+    t.writeAttribute("author_name", "Amy");
+    await assertQueriesCount(1, false, async () => {
+      await t.isValid();
+    });
   });
 
   it("uniqueness on relation", async () => {
-    const e1 = await Event.create({ title: "e-abc" });
-    const e2 = await Event.create({ title: "e-cde" });
+    // Rails declares `validates_uniqueness_of :event` here and clears it in the
+    // ensure block; trails' TopicWithEvent carries the declaration on the class,
+    // so redeclaring would run the validator twice (and clearing it would strip
+    // it for the rest of the file).
+    await Base.connection.addIndex("topics", "parent_id", {
+      unique: true,
+      name: "topics_index",
+    });
+
+    const e1 = await Event.createBang({ title: "abc" });
+    const e2 = await Event.createBang({ title: "cde" });
     const t = await TopicWithEvent.createBang({ parent_id: (e1 as any).id });
     try {
       t.writeAttribute("content", "hello world");
-      expect(await t.save()).toBe(true);
+      await assertNoQueries(false, async () => {
+        await t.isValid();
+      });
 
       t.writeAttribute("parent_id", (e2 as any).id);
-      expect(await t.save()).toBe(true);
+      await assertQueriesCount(1, false, async () => {
+        await t.isValid();
+      });
     } finally {
-      TopicWithEvent.clearValidatorsBang();
       await Event.deleteAll();
     }
   });
@@ -844,29 +911,56 @@ describe("UniquenessValidationWithIndexTest", () => {
     await LessonWithUniqKeyboard.createBang({ name: "Keyboard #1" });
 
     const another = new LessonWithUniqKeyboard({ name: "Keyboard #1" });
-    expect(await another.save()).toBe(false);
+    expect(await another.isValid()).toBe(false);
     expect(another.errors.get("keyboard")).toEqual(["has already been taken"]);
   });
 
   it("index of sublist of columns", async () => {
     Topic.validatesUniqueness("title", { scope: "author_name" });
-    await Topic.createBang({ title: "abc", author_name: "John" });
-    const t2 = new Topic({ title: "abc", author_name: "John" });
-    expect(await t2.save()).toBe(false);
+    await Base.connection.addIndex("topics", "author_name", {
+      unique: true,
+      name: "topics_index",
+    });
+
+    const t = await Topic.createBang({ title: "abc", author_name: "John" });
+    t.writeAttribute("content", "hello world");
+    await assertNoQueries(false, async () => {
+      await t.isValid();
+    });
+
+    t.writeAttribute("author_name", "Amy");
+    await assertQueriesCount(1, false, async () => {
+      await t.isValid();
+    });
   });
 
   it("index of columns list and extra columns", async () => {
     Topic.validatesUniqueness("title");
-    await Topic.createBang({ title: "abc", author_name: "John" });
-    const t2 = new Topic({ title: "abc", author_name: "Amy" });
-    expect(await t2.save()).toBe(false);
+    await Base.connection.addIndex("topics", ["title", "author_name"], {
+      unique: true,
+      name: "topics_index",
+    });
+
+    const t = await Topic.createBang({ title: "abc", author_name: "John" });
+    t.writeAttribute("content", "hello world");
+    await assertQueriesCount(1, false, async () => {
+      await t.isValid();
+    });
   });
 
   it.skipIf(adapterType !== "postgres")("expression index", async () => {
     Topic.validatesUniqueness("title");
-    await Topic.createBang({ title: "abc", author_name: "John" });
-    const t2 = new Topic({ title: "abc", author_name: "John" });
-    expect(await t2.save()).toBe(false);
+    await Base.connection.addIndex("topics", "LOWER(title)", {
+      unique: true,
+      name: "topics_index",
+    });
+
+    const t = await Topic.createBang({ title: "abc", author_name: "John" });
+    t.writeAttribute("content", "hello world");
+
+    await assertQueriesCount(1, false, async () => {
+      await t.isValid();
+    });
   });
 });
 

--- a/packages/activerecord/src/validations/uniqueness-validation.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.test.ts
@@ -833,6 +833,9 @@ describe("UniquenessValidationWithIndexTest", () => {
     });
   });
 
+  // Rails `skip unless @connection.supports_partial_index?` — MySQL is the only
+  // adapter whose `supportsPartialIndex()` is false, and the vitest lint rule
+  // forbids a runtime conditional inside the test body.
   it.skipIf(adapterType === "mysql")("partial index", async () => {
     Topic.validatesUniqueness("title");
     await Base.connection.addIndex("topics", "title", {

--- a/packages/activerecord/src/validations/uniqueness-validation.trails.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.trails.test.ts
@@ -5,11 +5,15 @@
  * gate it exactly like any other validator (the sibling deviation
  * `async-validations-honor-validation-context`).
  */
-import { describe, it, expect, beforeAll, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { StrictValidationFailed } from "@blazetrails/activemodel";
 import { registerModel } from "../associations.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { Topic } from "../test-helpers/models/topic.js";
+import { newRawTestAdapter } from "../test-adapter.js";
+import type { TestDatabaseAdapter } from "../test-adapter.js";
+import { rebuildCanonicalTables } from "../test-helpers/canonical-schema.js";
+import { assertQueriesCount, assertNoQueries } from "../testing/query-assertions.js";
 
 describe("UniquenessValidationContextTest", () => {
   fixtures(["topics"]);
@@ -71,5 +75,50 @@ describe("UniquenessValidationContextTest", () => {
 
     const unique = new Topic({ title: "strict-unique" });
     expect(await unique.isValid()).toBe(true);
+  });
+});
+
+describe("UniquenessCoveredByUniqueIndexAdapterResolutionTest", () => {
+  // A model whose adapter is assigned directly (rather than leased from a pool)
+  // carries a NullPool. `covered_by_unique_index?` must still see the table's
+  // indexes: resolving the schema-cache target as `pool ?? adapter` hands the
+  // raw cache the NullPool, which exposes neither `withConnection` nor
+  // `indexes`, so the lookup quietly yields `[]` and the optimization silently
+  // stays off for every directly-assigned model. Rails has no counterpart —
+  // its `klass.schema_cache` is always pool-resolved.
+  let adapter: TestDatabaseAdapter;
+
+  class DirectTopic extends Topic {
+    static _tableName = "topics";
+  }
+
+  beforeAll(async () => {
+    adapter = newRawTestAdapter();
+    await rebuildCanonicalTables(adapter, ["topics"]);
+    await adapter.addIndex("topics", "title", { unique: true, name: "topics_direct_index" });
+    (DirectTopic as unknown as { _adapter: TestDatabaseAdapter })._adapter = adapter;
+  });
+
+  afterAll(async () => {
+    await adapter.disconnect?.();
+  });
+
+  it("skips the existence check for a directly assigned adapter", async () => {
+    DirectTopic.clearValidatorsBang();
+    DirectTopic.validatesUniqueness("title");
+
+    const t = await DirectTopic.createBang({ title: "direct-abc" });
+    t.writeAttribute("author_name", "John");
+
+    // title is unchanged and covered by a unique index, so no SELECT is issued.
+    await assertNoQueries(false, async () => {
+      await t.isValid();
+    });
+
+    // A changed title still consults the database.
+    t.writeAttribute("title", "direct-abc v2");
+    await assertQueriesCount(1, false, async () => {
+      await t.isValid();
+    });
   });
 });

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -9,6 +9,7 @@ import { EachValidator, ArgumentError } from "@blazetrails/activemodel";
 import { isBlank } from "@blazetrails/activesupport";
 import { UnknownPrimaryKey } from "../errors.js";
 import { threadedConnectionFor } from "../connection-handling.js";
+import { realPool } from "../connection-adapters/abstract/connection-pool.js";
 
 /**
  * Shared scope option validation — called eagerly from validatesUniqueness (declaration time)
@@ -337,10 +338,21 @@ async function isCoveredByUniqueIndex(
 
 /**
  * Reads the model's index list off the schema cache — Rails'
- * `klass.schema_cache.indexes(klass.table_name)`. Trails' SchemaCache#indexes
- * is async and pool-scoped, so the pool is threaded through explicitly; the
- * lookup is cache-backed, so a warm cache costs no query (the whole point of
- * the optimization is to avoid one).
+ * `klass.schema_cache.indexes(klass.table_name)`. Trails' equivalent is async,
+ * so this awaits; the lookup is cache-backed, so a warm cache costs no query
+ * (the whole point of the optimization is to avoid one).
+ *
+ * Reads the raw `SchemaCache` rather than the Rails-shaped one-arg
+ * `schemaCacheBound`: `addIndex` invalidates only the raw cache
+ * (`adapter.schemaCache.clearDataSourceCacheBang`), so the bound reflection can
+ * serve a stale, pre-index list and silently keep the optimization off after a
+ * migration adds the covering index.
+ *
+ * The pool target must be `realPool(pool) ?? adapter`, NOT `pool ?? adapter`: a
+ * directly assigned adapter carries a NullPool, which exposes neither
+ * `withConnection` nor `indexes`, so the cache would introspect the NullPool and
+ * quietly yield `[]` — leaving covered_by_unique_index? permanently false for
+ * every such model.
  *
  * @internal
  */
@@ -351,14 +363,14 @@ async function tableIndexes(
   // pinned connection is the only one that sees uncommitted DDL, so a cold cache
   // must introspect through it or it reflects the wrong index list.
   const adapter = threadedConnectionFor(klass) ?? klass?.connection;
-  const cache = adapter?.schemaCache;
   const tableName = klass?.tableName;
-  if (!cache || typeof cache.indexes !== "function" || !tableName) return [];
-  return (await cache.indexes(adapter.pool ?? adapter, tableName)) as {
-    unique?: boolean;
-    where?: string | null;
-    columns?: unknown;
-  }[];
+  if (!adapter || !tableName) return [];
+
+  type Index = { unique?: boolean; where?: string | null; columns?: unknown };
+
+  const cache = adapter.schemaCache;
+  if (!cache || typeof cache.indexes !== "function") return [];
+  return (await cache.indexes(realPool(adapter.pool) ?? adapter, tableName)) as Index[];
 }
 
 /**

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -104,6 +104,14 @@ export class UniquenessValidator extends EachValidator {
   private _klass: any;
 
   /**
+   * Memoized list of attribute names covered by a unique index — Rails' `@covered`
+   * in `covered_by_unique_index?`, computed once per validator instance across
+   * all of its `attributes`.
+   * @internal
+   */
+  _covered: string[] | null = null;
+
+  /**
    * Mirrors: ActiveRecord::Validations::UniquenessValidator#initialize
    *
    * Validates options: :conditions must be callable, :scope must be
@@ -166,7 +174,7 @@ export class UniquenessValidator extends EachValidator {
 
     if (
       record.isPersisted?.() &&
-      !isValidationNeeded(modelClass, record, attribute, this.options)
+      !(await isValidationNeeded(this, modelClass, record, attribute, this.options))
     ) {
       return;
     }
@@ -258,24 +266,21 @@ function findFinderClassFor(record: any, klassOption: any): any {
 }
 
 /**
- * Returns true if uniqueness must consult the database. Rails additionally
- * short-circuits to `false` when the value/scope columns haven't changed
- * AND a unique index already covers them; in Trails that branch is
- * effectively disabled because `isCoveredByUniqueIndex` always returns
- * false (the schema-cache index lookup is async and can't safely run from
- * this synchronous path — see the helper's comment). The other gates
- * (conditions/caseSensitive option, dirty/null checks) match Rails.
+ * Returns true if uniqueness must consult the database: when the :conditions
+ * or :caseSensitive option is set, when any of the value/scope columns changed
+ * or is null, or when no unique index already covers them.
  *
  * Mirrors: ActiveRecord::Validations::UniquenessValidator#validation_needed?
  *
  * @internal
  */
-function isValidationNeeded(
+async function isValidationNeeded(
+  validator: UniquenessValidator,
   klass: any,
   record: any,
   attribute: string,
   options: Record<string, unknown>,
-): boolean {
+): Promise<boolean> {
   if (options.conditions || Object.prototype.hasOwnProperty.call(options, "caseSensitive")) {
     return true;
   }
@@ -290,7 +295,7 @@ function isValidationNeeded(
     (a) => dirty?.attributeChanged?.(a) || record.readAttribute?.(a) == null,
   );
   if (anyChangedOrNull) return true;
-  return !isCoveredByUniqueIndex(klass, record, attribute, scope, options);
+  return !(await isCoveredByUniqueIndex(validator, klass, record, attribute, scope));
 }
 
 /**
@@ -302,21 +307,54 @@ function isValidationNeeded(
  *
  * @internal
  */
-function isCoveredByUniqueIndex(
-  _klass: any,
-  _record: any,
-  _attribute: string,
-  _scope: string[],
-  _options: Record<string, unknown>,
-): boolean {
-  // Rails reads `klass.schema_cache.indexes(klass.table_name)` synchronously,
-  // but Trails' SchemaCache#indexes is async (requires a pool + I/O) and this
-  // helper is synchronous. Conservatively return false so uniqueness always
-  // performs the existence check — correct, just skips the Rails optimization
-  // that drops a redundant SELECT when the DB already enforces uniqueness via a
-  // unique index. (The validation chain itself is async now, so awaiting the
-  // index lookup is a possible future optimization.)
-  return false;
+async function isCoveredByUniqueIndex(
+  validator: UniquenessValidator,
+  klass: any,
+  record: any,
+  attribute: string,
+  scope: string[],
+): Promise<boolean> {
+  if (validator._covered == null) {
+    const indexes = await tableIndexes(klass);
+    const covered: string[] = [];
+    for (const attr of (validator.attributes ?? []).map((a: unknown) => String(a))) {
+      const attributes = resolveAttributes(record, [...scope, attr]);
+      const isCovered = indexes.some((index) => {
+        if (!index.unique || index.where != null) return false;
+        // Rails' `(Array(index.columns) - attributes).empty?` — an expression
+        // index stores a String rather than a column list, which `Array()`
+        // wraps as a single (never-matching) entry.
+        const columns = Array.isArray(index.columns) ? index.columns : [index.columns];
+        return columns.every((c) => attributes.includes(String(c)));
+      });
+      if (isCovered) covered.push(attr);
+    }
+    validator._covered = covered;
+  }
+  return validator._covered.includes(String(attribute));
+}
+
+/**
+ * Reads the model's index list off the schema cache — Rails'
+ * `klass.schema_cache.indexes(klass.table_name)`. Trails' SchemaCache#indexes
+ * is async and pool-scoped, so the pool is threaded through explicitly; the
+ * lookup is cache-backed, so a warm cache costs no query (the whole point of
+ * the optimization is to avoid one).
+ *
+ * @internal
+ */
+async function tableIndexes(
+  klass: any,
+): Promise<{ unique?: boolean; where?: string | null; columns?: unknown }[]> {
+  const adapter = klass?.connection;
+  const cache = adapter?.schemaCache;
+  const tableName = klass?.tableName;
+  if (!cache || typeof cache.indexes !== "function" || !tableName) return [];
+  return (await cache.indexes(adapter.pool ?? adapter, tableName)) as {
+    unique?: boolean;
+    where?: string | null;
+    columns?: unknown;
+  }[];
 }
 
 /**

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -8,6 +8,7 @@
 import { EachValidator, ArgumentError } from "@blazetrails/activemodel";
 import { isBlank } from "@blazetrails/activesupport";
 import { UnknownPrimaryKey } from "../errors.js";
+import { threadedConnectionFor } from "../connection-handling.js";
 
 /**
  * Shared scope option validation — called eagerly from validatesUniqueness (declaration time)
@@ -346,7 +347,10 @@ async function isCoveredByUniqueIndex(
 async function tableIndexes(
   klass: any,
 ): Promise<{ unique?: boolean; where?: string | null; columns?: unknown }[]> {
-  const adapter = klass?.connection;
+  // Prefer the transaction-pinned connection: inside transactional fixtures the
+  // pinned connection is the only one that sees uncommitted DDL, so a cold cache
+  // must introspect through it or it reflects the wrong index list.
+  const adapter = threadedConnectionFor(klass) ?? klass?.connection;
   const cache = adapter?.schemaCache;
   const tableName = klass?.tableName;
   if (!cache || typeof cache.indexes !== "function" || !tableName) return [];


### PR DESCRIPTION
Converges `UniquenessValidator#covered_by_unique_index?`
(`activerecord/lib/active_record/validations/uniqueness.rb`).

`isCoveredByUniqueIndex` was hardcoded to `return false`, disabling Rails'
optimization that skips the pre-save existence `SELECT` when the value/scope
columns are unchanged and a non-partial unique index already covers them (the
DB enforces uniqueness on INSERT, so the check is redundant). The documented
reason was that `SchemaCache#indexes` is async and the validator path was
synchronous.

RFC 0063 removed that constraint: `validateEach` is async and runs inside the
awaited validation chain, so `isValidationNeeded` / `isCoveredByUniqueIndex`
are now async and consult the schema cache's index list.

- Ports Rails' matching rule verbatim: `index.unique && index.where.nil? &&
  (Array(index.columns) - attributes).empty?`, including the expression-index
  case (`columns` arrives as a String, so it never matches a column list).
  Note the vendored source gates on `where` only — not `type`.
- Ports the `@covered` memoization — computed once per validator instance
  across all of its `attributes`.
- `tableIndexes` resolves the adapter via the established
  `threadedConnectionFor(klass) ?? klass.connection` pattern: inside
  transactional fixtures the pinned connection is the only one that sees
  uncommitted DDL, so a cold cache must introspect through it. The pool target
  is `realPool(pool) ?? adapter` — a directly assigned adapter carries a
  NullPool, which exposes neither `withConnection` nor `indexes`, so the plain
  `pool ?? adapter` idiom hands the cache the NullPool and quietly yields `[]`.
  The lookup is cache-backed, so a warm cache costs no query — the point of the
  optimization.

## Tests

`UniquenessValidationWithIndexTest` previously carried a note that the Rails
counterparts assert query *counts* against a unique index — "an index-aware
skip optimization trails does not model" — and its bodies were behavioral
stand-ins. With the optimization in place the block is converted to Rails'
actual form: real `addIndex`/`removeIndex` around each test plus
`assertQueriesCount` / `assertNoQueries`, matching Rails' test names verbatim.

Two deliberate deviations, both commented in place:

- `uniqueness on relation`: trails' `TopicWithEvent` declares
  `validatesUniqueness("event")` on the class, where Rails' fixture model does
  not — so the test neither re-declares it (which would run the validator
  twice) nor clears it (which would strip it for the rest of the file).
- `partial index`: gated on `adapterType === "mysql"` rather than a runtime
  `supports_partial_index?` check, because the vitest lint rule forbids
  conditionals in test bodies. Verified equivalent: sqlite3 and postgresql
  override the predicate to `true`, MySQL inherits the `false` default.

The suite runs with `useTransactionalTests: false` (Rails does the same) since
each test issues DDL, and clears the `topics` datasource cache per test so a
freshly added index is reflected.

## Review follow-up (codex)

Codex correctly caught that `pool ?? adapter` breaks directly assigned
adapters. Fixed, with one deviation from the suggested remedy, backed by new
evidence:

- **Applied**: the `realPool(pool) ?? adapter` idiom, exactly as `realPool`'s
  own doc comment prescribes for code that previously wrote `pool ?? adapter`.
- **Not applied**: switching to the Rails-shaped one-arg
  `schemaCacheBound.indexes(tableName)`. `addIndex` invalidates only the raw
  cache (`adapter.schemaCache.clearDataSourceCacheBang`), so the bound
  reflection serves a stale pre-index list — I tried it and it reds four of the
  pooled `WithIndexTest` cases (`changing non unique attribute`, `scope`,
  `uniqueness on relation`, `index of sublist of columns`). The raw cache is the
  layer `addIndex` actually invalidates, so this reads it and fixes only the
  pool resolution. Both reasons are documented on `tableIndexes`.
- Added `UniquenessCoveredByUniqueIndexAdapterResolutionTest` covering the
  direct-adapter path, **verified red against the pre-fix code** (`1 instead of
  0 queries`) and green after. The original bug was invisible to the suite,
  which is why it slipped through.

## Verification

- `packages/activerecord/src/validations/` — 137 passed, 2 skipped.
- Regression sweep, since this changes query behavior suite-wide: every
  query-count test file that also uses a model carrying a uniqueness
  validation (Topic/Reply/Book/Event/WarehouseThing), plus the encryption
  uniqueness suite — **1,717 passed, 0 failed**.
- `api:compare` — `validations/uniqueness.rb` → `validations/uniqueness.ts`
  stays 9/9, 100%.
- tsc + eslint clean. 207 insertions / 75 deletions, 2 files.

Closes-story: uniqueness-covered-by-unique-index
