### PR TITLE
fix(arel): debug quoter honours default_timezone instead of hardcoding UTC

### DIFF
--- a/packages/arel/src/visitors/default-quoter.ts
+++ b/packages/arel/src/visitors/default-quoter.ts
@@ -2,6 +2,7 @@ import type { ArelConnection } from "./connection.js";
 import { quoteSchemaQualifiedName } from "./split-schema-qualified-name.js";
 import { quoteArrayLiteral } from "../quote-array.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
+import { configuredTimezone } from "@blazetrails/activemodel";
 
 // Standalone comment sanitize for connection-less `Node#toSql()` (debug aid):
 // strips block-comment delimiters (leaving `--` alone, like Rails' abstract
@@ -41,18 +42,21 @@ type TemporalDateLike =
 // inline instead — as it already does for every other value-formatting decision
 // on the connection-less path.
 //
-// Deviation: Rails' `quoted_date` is timezone-aware via
-// `ActiveRecord.default_timezone`; that setting lives in activerecord, which arel
-// must not depend on. Instant/ZonedDateTime are therefore rendered in UTC here.
-// Real adapters (which own the setting) never reach this host.
+// Timezone-aware like Rails' `quoted_date` (abstract/quoting.rb:184-192):
+// `value.getutc` when `default_timezone == :utc`, `value.getlocal` otherwise.
+// The setting is reached through activemodel's `configuredTimezone()` — arel
+// already depends on activemodel, and activerecord's `setDefaultTimezone` keeps
+// activemodel's copy in lockstep, so this host and the adapter twin's
+// `defaultSqlTimezone()` (connection-adapters/abstract/sql-datetime.ts:23-25)
+// always agree without arel depending on activerecord.
 function quotedDate(value: TemporalDateLike): string {
   if (value instanceof Temporal.Instant)
-    return formatPlainDateTime(value.toZonedDateTimeISO("UTC"));
+    return formatPlainDateTime(value.toZonedDateTimeISO(configuredTimezone()));
   // Converts rather than reading the wall clock, mirroring the adapter twin's
   // `value.toInstant()` (connection-adapters/abstract/quoting.ts:591) and Rails'
   // `value.getutc` (abstract/quoting.rb:186-188).
   if (value instanceof Temporal.ZonedDateTime)
-    return formatPlainDateTime(value.toInstant().toZonedDateTimeISO("UTC"));
+    return formatPlainDateTime(value.toInstant().toZonedDateTimeISO(configuredTimezone()));
   if (value instanceof Temporal.PlainDateTime) return formatPlainDateTime(value);
   if (value instanceof Temporal.PlainDate) {
     return `${padYear(value.year)}-${pad(value.month)}-${pad(value.day)}`;

--- a/packages/arel/src/visitors/to-sql.trails.test.ts
+++ b/packages/arel/src/visitors/to-sql.trails.test.ts
@@ -2,7 +2,9 @@
  * Trails-specific ToSql tests: no like-named Rails test exists in
  * arel/test/visitors/test_to_sql.rb.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
+import { Temporal } from "@blazetrails/activesupport/temporal";
+import { setDefaultTimezone } from "@blazetrails/activemodel";
 import * as Nodes from "../nodes/index.js";
 import * as Visitors from "./index.js";
 import { Table } from "../table.js";
@@ -97,5 +99,30 @@ describe("ToSql raw scalars in quoting slots", () => {
   it("quotes a bare string in an Assignment right instead of raising", () => {
     const node = new Nodes.Assignment(users.get("name"), "x");
     expect(new Visitors.ToSql().compile(node)).toBe('"users"."name" = \'x\'');
+  });
+});
+
+// Rails' `quoted_date` (abstract/quoting.rb:184-192) converts an instant with
+// `value.getutc` or `value.getlocal` depending on `ActiveRecord.default_timezone`.
+// The connection-less debug quoter reaches the same setting through activemodel's
+// `configuredTimezone()`, so it agrees with the adapter twin's
+// `defaultSqlTimezone()` instead of hardcoding UTC.
+describe("ToSql quoted_date timezone", () => {
+  const instant = Temporal.Instant.from("2020-01-02T12:00:00Z");
+  const compile = () => new Visitors.ToSql().compile(new Nodes.Quoted(instant));
+
+  afterEach(() => setDefaultTimezone("utc"));
+
+  it("renders an instant in UTC when default_timezone is :utc", () => {
+    setDefaultTimezone("utc");
+    expect(compile()).toBe("'2020-01-02 12:00:00'");
+  });
+
+  it("renders an instant in the local zone when default_timezone is :local", () => {
+    setDefaultTimezone("local");
+    const expected = instant.toZonedDateTimeISO(Temporal.Now.timeZoneId());
+    expect(compile()).toBe(
+      `'${expected.toPlainDateTime().toString({ smallestUnit: "second" }).replace("T", " ")}'`,
+    );
   });
 });

--- a/packages/arel/src/visitors/to-sql.trails.test.ts
+++ b/packages/arel/src/visitors/to-sql.trails.test.ts
@@ -118,11 +118,22 @@ describe("ToSql quoted_date timezone", () => {
     expect(compile()).toBe("'2020-01-02 12:00:00'");
   });
 
-  it("renders an instant in the local zone when default_timezone is :local", () => {
-    setDefaultTimezone("local");
-    const expected = instant.toZonedDateTimeISO(Temporal.Now.timeZoneId());
-    expect(compile()).toBe(
-      `'${expected.toPlainDateTime().toString({ smallestUnit: "second" }).replace("T", " ")}'`,
-    );
-  });
+  // Skipped rather than run vacuously when the host zone IS UTC: there the
+  // :local rendering is byte-identical to the :utc one, so the assertion would
+  // pass against the pre-fix hardcoded-UTC baseline and guard nothing. Pinning
+  // the zone would mean setting process.env.TZ, which this repo forbids, so the
+  // gap is made visible in the run output instead of silently passing.
+  it.skipIf(Temporal.Now.timeZoneId() === "UTC")(
+    "renders an instant in the local zone when default_timezone is :local",
+    () => {
+      setDefaultTimezone("local");
+      const expected = instant.toZonedDateTimeISO(Temporal.Now.timeZoneId());
+      const sql = compile();
+      expect(sql).toBe(
+        `'${expected.toPlainDateTime().toString({ smallestUnit: "second" }).replace("T", " ")}'`,
+      );
+      // The point of the test: :local must not render as :utc did.
+      expect(sql).not.toBe("'2020-01-02 12:00:00'");
+    },
+  );
 });


