### PR TITLE
fix(arel): converge in/notIn Enumerable arm across predications and Attribute

### DIFF
--- a/packages/arel/src/attributes/attribute.trails.test.ts
+++ b/packages/arel/src/attributes/attribute.trails.test.ts
@@ -39,6 +39,24 @@ describe("AttributeTest (trails)", () => {
         new Nodes.In(attribute, new Nodes.Casted("abc", attribute)),
       );
     });
+
+    // The Hash half of the decided split (see isEnumerable in predications.ts):
+    // a Map is the Ruby Hash analogue, so it expands into PAIRS exactly as
+    // Rails' `in({a: 1})` does — distinct from iterating `.keys()`. The
+    // object-literal half is pinned by the scalar-arm test above.
+    it("expands a Map into pairs, matching Ruby's Enumerable Hash", () => {
+      const attribute = users.get("id");
+      const map = new Map<string, number>([
+        ["a", 1],
+        ["b", 2],
+      ]);
+      expect(attribute.in(map)).toEqual(
+        new Nodes.In(attribute, [
+          new Nodes.Casted(["a", 1], attribute),
+          new Nodes.Casted(["b", 2], attribute),
+        ]),
+      );
+    });
   });
 
   describe("#not_in", () => {
@@ -51,6 +69,22 @@ describe("AttributeTest (trails)", () => {
       const attribute = users.get("id");
       expect(attribute.notIn("abc")).toEqual(
         new Nodes.NotIn(attribute, new Nodes.Casted("abc", attribute)),
+      );
+    });
+
+    it("casts a non-iterable object through the scalar arm", () => {
+      const attribute = users.get("id");
+      const randomObject = {};
+      expect(attribute.notIn(randomObject)).toEqual(
+        new Nodes.NotIn(attribute, new Nodes.Casted(randomObject, attribute)),
+      );
+    });
+
+    it("expands a Map into pairs, matching Ruby's Enumerable Hash", () => {
+      const attribute = users.get("id");
+      const map = new Map<string, number>([["a", 1]]);
+      expect(attribute.notIn(map)).toEqual(
+        new Nodes.NotIn(attribute, [new Nodes.Casted(["a", 1], attribute)]),
       );
     });
   });

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -602,19 +602,21 @@ export class Attribute extends Node {
     return new Overlaps(this, this.quotedNode(other));
   }
 
+  // Rails' Attribute inherits this from Predications via `include`
+  // (attribute.rb:8); there is exactly one `quoted_array`
+  // (predications.rb:227-229). Delegate rather than reimplement, matching the
+  // other inherited-helper shims above. `this` is threaded through, so the
+  // elements still route via this class's `quotedNode` — the hook subclasses
+  // override — keeping every element on the same path as a scalar RHS.
+  quotedArray(others: unknown[]): Node[] {
+    return Predications.quotedArray.call(this, others);
+  }
+
   /**
    * Apply a window to this expression.
    *
    * Mirrors: `OVER` support on Arel expressions.
    */
-  // Mirrors Arel::Predications#quoted_array — `others.map { |v| quoted_node(v) }`
-  // (predications.rb:227-229). Delegates to `quotedNode` rather than calling
-  // `buildQuoted` directly: `quoted_node` is the hook subclasses override, so
-  // routing through it keeps every element on the same path as a scalar RHS.
-  quotedArray(others: unknown[]): Node[] {
-    return others.map((v) => this.quotedNode(v));
-  }
-
   over(window?: Window | NamedWindow | string | null): Over {
     if (!window) return new Over(this, null);
     if (typeof window === "string") return new Over(this, new SqlLiteral(window));

--- a/packages/arel/src/predications.trails.test.ts
+++ b/packages/arel/src/predications.trails.test.ts
@@ -32,6 +32,15 @@ describe("PredicationsMixin in/notIn Enumerable arm", () => {
       );
     });
 
