### PR TITLE
refactor(arel): NodeOrValue drops undefined, justifies every surviving arm

### DIFF
--- a/packages/arel/src/nodes/binary.ts
+++ b/packages/arel/src/nodes/binary.ts
@@ -17,13 +17,20 @@ import type { Cte } from "./cte.js";
 // wider set than what `ToSql` can *visit*. Most scalar visitors are aliased to
 // `unsupported` (to_sql.rb:832-845), so it is tempting to read that alias list
 // as the set of types to exclude here. That inference is wrong: a slot value
-// only reaches `visit` if the enclosing visitor sends it there, and the two
-// visitors that carry raw values do not. Both `visit_Arel_Nodes_Assignment`
-// (to_sql.rb:629-641) and `visit_Arel_Nodes_ValuesList` (to_sql.rb:100-118)
-// `case` on the value and route anything that is not a Node/Attribute to
-// `quote(value)` — never to `visit`. So an arm below is justified by either a
-// Rails *quoting* slot or a real rendering visitor, and the `unsupported`
-// aliases only govern values that reach dispatch directly.
+// only reaches `visit` if the enclosing visitor sends it there, and the visitor
+// that carries raw values into a slot this union types does not.
+// `visit_Arel_Nodes_Assignment` (to_sql.rb:629-641) `case`s on the value and
+// routes anything that is not a Node/Attribute to `quote(o.right)` — never to
+// `visit`. So an arm below is justified by either a Rails *quoting* slot or a
+// real rendering visitor, and the `unsupported` aliases only govern values that
+// reach dispatch directly.
+//
+// `visit_Arel_Nodes_ValuesList` (to_sql.rb:100-118) has the identical
+// quote-don't-visit shape and is cited below only as corroborating evidence for
+// that Rails semantic — NOT as a slot this union types. `ValuesList` extends
+// Unary and stores `rows: unknown[][]` in the expr slot (values-list.ts:10-17),
+// and this union's array arm is `Node[]`, so no ValuesList row is typed by
+// `NodeOrValue`.
 export type NodeOrValue =
   | Node
   | ModelAttribute
@@ -41,13 +48,14 @@ export type NodeOrValue =
   // (`visit_Float` → `unsupported`, to_sql.rb:839), matching Rails.
   | number
   | bigint
-  // Booleans reach a slot through `UpdateManager#set` (`update-manager.ts`) and
-  // `InsertManager#values`, whose values are user-supplied and passed through
-  // raw exactly as Rails passes them. They render rather than raise, because
-  // Assignment and ValuesList quote a non-Node right instead of visiting it
-  // (to_sql.rb:637-639, :111-112) — `UPDATE "users" SET "admin" = TRUE`. The
-  // `visit_TrueClass`/`visit_FalseClass` aliases (to_sql.rb:845, :838) govern
-  // only the direct-dispatch path, which these slots never take.
+  // Booleans reach a slot through `UpdateManager#set` (update-manager.ts),
+  // whose values are user-supplied and passed through raw exactly as Rails
+  // passes them. They render rather than raise, because Assignment quotes a
+  // non-Node right instead of visiting it (to_sql.rb:637-639) —
+  // `UPDATE "users" SET "admin" = TRUE`. The `visit_TrueClass`/
+  // `visit_FalseClass` aliases (to_sql.rb:845, :838) govern only the
+  // direct-dispatch path, which this slot never takes. Assignment is the sole
+  // justifying slot; see the ValuesList caveat in the header comment.
   | boolean
   // The five Temporal types to-sql.ts actually visits and quotes (see
   // TEMPORAL_CLASS_NAMES in temporal-tag.ts). Duration/PlainYearMonth/

--- a/packages/arel/src/nodes/binary.ts
+++ b/packages/arel/src/nodes/binary.ts
@@ -12,12 +12,30 @@ import type { Cte } from "./cte.js";
 // `ModelAttribute` is not an Arel node but occupies node slots in Rails:
 // `build_quoted` returns one unwrapped into the AST (casted.rb:50), and both
 // Assignment (to_sql.rb:631) and ValuesList (to_sql.rb:110) accept one.
+//
+// This union types what may *occupy* a Binary slot, which in Rails is a
+// strictly wider set than what `ToSql` can *visit*. Most scalar visitors are
+// aliased to `unsupported` (to_sql.rb:832-845), yet Rails still constructs and
+// compares nodes holding those scalars — so an arm here is justified by a
+// Rails construction site, not by a rendering visitor. Each non-Node arm below
+// names one.
 export type NodeOrValue =
   | Node
   | ModelAttribute
