### PR TITLE
fix(activesupport): runCallbacks returns the block value, not a boolean

### DIFF
--- a/packages/activemodel/src/callbacks.test.ts
+++ b/packages/activemodel/src/callbacks.test.ts
@@ -572,7 +572,10 @@ describe("unified sync/async runner", () => {
     _registerCallbackOnProto(proto, "after", "save", () => {
       log.push("after");
     });
-    const result = runAllCallbacks(proto, "save", {}, () => log.push("block"));
+    const result = runAllCallbacks(proto, "save", {}, () => {
+      log.push("block");
+      return true;
+    });
     expect(result).toBe(true);
     expect(log).toEqual(["before", "block", "after"]);
   });
@@ -587,7 +590,10 @@ describe("unified sync/async runner", () => {
     _registerCallbackOnProto(proto, "after", "save", () => {
       log.push("after");
     });
-    const result = runAllCallbacks(proto, "save", {}, () => log.push("block"));
+    const result = runAllCallbacks(proto, "save", {}, () => {
+      log.push("block");
+      return true;
+    });
     expect(result).toBeInstanceOf(Promise);
     expect(await result).toBe(true);
     expect(log).toEqual(["before", "block", "after"]);
@@ -601,6 +607,7 @@ describe("unified sync/async runner", () => {
     const result = runAllCallbacks(proto, "save", {}, async () => {
       await Promise.resolve();
       log.push("block");
+      return true;
     });
     expect(result).toBeInstanceOf(Promise);
     expect(await result).toBe(true);
@@ -716,9 +723,16 @@ describe("unified sync/async runner", () => {
     const log: string[] = [];
     _registerCallbackOnProto(proto, "before", "validation", () => log.push("before"));
     _registerCallbackOnProto(proto, "after", "validation", () => log.push("after"));
-    const result = runAllCallbacks(proto, "validation", {}, () => log.push("block"), {
-      strict: "sync",
-    });
+    const result = runAllCallbacks(
+      proto,
+      "validation",
+      {},
+      () => {
+        log.push("block");
+        return true;
+      },
+      { strict: "sync" },
+    );
     expect(result).toBe(true);
     expect(log).toEqual(["before", "block", "after"]);
   });

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -476,12 +476,11 @@ export function runAllCallbacks(
   record: CallbackRecord,
   block?: () => unknown,
   opts?: RunCallbacksOptions,
-): boolean | Promise<boolean> {
+): unknown {
   const chain = asPeekCallbackChain(proto, event);
   if (!chain) {
-    const r = block?.();
-    if (isThenable(r)) return Promise.resolve(r).then(() => true);
-    return true;
+    // Rails run_callbacks with an empty chain: `yield if block_given?`.
+    return block?.();
   }
   return chain.compile().invoke(record, block, opts as ASRunCallbacksOptions);
 }
@@ -496,7 +495,7 @@ export function runBeforeCallbacksOnProto(
   event: string,
   record: CallbackRecord,
   opts?: RunCallbacksOptions,
-): boolean | Promise<boolean> {
+): unknown {
   const chain = asPeekCallbackChain(proto, event);
   if (!chain) return true;
   const tmp = new ASCallbackChain(event, chain.config);

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -480,6 +480,10 @@ export function runAllCallbacks(
   const chain = asPeekCallbackChain(proto, event);
   if (!chain) {
     // Rails run_callbacks with an empty chain: `yield if block_given?`.
+    // NOTE: the activesupport sibling additionally throws on a thenable block
+    // under `strict: "sync"`. That guard is a trails invention with no Rails
+    // counterpart, and it survives lint only via the rails-error-parity
+    // grandfather list; it is deliberately not propagated here.
     return block?.();
   }
   return chain.compile().invoke(record, block, opts as ASRunCallbacksOptions);

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1890,8 +1890,11 @@ export class Model {
     this._validationContext = normalized;
 
     try {
+      // Rails: `run_validations!` is the block, and its truthy return becomes
+      // run_callbacks' value; `false` here means the chain halted.
       const completed = await runAllCallbacks(ctor.prototype, "validation", this, async () => {
         await this.runValidationsBang();
+        return true;
       });
       if (!completed) return false;
       return this.errors.empty;
@@ -2609,17 +2612,9 @@ export class Model {
     event: string,
     block: () => unknown,
     opts: RunCallbacksOptions & { strict: "sync" },
-  ): boolean;
-  runCallbacks(
-    event: string,
-    block: () => unknown,
-    opts?: RunCallbacksOptions,
-  ): boolean | Promise<boolean>;
-  runCallbacks(
-    event: string,
-    block: () => unknown,
-    opts?: RunCallbacksOptions,
-  ): boolean | Promise<boolean> {
+  ): unknown;
+  runCallbacks(event: string, block: () => unknown, opts?: RunCallbacksOptions): unknown;
+  runCallbacks(event: string, block: () => unknown, opts?: RunCallbacksOptions): unknown {
     return runAllCallbacks((this.constructor as typeof Model).prototype, event, this, block, opts);
   }
 }

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -2608,12 +2608,6 @@ export class Model {
 
   // -- Callbacks helper for subclasses --
 
-  runCallbacks(
-    event: string,
-    block: () => unknown,
-    opts: RunCallbacksOptions & { strict: "sync" },
-  ): unknown;
-  runCallbacks(event: string, block: () => unknown, opts?: RunCallbacksOptions): unknown;
   runCallbacks(event: string, block: () => unknown, opts?: RunCallbacksOptions): unknown {
     return runAllCallbacks((this.constructor as typeof Model).prototype, event, this, block, opts);
   }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -3979,6 +3979,9 @@ export class Base extends Model {
       // caches intact: loaded associations stay readable on a destroyed record
       // exactly as in Rails (and as `Core#freeze` already documents).
       this.freeze();
+      // Rails' `_run_destroy_callbacks { super }` block value is truthy; only a
+      // halted chain yields false (run_callbacks returns env.value).
+      return true;
     });
 
     if (!destroyResult) return false;

--- a/packages/activerecord/src/callbacks.ts
+++ b/packages/activerecord/src/callbacks.ts
@@ -297,91 +297,102 @@ export function createOrUpdate(this: any): Promise<boolean> {
 
 /** @internal */
 export async function _createRecord(this: any): Promise<boolean> {
-  // Rails: _run_create_callbacks { super } — returns whether callbacks completed.
+  // Rails: _run_create_callbacks { super }, whose value is the block's return
+  // (run_callbacks returns env.value). Rails coerces one level up, in
+  // create_or_update: `result != false` (persistence.rb:895) — so a nil/absent
+  // value is truthy and only an explicit `false` (a halted chain) is falsey.
+  // Our signature is Promise<boolean>, so that predicate is applied here.
   const ctor = this.constructor;
-  return !!(await runAllCallbacks(ctor.prototype, "create", this, async () => {
-    if (!this._performInsert) throw new Error("_performInsert not implemented");
-    // Reinstate constructor-assigned attrs as dirty vs schema defaults BEFORE the
-    // insert. Rails new records are dirty from construction, so partial_inserts'
-    // `attribute_names & changed_attribute_names_to_save` (attributesForCreate)
-    // correctly includes attrs the user set to a non-default value — e.g. an
-    // hstore column with a DB default of "" that was assigned {key: null}.
-    // Running this after the insert would leave the dirty set empty at column-
-    // selection time and wrongly drop such columns. Only a *null* PK column is
-    // skipped: that's the auto-populated key, tracked via
-    // _writeAttribute(pk, insertedId) in _performInsert. A user-assigned
-    // (non-null) PK column — e.g. a composite key — must stay dirty so it's
-    // inserted; otherwise the row is written with a missing key and
-    // find/destroy by that key raises RecordNotFound.
-    const _pk = ctor.primaryKey;
-    const _pkSet = new Set(
-      (Array.isArray(_pk) ? _pk : [_pk]).filter((n) => this._readAttribute?.(n) == null),
-    );
-    this._dirty.reinstateNewRecordChanges(this._attributes, _pkSet);
-    await this._performInsert();
-    if (this._pendingOperation) {
-      await this._pendingOperation;
-      this._pendingOperation = null;
-    }
-    this._previouslyNewRecord = true;
-    this._newRecord = false;
-    this.changesApplied();
-    // Rails' block is `super`, whose truthy return becomes run_callbacks' value.
-    return true;
-  }));
+  return (
+    (await runAllCallbacks(ctor.prototype, "create", this, async () => {
+      if (!this._performInsert) throw new Error("_performInsert not implemented");
+      // Reinstate constructor-assigned attrs as dirty vs schema defaults BEFORE the
+      // insert. Rails new records are dirty from construction, so partial_inserts'
+      // `attribute_names & changed_attribute_names_to_save` (attributesForCreate)
+      // correctly includes attrs the user set to a non-default value — e.g. an
+      // hstore column with a DB default of "" that was assigned {key: null}.
+      // Running this after the insert would leave the dirty set empty at column-
+      // selection time and wrongly drop such columns. Only a *null* PK column is
+      // skipped: that's the auto-populated key, tracked via
+      // _writeAttribute(pk, insertedId) in _performInsert. A user-assigned
+      // (non-null) PK column — e.g. a composite key — must stay dirty so it's
+      // inserted; otherwise the row is written with a missing key and
+      // find/destroy by that key raises RecordNotFound.
+      const _pk = ctor.primaryKey;
+      const _pkSet = new Set(
+        (Array.isArray(_pk) ? _pk : [_pk]).filter((n) => this._readAttribute?.(n) == null),
+      );
+      this._dirty.reinstateNewRecordChanges(this._attributes, _pkSet);
+      await this._performInsert();
+      if (this._pendingOperation) {
+        await this._pendingOperation;
+        this._pendingOperation = null;
+      }
+      this._previouslyNewRecord = true;
+      this._newRecord = false;
+      this.changesApplied();
+      // Rails' block is `super`, whose truthy return becomes run_callbacks' value.
+      return true;
+    })) !== false
+  );
 }
 
 /** @internal */
 export async function _updateRecord(this: any): Promise<boolean> {
-  // Rails: _run_update_callbacks { record_update_timestamps { super } } — returns boolean.
+  // Rails: _run_update_callbacks { record_update_timestamps { super } }, whose
+  // value is the block's return. As in _createRecord, Rails' `result != false`
+  // (create_or_update, persistence.rb:895) is applied here to keep the
+  // Promise<boolean> signature.
   // record_update_timestamps writes updated_at/updated_on when @_touch_record
   // and should_record_timestamps? are true, then yields to the actual update.
   const ctor = this.constructor;
-  return !!(await runAllCallbacks(ctor.prototype, "update", this, async () => {
-    // Mirror record_update_timestamps: write timestamp columns before the update
-    // when the model has record_timestamps enabled and has changes to save.
-    // Mirror record_update_timestamps: use _skipTouch (Rails' @_touch_record flag)
-    // and the shared currentTimeFromProperTimezone() helper (Temporal.Instant).
-    // With partial_writes=false Rails always issues an UPDATE; treat it as having changes.
-    const hasChanges =
-      !ctor.partialUpdates ||
-      ("hasChangesToSave" in this
-        ? !!(this.hasChangesToSave as boolean)
-        : Object.keys(this.changes ?? {}).length > 0);
-    const instanceRecordTs = this.recordTimestamps ?? ctor.recordTimestamps;
-    const wroteTimestamps = !this._skipTouch && instanceRecordTs !== false && hasChanges;
-    if (wroteTimestamps) {
-      const time = currentTimeFromProperTimezone();
-      const updateAttrs = timestampAttributesForUpdateInModel.call(ctor);
-      for (const col of updateAttrs) {
-        if (ctor._attributeDefinitions?.has(col) && !this.willSaveChangeToAttribute?.(col)) {
-          this.writeAttribute?.(col, time);
+  return (
+    (await runAllCallbacks(ctor.prototype, "update", this, async () => {
+      // Mirror record_update_timestamps: write timestamp columns before the update
+      // when the model has record_timestamps enabled and has changes to save.
+      // Mirror record_update_timestamps: use _skipTouch (Rails' @_touch_record flag)
+      // and the shared currentTimeFromProperTimezone() helper (Temporal.Instant).
+      // With partial_writes=false Rails always issues an UPDATE; treat it as having changes.
+      const hasChanges =
+        !ctor.partialUpdates ||
+        ("hasChangesToSave" in this
+          ? !!(this.hasChangesToSave as boolean)
+          : Object.keys(this.changes ?? {}).length > 0);
+      const instanceRecordTs = this.recordTimestamps ?? ctor.recordTimestamps;
+      const wroteTimestamps = !this._skipTouch && instanceRecordTs !== false && hasChanges;
+      if (wroteTimestamps) {
+        const time = currentTimeFromProperTimezone();
+        const updateAttrs = timestampAttributesForUpdateInModel.call(ctor);
+        for (const col of updateAttrs) {
+          if (ctor._attributeDefinitions?.has(col) && !this.willSaveChangeToAttribute?.(col)) {
+            this.writeAttribute?.(col, time);
+          }
         }
       }
-    }
-    if (!this._performUpdate) throw new Error("_performUpdate not implemented");
-    // _performUpdate also auto-touches updated_at; skip its inner write when:
-    //   - the outer wrapper just handled timestamps, OR
-    //   - recordTimestamps is disabled, OR
-    //   - there are no dirty changes (Rails no-op — don't auto-touch and don't
-    //     desync updated_at vs updated_on by writing inside the inner layer).
-    // Rails: Timestamp#_update_record writes once via record_update_timestamps;
-    // super does not.
-    const previousSkipTouch = this._skipTouch;
-    const skipInnerTouch = wroteTimestamps || instanceRecordTs === false || !hasChanges;
-    if (skipInnerTouch) this._skipTouch = true;
-    try {
-      await this._performUpdate();
-    } finally {
-      this._skipTouch = previousSkipTouch;
-    }
-    if (this._pendingOperation) {
-      await this._pendingOperation;
-      this._pendingOperation = null;
-    }
-    this._previouslyNewRecord = false;
-    this.changesApplied();
-    // Rails' block is `super`, whose truthy return becomes run_callbacks' value.
-    return true;
-  }));
+      if (!this._performUpdate) throw new Error("_performUpdate not implemented");
+      // _performUpdate also auto-touches updated_at; skip its inner write when:
+      //   - the outer wrapper just handled timestamps, OR
+      //   - recordTimestamps is disabled, OR
+      //   - there are no dirty changes (Rails no-op — don't auto-touch and don't
+      //     desync updated_at vs updated_on by writing inside the inner layer).
+      // Rails: Timestamp#_update_record writes once via record_update_timestamps;
+      // super does not.
+      const previousSkipTouch = this._skipTouch;
+      const skipInnerTouch = wroteTimestamps || instanceRecordTs === false || !hasChanges;
+      if (skipInnerTouch) this._skipTouch = true;
+      try {
+        await this._performUpdate();
+      } finally {
+        this._skipTouch = previousSkipTouch;
+      }
+      if (this._pendingOperation) {
+        await this._pendingOperation;
+        this._pendingOperation = null;
+      }
+      this._previouslyNewRecord = false;
+      this.changesApplied();
+      // Rails' block is `super`, whose truthy return becomes run_callbacks' value.
+      return true;
+    })) !== false
+  );
 }

--- a/packages/activerecord/src/callbacks.ts
+++ b/packages/activerecord/src/callbacks.ts
@@ -299,7 +299,7 @@ export function createOrUpdate(this: any): Promise<boolean> {
 export async function _createRecord(this: any): Promise<boolean> {
   // Rails: _run_create_callbacks { super } — returns whether callbacks completed.
   const ctor = this.constructor;
-  return runAllCallbacks(ctor.prototype, "create", this, async () => {
+  return !!(await runAllCallbacks(ctor.prototype, "create", this, async () => {
     if (!this._performInsert) throw new Error("_performInsert not implemented");
     // Reinstate constructor-assigned attrs as dirty vs schema defaults BEFORE the
     // insert. Rails new records are dirty from construction, so partial_inserts'
@@ -326,7 +326,9 @@ export async function _createRecord(this: any): Promise<boolean> {
     this._previouslyNewRecord = true;
     this._newRecord = false;
     this.changesApplied();
-  });
+    // Rails' block is `super`, whose truthy return becomes run_callbacks' value.
+    return true;
+  }));
 }
 
 /** @internal */
@@ -335,7 +337,7 @@ export async function _updateRecord(this: any): Promise<boolean> {
   // record_update_timestamps writes updated_at/updated_on when @_touch_record
   // and should_record_timestamps? are true, then yields to the actual update.
   const ctor = this.constructor;
-  return runAllCallbacks(ctor.prototype, "update", this, async () => {
+  return !!(await runAllCallbacks(ctor.prototype, "update", this, async () => {
     // Mirror record_update_timestamps: write timestamp columns before the update
     // when the model has record_timestamps enabled and has changes to save.
     // Mirror record_update_timestamps: use _skipTouch (Rails' @_touch_record flag)
@@ -379,5 +381,7 @@ export async function _updateRecord(this: any): Promise<boolean> {
     }
     this._previouslyNewRecord = false;
     this.changesApplied();
-  });
+    // Rails' block is `super`, whose truthy return becomes run_callbacks' value.
+    return true;
+  }));
 }

--- a/packages/activesupport/src/callbacks.test.ts
+++ b/packages/activesupport/src/callbacks.test.ts
@@ -285,6 +285,7 @@ describe("Callbacks", () => {
 
       const result = runCallbacks(target, "save", () => {
         target.log.push("block");
+        return true;
       });
 
       expect(result).toBe(true);
@@ -318,7 +319,9 @@ describe("Callbacks", () => {
       const result = runCallbacks(target, "save", () => {
         target.log.push("block");
       });
-      expect(result).toBe(false);
+      // Rails: an around that never yields leaves env.value unset, and
+      // run_callbacks returns env.value — nil, not false.
+      expect(result).toBeUndefined();
       expect(target.log).toEqual(["around"]);
     });
 
@@ -1491,18 +1494,22 @@ describe("UsingObjectTest", () => {
     save(u);
     expect(u.record).toEqual(["around before", "yielded", "around after"]);
   });
+  // Mirrors Rails CustomScopeObject#save, whose run_callbacks block ends in
+  // "CallbackResult" — run_callbacks returns env.value, i.e. the block's value.
+  const customScopeSave = (u: { record: string[] }) =>
+    runCallbacks(u, "save", () => {
+      u.record.push("yielded");
+      return "CallbackResult";
+    });
+
   it("customized object", () => {
     const u = customScopeObject();
-    save(u);
+    customScopeSave(u);
     expect(u.record).toEqual(["before save", "yielded"]);
   });
   it("block result is returned", () => {
-    const target = { result: "" };
-    defineCallbacks(target, "save");
-    runCallbacks(target, "save", () => {
-      target.result = "done";
-    });
-    expect(target.result).toBe("done");
+    const u = customScopeObject();
+    expect(customScopeSave(u)).toBe("CallbackResult");
   });
 });
 
@@ -1894,7 +1901,10 @@ describe("Callbacks — async propagation", () => {
     defineCallbacks(t, "save");
     setCallback(t, "save", "before", (x: any) => x.log.push("b"));
     setCallback(t, "save", "after", (x: any) => x.log.push("a"));
-    const r = runCallbacks(t, "save", () => t.log.push("block"));
+    const r = runCallbacks(t, "save", () => {
+      t.log.push("block");
+      return true;
+    });
     expect(r).toBe(true);
     expect(typeof (r as any)?.then).toBe("undefined");
     expect(t.log).toEqual(["b", "block", "a"]);

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -840,12 +840,6 @@ export class CallbackSequence {
     }
   }
 
-  invoke(
-    target: object,
-    block: (() => unknown) | undefined,
-    opts: RunCallbacksOptions & { strict: "sync" },
-  ): unknown;
-  invoke(target: object, block?: () => unknown, opts?: RunCallbacksOptions): unknown;
   invoke(target: object, block?: () => unknown, opts?: RunCallbacksOptions): unknown {
     const chainName = this._callbackChain?.name ?? "";
     const env: FilterEnvironment = { target, halted: false, value: undefined };
@@ -872,8 +866,8 @@ export class CallbackSequence {
    * with the continuation as their block (`expand_call_template` + `send`), and
    * running each `invoke_after` as the recursion unwinds. Async is threaded with
    * the same fire-and-forget / awaited-rescue semantics the retired
-   * `_runAroundAndAfter` provided. Returns whether the final block executed
-   * without the chain halting.
+   * `_runAroundAndAfter` provided. Returns `env.value` — Rails' invoke_sequence
+   * Proc ends in `break env.value`.
    */
   private _invokeAround(
     env: FilterEnvironment,
@@ -1361,18 +1355,6 @@ export namespace Callbacks {
   export function runCallbacks(
     target: object,
     name: string,
-    block: (() => unknown) | undefined,
-    opts: RunCallbacksOptions & { strict: "sync" },
-  ): unknown;
-  export function runCallbacks(
-    target: object,
-    name: string,
-    block?: () => unknown,
-    opts?: RunCallbacksOptions,
-  ): unknown;
-  export function runCallbacks(
-    target: object,
-    name: string,
     block?: () => unknown,
     opts?: RunCallbacksOptions,
   ): unknown {
@@ -1424,18 +1406,6 @@ export function resetCallbacks(target: object, name: string): void {
   Callbacks.resetCallbacks(target, name);
 }
 
-export function runCallbacks(
-  target: object,
-  name: string,
-  block: (() => unknown) | undefined,
-  opts: RunCallbacksOptions & { strict: "sync" },
-): unknown;
-export function runCallbacks(
-  target: object,
-  name: string,
-  block?: () => unknown,
-  opts?: RunCallbacksOptions,
-): unknown;
 export function runCallbacks(
   target: object,
   name: string,
@@ -1497,12 +1467,6 @@ export function CallbacksMixin<TBase extends new (...args: any[]) => object>(Bas
       resetCallbacks(this.prototype, name);
     }
 
-    runCallbacks(
-      name: string,
-      block: (() => unknown) | undefined,
-      opts: RunCallbacksOptions & { strict: "sync" },
-    ): unknown;
-    runCallbacks(name: string, block?: () => unknown, opts?: RunCallbacksOptions): unknown;
     runCallbacks(name: string, block?: () => unknown, opts?: RunCallbacksOptions): unknown {
       return runCallbacks(this, name, block, opts);
     }

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -844,17 +844,9 @@ export class CallbackSequence {
     target: object,
     block: (() => unknown) | undefined,
     opts: RunCallbacksOptions & { strict: "sync" },
-  ): boolean;
-  invoke(
-    target: object,
-    block?: () => unknown,
-    opts?: RunCallbacksOptions,
-  ): boolean | Promise<boolean>;
-  invoke(
-    target: object,
-    block?: () => unknown,
-    opts?: RunCallbacksOptions,
-  ): boolean | Promise<boolean> {
+  ): unknown;
+  invoke(target: object, block?: () => unknown, opts?: RunCallbacksOptions): unknown;
+  invoke(target: object, block?: () => unknown, opts?: RunCallbacksOptions): unknown {
     const chainName = this._callbackChain?.name ?? "";
     const env: FilterEnvironment = { target, halted: false, value: undefined };
 
@@ -888,9 +880,7 @@ export class CallbackSequence {
     block: (() => unknown) | undefined,
     opts: RunCallbacksOptions | undefined,
     chainName: string,
-  ): boolean | Promise<boolean> {
-    let reachedFinal = false;
-
+  ): unknown {
     // Final sequence: env.value = !halted && (!block || yield); then invoke_after.
     const runFinal = (current: CallbackSequence): void | Promise<void> => {
       if (env.halted) {
@@ -905,12 +895,10 @@ export class CallbackSequence {
         }
         return Promise.resolve(y).then((v) => {
           env.value = v;
-          reachedFinal = true;
           return current.invokeAfter(env, opts, chainName);
         });
       }
       env.value = y;
-      reachedFinal = true;
       return current.invokeAfter(env, opts, chainName);
     };
 
@@ -1024,8 +1012,8 @@ export class CallbackSequence {
     };
 
     const result = runSeq(this);
-    if (isThenable(result)) return Promise.resolve(result).then(() => reachedFinal);
-    return reachedFinal;
+    if (isThenable(result)) return Promise.resolve(result).then(() => env.value);
+    return env.value;
   }
 
   private _finishFinal(
@@ -1033,7 +1021,7 @@ export class CallbackSequence {
     block: (() => unknown) | undefined,
     opts: RunCallbacksOptions | undefined,
     chainName: string,
-  ): boolean | Promise<boolean> {
+  ): unknown {
     // Rails: env.value = !env.halted && (!block_given? || yield)
     if (env.halted) {
       env.value = false;
@@ -1050,14 +1038,14 @@ export class CallbackSequence {
       return Promise.resolve(y).then((v) => {
         env.value = v;
         const afterDone = this.invokeAfter(env, opts, chainName);
-        if (isThenable(afterDone)) return Promise.resolve(afterDone).then(() => true);
-        return true;
+        if (isThenable(afterDone)) return Promise.resolve(afterDone).then(() => env.value);
+        return env.value;
       });
     }
     env.value = y;
     const afterDone = this.invokeAfter(env, opts, chainName);
-    if (isThenable(afterDone)) return Promise.resolve(afterDone).then(() => true);
-    return true;
+    if (isThenable(afterDone)) return Promise.resolve(afterDone).then(() => env.value);
+    return env.value;
   }
 
   // Back-reference set by CallbackChain.compile() for invoke() convenience
@@ -1375,29 +1363,30 @@ export namespace Callbacks {
     name: string,
     block: (() => unknown) | undefined,
     opts: RunCallbacksOptions & { strict: "sync" },
-  ): boolean;
+  ): unknown;
   export function runCallbacks(
     target: object,
     name: string,
     block?: () => unknown,
     opts?: RunCallbacksOptions,
-  ): boolean | Promise<boolean>;
+  ): unknown;
   export function runCallbacks(
     target: object,
     name: string,
     block?: () => unknown,
     opts?: RunCallbacksOptions,
-  ): boolean | Promise<boolean> {
+  ): unknown {
     const chains = getCallbackChains(target);
     const chain = chains.get(name);
     if (!chain) {
+      // Rails: `yield if block_given?` — the block's value, not a boolean.
       const r = block?.();
-      if (!isThenable(r)) return true;
+      if (!isThenable(r)) return r;
       if (opts?.strict === "sync") {
         swallowRejection(r);
         throw new Error("Async block on chain with no callbacks");
       }
-      return Promise.resolve(r).then(() => true);
+      return r;
     }
     const sequence = chain.compile();
     return sequence.invoke(target, block, opts);
@@ -1440,19 +1429,19 @@ export function runCallbacks(
   name: string,
   block: (() => unknown) | undefined,
   opts: RunCallbacksOptions & { strict: "sync" },
-): boolean;
+): unknown;
 export function runCallbacks(
   target: object,
   name: string,
   block?: () => unknown,
   opts?: RunCallbacksOptions,
-): boolean | Promise<boolean>;
+): unknown;
 export function runCallbacks(
   target: object,
   name: string,
   block?: () => unknown,
   opts?: RunCallbacksOptions,
-): boolean | Promise<boolean> {
+): unknown {
   return Callbacks.runCallbacks(target, name, block, opts);
 }
 
@@ -1512,17 +1501,9 @@ export function CallbacksMixin<TBase extends new (...args: any[]) => object>(Bas
       name: string,
       block: (() => unknown) | undefined,
       opts: RunCallbacksOptions & { strict: "sync" },
-    ): boolean;
-    runCallbacks(
-      name: string,
-      block?: () => unknown,
-      opts?: RunCallbacksOptions,
-    ): boolean | Promise<boolean>;
-    runCallbacks(
-      name: string,
-      block?: () => unknown,
-      opts?: RunCallbacksOptions,
-    ): boolean | Promise<boolean> {
+    ): unknown;
+    runCallbacks(name: string, block?: () => unknown, opts?: RunCallbacksOptions): unknown;
+    runCallbacks(name: string, block?: () => unknown, opts?: RunCallbacksOptions): unknown {
       return runCallbacks(this, name, block, opts);
     }
 


### PR DESCRIPTION
Rails' `run_callbacks` returns `env.value` — the block's return value — and
`false` only when the chain halts
([callbacks.rb](https://github.com/rails/rails/blob/main/activesupport/lib/active_support/callbacks.rb)).
trails returned a boolean ("did the final block run without the chain halting"),
so Rails' `test_block_result_is_returned` could not be asserted through the
public API — the trails port checked a side effect instead.

## Changes

- `CallbackSequence#invoke`, `_finishFinal`, and `_invokeAround` now return
  `env.value`; the `reachedFinal` bookkeeping is gone.
- Every `runCallbacks` wrapper (namespace, module-level, `CallbacksMixin`,
  `Model#runCallbacks`) and activemodel's `runAllCallbacks` /
  `runBeforeCallbacksOnProto` return `unknown`.
- The empty-chain branch mirrors Rails' `yield if block_given?` — the block's
  value, not `true`.
- Ported `test_block_result_is_returned` asserting the returned value is
  `"CallbackResult"`, via a `customScopeSave` helper mirroring Rails'
  `CustomScopeObject#save`.

## Caller audit

All `runAllCallbacks` / `runCallbacks` gates were checked. `false`-on-halt is
preserved, so truthiness gates still hold. Three blocks previously returned
`undefined` (JS void) where Rails' block is `super` with a truthy return — they
now `return true` explicitly:

- `base.ts` `destroy` (`_run_destroy_callbacks { super }`)
- `callbacks.ts` `_createRecord` / `_updateRecord`
- `model.ts` `valid?` (`run_validations!`)

`save` already threaded `saved` as the block value. `_createRecord` /
`_updateRecord` coerce with `!!` to keep their `Promise<boolean>` signature.

One behavior refinement: an around callback that never yields now returns
`undefined` rather than `false` — matching Rails, where `env.value` is never
assigned in that path. Both are falsy, so no gate changes.

## Testing

`typecheck`, `lint`, and the activesupport/activemodel/activerecord callback,
persistence, transaction, validation, base and actionpack suites all pass.

Closes-story: runcallbacks-returns-block-value
