### PR TITLE
refactor(arel): share PG array element encoding with OID::Array#encode

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql/oid/array-encode-parity.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/array-encode-parity.trails.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { Visitors } from "@blazetrails/arel";
+import { Array as OidArray, Data as ArrayData } from "./array.js";
+import { StringType } from "@blazetrails/activemodel";
+
+// trails-only: the connection-less Arel quoter (`postgresqlDefaultQuoter`)
+// re-implements the array literal that the adapter builds via
+// `quote(ArrayData)` -> `encode_array`. Three PRs (#4867, #4869, #4872) each had
+// to re-converge the copy after it drifted. Both now share
+// `encodeArrayElement`; this pins that they agree byte-for-byte.
+describe("PostgreSQL array literal encoding", () => {
+  const encoder = new OidArray(new StringType());
+  const arelQuoter = Visitors.postgresqlDefaultQuoter;
+
+  const cases: [string, unknown[]][] = [
+    ["strings", ["a", "b"]],
+    ["booleans", [true, false]],
+    ["nested arrays", [["a"], ["b", "c"]]],
+    ["NULL", [null]],
+    ["the NULL string", ["NULL", "null"]],
+    ["empty strings", [""]],
+    ["delimiter-bearing content", ["a,b"]],
+    ["whitespace content", ["a b", "a\tb"]],
+    ["quotes and backslashes", ['he said "hi"', "a\\b"]],
+    ["braces", ["{a}"]],
+    // The live drift this story removed: `encode` tested `/\s/`, which matches
+    // non-ASCII spaces, where pg's `isspace()` (and the Arel copy) is ASCII-only,
+    // so the adapter over-quoted a NBSP b.
+    ["non-ASCII whitespace", ["a\u00a0b"]],
+  ];
+
+  for (const [name, values] of cases) {
+    it(`agrees between the Arel quoter and encode_array for ${name}`, () => {
+      const viaAdapter = new ArrayData(encoder, values).toString();
+      // The Arel path wraps the literal in single quotes; strip them to compare
+      // the encoding itself.
+      const viaArel = arelQuoter.quote(values).slice(1, -1);
+      expect(viaArel).toBe(viaAdapter);
+    });
+  }
+});

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/array.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/array.ts
@@ -6,6 +6,7 @@
  */
 
 import { ValueType } from "@blazetrails/activemodel";
