### PR TITLE
feat(timestamp): support touch(name, { time: }) in one call

### DIFF
--- a/packages/activerecord/src/timestamp.test.ts
+++ b/packages/activerecord/src/timestamp.test.ts
@@ -6,7 +6,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { travel, travelBack, travelTo } from "@blazetrails/activesupport";
+import { travel, travelBack } from "@blazetrails/activesupport";
 import { Base, MigrationContext, registerModel } from "./index.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import {
@@ -178,14 +178,7 @@ describe("TimestampTest", () => {
     const previouslyUpdatedAt2 = developer.legacy_updated_at as Temporal.Instant;
     const previousCreatedAt = developer.legacy_created_at as Temporal.Instant;
     const newTime = new Date(Date.UTC(2015, 1, 16, 4, 54, 0)); // Time.utc(2015, 2, 16, 4, 54, 0)
-    // Rails: @developer.touch(:created_at, time: new_time) — touch a named attr with given time.
-    // trails touch() doesn't support (name, {time}) — travel to the target time instead.
-    travelTo(newTime);
-    try {
-      await developer.touch("legacy_created_at");
-    } finally {
-      travelBack();
-    }
+    await developer.touch("legacy_created_at", { time: newTime });
 
     expect(developer.legacy_created_at).not.toEqual(previousCreatedAt);
     expect(developer.legacy_updated_at).not.toEqual(previouslyUpdatedAt2);

--- a/packages/activerecord/src/timestamp.ts
+++ b/packages/activerecord/src/timestamp.ts
@@ -22,8 +22,7 @@ import { withTransactionReturningStatus } from "./transactions.js";
  */
 export async function touch(
   this: Base,
-  optionsOrName?: { time?: Date | Temporal.Instant | null } | string,
-  ...rest: string[]
+  ...args: (string | { time?: Date | Temporal.Instant | null } | undefined)[]
 ): Promise<boolean> {
   // Mirrors Rails' NoTouching#touch (`super unless no_touching?`), which is
   // prepended ahead of Persistence#touch: a no_touching block short-circuits
@@ -41,20 +40,22 @@ export async function touch(
     throw new ReadOnlyRecord(`${this.constructor.name} is marked as readonly`);
   }
 
-  let time: Temporal.Instant;
-  let names: string[];
-  if (typeof optionsOrName === "string") {
-    time = currentTimeFromProperTimezone();
-    names = [optionsOrName, ...rest];
-  } else if (optionsOrName?.time != null) {
-    const t = optionsOrName.time;
-    time = t instanceof Temporal.Instant ? t : Temporal.Instant.fromEpochMilliseconds(t.getTime()); // boundary: accepts JS Date from touch(time:) callers
-    names = rest;
-  } else {
-    time = currentTimeFromProperTimezone();
-    names = rest;
+  // Mirrors Rails' `touch(*names, time: nil)`: any number of column names plus a
+  // trailing keyword hash. In TS the keyword hash arrives as a plain object in
+  // the argument list, so split the two apart rather than overloading arg 0.
+  const names: string[] = [];
+  let options: { time?: Date | Temporal.Instant | null } | undefined;
+  for (const arg of args) {
+    if (typeof arg === "string") names.push(arg);
+    else if (arg != null) options = arg;
   }
-  const now = time;
+  const t = options?.time;
+  const now =
+    t == null
+      ? currentTimeFromProperTimezone()
+      : t instanceof Temporal.Instant
+        ? t
+        : Temporal.Instant.fromEpochMilliseconds(t.getTime()); // boundary: accepts JS Date from touch(time:) callers
   const aliases: Record<string, string> = (ctor as any)._attributeAliases ?? {};
   const resolvedNames = names.map((name) => aliases[name] ?? name);
 

--- a/packages/activerecord/src/timestamp.ts
+++ b/packages/activerecord/src/timestamp.ts
@@ -18,12 +18,12 @@ export interface TouchOptions {
 }
 
 /**
- * One argument of Rails' `touch(*names, time: nil)`: a column name, or the
- * trailing keyword hash. Ruby keywords have no TS equivalent, so the hash
- * travels in the same variadic list and is separated out by position-free
- * type check rather than by being pinned to argument 0.
+ * Argument list for Rails' `touch(*names, time: nil)`. Ruby's trailing keyword
+ * becomes an optional trailing options object in TS, mirroring `TouchAllArgs` —
+ * the options object is only valid in last position, so `touch({ time }, "col")`
+ * is a type error just as `touch(time: t, :col)` is a syntax error in Ruby.
  */
-export type TouchArg = string | TouchOptions | undefined;
+export type TouchArgs = string[] | [...names: string[], options: TouchOptions];
 
 /**
  * Update the updated_at timestamp (and optionally other timestamp
@@ -32,7 +32,7 @@ export type TouchArg = string | TouchOptions | undefined;
  *
  * Mirrors: ActiveRecord::Timestamp#touch
  */
-export async function touch(this: Base, ...args: TouchArg[]): Promise<boolean> {
+export async function touch(this: Base, ...args: TouchArgs): Promise<boolean> {
   // Mirrors Rails' NoTouching#touch (`super unless no_touching?`), which is
   // prepended ahead of Persistence#touch: a no_touching block short-circuits
   // the whole method — including the persisted?/readonly? guards below — so a
@@ -49,16 +49,7 @@ export async function touch(this: Base, ...args: TouchArg[]): Promise<boolean> {
     throw new ReadOnlyRecord(`${this.constructor.name} is marked as readonly`);
   }
 
-  // Mirrors Rails' `touch(*names, time: nil)`: any number of column names plus a
-  // trailing keyword hash. In TS the keyword hash arrives as a plain object in
-  // the argument list, so split the two apart rather than overloading arg 0.
-  const names: string[] = [];
-  let options: TouchOptions | undefined;
-  for (const arg of args) {
-    if (typeof arg === "string") names.push(arg);
-    else if (arg != null) options = arg;
-  }
-  const t = options?.time;
+  const { names, time: t } = parseTouchArgs(args);
   const now =
     t == null
       ? currentTimeFromProperTimezone()
@@ -101,6 +92,21 @@ export async function touch(this: Base, ...args: TouchArg[]): Promise<boolean> {
   return withTransactionReturningStatus.call(this, async () => {
     return touchRow.call(this, touchCols, now);
   }) as Promise<boolean>;
+}
+
+/**
+ * Split `touch(*names, time: nil)` args into the splatted names and the
+ * trailing keyword hash. Mirrors parseTouchArgs' sibling `parseTouchAllArgs`.
+ */
+export function parseTouchArgs(args: TouchArgs): {
+  names: string[];
+  time: Date | Temporal.Instant | null | undefined;
+} {
+  const last = args[args.length - 1];
+  if (last !== undefined && typeof last !== "string") {
+    return { names: args.slice(0, -1) as string[], time: last.time };
+  }
+  return { names: args as string[], time: undefined };
 }
 
 /**

--- a/packages/activerecord/src/timestamp.ts
+++ b/packages/activerecord/src/timestamp.ts
@@ -13,6 +13,18 @@ import { withTransactionReturningStatus } from "./transactions.js";
  * Mirrors: ActiveRecord::Timestamp
  */
 
+export interface TouchOptions {
+  time?: Date | Temporal.Instant | null;
+}
+
+/**
+ * One argument of Rails' `touch(*names, time: nil)`: a column name, or the
+ * trailing keyword hash. Ruby keywords have no TS equivalent, so the hash
+ * travels in the same variadic list and is separated out by position-free
+ * type check rather than by being pinned to argument 0.
+ */
+export type TouchArg = string | TouchOptions | undefined;
+
 /**
  * Update the updated_at timestamp (and optionally other timestamp
  * columns) without changing other attributes. Skips validations
@@ -20,10 +32,7 @@ import { withTransactionReturningStatus } from "./transactions.js";
  *
  * Mirrors: ActiveRecord::Timestamp#touch
  */
-export async function touch(
-  this: Base,
-  ...args: (string | { time?: Date | Temporal.Instant | null } | undefined)[]
-): Promise<boolean> {
+export async function touch(this: Base, ...args: TouchArg[]): Promise<boolean> {
   // Mirrors Rails' NoTouching#touch (`super unless no_touching?`), which is
   // prepended ahead of Persistence#touch: a no_touching block short-circuits
   // the whole method — including the persisted?/readonly? guards below — so a
@@ -44,7 +53,7 @@ export async function touch(
   // trailing keyword hash. In TS the keyword hash arrives as a plain object in
   // the argument list, so split the two apart rather than overloading arg 0.
   const names: string[] = [];
-  let options: { time?: Date | Temporal.Instant | null } | undefined;
+  let options: TouchOptions | undefined;
   for (const arg of args) {
     if (typeof arg === "string") names.push(arg);
     else if (arg != null) options = arg;

--- a/packages/activerecord/src/touch-later.ts
+++ b/packages/activerecord/src/touch-later.ts
@@ -5,6 +5,7 @@ import {
   timestampAttributesForUpdateInModel,
   currentTimeFromProperTimezone,
 } from "./timestamp.js";
+import type { TouchArg } from "./timestamp.js";
 import type { Temporal } from "@blazetrails/activesupport/temporal";
 import { reflectOnAllAssociations } from "./reflection.js";
 import { BelongsTo as BelongsToBuilder } from "./associations/builder/belongs-to.js";
@@ -105,16 +106,15 @@ export async function touchLater(this: Base, ...names: string[]): Promise<void> 
  *
  * Mirrors: ActiveRecord::TouchLater#touch
  */
-export async function touch(
-  this: Base,
-  ...args: (string | { time?: Date | Temporal.Instant | null } | undefined)[]
-): Promise<boolean> {
+export async function touch(this: Base, ...args: TouchArg[]): Promise<boolean> {
   const self = this as any;
   if (self._deferTouchAttrs?.length) {
     const deferredAttrs = self._deferTouchAttrs as string[];
     const deferredTime = self._touchTime as Temporal.Instant | null;
     const names = args.filter((a): a is string => typeof a === "string");
     const options = args.filter((a) => typeof a === "object" && a != null);
+    // Deferred attrs merge with the caller's names; the caller's `time:` (if
+    // any) still governs, matching Rails' single flushing touch call.
     const merged: string[] = [...new Set([...names, ...deferredAttrs])];
     self._deferTouchAttrs = null;
     self._touchTime = null;

--- a/packages/activerecord/src/touch-later.ts
+++ b/packages/activerecord/src/touch-later.ts
@@ -107,28 +107,26 @@ export async function touchLater(this: Base, ...names: string[]): Promise<void> 
  */
 export async function touch(
   this: Base,
-  optionsOrName?: { time?: Date | Temporal.Instant | null } | string,
-  ...rest: string[]
+  ...args: (string | { time?: Date | Temporal.Instant | null } | undefined)[]
 ): Promise<boolean> {
   const self = this as any;
   if (self._deferTouchAttrs?.length) {
     const deferredAttrs = self._deferTouchAttrs as string[];
     const deferredTime = self._touchTime as Temporal.Instant | null;
-    const names: string[] = typeof optionsOrName === "string" ? [optionsOrName, ...rest] : rest;
+    const names = args.filter((a): a is string => typeof a === "string");
+    const options = args.filter((a) => typeof a === "object" && a != null);
     const merged: string[] = [...new Set([...names, ...deferredAttrs])];
     self._deferTouchAttrs = null;
     self._touchTime = null;
     try {
-      return typeof optionsOrName === "object" && optionsOrName != null
-        ? await timestampTouch.call(this, optionsOrName, ...merged)
-        : await timestampTouch.call(this, ...merged);
+      return await timestampTouch.call(this, ...merged, ...options);
     } catch (error) {
       self._deferTouchAttrs = deferredAttrs;
       self._touchTime = deferredTime;
       throw error;
     }
   }
-  return timestampTouch.call(this, optionsOrName, ...rest);
+  return timestampTouch.call(this, ...args);
 }
 
 /**

--- a/packages/activerecord/src/touch-later.ts
+++ b/packages/activerecord/src/touch-later.ts
@@ -5,7 +5,7 @@ import {
   timestampAttributesForUpdateInModel,
   currentTimeFromProperTimezone,
 } from "./timestamp.js";
-import type { TouchArg } from "./timestamp.js";
+import { parseTouchArgs, type TouchArgs } from "./timestamp.js";
 import type { Temporal } from "@blazetrails/activesupport/temporal";
 import { reflectOnAllAssociations } from "./reflection.js";
 import { BelongsTo as BelongsToBuilder } from "./associations/builder/belongs-to.js";
@@ -106,20 +106,20 @@ export async function touchLater(this: Base, ...names: string[]): Promise<void> 
  *
  * Mirrors: ActiveRecord::TouchLater#touch
  */
-export async function touch(this: Base, ...args: TouchArg[]): Promise<boolean> {
+export async function touch(this: Base, ...args: TouchArgs): Promise<boolean> {
   const self = this as any;
   if (self._deferTouchAttrs?.length) {
     const deferredAttrs = self._deferTouchAttrs as string[];
     const deferredTime = self._touchTime as Temporal.Instant | null;
-    const names = args.filter((a): a is string => typeof a === "string");
-    const options = args.filter((a) => typeof a === "object" && a != null);
-    // Deferred attrs merge with the caller's names; the caller's `time:` (if
-    // any) still governs, matching Rails' single flushing touch call.
+    const { names, time } = parseTouchArgs(args);
+    // Mirrors touch_later.rb:38-44 `names |= @_defer_touch_attrs; super(*names,
+    // time: time)` — the caller's `time:` governs; the deferred @_touch_time is
+    // deliberately NOT substituted when the caller passed none.
     const merged: string[] = [...new Set([...names, ...deferredAttrs])];
     self._deferTouchAttrs = null;
     self._touchTime = null;
     try {
-      return await timestampTouch.call(this, ...merged, ...options);
+      return await timestampTouch.call(this, ...merged, { time });
     } catch (error) {
       self._deferTouchAttrs = deferredAttrs;
       self._touchTime = deferredTime;
@@ -181,7 +181,7 @@ export async function touchDeferredAttributes(this: Base): Promise<void> {
   // mirrors touch_later.rb where @_defer_touch_attrs/@_touch_time are cleared
   // only after the super call succeeds.
   try {
-    await timestampTouch.call(this, { time }, ...deferredAttrs);
+    await timestampTouch.call(this, ...deferredAttrs, { time });
   } catch (error) {
     self._deferTouchAttrs = deferredAttrs;
     self._touchTime = time;


### PR DESCRIPTION
Rails' `touch(*names, time: nil)` accepts column names and an explicit time together. trails overloaded arg 0 as either options or a name, so both could not be passed.

Both `Timestamp#touch` and `TouchLater#touch` now take a variadic arg list, splitting string names from a trailing options object — matching Ruby's `*names, **kwargs` shape.

Removes the `travelTo` workaround in `timestamp.test.ts` for `touching an attribute updates timestamp with given time`.

Closes-story: touch-name-and-time-option