### PR TITLE
fix(persistence): run save validations inside the save transaction

### DIFF
--- a/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.test.ts
@@ -20,7 +20,7 @@ const encryptorB: EncryptorLike = {
 };
 
 describe("ActiveRecord::Encryption::ExtendedDeterministicUniquenessValidatorTest", () => {
-  it("validateEach calls originalValidateEach for current and previous scheme ciphertexts", () => {
+  it("validateEach calls originalValidateEach for current and previous scheme ciphertexts", async () => {
     const prevScheme = new Scheme({ deterministic: true, encryptor: encryptorB });
     const type = new EncryptedAttributeType({
       scheme: new Scheme({
@@ -41,7 +41,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicUniquenessValidatorTest
       calls.push({ attribute, value, encryptionDisabled: isEncryptionDisabled() });
     };
 
-    new EncryptedUniquenessValidator().validateEach(
+    await new EncryptedUniquenessValidator().validateEach(
       originalValidateEach,
       record,
       "email",
@@ -58,7 +58,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicUniquenessValidatorTest
     expect(calls[1].encryptionDisabled).toBe(true);
   });
 
-  it("validateEach skips non-deterministic attributes", () => {
+  it("validateEach skips non-deterministic attributes", async () => {
     const type = new EncryptedAttributeType({
       scheme: new Scheme({ deterministic: false, encryptor: encryptorA }),
     });
@@ -71,7 +71,12 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicUniquenessValidatorTest
     const calls: unknown[] = [];
     const originalValidateEach = (_r: any, _a: string, value: unknown) => calls.push(value);
 
-    new EncryptedUniquenessValidator().validateEach(originalValidateEach, record, "body", "hello");
+    await new EncryptedUniquenessValidator().validateEach(
+      originalValidateEach,
+      record,
+      "body",
+      "hello",
+    );
 
     expect(calls).toHaveLength(1);
   });

--- a/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.ts
@@ -46,13 +46,17 @@ export class ExtendedDeterministicUniquenessValidator {
     // EncryptedUniquenessValidator skips the extra previous-scheme query in
     // that case to avoid duplicate errors and redundant DB round-trips.
     const validator = new EUV();
+    // `original` (UniquenessValidator#validateEach) is async — it awaits the
+    // `SELECT 1 ... WHERE attr = ?` round-trip. The wrapper must return that
+    // promise so the validation chain awaits it; dropping it leaves the query
+    // in flight and its errors land on the record at an arbitrary later tick.
     UniquenessValidator.prototype.validateEach = function (
       this: unknown,
       record: any,
       attribute: string,
       value: unknown,
     ) {
-      validator.validateEach(original.bind(this), record, attribute, value);
+      return validator.validateEach(original.bind(this), record, attribute, value);
     };
   }
 
@@ -79,13 +83,13 @@ export class ExtendedDeterministicUniquenessValidator {
  * Mirrors: ActiveRecord::Encryption::ExtendedDeterministicUniquenessValidator::EncryptedUniquenessValidator
  */
 export class EncryptedUniquenessValidator {
-  validateEach(
-    originalValidateEach: (record: any, attribute: string, value: unknown) => void,
+  async validateEach(
+    originalValidateEach: (record: any, attribute: string, value: unknown) => unknown,
     record: any,
     attribute: string,
     value: unknown,
-  ): void {
-    originalValidateEach(record, attribute, value);
+  ): Promise<void> {
+    await originalValidateEach(record, attribute, value);
 
     const klass = record.constructor;
     const deterministicAttrs = EncryptableRecord.deterministicEncryptedAttributes(klass);
@@ -101,9 +105,7 @@ export class EncryptedUniquenessValidator {
     if (!ExtendedDeterministicQueries.installed) {
       const prevCiphertexts = encryptedType.previousTypes.map((pt) => pt.serialize(value));
       if (prevCiphertexts.length > 0) {
-        withoutEncryption(() => {
-          originalValidateEach(record, attribute, prevCiphertexts);
-        });
+        await withoutEncryption(() => originalValidateEach(record, attribute, prevCiphertexts));
       }
     }
   }

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -821,34 +821,35 @@ export async function save<T extends SaveRecord>(
     this.constructor,
     true,
   );
-  // Mirrors the Rails module layering: ActiveRecord::Validations#save! runs
-  // `perform_validations` first and only on success calls super →
-  // Persistence#save! → create_or_update, where the readonly/destroyed guards
-  // live. So validations run *before* the guards: a record that is both
-  // destroyed and invalid raises RecordInvalid (validations first), not
-  // RecordNotSaved.
   const self = this as any;
-  // Resolve `belongs_to ..., default:` blocks before validation. Rails registers
-  // these on before_validation (builder/belongs_to.rb#add_default_callbacks) so a
-  // required association's presence validation sees the defaulted FK. The block
-  // may be async (e.g. `() => Developer.first()`), so on the save path we resolve
-  // it here — a pre-validation pass — before running the chain. Gated on
-  // `validate !== false`: Rails skips
-  // perform_validations (and thus every before_validation callback, including
-  // this default) when `validate: false` (validations.rb:47-49), so the default
-  // must not fire on that path. `_belongsToDefaultsApplied` then suppresses the
-  // in-chain before_validation callback so the block runs exactly once per save
-  // (it would otherwise re-fire when the pre-pass left the reader nil).
   const ctor = this.constructor;
 
-  // Mirrors: ActiveRecord::Transactions#save wrapping `Validations#save`, so
-  // `perform_validations` — and every `before_validation` callback it runs —
-  // executes *inside* the save transaction (transactions.rb:360,
-  // validations.rb:47; transactions_test.rb:714). A cancelling filter's DB write
-  // therefore rolls back with the transaction, and a `throw :abort` halts before
-  // the validators ever run (so no errors are recorded).
+  // Mirrors the full Rails module layering: `Transactions#save {
+  // Validations#save { perform_validations; Persistence#save → create_or_update
+  // } }` (transactions.rb:360, validations.rb:47). Two orderings fall out of it,
+  // and both are load-bearing:
+  //
+  //  1. `perform_validations` — and every `before_validation` it runs — is
+  //     *inside* the transaction, so a cancelling filter's DB write rolls back
+  //     with it and a `throw :abort` halts before the validators ever run (no
+  //     errors recorded). transactions_test.rb:714.
+  //  2. Validations run *before* the readonly/destroyed guards, which live in
+  //     `create_or_update`. So a record that is both destroyed and invalid
+  //     raises RecordInvalid, not RecordNotSaved.
   try {
     return (await withTransactionReturningStatus.call(self, async () => {
+      // Resolve `belongs_to ..., default:` blocks before validation. Rails
+      // registers these on before_validation
+      // (builder/belongs_to.rb#add_default_callbacks) so a required
+      // association's presence validation sees the defaulted FK. The block may
+      // be async (e.g. `() => Developer.first()`), so on the save path we
+      // resolve it here — a pre-validation pass — before running the chain.
+      // Gated on `validate !== false`: Rails skips perform_validations (and thus
+      // every before_validation callback, including this default) when
+      // `validate: false` (validations.rb:47-49), so the default must not fire
+      // on that path. `_belongsToDefaultsApplied` then suppresses the in-chain
+      // before_validation callback so the block runs exactly once per save (it
+      // would otherwise re-fire when the pre-pass left the reader nil).
       if (options?.validate !== false && typeof self._runBelongsToDefaults === "function") {
         await self._runBelongsToDefaults();
         self._belongsToDefaultsApplied = true;
@@ -865,7 +866,7 @@ export async function save<T extends SaveRecord>(
       // Mirrors ActiveRecord::Persistence#create_or_update: readonly raises
       // first, then `return false if destroyed?`. `save` returns false (it does
       // not raise) for a destroyed record; `save!` turns that false into
-      // RecordNotSaved("Failed to save the record").
+      // RecordNotSaved("Failed to save the record"). See ordering (2) above.
       if (this._readonly) {
         throw new ReadOnlyRecord(`${this.constructor.name} is marked as readonly`);
       }

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -6,7 +6,6 @@
  */
 
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { isAbortSignal } from "@blazetrails/activesupport";
 import {
   ArgumentError,
   sanitizeForMassAssignment,
@@ -840,81 +839,50 @@ export async function save<T extends SaveRecord>(
   // must not fire on that path. `_belongsToDefaultsApplied` then suppresses the
   // in-chain before_validation callback so the block runs exactly once per save
   // (it would otherwise re-fire when the pre-pass left the reader nil).
-  if (options?.validate !== false && typeof self._runBelongsToDefaults === "function") {
-    await self._runBelongsToDefaults();
-    self._belongsToDefaultsApplied = true;
-  }
-  // A `before_validation` that needs async DB work should run inside the save
-  // transaction (Rails wraps `super` in `with_transaction_returning_status` and
-  // `perform_validations` runs inside it — transactions.rb:360, validations.rb:47;
-  // transactions_test.rb:714). Trails runs `performValidations` before opening
-  // the save transaction, so such a callback defers its thunk here for `save` to
-  // drain inside the transaction instead of running it during validation. Reset
-  // the queue before the chain populates it so a prior save that bailed at
-  // validation doesn't leak a stale thunk into this one.
-  self._beforeValidationSideEffects = [];
-  let validationsPassed: boolean;
-  try {
-    validationsPassed = await performValidations.call(this, options);
-  } finally {
-    // Clear even if a validation callback throws, so a later standalone
-    // `valid?` on this instance still fires the belongs_to default.
-    self._belongsToDefaultsApplied = false;
-  }
-  if (!validationsPassed) return false;
-  // Mirrors ActiveRecord::Persistence#create_or_update: readonly raises first,
-  // then `return false if destroyed?`. `save` returns false (it does not raise)
-  // for a destroyed record; `save!` turns that false into
-  // RecordNotSaved("Failed to save the record").
-  if (this._readonly) {
-    throw new ReadOnlyRecord(`${this.constructor.name} is marked as readonly`);
-  }
-  if (this._destroyed) {
-    return false;
-  }
-
-  self._skipTouch = options?.touch === false;
   const ctor = this.constructor;
 
-  // Auto-set STI type column on new records
-  if (this._newRecord && isStiSubclass(ctor)) {
-    const col = getInheritanceColumn(getStiBase(ctor));
-    if (col && !this._readAttribute(col)) {
-      this._attributes.set(col, this.constructor.name);
-    }
-  }
-
-  // Mirrors: ActiveRecord::Transactions#save
+  // Mirrors: ActiveRecord::Transactions#save wrapping `Validations#save`, so
+  // `perform_validations` — and every `before_validation` callback it runs —
+  // executes *inside* the save transaction (transactions.rb:360,
+  // validations.rb:47; transactions_test.rb:714). A cancelling filter's DB write
+  // therefore rolls back with the transaction, and a `throw :abort` halts before
+  // the validators ever run (so no errors are recorded).
   try {
     return (await withTransactionReturningStatus.call(self, async () => {
-      // Drain deferred `before_validation` side effects inside the transaction
-      // so a cancelling filter's DB write (`Book.create`) rolls back with it.
-      // A drained thunk that `throw :abort`s halts the save (status false →
-      // Rollback), matching Rails' halted validation callback.
-      //
-      // ORDERING DEVIATION: Rails layers save as `Transactions#save {
-      // Validations#save { perform_validations; Persistence#save } }`
-      // (transactions.rb:360, validations.rb:47), so `before_validation` runs
-      // *inside* the transaction and *before* `valid?`. trails runs
-      // `performValidations` above (outside the transaction), so the
-      // deferred thunk's async body runs here — after the validators, not
-      // before. Observable only when a record has BOTH a failing validation and
-      // an aborting async `before_validation`: trails reports `errors.any`
-      // (validators already ran) where Rails reports none (abort halts first).
-      // The four cancellation tests don't hit this (validations pass); the
-      // governing constraint is that `performValidations` runs outside the
-      // transaction — see the Topic wiring and `validations.ts#isValid`. Tracked
-      // for convergence: RFC 0023 story
-      // `save-runs-validations-inside-transaction`.
-      const sideEffects = self._beforeValidationSideEffects as Array<() => unknown>;
-      for (const thunk of sideEffects) {
-        try {
-          await thunk();
-        } catch (e) {
-          if (isAbortSignal(e)) return false;
-          throw e;
+      if (options?.validate !== false && typeof self._runBelongsToDefaults === "function") {
+        await self._runBelongsToDefaults();
+        self._belongsToDefaultsApplied = true;
+      }
+      let validationsPassed: boolean;
+      try {
+        validationsPassed = await performValidations.call(this, options);
+      } finally {
+        // Clear even if a validation callback throws, so a later standalone
+        // `valid?` on this instance still fires the belongs_to default.
+        self._belongsToDefaultsApplied = false;
+      }
+      if (!validationsPassed) return false;
+      // Mirrors ActiveRecord::Persistence#create_or_update: readonly raises
+      // first, then `return false if destroyed?`. `save` returns false (it does
+      // not raise) for a destroyed record; `save!` turns that false into
+      // RecordNotSaved("Failed to save the record").
+      if (this._readonly) {
+        throw new ReadOnlyRecord(`${this.constructor.name} is marked as readonly`);
+      }
+      if (this._destroyed) {
+        return false;
+      }
+
+      self._skipTouch = options?.touch === false;
+
+      // Auto-set STI type column on new records
+      if (this._newRecord && isStiSubclass(ctor)) {
+        const col = getInheritanceColumn(getStiBase(ctor));
+        if (col && !this._readAttribute(col)) {
+          this._attributes.set(col, this.constructor.name);
         }
       }
+
       return self.createOrUpdate();
     })) as boolean | undefined;
   } catch (e) {

--- a/packages/activerecord/src/test-helpers/models/topic.ts
+++ b/packages/activerecord/src/test-helpers/models/topic.ts
@@ -105,17 +105,12 @@ export class Topic extends Base {
     // (`before_validation :before_validation_for_transaction`, etc. —
     // all `def ...; end`), so we mirror them as sync. The record arrives as the
     // callback arg (not `this`), matching the `afterInitialize`/`setEmailAddress`
-    // hook below. Deferred rather than run inline: the cancellation test installs
-    // a `before_validation_for_transaction` that performs a DB write then
-    // `throw :abort`. Rails runs it inside the save transaction so the write
-    // rolls back with it; enqueuing the thunk lets `save` await it inside the
-    // transaction rather than during the (pre-transaction) validation pass. The
-    // default no-op hook is a harmless enqueued no-op.
-    this.beforeValidation((record: Topic) => {
-      ((record as any)._beforeValidationSideEffects ??= []).push(() =>
-        (record as any).beforeValidationForTransaction(),
-      );
-    });
+    // hook below. Returned so the async validation chain awaits the hook: the
+    // cancellation test installs a `before_validation_for_transaction` that
+    // performs a DB write then `throw :abort`, and `perform_validations` runs
+    // inside the save transaction so the write rolls back with it
+    // (transactions_test.rb:714).
+    this.beforeValidation((record: Topic) => (record as any).beforeValidationForTransaction());
     // Returned so the async save-callback chain awaits the hook: a cancelling
     // `before_save` that performs a DB side effect then `throw :abort` must run
     // inside the save transaction so the write rolls back with it

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -615,10 +615,8 @@ describe("TransactionTest", () => {
   // before-filter. The canonical Topic `before_save_for_transaction` runs on the
   // async save-callback chain (the wrapper returns the hook's Promise so it is
   // awaited inside the save transaction). `before_validation_for_transaction`
-  // runs during `performValidations`, which trails invokes outside the save
-  // transaction, so the Topic wrapper defers its thunk into
-  // `_beforeValidationSideEffects`, which `save` drains inside the transaction
-  // (persistence.ts). In both paths the `throw :abort`
+  // runs during `performValidations`, which `save` invokes inside the same
+  // transaction (persistence.ts). In both paths the `throw :abort`
   // halts the save (status false → Rollback), rolling back `Book.create`.
   for (const filter of ["validation", "save"] as const) {
     const hook =

--- a/packages/activerecord/src/transactions.trails.test.ts
+++ b/packages/activerecord/src/transactions.trails.test.ts
@@ -9,10 +9,12 @@
  * mirrors transactions_test.rb) so the convention file tracks Rails 1:1.
  */
 import { describe, it, expect, beforeAll, afterEach, afterAll, vi } from "vitest";
+import { throwAbort } from "@blazetrails/activesupport";
 import { Base, transaction } from "./index.js";
 import { NullTransaction } from "./connection-adapters/abstract/transaction.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { Topic as CanonicalTopic } from "./test-helpers/models/topic.js";
+import { Reply } from "./test-helpers/models/reply.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import { AbstractSQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "./connection-adapters/better-sqlite3-adapter.js";
@@ -598,5 +600,32 @@ describe("SchemaAdapter TM delegation", () => {
     expect(testAdapter.inTransaction).toBe(true);
     await testAdapter.rollback();
     expect(testAdapter.inTransaction).toBe(false);
+  });
+});
+
+describe("aborting before_validation halts before the validators run", () => {
+  fixtures({});
+
+  // No Rails counterpart: Rails gets this for free from the module layering
+  // (`Transactions#save { Validations#save { perform_validations; ... } }`), so
+  // there is no test asserting it. trails used to run `performValidations`
+  // outside the save transaction, which made the validators run even when an
+  // aborting `before_validation` should have halted first — leaving errors on a
+  // record Rails leaves clean. This pins the converged ordering.
+  it("leaves no errors when a record is also invalid", async () => {
+    // Reply validates content presence (errorsOnEmptyContent), so this record
+    // is invalid on its own; the aborting hook must halt before that runs.
+    const reply = Reply.new({ title: "a reply", content: "" }) as unknown as {
+      save(): Promise<boolean | undefined>;
+      errors: { any: boolean };
+      beforeValidationForTransaction: () => Promise<void>;
+    };
+    reply.beforeValidationForTransaction = async () => {
+      await Promise.resolve();
+      throwAbort();
+    };
+
+    expect(await reply.save()).toBeFalsy();
+    expect(reply.errors.any).toBe(false);
   });
 });

--- a/packages/activerecord/src/transactions.trails.test.ts
+++ b/packages/activerecord/src/transactions.trails.test.ts
@@ -14,7 +14,7 @@ import { Base, transaction } from "./index.js";
 import { NullTransaction } from "./connection-adapters/abstract/transaction.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { Topic as CanonicalTopic } from "./test-helpers/models/topic.js";
-import { Reply } from "./test-helpers/models/reply.js";
+import { WrongReply } from "./test-helpers/models/reply.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import { AbstractSQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "./connection-adapters/better-sqlite3-adapter.js";
@@ -612,14 +612,27 @@ describe("aborting before_validation halts before the validators run", () => {
   // outside the save transaction, which made the validators run even when an
   // aborting `before_validation` should have halted first — leaving errors on a
   // record Rails leaves clean. This pins the converged ordering.
-  it("leaves no errors when a record is also invalid", async () => {
-    // Reply validates content presence (errorsOnEmptyContent), so this record
-    // is invalid on its own; the aborting hook must halt before that runs.
-    const reply = Reply.new({ title: "a reply", content: "" }) as unknown as {
+  // WrongReply validates content presence (errorsOnEmptyContent), so a blank-content
+  // WrongReply is invalid on its own.
+  const newInvalidReply = () =>
+    WrongReply.new({ title: "a reply", content: "" }) as unknown as {
       save(): Promise<boolean | undefined>;
       errors: { any: boolean };
       beforeValidationForTransaction: () => Promise<void>;
     };
+
+  // Positive control: without the aborting hook the validators DO run and DO
+  // record an error. Without this, the assertion below would pass vacuously if
+  // WrongReply ever stopped being invalid here.
+  it("records the validation error when nothing aborts", async () => {
+    const reply = newInvalidReply();
+
+    expect(await reply.save()).toBeFalsy();
+    expect(reply.errors.any).toBe(true);
+  });
+
+  it("leaves no errors when a record is also invalid", async () => {
+    const reply = newInvalidReply();
     reply.beforeValidationForTransaction = async () => {
       await Promise.resolve();
       throwAbort();


### PR DESCRIPTION
`Base.encrypts` deliberately routed an STI subclass declaration to the STI
base:

```ts
const target = isStiSubclass(this) ? getStiBase(this) : this;
```

Net effect: `encrypts` declared on one STI subclass wrapped the attribute type
on the STI **base**, so the base and every sibling subclass saw the
`EncryptedAttributeType` — a subclass opting one column into encryption
silently changed how the base and its siblings read and wrote that column.

Rails keeps this per-class: `encrypted_attributes` is a `class_attribute` and
`_default_attributes` replays only that class's own pending decorators
(`activerecord/lib/active_record/encryption/encryptable_record.rb`,
`activemodel/lib/active_model/attribute_registration.rb`).

The routing was a workaround for `applyPendingEncryptions` forking
`_attributeDefinitions` on the subclass and reintroducing shadowing. #4981
restored proper copy-on-write for an STI subclass's `_attributeDefinitions`,
and the durable declaration path already wraps types through
`decorateAttributes`, which honours it — so the routing is now dead weight.

## Review follow-up (Codex)

Codex flagged that `rails-deprecated-methods.json` was still `.prettierignore`d
while routed through the helper. Chasing it found the helper was broken more
broadly than reported: because `--stdin-filepath` honours `.gitignore` too, and
two manifests are gitignored, **four of six write sites were silently doing
nothing** while appearing to pass. Fixed via `--ignore-path /dev/null`, both
ignore entries deleted, `scripts/schema-compare/compare.ts` (the second entry's
emitter) routed through the helper, and a regression test added for the
ignored-path case.

## Second fix: a dropped promise in the encryption uniqueness patch

Moving validations inside the transaction turned up a genuine latent bug (CI failed on **all three adapters**, deterministically — not a flake).

`ExtendedDeterministicUniquenessValidator.installSupport` wrapped `UniquenessValidator#validateEach` — which RFC 0063 made `async` — in a **synchronous** function that dropped the returned promise. The uniqueness `SELECT` was left in flight and its errors landed on the record at an arbitrary later tick.

Nothing caught it because the race happened to resolve favourably while `performValidations` ran outside the save transaction; the new ordering changed the timing and exposed it.

Fixed by returning/awaiting the promise through both layers. `withEncryptionContext` is already promise-aware (it defers its context pop until the promise settles), so the previous-scheme query keeps its `withoutEncryption` context for the full round-trip. Two unit tests that called `validateEach` synchronously now await it — names unchanged.

## Review follow-up: previous-scheme query shape (deferred to a story)

A Codex review correctly flagged that `EncryptedUniquenessValidator#validateEach` gates its previous-scheme checks on `ExtendedDeterministicQueries.installed` and batches the ciphertexts into one array, where Rails has no gate and calls `super` once per scalar (`extended_deterministic_uniqueness_validator.rb:11-21`). Both observations are right, including that the gate is dead in any real config — the railtie installs both patches under the same `extend_queries` flag (`railtie.rb:349-353`).

I tried the suggested fix and it does not stand alone: removing the gate and iterating per-scalar turns `errors.count` from 1 into **2** in three tests, including the Rails-named "uniqueness validation does not revalidate the attribute with current encryption type".

The reason is that trails matches the plaintext variant **twice**. Rails finds it once, via the clean-text scheme appended to `previous_types` when `support_unencrypted_data?` (`encrypted_attribute_type.rb:66-68`), which trails mirrors correctly. But trails *also* finds it in the first `super`, because `buildRelation` has a `supportUnencryptedData` special-case that switches to a hash-style `where` so `processArguments` expands the IN list to include the plain text (`validations/uniqueness.ts:415-423`). That special-case is the real trails invention; the gate is a band-aid compensating for the double-match it causes.

Converging properly therefore means removing the `buildRelation` special-case too — a multi-file change in the encryption query stack, outside this story's scope. Registered as `0023-surfaced-deviations/encryption-uniqueness-previous-scheme-query-shape` with the full analysis and acceptance criteria. This PR keeps the gate as-is (green) and changes only the dropped-promise bug.

## Verification

All three tests fail on `main` before the fix and pass after. The first fails
with exactly the leak described:

```
expected EncryptedAttributeType{ …(13) } to not be an instance of EncryptedAttributeType
```

Coverage goes beyond type identity deliberately:

- **Type isolation** — subclass wrapped; base and sibling untouched.
- **Behaviour at rest** — the subclass round-trips ciphertext (`ciphertextFor`
  is not the plaintext) while the base genuinely stores plaintext
  (`encryptedAttribute === false`). This is what the leak actually corrupted.
- **Replay** — the decoration survives `resetColumnInformation()` plus
  re-reflection, on the `_pendingEncryptions` buffer alone.

The test encrypts `description`, not `name`: `name` is a restricted attribute
with no dirty tracking, which would have muddied the persistence round-trip.

Green locally: full `encryption/` suite, `normalized-attribute.trails`,
`inheritance`, `attributes`, `model-schema`, `base` — 440 tests.

## Deliberately out of scope

I also tried removing the hand-rolled copy-on-write fork at the top of
`applyPendingEncryptions`, on the theory that #4981 made it redundant. I
reverted that: with the fork restored and only the routing fixed, the entire
encryption suite **and** the new guard pass identically, so nothing pins the
behaviour down in either direction and removing it would have been an
unverified change riding along. It stays, now with a comment explaining what
still depends on it, and the open question (including whether it should be
reconciled with `rebuildStiSubclassOverlay`'s revision bookkeeping) is filed as
`apply-pending-encryptions-hand-rolled-cow-vs-4981-overlay`.

Closes-story: sti-subclass-encrypts-routes-to-sti-base-leaking-type


## Review follow-up

`sti-attribute-routing.test.ts:71` asserted the old base-routing behavior
(`encrypts` on a subclass recording `_pendingEncryptions` on the STI base and
sharing the base's `_attributeDefinitions`) and failed against this change.
Confirmed and fixed rather than rebutted — the cited Rails source is right:
`encrypt_attribute` calls `decorate_attributes` on the receiver
(`encryption/encryptable_record.rb:84-95`) and
`apply_pending_attribute_modifications` replays the superclass's modifications
first and then only the class's own
(`activemodel/lib/active_model/attribute_registration.rb:81-88`).

The test now asserts the per-class behavior, and is renamed since its old name
described the removed routing. Renaming is safe here: `pnpm rails:find` returns
no mapping for it, so it is a trails-only invention test, not a Rails-matched
name that `test:compare` keys on.

Worth noting the updated assertion `Dog._attributeDefinitions !==
Animal._attributeDefinitions` is produced by the hand-rolled copy-on-write fork
in `applyPendingEncryptions` — independent evidence that reverting its removal
(above) was the right call.

This slipped through because my first verification pass picked test files by
directory rather than by symbol. Re-verified by grepping every test referencing
`encrypts(` / `_pendingEncryptions` / `_encryptedAttributes` /
`isEncryptedAttribute` and running all of them: 620 tests, plus 358 across the
STI and attribute suites.


### Second review round

`model-schema.ts:1126` still described subclass `encrypts()` as routing through
the STI base. Confirmed stale and fixed. The cited Rails source is right and
matches the first round: `encrypts` mutates the receiver's
`encrypted_attributes` and calls `encrypt_attribute`/`decorate_attributes` on
that class (`encryption/encryptable_record.rb:49-55`, `:84-95`), then
`_default_attributes` replays superclass modifications before only the class's
own pending decorators (`attribute_registration.rb:31-34`, `:81-88`).

The comment was stale in a second way the review did not name: its closing
advice was to add new decorators to the STI redirect list so they don't fork
the map. #4981 inverted that. `decorateAttributes` deliberately copy-on-writes
`_attributeDefinitions` onto the calling class
(`activemodel/src/attribute-registration.ts:191-193`) and
`rebuildStiSubclassOverlay` keeps the overlay in sync, so per-class decorators
are now *expected* to fork — routing one to the base is exactly the bug this PR
fixes. The note now says so, leaving only `attribute()` in the base-routing
bucket.

Comment-only change; re-ran model-schema, sti-attribute-routing, both STI
decorator guards, and inheritance. Also grepped for other stale references to
the removed routing across `packages/` and `docs/` — none outside this PR's own
test file, which uses past tense correctly.
