### PR TITLE
ci: run trails-tsc unit tests in a blocking job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,8 @@ jobs:
           # actionpack/actionview/activerecord/rack/activesupport, so any of
           # their workspace upstreams also flips this on.
           TRAILTIES_PKGS_RE='^packages/(trailties|actionpack|actionview|activerecord|arel|activemodel|activesupport|globalid|rack|did-you-mean|trails-tsc)/'
-          # trails_tsc_affected gates the virtualized DX type tests.
+          # trails_tsc_affected gates the virtualized DX type tests, the
+          # blocking trails-tsc-tests job, and trails-tsc-coverage.
           # Workspace consumers of @blazetrails/trails-tsc today: activerecord
           # (tsc-wrapper + type-virtualization) and scripts/guides-typecheck;
           # AR consumption is the reason trails-tsc is also in AR_PKGS_RE.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -869,6 +869,32 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+  trails-tsc-tests:
+    name: trails-tsc Tests
+    needs: changes
+    # Gated like trails-tsc-coverage below: trails-tsc is the covered source and
+    # tse-compiler is what its tests exercise.
+    if: >-
+      needs.changes.outputs.docs_only != 'true' &&
+      (needs.changes.outputs.trails_tsc_affected == 'true' ||
+       needs.changes.outputs.tse_compiler_affected == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-pnpm
+      - run: pnpm install --frozen-lockfile --prefer-offline
+      # Blocking gate for trails-tsc's runtime unit tests. Deliberately plain:
+      # no --coverage, so the v8 instrumentation that pegs a worker long enough
+      # to trip vitest's `onTaskUpdate` worker-RPC timeout is absent, and
+      # dangerouslyIgnoreUnhandledErrors (gated on TRAILS_TSC_COVERAGE in
+      # vitest.config.ts) stays OFF — an unhandled error is real signal here.
+      # TRAILS_TEST_FORKS=1 removes fork contention and --test-timeout=60000
+      # absorbs the heavy tsc compiles these tests drive.
+      - run: pnpm vitest run packages/trails-tsc --test-timeout=60000
+        env:
+          TRAILS_TEST_FORKS: "1"
+
   trails-tsc-coverage:
     name: trails-tsc Coverage (reporting-only)
     needs: changes
@@ -1482,6 +1508,7 @@ jobs:
       - guides-typecheck
       - leaf-tests
       - virtualized-dx-type-tests
+      - trails-tsc-tests
       - unit-tests
       - actionpack-tests
       - trailties-tests
@@ -1603,6 +1630,12 @@ jobs:
                   # Legitimate skip when website_affected is false AND no
                   # website/release label opted the job in.
                   if [ "$WEBSITE_AFFECTED" = "false" ] && [ "$WEBSITE_LABEL" != "true" ]; then
+                    continue
+                  fi
+                  ;;
+                trails-tsc-tests)
+                  # Legitimate skip when neither trails-tsc nor tse-compiler changed.
+                  if [ "$TRAILS_TSC_AFFECTED" = "false" ] && [ "$TSE_COMPILER_AFFECTED" = "false" ]; then
                     continue
                   fi
                   ;;


### PR DESCRIPTION
Adds a blocking `trails-tsc-tests` CI job running `packages/trails-tsc/**/*.test.ts`.

Previously no gating job ran these: `coverage` omits trails-tsc, `leaf-tests`/`unit-tests` list other packages, `virtualized-dx-type-tests` is type-level only, and `trails-tsc-coverage` is `continue-on-error` (reporting-only). A real `expect` failure was visible but never blocked merge.

The new job runs **plain — no `--coverage`**, which is what makes it safe to block on: v8 instrumentation is the pressure that trips vitest's `onTaskUpdate` worker-RPC timeout, and `dangerouslyIgnoreUnhandledErrors` is gated on `TRAILS_TSC_COVERAGE` in `vitest.config.ts`, so it stays off here and an unhandled error remains real signal. `TRAILS_TEST_FORKS=1` removes fork contention; `--test-timeout=60000` absorbs the tsc compiles.

Gated on `trails_tsc_affected || tse_compiler_affected`, added to the `ci` all-jobs gate's `needs`, and wired into its expected-skip allow-list so a legitimate skip doesn't trip it.

Closes-story: trails-tsc-blocking-test-gate
