### PR TITLE
refactor(arel): TableAlias#get delegates to Table#get for Table relations

### DIFF
--- a/packages/arel/src/nodes/table-alias.ts
+++ b/packages/arel/src/nodes/table-alias.ts
@@ -3,6 +3,9 @@ import { Binary } from "./binary.js";
 import { Cte } from "./cte.js";
 import { SqlLiteral } from "./sql-literal.js";
 import { Attribute } from "../attributes/attribute.js";
+// Cyclic with table.ts (which imports TableAlias); safe because the binding is
+// only dereferenced inside `get()`, never at class-evaluation time.
+import { Table } from "../table.js";
 
 /** Structural view of `TableAlias#relation`.
  *
@@ -64,14 +67,10 @@ export class TableAlias extends Binary {
     return this.name instanceof SqlLiteral ? this.name.value : this.name;
   }
 
-  get(columnName: string): Attribute {
-    // Resolve attribute aliases through the underlying relation's klass, the
-    // same way Table#get does, so `where("clients.new_name": …)` against a
-    // self-join alias still maps `new_name` to the real column.
-    const klass = (this.relation as { klass?: { _attributeAliases?: Record<string, string> } })
-      ?.klass;
-    const resolved = klass?._attributeAliases?.[columnName] ?? columnName;
-    return new Attribute(this, resolved);
+  get(name: string): Attribute {
+    return this.relation instanceof Table
+      ? this.relation.get(name, this)
+      : new Attribute(this, name);
   }
 
   accept<T>(visitor: NodeVisitor<T>): T {


### PR DESCRIPTION
Mirrors Rails `TableAlias#[]` (`arel/nodes/table_alias.rb:11-13`): branch on the relation being a `Table` and delegate to `Table#[]`'s two-arg form, passing the alias as the attribute's relation; otherwise build a bare `Attribute`.

The duplicated `_attributeAliases` lookup in `table-alias.ts` is gone — alias resolution now lives only in `Table#get`.

Tests: full `packages/arel` suite (1563) and `attribute-methods` (self-join `clients.new_name` coverage) green.

Closes-story: table-alias-get-skips-rails-table-branch
