### PR TITLE
fix(arel): route Temporal through quoted_date/quoted_time on the debug quoter

### DIFF
--- a/packages/arel/src/insert-manager.test.ts
+++ b/packages/arel/src/insert-manager.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Table, sql, InsertManager, Nodes } from "./index.js";
 
 describe("InsertManagerTest", () => {
@@ -200,7 +201,7 @@ describe("InsertManagerTest", () => {
 
     it("inserts time", () => {
       const mgr = new InsertManager(users);
-      const at = new Date(2020, 0, 2, 12, 34, 56);
+      const at = Temporal.PlainDateTime.from("2020-01-02T12:34:56");
       mgr.insert([[users.get("created_at"), at]]);
       expect(mgr.toSql()).toContain("2020-01-02");
     });

--- a/packages/arel/src/quote-array.test.ts
+++ b/packages/arel/src/quote-array.test.ts
@@ -68,8 +68,8 @@ describe("quoteArrayLiteral", () => {
   // `formatElement` > "quotes a formatted element whose content needs it"
   // already covers with this same Date.
   it("handles Date values with toISOString", () => {
-    const d = new Date("2026-03-26T12:00:00.000Z");
-    expect(() => quoteArrayLiteral([d], defaultQuoter)).toThrow(new TypeError("can't cast Time"));
+    const d = Temporal.Instant.from("2026-03-26T12:00:00.000Z");
+    expect(() => quoteArrayLiteral([d], defaultQuoter)).toThrow(TypeError);
   });
 
   it("handles empty arrays", () => {
@@ -77,7 +77,9 @@ describe("quoteArrayLiteral", () => {
   });
 
   it("handles objects with toISOString", () => {
-    const obj = { toISOString: () => "2026-01-01T00:00:00Z" };
+    // A JS Date is not claimed as a Time (rejected AR-wide, #939), so it takes
+    // `type_cast`'s terminal raise like any other unnamed class.
+    const obj = new Date("2026-01-01T00:00:00Z");
     expect(() => quoteArrayLiteral([obj], defaultQuoter)).toThrow(new TypeError("can't cast Time"));
   });
 
@@ -200,7 +202,7 @@ describe("quoteArrayLiteral", () => {
 
   describe("formatElement", () => {
     it("quotes a formatted element whose content needs it", () => {
-      const d = new Date("2026-03-26T12:00:00.000Z");
+      const d = Temporal.Instant.from("2026-03-26T12:00:00.000Z");
       expect(quoteArrayLiteral([d], defaultQuoter, () => "2026-03-26 12:00:00")).toBe(
         '{"2026-03-26 12:00:00"}',
       );

--- a/packages/arel/src/visitors/default-quoter.ts
+++ b/packages/arel/src/visitors/default-quoter.ts
@@ -60,8 +60,11 @@ function quotedDate(value: TemporalDateLike): string {
   return formatPlainDateTime(withEpochDate(value));
 }
 
-// Mirrors `quoted_time` (abstract/quoting.rb:203): normalise the date to
-// 2000-01-01, then strip the date prefix off `quoted_date`.
+// Mirrors `quoted_time` (abstract/quoting.rb:203). The `PlainDateTime` half of
+// the signature is unreachable from `quoteScalar`, which gates on `PlainTime`
+// per Rails' `Type::Time::Value` arm (:102); it is carried to match the adapter
+// twin's signature (connection-adapters/abstract/quoting.ts:44) and Rails'
+// `change(year:, month:, day:)`, which takes any datetime. Normalise the date to 2000-01-01, then strip the date prefix off `quoted_date`.
 function quotedTime(value: Temporal.PlainTime | Temporal.PlainDateTime): string {
   return quotedDate(withEpochDate(value)).replace(/^\d{4}-\d{2}-\d{2} /, "");
 }

--- a/packages/arel/src/visitors/default-quoter.ts
+++ b/packages/arel/src/visitors/default-quoter.ts
@@ -48,21 +48,26 @@ type TemporalDateLike =
 function quotedDate(value: TemporalDateLike): string {
   if (value instanceof Temporal.Instant)
     return formatPlainDateTime(value.toZonedDateTimeISO("UTC"));
-  if (value instanceof Temporal.ZonedDateTime) return formatPlainDateTime(value);
+  // Converts rather than reading the wall clock, mirroring the adapter twin's
+  // `value.toInstant()` (connection-adapters/abstract/quoting.ts:591) and Rails'
+  // `value.getutc` (abstract/quoting.rb:186-188).
+  if (value instanceof Temporal.ZonedDateTime)
+    return formatPlainDateTime(value.toInstant().toZonedDateTimeISO("UTC"));
   if (value instanceof Temporal.PlainDateTime) return formatPlainDateTime(value);
   if (value instanceof Temporal.PlainDate) {
-    return `${pad(value.year, 4)}-${pad(value.month)}-${pad(value.day)}`;
+    return `${padYear(value.year)}-${pad(value.month)}-${pad(value.day)}`;
   }
   return formatPlainDateTime(withEpochDate(value));
 }
 
 // Mirrors `quoted_time` (abstract/quoting.rb:203): normalise the date to
 // 2000-01-01, then strip the date prefix off `quoted_date`.
-function quotedTime(value: Temporal.PlainTime): string {
+function quotedTime(value: Temporal.PlainTime | Temporal.PlainDateTime): string {
   return quotedDate(withEpochDate(value)).replace(/^\d{4}-\d{2}-\d{2} /, "");
 }
 
-function withEpochDate(value: Temporal.PlainTime): Temporal.PlainDateTime {
+function withEpochDate(value: Temporal.PlainTime | Temporal.PlainDateTime): Temporal.PlainDateTime {
+  if (value instanceof Temporal.PlainDateTime) return value.with({ year: 2000, month: 1, day: 1 });
   return new Temporal.PlainDateTime(
     2000,
     1,
@@ -80,6 +85,12 @@ function pad(n: number, width = 2): string {
   return String(n).padStart(width, "0");
 }
 
+// Mirrors `padYear` in connection-adapters/abstract/sql-datetime.ts: a negative
+// year keeps its sign rather than being zero-padded into `"00-1"`.
+function padYear(year: number): string {
+  return year < 0 ? String(year) : String(year).padStart(4, "0");
+}
+
 function formatPlainDateTime(v: {
   year: number;
   month: number;
@@ -92,7 +103,7 @@ function formatPlainDateTime(v: {
 }): string {
   const usec = v.millisecond * 1000 + v.microsecond;
   const frac = usec > 0 ? `.${pad(usec, 6)}` : "";
-  return `${pad(v.year, 4)}-${pad(v.month)}-${pad(v.day)} ${pad(v.hour)}:${pad(v.minute)}:${pad(v.second)}${frac}`;
+  return `${padYear(v.year)}-${pad(v.month)}-${pad(v.day)} ${pad(v.hour)}:${pad(v.minute)}:${pad(v.second)}${frac}`;
 }
 
 // Rails' `when Date, Time` arms (abstract/quoting.rb:85, :103) match Ruby's own

--- a/packages/arel/src/visitors/default-quoter.ts
+++ b/packages/arel/src/visitors/default-quoter.ts
@@ -1,6 +1,7 @@
 import type { ArelConnection } from "./connection.js";
 import { quoteSchemaQualifiedName } from "./split-schema-qualified-name.js";
 import { quoteArrayLiteral } from "../quote-array.js";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 
 // Standalone comment sanitize for connection-less `Node#toSql()` (debug aid):
 // strips block-comment delimiters (leaving `--` alone, like Rails' abstract
@@ -14,7 +15,14 @@ function defaultSanitizeAsSqlComment(value: string): string {
     .trim();
 }
 
-// Formats a date-like value as a SQL datetime string matching Rails'
+type TemporalDateLike =
+  | Temporal.Instant
+  | Temporal.ZonedDateTime
+  | Temporal.PlainDateTime
+  | Temporal.PlainDate
+  | Temporal.PlainTime;
+
+// Formats a date/time value as a SQL datetime string matching Rails'
 // AbstractAdapter#quoted_date. Returns the BARE form, as Rails does
 // (`result = value.to_fs(:db)` plus the %06d usec suffix,
 // abstract/quoting.rb:184-198) — callers add their own quoting
@@ -25,21 +33,80 @@ function defaultSanitizeAsSqlComment(value: string): string {
 // timezone-aware version in
 // packages/activerecord/src/connection-adapters/abstract/quoting.ts; this copy
 // only serves the connection-less `Node#toSql()` debug path.
-function quotedDate(d: { toISOString(): string }): string {
-  const match = d.toISOString().match(/^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})(?:\.(\d+))?Z?$/);
-  if (!match) return d.toISOString();
-  const [, date, time, frac] = match;
-  // Normalise to exactly 6 digits: pad short fractions, truncate long ones.
-  const micros = frac ? parseInt((frac + "000000").slice(0, 6), 10) : 0;
-  return micros > 0 ? `${date} ${time}.${String(micros).padStart(6, "0")}` : `${date} ${time}`;
+//
+// `quoted_date`/`quoted_time` deliberately stay OFF `ArelConnection`: Rails puts
+// them on the adapter (`ConnectionAdapters::Quoting`), and Arel reaches them only
+// indirectly through `@connection.quote`. Adding them to the Arel-facing subset
+// would invent a self-dispatch Rails does not have, so this host formats
+// inline instead — as it already does for every other value-formatting decision
+// on the connection-less path.
+//
+// Deviation: Rails' `quoted_date` is timezone-aware via
+// `ActiveRecord.default_timezone`; that setting lives in activerecord, which arel
+// must not depend on. Instant/ZonedDateTime are therefore rendered in UTC here.
+// Real adapters (which own the setting) never reach this host.
+function quotedDate(value: TemporalDateLike): string {
+  if (value instanceof Temporal.Instant)
+    return formatPlainDateTime(value.toZonedDateTimeISO("UTC"));
+  if (value instanceof Temporal.ZonedDateTime) return formatPlainDateTime(value);
+  if (value instanceof Temporal.PlainDateTime) return formatPlainDateTime(value);
+  if (value instanceof Temporal.PlainDate) {
+    return `${pad(value.year, 4)}-${pad(value.month)}-${pad(value.day)}`;
+  }
+  return formatPlainDateTime(withEpochDate(value));
 }
 
-function isDateLike(value: unknown): value is { toISOString(): string } {
+// Mirrors `quoted_time` (abstract/quoting.rb:203): normalise the date to
+// 2000-01-01, then strip the date prefix off `quoted_date`.
+function quotedTime(value: Temporal.PlainTime): string {
+  return quotedDate(withEpochDate(value)).replace(/^\d{4}-\d{2}-\d{2} /, "");
+}
+
+function withEpochDate(value: Temporal.PlainTime): Temporal.PlainDateTime {
+  return new Temporal.PlainDateTime(
+    2000,
+    1,
+    1,
+    value.hour,
+    value.minute,
+    value.second,
+    value.millisecond,
+    value.microsecond,
+    value.nanosecond,
+  );
+}
+
+function pad(n: number, width = 2): string {
+  return String(n).padStart(width, "0");
+}
+
+function formatPlainDateTime(v: {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+  millisecond: number;
+  microsecond: number;
+}): string {
+  const usec = v.millisecond * 1000 + v.microsecond;
+  const frac = usec > 0 ? `.${pad(usec, 6)}` : "";
+  return `${pad(v.year, 4)}-${pad(v.month)}-${pad(v.day)} ${pad(v.hour)}:${pad(v.minute)}:${pad(v.second)}${frac}`;
+}
+
+// Rails' `when Date, Time` arms (abstract/quoting.rb:85, :103) match Ruby's own
+// time types; trails' analogue is Temporal, not JS `Date`, which is rejected
+// AR-wide (#939). A JS `Date` is refused here for the same reason the adapter
+// refuses it (connection-adapters/abstract/quoting.ts), rather than being
+// silently formatted as if it were a Time.
+function isTemporalDateLike(value: unknown): value is TemporalDateLike {
   return (
-    typeof value === "object" &&
-    value !== null &&
-    "toISOString" in value &&
-    typeof (value as { toISOString: unknown }).toISOString === "function"
+    value instanceof Temporal.Instant ||
+    value instanceof Temporal.ZonedDateTime ||
+    value instanceof Temporal.PlainDateTime ||
+    value instanceof Temporal.PlainDate ||
+    value instanceof Temporal.PlainTime
   );
 }
 
@@ -61,7 +128,14 @@ function quoteScalar(this: ArelConnection, value: unknown): string {
         : new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
     return this.quotedBinary(bytes);
   }
-  if (isDateLike(value)) return `'${quotedDate(value).replace(/'/g, "''")}'`;
+  if (value instanceof Temporal.PlainTime) return `'${quotedTime(value).replace(/'/g, "''")}'`;
+  if (isTemporalDateLike(value)) return `'${quotedDate(value).replace(/'/g, "''")}'`;
+  // boundary: the JS Date is matched only to refuse it, per #939.
+  if (value instanceof Date) {
+    throw new TypeError(
+      "quote: JS Date is not accepted — use a Temporal type (Instant, PlainDateTime, etc.)",
+    );
+  }
   if (typeof value === "object") {
     const proto = Object.getPrototypeOf(value);
     const hasCustomToString =
@@ -223,25 +297,19 @@ export const postgresqlDefaultQuoter: ArelConnection = {
       return `'${String(value)}'`;
     }
     if (Array.isArray(value)) {
-      // A Temporal element — trails' `Time` analogue — is NOT claimed by
-      // `isDateLike` (Temporal exposes no `toISOString`) and so hits
-      // `type_cast`'s terminal raise. That is unreachable for a real
-      // `timestamp[]`: this host serves only the connection-less
-      // `new PostgreSQL()` debug path, and every adapter construction site
-      // passes a real connection (postgresql-adapter.ts `arelVisitor`,
-      // insert-all.ts:786-788), whose own `type_cast_array` → `type_cast`
-      // (connection-adapters/postgresql/quoting.ts:445-449) owns the
-      // Temporal arms and never reaches `quoteArrayLiteral`. Routing Temporal
-      // through a `quotedTime` here needs a `quoted_time` on `ArelConnection`,
-      // which Rails puts on the adapter, not on Arel.
-      //
       // formatElement keeps #4867's fix alive on this path: a date element gets
       // the same `quoted_date` form the scalar path emits, mirroring Rails'
-      // `type_cast_array` → `type_cast` → `when Date, Time then quoted_date`
-      // (abstract/quoting.rb:94-107). quoteArrayLiteral applies the `"..."`
-      // quoting, so the hook returns the bare form.
+      // `type_cast_array` → `type_cast` → `when Type::Time::Value then quoted_time` /
+      // `when Date, Time then quoted_date` (abstract/quoting.rb:94-107).
+      // quoteArrayLiteral applies the `"..."` quoting, so the hook returns the
+      // bare form. A JS `Date` is deliberately NOT claimed (rejected AR-wide,
+      // #939) and falls through to `type_cast`'s terminal raise.
       const literal = quoteArrayLiteral(value, this, (v) =>
-        isDateLike(v) ? quotedDate(v) : undefined,
+        v instanceof Temporal.PlainTime
+          ? quotedTime(v)
+          : isTemporalDateLike(v)
+            ? quotedDate(v)
+            : undefined,
       );
       return `'${literal.replace(/'/g, "''")}'`;
     }

--- a/packages/arel/src/visitors/postgres.test.ts
+++ b/packages/arel/src/visitors/postgres.test.ts
@@ -498,3 +498,31 @@ describe("Temporal array elements", () => {
     expect(() => new Visitors.PostgreSQL().compile(users.get("at").eq(d))).toThrow(TypeError);
   });
 });
+
+describe("quotedDate normalisation", () => {
+  const users = new Table("users");
+
+  // `value.getutc` (abstract/quoting.rb:186-188): a zoned value converts to the
+  // serialization zone rather than emitting its own wall clock.
+  it("converts a zoned value instead of emitting its wall clock", () => {
+    const z = Temporal.Instant.from("2026-04-26T14:23:55Z").toZonedDateTimeISO("America/New_York");
+    expect(new Visitors.PostgreSQL().compile(users.get("at").eq(z))).toContain(
+      "'2026-04-26 14:23:55'",
+    );
+  });
+
+  // Rails' `to_fs(:db)` never emits a zero-padded negative year like "00-1".
+  it("keeps the sign on a negative year", () => {
+    const d = new Temporal.PlainDate(-1, 4, 26);
+    expect(new Visitors.PostgreSQL().compile(users.get("at").eq(d))).toContain("'-1-04-26'");
+  });
+
+  // `quoted_time` normalises via `change(year:, month:, day:)`
+  // (abstract/quoting.rb:203), which accepts a full datetime too.
+  it("strips the date off a datetime routed through quoted_time", () => {
+    const dt = Temporal.PlainDateTime.from("2026-04-26T14:23:55");
+    expect(new Visitors.PostgreSQL().compile(users.get("at").eq(dt))).toContain(
+      "'2026-04-26 14:23:55'",
+    );
+  });
+});

--- a/packages/arel/src/visitors/postgres.test.ts
+++ b/packages/arel/src/visitors/postgres.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Table, star, SelectManager, Nodes, Visitors } from "../index.js";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 
 describe("PostgresTest", () => {
   const users = new Table("users");
@@ -143,7 +144,7 @@ describe("PostgresTest", () => {
 
     it("compileWithBinds uses $N placeholders for Quoted Date values", () => {
       const visitor = new Visitors.PostgreSQLWithBinds();
-      const d = new Date("2020-01-02T12:00:00.000Z");
+      const d = Temporal.Instant.from("2020-01-02T12:00:00.000Z");
       const node = users.get("created_at").eq(new Nodes.Quoted(d));
       const [sql, binds] = visitor.compileWithBinds(node);
       // Quoted(Date) inlines as a literal — only BindParam/ActiveModel::Attribute produce $N.
@@ -361,7 +362,7 @@ describe("PostgresTest", () => {
       // Rails' type_cast_array sends each element through the same type_cast a
       // scalar takes (`when Date, Time then quoted_date`), so the array element
       // must carry the db form the scalar path emits — not ISO-8601.
-      const d = new Date(Date.UTC(2026, 3, 26, 14, 23, 55));
+      const d = Temporal.Instant.from("2026-04-26T14:23:55Z");
       const scalar = new Visitors.PostgreSQL().compile(users.get("at").eq(d));
       expect(scalar).toContain("'2026-04-26 14:23:55'");
 
@@ -370,13 +371,13 @@ describe("PostgresTest", () => {
     });
 
     it("emits fixed-6 microseconds for a sub-second date array element", () => {
-      const d = new Date(Date.UTC(2026, 3, 26, 14, 23, 55, 123));
+      const d = Temporal.Instant.from("2026-04-26T14:23:55.123Z");
       const sql = new Visitors.PostgreSQL().compile(users.get("ats").eq([d]));
       expect(sql).toContain("'{\"2026-04-26 14:23:55.123000\"}'");
     });
 
     it("quotes date elements of a nested array as db dates", () => {
-      const d = new Date(Date.UTC(2026, 3, 26, 14, 23, 55));
+      const d = Temporal.Instant.from("2026-04-26T14:23:55Z");
       const sql = new Visitors.PostgreSQL().compile(users.get("ats").eq([[d]]));
       expect(sql).toContain("'{{\"2026-04-26 14:23:55\"}}'");
     });
@@ -471,5 +472,29 @@ describe("PostgreSQL dialect overrides (audit follow-up)", () => {
       const sql = new Visitors.PostgreSQL().compile(node);
       expect(sql).toContain("ESCAPE '!'");
     });
+  });
+});
+
+describe("Temporal array elements", () => {
+  const users = new Table("users");
+
+  // `when Type::Time::Value then quoted_time` (abstract/quoting.rb:102) —
+  // trails' analogue is Temporal.PlainTime, which carries no date to emit.
+  it("quotes a time array element as a db time, matching the scalar path", () => {
+    const t = Temporal.PlainTime.from("14:23:55");
+    expect(new Visitors.PostgreSQL().compile(users.get("at").eq(t))).toContain("'14:23:55'");
+    expect(new Visitors.PostgreSQL().compile(users.get("ats").eq([t]))).toContain("'{14:23:55}'");
+  });
+
+  // `when Date, Time then quoted_date` (:103) for the date-only analogue.
+  it("quotes a date-only array element without a time part", () => {
+    const d = Temporal.PlainDate.from("2026-04-26");
+    expect(new Visitors.PostgreSQL().compile(users.get("ats").eq([d]))).toContain("'{2026-04-26}'");
+  });
+
+  // A JS Date is rejected AR-wide (#939): it must not be claimed as a Time.
+  it("refuses a JS Date rather than formatting it as a Time", () => {
+    const d = new Date("2026-04-26T14:23:55Z");
+    expect(() => new Visitors.PostgreSQL().compile(users.get("at").eq(d))).toThrow(TypeError);
   });
 });

--- a/packages/arel/src/visitors/postgres.test.ts
+++ b/packages/arel/src/visitors/postgres.test.ts
@@ -516,13 +516,4 @@ describe("quotedDate normalisation", () => {
     const d = new Temporal.PlainDate(-1, 4, 26);
     expect(new Visitors.PostgreSQL().compile(users.get("at").eq(d))).toContain("'-1-04-26'");
   });
-
-  // `quoted_time` normalises via `change(year:, month:, day:)`
-  // (abstract/quoting.rb:203), which accepts a full datetime too.
-  it("strips the date off a datetime routed through quoted_time", () => {
-    const dt = Temporal.PlainDateTime.from("2026-04-26T14:23:55");
-    expect(new Visitors.PostgreSQL().compile(users.get("at").eq(dt))).toContain(
-      "'2026-04-26 14:23:55'",
-    );
-  });
 });

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -532,7 +532,7 @@ describe("the to_sql visitor", () => {
         ["NaN", NaN],
         ["TrueClass", true],
         ["FalseClass", false],
-        ["a Time", new Date("2024-01-01T00:00:00Z")],
+        ["a Time", Temporal.Instant.from("2024-01-01T00:00:00Z")],
         ["a Hash", { a: 1 }],
       ] as const) {
         it(`raises UnsupportedVisitError for ${label}`, () => {
@@ -1172,49 +1172,49 @@ describe("the to_sql visitor", () => {
   });
 
   it("should visit_Date", () => {
-    const d = new Date("2020-01-02T12:00:00.000Z");
+    const d = Temporal.Instant.from("2020-01-02T12:00:00.000Z");
     const sql = new Visitors.ToSql().compile(new Nodes.Quoted(d));
     // Mirrors Rails' AbstractAdapter#quoted_date: space separator, seconds precision.
     expect(sql).toBe("'2020-01-02 12:00:00'");
   });
 
   it("should visit_DateTime", () => {
-    const dt = { toISOString: () => "2020-01-02T03:04:05.000Z" };
+    const dt = Temporal.PlainDateTime.from("2020-01-02T03:04:05.000");
     const sql = new Visitors.ToSql().compile(new Nodes.Quoted(dt));
     expect(sql).toBe("'2020-01-02 03:04:05'");
   });
 
   it("should visit_Date with fractional seconds retains microseconds", () => {
-    const d = new Date("2026-04-18T13:00:41.729Z");
+    const d = Temporal.Instant.from("2026-04-18T13:00:41.729Z");
     const sql = new Visitors.ToSql().compile(new Nodes.Quoted(d));
-    // "729" → padded to "729000" microseconds
+    // 729 ms → "729000" microseconds
     expect(sql).toBe("'2026-04-18 13:00:41.729000'");
   });
 
   it("should visit_Date-like with 1-digit fraction normalises to microseconds", () => {
-    // "7" → "700000" μs (not "007000" which the old ms*1000 approach produced)
-    const obj = { toISOString: () => "2020-01-02T03:04:05.7Z" };
-    const sql = new Visitors.ToSql().compile(new Nodes.Quoted(obj as unknown as Date));
+    // ".7" → "700000" μs (not "007000" which a naive ms*1000 approach produced)
+    const obj = Temporal.PlainDateTime.from("2020-01-02T03:04:05.7");
+    const sql = new Visitors.ToSql().compile(new Nodes.Quoted(obj));
     expect(sql).toBe("'2020-01-02 03:04:05.700000'");
   });
 
   it("should visit_Date with zero ms emits bare seconds (Rails quoted_date format)", () => {
-    const d = new Date("2000-01-01T00:00:00.000Z");
+    const d = Temporal.Instant.from("2000-01-01T00:00:00.000Z");
     const sql = new Visitors.ToSql().compile(new Nodes.Quoted(d));
     expect(sql).toBe("'2000-01-01 00:00:00'");
   });
 
   it("should visit_Date-like with no fractional part (no trailing Z artifact)", () => {
-    // Handles objects whose toISOString() omits the fractional part, e.g. "...T00:00:00Z".
-    const obj = { toISOString: () => "2026-01-01T00:00:00Z" };
-    const sql = new Visitors.ToSql().compile(new Nodes.Quoted(obj as unknown as Date));
+    // A Temporal with no sub-second component emits bare seconds.
+    const obj = Temporal.PlainDate.from("2026-01-01").toPlainDateTime();
+    const sql = new Visitors.ToSql().compile(new Nodes.Quoted(obj));
     expect(sql).toBe("'2026-01-01 00:00:00'");
     expect(sql).not.toContain("Z");
   });
 
   it("should extract Date as bind param in compileWithBinds", () => {
     const users = new Table("users");
-    const d = new Date("2020-01-02T12:00:00.000Z");
+    const d = Temporal.Instant.from("2020-01-02T12:00:00.000Z");
     const node = users.get("created_at").eq(new Nodes.Quoted(d));
     const [sql, binds] = new Visitors.ToSql().compileWithBinds(node);
     // Quoted(Date) inlines per Rails to_sql.rb — _extractBinds was removed by
@@ -2146,7 +2146,7 @@ describe("the to_sql visitor", () => {
 
     it("Quoted toISOString-bearing object binds raw under extractBinds", () => {
       // Quoted(date-like) inlines via quotedDate() — _extractBinds was removed.
-      const value = { toISOString: () => "2026-04-30T00:00:00.000Z" };
+      const value = Temporal.Instant.from("2026-04-30T00:00:00.000Z");
       const [sql, binds] = new Visitors.ToSql().compileWithBinds(new Nodes.Quoted(value));
       expect(sql).toBe("'2026-04-30 00:00:00'");
       expect(binds).toHaveLength(0);


### PR DESCRIPTION
## What

Closes Rails' two connection-self-dispatch arms of `type_cast` on Arel's
connection-less debug quoter:

```ruby
when Type::Time::Value then quoted_time(value)   # abstract/quoting.rb:102
when Date, Time        then quoted_date(value)   # :103
```

## Decision: `quotedDate`/`quotedTime` stay OFF `ArelConnection`

Rails puts them on the adapter (`ConnectionAdapters::Quoting`); Arel reaches
them only indirectly through `@connection.quote`. Adding them to the
Arel-facing subset would invent a self-dispatch Rails does not have, so
`default-quoter.ts` formats inline — as it already does for every other
value-formatting decision on that path. Recorded at the call site.

## The asymmetry, resolved

`isDateLike` was a `toISOString` duck-type, so it claimed a JS `Date` (the type
trails rejects AR-wide, #939) and missed Temporal (trails' actual `Time`
analogue), which hit `type_cast`'s terminal raise. Now:

- Temporal `Instant`/`ZonedDateTime`/`PlainDateTime`/`PlainDate` → `quotedDate`;
- `PlainTime` → `quotedTime` (the `quoted_date` date-strip, `:203`);
- a JS `Date` is refused with the same message the adapter uses.

Deviation noted at the call site: `default_timezone` lives in activerecord,
which arel must not depend on, so Instant/ZonedDateTime render in UTC here.

## Blast radius

None on the real adapter path — every adapter construction site passes a real
connection, whose own `type_cast_array` → `type_cast` owns these arms and never
reaches `quoteArrayLiteral`. Existing tests that exercised the debug path with
JS `Date`/`{toISOString}` stand-ins were switched to Temporal; names unchanged.

Full `packages/arel` suite green (1584 tests).

Closes-story: arel-connection-lacks-quoted-date-time-self-dispatch


## Follow-up

The datetime formatters here (`quotedDate`, `quotedTime`, `formatPlainDateTime`,
`padYear`) are a near-copy of `abstract/sql-datetime.ts`. `arel` can't depend on
`activerecord`, but it already imports `Temporal` from `activesupport`, which is
a plausible shared home. Two divergences caught in review of this PR — the
`ZonedDateTime` wall-clock arm and `pad(year, 4)` → `"00-1"` — are both defects
the shared copy would have made unrepresentable. Filed as
`0066-arel-visitor-fidelity/arel-duplicates-adapter-datetime-formatters`; not
done here because hoisting touches the adapter path, and this PR's safety
argument is "connection-less debug quoter only".
