### PR TITLE
fix(activesupport): increment whole code points in stringSucc no-alnum branch

### DIFF
--- a/packages/activesupport/src/core-ext/range-ext.test.ts
+++ b/packages/activesupport/src/core-ext/range-ext.test.ts
@@ -258,6 +258,8 @@ describe("RangeTest", () => {
     // Carry stops at a non-alnum gap into a different class.
     expect(stringSucc("z.9")).toBe("z.10");
     expect(stringSucc("a.z")).toBe("b.a");
+    // Astral (non-alnum) chars succ as whole code points, not UTF-16 units.
+    expect(stringSucc("\u{1F600}")).toBe("\u{1F601}");
   });
 
   it("date time with step", () => {

--- a/packages/activesupport/src/core-ext/range-ext.test.ts
+++ b/packages/activesupport/src/core-ext/range-ext.test.ts
@@ -260,7 +260,11 @@ describe("RangeTest", () => {
     expect(stringSucc("a.z")).toBe("b.a");
     // Astral (non-alnum) chars succ as whole code points, not UTF-16 units.
     expect(stringSucc("\u{1F600}")).toBe("\u{1F601}");
-    expect(Array.from(stringSucc("\u{10FFFF}"), (c) => c.codePointAt(0))).toEqual([0x1, 0x10000]);
+    // Wrapping is per UTF-8 encoded width (`enc_succ_char` NEIGHBOR_WRAPPED).
+    const points = (str: string) => Array.from(str, (c) => c.codePointAt(0));
+    expect(points(stringSucc("\u{10FFFF}"))).toEqual([0x1, 0x10000]);
+    expect(points(stringSucc("\u{FFFF}"))).toEqual([0x1, 0x800]);
+    expect(points(stringSucc("\u{07FF}"))).toEqual([0x1, 0x80]);
   });
 
   it("date time with step", () => {

--- a/packages/activesupport/src/core-ext/range-ext.test.ts
+++ b/packages/activesupport/src/core-ext/range-ext.test.ts
@@ -260,6 +260,7 @@ describe("RangeTest", () => {
     expect(stringSucc("a.z")).toBe("b.a");
     // Astral (non-alnum) chars succ as whole code points, not UTF-16 units.
     expect(stringSucc("\u{1F600}")).toBe("\u{1F601}");
+    expect(Array.from(stringSucc("\u{10FFFF}"), (c) => c.codePointAt(0))).toEqual([0x1, 0x10000]);
   });
 
   it("date time with step", () => {

--- a/packages/activesupport/src/range-ext.ts
+++ b/packages/activesupport/src/range-ext.ts
@@ -68,6 +68,14 @@ const isAsciiAlnum = (c: number): boolean =>
  * `"99".succ == "100"`). Strings with no alphanumeric increment by raw code
  * unit instead (`"<<".succ == "<="`).
  */
+/** Inclusive [min, max] code-point bounds of the UTF-8 width encoding `cp`. */
+function utf8WidthBounds(cp: number): [number, number] {
+  if (cp < 0x80) return [0x00, 0x7f];
+  if (cp < 0x800) return [0x80, 0x7ff];
+  if (cp < 0x10000) return [0x800, 0xffff];
+  return [0x10000, 0x10ffff];
+}
+
 export function stringSucc(s: string): string {
   if (s.length === 0) return "";
   const codes = Array.from(s, (ch) => ch.codePointAt(0) as number);
@@ -87,13 +95,14 @@ export function stringSucc(s: string): string {
     let i = codes.length - 1;
     let carry = true;
     while (i >= 0 && carry) {
-      if (codes[i] >= 0x10ffff) {
-        // Ruby zeroes the wrapped character's bytes and then advances to the
-        // next *valid* character of that encoded width (string.c
-        // `enc_succ_char` / `str_succ`), so a wrapped 4-byte UTF-8 char lands
-        // on U+10000 — `"\u{10FFFF}".succ.codepoints == [0x1, 0x10000]`, not
-        // [0x1, 0x0].
-        codes[i] = 0x10000;
+      const [min, max] = utf8WidthBounds(codes[i]);
+      if (codes[i] >= max) {
+        // `enc_succ_char` reports NEIGHBOR_WRAPPED whenever the successor's
+        // encoded length would differ (string.c: `l != len`), so a character
+        // at the top of its UTF-8 width wraps to that width's *minimum* and
+        // carries — `"\u{FFFF}".succ.codepoints == [0x1, 0x800]`, not
+        // [0x10000]. The carry then prepends U+0001 below.
+        codes[i] = min;
       } else {
         codes[i]++;
         // Surrogates are not valid characters; `enc_succ_char` skips past

--- a/packages/activesupport/src/range-ext.ts
+++ b/packages/activesupport/src/range-ext.ts
@@ -88,9 +88,17 @@ export function stringSucc(s: string): string {
     let carry = true;
     while (i >= 0 && carry) {
       if (codes[i] >= 0x10ffff) {
-        codes[i] = 0;
+        // Ruby zeroes the wrapped character's bytes and then advances to the
+        // next *valid* character of that encoded width (string.c
+        // `enc_succ_char` / `str_succ`), so a wrapped 4-byte UTF-8 char lands
+        // on U+10000 — `"\u{10FFFF}".succ.codepoints == [0x1, 0x10000]`, not
+        // [0x1, 0x0].
+        codes[i] = 0x10000;
       } else {
         codes[i]++;
+        // Surrogates are not valid characters; `enc_succ_char` skips past
+        // them to the next valid one rather than emitting an unpaired half.
+        if (codes[i] >= 0xd800 && codes[i] <= 0xdfff) codes[i] = 0xe000;
         carry = false;
       }
       i--;

--- a/packages/activesupport/src/range-ext.ts
+++ b/packages/activesupport/src/range-ext.ts
@@ -70,7 +70,7 @@ const isAsciiAlnum = (c: number): boolean =>
  */
 export function stringSucc(s: string): string {
   if (s.length === 0) return "";
-  const codes = Array.from(s, (ch) => ch.charCodeAt(0));
+  const codes = Array.from(s, (ch) => ch.codePointAt(0) as number);
 
   let lastAlnum = -1;
   for (let i = codes.length - 1; i >= 0; i--) {
@@ -81,11 +81,13 @@ export function stringSucc(s: string): string {
   }
 
   if (lastAlnum === -1) {
-    // No alphanumeric: raw code-unit increment with carry.
+    // No alphanumeric: whole-code-point increment with carry, matching Ruby's
+    // `enc_succ_char`, which advances by encoded character — not by UTF-16
+    // code unit, which would truncate an astral char to its high surrogate.
     let i = codes.length - 1;
     let carry = true;
     while (i >= 0 && carry) {
-      if (codes[i] >= 0xffff) {
+      if (codes[i] >= 0x10ffff) {
         codes[i] = 0;
       } else {
         codes[i]++;
@@ -94,7 +96,7 @@ export function stringSucc(s: string): string {
       i--;
     }
     if (carry) codes.unshift(1);
-    return String.fromCharCode(...codes);
+    return String.fromCodePoint(...codes);
   }
 
   // Carry leftward from the rightmost alphanumeric, wrapping within a class.
@@ -138,7 +140,7 @@ export function stringSucc(s: string): string {
     i--;
   }
   if (carry) codes.splice(overflowPos, 0, overflowChar);
-  return String.fromCharCode(...codes);
+  return String.fromCodePoint(...codes);
 }
 
 const lexCmp = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0);


### PR DESCRIPTION
Ruby's `String#succ` (string.c `enc_succ_char`) advances by encoded character. The no-alphanumeric branch of `stringSucc` used `charCodeAt(0)`, truncating astral chars to their high surrogate. Now iterates code points and wraps at 0x10FFFF.

Closes-story: string-succ-astral-codepoint-fidelity