### PR TITLE
test(arel): dedupe insert-manager inserts null/false and port Rails assertions

### DIFF
--- a/packages/arel/src/insert-manager.test.ts
+++ b/packages/arel/src/insert-manager.test.ts
@@ -58,16 +58,19 @@ describe("InsertManagerTest", () => {
 
     it("inserts false", () => {
       const mgr = new InsertManager();
-      mgr.into(users);
-      mgr.insert([[users.get("active"), false]]);
-      expect(mgr.toSql()).toContain("FALSE");
+      mgr.insert([[users.get("bool"), false]]);
+      // Rails asserts VALUES ('f'): that rendering comes from the Arel suite's
+      // FakeRecord connection double (test/cases/arel/support/fake_record.rb:79-80),
+      // not from any adapter — SQLite quotes false as 0, the abstract adapter as
+      // FALSE. We have no FakeRecord port, so toSql() renders via the
+      // connection-less default quoter.
+      expect(mgr.toSql()).toBe(`INSERT INTO "users" ("bool") VALUES (FALSE)`);
     });
 
     it("inserts null", () => {
       const mgr = new InsertManager();
-      mgr.into(users);
-      mgr.insert([[users.get("name"), null]]);
-      expect(mgr.toSql()).toBe('INSERT INTO "users" ("name") VALUES (NULL)');
+      mgr.insert([[users.get("id"), null]]);
+      expect(mgr.toSql()).toBe(`INSERT INTO "users" ("id") VALUES (NULL)`);
     });
 
     it("takes a list of lists", () => {
@@ -168,28 +171,12 @@ describe("InsertManagerTest", () => {
     expect(mgr.toSql()).toBe(`INSERT INTO "users" ("name", "age") VALUES ('dean', 30)`);
   });
 
-  describe("insert", () => {
-    it("inserts null", () => {
-      const mgr = new InsertManager();
-      mgr.into(users);
-      mgr.insert([[users.get("name"), null]]);
-      expect(mgr.toSql()).toBe(`INSERT INTO "users" ("name") VALUES (NULL)`);
-    });
-  });
-
   it("returns empty array before insert", () => {
     const manager = new InsertManager();
     expect(manager.columns).toEqual([]);
   });
 
   describe("insert", () => {
-    it("inserts false", () => {
-      const mgr = new InsertManager();
-      mgr.into(users);
-      mgr.insert([[users.get("active"), false]]);
-      expect(mgr.toSql()).toContain("FALSE");
-    });
-
     it("inserts time", () => {
       const mgr = new InsertManager(users);
       const at = Temporal.PlainDateTime.from("2020-01-02T12:34:56");


### PR DESCRIPTION
Dedupes the two `inserts false` / `inserts null` tests in
`packages/arel/src/insert-manager.test.ts` (each declared twice across
fragmented `describe("insert")` blocks) and ports the surviving copies to
Rails' assertions in `insert_manager_test.rb:79-96`.

- `inserts false` — uses `table[:bool]`, no `into` call, exact `toSql()`
  equality (was `toContain("FALSE")`, which passed on renderings Rails would
  never produce).
- `inserts null` — uses `table[:id]`, no `into` call, so it exercises the
  defaults-the-table path.

One justified deviation, noted at the call site: Rails asserts
`VALUES ('f')`, but that rendering comes from the Arel suite's `FakeRecord`
connection double (`test/cases/arel/support/fake_record.rb:79-80`), not from
any adapter — SQLite quotes false as `0` and the abstract adapter as `FALSE`.
With no FakeRecord port, `toSql()` renders via the connection-less default
quoter, so we assert `FALSE`.

The three `converts to sql` tests are untouched — those are three distinct
Rails tests, not duplicates.

Closes-story: insert-manager-inserts-null-false-duplicated-and-diverge
