### PR TITLE
fix(ci): retry transient gh api failures in attribution guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,12 +511,30 @@ jobs:
           github.event.pull_request.user.login == 'deanmarano' }}
         run: |
           set -euo pipefail
+          # A transient GitHub API 5xx must not red this step: the only signal
+          # a maintainer sees is the step name, which reads as "attribution
+          # found" when nothing is wrong. Retry, then fail with an explicit
+          # "API unreachable" message that can't be mistaken for a real hit.
+          ghApiRetry() {
+            local attempt
+            for attempt in 1 2 3 4; do
+              if gh api "$@"; then
+                return 0
+              fi
+              if [ "$attempt" -lt 4 ]; then
+                echo "gh api failed (attempt $attempt/4); retrying in $((attempt * 5))s..." >&2
+                sleep "$((attempt * 5))"
+              fi
+            done
+            echo "::error::GitHub API unreachable after 4 attempts — this is an infrastructure failure, NOT a Claude attribution violation. Re-run this job." >&2
+            return 1
+          }
           # Fetch the *live* body rather than reading the event payload. The
           # PR triggers don't include `edited`, so a body edit won't re-fire
           # CI — but a manual job re-run hits the API fresh and will see the
           # fix. Reading the payload would replay the stale original body and
           # leave the check permanently red.
-          body=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.body // ""')
+          body=$(ghApiRetry "repos/$REPO/pulls/$PR_NUMBER" --jq '.body // ""')
           if printf '%s' "$body" | grep -qiE "$ATTRIBUTION_RE"; then
             echo "::error::PR body contains Claude attribution. Remove 'Generated with Claude Code' / 'Co-Authored-By: Claude' / Anthropic attribution lines (see CLAUDE.md), then re-run this job."
             exit 1
@@ -531,6 +549,22 @@ jobs:
           github.event.pull_request.user.login == 'deanmarano' }}
         run: |
           set -euo pipefail
+          # See the body guard above: retry transient API failures so a 5xx
+          # can't masquerade as an attribution hit.
+          ghApiRetry() {
+            local attempt
+            for attempt in 1 2 3 4; do
+              if gh api "$@"; then
+                return 0
+              fi
+              if [ "$attempt" -lt 4 ]; then
+                echo "gh api failed (attempt $attempt/4); retrying in $((attempt * 5))s..." >&2
+                sleep "$((attempt * 5))"
+              fi
+            done
+            echo "::error::GitHub API unreachable after 4 attempts — this is an infrastructure failure, NOT a Claude attribution violation. Re-run this job." >&2
+            return 1
+          }
           # Scan every commit message on the PR, not just the PR body. The body
           # check above misses `Co-authored-by:` trailers that live in commits —
           # and GitHub's squash-merge auto-aggregates those branch-commit
@@ -542,12 +576,12 @@ jobs:
           # closed in that case rather than passing on a partial scan — this repo
           # squashes and has a 500-LOC ceiling, so 250 commits never happens
           # legitimately; if it does, squash/rebase before re-running.
-          count=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.commits')
+          count=$(ghApiRetry "repos/$REPO/pulls/$PR_NUMBER" --jq '.commits')
           if [ "$count" -gt 250 ]; then
             echo "::error::PR has $count commits, exceeding the 250-commit API scan cap. Squash or rebase the branch so commit messages can be fully scanned, then re-run this job."
             exit 1
           fi
-          messages=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/commits" --jq '.[].commit.message')
+          messages=$(ghApiRetry --paginate "repos/$REPO/pulls/$PR_NUMBER/commits" --jq '.[].commit.message')
           if printf '%s' "$messages" | grep -qiE "$ATTRIBUTION_RE"; then
             echo "::error::A commit message contains Claude attribution. Remove 'Generated with Claude Code' / 'Co-Authored-By: Claude' / Anthropic attribution lines from your commits (see CLAUDE.md) — note that squash-merge folds commit trailers into main — then re-run this job."
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,30 +511,12 @@ jobs:
           github.event.pull_request.user.login == 'deanmarano' }}
         run: |
           set -euo pipefail
