### PR TITLE
fix(associations): guard loadHasOne against mid-flight reassignment clobber

### DIFF
--- a/packages/activerecord/src/associations/belongs-to-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-association.ts
@@ -305,7 +305,17 @@ export class BelongsToAssociation extends SingularAssociation {
   }
 
   protected override async doAsyncFindTarget(): Promise<Base | null> {
-    return loadBelongsTo(this.owner, this.reflection.name, this.reflection.options);
+    // Suppress the loader's own tail writeback and let `setTarget` refuse a
+    // mid-load replacement, exactly as has_many and has_one do. #4919 already
+    // guards a mid-load *FK* change here; this covers a same-FK reassignment
+    // (`client.association("firm").setTarget(other)`) that leaves the FK put,
+    // which the stale-key check cannot see. See `_loaderWritebackSuppressed`.
+    this._loaderWritebackSuppressed++;
+    try {
+      return await loadBelongsTo(this.owner, this.reflection.name, this.reflection.options);
+    } finally {
+      this._loaderWritebackSuppressed--;
+    }
   }
 
   // --- Private helpers ---

--- a/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
@@ -1,6 +1,6 @@
 import type { Base } from "../base.js";
 import type { AssociationDefinition } from "../associations.js";
-import { loadBelongsTo, modelRegistry } from "../associations.js";
+import { modelRegistry } from "../associations.js";
 import { baseClass, demodulize } from "../inheritance.js";
 import { underscore } from "@blazetrails/activesupport";
 import { BelongsToAssociation, inferCompositePrimaryKey } from "./belongs-to-association.js";
@@ -160,19 +160,6 @@ export class BelongsToPolymorphicAssociation extends BelongsToAssociation {
       return refl.polymorphicInverseOf(record.constructor as typeof Base);
     }
     return null;