+  // Rails puts bare Strings in both slots: `Cte#initialize` stores the CTE
+  // name as `@left` (cte.rb:10-12), `TableAlias` the alias name as `@right`
+  // (table_alias.rb), and Rails' own tests build `Equality.new("foo", "bar")`
+  // (test/cases/arel/nodes/binary_test.rb:11). Visiting one still raises —
+  // `visit_String` is aliased to `unsupported` (to_sql.rb:842) — because these
+  // slots are read structurally (`o.name`) and quoted, never visited.
   | string
+  // The one scalar Rails actually renders: `visit_Integer` is a real visitor
+  // (to_sql.rb:824-826). `bigint` rides along because Ruby's Integer is
+  // arbitrary-precision with no separate bignum visitor. TS cannot split
+  // integral from fractional `number`, so a non-integral one is admitted here
+  // and raises at visit time via `visitFloat` (`visit_Float` → `unsupported`,
+  // to_sql.rb:839), matching Rails.
   | number
-  | boolean
   | bigint
   // The five Temporal types to-sql.ts actually visits and quotes (see
   // TEMPORAL_CLASS_NAMES in temporal-tag.ts). Duration/PlainYearMonth/
@@ -31,8 +49,20 @@ export type NodeOrValue =
   | Temporal.PlainDate
   | Temporal.PlainTime
   | Node[]
-  | null
-  | undefined;
+  // `nil` is a structural slot value in Rails, and every visitor that can meet
+  // one guards first: `JoinSource#initialize(single_source, joinop = [])` takes
+  // a nil source and `visit_Arel_Nodes_JoinSource` tests `if o.left`
+  // (join_source.rb:11, to_sql.rb:510); `Join` defaults `right` to nil; and
+  // `Equality`/`NotEqual` with a nil right render `IS NULL` / `IS NOT NULL`
+  // rather than visiting it. So `visit_NilClass` being aliased to
+  // `unsupported` (to_sql.rb:841) is not reachable from these slots.
+  //
+  // `boolean` and `undefined` are deliberately absent. `visit_TrueClass` /
+  // `visit_FalseClass` are aliased to `unsupported` (to_sql.rb:845, :838) and
+  // Rails has no construction site putting a bare true/false in a node slot —
+  // callers wrap in `Casted`/`BindParam`, or use `Nodes::True`/`Nodes::False`.
+  // `undefined` has no Ruby analogue at all; `null` is the sole nil.
+  | null;
 
 export const ATTRIBUTE_BRAND = Symbol.for("arel.Attribute");
 

--- a/packages/arel/src/nodes/binary.ts
+++ b/packages/arel/src/nodes/binary.ts
@@ -13,30 +13,42 @@ import type { Cte } from "./cte.js";
 // `build_quoted` returns one unwrapped into the AST (casted.rb:50), and both
 // Assignment (to_sql.rb:631) and ValuesList (to_sql.rb:110) accept one.
 //
-// This union types what may *occupy* a Binary slot, which in Rails is a
-// strictly wider set than what `ToSql` can *visit*. Most scalar visitors are
-// aliased to `unsupported` (to_sql.rb:832-845), yet Rails still constructs and
-// compares nodes holding those scalars — so an arm here is justified by a
-// Rails construction site, not by a rendering visitor. Each non-Node arm below
-// names one.
+// This union types what may *occupy* a node slot, which in Rails is a strictly
+// wider set than what `ToSql` can *visit*. Most scalar visitors are aliased to
+// `unsupported` (to_sql.rb:832-845), so it is tempting to read that alias list
+// as the set of types to exclude here. That inference is wrong: a slot value
+// only reaches `visit` if the enclosing visitor sends it there, and the two
+// visitors that carry raw values do not. Both `visit_Arel_Nodes_Assignment`
+// (to_sql.rb:629-641) and `visit_Arel_Nodes_ValuesList` (to_sql.rb:100-118)
+// `case` on the value and route anything that is not a Node/Attribute to
+// `quote(value)` — never to `visit`. So an arm below is justified by either a
+// Rails *quoting* slot or a real rendering visitor, and the `unsupported`
+// aliases only govern values that reach dispatch directly.
 export type NodeOrValue =
   | Node
   | ModelAttribute
