### PR TITLE
fix(activerecord): seed _defaultAttributes from the bare reflected column type

### DIFF
--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -41,6 +41,13 @@ interface AttributeDefinition {
    * defs from ones reflected against this class's own table.
    */
   reflectedTable?: string;
+  /**
+   * The bare `type_for_column` result for this column, before any decoration
+   * was baked into `type`. `_defaultAttributes` seeds from this so the
+   * pending-decorator replay is the ONLY thing that wraps — mirroring Rails,
+   * which seeds from `type_for_column` (attributes.rb:241-245).
+   */
+  reflectedColumnType?: Type;
 }
 
 /**
@@ -197,7 +204,12 @@ export function _defaultAttributes(this: AnyClass): AttributeSet {
       const source = def.source ?? (def.userProvided === false ? "schema" : "user");
       const column = columns[name];
       if (source === "schema") {
-        attrMap.set(name, Attribute.fromDatabase(name, def.defaultValue ?? null, def.type));
+        // Seed from the BARE reflected column type, not `def.type` — trails
+        // eagerly bakes decorations into `def.type` (a back-compat convenience
+        // Rails lacks), and phase 2 replays those same decorators, so seeding
+        // from `def.type` applies each one twice.
+        const seedType = def.reflectedColumnType ?? def.type;
+        attrMap.set(name, Attribute.fromDatabase(name, def.defaultValue ?? null, seedType));
       } else if (column !== undefined) {
         // User type-override on a real DB column (e.g. enum, serialize,
         // normalizes, encryption): seed with the REFLECTED column type, not the

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -222,8 +222,7 @@ export function _defaultAttributes(this: AnyClass): AttributeSet {
         // `reflectedColumnType` is stashed by applyColumnsHash (model-schema.ts)
         // where the adapter is in hand; fall back to the def's own type before
         // the schema has reflected.
-        const seedType =
-          (def as { reflectedColumnType?: typeof def.type }).reflectedColumnType ?? def.type;
+        const seedType = def.reflectedColumnType ?? def.type;
         attrMap.set(name, Attribute.fromDatabase(name, column.default ?? null, seedType));
       } else if (def.defaultValue != null) {
         const base = Attribute.withCastValue(name, null, def.type);

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -722,16 +722,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     await assertEncryptedAttribute(await Book.create({ logo: lowBytes }), "logo", lowBytes);
     await assertEncryptedAttribute(await Book.create({ logo: highBytes }), "logo", highBytes);
   });
-  // TRACKED-PENDING-CONVERGENCE (serialize-encrypts-decorator-ordering): now
-  // rides the canonical Rails fixtures (reflection-typed binary `logo`, no
-  // bespoke string column), which shows the residual gap is NOT the binary
-  // text-ciphertext round-trip this story closed — that works. It is decorator
-  // ordering: Rails applies pending decorators in declaration order, so
-  // `serialize` + `encrypts` yields EncryptedAttributeType(Serialized(Bytea)).
-  // We replay them reversed AND seed `serialize` from the pre-reflection
-  // ValueType, producing Serialized(non-binary) and a coder that receives raw
-  // bytes. Fixing that is attribute-registration surgery, not an encryption fix.
-  it.skip("serialized binary data can be encrypted", async () => {
+  it("serialized binary data can be encrypted", async () => {
     const jsonBytes = Array.from({ length: 96 }, (_, i) => String.fromCharCode(i + 32));
     await freshAdapter();
     await assertEncryptedAttribute(

--- a/packages/activerecord/src/encryption/encryptable-record.trails.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.trails.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  freshAdapter,
+  configureEncryption,
+  snapshotEncryptionConfig,
+  restoreEncryptionConfig,
+} from "./test-helpers.js";
+import { Configurable } from "./configurable.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+import {
+  EncryptedBookWithSerializedFirstBinary,
+  EncryptedBookWithSerializedSecondBinary,
+} from "../test-helpers/models/book-encrypted.js";
+import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
+import { Serialized } from "../type/serialized.js";
+import { BinaryType } from "@blazetrails/activemodel";
+
+/**
+ * TS-only extras for EncryptableRecord. Rails has no equivalent test: its
+ * `serialized binary data can be encrypted` asserts only the round-trip, which
+ * a doubly-wrapped type can still satisfy for some coders. trails eagerly bakes
+ * decorations into `_attributeDefinitions[name].type` (a back-compat
+ * convenience Rails lacks), so seeding `_defaultAttributes` from that decorated
+ * type silently double-applied every decorator that also lives in the pending
+ * queue. These assert the resolved chain directly so a re-introduced wrapper
+ * fails loudly rather than round-tripping by accident.
+ */
+describe("ActiveRecord::Encryption::EncryptableRecordTest (trails)", () => {
+  fixtures({});
+
+  let configSnapshot: ReturnType<typeof snapshotEncryptionConfig>;
+
+  beforeEach(() => {
+    configSnapshot = snapshotEncryptionConfig();
+    Configurable.config.previousSchemes = [];
+    configureEncryption();
+  });
+
+  afterEach(() => {
+    restoreEncryptionConfig(configSnapshot);
+  });
+
+  // Rails resolves `serialize :logo, coder: JSON` + `encrypts :logo` to
+  // EncryptedAttributeType(Serialized(<binary column type>)) — the pending
+  // decorators replay over a seed built from `type_for_column`
+  // (activemodel/lib/active_model/attribute_registration.rb:23-34,
+  // activerecord/lib/active_record/attributes.rb:241-245), so each decorator
+  // is applied exactly once.
+  it.each([
+    ["serialize before encrypts", EncryptedBookWithSerializedFirstBinary],
+    ["encrypts before serialize", EncryptedBookWithSerializedSecondBinary],
+  ])("resolves logo to Encrypted(Serialized(binary)) — %s", async (_label, model) => {
+    await freshAdapter();
+
+    const encrypted = model.typeForAttribute("logo");
+    expect(encrypted).toBeInstanceOf(EncryptedAttributeType);
+
+    const serialized = (encrypted as EncryptedAttributeType).castType;
+    expect(serialized).toBeInstanceOf(Serialized);
+
+    // The exact defect this guards: the seed used to carry an
+    // EncryptedAttributeType, yielding Encrypted(Serialized(Encrypted(Binary))).
+    const subtype = (serialized as Serialized).subtype;
+    expect(subtype).toBeInstanceOf(BinaryType);
+    expect(subtype).not.toBeInstanceOf(EncryptedAttributeType);
+  });
+});

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1204,12 +1204,7 @@ function applyColumnsHash(
       // (the adapter is in hand) via the SAME `type_for_column` pipeline the
       // non-user schema path uses — immutable-string conversion +
       // `hook_attribute_type` (attributes.rb:301-302, model_schema.rb:622-629).
-      (existing as { reflectedColumnType?: Type }).reflectedColumnType = reflectedTypeForColumn(
-        host,
-        adapter,
-        name,
-        column,
-      );
+      existing.reflectedColumnType = reflectedTypeForColumn(host, adapter, name, column);
       continue;
     }
 

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1213,7 +1213,8 @@ function applyColumnsHash(
       continue;
     }
 