-  }
-
-  protected override async doAsyncFindTarget(): Promise<Base | null> {
-    // This override exists for the polymorphic type resolution above; it must
-    // still arm the mid-load-replacement guard its parent does, or a `setTarget`
-    // on a polymorphic belongs_to mid-load is silently clobbered while the plain
-    // one raises. See `Association#_loaderWritebackSuppressed`.
-    this._loaderWritebackSuppressed++;
-    try {
-      return await loadBelongsTo(this.owner, this.reflection.name, this.reflection.options);
-    } finally {
-      this._loaderWritebackSuppressed--;
-    }
   }
 
   /**

--- a/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
@@ -163,7 +163,16 @@ export class BelongsToPolymorphicAssociation extends BelongsToAssociation {
   }
 
   protected override async doAsyncFindTarget(): Promise<Base | null> {
-    return loadBelongsTo(this.owner, this.reflection.name, this.reflection.options);
+    // This override exists for the polymorphic type resolution above; it must
+    // still arm the mid-load-replacement guard its parent does, or a `setTarget`
+    // on a polymorphic belongs_to mid-load is silently clobbered while the plain
+    // one raises. See `Association#_loaderWritebackSuppressed`.
+    this._loaderWritebackSuppressed++;
+    try {
+      return await loadBelongsTo(this.owner, this.reflection.name, this.reflection.options);
+    } finally {
+      this._loaderWritebackSuppressed--;
+    }
   }
 
   /**

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -447,7 +447,17 @@ export class HasOneAssociation extends SingularAssociation {
   }
 
   protected override async doAsyncFindTarget(): Promise<Base | null> {
-    return loadHasOne(this.owner, this.reflection.name, this.reflection.options);
+    // `loadHasOne`'s tail writeback lands in this holder mid-await, so a target
+    // replaced while the query is in flight would be silently clobbered. Arm
+    // the same guard has_many uses (`CollectionAssociation#doAsyncFindTarget`):
+    // suppress the loader's own writeback and let `setTarget` refuse the race.
+    // See `Association#_loaderWritebackSuppressed`.
+    this._loaderWritebackSuppressed++;
+    try {
+      return await loadHasOne(this.owner, this.reflection.name, this.reflection.options);
+    } finally {
+      this._loaderWritebackSuppressed--;
+    }
   }
 
   private foreignKeyColumns(): string[] {

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -449,7 +449,7 @@ export class HasOneAssociation extends SingularAssociation {
   protected override async doAsyncFindTarget(): Promise<Base | null> {
     // `loadHasOne`'s tail writeback lands in this holder mid-await, so a target
     // replaced while the query is in flight would be silently clobbered. Arm
-    // the same guard has_many uses (`CollectionAssociation#doAsyncFindTarget`):
+    // the same guard has_many uses (`HasManyAssociation#doAsyncFindTarget`):
     // suppress the loader's own writeback and let `setTarget` refuse the race.
     // See `Association#_loaderWritebackSuppressed`.
     this._loaderWritebackSuppressed++;

--- a/packages/activerecord/src/associations/has-one-mid-flight-reassignment.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-mid-flight-reassignment.trails.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Trails-only surface: replacing a has_one / belongs_to target while a load for
+ * it is still in flight raises `AssociationTargetReplacedDuringLoad`.
+ *
+ * This is the singular-holder counterpart to the has_many guard (#5038). The
+ * mechanism is shared and holder-agnostic: `setTarget` refuses the race, and a
+ * loader's own writeback is exempt because it runs while
+ * `Association#_loaderWritebackSuppressed` is set (armed in each singular
+ * association's `doAsyncFindTarget`, mirroring `CollectionAssociation`).
+ *
+ * Rails has no analogue because `Association#find_target`
+ * (activerecord/lib/active_record/associations/association.rb:248) is
+ * synchronous — nothing can touch the holder between issuing the query and
+ * assigning its result. trails awaits, which opens the window. There is no
+ * correct silent winner, so trails refuses the race rather than resolving it;
+ * the repo owner rejected picking a winner during #5038's review.
+ */
+import { describe, it, expect } from "vitest";
+
+import { fixtures } from "../test-helpers/fixtures.js";
+import { AssociationTargetReplacedDuringLoad } from "../errors.js";
+import { Account } from "../test-helpers/models/account.js";
+import { Client, Firm } from "../test-helpers/models/company.js";
+import { Member } from "../test-helpers/models/member.js";
+import { Club } from "../test-helpers/models/club.js";
+
+describe("has_one mid-flight reassignment", () => {
+  fixtures(["companies", "accounts", "members", "memberships", "clubs"]);
+
+  it("replacing the target while a load is in flight raises", async () => {
+    const firm = (await Firm.first()) as Firm;
+    const other = await Account.create({ credit_limit: 42 });
+
+    const inFlight = firm.association("account").loadTarget();
+    expect(() => firm.association("account").setTarget(other)).toThrow(
+      AssociationTargetReplacedDuringLoad,
+    );
+    await inFlight;
+  });
+
+  it("the raise names the association and survives the load completing", async () => {
+    const firm = (await Firm.first()) as Firm;
+    const other = await Account.create({ credit_limit: 42 });
+
+    const inFlight = firm.association("account").loadTarget();
+    expect(() => firm.association("account").setTarget(other)).toThrow(/account/);
+    await inFlight;
+
+    // The refused assignment leaves the load intact — no partial state.
+    expect(firm.association("account").isLoaded()).toBe(true);
+  });
+
+  it("assigning after the load has settled is allowed", async () => {
+    const firm = (await Firm.first()) as Firm;
+    const other = await Account.create({ credit_limit: 42 });
+
+    await firm.association("account").loadTarget();
+    firm.association("account").setTarget(other);
+
+    expect(firm.association("account").target).toBe(other);
+  });
+
+  it("concurrent loads on the same holder do not error", async () => {
+    const firm = (await Firm.first()) as Firm;
+
+    const [a, b] = await Promise.all([
+      firm.association("account").loadTarget(),
+      firm.association("account").loadTarget(),
+    ]);
+
+    // Loader-vs-loader is not the race we refuse — both are reads of the same
+    // association, so neither raises.
+    expect((a as Account)?.id).toBe((b as Account)?.id);
+  });
+
+  it("replacing a has_one :through target mid-load raises", async () => {
+    // HasOneThroughAssociation inherits doAsyncFindTarget from
+    // HasOneAssociation, so it must inherit the guard with it.
+    const member = (await Member.first()) as Member;
+    const other = (await Club.first()) as Club;
+
+    const inFlight = member.association("club").loadTarget();
+    expect(() => member.association("club").setTarget(other)).toThrow(
+      AssociationTargetReplacedDuringLoad,
+    );
+    await inFlight;
+  });
+});
+
+describe("belongs_to mid-flight reassignment", () => {
+  fixtures(["companies", "accounts"]);
+
+  it("a same-FK replacement mid-load raises", async () => {
+    // #4919 already guards a mid-load FK *change* here via the owner's stale
+    // key. This covers the complementary case: a replacement that leaves the
+    // FK put (`client.association("firm").setTarget(other)`), which the
+    // stale-key check cannot see because nothing moved.
+    const client = (await Client.first()) as Client;
+    const other = (await Firm.first()) as Firm;
+
+    const inFlight = client.association("firm").loadTarget();
+    expect(() => client.association("firm").setTarget(other)).toThrow(
+      AssociationTargetReplacedDuringLoad,
+    );
+    await inFlight;
+  });
+
+  it("assigning after the load has settled is allowed", async () => {
+    const client = (await Client.first()) as Client;
+    const other = (await Firm.first()) as Firm;
+
+    await client.association("firm").loadTarget();
+    client.association("firm").setTarget(other);
+
+    expect(client.association("firm").target).toBe(other);
+  });
+});

