### PR TITLE
fix(parity): repair trails-side schema dump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1314,7 +1314,7 @@ jobs:
       - uses: ./.github/actions/setup-pnpm
       - run: pnpm install --frozen-lockfile --prefer-offline
       - name: Build dependency packages for trails introspection
-        run: pnpm --filter @blazetrails/arel --filter @blazetrails/activesupport --filter @blazetrails/activemodel --filter @blazetrails/globalid build
+        run: pnpm --filter "@blazetrails/activerecord^..." build
       - name: Run trails-side dump
         run: pnpm tsx scripts/parity/run.ts --side=trails
       - uses: actions/upload-artifact@v4

--- a/scripts/parity/schema/node/dump.ts
+++ b/scripts/parity/schema/node/dump.ts
@@ -24,6 +24,7 @@ import {
   introspectIndexes,
   introspectPrimaryKey,
 } from "../../../../packages/activerecord/src/schema-introspection.js";
+import { getFsAsync } from "@blazetrails/activesupport";
 import { canonicalize } from "./canonicalize.js";
 import type { NativeDump, NativeColumn, NativeIndex } from "./canonicalize.js";
 
@@ -58,6 +59,10 @@ async function main(): Promise<void> {
   const fixtureDirAbs = resolve(fixtureDir);
   const outPathAbs = resolve(outPath);
 
+  // The sync node fs auto-register relies on `require`, which is absent under
+  // pure ESM; awaiting the async path registers the adapter up front.
+  await getFsAsync();
+
   const tmpDir = mkdtempSync(join(tmpdir(), "parity-node-"));
   const dbPath = join(tmpDir, "schema.db");
 
@@ -72,8 +77,9 @@ async function main(): Promise<void> {
     }
 
     // 2. Connect via trails adapter
-    // Pass dbPath directly — adapterNameFromUrl recognises .db extension as sqlite.
-    await Base.establishConnection(dbPath);
+    // A bare path is treated as a configuration name, not a URL, so pass an
+    // explicit hash config.
+    await Base.establishConnection({ adapter: "sqlite3", database: dbPath });
     const adapter = Base.adapter;
 
     // 3. Introspect tables, columns, indexes


### PR DESCRIPTION
Schema Parity (trails side) was red on `main`. Three independent breakages, each of which masked the next:

**1. CI build step had drifted.** The job hand-listed activerecord's workspace deps, and `@blazetrails/did-you-mean` was never added, so `associations.ts` failed to resolve at import time. Replaced with `pnpm --filter "@blazetrails/activerecord^..." build`, which derives the set from the manifest and can't drift again.

**2. `establishConnection` got a bare path.** `dump.ts` passed the temp db path as a string. A string argument is resolved as a *configuration name*, not a URL, so it raised ``The `/tmp/.../schema.db` database is not configured for the `development` environment``. Now passes an explicit `{ adapter: "sqlite3", database }` hash. (The stale comment claiming `adapterNameFromUrl` recognises the `.db` extension described behaviour that has since converged to Rails.)

**3. Sync fs auto-register is broken under ESM.** `getFs()`'s node fallback goes through `require("node:module")`, which doesn't exist under pure ESM, so introspection hit `No filesystem adapter configured`. `dump.ts` now awaits `getFsAsync()` at startup — imported from the package, not `src/`, so it registers on the same module instance activerecord's `dist` build resolves.

Fix 3 is deliberately a call-site workaround: the underlying `getFs()` defect affects every Node ESM consumer and is hidden from the test suite by vitest's `require` shim. Fixing it properly needs a regression test that runs outside vitest, which is out of scope for a red-CI repair. Registered as `0061-ci-failures/fs-adapter-sync-autoregister-fails-under-esm`, which also removes this workaround.

## Verification

Whole pipeline, both sides, locally:

```
pnpm tsx scripts/parity/run.ts --side=trails   # wrote 01-trivial, 02-moderate
pnpm tsx scripts/parity/run.ts --side=rails    # wrote 01-trivial, 02-moderate
pnpm tsx scripts/parity/schema/diff.ts --rails-dir ... --trails-dir ...
# PASS 01-trivial / PASS 02-moderate — 2/2 fixtures passed
```

Before this branch, the trails side failed at breakage 1 and produced no artifacts at all.

Closes-story: red-845861b1
