### PR TITLE
refactor(arel): over lives on WindowPredications, not Attribute

### DIFF
--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -20,8 +20,6 @@ import {
 } from "../nodes/infix-operation.js";
 import { BitwiseNot } from "../nodes/unary-operation.js";
 import type { NodeOrValue } from "../nodes/binary.js";
-import { Over } from "../nodes/over.js";
-import { NamedWindow, Window } from "../nodes/window.js";
 import { Predications } from "../predications.js";
 
 /**
@@ -193,18 +191,6 @@ export class Attribute extends Node {
   extract(field: string): Extract {
     // Mirrors Rails: `Nodes::Extract.new [self], field` (expressions.rb).
     return new Extract([this], field);
-  }
-
-  /**
-   * Apply a window to this expression.
-   *
-   * Mirrors: `OVER` support on Arel expressions.
-   */
-  over(window?: Window | NamedWindow | string | null): Over {
-    if (!window) return new Over(this, null);
-    if (typeof window === "string") return new Over(this, new SqlLiteral(window));
-    if (window instanceof NamedWindow) return new Over(this, new SqlLiteral(`"${window.name}"`));
-    return new Over(this, window);
   }
 
   accept<T>(visitor: NodeVisitor<T>): T {

--- a/packages/arel/src/expression-mixins.test.ts
+++ b/packages/arel/src/expression-mixins.test.ts
@@ -75,9 +75,10 @@ describe("WindowPredications.over (mixed into Function)", () => {
   });
 
   it("with a string emits OVER <name> as a raw SQL fragment", () => {
-    // A bare string window name must render as SQL (`OVER w`), not as a
-    // quoted value (`OVER 'w'`) — the latter is invalid SQL.
-    expect(compile(sum.over("w"))).toBe("SUM(col) OVER w");
+    // Rails quotes a bare string window name as an identifier
+    // (to_sql.rb:306-307); only a SqlLiteral renders as a raw fragment.
+    expect(compile(sum.over("w"))).toBe('SUM(col) OVER "w"');
+    expect(compile(sum.over(new Nodes.SqlLiteral("w")))).toBe("SUM(col) OVER w");
   });
 
   it("NamedFunction#over with a NamedWindow doubles embedded quotes in the name", () => {

--- a/packages/arel/src/index.ts
+++ b/packages/arel/src/index.ts
@@ -40,6 +40,7 @@ import { Node } from "./nodes/node.js";
 import { NodeExpression } from "./nodes/node-expression.js";
 import { InfixOperation } from "./nodes/infix-operation.js";
 import { Function as FunctionNode } from "./nodes/function.js";
+import { Filter as FilterNode } from "./nodes/filter.js";
 import { Predications } from "./predications.js";
 import { Math as MathMixin } from "./math.js";
 import { FactoryMethods } from "./factory-methods.js";
@@ -82,6 +83,8 @@ include(_SqlLiteral, asRuntime(OrderPredications));
 // Function includes WindowPredications and FilterPredications.
 include(FunctionNode, asRuntime(WindowPredications));
 include(FunctionNode, asRuntime(FilterPredications));
+// Filter includes WindowPredications (nodes/filter.rb:6).
+include(FilterNode, asRuntime(WindowPredications));
 
 /**
  * Arel.sql() — escape hatch for raw SQL.

--- a/packages/arel/src/nodes/filter.ts
+++ b/packages/arel/src/nodes/filter.ts
@@ -1,22 +1,22 @@
 import { Node } from "./node.js";
 import { Binary } from "./binary.js";
-import { SqlLiteral } from "./sql-literal.js";
-import { Over } from "./over.js";
 
 /**
  * Filter — FILTER (WHERE ...) clause for aggregate functions.
  *
- * Mirrors: Arel::Nodes::Filter (extends Binary)
+ * Mirrors: Arel::Nodes::Filter (extends Binary), which includes
+ * Arel::WindowPredications (filter.rb:6). Runtime mixin wiring lives in
+ * ../index.ts.
  */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Filter extends Binary {
   constructor(left: Node, right: Node) {
     super(left, right);
   }
-
-  over(windowOrName?: Node | string): Over {
-    if (typeof windowOrName === "string") {
-      return new Over(this, new SqlLiteral(`"${windowOrName}"`));
-    }
-    return new Over(this, windowOrName ?? null);
-  }
 }
+
+type _WindowPredications = import("../window-predications.js").WindowPredicationsModule;
+
+/* eslint-disable-next-line @typescript-eslint/no-empty-object-type,
+   @typescript-eslint/no-unsafe-declaration-merging */
+export interface Filter extends _WindowPredications {}

--- a/packages/arel/src/nodes/filter.ts
+++ b/packages/arel/src/nodes/filter.ts
@@ -1,4 +1,3 @@
-import { Node } from "./node.js";
 import { Binary } from "./binary.js";
 
 /**
@@ -9,11 +8,7 @@ import { Binary } from "./binary.js";
  * ../index.ts.
  */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export class Filter extends Binary {
-  constructor(left: Node, right: Node) {
-    super(left, right);
-  }
-}
+export class Filter extends Binary {}
 
 type _WindowPredications = import("../window-predications.js").WindowPredicationsModule;
 

--- a/packages/arel/src/nodes/over.test.ts
+++ b/packages/arel/src/nodes/over.test.ts
@@ -27,8 +27,8 @@ describe("Arel::Nodes::OverTest", () => {
     it("should reference the window definition by name", () => {
       const count = new Nodes.NamedFunction("COUNT", [new Nodes.SqlLiteral("*")]);
       const filter = new Nodes.Filter(count, users.get("active").eq(true));
-      const over = filter.over("w");
-      expect(over).toBeInstanceOf(Nodes.Over);
+      const sql = new Visitors.ToSql().compile(filter.over("w"));
+      expect(sql).toBe('COUNT(*) FILTER (WHERE "users"."active" = TRUE) OVER "w"');
     });
   });
 
@@ -70,9 +70,8 @@ describe("Arel::Nodes::OverTest", () => {
 
   describe("with literal", () => {
     it("should reference the window definition by name", () => {
-      const over = new Nodes.Over(users.get("id").count(), new Nodes.SqlLiteral("foo"));
-      const sql = new Visitors.ToSql().compile(over);
-      expect(sql).toContain("OVER foo");
+      const sql = new Visitors.ToSql().compile(users.get("id").count().over("foo"));
+      expect(sql).toBe('COUNT("users"."id") OVER "foo"');
     });
   });
 });

--- a/packages/arel/src/nodes/over.test.ts
+++ b/packages/arel/src/nodes/over.test.ts
@@ -5,30 +5,15 @@ describe("Arel::Nodes::OverTest", () => {
   const users = new Table("users");
   describe("as", () => {
     it("should alias the expression", () => {
-      const fn = new Nodes.NamedFunction("ROW_NUMBER", []);
-      const over = new Nodes.Over(fn);
-      const visitor = new Visitors.ToSql();
-      expect(visitor.compile(over)).toBe("ROW_NUMBER() OVER ()");
+      const over = users.get("id").count().over().as("foo");
+      expect(new Visitors.ToSql().compile(over)).toBe('COUNT("users"."id") OVER () AS foo');
     });
   });
 
   describe("with SQL literal", () => {
     it("should reference the window definition by name", () => {
-      const fn = new Nodes.NamedFunction("ROW_NUMBER", []);
-      const w = new Nodes.Window();
-      w.order(users.get("id").asc());
-      const over = new Nodes.Over(fn, w);
-      const visitor = new Visitors.ToSql();
-      const result = visitor.compile(over);
-      expect(result).toContain("OVER");
-      expect(result).toContain("ORDER BY");
-    });
-
-    it("should reference the window definition by name", () => {
-      const count = new Nodes.NamedFunction("COUNT", [new Nodes.SqlLiteral("*")]);
-      const filter = new Nodes.Filter(count, users.get("active").eq(true));
-      const sql = new Visitors.ToSql().compile(filter.over("w"));
-      expect(sql).toBe('COUNT(*) FILTER (WHERE "users"."active" = TRUE) OVER "w"');
+      const over = users.get("id").count().over(new Nodes.SqlLiteral("foo"));
+      expect(new Visitors.ToSql().compile(over)).toBe('COUNT("users"."id") OVER foo');
     });
   });
 

--- a/packages/arel/src/nodes/over.ts
+++ b/packages/arel/src/nodes/over.ts
@@ -7,7 +7,10 @@ import { Binary } from "./binary.js";
  * Mirrors: Arel::Nodes::Over (extends Binary)
  */
 export class Over extends Binary {
-  constructor(left: Node, right: Node | null = null) {
+  // Rails' `initialize(left, right = nil)` puts no constraint on right; the
+  // visitor branches on its runtime type, quoting a bare String window name
+  // as an identifier and rendering a SqlLiteral bare (to_sql.rb:300-309).
+  constructor(left: Node, right: Node | string | null = null) {
     super(left, right);
   }
 

--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -1242,9 +1242,8 @@ describe("SelectManagerTest", () => {
   describe("group", () => {
     it("takes an attribute", () => {
       const mgr = new SelectManager(users);
-      mgr.project(users.get("id").over(mgr.window("w")));
-      const sql = mgr.toSql();
-      expect(sql).toContain("OVER");
+      mgr.group(users.get("id"));
+      expect(mgr.toSql()).toBe('SELECT FROM "users" GROUP BY "users"."id"');
     });
 
     it("makes strings literals", () => {
@@ -1258,46 +1257,42 @@ describe("SelectManagerTest", () => {
   describe("window definition", () => {
     it("takes an order", () => {
       const mgr = new SelectManager(users);
-      mgr.project(users.get("id").over(mgr.window("w").order(users.get("id").asc())));
-      expect(mgr.toSql()).toContain("ORDER BY");
+      mgr.window("a_window").order(users.get("foo").asc());
+      expect(mgr.toSql()).toBe(
+        'SELECT FROM "users" WINDOW "a_window" AS (ORDER BY "users"."foo" ASC)',
+      );
     });
 
     it("takes an order with multiple columns", () => {
       const mgr = new SelectManager(users);
-      mgr.project(
-        users
-          .get("id")
-          .over(mgr.window("w").order(users.get("id").asc(), users.get("name").desc())),
+      mgr.window("a_window").order(users.get("foo").asc(), users.get("bar").desc());
+      expect(mgr.toSql()).toBe(
+        'SELECT FROM "users" WINDOW "a_window" AS (ORDER BY "users"."foo" ASC, "users"."bar" DESC)',
       );
-      const sql = mgr.toSql();
-      expect(sql).toContain("ORDER BY");
-      expect(sql).toContain(",");
     });
 
     it("takes a partition", () => {
       const mgr = new SelectManager(users);
-      mgr.project(users.get("id").over(mgr.window("w").partition(users.get("name"))));
-      expect(mgr.toSql()).toContain("PARTITION BY");
+      mgr.window("a_window").partition(users.get("bar"));
+      expect(mgr.toSql()).toBe(
+        'SELECT FROM "users" WINDOW "a_window" AS (PARTITION BY "users"."bar")',
+      );
     });
 
     it("takes a partition with multiple columns", () => {
       const mgr = new SelectManager(users);
-      mgr.project(
-        users.get("id").over(mgr.window("w").partition(users.get("name"), users.get("age"))),
+      mgr.window("a_window").partition(users.get("bar"), users.get("baz"));
+      expect(mgr.toSql()).toBe(
+        'SELECT FROM "users" WINDOW "a_window" AS (PARTITION BY "users"."bar", "users"."baz")',
       );
-      const sql = mgr.toSql();
-      expect(sql).toContain("PARTITION BY");
-      expect(sql).toContain(",");
     });
 
     it("takes a range frame, unbounded following", () => {
       const mgr = new SelectManager(users);
-      mgr.project(users.get("id"));
-      const win = mgr.window("w");
-      win.frame(new Nodes.Range(new Nodes.Following()));
-      const sql = mgr.toSql();
-      expect(sql).toContain("RANGE");
-      expect(sql).toContain("UNBOUNDED FOLLOWING");
+      mgr.window("a_window").range(new Nodes.Following());
+      expect(mgr.toSql()).toBe(
+        'SELECT FROM "users" WINDOW "a_window" AS (RANGE UNBOUNDED FOLLOWING)',
+      );
     });
   });
 

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -790,10 +790,16 @@ export class ToSql extends Visitor {
   private visitArelNodesOver(node: Nodes.Over, collector: SQLString): SQLString {
     this.visit(node.left, collector);
     collector.append(" OVER ");
-    if (node.right) {
-      this.visit(node.right, collector);
-    } else {
+    if (!node.right) {
       collector.append("()");
+    } else if (typeof node.right === "string") {
+      // Rails' `when String, Symbol` arm quotes a bare window name as an
+      // identifier (to_sql.rb:306-307). A SqlLiteral right, by contrast,
+      // renders bare — `over("foo")` is `OVER "foo"` but
+      // `over(Arel.sql("foo"))` is `OVER foo`.
+      collector.append(this.quoteColumnName(node.right));
+    } else {
+      this.visit(node.right, collector);
     }
     return collector;
   }

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -727,7 +727,7 @@ export class ToSql extends Visitor {
       this.injectJoin(node.orders, ", ", collector);
     }
     if (node.framing) {
-      collector.append(" ");
+      if (node.partitions.length > 0 || node.orders.length > 0) collector.append(" ");
       this.visit(node.framing, collector);
     }
     collector.append(")");

--- a/packages/arel/src/window-predications.ts
+++ b/packages/arel/src/window-predications.ts
@@ -1,6 +1,5 @@
 import type { Node } from "./nodes/node.js";
 import { Over } from "./nodes/over.js";
-import { SqlLiteral } from "./nodes/sql-literal.js";
 
 /**
  * WindowPredications — `over` mixin.
@@ -8,23 +7,15 @@ import { SqlLiteral } from "./nodes/sql-literal.js";
  * Mirrors: Arel::WindowPredications (activerecord/lib/arel/window_predications.rb).
  */
 export interface WindowPredicationsModule {
-  // Rails accepts any expr (`def over(expr = nil)`) and renders it
-  // through the Over-node visitor unchanged. We accept Node, a trusted
-  // raw SQL string fragment, or null. NamedFunction#over widens further
-  // to handle NamedWindow specifically (rendering it as a quoted name
-  // reference); the base mixin defers to whatever the Over visitor does
-  // with whatever Node it's given — passing a NamedWindow here renders
-  // an inline window definition (`OVER "name" AS (...)`), matching Rails.
+  // Rails accepts any expr (`def over(expr = nil)`) and hands it to the
+  // Over node unchanged — the visitor, not this mixin, decides how it
+  // renders. A bare string is quoted as a window-name identifier
+  // (`OVER "w"`); wrap it in SqlLiteral for a raw fragment (`OVER w`).
   over(expr?: Node | string | null): Over;
 }
 
 export const WindowPredications: WindowPredicationsModule = {
   over(this: Node, expr: Node | string | null = null): Over {
-    // String arguments are wrapped in SqlLiteral and emitted verbatim
-    // (trusted raw SQL fragment) in the OVER clause — they are not
-    // escaped as identifiers. Without this wrapping the visitor would
-    // treat the string as a value and emit `OVER 'w'` instead of `OVER w`.
-    const right = typeof expr === "string" ? new SqlLiteral(expr) : expr;
-    return new Over(this, right);
+    return new Over(this, expr);
   },
 };

--- a/scripts/api-compare/call-mismatches-wide-exclude/arel/visitors/to-sql.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/arel/visitors/to-sql.json
@@ -276,13 +276,6 @@
     "package": "arel",
     "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_Over",
-    "call": "quote_column_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_Over",
     "call": "to_s",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
`Attribute#over` is an invented surface. `Arel::WindowPredications` is included by exactly two nodes — `Nodes::Function` (`function.rb:6`) and `Nodes::Filter` (`filter.rb:6`). `attributes/attribute.rb:6-10` includes `Expressions`, `Predications`, `AliasPredication`, `OrderPredications` and `Math` — not `WindowPredications` — so `attribute.over(...)` raises `NoMethodError` in Rails. The window belongs on the aggregate (`attribute.sum.over(w)`), not the bare column.

## Changes

- Remove `Attribute#over` and its `OVER support on Arel expressions` non-citation.
- `Filter` now takes `over` from the existing `WindowPredications` mixin (wired in `index.ts` alongside `Function`).
- Drop `Filter`'s `(left, right)` passthrough constructor — Rails' `Nodes::Filter` defines no `initialize`.
- The `select-manager` window-definition tests reached `OVER` through a bare attribute. Rewired to Rails' own bodies (`select_manager_test.rb:728+`), which drive `manager.window(...)` directly. Test names unchanged.

## Incidental fidelity fixes

Both found by switching invented `toContain(...)` assertions to Rails' exact SQL.

**1. Window framing separator.** `visit_Arel_Nodes_Window` emitted the space before the framing clause unconditionally, producing `AS ( RANGE UNBOUNDED FOLLOWING)`. Rails emits it only when partitions or orders are present (`to_sql.rb:244`). Rails' `must_be_like` normalizes whitespace, so its own suite cannot catch this.

**2. `OVER` with a string window name.** Rails' `visit_Arel_Nodes_Over` has an explicit `when String, Symbol` arm that quotes the name via `quote_column_name` (`to_sql.rb:306-307`), distinct from the `SqlLiteral` arm that renders bare. `over_test.rb` asserts both: `over("foo")` → `OVER "foo"`, `over(Arel.sql("foo"))` → `OVER foo`.

Our `Over` visitor had no String arm, so `WindowPredications#over` wrapped every string in `SqlLiteral` to stop it being emitted as a quoted *value*. That workaround collapsed Rails' two shapes into one. Fixed by adding the String arm to the visitor and reducing the mixin to Rails' one-line body (`Nodes::Over.new(self, expr)`). `Over`'s constructor also narrowed `right` to `Node`; Rails' `initialize` puts no constraint on it, so it's widened to match.

Removing the now-converged `visit_Arel_Nodes_Over` / `quote_column_name` entry from the wide call-mismatches baseline is the CI fix that follows from this — the only-shrink ratchet correctly failed on the stale entry. Removed that single entry rather than `--write` reseeding, which regenerates the whole baseline and could silently absorb unrelated mismatches.

## `over_test.rb` structure

`describe("with SQL literal")` held two same-named `it`s, neither being Rails' case. Now holds Rails' single test (`over(Arel.sql("foo"))` → `OVER foo`), so the SqlLiteral-vs-String split is pinned in `over.test.ts` itself, not only in `expression-mixins.test.ts`. The duplicate Filter test was dropped: its Rails home is `filter_test.rb:25-32`, and `filter.test.ts` already carries that case faithfully (with a `Window`, as Rails passes). `describe("as")` now asserts Rails' `COUNT("users"."id") OVER () AS foo` rather than only `OVER ()`.

## Note on `Filter#as` (raised twice in review)

Not missing, and not out of scope — verified against source both passes. Rails' `Filter < Binary`, and `binary.rb:5` is `class Binary < Arel::Nodes::NodeExpression`; `node_expression.rb` includes `Arel::AliasPredication`. So `Filter#as` is inherited in Rails, and the `include Arel::AliasPredication` on `filter.rb:7` is redundant there. trails mirrors this exactly: `binary.ts:54` is `export class Binary extends NodeExpression`. Confirmed at runtime — `Filter#as` is a function and compiles `AS foo` — and `filter.test.ts` already has Rails' `describe("as")` case asserting `... AS rich_users_count`, which passes.

## Verification

- All `packages/arel` tests pass; typecheck and lint clean.
- api:compare — arel `938/938 methods (100%)`, `69/69 files`, 0 missing. At ceiling; delta zero.
- test:compare — baselined against detached `origin/main` (`6497cdf6c`); Overall byte-identical at `14476/21663 (66.8%) … 747/1020 files … 209 misplaced`. Delta zero.
- Wide call ratchet `OK (6650 baselined)`, narrow `OK (19 baselined)`, body-pins `OK`.

## Known remaining drift (not touched)

`over.test.ts`'s `describe("equality")` bodies are invented — Rails uses `Over.new("foo","bar")` array-uniq semantics (`over_test.rb:52-68`). Converging that depends on node equality/hash semantics, which is a separate concern from `over`'s placement.

Closes-story: arel-attribute-over-not-in-window-predications
