### PR TITLE
refactor(arel): dot visitor class-dispatches raw values via Visitor#visit

### DIFF
--- a/packages/arel/src/visitors/dot.test.ts
+++ b/packages/arel/src/visitors/dot.test.ts
@@ -282,6 +282,22 @@ describe("TestDot", () => {
       );
     });
 
+    it("a mis-registered dispatch method is not reported as an unvisitable value", () => {
+      // Dot translates the base visitor's "no handler at all" error into
+      // Rails' `TypeError, "Cannot visit ..."` (visitor.rb:39). That must not
+      // also swallow the base visitor's *other* error — a typo'd method name
+      // in the dispatch table — or a Dot registration bug is indistinguishable
+      // from a value Rails genuinely cannot visit.
+      class Weird extends Nodes.Unary {}
+      const v = new Visitors.Dot();
+      (v as unknown as { dispatch: Map<unknown, string> }).dispatch.set(Weird, "visitTypoed");
+      type Internals = { visit(o: unknown): void };
+      v.compile(new Nodes.SqlLiteral("seed"));
+      expect(() => (v as unknown as Internals).visit(new Weird(null))).toThrow(
+        /Dispatch method 'visitTypoed' is not defined on Dot/,
+      );
+    });
+
     it("Temporal values reach visit_Date / visit_Time instead of raising", () => {
       // Temporal is this codebase's Time/Date analogue, so these have a
       // visitable Rails ancestor and must not hit the TypeError arm.

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -2,6 +2,7 @@ import { Node } from "../nodes/node.js";
 import * as Nodes from "../nodes/index.js";
 import { Table } from "../table.js";
 import { Visitor, type NodeCtor } from "./visitor.js";
+import { UnsupportedVisitError } from "../errors.js";
 import { PlainString } from "../collectors/plain-string.js";
 import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 import { temporalClassName } from "../temporal-tag.js";
@@ -495,34 +496,24 @@ export class Dot extends Visitor {
       this.seen.set(seenKey, node);
     }
     this.nodes.push(node);
-    const temporalClass = temporalClassName(object);
     this.withNode(node, () => {
-      if (this.isPrimitive(object)) {
-        this.visitString(object);
-      } else if (Array.isArray(object)) {
-        this.visitArray(object);
-      } else if (object instanceof Set) {
-        // Rails: `alias :visit_Set :visit_Array` (dot.rb:231). Without this
-        // arm a Set reaches no handler and falls to the leaf below.
-        this.visitSet(object);
-      } else if (temporalClass === "Date") {
-        this.visitDate(object);
-      } else if (temporalClass === "DateTime") {
-        this.visitDateTime(object);
-      } else if (temporalClass !== null) {
-        this.visitTime(object);
-      } else if (object instanceof Node) {
-        super.visit(object);
-      } else if (this.isActiveModelAttribute(object)) {
-        // Mirrors Rails' `visit_ActiveModel_Attribute` (dot.rb:216), which
-        // Ruby reaches by class dispatch — including via the ancestor walk in
-        // visitor.rb:36-41, so every Attribute subclass lands here too.
-        this.visitActiveModelAttribute(object);
-      } else if (this.isHash(object)) {
+      // Residue over the shared class dispatch: `rubyClassName` names a value
+      // `Hash` only when its prototype is Object.prototype, but Ruby's
+      // ancestor walk (visitor.rb:36-41) reaches `visit_Hash` for any Hash
+      // descendant — in JS, any record derived from a plain record (isHash).
+      if (this.isHash(object)) {
         this.visitHash(object as Record<string, unknown>);
-      } else {
-        // visitor.rb:39 — no ancestor answered the dispatch.
-        throw new TypeError(`Cannot visit ${this.classNameOf(object)}`);
+        return;
+      }
+      try {
+        super.visit(object);
+      } catch (e) {
+        // visitor.rb:39 — no ancestor answered the dispatch. Dot has always
+        // reported that as Ruby's TypeError with the value's class name.
+        if (e instanceof UnsupportedVisitError) {
+          throw new TypeError(`Cannot visit ${this.classNameOf(object)}`, { cause: e });
+        }
+        throw e;
       }
     });
     return undefined;
@@ -608,24 +599,6 @@ export class Dot extends Visitor {
    */
   protected visitArelNodesOptimizerHints(o: Nodes.OptimizerHints): void {
     this.visitEdge(o, "hints");
-  }
-
-  private isPrimitive(o: unknown): boolean {
-    if (o === null || o === undefined) return true;
-    const t = typeof o;
-    return (
-      t === "string" ||
-      t === "number" ||
-      t === "boolean" ||
-      t === "bigint" ||
-      t === "symbol" ||
-      // boundary: Arel dot-graph leaf detection includes legacy Date values.
-      o instanceof Date
-    );
-  }
-
-  private isActiveModelAttribute(o: unknown): o is ModelAttribute {
-    return o instanceof ModelAttribute;
   }
 
   /**
@@ -750,6 +723,12 @@ export class Dot extends Visitor {
     reg(Nodes.BindParam, "visitArelNodesBindParam");
     reg(Nodes.Comment, "visitArelNodesComment");
     reg(Nodes.Case, "visitArelNodesCase");
+    // Non-Arel classes Rails dispatches on too: `visit_ActiveModel_Attribute`
+    // (dot.rb:216) and `alias :visit_Set :visit_Array` (dot.rb:231). Neither
+    // has a Ruby-class name `rubyClassName` can synthesize, so both go in the
+    // ctor-keyed table (the prototype walk covers Attribute subclasses).
+    reg(ModelAttribute as unknown as NodeCtor, "visitActiveModelAttribute");
+    reg(Set as unknown as NodeCtor, "visitSet");
     // Quoted, True, False, BoundSqlLiteral, Fragments don't extend any
     // ancestor with a useful Dot handler — register explicitly as leaves.
     reg(Nodes.Quoted, "visitNoEdges");

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -510,9 +510,17 @@ export class Dot extends Visitor {
       } catch (e) {
         // visitor.rb:39 — no ancestor answered the dispatch. Dot has always
         // reported that as Ruby's TypeError with the value's class name.
+        //
+        // `cause` has no counterpart in `raise TypeError, "Cannot visit ..."`
+        // because Ruby chains the active exception into `#cause` implicitly;
+        // JS does not, so passing it is what keeps the two equivalent. It is
+        // also required here by the `preserve-caught-error` lint rule. The
+        // class and message still match visitor.rb:39 exactly.
         if (e instanceof UnsupportedVisitError) {
           throw new TypeError(`Cannot visit ${this.classNameOf(object)}`, { cause: e });
         }
+        // A mis-registered dispatch method (a plain Error from visitor.ts) is
+        // a bug in this visitor, not an unvisitable value — never relabel it.
         throw e;
       }
     });

--- a/packages/arel/src/visitors/visitor.ts
+++ b/packages/arel/src/visitors/visitor.ts
@@ -78,9 +78,14 @@ export abstract class Visitor {
     if (typeof fn !== "function") {
       // Cache hit but the instance has no such method — almost always a
       // mis-registration (a typo'd method name landed in the dispatch
-      // cache). Distinct from the "no entry at all" case above so the
-      // failure mode is unambiguous.
-      throw new UnsupportedVisitError(
+      // cache). This is a visitor bug, not an unvisitable value, so it is
+      // a plain Error rather than an UnsupportedVisitError (matching the
+      // same check in to-sql.ts:479). Subclasses that translate the
+      // "no entry at all" case into their own error — Dot re-raises it as
+      // Rails' `TypeError, "Cannot visit ..."` (visitor.rb:39) — must not
+      // swallow this one, or a typo'd registration masquerades as an
+      // unvisitable value.
+      throw new Error(
         `Dispatch method '${methodName}' is not defined on ${this.constructor.name} for node ${describeClass(object)}`,
       );
     }


### PR DESCRIPTION
Deletes `dot.ts`'s hand-rolled raw-value dispatch ladder and routes every
value through the inherited `Visitor#visit` class dispatch (converged for
`ToSql`/`Mysql`/`PostgreSQL` in #4990), mirroring `dot.rb`, which defines no
such ladder and inherits `visit` from `Visitor`.

- `visit_Set` (dot.rb:231) and `visit_ActiveModel_Attribute` (dot.rb:216)
  dispatch on real Ruby classes with no `rubyClassName` analogue, so they
  move into the ctor-keyed dispatch table; the prototype walk covers
  `Attribute` subclasses.
- Primitives / temporals / Array reach `visitString` & friends by name via
  `rubyClassName`, so `isPrimitive` is dead and removed.
- Residue (justified): `rubyClassName` names a value `Hash` only when its
  prototype is `Object.prototype`, but Ruby's ancestor walk
  (visitor.rb:36-41) reaches `visit_Hash` for any `Hash` descendant — in JS
  any record derived from a plain record. That arm stays, using `isHash`.
- `UnsupportedVisitError` is translated back to Ruby's
  `TypeError("Cannot visit #{class}")` that `Dot` has always raised
  (visitor.rb:39).

`dot.test.ts` 48/48 green; full `packages/arel/src/visitors` 493/493 green.

Closes-story: dot-visitor-uses-class-dispatch

---

## Review round 1

**(1) Catch swallowed the mis-registration diagnostic — fixed.** Correct and
confirmed by baseline: with the fix reverted, a typo'd registration on `Dot`
raised `Cannot visit Weird`, destroying `visitor.ts`'s deliberate second
error. `visitor.ts` has a test literally named *"distinguishes a
mis-registered method from an unknown node type"* — this PR was silently
undoing that for `Dot`.

Fixed at the source rather than by message-sniffing in the catch: the
mis-registration branch now throws a plain `Error`, not an
`UnsupportedVisitError`. It is a visitor bug, not an unvisitable value, so
`instanceof UnsupportedVisitError` in `Dot` naturally excludes it. This
matches the identical check already in `to-sql.ts:479`, which throws a plain
`Error`. `visitor.test.ts` asserts only the message, so it is unaffected.

Regression test added (`dot.test.ts`, "a mis-registered dispatch method is
not reported as an unvisitable value") — verified failing on the unfixed
code with `Cannot visit Weird`, passing after.

**(2) `{ cause: e }` — deliberate, and not optional.** The repo's
`preserve-caught-error` ESLint rule rejects re-throwing without a `cause`
(it failed the pre-commit hook on the first attempt). Rails has no analogue
because Ruby's `raise` chains `$!` implicitly — `cause` is JS's version of
the same thing, so this is closer to Ruby's semantics than dropping it. It
is non-observable metadata: the error class and message still match
visitor.rb:39 exactly, and no test asserts on it.

Tests: `packages/arel` 1561/1561; `dot.test.ts` 49/49 (48 + the new
regression); `packages/activerecord/src/relation` 1102 passed.
api:compare arel unchanged at `938/938 methods (100%) | files 69/69 |
inheritance 100% | arity 100%`.

## Review round 2

**`{ cause: e }` — deliberate; justification moved into the code.** The
rationale was already in this description (round 1, item 2), but a PR body
is the wrong home for it: nobody reading `dot.ts` in six months sees it, and
it got re-flagged on a second pass. It now lives at the call site, along with
a note on why the non-`UnsupportedVisitError` rethrow must not be relabeled.

Substance unchanged and re-confirmed: Ruby chains the active exception into
`#cause` implicitly at `raise`, so passing `cause` in JS — which has no
implicit chaining — is what makes the two equivalent, not an addition over
the Ruby. It is independently required by the `preserve-caught-error` lint
rule. The error class and message still match visitor.rb:39 exactly, and no
test asserts on the shape.

Tests: `packages/arel/src/visitors` 494/494.