+import { encodeArrayElement } from "@blazetrails/arel";
 
 function stableStringify(value: unknown): string {
   try {
@@ -164,23 +165,9 @@ export class Array extends ValueType<unknown> {
 
   encode(values: readonly unknown[]): string {
     const items = values.map((value) => {
-      if (value == null) return "NULL";
+      if (value == null) return encodeArrayElement(null, this.delimiter);
       if (globalThis.Array.isArray(value)) return this.encode(value);
-
-      const str = String(value);
-      if (
-        str === "" ||
-        str.toUpperCase() === "NULL" ||
-        str.includes(this.delimiter) ||
-        str.includes('"') ||
-        str.includes("\\") ||
-        str.includes("{") ||
-        str.includes("}") ||
-        /\s/.test(str)
-      ) {
-        return `"${str.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
-      }
-      return str;
+      return encodeArrayElement(String(value), this.delimiter);
     });
     return `{${items.join(this.delimiter)}}`;
   }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/array.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/array.ts
@@ -163,6 +163,10 @@ export class Array extends ValueType<unknown> {
     return this.subtype.cast(value);
   }
 
+  // Stands in for Rails' `@pg_encoder = PG::TextEncoder::Array.new(...)`
+  // (`oid/array.rb:19`), which is the ruby-pg C extension, not Rails code. The
+  // element rule is shared with the connection-less Arel quoter so the two
+  // renderings of a PG array literal cannot drift.
   encode(values: readonly unknown[]): string {
     const items = values.map((value) => {
       if (value == null) return encodeArrayElement(null, this.delimiter);

--- a/packages/arel/src/index.ts
+++ b/packages/arel/src/index.ts
@@ -11,6 +11,13 @@ import { TreeManager } from "./tree-manager.js";
 export { TreeManager };
 export { ArelError, EmptyJoinError, BindError } from "./errors.js";
 export { relationName } from "./attributes/attribute.js";
+// Deliberate: no Arel counterpart in Rails — ruby-pg owns this encoder, and
+// activerecord's OID::Array shares it from here so the two renderings of a PG
+// array literal cannot drift. api:compare extracts per-file declarations, not
+// index re-exports, so this line adds no symbol to its view (verified
+// cold-cache both ways). The alternative, a subpath import, would have to spell
+// the build layout — @blazetrails/arel has no `exports` map, so under
+// moduleResolution Node16 it resolves as `@blazetrails/arel/dist/...`.
 export { encodeArrayElement } from "./quote-array.js";
 
 import { SqlLiteral } from "./nodes/sql-literal.js";

--- a/packages/arel/src/index.ts
+++ b/packages/arel/src/index.ts
@@ -11,6 +11,7 @@ import { TreeManager } from "./tree-manager.js";
 export { TreeManager };
 export { ArelError, EmptyJoinError, BindError } from "./errors.js";
 export { relationName } from "./attributes/attribute.js";
+export { encodeArrayElement } from "./quote-array.js";
 
 import { SqlLiteral } from "./nodes/sql-literal.js";
 import { registerNodeDeps, setToSqlVisitor } from "./nodes/node.js";

--- a/packages/arel/src/quote-array.ts
+++ b/packages/arel/src/quote-array.ts
@@ -39,6 +39,12 @@ const NULL_LITERAL = /^null$/i;
  * The `PG::TextEncoder::Array` element rule, shared so the connection-less Arel
  * path and `OID::Array#encode` cannot drift apart again (they did three times:
  * #4867, #4869, #4872). Takes the already-`type_cast`ed element text.
+ *
+ * `delimiter` is `OID::Array`'s, which Rails hands ruby-pg alongside the same
+ * text (`oid/array.rb:15-19`): the `","` default or `";"` for `box[]`. It is
+ * never empty — the type map is the only construction site — so the
+ * `includes(delimiter)` test needs no empty-string guard, exactly as
+ * `OID::Array#parseArray`'s delimiter scan doesn't.
  */
 export function encodeArrayElement(text: string | null, delimiter = ","): string {
   // Rendering nil as the bare `NULL` token is the encoder's job, not

--- a/packages/arel/src/quote-array.ts
+++ b/packages/arel/src/quote-array.ts
@@ -23,13 +23,10 @@ export type FormatArrayElement = (value: unknown) => string | undefined;
 //
 // ruby-pg reads the delimiter from `this->delimiter`, which Rails threads in
 // via `OID::Array#initialize(subtype, delimiter = ",")` (`oid/array.rb:15`).
-// It is hardcoded here because there is nothing to thread: Rails' PG `quote`
-// only encodes an `OID::Array::Data` (`postgresql/quoting.rb:117`) and sends a
-// bare `::Array` to `super`, which raises TypeError — whereas this function is
-// reached with a bare JS array, carrying no subtype and so no delimiter. `,`
-// is the default and the only reachable value on this path, not a
-// simplification of a parameter we could honour.
-const ELEMENT_NEEDS_QUOTING = /[{},"\\ \t\n\r\v\f]/;
+// `OID::Array#encode` threads its own; the connection-less Arel path is reached
+// with a bare JS array carrying no subtype, so it passes the `,` default —
+// the only reachable value there.
+const STRUCTURAL_CHARS = /[{}"\\ \t\n\r\v\f]/;
 // `/i` on a non-unicode pattern folds ASCII only, mirroring pg's
 // `pg_strcasecmp(ptr, "NULL")`; `toUpperCase()` would be a Unicode-aware fold,
 // a wider net than pg casts. The difference is unobservable by construction —
@@ -38,13 +35,23 @@ const ELEMENT_NEEDS_QUOTING = /[{},"\\ \t\n\r\v\f]/;
 // it's the exact mirror, not because a collision is reachable.
 const NULL_LITERAL = /^null$/i;
 
-function encodeArrayElement(text: string | null): string {
+/**
+ * The `PG::TextEncoder::Array` element rule, shared so the connection-less Arel
+ * path and `OID::Array#encode` cannot drift apart again (they did three times:
+ * #4867, #4869, #4872). Takes the already-`type_cast`ed element text.
+ */
+export function encodeArrayElement(text: string | null, delimiter = ","): string {
   // Rendering nil as the bare `NULL` token is the encoder's job, not
   // `type_cast`'s — the latter returns nil unchanged (`when nil, Numeric,
   // String then value`, `abstract/quoting.rb:101`). Keeping the split here is
   // what makes the `"NULL"` string quotable while real nil stays bare.
   if (text === null) return "NULL";
-  if (text === "" || NULL_LITERAL.test(text) || ELEMENT_NEEDS_QUOTING.test(text)) {
+  if (
+    text === "" ||
+    NULL_LITERAL.test(text) ||
+    text.includes(delimiter) ||
+    STRUCTURAL_CHARS.test(text)
+  ) {
     return `"${text.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
   }
   return text;


### PR DESCRIPTION
## What

`packages/arel/src/quote-array.ts` (`quoteArrayLiteral`, the connection-less
Arel path) re-implemented the `PG::TextEncoder::Array` element rule that
`OID::Array#encode` also implements. The two drifted three times — #4867,
#4869, #4872 each re-converged the copy on behaviour the adapter already had.

**Decision: share the encoding.** The element rule is extracted as
`encodeArrayElement(text, delimiter)` and `OID::Array#encode` now calls it, so
`quote(ArrayData)` and `postgresqlDefaultQuoter` cannot disagree by
construction. The `type_cast` layer is unchanged and stays per-path (the Arel
side has no connection/subtype to delegate to — that residue is #4868's,
deliberately not re-litigated here).

## Behaviour

One live divergence is converged rather than preserved: `encode` tested `/\s/`,
which matches non-ASCII spaces, where pg's `isspace()` is ASCII-only. The
adapter over-quoted elements containing e.g. U+00A0; the Arel copy already had
the correct ASCII set, which the shared function keeps. Everything else is
byte-identical on both paths.

## Testing

`array-encode-parity.trails.test.ts` pins the two paths byte-identical across
booleans, nested arrays, NULL, the `"NULL"` string, empty strings,
delimiter-bearing content, whitespace, quotes/backslashes and braces. The
non-ASCII-whitespace case fails on the parent commit and passes here.
api:compare and test:compare are flat against `origin/main`.

## Review replies

**1. `delimiter === ""` would quote every element.** Confirmed unreachable, not
guarded. `OID::Array` has exactly two construction sites: the default `","` and
`type-map-initializer.ts:134`, which passes `row.typdelim` from `pg_type` — a
`char` column that is never empty. Rails hands the same value to ruby-pg
(`oid/array.rb:15-19`). Documented at the call site in `quote-array.ts`.

**2. Package-root export vs. module-path import.** Keeping the root export;
rationale is at `index.ts:14-20`. api:compare extracts per-file declarations,
not index re-exports — verified cold-cache both ways, the `ts-api.json`
footprint is identical with and without the re-export. The subpath alternative
would have to spell the build layout (`@blazetrails/arel/dist/quote-array.js`),
since the package has no `exports` map under `moduleResolution: Node16`.

Closes-story: arel-quote-array-duplicates-adapter-encode-array
