### PR TITLE
fix(arel): route SelectManager#on through collapse, converge unrouted privates

### DIFF
--- a/packages/arel/src/factory-methods.ts
+++ b/packages/arel/src/factory-methods.ts
@@ -32,7 +32,7 @@ import { On } from "./nodes/unary.js";
 export interface FactoryMethodsModule {
   createTrue(): True;
   createFalse(): False;
-  createTableAlias(relation: Node, name: string): TableAlias;
+  createTableAlias(relation: Node, name: string | SqlLiteral): TableAlias;
   createJoin(
     to: Node,
     constraint?: Node | null,
@@ -56,7 +56,7 @@ export const FactoryMethods: FactoryMethodsModule = {
     return new False();
   },
 
-  createTableAlias(relation: Node, name: string): TableAlias {
+  createTableAlias(relation: Node, name: string | SqlLiteral): TableAlias {
     return new TableAlias(relation, name);
   },
 
@@ -71,7 +71,7 @@ export const FactoryMethods: FactoryMethodsModule = {
 
   createStringJoin(to: string | Node): StringJoin {
     const node = typeof to === "string" ? new SqlLiteral(to) : to;
-    return new StringJoin(node, null);
+    return this.createJoin(node, null, StringJoin) as StringJoin;
   },
 
   createAnd(clauses: Node[]): And {

--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -147,16 +147,15 @@ describe("SelectManagerTest", () => {
       it("converts to sqlliterals", () => {
         const right = users.alias();
         const mgr = users.from();
-        mgr.join(right).on(new Nodes.SqlLiteral("omg"));
-        expect(mgr.toSql()).toContain("omg");
+        mgr.join(right).on("omg");
+        expect(mgr.toSql()).toBe('SELECT FROM "users" INNER JOIN "users" "users_2" ON omg');
       });
 
       it("converts to sqlliterals with multiple items", () => {
         const right = users.alias();
         const mgr = users.from();
-        mgr.join(right).on(new Nodes.SqlLiteral("omg"), new Nodes.SqlLiteral("123"));
-        expect(mgr.toSql()).toContain("omg");
-        expect(mgr.toSql()).toContain("123");
+        mgr.join(right).on("omg", "123");
+        expect(mgr.toSql()).toBe('SELECT FROM "users" INNER JOIN "users" "users_2" ON omg AND 123');
       });
     });
   });

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -23,7 +23,6 @@ import type { UpdateValues } from "./crud.js";
 import { Comment } from "./nodes/comment.js";
 import { Lateral } from "./nodes/unary.js";
 import { And } from "./nodes/and.js";
-import { Grouping } from "./nodes/grouping.js";
 import { JoinSource } from "./nodes/join-source.js";
 import { InsertManager } from "./insert-manager.js";
 
@@ -59,6 +58,11 @@ export class SelectManager extends TreeManager {
    */
   set limit(value: number | Node | null) {
     this.take(value);
+  }
+
+  /** @internal */
+  get taken(): Limit["expr"] | null {
+    return this.limit;
   }
 
   /**
@@ -111,7 +115,10 @@ export class SelectManager extends TreeManager {
    * Mirrors: Arel::SelectManager#as
    */
   as(alias: string): TableAlias {
-    return new TableAlias(new Grouping(this.ast), new SqlLiteral(alias, { retryable: true }));
+    return this.createTableAlias(
+      this.grouping(this.ast),
+      new SqlLiteral(alias, { retryable: true }),
+    );
   }
 
   /**
@@ -142,15 +149,11 @@ export class SelectManager extends TreeManager {
    *
    * Mirrors: Arel::SelectManager#on
    */
-  on(...exprs: Node[]): this {
+  on(...exprs: (Node | string | null | undefined)[]): this {
     const joins = this.core.source.right;
     if (joins.length > 0) {
       const lastJoin = joins[joins.length - 1];
-      if (exprs.length === 1) {
-        (lastJoin as unknown as { right: Node | null }).right = new On(exprs[0]);
-      } else {
-        (lastJoin as unknown as { right: Node | null }).right = new On(new And(exprs));
-      }
+      (lastJoin as unknown as { right: Node | null }).right = new On(this.collapse(exprs));
     }
     return this;
   }
@@ -377,6 +380,11 @@ export class SelectManager extends TreeManager {
     return new Except(this.ast, otherAst);
   }
 
+  /** @internal */
+  minus(other: SelectManager | SelectStatement): Node {
+    return this.except(other);
+  }
+
   /**
    * Wrap the AST in a LATERAL subquery.
    *
@@ -444,9 +452,7 @@ export class SelectManager extends TreeManager {
   // Mirrors Arel::SelectManager#collapse (private). Compacts an array
   // of expressions, wraps bare strings as SqlLiteral (Rails: `Arel.sql`),
   // and folds them into a single Node — either the single remaining
-  // expr or an `And` of all of them. Rails uses this from `on(*exprs)`
-  // and similar multi-arg condition methods. Trails' single-arg `where`
-  // / `on` shapes don't reach for it internally; surfaced for parity.
+  // expr or an `And` of all of them.
   protected collapse(exprs: unknown[]): Node {
     const filtered = exprs
       .filter((e) => e !== null && e !== undefined)
@@ -504,18 +510,8 @@ export class SelectManager extends TreeManager {
     return new UnionAll(this.ast, otherAst);
   }
 
-  /** @internal */
-  minus(other: SelectManager | SelectStatement): Node {
-    return this.except(other);
-  }
-
   get joinSourceCount(): number {
     return this.core.source.right.length;
-  }
-
-  /** @internal */
-  get taken(): Limit["expr"] | null {
-    return this.limit;
   }
 
   /**

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -151,10 +151,8 @@ export class SelectManager extends TreeManager {
    */
   on(...exprs: (Node | string | null | undefined)[]): this {
     const joins = this.core.source.right;
-    if (joins.length > 0) {
-      const lastJoin = joins[joins.length - 1];
-      (lastJoin as unknown as { right: Node | null }).right = new On(this.collapse(exprs));
-    }
+    const lastJoin = joins[joins.length - 1] as unknown as { right: Node | null };
+    lastJoin.right = new On(this.collapse(exprs));
     return this;
   }
 
@@ -449,10 +447,7 @@ export class SelectManager extends TreeManager {
     return this;
   }
 
-  // Mirrors Arel::SelectManager#collapse (private). Compacts an array
-  // of expressions, wraps bare strings as SqlLiteral (Rails: `Arel.sql`),
-  // and folds them into a single Node — either the single remaining
-  // expr or an `And` of all of them.
+  // Mirrors Arel::SelectManager#collapse (select_manager.rb:256-268).
   protected collapse(exprs: unknown[]): Node {
     const filtered = exprs
       .filter((e) => e !== null && e !== undefined)

--- a/packages/arel/src/table.test.ts
+++ b/packages/arel/src/table.test.ts
@@ -61,8 +61,7 @@ describe("TableTest", () => {
     describe("join", () => {
       it("noops on nil", () => {
         const mgr = users.join(null);
-        expect(mgr.toSql()).toContain("FROM");
-        expect(mgr.toSql()).not.toContain("JOIN");
+        expect(mgr.toSql()).toBe('SELECT FROM "users"');
       });
 
       it("raises EmptyJoinError on empty", () => {
@@ -73,14 +72,18 @@ describe("TableTest", () => {
         const right = users.alias();
         const predicate = users.get("id").eq(right.get("id"));
         const mgr = users.join(right, Nodes.OuterJoin).on(predicate);
-        expect(mgr.toSql()).toContain("LEFT OUTER JOIN");
+        expect(mgr.toSql()).toBe(
+          'SELECT FROM "users" LEFT OUTER JOIN "users" "users_2" ON "users"."id" = "users_2"."id"',
+        );
       });
 
       it("creates an outer join", () => {
         const right = users.alias();
         const predicate = users.get("id").eq(right.get("id"));
         const mgr = users.outerJoin(right).on(predicate);
-        expect(mgr.toSql()).toContain("LEFT OUTER JOIN");
+        expect(mgr.toSql()).toBe(
+          'SELECT FROM "users" LEFT OUTER JOIN "users" "users_2" ON "users"."id" = "users_2"."id"',
+        );
       });
     });
   });

--- a/packages/arel/src/table.trails.test.ts
+++ b/packages/arel/src/table.trails.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { Table, Nodes, EmptyJoinError } from "./index.js";
+
+// Trails-only coverage for the `Nodes::SqlLiteral` arm of Arel::Table#join's
+// `case relation when String, Nodes::SqlLiteral` (table.rb:41-45). Rails'
+// table_test.rb exercises the arm with a bare String only; in Ruby SqlLiteral
+// subclasses String, so one `when` covers both. TypeScript has no such
+// subtyping, so the SqlLiteral half is a distinct branch and needs its own pin.
+describe("TableTest (trails)", () => {
+  const users = new Table("users");
+
+  it("promotes a SqlLiteral relation to a StringJoin", () => {
+    const mgr = users.join(new Nodes.SqlLiteral("comments ON comments.user_id = users.id"));
+    const join = mgr.ast.cores[0].source.right[0];
+    expect(join).toBeInstanceOf(Nodes.StringJoin);
+    expect(mgr.toSql()).toBe('SELECT FROM "users" comments ON comments.user_id = users.id');
+  });
+
+  it("raises EmptyJoinError on an empty SqlLiteral", () => {
+    expect(() => users.join(new Nodes.SqlLiteral(""))).toThrow(EmptyJoinError);
+  });
+
+  // Rails uses `String#empty?`, which is length-based — a whitespace-only
+  // relation is NOT empty and must join rather than raise.
+  it("does not raise on a whitespace-only relation", () => {
+    expect(() => users.join(" ")).not.toThrow();
+  });
+});

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -101,9 +101,7 @@ export class Table extends Node {
    * Mirrors: Arel::Table#group
    */
   group(...columns: (Node | string)[]): SelectManager {
-    const manager = this.from();
-    manager.group(...columns);
-    return manager;
+    return this.from().group(...columns);
   }
 
   /**
@@ -112,9 +110,7 @@ export class Table extends Node {
    * Mirrors: Arel::Table#order
    */
   order(...exprs: Node[]): SelectManager {
-    const manager = this.from();
-    manager.order(...exprs);
-    return manager;
+    return this.from().order(...exprs);
   }
 
   /**
@@ -123,17 +119,11 @@ export class Table extends Node {
    * Mirrors: Arel::Table#where
    */
   where(condition: Node): SelectManager {
-    const manager = this.from();
-    manager.where(condition);
-    return manager;
+    return this.from().where(condition);
   }
 
   project(...projections: (Node | string)[]): SelectManager {
-    const manager = this.from();
-    if (projections.length > 0) {
-      manager.project(...projections);
-    }
-    return manager;
+    return this.from().project(...projections);
   }
 
   /**
@@ -142,9 +132,7 @@ export class Table extends Node {
    * Mirrors: Arel::Table#take
    */
   take(amount: number): SelectManager {
-    const manager = this.from();
-    manager.take(amount);
-    return manager;
+    return this.from().take(amount);
   }
 
   /**
@@ -153,9 +141,7 @@ export class Table extends Node {
    * Mirrors: Arel::Table#skip
    */
   skip(amount: number): SelectManager {
-    const manager = this.from();
-    manager.skip(amount);
-    return manager;
+    return this.from().skip(amount);
   }
 
   /**
@@ -164,9 +150,7 @@ export class Table extends Node {
    * Mirrors: Arel::Table#having
    */
   having(expr: Node): SelectManager {
-    const manager = this.from();
-    manager.having(expr);
-    return manager;
+    return this.from().having(expr);
   }
 
   typeCastForDatabase(attrName: string, value: unknown): unknown {

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -69,7 +69,7 @@ export class Table extends Node {
     relation: Node | string | null,
     klass?: new (left: Node, right: Node | null) => Join,
   ): SelectManager {
-    const manager = new SelectManager(this);
+    const manager = this.from();
     if (relation === null) return manager;
     if (typeof relation === "string" && relation.trim() === "") {
       throw new EmptyJoinError("EmptyJoinError");
@@ -84,7 +84,7 @@ export class Table extends Node {
    * Mirrors: Arel::Table#outer_join
    */
   outerJoin(relation: Node | string): SelectManager {
-    const manager = new SelectManager(this);
+    const manager = this.from();
     manager.outerJoin(relation);
     return manager;
   }
@@ -95,7 +95,7 @@ export class Table extends Node {
    * Mirrors: Arel::Table#group
    */
   group(...columns: (Node | string)[]): SelectManager {
-    const manager = new SelectManager(this);
+    const manager = this.from();
     manager.group(...columns);
     return manager;
   }
@@ -106,7 +106,7 @@ export class Table extends Node {
    * Mirrors: Arel::Table#order
    */
   order(...exprs: Node[]): SelectManager {
-    const manager = new SelectManager(this);
+    const manager = this.from();
     manager.order(...exprs);
     return manager;
   }
@@ -117,13 +117,13 @@ export class Table extends Node {
    * Mirrors: Arel::Table#where
    */
   where(condition: Node): SelectManager {
-    const manager = new SelectManager(this);
+    const manager = this.from();
     manager.where(condition);
     return manager;
   }
 
   project(...projections: (Node | string)[]): SelectManager {
-    const manager = new SelectManager(this);
+    const manager = this.from();
     if (projections.length > 0) {
       manager.project(...projections);
     }
@@ -136,7 +136,7 @@ export class Table extends Node {
    * Mirrors: Arel::Table#take
    */
   take(amount: number): SelectManager {
-    const manager = new SelectManager(this);
+    const manager = this.from();
     manager.take(amount);
     return manager;
   }
@@ -147,7 +147,7 @@ export class Table extends Node {
    * Mirrors: Arel::Table#skip
    */
   skip(amount: number): SelectManager {
-    const manager = new SelectManager(this);
+    const manager = this.from();
     manager.skip(amount);
     return manager;
   }
@@ -158,7 +158,7 @@ export class Table extends Node {
    * Mirrors: Arel::Table#having
    */
   having(expr: Node): SelectManager {
-    const manager = new SelectManager(this);
+    const manager = this.from();
     manager.having(expr);
     return manager;
   }

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -3,6 +3,9 @@ import { EmptyJoinError } from "./errors.js";
 import { Node, NodeVisitor } from "./nodes/node.js";
 import { SelectManager } from "./select-manager.js";
 import { InnerJoin } from "./nodes/inner-join.js";
+import { OuterJoin } from "./nodes/outer-join.js";
+import { SqlLiteral } from "./nodes/sql-literal.js";
+import { StringJoin } from "./nodes/string-join.js";
 import type { Join } from "./nodes/binary.js";
 import { TableAlias } from "./nodes/table-alias.js";
 
@@ -66,16 +69,21 @@ export class Table extends Node {
    * Mirrors: Arel::Table#join
    */
   join(
-    relation: Node | string | null,
-    klass?: new (left: Node, right: Node | null) => Join,
+    relation: Node | string | null | undefined,
+    klass: new (left: Node, right: Node | null) => Join = InnerJoin,
   ): SelectManager {
-    const manager = this.from();
-    if (relation === null) return manager;
-    if (typeof relation === "string" && relation.trim() === "") {
-      throw new EmptyJoinError("EmptyJoinError");
+    if (relation == null) return this.from();
+
+    // Rails: `case relation when String, Nodes::SqlLiteral` (table.rb:41-45).
+    // SqlLiteral subclasses String in Ruby, so both arms share the emptiness
+    // check and the StringJoin promotion.
+    if (typeof relation === "string" || relation instanceof SqlLiteral) {
+      const text = typeof relation === "string" ? relation : relation.value;
+      if (text.length === 0) throw new EmptyJoinError("EmptyJoinError");
+      klass = StringJoin as unknown as new (left: Node, right: Node | null) => Join;
     }
-    manager.join(relation, klass);
-    return manager;
+
+    return this.from().join(relation, klass);
   }
 
   /**
@@ -84,9 +92,7 @@ export class Table extends Node {
    * Mirrors: Arel::Table#outer_join
    */
   outerJoin(relation: Node | string): SelectManager {
-    const manager = this.from();
-    manager.outerJoin(relation);
-    return manager;
+    return this.join(relation, OuterJoin);
   }
 
   /**

--- a/scripts/api-compare/call-mismatches-wide-exclude/arel/factory-methods.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/arel/factory-methods.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "arel",
-    "tsFile": "factory-methods.ts",
-    "rubyName": "create_string_join",
-    "call": "create_join",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  }
-]

--- a/scripts/api-compare/call-mismatches-wide-exclude/arel/select-manager.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/arel/select-manager.json
@@ -2,20 +2,6 @@
   {
     "package": "arel",
     "tsFile": "select-manager.ts",
-    "rubyName": "as",
-    "call": "create_table_alias",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "select-manager.ts",
-    "rubyName": "as",
-    "call": "grouping",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "select-manager.ts",
     "rubyName": "collapse",
     "call": "compact",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -67,13 +53,6 @@
     "tsFile": "select-manager.ts",
     "rubyName": "lock",
     "call": "sql",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "select-manager.ts",
-    "rubyName": "on",
-    "call": "collapse",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/arel/table.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/arel/table.json
@@ -2,20 +2,6 @@
   {
     "package": "arel",
     "tsFile": "table.ts",
-    "rubyName": "group",
-    "call": "from",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "table.ts",
-    "rubyName": "having",
-    "call": "from",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "table.ts",
     "rubyName": "initialize",
     "call": "to_s",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -23,50 +9,8 @@
   {
     "package": "arel",
     "tsFile": "table.ts",
-    "rubyName": "join",
-    "call": "from",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "table.ts",
-    "rubyName": "order",
-    "call": "from",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "table.ts",
     "rubyName": "outer_join",
     "call": "join",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "table.ts",
-    "rubyName": "project",
-    "call": "from",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "table.ts",
-    "rubyName": "skip",
-    "call": "from",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "table.ts",
-    "rubyName": "take",
-    "call": "from",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "table.ts",
-    "rubyName": "where",
-    "call": "from",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/arel/table.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/arel/table.json
@@ -5,12 +5,5 @@
     "rubyName": "initialize",
     "call": "to_s",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "table.ts",
-    "rubyName": "outer_join",
-    "call": "join",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]


### PR DESCRIPTION
Sweep of `packages/arel/` for ported Rails privates that no internal caller
routes through, checking each against the vendored Rails body for arguments
the trails call sites drop.

## The bug

`SelectManager#on` built its `On`/`And` node inline instead of dispatching
through the ported private `collapse`, so the two things `collapse` exists to
do never happened:

- bare strings were not wrapped as `SqlLiteral` (Rails' `Arel.sql`)
- `nil`/`undefined` exprs were not compacted

`select_manager.rb:69-72` calls `collapse(exprs)`; `collapse` is at
`select_manager.rb:256-268`. A bare string passed to `on()` reached the
visitor raw and raised `Unsupported argument type: String`.

This survived because the two existing tests pre-wrapped their arguments in
`SqlLiteral` and asserted with `toContain` — the same "returns the right node
class" weakness that let the `matches` case sit in #5023. Rails'
`select_manager_test.rb` passes bare `"omg"` / `"omg", "123"` and asserts the
full SQL; both tests are converged to that shape and both fail on baseline.

## `Table#join` — same defect class, found in review

`Table#join` reimplemented `table.rb:38-47` inline rather than delegating to
`from.join`, and the reimplementation was lossy beyond the missing call edge:

- it tested only `typeof relation === "string"`, so a `SqlLiteral` skipped
  **both** the `EmptyJoinError` check and the `StringJoin` promotion. Rails'
  `case relation when String, Nodes::SqlLiteral` applies both to both arms
  (`SqlLiteral` subclasses `String` in Ruby; in TypeScript that is a separate
  branch that has to be written out).
- it used `.trim() === ""` where Rails uses `String#empty?`, so a
  whitespace-only relation raised in trails and joins in Rails.

`Table#outerJoin` now routes through `join(relation, OuterJoin)` per
`table.rb:50`, which is what gives it that handling rather than none.

`Table#project` also carried an `if (projections.length > 0)` guard with no
counterpart in `table.rb:66-68`; dropped, and the other six helpers collapsed to
the one-line `return this.from().X(...)` form Rails uses throughout table.rb.

## Also converged (no behavior change, call edge now exists)

- `SelectManager#as` → `createTableAlias` / `grouping` (select_manager.rb:48-50)
- `FactoryMethods#createStringJoin` → `createJoin` (factory_methods.rb:23-25)
- `Table`'s manager helpers → `from()` (table.rb:33-35)

`createTableAlias`'s `name` parameter widens to `string | SqlLiteral`, which is
what `TableAlias` already accepts and what `SelectManager#as` passes.

Dropped the no-join guard on `SelectManager#on`: `select_manager.rb:69-72`
dereferences `.last` bare and raises, where trails silently no-opped. The only
Arel `on` caller (`query-methods.ts:3143`) always joins first, so the guard was
unreachable divergence.

## Tests

Four `table_test.rb` join assertions converged to Rails' full-SQL form (they
were `toContain`, which passed regardless of join class). New
`table.trails.test.ts` pins the `SqlLiteral` arm and the whitespace case —
Rails' `table_test.rb` covers the `String` arm only, so the TypeScript-specific
branch needs its own pin. All three fail on the pre-fix `table.ts`, as do both
converged `on` tests on the pre-fix `select-manager.ts`.

Full arel suite green: 75 files, 1581 tests.

## Inventory result

The remaining unrouted arel privates carry no droppable arguments:
`isDistinctFrom(o, collector)` and `collectCtes(children, collector)` take only
the node and the collector. The rest of the wide baseline for arel is `each` /
`to_s` / `new` noise, or genuinely-equivalent inlining.

Drops the 13 converged wide-baseline entries (`factory-methods.json` empties out
and is removed; `table.json` is down to one `initialize -> to_s` noise entry).
Baseline only shrinks; artifact regenerated with `API_COMPARE_FORCE=1` before
re-running the gate, which reports OK. `test:compare` arel row is unchanged at
704/707 — no test names changed.

## Known follow-up (not in this PR)

`SelectManager#join` (`select-manager.ts`) has the *same* String/SqlLiteral
divergence as `Table#join` did: `select_manager.rb:102-111` does the emptiness
check and `StringJoin` promotion there too, and trails' version does neither.
`Table#join` now handles it before delegating, so this PR's paths are correct,
but the `SelectManager#join` entry point is still lossy when called directly.
Registered as a separate story per the no-fan-out rule rather than widening this
PR: `0066-arel-visitor-fidelity/arel-select-manager-join-string-literal-case`.

The `rails-file-structure-method-order` error on `select-manager.ts` is
pre-existing — it reproduces identically on `origin/main`.

Closes-story: arel-unrouted-privates-drop-carried-arguments
