### PR TITLE
fix(arel): retire invented Attribute#coalesce in favor of FactoryMethods#coalesce

### DIFF
--- a/packages/arel/src/attributes/attribute.test.ts
+++ b/packages/arel/src/attributes/attribute.test.ts
@@ -1274,16 +1274,6 @@ describe("AttributeTest", () => {
     expect(sql).toContain("UPPER");
   });
 
-  it("coalesce", () => {
-    const name = users.get("name");
-    const fn = name.coalesce("Unknown");
-    const mgr = new SelectManager(users);
-    mgr.project(fn);
-    const sql = mgr.toSql();
-    expect(sql).toContain("COALESCE");
-    expect(sql).toContain("'Unknown'");
-  });
-
   it("generates LENGTH()", () => {
     const node = users.attr("name").length();
     expect(visitor.compile(node)).toBe('LENGTH("users"."name")');

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -547,12 +547,6 @@ export class Attribute extends Node {
     return new Extract([this], field);
   }
 
-  // -- Null handling --
-
-  coalesce(...others: unknown[]): NamedFunction {
-    return new NamedFunction("COALESCE", [this, ...others.map(buildQuoted)]);
-  }
-
   // -- Distinct From --
 
   isDistinctFrom(other: unknown): IsDistinctFrom {

--- a/packages/arel/src/factory-methods.test.ts
+++ b/packages/arel/src/factory-methods.test.ts
@@ -55,6 +55,7 @@ describe("TestFactoryMethods", () => {
     const fn = users.coalesce(users.get("name"), new Nodes.Quoted("default"));
     expect(fn).toBeInstanceOf(Nodes.NamedFunction);
     expect(fn.name).toBe("COALESCE");
+    expect(new Visitors.ToSql().compile(fn)).toBe('COALESCE("users"."name", \'default\')');
   });
 
   it("cast", () => {


### PR DESCRIPTION
Rails has no `Attribute#coalesce`. Its only `coalesce` is `Arel::FactoryMethods#coalesce` (`factory_methods.rb:45-47`), already ported at `packages/arel/src/factory-methods.ts:93` — it does no quoting and does not prepend a receiver.

The Attribute method was a trails invention that both prepended `this` and quoted its args, and it passed `buildQuoted` bare to `map`, so each arg was built as `buildQuoted(v, index)` with the array index landing in the attribute slot (the same bug #4881 fixed on `in`/`notIn`).

Resolution: delete the invented surface; keep the Rails-layout home. Added compiled-SQL coverage to the factory-methods test.

Closes-story: arel-attribute-coalesce-invented-surface-and-map-index-bug