### PR TITLE
test(encryption): restore logo asserts in "encrypts normalized data"

### DIFF
--- a/packages/activerecord/src/encryption/contexts.test.ts
+++ b/packages/activerecord/src/encryption/contexts.test.ts
@@ -137,7 +137,7 @@ describe("ActiveRecord::Encryption::ContextsTest", () => {
     // NullEncryptor.isBinary() === false gate in encryptAsText. TS strings
     // carry no binary encoding, so this payload is degenerate and the binary
     // gate itself can't be meaningfully driven here — the actual binary-column
-    // encryption path is covered by makeEncryptedBookWithBinary in
+    // encryption path is covered by EncryptedBookWithBinary in
     // encryptable-record.test.ts. This test retains the name-for-name parity
     // and still asserts the create-under-NullEncryptor path doesn't raise.
     await expect(

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -708,7 +708,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
 
   it("binary data can be encrypted", async () => {
     await freshAdapter();
-    const Book = EncryptedBookWithBinary as any;
+    const Book = EncryptedBookWithBinary;
     const allBytes = Uint8Array.from({ length: 256 }, (_, i) => i);
     expect((await Book.create({ logo: allBytes })).logo).toEqual(allBytes);
     expect((await Book.create({ logo: null })).logo).toBeNull();
@@ -716,7 +716,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
   });
   it("binary data can be encrypted uncompressed", async () => {
     await freshAdapter();
-    const Book = EncryptedBookWithBinary as any;
+    const Book = EncryptedBookWithBinary;
     const lowBytes = Uint8Array.from({ length: 128 }, (_, i) => i);
     const highBytes = Uint8Array.from({ length: 128 }, (_, i) => i + 128);
     await assertEncryptedAttribute(await Book.create({ logo: lowBytes }), "logo", lowBytes);

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -11,7 +11,6 @@ import {
   makeEncryptedBookThatIgnoresCase,
   makeEncryptedAuthor,
   makeBookThatWillFailToEncryptName,
-  makeEncryptedBookWithBinary,
   makeEncryptedBookWithCustomCompressor,
   makeEncryptedTrafficLight,
   makeEncryptedTrafficLightWithStoreState,
@@ -33,6 +32,7 @@ import {
   EncryptedBook,
   EncryptedBookNormalizedFirst,
   EncryptedBookNormalizedSecond,
+  EncryptedBookWithBinary,
   EncryptedBookWithSerializedFirstBinary,
   EncryptedBookWithSerializedSecondBinary,
 } from "../test-helpers/models/book-encrypted.js";
@@ -707,14 +707,16 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
   });
 
   it("binary data can be encrypted", async () => {
-    const Book = makeEncryptedBookWithBinary(await freshAdapter());
+    await freshAdapter();
+    const Book = EncryptedBookWithBinary as any;
     const allBytes = Uint8Array.from({ length: 256 }, (_, i) => i);
     expect((await Book.create({ logo: allBytes })).logo).toEqual(allBytes);
     expect((await Book.create({ logo: null })).logo).toBeNull();
     expect((await Book.create({ logo: new Uint8Array(0) })).logo).toEqual(new Uint8Array(0));
   });
   it("binary data can be encrypted uncompressed", async () => {
-    const Book = makeEncryptedBookWithBinary(await freshAdapter());
+    await freshAdapter();
+    const Book = EncryptedBookWithBinary as any;
     const lowBytes = Uint8Array.from({ length: 128 }, (_, i) => i);
     const highBytes = Uint8Array.from({ length: 128 }, (_, i) => i + 128);
     await assertEncryptedAttribute(await Book.create({ logo: lowBytes }), "logo", lowBytes);

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -12,8 +12,6 @@ import {
   makeEncryptedAuthor,
   makeBookThatWillFailToEncryptName,
   makeEncryptedBookWithBinary,
-  makeEncryptedBookWithSerializedFirstBinary,
-  makeEncryptedBookWithSerializedSecondBinary,
   makeEncryptedBookWithCustomCompressor,
   makeEncryptedTrafficLight,
   makeEncryptedTrafficLightWithStoreState,
@@ -35,6 +33,8 @@ import {
   EncryptedBook,
   EncryptedBookNormalizedFirst,
   EncryptedBookNormalizedSecond,
+  EncryptedBookWithSerializedFirstBinary,
+  EncryptedBookWithSerializedSecondBinary,
 } from "../test-helpers/models/book-encrypted.js";
 import { isEncryptedAttribute } from "../encryption.js";
 import { RecordInvalid } from "../index.js";
@@ -720,22 +720,28 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     await assertEncryptedAttribute(await Book.create({ logo: lowBytes }), "logo", lowBytes);
     await assertEncryptedAttribute(await Book.create({ logo: highBytes }), "logo", highBytes);
   });
-  // TRACKED-PENDING-CONVERGENCE (converge-encryption-makefreshmodel-onto-canonical):
-  // These two fixtures ride the canonical `encrypted_books.logo` (binary) column
-  // like Rails, but store a JSON-*text* encrypted message via `_JsonArrayType`
-  // (a string castType, so `isBinary()` is false and the bytea/BLOB round-trip
-  // coercion in EncryptedAttributeType never runs). On PostgreSQL/MariaDB the
-  // driver returns the stored ciphertext as raw bytes and decryption fails with
-  // "hash without payload"; SQLite is loose so it passes. The fix is an impl
-  // change (model `logo` as binary end-to-end, or decode the DB value before the
-  // text serializer) — not a schema fork. Skipped until that lands rather than
-  // reintroducing a bespoke `text` table this convergence exists to remove.
+  // TRACKED-PENDING-CONVERGENCE (serialize-encrypts-decorator-ordering): now
+  // rides the canonical Rails fixtures (reflection-typed binary `logo`, no
+  // bespoke string column), which shows the residual gap is NOT the binary
+  // text-ciphertext round-trip this story closed — that works. It is decorator
+  // ordering: Rails applies pending decorators in declaration order, so
+  // `serialize` + `encrypts` yields EncryptedAttributeType(Serialized(Bytea)).
+  // We replay them reversed AND seed `serialize` from the pre-reflection
+  // ValueType, producing Serialized(non-binary) and a coder that receives raw
+  // bytes. Fixing that is attribute-registration surgery, not an encryption fix.
   it.skip("serialized binary data can be encrypted", async () => {
     const jsonBytes = Array.from({ length: 96 }, (_, i) => String.fromCharCode(i + 32));
-    const Book1 = makeEncryptedBookWithSerializedFirstBinary(await freshAdapter());
-    await assertEncryptedAttribute(await Book1.create({ logo: jsonBytes }), "logo", jsonBytes);
-    const Book2 = makeEncryptedBookWithSerializedSecondBinary(await freshAdapter());
-    await assertEncryptedAttribute(await Book2.create({ logo: jsonBytes }), "logo", jsonBytes);
+    await freshAdapter();
+    await assertEncryptedAttribute(
+      await EncryptedBookWithSerializedFirstBinary.create({ logo: jsonBytes }),
+      "logo",
+      jsonBytes,
+    );
+    await assertEncryptedAttribute(
+      await EncryptedBookWithSerializedSecondBinary.create({ logo: jsonBytes }),
+      "logo",
+      jsonBytes,
+    );
   });
   it("deterministic ciphertexts remain constant", async () => {
     // We need to make sure these don't change or existing apps will stop working.
@@ -784,25 +790,33 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
 
   it("encrypts normalized data", async () => {
     // Rides EncryptedBookNormalizedFirst/Second (encrypted_books, `name` + `logo`),
-    // mirroring Rails. Rails also passes `logo: "DUNE"` and asserts it normalizes
-    // to "dune", but the encrypted binary `logo` column can't round-trip a text
-    // ciphertext on PG/MariaDB (see the `serialized binary data can be encrypted`
-    // skip). Until that impl gap closes we ride only the `name` half; a persisted
-    // `logo` ciphertext would trip the record's reload, so it stays omitted.
+    // mirroring Rails.
     // Rides the canonical reflection-based `EncryptedBookNormalized{First,Second}`
     // (name obtained via schema reflection, non-null default `<untitled>`), not
     // an explicit `attribute("name", ...)` declaration. Encryption is configured
     // suite-wide before these models load (test-setup-ar.ts), so the bare
     // `encrypts` builds its scheme against real key material.
     await freshAdapter();
-    let book = await EncryptedBookNormalizedFirst.create({ name: "Book" });
-    await assertEncryptedAttribute(book, "name", "book");
-    // TRACKED-PENDING-CONVERGENCE (binary text-ciphertext round-trip):
-    // await assertEncryptedAttribute(book, "logo", "book");
-
-    book = await EncryptedBookNormalizedSecond.create({ name: "Book" });
-    await assertEncryptedAttribute(book, "name", "book");
-    // await assertEncryptedAttribute(book, "logo", "book");
+    await assertEncryptedAttribute(
+      await EncryptedBookNormalizedFirst.create({ name: "Book" }),
+      "name",
+      "book",
+    );
+    await assertEncryptedAttribute(
+      await EncryptedBookNormalizedSecond.create({ name: "Book" }),
+      "name",
+      "book",
+    );
+    await assertEncryptedAttribute(
+      await EncryptedBookNormalizedFirst.create({ logo: "Book" }),
+      "logo",
+      "book",
+    );
+    await assertEncryptedAttribute(
+      await EncryptedBookNormalizedSecond.create({ logo: "Book" }),
+      "logo",
+      "book",
+    );
   });
 
   it("EncryptableRecord.validateEncryptionAllowed throws when encryption is frozen", () => {

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -376,22 +376,6 @@ export function makeEncryptedTrafficLightWithStoreState(adapter: DatabaseAdapter
 }
 
 /**
- * EncryptedBookWithBinary: logo is a binary attribute, encrypted.
- * Mirrors Rails' EncryptedBookWithBinary fixture (book_encrypted.rb).
- */
-export function makeEncryptedBookWithBinary(adapter: DatabaseAdapter) {
-  return class EncryptedBookWithBinary extends Base {
-    static {
-      this._tableName = "encrypted_books";
-      this.attribute("id", "integer");
-      this.attribute("logo", "binary");
-      this.adapter = adapter;
-      this.encrypts("logo");
-    }
-  } as any;
-}
-
-/**
  * EncryptedBookWithBinaryMessagePackSerialized: logo is a binary attribute
  * encrypted with a MessagePack message serializer. Mirrors the fixture class
  * defined inline in encryptable_record_message_pack_serialized_test.rb.

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -384,8 +384,10 @@ export function makeEncryptedBookWithBinaryMessagePackSerialized(adapter: Databa
   return class EncryptedBookWithBinaryMessagePackSerialized extends Base {
     static {
       this._tableName = "encrypted_books";
-      this.attribute("id", "integer");
-      this.attribute("logo", "binary");
+      // No declared `logo`/`id` type — Rails' inline fixture
+      // (encryptable_record_message_pack_serialized_test.rb:37-41) declares
+      // none either, so `logo` reflects as binary from the column. A declared
+      // type here would mask a reflection regression.
       this.adapter = adapter;
       this.encrypts("logo", { messageSerializer: new MessagePackMessageSerializer() });
     }
@@ -460,6 +462,27 @@ export function makeEncryptedBookAttribute(adapter: DatabaseAdapter) {
 // ─── Assertion helpers ────────────────────────────────────────────────────────
 
 /**
+ * Whether `attrName` is backed by a binary column, walking the decorator chain
+ * to find out. The attribute's outermost type is whatever `normalizes` /
+ * `encrypts` / `serialize` wrapped it in, and none of those are themselves
+ * binary (Rails' `EncryptedAttributeType` is a plain `Type::Value` too) — only
+ * the innermost column type is. `normalizes` + `encrypts` on a binary column
+ * nests two deep, so unwrap until a link reports binary or the chain ends.
+ *
+ * @internal
+ */
+function _isBinaryAttribute(model: any, attrName: string): boolean {
+  let type = model._attributes?.getAttribute?.(attrName)?.type;
+  const seen = new Set<unknown>();
+  while (type != null && !seen.has(type)) {
+    if (type.isBinary?.() === true) return true;
+    seen.add(type);
+    type = type.castType ?? type.subtype;
+  }
+  return false;
+}
+
+/**
  * Mirrors Rails' assert_encrypted_attribute.
  * Checks that the actual DB-bound value is ciphertext (≠ plaintext) and
  * that reading the attribute returns the expected plaintext. For persisted
@@ -479,7 +502,11 @@ export async function assertEncryptedAttribute(
   }
 }
 
-function _valuesEqual(readValue: unknown, expectedValue: unknown): boolean {
+function _valuesEqual(
+  readValue: unknown,
+  expectedValue: unknown,
+  isBinaryAttribute = false,
+): boolean {
   if (readValue === expectedValue) return true;
   if (
     readValue instanceof Temporal.Instant &&
@@ -510,7 +537,13 @@ function _valuesEqual(readValue: unknown, expectedValue: unknown): boolean {
   // (binary-encoding) String, so Rails' `assert_equal "book", record.logo`
   // compares text to it directly. Our BinaryType deserializes to Uint8Array,
   // so decode Latin-1 (bytes 1:1) to make the same assertion meaningful.
-  if (readValue instanceof Uint8Array && typeof expectedValue === "string")
+  //
+  // Gated on the attribute's declared type, NOT on `readValue` being a
+  // Uint8Array: keying off the runtime shape would extend Rails' laxity to
+  // every attribute, so a *string* column that wrongly read back as bytes
+  // would silently pass. Rails earns the laxity only where the column really
+  // is binary, so we spend it only there too.
+  if (isBinaryAttribute && readValue instanceof Uint8Array && typeof expectedValue === "string")
     return Buffer.from(readValue).toString("latin1") === expectedValue;
   if (
     Array.isArray(readValue) &&
@@ -537,7 +570,7 @@ function _assertEncryptedAttributeOnModel(
   expectedValue: unknown,
 ): void {
   const readValue = model[attrName];
-  if (!_valuesEqual(readValue, expectedValue)) {
+  if (!_valuesEqual(readValue, expectedValue, _isBinaryAttribute(model, attrName))) {
     throw new Error(
       `assertEncryptedAttribute: expected ${attrName} to equal ` +
         `${JSON.stringify(expectedValue)}, got ${JSON.stringify(readValue)}`,
@@ -601,7 +634,7 @@ export function assertNotEncryptedAttribute(
   expectedValue: unknown,
 ): void {
   const readValue = model[attrName];
-  if (!_valuesEqual(readValue, expectedValue)) {
+  if (!_valuesEqual(readValue, expectedValue, _isBinaryAttribute(model, attrName))) {
     throw new Error(
       `assertNotEncryptedAttribute: expected ${attrName} to read as ` +
         `${JSON.stringify(expectedValue)}, got ${JSON.stringify(readValue)}`,

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -20,47 +20,11 @@ import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 import { clearDefaultKeyProviderCache, type Scheme } from "./scheme.js";
 import { withEncryptionContext, withoutEncryption } from "./context.js";
 import { DecryptionError, EncryptionError } from "./errors.js";
-import { ValueType, BinaryData } from "@blazetrails/activemodel";
+import { BinaryData } from "@blazetrails/activemodel";
 // Side-effect: registers encryptionHooks so Base.encrypts() is wired up.
 import "../encryption.js";
 import type { Encryptor } from "../encryption.js";
 import { MessagePackMessageSerializer } from "./message-pack-message-serializer.js";
-
-// JSON array type: cast/serialize produce a JSON string; deserialize parses it back.
-// Used as the castType for EncryptedBookWithSerialized*Binary factories.
-class _JsonArrayType extends ValueType<unknown> {
-  readonly name = "string";
-  cast(value: unknown): unknown {
-    if (value === null || value === undefined) return null;
-    if (Array.isArray(value)) return value;
-    if (typeof value === "string") {
-      try {
-        return JSON.parse(value);
-      } catch {
-        return value;
-      }
-    }
-    return value;
-  }
-  serialize(value: unknown): string | null {
-    if (value === null || value === undefined) return null;
-    return JSON.stringify(value);
-  }
-  deserialize(value: unknown): unknown {
-    if (value === null || value === undefined) return null;
-    if (typeof value === "string") {
-      try {
-        return JSON.parse(value);
-      } catch {
-        return value;
-      }
-    }
-    return value;
-  }
-  type(): string {
-    return "string";
-  }
-}
 
 export { withEncryptionContext, withoutEncryption, DecryptionError, EncryptionError };
 
@@ -428,46 +392,6 @@ export function makeEncryptedBookWithBinary(adapter: DatabaseAdapter) {
 }
 
 /**
- * EncryptedBookWithSerializedFirstBinary: logo stores an Array via JSON serialization,
- * then encrypted. Mirrors Rails' EncryptedBookWithSerializedFirstBinary fixture.
- */
-export function makeEncryptedBookWithSerializedFirstBinary(adapter: DatabaseAdapter) {
-  const jsonArrayType = new _JsonArrayType();
-  return class EncryptedBookWithSerializedFirstBinary extends Base {
-    static {
-      this._tableName = "encrypted_books";
-      this.attribute("id", "integer");
-      this.attribute("logo", "string");
-      // Replace string type with JSON-array type via the pending queue so
-      // _defaultAttributes() uses _JsonArrayType as the castType when encrypts wraps it.
-      this.decorateAttributes(["logo"], () => jsonArrayType);
-      this.adapter = adapter;
-      this.encrypts("logo");
-    }
-  } as any;
-}
-
-/**
- * EncryptedBookWithSerializedSecondBinary: logo stores an Array, encrypted.
- * Mirrors Rails' EncryptedBookWithSerializedSecondBinary fixture.
- * Uses JSON array serialization (YAML is not available in TS; both produce
- * equivalent results for the ASCII-only test data).
- */
-export function makeEncryptedBookWithSerializedSecondBinary(adapter: DatabaseAdapter) {
-  const jsonArrayType = new _JsonArrayType();
-  return class EncryptedBookWithSerializedSecondBinary extends Base {
-    static {
-      this._tableName = "encrypted_books";
-      this.attribute("id", "integer");
-      this.attribute("logo", "string");
-      this.decorateAttributes(["logo"], () => jsonArrayType);
-      this.adapter = adapter;
-      this.encrypts("logo");
-    }
-  } as any;
-}
-
-/**
  * EncryptedBookWithBinaryMessagePackSerialized: logo is a binary attribute
  * encrypted with a MessagePack message serializer. Mirrors the fixture class
  * defined inline in encryptable_record_message_pack_serialized_test.rb.
@@ -598,6 +522,12 @@ function _valuesEqual(readValue: unknown, expectedValue: unknown): boolean {
     readValue.every((b, i) => b === expectedValue[i])
   )
     return true;
+  // Ruby has no separate byte-array type: a binary column reads back as a
+  // (binary-encoding) String, so Rails' `assert_equal "book", record.logo`
+  // compares text to it directly. Our BinaryType deserializes to Uint8Array,
+  // so decode Latin-1 (bytes 1:1) to make the same assertion meaningful.
+  if (readValue instanceof Uint8Array && typeof expectedValue === "string")
+    return Buffer.from(readValue).toString("latin1") === expectedValue;
   if (
     Array.isArray(readValue) &&
     Array.isArray(expectedValue) &&


### PR DESCRIPTION
Rails' `encrypts normalized data` ([`encryptable_record_test.rb`](https://github.com/rails/rails/blob/main/activerecord/test/cases/encryption/encryptable_record_test.rb)) asserts both the `name` and the `logo` (binary column) halves. Trails rode only `name`, with the two `logo` assertions commented out as `TRACKED-PENDING-CONVERGENCE` on the premise that an encrypted binary column can't round-trip a text ciphertext on PG (`bytea`) / MariaDB (`BLOB`).

**That premise was wrong.** `EncryptedAttributeType`'s `textToDatabaseType` / `databaseTypeToText` already Latin-1 bridge the payload, so the round-trip works today — no implementation change was needed. The assertions only failed because Ruby has no separate byte-array type: a binary column reads back as a (binary-encoding) `String`, so Rails compares it to `"book"` directly, while our `BinaryType` deserializes to a `Uint8Array`. `assertEncryptedAttribute` now Latin-1 decodes that arm, and the two `logo` assertions are restored verbatim.

Verified against live PostgreSQL and MySQL, not just sqlite.

### Riding the canonical fixtures

The `logo` tests used bespoke factories — one declaring `attribute("logo", "binary")` explicitly (a type Rails' fixture never declares, since `encrypted_books.logo` reflects as binary from the column), two more declaring `logo` as a **string** with a hand-rolled `_JsonArrayType`. All three now ride the canonical Rails models, so the whole `logo` cluster exercises the reflection path the restored assertions depend on, rather than declared types that could mask a reflection regression.

### `serialized binary data can be encrypted` stays skipped — for a different reason

The story allowed leaving it skipped if it turned out to be a distinct sub-case. It is, and the old skip reason was wrong. Moving it onto the canonical fixtures is what exposed the real cause, now recorded at the call site.

Instrumenting the decorators against PG shows trails diverges from `attribute_registration.rb` twice:

1. Pending decorators replay in **reverse** declaration order, so `serialize`'s decorator receives an `EncryptedAttributeType` and yields `Serialized(Encrypted(...))` instead of Rails' `Encrypted(Serialized(Bytea))`.
2. `serialize`'s decorator is also seeded from the **pre-reflection** `ValueType`, so `Serialized#subtype.isBinary()` is `false` and the binary bridge never fires — the JSON coder then receives raw bytes, and `cast()` returns a `Uint8Array` of the JSON text instead of the array.

That is attribute-registration surgery, not an encryption fix, so it is registered separately as `serialize-encrypts-decorator-ordering` (RFC 0055) rather than fanned out here.

### Review follow-ups (both fixed)

- **Assert arm was too broad.** `_valuesEqual`'s new `Uint8Array`-vs-`string` arm keyed off the runtime shape of the read value, extending Rails' laxity to every attribute. It is now gated on the attribute's column type actually being binary, walking the decorator chain to find it (none of `normalizes` / `encrypts` / `serialize` is itself binary — `logo` nests two deep). Confirmed the gate bites: a string column reading back as bytes still fails the assertion.
- **Cluster was half-converged.** `makeEncryptedBookWithBinaryMessagePackSerialized` still declared `attribute("logo", "binary")`. Rails' inline fixture (`encryptable_record_message_pack_serialized_test.rb:37-41`) declares no type, so it is dropped — folded in here rather than deferred, since it is the same one-line pattern as its three siblings.

### Testing

`packages/activerecord/src/encryption/` green on sqlite (320 passed); `encryptable-record.test.ts` + `contexts.test.ts` + `encryptable-record-message-pack-serialized.test.ts` green on PostgreSQL 16 and MySQL 8 via an isolated compose stack. Net −70 LOC.

Closes-story: encrypted-binary-column-text-ciphertext-roundtrip
