### PR TITLE
fix(arel): NodeOrValue admits the visited Temporal types, drops JS Date

### DIFF
--- a/packages/arel/src/nodes/binary.ts
+++ b/packages/arel/src/nodes/binary.ts
@@ -24,7 +24,7 @@ export type NodeOrValue =
   // PlainMonthDay are deliberately absent: Rails has no visitor for them.
   // JS `Date` is absent too — it is rejected AR-wide (Temporal is the `Time`
   // analogue), and Rails aliases `visit_Date` to `unsupported`
-  // (to_sql.rb:918), so a `Date` in a node slot can only ever raise.
+  // (to_sql.rb:836), so a `Date` in a node slot can only ever raise.
   | Temporal.Instant
   | Temporal.ZonedDateTime
   | Temporal.PlainDateTime

--- a/packages/arel/src/nodes/binary.ts
+++ b/packages/arel/src/nodes/binary.ts
@@ -1,4 +1,5 @@
 import type { Attribute as ModelAttribute } from "@blazetrails/activemodel";
+import type { Temporal } from "@blazetrails/activesupport/temporal";
 import { Node, NodeVisitor } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
 import { SqlLiteral } from "./sql-literal.js";
@@ -18,7 +19,17 @@ export type NodeOrValue =
   | number
   | boolean
   | bigint
-  | Date
+  // The five Temporal types to-sql.ts actually visits and quotes (see
+  // TEMPORAL_CLASS_NAMES in temporal-tag.ts). Duration/PlainYearMonth/
+  // PlainMonthDay are deliberately absent: Rails has no visitor for them.
+  // JS `Date` is absent too — it is rejected AR-wide (Temporal is the `Time`
+  // analogue), and Rails aliases `visit_Date` to `unsupported`
+  // (to_sql.rb:918), so a `Date` in a node slot can only ever raise.
+  | Temporal.Instant
+  | Temporal.ZonedDateTime
+  | Temporal.PlainDateTime
+  | Temporal.PlainDate
+  | Temporal.PlainTime
   | Node[]
   | null
   | undefined;

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -614,20 +614,10 @@ describe("the to_sql visitor", () => {
         };
         const attr = new Table("users").get("id");
         expect(() =>
-          spy.compile(
-            new Nodes.Equality(
-              attr,
-              Temporal.Instant.from("2026-04-30T12:34:56Z") as unknown as Nodes.NodeOrValue,
-            ),
-          ),
+          spy.compile(new Nodes.Equality(attr, Temporal.Instant.from("2026-04-30T12:34:56Z"))),
         ).toThrow(Visitors.UnsupportedVisitError);
         expect(() =>
-          spy.compile(
-            new Nodes.Equality(
-              attr,
-              Temporal.PlainDate.from("2026-04-30") as unknown as Nodes.NodeOrValue,
-            ),
-          ),
+          spy.compile(new Nodes.Equality(attr, Temporal.PlainDate.from("2026-04-30"))),
         ).toThrow(Visitors.UnsupportedVisitError);
         expect(seen).toEqual(["Time", "Date"]);
       });
@@ -653,6 +643,9 @@ describe("the to_sql visitor", () => {
           Temporal.PlainMonthDay.from("04-30"),
         ]) {
           expect(() =>
+            // The cast is the point: these three Temporal types are
+            // deliberately outside NodeOrValue, and this asserts the runtime
+            // raises for anyone who reaches them anyway.
             spy.compile(new Nodes.Equality(attr, value as unknown as Nodes.NodeOrValue)),
           ).toThrow(TypeError);
         }
@@ -672,7 +665,7 @@ describe("the to_sql visitor", () => {
           spy.compile(
             new Nodes.Equality(
               new Table("users").get("id"),
-              Temporal.PlainDateTime.from("2026-04-30T12:34:56") as unknown as Nodes.NodeOrValue,
+              Temporal.PlainDateTime.from("2026-04-30T12:34:56"),
             ),
           ),
         ).toThrow(Visitors.UnsupportedVisitError);


### PR DESCRIPTION
Aligns `NodeOrValue` with what `to-sql.ts` actually visits.

- Adds the five Temporal types from the `TEMPORAL_CLASS_NAMES` whitelist
  (`Instant`, `ZonedDateTime`, `PlainDateTime`, `PlainDate`, `PlainTime`).
  Not widened past it — `Duration`/`PlainYearMonth`/`PlainMonthDay` have no
  visitable Rails ancestor and raise at `visitor.rb:39`.
- Drops JS `Date`. Rails aliases `visit_Date` to `unsupported`
  (`arel/visitors/to_sql.rb:836`), we alias it the same way, and JS `Date` is
  rejected AR-wide with Temporal as the `Time` analogue (#939) — so a `Date`
  in a node slot could only ever raise. Nothing in the repo passed one;
  `pnpm typecheck` is clean repo-wide.
- Removes three escape casts in `to-sql.test.ts`. The fourth is kept, with a
  call-site comment: that test deliberately feeds the *excluded* Temporal
  types in to assert the runtime raises, so the cast is the assertion.

Note on scope: Rails' plain `ToSql` aliases `visit_Time`/`visit_DateTime` to
`unsupported` as well. Our visitor quoting Temporal for real is the
pre-existing, deliberate deviation established by #5002/#5020; this PR does
not change it, only makes the type surface agree with it.

api:compare / test:compare delta zero (type-only change, no test names
touched). `to-sql.test.ts` 288/288.

Closes-story: arel-nodeorvalue-excludes-temporal-admits-date