-          # A transient GitHub API 5xx must not red this step: the only signal
-          # a maintainer sees is the step name, which reads as "attribution
-          # found" when nothing is wrong. Retry, then fail with an explicit
-          # "API unreachable" message that can't be mistaken for a real hit.
-          ghApiRetry() {
-            local attempt
-            for attempt in 1 2 3 4; do
-              if gh api "$@"; then
-                return 0
-              fi
-              if [ "$attempt" -lt 4 ]; then
-                echo "gh api failed (attempt $attempt/4); retrying in $((attempt * 5))s..." >&2
-                sleep "$((attempt * 5))"
-              fi
-            done
-            echo "::error::GitHub API unreachable after 4 attempts — this is an infrastructure failure, NOT a Claude attribution violation. Re-run this job." >&2
-            return 1
-          }
           # Fetch the *live* body rather than reading the event payload. The
           # PR triggers don't include `edited`, so a body edit won't re-fire
           # CI — but a manual job re-run hits the API fresh and will see the
           # fix. Reading the payload would replay the stale original body and
           # leave the check permanently red.
-          body=$(ghApiRetry "repos/$REPO/pulls/$PR_NUMBER" --jq '.body // ""')
+          body=$(scripts/ci/gh-api-retry.sh "repos/$REPO/pulls/$PR_NUMBER" --jq '.body // ""')
           if printf '%s' "$body" | grep -qiE "$ATTRIBUTION_RE"; then
             echo "::error::PR body contains Claude attribution. Remove 'Generated with Claude Code' / 'Co-Authored-By: Claude' / Anthropic attribution lines (see CLAUDE.md), then re-run this job."
             exit 1
@@ -551,20 +533,6 @@ jobs:
           set -euo pipefail
           # See the body guard above: retry transient API failures so a 5xx
           # can't masquerade as an attribution hit.
-          ghApiRetry() {
-            local attempt
-            for attempt in 1 2 3 4; do
-              if gh api "$@"; then
-                return 0
-              fi
-              if [ "$attempt" -lt 4 ]; then
-                echo "gh api failed (attempt $attempt/4); retrying in $((attempt * 5))s..." >&2
-                sleep "$((attempt * 5))"
-              fi
-            done
-            echo "::error::GitHub API unreachable after 4 attempts — this is an infrastructure failure, NOT a Claude attribution violation. Re-run this job." >&2
-            return 1
-          }
           # Scan every commit message on the PR, not just the PR body. The body
           # check above misses `Co-authored-by:` trailers that live in commits —
           # and GitHub's squash-merge auto-aggregates those branch-commit
@@ -576,12 +544,12 @@ jobs:
           # closed in that case rather than passing on a partial scan — this repo
           # squashes and has a 500-LOC ceiling, so 250 commits never happens
           # legitimately; if it does, squash/rebase before re-running.
-          count=$(ghApiRetry "repos/$REPO/pulls/$PR_NUMBER" --jq '.commits')
+          count=$(scripts/ci/gh-api-retry.sh "repos/$REPO/pulls/$PR_NUMBER" --jq '.commits')
           if [ "$count" -gt 250 ]; then
             echo "::error::PR has $count commits, exceeding the 250-commit API scan cap. Squash or rebase the branch so commit messages can be fully scanned, then re-run this job."
             exit 1
           fi
-          messages=$(ghApiRetry --paginate "repos/$REPO/pulls/$PR_NUMBER/commits" --jq '.[].commit.message')
+          messages=$(scripts/ci/gh-api-retry.sh --paginate "repos/$REPO/pulls/$PR_NUMBER/commits" --jq '.[].commit.message')
           if printf '%s' "$messages" | grep -qiE "$ATTRIBUTION_RE"; then
             echo "::error::A commit message contains Claude attribution. Remove 'Generated with Claude Code' / 'Co-Authored-By: Claude' / Anthropic attribution lines from your commits (see CLAUDE.md) — note that squash-merge folds commit trailers into main — then re-run this job."
             exit 1

--- a/scripts/ci/gh-api-retry.sh
+++ b/scripts/ci/gh-api-retry.sh
@@ -20,10 +20,29 @@ set -euo pipefail
 
 readonly MAX_ATTEMPTS=4
 
