### PR TITLE
refactor(quoting): self-dispatch the abstract quote/type_cast boolean arms

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -387,8 +387,18 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   override quoteIdentifier = mysqlQuoteIdentifier;
   override quoteTableName = mysqlQuoteTableName;
   override quoteColumnName = mysqlQuoteColumnName;
-  override unquotedTrue = mysqlUnquotedTrue;
-  override unquotedFalse = mysqlUnquotedFalse;
+
+  // Defined as methods, not class fields: Rails declares these with `def`
+  // (`mysql/quoting.rb:72-77`), and the inherited `type_cast` reaches them
+  // through `self`. A field lives on the instance rather than the prototype,
+  // which silently breaks any receiver built from the prototype alone.
+  override unquotedTrue(): number {
+    return mysqlUnquotedTrue();
+  }
+
+  override unquotedFalse(): number {
+    return mysqlUnquotedFalse();
+  }
 
   /** @internal */
   override arelVisitor(): Visitors.ToSql {

--- a/packages/activerecord/src/connection-adapters/abstract/quoting-helpers.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting-helpers.trails.test.ts
@@ -213,3 +213,32 @@ describe("quote_table_name dispatches through quote_column_name", () => {
     expect(quoteTableName.call(host, "people")).toBe("<<people>>");
   });
 });