-  // Rails puts bare Strings in both slots: `Cte#initialize` stores the CTE
-  // name as `@left` (cte.rb:10-12), `TableAlias` the alias name as `@right`
-  // (table_alias.rb), and Rails' own tests build `Equality.new("foo", "bar")`
-  // (test/cases/arel/nodes/binary_test.rb:11). Visiting one still raises —
-  // `visit_String` is aliased to `unsupported` (to_sql.rb:842) — because these
-  // slots are read structurally (`o.name`) and quoted, never visited.
+  // Rails puts bare Strings in node slots structurally: `Cte#initialize` stores
+  // the CTE name as `@left` (cte.rb:10-12), `TableAlias` the alias name as
+  // `@right` (table_alias.rb), and Rails' own tests build
+  // `Equality.new("foo", "bar")` (test/cases/arel/nodes/binary_test.rb:11).
+  // These are read as `o.name` and quoted, so `visit_String` → `unsupported`
+  // (to_sql.rb:842) is not reachable from them.
   | string
-  // The one scalar Rails actually renders: `visit_Integer` is a real visitor
-  // (to_sql.rb:824-826). `bigint` rides along because Ruby's Integer is
-  // arbitrary-precision with no separate bignum visitor. TS cannot split
-  // integral from fractional `number`, so a non-integral one is admitted here
-  // and raises at visit time via `visitFloat` (`visit_Float` → `unsupported`,
-  // to_sql.rb:839), matching Rails.
+  // `visit_Integer` is a real rendering visitor (to_sql.rb:824-826). `bigint`
+  // rides along because Ruby's Integer is arbitrary-precision with no separate
+  // bignum visitor. TS cannot split integral from fractional `number`, so a
+  // non-integral one is admitted here and raises at visit time via `visitFloat`
+  // (`visit_Float` → `unsupported`, to_sql.rb:839), matching Rails.
   | number
   | bigint
+  // Booleans reach a slot through `UpdateManager#set` (`update-manager.ts`) and
+  // `InsertManager#values`, whose values are user-supplied and passed through
+  // raw exactly as Rails passes them. They render rather than raise, because
+  // Assignment and ValuesList quote a non-Node right instead of visiting it
+  // (to_sql.rb:637-639, :111-112) — `UPDATE "users" SET "admin" = TRUE`. The
+  // `visit_TrueClass`/`visit_FalseClass` aliases (to_sql.rb:845, :838) govern
+  // only the direct-dispatch path, which these slots never take.
+  | boolean
   // The five Temporal types to-sql.ts actually visits and quotes (see
   // TEMPORAL_CLASS_NAMES in temporal-tag.ts). Duration/PlainYearMonth/
   // PlainMonthDay are deliberately absent: Rails has no visitor for them.
@@ -57,11 +69,11 @@ export type NodeOrValue =
   // rather than visiting it. So `visit_NilClass` being aliased to
   // `unsupported` (to_sql.rb:841) is not reachable from these slots.
   //
-  // `boolean` and `undefined` are deliberately absent. `visit_TrueClass` /
-  // `visit_FalseClass` are aliased to `unsupported` (to_sql.rb:845, :838) and
-  // Rails has no construction site putting a bare true/false in a node slot —
-  // callers wrap in `Casted`/`BindParam`, or use `Nodes::True`/`Nodes::False`.
-  // `undefined` has no Ruby analogue at all; `null` is the sole nil.
+  // `undefined` is deliberately absent — the one arm this union drops. Ruby has
+  // no analogue for it, so no Rails slot can hold one and no citation could
+  // justify it; `null` is the sole nil, matching `visit_NilClass` being the
+  // sole nil visitor. Admitting both let a JS-ism stand in for `nil` in a slot
+  // whose Rails counterpart has exactly one.
   | null;
 
 export const ATTRIBUTE_BRAND = Symbol.for("arel.Attribute");