### PR DESCRIPTION
Arel's connection-less `quotedDate` (`packages/arel/src/visitors/default-quoter.ts`, added in #5020) rendered `Temporal.Instant`/`ZonedDateTime` in UTC unconditionally. Rails' `quoted_date` (`abstract/quoting.rb:184-192`) instead branches on `default_timezone` — `value.getutc` when `:utc`, `value.getlocal` otherwise.

The story asked whether the setting could live somewhere both packages reach. It already does: **arel depends on activemodel**, activemodel owns `configuredTimezone()` (`type/helpers/timezone.ts:31`), and activerecord's `setDefaultTimezone` explicitly keeps activemodel's copy in lockstep. So the deviation converges with no new dependency and no hoist — this host and the adapter twin's `defaultSqlTimezone()` (`connection-adapters/abstract/sql-datetime.ts:23-25`) now always agree.

No behaviour change on the real adapter path: every adapter construction site passes a connection whose own `quoted_date` owns the branch, and the default remains `"utc"`.

## Review responses

**1. `:local` test vacuous on UTC hosts — fixed.** Real defect; the assertion would have passed against the hardcoded-UTC baseline on a UTC runner. Pinning `process.env.TZ` isn't available (CLAUDE.md hard rule: no `process.*` references), so the test now `skipIf`s a UTC host rather than running vacuously, and adds an explicit `not.toBe` against the UTC rendering so the guard is real where it runs. The trade-off is recorded at the call site: on a UTC runner this is visibly skipped instead of silently green. Verified it still fails against the pre-fix baseline locally (`America/Detroit`).

**1b. Follow-up: "drop the skip and assert unconditionally" — keeping the skip.** The suggested alternative doesn't close the gap it identifies. On a UTC host, `instant.toZonedDateTimeISO(Temporal.Now.timeZoneId())` *is* the UTC rendering, so asserting against it unconditionally is the exact vacuous assertion the previous round flagged — it just hides the vacuity instead of surfacing it. The deeper issue: on a UTC host the hardcoded-UTC code and the fixed code are **behaviourally identical by construction**, so no behavioural assertion can distinguish them there. A spy on `configuredTimezone()` would distinguish them, but it asserts the implementation calls a particular function rather than that the output is right — testing the mock, not the setting.

So the honest options are (a) skip visibly on UTC hosts, or (b) pin a non-UTC `TZ`. (b) needs `process.env`, which CLAUDE.md forbids repo-wide, and there is no existing `TZ` handling in any vitest config to extend. Keeping (a), with the tradeoff stated here as requested: **on a UTC CI runner this PR ships no CI-effective regression guard** — the guard is real only on non-UTC hosts (verified locally on `America/Detroit`, where it fails on the pre-fix baseline). If that's unacceptable, the fix is a `TZ` pin in vitest config plus a CLAUDE.md carve-out for it, which I'd rather have the user decide than smuggle in here.

**2. Test drives activemodel's raw `setDefaultTimezone`, bypassing activerecord's validating wrapper — no change.** Agreed on the analysis, and agreed it's correct as-is: arel cannot import activerecord (that dependency direction is the whole point of this PR), so the activemodel setter is the only reachable one. The `afterEach` reset covers the leak, and the validating wrapper's only added behaviour is an `ArgumentError` on invalid input, which these tests don't exercise.

Closes-story: arel-debug-quoter-hardcodes-utc-ignoring-default-timezone