-    let type = reflectedTypeForColumn(host, adapter, name, column);
+    const reflectedColumnType = reflectedTypeForColumn(host, adapter, name, column);
+    let type = reflectedColumnType;
 
     // Preserve encryption wrappers across schema reflection. Both
     // EncryptedAttributeType variants implement `WrappedType`; any
@@ -1232,6 +1233,14 @@ function applyColumnsHash(
     host._attributeDefinitions.set(name, {
       name,
       type,
+      // The BARE reflected `type_for_column` result, before the wrapper
+      // preservation above re-applies any decoration already baked into
+      // `type`. Rails seeds `_default_attributes` from `type_for_column`
+      // (attributes.rb:241-245) and lets the pending-decorator queue do ALL
+      // the wrapping; seeding from the decorated `type` instead double-applies
+      // every decorator that also lives in the queue — e.g. `serialize` +
+      // `encrypts` on one column yields Encrypted(Serialized(Encrypted(...))).
+      reflectedColumnType,
       defaultValue,
       userProvided: false,
       source: "schema",


### PR DESCRIPTION
## Problem

Rails seeds `_default_attributes` from `type_for_column` and lets the
pending-decorator queue perform **all** type wrapping
(`activerecord/lib/active_record/attributes.rb:241-245`).

trails additionally bakes decorations eagerly into
`_attributeDefinitions[name].type` (a back-compat convenience Rails lacks), and
`applyColumnsHash` re-applies any surviving wrapper onto the freshly reflected
type. Phase 1 of `_defaultAttributes` then seeded from that **decorated**
`def.type` — so every decorator that also lives in the pending queue got
applied twice.

With `serialize :logo, coder: JSON` + `encrypts :logo` on a binary column:

| | type resolved for `logo` |
|---|---|
| Rails | `EncryptedAttributeType(Serialized(Binary))` |
| trails (before) | `EncryptedAttributeType(Serialized(EncryptedAttributeType(Binary)))` |

The stored plaintext was a `JSON.stringify` of a byte array and reads came back
as a `Uint8Array` instead of the round-tripped array.

Note this differs from the diagnosis recorded on the story: the decorators do
**not** replay reversed, and `serialize` is **not** seeded from a pre-reflection
`ValueType`. The queue order and the reflected seed were already correct — the
sole defect was the double-applied decoration described above.

## Fix

Stash the bare `type_for_column` result as `reflectedColumnType` on
schema-sourced attribute defs, and seed phase 1 from it. The decorated
`def.type` is left intact for the back-compat readers that depend on it, so the
change is confined to the seed.

Both `EncryptedBookWithSerializedFirstBinary` and `...SecondBinary` now resolve
to `EncryptedAttributeType(Serialized(BinaryType))`.

## `def.type` readers after this change

The seed no longer reads `def.type`; these still do, and the divergence is
intentional in each case:

- **`encryption/encryptable-record.ts:311` and the decorator body below it** —
  the idempotence guard (`def.type instanceof EncryptedAttributeType`). This is
  load-bearing and depends on the *decorated* view: it is precisely why the
  `isWrappedType` wrapper-preservation in `applyColumnsHash` must stay. Strip
  the preservation and `def.type` goes bare after every reflection, so a fresh
  decorator is pushed on each replay and the pending queue grows unbounded.
- **`reflection.ts:2389` (`columns()`)** — reports
  `def.type.constructor.name`. This is a **pre-existing** divergence unrelated
  to this PR: Rails' `columns` is `columns_hash.values`
  (`model_schema.rb:432-434`), i.e. database column objects that never carry a
  decorated cast type at all. This PR does not change it — the diff leaves the
  `def.type` assignment identical (`reflectedColumnType` is just the extracted
  variable already being assigned), so `columns()` output is byte-for-byte the
  same before and after. Converging `columns()` onto `columns_hash` is a
  separate story, not a regression introduced here.

## Testing

- Un-skipped `serialized binary data can be encrypted` (name unchanged) and
  removed its `TRACKED-PENDING-CONVERGENCE` comment.
- Added `encryption/encryptable-record.trails.test.ts` asserting the resolved
  `typeForAttribute("logo")` chain is exactly `Encrypted(Serialized(Binary))`
  for both declaration orders — the Rails test asserts only the round-trip,
  which an extra wrapper can still satisfy for some coders. **Verified to fail
  on the pre-fix implementation** (`expected EncryptedAttributeType to be an
  instance of BinaryType`), so it is a real guard rather than a tautology.
- `encryptable-record.test.ts` — 76 passed.
- Suites most exposed to the seed change (attributes, model-schema, serialize,
  enum, locking, attribute-methods, dirty, type/, encryption/): 939 passed.
- `pnpm typecheck` and `pnpm lint` — exit 0.
- `pnpm api:compare` — exit 0, data layer 7471/7474, no autofix drift.
- `pnpm test:compare` vs detached `origin/main` (613795e5e):
  **14477 → 14478** passing, skipped **1160 → 1159**. Delta +1, non-negative.

CI covers PG and MariaDB.

Closes-story: serialize-encrypts-decorator-ordering
