### PR TITLE
refactor(arel): drop Node casts on raw ValuesList rows

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -2064,7 +2064,7 @@ export function buildFixtureSql(
     // Single-row: strip DEFAULT columns so the DB fills them from its own
     // defaults, matching Rails' single-row optimisation exactly.
     const row = valuesList[0];
-    const filteredValues: Nodes.Node[] = [];
+    const filteredValues: unknown[] = [];
     allColumns.forEach((col, i) => {
       if (row[i] !== DEFAULT_VALUE) {
         filteredValues.push(row[i] as Nodes.Node);
@@ -2074,7 +2074,7 @@ export function buildFixtureSql(
     manager.values = manager.createValues(filteredValues);
   } else {
     allColumns.forEach((col) => manager.columns.push(table.get(col)));
-    manager.values = manager.createValuesList(valuesList as Nodes.Node[][]);
+    manager.values = manager.createValuesList(valuesList);
   }
 
   // Compile via the adapter's Arel visitor when available (matches Rails'

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -2067,7 +2067,7 @@ export function buildFixtureSql(
     const filteredValues: unknown[] = [];
     allColumns.forEach((col, i) => {
       if (row[i] !== DEFAULT_VALUE) {
-        filteredValues.push(row[i] as Nodes.Node);
+        filteredValues.push(row[i]);
         manager.columns.push(table.get(col));
       }
     });

--- a/packages/arel/src/insert-manager.ts
+++ b/packages/arel/src/insert-manager.ts
@@ -97,7 +97,7 @@ export class InsertManager extends TreeManager {
    * Mirrors: Arel::InsertManager#create_values
    */
   createValues(row: unknown[]): ValuesList {
-    return new ValuesList([row as Node[]]);
+    return new ValuesList([row]);
   }
 
   /**


### PR DESCRIPTION
Removes two `Node` casts asserted on rows that are — in Rails and in our own
signatures — arbitrary raw values.

- `packages/arel/src/insert-manager.ts` — `new ValuesList([row as Node[]])` →
  `new ValuesList([row])`. `ValuesList`'s constructor already takes
  `unknown[][]` and `createValues` takes `unknown[]`.
- `packages/activerecord/src/connection-adapters/abstract/database-statements.ts`
  — `filteredValues` is now `unknown[]` (dropping the per-element
  `row[i] as Nodes.Node`), and `createValuesList(valuesList)` loses its
  `as Nodes.Node[][]`. PR #4873 widened `createValuesList` to `unknown[][]`.

Rails' rows hold raw values (`create_values_list([%w{ a b }, %w{ c d }])`,
`insert_manager_test.rb:10`), quoted by the visitor at `to_sql.rb:112`.

The casts were inert today, so this is cleanup rather than a bug fix. It is
worth doing because the same class of wrong annotation actively masked a real
break in #4873: `createValuesList` declared `rows: Node[][]`, which
type-checked `schema-migration.ts`'s `[new Nodes.Quoted(v)]` rows while the
narrowed `ValuesList` case sent them to `quote()` →
`TypeError: can't quote Quoted`. These two casts assert the same untruth in
the opposite direction and would silently accept a Node row Rails raises on.

No new casts introduced at the call sites; values flow as `unknown` end to end.

`pnpm -w typecheck` clean; `insert-manager.test.ts`, `visitors/to-sql.test.ts`,
and `insert-all.test.ts` green (382 passed).

Closes-story: arel-valueslist-row-casts-assert-node-on-raw-values
