### PR TITLE
audit(associations): has_one mid-flight reassignment clobber is real but not soundly fixable yet

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1633,15 +1633,6 @@ export async function loadHasOne(
     return loaded.value;
   }
 
-  // Snapshot for the mid-flight reassignment guard below. Not always false
-  // despite the early return: a *stale* target (`isStaleTarget()`) leaves the
-  // holder loaded while still requiring a re-fetch, and that re-fetch must be
-  // allowed to win.
-  const holderLoadedAtStart =
-    (
-      record._associationInstances.get(assocName) as { isLoaded?: () => boolean } | undefined
-    )?.isLoaded?.() ?? false;
-
   // Strict loading check. Gated by `find_target?`: a new-record owner without
   // the FK present never reaches `find_target` and so never raises.
   if (
@@ -1806,42 +1797,6 @@ export async function loadHasOne(
       });
     }
   }
-
-  // Same mid-flight reassignment clobber the `loadBelongsTo` guard above
-  // closes, reached by the opposite signal. Rails' `find_target` is
-  // synchronous, so it never observes a reassignment mid-load; our loader
-  // awaits DB I/O, so an in-flight reader (`firm.account` accessed but never
-  // awaited) can still be pending when the caller assigns
-  // `firm.association("account").setTarget(other)`. Without this check the
-  // stale queried row wins the post-await `syncToAssociationInstance` and the
-  // assignment silently disappears.
-  //
-  // has_one has no owner-side stale key to snapshot — Rails' `stale_state` is
-  // nil for foreign associations, only `BelongsToAssociation` overrides it —
-  // so the belongs_to FK snapshot does not transfer. A false→true flip in the
-  // holder's loaded-ness across the await is the equivalent signal: something
-  // set a newer target while we were querying. Leave that target intact and
-  // return it. Holders already loaded at entry are the stale-target re-fetch
-  // path, which must not be short-circuited.
-  //
-  // Load-bearing assumption: loaded-ness only flips false→true during our await
-  // via an external setter. That is *usually* a reassignment, but not
-  // exclusively — two concurrent cold readers also hit this branch, with the
-  // loser returning the winner's target. Benign, since the winner already ran
-  // the inverse wiring and sync below that the loser now skips; if a future
-  // caller makes those non-idempotent, this branch needs to distinguish the
-  // two cases rather than assuming reassignment.
-  //
-  // Only the singular loaders need this. `loadHasOneThrough` and
-  // `_loadSingularThroughViaDisableJoinsScope` return above without ever
-  // calling `syncToAssociationInstance` on the outer holder, so they have no
-  // writeback to clobber — structurally immune, not a scope cut. (The
-  // AssociationScope through shape does fall through to here, and is what
-  // exercises the `holderLoadedAtStart === true` arm.)
-  const holder = record._associationInstances.get(assocName) as
-    | { isLoaded?: () => boolean; target?: Base | null }
-    | undefined;
-  if (!holderLoadedAtStart && holder?.isLoaded?.()) return holder.target ?? null;
 
   // Set inverse_of: store reference back to the owner. Resolve via the
   // reflection so automatic_inverse_of also wires the parent.

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1633,6 +1633,15 @@ export async function loadHasOne(
     return loaded.value;
   }
 
+  // Snapshot for the mid-flight reassignment guard below. Not always false
+  // despite the early return: a *stale* target (`isStaleTarget()`) leaves the
+  // holder loaded while still requiring a re-fetch, and that re-fetch must be
+  // allowed to win.
+  const holderLoadedAtStart =
+    (
+      record._associationInstances.get(assocName) as { isLoaded?: () => boolean } | undefined
+    )?.isLoaded?.() ?? false;
+
   // Strict loading check. Gated by `find_target?`: a new-record owner without
   // the FK present never reaches `find_target` and so never raises.
   if (
@@ -1797,6 +1806,27 @@ export async function loadHasOne(
       });
     }
   }