--- a/packages/arel/src/visitors/to-sql.trails.test.ts
+++ b/packages/arel/src/visitors/to-sql.trails.test.ts
@@ -82,14 +82,13 @@ describe("ToSql Array-named identifiers", () => {
 describe("ToSql raw scalars in quoting slots", () => {
   const users = new Table("users");
 
-  // Regression guard for the `NodeOrValue` union. Rails' Assignment and
-  // ValuesList visitors `case` on the value and send anything that is not a
-  // Node/Attribute to `quote(value)` rather than `visit` (to_sql.rb:637-639,
-  // :111-112). That is why a bare boolean renders here even though
-  // `visit_TrueClass`/`visit_FalseClass` are aliased to `unsupported`
-  // (to_sql.rb:845, :838) — the alias governs direct dispatch, which these
-  // slots never reach. Dropping `boolean` from the union on the strength of
-  // that alias alone would contradict this behaviour.
+  // Regression guard for the `NodeOrValue` union. Rails' Assignment visitor
+  // `case`s on the value and sends anything that is not a Node/Attribute to
+  // `quote(o.right)` rather than `visit` (to_sql.rb:637-639). That is why a
+  // bare boolean renders here even though `visit_TrueClass`/`visit_FalseClass`
+  // are aliased to `unsupported` (to_sql.rb:845, :838) — the alias governs
+  // direct dispatch, which this slot never reaches. Dropping `boolean` from the
+  // union on the strength of that alias alone would contradict this behaviour.
   it("quotes a bare boolean in an Assignment right instead of raising", () => {
     const node = new Nodes.Assignment(users.get("admin"), true);
     expect(new Visitors.ToSql().compile(node)).toBe('"users"."admin" = TRUE');

--- a/packages/arel/src/visitors/to-sql.trails.test.ts
+++ b/packages/arel/src/visitors/to-sql.trails.test.ts
@@ -78,3 +78,25 @@ describe("ToSql Array-named identifiers", () => {
     expect(new Visitors.MySQL().compile(cte)).toContain('`["a", "b"]` AS ');
   });
 });
+
+describe("ToSql raw scalars in quoting slots", () => {
+  const users = new Table("users");
+
+  // Regression guard for the `NodeOrValue` union. Rails' Assignment and
+  // ValuesList visitors `case` on the value and send anything that is not a
+  // Node/Attribute to `quote(value)` rather than `visit` (to_sql.rb:637-639,
+  // :111-112). That is why a bare boolean renders here even though
+  // `visit_TrueClass`/`visit_FalseClass` are aliased to `unsupported`
+  // (to_sql.rb:845, :838) — the alias governs direct dispatch, which these
+  // slots never reach. Dropping `boolean` from the union on the strength of
+  // that alias alone would contradict this behaviour.
+  it("quotes a bare boolean in an Assignment right instead of raising", () => {
+    const node = new Nodes.Assignment(users.get("admin"), true);
+    expect(new Visitors.ToSql().compile(node)).toBe('"users"."admin" = TRUE');
+  });
+
+  it("quotes a bare string in an Assignment right instead of raising", () => {
+    const node = new Nodes.Assignment(users.get("name"), "x");
+    expect(new Visitors.ToSql().compile(node)).toBe('"users"."name" = \'x\'');
+  });
+});

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -66,6 +66,19 @@ function isActiveModelAttribute(v: unknown): boolean {
 // Rails' UnsupportedVisitError message interpolates `object.class.name`
 // (to_sql.rb:5-8). `null`/`undefined` have no constructor; Ruby's analogue for
 // both is NilClass.
+//
+// Folding `undefined` in here is deliberate, and survives `undefined` being
+// dropped from `NodeOrValue` (binary.ts). The two are complementary rather than
+// contradictory: the union declines to *declare* `undefined` a legal slot
+// occupant, while this normalizes one that arrives anyway. It can still arrive,
+// because `math.ts` / `attribute.ts` / `update-manager.ts` launder values into
+// slots via `as NodeOrValue` casts from `unknown`. The primary normalization is
+// `rubyClassName` (ruby-class.ts:32), which maps `undefined` to `"NilClass"` at
+// the dispatch boundary so it routes to `visitNilClass`; this helper and
+// `rubyInspect` below just keep the downstream message consistent with that.
+// Removing them would be strictly less faithful — an `undefined` would read its
+// `.constructor` off nothing and surface as a "Cannot visit" TypeError instead
+// of Rails' NilClass UnsupportedVisitError.
 function constructorName(v: unknown): string {
   if (v === null || v === undefined) return "NilClass";
   return (v as { constructor?: { name?: string } }).constructor?.name ?? typeof v;


### PR DESCRIPTION
Audits each scalar arm of `NodeOrValue` against Rails and either drops it or justifies it inline. Net effect: **`undefined` is dropped; every other arm stays with a Rails citation.**

## The key correction

I opened this PR dropping `boolean` as well, reasoning from the `unsupported` alias list: `visit_TrueClass`/`visit_FalseClass` alias to `unsupported` (to_sql.rb:845, :838), so a bare boolean in a slot could only raise. **That inference is wrong, and self-review caught it.**

A slot value only reaches `visit` if the enclosing visitor sends it there — and the visitor that carries raw values into a slot this union types does not. `visit_Arel_Nodes_Assignment` (to_sql.rb:629-641) `case`s on the value and routes anything that is not a Node/Attribute to `quote(o.right)`, never to `visit`:

```ruby
else
  collector = visit o.left, collector
  collector << " = "
  collector << quote(o.right).to_s
end
```

So a bare boolean in an Assignment right *renders*, and does so today — verified empirically rather than by reading the alias list:

```
UPDATE "users" SET "admin" = TRUE
```

`UpdateManager#set` passes user-supplied values through raw exactly as Rails does, so this path is live, not hypothetical. `boolean` is reinstated with that citation, and two trails-only regression tests pin the quote path for a bare boolean and a bare string in an Assignment right. Both fail to typecheck if the arm is removed again — confirmed by re-deleting it.

The general lesson is now the header comment: an arm is justified by **either a Rails quoting slot or a real rendering visitor**, and the `unsupported` aliases govern only values that reach dispatch directly. Reading the alias list as "the types to exclude" is the trap.

## Findings per arm

| Arm | Verdict | Rails citation |
| --- | --- | --- |
| `string` | **stays** | `Cte` stores the CTE name as `@left` (cte.rb:10-12); `TableAlias` the alias as `@right`; Rails' own tests build `Equality.new("foo", "bar")` (binary_test.rb:11). Read as `o.name` and quoted. |
| `number` / `bigint` | **stays** | `visit_Integer` is a real rendering visitor (to_sql.rb:824-826). |
| `boolean` | **stays** | Assignment quotes a non-Node right (to_sql.rb:637-639). Reached live via `UpdateManager#set`. |
| `null` | **stays** | Structural, and every visitor guards first: `JoinSource` takes a nil source and `visit_Arel_Nodes_JoinSource` tests `if o.left` (join_source.rb:11, to_sql.rb:510); `Join` defaults `right` to nil; `Equality`/`NotEqual` with a nil right render `IS NULL`/`IS NOT NULL`. |
| `undefined` | **dropped** | No Ruby analogue, so no Rails slot can hold one and no citation could justify it. `null` is the sole nil, matching `visit_NilClass` as the sole nil visitor. |

On the "split `number`" criterion: TS has no integral type, so the split cannot be expressed statically. A non-integral `number` is admitted and raises at visit time via `visitFloat` (`visit_Float` → `unsupported`, to_sql.rb:839) — the `Number.isInteger` dispatch split in `Visitor#visit` already mirrors Ruby's Integer-vs-Float, so runtime behaviour matches Rails exactly. Noted at the call site.

## Review follow-ups (both addressed)

**ValuesList citation narrowed.** Review correctly caught that citing `ValuesList` / `InsertManager#values` as a *justifying slot* overreached: `ValuesList` extends Unary and stores `rows: unknown[][]` in the expr slot (values-list.ts:10-17), while this union's array arm is `Node[]` — so no ValuesList row is ever typed by `NodeOrValue`. **Assignment is the sole justifying slot.** ValuesList is retained in the header only as corroborating evidence for Rails' quote-don't-visit semantics (to_sql.rb:100-118), now explicitly labelled as not a slot this union types.

**`undefined` nil-fold is intentional, and now says so.** `constructorName` (to-sql.ts) and `rubyInspect` still fold `undefined` into NilClass/"nil". Kept deliberately — the type drop and the runtime fold are complementary: the union declines to *declare* `undefined` a legal slot occupant, while the runtime normalizes one that arrives anyway (still possible via the `as NodeOrValue` casts). The note also records the site review didn't reach: `rubyClassName` (ruby-class.ts:32) is the *primary* normalization, mapping `undefined` to `"NilClass"` at the dispatch boundary so it routes to `visitNilClass`. Removing them would be strictly *less* faithful — an `undefined` would read `.constructor` off nothing and surface as a "Cannot visit" TypeError instead of Rails' NilClass UnsupportedVisitError.

## Caveat on method

Type-level auditing under-detects here. `math.ts`, `attribute.ts` and `update-manager.ts` all launder values through `as NodeOrValue` casts from `unknown`, so `pnpm typecheck` cannot see what actually flows into those slots — which is exactly how the `boolean` error survived a clean typecheck. The reinstatement rests on an executed probe, not on the type checker. Filed as follow-up story `arel-nodeorvalue-casts-make-union-load-bearing`.

## Verification

- `pnpm typecheck`, `pnpm lint` clean.
- `pnpm vitest run packages/arel/` — 75 files, 1571 passed.
- Regression tests confirmed to fail on the bad version.
- `api:compare` 67.3% overall, no method surface change (type-only + tests).
- `test:compare` 14476/21663 (66.8%); the 2 added tests live in `*.trails.test.ts` (trails-only, unmatched by design). Delta non-negative on both.

Follow-up to #5026, which dropped the Temporal arms — on the visitor-alias argument that this PR shows must be applied more carefully.

Closes-story: arel-nodeorvalue-scalars-rails-unsupported