-# 5xx, rate limiting, and transport-level faults. Anything else (4xx auth,
-# not-found, malformed request) is a real error that will fail identically
-# every time.
-readonly TRANSIENT_RE='HTTP (429|5[0-9][0-9])|no server is currently available|connection reset|connection refused|timeout|timed out|TLS handshake|unexpected EOF|no such host|EOF$'
+# 5xx and transport-level faults. Anything not matched here or by
+# RATE_LIMIT_RE (4xx auth, not-found, malformed request) is a real error that
+# will fail identically every time, so retrying it just wastes runner minutes
+# and delays a message the maintainer needs to see.
+readonly TRANSIENT_RE='HTTP 5[0-9][0-9]|no server is currently available|connection reset|connection refused|timeout|timed out|TLS handshake|unexpected EOF|no such host|EOF$'
+
+# Rate limiting is transient but must be matched on *wording*, not status:
+# GitHub returns primary and secondary rate-limit errors as EITHER 403 or 429,
+# and a bare 403 is otherwise permanent (a token missing a scope). Keying on
+# the code alone would either retry real permission failures for minutes or —
+# as originally written here — fail the guard instantly on a rate limit.
+# See GitHub REST docs, "Troubleshooting the REST API > Rate limit errors".
+readonly RATE_LIMIT_RE='rate limit|abuse detection|please wait a few minutes'
+
+# GitHub asks callers to back off at least a minute on secondary limits, so
+# rate-limit retries use their own (much longer) schedule than 5xx retries.
+# They also get their own, smaller attempt cap: Preflight runs under
+# `timeout-minutes: 10` and makes three of these calls, so a full 4-attempt
+# schedule at 60s could exhaust the job budget and leave a bare "cancelled" —
+# the same uninformative signal this script exists to prevent. Two waits per
+# call bounds the worst case at ~6 min across all three.
+readonly RATE_LIMIT_DELAY=60
+readonly RATE_LIMIT_MAX_ATTEMPTS=3
 
 stderrFile=$(mktemp)
 trap 'rm -f "$stderrFile"' EXIT
@@ -35,17 +54,25 @@ for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
 
   cat "$stderrFile" >&2
 
-  if ! grep -qiE "$TRANSIENT_RE" "$stderrFile"; then
+  if grep -qiE "$RATE_LIMIT_RE" "$stderrFile"; then
+    kind="rate limit"
+    delay=$RATE_LIMIT_DELAY
+    maxAttempts=$RATE_LIMIT_MAX_ATTEMPTS
+  elif grep -qiE "$TRANSIENT_RE" "$stderrFile"; then
+    kind="transient failure"
+    delay=$((attempt * 5))
+    maxAttempts=$MAX_ATTEMPTS
+  else
     echo "::error::\`gh api\` failed with a non-transient error (see above). This is an API/permissions failure, NOT a Claude attribution violation — the attribution scan never ran." >&2
     exit 1
   fi
 
-  if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
-    delay=$((attempt * 5))
-    echo "gh api: transient failure (attempt $attempt/$MAX_ATTEMPTS); retrying in ${delay}s..." >&2
-    sleep "$delay"
+  if [ "$attempt" -ge "$maxAttempts" ]; then
+    break
   fi
+  echo "gh api: $kind (attempt $attempt/$maxAttempts); retrying in ${delay}s..." >&2
+  sleep "$delay"
 done
 
-echo "::error::GitHub API still unreachable after $MAX_ATTEMPTS attempts (see errors above). This is an infrastructure failure, NOT a Claude attribution violation — the attribution scan never ran. Re-run this job." >&2
+echo "::error::GitHub API still failing ($kind) after $maxAttempts attempts (see errors above). This is an infrastructure failure, NOT a Claude attribution violation — the attribution scan never ran. Re-run this job." >&2
 exit 1

