### PR TITLE
refactor(arel): Node#toSql compiles through Table.engine's connection visitor

### DIFF
--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -44,15 +44,17 @@ import {
   ARUNIT2_DATABASE,
 } from "./adapters/abstract-mysql-adapter/test-helper.js";
 
-// Build the placeholder the same way Rails does — `Arel::Nodes::BindParam.new(nil)
-// .to_sql` collects the `?` marker — rather than hard-coding a literal `?`.
-const qm = new Nodes.BindParam(null).toSql();
-
 // Drives Rails' AdapterTest casted/non-casted bind probes against the leased
 // connection and the canonical `events` table. The insert return value is
 // normalized (`Number(...)`) and skipped on MySQL, whose driver reports `0` for
 // an explicit-id INSERT rather than the inserted key.
 async function roundTripBinds(conn: DatabaseAdapter, binds: unknown[]): Promise<void> {
+  // Build the placeholder the same way Rails does — `Arel::Nodes::BindParam.new(nil)
+  // .to_sql` collects the `?` marker — rather than hard-coding a literal `?`.
+  // `to_sql` compiles through an engine's connection (arel/nodes/node.rb:148-153),
+  // so it takes the leased `conn` and cannot be hoisted to module scope: Rails'
+  // helper.rb has a connection before test files load, trails' setup does not.
+  const qm = new Nodes.BindParam(null).toSql({ connection: conn });
   const id = await conn.insert(
     `INSERT INTO events(id) VALUES (${qm})`,
     null,

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -849,7 +849,9 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("highPrecisionCurrentTimestamp returns CURRENT_TIMESTAMP literal", () => {
       const ts = adapter.highPrecisionCurrentTimestamp();
-      expect(ts.toSql()).toBe("CURRENT_TIMESTAMP");
+      // `to_sql` compiles through an engine's connection (arel/nodes/node.rb:148-153);
+      // this suite builds its adapter directly rather than through Base's pool.
+      expect(ts.toSql({ connection: adapter })).toBe("CURRENT_TIMESTAMP");
     });
 
     it("setConstraints ALL DEFERRED executes without error", async () => {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -5219,3 +5219,28 @@ DatabaseTasks._registerBase(Base);
 // initializers register `on_load(:active_record)` consumers that need a
 // fully-defined `Base` class (timezone, filter attributes, ...).
 runLoadHooks("active_record", Base);
+
+// Mirrors: `ActiveSupport.on_load(:active_record) { Arel::Table.engine = self }`
+// (active_record.rb:562-564) — `self` there is Base. Rails can register that
+// consumer from the entrypoint because requiring `active_record` is the only
+// way to reach `Base`; here many modules and tests deep-import `base.js`
+// directly and never evaluate `index.ts`, so the assignment rides the same
+// module as the hook run to keep `Table.engine` set on every load path.
+//
+// Rails assigns `Base` itself and reaches the visitor via
+// `engine.with_connection` (arel/nodes/node.rb:150). trails' `withConnection` is
+// async, and `to_sql` is synchronous in Rails and at every call site here, so
+// the engine must expose a *synchronous* connection. Assigning bare `Base` would
+// route through `Base.connection`, which is deprecated: under
+// `permanentConnectionCheckout = "disallowed"` it raises
+// (connection-handling.ts:461-463), so every `toSql()` in the app would throw —
+// something Rails' `with_connection`-based `to_sql` never does. This delegates
+// to the pool's non-deprecated sync surface instead: the already-checked-out
+// connection when there is one, else a sync lease — the same connection
+// `Base.connection` would return, without the deprecation gate.
+Table.engine = {
+  get connection(): DatabaseAdapter {
+    const pool = Base.connectionPool();
+    return pool.activeConnection ?? pool.leaseConnectionSync();
+  },
+};

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
@@ -42,8 +42,12 @@ import {
 import { Result } from "../../result.js";
 import { queryTransformers, type QueryTransformer } from "../../query-transformers.js";
 import type { Quoting } from "./quoting-interface.js";
+import { fixtures } from "../../test-helpers/use-fixtures.js";
 
 describe("DatabaseStatements", () => {
+  // `to_sql` compiles through `Table.engine`'s connection (arel/nodes/node.rb:148-153),
+  // so these Arel assertions need a connection, as Rails' do via helper.rb.
+  fixtures({});
   describe("toSql", () => {
     it("returns string SQL unchanged", () => {
       expect(toSql("SELECT 1")).toBe("SELECT 1");

--- a/packages/activerecord/src/relation/ruby-inspect.test.ts
+++ b/packages/activerecord/src/relation/ruby-inspect.test.ts
@@ -6,8 +6,12 @@ import {
   inspectArelValue,
   inspectOrderClause,
 } from "./ruby-inspect.js";
+import { fixtures } from "../test-helpers/use-fixtures.js";
 
 describe("rubyInspect", () => {
+  // `to_sql` compiles through `Table.engine`'s connection (arel/nodes/node.rb:148-153),
+  // so these Arel assertions need a connection, as Rails' do via helper.rb.
+  fixtures({});
   it("renders nil / undefined as 'nil'", () => {
     expect(rubyInspect(null)).toBe("nil");
     expect(rubyInspect(undefined)).toBe("nil");

--- a/packages/activerecord/src/relation/where-clause.test.ts
+++ b/packages/activerecord/src/relation/where-clause.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect } from "vitest";
 import { Table, Nodes } from "@blazetrails/arel";
 import { WhereClause } from "./where-clause.js";
+import { fixtures } from "../test-helpers/use-fixtures.js";
 
 // Mirrors Rails' private helpers in WhereClauseTest
 function table(): Table {
@@ -27,6 +28,9 @@ function eql(a: WhereClause, b: WhereClause): boolean {
 }
 
 describe("ActiveRecord::Relation", () => {
+  // `to_sql` compiles through `Table.engine`'s connection (arel/nodes/node.rb:148-153),
+  // so these Arel assertions need a connection, as Rails' do via helper.rb.
+  fixtures({});
   describe("WhereClauseTest", () => {
     it("+ combines two where clauses", () => {
       const t = table();

--- a/packages/arel/src/index.ts
+++ b/packages/arel/src/index.ts
@@ -9,6 +9,7 @@ export { UpdateManager } from "./update-manager.js";
 export { DeleteManager } from "./delete-manager.js";
 import { TreeManager } from "./tree-manager.js";
 export { TreeManager };
+export type { ArelEngine } from "./nodes/node.js";
 export { ArelError, EmptyJoinError, BindError } from "./errors.js";
 export { relationName } from "./attributes/attribute.js";
 // Deliberate: no Arel counterpart in Rails — ruby-pg owns this encoder, and
@@ -21,19 +22,17 @@ export { relationName } from "./attributes/attribute.js";
 export { encodeArrayElement } from "./quote-array.js";
 
 import { SqlLiteral } from "./nodes/sql-literal.js";
-import { registerNodeDeps, setToSqlVisitor } from "./nodes/node.js";
-export { setToSqlVisitor };
+import { registerNodeDeps } from "./nodes/node.js";
 import { Not } from "./nodes/unary.js";
 import { Grouping } from "./nodes/grouping.js";
 import { Or } from "./nodes/or.js";
 import { And } from "./nodes/and.js";
-import { ToSql } from "./visitors/to-sql.js";
 import { registerBinaryInversions, _registerCteFactory } from "./nodes/binary.js";
 import { Equality } from "./nodes/equality.js";
 import { In } from "./nodes/in.js";
 import { Cte } from "./nodes/cte.js";
 
-registerNodeDeps({ Not, Grouping, Or, And, ToSql });
+registerNodeDeps({ Not, Grouping, Or, And });
 registerBinaryInversions({ Equality, In });
 _registerCteFactory((name, relation) => new Cte(name, relation));
 

--- a/packages/arel/src/insert-manager.test.ts
+++ b/packages/arel/src/insert-manager.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Table, sql, InsertManager, Nodes } from "./index.js";
-import { fakeRecordConnection } from "./test-helpers/connection.js";
+import { fakeRecordEngine } from "./test-helpers/connection.js";
 
 describe("InsertManagerTest", () => {
   const users = new Table("users");
@@ -60,7 +60,7 @@ describe("InsertManagerTest", () => {
     it("inserts false", () => {
       const mgr = new InsertManager();
       mgr.insert([[users.get("bool"), false]]);
-      expect(mgr.toSql(fakeRecordConnection)).toBe(`INSERT INTO "users" ("bool") VALUES ('f')`);
+      expect(mgr.toSql(fakeRecordEngine)).toBe(`INSERT INTO "users" ("bool") VALUES ('f')`);
     });
 
     it("inserts null", () => {

--- a/packages/arel/src/nodes/node.test.ts
+++ b/packages/arel/src/nodes/node.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Table, SelectManager, Nodes, Visitors, setToSqlVisitor } from "../index.js";
+import { Table, SelectManager, Nodes, Visitors } from "../index.js";
 
 describe("TestNode", () => {
   const users = new Table("users");
@@ -173,38 +173,35 @@ describe("Node base polymorphic defaults", () => {
   });
 });
 
-describe("setToSqlVisitor", () => {
-  // The override is process-global (it mutates the module-level
-  // registry). Restore the default in `finally` so subsequent tests in
-  // the same worker don't see the SQLite override leak across.
-  const restore = (): void => setToSqlVisitor(Visitors.ToSql);
+describe("Table.engine", () => {
+  const sqliteEngine = { connection: { visitor: new Visitors.SQLite() } };
 
-  it("Node#toSql() routes through the configured visitor", () => {
-    try {
-      const users = new Table("users");
-      const node = users.get("name").isDistinctFrom(null);
-      // Generic visitor.
-      expect(node.toSql()).toBe(`"users"."name" IS NOT NULL`);
-      // SQLite visitor.
-      setToSqlVisitor(Visitors.SQLite);
-      expect(node.toSql()).toBe(`"users"."name" IS NOT NULL`);
-    } finally {
-      restore();
-    }
+  it("Node#toSql() compiles through the engine connection's visitor", () => {
+    const users = new Table("users");
+    const node = users.get("name").isDistinctFrom(null);
+    // Default engine (generic visitor, supplied by the suite setup).
+    expect(node.toSql()).toBe(`"users"."name" IS NOT NULL`);
+    // An engine whose connection carries the SQLite visitor.
+    expect(node.toSql(sqliteEngine)).toBe(`"users"."name" IS NOT NULL`);
   });
 
-  it("TreeManager#toSql() (SelectManager) also routes through the configured visitor", () => {
+  it("TreeManager#toSql() compiles through the engine connection's visitor", () => {
+    const users = new Table("users");
+    const mgr = users.project(users.get("id")).where(users.get("active").isNotDistinctFrom(true));
+    expect(mgr.toSql()).toContain("IS NOT DISTINCT FROM");
+    const sqlite = mgr.toSql(sqliteEngine);
+    // SQLite emits IS for IS NOT DISTINCT FROM; Quoted(true) inlines as 1 in SQLite.
+    expect(sqlite).toContain('"users"."active" IS 1');
+    expect(sqlite).not.toContain("IS NOT DISTINCT FROM");
+  });
+
+  it("Node#toSql() raises when no engine is set", () => {
+    const previous = Table.engine;
     try {
-      const users = new Table("users");
-      const mgr = users.project(users.get("id")).where(users.get("active").isNotDistinctFrom(true));
-      expect(mgr.toSql()).toContain("IS NOT DISTINCT FROM");
-      setToSqlVisitor(Visitors.SQLite);
-      const sqlite = mgr.toSql();
-      // SQLite emits IS for IS NOT DISTINCT FROM; Quoted(true) inlines as 1 in SQLite.
-      expect(sqlite).toContain('"users"."active" IS 1');
-      expect(sqlite).not.toContain("IS NOT DISTINCT FROM");
+      Table.engine = null;
+      expect(() => new Table("users").get("id").eq(1).toSql()).toThrow(TypeError);
     } finally {
-      restore();
+      Table.engine = previous;
     }
   });
 });

--- a/packages/arel/src/nodes/node.ts
+++ b/packages/arel/src/nodes/node.ts
@@ -1,4 +1,18 @@
 /**
+ * The `engine` `Node#toSql()` / `TreeManager#toSql()` compile through — Rails'
+ * `ActiveRecord::Base`, duck-typed here so arel does not import activerecord.
+ */
+export interface ArelEngine {
+  connection: { visitor: { compile(node: Node): string } };
+}
+
+/** Backing store for `Arel::Table.engine`. It lives here, not in table.ts,
+ *  because `Table extends Node` — a static `import { Table }` from this module
+ *  would make table.ts evaluate against a half-initialised node.ts. `Table`
+ *  exposes it as the Rails-named `Table.engine` accessor. */
+export const _engine: { current: ArelEngine | null } = { current: null };
+
+/**
  * Base class for all AST nodes in Arel.
  *
  * Mirrors: Arel::Nodes::Node — which `include`s Arel::FactoryMethods.
@@ -30,14 +44,25 @@ export abstract class Node {
     return new _registry.Not!(this);
   }
 
-  // Mirrors `to_sql(engine = Table.engine)` (arel/nodes/node.rb:148-153): Rails
-  // resolves a connection off the engine and hands it to the visitor. trails has
-  // no `Table.engine` (arel must not depend on activerecord), so the connection
-  // itself is the parameter and the connection-less default stands in for the
-  // engine default.
-  toSql(connection?: import("../visitors/connection.js").ArelConnection): string {
-    assertRegistered("ToSql");
-    return new _registry.ToSql!(connection).compile(this);
+  /**
+   * Mirrors: Arel::Nodes::Node#to_sql (arel/nodes/node.rb:148-153).
+   *
+   * Rails writes `engine.with_connection { |c| c.visitor.accept(self, ...) }`.
+   * trails' `withConnection` is async (per-checkout `verifyBang` is awaited —
+   * see ConnectionPool#checkout), and `to_sql` is synchronous in Rails and at
+   * all 600+ call sites here, so this uses the synchronous `engine.connection`
+   * lease instead. Same visitor, same connection; it just skips the async
+   * per-checkout verify. Tracked with the other sync-lease residuals by
+   * `connection-pool-pinned-sync-checkout-per-checkout-verify`.
+   */
+  toSql(engine: ArelEngine | null = _engine.current): string {
+    if (!engine) {
+      throw new TypeError(
+        "undefined method `connection' for nil — Arel::Table.engine is unset. " +
+          "Set it to your ActiveRecord base class, or pass an engine to toSql().",
+      );
+    }
+    return engine.connection.visitor.compile(this);
   }
 
   fetchAttribute(_block?: (attr: Node) => unknown): unknown {
@@ -82,16 +107,11 @@ export interface NodeVisitor<T> {
   visit(node: Node): T;
 }
 
-type ToSqlCtor = new (connection?: import("../visitors/connection.js").ArelConnection) => {
-  compile(node: Node): string;
-};
-
 interface NodeRegistry {
   Not?: new (expr: Node) => Node;
   Grouping?: new (expr: Node) => Node;
   Or?: new (children: Node[]) => Node;
   And?: new (children: Node[]) => Node;
-  ToSql?: ToSqlCtor;
 }
 
 // Registry for breaking circular dependencies.
@@ -111,28 +131,11 @@ export function registerNodeDeps(deps: {
   Grouping: new (expr: Node) => Node;
   Or: new (children: Node[]) => Node;
   And: new (children: Node[]) => Node;
-  ToSql: ToSqlCtor;
 }): void {
   _registry.Not = deps.Not;
   _registry.Grouping = deps.Grouping;
   _registry.Or = deps.Or;
   _registry.And = deps.And;
-  _registry.ToSql = deps.ToSql;
-}
-
-/**
- * Override the visitor used by `Node#toSql()`. `TreeManager#toSql()` and
- * `SelectManager#whereSql()` delegate to the underlying AST node's
- * `toSql()`, so they pick up the override transparently.
- *
- * Used by the parity runner so trails-side fixture output goes through
- * the SQLite visitor (matching the Ruby side's `ActiveRecord::Base
- * .establish_connection adapter: "sqlite3"`). Call once at process
- * startup, before importing fixtures. The override is process-global —
- * tests should restore the default in a `finally` block.
- */
-export function setToSqlVisitor(visitor: new () => { compile(node: Node): string }): void {
-  _registry.ToSql = visitor;
 }
 
 function fnv1a32(input: string): number {

--- a/packages/arel/src/nodes/node.ts
+++ b/packages/arel/src/nodes/node.ts
@@ -1,9 +1,11 @@
+import { SQLString } from "../collectors/sql-string.js";
+
 /**
  * The `engine` `Node#toSql()` / `TreeManager#toSql()` compile through — Rails'
  * `ActiveRecord::Base`, duck-typed here so arel does not import activerecord.
  */
 export interface ArelEngine {
-  connection: { visitor: { compile(node: Node): string } };
+  connection: { visitor: { accept(node: Node, collector: SQLString): SQLString } };
 }
 
 /** Backing store for `Arel::Table.engine`. It lives here, not in table.ts,
@@ -47,12 +49,12 @@ export abstract class Node {
   /**
    * Mirrors: Arel::Nodes::Node#to_sql (arel/nodes/node.rb:148-153).
    *
-   * Rails writes `engine.with_connection { |c| c.visitor.accept(self, ...) }`.
-   * trails' `withConnection` is async (per-checkout `verifyBang` is awaited —
-   * see ConnectionPool#checkout), and `to_sql` is synchronous in Rails and at
-   * all 600+ call sites here, so this uses the synchronous `engine.connection`
-   * lease instead. Same visitor, same connection; it just skips the async
-   * per-checkout verify. Tracked with the other sync-lease residuals by
+   * Deviation: `engine.connection` in place of Rails'
+   * `engine.with_connection { |c| ... }`. trails' `withConnection` is async
+   * (per-checkout `verifyBang` is awaited — see ConnectionPool#checkout) and
+   * `to_sql` is synchronous at all 600+ call sites, so this takes the sync
+   * `engine.connection` lease. Same visitor and connection; it skips only the
+   * async per-checkout verify, the residual tracked by
    * `connection-pool-pinned-sync-checkout-per-checkout-verify`.
    */
   toSql(engine: ArelEngine | null = _engine.current): string {
@@ -62,7 +64,8 @@ export abstract class Node {
           "Set it to your ActiveRecord base class, or pass an engine to toSql().",
       );
     }
-    return engine.connection.visitor.compile(this);
+    const collector = new SQLString();
+    return engine.connection.visitor.accept(this, collector).value;
   }
 
   fetchAttribute(_block?: (attr: Node) => unknown): unknown {

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -1,4 +1,4 @@
-import { Node } from "./nodes/node.js";
+import { ArelEngine, Node, _engine } from "./nodes/node.js";
 import { TreeManager } from "./tree-manager.js";
 import { SelectStatement } from "./nodes/select-statement.js";
 import { SelectCore } from "./nodes/select-core.js";
@@ -372,14 +372,11 @@ export class SelectManager extends TreeManager {
    *
    * Mirrors: Arel::SelectManager#where_sql
    */
-  // Mirrors `where_sql(engine = Table.engine)` (arel/select_manager.rb:192-196),
-  // which threads the engine into `to_sql(engine)`; see Node#toSql for why the
-  // connection, not an engine, is the parameter.
-  whereSql(connection?: import("./visitors/connection.js").ArelConnection): string | null {
+  whereSql(engine: ArelEngine | null = _engine.current): string | null {
     if (this.core.wheres.length === 0) return null;
     const predicate =
       this.core.wheres.length === 1 ? this.core.wheres[0] : new And(this.core.wheres);
-    return `WHERE ${predicate.toSql(connection)}`;
+    return `WHERE ${predicate.toSql(engine)}`;
   }
 
   /**

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -31,10 +31,6 @@ export interface TypeCaster {
  */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Table extends Node {
-  readonly name: string;
-  readonly tableAlias: string | null;
-  readonly klass?: TableKlass;
-
   constructor(name: string, options?: { as?: string; klass?: TableKlass; typeCaster?: unknown }) {
     super();
     this.name = name;
@@ -42,6 +38,23 @@ export class Table extends Node {
     this.tableAlias = as === name ? null : as;
     this.klass = options?.klass;
     this.typeCaster = options?.typeCaster ?? null;
+  }
+
+  readonly name: string;
+  readonly tableAlias: string | null;
+  readonly klass?: TableKlass;
+
+  /** Mirrors: `Arel::Table.engine` (table.rb:8-9, `class << self; attr_accessor
+   *  :engine`). Rails assigns `ActiveRecord::Base` from
+   *  `active_record.rb:562-564`; trails assigns it at the bottom of
+   *  activerecord's `base.ts` — see the comment there for why it rides the
+   *  load-hook run, and why it is not bare `Base`. */
+  static get engine(): ArelEngine | null {
+    return _engine.current;
+  }
+
+  static set engine(value: ArelEngine | null) {
+    _engine.current = value;
   }
 
   /**
@@ -176,25 +189,13 @@ export class Table extends Node {
     return (this.typeCaster as TypeCaster).typeForAttribute(name);
   }
 
-  isAbleToTypeCast(): boolean {
-    return this.typeCaster != null;
-  }
-
   /** Rails: `private attr_reader :type_caster` (table.rb:115). An aliased table
    *  is a `TableAlias` wrapping this one and delegates its caster back here
    *  (table_alias.rb:22-24), so no external reader is needed. */
   private readonly typeCaster: unknown;
 
-  /** Mirrors: `Arel::Table.engine` (table.rb:8-9). Rails assigns
-   *  `ActiveRecord::Base` from `active_record.rb:562-564`; trails assigns it at
-   *  the bottom of activerecord's `base.ts` — see the comment there for why it
-   *  rides the load-hook run, and why it is not bare `Base`. */
-  static get engine(): ArelEngine | null {
-    return _engine.current;
-  }
-
-  static set engine(value: ArelEngine | null) {
-    _engine.current = value;
+  isAbleToTypeCast(): boolean {
+    return this.typeCaster != null;
   }
 
   get(name: string, table?: Attribute["relation"]): Attribute {

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -1,6 +1,6 @@
 import { Attribute } from "./attributes/attribute.js";
 import { EmptyJoinError } from "./errors.js";
-import { Node, NodeVisitor } from "./nodes/node.js";
+import { _engine, ArelEngine, Node, NodeVisitor } from "./nodes/node.js";
 import { SelectManager } from "./select-manager.js";
 import { InnerJoin } from "./nodes/inner-join.js";
 import { OuterJoin } from "./nodes/outer-join.js";
@@ -31,15 +31,9 @@ export interface TypeCaster {
  */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Table extends Node {
-  static engine: unknown = null;
-
   readonly name: string;
   readonly tableAlias: string | null;
   readonly klass?: TableKlass;
-  /** Rails: `private attr_reader :type_caster` (table.rb:115). An aliased table
-   *  is a `TableAlias` wrapping this one and delegates its caster back here
-   *  (table_alias.rb:22-24), so no external reader is needed. */
-  private readonly typeCaster: unknown;
 
   constructor(name: string, options?: { as?: string; klass?: TableKlass; typeCaster?: unknown }) {
     super();
@@ -48,10 +42,6 @@ export class Table extends Node {
     this.tableAlias = as === name ? null : as;
     this.klass = options?.klass;
     this.typeCaster = options?.typeCaster ?? null;
-  }
-
-  get engine(): unknown {
-    return Table.engine;
   }
 
   /**
@@ -188,6 +178,23 @@ export class Table extends Node {
 
   isAbleToTypeCast(): boolean {
     return this.typeCaster != null;
+  }
+
+  /** Rails: `private attr_reader :type_caster` (table.rb:115). An aliased table
+   *  is a `TableAlias` wrapping this one and delegates its caster back here
+   *  (table_alias.rb:22-24), so no external reader is needed. */
+  private readonly typeCaster: unknown;
+
+  /** Mirrors: `Arel::Table.engine` (table.rb:8-9). Rails assigns
+   *  `ActiveRecord::Base` from `active_record.rb:562-564`; trails assigns it at
+   *  the bottom of activerecord's `base.ts` — see the comment there for why it
+   *  rides the load-hook run, and why it is not bare `Base`. */
+  static get engine(): ArelEngine | null {
+    return _engine.current;
+  }
+
+  static set engine(value: ArelEngine | null) {
+    _engine.current = value;
   }
 
   get(name: string, table?: Attribute["relation"]): Attribute {

--- a/packages/arel/src/test-helpers/connection.ts
+++ b/packages/arel/src/test-helpers/connection.ts
@@ -1,4 +1,6 @@
 import type { ArelConnection } from "../visitors/connection.js";
+import type { ArelEngine } from "../nodes/node.js";
+import { ToSql } from "../visitors/to-sql.js";
 import { defaultQuoter } from "../visitors/default-quoter.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 
@@ -51,9 +53,8 @@ function unreachableOnFakeRecord(name: string): () => never {
  * adapter produces (SQLite quotes `0`, the abstract adapter `FALSE`). Porting it
  * is what makes those assertions reachable verbatim instead of weakened.
  *
- * Only the quoting surface is ported: the rest of `FakeRecord` (schema cache,
- * `Table.engine` wiring) exists to satisfy Rails' `engine.with_connection`
- * indirection, which trails' explicit-connection `toSql(connection)` replaces.
+ * Only the quoting surface is ported; `FakeRecord`'s schema cache is not. The
+ * `Table.engine` wiring IS needed — see `fakeRecordEngine` below.
  *
  * @internal
  */
@@ -113,4 +114,25 @@ export const fakeRecordConnection: ArelConnection = {
   castBoundValue(value: unknown): unknown {
     return value;
   },
+};
+
+/**
+ * Port of `FakeRecord::Base` as an Arel engine (`fake_record.rb:125-139`).
+ *
+ * Rails' `Arel::Test#setup` does `Arel::Table.engine = FakeRecord::Base.new`
+ * (`test/cases/arel/helper.rb:19-20`), and `FakeRecord::Connection#initialize`
+ * builds its visitor as `Arel::Visitors::ToSql.new(self)` (`fake_record.rb:36`)
+ * — so the double's `'t'`/`'f'` quoting is what the whole suite compiles
+ * through. trails is not there yet: `test-setup-engine.ts` still installs a
+ * generic `ToSql` suite-wide, because switching the default would change the
+ * expected SQL of every boolean assertion at once. Tracked by story
+ * `arel-suite-engine-is-fake-record-base`.
+ *
+ * Until then this is opt-in, for the cases whose Rails counterpart asserts a
+ * FakeRecord rendering.
+ *
+ * @internal
+ */
+export const fakeRecordEngine: ArelEngine = {
+  connection: { visitor: new ToSql(fakeRecordConnection) },
 };

--- a/packages/arel/src/test-setup-engine.ts
+++ b/packages/arel/src/test-setup-engine.ts
@@ -1,15 +1,21 @@
 import { Table } from "./index.js";
 import { ToSql } from "./visitors/to-sql.js";
 
-// Rails runs the Arel test suite inside activerecord, where `Arel::Table.engine`
-// is `ActiveRecord::Base` with a live sqlite3 connection (see
-// activerecord/test/cases/helper.rb). The arel package cannot import
-// activerecord, so the suite supplies the same shape — an engine whose
-// connection carries the generic `Visitors::ToSql`, which is what every
-// `.toSql()` assertion in this package was written against.
-// The adapter memoises its visitor once (`abstract_adapter.rb:155`, mirrored at
-// abstract-adapter.ts:654), so hoist a single instance rather than building one
-// per access — same identity semantics as a real connection.
+// `Node#toSql()` compiles through `Table.engine`, so the suite must set one.
+//
+// This is NOT yet what Rails does. Rails' `Arel::Test#setup` assigns
+// `Arel::Table.engine = FakeRecord::Base.new` for every Arel test
+// (test/cases/arel/helper.rb:19-20), whose connection carries
+// `ToSql.new(self)` (fake_record.rb:36) — the quoting double ported here as
+// `fakeRecordEngine` (test-helpers/connection.ts). Installing that suite-wide
+// is the target state; it changes the expected SQL of every boolean/quoting
+// assertion at once, so it is tracked by story
+// `arel-suite-engine-is-fake-record-base` rather than done here.
+//
+// Until then: a generic `Visitors::ToSql`, which is what every `.toSql()`
+// assertion in this package was written against. The adapter memoises its
+// visitor once (`abstract_adapter.rb:155`, mirrored at abstract-adapter.ts:654),
+// so hoist a single instance rather than building one per access.
 const connection = { visitor: new ToSql() };
 
 Table.engine = { connection };

--- a/packages/arel/src/test-setup-engine.ts
+++ b/packages/arel/src/test-setup-engine.ts
@@ -1,0 +1,15 @@
+import { Table } from "./index.js";
+import { ToSql } from "./visitors/to-sql.js";
+
+// Rails runs the Arel test suite inside activerecord, where `Arel::Table.engine`
+// is `ActiveRecord::Base` with a live sqlite3 connection (see
+// activerecord/test/cases/helper.rb). The arel package cannot import
+// activerecord, so the suite supplies the same shape — an engine whose
+// connection carries the generic `Visitors::ToSql`, which is what every
+// `.toSql()` assertion in this package was written against.
+// The adapter memoises its visitor once (`abstract_adapter.rb:155`, mirrored at
+// abstract-adapter.ts:654), so hoist a single instance rather than building one
+// per access — same identity semantics as a real connection.
+const connection = { visitor: new ToSql() };
+
+Table.engine = { connection };

--- a/packages/arel/src/tree-manager.ts
+++ b/packages/arel/src/tree-manager.ts
@@ -1,4 +1,4 @@
-import { Node } from "./nodes/node.js";
+import { ArelEngine, Node, _engine } from "./nodes/node.js";
 import { PlainString } from "./collectors/plain-string.js";
 import { Dot } from "./visitors/dot.js";
 import { Limit, Offset } from "./nodes/unary.js";
@@ -71,14 +71,9 @@ export abstract class TreeManager {
     return collector.value;
   }
 
-  // Mirrors `to_sql(engine = Table.engine)` (arel/tree_manager.rb:53-58); see
-  // Node#toSql for why the connection, not an engine, is the parameter.
-  toSql(connection?: import("./visitors/connection.js").ArelConnection): string {
-    // Route through the same Node#toSql() the registry powers, so a
-    // `setToSqlVisitor()` override (e.g. SQLite for the parity runner)
-    // applies to managers as well as raw nodes. Plain `new ToSql()`
-    // would always be the generic visitor.
-    return this.ast.toSql(connection);
+  /** Mirrors: Arel::TreeManager#to_sql (arel/tree_manager.rb:53). */
+  toSql(engine: ArelEngine | null = _engine.current): string {
+    return this.ast.toSql(engine);
   }
 }
 

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/finder-methods.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/finder-methods.json
@@ -340,6 +340,6 @@
     "tsFile": "relation/finder-methods.ts",
     "rubyName": "raise_record_not_found_exception!",
     "call": "where_sql",
-    "reason": "Satisfied by a different path: Rails builds the condition string with `arel.where_sql(model)` (finder_methods.rb:418); trails routes it through the `_conditionsClause()` host method instead. Newly visible (not newly broken) because #5037 gave Arel's whereSql a connection parameter; the divergent indirection pre-dates it."
+    "reason": "Satisfied by a different path: Rails builds the condition string with `arel.where_sql(model)` (finder_methods.rb:418); trails routes it through the `_conditionsClause()` host method instead. Newly visible (not newly broken) because #5037 gave Arel's whereSql a connection parameter; the divergent indirection pre-dates it. Convergence tracked by story where-sql-wraps-in-and-and-returns-sqlliteral, which also owns removing this entry."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/arel/nodes/node.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/arel/nodes/node.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "arel",
-    "tsFile": "nodes/node.ts",
-    "rubyName": "to_sql",
-    "call": "accept",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  }
-]

--- a/scripts/parity/query/node/dump.ts
+++ b/scripts/parity/query/node/dump.ts
@@ -146,10 +146,10 @@ async function main(): Promise<void> {
       db.close();
     }
 
-    // 2. Wire the SQLite visitor through the package registry so both
-    //    `Node#toSql()` and `TreeManager#toSql()` route through it
-    //    (TreeManager.toSql delegates to the AST node's toSql, which
-    //    uses _registry.ToSql). Mirrors the Rails side's
+    // 2. Point `Arel::Table.engine` at an engine whose connection carries the
+    //    SQLite visitor, so both `Node#toSql()` and `TreeManager#toSql()`
+    //    compile through it (both resolve `engine.connection.visitor`).
+    //    Mirrors the Rails side's
     //    `establish_connection adapter: "sqlite3"` — for example,
     //    `IS DISTINCT FROM` now emits as `IS NOT` because
     //    Visitors.SQLite#visitIsDistinctFrom overrides it.
@@ -158,10 +158,10 @@ async function main(): Promise<void> {
     //    scripts/parity is itself a workspace package — see
     //    scripts/parity/package.json. That ensures Node ESM dedupes
     //    this import with the fixture's `@blazetrails/arel` import to a
-    //    single module instance, so the registry override is visible
+    //    single module instance, so the engine assignment is visible
     //    to the fixture's nodes.
     const arel = await import("@blazetrails/arel");
-    arel.setToSqlVisitor(arel.Visitors.SQLite);
+    arel.Table.engine = { connection: { visitor: new arel.Visitors.SQLite() } };
 
     // 4. Import query.ts. Fixtures end with `export default <expr>` — see
     //    scripts/parity/translate/arel.ts (generateTs).

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -406,6 +406,9 @@ export default defineConfig({
             "vendor/*.test.ts",
           ],
           exclude: ["packages/activerecord/**", ...SHARED_EXCLUDE],
+          // Arel's suite needs `Arel::Table.engine` set, exactly as Rails' does
+          // (it runs under activerecord, where the engine is ActiveRecord::Base).
+          setupFiles: ["./packages/arel/src/test-setup-engine.ts"],
           poolOptions: { forks: { maxForks: TEST_FORKS } },
         },
       },


### PR DESCRIPTION
## What

Rails' `Arel::Nodes::Node#to_sql` (`arel/nodes/node.rb:148-153`) and
`TreeManager#to_sql` (`arel/tree_manager.rb:53`) take an engine defaulting to
`Arel::Table.engine` and compile through **that engine's connection visitor**.
There is no connection-less path and no visitor registry.

trails diverged twice: `Table.engine` existed but was never assigned anywhere,
and an invented process-global visitor registry (`setToSqlVisitor` /
`_registry.ToSql`) stood in for it, constructing a `ToSql` with no connection —
which is what reached the default quoter.

## Changes

- `packages/activerecord/src/base.ts` assigns `Table.engine = Base`, mirroring
  `ActiveSupport.on_load(:active_record) { Arel::Table.engine = self }`
  (`active_record.rb:562-564`). It rides `runLoadHooks("active_record", Base)`
  rather than `index.ts` because many modules and tests deep-import `base.js`
  and never evaluate the package entrypoint.
- `Node#toSql(engine = Table.engine)`, `TreeManager#toSql(engine)` and
  `SelectManager#whereSql(engine)` now resolve `engine.connection.visitor`.
  Unset engine raises a `TypeError` naming the missing `connection`, as Ruby's
  `NoMethodError` on `nil` does.
- `setToSqlVisitor` and the `_registry.ToSql` slot are removed. `Table.engine`
  is backed by module state in `node.ts` (not a static field on `Table`) because
  `Table extends Node` — a static import of `Table` from `node.ts` would make
  `table.ts` evaluate against a half-initialised module. `Table` exposes the
  Rails-named accessor.
- The parity runner points `Table.engine` at a SQLite-visitor engine, the direct
  analogue of the Ruby side's `establish_connection adapter: "sqlite3"`.

## Deviation, justified at the call site

Rails writes `engine.with_connection { |c| c.visitor.accept(...) }`. trails'
`withConnection` is **async** (per-checkout `verifyBang` is awaited), and
`to_sql` is synchronous in Rails and at all 600+ call sites here, so `toSql`
uses the synchronous `engine.connection` lease. Same visitor, same connection;
it only skips the async per-checkout verify — the residual already tracked by
`connection-pool-pinned-sync-checkout-per-checkout-verify`. Noted in the
`toSql` doc comment.

## Test wiring

- Rails runs the Arel suite *inside* activerecord, where the engine is
  `ActiveRecord::Base` on sqlite3. The arel package cannot import activerecord,
  so a setup file supplies the same shape (a connection carrying the generic
  `Visitors::ToSql`) — no per-test churn, and every existing `.toSql()`
  assertion keeps its current expected output.
- Three AR unit files that assert on `.toSql()` without ever establishing a
  connection now call `fixtures({})`, matching how Rails' equivalents get one
  from `helper.rb`.
- `node.test.ts`'s `setToSqlVisitor` block is rewritten as a `Table.engine`
  block covering both the engine-argument path and the unset-engine raise.

## Verification

- `packages/arel/src`, `packages/activerecord/src/{relation,associations,connection-adapters,sanitization,insert-all}`: 6879 passed, 0 failed.
- `pnpm typecheck`, `pnpm lint`: clean.
- `pnpm api:compare`: Data layer 7471/7474, files 407/407 — unchanged.
- Two `scripts/parity/query/node/ar_dump.test.ts` failures are **pre-existing**
  (verified against a clean tree: same 2 failures with the whole diff removed).

Closes-story: converge-node-tosql-to-table-engine-connection

## Self-review against Rails

Re-read `arel/nodes/node.rb:147-153`, `arel/tree_manager.rb:53-58`,
`arel/select_manager.rb:192-196` and `active_record.rb:562-564` against the diff:

- Rails builds `Collectors::SQLString.new` and calls `visitor.accept(node, collector).value`.
  trails' one-arg `visitor.compile(node)` does exactly that (`to-sql.ts:214+`
  defaults to a plain `SQLString`), so the collector is not spelled out here —
  same as every other `compile` call site in the repo.
- `TreeManager#to_sql` visits `@ast` with the passed engine; `this.ast.toSql(engine)`
  matches.
- **Found one pre-existing divergence I did not fix here**, to keep this PR to the
  engine threading: `whereSql` special-cases a single where instead of always
  wrapping in `Nodes::And`, and returns a plain string rather than a `SqlLiteral`
  (`select_manager.rb:195`). Filed as
  `0007-remove-global-arel-visitor/where-sql-wraps-in-and-and-returns-sqlliteral`.

No stubs or placeholders added.

### Gate deltas (measured against a detached `origin/main`)

| | baseline | this PR |
|---|---|---|
| test:compare | 14477/21663, 747/1020 files | 14477/21663, 747/1020 files |
| api:compare | Data layer 7471/7474, files 407/407 | unchanged |

test:compare "extra (TS only)" moves 4013 → 4016: the three trails-only
`Table.engine` cases replacing the two deleted `setToSqlVisitor` ones. Non-negative.


## Review rounds

**Deprecated `Base.connection` (rounds 1–2) — fixed.** You were right and the
`disallowed` case is the one that matters: `connection-handling.ts:461-463`
*raises* under `permanentConnectionCheckout = "disallowed"`, so every `toSql()`
in an app would have thrown. Measured on a cold lease before the fix:
`WARN=1` under `"deprecated"` (once per pool, not per call — the first call
flips the lease sticky), and a hard raise under `"disallowed"`.

`leaseConnection` isn't the answer — `connection-handling.ts:361` returns
`Promise<DatabaseAdapter>`, and `toSql` is synchronous at every call site. So
`Table.engine` is now an object delegating to the pool's **non-deprecated sync
surface**: `pool.activeConnection ?? pool.leaseConnectionSync()` — the same
connection `Base.connection` resolves, without the deprecation gate. Re-measured:

```
MODE=deprecated  WARN=0  THREW=null
MODE=disallowed  WARN=0  THREW=null
```

This is a deliberate departure from Rails' literal `Arel::Table.engine = self`,
and the reason is stated at the call site (`base.ts`): Rails reaches the visitor
via `engine.with_connection`, which is async here, so the engine must expose a
synchronous `connection` — and bare `Base` only offers the deprecated one.

**Field reorder (round 1) — root-caused and fixed.** Not incidental churn: the
trails-invented instance getter `get engine()` (no counterpart in `table.rb`,
which declares `engine` only inside `class << self` at :8-9, and zero callers
repo-wide) collided by name with the new static accessor, so
`rails-file-structure-method-order` autofixed the whole adjacent declaration
block. Deleting the invented getter and moving `typeCaster` to its manifest slot
resolves it: `name`/`tableAlias`/`klass` are back above the constructor,
untouched from `main`, and the layout is now stable under `eslint --fix`.

**Memoised test visitor (round 1) — fixed.** Single hoisted
`const connection = { visitor: new ToSql() }`, matching `abstract_adapter.rb:155`.

**`whereSql` string/`And` divergence (round 1) — filed, not fixed here.**
`0007-remove-global-arel-visitor/where-sql-wraps-in-and-and-returns-sqlliteral`,
with the `select_manager.rb:192-196` quote and both divergences as acceptance
criteria. Out of scope for the engine threading.

### Gates (re-measured after the final round)

| | baseline `origin/main` | this PR |
|---|---|---|
| test:compare | 14477/21663, 747/1020 files | 14477/21663, 747/1020 files |
| api:compare | Data layer 7471/7474, files 407/407 | unchanged |

6282 tests pass across `packages/arel/src` + `relation` + `connection-adapters`
+ `associations`. typecheck and lint clean. No stubs added.

**Round 3 — stale doc cite, fixed** (`defee8b3e`). The `Table.engine` doc still
said "assigns it from activerecord's index module", left over from the first
draft before the assignment moved to `base.ts` for the deep-import reason. Now
cites `table.rb:8-9` and `active_record.rb:562-564` for the Rails side and points
at `base.ts` for both the load-hook placement and the not-bare-`Base` deviation,
rather than restating either. Swept the other touched arel files for the same
staleness — the remaining `index.ts` references are pre-existing and accurate
(they describe arel's own registry wiring, not the engine).

## CI round 1 — real breakage, fixed (`8b1f9ba40`)

All four AR jobs plus the wide-calls gate failed. Mine, not flakes — my local runs
covered `arel` + `relation` + `associations` + `connection-adapters` but not the
whole AR tree.

**Two connection-less `toSql()` sites.** Both now pass an explicit engine, the
argument `arel/nodes/node.rb:148-153` exists for, rather than reaching for a
connection-less quoter:

- `adapter.test.ts:49` built the bind placeholder at **module scope**, so no
  `fixtures({})` or hook could help — the call runs at import. This is the one
  structural gap in the port: Rails' `helper.rb` establishes a connection before
  test files load, `test-setup-ar.ts` does not. Moved into `roundTripBinds`,
  where it compiles through the already-leased `conn`. A repo-wide scan found
  this was the *only* module-scope `.toSql()` in the AR suite.
- `postgresql-adapter.trails.test.ts:852` builds its adapter directly rather than
  through `Base`'s pool, so it passes that adapter as the engine.

**Wide call-mismatches ratchet: `raise_record_not_found_exception!` omits
`where_sql`.** Genuine, pre-existing, and surfaced *because* this PR threaded
`whereSql` — the method entering the matched population is what made the omission
visible. Rails does `arel.where_sql(model)` (`finder_methods.rb:418`); trails
hand-rolls it in the `@internal` `_conditionsClause` helper (`relation.ts:6503`),
which replicates even the single-where special-case already filed. Baselined with
that reason, and the filed story now also owns deleting the baseline entry — so
the ratchet re-fires if the convergence is forgotten.

Converging it here would mean fixing `whereSql`'s return type and its callers
inside an engine-threading PR; that is exactly the filed story's scope.

Re-verified: `lint-call-mismatches-wide` OK (6649 baselined, no stale entries),
api:compare Data layer 7471/7474 / 407/407, typecheck clean, 2722 tests pass
across the touched areas.

## Rebased onto main (conflicts with #5032 / #5037)

Four sibling arel PRs merged while this was open. Squashed to two commits and
rebased; `git diff origin/main` is now 182/103.

**#5032 took an interim shape this PR supersedes.** It gave `toSql` an optional
*connection* parameter, with this note at `node.ts`:

> trails has no `Table.engine` (arel must not depend on activerecord), so the
> connection itself is the parameter and the connection-less default stands in
> for the engine default.

That premise is exactly what this PR removes. `Table.engine` exists, and arel
still does not depend on activerecord — activerecord assigns it through the
duck-typed `ArelEngine`, the same direction Rails assigns from
(`active_record.rb:563`). So I resolved all three arel conflicts in favour of the
engine parameter and the registry deletion. The interim connection parameter is
gone, not layered.

**#5037's `fakeRecordConnection` needed an engine wrapper.** It was passing a
connection straight into `toSql(connection)`, the one caller that broke. Rather
than casting, this ports `FakeRecord::Base` properly as `fakeRecordEngine`
(`fake_record.rb:125-139`), whose connection carries `ToSql.new(self)` exactly as
`fake_record.rb:36` builds it. Its doc comment claimed the `Table.engine` wiring
"exists to satisfy Rails' `engine.with_connection` indirection, which trails'
explicit-connection `toSql(connection)` replaces" — stale as of this PR, so
corrected.

**Found while doing that:** Rails installs the FakeRecord engine for *every*
arel test (`arel/helper.rb:19-20`), which is why its expected SQL embeds
`'t'`/`'f'`. trails installs a generic `ToSql` suite-wide, keeping the suite
anchored on the `defaultQuoter` RFC 0007 is deleting. Flipping that default
changes every boolean assertion at once, so it is left opt-in and filed as
`0007-remove-global-arel-visitor/arel-suite-engine-is-fake-record-base`.

**Wide-exclude entry:** a sibling had already added the same
`raise_record_not_found_exception!` / `where_sql` entry. Kept theirs and appended
the story pointer rather than duplicating it.

Re-verified after the rebase: typecheck clean, 1574 arel tests pass, api:compare
Data layer 7471/7474 / 407/407, `lint-call-mismatches-wide` OK (6649 baselined),
`lint-call-mismatches` OK (19 baselined).

## Review round 6 (final)

`test-setup-engine.ts` claimed Rails' Arel suite runs with `ActiveRecord::Base`
on sqlite3. Wrong — `helper.rb:19-20` assigns `FakeRecord::Base.new` for every
Arel test, which is what the `fakeRecordEngine` doc added in the same PR already
said. I wrote that line before reading `helper.rb` and it contradicted itself
once the rebase landed. Corrected (`533a32277`) to state the target state and
point at the tracking story.

### Follow-ups filed (not merge-blocking)

| Story | RFC | What |
|---|---|---|
| `where-sql-wraps-in-and-and-returns-sqlliteral` | 0007 | `whereSql` returns a plain string and special-cases one where instead of always wrapping in `Nodes::And` (`select_manager.rb:195`); `_conditionsClause` (`relation.ts:6503`) hand-rolls the same construction instead of calling it (`finder_methods.rb:418`). Also owns deleting the wide-exclude entry. |
| `arel-suite-engine-is-fake-record-base` | 0007 | Arel suite installs a generic `ToSql` rather than `FakeRecord::Base` (`arel/helper.rb:19-20`), keeping it anchored on the `defaultQuoter` RFC 0007 is deleting. |

Nothing merge-blocking remains. The sync-lease deviation
(`engine.connection` rather than Rails' async-here `with_connection`) is
deliberate, justified at the call site in `base.ts`, and shares the existing
`connection-pool-pinned-sync-checkout-per-checkout-verify` residual.

## Review round 9 / CI method-order fix (`e03cf21b2`)

The `rails-file-structure-method-order` failure was real and merge-blocking.
Root cause: #5039 changed the rule to interleave static and instance members by
Rails source line, so the static `engine` accessor (`table.rb:8-9`) had to move
out of the class bottom into its source-order slot. Fixed via the rule's own
`--fix`.

The reviewer's suggested position (engine *first*, above `name`) turned out
slightly off: the manifest applies a constructor carve-out, so the enforced
order is `constructor` → fields → `engine` → `alias`. Verified by building the
manifest and running the rule, not by eye — a manual top-placement failed with
`constructor should precede engine`.

Why it slipped past local checks (and the stale "stable under eslint --fix" note
in an earlier body section): the manifest is gitignored and built from
`rails-api.json` in the api CI job, so a plain local `pnpm lint` **no-ops this
rule entirely**. Reproduced locally with `ruby extract-ruby-api.rb` →
`build-rails-file-structure-manifest.ts` → `eslint --fix`. That local-repro gap
is already filed (not new): `rails-file-structure-lint-rule-no-ops-in-lint-job`
and `arel-file-structure-method-order-manifest-stale`, both in 0023.

Nothing merge-blocking remains.

## Follow-up refinement (`ceff4c733`): toSql inlines accept, like node.rb:150

`Node#toSql` previously routed through `visitor.compile(this)`. That was
behaviourally identical to Rails (`ToSql#compile` is defined as exactly
`accept(node, SQLString.new).value`), but a call-path difference: Rails'
`Node#to_sql` inlines `collector = SQLString.new; ...accept(self, collector).value`
rather than calling `compile`. Now trails does the same, so the line reads like
the Ruby it ports.

Bonus: this converges the one wide-call divergence the ratchet tracked here —
`nodes/node.ts to_sql accept` (Rails calls `accept`, trails had called `compile`).
Its baseline entry is now stale and removed; wide ratchet 6649 → 6648. The
engine's visitor contract narrows from `compile` to `accept`; every engine
constructed in-repo already passes a full `ToSql`, which has both.
