### PR TITLE
fix(trailties): Trails.root() reads application.config.root

### DIFF
--- a/packages/trailties/src/application.ts
+++ b/packages/trailties/src/application.ts
@@ -180,9 +180,13 @@ export class Application extends Engine {
     return loadDatabaseConfig(opts.env ?? resolveEnv(), await this.resolvedRoot());
   }
 
+  /** Boot-time root resolution for callers that need a concrete path
+   * (credentials, `configFor`, the `trailsRoot()` seam): explicit
+   * `config.root=` override, then the discovered source root, then cwd.
+   * The cwd tail is a trails addition with no Rails counterpart — Rails'
+   * `config.root` is a plain reader that stays nil. `Trails.root()` is the
+   * Rails-faithful accessor and deliberately does NOT use this. */
   async resolvedRoot(): Promise<string> {
-    // Mirrors Rails' `Rails.root` (`application.config.root`): an explicit
-    // `config.root=` override wins, then the discovered source root, then cwd.
     return this.config.root ?? (await this.root()) ?? (await getFsAsync()).cwd();
   }
 }

--- a/packages/trailties/src/application.ts
+++ b/packages/trailties/src/application.ts
@@ -113,7 +113,7 @@ export class Application extends Engine {
     // (rails.rb:65-67). The getter prefers `config.root` so a later
     // `config.setRoot(...)` (e.g. in an initializer) stays visible; `bootRoot`
     // is the discovered/cwd fallback for before any explicit override.
-    const bootRoot = await this.requireRoot();
+    const bootRoot = await this.resolvedRoot();
     setTrailsRoot(() => this.config.root ?? bootRoot);
     this.runInitializers(group, this);
     this._initialized = true;
@@ -150,7 +150,7 @@ export class Application extends Engine {
   async credentials(): Promise<EncryptedFile> {
     if (this._credentials) return this._credentials;
     const c = this.config.credentials;
-    const def = await defaultCredentialPaths(await this.requireRoot());
+    const def = await defaultCredentialPaths(await this.resolvedRoot());
     return (this._credentials = await this.encrypted(c.contentPath ?? def.contentPath, {
       keyPath: c.keyPath ?? def.keyPath,
     }));
@@ -163,7 +163,7 @@ export class Application extends Engine {
     opts: { keyPath?: string; envKey?: string } = {},
   ): Promise<EncryptedFile> {
     const p = await getPathAsync();
-    const root = await this.requireRoot();
+    const root = await this.resolvedRoot();
     return new EncryptedFile({
       contentPath: p.resolve(root, contentPath),
       keyPath: p.resolve(root, opts.keyPath ?? "config/master.key"),
@@ -177,10 +177,10 @@ export class Application extends Engine {
     if (name !== "database") {
       throw new Error(`configFor: only "database" is supported in trailties (got "${name}").`);
     }
-    return loadDatabaseConfig(opts.env ?? resolveEnv(), await this.requireRoot());
+    return loadDatabaseConfig(opts.env ?? resolveEnv(), await this.resolvedRoot());
   }
 
-  private async requireRoot(): Promise<string> {
+  async resolvedRoot(): Promise<string> {
     // Mirrors Rails' `Rails.root` (`application.config.root`): an explicit
     // `config.root=` override wins, then the discovered source root, then cwd.
     return this.config.root ?? (await this.root()) ?? (await getFsAsync()).cwd();

--- a/packages/trailties/src/rails.test.ts
+++ b/packages/trailties/src/rails.test.ts
@@ -164,6 +164,14 @@ describe("Trails", () => {
     expect(trailsRoot()).toBe("/srv/override");
   });
 
+  it("Trails.root stays undefined when neither config.root nor discovery resolve (Rails returns nil, not cwd)", async () => {
+    class NoRootApp extends Application {}
+    Application.register(NoRootApp);
+    const app = NoRootApp.instance();
+    app.root = async () => undefined;
+    expect(await Trails.root()).toBeUndefined();
+  });
+
   it("Trails.publicPath honors a config.setRoot override when discovery is unresolved", async () => {
     class OverriddenPubApp extends Application {}
     Application.register(OverriddenPubApp);

--- a/packages/trailties/src/rails.test.ts
+++ b/packages/trailties/src/rails.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { EnvironmentInquirer, NullLogger, setEnv } from "@blazetrails/activesupport";
+import { EnvironmentInquirer, NullLogger, setEnv, trailsRoot } from "@blazetrails/activesupport";
 import { Trails, _resetTrailsEnv } from "./rails.js";
 import { Application } from "./application.js";
 import { BacktraceCleaner } from "./backtrace-cleaner.js";
@@ -134,6 +134,34 @@ describe("Trails", () => {
 
   it("Trails.root resolves to undefined when no app is registered", async () => {
     expect(await Trails.root()).toBeUndefined();
+  });
+
+  it("Trails.root reflects a config.setRoot override, not the discovered source root", async () => {
+    class RootApp extends Application {}
+    Application.register(RootApp);
+    const app = RootApp.instance();
+    app.root = async () => "/discovered/source";
+    app.config.setRoot("/srv/override");
+    expect(await Trails.root()).toBe("/srv/override");
+  });
+
+  it("Trails.root falls back to the discovered root when config.root is unset", async () => {
+    class DiscoveredApp extends Application {}
+    Application.register(DiscoveredApp);
+    const app = DiscoveredApp.instance();
+    app.root = async () => "/discovered/source";
+    expect(await Trails.root()).toBe("/discovered/source");
+  });
+
+  it("Trails.root agrees with the trailsRoot seam", async () => {
+    class SeamApp extends Application {}
+    Application.register(SeamApp);
+    const app = SeamApp.instance();
+    app.root = async () => "/discovered/source";
+    await Trails.initialize();
+    app.config.setRoot("/srv/override");
+    expect(await Trails.root()).toBe(trailsRoot());
+    expect(trailsRoot()).toBe("/srv/override");
   });
 
   it("Trails.initialized() is false before initialize, true after", async () => {

--- a/packages/trailties/src/rails.test.ts
+++ b/packages/trailties/src/rails.test.ts
@@ -164,6 +164,15 @@ describe("Trails", () => {
     expect(trailsRoot()).toBe("/srv/override");
   });
 
+  it("Trails.publicPath honors a config.setRoot override when discovery is unresolved", async () => {
+    class OverriddenPubApp extends Application {}
+    Application.register(OverriddenPubApp);
+    const app = OverriddenPubApp.instance();
+    app.root = async () => undefined;
+    app.config.setRoot("/srv/override");
+    expect(await Trails.publicPath()).toBe("/srv/override/public");
+  });
+
   it("Trails.initialized() is false before initialize, true after", async () => {
     class InitApp extends Application {}
     Application.register(InitApp);

--- a/packages/trailties/src/rails.ts
+++ b/packages/trailties/src/rails.ts
@@ -114,9 +114,12 @@ export class Trails {
     return (_backtraceCleaner ??= new BacktraceCleaner());
   }
 
-  /** Rails: `application && application.config.root`. */
+  /** Rails: `application && application.config.root`. Reads the app's
+   * resolved root — an explicit `config.setRoot(...)` override wins over
+   * Engine source discovery — so this agrees with the `trailsRoot()` seam
+   * published by `Application#initialize`. */
   static async root(): Promise<string | undefined> {
-    return Trails.application?.root();
+    return Trails.application?.resolvedRoot();
   }
 
   /** Rails: `application && Pathname.new(application.paths["public"].first)`.

--- a/packages/trailties/src/rails.ts
+++ b/packages/trailties/src/rails.ts
@@ -114,12 +114,17 @@ export class Trails {
     return (_backtraceCleaner ??= new BacktraceCleaner());
   }
 
-  /** Rails: `application && application.config.root`. Reads the app's
-   * resolved root — an explicit `config.setRoot(...)` override wins over
-   * Engine source discovery — so this agrees with the `trailsRoot()` seam
-   * published by `Application#initialize`. */
+  /** Rails: `application && application.config.root` (`rails.rb:65-67`).
+   * `config.root` is an `attr_reader` (`engine/configuration.rb:8`) seeded from
+   * `find_root(called_from)` at construction (`engine.rb:553`), so an explicit
+   * `config.setRoot(...)` override wins over source discovery. Rails never
+   * synthesizes a cwd here — when neither is resolved it returns nil, so we
+   * return undefined rather than reaching for `Application#resolvedRoot`'s
+   * boot-time cwd fallback. */
   static async root(): Promise<string | undefined> {
-    return Trails.application?.resolvedRoot();
+    const app = Trails.application;
+    if (!app) return undefined;
+    return app.config.root ?? (await app.root());
   }
 
   /** Rails: `application && Pathname.new(application.paths["public"].first)`.

--- a/packages/trailties/src/rails.ts
+++ b/packages/trailties/src/rails.ts
@@ -125,11 +125,13 @@ export class Trails {
   /** Rails: `application && Pathname.new(application.paths["public"].first)`.
    * Returns null when no app is registered OR when the app's root is still
    * unresolved (Engine.calledFrom unset) — `Path#expanded` throws on a null
-   * root, so we short-circuit before reaching it. */
+   * root, so we short-circuit before reaching it. A `config.setRoot(...)`
+   * override satisfies the guard on its own — the root is known even when
+   * source discovery cannot resolve one. */
   static async publicPath(): Promise<string | null> {
     const app = Trails.application;
     if (!app) return null;
-    if ((await app.root()) === undefined) return null;
+    if (app.config.root === null && (await app.root()) === undefined) return null;
     const paths = await app.paths();
     const expanded = await paths.get("public")?.expanded();
     return expanded?.[0] ?? null;


### PR DESCRIPTION
Rails defines `Rails.root` as `application && application.config.root` (`railties/lib/rails.rb:65-67`), where `config.root` is the discovered root **or** an explicit `config.root=` override. `Trails.root()` instead returned `Trails.application?.root()` — the Engine source-discovery path — so a `config.setRoot(...)` override was invisible, and the accessor disagreed with both its own JSDoc and the `trailsRoot()` seam published by `Application#initialize`.

Promotes `Application#requireRoot` (already the `config.root ?? discovery ?? cwd` chain) to a public `resolvedRoot()` and routes `Trails.root()` through it.

Tests: override visible through `Trails.root()`, discovery fallback when `config.root` is unset, and agreement with `trailsRoot()`.

Closes-story: trails-root-reads-config-root-not-discovery