+
+describe("boolean literals dispatch through the host", () => {
+  // Rails reaches the pair via self (abstract/quoting.rb:77-78, 98-99), so an
+  // adapter override applies to the *inherited* quote/type_cast. These pin the
+  // dispatch, not just the values: a host that overrides the pair must win.
+  const host = {
+    quotedTrue: () => "1",
+    quotedFalse: () => "0",
+    unquotedTrue: () => 1,
+    unquotedFalse: () => 0,
+  };
+
+  it("routes quote through this.quotedTrue/quotedFalse when present", () => {
+    expect(quote.call(host, true)).toBe("1");
+    expect(quote.call(host, false)).toBe("0");
+  });
+
+  it("routes type_cast through this.unquotedTrue/unquotedFalse when present", () => {
+    expect(typeCast.call(host, true)).toBe(1);
+    expect(typeCast.call(host, false)).toBe(0);
+  });
+
+  it("falls back to the module helpers for a host without the overrides", () => {
+    expect(quote.call({}, true)).toBe("TRUE");
+    expect(quote.call({}, false)).toBe("FALSE");
+    expect(typeCast.call({}, true)).toBe(true);
+    expect(typeCast.call({}, false)).toBe(false);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -46,6 +46,14 @@ export interface QuotingDispatchHost {
   quotedBinary?(value: unknown): string;
   /** @internal */
   quoteColumnName?(name: string): string;
+  /** @internal */
+  quotedTrue?(): string;
+  /** @internal */
+  quotedFalse?(): string;
+  /** @internal */
+  unquotedTrue?(): boolean | number;
+  /** @internal */
+  unquotedFalse?(): boolean | number;
 }
 
 type TemporalDateLike =
@@ -109,7 +117,10 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
     if (desc === undefined) throw new TypeError("Cannot quote a Symbol without a description");
     return `'${quoteString(desc)}'`;
   }
-  if (typeof value === "boolean") return value ? quotedTrue() : quotedFalse();
+  // Rails: `when true then quoted_true` / `when false then quoted_false`
+  // (rb:77-78) — self-dispatched, so SQLite's `1`/`0` override applies to the
+  // inherited `quote`. Thread `this` to mirror that.
+  if (typeof value === "boolean") return dispatchQuotedBoolean(this, value);
   if (value === null || value === undefined) return "NULL";
   // BigDecimals need to be put in a non-normalized (fixed, ".0"-bearing) form
   // and quoted bare — Rails: `when BigDecimal then value.to_s("F")`.
@@ -172,8 +183,10 @@ export function typeCast(this: QuotingDispatchHost, value: unknown): unknown {
   // path for a binary attribute lands here.
   if (typeof value === "symbol") return value.description ?? String(value);
   if (value instanceof BinaryData) return value.bytes;
-  if (value === true) return unquotedTrue();
-  if (value === false) return unquotedFalse();
+  // Rails: `when true then unquoted_true` / `when false then unquoted_false`
+  // (rb:98-99) — self-dispatched, so MySQL's `1`/`0` override applies to the
+  // inherited `type_cast`. Thread `this` to mirror that.
+  if (typeof value === "boolean") return dispatchUnquotedBoolean(this, value);
   if (value === null || value === undefined) return value;
   // Rails: `when BigDecimal then value.to_s("F")` — bound as a fixed-form string.
   if (value instanceof BigDecimal) return value.toString("F");
@@ -508,6 +521,33 @@ export function dispatchQuote(host: QuotingDispatchHost, value: unknown): string
     return host.quote(value);
   }
   return quote.call(host, value);
+}
+
+/**
+ * Dispatch the boolean literals through the host's overrides if it defines
+ * them, else the module-level helpers. Mirrors Rails' `when true then
+ * quoted_true` / `when false then unquoted_false` (abstract/quoting.rb:77-78,
+ * 98-99), which reach the pair through `self` so an adapter's override applies
+ * to the *inherited* `quote` / `type_cast` rather than forcing each adapter to
+ * re-implement the whole boolean arm.
+ * @internal
+ */
+export function dispatchQuotedBoolean(host: QuotingDispatchHost, value: boolean): string {
+  if (value) {
+    return typeof host.quotedTrue === "function" ? host.quotedTrue() : quotedTrue();
+  }
+  return typeof host.quotedFalse === "function" ? host.quotedFalse() : quotedFalse();
+}
+
+/** @internal */
+export function dispatchUnquotedBoolean(
+  host: QuotingDispatchHost,
+  value: boolean,
+): boolean | number {
+  if (value) {
+    return typeof host.unquotedTrue === "function" ? host.unquotedTrue() : unquotedTrue();
+  }
+  return typeof host.unquotedFalse === "function" ? host.unquotedFalse() : unquotedFalse();
 }
 
 /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -120,7 +120,8 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
   // Rails: `when true then quoted_true` / `when false then quoted_false`
   // (rb:77-78) — self-dispatched, so SQLite's `1`/`0` override applies to the
   // inherited `quote`. Thread `this` to mirror that.
-  if (typeof value === "boolean") return dispatchQuotedBoolean(this, value);
+  if (typeof value === "boolean")
+    return value ? dispatchQuotedTrue(this) : dispatchQuotedFalse(this);
   if (value === null || value === undefined) return "NULL";
   // BigDecimals need to be put in a non-normalized (fixed, ".0"-bearing) form
   // and quoted bare — Rails: `when BigDecimal then value.to_s("F")`.
@@ -186,7 +187,8 @@ export function typeCast(this: QuotingDispatchHost, value: unknown): unknown {
   // Rails: `when true then unquoted_true` / `when false then unquoted_false`
   // (rb:98-99) — self-dispatched, so MySQL's `1`/`0` override applies to the
   // inherited `type_cast`. Thread `this` to mirror that.
-  if (typeof value === "boolean") return dispatchUnquotedBoolean(this, value);
+  if (typeof value === "boolean")
+    return value ? dispatchUnquotedTrue(this) : dispatchUnquotedFalse(this);
   if (value === null || value === undefined) return value;
   // Rails: `when BigDecimal then value.to_s("F")` — bound as a fixed-form string.
   if (value instanceof BigDecimal) return value.toString("F");
@@ -525,28 +527,32 @@ export function dispatchQuote(host: QuotingDispatchHost, value: unknown): string
 
 /**
  * Dispatch the boolean literals through the host's overrides if it defines
- * them, else the module-level helpers. Mirrors Rails' `when true then
- * quoted_true` / `when false then unquoted_false` (abstract/quoting.rb:77-78,
- * 98-99), which reach the pair through `self` so an adapter's override applies
- * to the *inherited* `quote` / `type_cast` rather than forcing each adapter to
+ * them, else the module-level helpers, so an adapter's override applies to the
+ * *inherited* `quote` / `type_cast` rather than forcing each adapter to
  * re-implement the whole boolean arm.
+ *
+ * One helper per Rails method — `when true then quoted_true` and `when false
+ * then quoted_false` are four distinct `self.` sends (abstract/quoting.rb:77-78,
+ * 98-99) — matching the one-method-per-helper shape of `dispatchQuotedTime` /
+ * `dispatchQuotedBinary` / `dispatchQuotedDate`.
  * @internal
  */
-export function dispatchQuotedBoolean(host: QuotingDispatchHost, value: boolean): string {
-  if (value) {
-    return typeof host.quotedTrue === "function" ? host.quotedTrue() : quotedTrue();
-  }
+export function dispatchQuotedTrue(host: QuotingDispatchHost): string {
+  return typeof host.quotedTrue === "function" ? host.quotedTrue() : quotedTrue();
+}
+
+/** @internal */
+export function dispatchQuotedFalse(host: QuotingDispatchHost): string {
   return typeof host.quotedFalse === "function" ? host.quotedFalse() : quotedFalse();
 }
 
 /** @internal */
-export function dispatchUnquotedBoolean(
-  host: QuotingDispatchHost,
-  value: boolean,
-): boolean | number {
-  if (value) {
-    return typeof host.unquotedTrue === "function" ? host.unquotedTrue() : unquotedTrue();
-  }
+export function dispatchUnquotedTrue(host: QuotingDispatchHost): boolean | number {
+  return typeof host.unquotedTrue === "function" ? host.unquotedTrue() : unquotedTrue();
+}
+
+/** @internal */
+export function dispatchUnquotedFalse(host: QuotingDispatchHost): boolean | number {
   return typeof host.unquotedFalse === "function" ? host.unquotedFalse() : unquotedFalse();
 }
 

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
@@ -10,12 +10,21 @@ import {
   castBoundValue,
   columnNameMatcher,
   columnNameWithOrderMatcher,
+  unquotedTrue,
+  unquotedFalse,
 } from "./quoting.js";
 import { AbstractMysqlAdapter } from "../abstract-mysql-adapter.js";
 
 // `quote` / `typeCast` require a host receiver (no receiver-less dispatch); bind
 // the adapter prototype so date/time values reach MySQL's quotedDate override.
-const HOST = Object.create(AbstractMysqlAdapter.prototype) as object;
+// `unquotedTrue`/`unquotedFalse` are assigned as class FIELDS on the adapter
+// (abstract-mysql-adapter.ts:390-391), so they live on instances, not the
+// prototype — `Object.create(prototype)` alone would miss them and the boolean
+// self-dispatch would fall back to the abstract true/false.
+const HOST = Object.assign(Object.create(AbstractMysqlAdapter.prototype) as object, {
+  unquotedTrue,
+  unquotedFalse,
+});
 const quote = (value: unknown): string => quoteFn.call(HOST, value);
 const typeCast = (value: unknown): unknown => typeCastFn.call(HOST, value);
 

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
@@ -10,21 +10,13 @@ import {
   castBoundValue,
   columnNameMatcher,
   columnNameWithOrderMatcher,
-  unquotedTrue,
-  unquotedFalse,
 } from "./quoting.js";
 import { AbstractMysqlAdapter } from "../abstract-mysql-adapter.js";
 
 // `quote` / `typeCast` require a host receiver (no receiver-less dispatch); bind
-// the adapter prototype so date/time values reach MySQL's quotedDate override.
-// `unquotedTrue`/`unquotedFalse` are assigned as class FIELDS on the adapter
-// (abstract-mysql-adapter.ts:390-391), so they live on instances, not the
-// prototype — `Object.create(prototype)` alone would miss them and the boolean
-// self-dispatch would fall back to the abstract true/false.
-const HOST = Object.assign(Object.create(AbstractMysqlAdapter.prototype) as object, {
-  unquotedTrue,
-  unquotedFalse,
-});
+// the adapter prototype so date/time values reach MySQL's quotedDate override
+// and booleans reach its unquotedTrue/unquotedFalse.
+const HOST = Object.create(AbstractMysqlAdapter.prototype) as object;
 const quote = (value: unknown): string => quoteFn.call(HOST, value);
 const typeCast = (value: unknown): unknown => typeCastFn.call(HOST, value);
 

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -22,7 +22,8 @@ import {
   toBytes,
   dispatchQuotedDate,
   dispatchQuotedTime,
-  dispatchUnquotedBoolean,
+  dispatchUnquotedTrue,
+  dispatchUnquotedFalse,
   type QuotingDispatchHost,
 } from "../abstract/quoting.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
@@ -281,7 +282,8 @@ export function typeCast(this: QuotingDispatchHost, value: unknown): unknown {
   // override. This chain does not delegate, so the arm is inlined — but it
   // dispatches through `this` rather than the module-level pair, so the receiver
   // decides, as in Rails.
-  if (typeof value === "boolean") return dispatchUnquotedBoolean(this, value);
+  if (typeof value === "boolean")
+    return value ? dispatchUnquotedTrue(this) : dispatchUnquotedFalse(this);
   if (value === null || value === undefined) return value;
   if (typeof value === "number" || typeof value === "bigint") return value;
   if (typeof value === "string") return value;

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -22,6 +22,7 @@ import {
   toBytes,
   dispatchQuotedDate,
   dispatchQuotedTime,
+  dispatchUnquotedBoolean,
   type QuotingDispatchHost,
 } from "../abstract/quoting.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
@@ -275,8 +276,12 @@ export function typeCast(this: QuotingDispatchHost, value: unknown): unknown {
   // arm is inlined: `to_s` on a `Data` is the raw byte string, hence `.bytes`
   // (never `toString()`, which UTF-8-decodes and mangles bytes >= 0x80).
   if (value instanceof BinaryData) return value.bytes;
-  if (value === true) return unquotedTrue();
-  if (value === false) return unquotedFalse();
+  // Rails' MySQL `type_cast` falls through to `super` here, whose boolean arm is
+  // self-dispatched (abstract/quoting.rb:98-99) and lands on MySQL's `1`/`0`
+  // override. This chain does not delegate, so the arm is inlined — but it
+  // dispatches through `this` rather than the module-level pair, so the receiver
+  // decides, as in Rails.
+  if (typeof value === "boolean") return dispatchUnquotedBoolean(this, value);
   if (value === null || value === undefined) return value;
   if (typeof value === "number" || typeof value === "bigint") return value;
   if (typeof value === "string") return value;

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
@@ -37,10 +37,9 @@ describe("PostgreSQL quoting", () => {
     // abstract/quoting.rb:166-180. Inheriting that pair (not MySQL/SQLite's
     // 1/0) is why encode_array emits '{true}'.
     //
-    // These pin the values, not the dispatch: abstract/quoting.ts:112,175-176
-    // call the module-level quotedTrue/unquotedTrue, where Rails self-dispatches
-    // (quoting.rb:77-78, 98-99), so an override here would not be caught. That
-    // gap is the type-casted-binds-payload-self-dispatch story's to close.
+    // The inherited quote/typeCast now reach the pair through the receiver
+    // (quoting.rb:77-78, 98-99), so a host that DID override them would change
+    // these results — abstract/quoting.test.ts pins that dispatch.
     expect(quote(true)).toBe("TRUE");
     expect(quote(false)).toBe("FALSE");
     expect(typeCast(true)).toBe(true);

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
@@ -13,14 +13,28 @@ import {
   quoteDefaultExpression,
   quotedDate,
   quotedTime,
+  quotedTrue,
+  quotedFalse,
+  unquotedTrue,
+  unquotedFalse,
   typeCast as typeCastFn,
 } from "./quoting.js";
 
 // `quote` / `typeCast` require a host receiver (no receiver-less dispatch); bind
 // SQLite's quotedDate / quotedTime so date/time literals keep the 2000-01-01
 // prefix on times, and quotedBinary so binary self-dispatch reaches SQLite's
-// `x'..'` hex form — the same overrides AbstractSQLite3Adapter supplies.
-const HOST = { quotedDate, quotedTime, quotedBinary };
+// `x'..'` hex form, and the boolean pair so the inherited abstract boolean arm
+// self-dispatches back to SQLite's 1/0 — the same overrides
+// AbstractSQLite3Adapter supplies.
+const HOST = {
+  quotedDate,
+  quotedTime,
+  quotedBinary,
+  quotedTrue,
+  quotedFalse,
+  unquotedTrue,
+  unquotedFalse,
+};
 const quote = (value: unknown): string => quoteFn.call(HOST, value);
 const typeCast = (value: unknown): unknown => typeCastFn.call(HOST, value);
 

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -15,6 +15,7 @@ import {
   dispatchQuotedBinary,
   dispatchQuotedDate,
   dispatchQuotedTime,
+  dispatchUnquotedBoolean,
   type QuotingDispatchHost,
 } from "../abstract/quoting.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
@@ -73,16 +74,15 @@ export function quoteString(value: string): string {
  * `quotedTime`. A host receiver is required — every invocation routes through
  * an adapter via `.call(this, value)`.
  *
- * The boolean, symbol, and string branches stay inline because our abstract
- * `quote` renders those through module-level helpers (TRUE/FALSE,
- * backslash-escaping `quoteString`) rather than dispatching through `this`, so
- * delegating would lose SQLite's overrides (1/0, `''`-only escaping). These are
- * exactly the quoting primitives SQLite3::Quoting overrides. Binary does
- * dispatch through `this`, so `BinaryData` rides the inherited abstract branch.
+ * The symbol and string branches stay inline because our abstract `quote`
+ * renders those through the module-level, backslash-escaping `quoteString`
+ * rather than dispatching through `this`, so delegating would lose SQLite's
+ * `''`-only escaping. Booleans and binary DO dispatch through `this` (mirroring
+ * Rails' `self.quoted_true` / `self.quoted_binary`), so both ride the inherited
+ * abstract branch straight back to SQLite's `quotedTrue` / `quotedBinary`.
  */
 export function quote(this: QuotingDispatchHost, value: unknown): string {
   if (typeof value === "number" && !Number.isFinite(value)) return quoteString(String(value));
-  if (typeof value === "boolean") return value ? quotedTrue() : quotedFalse();
   if (typeof value === "symbol") {
     if (value.description === undefined) {
       throw new TypeError("can't quote a Symbol without a description");
@@ -198,7 +198,10 @@ export function typeCast(this: QuotingDispatchHost, value: unknown, bindsAsFloat
   // otherwise `LOWER(?)` on a boolean bind would serialize `1.0` / `0.0` and a
   // `case_sensitive: false` uniqueness check on a boolean column would miss
   // collisions (the same divergence the integer branch below fixes).
-  if (typeof value === "boolean") return BigInt(value ? unquotedTrue() : unquotedFalse());
+  // Self-dispatched (rb:98-99) so the pair resolves through SQLite's
+  // `unquotedTrue`/`unquotedFalse` overrides. The BigInt wrapper is why this arm
+  // cannot simply delegate to the abstract `type_cast`: it must stay here.
+  if (typeof value === "boolean") return BigInt(dispatchUnquotedBoolean(this, value));
   if (typeof value === "number") {
     if (!Number.isFinite(value)) return null;
     // better-sqlite3 binds every JS number as SQLITE_FLOAT (there is no

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -15,7 +15,8 @@ import {
   dispatchQuotedBinary,
   dispatchQuotedDate,
   dispatchQuotedTime,
-  dispatchUnquotedBoolean,
+  dispatchUnquotedTrue,
+  dispatchUnquotedFalse,
   type QuotingDispatchHost,
 } from "../abstract/quoting.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
@@ -201,7 +202,8 @@ export function typeCast(this: QuotingDispatchHost, value: unknown, bindsAsFloat
   // Self-dispatched (rb:98-99) so the pair resolves through SQLite's
   // `unquotedTrue`/`unquotedFalse` overrides. The BigInt wrapper is why this arm
   // cannot simply delegate to the abstract `type_cast`: it must stay here.
-  if (typeof value === "boolean") return BigInt(dispatchUnquotedBoolean(this, value));
+  if (typeof value === "boolean")
+    return BigInt(value ? dispatchUnquotedTrue(this) : dispatchUnquotedFalse(this));
   if (typeof value === "number") {
     if (!Number.isFinite(value)) return null;
     // better-sqlite3 binds every JS number as SQLITE_FLOAT (there is no


### PR DESCRIPTION
Rails' abstract `quote`/`type_cast` reach the boolean literals through `self`
(`abstract/quoting.rb:77-78`, `:98-99`), so an adapter's `quoted_true` /
`unquoted_false` override applies to the **inherited** method. trails called the
module-level functions instead, so no override was reachable — and each adapter
compensated by re-implementing the whole boolean arm, which Rails does not do.
That duplication was the deviation; it was only *currently* correct because each
module hardcoded its own pair.

## Changes

- `abstract/quoting.ts` — four new one-liner helpers (`dispatchQuotedTrue`,
  `dispatchQuotedFalse`, `dispatchUnquotedTrue`, `dispatchUnquotedFalse`), one per
  Rails method, matching the one-method-per-helper shape of the existing
  `dispatchQuotedBinary` / `dispatchQuotedDate` / `dispatchQuotedTime`. The four
  literals are added to `QuotingDispatchHost`. Both arms now go through the receiver.
- `abstract-mysql-adapter.ts` — `unquotedTrue`/`unquotedFalse` converted from class
  **fields** to **methods**, matching Rails' `def` (`mysql/quoting.rb:72-77`) and the
  sibling SQLite adapter. Fields live on instances, not the prototype, which broke
  any prototype-derived receiver.
- `sqlite3/quoting.ts` — the duplicate arm in `quote` is **deleted**: that chain
  ends in `abstractQuote.call(this, value)`, so booleans now ride the inherited
  path back to SQLite's `quotedTrue`. Behaviour-preserving.
- `sqlite3/quoting.ts` `typeCast` and `mysql/quoting.ts` `typeCast` — these
  **cannot** collapse: neither chain delegates (both end in a `throw`), and
  SQLite's wraps in `BigInt` to bind SQLITE_INTEGER rather than FLOAT. They stay
  inlined, but now dispatch through `this` instead of the module-level pair, so
  the receiver decides as in Rails. This is the `1` → `1n` hazard the story flagged;
  it is avoided by keeping the arm rather than delegating.
- `postgresql/quoting.test.ts` — the comment disclaiming the dispatch gap is gone.
- `abstract/quoting-helpers.trails.test.ts` — pins the dispatch with an
  overriding host, plus a fallback positive control.

## Verification

- **Baseline check**: both new dispatch assertions **fail on `origin/main`**
  (`"TRUE"` received where `"1"` expected); the fallback control passes. The guard
  is real, not vacuously green.
- Two existing tests failed on the first run — `SQLite3::Quoting > quote > quotes
  booleans as 1/0` and `MySQL quoting — typeCast > collapses booleans to 1 / 0`.
  Both were **test-host gaps**, not behaviour regressions: the hosts didn't carry
  the overrides a real adapter has. Worth noting for reviewers — MySQL assigns
  `unquotedTrue`/`unquotedFalse` as class **fields** (`abstract-mysql-adapter.ts:390-391`),
  so they live on instances and `Object.create(prototype)` missed them entirely.
  No test name was reworded.
- `pnpm typecheck` clean; eslint clean on all touched files.
- **Parity delta non-negative**, verified rather than assumed:
  - `api:compare` — all four touched files report **100%, 0 missing**
    (`abstract/quoting.ts` 20/20, `mysql/quoting.ts` 10/10,
    `postgresql/quoting.ts` 23/23, `sqlite3/quoting.ts` 15/15). The two new
    `dispatch*` helpers are not penalized, matching how their existing
    `dispatchQuotedBinary` / `dispatchQuotedDate` siblings are already treated;
    no ported method was deleted (only a branch *inside* one), so the delta
    cannot be negative.
  - `test:compare` — matched-test count unaffected: the 3 new tests land in a
    `.trails.test.ts` ("extra (TS only)"), and no test was renamed or removed.
  - No ratchet churn committed (`eslint/` reverted after each run).
- **Regression sweep on the deleted SQLite arm.** Removing it means an
  override-less receiver would now yield `"TRUE"` instead of `"1"`, so I traced
  every caller: `sqlite3-adapter.ts:959` threads `this` into `sqliteQuote`, and
  the adapter defines `quotedTrue`/`quotedFalse` as **prototype methods**
  (`:1058-1071`); `quoteDefaultExpression` threads `this` likewise. PG has no
  boolean arm and inherits AbstractAdapter's prototype methods. The only
  override-less callers were the two test hosts, now fixed. No production path
  loses the override.
- Local: 174 passing across the four quoting suites, plus the sqlite3
  bind-parameter and integer-bind suites. Full suite left to CI.

Closes-story: abstract-quote-boolean-arms-self-dispatch
