### PR TITLE
fix(relation): let touchAll/updateCounters raise on empty updates

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3953,10 +3953,9 @@ export class Relation<T extends Base> {
       updates[col] = new Nodes.Quoted(touchedAt);
     }
 
-    // Deviation: Rails passes the empty hash straight to update_all, which
-    // raises ArgumentError (relation.rb:589). Tracked by the
-    // `touch-all-update-counters-empty-updates-raise` story.
-    if (Object.keys(updates).length === 0) return 0;
+    // No empty-updates guard: Rails passes the hash straight to update_all,
+    // which raises ArgumentError on a blank hash (relation.rb:589) — before
+    // its `none?` check, so a `none` relation raises too.
 
     return this.updateAll(updates);
   }
@@ -6114,11 +6113,8 @@ export class Relation<T extends Base> {
       }
     }
 
-    // Nothing to update (e.g. `updateCounters({})` or
-    // `updateCounters({}, { touch: [] })`) — skip updateAll, which would
-    // otherwise build an UPDATE with no SET clause and produce invalid SQL.
-    if (Object.keys(updates).length === 0) return 0;
-
+    // No empty-updates guard: Rails ends in a bare `update_all updates`
+    // (relation.rb:943), which raises ArgumentError on a blank hash.
     return this.updateAll(updates);
   }
 

--- a/packages/activerecord/src/relation/update-all.trails.test.ts
+++ b/packages/activerecord/src/relation/update-all.trails.test.ts
@@ -7,6 +7,8 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Nodes } from "@blazetrails/arel";
 import { fixtures } from "../test-helpers/fixtures.js";
+import { ArgumentError } from "@blazetrails/activemodel";
+import { Post } from "../test-helpers/models/post.js";
 import { Topic } from "../test-helpers/models/topic.js";
 import { initializeAssociations } from "../associations.js";
 
@@ -101,5 +103,61 @@ describe("update_all value substitution", () => {
     );
 
     expect(sql).toContain("(UPPER(title))");
+  });
+});
+
+/**
+ * TS-only coverage for the empty-updates path of `touch_all` / `update_counters`
+ * (relation.rb:926-944, 969-971). Neither method guards a blank hash: both hand
+ * it to `update_all`, whose first line raises `ArgumentError` (relation.rb:589)
+ * — before the `none?` check on the next line, so a `none` relation raises too.
+ *
+ * `posts` has no `updated_at`/`updated_on`, so `touch_attributes_with_time`
+ * returns `{}` for `Post`.
+ */
+describe("touch_all / update_counters with empty updates", () => {
+  const { topics } = fixtures(["posts", "topics"]);
+
+  it("touch_all raises when the model has no timestamp columns", async () => {
+    await expect(Post.all().touchAll()).rejects.toThrow(
+      new ArgumentError("Empty list of attributes to change"),
+    );
+  });
+
+  it("touch_all raises on a none relation, since the blank check precedes none?", async () => {
+    await expect(Post.none().touchAll()).rejects.toThrow(
+      new ArgumentError("Empty list of attributes to change"),
+    );
+  });
+
+  it("update_counters raises on an empty counters hash", async () => {
+    await expect(Post.all().updateCounters({})).rejects.toThrow(
+      new ArgumentError("Empty list of attributes to change"),
+    );
+  });
+
+  it("update_counters raises on a none relation with an empty counters hash", async () => {
+    await expect(Post.none().updateCounters({})).rejects.toThrow(
+      new ArgumentError("Empty list of attributes to change"),
+    );
+  });
+
+  it("update_counters with touch: [] raises when there are no timestamp columns", async () => {
+    // `touch: []` is truthy in Ruby too, so Rails calls
+    // touch_attributes_with_time with no names; on a model without
+    // updated_at/updated_on that yields {} and update_all raises.
+    await expect(Post.all().updateCounters({}, { touch: [] })).rejects.toThrow(
+      new ArgumentError("Empty list of attributes to change"),
+    );
+  });
+
+  it("update_counters still updates when only the touch option contributes columns", async () => {
+    const first = topics("first");
+    const before = await Topic.find(first.id);
+    const count = await Topic.where({ id: first.id }).updateCounters({}, { touch: true });
+
+    expect(count).toBe(1);
+    const after = await Topic.find(first.id);
+    expect(after.readAttribute("updated_at")).not.toEqual(before.readAttribute("updated_at"));
   });
 });


### PR DESCRIPTION
Converges `touchAll` / `updateCounters` on Rails' empty-updates behavior.

Both methods early-returned `0` when the computed update hash came out empty.
Rails has no such guard:

- `touch_all` (relation.rb:969-971) is a bare `update_all model.touch_attributes_with_time(*names, time: time)`.
- `update_counters` (relation.rb:926-944) ends in `update_all updates`.

An empty hash therefore reaches `update_all`, whose **first** line is
`raise ArgumentError, "Empty list of attributes to change" if updates.blank?`
(relation.rb:589). That check *precedes* the `return 0 if @none` on the next
line, so a `none` relation with empty updates raises rather than returning 0.

## Changes

- Drop the empty-updates early-return from `touchAll` and `updateCounters`.
- Tests covering: `touchAll` on a model with no timestamp columns (`posts` has
  none), the same on a `none` relation, `updateCounters({})` on both `all` and
  `none`, and `updateCounters({}, { touch: [] })`.

On the `touch: []` acceptance-criteria question: the old comment claimed the
guard existed to stop `updateAll` from building a SET-less UPDATE. Checked
against Rails — `[]` is truthy in Ruby, so `if touch` is entered and
`touch_attributes_with_time` is called with no names. On a model *with*
timestamps that yields `{updated_at: ...}` and the update proceeds normally
(covered by a positive-control test on `Topic`); on a model without them it
yields `{}` and `update_all` raises. No SET-less UPDATE is ever reachable.

Closes-story: touch-all-update-counters-empty-updates-raise

## Verification

**Regression tests fail on baseline.** Reverted only `relation.ts` to
`origin/main` (1d0f44661) while keeping the new tests: all 5 empty-updates
tests fail, and the `touch: true` positive control still passes — so they
fail for the intended reason, not an unrelated break.

**No internal caller relied on the old `return 0`.** Audited every
`.touchAll(` / `.updateCounters(` call site outside tests
(belongs-to-association, collection-proxy, has-many-association,
counter-cache, persistence `increment!`/`decrement!`, batch-enumerator,
timestamp): all pass at least one named counter or column, so none can reach
`updateAll` with a blank hash. Only user-facing `Model.updateCounters(id, {})`
changes behavior, which is the point of this PR.

Suites run green: update-all(+trails), counter-cache, relation, timestamp,
persistence, belongs-to-associations, collection-proxy, delegation, thenable.