+
+  // Same mid-flight reassignment clobber the `loadBelongsTo` guard above
+  // closes, reached by the opposite signal. Rails' `find_target` is
+  // synchronous, so it never observes a reassignment mid-load; our loader
+  // awaits DB I/O, so an in-flight reader (`firm.account` accessed but never
+  // awaited) can still be pending when the caller assigns
+  // `firm.association("account").setTarget(other)`. Without this check the
+  // stale queried row wins the post-await `syncToAssociationInstance` and the
+  // assignment silently disappears.
+  //
+  // has_one has no owner-side stale key to snapshot — Rails' `stale_state` is
+  // nil for foreign associations, only `BelongsToAssociation` overrides it —
+  // so the belongs_to FK snapshot does not transfer. A false→true flip in the
+  // holder's loaded-ness across the await is the equivalent signal: something
+  // set a newer target while we were querying. Leave that target intact and
+  // return it. Holders already loaded at entry are the stale-target re-fetch
+  // path, which must not be short-circuited.
+  const holder = record._associationInstances.get(assocName) as
+    | { isLoaded?: () => boolean; target?: Base | null }
+    | undefined;
+  if (!holderLoadedAtStart && holder?.isLoaded?.()) return holder.target ?? null;
 
   // Set inverse_of: store reference back to the owner. Resolve via the
   // reflection so automatic_inverse_of also wires the parent.

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1823,6 +1823,21 @@ export async function loadHasOne(
   // set a newer target while we were querying. Leave that target intact and
   // return it. Holders already loaded at entry are the stale-target re-fetch
   // path, which must not be short-circuited.
+  //
+  // Load-bearing assumption: loaded-ness only flips false→true during our await
+  // via an external setter. That is *usually* a reassignment, but not
+  // exclusively — two concurrent cold readers also hit this branch, with the
+  // loser returning the winner's target. Benign, since the winner already ran
+  // the inverse wiring and sync below that the loser now skips; if a future
+  // caller makes those non-idempotent, this branch needs to distinguish the
+  // two cases rather than assuming reassignment.
+  //
+  // Only the singular loaders need this. `loadHasOneThrough` and
+  // `_loadSingularThroughViaDisableJoinsScope` return above without ever
+  // calling `syncToAssociationInstance` on the outer holder, so they have no
+  // writeback to clobber — structurally immune, not a scope cut. (The
+  // AssociationScope through shape does fall through to here, and is what
+  // exercises the `holderLoadedAtStart === true` arm.)
   const holder = record._associationInstances.get(assocName) as
     | { isLoaded?: () => boolean; target?: Base | null }
     | undefined;

--- a/packages/activerecord/src/associations/has-one-mid-flight-reassignment.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-mid-flight-reassignment.trails.test.ts
@@ -7,13 +7,15 @@
  * mid-load. Our loader awaits DB I/O, which opens the window. has_one has no
  * owner-side stale key (Rails' `Association#stale_state` is nil for foreign
  * associations — only `BelongsToAssociation` overrides it), so the belongs_to
- * FK snapshot does not transfer; the holder's own loaded-ness is the signal.
+ * FK snapshot does not transfer; a false→true flip in the holder's loaded-ness
+ * across the await is the equivalent signal.
  */
 import { describe, expect, test } from "vitest";
 
 import { fixtures } from "../test-helpers/fixtures.js";
 import { Account } from "../test-helpers/models/account.js";
 import { Firm } from "../test-helpers/models/company.js";
+import { Minivan } from "../test-helpers/models/minivan.js";
 
 describe("has_one mid-flight reassignment", () => {
   fixtures(["companies", "accounts"]);
@@ -28,5 +30,52 @@ describe("has_one mid-flight reassignment", () => {
     await inFlight;
 
     expect(firm.association("account").target).toBe(other);
+  });
+
+  test("the in-flight reader resolves to the assigned target, not the persisted row", async () => {
+    const firm = (await Firm.first()) as Firm;
+    const other = await Account.create({ credit_limit: 42 });
+
+    const inFlight = firm.loadHasOne("account");
+    firm.association("account").setTarget(other);
+
+    // The awaited loader must hand back the newer target too: returning the
+    // stale row while the holder keeps the new one would split the two views.
+    expect(await inFlight).toBe(other);
+  });
+
+  test("an assignment to null is not resurrected by the in-flight reader", async () => {
+    const firm = (await Firm.first()) as Firm;
+
+    const inFlight = firm.loadHasOne("account");
+    firm.association("account").setTarget(null);
+
+    expect(await inFlight).toBeNull();
+    expect(firm.association("account").target).toBeNull();
+  });
+});
+
+describe("has_one stale target re-fetch", () => {
+  fixtures(["minivans", "dashboards", "speedometers"]);
+
+  test("a stale target is re-fetched rather than short-circuited by the guard", async () => {
+    // The guard keys on the loaded-ness *flip*, not the final state: a stale
+    // target leaves the holder loaded at entry while still requiring a
+    // re-fetch, and that re-fetch must win. Guarding on the final state alone
+    // silently pins the stale row here (it regressed
+    // has-one-through-associations mid-development).
+    const minivan = (await Minivan.first()) as Minivan;
+    const holder = minivan.association("dashboard");
+
+    const first = (await holder.loadTarget()) as { id?: unknown } | null;
+    expect(first).not.toBeNull();
+    expect(holder.isStaleTarget?.() ?? false).toBe(false);
+
+    const otherSpeedometerId = "s2";
+    (minivan as unknown as Record<string, unknown>).speedometer_id = otherSpeedometerId;
+    expect(holder.isStaleTarget?.()).toBe(true);
+
+    const refetched = (await holder.loadTarget()) as { id?: unknown } | null;
+    expect(refetched?.id).not.toBe(first?.id);
   });
 });

--- a/packages/activerecord/src/associations/has-one-mid-flight-reassignment.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-mid-flight-reassignment.trails.test.ts
@@ -1,0 +1,32 @@
+/**
+ * TS-only regression: `loadHasOne`'s post-await `syncToAssociationInstance`
+ * must not clobber a target that was reassigned while the reader query was
+ * still in flight.
+ *
+ * Rails' `find_target` is synchronous, so it can never observe a reassignment
+ * mid-load. Our loader awaits DB I/O, which opens the window. has_one has no
+ * owner-side stale key (Rails' `Association#stale_state` is nil for foreign
+ * associations — only `BelongsToAssociation` overrides it), so the belongs_to
+ * FK snapshot does not transfer; the holder's own loaded-ness is the signal.
+ */
+import { describe, expect, test } from "vitest";
+
+import { fixtures } from "../test-helpers/fixtures.js";
+import { Account } from "../test-helpers/models/account.js";
+import { Firm } from "../test-helpers/models/company.js";
+
+describe("has_one mid-flight reassignment", () => {
+  fixtures(["companies", "accounts"]);
+
+  test("an in-flight reader does not clobber a concurrently assigned target", async () => {
+    const firm = (await Firm.first()) as Firm;
+    const other = await Account.create({ credit_limit: 42 });
+
+    const inFlight = firm.loadHasOne("account");
+    firm.association("account").setTarget(other);
+
+    await inFlight;
+
+    expect(firm.association("account").target).toBe(other);
+  });
+});

--- a/packages/activerecord/src/associations/has-one-mid-flight-reassignment.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-mid-flight-reassignment.trails.test.ts
@@ -30,6 +30,17 @@
  *
  * A sound fix needs the holder to distinguish "our own load's writeback" from
  * "someone else's set" — a load-generation token, not an inferred signal.
+ *
+ * Note there are TWO writebacks on this path, and a fix must cover both: the
+ * inner loader's `syncToAssociationInstance` (`associations.ts:1838`) and the
+ * instance wrapper's own `setTarget` (`associations/instance-methods.ts:176`),
+ * which re-syncs unconditionally after the inner call returns. Guarding only
+ * the inner one leaves the clobber reachable.
+ *
+ * The race is driven through the public reader (`firm.account`, a Promise-
+ * returning getter that routes to `loadHasOne`) rather than the internal
+ * `record.loadHasOne("account")`, so the repro keeps exercising whatever path
+ * the accessor actually takes.
  */
 import { describe, expect, test } from "vitest";
 
@@ -44,7 +55,7 @@ describe("has_one mid-flight reassignment", () => {
     const firm = (await Firm.first()) as Firm;
     const other = await Account.create({ credit_limit: 42 });
 
-    const inFlight = firm.loadHasOne("account");
+    const inFlight = firm.account;
     firm.association("account").setTarget(other);
 
     await inFlight;
@@ -56,7 +67,7 @@ describe("has_one mid-flight reassignment", () => {
     const firm = (await Firm.first()) as Firm;
     const other = await Account.create({ credit_limit: 42 });
 
-    const inFlight = firm.loadHasOne("account");
+    const inFlight = firm.account;
     firm.association("account").setTarget(other);
 
     expect(await inFlight).toBe(other);
@@ -65,7 +76,7 @@ describe("has_one mid-flight reassignment", () => {
   test.skip("an assignment to null is not resurrected by the in-flight reader", async () => {
     const firm = (await Firm.first()) as Firm;
 
-    const inFlight = firm.loadHasOne("account");
+    const inFlight = firm.account;
     firm.association("account").setTarget(null);
 
     expect(await inFlight).toBeNull();

--- a/packages/activerecord/src/associations/has-one-mid-flight-reassignment.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-mid-flight-reassignment.trails.test.ts
@@ -64,6 +64,15 @@ describe("has_one stale target re-fetch", () => {
     // re-fetch, and that re-fetch must win. Guarding on the final state alone
     // silently pins the stale row here (it regressed
     // has-one-through-associations mid-development).
+    //
+    // `Minivan#dashboard` is has_one :through, but the through branches in
+    // `loadHasOne` that return early (`loadHasOneThrough` /
+    // `_loadSingularThroughViaDisableJoinsScope`) are not the ones this shape
+    // takes — it falls through the AssociationScope path and reaches the
+    // guard with `holderLoadedAtStart === true`, which is the arm under test.
+    // A plain has_one cannot stand in here: with `stale_state` nil for
+    // foreign associations, its holder is never stale, so the through owner's
+    // belongs_to key is the only way to reach this arm.
     const minivan = (await Minivan.first()) as Minivan;
     const holder = minivan.association("dashboard");
 

--- a/packages/activerecord/src/associations/has-one-mid-flight-reassignment.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-mid-flight-reassignment.trails.test.ts
@@ -1,26 +1,46 @@
 /**
- * TS-only regression: `loadHasOne`'s post-await `syncToAssociationInstance`
- * must not clobber a target that was reassigned while the reader query was
- * still in flight.
+ * TS-only audit repro: `loadHasOne`'s post-await `syncToAssociationInstance`
+ * clobbers a target that was reassigned while the reader query was still in
+ * flight.
  *
- * Rails' `find_target` is synchronous, so it can never observe a reassignment
- * mid-load. Our loader awaits DB I/O, which opens the window. has_one has no
- * owner-side stale key (Rails' `Association#stale_state` is nil for foreign
- * associations — only `BelongsToAssociation` overrides it), so the belongs_to
- * FK snapshot does not transfer; a false→true flip in the holder's loaded-ness
- * across the await is the equivalent signal.
+ * Rails' `find_target` (`associations/association.rb:194`) is synchronous, so
+ * it can never observe a reassignment mid-load. Our loader awaits DB I/O,
+ * which opens the window: an in-flight reader (`firm.account` accessed but
+ * never awaited) can still be pending when the caller sets a new target, and
+ * the stale queried row then wins the writeback.
+ *
+ * These are `skip`ped because the bug is still OPEN — the fix is not
+ * implementable with the holder bookkeeping we have today, and the naive guard
+ * is actively harmful. See the audit findings on PR #5009 and the follow-up
+ * story `fix-has-one-mid-flight-reassignment-clobber`:
+ *
+ * - `loadBelongsTo`'s guard (#4919) keys on the *owner's* stale key (FK +
+ *   `foreign_type`), which is independent of holder bookkeeping. has_one has
+ *   no owner-side stale key — Rails' `stale_state` is non-nil only on
+ *   `BelongsToAssociation` (`associations/belongs_to_association.rb:126`) —
+ *   so that approach does not transfer.
+ * - Keying on a false→true flip in holder loaded-ness looks equivalent but is
+ *   not: the association machinery marks holders loaded mid-await on its own
+ *   (observed on plain `Member#currentMembership` during a `:through` hop), so
+ *   the guard fires on ordinary loads and returns a stale target over a
+ *   correct result. That reproduces on PostgreSQL/MariaDB and stays invisible
+ *   on SQLite, where the timing keeps it from firing at all.
+ * - `_explicitTarget` is not the signal either: the has_one writer never sets
+ *   it, so it misses the real reassignment path entirely.
+ *
+ * A sound fix needs the holder to distinguish "our own load's writeback" from
+ * "someone else's set" — a load-generation token, not an inferred signal.
  */
 import { describe, expect, test } from "vitest";
 
 import { fixtures } from "../test-helpers/fixtures.js";
 import { Account } from "../test-helpers/models/account.js";
 import { Firm } from "../test-helpers/models/company.js";
-import { Minivan } from "../test-helpers/models/minivan.js";
 
 describe("has_one mid-flight reassignment", () => {
   fixtures(["companies", "accounts"]);
 
-  test("an in-flight reader does not clobber a concurrently assigned target", async () => {
+  test.skip("an in-flight reader does not clobber a concurrently assigned target", async () => {
     const firm = (await Firm.first()) as Firm;
     const other = await Account.create({ credit_limit: 42 });
 
@@ -32,19 +52,17 @@ describe("has_one mid-flight reassignment", () => {
     expect(firm.association("account").target).toBe(other);
   });
 
-  test("the in-flight reader resolves to the assigned target, not the persisted row", async () => {
+  test.skip("the in-flight reader resolves to the assigned target, not the persisted row", async () => {
     const firm = (await Firm.first()) as Firm;
     const other = await Account.create({ credit_limit: 42 });
 
     const inFlight = firm.loadHasOne("account");
     firm.association("account").setTarget(other);
 
-    // The awaited loader must hand back the newer target too: returning the
-    // stale row while the holder keeps the new one would split the two views.
     expect(await inFlight).toBe(other);
   });
 
-  test("an assignment to null is not resurrected by the in-flight reader", async () => {
+  test.skip("an assignment to null is not resurrected by the in-flight reader", async () => {
     const firm = (await Firm.first()) as Firm;
 
     const inFlight = firm.loadHasOne("account");
@@ -52,39 +70,5 @@ describe("has_one mid-flight reassignment", () => {
 
     expect(await inFlight).toBeNull();
     expect(firm.association("account").target).toBeNull();
-  });
-});
-
-describe("has_one stale target re-fetch", () => {
-  fixtures(["minivans", "dashboards", "speedometers"]);
-
-  test("a stale target is re-fetched rather than short-circuited by the guard", async () => {
-    // The guard keys on the loaded-ness *flip*, not the final state: a stale
-    // target leaves the holder loaded at entry while still requiring a
-    // re-fetch, and that re-fetch must win. Guarding on the final state alone
-    // silently pins the stale row here (it regressed
-    // has-one-through-associations mid-development).
-    //
-    // `Minivan#dashboard` is has_one :through, but the through branches in
-    // `loadHasOne` that return early (`loadHasOneThrough` /
-    // `_loadSingularThroughViaDisableJoinsScope`) are not the ones this shape
-    // takes — it falls through the AssociationScope path and reaches the
-    // guard with `holderLoadedAtStart === true`, which is the arm under test.
-    // A plain has_one cannot stand in here: with `stale_state` nil for
-    // foreign associations, its holder is never stale, so the through owner's
-    // belongs_to key is the only way to reach this arm.
-    const minivan = (await Minivan.first()) as Minivan;
-    const holder = minivan.association("dashboard");
-
-    const first = (await holder.loadTarget()) as { id?: unknown } | null;
-    expect(first).not.toBeNull();
-    expect(holder.isStaleTarget?.() ?? false).toBe(false);
-
-    const otherSpeedometerId = "s2";
-    (minivan as unknown as Record<string, unknown>).speedometer_id = otherSpeedometerId;
-    expect(holder.isStaleTarget?.()).toBe(true);
-
-    const refetched = (await holder.loadTarget()) as { id?: unknown } | null;
-    expect(refetched?.id).not.toBe(first?.id);
   });
 });

--- a/packages/activerecord/src/associations/has-one-mid-flight-reassignment.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-mid-flight-reassignment.trails.test.ts
@@ -3,11 +3,18 @@
  * clobbers a target that was reassigned while the reader query was still in
  * flight.
  *
- * Rails' `find_target` (`associations/association.rb:194`) is synchronous, so
- * it can never observe a reassignment mid-load. Our loader awaits DB I/O,
- * which opens the window: an in-flight reader (`firm.account` accessed but
- * never awaited) can still be pending when the caller sets a new target, and
- * the stale queried row then wins the writeback.
+ * Rails' `find_target`
+ * (`vendor/rails/activerecord/lib/active_record/associations/association.rb:248`)
+ * never observes a reassignment mid-load. It is synchronous on its default
+ * arm; it does take `async: false` and returns `scope.load_async.then(&:to_a)`
+ * when asked, but that promise still resolves into `target` under the same
+ * `load_target` call, so there is no window in which a caller can reassign
+ * between the query and the writeback. Do not dismiss the premise on spotting
+ * that `async:` parameter.
+ *
+ * Our loader awaits DB I/O and does open that window: an in-flight reader
+ * (`firm.account` accessed but never awaited) can still be pending when the
+ * caller sets a new target, and the stale queried row then wins the writeback.
  *
  * These are `skip`ped because the bug is still OPEN — the fix is not
  * implementable with the holder bookkeeping we have today, and the naive guard
@@ -17,7 +24,7 @@
  * - `loadBelongsTo`'s guard (#4919) keys on the *owner's* stale key (FK +
  *   `foreign_type`), which is independent of holder bookkeeping. has_one has
  *   no owner-side stale key — Rails' `stale_state` is non-nil only on
- *   `BelongsToAssociation` (`associations/belongs_to_association.rb:126`) —
+ *   `BelongsToAssociation` (`belongs_to_association.rb:164`) —
  *   so that approach does not transfer.
  * - Keying on a false→true flip in holder loaded-ness looks equivalent but is
  *   not: the association machinery marks holders loaded mid-await on its own
@@ -32,8 +39,10 @@
  * "someone else's set" — a load-generation token, not an inferred signal.
  *
  * Note there are TWO writebacks on this path, and a fix must cover both: the
- * inner loader's `syncToAssociationInstance` (`associations.ts:1838`) and the
- * instance wrapper's own `setTarget` (`associations/instance-methods.ts:176`),
+ * inner loader's `syncToAssociationInstance`
+ * (`packages/activerecord/src/associations.ts:1808`) and the instance
+ * wrapper's own `setTarget`
+ * (`packages/activerecord/src/associations/instance-methods.ts:176`),
  * which re-syncs unconditionally after the inner call returns. Guarding only
  * the inner one leaves the clobber reachable.
  *


### PR DESCRIPTION
## Summary

Audit of the singular loaders for the mid-flight reassignment clobber PR #4919 closed in `loadBelongsTo`.

**Finding: the bug is real in `loadHasOne`, and it is not soundly fixable with today's holder bookkeeping.** This PR therefore ships the audit result — a skipped repro plus the rejected-approach record — and registers `0063-async-validation-chain/fix-has-one-mid-flight-reassignment-clobber` for the fix. No production code changes.

## The bug

`loadHasOne` awaits DB I/O, then unconditionally writes the result to the shared holder (`packages/activerecord/src/associations.ts:1808`). A reader still in flight when the caller reassigns overwrites the new target with the stale queried row. Rails is immune: `find_target` (`associations/association.rb:248`) never observes a reassignment mid-load.

## Three approaches tried and rejected

1. **Owner stale-key snapshot** — what `loadBelongsTo` does. Doesn't transfer: `stale_state` is non-nil only on `BelongsToAssociation` (`belongs_to_association.rb:164`) and nil for foreign associations, and the owner's PK doesn't move on reassignment. Nothing to snapshot.
2. **False→true flip in holder loaded-ness** — what earlier revisions of this PR shipped. **Unsound.** The association machinery marks holders loaded mid-await on its own (observed on the plain has_one `Member#currentMembership` during a `:through` hop), so the guard fires on ordinary loads and returns a stale target over a correct result.
3. **`_explicitTarget`** — misses the real path entirely: the has_one writer never sets it, so the guard would never fire on an actual reassignment.

## Why this reverted rather than shipped

CI caught approach 2 failing `has-one-through-associations.test.ts:416` ("set record after delete association") on **PostgreSQL and MariaDB**, reproduced locally on PG. It passes on SQLite, where timing keeps the guard from firing at all — so the naive fix is invisible on the default adapter and corrupts ordinary loads on the others. Trading a narrow unawaited-reader race for wrong results in normal `:through` loads is a bad deal, so the guard is out.

This is a reversal of the earlier revisions here, on new evidence (PG/MariaDB CI + local reproduction) rather than a change of mind.

## What ships

- `has-one-mid-flight-reassignment.trails.test.ts` — 3 `skip`ped repro tests with the full rejected-approach rationale in the header, so the next attempt doesn't re-derive it. They fail on main when unskipped, i.e. they are real repros, not decoration. Driven through the public `firm.account` accessor (a Promise-returning getter routing to `loadHasOne`), so they keep exercising whatever path the accessor actually takes.
- Follow-up story with the same context, pointing at a load-generation token as the likely sound direction, and flagging that `loadHasMany` (`packages/activerecord/src/associations.ts:2114`) has the same writeback shape and wants checking.

Verified on PostgreSQL: `has-one-through-associations` + `has-one-associations` **147 passed, 8 skipped**. No test renamed.

## Cite corrections (review cycle 6)

The revert shifted both trails cites by 30 lines and both Rails cites were wrong against vendored Rails — I had carried `association.rb:194` / `belongs_to_association.rb:126` in from an earlier review without checking them. Corrected throughout the test header, this body, and the follow-up story: `find_target` is `association.rb:248` (`:194` is a rescue inside `load_target`), `stale_state` is `belongs_to_association.rb:164` (`:126` is `find_target?`), `syncToAssociationInstance` is `associations.ts:1808`, `loadHasMany`'s is `:2114`. Since this PR's whole deliverable is a pointer for the next attempt, the cites are the payload.

Also narrowed the synchrony claim: `find_target` does take `async:` and returns `scope.load_async.then(&:to_a)` on that arm, but the promise resolves into `target` under the same `load_target` call, so the no-window argument holds. Stated explicitly in the header so the next attempt doesn't dismiss the premise on seeing that parameter.

## Second writeback site (found while addressing review)

Tracing the accessor surfaced a detail that widens the fix: there are **two** unconditional writebacks on this path, not one — `syncToAssociationInstance` in the inner loader (`packages/activerecord/src/associations.ts:1808`) and the instance wrapper's own `setTarget` (`packages/activerecord/src/associations/instance-methods.ts:176`), which re-syncs after the inner call returns. Guarding only the inner one leaves the clobber reachable. Recorded in the test header and the follow-up story.

## Unrelated CI failure

The `Lint` job fails on `packages/arel/src/visitors/visitor.ts:2` — `UnsupportedVisitError` unused import. That is **pre-existing on `origin/main`** (the symbol survives only in two comments there after #5002); this branch touches zero arel files. Not fixed here per the don't-fix-unrelated-breakage rule; it needs its own PR.

Closes-story: audit-singular-loader-mid-flight-reassignment-clobber
