### PR TITLE
fix(arel): raise TypeError from Visitor#visit no-handler terminal

### DIFF
--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -467,13 +467,15 @@ describe("the to_sql visitor", () => {
   });
 
   it("unsupported input should raise UnsupportedVisitError", () => {
-    class Unknown extends Nodes.Node {
-      accept<T>(visitor: Nodes.NodeVisitor<T>): T {
-        return visitor.visit(this);
-      }
-    }
-    expect(() => new Visitors.ToSql().compile(new Unknown())).toThrow(
+    // Rails compiles `nil`, whose NilClass handler is aliased to `unsupported`
+    // (to_sql.rb:838) — the UnsupportedVisitError terminal. A class with no
+    // handler at all is the other terminal and raises TypeError
+    // (visitor.rb:38), covered in visitor.test.ts.
+    expect(() => new Visitors.ToSql().compile(null as unknown as Nodes.Node)).toThrow(
       Visitors.UnsupportedVisitError,
+    );
+    expect(() => new Visitors.ToSql().compile(null as unknown as Nodes.Node)).toThrow(
+      /^Unsupported/,
     );
   });
 
@@ -652,7 +654,7 @@ describe("the to_sql visitor", () => {
         ]) {
           expect(() =>
             spy.compile(new Nodes.Equality(attr, value as unknown as Nodes.NodeOrValue)),
-          ).toThrow(Visitors.UnsupportedVisitError);
+          ).toThrow(TypeError);
         }
       });
 

--- a/packages/arel/src/visitors/visitor.test.ts
+++ b/packages/arel/src/visitors/visitor.test.ts
@@ -62,10 +62,11 @@ describe("Visitor dispatch", () => {
     expect(FreshVisitor.dispatchCache().get(B)).toBe("visitA");
   });
 
-  it("throws UnsupportedVisitError for nodes with no handler", () => {
+  it("throws TypeError for nodes with no handler", () => {
     const v = new TestVisitor();
-    expect(() => v.accept(new C())).toThrow(UnsupportedVisitError);
-    expect(() => v.accept(new C())).toThrow(/Unknown node type: C/);
+    expect(() => v.accept(new C())).toThrow(TypeError);
+    expect(() => v.accept(new C())).toThrow(/Cannot visit C/);
+    expect(() => v.accept(new C())).not.toThrow(UnsupportedVisitError);
   });
 
   it("distinguishes a mis-registered method from an unknown node type", () => {
@@ -153,7 +154,8 @@ describe("Visitor dispatch", () => {
 
     it("raises when the value's class has no handler", () => {
       class Arbitrary {}
-      expect(() => new ValueVisitor().accept(new Arbitrary())).toThrow(UnsupportedVisitError);
+      expect(() => new ValueVisitor().accept(new Arbitrary())).toThrow(TypeError);
+      expect(() => new ValueVisitor().accept(new Arbitrary())).toThrow(/Cannot visit Arbitrary/);
     });
   });
 

--- a/packages/arel/src/visitors/visitor.ts
+++ b/packages/arel/src/visitors/visitor.ts
@@ -72,7 +72,11 @@ export abstract class Visitor {
   protected visit(object: unknown, collector?: unknown): unknown {
     const methodName = this.dispatchMethod(object);
     if (!methodName) {
-      throw new UnsupportedVisitError(`Unknown node type: ${describeClass(object)}`);
+      // Rails' second failure terminal: no handler on the class or any of its
+      // ancestors falls out of `rescue NoMethodError` as a TypeError
+      // (visitor.rb:38), distinct from a class whose handler is aliased to
+      // `unsupported` and raises UnsupportedVisitError (to_sql.rb:828).
+      throw new TypeError(`Cannot visit ${describeClass(object)}`);
     }
     const fn = (this as unknown as Record<string, unknown>)[methodName];
     if (typeof fn !== "function") {


### PR DESCRIPTION
Rails' `Arel::Visitors::Visitor#visit` has two distinct failure terminals; trails collapsed them into one.

- A class whose handler is aliased to `unsupported` (String, Hash, Float, Date, Time, NilClass, … `to_sql.rb:832-845`) raises `UnsupportedVisitError` (`to_sql.rb:828`). Already faithful — unchanged.
- A class with **no handler at all** falls into `rescue NoMethodError`, walks the ancestors, and raises `TypeError, "Cannot visit #{object.class}"` (`visitor.rb:38`). Trails raised `UnsupportedVisitError("Unknown node type: X")` here.

This PR makes the second terminal raise `TypeError` with the `Cannot visit <Class>` message, keeping the two terminals distinct.

## Notes

- No ActiveRecord caller catches `UnsupportedVisitError` for control flow — `git grep` shows every reference lives inside `packages/arel`.
- `to-sql.test.ts` "unsupported input should raise UnsupportedVisitError" was exercising the *wrong* terminal (a handler-less `Unknown` node). Rails' version compiles `nil`, whose NilClass handler is aliased to `unsupported`; the test body now mirrors Rails. Name unchanged.
- The Temporal case (`Duration`/`PlainYearMonth`/`PlainMonthDay`) has no Rails analogue class, so it is genuinely the no-handler terminal — its assertion moves to `TypeError`, matching the comment already in that test. **This is not a statement that Temporal is unsupported:** `PlainDate`/`PlainDateTime`/`Instant`/`ZonedDateTime`/`PlainTime` map to `Date`/`DateTime`/`Time` (`temporal-tag.ts`) and are untouched here. The three listed are spans/partials with no Ruby counterpart (`ActiveSupport::Duration` is a plain `Object` subclass Arel defines no visitor for), deliberately excluded from the whitelist so they can't be mislabelled as a `Time`.
- The mis-registered-dispatch-method branch (`visitor.ts:82-88`) is out of scope and untouched. **A story is registered for it:** `0066-arel-visitor-fidelity/stories/arel-visit-dispatch-respond-to-check`.

  For the record on the Rails semantics there: a dispatch entry naming a method the visitor does not have is the `respond_to?(dispatch_method, true) == false` case, so Rails does *not* take the `raise e` branch — it falls through to the ancestors walk (`visitor.rb:36-37`), visits successfully via an ancestor's handler if one responds, and only otherwise raises `TypeError, "Cannot visit X"` (`visitor.rb:38`). The `raise e` guard covers the opposite case: the method exists and raised `NoMethodError` from inside. Either way `UnsupportedVisitError` is never the outcome, which is exactly what the registered story converges. Trails' `resolveDispatch` currently tests only dispatch-table membership, never `respond_to?`, which is the root cause.

493 arel visitor tests pass.

Closes-story: arel-visit-no-handler-raises-typeerror

