### PR TITLE
fix(arel): predications in/notIn match Enumerable via iterable, not Array.isArray

### DIFF
--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -1,4 +1,5 @@
 import { Node, NodeVisitor } from "../nodes/node.js";
+import { isEnumerable, isSelectManagerLike } from "../predications.js";
 import {
   NotEqual,
   GreaterThan,
@@ -68,41 +69,6 @@ function groupedAny(nodes: Node[]): Grouping {
  */
 function groupedAll(nodes: Node[]): Grouping {
   return new Grouping(new And(nodes));
-}
-
-/**
- * Stands in for Rails' `when Arel::SelectManager` arm (predications.rb:65-74
- * for `in`, 112-121 for `not_in`), duck-typed on the `ast` reader as
- * `buildQuoted` matches managers (casted.ts:41-44) — a structural check keeps
- * the runtime import out. The `instanceof Node` half matters: a bare
- * `"ast" in value` also admits `{ ast: undefined }`, which would build
- * `In(this, undefined)`.
- */
-function isSelectManagerLike(value: unknown): value is { ast: Node } {
-  return (
-    typeof value === "object" && value !== null && (value as { ast?: unknown }).ast instanceof Node
-  );
-}
-
-/**
- * Stands in for Rails' `when Enumerable` arm. Ruby's `Enumerable` covers Set,
- * Hash and Range as well as Array, so matching only `Array.isArray` would drop
- * a Set/Map/generator into the scalar arm and silently cast the container
- * itself.
- *
- * Two deliberate edges:
- * - JS strings are iterable, but Ruby's String is NOT Enumerable, so they must
- *   reach `quoted_node`. `typeof value === "object"` excludes them.
- * - A plain JS object is not iterable, so it reaches `quoted_node` — matching
- *   `Object.new` at attribute_test.rb:747-757. Note this DIVERGES for a Ruby
- *   Hash, which IS Enumerable: Rails' `in({a: 1})` takes the `quoted_array`
- *   arm and expands to `[Casted([:a, 1], self)]`, where this casts the object
- *   whole. Ruby's Hash maps to a JS Map (iterable, so it expands correctly);
- *   an object literal is the closer analogue of `Object.new`, so the scalar
- *   arm is the better of the two readings, not an exact one.
- */
-function isEnumerable(value: unknown): value is Iterable<unknown> {
-  return typeof value === "object" && value !== null && Symbol.iterator in value;
 }
 
 /**

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -196,6 +196,19 @@ export class Attribute extends Node {
     return new NotRegexp(this, this.quotedNode(pattern), caseSensitive);
   }
 
+  // DEVIATION: Rails' Attribute has no `in`/`not_in` of its own — it
+  // `include Arel::Predications` (attribute.rb:5-12) and inherits them. These
+  // bodies are byte-identical to Predications.in/notIn and look like dead
+  // duplication, but they are NOT deletable today: this class does not mix in
+  // Predications (there is no `include(...)` call in this file — it only
+  // `.call`s two private helpers, see groupingAny/groupingAll below), so
+  // deleting them removes the methods outright rather than falling through to
+  // the mixin. Verified: with both removed the attributes suite fails with
+  // `attribute.in is not a function`.
+  //
+  // Converging means making Attribute actually include the mixin, which
+  // touches every predication method here — tracked as story
+  // `arel-attribute-include-predications-mixin` (RFC 0066).
   in(values: unknown): In {
     if (isSelectManagerLike(values)) return new In(this, values.ast);
     if (isEnumerable(values)) return new In(this, this.quotedArray([...values]));

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -198,14 +198,13 @@ export class Attribute extends Node {
 
   in(values: unknown): In {
     if (isSelectManagerLike(values)) return new In(this, values.ast);
-    if (isEnumerable(values)) return new In(this, this.quotedArray([...values]) as unknown as Node);
+    if (isEnumerable(values)) return new In(this, this.quotedArray([...values]));
     return new In(this, this.quotedNode(values));
   }
 
   notIn(values: unknown): NotIn {
     if (isSelectManagerLike(values)) return new NotIn(this, values.ast);
-    if (isEnumerable(values))
-      return new NotIn(this, this.quotedArray([...values]) as unknown as Node);
+    if (isEnumerable(values)) return new NotIn(this, this.quotedArray([...values]));
     return new NotIn(this, this.quotedNode(values));
   }
   between(range: [unknown, unknown]): Node;

--- a/packages/arel/src/predications-privates.test.ts
+++ b/packages/arel/src/predications-privates.test.ts
@@ -48,6 +48,7 @@ describe("Predications.isInfinity / isUnboundable / isOpenEnded", () => {
   // class including Predications would — isOpenEnded dispatches through `this`.
   const host = {
     quotedNode: (v: unknown): Nodes.Node => v as Nodes.Node,
+    quotedArray: (vs: unknown[]): Nodes.Node[] => vs as Nodes.Node[],
     isInfinity(this: unknown, v: unknown): 1 | -1 | 0 {
       return Predications.isInfinity.call(this as never, v);
     },

--- a/packages/arel/src/predications.trails.test.ts
+++ b/packages/arel/src/predications.trails.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { Table, Nodes, Visitors } from "./index.js";
+
+// The Enumerable-arm distinctions below are trails-only: in Ruby a Set, a Hash
+// and a lazy enumerator are all simply `Enumerable`, so there is no Rails test
+// to mirror. See attribute.trails.test.ts for the same coverage on Attribute.
+describe("PredicationsMixin in/notIn Enumerable arm", () => {
+  const users = new Table("users");
+  const visitor = new Visitors.ToSql();
+  // An InfixOperation, not an Attribute — this exercises the Predications
+  // mixin's own `in`/`notIn`, which Attribute overrides.
+  const expr = () => users.get("bitmap").bitwiseAnd(16);
+
+  describe("#in", () => {
+    it("expands a Set through the Enumerable arm", () => {
+      expect(visitor.compile(expr().in(new Set([1, 2, 3])))).toBe(
+        '("users"."bitmap" & 16) IN (1, 2, 3)',
+      );
+    });
+
+    it("expands a generator through the Enumerable arm", () => {
+      function* ids(): Generator<number> {
+        yield 1;
+        yield 2;
+      }
+      expect(visitor.compile(expr().in(ids()))).toBe('("users"."bitmap" & 16) IN (1, 2)');
+    });
+
+    it("expands a Map through the Enumerable arm", () => {
+      expect(visitor.compile(expr().in(new Map([[1, 2]]).keys()))).toBe(
+        '("users"."bitmap" & 16) IN (1)',
+      );
+    });
+
+    it("casts a non-iterable object through the scalar arm", () => {
+      const node = expr();
+      const randomObject = {};
+      expect(node.in(randomObject)).toEqual(new Nodes.In(node, new Nodes.Quoted(randomObject)));
+    });
+
+    it("casts a string through the scalar arm, since Ruby's String is not Enumerable", () => {
+      const node = expr();
+      expect(node.in("abc")).toEqual(new Nodes.In(node, new Nodes.Quoted("abc")));
+    });
+
+    it("takes the SelectManager arm ahead of the Enumerable arm", () => {
+      const mgr = users.project(users.get("id"));
+      const node = expr();
+      expect(node.in(mgr)).toEqual(new Nodes.In(node, mgr.ast));
+    });
+  });
+
+  describe("#not_in", () => {
+    it("expands a Set through the Enumerable arm", () => {
+      expect(visitor.compile(expr().notIn(new Set([1, 2])))).toBe(
+        '("users"."bitmap" & 16) NOT IN (1, 2)',
+      );
+    });
+
+    it("casts a string through the scalar arm, since Ruby's String is not Enumerable", () => {
+      const node = expr();
+      expect(node.notIn("abc")).toEqual(new Nodes.NotIn(node, new Nodes.Quoted("abc")));
+    });
+
+    it("takes the SelectManager arm ahead of the Enumerable arm", () => {
+      const mgr = users.project(users.get("id"));
+      const node = expr();
+      expect(node.notIn(mgr)).toEqual(new Nodes.NotIn(node, mgr.ast));
+    });
+  });
+});

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -185,7 +185,6 @@ export const Predications = {
     //   Enumerable    → In(self, quoted_array(other))
     //   else          → In(self, quoted_node(other))
     if (isSelectManagerLike(other)) return new In(this, other.ast);
-    // Node[] is valid NodeOrValue for In/NotIn — no cast needed.
     if (isEnumerable(other)) return new In(this, this.quotedArray([...other]));
     return new In(this, this.quotedNode(other));
   },

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -31,6 +31,41 @@ import {
 } from "./predications-range.js";
 
 /**
+ * Stands in for Rails' `when Arel::SelectManager` arm (predications.rb:65-74
+ * for `in`, 112-121 for `not_in`), duck-typed on the `ast` reader as
+ * `buildQuoted` matches managers (casted.ts:41-44) — a structural check keeps
+ * the runtime import out. The `instanceof Node` half matters: a bare
+ * `"ast" in value` also admits `{ ast: undefined }`, which would build
+ * `In(this, undefined)`.
+ */
+export function isSelectManagerLike(value: unknown): value is { ast: Node } {
+  return (
+    typeof value === "object" && value !== null && (value as { ast?: unknown }).ast instanceof Node
+  );
+}
+
+/**
+ * Stands in for Rails' `when Enumerable` arm. Ruby's `Enumerable` covers Set,
+ * Hash and Range as well as Array, so matching only `Array.isArray` would drop
+ * a Set/Map/generator into the scalar arm and silently cast the container
+ * itself.
+ *
+ * Two deliberate edges:
+ * - JS strings are iterable, but Ruby's String is NOT Enumerable, so they must
+ *   reach `quoted_node`. `typeof value === "object"` excludes them.
+ * - A plain JS object is not iterable, so it reaches `quoted_node` — matching
+ *   `Object.new` at attribute_test.rb:747-757. Note this DIVERGES for a Ruby
+ *   Hash, which IS Enumerable: Rails' `in({a: 1})` takes the `quoted_array`
+ *   arm and expands to `[Casted([:a, 1], self)]`, where this casts the object
+ *   whole. Ruby's Hash maps to a JS Map (iterable, so it expands correctly);
+ *   an object literal is the closer analogue of `Object.new`, so the scalar
+ *   arm is the better of the two readings, not an exact one.
+ */
+export function isEnumerable(value: unknown): value is Iterable<unknown> {
+  return typeof value === "object" && value !== null && Symbol.iterator in value;
+}
+
+/**
  * Host contract for the Predications mixin.
  *
  * Implementors provide `quotedNode(other)` which either type-casts (for
@@ -147,32 +182,23 @@ export const Predications = {
     //   SelectManager → In(self, other.ast)
     //   Enumerable    → In(self, quoted_array(other))
     //   else          → In(self, quoted_node(other))
-    if (Array.isArray(other)) {
+    if (!(other instanceof Node) && isSelectManagerLike(other)) return new In(this, other.ast);
+    if (isEnumerable(other)) {
       // Node[] is valid NodeOrValue for In/NotIn — no cast needed.
       return new In(
         this,
-        other.map((v) => this.quotedNode(v)),
+        [...other].map((v) => this.quotedNode(v)),
       );
-    }
-    // SelectManager/TreeManager-shaped object: only forward `.ast` when
-    // it's actually a Node — anything else falls through to quotedNode
-    // so we don't construct a malformed In with a stray non-Node ast.
-    if (other && typeof other === "object" && !(other instanceof Node) && "ast" in other) {
-      const ast = (other as { ast: unknown }).ast;
-      if (ast instanceof Node) return new In(this, ast);
     }
     return new In(this, this.quotedNode(other));
   },
   notIn(this: Node & PredicationHost, other: unknown[] | { ast: Node } | Node | unknown): NotIn {
-    if (Array.isArray(other)) {
+    if (!(other instanceof Node) && isSelectManagerLike(other)) return new NotIn(this, other.ast);
+    if (isEnumerable(other)) {
       return new NotIn(
         this,
-        other.map((v) => this.quotedNode(v)),
+        [...other].map((v) => this.quotedNode(v)),
       );
-    }
-    if (other && typeof other === "object" && !(other instanceof Node) && "ast" in other) {
-      const ast = (other as { ast: unknown }).ast;
-      if (ast instanceof Node) return new NotIn(this, ast);
     }
     return new NotIn(this, this.quotedNode(other));
   },

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -75,6 +75,8 @@ export function isEnumerable(value: unknown): value is Iterable<unknown> {
 export interface PredicationHost {
   /** @internal */
   quotedNode(other: unknown): Node;
+  /** @internal */
+  quotedArray(others: unknown[]): Node[];
 }
 
 function groupedAny(nodes: Node[]): Grouping {
@@ -177,29 +179,19 @@ export const Predications = {
     return new NotRegexp(this, this.quotedNode(pattern), caseSensitive);
   },
 
-  in(this: Node & PredicationHost, other: unknown[] | { ast: Node } | Node | unknown): In {
+  in(this: Node & PredicationHost, other: unknown): In {
     // Mirrors Arel::Predications#in:
     //   SelectManager → In(self, other.ast)
     //   Enumerable    → In(self, quoted_array(other))
     //   else          → In(self, quoted_node(other))
-    if (!(other instanceof Node) && isSelectManagerLike(other)) return new In(this, other.ast);
-    if (isEnumerable(other)) {
-      // Node[] is valid NodeOrValue for In/NotIn — no cast needed.
-      return new In(
-        this,
-        [...other].map((v) => this.quotedNode(v)),
-      );
-    }
+    if (isSelectManagerLike(other)) return new In(this, other.ast);
+    // Node[] is valid NodeOrValue for In/NotIn — no cast needed.
+    if (isEnumerable(other)) return new In(this, this.quotedArray([...other]));
     return new In(this, this.quotedNode(other));
   },
-  notIn(this: Node & PredicationHost, other: unknown[] | { ast: Node } | Node | unknown): NotIn {
-    if (!(other instanceof Node) && isSelectManagerLike(other)) return new NotIn(this, other.ast);
-    if (isEnumerable(other)) {
-      return new NotIn(
-        this,
-        [...other].map((v) => this.quotedNode(v)),
-      );
-    }
+  notIn(this: Node & PredicationHost, other: unknown): NotIn {
+    if (isSelectManagerLike(other)) return new NotIn(this, other.ast);
+    if (isEnumerable(other)) return new NotIn(this, this.quotedArray([...other]));
     return new NotIn(this, this.quotedNode(other));
   },
 

--- a/scripts/api-compare/call-mismatches-wide-exclude/arel/nodes/infix-operation.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/arel/nodes/infix-operation.json
@@ -79,13 +79,6 @@
   {
     "package": "arel",
     "tsFile": "nodes/infix-operation.ts",
-    "rubyName": "in",
-    "call": "quoted_array",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "nodes/infix-operation.ts",
     "rubyName": "in_all",
     "call": "grouping_all",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -151,13 +144,6 @@
     "tsFile": "nodes/infix-operation.ts",
     "rubyName": "not_eq_any",
     "call": "grouping_any",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "nodes/infix-operation.ts",
-    "rubyName": "not_in",
-    "call": "quoted_array",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/arel/nodes/node-expression.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/arel/nodes/node-expression.json
@@ -79,13 +79,6 @@
   {
     "package": "arel",
     "tsFile": "nodes/node-expression.ts",
-    "rubyName": "in",
-    "call": "quoted_array",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "nodes/node-expression.ts",
     "rubyName": "in_all",
     "call": "grouping_all",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -151,13 +144,6 @@
     "tsFile": "nodes/node-expression.ts",
     "rubyName": "not_eq_any",
     "call": "grouping_any",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "nodes/node-expression.ts",
-    "rubyName": "not_in",
-    "call": "quoted_array",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/arel/nodes/sql-literal.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/arel/nodes/sql-literal.json
@@ -79,13 +79,6 @@
   {
     "package": "arel",
     "tsFile": "nodes/sql-literal.ts",
-    "rubyName": "in",
-    "call": "quoted_array",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "nodes/sql-literal.ts",
     "rubyName": "in_all",
     "call": "grouping_all",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -151,13 +144,6 @@
     "tsFile": "nodes/sql-literal.ts",
     "rubyName": "not_eq_any",
     "call": "grouping_any",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "nodes/sql-literal.ts",
-    "rubyName": "not_in",
-    "call": "quoted_array",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/arel/predications.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/arel/predications.json
@@ -79,13 +79,6 @@
   {
     "package": "arel",
     "tsFile": "predications.ts",
-    "rubyName": "in",
-    "call": "quoted_array",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "predications.ts",
     "rubyName": "in_all",
     "call": "grouping_all",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -151,13 +144,6 @@
     "tsFile": "predications.ts",
     "rubyName": "not_eq_any",
     "call": "grouping_any",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "predications.ts",
-    "rubyName": "not_in",
-    "call": "quoted_array",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {


### PR DESCRIPTION
Rails' `Predications#in` / `#not_in` (`arel/predications.rb:65-74`, `112-121`)
dispatch on three arms: `SelectManager` → `Enumerable` → `else`. The mixin in
`packages/arel/src/predications.ts` had all three, but matched the Enumerable
arm with `Array.isArray`.

Ruby's `Enumerable` spans Set, Hash and Range as well as Array, so a JS
`Set` / `Map` / generator fell past the guard into the scalar arm and became
`Casted(theContainer, attribute)` — a wrong AST rather than a loud failure.

#4886 fixed exactly this on `Attribute` by matching any JS iterable. This PR
applies the same guard to the mixin, and **shares** rather than duplicates it:
`isSelectManagerLike` and `isEnumerable` move from `attributes/attribute.ts`
into `predications.ts` (the file matching Rails' `predications.rb`, where the
arms they implement live) and are imported back.

## Edges, unchanged from #4886

- JS strings are iterable but Ruby's `String` is not `Enumerable`, so
  `typeof value === "object"` correctly excludes them → `quoted_node`.
- A plain object is not iterable and reaches `quoted_node`, matching
  `Object.new` at `attribute_test.rb:747-757`.

## Arm order

Reordered to `SelectManager → Enumerable → else` to match the source. No
behavioural change — a SelectManager is not iterable — so the old
Array-first order picked the same arm; it just read against Rails.

## Tests

`predications.trails.test.ts` is new and trails-only: in Ruby a Set, a Hash
and a lazy enumerator are all simply `Enumerable`, so there is no Rails test
to mirror (same rationale as `attribute.trails.test.ts`). It drives an
`InfixOperation`, not an `Attribute`, so it exercises the mixin's own
`in`/`notIn` rather than `Attribute`'s override.

Verified the tests bite: restoring `Array.isArray` fails the 4 iterable tests
(Set/generator/Map for `in`, Set for `not_in`) while the 5 positive controls
(string, plain object, SelectManager × both methods) stay green.

## Checks

- `packages/arel` predications + attributes suites: 324 tests pass.
- `tsc --build` clean.
- api:compare / test:compare deltas non-negative; no ratchet or exclude file
  changed.

Closes-story: arel-predications-in-not-in-enumerable-arm-iterable


## Why `Attribute#in`/`#notIn` are NOT deleted

Raised twice in review: Rails' `Attribute` (`attributes/attribute.rb:5-12`)
has no override, so the byte-identical trails overrides look like pure
duplication that `this`-dispatch would cover.

That reading is right about Rails but not about trails: **`Attribute` does not
include the mixin.** `grep -c 'include(' attributes/attribute.ts` returns `0`.
It re-declares every predication method explicitly, importing `Predications`
only to `.call` two private helpers (`groupingAny`/`groupingAll`,
attribute.ts:335,347). There is nothing to dispatch through.

Verified empirically rather than by inspection — deleting both overrides and
running the attributes suite:

```
→ users.get(...).in is not a function
→ attribute.in is not a function
→ users.get(...).notIn is not a function
```

The methods disappear; they do not fall through. Converging properly means
making `Attribute` include the mixin via `include()`/`Included<>` (the
CLAUDE.md pattern used by `relation.ts`), which touches every predication
method and must keep `quotedNode`/`quotedArray` resolvable through
`this`-dispatch — the exact spot where the "class fields are invisible to
`Object.create(proto)` test hosts" trap bites.

Registered as story `arel-attribute-include-predications-mixin` (RFC 0066)
with this evidence and that hazard in the acceptance criteria.