+    // The Hash half of the decided split (see isEnumerable in predications.ts):
+    // a Map is the Ruby Hash analogue, so the Map ITSELF expands into pairs the
+    // way Rails' `in({a: 1})` does — not just an iterator taken off it.
+    it("expands a Map into pairs, matching Ruby's Enumerable Hash", () => {
+      const node = expr();
+      const map = new Map<string, number>([["a", 1]]);
+      expect(node.in(map)).toEqual(new Nodes.In(node, [new Nodes.Quoted(["a", 1])]));
+    });
+
     it("casts a non-iterable object through the scalar arm", () => {
       const node = expr();
       const randomObject = {};

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -36,11 +36,15 @@ import {
  * `buildQuoted` matches managers (casted.ts:41-44) — a structural check keeps
  * the runtime import out. The `instanceof Node` half matters: a bare
  * `"ast" in value` also admits `{ ast: undefined }`, which would build
- * `In(this, undefined)`.
+ * `In(this, undefined)`. A `Node` is excluded: it is the `else`-arm value
+ * itself, not a manager wrapping one.
  */
 export function isSelectManagerLike(value: unknown): value is { ast: Node } {
   return (
-    typeof value === "object" && value !== null && (value as { ast?: unknown }).ast instanceof Node
+    typeof value === "object" &&
+    value !== null &&
+    !(value instanceof Node) &&
+    (value as { ast?: unknown }).ast instanceof Node
   );
 }
 
@@ -53,13 +57,17 @@ export function isSelectManagerLike(value: unknown): value is { ast: Node } {
  * Two deliberate edges:
  * - JS strings are iterable, but Ruby's String is NOT Enumerable, so they must
  *   reach `quoted_node`. `typeof value === "object"` excludes them.
- * - A plain JS object is not iterable, so it reaches `quoted_node` — matching
- *   `Object.new` at attribute_test.rb:747-757. Note this DIVERGES for a Ruby
- *   Hash, which IS Enumerable: Rails' `in({a: 1})` takes the `quoted_array`
- *   arm and expands to `[Casted([:a, 1], self)]`, where this casts the object
- *   whole. Ruby's Hash maps to a JS Map (iterable, so it expands correctly);
- *   an object literal is the closer analogue of `Object.new`, so the scalar
- *   arm is the better of the two readings, not an exact one.
+ * - **A plain JS object casts whole rather than expanding.** Ruby's Hash IS
+ *   Enumerable, so Rails' `in({a: 1})` takes the `quoted_array` arm and
+ *   expands to `[Casted([:a, 1], self)]`. There is no single JS value that is
+ *   both the Hash analogue and the `Object.new` analogue, so the two Ruby arms
+ *   are split across two JS types: a `Map` is the Hash analogue and is
+ *   iterable, so it expands through this guard exactly as Ruby's Hash does; an
+ *   object literal is the `Object.new` analogue and correctly reaches
+ *   `quoted_node` (attribute_test.rb:747-757). Passing an object literal to
+ *   `in` / `notIn` therefore casts the container — use a `Map` to get Ruby
+ *   Hash pair-expansion. This is a decided split, not an accident; both arms
+ *   are pinned by tests.
  */
 export function isEnumerable(value: unknown): value is Iterable<unknown> {
   return typeof value === "object" && value !== null && Symbol.iterator in value;


### PR DESCRIPTION
Decides the `in` / `notIn` Hash-vs-`Object.new` divergence
(`arel/predications.rb:65-74`, `112-121`) and pins both halves.

## Scope note

#5005 (`arel-predications-in-not-in-enumerable-arm-iterable`) merged while this
was in review and landed the shared `isEnumerable` / `isSelectManagerLike`
guards, the `SelectManager → Enumerable → else` arm order, `quotedArray`
dispatch and the same 8 wide-ratchet baseline deletions this branch had pushed.
That work is dropped here — this branch was reset onto `main` and re-applies
only what is genuinely left.

## The decision

**A plain JS object casts whole; a `Map` expands into pairs.**

Ruby's `Hash` IS `Enumerable`, so `in({a: 1})` takes the `quoted_array` arm and
expands to `[Casted([:a, 1], self)]`. `Object.new` is NOT `Enumerable` and takes
the `else` arm (`attribute_test.rb:747-757`). No single JS value is both
analogues, so the two Ruby arms map onto two JS types rather than one silently
picking a reading:

- `Map` — the `Hash` analogue. Iterable, so it expands exactly as Ruby's Hash does.
- object literal — the `Object.new` analogue. Not iterable, so it reaches `quoted_node`.

#5005 relocated the `isEnumerable` doc but kept its original wording — "the
better of two readings, **not an exact one**". This story was explicitly to
decide and converge, not to ratify, so the guard now states the split as
decided, with both halves pinned by tests.

Options 2 and 3 from the story were rejected: expanding object literals via
`Object.entries` collides with the SelectManager `ast` duck-type and leaves no
`Object.new` analogue; rejecting a plain object at the boundary would diverge
from Rails, which accepts any object here.

## Coverage

A `Map` expands into **pairs** on both the `Attribute` and mixin paths. This is
distinct from #5005's existing Map test, which iterates `.keys()` off a Map —
that exercises an ordinary iterator, never the Hash analogue. Adds the missing
`notIn` object-literal pin.

## Also

- `isSelectManagerLike` excludes a `Node`: it is the `else`-arm value itself,
  not a manager wrapping one. Inert today (every `ast` holder extends
  `TreeManager`, none extend `Node`) but keeps the arm honest.
- `Attribute#quotedArray` delegates to `Predications.quotedArray` instead of
  reimplementing it. Rails has exactly one `quoted_array`
  (`predications.rb:227-229`), inherited via `include` (`attribute.rb:8`), and
  `attribute.ts` already delegates every other inherited helper this way.

## Follow-up

`Attribute` still re-declares `in` / `notIn` rather than including the
Predications mixin, so the three-arm bodies exist twice. The `quotedArray`
delegation here is a partial step; the structural half is tracked by
`arel-attribute-include-predications-mixin` (RFC 0066) and is not merge-blocking.

## Checks

`tsc --build` clean workspace-wide; arel suite 1576 tests green; wide ratchet OK
(6791), narrow OK (19), body-pins OK — no baseline file changed, since `main`
already carries the 8 deletions.

Closes-story: arel-in-not-in-hash-enumerable-arm-divergence
