### PR TITLE
test(arel): resolve duplicate it() names within describes in attribute.test.ts

### DIFF
--- a/packages/arel/src/attributes/attribute.test.ts
+++ b/packages/arel/src/attributes/attribute.test.ts
@@ -914,12 +914,12 @@ describe("AttributeTest", () => {
 
   describe("#not_in_any", () => {
     it("should create a Grouping node", () => {
-      // Rails passes bare scalars here (attribute_test.rb:1008). The cast is needed
-      // only because our notIn is typed notIn(o: unknown[]) while Rails' not_in
-      // takes any expr; see the arel-predications-not-in-expr-type story.
-      expect(users.get("id").notInAny([1, 2] as unknown as unknown[][])).toBeInstanceOf(
-        Nodes.Grouping,
-      );
+      // Rails passes bare scalars here (attribute_test.rb:1008); notIn is typed
+      // notIn(o: unknown[]) while Rails' not_in takes any expr. ts-expect-error
+      // (not a cast) so this fails to compile once the signature is widened by
+      // the arel-predications-not-in-expr-type story, forcing this line's removal.
+      // @ts-expect-error -- see above
+      expect(users.get("id").notInAny([1, 2])).toBeInstanceOf(Nodes.Grouping);
     });
 
     it("should generate ORs in sql", () => {
@@ -938,12 +938,12 @@ describe("AttributeTest", () => {
 
   describe("#not_in_all", () => {
     it("should create a Grouping node", () => {
-      // Rails passes bare scalars here (attribute_test.rb:1023). The cast is needed
-      // only because our notIn is typed notIn(o: unknown[]) while Rails' not_in
-      // takes any expr; see the arel-predications-not-in-expr-type story.
-      expect(users.get("id").notInAll([1, 2] as unknown as unknown[][])).toBeInstanceOf(
-        Nodes.Grouping,
-      );
+      // Rails passes bare scalars here (attribute_test.rb:1023); notIn is typed
+      // notIn(o: unknown[]) while Rails' not_in takes any expr. ts-expect-error
+      // (not a cast) so this fails to compile once the signature is widened by
+      // the arel-predications-not-in-expr-type story, forcing this line's removal.
+      // @ts-expect-error -- see above
+      expect(users.get("id").notInAll([1, 2])).toBeInstanceOf(Nodes.Grouping);
     });
 
     it("should generate ANDs in sql", () => {

--- a/packages/arel/src/attributes/attribute.test.ts
+++ b/packages/arel/src/attributes/attribute.test.ts
@@ -307,20 +307,6 @@ describe("AttributeTest", () => {
     });
   });
 
-  describe("#eq_all", () => {
-    it("should create a Grouping node", () => {
-      expect(users.get("id").eqAll([1, 2])).toBeInstanceOf(Nodes.Grouping);
-    });
-
-    it("should generate ANDs in sql", () => {
-      const mgr = users.project(users.get("id"));
-      mgr.where(users.get("id").eqAll([1, 2]));
-      expect(mgr.toSql()).toBe(
-        'SELECT "users"."id" FROM "users" WHERE ("users"."id" = 1 AND "users"."id" = 2)',
-      );
-    });
-  });
-
   describe("#average", () => {
     it("should create a AVG node", () => {
       const node = users.get("age").average();

--- a/packages/arel/src/attributes/attribute.test.ts
+++ b/packages/arel/src/attributes/attribute.test.ts
@@ -781,23 +781,14 @@ describe("AttributeTest", () => {
 
   describe("#not_in_any", () => {
     it("should create a Grouping node", () => {
-      expect(
-        users.get("id").notInAny([
-          [1, 2],
-          [3, 4],
-        ]),
-      ).toBeInstanceOf(Nodes.Grouping);
+      // Rails passes bare scalars here (attribute_test.rb:1008); notIn is typed
+      // notIn(o: unknown[]) while Rails' not_in takes any expr. ts-expect-error
+      // (not a cast) so this fails to compile once the signature is widened by
+      // the arel-predications-not-in-expr-type story, forcing this line's removal.
+      // @ts-expect-error -- see above
+      expect(users.get("id").notInAny([1, 2])).toBeInstanceOf(Nodes.Grouping);
     });
 
-    it("should generate ORs in sql", () => {
-      const relation = new Table("users");
-      const mgr = relation.project(relation.get("id"));
-      mgr.where(relation.get("id").notInAny([[1], [2]]));
-      expect(mgr.toSql()).toContain("OR");
-    });
-  });
-
-  describe("#not_in_any", () => {
     it("should generate ORs in sql", () => {
       const mgr = users.project(users.get("id"));
       mgr.where(
@@ -814,12 +805,12 @@ describe("AttributeTest", () => {
 
   describe("#not_in_all", () => {
     it("should create a Grouping node", () => {
-      expect(
-        users.get("id").notInAll([
-          [1, 2],
-          [3, 4],
-        ]),
-      ).toBeInstanceOf(Nodes.Grouping);
+      // Rails passes bare scalars here (attribute_test.rb:1023); notIn is typed
+      // notIn(o: unknown[]) while Rails' not_in takes any expr. ts-expect-error
+      // (not a cast) so this fails to compile once the signature is widened by
+      // the arel-predications-not-in-expr-type story, forcing this line's removal.
+      // @ts-expect-error -- see above
+      expect(users.get("id").notInAll([1, 2])).toBeInstanceOf(Nodes.Grouping);
     });
 
     it("should generate ANDs in sql", () => {
@@ -909,54 +900,6 @@ describe("AttributeTest", () => {
           .where(users.get("id").notIn([1, 2]))
           .toSql(),
       ).toBe('SELECT * FROM "users" WHERE "users"."id" NOT IN (1, 2)');
-    });
-  });
-
-  describe("#not_in_any", () => {
-    it("should create a Grouping node", () => {
-      // Rails passes bare scalars here (attribute_test.rb:1008); notIn is typed
-      // notIn(o: unknown[]) while Rails' not_in takes any expr. ts-expect-error
-      // (not a cast) so this fails to compile once the signature is widened by
-      // the arel-predications-not-in-expr-type story, forcing this line's removal.
-      // @ts-expect-error -- see above
-      expect(users.get("id").notInAny([1, 2])).toBeInstanceOf(Nodes.Grouping);
-    });
-
-    it("should generate ORs in sql", () => {
-      const mgr = users.project(users.get("id"));
-      mgr.where(
-        users.get("id").notInAny([
-          [1, 2],
-          [3, 4],
-        ]),
-      );
-      expect(mgr.toSql()).toBe(
-        'SELECT "users"."id" FROM "users" WHERE ("users"."id" NOT IN (1, 2) OR "users"."id" NOT IN (3, 4))',
-      );
-    });
-  });
-
-  describe("#not_in_all", () => {
-    it("should create a Grouping node", () => {
-      // Rails passes bare scalars here (attribute_test.rb:1023); notIn is typed
-      // notIn(o: unknown[]) while Rails' not_in takes any expr. ts-expect-error
-      // (not a cast) so this fails to compile once the signature is widened by
-      // the arel-predications-not-in-expr-type story, forcing this line's removal.
-      // @ts-expect-error -- see above
-      expect(users.get("id").notInAll([1, 2])).toBeInstanceOf(Nodes.Grouping);
-    });
-
-    it("should generate ANDs in sql", () => {
-      const mgr = users.project(users.get("id"));
-      mgr.where(
-        users.get("id").notInAll([
-          [1, 2],
-          [3, 4],
-        ]),
-      );
-      expect(mgr.toSql()).toBe(
-        'SELECT "users"."id" FROM "users" WHERE ("users"."id" NOT IN (1, 2) AND "users"."id" NOT IN (3, 4))',
-      );
     });
   });
 

--- a/packages/arel/src/attributes/attribute.test.ts
+++ b/packages/arel/src/attributes/attribute.test.ts
@@ -914,8 +914,9 @@ describe("AttributeTest", () => {
 
   describe("#not_in_any", () => {
     it("should create a Grouping node", () => {
-      // Rails passes bare scalars here (attribute_test.rb:1008/1023); the element
-      // type is unknown[] because each is forwarded to notIn.
+      // Rails passes bare scalars here (attribute_test.rb:1008). The cast is needed
+      // only because our notIn is typed notIn(o: unknown[]) while Rails' not_in
+      // takes any expr; see the arel-predications-not-in-expr-type story.
       expect(users.get("id").notInAny([1, 2] as unknown as unknown[][])).toBeInstanceOf(
         Nodes.Grouping,
       );
@@ -937,8 +938,9 @@ describe("AttributeTest", () => {
 
   describe("#not_in_all", () => {
     it("should create a Grouping node", () => {
-      // Rails passes bare scalars here (attribute_test.rb:1008/1023); the element
-      // type is unknown[] because each is forwarded to notIn.
+      // Rails passes bare scalars here (attribute_test.rb:1023). The cast is needed
+      // only because our notIn is typed notIn(o: unknown[]) while Rails' not_in
+      // takes any expr; see the arel-predications-not-in-expr-type story.
       expect(users.get("id").notInAll([1, 2] as unknown as unknown[][])).toBeInstanceOf(
         Nodes.Grouping,
       );

--- a/packages/arel/src/attributes/attribute.test.ts
+++ b/packages/arel/src/attributes/attribute.test.ts
@@ -404,12 +404,6 @@ describe("AttributeTest", () => {
       const node = users.get("name").eq(null);
       expect(visitor.compile(node)).toBe('"users"."name" IS NULL');
     });
-
-    it("should handle nil", () => {
-      const relation = new Table("users");
-      const node = relation.get("id").eq(null);
-      expect(new Visitors.ToSql().compile(node)).toContain("IS NULL");
-    });
   });
 
   describe("#matches_any", () => {
@@ -436,13 +430,6 @@ describe("AttributeTest", () => {
   });
 
   describe("#matches_all", () => {
-    it("should not eat input", () => {
-      const input = [1, 2, 3];
-      const copy = [...input];
-      users.get("id").eqAny(input);
-      expect(input).toEqual(copy);
-    });
-
     it("should create a Grouping node", () => {
       expect(users.get("name").matchesAll(["%foo%", "%bar%"])).toBeInstanceOf(Nodes.Grouping);
     });
@@ -453,13 +440,6 @@ describe("AttributeTest", () => {
       expect(mgr.toSql()).toBe(
         `SELECT "users"."id" FROM "users" WHERE ("users"."name" LIKE '%foo%' AND "users"."name" LIKE '%bar%')`,
       );
-    });
-
-    it("should not eat input", () => {
-      const input = [1, 2, 3];
-      const copy = [...input];
-      users.get("id").eqAll(input);
-      expect(input).toEqual(copy);
     });
   });
 
@@ -932,58 +912,63 @@ describe("AttributeTest", () => {
     });
   });
 
-  describe("#eq_all", () => {
-    it("should create a Grouping node", () => {
-      const left = users.get("age").between(18, 30);
-      const right = users.get("age").between(40, 50);
-      const node = new Nodes.Grouping(new Nodes.Or(left, right));
-      expect(node).toBeInstanceOf(Nodes.Grouping);
-    });
-  });
-
   describe("#not_in_any", () => {
+    it("should create a Grouping node", () => {
+      // Rails passes bare scalars here (attribute_test.rb:1008/1023); the element
+      // type is unknown[] because each is forwarded to notIn.
+      expect(users.get("id").notInAny([1, 2] as unknown as unknown[][])).toBeInstanceOf(
+        Nodes.Grouping,
+      );
+    });
+
     it("should generate ORs in sql", () => {
-      const left = users.get("age").between(18, 30);
-      const right = users.get("age").between(40, 50);
-      const node = new Nodes.Grouping(new Nodes.Or(left, right));
-      const visitor = new Visitors.ToSql();
-      const result = visitor.compile(node);
-      expect(result).toContain("OR");
-      expect(result).toContain("BETWEEN");
+      const mgr = users.project(users.get("id"));
+      mgr.where(
+        users.get("id").notInAny([
+          [1, 2],
+          [3, 4],
+        ]),
+      );
+      expect(mgr.toSql()).toBe(
+        'SELECT "users"."id" FROM "users" WHERE ("users"."id" NOT IN (1, 2) OR "users"."id" NOT IN (3, 4))',
+      );
+    });
+  });
+
+  describe("#not_in_all", () => {
+    it("should create a Grouping node", () => {
+      // Rails passes bare scalars here (attribute_test.rb:1008/1023); the element
+      // type is unknown[] because each is forwarded to notIn.
+      expect(users.get("id").notInAll([1, 2] as unknown as unknown[][])).toBeInstanceOf(
+        Nodes.Grouping,
+      );
+    });
+
+    it("should generate ANDs in sql", () => {
+      const mgr = users.project(users.get("id"));
+      mgr.where(
+        users.get("id").notInAll([
+          [1, 2],
+          [3, 4],
+        ]),
+      );
+      expect(mgr.toSql()).toBe(
+        'SELECT "users"."id" FROM "users" WHERE ("users"."id" NOT IN (1, 2) AND "users"."id" NOT IN (3, 4))',
+      );
     });
   });
 
   describe("#eq_all", () => {
     it("should create a Grouping node", () => {
-      const left = users.get("age").between(18, 65);
-      const right = users.get("score").between(1, 100);
-      const node = new Nodes.Grouping(new Nodes.And([left, right]));
-      expect(node).toBeInstanceOf(Nodes.Grouping);
+      expect(users.get("id").eqAll([1, 2])).toBeInstanceOf(Nodes.Grouping);
     });
 
     it("should generate ANDs in sql", () => {
-      const left = users.get("tags").contains("a");
-      const right = users.get("tags").contains("b");
-      const node = new Nodes.And([left, right]);
-      const visitor = new Visitors.ToSql();
-      expect(visitor.compile(node)).toContain("AND");
-    });
-
-    it("should create a Grouping node", () => {
-      const left = users.get("age").notBetween(18, 30);
-      const right = users.get("age").notBetween(40, 50);
-      const node = new Nodes.Grouping(new Nodes.Or(left, right));
-      expect(node).toBeInstanceOf(Nodes.Grouping);
-    });
-
-    it("should generate ANDs in sql", () => {
-      const left = users.get("age").between(18, 65);
-      const right = users.get("score").between(1, 100);
-      const node = new Nodes.Grouping(new Nodes.And([left, right]));
-      const visitor = new Visitors.ToSql();
-      const result = visitor.compile(node);
-      expect(result).toContain("AND");
-      expect(result).toContain("BETWEEN");
+      const mgr = users.project(users.get("id"));
+      mgr.where(users.get("id").eqAll([1, 2]));
+      expect(mgr.toSql()).toBe(
+        'SELECT "users"."id" FROM "users" WHERE ("users"."id" = 1 AND "users"."id" = 2)',
+      );
     });
   });
 


### PR DESCRIPTION
Resolves the remaining duplicate `it()` names within a single `describe` in
`packages/arel/src/attributes/attribute.test.ts` — the same class of defect
PR #4886 fixed for `#not_in`. Each pair was checked against
`vendor/rails/activerecord/test/cases/arel/attributes/attribute_test.rb`
before removal; no test was renamed.

### `#eq` — `"should handle nil"` x2

Rails has one (attribute_test.rb:410). Both slots exercised the same
`eq(null)` → `IS NULL` path; one asserted exact compiled SQL, the other only
`toContain("IS NULL")`. Kept the strictly stronger exact-assertion slot.

### `#matches_all` — `"should not eat input"` x2

Rails' `#matches_all` (498) has **no** such test — and neither slot called
`matchesAll`: one called `eqAny`, the other `eqAll`. Both are already covered
by the real `"should not eat input"` tests in `#eq_any` (rb:433) and `#eq_all`
(rb:457), which match Rails verbatim. Deleted both; no coverage lost.

### `#eq_all` — `"should create a Grouping node"` x2, `"should generate ANDs in sql"` x2

The two `#eq_all` blocks near `#asc` never called `eqAll` — they hand-built
`Nodes.Grouping`/`Nodes.And` from `between`/`notBetween`/`contains` and
asserted the constructor's own output, so they tested nothing about the
predication.

Rails has exactly two `#eq_all` describes: rb:441, which carries
`"should not eat input"`, and rb:1037, which does not. `:26` is the rb:441
port. Review caught that replacing the junk left **two** byte-identical
rb:1037 ports (`:310` and `:906`) — a third copy rather than a de-duplication.
Deleted the `:310` one, keeping the block before `#asc` since rb:1037
likewise precedes rb:1053. The file now holds one block per Rails describe.

### `#not_in_any` / `#not_in_all` (review correction)

An earlier revision of this PR claimed these blocks were "missing" and added
them. **That was wrong** — review caught it. The file already held
`#not_in_any` twice (:782, :800) and `#not_in_all` once (:815), the latter
already byte-identical to Rails. The added copies are gone. Instead, in line
with the de-duplication goal:

- the redundant second `#not_in_any` is folded into the first, keeping the
  exact `to_sql` assertion over the weaker `toContain("OR")`;
- both `"should create a Grouping node"` args are tightened to Rails' bare
  scalars, `notInAny([1, 2])` / `notInAll([1, 2])` (rb:1008/1023).

Net: one block per Rails describe in this region.

### The scalar `not_in` arg

`notIn` is typed `notIn(o: unknown[])` while Rails' `not_in` takes any expr,
so Rails' bare-scalar call needs suppression. This uses `@ts-expect-error`
rather than a cast: a cast compiles forever and would survive the signature
fix as dead cruft, whereas the directive becomes an unused-directive build
error once `notIn` is widened, forcing its own removal. Follow-up story
`0066-arel-visitor-fidelity/arel-predications-not-in-expr-type` is filed
(commit `20a8e15c1`, on the tasks repo's `origin/main`).

Verified the directive is currently live: deleting it yields
`TS2322: Type 'number' is not assignable to type 'unknown[]'` at both sites.
I could not cheaply simulate the future widening — hand-widening the `this:`
constraint in `predications.ts` did not make the call legal, since the
effective type comes through the mixin surface — so the self-destruct is
argued from TS2578 semantics, not demonstrated end-to-end.

### Verification

The story's reproduce script reports no within-describe duplicates. 233 tests
in the file pass; `tsc --build --force` clean.

`test:compare` (arel), baselined against `origin/main` @ 0dc3fed17:

| | matched | extra | files | misplaced |
|---|---|---|---|---|
| main | 703/707 | 637 | 59/59 | 0 |
| branch | 703/707 | 627 | 59/59 | 0 |

Matched holds; extras fall by 10. `api:compare` is unaffected — no source
files are touched.

Closes-story: arel-attribute-test-duplicate-it-names-within-describe

