### PR TITLE
refactor(arel): admit ActiveModel::Attribute into the AST type surface

### DIFF
--- a/packages/arel/src/nodes/binary.ts
+++ b/packages/arel/src/nodes/binary.ts
@@ -8,13 +8,9 @@ import { Not } from "./unary.js";
 import { Grouping } from "./grouping.js";
 import type { Cte } from "./cte.js";
 
-// Rails admits an `ActiveModel::Attribute` as a first-class AST occupant by
-// class, unwrapped: `build_quoted` returns one straight into the AST
-// (casted.rb:50), Assignment visits one on its right (to_sql.rb:631),
-// ValuesList accepts one (to_sql.rb:110), and there is a
-// `visit_ActiveModel_Attribute` (to_sql.rb:756). Ruby duck-types past this;
-// naming it here is what keeps the node slots honest instead of forcing an
-// `as unknown as Node` escape at every port.
+// `ModelAttribute` is not an Arel node but occupies node slots in Rails:
+// `build_quoted` returns one unwrapped into the AST (casted.rb:50), and both
+// Assignment (to_sql.rb:631) and ValuesList (to_sql.rb:110) accept one.
 export type NodeOrValue =
   | Node
   | ModelAttribute

--- a/packages/arel/src/nodes/binary.ts
+++ b/packages/arel/src/nodes/binary.ts
@@ -1,3 +1,4 @@
+import type { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 import { Node, NodeVisitor } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
 import { SqlLiteral } from "./sql-literal.js";
@@ -7,8 +8,16 @@ import { Not } from "./unary.js";
 import { Grouping } from "./grouping.js";
 import type { Cte } from "./cte.js";
 
+// Rails admits an `ActiveModel::Attribute` as a first-class AST occupant by
+// class, unwrapped: `build_quoted` returns one straight into the AST
+// (casted.rb:50), Assignment visits one on its right (to_sql.rb:631),
+// ValuesList accepts one (to_sql.rb:110), and there is a
+// `visit_ActiveModel_Attribute` (to_sql.rb:756). Ruby duck-types past this;
+// naming it here is what keeps the node slots honest instead of forcing an
+// `as unknown as Node` escape at every port.
 export type NodeOrValue =
   | Node
+  | ModelAttribute
   | string
   | number
   | boolean

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -745,8 +745,8 @@ export class Dot extends Visitor {
     // (dot.rb:216) and `alias :visit_Set :visit_Array` (dot.rb:231). Neither
     // has a Ruby-class name `rubyClassName` can synthesize, so both go in the
     // ctor-keyed table (the prototype walk covers Attribute subclasses).
-    reg(ModelAttribute as unknown as NodeCtor, "visitActiveModelAttribute");
-    reg(Set as unknown as NodeCtor, "visitSet");
+    reg(ModelAttribute, "visitActiveModelAttribute");
+    reg(Set, "visitSet");
     // Quoted, True, False, BoundSqlLiteral, Fragments don't extend any
     // ancestor with a useful Dot handler — register explicitly as leaves.
     reg(Nodes.Quoted, "visitNoEdges");

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1134,7 +1134,7 @@ describe("the to_sql visitor", () => {
     // it at runtime, which is what this asserts.
     const node = new Nodes.Assignment(
       users.get("name"),
-      AMAttribute.fromUser("name", "x", new ValueType()) as unknown as Nodes.NodeOrValue,
+      AMAttribute.fromUser("name", "x", new ValueType()),
     );
     expect(new Visitors.ToSql().compile(node)).toBe('"users"."name" = ?');
   });

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -564,7 +564,7 @@ export class ToSql extends Visitor {
     // visits (visitor.rb:29-30) and to_sql.rb:756 defines a handler for it,
     // so ValuesList/Assignment's visit branch resolves here rather than
     // raising UnsupportedVisitError.
-    reg(ModelAttribute as unknown as NodeCtor, "visitActiveModelAttribute");
+    reg(ModelAttribute, "visitActiveModelAttribute");
     reg(Nodes.Fragments, "visitArelNodesFragments");
     // Functions
     reg(Nodes.NamedFunction, "visitArelNodesNamedFunction");
@@ -1234,7 +1234,7 @@ export class ToSql extends Visitor {
     // `instanceof Node` covers rb:631's `Arel::Attributes::Attribute` arm too —
     // Arel's Attribute extends Node here (attributes/attribute.ts).
     if (node.right instanceof Node || isActiveModelAttribute(node.right)) {
-      this.visit(node.right as unknown as Node, collector);
+      this.visit(node.right, collector);
     } else {
       collector.append(this.quote(node.right));
     }

--- a/packages/arel/src/visitors/visitor.ts
+++ b/packages/arel/src/visitors/visitor.ts
@@ -12,11 +12,9 @@ function describeClass(object: unknown): string {
 /**
  * Opaque dispatch-cache key for a class the visitor dispatches on.
  *
- * The instance type is `object`, not `Node`: Rails' visitors dispatch on
- * `object.class` and the table is keyed by classes that are not Arel nodes
- * at all — `ActiveModel::Attribute` (to_sql.rb:756), `Set`, `Array`. Naming
- * the constrained `Node` here would be the type surface asserting
- * "impossible" about dispatch Rails does routinely.
+ * The instance type is `object`, not `Node`: Rails dispatches on
+ * `object.class`, and the table is keyed by classes that are not Arel nodes
+ * at all — `ActiveModel::Attribute` (to_sql.rb:756), `Set`.
  *
  * The parameter list is `never[]` (not `unknown[]`) because the dispatch
  * cache never constructs anything — the ctor is used purely as a Map key. TS

--- a/packages/arel/src/visitors/visitor.ts
+++ b/packages/arel/src/visitors/visitor.ts
@@ -1,4 +1,3 @@
-import { Node } from "../nodes/node.js";
 import { rubyClassName } from "./ruby-class.js";
 
 // Rails interpolates `object.class` straight into its "Cannot visit" TypeError
@@ -11,16 +10,22 @@ function describeClass(object: unknown): string {
 }
 
 /**
- * Opaque dispatch-cache key for a Node subclass.
+ * Opaque dispatch-cache key for a class the visitor dispatches on.
+ *
+ * The instance type is `object`, not `Node`: Rails' visitors dispatch on
+ * `object.class` and the table is keyed by classes that are not Arel nodes
+ * at all — `ActiveModel::Attribute` (to_sql.rb:756), `Set`, `Array`. Naming
+ * the constrained `Node` here would be the type surface asserting
+ * "impossible" about dispatch Rails does routinely.
  *
  * The parameter list is `never[]` (not `unknown[]`) because the dispatch
- * cache never constructs nodes — the ctor is used purely as a Map key. TS
+ * cache never constructs anything — the ctor is used purely as a Map key. TS
  * is contravariant in constructor parameter types, so `never[]` is the
  * only signature that accepts ctors of arbitrary arity (e.g.
  * `Binary(left, right)`, `BoundSqlLiteral(sql, binds)`). `unknown[]` would
  * reject any ctor with a more-specific parameter type.
  */
-export type NodeCtor = abstract new (...args: never[]) => Node;
+export type NodeCtor = abstract new (...args: never[]) => object;
 type VisitorCtor = typeof Visitor;
 
 const PER_CLASS_CACHE = new WeakMap<VisitorCtor, Map<NodeCtor, string>>();


### PR DESCRIPTION
Rails admits an `ActiveModel::Attribute` as a first-class AST occupant, by class: `build_quoted` returns one unwrapped into the AST (casted.rb:50), Assignment's arm visits one on its right (to_sql.rb:631), ValuesList accepts one (to_sql.rb:110), and there is a `visit_ActiveModel_Attribute` (to_sql.rb:756).

Ruby duck-types past this. trails' AST types were closed over `Node`, so each of those ports needed an `as unknown as` escape — the type surface asserting "impossible" about dispatch Rails does routinely.

- `NodeOrValue` (`nodes/binary.ts`) now names `ModelAttribute`, so a node slot holding one typechecks without a cast. `arel` already depends on `@blazetrails/activemodel`, so this is a type-only import, no new dep.
- `NodeCtor` (`visitors/visitor.ts`) resolves to `object`, not `Node`. The dispatch cache never constructs anything — the ctor is purely a Map key — and Rails keys it by classes that are not Arel nodes at all (`ActiveModel::Attribute`, `Set`).

Removes the casts #4882 added at the Assignment port (`to-sql.ts`), the `reg` line, and the Assignment test in `to-sql.test.ts` — plus the pre-existing `reg(ModelAttribute …)` / `reg(Set …)` casts in `dot.ts`, which the same widening makes unnecessary.

Runtime behavior is unchanged: `isActiveModelAttribute` still gates the Assignment branch. Does **not** converge the `BindParam` wrap — that stays for `arel-build-quoted-passes-model-attribute-unwrapped`, which this unblocks.

Typecheck and lint clean; `to-sql.test.ts` + `dot.test.ts` pass (339 tests).

Closes-story: arel-ast-type-surface-excludes-model-attribute