--- a/scripts/ci/gh-api-retry.sh
+++ b/scripts/ci/gh-api-retry.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Run `gh api "$@"`, retrying only *transient* failures.
+#
+# The attribution guards in ci.yml run under `set -euo pipefail`, so a bare
+# `gh api` turns a GitHub API blip into a red "Forbid Claude attribution"
+# step — and the step name is the only thing a maintainer sees in the checks
+# UI, so it reads as though attribution was actually found (see PR #4982,
+# which died on an HTTP 503 with a single clean commit).
+#
+# Retrying indiscriminately would trade that for a different lie: a 404 or a
+# 403 from a misconfigured token is permanent, and reporting it as "API
+# unreachable" after 30s of pointless backoff misdirects just as badly. So
+# classify first and only retry what can actually succeed on a retry.
+#
+# Payload goes to stdout; all diagnostics go to stderr, so callers can safely
+# capture output in a command substitution without retry chatter polluting
+# the text they are about to grep.
+
+set -euo pipefail
+
+readonly MAX_ATTEMPTS=4
+
+# 5xx, rate limiting, and transport-level faults. Anything else (4xx auth,
+# not-found, malformed request) is a real error that will fail identically
+# every time.
+readonly TRANSIENT_RE='HTTP (429|5[0-9][0-9])|no server is currently available|connection reset|connection refused|timeout|timed out|TLS handshake|unexpected EOF|no such host|EOF$'
+
+stderrFile=$(mktemp)
+trap 'rm -f "$stderrFile"' EXIT
+
+for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+  if gh api "$@" 2>"$stderrFile"; then
+    exit 0
+  fi
+
+  cat "$stderrFile" >&2
+
+  if ! grep -qiE "$TRANSIENT_RE" "$stderrFile"; then
+    echo "::error::\`gh api\` failed with a non-transient error (see above). This is an API/permissions failure, NOT a Claude attribution violation — the attribution scan never ran." >&2
+    exit 1
+  fi
+
+  if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+    delay=$((attempt * 5))
+    echo "gh api: transient failure (attempt $attempt/$MAX_ATTEMPTS); retrying in ${delay}s..." >&2
+    sleep "$delay"
+  fi
+done
+
+echo "::error::GitHub API still unreachable after $MAX_ATTEMPTS attempts (see errors above). This is an infrastructure failure, NOT a Claude attribution violation — the attribution scan never ran. Re-run this job." >&2
+exit 1


### PR DESCRIPTION
## Problem

Both attribution guards shell out to `gh api` under `set -euo pipefail`, so any
transient GitHub API failure fails the step. On #4982 Preflight went red with
`gh: No server is currently available to service your request. (HTTP 503)` on a
single-commit PR containing no attribution of any kind — the step never reached
its `grep`.

Beyond the wasted re-run, the failure is actively misleading: the only thing
visible in the checks UI is the step name, which reads as though an attribution
violation was found.

## Change

Extract `scripts/ci/gh-api-retry.sh` and route all three `gh api` calls (body
guard ×1, commit guard ×2) through it.

The obvious fix — retry everything — trades one misleading message for another:
a 404, or a 403 from a misconfigured token, is permanent, so blind retry burns
30s of backoff and *then* claims "API unreachable". So the script classifies
before retrying:

- **Transient** (5xx, connection reset/refused, timeout, TLS handshake,
  unexpected EOF, DNS) → up to 4 attempts, linear backoff (5s/10s/15s).
- **Rate limited** → up to 3 attempts at 60s, per GitHub's guidance. Matched on
  error *wording*, not status: GitHub returns primary and secondary rate limits
  as **either 403 or 429**, while a bare 403 (token missing a scope) is
  permanent. Rate limiting also gets a smaller attempt cap than 5xx because
  Preflight runs under `timeout-minutes: 10` and makes three of these calls — a
  4-attempt 60s schedule could exhaust the job budget and leave a bare
  "cancelled", the same uninformative signal this script exists to prevent.
- **Anything else** → fails immediately, surfacing gh's own error.

Both failure messages state explicitly that **the attribution scan never ran**,
so neither can be misread as a real hit. Diagnostics go to stderr, so retry
chatter can never land in `$body` / `$messages` and cause a false `grep` hit.

## Verification

Exercised against a stubbed `gh` on `PATH`:

| Scenario | Result |
| --- | --- |
| Success first try | exit 0, clean payload |
| 403 secondary rate limit | retries at 60s, capped at 3 attempts |
| 403 auth (`Resource not accessible`) | exit 1 in **0s** — no retry |
| Permanent 404 | exit 1 in **0s** — no retry, distinct message |
| 503 ×2 then success | exit 0, payload only (no chatter in output) |
| Persistent 502 | exit 1 after 4 attempts, "still unreachable" message |

Regression check on the guard itself, using the real `ATTRIBUTION_RE`: a
body carrying a co-author trailer that names Claude, and one carrying the
robot-emoji generated-with line, both still fail; a clean body, an empty body, and a body whose *prose* mentions
"HTTP 503 / retrying in 5s" all still pass.

`shellcheck` clean; YAML parses; prettier clean; exec bit committed (100755).

Closes-story: ci-attribution-guard-fails-closed-on-github-api-5xx


**Note:** this PR's description deliberately avoids quoting the literal
attribution strings its own tests exercise — an earlier revision spelled them
out to document the regression cases and the body guard correctly failed the
run. The guard scans the live PR body, so prose *about* attribution is
indistinguishable from the real thing.
