### PR TITLE
fix(test-deps): normalize namespaced fixture names so declared and dereferenced sets intersect

### DIFF
--- a/scripts/test-deps/rails-test-deps.test.ts
+++ b/scripts/test-deps/rails-test-deps.test.ts
@@ -103,12 +103,26 @@ describe("parseSource", () => {
   it("does not treat a local `fixtures =` assignment as a declaration", () => {
     const src = [
       "class T < ActiveRecord::TestCase",
+      "  fixtures :topics",
       "  def test_omap_fixtures",
       '    fixtures = ActiveRecord::FixtureSet.new(nil, "categories", Category, FIXTURES_ROOT + "/categories_ordered")',
       "  end",
+      "  def test_create",
+      "    fixtures = ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, :collections, collections: Course)",
+      "  end",
+      "  def test_nil",
+      "    fixtures = nil",
+      "  end",
+      "  def test_hash",
+      "    fixtures = {",
+      '      "one" => { "id" => 1 },',
+      "    }",
+      "  end",
       "end",
     ].join("\n");
-    expect(parseSource(src).fixtures).toEqual([]);
+    // Only the real declaration survives: no "/categories_ordered", "FixtureSet",
+    // or "collections" leaking in from the local variables.
+    expect(parseSource(src).fixtures).toEqual(["topics"]);
   });
 
   it("does not treat hash-syntax keys as fixture accessors", () => {

--- a/scripts/test-deps/rails-test-deps.test.ts
+++ b/scripts/test-deps/rails-test-deps.test.ts
@@ -86,6 +86,31 @@ describe("parseSource", () => {
     expect(parseSource(src).tests).toEqual({});
   });
 
+  it("keys a namespaced set's dereferences by its declared name", () => {
+    const src = [
+      "class T < ActiveRecord::TestCase",
+      '  fixtures :"admin/accounts"',
+      "  def test_namespaced",
+      "    admin_accounts(:david)",
+      "  end",
+      "end",
+    ].join("\n");
+    const deps = parseSource(src);
+    expect(deps.fixtures).toEqual(["admin/accounts"]);
+    expect(deps.tests.test_namespaced.fixtures).toEqual({ "admin/accounts": ["david"] });
+  });
+
+  it("does not treat a local `fixtures =` assignment as a declaration", () => {
+    const src = [
+      "class T < ActiveRecord::TestCase",
+      "  def test_omap_fixtures",
+      '    fixtures = ActiveRecord::FixtureSet.new(nil, "categories", Category, FIXTURES_ROOT + "/categories_ordered")',
+      "  end",
+      "end",
+    ].join("\n");
+    expect(parseSource(src).fixtures).toEqual([]);
+  });
+
   it("does not treat hash-syntax keys as fixture accessors", () => {
     const src = [
       "class T < ActiveRecord::TestCase",

--- a/scripts/test-deps/rails-test-deps.ts
+++ b/scripts/test-deps/rails-test-deps.ts
@@ -36,9 +36,12 @@ export interface FileDeps {
 }
 
 const REQUIRE_RE = /^\s*require\s+["']models\/([^"']+)["']/;
-// `(?!=)` rejects the local assignment `fixtures = ActiveRecord::FixtureSet.new(...)`,
-// which otherwise parses as a declaration and emits junk names (e.g. "/categories_ordered").
-const FIXTURES_START_RE = /^\s*fixtures\s+(?!=[^=])(.+)$/;
+// A real declaration's argument list always opens with a symbol or a string
+// (`fixtures :all`, `fixtures :a, :b`, `fixtures :"admin/accounts"`, `fixtures "warehouse-things"`).
+// Requiring that rejects the local variable `fixtures = ActiveRecord::FixtureSet.new(...)`,
+// which otherwise parsed as a declaration and emitted junk names ("FixtureSet",
+// "collections", "virtual_columns", and the leading-slash "/categories_ordered").
+const FIXTURES_START_RE = /^\s*fixtures\s+((?::|["']).+)$/;
 const SET_FIXTURE_CLASS_RE = /^\s*set_fixture_class\s+(.+)$/;
 const SYM_OR_STR = /(?::([a-zA-Z_]\w*)|["']([^"']+)["'])/g;
 const PAIR_RE = /([a-zA-Z_]\w*)\s*:\s*([A-Z][\w:]*)/g;

--- a/scripts/test-deps/rails-test-deps.ts
+++ b/scripts/test-deps/rails-test-deps.ts
@@ -38,9 +38,12 @@ export interface FileDeps {
 const REQUIRE_RE = /^\s*require\s+["']models\/([^"']+)["']/;
 // A real declaration's argument list always opens with a symbol or a string
 // (`fixtures :all`, `fixtures :a, :b`, `fixtures :"admin/accounts"`, `fixtures "warehouse-things"`).
-// Requiring that rejects the local variable `fixtures = ActiveRecord::FixtureSet.new(...)`,
-// which otherwise parsed as a declaration and emitted junk names ("FixtureSet",
-// "collections", "virtual_columns", and the leading-slash "/categories_ordered").
+// Requiring that rejects the local variable `fixtures = ActiveRecord::FixtureSet...`,
+// which otherwise parsed as a declaration and emitted junk names — SYM_OR_STR pulls
+// "FixtureSet" out of the `::` and the set name out of the argument list:
+//   fixtures_test.rb:573      -> "FixtureSet", "/categories_ordered"
+//   fixtures_test.rb:377      -> "FixtureSet", "collections"
+//   virtual_column_test.rb:109 -> "FixtureSet", "virtual_columns"  (sqlite3 + postgresql)
 const FIXTURES_START_RE = /^\s*fixtures\s+((?::|["']).+)$/;
 const SET_FIXTURE_CLASS_RE = /^\s*set_fixture_class\s+(.+)$/;
 const SYM_OR_STR = /(?::([a-zA-Z_]\w*)|["']([^"']+)["'])/g;
@@ -162,6 +165,12 @@ export function parseSource(src: string): FileDeps {
     // A namespaced set `admin/accounts` is dereferenced as `admin_accounts(:david)`.
     // Key the results by the DECLARED name so consumers can intersect the two
     // (eslint/expected-fixtures.mjs) instead of silently dropping every namespaced set.
+    // Collisions are last-write-wins. Declaring both `:"admin/accounts"` and
+    // `:admin_accounts` would drop the first from `tests.*.fixtures` silently, but
+    // Rails cannot reach that state — both generate the same `admin_accounts`
+    // accessor method, so the second definition wins there too and the pair is
+    // unusable. The vendored corpus has zero collisions; not worth a merge that
+    // would fold two distinct sets' records into one bucket.
     const accessorToDeclared = new Map<string, string>();
     for (const n of fxSet) {
       const accessor = n.replace(/\//g, "_").replace(/[^\w-]/g, "");

--- a/scripts/test-deps/rails-test-deps.ts
+++ b/scripts/test-deps/rails-test-deps.ts
@@ -36,7 +36,9 @@ export interface FileDeps {
 }
 
 const REQUIRE_RE = /^\s*require\s+["']models\/([^"']+)["']/;
-const FIXTURES_START_RE = /^\s*fixtures\s+(.+)$/;
+// `(?!=)` rejects the local assignment `fixtures = ActiveRecord::FixtureSet.new(...)`,
+// which otherwise parses as a declaration and emits junk names (e.g. "/categories_ordered").
+const FIXTURES_START_RE = /^\s*fixtures\s+(?!=[^=])(.+)$/;
 const SET_FIXTURE_CLASS_RE = /^\s*set_fixture_class\s+(.+)$/;
 const SYM_OR_STR = /(?::([a-zA-Z_]\w*)|["']([^"']+)["'])/g;
 const PAIR_RE = /([a-zA-Z_]\w*)\s*:\s*([A-Z][\w:]*)/g;
@@ -154,11 +156,15 @@ export function parseSource(src: string): FileDeps {
   deps.fixtures = [...fxSet].sort();
 
   if (fxSet.size > 0 && testRanges.length > 0) {
-    const fxAlt = [...fxSet]
-      .map((n) => n.replace(/[^\w-]/g, ""))
-      .filter((n) => n.length > 0)
-      .map((n) => n.replace(/-/g, "\\-"))
-      .join("|");
+    // A namespaced set `admin/accounts` is dereferenced as `admin_accounts(:david)`.
+    // Key the results by the DECLARED name so consumers can intersect the two
+    // (eslint/expected-fixtures.mjs) instead of silently dropping every namespaced set.
+    const accessorToDeclared = new Map<string, string>();
+    for (const n of fxSet) {
+      const accessor = n.replace(/\//g, "_").replace(/[^\w-]/g, "");
+      if (accessor.length > 0) accessorToDeclared.set(accessor, n);
+    }
+    const fxAlt = [...accessorToDeclared.keys()].map((n) => n.replace(/-/g, "\\-")).join("|");
     const callRe = new RegExp(`\\b(${fxAlt})\\s*\\(`, "g");
     for (const r of testRanges) {
       const body = lines.slice(r.start, r.end).join("\n");
@@ -166,7 +172,7 @@ export function parseSource(src: string): FileDeps {
       for (const m of body.matchAll(callRe)) {
         const records = collectRecordArgs(body, m.index! + m[0].length - 1);
         if (records.length === 0) continue;
-        const bucket = (used[m[1]] ??= new Set());
+        const bucket = (used[accessorToDeclared.get(m[1]) ?? m[1]] ??= new Set());
         for (const rec of records) bucket.add(rec);
       }
       if (Object.keys(used).length === 0) continue;

--- a/scripts/test-deps/rails-test-deps.ts
+++ b/scripts/test-deps/rails-test-deps.ts
@@ -43,7 +43,8 @@ const REQUIRE_RE = /^\s*require\s+["']models\/([^"']+)["']/;
 // "FixtureSet" out of the `::` and the set name out of the argument list:
 //   fixtures_test.rb:573      -> "FixtureSet", "/categories_ordered"
 //   fixtures_test.rb:377      -> "FixtureSet", "collections"
-//   virtual_column_test.rb:109 -> "FixtureSet", "virtual_columns"  (sqlite3 + postgresql)
+//   sqlite3/virtual_column_test.rb:109    -> "FixtureSet", "virtual_columns"
+//   postgresql/virtual_column_test.rb:85  -> "FixtureSet", "virtual_columns"
 const FIXTURES_START_RE = /^\s*fixtures\s+((?::|["']).+)$/;
 const SET_FIXTURE_CLASS_RE = /^\s*set_fixture_class\s+(.+)$/;
 const SYM_OR_STR = /(?::([a-zA-Z_]\w*)|["']([^"']+)["'])/g;


### PR DESCRIPTION
## Problem

`scripts/test-deps/rails-test-deps.ts` recorded a test class's **declared** and
**dereferenced** fixture sets under different naming schemes for namespaced sets:

- declared (`fixtures :"admin/accounts"`) → `admin/accounts`
- dereferenced (`admin_accounts(:david)`) → `adminaccounts` (slash stripped by `[^\w-]`)

`requiredFixtureSets` (eslint/expected-fixtures.mjs) intersects the two, so
namespaced sets **never** intersected and were silently filtered out — the rule
no-opped on every namespaced fixture set.

Second bug in the same extractor: `FIXTURES_START_RE` also matched the local
variable `fixtures = ...`, so local assignments parsed as declarations.

## Fix

- Build an accessor → declared map (`admin_accounts` → `admin/accounts`) and key
  dereferences by the **declared** name, so the two sides intersect.
- Require a declaration's argument list to open with a symbol or string
  (`fixtures :all`, `fixtures :"admin/accounts"`, `fixtures "warehouse-things"`),
  which is what every real declaration looks like and no `fixtures =` assignment does.

## Verification

A corpus diff of the old vs new extractor over **all** of
`vendor/rails/activerecord/test/cases`:

```
DECL adapters/postgresql/virtual_column_test.rb: -["FixtureSet","virtual_columns"] +[]
DECL adapters/sqlite3/virtual_column_test.rb:     -["FixtureSet","virtual_columns"] +[]
DECL fixtures_test.rb: -["/categories_ordered","FixtureSet","collections"] +[]

files with decl changes: 3
dereferences LOST (regression): 0
accessor collisions: 0
```

The junk was broader than the story described — besides the leading-slash
`"/categories_ordered"`, the extractor was also inventing `FixtureSet`,
`collections`, and `virtual_columns` from `fixtures = ActiveRecord::FixtureSet…`
lines. Every removal traces to an assignment; the real declarations
(`fixtures_test.rb:48,609,632,709`) survive, and **zero** dereferences were lost.

On `fixtures_test.rb`, all four `admin/*` sets are now declared **and**
dereferenced by two tests (`test_namespaced_models`,
`test_named_accessor_for_randomly_named_namespaced_fixture_and_class`), so they
finally intersect.

- Both new regression tests **fail on the pre-fix extractor** and pass after
  (verified by running the suite against the `HEAD~` parser).
- `pnpm lint` — clean, no manifest churn.
- `pnpm vitest run scripts/test-deps/rails-test-deps.test.ts eslint/expected-fixtures.test.mjs`
  — 17 passed (existing namespaced-camelize test still green).
- `pnpm test:deps && pnpm tsx scripts/test-deps/build-fixture-baseline.ts` regenerate
  the tracked `eslint/expected-fixtures-exclude.json` **byte-identical** — no files
  become newly-enforced, so nothing needed fixing or hand-trimming.

## Scope of the tightened regex

`FIXTURES_START_RE` now requires the argument list to open with a symbol or
string. The one *real* declaration this newly rejects is `fixtures_test.rb:1221`
(`fixtures rand.to_s # bypass fixtures cache`) — a dynamic argument that yielded
no `SYM_OR_STR` matches under the old regex either, so no declared name is lost
and the extracted output is unchanged.

Worth stating plainly: the corpus diff above compares *extracted names*, so it is
structurally blind to a line that both versions parse to nothing — `:1221` was
found by reading the rejected lines, not by the diff. The equivalence claim is
therefore "identical output on the vendored corpus," not "identical predicate."
A hypothetical dynamic argument containing a symbol or quoted string would be
dropped where the old regex kept it. No such line exists in Rails today, and a
static extractor cannot resolve a dynamic fixture name regardless.

## Note on accessor collisions

The accessor → declared map would silently overwrite if two declared sets shared
one accessor (`admin/accounts` vs `admin_accounts`). That is impossible in Rails —
both would define the same Ruby accessor method — and the corpus confirms zero
collisions, so no defensive branch was added.

Closes-story: test-deps-namespaced-fixture-name-normalization