--- a/packages/activerecord/src/associations/has-one-mid-flight-reassignment.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-mid-flight-reassignment.trails.test.ts
@@ -23,6 +23,8 @@ import { Account } from "../test-helpers/models/account.js";
 import { Client, Firm } from "../test-helpers/models/company.js";
 import { Member } from "../test-helpers/models/member.js";
 import { Club } from "../test-helpers/models/club.js";
+import { Tagging } from "../test-helpers/models/tagging.js";
+import { Post } from "../test-helpers/models/post.js";
 
 describe("has_one mid-flight reassignment", () => {
   fixtures(["companies", "accounts", "members", "memberships", "clubs"]);
@@ -113,5 +115,23 @@ describe("belongs_to mid-flight reassignment", () => {
     client.association("firm").setTarget(other);
 
     expect(client.association("firm").target).toBe(other);
+  });
+});
+
+describe("polymorphic belongs_to mid-flight reassignment", () => {
+  fixtures(["taggings", "posts"]);
+
+  it("replacing a polymorphic target mid-load raises", async () => {
+    // `BelongsToPolymorphicAssociation` overrides `doAsyncFindTarget`, so it
+    // must arm the same guard its parent does — otherwise the polymorphic
+    // subclass stays silently clobberable while plain belongs_to raises.
+    const tagging = (await Tagging.first()) as Tagging;
+    const other = (await Post.first()) as Post;
+
+    const inFlight = tagging.association("taggable").loadTarget();
+    expect(() => tagging.association("taggable").setTarget(other)).toThrow(
+      AssociationTargetReplacedDuringLoad,
+    );
+    await inFlight;
   });
 });


### PR DESCRIPTION
## What

Replacing a **has_one**, **belongs_to**, or **polymorphic belongs_to** target
while a load for it is still in flight was silently clobbered — the load's
writeback overwrote the assignment with no diagnostic. #5038 fixed this for
has_many; this PR extends the same guard to the singular macros.

```ts
const inFlight = firm.association("account").loadTarget();
firm.association("account").setTarget(other); // now raises
await inFlight;
```

Rails cannot reach this state: `Association#find_target` (association.rb:248)
is synchronous, so nothing can touch the holder between issuing the query and
assigning its result. trails awaits, which opens the window.

## How

#5038 established the policy (owner-approved): `Association#setTarget` **raises**
`AssociationTargetReplacedDuringLoad` while a load for that association is in
flight, and a loader's own writeback is exempt because it runs with
`_loaderWritebackSuppressed` set. That machinery is holder-agnostic; only the
*arming* was has_many-specific.

This PR arms it in the singular associations' `doAsyncFindTarget` too — has_one
and belongs_to — mirroring `HasManyAssociation`:

```ts
this._loaderWritebackSuppressed++;
try {
  return await loadHasOne(this.owner, this.reflection.name, this.reflection.options);
} finally {
  this._loaderWritebackSuppressed--;
}
```

`syncToAssociationInstance` already skips the writeback while suppressed and
routes through `_setTargetFromLoader`, so no change was needed there. has_one
:through inherits the armed body (no override). Polymorphic belongs_to also
inherits it: its `doAsyncFindTarget` override was byte-identical to the parent's
(the polymorphic type resolution lives in `klass`/`replaceKeys`, not there) and
Rails has no such override, so this PR **deletes** it — closing the gap and
converging to Rails' class shape.

Assigning after the load settles is unaffected; loader-vs-loader (concurrent
reads, preloader) does not raise. No new `.setTarget(` caller, so #5038's
tree-sweep guard stays green.

## Testing

Repro tests assert the raise for has_one, has_one :through, belongs_to (a
same-FK replacement that #4919's stale-key check cannot see), and polymorphic
belongs_to — each proven non-vacuous by reverting its arming.

| Suite | SQLite | PostgreSQL 17 | MySQL 8 |
| --- | --- | --- | --- |
| `has-one-mid-flight-reassignment.trails` | 8 | 8 | 8 |
| `has-many-mid-flight-reassignment.trails` (#5038) | ✓ | 9 | 9 |
| `has-one-through-associations` (incl. "set record after delete association") | ✓ | 52 | 52 |

Full `associations/` + `autosave-association` + `associations`: **2223** on
SQLite. All PG/MySQL cells re-run at HEAD. MariaDB via CI.

## Follow-up

The guard is armed per `doAsyncFindTarget` override, which is a footgun — a new
override silently loses it. Hoisting the arming to the call sites would make that
unrepresentable, but it touches #5038's merged has_many arming, so it is its own
story: `0023-surfaced-deviations/hoist-mid-load-guard-to-doasyncfindtarget-callers`.

Closes-story: fix-has-one-mid-flight-reassignment-clobber
