### PR TITLE
fix(arel): typeCastArrayElement raises TypeError on unmapped values, like Rails

### DIFF
--- a/packages/arel/src/quote-array.test.ts
+++ b/packages/arel/src/quote-array.test.ts
@@ -56,9 +56,15 @@ describe("quoteArrayLiteral", () => {
     });
   });
 
+  // `type_cast` reaches a Date/Time only through `quoted_date`
+  // (`abstract/quoting.rb:103`), which on this path is the caller's
+  // `formatElement` hook — never a bare ISO-8601 string, a format no Rails
+  // path emits.
   it("handles Date values with toISOString", () => {
     const d = new Date("2026-03-26T12:00:00.000Z");
-    expect(quoteArrayLiteral([d], defaultQuoter)).toBe(`{${d.toISOString()}}`);
+    expect(quoteArrayLiteral([d], defaultQuoter, () => "2026-03-26 12:00:00")).toBe(
+      '{"2026-03-26 12:00:00"}',
+    );
   });
 
   it("handles empty arrays", () => {
@@ -67,11 +73,36 @@ describe("quoteArrayLiteral", () => {
 
   it("handles objects with toISOString", () => {
     const obj = { toISOString: () => "2026-01-01T00:00:00Z" };
-    expect(quoteArrayLiteral([obj], defaultQuoter)).toBe("{2026-01-01T00:00:00Z}");
+    expect(() => quoteArrayLiteral([obj], defaultQuoter)).toThrow(new TypeError("can't cast Time"));
   });
 
   it("handles bigint values inside objects", () => {
-    expect(quoteArrayLiteral([{ id: 42n }], defaultQuoter)).toBe('{"{\\"id\\":\\"42\\"}"}');
+    expect(() => quoteArrayLiteral([{ id: 42n }], defaultQuoter)).toThrow(
+      new TypeError("can't cast Hash"),
+    );
+  });
+
+  // `else raise TypeError, "can't cast #{value.class.name}"`
+  // (`abstract/quoting.rb:105`) — the closed set's terminal arm.
+  describe("raises TypeError on a value type_cast does not name", () => {
+    it("raises on a class instance", () => {
+      class Point {}
+      expect(() => quoteArrayLiteral([new Point()], defaultQuoter)).toThrow(
+        new TypeError("can't cast Point"),
+      );
+    });
+
+    it("raises on a function", () => {
+      expect(() => quoteArrayLiteral([() => 1], defaultQuoter)).toThrow(TypeError);
+    });
+  });
+
+  // `when nil, Numeric, String then value` plus `when Symbol ... value.to_s`
+  // (`abstract/quoting.rb:95-101`).
+  it("casts the scalar arms type_cast names", () => {
+    expect(quoteArrayLiteral([1, 42n, "a", null, Symbol("sym")], defaultQuoter)).toBe(
+      "{1,42,a,NULL,sym}",
+    );
   });
 
   // Each expectation below was captured from `PG::TextEncoder::Array#encode`,

--- a/packages/arel/src/quote-array.test.ts
+++ b/packages/arel/src/quote-array.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import { quoteArrayLiteral } from "./quote-array.js";
 import { defaultQuoter } from "./visitors/default-quoter.js";
 import { BinaryData } from "@blazetrails/activemodel";
+import { BigDecimal } from "@blazetrails/activesupport";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 
 describe("quoteArrayLiteral", () => {
   it("formats simple string arrays", () => {
@@ -96,7 +98,18 @@ describe("quoteArrayLiteral", () => {
     });
 
     it("raises on a function", () => {
-      expect(() => quoteArrayLiteral([() => 1], defaultQuoter)).toThrow(TypeError);
+      expect(() => quoteArrayLiteral([() => 1], defaultQuoter)).toThrow(
+        new TypeError("can't cast Function"),
+      );
+    });
+
+    // Trails' `Type::Time::Value` analogue: `quoted_time` is a connection
+    // self-dispatch (`abstract/quoting.rb:102`) and `ArelConnection` has no
+    // such method, so it must arrive pre-formatted via `formatElement`.
+    it("raises on a Temporal value no formatElement hook claimed", () => {
+      expect(() => quoteArrayLiteral([Temporal.PlainTime.from("12:00")], defaultQuoter)).toThrow(
+        TypeError,
+      );
     });
   });
 
@@ -104,6 +117,12 @@ describe("quoteArrayLiteral", () => {
   // value.to_s` (`abstract/quoting.rb:95-96`).
   it("casts a Type::Binary::Data to its byte string", () => {
     expect(quoteArrayLiteral([new BinaryData("hi")], defaultQuoter)).toBe("{hi}");
+  });
+
+  // `when BigDecimal then value.to_s("F")` (`abstract/quoting.rb:99`) — the
+  // fixed form, not the default `to_s`.
+  it("casts a BigDecimal to its non-normalized fixed form", () => {
+    expect(quoteArrayLiteral([new BigDecimal("1.5")], defaultQuoter)).toBe("{1.5}");
   });
 
   // `when nil, Numeric, String then value` plus `when Symbol ... value.to_s`

--- a/packages/arel/src/quote-array.test.ts
+++ b/packages/arel/src/quote-array.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { quoteArrayLiteral } from "./quote-array.js";
 import { defaultQuoter } from "./visitors/default-quoter.js";
+import { BinaryData } from "@blazetrails/activemodel";
 
 describe("quoteArrayLiteral", () => {
   it("formats simple string arrays", () => {
@@ -95,6 +96,12 @@ describe("quoteArrayLiteral", () => {
     it("raises on a function", () => {
       expect(() => quoteArrayLiteral([() => 1], defaultQuoter)).toThrow(TypeError);
     });
+  });
+
+  // `when Symbol, ActiveSupport::Multibyte::Chars, Type::Binary::Data then
+  // value.to_s` (`abstract/quoting.rb:95-96`).
+  it("casts a Type::Binary::Data to its byte string", () => {
+    expect(quoteArrayLiteral([new BinaryData("hi")], defaultQuoter)).toBe("{hi}");
   });
 
   // `when nil, Numeric, String then value` plus `when Symbol ... value.to_s`

--- a/packages/arel/src/quote-array.test.ts
+++ b/packages/arel/src/quote-array.test.ts
@@ -61,11 +61,13 @@ describe("quoteArrayLiteral", () => {
   // (`abstract/quoting.rb:103`), which on this path is the caller's
   // `formatElement` hook — never a bare ISO-8601 string, a format no Rails
   // path emits.
+  // A hookless caller has no `quoted_date` to route through, so the value is
+  // not castable — asserted here rather than re-asserting the hook path, which
+  // `formatElement` > "quotes a formatted element whose content needs it"
+  // already covers with this same Date.
   it("handles Date values with toISOString", () => {
     const d = new Date("2026-03-26T12:00:00.000Z");
-    expect(quoteArrayLiteral([d], defaultQuoter, () => "2026-03-26 12:00:00")).toBe(
-      '{"2026-03-26 12:00:00"}',
-    );
+    expect(() => quoteArrayLiteral([d], defaultQuoter)).toThrow(new TypeError("can't cast Time"));
   });
 
   it("handles empty arrays", () => {

--- a/packages/arel/src/quote-array.ts
+++ b/packages/arel/src/quote-array.ts
@@ -1,6 +1,7 @@
 import type { ArelConnection } from "./visitors/connection.js";
 import { rubyClassName } from "./visitors/ruby-class.js";
 import { BinaryData } from "@blazetrails/activemodel";
+import { BigDecimal } from "@blazetrails/activesupport";
 
 /** The slice of the connection an array element's `type_cast` needs. */
 export type ArrayElementQuoter = Pick<ArelConnection, "unquotedTrue" | "unquotedFalse">;
@@ -79,21 +80,43 @@ function typeCastArrayElement(
   // other two. `String(data)` is `Data#to_s`: its `toString()` decodes bytes.
   if (value instanceof BinaryData) return String(value);
   // Same arm: Ruby's `Symbol#to_s` is the bare name, which `description` is
-  // the analogue of.
+  // the analogue of. Ruby has no descriptionless Symbol, so the `?? ""` is
+  // unreachable by construction (only `Symbol()` produces it here) rather than
+  // a port of an empty-name arm.
   if (typeof value === "symbol") return value.description ?? "";
+  // `when BigDecimal then value.to_s("F")` (`abstract/quoting.rb:99`) — the
+  // non-normalized fixed form, not the default `to_s`. Same arm as the sibling
+  // port in
+  // packages/activerecord/src/connection-adapters/abstract/quoting.ts:194.
+  if (value instanceof BigDecimal) return value.toString("F");
   // `else raise TypeError, "can't cast #{value.class.name}"`
   // (`abstract/quoting.rb:105`). Everything Rails' closed set does not name
-  // raises here rather than being JSON- or String-encoded — including the
-  // Date/Time arm, which reaches `type_cast` only through `quoted_date` and so
-  // is served by `formatElement` above (the only caller,
-  // `postgresqlDefaultQuoter.quote`, passes it). A value that gets past that
-  // hook has no `quoted_date` to route through and is not castable.
+  // raises here rather than being JSON- or String-encoded.
+  //
+  // That includes the two remaining arms, `when Type::Time::Value then
+  // quoted_time` and `when Date, Time then quoted_date` (`:102-103`), which are
+  // self-dispatches onto the connection. `ArelConnection` (visitors/
+  // connection.ts) carries no `quotedDate`/`quotedTime` to dispatch onto —
+  // Rails' Arel does no value formatting, so those live on the adapter — which
+  // is exactly what `formatElement` exists to supply: the only caller,
+  // `postgresqlDefaultQuoter.quote` (visitors/default-quoter.ts:231), routes
+  // date-likes through its `quotedDate` before the value reaches here. A
+  // Temporal value (trails' `Type::Time::Value` analogue) has no `toISOString`
+  // and so is NOT covered by that hook; it raises here rather than silently
+  // encoding, which is what the pre-convergence fallback did to it (an object
+  // with no `toISOString` fell to `JSON.stringify`, i.e. `{}`). Giving the
+  // connection-less quoter a real `quotedTime` is adapter work, not this
+  // function's.
   throw new TypeError(`can't cast ${rubyClassName(value) ?? classNameOf(value)}`);
 }
 
+// Rails is unconditionally `value.class.name`. `constructor.name` is the
+// analogue; the `"Object"` last resort is for a null-prototype object, which
+// has no constructor — and is unreachable here because `rubyClassName` already
+// claims those as `Hash`. It exists so the template can never read `undefined`.
 function classNameOf(value: unknown): string {
   const named = (value as { constructor?: { name?: unknown } })?.constructor?.name;
-  return typeof named === "string" && named !== "" ? named : String(typeof value);
+  return typeof named === "string" && named !== "" ? named : "Object";
 }
 
 /**

--- a/packages/arel/src/quote-array.ts
+++ b/packages/arel/src/quote-array.ts
@@ -78,8 +78,8 @@ function typeCastArrayElement(
   // analogue — JS strings are already the wrapped form — so the arm is the
   // other two. `String(data)` is `Data#to_s`: its `toString()` decodes bytes.
   if (value instanceof BinaryData) return String(value);
-  // `when Symbol ... then value.to_s` (`abstract/quoting.rb:95-96`). Ruby's
-  // `Symbol#to_s` is the bare name, which `description` is the analogue of.
+  // Same arm: Ruby's `Symbol#to_s` is the bare name, which `description` is
+  // the analogue of.
   if (typeof value === "symbol") return value.description ?? "";
   // `else raise TypeError, "can't cast #{value.class.name}"`
   // (`abstract/quoting.rb:105`). Everything Rails' closed set does not name

--- a/packages/arel/src/quote-array.ts
+++ b/packages/arel/src/quote-array.ts
@@ -1,5 +1,6 @@
 import type { ArelConnection } from "./visitors/connection.js";
 import { rubyClassName } from "./visitors/ruby-class.js";
+import { BinaryData } from "@blazetrails/activemodel";
 
 /** The slice of the connection an array element's `type_cast` needs. */
 export type ArrayElementQuoter = Pick<ArelConnection, "unquotedTrue" | "unquotedFalse">;
@@ -72,6 +73,11 @@ function typeCastArrayElement(
   // Ruby has no fixnum/bignum split at this layer — a bigint is Numeric too.
   if (typeof value === "bigint") return String(value);
   if (typeof value === "string") return value;
+  // `when Symbol, ActiveSupport::Multibyte::Chars, Type::Binary::Data then
+  // value.to_s` (`abstract/quoting.rb:95-96`). `Multibyte::Chars` has no trails
+  // analogue — JS strings are already the wrapped form — so the arm is the
+  // other two. `String(data)` is `Data#to_s`: its `toString()` decodes bytes.
+  if (value instanceof BinaryData) return String(value);
   // `when Symbol ... then value.to_s` (`abstract/quoting.rb:95-96`). Ruby's
   // `Symbol#to_s` is the bare name, which `description` is the analogue of.
   if (typeof value === "symbol") return value.description ?? "";

--- a/packages/arel/src/quote-array.ts
+++ b/packages/arel/src/quote-array.ts
@@ -1,4 +1,5 @@
 import type { ArelConnection } from "./visitors/connection.js";
+import { rubyClassName } from "./visitors/ruby-class.js";
 
 /** The slice of the connection an array element's `type_cast` needs. */
 export type ArrayElementQuoter = Pick<ArelConnection, "unquotedTrue" | "unquotedFalse">;
@@ -68,25 +69,25 @@ function typeCastArrayElement(
   // override the pair to 1/0.
   if (typeof value === "boolean")
     return String(value ? connection.unquotedTrue() : connection.unquotedFalse());
-  // boundary: defensive Date formatting for caller-supplied array literals.
-  // Duck-typed rather than `instanceof Date` so cross-realm dates and Temporal
-  // land here too; a real Date satisfies it, so it needs no arm of its own.
-  if (
-    typeof value === "object" &&
-    "toISOString" in value &&
-    typeof (value as { toISOString: unknown }).toISOString === "function"
-  ) {
-    return (value as { toISOString: () => string }).toISOString();
-  }
-  if (typeof value === "object") {
-    const replacer = (_k: string, val: unknown) => (typeof val === "bigint" ? val.toString() : val);
-    try {
-      return JSON.stringify(value, replacer) ?? String(value);
-    } catch {
-      return String(value);
-    }
-  }
-  return String(value);
+  // Ruby has no fixnum/bignum split at this layer — a bigint is Numeric too.
+  if (typeof value === "bigint") return String(value);
+  if (typeof value === "string") return value;
+  // `when Symbol ... then value.to_s` (`abstract/quoting.rb:95-96`). Ruby's
+  // `Symbol#to_s` is the bare name, which `description` is the analogue of.
+  if (typeof value === "symbol") return value.description ?? "";
+  // `else raise TypeError, "can't cast #{value.class.name}"`
+  // (`abstract/quoting.rb:105`). Everything Rails' closed set does not name
+  // raises here rather than being JSON- or String-encoded — including the
+  // Date/Time arm, which reaches `type_cast` only through `quoted_date` and so
+  // is served by `formatElement` above (the only caller,
+  // `postgresqlDefaultQuoter.quote`, passes it). A value that gets past that
+  // hook has no `quoted_date` to route through and is not castable.
+  throw new TypeError(`can't cast ${rubyClassName(value) ?? classNameOf(value)}`);
+}
+
+function classNameOf(value: unknown): string {
+  const named = (value as { constructor?: { name?: unknown } })?.constructor?.name;
+  return typeof named === "string" && named !== "" ? named : String(typeof value);
 }
 
 /**

--- a/packages/arel/src/visitors/default-quoter.ts
+++ b/packages/arel/src/visitors/default-quoter.ts
@@ -223,6 +223,18 @@ export const postgresqlDefaultQuoter: ArelConnection = {
       return `'${String(value)}'`;
     }
     if (Array.isArray(value)) {
+      // A Temporal element — trails' `Time` analogue — is NOT claimed by
+      // `isDateLike` (Temporal exposes no `toISOString`) and so hits
+      // `type_cast`'s terminal raise. That is unreachable for a real
+      // `timestamp[]`: this host serves only the connection-less
+      // `new PostgreSQL()` debug path, and every adapter construction site
+      // passes a real connection (postgresql-adapter.ts `arelVisitor`,
+      // insert-all.ts:786-788), whose own `type_cast_array` → `type_cast`
+      // (connection-adapters/postgresql/quoting.ts:445-449) owns the
+      // Temporal arms and never reaches `quoteArrayLiteral`. Routing Temporal
+      // through a `quotedTime` here needs a `quoted_time` on `ArelConnection`,
+      // which Rails puts on the adapter, not on Arel.
+      //
       // formatElement keeps #4867's fix alive on this path: a date element gets
       // the same `quoted_date` form the scalar path emits, mirroring Rails'
       // `type_cast_array` → `type_cast` → `when Date, Time then quoted_date`


### PR DESCRIPTION
Rails' `type_cast` (`abstract/quoting.rb:94-107`) is a closed set of arms ending in `else raise TypeError, "can't cast #{value.class.name}"`. trails' `typeCastArrayElement` instead fell through to three invented arms: a bare ISO-8601 string, `JSON.stringify`, then `String(value)` — so a POJO silently encoded as `{"{\"id\":\"42\"}"}` where Rails refuses the value outright.

This converges the arms onto the closed set (nil / Numeric / String / true / false / Symbol) and raises a TypeError with Rails' message shape otherwise, naming the value's Ruby class via the existing `rubyClassName` helper.

The bare-ISO-8601 arm is removed rather than reformatted: `type_cast` reaches a Date/Time only through `quoted_date`, which on this path is the caller's `formatElement` hook — and the only caller, `postgresqlDefaultQuoter.quote`, already passes it. No path now emits a format Rails never produces.

`quote-array.test.ts`'s "handles bigint values inside objects" and "handles objects with toISOString" are replaced (they pinned the removed fallbacks), plus new coverage for the terminal raise and the scalar arms.

No in-repo caller reached the removed arms, so this is a fidelity fix, not a behaviour change for existing callers.

Closes-story: converge-arel-array-type-cast-fallback-to-typeerror