### PR TITLE
fix(arel): SelectManager#join converges to Rails' string-literal case

### DIFF
--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -8,6 +8,7 @@ import {
   UpdateManager,
   Nodes,
   Visitors,
+  EmptyJoinError,
 } from "./index.js";
 
 describe("SelectManagerTest", () => {
@@ -483,40 +484,64 @@ describe("SelectManagerTest", () => {
     expect(join).toBeInstanceOf(Nodes.InnerJoin);
   });
 
+  describe("join", () => {
+    it("responds to join", () => {
+      const left = new Table("users");
+      const right = left.alias();
+      const predicate = left.get("id").eq(right.get("id"));
+      const mgr = new SelectManager();
+
+      mgr.from(left);
+      mgr.join(right).on(predicate);
+      expect(mgr.toSql()).toBe(
+        'SELECT FROM "users" INNER JOIN "users" "users_2" ON "users"."id" = "users_2"."id"',
+      );
+    });
+
+    it("takes a class", () => {
+      const left = new Table("users");
+      const right = left.alias();
+      const predicate = left.get("id").eq(right.get("id"));
+      const mgr = new SelectManager();
+
+      mgr.from(left);
+      mgr.join(right, Nodes.OuterJoin).on(predicate);
+      expect(mgr.toSql()).toBe(
+        'SELECT FROM "users" LEFT OUTER JOIN "users" "users_2" ON "users"."id" = "users_2"."id"',
+      );
+    });
+
+    it("noops on nil", () => {
+      const mgr = new SelectManager();
+      expect(mgr.join(null)).toBe(mgr);
+    });
+
+    it("raises EmptyJoinError on empty", () => {
+      const left = new Table("users");
+      const mgr = new SelectManager();
+
+      mgr.from(left);
+      expect(() => mgr.join("")).toThrow(EmptyJoinError);
+    });
+  });
+
   describe("outer join", () => {
     it("responds to join", () => {
-      const mgr = users.project(star);
-      expect(mgr).toHaveProperty("join");
-    });
-  });
+      const left = new Table("users");
+      const right = left.alias();
+      const predicate = left.get("id").eq(right.get("id"));
+      const mgr = new SelectManager();
 
-  describe("join", () => {
-    it("takes a class", () => {
-      // In Rails, SelectManager can take a class. We take a Table.
-      const mgr = new SelectManager(users);
-      expect(mgr).toBeInstanceOf(SelectManager);
+      mgr.from(left);
+      mgr.outerJoin(right).on(predicate);
+      expect(mgr.toSql()).toBe(
+        'SELECT FROM "users" LEFT OUTER JOIN "users" "users_2" ON "users"."id" = "users_2"."id"',
+      );
     });
-  });
 
-  describe("join", () => {
     it("noops on nil", () => {
-      // Table.join with a null-like argument - the manager still works
-      const mgr = users.from();
-      expect(mgr).toBeInstanceOf(SelectManager);
-    });
-  });
-
-  describe("join", () => {
-    it("raises EmptyJoinError on empty", () => {
-      expect(() => users.join("")).toThrow("EmptyJoinError");
-    });
-  });
-
-  describe("outer join", () => {
-    it("noops on nil", () => {
-      // Creating a SelectManager with no table
-      const mgr = new SelectManager(null);
-      expect(mgr).toBeInstanceOf(SelectManager);
+      const mgr = new SelectManager();
+      expect(mgr.outerJoin(null)).toBe(mgr);
     });
   });
 

--- a/packages/arel/src/select-manager.trails.test.ts
+++ b/packages/arel/src/select-manager.trails.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { Table, SelectManager, Nodes, EmptyJoinError } from "./index.js";
+
+// Trails-only coverage for the `Nodes::SqlLiteral` arm of
+// Arel::SelectManager#join's `case relation when String, Nodes::SqlLiteral`
+// (select_manager.rb:105-109). Rails' select_manager_test.rb exercises the arm
+// with a bare String only; in Ruby SqlLiteral subclasses String, so one `when`
+// covers both. TypeScript has no such subtyping, so the SqlLiteral half is a
+// distinct branch and needs its own pin.
+describe("SelectManagerTest (trails)", () => {
+  const users = new Table("users");
+
+  it("promotes a SqlLiteral relation to a StringJoin", () => {
+    const mgr = new SelectManager(users);
+    mgr.join(new Nodes.SqlLiteral("comments ON comments.user_id = users.id"));
+    expect(mgr.joinSources[0]).toBeInstanceOf(Nodes.StringJoin);
+    expect(mgr.toSql()).toContain("comments ON comments.user_id = users.id");
+  });
+
+  it("raises EmptyJoinError on an empty SqlLiteral", () => {
+    const mgr = new SelectManager(users);
+    expect(() => mgr.join(new Nodes.SqlLiteral(""))).toThrow(EmptyJoinError);
+  });
+
+  // Rails uses String#empty? (length), not a whitespace check: a blank-but-
+  // non-empty relation is NOT empty and must join rather than raise.
+  it("does not raise on a whitespace-only relation", () => {
+    const mgr = new SelectManager(users);
+    expect(() => mgr.join(" ")).not.toThrow();
+  });
+
+  it("promotes a bare string relation to a StringJoin", () => {
+    const mgr = new SelectManager(users);
+    mgr.join("comments ON comments.user_id = users.id");
+    expect(mgr.joinSources[0]).toBeInstanceOf(Nodes.StringJoin);
+  });
+});

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -202,6 +202,12 @@ export class SelectManager extends TreeManager {
   ): this {
     if (table == null) return this;
 
+    // Rails' signature is `join(relation, klass = Nodes::InnerJoin)` and it
+    // always passes `nil` as create_join's constraint. The second arg here is
+    // overloaded to also accept an ON predicate — a pre-existing trails
+    // extension several activerecord callers rely on positionally (e.g.
+    // query-methods.ts's `manager.join(tableNode, onNode)`), where Rails would
+    // chain `.on(...)`. Narrowing that surface is a separate change.
     let klass: new (left: Node, right: Node | null) => Join = InnerJoin;
     let constraint: Node | null = null;
     if (klassOrCondition && typeof klassOrCondition === "function" && klassOrCondition.prototype) {

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -223,7 +223,7 @@ export class SelectManager extends TreeManager {
     // check and the StringJoin promotion.
     if (typeof table === "string" || table instanceof SqlLiteral) {
       const text = typeof table === "string" ? table : table.value;
-      if (text.length === 0) throw new EmptyJoinError("EmptyJoinError");
+      if (text.length === 0) throw new EmptyJoinError();
       klass = StringJoin as unknown as new (left: Node, right: Node | null) => Join;
     }
 

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -11,6 +11,7 @@ import { OuterJoin } from "./nodes/outer-join.js";
 import { RightOuterJoin } from "./nodes/right-outer-join.js";
 import { FullOuterJoin } from "./nodes/full-outer-join.js";
 import { StringJoin } from "./nodes/string-join.js";
+import { EmptyJoinError } from "./errors.js";
 import { Union, UnionAll, Intersect, Except } from "./nodes/binary.js";
 import { With, WithRecursive } from "./nodes/with.js";
 import { TableAlias } from "./nodes/table-alias.js";
@@ -196,30 +197,48 @@ export class SelectManager extends TreeManager {
    * INNER JOIN.
    */
   join(
-    table: Node | string,
+    table: Node | string | null | undefined,
     klassOrCondition?: (new (left: Node, right: Node | null) => Join) | Node,
   ): this {
-    const tableNode = typeof table === "string" ? new SqlLiteral(table) : table;
+    if (table == null) return this;
+
+    let klass: new (left: Node, right: Node | null) => Join = InnerJoin;
+    let constraint: Node | null = null;
     if (klassOrCondition && typeof klassOrCondition === "function" && klassOrCondition.prototype) {
-      const JoinClass = klassOrCondition as new (left: Node, right: Node | null) => Join;
-      this.core.source.right.push(new JoinClass(tableNode, null));
+      klass = klassOrCondition as new (left: Node, right: Node | null) => Join;
     } else if (klassOrCondition instanceof Node) {
-      const onNode = new On(klassOrCondition);
-      this.core.source.right.push(new InnerJoin(tableNode, onNode));
-    } else {
-      this.core.source.right.push(new InnerJoin(tableNode, null));
+      constraint = klassOrCondition;
     }
+
+    const tableNode = typeof table === "string" ? new SqlLiteral(table) : table;
+
+    // Rails: `case relation when String, Nodes::SqlLiteral` (select_manager.rb:105-109).
+    // SqlLiteral subclasses String in Ruby, so both arms share the emptiness
+    // check and the StringJoin promotion.
+    if (typeof table === "string" || table instanceof SqlLiteral) {
+      const text = typeof table === "string" ? table : table.value;
+      if (text.length === 0) throw new EmptyJoinError("EmptyJoinError");
+      klass = StringJoin as unknown as new (left: Node, right: Node | null) => Join;
+    }
+
+    this.core.source.right.push(this.createJoin(tableNode, constraint, klass));
     return this;
   }
 
   /**
    * LEFT OUTER JOIN.
    */
-  outerJoin(table: Node | string, onCondition?: Node): this {
-    const tableNode = typeof table === "string" ? new SqlLiteral(table) : table;
-    const onNode = onCondition ? new On(onCondition) : null;
-    this.core.source.right.push(new OuterJoin(tableNode, onNode));
-    return this;
+  outerJoin(table: Node | string | null | undefined, onCondition?: Node): this {
+    // Rails: `outer_join(relation) = join(relation, Nodes::OuterJoin)`
+    // (select_manager.rb:115-117). The onCondition arg is a trails extension
+    // used by callers that would otherwise chain `.on(...)`.
+    if (onCondition) {
+      if (table == null) return this;
+      const tableNode = typeof table === "string" ? new SqlLiteral(table) : table;
+      this.core.source.right.push(this.createJoin(tableNode, onCondition, OuterJoin));
+      return this;
+    }
+    return this.join(table, OuterJoin);
   }
 
   /**

--- a/packages/arel/src/table.test.ts
+++ b/packages/arel/src/table.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Table, sql, star, SelectManager, Nodes, Visitors } from "./index.js";
+import { Table, sql, star, SelectManager, Nodes, Visitors, EmptyJoinError } from "./index.js";
 
 describe("TableTest", () => {
   const users = new Table("users");
@@ -65,7 +65,7 @@ describe("TableTest", () => {
       });
 
       it("raises EmptyJoinError on empty", () => {
-        expect(() => users.join("")).toThrow("EmptyJoinError");
+        expect(() => users.join("")).toThrow(EmptyJoinError);
       });
 
       it("takes a second argument for join type", () => {

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -79,7 +79,7 @@ export class Table extends Node {
     // check and the StringJoin promotion.
     if (typeof relation === "string" || relation instanceof SqlLiteral) {
       const text = typeof relation === "string" ? relation : relation.value;
-      if (text.length === 0) throw new EmptyJoinError("EmptyJoinError");
+      if (text.length === 0) throw new EmptyJoinError();
       klass = StringJoin as unknown as new (left: Node, right: Node | null) => Join;
     }
 

--- a/scripts/api-compare/call-mismatches-wide-exclude/arel/select-manager.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/arel/select-manager.json
@@ -44,13 +44,6 @@
   {
     "package": "arel",
     "tsFile": "select-manager.ts",
-    "rubyName": "join",
-    "call": "create_join",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "select-manager.ts",
     "rubyName": "lock",
     "call": "sql",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -74,13 +67,6 @@
     "tsFile": "select-manager.ts",
     "rubyName": "order",
     "call": "include?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "select-manager.ts",
-    "rubyName": "outer_join",
-    "call": "join",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {


### PR DESCRIPTION
Follow-up from #5025, which converged `Arel::Table#join`. `SelectManager#join`
had the same divergence.

`select_manager.rb:102-111`:

```ruby
def join(relation, klass = Nodes::InnerJoin)
  return self unless relation

  case relation
  when String, Nodes::SqlLiteral
    raise EmptyJoinError if relation.empty?
    klass = Nodes::StringJoin
  end

  @ctx.source.right << create_join(relation, nil, klass)
  self
end
```

Trails wrapped a string relation in `SqlLiteral` and pushed an `InnerJoin` —
no nil guard, no `EmptyJoinError` check, no `StringJoin` promotion, and it
bypassed `createJoin`. Calling `SelectManager#join` directly with a string or
`SqlLiteral` was lossy (paths through `Table#join` were already correct after
#5025, since `Table` promotes before delegating).

## Changes

- `SelectManager#join` mirrors `select_manager.rb:102-111`: nil guard, the
  `String`/`SqlLiteral` case with the `String#empty?` check (length, not
  `trim()`) and `StringJoin` promotion, and dispatch through `createJoin`.
- `outerJoin` delegates to `join(relation, OuterJoin)` per
  `select_manager.rb:115-117`, so it inherits the same guards. The
  `onCondition` second argument is a pre-existing trails extension used by
  callers that would otherwise chain `.on(...)`; it keeps its own arm and is
  documented at the call site.
- The pre-existing `klassOrCondition` overload is retained — several
  activerecord callers pass an ON predicate positionally. Narrowing that
  surface is out of scope here.
- `select_manager_test.rb`'s `join` / `outer join` blocks were hollowed-out
  placeholders in trails (`expect(mgr).toBeInstanceOf(SelectManager)`);
  they are now converged to the Rails assertions verbatim.
- New `select-manager.trails.test.ts` pins the `Nodes::SqlLiteral` arm, as in
  `table.trails.test.ts` — Ruby's `SqlLiteral < String` makes one `when` cover
  both, but TS has no String subtyping so it is a distinct branch.
- Removed two wide-call baseline entries that converge: `join -> create_join`
  and `outer_join -> join`. `pnpm api:calls:wide` is green.

## Verification

- 4 of the new tests fail on the pre-fix `select-manager.ts` (verified by
  checking out `origin/main`'s copy): the three `SqlLiteral`/string-promotion
  pins and `join > raises EmptyJoinError on empty`.
- Full arel suite: 1574 passed. `typecheck`, `eslint`, `api:calls:wide` clean.
- AR join callers exercised: `association-scope.test.ts`, join-dependency and
  `join-model.test.ts` (157 passed).

Closes-story: arel-select-manager-join-string-literal-case


---

## Review round 1

**Fixed — bare `EmptyJoinError`.** `select_manager.rb:107` raises bare, and
`errors.ts:11` already sets `name`, so the message was redundant. Also fixed the
identical `new EmptyJoinError("EmptyJoinError")` in `table.ts:82` (landed in
\#5025) — one-line sibling of the same convergence. `table.test.ts:68` asserted
on the message substring; it now asserts the class, matching
`select-manager.test.ts`. Test name unchanged.

**Not fixed — `On` wrapper is not dropped.** The review reads
`this.createJoin` as resolving to `FactoryMethods.createJoin`
(`factory-methods.ts:63-69`, no `On` wrap), but `SelectManager` defines its own
`createJoin` at `select-manager.ts:624` which does
`new JoinKlass(to, constraint ? new On(constraint) : null)`. A class method
shadows an `include()`-mixed prototype method, so the override wins.

Probed the three affected shapes directly, including the exact bare-`SqlLiteral`
shape `query-methods.ts:2975-2979` passes:

```
INNER:   SELECT * FROM "users" INNER JOIN "posts" ON "users"."id" = "posts"."user_id"
LITERAL: SELECT FROM "users" INNER JOIN "posts" ON users.id = posts.user_id
OUTER:   SELECT FROM "users" LEFT OUTER JOIN "posts" ON "users"."id" = "posts"."user_id"
```

The `ON` keyword is emitted on all three paths. The live callers are also green
end-to-end: `association-scope.test.ts`, `join-model.test.ts`, and
`relation/` — 1237 passed.

**Not fixed — comment at `select-manager.ts:588-589` is accurate.** It says
"createJoin is overridden below"; the override is below, at line 624. Same root
cause as the finding above.

## Deltas (re-measured after the fix)

`test:compare` overall 14476 → **14477**; arel 704/707 → **705/707**;
`select_manager_test.rb` 110 → **111** matched (assertion-mismatch 3 → 2).
`api:compare` arel 938/938 unchanged. `api:calls:wide` OK (6649 baselined).
`typecheck` clean. Full arel suite 1574 passed.
