### PR TITLE
fix(arel): in/notIn Any/All accept the full expr surface Rails accepts

### DIFF
--- a/packages/arel/src/attributes/attribute.test.ts
+++ b/packages/arel/src/attributes/attribute.test.ts
@@ -767,11 +767,6 @@ describe("AttributeTest", () => {
 
   describe("#not_in_any", () => {
     it("should create a Grouping node", () => {
-      // Rails passes bare scalars here (attribute_test.rb:1008); notIn is typed
-      // notIn(o: unknown[]) while Rails' not_in takes any expr. ts-expect-error
-      // (not a cast) so this fails to compile once the signature is widened by
-      // the arel-predications-not-in-expr-type story, forcing this line's removal.
-      // @ts-expect-error -- see above
       expect(users.get("id").notInAny([1, 2])).toBeInstanceOf(Nodes.Grouping);
     });
 
@@ -791,11 +786,6 @@ describe("AttributeTest", () => {
 
   describe("#not_in_all", () => {
     it("should create a Grouping node", () => {
-      // Rails passes bare scalars here (attribute_test.rb:1023); notIn is typed
-      // notIn(o: unknown[]) while Rails' not_in takes any expr. ts-expect-error
-      // (not a cast) so this fails to compile once the signature is widened by
-      // the arel-predications-not-in-expr-type story, forcing this line's removal.
-      // @ts-expect-error -- see above
       expect(users.get("id").notInAll([1, 2])).toBeInstanceOf(Nodes.Grouping);
     });
 

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -400,26 +400,26 @@ export const Predications = {
     return this.groupingAll("doesNotMatch", others, escape);
   },
   inAny(
-    this: PredicationHost & GroupingFolders & { in(o: unknown[]): Node },
-    others: unknown[][],
+    this: PredicationHost & GroupingFolders & { in(o: unknown): Node },
+    others: unknown[],
   ): Grouping {
     return this.groupingAny("in", others);
   },
   inAll(
-    this: PredicationHost & GroupingFolders & { in(o: unknown[]): Node },
-    others: unknown[][],
+    this: PredicationHost & GroupingFolders & { in(o: unknown): Node },
+    others: unknown[],
   ): Grouping {
     return this.groupingAll("in", others);
   },
   notInAny(
-    this: PredicationHost & GroupingFolders & { notIn(o: unknown[]): Node },
-    others: unknown[][],
+    this: PredicationHost & GroupingFolders & { notIn(o: unknown): Node },
+    others: unknown[],
   ): Grouping {
     return this.groupingAny("notIn", others);
   },
   notInAll(
-    this: PredicationHost & GroupingFolders & { notIn(o: unknown[]): Node },
-    others: unknown[][],
+    this: PredicationHost & GroupingFolders & { notIn(o: unknown): Node },
+    others: unknown[],
   ): Grouping {
     return this.groupingAll("notIn", others);
   },


### PR DESCRIPTION
`Arel::Predications#in`/`#not_in` (vendor/rails/activerecord/lib/arel/predications.rb:107) accept an Array, Range, SelectManager, or a bare scalar, and `grouping_any`/`grouping_all` (232, 239) `send` each element straight through. Our `inAny`/`inAll`/`notInAny`/`notInAll` narrowed the element type to `unknown[]`, which did not match `in`/`notIn` (already `unknown`) and forced two `@ts-expect-error` suppressions on the verbatim Rails call shape `notInAny([1, 2])` (attribute_test.rb:1008, :1023).

Widens the wrappers and deletes both suppressions. No test renamed; no runtime change.

Closes-story: arel-predications-not-in-expr-type