### PR TITLE
fix(eslint): key method-order manifest per class; make rule live in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1281,6 +1281,20 @@ jobs:
         # blazetrails/rails-private-jsdoc. The standalone Lint job has
         # no Ruby and intentionally no-ops this rule.
         run: pnpm exec tsx scripts/build-rails-privates-manifest.ts && pnpm exec eslint packages/arel/src
+      - name: Rails file-structure method-order lint
+        # Needs rails-api.json (extracted above) to build the per-class
+        # method-order manifest, then enforce
+        # blazetrails/rails-file-structure-method-order. The manifest is
+        # gitignored and only exists here (never committed), so the
+        # standalone Lint job intentionally no-ops this rule — this is the
+        # only job where it goes live. Enabled per-package via
+        # eslint.config.mjs (arel + activemodel). RAILS_STRUCTURE_REPORT=1 prints
+        # (to stderr, non-failing) any manifest bucket that matched no container
+        # — a renamed class past the fallback, or a module ported as a class —
+        # so the silent-drop surface stays visible in the job log.
+        env:
+          RAILS_STRUCTURE_REPORT: "1"
+        run: pnpm exec tsx scripts/build-rails-file-structure-manifest.ts && pnpm exec eslint packages/arel/src packages/activemodel/src
       - name: Test comparison
         # --gates prints the advisory adapter/feature gate-mismatch breakdown
         # (should-gate / missing-gate / wrong-gate / over-gated) in the log.

--- a/docs/infrastructure/rails-file-structure-mirror-plan.md
+++ b/docs/infrastructure/rails-file-structure-mirror-plan.md
@@ -5,6 +5,19 @@ Status: planning. The `method-order` slice landed in
 the remaining sibling rules and packages are future work per the wave
 plan below.
 
+**Enforcement model (updated).** The `method-order` manifest is keyed
+**per container** — `classes[Name]` for each class body plus `functions`
+for the file's top-level functions — not a single flat per-file list. A
+flat list collapsed multiple classes in one file with overlapping member
+names into one order (e.g. `casted.rb`'s `Casted` and `Quoted`, whose
+`value_before_type_cast` / `value_for_database` appear in opposite order);
+per-class keying lets each express its own Rails order. The rule goes
+**live only in the `rails-comparison` CI job**, which builds the
+(gitignored) manifest after extracting `rails-api.json`, mirroring the
+`rails-private-jsdoc` step. The standalone `Lint` job has no manifest and
+intentionally no-ops, so the pre-commit auto-fix cannot silently reorder
+files outside a staged change's intent.
+
 `scripts/api-compare/` validates that **methods exist** at the right
 Rails-mirroring file paths. It does **not** validate **structure within a file**
 — definition order, module nesting, public/private grouping, position of

--- a/eslint/rails-file-structure-method-order.mjs
+++ b/eslint/rails-file-structure-method-order.mjs
@@ -12,11 +12,19 @@
  *   - Class instance + static methods (one container per ClassBody).
  *   - Top-level FunctionDeclaration (incl. `export function …`).
  *
- * The manifest provides a single flat expected order per file. For each
- * container, the rule filters expected names to those present in that
- * container; the relative order between mapped names must match. Names
- * not in the manifest (TS-only helpers) preserve their relative order
- * after the mapped block.
+ * The manifest keys expected order per container: `classes[Name]` for
+ * each class body (matched by the class's declared name) and `functions`
+ * for the file's top-level functions. For each container, the rule
+ * filters expected names to those present in that container; the relative
+ * order between mapped names must match. Names not in the manifest
+ * (TS-only helpers) preserve their relative order after the mapped block.
+ * Keying per class lets one file define several classes whose members
+ * share names but appear in different Rails order (e.g. `casted.rb`'s
+ * `Casted` vs `Quoted`). A class body is matched to a bucket by exact TS
+ * name; when trails renamed the Rails constant (`Type::Integer` →
+ * `IntegerType`, `Name` → `ModelName`), it falls back to pairing the sole
+ * unmatched class body with the sole unmatched bucket. Anything more
+ * ambiguous is left unordered.
  *
  * Autofix carries leading JSDoc / line comments with each declaration
  * (a comment is attached if it ends on the line immediately preceding
@@ -40,6 +48,36 @@ function loadManifest() {
   }
   manifestCache = JSON.parse(fs.readFileSync(MANIFEST_PATH, "utf8"));
   return manifestCache;
+}
+
+// Opt-in coverage report (set RAILS_STRUCTURE_REPORT=1, as the CI step does).
+// Manifest buckets that match no container in their file are silently dropped —
+// a Rails constant trails renamed past the substring fallback, or a Ruby module
+// ported as a TS class (its order lands in `functions`, which no class body
+// reads). This surfaces them so the drop is visible rather than invisible.
+const coverageReport = process.env.RAILS_STRUCTURE_REPORT ? [] : null;
+let reportHookInstalled = false;
+function installReportHook() {
+  if (reportHookInstalled || !coverageReport) return;
+  reportHookInstalled = true;
+  process.on("exit", () => {
+    if (coverageReport.length === 0) return;
+    let dropped = 0;
+    const lines = [];
+    for (const { rel, classes, functionsDropped } of coverageReport) {
+      const parts = [];
+      if (classes.length) parts.push(`classes: ${classes.join(", ")}`);
+      if (functionsDropped) parts.push("functions (no top-level fns)");
+      if (parts.length === 0) continue;
+      dropped += classes.length + (functionsDropped ? 1 : 0);
+      lines.push(`  ${rel} — ${parts.join("; ")}`);
+    }
+    if (lines.length === 0) return;
+    process.stderr.write(
+      `[rails-file-structure-method-order] ${dropped} manifest bucket(s) matched no ` +
+        `container (order not enforced):\n${lines.join("\n")}\n`,
+    );
+  });
 }
 
 let repoRootCache = null;
@@ -114,6 +152,27 @@ function memberName(node) {
       node.declaration?.type === "TSDeclareFunction")
   ) {
     return node.declaration.id?.name ?? null;
+  }
+  return null;
+}
+
+// Name of the class a ClassBody belongs to, for manifest lookup. Handles
+// `class Foo {}` / `export class Foo` / `export default class Foo`
+// (ClassDeclaration.id) and `const Foo = class {}` (ClassExpression under a
+// VariableDeclarator). Anonymous class expressions with no binding name
+// return null and are skipped — the manifest can't address them.
+function classNameOf(classBody) {
+  const parent = classBody.parent;
+  if (!parent) return null;
+  if (
+    (parent.type === "ClassDeclaration" || parent.type === "ClassExpression") &&
+    parent.id?.type === "Identifier"
+  ) {
+    return parent.id.name;
+  }
+  if (parent.type === "ClassExpression" && parent.parent?.type === "VariableDeclarator") {
+    const id = parent.parent.id;
+    if (id?.type === "Identifier") return id.name;
   }
   return null;
 }
