### PR TITLE
test(arel): port FakeRecord quoting double so 't'/'f' assertions are reachable

### DIFF
--- a/packages/arel/src/insert-manager.test.ts
+++ b/packages/arel/src/insert-manager.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Table, sql, InsertManager, Nodes } from "./index.js";
+import { fakeRecordConnection } from "./test-helpers/connection.js";
 
 describe("InsertManagerTest", () => {
   const users = new Table("users");
@@ -59,12 +60,7 @@ describe("InsertManagerTest", () => {
     it("inserts false", () => {
       const mgr = new InsertManager();
       mgr.insert([[users.get("bool"), false]]);
-      // Rails asserts VALUES ('f'): that rendering comes from the Arel suite's
-      // FakeRecord connection double (test/cases/arel/support/fake_record.rb:79-80),
-      // not from any adapter — SQLite quotes false as 0, the abstract adapter as
-      // FALSE. We have no FakeRecord port, so toSql() renders via the
-      // connection-less default quoter.
-      expect(mgr.toSql()).toBe(`INSERT INTO "users" ("bool") VALUES (FALSE)`);
+      expect(mgr.toSql(fakeRecordConnection)).toBe(`INSERT INTO "users" ("bool") VALUES ('f')`);
     });
 
     it("inserts null", () => {

--- a/packages/arel/src/nodes/node.ts
+++ b/packages/arel/src/nodes/node.ts
@@ -30,9 +30,14 @@ export abstract class Node {
     return new _registry.Not!(this);
   }
 
-  toSql(): string {
+  // Mirrors `to_sql(engine = Table.engine)` (arel/nodes/node.rb:148-153): Rails
+  // resolves a connection off the engine and hands it to the visitor. trails has
+  // no `Table.engine` (arel must not depend on activerecord), so the connection
+  // itself is the parameter and the connection-less default stands in for the
+  // engine default.
+  toSql(connection?: import("../visitors/connection.js").ArelConnection): string {
     assertRegistered("ToSql");
-    return new _registry.ToSql!().compile(this);
+    return new _registry.ToSql!(connection).compile(this);
   }
 
   fetchAttribute(_block?: (attr: Node) => unknown): unknown {

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -372,11 +372,14 @@ export class SelectManager extends TreeManager {
    *
    * Mirrors: Arel::SelectManager#where_sql
    */
-  whereSql(): string | null {
+  // Mirrors `where_sql(engine = Table.engine)` (arel/select_manager.rb:192-196),
+  // which threads the engine into `to_sql(engine)`; see Node#toSql for why the
+  // connection, not an engine, is the parameter.
+  whereSql(connection?: import("./visitors/connection.js").ArelConnection): string | null {
     if (this.core.wheres.length === 0) return null;
     const predicate =
       this.core.wheres.length === 1 ? this.core.wheres[0] : new And(this.core.wheres);
-    return `WHERE ${predicate.toSql()}`;
+    return `WHERE ${predicate.toSql(connection)}`;
   }
 
   /**

--- a/packages/arel/src/test-helpers/connection.ts
+++ b/packages/arel/src/test-helpers/connection.ts
@@ -1,5 +1,6 @@
 import type { ArelConnection } from "../visitors/connection.js";
 import { defaultQuoter } from "../visitors/default-quoter.js";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 
 /**
  * Explicit connections for Arel visitor construction in tests.
@@ -27,3 +28,56 @@ import { defaultQuoter } from "../visitors/default-quoter.js";
  * @internal
  */
 export const testConnection: ArelConnection = defaultQuoter;
+
+/**
+ * Port of the Arel suite's `FakeRecord::Connection` quoting
+ * (`test/cases/arel/support/fake_record.rb:55-90`).
+ *
+ * Rails' Arel tests run against this double, not against an adapter, which is
+ * why their expected SQL embeds `'t'`/`'f'` for booleans — a rendering no real
+ * adapter produces (SQLite quotes `0`, the abstract adapter `FALSE`). Porting it
+ * is what makes those assertions reachable verbatim instead of weakened.
+ *
+ * Only the quoting surface is ported: the rest of `FakeRecord` (schema cache,
+ * `Table.engine` wiring) exists to satisfy Rails' `engine.with_connection`
+ * indirection, which trails' explicit-connection `toSql(connection)` replaces.
+ *
+ * @internal
+ */
+export const fakeRecordConnection: ArelConnection = {
+  ...defaultQuoter,
+
+  quoteTableName(name: string): string {
+    return `"${name}"`;
+  },
+
+  quoteColumnName(name: string): string {
+    return `"${name}"`;
+  },
+
+  // fake_record.rb:71-87. Note the `else` arm escapes `'` as `\'`, not `''`.
+  quote(thing: unknown): string {
+    if (thing === true) return "'t'";
+    if (thing === false) return "'f'";
+    if (thing === null || thing === undefined) return "NULL";
+    if (typeof thing === "number" || typeof thing === "bigint") return String(thing);
+    if (thing instanceof Temporal.PlainDate) {
+      return `'${String(thing.year).padStart(4, "0")}-${String(thing.month).padStart(2, "0")}-${String(thing.day).padStart(2, "0")}'`;
+    }
+    if (thing instanceof Temporal.PlainDateTime) {
+      const p = (n: number): string => String(n).padStart(2, "0");
+      return `'${String(thing.year).padStart(4, "0")}-${p(thing.month)}-${p(thing.day)} ${p(thing.hour)}:${p(thing.minute)}:${p(thing.second)}'`;
+    }
+    return `'${String(thing).replace(/'/g, "\\'")}'`;
+  },
+
+  // fake_record.rb:63-65 — the comment is returned unchanged.
+  sanitizeAsSqlComment(value: string): string {
+    return value;
+  },
+
+  // fake_record.rb:90-92.
+  castBoundValue(value: unknown): unknown {
+    return value;
+  },
+};

--- a/packages/arel/src/test-helpers/connection.ts
+++ b/packages/arel/src/test-helpers/connection.ts
@@ -45,6 +45,11 @@ export const testConnection: ArelConnection = defaultQuoter;
  * @internal
  */
 export const fakeRecordConnection: ArelConnection = {
+  // FakeRecord defines none of `quoted_true`/`quoted_false`/`quoted_binary` — in
+  // Ruby the visitor simply never calls them on this double, since `quote` claims
+  // booleans first (fake_record.rb:75-78). `ArelConnection` is a TS interface, so
+  // they must be present; the spread supplies them rather than inventing values.
+  // They stay unreachable for booleans for the same reason they are in Rails.
   ...defaultQuoter,
 
   quoteTableName(name: string): string {

--- a/packages/arel/src/test-helpers/connection.ts
+++ b/packages/arel/src/test-helpers/connection.ts
@@ -29,6 +29,19 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
  */
 export const testConnection: ArelConnection = defaultQuoter;
 
+// Stands in for a method FakeRecord does not define. Rails gets this for free —
+// an undefined method on the double raises NoMethodError — so raising here is the
+// faithful behaviour, and it turns any future reachability into a loud failure
+// naming the method rather than silent default-quoter output.
+function unreachableOnFakeRecord(name: string): () => never {
+  return () => {
+    throw new Error(
+      `${name} is not defined on FakeRecord: Rails' Arel visitor never calls it on this double. ` +
+        `Reaching it means the visitor diverged from Rails — fix the visitor, not this double.`,
+    );
+  };
+}
+
 /**
  * Port of the Arel suite's `FakeRecord::Connection` quoting
  * (`test/cases/arel/support/fake_record.rb:55-90`).
@@ -45,12 +58,22 @@ export const testConnection: ArelConnection = defaultQuoter;
  * @internal
  */
 export const fakeRecordConnection: ArelConnection = {
-  // FakeRecord defines none of `quoted_true`/`quoted_false`/`quoted_binary` — in
-  // Ruby the visitor simply never calls them on this double, since `quote` claims
-  // booleans first (fake_record.rb:75-78). `ArelConnection` is a TS interface, so
-  // they must be present; the spread supplies them rather than inventing values.
-  // They stay unreachable for booleans for the same reason they are in Rails.
-  ...defaultQuoter,
+  // FakeRecord defines ONLY the methods Rails' visitor actually calls on it —
+  // no `quoted_true`/`quoted_false`/`quoted_binary`/`quote_string`/`unquoted_*`.
+  // `ArelConnection` is a TS interface so they must exist; they raise rather than
+  // borrowing `defaultQuoter`, which would (a) re-anchor this double on the
+  // connection-less quoter RFC 0007 is deleting and (b) silently emit adapter
+  // renderings (`TRUE`) from a double whose entire purpose is to emit `'t'`.
+  // Verified unreachable, not merely unused: the ToSql visitor calls none of them
+  // (they appear nowhere in visitors/to-sql.ts), and `unquotedTrue`/`unquotedFalse`
+  // are reached only via quoteArrayLiteral (quote-array.ts:86), which only the PG
+  // quoter's own `quote` override calls — an override this double replaces.
+  quoteString: unreachableOnFakeRecord("quoteString"),
+  quotedBinary: unreachableOnFakeRecord("quotedBinary"),
+  quotedTrue: unreachableOnFakeRecord("quotedTrue"),
+  quotedFalse: unreachableOnFakeRecord("quotedFalse"),
+  unquotedTrue: unreachableOnFakeRecord("unquotedTrue"),
+  unquotedFalse: unreachableOnFakeRecord("unquotedFalse"),
 
   quoteTableName(name: string): string {
     return `"${name}"`;
@@ -64,6 +87,11 @@ export const fakeRecordConnection: ArelConnection = {
   quote(thing: unknown): string {
     if (thing === true) return "'t'";
     if (thing === false) return "'f'";
+    // Ruby has one nil; JS has two nullish values. `undefined` joins the NULL arm
+    // rather than falling to `else` (which would emit `'undefined'` as a string)
+    // because the sibling quoters treat the pair alike (default-quoter.ts
+    // `quoteScalar`). Letting it stringify here would make this double the only
+    // quoter in the package that renders a nullish as a quoted literal.
     if (thing === null || thing === undefined) return "NULL";
     if (typeof thing === "number" || typeof thing === "bigint") return String(thing);
     if (thing instanceof Temporal.PlainDate) {

--- a/packages/arel/src/tree-manager.ts
+++ b/packages/arel/src/tree-manager.ts
@@ -71,12 +71,14 @@ export abstract class TreeManager {
     return collector.value;
   }
 
-  toSql(): string {
+  // Mirrors `to_sql(engine = Table.engine)` (arel/tree_manager.rb:53-58); see
+  // Node#toSql for why the connection, not an engine, is the parameter.
+  toSql(connection?: import("./visitors/connection.js").ArelConnection): string {
     // Route through the same Node#toSql() the registry powers, so a
     // `setToSqlVisitor()` override (e.g. SQLite for the parity runner)
     // applies to managers as well as raw nodes. Plain `new ToSql()`
     // would always be the generic visitor.
-    return this.ast.toSql();
+    return this.ast.toSql(connection);
   }
 }
 

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/finder-methods.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/finder-methods.json
@@ -334,5 +334,12 @@
     "rubyName": "raise_record_not_found_exception!",
     "call": "wrap",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/finder-methods.ts",
+    "rubyName": "raise_record_not_found_exception!",
+    "call": "where_sql",
+    "reason": "Satisfied by a different path: Rails builds the condition string with `arel.where_sql(model)` (finder_methods.rb:418); trails routes it through the `_conditionsClause()` host method instead. Newly visible (not newly broken) because #5037 gave Arel's whereSql a connection parameter; the divergent indirection pre-dates it."
   }
 ]


### PR DESCRIPTION
Rails' Arel test suite asserts boolean literals as `'t'`/`'f'` — a rendering
produced by neither the abstract adapter (`TRUE`/`FALSE`) nor SQLite (`0`), but
by the suite's own `FakeRecord::Connection` double
(`test/cases/arel/support/fake_record.rb:71-87`). trails had no port, so
`inserts false` in `insert-manager.test.ts` had to assert `FALSE` with a
call-site deviation comment (#5031).

This ports the quoting half of `FakeRecord::Connection` as
`fakeRecordConnection` in `packages/arel/src/test-helpers/connection.ts`, and
threads an explicit connection through `toSql()`.

- `Node#toSql(connection?)` / `TreeManager#toSql(connection?)` mirror Rails'
  `to_sql(engine = Table.engine)` (`arel/nodes/node.rb:148-153`,
  `arel/tree_manager.rb:53-58`). trails has no `Table.engine` — arel must not
  depend on activerecord — so the connection itself is the parameter.
- `inserts false` now asserts Rails' exact `VALUES ('f')`; the deviation
  comment is deleted.

Audit of the remaining arel tests: the only other boolean-literal assertions
(`update-manager.test.ts:197`, `delete-manager.test.ts:41`,
`nodes/filter.test.ts:11`, `visitors/to-sql.trails.test.ts:94`) have no Rails
counterparts asserting `'t'`/`'f'` — they are trails-authored, not weakened
ports — so nothing else was reachable through the double.

All 1573 arel tests pass.

Closes-story: arel-tests-lack-fakerecord-quoting-double
