### PR TITLE
refactor(arel): dispatch raw values on their class in Visitor#visit

### DIFF
--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -428,7 +428,7 @@ export class Attribute extends Node {
   // -- Math --
   //
   // Mirrors Arel::Math: operands pass through unwrapped. The visitor
-  // renders primitive values via `visitNodeOrValue`.
+  // renders primitive values via `visit` class dispatch.
 
   add(other: unknown): Grouping {
     return new Grouping(new Addition(this, other as NodeOrValue));

--- a/packages/arel/src/insert-manager.test.ts
+++ b/packages/arel/src/insert-manager.test.ts
@@ -251,7 +251,7 @@ describe("InsertManagerTest", () => {
 
   // Mirrors Rails: `InsertManager#select` stores the manager itself
   // (insert_manager.rb), not its inner `.ast`. The visitor handles
-  // the SelectManager-shaped duck-type via `visitNodeOrValue`.
+  // the SelectManager-shaped duck-type via `visit`.
   describe("select (Rails parity)", () => {
     it("stores the SelectManager itself on ast.select", () => {
       const mgr = new InsertManager(users);

--- a/packages/arel/src/insert-manager.ts
+++ b/packages/arel/src/insert-manager.ts
@@ -49,7 +49,7 @@ export class InsertManager extends TreeManager {
    * Mirrors: Arel::InsertManager#select — stores the manager itself
    * rather than unwrapping to its inner `.ast`. The visitor handles
    * either shape (raw Node or SelectManager-shaped duck-type) via
-   * `visitNodeOrValue`.
+   * `visit`.
    */
   select(selectManager: InsertSelectSource): this {
     this.ast.select = selectManager;

--- a/packages/arel/src/math.ts
+++ b/packages/arel/src/math.ts
@@ -21,7 +21,7 @@ import type { NodeOrValue } from "./nodes/binary.js";
  * bitwise operators wrap in Grouping so precedence is preserved when the
  * result is further chained; `*` and `/` do not — same as Rails. The
  * right-hand operand is passed through raw (Rails does not pre-quote);
- * the visitor renders primitive values via `visitNodeOrValue`.
+ * the visitor renders primitive values via `visit` class dispatch.
  */
 export const Math = {
   add(this: Node, other: unknown): Grouping {

--- a/packages/arel/src/nodes/values-list.ts
+++ b/packages/arel/src/nodes/values-list.ts
@@ -5,7 +5,7 @@ import { Unary } from "./unary.js";
  *
  * Mirrors: Arel::Nodes::ValuesList (extends Unary; rows stored in expr slot).
  * Rails carries arbitrary value objects in each row; the visitor delegates
- * rendering to `visitNodeOrValue`, so raw primitives flow through unwrapped.
+ * rendering to `visit` class dispatch, so raw primitives flow through unwrapped.
  */
 export class ValuesList extends Unary {
   constructor(rows: unknown[][]) {

--- a/packages/arel/src/update-manager.test.ts
+++ b/packages/arel/src/update-manager.test.ts
@@ -120,7 +120,7 @@ describe("UpdateManagerTest", () => {
     });
 
     // Mirrors Rails: values pass through raw (no Quoted wrap); the
-    // visitor's `visitNodeOrValue` quotes primitives.
+    // visitor's `visit` class dispatch quotes primitives.
     it("stores the raw value on the Assignment (no Quoted wrap)", () => {
       const mgr = new UpdateManager();
       mgr.table(users);

--- a/packages/arel/src/update-manager.ts
+++ b/packages/arel/src/update-manager.ts
@@ -49,7 +49,7 @@ export class UpdateManager extends TreeManager {
   set(values: UpdateValues): this {
     // Mirrors Arel::UpdateManager#set (update_manager.rb): pairs become
     // `Assignment(UnqualifiedColumn(col), value)` with the value passed
-    // through raw — the visitor's `visitNodeOrValue` dispatch quotes
+    // through raw — the visitor's `visit` class dispatch quotes
     // primitives. The `UnqualifiedColumn` wrapper strips the table
     // qualifier so the visitor does not need an `_inUpdateSet` mode flag.
     if (typeof values === "string") {

--- a/packages/arel/src/visitors/mysql.ts
+++ b/packages/arel/src/visitors/mysql.ts
@@ -146,9 +146,9 @@ export class MySQL extends ToSql {
 
   protected override visitArelNodesConcat(node: Nodes.Concat, collector: SQLString): SQLString {
     collector.append(" CONCAT(");
-    this.visitNodeOrValue(node.left, collector);
+    this.visit(node.left, collector);
     collector.append(", ");
-    this.visitNodeOrValue(node.right, collector);
+    this.visit(node.right, collector);
     collector.append(") ");
     return collector;
   }
@@ -160,9 +160,9 @@ export class MySQL extends ToSql {
     node: Nodes.IsNotDistinctFrom,
     collector: SQLString,
   ): SQLString {
-    this.visitNodeOrValue(node.left, collector);
+    this.visit(node.left, collector);
     collector.append(" <=> ");
-    this.visitNodeOrValue(node.right, collector);
+    this.visit(node.right, collector);
     return collector;
   }
 
@@ -171,9 +171,9 @@ export class MySQL extends ToSql {
     collector: SQLString,
   ): SQLString {
     collector.append("NOT ");
-    this.visitNodeOrValue(node.left, collector);
+    this.visit(node.left, collector);
     collector.append(" <=> ");
-    this.visitNodeOrValue(node.right, collector);
+    this.visit(node.right, collector);
     return collector;
   }
 
@@ -181,9 +181,9 @@ export class MySQL extends ToSql {
   // `!~` (which is Postgres). Mirrors Rails MySQL's `infix_value`
   // helper — same shape as visitArelNodesMatches.
   protected override visitArelNodesRegexp(node: Nodes.Regexp, collector: SQLString): SQLString {
-    this.visitNodeOrValue(node.left, collector);
+    this.visit(node.left, collector);
     collector.append(" REGEXP ");
-    this.visitNodeOrValue(node.right, collector);
+    this.visit(node.right, collector);
     return collector;
   }
 
@@ -191,9 +191,9 @@ export class MySQL extends ToSql {
     node: Nodes.NotRegexp,
     collector: SQLString,
   ): SQLString {
-    this.visitNodeOrValue(node.left, collector);
+    this.visit(node.left, collector);
     collector.append(" NOT REGEXP ");
-    this.visitNodeOrValue(node.right, collector);
+    this.visit(node.right, collector);
     return collector;
   }
 
@@ -203,7 +203,7 @@ export class MySQL extends ToSql {
   ): SQLString {
     // MySQL has no NULLS FIRST; emulate: col IS NOT NULL, col ASC/DESC
     const ordering = node.expr as Nodes.Ascending | Nodes.Descending;
-    this.visitNodeOrValue(ordering.expr as Nodes.NodeOrValue, collector);
+    this.visit(ordering.expr as Nodes.NodeOrValue, collector);
     collector.append(" IS NOT NULL, ");
     this.visit(ordering, collector);
     return collector;
@@ -215,7 +215,7 @@ export class MySQL extends ToSql {
   ): SQLString {
     // MySQL has no NULLS LAST; emulate: col IS NULL, col ASC/DESC
     const ordering = node.expr as Nodes.Ascending | Nodes.Descending;
-    this.visitNodeOrValue(ordering.expr as Nodes.NodeOrValue, collector);
+    this.visit(ordering.expr as Nodes.NodeOrValue, collector);
     collector.append(" IS NULL, ");
     this.visit(ordering, collector);
     return collector;

--- a/packages/arel/src/visitors/postgresql.ts
+++ b/packages/arel/src/visitors/postgresql.ts
@@ -23,9 +23,9 @@ export class PostgreSQL extends ToSql {
   }
 
   protected override visitArelNodesMatches(node: Nodes.Matches, collector: SQLString): SQLString {
-    this.visitNodeOrValue(node.left, collector);
+    this.visit(node.left, collector);
     collector.append(node.caseSensitive ? " LIKE " : " ILIKE ");
-    this.visitNodeOrValue(node.right, collector);
+    this.visit(node.right, collector);
     this.appendEscape(node.escape, collector);
     return collector;
   }
@@ -34,9 +34,9 @@ export class PostgreSQL extends ToSql {
     node: Nodes.DoesNotMatch,
     collector: SQLString,
   ): SQLString {
-    this.visitNodeOrValue(node.left, collector);
+    this.visit(node.left, collector);
     collector.append(node.caseSensitive ? " NOT LIKE " : " NOT ILIKE ");
-    this.visitNodeOrValue(node.right, collector);
+    this.visit(node.right, collector);
     this.appendEscape(node.escape, collector);
     return collector;
   }
@@ -104,9 +104,9 @@ export class PostgreSQL extends ToSql {
     node: Nodes.IsNotDistinctFrom,
     collector: SQLString,
   ): SQLString {
-    this.visitNodeOrValue(node.left, collector);
+    this.visit(node.left, collector);
     collector.append(" IS NOT DISTINCT FROM ");
-    this.visitNodeOrValue(node.right, collector);
+    this.visit(node.right, collector);
     return collector;
   }
 
@@ -114,9 +114,9 @@ export class PostgreSQL extends ToSql {
     node: Nodes.IsDistinctFrom,
     collector: SQLString,
   ): SQLString {
-    this.visitNodeOrValue(node.left, collector);
+    this.visit(node.left, collector);
     collector.append(" IS DISTINCT FROM ");
-    this.visitNodeOrValue(node.right, collector);
+    this.visit(node.right, collector);
     return collector;
   }
 

--- a/packages/arel/src/visitors/ruby-class.ts
+++ b/packages/arel/src/visitors/ruby-class.ts
@@ -1,0 +1,71 @@
+import { temporalClassName, temporalTag } from "../temporal-tag.js";
+
+/**
+ * The Ruby class name `Visitor#visit` would dispatch a raw value on.
+ *
+ * Rails gets this for free: `dispatch[object.class]` (visitor.rb:29) reads the
+ * runtime class off any object, and `dispatch_cache` (visitor.rb:17-21) turns
+ * it into `:"visit_#{klass.name}"`. JS primitives have no such class, so this
+ * function is the missing half of `object.class` — it names the Ruby class a
+ * value would have had, and `Visitor#visit` turns that name into `visit<Name>`.
+ *
+ * Returns `null` for values that dispatch on their JS constructor instead
+ * (every Arel node, ActiveModel::Attribute, and any other real class), which
+ * is the dispatch path `Visitor#visit` tries first.
+ */
+export function rubyClassName(v: unknown): string | null {
+  // Not a Node and not importable here (SelectManager → ToSql → SelectManager
+  // is circular), so it is recognised by shape. Rails dispatches it on its
+  // real class to `visit_Arel_SelectManager` (to_sql.rb:106).
+  if (v !== null && typeof v === "object" && "ast" in v && "toSql" in v) {
+    return "ArelSelectManager";
+  }
+  if (Array.isArray(v)) return "Array";
+  if (typeof v === "number") {
+    // Ruby splits Integer (renders, to_sql.rb:824) from Float (raises,
+    // rb:839); `Number.isInteger` is that split. A non-finite number is never
+    // integral, so it lands on Float and raises, as Rails' Float does.
+    return Number.isInteger(v) ? "Integer" : "Float";
+  }
+  // Ruby has no fixnum/bignum distinction at this layer — both are Integer.
+  if (typeof v === "bigint") return "Integer";
+  if (v === null || v === undefined) return "NilClass";
+  if (typeof v === "string") return "String";
+  if (typeof v === "boolean") return v ? "TrueClass" : "FalseClass";
+  if (typeof v === "symbol") return "Symbol";
+  const dateTime = dateTimeClassName(v);
+  if (dateTime !== null) return dateTime;
+  if (isPlainObject(v)) return "Hash";
+  return null;
+}
+
+// The analogue of Ruby's Hash — an object literal, i.e. one whose prototype is
+// Object.prototype (or null). Anything else is an instance of some other class
+// and dispatches on that class in Rails, not on Hash.
+function isPlainObject(v: unknown): boolean {
+  if (typeof v !== "object" || v === null) return false;
+  const proto = Object.getPrototypeOf(v);
+  return proto === Object.prototype || proto === null;
+}
+
+// The Ruby class Rails would dispatch a date/time value on, all three of which
+// Rails aliases to `unsupported` (to_sql.rb:836-844). Temporal is the Time/Date
+// analogue in this codebase and Temporal types expose no `toISOString`, so they
+// match on their tag via the shared whitelist; a JS Date (or any toISOString
+// duck-type) is an instant-in-time and maps to Time.
+//
+// Only the whitelisted tags answer: `Duration`, `PlainYearMonth` and
+// `PlainMonthDay` have no Ruby analogue and so fall through to the same
+// no-visitable-ancestor path an arbitrary object takes, rather than being
+// mislabelled as a Time.
+function dateTimeClassName(v: unknown): string | null {
+  const temporalClass = temporalClassName(v);
+  if (temporalClass !== null) return temporalClass;
+  if (temporalTag(v) !== null) return null;
+  const isInstantDuckType =
+    typeof v === "object" &&
+    v !== null &&
+    "toISOString" in v &&
+    typeof (v as { toISOString: unknown }).toISOString === "function";
+  return isInstantDuckType ? "Time" : null;
+}

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -17,7 +17,6 @@ import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 export { UnsupportedVisitError };
 
 import { defaultQuoter } from "./default-quoter.js";
-import { temporalClassName, temporalTag, type TemporalClassName } from "../temporal-tag.js";
 export type { ArelConnection } from "./connection.js";
 import type { ArelConnection } from "./connection.js";
 
@@ -51,8 +50,8 @@ export function resolveValueForDatabase(value: unknown): unknown {
 // -- Raw-value dispatch helpers --
 //
 // Rails dispatches a raw value on its Ruby class (visitor.rb:29-30). These map
-// each JS analogue onto the class Rails would pick, so `visitNodeOrValue` can
-// hand off to the matching visit_* method.
+// each JS analogue onto the class Rails would pick; the mapping itself lives
+// in `rubyClassName` (ruby-class.ts), which `Visitor#visit` consults.
 
 // The analogue of Rails' `ActiveModel::Attribute` case in the ValuesList /
 // Assignment visitors (to_sql.rb:110, 632). Rails dispatches on the class, and
@@ -62,37 +61,6 @@ export function resolveValueForDatabase(value: unknown): unknown {
 // rb:110's narrow `when` requires.
 function isActiveModelAttribute(v: unknown): boolean {
   return v instanceof ModelAttribute;
-}
-
-// The analogue of Ruby's Hash — an object literal, i.e. one whose prototype is
-// Object.prototype (or null). Anything else is an instance of some other class
-// and dispatches on that class in Rails, not on Hash.
-function isPlainObject(v: unknown): boolean {
-  if (typeof v !== "object" || v === null) return false;
-  const proto = Object.getPrototypeOf(v);
-  return proto === Object.prototype || proto === null;
-}
-
-// The Ruby class Rails would dispatch a date/time value on, all three of which
-// Rails aliases to `unsupported` (to_sql.rb:836-844). Temporal is the Time/Date
-// analogue in this codebase and Temporal types expose no `toISOString`, so they
-// match on their tag via the shared whitelist; a JS Date (or any toISOString
-// duck-type) is an instant-in-time and maps to Time.
-//
-// Only the whitelisted tags answer: `Duration`, `PlainYearMonth` and
-// `PlainMonthDay` have no Ruby analogue and so fall through to the same
-// no-visitable-ancestor path an arbitrary object takes, rather than being
-// mislabelled as a Time.
-function dateTimeClassName(v: unknown): TemporalClassName | null {
-  const temporalClass = temporalClassName(v);
-  if (temporalClass !== null) return temporalClass;
-  if (temporalTag(v) !== null) return null;
-  const isInstantDuckType =
-    typeof v === "object" &&
-    v !== null &&
-    "toISOString" in v &&
-    typeof (v as { toISOString: unknown }).toISOString === "function";
-  return isInstantDuckType ? "Time" : null;
 }
 
 // Rails' UnsupportedVisitError message interpolates `object.class.name`
@@ -331,14 +299,14 @@ export class ToSql extends Visitor {
 
     // Mirrors Rails: prefer `node.values` when both are present
     // (insert_statement.rb / to_sql.rb pattern). Routes through
-    // `visitNodeOrValue` so a SelectManager-shaped duck-type (the form
+    // `visit` so a SelectManager-shaped duck-type (the form
     // `InsertManager#select` stores) lands in `visitArelSelectManager`.
     if (node.values) {
       collector.append(" ");
       this.visit(node.values, collector);
     } else if (node.select) {
       collector.append(" ");
-      this.visitNodeOrValue(node.select as Nodes.NodeOrValue, collector);
+      this.visit(node.select as Nodes.NodeOrValue, collector);
     }
 
     return collector;
@@ -769,9 +737,9 @@ export class ToSql extends Visitor {
   // -- Filter --
 
   private visitArelNodesFilter(node: Nodes.Filter, collector: SQLString): SQLString {
-    this.visitNodeOrValue(node.left, collector);
+    this.visit(node.left, collector);
     collector.append(" FILTER (WHERE ");
-    this.visitNodeOrValue(node.right, collector);
+    this.visit(node.right, collector);
     collector.append(")");
     return collector;
   }
@@ -820,10 +788,10 @@ export class ToSql extends Visitor {
   }
 
   private visitArelNodesOver(node: Nodes.Over, collector: SQLString): SQLString {
-    this.visitNodeOrValue(node.left, collector);
+    this.visit(node.left, collector);
     collector.append(" OVER ");
     if (node.right) {
-      this.visitNodeOrValue(node.right, collector);
+      this.visit(node.right, collector);
     } else {
       collector.append("()");
     }
@@ -1005,7 +973,7 @@ export class ToSql extends Visitor {
   }
 
   private visitArelNodesBetween(node: Nodes.Between, collector: SQLString): SQLString {
-    this.visitNodeOrValue(node.left, collector);
+    this.visit(node.left, collector);
     collector.append(" BETWEEN ");
     if (node.right instanceof Nodes.And) {
       const and = node.right;
@@ -1013,7 +981,7 @@ export class ToSql extends Visitor {
       collector.append(" AND ");
       this.visit(and.children[1], collector);
     } else {
-      this.visitNodeOrValue(node.right, collector);
+      this.visit(node.right, collector);
     }
     return collector;
   }
@@ -1057,17 +1025,17 @@ export class ToSql extends Visitor {
   // -- Matches with ESCAPE --
 
   protected visitArelNodesMatches(node: Nodes.Matches, collector: SQLString): SQLString {
-    this.visitNodeOrValue(node.left, collector);
+    this.visit(node.left, collector);
     collector.append(" LIKE ");
-    this.visitNodeOrValue(node.right, collector);
+    this.visit(node.right, collector);
     this.appendEscape(node.escape, collector);
     return collector;
   }
 
   protected visitArelNodesDoesNotMatch(node: Nodes.DoesNotMatch, collector: SQLString): SQLString {
-    this.visitNodeOrValue(node.left, collector);
+    this.visit(node.left, collector);
     collector.append(" NOT LIKE ");
-    this.visitNodeOrValue(node.right, collector);
+    this.visit(node.right, collector);
     this.appendEscape(node.escape, collector);
     return collector;
   }
@@ -1183,8 +1151,8 @@ export class ToSql extends Visitor {
         return collector;
       }
     }
-    this.visitNodeOrValue(node.left, collector);
-    // Duck-type check for SelectManager subquery - visitNodeOrValue wraps it in parens
+    this.visit(node.left, collector);
+    // Duck-type check for SelectManager subquery - visit wraps it in parens
     if (
       values &&
       typeof values === "object" &&
@@ -1193,7 +1161,7 @@ export class ToSql extends Visitor {
       "toSql" in (values as unknown as Record<string, unknown>)
     ) {
       collector.append(" IN ");
-      this.visitNodeOrValue(values, collector);
+      this.visit(values, collector);
       return collector;
     }
     collector.append(" IN (");
@@ -1203,7 +1171,7 @@ export class ToSql extends Visitor {
         this.visit(values[i], collector);
       }
     } else {
-      this.visitNodeOrValue(values, collector);
+      this.visit(values, collector);
     }
     collector.append(")");
     return collector;
@@ -1222,7 +1190,7 @@ export class ToSql extends Visitor {
         return collector;
       }
     }
-    this.visitNodeOrValue(node.left, collector);
+    this.visit(node.left, collector);
     if (Array.isArray(values)) {
       collector.append(" NOT IN (");
       for (let i = 0; i < values.length; i++) {
@@ -1232,7 +1200,7 @@ export class ToSql extends Visitor {
       collector.append(")");
     } else {
       collector.append(" NOT IN (");
-      this.visitNodeOrValue(values, collector);
+      this.visit(values, collector);
       collector.append(")");
     }
     return collector;
@@ -1259,7 +1227,7 @@ export class ToSql extends Visitor {
   private visitArelNodesAssignment(node: Nodes.Assignment, collector: SQLString): SQLString {
     // Column-name unqualification is the responsibility of `UnqualifiedColumn`,
     // which `UpdateManager#set` wraps each LHS in.
-    this.visitNodeOrValue(node.left, collector);
+    this.visit(node.left, collector);
     collector.append(" = ");
     // Mirrors Rails (to_sql.rb:630-641): a Node/Attribute right is visited; a
     // raw value is quoted directly rather than dispatched through `visit`.
@@ -1280,13 +1248,13 @@ export class ToSql extends Visitor {
       return collector.append("1=0");
     }
     if (this.rightIsNull(node.right)) {
-      this.visitNodeOrValue(node.left, collector);
+      this.visit(node.left, collector);
       collector.append(" IS NULL");
       return collector;
     }
-    this.visitNodeOrValue(node.left, collector);
+    this.visit(node.left, collector);
     collector.append(" = ");
-    this.visitNodeOrValue(node.right, collector);
+    this.visit(node.right, collector);
     return collector;
   }
 
@@ -1295,7 +1263,7 @@ export class ToSql extends Visitor {
     collector: SQLString,
   ): SQLString {
     if (this.rightIsNull(node.right)) {
-      this.visitNodeOrValue(node.left, collector);
+      this.visit(node.left, collector);
       collector.append(" IS NULL");
       return collector;
     }
@@ -1307,7 +1275,7 @@ export class ToSql extends Visitor {
     collector: SQLString,
   ): SQLString {
     if (this.rightIsNull(node.right)) {
-      this.visitNodeOrValue(node.left, collector);
+      this.visit(node.left, collector);
       collector.append(" IS NOT NULL");
       return collector;
     }
@@ -1319,20 +1287,20 @@ export class ToSql extends Visitor {
       return collector.append("1=1");
     }
     if (this.rightIsNull(node.right)) {
-      this.visitNodeOrValue(node.left, collector);
+      this.visit(node.left, collector);
       collector.append(" IS NOT NULL");
       return collector;
     }
-    this.visitNodeOrValue(node.left, collector);
+    this.visit(node.left, collector);
     collector.append(" != ");
-    this.visitNodeOrValue(node.right, collector);
+    this.visit(node.right, collector);
     return collector;
   }
 
   private visitArelNodesAs(node: Nodes.As, collector: SQLString): SQLString {
-    this.visitNodeOrValue(node.left, collector);
+    this.visit(node.left, collector);
     collector.append(" AS ");
-    this.visitNodeOrValue(node.right, collector);
+    this.visit(node.right, collector);
     return collector;
   }
 
@@ -1359,16 +1327,16 @@ export class ToSql extends Visitor {
   // Mirrors Rails: visit_Arel_Nodes_When (to_sql.rb).
   protected visitArelNodesWhen(node: Nodes.When, collector: SQLString): SQLString {
     collector.append("WHEN ");
-    this.visitNodeOrValue(node.left, collector);
+    this.visit(node.left, collector);
     collector.append(" THEN ");
-    this.visitNodeOrValue(node.right, collector);
+    this.visit(node.right, collector);
     return collector;
   }
 
   // Mirrors Rails: visit_Arel_Nodes_Else (to_sql.rb).
   protected visitArelNodesElse(node: Nodes.Else, collector: SQLString): SQLString {
     collector.append("ELSE ");
-    this.visitNodeOrValue(node.expr as Nodes.NodeOrValue, collector);
+    this.visit(node.expr as Nodes.NodeOrValue, collector);
     return collector;
   }
 
@@ -1519,7 +1487,7 @@ export class ToSql extends Visitor {
    * as well as `number`: Ruby's `Integer` is arbitrary-precision and Arel has
    * no separate bignum visitor, so both JS numeric types land here.
    *
-   * Callers: `visitNodeOrValue` routes every `bigint` here, and every
+   * Callers: `Visitor#visit` routes every `bigint` here, and every
    * *integral* `number` — the `Number.isInteger` split mirrors Ruby's
    * Integer-vs-Float, so a `1.5` reaches `visitFloat` and raises (rb:839) as
    * it does in Rails.
@@ -1545,7 +1513,7 @@ export class ToSql extends Visitor {
   // `UnsupportedVisitError`. TS has no method-alias, so each delegates to
   // the shared helper. Each keeps the Rails `(o, collector)` shape.
   //
-  // `visitNodeOrValue` dispatches raw values onto these, so the unsupported
+  // `Visitor#visit` class-dispatches raw values onto these, so the unsupported
   // contract is enforced on the one path that can reach it — they are not
   // documentation-only. The exception is the Ruby-specific string classes
   // (Multibyte::Chars, StringInquirer), which have no JS analogue to dispatch
@@ -1627,9 +1595,9 @@ export class ToSql extends Visitor {
     node: Nodes.InfixOperation,
     collector: SQLString,
   ): SQLString {
-    this.visitNodeOrValue(node.left, collector);
+    this.visit(node.left, collector);
     collector.append(` ${node.operator} `);
-    this.visitNodeOrValue(node.right, collector);
+    this.visit(node.right, collector);
     return collector;
   }
 
@@ -1651,13 +1619,13 @@ export class ToSql extends Visitor {
    * Mirrors Rails: `visit_Array` (to_sql.rb:858). Rails delegates to
    * `inject_join` which calls `visit` on each element; in Ruby `visit` of
    * a primitive routes through `visit_Integer`/`visit_String`/etc. Trails
-   * doesn't dispatch on JS primitives — `visitNodeOrValue` is the
+   * doesn't dispatch on JS primitives — `rubyClassName` (ruby-class.ts) is the
    * equivalent path that handles both Node and non-Node entries.
    */
   protected visitArray(items: ReadonlyArray<Nodes.NodeOrValue>, collector: SQLString): SQLString {
     items.forEach((item, i) => {
       if (i > 0) collector.append(", ");
-      this.visitNodeOrValue(item, collector);
+      this.visit(item, collector);
     });
     return collector;
   }
@@ -1996,9 +1964,9 @@ export class ToSql extends Visitor {
   }
 
   protected visitBinaryOp(node: Nodes.Binary, op: string, collector: SQLString): SQLString {
-    this.visitNodeOrValue(node.left, collector);
+    this.visit(node.left, collector);
     collector.append(` ${op} `);
-    this.visitNodeOrValue(node.right, collector);
+    this.visit(node.right, collector);
     return collector;
   }
 
@@ -2066,9 +2034,9 @@ export class ToSql extends Visitor {
   // -- Concat --
 
   protected visitArelNodesConcat(node: Nodes.Concat, collector: SQLString): SQLString {
-    this.visitNodeOrValue(node.left, collector);
+    this.visit(node.left, collector);
     collector.append(" || ");
-    this.visitNodeOrValue(node.right, collector);
+    this.visit(node.right, collector);
     return collector;
   }
 
@@ -2134,71 +2102,6 @@ export class ToSql extends Visitor {
   }
 
   // -- Helpers --
-
-  protected visitNodeOrValue(v: Nodes.NodeOrValue, collector: SQLString): SQLString {
-    // Duck-type check for SelectManager (not a Node, but has ast/toSql).
-    // Delegates to visitArelSelectManager — the Rails-named visitor for
-    // a bare SelectManager — so the wrapping behavior lives in one place.
-    if (v !== null && v !== undefined && typeof v === "object" && "ast" in v && "toSql" in v) {
-      return this.visitArelSelectManager(v as unknown as { ast: Node }, collector);
-    }
-    if (Array.isArray(v)) {
-      // Mirrors Rails: `visit_Array` (to_sql.rb) — primitives and Nodes in
-      // arrays both flow through here, joined by ", ".
-      return this.visitArray(v, collector);
-    }
-    if (v instanceof Node) {
-      // Duck-type check to avoid circular dependency (SelectManager → ToSql → SelectManager)
-      if ("ast" in v && "toSql" in v) {
-        return this.visitArelSelectManager(v as unknown as { ast: Node }, collector);
-      }
-      return this.visit(v, collector);
-    }
-    // Raw-value dispatch — trails' stand-in for Rails' `visit` class dispatch
-    // on a stray Ruby value. Rails renders exactly ONE raw scalar here,
-    // Integer, via `visit_Integer` (to_sql.rb:824-826). NilClass (rb:841),
-    // String (rb:842), Float (rb:839), TrueClass (rb:845), FalseClass
-    // (rb:838), Date (rb:836), Time (rb:844), BigDecimal (rb:834), Symbol
-    // (rb:843) and Hash (rb:840) all alias to `unsupported` and raise
-    // (rb:828-845); the branches below dispatch to those ports so the anchor
-    // is structural rather than a comment that can drift.
-    //
-    // Note to_sql.rb:87-90 (`visit_Arel_Nodes_Casted`) is the *other* value
-    // path, the one that routes through quote(); it is ported in
-    // `visitArelNodesCasted` and is what ActiveRecord actually uses, so
-    // nothing on the AR-facing path reaches this dispatch.
-    if (typeof v === "number") {
-      // Ruby splits Integer (renders) from Float (raises); `Number.isInteger`
-      // is that split. A non-finite number is never integral, so it lands on
-      // the Float branch and raises, as Rails' Float does.
-      return Number.isInteger(v) ? this.visitInteger(v, collector) : this.visitFloat(v, collector);
-    }
-    if (typeof v === "bigint") {
-      // Ruby has no fixnum/bignum distinction at this layer — both are
-      // Integer, so a bigint renders bare via visit_Integer.
-      return this.visitInteger(v, collector);
-    }
-    if (v === null || v === undefined) return this.visitNilClass(v, collector);
-    if (typeof v === "string") return this.visitString(v, collector);
-    if (typeof v === "boolean") {
-      return v ? this.visitTrueClass(v, collector) : this.visitFalseClass(v, collector);
-    }
-    if (typeof v === "symbol") return this.visitSymbol(v, collector);
-    switch (dateTimeClassName(v)) {
-      case "Date":
-        return this.visitDate(v, collector);
-      case "DateTime":
-        return this.visitDateTime(v, collector);
-      case "Time":
-        return this.visitTime(v, collector);
-    }
-    if (isPlainObject(v)) return this.visitHash(v, collector);
-    // Rails dispatches on the object's actual class (visitor.rb:29-30), so an
-    // arbitrary object never reaches visit_Hash — it finds no handler and
-    // raises. Going straight to `unsupported` keeps the reported class honest
-    // rather than mislabelling it as a Hash.
-    return this.unsupported(v, collector);
-  }
 
   /**
    * Mirrors `to_sql.rb#unboundable?` (to_sql.rb:905-907), returning the sign

--- a/packages/arel/src/visitors/visitor.test.ts
+++ b/packages/arel/src/visitors/visitor.test.ts
@@ -102,6 +102,61 @@ describe("Visitor dispatch", () => {
     expect(TestVisitor.dispatchCache().has(C)).toBe(false);
   });
 
+  describe("raw values dispatch on their Ruby class", () => {
+    // Rails' `visit` reads `object.class` for every object (visitor.rb:29), so
+    // raw values and nodes share one method table and one entry point — there
+    // is no separate raw-value path. These pin that the same `accept` that
+    // dispatches a Node also resolves a bare JS value to `visit<RubyClass>`.
+    class ValueVisitor extends Visitor {
+      visitInteger(o: number | bigint): string {
+        return `Integer:${o}`;
+      }
+      visitString(o: string): string {
+        return `String:${o}`;
+      }
+      visitFloat(o: number): string {
+        return `Float:${o}`;
+      }
+      visitTrueClass(): string {
+        return "TrueClass";
+      }
+      visitFalseClass(): string {
+        return "FalseClass";
+      }
+      visitNilClass(): string {
+        return "NilClass";
+      }
+      visitHash(): string {
+        return "Hash";
+      }
+      visitTime(): string {
+        return "Time";
+      }
+    }
+
+    it.each([
+      [1, "Integer:1"],
+      // Ruby has no fixnum/bignum split at this layer — both are Integer.
+      [10n, "Integer:10"],
+      // Ruby splits Integer from Float; a non-integral number is a Float.
+      [1.5, "Float:1.5"],
+      ["x", "String:x"],
+      [true, "TrueClass"],
+      [false, "FalseClass"],
+      [null, "NilClass"],
+      [undefined, "NilClass"],
+      [{ a: 1 }, "Hash"],
+      [new Date("2024-01-01T00:00:00Z"), "Time"],
+    ])("dispatches %o through visit", (value, expected) => {
+      expect(new ValueVisitor().accept(value)).toBe(expected);
+    });
+
+    it("raises when the value's class has no handler", () => {
+      class Arbitrary {}
+      expect(() => new ValueVisitor().accept(new Arbitrary())).toThrow(UnsupportedVisitError);
+    });
+  });
+
   it("a subclass override of the visit method dispatches polymorphically", () => {
     class Sub extends TestVisitor {
       override visitA(_n: A): string {

--- a/packages/arel/src/visitors/visitor.ts
+++ b/packages/arel/src/visitors/visitor.ts
@@ -1,5 +1,15 @@
 import { Node } from "../nodes/node.js";
 import { UnsupportedVisitError } from "../errors.js";
+import { rubyClassName } from "./ruby-class.js";
+
+// Rails interpolates `object.class` straight into its "Cannot visit" TypeError
+// (visitor.rb:38). The nearest handle here is the Ruby class the value would
+// have had, falling back to the JS constructor for a real class.
+function describeClass(object: unknown): string {
+  const rubyClass = rubyClassName(object);
+  if (rubyClass !== null) return rubyClass;
+  return (object as { constructor?: { name?: string } })?.constructor?.name ?? typeof object;
+}
 
 /**
  * Opaque dispatch-cache key for a Node subclass.
@@ -28,6 +38,13 @@ const PER_CLASS_CACHE = new WeakMap<VisitorCtor, Map<NodeCtor, string>>();
  * `dispatchCache` (a `Map<NodeCtor, methodName>`), and `visit` looks up the
  * runtime constructor, falling back to the prototype chain (mirroring
  * Ruby's `klass.ancestors` walk).
+ *
+ * Raw JS values reach the same method table. Ruby has a class for every
+ * object, so `visit(1)` is `visit_Integer` and `visit("x")` is `visit_String`
+ * (which aliases to `unsupported` and raises, to_sql.rb:842) — there is no
+ * separate entry point for values. A JS primitive has no such class, so
+ * `rubyClassName` names the Ruby class it would have had and `visit` resolves
+ * that to the matching `visit<Name>` method.
  */
 export abstract class Visitor {
   protected dispatch: Map<NodeCtor, string>;
@@ -36,9 +53,9 @@ export abstract class Visitor {
     this.dispatch = this.getDispatchCache();
   }
 
-  accept<C>(object: Node, collector: C): C;
-  accept(object: Node): unknown;
-  accept(object: Node, collector?: unknown): unknown {
+  accept<C>(object: unknown, collector: C): C;
+  accept(object: unknown): unknown;
+  accept(object: unknown, collector?: unknown): unknown {
     return this.visit(object, collector);
   }
 
@@ -50,13 +67,12 @@ export abstract class Visitor {
     return (this.constructor as VisitorCtor).dispatchCache();
   }
 
-  protected visit<C>(object: Node, collector: C): C;
-  protected visit(object: Node): unknown;
-  protected visit(object: Node, collector?: unknown): unknown {
-    const ctor = object.constructor as NodeCtor;
-    const methodName = this.resolveDispatch(ctor);
+  protected visit<C>(object: unknown, collector: C): C;
+  protected visit(object: unknown): unknown;
+  protected visit(object: unknown, collector?: unknown): unknown {
+    const methodName = this.dispatchMethod(object);
     if (!methodName) {
-      throw new UnsupportedVisitError(`Unknown node type: ${ctor.name}`);
+      throw new UnsupportedVisitError(`Unknown node type: ${describeClass(object)}`);
     }
     const fn = (this as unknown as Record<string, unknown>)[methodName];
     if (typeof fn !== "function") {
@@ -65,10 +81,10 @@ export abstract class Visitor {
       // cache). Distinct from the "no entry at all" case above so the
       // failure mode is unambiguous.
       throw new UnsupportedVisitError(
-        `Dispatch method '${methodName}' is not defined on ${this.constructor.name} for node ${ctor.name}`,
+        `Dispatch method '${methodName}' is not defined on ${this.constructor.name} for node ${describeClass(object)}`,
       );
     }
-    return (fn as (n: Node, c?: unknown) => unknown).call(this, object, collector);
+    return (fn as (n: unknown, c?: unknown) => unknown).call(this, object, collector);
   }
 
   /**
@@ -89,6 +105,25 @@ export abstract class Visitor {
       PER_CLASS_CACHE.set(this, cache);
     }
     return cache;
+  }
+
+  /**
+   * The dispatch method name for `object`, mirroring `dispatch[object.class]`
+   * (visitor.rb:29). Rails reads one runtime class off every object it visits,
+   * nodes and raw values alike; TS has no single such handle, so a real class
+   * resolves through the constructor-keyed cache and a raw JS value resolves
+   * through `rubyClassName` — the name of the Ruby class it would have had.
+   * Both arrive at the same `visit<Name>` method table, so there is no second
+   * entry point for raw values.
+   */
+  private dispatchMethod(object: unknown): string | undefined {
+    const ctor = (object as { constructor?: NodeCtor } | null | undefined)?.constructor;
+    if (ctor) {
+      const byCtor = this.resolveDispatch(ctor);
+      if (byCtor) return byCtor;
+    }
+    const rubyClass = rubyClassName(object);
+    return rubyClass === null ? undefined : `visit${rubyClass}`;
   }
 
   /**

--- a/scripts/api-compare/call-mismatches-wide-exclude/arel/visitors/mysql.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/arel/visitors/mysql.json
@@ -16,22 +16,8 @@
   {
     "package": "arel",
     "tsFile": "visitors/mysql.ts",
-    "rubyName": "visit_Arel_Nodes_Concat",
-    "call": "visit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/mysql.ts",
     "rubyName": "visit_Arel_Nodes_IsDistinctFrom",
     "call": "visit_Arel_Nodes_IsNotDistinctFrom",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/mysql.ts",
-    "rubyName": "visit_Arel_Nodes_IsNotDistinctFrom",
-    "call": "visit",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/arel/visitors/postgresql.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/arel/visitors/postgresql.json
@@ -9,36 +9,8 @@
   {
     "package": "arel",
     "tsFile": "visitors/postgresql.ts",
-    "rubyName": "visit_Arel_Nodes_DoesNotMatch",
-    "call": "visit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/postgresql.ts",
-    "rubyName": "visit_Arel_Nodes_IsDistinctFrom",
-    "call": "visit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/postgresql.ts",
-    "rubyName": "visit_Arel_Nodes_IsNotDistinctFrom",
-    "call": "visit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/postgresql.ts",
     "rubyName": "visit_Arel_Nodes_Matches",
     "call": "infix_value",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/postgresql.ts",
-    "rubyName": "visit_Arel_Nodes_Matches",
-    "call": "visit",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/arel/visitors/to-sql.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/arel/visitors/to-sql.json
@@ -37,13 +37,6 @@
   {
     "package": "arel",
     "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_As",
-    "call": "visit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_Assignment",
     "call": "to_s",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -128,20 +121,6 @@
   {
     "package": "arel",
     "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_DoesNotMatch",
-    "call": "visit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_Else",
-    "call": "visit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_Equality",
     "call": "unboundable?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -149,22 +128,8 @@
   {
     "package": "arel",
     "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_Equality",
-    "call": "visit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_Extract",
     "call": "to_s",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_Filter",
-    "call": "visit",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -212,13 +177,6 @@
   {
     "package": "arel",
     "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_InfixOperation",
-    "call": "visit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_InsertStatement",
     "call": "maybe_visit",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -233,22 +191,8 @@
   {
     "package": "arel",
     "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_IsDistinctFrom",
-    "call": "visit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_IsNotDistinctFrom",
     "call": "is_distinct_from",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_IsNotDistinctFrom",
-    "call": "visit",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -296,22 +240,8 @@
   {
     "package": "arel",
     "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_Matches",
-    "call": "visit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_NotEqual",
     "call": "unboundable?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_NotEqual",
-    "call": "visit",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -354,13 +284,6 @@
     "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_Over",
     "call": "to_s",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_Over",
-    "call": "visit",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -410,13 +333,6 @@
     "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_ValuesList",
     "call": "to_s",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_When",
-    "call": "visit",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {


### PR DESCRIPTION
Story: `arel-visit-dispatches-raw-classes-like-rails` (RFC 0066).

## What

Rails' `Visitor#visit` (`visitor.rb:27-33`) dispatches on the runtime class of
*any* object — `dispatch[object.class]` — so nodes and raw values share one
method table and one entry point. `visit(1)` resolves to `visit_Integer`
(`to_sql.rb:824-826`, renders bare); `visit("x")` resolves to `visit_String`,
which aliases to `unsupported` and raises (`to_sql.rb:842`).

Trails' `visit` keyed only on Node constructors and threw `UnsupportedVisitError`
for a raw value, so the codebase grew **`visitNodeOrValue`** — a parallel
hand-rolled `typeof` chain with no Rails counterpart
(`grep -rn "node_or_value" vendor/rails/activerecord/lib/arel/` is empty).

`visit` now resolves a dispatch method for any object:

- a real class → the existing constructor-keyed dispatch cache (unchanged);
- a raw JS value → `rubyClassName` (new `visitors/ruby-class.ts`), which names
  the Ruby class the value would have had, mapped to `visit<Name>`.

The JS→Ruby class mapping **moves out of `to-sql.ts` unchanged**, so the
Integer/Float split, the Date/DateTime/Time analogues and the Hash (plain-object)
case keep their existing behaviour — this PR is a restructure of *where* dispatch
happens, not a change to *what* each value renders.

`visitNodeOrValue` is deleted; its ~64 call sites in `to-sql.ts`, `mysql.ts` and
`postgresql.ts` now call `visit`. Zero references remain repo-wide.

## Why it matters

- The Rails-native value ports (`visitInteger`, `visitString`, `visitNilClass`,
  `visitFloat`, `visitTrueClass`/`visitFalseClass`, `visitDate`, `visitTime`,
  `visitHash`, …) are now reachable through `visit`, not just by direct call.
  The `visitInteger` direct-call shims #4871 added as an interim anchor are gone
  with the method that held them.
- Two methods no longer have to be kept in agreement about the same subject
  (they drifted twice within #4871 alone).

## Ratchet

Converging the call bodies made **18 wide call-ratchet entries stale** — places
where Rails calls `visit` and trails called `visitNodeOrValue`. Those baseline
entries are deleted by hand (not a blind `--write`); `pnpm api:calls:wide` is
green and the baseline shrank 6821 → 6803.

## Testing

- `packages/arel` full package: 1560 passed / 73 files.
- AR arel-facing slice (`relation.test.ts`, `arel-ast-convergence`,
  `build-arel-helpers`, `composite-where`, `finder-methods`, `sanitize`,
  `where-clause`): 240 passed.
- New `visitor.test.ts` cases pin the structural claim: the same `accept` that
  dispatches a Node resolves a bare JS value to `visit<RubyClass>`, with an
  arbitrary class still raising.

## Parity gates (measured against `origin/main` at 845861b19)

| gate | main | branch | delta |
| --- | --- | --- | --- |
| api:compare (arel) | 938/938 methods, 69/69 files | 938/938 methods, 69/69 files | 0 |
| test:compare (arel) | 703/707 (99.4%), 59/59 files | 703/707 (99.4%), 59/59 files | 0 |
| wide call ratchet | 6821 baselined | 6803 baselined | -18 (converged) |

Both deltas non-negative. `visitNodeOrValue` no longer appears in the TS API
surface, and the new `ruby-class.ts` does not cost a file match.

## Two terminals, deliberately kept distinct

Rails has two failure paths and this PR preserves both. A class that *has* a
handler aliased to `unsupported` (String, Hash, Float, …) raises
`UnsupportedVisitError` from `unsupported` (`to_sql.rb:828`); a class with no
handler at all falls out of `visit` itself (`visitor.rb:38`). Arbitrary objects
now reach the second terminal rather than being routed by hand into the first,
which is the Rails split.

Rails raises `TypeError` there where trails raises `UnsupportedVisitError` —
a pre-existing divergence in the base visitor, not introduced here. Filed as
`arel-visit-no-handler-raises-typeerror` (RFC 0066) rather than widened into
this PR.

## Not in scope

`dot.ts` has its own hand-rolled raw-value dispatch (`dot.ts:495-525`). It is a
separate visitor whose Rails counterpart `dot.rb` renders rather than raises, so
the mapping is not `to_sql.rb`'s; outside this story's acceptance criteria and
filed as `dot-visitor-uses-class-dispatch` (RFC 0066).
