### PR TITLE
fix(arel): Dot#isHash ignores a literal constructor key on a prototype

### DIFF
--- a/packages/arel/src/visitors/dot.test.ts
+++ b/packages/arel/src/visitors/dot.test.ts
@@ -519,6 +519,33 @@ describe("TestDot", () => {
       expect(out).not.toMatch(/-> \d+ \[label="valueBeforeTypeCast"\];/);
     });
 
+    it("a record inheriting a literal constructor key is a Hash", () => {
+      // Dispatch is by ancestry in Ruby (visitor.rb:36-41), so a Hash with a
+      // `:constructor` key still reaches visit_Hash (dot.rb:220) — the key's
+      // *name* is irrelevant. Here the prototype's `constructor` is an
+      // enumerable data key, not the non-enumerable one a `class` installs.
+      const derived: Record<string, unknown> = Object.create({ constructor: "x" });
+      derived.alpha = "A";
+      const out = visitStandalone(derived);
+      expect(out).toMatch(/\d+ \[label="<f0>Hash"\];/);
+      expect(out).toContain('[label="pair_0"]');
+      expect(out).toContain("alpha");
+    });
+
+    it("a class instance with an enumerable constructor member is not a Hash", () => {
+      class Config {
+        alpha = "A";
+      }
+      Object.defineProperty(Config.prototype, "constructor", {
+        value: Config,
+        enumerable: true,
+        writable: true,
+        configurable: true,
+      });
+      // Not a Hash, so it falls to the unknown-class leaf arm (visitor.rb:39).
+      expect(() => visitStandalone(new Config())).toThrow(/Cannot visit Config/);
+    });
+
     it("a Set emits index-labeled edges like an Array", () => {
       // Rails: `alias :visit_Set :visit_Array` (dot.rb:231). A Set is not a
       // Hash (its prototype's ctor is Set), so without a dedicated arm it

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -661,19 +661,19 @@ export class Dot extends Visitor {
       proto = Object.getPrototypeOf(proto)
     ) {
       if (proto === Object.prototype) return true;
-      // A prototype with no own `constructor` descends from
-      // Object.create(null) — still a record, so keep walking. What marks a
-      // *class* prototype is not the mere presence of the key but the
-      // back-reference: `class C {}` installs `C.prototype.constructor === C`
-      // with `C.prototype === proto`. A record carrying a literal
-      // `constructor` key (`{ constructor: "x" }`) fails that identity, and
-      // its name is irrelevant to dispatch — Ruby dispatches by ancestry
-      // (visitor.rb:36-41), so a Hash with a `:constructor` key is still a
-      // Hash and reaches visit_Hash (dot.rb:220).
+      // What marks a *class* prototype is the back-reference: `class C {}`
+      // installs `C.prototype.constructor === C`, so the own `constructor`
+      // is a function pointing back at this very object. Anything else —
+      // absent, a non-function, or a function whose `.prototype` is some
+      // other object — leaves the value a record, so keep walking. A literal
+      // `constructor` key (`{ constructor: "x" }`) fails the identity, and
+      // its name is irrelevant to dispatch anyway: Ruby dispatches by
+      // ancestry (visitor.rb:36-41), so a Hash with a `:constructor` key is
+      // still a Hash and reaches visit_Hash (dot.rb:220).
       const ctor = Object.getOwnPropertyDescriptor(proto, "constructor")?.value as
         | { prototype?: unknown }
         | undefined;
-      if (typeof ctor === "function" && ctor.prototype === proto && ctor !== Object) {
+      if (typeof ctor === "function" && ctor.prototype === proto) {
         return false;
       }
     }

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -661,11 +661,21 @@ export class Dot extends Visitor {
       proto = Object.getPrototypeOf(proto)
     ) {
       if (proto === Object.prototype) return true;
-      // A prototype with no `constructor` at all descends from
-      // Object.create(null) — still a record, so keep walking. Only a
-      // constructor naming some *other* class marks a class prototype.
-      const ctor = (proto as { constructor?: unknown }).constructor;
-      if (ctor !== undefined && ctor !== Object) return false;
+      // A prototype with no own `constructor` descends from
+      // Object.create(null) — still a record, so keep walking. What marks a
+      // *class* prototype is not the mere presence of the key but the
+      // back-reference: `class C {}` installs `C.prototype.constructor === C`
+      // with `C.prototype === proto`. A record carrying a literal
+      // `constructor` key (`{ constructor: "x" }`) fails that identity, and
+      // its name is irrelevant to dispatch — Ruby dispatches by ancestry
+      // (visitor.rb:36-41), so a Hash with a `:constructor` key is still a
+      // Hash and reaches visit_Hash (dot.rb:220).
+      const ctor = Object.getOwnPropertyDescriptor(proto, "constructor")?.value as
+        | { prototype?: unknown }
+        | undefined;
+      if (typeof ctor === "function" && ctor.prototype === proto && ctor !== Object) {
+        return false;
+      }
     }
     return true;
   }


### PR DESCRIPTION
Fixes `Dot#isHash` misclassifying a record whose prototype carries a literal `constructor` data key.

`Object.create({ constructor: "x" })` was falling to the unknown-object leaf arm instead of `visitHash`, because the prototype walk read `proto.constructor` and bailed on any value that wasn't `Object`. In Ruby the equivalent Hash still routes to `visit_Hash` (dot.rb:220) — dispatch is by ancestry (visitor.rb:36-41) and the key's *name* is irrelevant.

Now the walk discriminates a class prototype by the constructor back-reference (`C.prototype.constructor === C`), which a literal key can't fake. Deferred as a known limitation in #4883.

Verified the new regression test fails on baseline; the class-instance guard test passes both ways as a control.

Closes-story: arel-dot-ishash-misreads-literal-constructor-key