@@ -240,8 +299,13 @@ const rule = {
     if (!filename) return {};
     const rel = relFromRepoRoot(filename);
     const manifest = loadManifest();
-    const expectedOrder = manifest.files?.[rel];
-    if (!expectedOrder || expectedOrder.length === 0) return {};
+    const fileOrder = manifest.files?.[rel];
+    if (!fileOrder) return {};
+    const classOrders = fileOrder.classes ?? {};
+    const functionOrder = fileOrder.functions ?? [];
+    const hasAnyOrder =
+      functionOrder.length > 0 || Object.values(classOrders).some((a) => a.length > 0);
+    if (!hasAnyOrder) return {};
 
     const sourceCode = context.sourceCode ?? context.getSourceCode();
 
@@ -269,6 +333,13 @@ const rule = {
     // would risk TDZ violations (plan §7) — don't do it without scope
     // analysis to verify each move is safe.
     const containers = [];
+    // Eligible class bodies collected during traversal, resolved to their
+    // manifest bucket at Program:exit (see `resolveClassOrder`).
+    const classCandidates = [];
+    // Every class name in the file, including bodies with <2 orderable members;
+    // used only to keep the coverage report signal (renames / module-as-class)
+    // free of noise from small classes that were never orderable anyway.
+    const allClassNames = new Set();
 
     return {
       ClassBody(node) {
@@ -296,21 +367,81 @@ const rule = {
           ancestor = ancestor.parent;
         }
         if (nested) return;
+        const name = classNameOf(node);
+        if (name) allClassNames.add(name);
         const orderable = node.body.filter(isOrderableClassMember);
         if (orderable.length < 2) return;
-        containers.push({ container: node, members: orderable });
+        classCandidates.push({ node, name, members: orderable });
       },
       "Program:exit"(programNode) {
+        // Assign each class body its manifest bucket. Exact TS-name match
+        // first; then, because trails often RENAMES the Rails constant
+        // (`ActiveModel::Type::Integer` → `IntegerType`, `ActiveModel::Name`
+        // → `ModelName`, `Arel::Visitors::Dot::Node` → `DotNode`), fall back
+        // to pairing when EXACTLY ONE class body and EXACTLY ONE manifest
+        // bucket remain unmatched — an unambiguous 1:1 rename. Anything more
+        // ambiguous is left unordered rather than risk a wrong pairing.
+        const bucketKeys = Object.keys(classOrders).filter((k) => classOrders[k].length > 0);
+        const usedBucket = new Set();
+        for (const cand of classCandidates) {
+          if (cand.name && bucketKeys.includes(cand.name) && classOrders[cand.name].length > 0) {
+            cand.expectedOrder = classOrders[cand.name];
+            usedBucket.add(cand.name);
+          }
+        }
+        const unresolved = classCandidates.filter((c) => !c.expectedOrder);
+        const freeBuckets = bucketKeys.filter((k) => !usedBucket.has(k));
+        if (unresolved.length === 1 && freeBuckets.length === 1) {
+          // Require evidence the two are the same entity before pairing: the
+          // Rails constant must be a case-insensitive substring of the TS class
+          // name (or vice versa). Every real rename satisfies this — `Name` ⊂
+          // `ModelName`, `Integer` ⊂ `IntegerType`, `Node` ⊂ `DotNode`. Without
+          // it, a file with one matched class, one TS-only helper class, and one
+          // never-ported Ruby class hits the same 1/1 shape and the helper would
+          // be reordered to an unrelated Rails order.
+          const tsName = (unresolved[0].name ?? "").toLowerCase();
+          const bucket = freeBuckets[0].toLowerCase();
+          if (tsName && (tsName.includes(bucket) || bucket.includes(tsName))) {
+            unresolved[0].expectedOrder = classOrders[freeBuckets[0]];
+            usedBucket.add(freeBuckets[0]);
+          }
+        }
+        for (const cand of classCandidates) {
+          if (cand.expectedOrder) {
+            containers.push({ members: cand.members, expectedOrder: cand.expectedOrder });
+          }
+        }
+
         const topLevel = programNode.body.filter(isOrderableTopLevel);
-        if (topLevel.length >= 2) {
-          containers.push({ container: programNode, members: topLevel });
+        const functionsConsumed = topLevel.length >= 2 && functionOrder.length > 0;
+        if (functionsConsumed) {
+          containers.push({
+            container: programNode,
+            members: topLevel,
+            expectedOrder: functionOrder,
+          });
+        }
+
+        if (coverageReport) {
+          installReportHook();
+          // Only buckets with no class of that name at all — the genuine
+          // rename/module-as-class drops. A bucket whose class exists but has
+          // <2 orderable members is not a concerning drop, so drop it from the
+          // report signal.
+          const unmatchedClasses = bucketKeys.filter(
+            (k) => !usedBucket.has(k) && !allClassNames.has(k),
+          );
+          const functionsDropped = functionOrder.length > 0 && !functionsConsumed;
+          if (unmatchedClasses.length > 0 || functionsDropped) {
+            coverageReport.push({ rel, classes: unmatchedClasses, functionsDropped });
+          }
         }
 
         const fixes = [];
         let firstMismatch = null; // { node, expectedName, beforeName }
         let mismatchCount = 0;
 
-        for (const { members } of containers) {
+        for (const { members, expectedOrder } of containers) {
           // Collapse consecutive same-named members into units before
           // reorder, so TS overload groups (and class accessor pairs
           // where the pair is already adjacent) move as a single block.

--- a/eslint/rails-file-structure-method-order.test.mjs
+++ b/eslint/rails-file-structure-method-order.test.mjs
@@ -10,11 +10,50 @@ const MANIFEST_PATH = path.join(__dirname, "rails-file-structure-method-order.js
 
 const hadExisting = fs.existsSync(MANIFEST_PATH);
 const original = hadExisting ? fs.readFileSync(MANIFEST_PATH, "utf8") : null;
+// Order data is keyed per container: `classes[Name]` per class, `functions`
+// for top-level functions. `fixture-class.ts` gives the same order to every
+// class name the tests use (X / A / B / Outer); `fixture-multi.ts` gives two
+// classes OPPOSITE orders to exercise per-class keying (the casted.rb
+// Casted/Quoted case a flat per-file list could not express).
+const sharedClassOrder = ["first", "second", "third"];
 const fixture = {
   files: {
-    "packages/arel/src/fixture-class.ts": ["first", "second", "third"],
-    "packages/arel/src/fixture-fns.ts": ["alpha", "beta", "gamma"],
-    "packages/arel/src/fixture-mixed.ts": ["one", "two"],
+    "packages/arel/src/fixture-class.ts": {
+      classes: {
+        X: sharedClassOrder,
+        A: sharedClassOrder,
+        B: sharedClassOrder,
+        Outer: sharedClassOrder,
+      },
+      functions: [],
+    },
+    "packages/arel/src/fixture-fns.ts": {
+      classes: {},
+      functions: ["alpha", "beta", "gamma"],
+    },
+    "packages/arel/src/fixture-multi.ts": {
+      classes: { Casted: ["before", "database"], Quoted: ["database", "before"] },
+      functions: [],
+    },
+    // Bucket key `Integer` (the Rails constant) has no class named `Integer`;
+    // the 1:1 rename fallback pairs it with the sole class body (`IntegerType`).
+    "packages/arel/src/fixture-rename.ts": {
+      classes: { Integer: sharedClassOrder },
+      functions: [],
+    },
+    // Two buckets, neither exact-matching a class name → ambiguous, so the
+    // fallback must NOT pair; both classes stay unordered.
+    "packages/arel/src/fixture-ambiguous.ts": {
+      classes: { Foo: sharedClassOrder, Bar: sharedClassOrder },
+      functions: [],
+    },
+    // Single 1/1 unmatched shape, but the bucket name is neither a substring of
+    // the TS class name nor vice versa → no identity evidence, so the fallback
+    // must NOT pair (guards a TS-only helper class from a never-ported bucket).
+    "packages/arel/src/fixture-noevidence.ts": {
+      classes: { Zzz: sharedClassOrder },
+      functions: [],
+    },
   },
 };
 function restoreManifest() {
@@ -31,6 +70,10 @@ process.on("exit", restoreManifest);
 const classFile = path.join(REPO_ROOT, "packages/arel/src/fixture-class.ts");
 const fnFile = path.join(REPO_ROOT, "packages/arel/src/fixture-fns.ts");
 const unlistedFile = path.join(REPO_ROOT, "packages/arel/src/fixture-unlisted.ts");
+const multiFile = path.join(REPO_ROOT, "packages/arel/src/fixture-multi.ts");
+const renameFile = path.join(REPO_ROOT, "packages/arel/src/fixture-rename.ts");
+const ambiguousFile = path.join(REPO_ROOT, "packages/arel/src/fixture-ambiguous.ts");
+const noEvidenceFile = path.join(REPO_ROOT, "packages/arel/src/fixture-noevidence.ts");
 
 const tester = new RuleTester({
   languageOptions: {
@@ -86,6 +129,35 @@ try {
           `  second() {}\n` +
           `  third() {}\n` +
           `}\n`,
+      },
+      // Per-class keying: two classes in one file with members sharing
+      // names but in OPPOSITE Rails order. A flat per-file list forced one
+      // order on both (the casted.rb bug); per-class keying lets each pass
+      // in its own order. Here `Casted` wants before→database and `Quoted`
+      // wants database→before, and both are already correct.
+      {
+        filename: multiFile,
+        code:
+          `class Casted {\n  before() {}\n  database() {}\n}\n` +
+          `class Quoted {\n  database() {}\n  before() {}\n}\n`,
+      },
+      // Ambiguity guard: two manifest buckets, neither matching a class
+      // name by exact spelling. The 1:1 rename fallback only fires when
+      // exactly one bucket AND one class remain unmatched, so here it must
+      // NOT pair — both classes stay unordered even though out of order.
+      {
+        filename: ambiguousFile,
+        code:
+          `class Xyz {\n  third() {}\n  first() {}\n}\n` +
+          `class Zzz {\n  third() {}\n  first() {}\n}\n`,
+      },
+      // Identity guard: exactly one class body and one bucket unmatched, but
+      // `Zzz` is not a substring of `Helper` (nor vice versa). No evidence they
+      // are the same entity → the 1/1 fallback must NOT pair, so the class
+      // stays unordered even though its members are out of manifest order.
+      {
+        filename: noEvidenceFile,
+        code: `class Helper {\n  third() {}\n  first() {}\n}\n`,
       },
       // Class nested inside a function body is not reordered. If we
       // also reordered the outer function (it has 0 siblings here so
@@ -294,6 +366,29 @@ try {
         output:
           `class A {\n  first() {}\n  second() {}\n}\n` +
           `class B {\n  second() {}\n  third() {}\n}\n`,
+      },
+      // Per-class keying, both classes out of order: `Casted` reorders to
+      // before→database while `Quoted` reorders to database→before, from the
+      // same file. Impossible with a flat per-file list.
+      {
+        filename: multiFile,
+        code:
+          `class Casted {\n  database() {}\n  before() {}\n}\n` +
+          `class Quoted {\n  before() {}\n  database() {}\n}\n`,
+        errors: [{ messageId: "outOfOrder" }],
+        output:
+          `class Casted {\n  before() {}\n  database() {}\n}\n` +
+          `class Quoted {\n  database() {}\n  before() {}\n}\n`,
+      },
+      // Rename fallback: the manifest bucket is keyed `Integer` (the Rails
+      // constant) but trails named the class `IntegerType`. With one bucket
+      // and one class both unmatched, the 1:1 fallback pairs them and the
+      // class is reordered to the bucket's Rails order.
+      {
+        filename: renameFile,
+        code: `class IntegerType {\n  third() {}\n  first() {}\n  second() {}\n}\n`,
+        errors: [{ messageId: "outOfOrder" }],
+        output: `class IntegerType {\n  first() {}\n  second() {}\n  third() {}\n}\n`,
       },
       // Section header separated by one blank line travels with the
       // next method.

--- a/packages/activemodel/src/attribute-mutation-tracker.ts
+++ b/packages/activemodel/src/attribute-mutation-tracker.ts
@@ -150,6 +150,10 @@ export class AttributeMutationTracker {
 export class ForcedMutationTracker extends AttributeMutationTracker {
   private finalizedChanges: Record<string, [unknown, unknown]> | null = null;
 
+  changedInPlace(_name: string): boolean {
+    return false;
+  }
+
   changeToAttribute(name: string): [unknown, unknown] | null {
     if (
       this.finalizedChanges &&
@@ -158,10 +162,6 @@ export class ForcedMutationTracker extends AttributeMutationTracker {
       return [...this.finalizedChanges[name]];
     }
     return super.changeToAttribute(name);
-  }
-
-  changedInPlace(_name: string): boolean {
-    return false;
   }
 
   forgetChange(name: string): void {
@@ -181,6 +181,10 @@ export class ForcedMutationTracker extends AttributeMutationTracker {
     this.forcedChanges.set(name, cloneValue(value));
   }
 
+  finalizeChanges(): void {
+    this.finalizedChanges = this.changes();
+  }
+
   protected override attrNames(): string[] {
     return Array.from(this.forcedChanges.keys());
   }
@@ -192,10 +196,6 @@ export class ForcedMutationTracker extends AttributeMutationTracker {
   /** @internal */
   protected override typeCast(_name: string, value: unknown): unknown {
     return value;
-  }
-
-  finalizeChanges(): void {
-    this.finalizedChanges = this.changes();
   }
 }
 
@@ -233,11 +233,11 @@ export class NullMutationTracker {
     return false;
   }
 
-  forgetChange(_name: string): void {}
-
   originalValue(_name: string): unknown {
     return undefined;
   }
+
+  forgetChange(_name: string): void {}
   forceChange(_name: string): void {}
   finalizeChanges(): void {}
 }

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -104,70 +104,6 @@ export class PendingDefault implements PendingModification {
  */
 let _decoratorReplayDepth = 0;
 
-/** True while a PendingDecorator is replaying during materialization. @internal */
-export function isDecoratorReplay(): boolean {
-  return _decoratorReplayDepth > 0;
-}
-
-/**
- * Run `fn` in decorator-replay context, so `isDecoratorReplay()` reports true.
- *
- * Mirrors: the replay performed by
- * ActiveModel::AttributeRegistration::PendingDecorator#apply_to. Every path that
- * replays a pending decorator MUST go through this, or decorators gated on
- * replay context (notably enum's undeclared-type check) silently change behavior.
- *
- * @internal
- */
-function inDecoratorReplay<T>(fn: () => T): T {
-  _decoratorReplayDepth++;
-  try {
-    return fn();
-  } finally {
-    _decoratorReplayDepth--;
-  }
-}
-
-/** @internal Rails-private helper. */
-export class PendingDecorator implements PendingModification {
-  constructor(
-    readonly names: string[] | null,
-    readonly decorator: AttributeDecorator,
-  ) {}
-
-  /** @internal */
-  applyTo(attributeSet: AttributeSet, host?: unknown): void {
-    const targets = this.names ?? attributeSet.keys();
-    for (const name of targets) {
-      const existing = attributeSet.getAttribute(name);
-      const newType = inDecoratorReplay(() => this.decorator(name, existing.type, host));
-      if (newType) {
-        attributeSet.set(name, existing.withType(newType));
-      }
-    }
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Subclass registry
-// Mirrors: ActiveSupport::DescendantsTracker used by reset_default_attributes
-// ---------------------------------------------------------------------------
-
-/**
- * Register cls as a direct subclass of its prototype-chain superclass so
- * resetDefaultAttributes() can cascade to it.
- *
- * Delegates to DescendantsTracker (WeakRef-backed, dedup'd) — the same
- * infrastructure Rails uses via ActiveSupport::DescendantsTracker. Rails
- * registers via the `inherited` hook; we register lazily on the first
- * _defaultAttributes() call instead (same effect: only classes that have
- * a cache worth invalidating are tracked).
- *
- * Mirrors: ActiveSupport::DescendantsTracker registration triggered by
- * Class.inherited in Rails.
- */
-type HostAsClass = new (...args: unknown[]) => unknown;
-
 /**
  * Mirrors: ActiveModel::AttributeRegistration::ClassMethods#decorate_attributes
  *
@@ -225,6 +161,46 @@ export function _defaultAttributes(this: AttributeHostInternals): AttributeSet {
   }
   return this._cachedDefaultAttributes;
 }
+
+/** @internal Rails-private helper. */
+export class PendingDecorator implements PendingModification {
+  constructor(
+    readonly names: string[] | null,
+    readonly decorator: AttributeDecorator,
+  ) {}
+
+  /** @internal */
+  applyTo(attributeSet: AttributeSet, host?: unknown): void {
+    const targets = this.names ?? attributeSet.keys();
+    for (const name of targets) {
+      const existing = attributeSet.getAttribute(name);
+      const newType = inDecoratorReplay(() => this.decorator(name, existing.type, host));
+      if (newType) {
+        attributeSet.set(name, existing.withType(newType));
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Subclass registry
+// Mirrors: ActiveSupport::DescendantsTracker used by reset_default_attributes
+// ---------------------------------------------------------------------------
+
+/**
+ * Register cls as a direct subclass of its prototype-chain superclass so
+ * resetDefaultAttributes() can cascade to it.
+ *
+ * Delegates to DescendantsTracker (WeakRef-backed, dedup'd) — the same
+ * infrastructure Rails uses via ActiveSupport::DescendantsTracker. Rails
+ * registers via the `inherited` hook; we register lazily on the first
+ * _defaultAttributes() call instead (same effect: only classes that have
+ * a cache worth invalidating are tracked).
+ *
+ * Mirrors: ActiveSupport::DescendantsTracker registration triggered by
+ * Class.inherited in Rails.
+ */
+type HostAsClass = new (...args: unknown[]) => unknown;
 
 /**
  * Mirrors: ActiveModel::AttributeRegistration::ClassMethods#attribute_types
@@ -381,6 +357,30 @@ export function hookAttributeType(
   type: Type,
 ): Type {
   return type;
+}
+
+/** True while a PendingDecorator is replaying during materialization. @internal */
+export function isDecoratorReplay(): boolean {
+  return _decoratorReplayDepth > 0;
+}
+
+/**
+ * Run `fn` in decorator-replay context, so `isDecoratorReplay()` reports true.
+ *
+ * Mirrors: the replay performed by
+ * ActiveModel::AttributeRegistration::PendingDecorator#apply_to. Every path that
+ * replays a pending decorator MUST go through this, or decorators gated on
+ * replay context (notably enum's undeclared-type check) silently change behavior.
+ *
+ * @internal
+ */
+function inDecoratorReplay<T>(fn: () => T): T {
+  _decoratorReplayDepth++;
+  try {
+    return fn();
+  } finally {
+    _decoratorReplayDepth--;
+  }
 }
 
 export function registerWithSuperclass(cls: AttributeHostInternals): void {

--- a/packages/activemodel/src/attribute-set.ts
+++ b/packages/activemodel/src/attribute-set.ts
@@ -149,28 +149,6 @@ export class AttributeSet {
     }
   }
 
-  /**
-   * Force a database value to be cast through the supplied `type`, replacing any
-   * existing (schema-declared) attribute. Unlike {@link writeFromDatabase}, whose
-   * known-column path keeps the declared cast type, this always wins — mirroring
-   * how Rails' `LazyAttributeHash` resolves each name via
-   * `additional_types[name] || types[name]`, letting an explicit per-attribute
-   * `types` override supersede the schema type. Used only by the public
-   * `instantiate(attributes, types)` entry point; the result-set hydration path
-   * still ignores column types for known columns.
-   */
-  overrideFromDatabase(
-    name: string,
-    value: unknown,
-    type: { deserialize(value: unknown): unknown },
-  ): void {
-    this.assertNotFrozen();
-    this.attributes.set(
-      name,
-      Attribute.fromDatabase(name, value, type as import("./type/value.js").Type),
-    );
-  }
-
   writeFromUser(name: string, value: unknown): unknown {
     this.assertNotFrozen();
     // Rails one-liner (attribute_set.rb:58-61):
@@ -241,6 +219,28 @@ export class AttributeSet {
   /** @internal */
   protected defaultAttribute(name: string): Attribute {
     return Attribute.null(name);
+  }
+
+  /**
+   * Force a database value to be cast through the supplied `type`, replacing any
+   * existing (schema-declared) attribute. Unlike {@link writeFromDatabase}, whose
+   * known-column path keeps the declared cast type, this always wins — mirroring
+   * how Rails' `LazyAttributeHash` resolves each name via
+   * `additional_types[name] || types[name]`, letting an explicit per-attribute
+   * `types` override supersede the schema type. Used only by the public
+   * `instantiate(attributes, types)` entry point; the result-set hydration path
+   * still ignores column types for known columns.
+   */
+  overrideFromDatabase(
+    name: string,
+    value: unknown,
+    type: { deserialize(value: unknown): unknown },
+  ): void {
+    this.assertNotFrozen();
+    this.attributes.set(
+      name,
+      Attribute.fromDatabase(name, value, type as import("./type/value.js").Type),
+    );
   }
 
   /**

--- a/packages/activemodel/src/attribute-set/builder.ts
+++ b/packages/activemodel/src/attribute-set/builder.ts
@@ -125,19 +125,6 @@ export class LazyAttributeHash {
     this.delegate = delegateHash;
   }
 
-  isKey(key: string): boolean {
-    return this.has(key);
-  }
-
-  keys(): string[] {
-    const allKeys = new Set([
-      ...this.delegate.keys(),
-      ...Object.keys(this.values),
-      ...this.types.keys(),
-    ]);
-    return [...allKeys];
-  }
-
   /**
    * Return a new map applying `fn` to each materialized Attribute.
    *
@@ -190,6 +177,10 @@ export class LazyAttributeHash {
       if (!drop.has(name)) result.set(name, attr);
     }
     return result;
+  }
+
+  isKey(key: string): boolean {
+    return this.has(key);
   }
 
   deepDup(): LazyAttributeHash {
@@ -263,6 +254,15 @@ export class LazyAttributeHash {
    */
   assignDefaultValue(name: string): Attribute {
     return this.assignDefault(name);
+  }
+
+  keys(): string[] {
+    const allKeys = new Set([
+      ...this.delegate.keys(),
+      ...Object.keys(this.values),
+      ...this.types.keys(),
+    ]);
+    return [...allKeys];
   }
 
   get(name: string): Attribute {

--- a/packages/activemodel/src/attribute.ts
+++ b/packages/activemodel/src/attribute.ts
@@ -160,12 +160,16 @@ export abstract class Attribute {
     return this._originalValueForDatabase();
   }
 
+  private isAssigned(): boolean {
+    return this.originalAttribute !== null;
+  }
+
+  abstract typeCast(value: unknown): unknown;
+
   private changedFromAssignment(): boolean {
     if (!this.isAssigned()) return false;
     return this.type.isChanged(this.originalValue, this.value, this.valueBeforeTypeCast);
   }
-
-  abstract typeCast(value: unknown): unknown;
 
   /** @internal */
   protected _valueForDatabase(): unknown {
@@ -250,10 +254,6 @@ export abstract class Attribute {
     this.originalAttribute = attr;
   }
 
-  private isAssigned(): boolean {
-    return this.originalAttribute !== null;
-  }
-
   /**
    * Create an attribute where we already have both the raw and cast values.
    * Used in the Model constructor after applying normalization/nullify.
@@ -269,6 +269,10 @@ export abstract class Attribute {
 }
 
 export class FromDatabase extends Attribute {
+  typeCast(value: unknown): unknown {
+    return this.type.deserialize(value);
+  }
+
   override forgettingAssignment(): Attribute {
     // Rails condition: `!defined?(@value_for_database) && !changed_in_place?`
     // → fast-path creates a new FromDatabase using the existing value_before_type_cast.
@@ -278,10 +282,6 @@ export class FromDatabase extends Attribute {
     // a new FromDatabase, resetting the baseline to the post-mutation state.
     if (!this.changedInPlace()) return this;
     return super.forgettingAssignment();
-  }
-
-  typeCast(value: unknown): unknown {
-    return this.type.deserialize(value);
   }
 
   /** @internal */
@@ -310,12 +310,12 @@ export class FromUser extends Attribute {
 }
 
 export class WithCastValue extends Attribute {
-  changedInPlace(): boolean {
-    return false;
-  }
-
   typeCast(value: unknown): unknown {
     return value;
+  }
+
+  changedInPlace(): boolean {
+    return false;
   }
 }
 
@@ -324,20 +324,20 @@ export class Null extends Attribute {
     super(name, null, typeRegistry.lookup("value"));
   }
 
-  withValueFromUser(_value: unknown): Attribute {
-    throw new MissingAttributeError(`can't write unknown attribute \`${this.name ?? ""}\``);
-  }
-
-  withValueFromDatabase(_value: unknown): Attribute {
-    throw new MissingAttributeError(`can't write unknown attribute \`${this.name ?? ""}\``);
+  typeCast(): unknown {
+    return null;
   }
 
   override withType(type: Type): Attribute {
     return Attribute.withCastValue(this.name, null, type);
   }
 
-  typeCast(): unknown {
-    return null;
+  withValueFromDatabase(_value: unknown): Attribute {
+    throw new MissingAttributeError(`can't write unknown attribute \`${this.name ?? ""}\``);
+  }
+
+  withValueFromUser(_value: unknown): Attribute {
+    throw new MissingAttributeError(`can't write unknown attribute \`${this.name ?? ""}\``);
   }
 }
 
@@ -358,6 +358,10 @@ export class Uninitialized extends Attribute {
     return undefined;
   }
 
+  isInitialized(): boolean {
+    return false;
+  }
+
   forgettingAssignment(): Attribute {
     return new Uninitialized(this.name, this.type);
   }
@@ -368,9 +372,5 @@ export class Uninitialized extends Attribute {
 
   typeCast(): unknown {
     return undefined;
-  }
-
-  isInitialized(): boolean {
-    return false;
   }
 }

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -223,6 +223,69 @@ export class ModelName {
     return this.collection;
   }
 
+  /**
+   * Mirrors Rails `@name.match?(regexp)`. Returns whether the class
+   * name matches the given regex (boolean — this is `match?` semantic,
+   * not the integer position that Ruby `=~` returns).
+   *
+   * Preserves `pattern.lastIndex` so repeated calls with `/g` or `/y`
+   * regexes stay stable — `RegExp.prototype.test` advances `lastIndex`
+   * on stateful flags, but Ruby `match?` is stateless.
+   */
+  match(pattern: unknown): boolean {
+    if (!(pattern instanceof RegExp)) {
+      throw new ArgumentError("ModelName#match requires a RegExp");
+    }
+    const savedLastIndex = pattern.lastIndex;
+    try {
+      return pattern.test(this.name);
+    } finally {
+      pattern.lastIndex = savedLastIndex;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // String-ness — Rails `ActiveModel::Name < String` (naming.rb:10, :151-152):
+  //   include Comparable
+  //   delegate :==, :===, :<=>, :=~, :"!~", :eql?, :match?, :to_s,
+  //            :to_str, :as_json, to: :name
+  //
+  // JS can't overload operators, so we expose methods + the one coercion
+  // hook JS does have: `Symbol.toPrimitive`. That covers IMPLICIT string
+  // coercion only — `String(modelName)`, template literals, `modelName +
+  // ""`, and loose `==` against a string. It does NOT trigger on strict
+  // `===` / `Object.is` / matchers that use strict identity without
+  // coercion; for those, callers use `mn.name` or `mn.equals(other)`.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Mirrors Rails `to_s` / `to_str` delegated to `@name`
+   * (naming.rb:131-152). Rails' `@name` is the full constant path
+   * (`"Blog::Post"`). TS class names carry no `::`, so we reconstruct the
+   * qualified path from the namespace segments in the constructor; `toString`
+   * returns that full path (`"Blog::Post"`) to match Rails.
+   */
+  toString(): string {
+    return this.name;
+  }
+
+  /**
+   * Mirrors Rails `@name.as_json` — `String#as_json` just returns the
+   * string (and accepts an ignored `options` Hash). Returns `this.name`
+   * as-is; accepts (but ignores) an options argument so callers match
+   * Rails' signature and the rest of this codebase's `asJson(options?)`
+   * conventions. Lets `JSON.stringify(mn)` emit the plain class name
+   * rather than `{}` / the object form.
+   */
+  asJson(_options?: unknown): string {
+    return this.name;
+  }
+
+  /** Implicit coercion hook so `String(mn)`, `"${mn}"`, `mn + ""` all work. */
+  [Symbol.toPrimitive](_hint: string): string {
+    return this.name;
+  }
+
   get human(): string {
     if (!this._klass) return this._humanFallback;
 
@@ -276,11 +339,6 @@ export class ModelName {
     return keys;
   }
 
-  /** Implicit coercion hook so `String(mn)`, `"${mn}"`, `mn + ""` all work. */
-  [Symbol.toPrimitive](_hint: string): string {
-    return this.name;
-  }
-
   // Uncountable lookup delegates to `@blazetrails/activesupport`'s
   // `Inflections.instance("en")` — the same store Rails models go
   // through via `ActiveSupport::Inflector.inflections { |i| i.uncountable ... }`
@@ -300,31 +358,6 @@ export class ModelName {
    */
   static addUncountable(word: string): void {
     Inflections.instance("en").uncountable(word);
-  }
-
-  // ---------------------------------------------------------------------------
-  // String-ness — Rails `ActiveModel::Name < String` (naming.rb:10, :151-152):
-  //   include Comparable
-  //   delegate :==, :===, :<=>, :=~, :"!~", :eql?, :match?, :to_s,
-  //            :to_str, :as_json, to: :name
-  //
-  // JS can't overload operators, so we expose methods + the one coercion
-  // hook JS does have: `Symbol.toPrimitive`. That covers IMPLICIT string
-  // coercion only — `String(modelName)`, template literals, `modelName +
-  // ""`, and loose `==` against a string. It does NOT trigger on strict
-  // `===` / `Object.is` / matchers that use strict identity without
-  // coercion; for those, callers use `mn.name` or `mn.equals(other)`.
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Mirrors Rails `to_s` / `to_str` delegated to `@name`
-   * (naming.rb:131-152). Rails' `@name` is the full constant path
-   * (`"Blog::Post"`). TS class names carry no `::`, so we reconstruct the
-   * qualified path from the namespace segments in the constructor; `toString`
-   * returns that full path (`"Blog::Post"`) to match Rails.
-   */
-  toString(): string {
-    return this.name;
   }
 
   /**
@@ -371,39 +404,6 @@ export class ModelName {
     // `name` is already the full `::`-qualified constant path, so it doubles as
     // the single-string sort key Rails' `String#<=>` compares.
     return mn.name;
-  }
-
-  /**
-   * Mirrors Rails `@name.match?(regexp)`. Returns whether the class
-   * name matches the given regex (boolean — this is `match?` semantic,
-   * not the integer position that Ruby `=~` returns).
-   *
-   * Preserves `pattern.lastIndex` so repeated calls with `/g` or `/y`
-   * regexes stay stable — `RegExp.prototype.test` advances `lastIndex`
-   * on stateful flags, but Ruby `match?` is stateless.
-   */
-  match(pattern: unknown): boolean {
-    if (!(pattern instanceof RegExp)) {
-      throw new ArgumentError("ModelName#match requires a RegExp");
-    }
-    const savedLastIndex = pattern.lastIndex;
-    try {
-      return pattern.test(this.name);
-    } finally {
-      pattern.lastIndex = savedLastIndex;
-    }
-  }
-
-  /**
-   * Mirrors Rails `@name.as_json` — `String#as_json` just returns the
-   * string (and accepts an ignored `options` Hash). Returns `this.name`
-   * as-is; accepts (but ignores) an options argument so callers match
-   * Rails' signature and the rest of this codebase's `asJson(options?)`
-   * conventions. Lets `JSON.stringify(mn)` emit the plain class name
-   * rather than `{}` / the object form.
-   */
-  asJson(_options?: unknown): string {
-    return this.name;
   }
 
   private _cachedI18nKeys?: string[];

--- a/packages/activemodel/src/translation.ts
+++ b/packages/activemodel/src/translation.ts
@@ -36,13 +36,6 @@ const MISSING_TRANSLATION = "\x00__MISSING_TRANSLATION__\x00";
 
 let _raiseOnMissingTranslations = false;
 
-export function raiseOnMissingTranslations(value?: boolean): boolean {
-  if (value !== undefined) {
-    _raiseOnMissingTranslations = value;
-  }
-  return _raiseOnMissingTranslations;
-}
-
 /**
  * Walk the class prototype chain collecting constructors that expose a
  * modelName static (i.e. those that include ActiveModel::Naming in Rails).
@@ -106,6 +99,13 @@ export function humanAttributeName(
     }
     return result;
   }
+}
+
+export function raiseOnMissingTranslations(value?: boolean): boolean {
+  if (value !== undefined) {
+    _raiseOnMissingTranslations = value;
+  }
+  return _raiseOnMissingTranslations;
 }
 
 function _callI18n(

--- a/packages/arel/src/nodes/bind-param.ts
+++ b/packages/arel/src/nodes/bind-param.ts
@@ -22,11 +22,6 @@ export class BindParam extends Node {
     this.value = value;
   }
 
-  valueBeforeTypeCast(): unknown {
-    const v = this.value as { valueBeforeTypeCast?: () => unknown } | null | undefined;
-    return typeof v?.valueBeforeTypeCast === "function" ? v.valueBeforeTypeCast() : this.value;
-  }
-
   /**
    * Mirrors `Arel::Nodes::BindParam#nil?` (bind_param.rb:23-25), which
    * delegates to `value.nil?`. A bare raw `null` value is nil; a wrapped
@@ -40,6 +35,11 @@ export class BindParam extends Node {
     if (this.value === null) return true;
     const v = this.value as { isNil?: () => boolean } | undefined;
     return typeof v?.isNil === "function" && v.isNil();
+  }
+
+  valueBeforeTypeCast(): unknown {
+    const v = this.value as { valueBeforeTypeCast?: () => unknown } | null | undefined;
+    return typeof v?.valueBeforeTypeCast === "function" ? v.valueBeforeTypeCast() : this.value;
   }
 
   /**

--- a/packages/arel/src/nodes/casted.ts
+++ b/packages/arel/src/nodes/casted.ts
@@ -103,10 +103,6 @@ export class Quoted extends Unary {
     super(value);
   }
 
-  get value(): unknown {
-    return this.expr;
-  }
-
   valueForDatabase(): unknown {
     return this.value;
   }
@@ -138,6 +134,10 @@ export class Quoted extends Unary {
     if (this.value === -Infinity) return -1;
     const v = this.value as { isInfinite?: () => 1 | -1 | false } | null | undefined;
     return typeof v?.isInfinite === "function" ? v.isInfinite() : false;
+  }
+
+  get value(): unknown {
+    return this.expr;
   }
 
   accept<T>(visitor: NodeVisitor<T>): T {

--- a/packages/arel/src/nodes/unqualified-column.ts
+++ b/packages/arel/src/nodes/unqualified-column.ts
@@ -1,6 +1,10 @@
 import { Unary } from "./unary.js";
 
 export class UnqualifiedColumn extends Unary {
+  get attribute() {
+    return this.expr;
+  }
+
   get relation(): unknown {
     return (this.expr as { relation: unknown })?.relation;
   }
@@ -11,9 +15,5 @@ export class UnqualifiedColumn extends Unary {
 
   get name(): unknown {
     return (this.expr as { name: unknown })?.name;
-  }
-
-  get attribute() {
-    return this.expr;
   }
 }

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -153,6 +153,27 @@ export class Table extends Node {
     return this.from().having(expr);
   }
 
+  /**
+   * Mirrors: Arel::Table#hash — only name (Rails excludes aliases to avoid loops).
+   */
+  override hash(): number {
+    let h = 0x811c9dc5;
+    for (let i = 0; i < this.name.length; i++) {
+      h ^= this.name.charCodeAt(i);
+      h = Math.imul(h, 0x01000193);
+    }
+    return h >>> 0;
+  }
+
+  /**
+   * Mirrors: Arel::Table#eql? — compares name and tableAlias (not klass).
+   * Rails excludes aliases array and engine from the hash to avoid loops.
+   */
+  eql(other: unknown): boolean {
+    if (!(other instanceof Table)) return false;
+    return this.name === other.name && this.tableAlias === other.tableAlias;
+  }
+
   typeCastForDatabase(attrName: string, value: unknown): unknown {
     return (this.typeCaster as TypeCaster).typeCastForDatabase(attrName, value);
   }
@@ -215,27 +236,6 @@ export class Table extends Node {
    */
   as(aliasName: string): TableAlias {
     return new TableAlias(this, aliasName);
-  }
-
-  /**
-   * Mirrors: Arel::Table#eql? — compares name and tableAlias (not klass).
-   * Rails excludes aliases array and engine from the hash to avoid loops.
-   */
-  eql(other: unknown): boolean {
-    if (!(other instanceof Table)) return false;
-    return this.name === other.name && this.tableAlias === other.tableAlias;
-  }
-
-  /**
-   * Mirrors: Arel::Table#hash — only name (Rails excludes aliases to avoid loops).
-   */
-  override hash(): number {
-    let h = 0x811c9dc5;
-    for (let i = 0; i < this.name.length; i++) {
-      h ^= this.name.charCodeAt(i);
-      h = Math.imul(h, 0x01000193);
-    }
-    return h >>> 0;
   }
 
   accept<T>(visitor: NodeVisitor<T>): T {

--- a/scripts/build-rails-file-structure-manifest.ts
+++ b/scripts/build-rails-file-structure-manifest.ts
@@ -5,8 +5,11 @@
  *
  * Currently emits:
  *   eslint/rails-file-structure-method-order.json — maps each TS source
- *     path (relative to repo root) to an ordered list of TS member
- *     names, derived from the Rails source file's method order. Read by
+ *     path (relative to repo root) to `{ classes, functions }`: per-class
+ *     ordered member-name lists plus the file's top-level function order,
+ *     derived from the Rails source's method order. Keyed per class so a
+ *     file defining several classes with overlapping member names can
+ *     express each class's own order. Read by
  *     `blazetrails/rails-file-structure-method-order`.
  *
  * Future sibling rules (include-position, visibility-grouping, module-
@@ -66,86 +69,206 @@ interface RubyEntity {
 
 const railsApi = JSON.parse(fs.readFileSync(RAILS_API_PATH, "utf8"));
 
+// Order data is keyed per TS container, not per file: `classes[Name]` holds
+// the member order for the class `Name`, and `functions` holds the order for
+// the file's top-level functions. A single Ruby file may define several
+// classes whose members share names (e.g. `casted.rb`'s `Casted` and `Quoted`
+// both define `value_for_database` / `value_before_type_cast` in OPPOSITE
+// order); a flat per-file list collapsed them and forced one order on both.
+// Keying per class lets each express its own Rails order.
+interface FileOrder {
+  classes: Record<string, string[]>;
+  functions: string[];
+}
 interface Manifest {
-  files: Record<string, string[]>;
+  files: Record<string, FileOrder>;
 }
 const manifest: Manifest = { files: {} };
+
+// Universal Object methods that api-compare's SKIP set drops (they don't count
+// toward method-existence coverage — every object inherits them). But when a
+// Rails class *overrides* one it is a real definition with a real source
+// POSITION and a real TS spelling, so method-ORDER must place it. Without this,
+// `rubyMethodToTs("nil?")` returns null and the rule treats the override (e.g.
+// `Casted#nil?` at casted.rb:15, which sits BETWEEN value_before_type_cast and
+// value_for_database) as an unmapped TS-only helper and shoves it past the
+// mapped block — actively degrading fidelity. Map the common overridables to
+// the candidates rubyMethodToTs would produce if they weren't skipped.
+const ORDER_ONLY_CANDIDATES: Record<string, string[]> = {
+  "nil?": ["isNil", "nil"],
+  hash: ["hash"],
+  "eql?": ["isEql", "eql"],
+  // Ruby OPERATORS are deliberately NOT mapped. Unlike the three universal
+  // predicates above — each with one canonical trails spelling — operator
+  // ports are class-specific and ambiguous, so a name-only global map is unsafe:
+  // `[]` ports to `get` in `Arel::Table` / `ActiveModel::Errors` /
+  // `LazyAttributeHash` but to `getAttribute` in `ActiveModel::AttributeSet`,
+  // where `get` is instead a non-Rails Map-compat helper (attribute_set.rb:16
+  // `[]` → `getAttribute` at attribute-set.ts:298; the `get` at :63 has no Rails
+  // counterpart). Mapping `[]`→`get` would promote that invention into Rails'
+  // `[]` slot. `==` / `<=>` similarly vary (`equals` / `isEqualTo` / `compare`).
+  // Such operator ports — rare — sort after the mapped block; if one becomes a
+  // real fidelity gap, the RAILS_STRUCTURE_REPORT class-level surface flags it.
+};
+
+// Append TS candidate names for a Ruby method onto `list`, deduping against
+// `seen`. Emits ALL candidates from rubyMethodToTs, not just the first. Some
+// Ruby predicates camelize to multiple acceptable TS names (e.g. `empty?` →
+// `["isEmpty", "empty"]`, `has_attribute?` → `["hasAttribute",
+// "isHasAttribute"]`). Recording only the first means a TS port that chose the
+// alternate spelling becomes "unmapped" and skips ordering. The rule filters
+// each container's expected names to those actually present, so emitting both
+// is a safe no-op for whichever spelling wasn't used.
+const pushMethod = (list: string[], seen: Set<string>, name: string) => {
+  const candidates = rubyMethodToTs(name) ?? ORDER_ONLY_CANDIDATES[name];
+  if (!candidates || candidates.length === 0) return;
+  for (const ts of candidates) {
+    if (seen.has(ts)) continue;
+    seen.add(ts);
+    list.push(ts);
+  }
+};
+
+// A TS container: `{ file, key }` where `key` is a class name or the sentinel
+// `FUNCTIONS_KEY` for the file's top-level functions. Ruby methods are bucketed
+// per (rubyFile, container) so each class keeps its own dedup scope.
+const FUNCTIONS_KEY = Symbol("functions");
+interface Bucket {
+  names: string[];
+  seen: Set<string>;
+}
 
 for (const [pkg, rubyPkg] of Object.entries<any>(railsApi.packages)) {
   const pkgDir = PACKAGE_DIRS[pkg];
   if (!pkgDir) continue;
 
-  // rubyFile → ordered list of TS candidate names (first candidate wins).
-  // Map preserves insertion order — we walk Rails entities in extraction
-  // order, then walk each entity's instance methods + class methods in
-  // Rails source order. Method-level `file` is preferred over the
-  // entity's `file` so methods reopen-defined in sibling files land in
-  // the correct bucket (Rails does this with `class Foo` blocks reopened
-  // across files in the same namespace).
-  const byFile = new Map<string, string[]>();
-  const seenPerFile = new Map<string, Set<string>>();
+  // (rubyFile) → (containerKey) → Bucket. Map preserves insertion order — we
+  // walk Rails entities in extraction order, then each entity's instance
+  // methods + class methods in Rails source order. Method-level `file` is
+  // preferred over the entity's `file` so methods reopen-defined in sibling
+  // files land in the correct bucket (Rails reopens `class Foo` across files).
+  const byFile = new Map<string, Map<string | symbol, Bucket>>();
 
-  // Emit ALL candidates from rubyMethodToTs, not just the first. Some
-  // Ruby predicates camelize to multiple acceptable TS names (e.g.
-  // `empty?` → `["isEmpty", "empty"]`, `has_attribute?` → `["hasAttribute",
-  // "isHasAttribute"]`). Recording only the first means a TS port that
-  // chose the alternate spelling becomes "unmapped" and skips ordering.
-  // The rule's `for (const name of expectedOrder)` loop naturally
-  // handles alternates: candidates that aren't present in the container
-  // are no-ops, so emitting both is safe.
-  const push = (rubyFile: string, name: string) => {
-    const candidates = rubyMethodToTs(name);
-    if (!candidates || candidates.length === 0) return;
-    let seen = seenPerFile.get(rubyFile);
-    if (!seen) {
-      seen = new Set();
-      seenPerFile.set(rubyFile, seen);
+  const bucketFor = (rubyFile: string, key: string | symbol): Bucket => {
+    let byKey = byFile.get(rubyFile);
+    if (!byKey) {
+      byKey = new Map();
+      byFile.set(rubyFile, byKey);
     }
-    let list = byFile.get(rubyFile);
-    if (!list) {
-      list = [];
-      byFile.set(rubyFile, list);
+    let bucket = byKey.get(key);
+    if (!bucket) {
+      bucket = { names: [], seen: new Set() };
+      byKey.set(key, bucket);
     }
-    for (const ts of candidates) {
-      if (seen.has(ts)) continue;
-      seen.add(ts);
-      list.push(ts);
-    }
+    return bucket;
   };
 
-  const visit = (entities: Record<string, RubyEntity>) => {
+  // The bucket key is the fqn's last segment, so two class entities in one file
+  // whose last segments collide across namespaces (e.g. `Foo::Builder` and
+  // `Bar::Builder`) would silently merge into one blended order. Track fqns per
+  // (bucketFile, last-segment); a colliding bucket is DROPPED (not emitted) and
+  // warned — enforcing a blended order would be worse than no order at all.
+  // (Repo-wide this is currently vanishingly rare.)
+  const classFqnsByKey = new Map<string, Set<string>>();
+  const noteClass = (bucketFile: string, className: string, fqn: string) => {
+    const collKey = `${bucketFile}\0${className}`;
+    let fqns = classFqnsByKey.get(collKey);
+    if (!fqns) classFqnsByKey.set(collKey, (fqns = new Set()));
+    fqns.add(fqn);
+  };
+
+  // Ruby classes port to TS classes: instance + static members live in the
+  // class container keyed by the fqn's last segment (`Arel::Nodes::Casted` →
+  // `Casted`). Ruby modules port to top-level `this`-typed / mixin functions
+  // (CLAUDE.md "Module mixins"), so their methods go in the functions bucket.
+  const visitClasses = (entities: Record<string, RubyEntity>) => {
+    for (const host of Object.values(entities)) {
+      if (!host.file) continue;
+      const className = host.fqn.split("::").pop() ?? host.fqn;
+      for (const m of host.instanceMethods ?? []) {
+        const file = m.file ?? host.file;
+        noteClass(file, className, host.fqn);
+        const b = bucketFor(file, className);
+        pushMethod(b.names, b.seen, m.name);
+      }
+      for (const m of host.classMethods ?? []) {
+        const file = m.file ?? host.file;
+        noteClass(file, className, host.fqn);
+        const b = bucketFor(file, className);
+        pushMethod(b.names, b.seen, m.name);
+      }
+    }
+  };
+  const visitModules = (entities: Record<string, RubyEntity>) => {
     for (const host of Object.values(entities)) {
       if (!host.file) continue;
       for (const m of host.instanceMethods ?? []) {
-        push(m.file ?? host.file, m.name);
+        const b = bucketFor(m.file ?? host.file, FUNCTIONS_KEY);
+        pushMethod(b.names, b.seen, m.name);
       }
       for (const m of host.classMethods ?? []) {
-        push(m.file ?? host.file, m.name);
+        const b = bucketFor(m.file ?? host.file, FUNCTIONS_KEY);
+        pushMethod(b.names, b.seen, m.name);
       }
     }
   };
-  visit(rubyPkg.classes ?? {});
-  visit(rubyPkg.modules ?? {});
+  visitClasses(rubyPkg.classes ?? {});
+  visitModules(rubyPkg.modules ?? {});
 
-  for (const [rubyFile, names] of byFile) {
+  const collided = new Set<string>();
+  for (const [collKey, fqns] of classFqnsByKey) {
+    if (fqns.size > 1) {
+      collided.add(collKey);
+      const [file, seg] = collKey.split("\0");
+      console.warn(
+        `[build-rails-file-structure-manifest] last-segment collision in ${pkg}/${file}: ` +
+          `\`${seg}\` shared by ${[...fqns].join(", ")} — bucket DROPPED (no order enforced). ` +
+          `Rename the TS classes or split the file so each resolves independently.`,
+      );
+    }
+  }
+
+  for (const [rubyFile, byKey] of byFile) {
     const tsRel = path.posix.join(pkgDir, rubyFileToTs(rubyFile, pkg).split(path.sep).join("/"));
-    const existing = manifest.files[tsRel];
-    if (existing) {
-      // Multiple Ruby files may map to the same TS file (rare). Append
-      // novel names in encounter order; existing order wins for dupes.
-      const have = new Set(existing);
-      for (const n of names) if (!have.has(n)) existing.push(n);
-    } else {
-      manifest.files[tsRel] = [...names];
+    let order = manifest.files[tsRel];
+    if (!order) {
+      order = { classes: {}, functions: [] };
+      manifest.files[tsRel] = order;
+    }
+    for (const [key, bucket] of byKey) {
+      // A colliding class bucket is dropped so the lint step never enforces a
+      // blended order (see the warning above).
+      if (key !== FUNCTIONS_KEY && collided.has(`${rubyFile}\0${key as string}`)) continue;
+      // Multiple Ruby files may map to the same TS file (rare); append novel
+      // names in encounter order, existing order wins for dupes.
+      const target =
+        key === FUNCTIONS_KEY ? order.functions : (order.classes[key as string] ??= []);
+      const have = new Set(target);
+      for (const n of bucket.names) if (!have.has(n)) target.push(n);
     }
   }
 }
 
-const sortedFiles: Record<string, string[]> = {};
-for (const k of Object.keys(manifest.files).sort()) sortedFiles[k] = manifest.files[k];
+// Drop empty containers and files with no order data at all, then sort keys
+// for a stable, diff-friendly manifest.
+const sortedFiles: Record<string, FileOrder> = {};
+for (const k of Object.keys(manifest.files).sort()) {
+  const order = manifest.files[k];
+  const classes: Record<string, string[]> = {};
+  for (const cn of Object.keys(order.classes).sort()) {
+    if (order.classes[cn].length > 0) classes[cn] = order.classes[cn];
+  }
+  const hasFns = order.functions.length > 0;
+  if (Object.keys(classes).length === 0 && !hasFns) continue;
+  const out: FileOrder = { classes, functions: order.functions };
+  sortedFiles[k] = out;
+}
 const final: Manifest = { files: sortedFiles };
 
 writeJsonManifest(OUT, final);
 const fileCount = Object.keys(final.files).length;
-const nameCount = Object.values(final.files).reduce((n, a) => n + a.length, 0);
+const nameCount = Object.values(final.files).reduce(
+  (n, o) => n + o.functions.length + Object.values(o.classes).reduce((m, a) => m + a.length, 0),
+  0,
+);
 console.log(`Wrote ${OUT} — ${fileCount} files (${nameCount} ordered names)`);


### PR DESCRIPTION
## Problem

`blazetrails/rails-file-structure-method-order` was dormant in CI (gitignored
manifest, built only by local `api:compare`) yet auto-fixed locally, and its
per-file, name-deduped order collapsed multi-class files — `casted.rb`'s
`Casted`/`Quoted` define `value_before_type_cast`/`value_for_database` in
opposite order but were forced into one (the autofix reverted the correct one).

## Changes

- **Per-class keying.** Manifest maps each file to `{ classes, functions }`;
  each class expresses its own Rails order. `casted.ts` passes with `Casted` =
  `valueBeforeTypeCast → valueForDatabase` (casted.rb:7,17) and `Quoted` =
  `valueForDatabase → valueBeforeTypeCast` (casted.rb:38-39).
- **Live in CI.** A new step in `rails-comparison` builds the manifest and runs
  the rule over `arel` + `activemodel` — the only job with the manifest present,
  mirroring rails-private-jsdoc. Standalone Lint keeps no-op'ing.
- Violating files reordered to Rails order via the rule's own autofix.

## Review responses (round 4)

1. **`[]`→`get` hijacked `AttributeSet` — reverted; operators now unmapped by
   decision.** `get` is the `[]` port in `Table`/`Errors`/`LazyAttributeHash`
   but a non-Rails Map-compat helper in `AttributeSet` (whose real `[]` port is
   `getAttribute`, attribute_set.rb:16 → attribute-set.ts:298). A name-only
   global map can't tell them apart — `["getAttribute","get"]` still pulls the
   `AttributeSet` invention up next to `getAttribute` (`pushMethod` emits all
   candidates, and the rule places every present name at the manifest slot). So
   the `[]`→`get` entry is **removed** and operators are documented as
   deliberately unmapped (rationale at `ORDER_ONLY_CANDIDATES`). `table.ts`
   `get`/`errors.ts`/`table-alias.ts` reorders are dropped; those `[]` ports
   sort after the mapped block as before.
2. **Class-methods-after-instance-methods — DEFERRED (extractor change),
   filed.** `visitClasses` appends `classMethods` after `instanceMethods`, so a
   `class << self` at the top (attribute.rb:8-24) is expected last. The suggested
   fix (merge by `line`) is **not possible with current data**: I re-verified
   `rails-api.json` method objects are `{name, visibility, params, file, calls,
   bodyDigest}` — no `line`; `extract-ruby-api.rb` records `@current_file` only.
   The real fix (capture source line across the shared 2131-line Ripper
   extractor + interleave) is filed as
   `method-order-interleave-class-instance-methods-by-line` (RFC 0025). This PR
   does not worsen it — `attribute.ts` statics are byte-identical to `main` and
   lint clean. **Explicitly deferred, not silent.**
3. **Out-of-scope files removed.** `test-helpers/connection.ts`,
   `to-sql.test.ts`, `insert-manager.test.ts` (RFC 0007 quoter work on `main`)
   were pulled in by an earlier `git checkout origin/main -- packages/`. The
   branch is now rebased onto current `main`, so they're in the base and gone
   from this diff. Final diff is 15 files: the rule, builder, CI step, docs,
   tests, and mechanical reorders only.

## Review responses (rounds 1–3)

1. **`isNil` past the mapped block — fixed.** `nil?`/`hash`/`eql?` are SKIP-set
   but overrides have real positions; builder maps them. `casted.ts`/`bind-param.ts`
   place `isNil` in its Rails position (casted.rb:15,41).
2. **1:1 rename fallback + substring identity guard.** Pairs only when the Rails
   constant is a case-insensitive substring of the TS name (`Name`⊂`ModelName`,
   `Integer`⊂`IntegerType`, `Node`⊂`DotNode`); recovers `naming.ts`, `type/*`.
   `fixture-noevidence` covers the guard.
3. **Silent drops visible.** `RAILS_STRUCTURE_REPORT=1` (CI step) prints, stderr
   non-failing, every bucket that matched no container; `<2`-member classes
   filtered.
4. **Collision drops the bucket, not blends** (+ warns). The one repo-wide case
   (`Scanner`/`Scanner::Scanner`) drops cleanly.
5. **Module → `functions`.** Modules port to top-level `export function`s
   (ordered) or `include()` object-literal/interface mixins (never orderable);
   module-as-class is surfaced by the report.

## Verification

- `RAILS_STRUCTURE_REPORT=1 pnpm exec tsx scripts/build-rails-file-structure-manifest.ts && pnpm exec eslint packages/arel/src packages/activemodel/src` → 0 violations.
- Unit tests (multi-class opposite orders, rename fallback, ambiguity + identity guards); affected package tests (393) and `tsc --build` typecheck pass; prettier clean.

## Notes

- Manifest stays gitignored (never committed) — the "generate in CI" model.
- **Exceeds the 500 LOC ceiling (user-waived)** — bulk is mechanical,
  Rails-faithful autofix reorders.

Closes-story: rails-file-structure-method-order-dormant-and-per-file
