### PR TITLE
docs(arel): justify NodeOrValue's Temporal arms by their quoting slot

### DIFF
--- a/packages/arel/src/nodes/binary.ts
+++ b/packages/arel/src/nodes/binary.ts
@@ -57,12 +57,18 @@ export type NodeOrValue =
   // direct-dispatch path, which this slot never takes. Assignment is the sole
   // justifying slot; see the ValuesList caveat in the header comment.
   | boolean
-  // The five Temporal types to-sql.ts actually visits and quotes (see
-  // TEMPORAL_CLASS_NAMES in temporal-tag.ts). Duration/PlainYearMonth/
-  // PlainMonthDay are deliberately absent: Rails has no visitor for them.
-  // JS `Date` is absent too — it is rejected AR-wide (Temporal is the `Time`
-  // analogue), and Rails aliases `visit_Date` to `unsupported`
-  // (to_sql.rb:836), so a `Date` in a node slot can only ever raise.
+  // Temporal is justified by a quoting slot, not a rendering visitor — the
+  // same shape as `boolean` above. `UpdateManager#set` carries a raw temporal
+  // into an Assignment, which quotes a non-Node right rather than visiting it
+  // (to_sql.rb:637-639), so it renders. The `visit_Date`/`visit_DateTime`/
+  // `visit_Time` aliases (to_sql.rb:836/837/844) govern only direct dispatch,
+  // which this slot never takes: a bare temporal handed straight to `visit`
+  // (e.g. as an `Equality` right) does raise, and to-sql.test.ts pins that.
+  //
+  // Duration/PlainYearMonth/PlainMonthDay are deliberately absent: they have no
+  // Ruby analogue at all (see TEMPORAL_CLASS_NAMES in temporal-tag.ts). JS
+  // `Date` is absent because it is rejected AR-wide — Temporal is the `Time`
+  // analogue here.
   | Temporal.Instant
   | Temporal.ZonedDateTime
   | Temporal.PlainDateTime

--- a/packages/arel/src/update-manager.trails.test.ts
+++ b/packages/arel/src/update-manager.trails.test.ts
@@ -13,7 +13,7 @@ describe("UpdateManager#set with a temporal value", () => {
     um.table(users);
     um.set([[users.get("created_at"), Temporal.Instant.from("2026-04-30T12:34:56Z")]]);
     // Full SQL, not a substring: a bare or ISO-8601 literal would still contain
-    // the date, but only the quoted `quoted_time` form proves the value went
+    // the date, but only the quoted `quoted_date` form (quoting.rb:184) proves the value went
     // through quote() rather than reaching a visitor.
     expect(um.toSql()).toBe('UPDATE "users" SET "created_at" = \'2026-04-30 12:34:56\'');
   });

--- a/packages/arel/src/update-manager.trails.test.ts
+++ b/packages/arel/src/update-manager.trails.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { Temporal } from "@blazetrails/activesupport/temporal";
+import { Table, UpdateManager } from "./index.js";
+
+// TS-only: pins the slot/dispatch distinction that justifies the Temporal arms
+// of `NodeOrValue` (nodes/binary.ts). Rails aliases visit_Time/visit_Date to
+// `unsupported` (to_sql.rb:844/836), but Assignment quotes a non-Node right
+// instead of visiting it (to_sql.rb:637-639), so this path renders.
+describe("UpdateManager#set with a temporal value", () => {
+  it("quotes the value through Assignment rather than dispatching visit_Time", () => {
+    const users = new Table("users");
+    const um = new UpdateManager();
+    um.table(users);
+    um.set([[users.get("created_at"), Temporal.Instant.from("2026-04-30T12:34:56Z")]]);
+    expect(um.toSql()).toContain("2026-04-30");
+  });
+});

--- a/packages/arel/src/update-manager.trails.test.ts
+++ b/packages/arel/src/update-manager.trails.test.ts
@@ -12,6 +12,9 @@ describe("UpdateManager#set with a temporal value", () => {
     const um = new UpdateManager();
     um.table(users);
     um.set([[users.get("created_at"), Temporal.Instant.from("2026-04-30T12:34:56Z")]]);
-    expect(um.toSql()).toContain("2026-04-30");
+    // Full SQL, not a substring: a bare or ISO-8601 literal would still contain
+    // the date, but only the quoted `quoted_time` form proves the value went
+    // through quote() rather than reaching a visitor.
+    expect(um.toSql()).toBe('UPDATE "users" SET "created_at" = \'2026-04-30 12:34:56\'');
   });
 });


### PR DESCRIPTION
## Reversal — the original premise was refuted by #5028

This PR originally **removed** the five Temporal arms from `NodeOrValue`, on the
reasoning that Rails aliases `visit_Date`/`visit_DateTime`/`visit_Time` to
`unsupported` (to_sql.rb:836/837/844), so a temporal in a node slot can only
raise.

That reasoning is wrong, and #5028 (merged since) is why: **the `unsupported`
alias list is not the slot-exclusion set.** A slot value only reaches `visit` if
the enclosing visitor sends it there, and `visit_Arel_Nodes_Assignment`
(to_sql.rb:629-641) `case`s on the value and routes a non-Node right to
`quote(o.right)` — never to `visit`.

Verified empirically, not just by reading: `UpdateManager#set` with a
`Temporal.Instant` renders the quoted timestamp. It does not raise. So Temporal
has a justifying quoting slot, in exactly the shape #5028 established for
`boolean`. Removing the arms would have been a real regression that typecheck
could not catch, since the callers cast.

## What this PR now does

Rebased onto `main` and reduced to the correct outcome — acceptance criterion 3
("if some path does: document it at the call site as a justified deviation"):

- `nodes/binary.ts` — replaces the stale Temporal comment (which claimed
  to-sql "actually visits and quotes" these, contradicting #5028's header) with
  the quoting-slot justification and the dispatch caveat.
- `update-manager.trails.test.ts` — new TS-only test pinning that the Assignment
  path quotes a temporal rather than dispatching `visit_Time`. That behavior was
  previously untested, which is how the wrong premise survived review twice.

Net: no type or behavior change. The bare-temporal-raises coverage in
`to-sql.test.ts` is untouched and still passes.

Closes-story: arel-visitor-quotes-temporal-where-rails-raises
