### PR TITLE
fix(associations)!: raise when a has_many target is replaced mid-load

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1293,7 +1293,11 @@ async function _loadSingularThroughViaDisableJoinsScope(
  * Sync loaded result to the association instance if one exists.
  */
 function syncToAssociationInstance(record: Base, assocName: string, result: unknown): void {
-  record._associationInstances.get(assocName)?.setTarget(result as Base | Base[] | null);
+  const holder = record._associationInstances.get(assocName) as
+    | { setTarget(t: Base | Base[] | null): void; _loaderWritebackSuppressed?: number }
+    | undefined;
+  if (!holder || holder._loaderWritebackSuppressed) return;
+  holder.setTarget(result as Base | Base[] | null);
 }
 
 /**

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -513,10 +513,10 @@ export function _cacheSingularTarget(record: Base, assocName: string, target: Ba
   // a minimal loaded holder keyed by the name for ad-hoc inverses. Surfaced
   // through `Base#_associationCache`.
   const existing = record._associationInstances.get(assocName) as
-    | { setTarget(t: unknown): void; _explicitTarget?: boolean }
+    | { _setTargetFromLoader(t: unknown): void; _explicitTarget?: boolean }
     | undefined;
   if (existing) {
-    existing.setTarget(target);
+    existing._setTargetFromLoader(target);
     existing._explicitTarget = true;
   } else {
     record._associationInstances.set(assocName, {
@@ -1294,10 +1294,10 @@ async function _loadSingularThroughViaDisableJoinsScope(
  */
 function syncToAssociationInstance(record: Base, assocName: string, result: unknown): void {
   const holder = record._associationInstances.get(assocName) as
-    | { setTarget(t: Base | Base[] | null): void; _loaderWritebackSuppressed?: number }
+    | { _setTargetFromLoader(t: Base | Base[] | null): void; _loaderWritebackSuppressed?: number }
     | undefined;
   if (!holder || holder._loaderWritebackSuppressed) return;
-  holder.setTarget(result as Base | Base[] | null);
+  holder._setTargetFromLoader(result as Base | Base[] | null);
 }
 
 /**

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -459,6 +459,12 @@ export class Association {
       // Rails applies set_strict_loading per record in find_target's DB
       // execute block — only freshly loaded records, never cached ones.
       if (result !== null) this.setStrictLoading(result as Base);
+      // Deliberately a direct assignment, not `setTarget`: this is the loader
+      // storing what it just fetched, not a caller replacing the target, so it
+      // must not bump `_setTargetCount`. Routing it through `setTarget` would
+      // make every load look like a wholesale replacement to a concurrent
+      // load's guard. (Only `CollectionAssociation#loadTarget` reads the
+      // counter today; the singular path keeps the invariant honest anyway.)
       this.target = result;
     }
   }

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -48,6 +48,35 @@ export class Association {
   /** True after asyncLoadTarget() completes a full DB load — signals the dotted
    *  collection proxy that it can hydrate from this instance's target. */
   _loadedViaAsync = false;
+  /**
+   * Nonzero while THIS holder is itself driving a loader (`loadHasMany` &c.)
+   * through `doAsyncFindTarget`, so the loader's own `setTarget` writeback
+   * into this holder must be skipped — the driving caller assigns the result
+   * itself the moment its `await` resumes.
+   *
+   * Rails needs no such flag: `Association#find_target`
+   * (association.rb:248) is synchronous, so nothing can touch the holder
+   * between issuing the query and assigning the result. Ours awaits, and an
+   * assignment landing in that window (`firm.association("clients")
+   * .setTarget([other])`) was silently clobbered by the loader's redundant
+   * writeback. Suppressing the writeback keys off the loader/driver relation
+   * itself rather than on any observed holder state, so a collection that
+   * legitimately mutates its own target mid-load (dirty targets, in-memory
+   * built/pushed records, target merging) is unaffected.
+   * @internal
+   */
+  _loaderWritebackSuppressed = 0;
+  /**
+   * Counts *wholesale* target replacements — `setTarget` calls, and only
+   * those. A loader snapshots it before awaiting and compares afterwards to
+   * tell "someone replaced my target while I was in flight" (skip the
+   * writeback) from "the collection mutated its own target during this load"
+   * (dirty targets, in-memory built/pushed records, target merging — all of
+   * which assign `this.target` in place and must still be merged with the
+   * freshly loaded rows). A bare generation counter conflates the two.
+   * @internal
+   */
+  _setTargetCount = 0;
 
   private _staleState: unknown = undefined;
   /**
@@ -173,6 +202,7 @@ export class Association {
 
   setTarget(target: Base | Base[] | null): void {
     this.target = target;
+    this._setTargetCount++;
     this.loadedBang();
   }
 

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -63,10 +63,20 @@ export class Association {
    * between issuing the query and assigning the result. Ours awaits, and an
    * assignment landing in that window (`firm.association("clients")
    * .setTarget([other])`) was silently clobbered by the loader's redundant
-   * writeback. Suppressing the writeback keys off the loader/driver relation
-   * itself rather than on any observed holder state, so a collection that
-   * legitimately mutates its own target mid-load (dirty targets, in-memory
-   * built/pushed records, target merging) is unaffected.
+   * writeback.
+   *
+   * **Scoping — this flag is holder-scoped, not loader-scoped.** While it is
+   * set, `syncToAssociationInstance` suppresses *every* writeback into this
+   * holder, not just the driving loader's own. A concurrent
+   * `loadHasMany(owner, sameName, differentOptions)` carrying differently
+   * scoped rows is therefore dropped from the holder too (it still returns its
+   * rows to its own caller; only the holder cache goes unwritten, and the
+   * driving load assigns the holder immediately after). Making it
+   * loader-scoped would require threading a per-load token through
+   * `loadHasMany`; the holder-scoped version is what the guard needs, since a
+   * collection that legitimately mutates its own target mid-load (dirty
+   * targets, in-memory built/pushed records, target merging) is unaffected
+   * either way.
    * @internal
    */
   _loaderWritebackSuppressed = 0;
@@ -194,20 +204,45 @@ export class Association {
   }
 
   setTarget(target: Base | Base[] | null): void {
-    // Refuse the race rather than silently picking a winner. `find_target` is
-    // synchronous in Rails (association.rb:248) so this cannot arise there;
-    // ours awaits, and an assignment landing inside that window used to be
-    // silently clobbered by the load. `_loaderWritebackSuppressed` is what
-    // makes this safe to raise on: the loader's own writeback bails before
-    // reaching here, so only a genuine external replacement trips it.
-    if (this._loaderWritebackSuppressed) {
-      throw new AssociationTargetReplacedDuringLoad(
-        `Cannot replace the target of association \`${this.reflection.name}\` while a load for it is still in flight. ` +
-          `Await the load (or the reader) before assigning.`,
-      );
-    }
+    this.raiseIfLoadInFlight();
+    this._setTargetFromLoader(target);
+  }
+
+  /**
+   * Assign the target WITHOUT the in-flight guard — the entry point for code
+   * that is itself a loader (the `Preloader`), as opposed to a caller
+   * replacing the target.
+   *
+   * Loader-vs-loader is not the race we refuse: both sides are reads of the
+   * same association, so whichever lands last is a legitimate result rather
+   * than a lost intent. Raising here would instead abort an entire preload
+   * batch because one unrelated owner happened to have a lazy load in flight.
+   * @internal
+   */
+  _setTargetFromLoader(target: Base | Base[] | null): void {
     this.target = target;
     this.loadedBang();
+  }
+
+  /**
+   * Raise if a load for this association is still in flight. Guards the
+   * *assignment* paths (`setTarget`, `CollectionAssociation#replace`) — the
+   * ones that carry a caller's explicit intent.
+   *
+   * Refuses the race rather than silently picking a winner. `find_target` is
+   * synchronous in Rails (association.rb:248) so this cannot arise there; ours
+   * awaits, and an assignment landing inside that window used to be silently
+   * clobbered by the load. `_loaderWritebackSuppressed` is what makes this safe
+   * to raise on: a loader's own writeback never reaches an assignment path, so
+   * only a genuine external replacement trips it.
+   * @internal
+   */
+  protected raiseIfLoadInFlight(): void {
+    if (!this._loaderWritebackSuppressed) return;
+    throw new AssociationTargetReplacedDuringLoad(
+      `Cannot replace the target of association \`${this.reflection.name}\` while a load for it is still in flight. ` +
+        `Await the load (or the reader) before assigning.`,
+    );
   }
 
   /**

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -7,7 +7,11 @@ import { ScopeRegistry } from "../scoping.js";
 import { getDjasScopeBuilder, getAssociationRelationFactory } from "./_scope-slots.js";
 import { validateReflectionValidity } from "./validate-through-reflection.js";
 import { camelize, singularize, underscore } from "@blazetrails/activesupport";
-import { AssociationTypeMismatch, NameError } from "../errors.js";
+import {
+  AssociationTargetReplacedDuringLoad,
+  AssociationTypeMismatch,
+  NameError,
+} from "../errors.js";
 
 /**
  * Base class for all association proxies. An Association wraps a single
@@ -66,17 +70,6 @@ export class Association {
    * @internal
    */
   _loaderWritebackSuppressed = 0;
-  /**
-   * Counts *wholesale* target replacements — `setTarget` calls, and only
-   * those. A loader snapshots it before awaiting and compares afterwards to
-   * tell "someone replaced my target while I was in flight" (skip the
-   * writeback) from "the collection mutated its own target during this load"
-   * (dirty targets, in-memory built/pushed records, target merging — all of
-   * which assign `this.target` in place and must still be merged with the
-   * freshly loaded rows). A bare generation counter conflates the two.
-   * @internal
-   */
-  _setTargetCount = 0;
 
   private _staleState: unknown = undefined;
   /**
@@ -201,8 +194,19 @@ export class Association {
   }
 
   setTarget(target: Base | Base[] | null): void {
+    // Refuse the race rather than silently picking a winner. `find_target` is
+    // synchronous in Rails (association.rb:248) so this cannot arise there;
+    // ours awaits, and an assignment landing inside that window used to be
+    // silently clobbered by the load. `_loaderWritebackSuppressed` is what
+    // makes this safe to raise on: the loader's own writeback bails before
+    // reaching here, so only a genuine external replacement trips it.
+    if (this._loaderWritebackSuppressed) {
+      throw new AssociationTargetReplacedDuringLoad(
+        `Cannot replace the target of association \`${this.reflection.name}\` while a load for it is still in flight. ` +
+          `Await the load (or the reader) before assigning.`,
+      );
+    }
     this.target = target;
-    this._setTargetCount++;
     this.loadedBang();
   }
 
@@ -461,10 +465,7 @@ export class Association {
       if (result !== null) this.setStrictLoading(result as Base);
       // Deliberately a direct assignment, not `setTarget`: this is the loader
       // storing what it just fetched, not a caller replacing the target, so it
-      // must not bump `_setTargetCount`. Routing it through `setTarget` would
-      // make every load look like a wholesale replacement to a concurrent
-      // load's guard. (Only `CollectionAssociation#loadTarget` reads the
-      // counter today; the singular path keeps the invariant honest anyway.)
+      // must not trip `setTarget`'s in-flight guard.
       this.target = result;
     }
   }

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -567,7 +567,13 @@ export class CollectionAssociation extends Association {
       if (cached !== undefined && Array.isArray(cached)) {
         this.target = this.mergeTargetLists(cached, this.target);
       } else {
+        // Rails' find_target is synchronous, so nothing can replace the
+        // target between the query and the merge below. Ours awaits: if a
+        // wholesale `setTarget` landed in that window, the assignment wins
+        // and the loaded rows are discarded. See `_setTargetCount`.
+        const setTargetCountAtEntry = this._setTargetCount;
         const found = await this.doAsyncFindTarget();
+        if (this._setTargetCount !== setTargetCountAtEntry) return this.target;
         if (found !== undefined && found !== null && Array.isArray(found)) {
           // Rails applies set_strict_loading per record in find_target's DB
           // execute block — only freshly loaded records, never cached ones.

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -573,12 +573,20 @@ export class CollectionAssociation extends Association {
         // and the loaded rows are discarded. See `_setTargetCount`.
         const setTargetCountAtEntry = this._setTargetCount;
         const found = await this.doAsyncFindTarget();
-        if (this._setTargetCount !== setTargetCountAtEntry) return this.target;
+        const replacedMidLoad = this._setTargetCount !== setTargetCountAtEntry;
         if (found !== undefined && found !== null && Array.isArray(found)) {
           // Rails applies set_strict_loading per record in find_target's DB
           // execute block — only freshly loaded records, never cached ones.
+          // It runs unconditionally on load (association.rb:270), so it must
+          // happen even when the merge below is skipped: the rows we drop can
+          // still be reachable through the inverse instances wired into them
+          // during instantiation.
           for (const record of found) this.setStrictLoading(record);
-          this.target = this.mergeTargetLists(found, this.target);
+          // A wholesale `setTarget` landed while we were awaiting — the
+          // assignment wins and the loaded rows are discarded. Falls through
+          // to `loadedBang()` rather than returning early, so the loaded flag
+          // and stale state are refreshed on exactly one path.
+          if (!replacedMidLoad) this.target = this.mergeTargetLists(found, this.target);
         }
       }
     }

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -567,26 +567,12 @@ export class CollectionAssociation extends Association {
       if (cached !== undefined && Array.isArray(cached)) {
         this.target = this.mergeTargetLists(cached, this.target);
       } else {
-        // Rails' find_target is synchronous, so nothing can replace the
-        // target between the query and the merge below. Ours awaits: if a
-        // wholesale `setTarget` landed in that window, the assignment wins
-        // and the loaded rows are discarded. See `_setTargetCount`.
-        const setTargetCountAtEntry = this._setTargetCount;
         const found = await this.doAsyncFindTarget();
-        const replacedMidLoad = this._setTargetCount !== setTargetCountAtEntry;
         if (found !== undefined && found !== null && Array.isArray(found)) {
           // Rails applies set_strict_loading per record in find_target's DB
           // execute block — only freshly loaded records, never cached ones.
-          // It runs unconditionally on load (association.rb:270), so it must
-          // happen even when the merge below is skipped: the rows we drop can
-          // still be reachable through the inverse instances wired into them
-          // during instantiation.
           for (const record of found) this.setStrictLoading(record);
-          // A wholesale `setTarget` landed while we were awaiting — the
-          // assignment wins and the loaded rows are discarded. Falls through
-          // to `loadedBang()` rather than returning early, so the loaded flag
-          // and stale state are refreshed on exactly one path.
-          if (!replacedMidLoad) this.target = this.mergeTargetLists(found, this.target);
+          this.target = this.mergeTargetLists(found, this.target);
         }
       }
     }

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -431,6 +431,12 @@ export class CollectionAssociation extends Association {
    * delete/add only records that have changed.
    */
   replace(otherArray: Base[]): void {
+    // The writer path (`firm.clients = [...]`, `firm.client_ids = [...]`, mass
+    // assignment) mutates `target` directly rather than going through
+    // `setTarget`, so it needs the in-flight guard applied here too —
+    // otherwise the ordinary user-facing assignment stays silently clobberable
+    // while only the raw `association(name).setTarget(...)` call is protected.
+    this.raiseIfLoadInFlight();
     for (const val of otherArray) (this as any).raiseOnTypeMismatchBang(val);
     const wasLoaded = this.isLoaded();
     const originalTarget = [...this.target];

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -108,7 +108,17 @@ export class HasManyAssociation extends CollectionAssociation {
   }
 
   protected override async doAsyncFindTarget(): Promise<Base[]> {
-    return loadHasMany(this.owner, this.reflection.name, this.reflection.options);
+    // Every caller of doAsyncFindTarget assigns the returned records into
+    // this holder itself, so loadHasMany's tail writeback into the same
+    // holder is redundant — and, because it lands mid-await, clobbers any
+    // reassignment made while the query was in flight. See
+    // `_loaderWritebackSuppressed`.
+    this._loaderWritebackSuppressed++;
+    try {
+      return await loadHasMany(this.owner, this.reflection.name, this.reflection.options);
+    } finally {
+      this._loaderWritebackSuppressed--;
+    }
   }
 
   protected override setOwnerAttributes(record: Base): void {

--- a/packages/activerecord/src/associations/has-many-mid-flight-reassignment.trails.test.ts
+++ b/packages/activerecord/src/associations/has-many-mid-flight-reassignment.trails.test.ts
@@ -12,6 +12,8 @@
  */
 import { describe, it, expect } from "vitest";
 import { fixtures } from "../test-helpers/fixtures.js";
+import { loadHasMany } from "../associations.js";
+import type { Base } from "../base.js";
 import { Firm, Client } from "../test-helpers/models/company.js";
 import { Author } from "../test-helpers/models/author.js";
 import { Comment } from "../test-helpers/models/comment.js";
@@ -28,6 +30,38 @@ describe("has_many mid-flight reassignment", () => {
     await inFlight;
 
     expect(firm.association("clients").target).toEqual([other]);
+    // The guard path falls through to loadedBang() rather than returning
+    // early, so the holder is loaded on exactly one exit path.
+    expect(firm.association("clients").isLoaded()).toBe(true);
+  });
+
+  it("a sibling load landing mid-await does not discard the loaded rows", async () => {
+    // `_loaderWritebackSuppressed` is scoped to this holder for the whole
+    // window, so a sibling loader's `syncToAssociationInstance` writeback is
+    // swallowed rather than counted as a wholesale replacement — the guard
+    // must not mistake it for a user reassignment and drop the DB rows.
+    const firm = (await Firm.first()) as Firm;
+    const persisted = await Client.where({ firm_id: firm.id });
+    expect(persisted.length).toBeGreaterThan(0);
+
+    const inFlight = firm.association("clients").loadTarget();
+    await loadHasMany(firm, "clients", {});
+    const loaded = (await inFlight) as Base[];
+
+    expect(loaded.length).toBe(persisted.length);
+  });
+
+  it("concurrent loads on the same holder do not drop rows", async () => {
+    const firm = (await Firm.first()) as Firm;
+    const persisted = await Client.where({ firm_id: firm.id });
+
+    const [a, b] = (await Promise.all([
+      firm.association("clients").loadTarget(),
+      firm.association("clients").loadTarget(),
+    ])) as [Base[], Base[]];
+
+    expect(a.length).toBe(persisted.length);
+    expect(b.length).toBe(persisted.length);
   });
 
   it("a target assigned mid-load survives on a has_many :through", async () => {

--- a/packages/activerecord/src/associations/has-many-mid-flight-reassignment.trails.test.ts
+++ b/packages/activerecord/src/associations/has-many-mid-flight-reassignment.trails.test.ts
@@ -13,6 +13,7 @@
 import { describe, it, expect } from "vitest";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { loadHasMany } from "../associations.js";
+import { Preloader } from "./preloader.js";
 import { AssociationTargetReplacedDuringLoad } from "../errors.js";
 import type { Base } from "../base.js";
 import { Firm, Client } from "../test-helpers/models/company.js";
@@ -83,6 +84,50 @@ describe("has_many mid-flight reassignment", () => {
 
     expect(a.length).toBe(persisted.length);
     expect(b.length).toBe(persisted.length);
+  });
+
+  it("the writer path raises too, not just the raw setTarget", async () => {
+    // `firm.clients = [...]` goes through CollectionAssociation#replace, which
+    // mutates target directly rather than calling setTarget — so the guard has
+    // to be applied there as well or the ordinary user-facing assignment stays
+    // silently clobberable.
+    const firm = (await Firm.first()) as Firm;
+    const other = (await Client.first()) as Client;
+
+    const inFlight = firm.association("clients").loadTarget();
+    const holder = firm.association("clients") as unknown as { replace(r: Base[]): void };
+    expect(() => holder.replace([other])).toThrow(AssociationTargetReplacedDuringLoad);
+    await inFlight;
+  });
+
+  it("a preload landing mid-load neither raises nor aborts the batch", async () => {
+    // The Preloader is a loader, not a caller replacing the target:
+    // loader-vs-loader is not the race we refuse, and raising would abort the
+    // whole batch because ONE owner happened to have a lazy load in flight.
+    //
+    // The in-flight window is held open directly rather than by racing a real
+    // `loadTarget()`: driving it through the public API is timing-dependent
+    // (the load's query resolves before the preloader reaches its associate
+    // step, so the window has already closed and the test passes vacuously —
+    // confirmed by reverting the fix). Setting the flag pins the invariant
+    // deterministically instead of hoping for an interleaving.
+    const firm = (await Firm.first()) as Firm;
+    const other = (await Firm.where({ id: firm.id }))[0];
+    const holder = firm.association("clients") as unknown as {
+      _loaderWritebackSuppressed: number;
+    };
+
+    holder._loaderWritebackSuppressed++;
+    try {
+      await expect(
+        new Preloader({ records: [firm, other], associations: "clients" }).call(),
+      ).resolves.not.toThrow();
+    } finally {
+      holder._loaderWritebackSuppressed--;
+    }
+
+    // The non-racing owner in the same batch still got its target.
+    expect(other.association("clients").isLoaded()).toBe(true);
   });
 
   it("replacing a has_many :through target mid-load raises", async () => {

--- a/packages/activerecord/src/associations/has-many-mid-flight-reassignment.trails.test.ts
+++ b/packages/activerecord/src/associations/has-many-mid-flight-reassignment.trails.test.ts
@@ -1,18 +1,19 @@
 /**
- * Trails-only surface: a has_many target reassigned while its load is still
- * in flight must survive the load.
+ * Trails-only surface: replacing a has_many target while a load for it is
+ * still in flight raises `AssociationTargetReplacedDuringLoad`.
  *
  * Rails has no analogue because `Association#find_target`
  * (activerecord/lib/active_record/associations/association.rb:248) is
  * synchronous — nothing can touch the holder between issuing the query and
- * assigning its result. trails awaits, so an assignment landing inside that
- * window used to be silently clobbered by `loadHasMany`'s tail writeback into
- * the holder that was already driving the load. See
- * `Association#_loaderWritebackSuppressed`.
+ * assigning its result, so the race cannot arise. trails awaits, which opens
+ * a window in which an assignment and a load both claim the target. There is
+ * no correct silent winner, so trails refuses the race rather than resolving
+ * it: previously the load clobbered the assignment with no diagnostic.
  */
 import { describe, it, expect } from "vitest";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { loadHasMany } from "../associations.js";
+import { AssociationTargetReplacedDuringLoad } from "../errors.js";
 import type { Base } from "../base.js";
 import { Firm, Client } from "../test-helpers/models/company.js";
 import { Author } from "../test-helpers/models/author.js";
@@ -21,25 +22,45 @@ import { Comment } from "../test-helpers/models/comment.js";
 describe("has_many mid-flight reassignment", () => {
   fixtures(["companies", "authors", "posts", "comments"]);
 
-  it("a target assigned while the load is in flight is not clobbered by the load", async () => {
+  it("replacing the target while a load is in flight raises", async () => {
     const firm = (await Firm.first()) as Firm;
     const other = (await Client.first()) as Client;
 
     const inFlight = firm.association("clients").loadTarget();
-    firm.association("clients").setTarget([other]);
+    expect(() => firm.association("clients").setTarget([other])).toThrow(
+      AssociationTargetReplacedDuringLoad,
+    );
     await inFlight;
+  });
 
-    expect(firm.association("clients").target).toEqual([other]);
-    // The guard path falls through to loadedBang() rather than returning
-    // early, so the holder is loaded on exactly one exit path.
+  it("the raise names the association and survives the load completing", async () => {
+    const firm = (await Firm.first()) as Firm;
+    const other = (await Client.first()) as Client;
+    const persisted = await Client.where({ firm_id: firm.id });
+
+    const inFlight = firm.association("clients").loadTarget();
+    expect(() => firm.association("clients").setTarget([other])).toThrow(/clients/);
+    const loaded = (await inFlight) as Base[];
+
+    // The refused assignment leaves the load intact — no partial state.
+    expect(loaded.length).toBe(persisted.length);
     expect(firm.association("clients").isLoaded()).toBe(true);
   });
 
-  it("a sibling load landing mid-await does not discard the loaded rows", async () => {
-    // `_loaderWritebackSuppressed` is scoped to this holder for the whole
-    // window, so a sibling loader's `syncToAssociationInstance` writeback is
-    // swallowed rather than counted as a wholesale replacement — the guard
-    // must not mistake it for a user reassignment and drop the DB rows.
+  it("assigning after the load has settled is allowed", async () => {
+    const firm = (await Firm.first()) as Firm;
+    const other = (await Client.first()) as Client;
+
+    await firm.association("clients").loadTarget();
+    firm.association("clients").setTarget([other]);
+
+    expect(firm.association("clients").target).toEqual([other]);
+  });
+
+  it("a sibling load landing mid-await neither raises nor discards the loaded rows", async () => {
+    // `_loaderWritebackSuppressed` is what makes the raise safe: a loader's own
+    // `syncToAssociationInstance` writeback bails before reaching `setTarget`,
+    // so only a genuine external replacement trips the guard.
     const firm = (await Firm.first()) as Firm;
     const persisted = await Client.where({ firm_id: firm.id });
     expect(persisted.length).toBeGreaterThan(0);
@@ -64,16 +85,16 @@ describe("has_many mid-flight reassignment", () => {
     expect(b.length).toBe(persisted.length);
   });
 
-  it("a target assigned mid-load survives on a has_many :through", async () => {
+  it("replacing a has_many :through target mid-load raises", async () => {
     // HasManyThroughAssociation inherits doAsyncFindTarget from
     // HasManyAssociation, so it must inherit the guard with it.
     const author = (await Author.first()) as Author;
     const other = (await Comment.first()) as Comment;
 
     const inFlight = author.association("comments").loadTarget();
-    author.association("comments").setTarget([other]);
+    expect(() => author.association("comments").setTarget([other])).toThrow(
+      AssociationTargetReplacedDuringLoad,
+    );
     await inFlight;
-
-    expect(author.association("comments").target).toEqual([other]);
   });
 });

--- a/packages/activerecord/src/associations/has-many-mid-flight-reassignment.trails.test.ts
+++ b/packages/activerecord/src/associations/has-many-mid-flight-reassignment.trails.test.ts
@@ -11,6 +11,7 @@
  * it: previously the load clobbered the assignment with no diagnostic.
  */
 import { describe, it, expect } from "vitest";
+import { readdir, readFile } from "node:fs/promises";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { loadHasMany } from "../associations.js";
 import { Preloader } from "./preloader.js";
@@ -128,6 +129,36 @@ describe("has_many mid-flight reassignment", () => {
 
     // The non-racing owner in the same batch still got its target.
     expect(other.association("clients").isLoaded()).toBe(true);
+  });
+
+  it("no internal caller reaches setTarget — every loader writeback is exempt", async () => {
+    // Three review rounds found the same defect in different files: an
+    // internal loader calling `setTarget`, which now raises and aborts its
+    // batch. Enumerating by hand kept missing sites, so pin the invariant
+    // instead — `setTarget` is the caller-facing API (guarded), and every
+    // internal writeback goes through `_setTargetFromLoader`.
+    const root = new URL("../", import.meta.url);
+    const offenders: string[] = [];
+
+    const walk = async (dir: URL): Promise<void> => {
+      for (const entry of await readdir(dir, { withFileTypes: true })) {
+        const child = new URL(`${entry.name}${entry.isDirectory() ? "/" : ""}`, dir);
+        if (entry.isDirectory()) {
+          if (entry.name !== "node_modules") await walk(child);
+          continue;
+        }
+        if (!entry.name.endsWith(".ts") || entry.name.includes(".test.")) continue;
+        const source = await readFile(child, "utf8");
+        source.split("\n").forEach((line, i) => {
+          if (!line.includes(".setTarget(")) return;
+          if (line.trimStart().startsWith("*") || line.trimStart().startsWith("//")) return;
+          offenders.push(`${entry.name}:${i + 1}`);
+        });
+      }
+    };
+    await walk(root);
+
+    expect(offenders).toEqual([]);
   });
 
   it("replacing a has_many :through target mid-load raises", async () => {

--- a/packages/activerecord/src/associations/has-many-mid-flight-reassignment.trails.test.ts
+++ b/packages/activerecord/src/associations/has-many-mid-flight-reassignment.trails.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Trails-only surface: a has_many target reassigned while its load is still
+ * in flight must survive the load.
+ *
+ * Rails has no analogue because `Association#find_target`
+ * (activerecord/lib/active_record/associations/association.rb:248) is
+ * synchronous — nothing can touch the holder between issuing the query and
+ * assigning its result. trails awaits, so an assignment landing inside that
+ * window used to be silently clobbered by `loadHasMany`'s tail writeback into
+ * the holder that was already driving the load. See
+ * `Association#_loaderWritebackSuppressed`.
+ */
+import { describe, it, expect } from "vitest";
+import { fixtures } from "../test-helpers/fixtures.js";
+import { Firm, Client } from "../test-helpers/models/company.js";
+
+describe("has_many mid-flight reassignment", () => {
+  fixtures(["companies"]);
+
+  it("a target assigned while the load is in flight is not clobbered by the load", async () => {
+    const firm = (await Firm.first()) as Firm;
+    const other = (await Client.first()) as Client;
+
+    const inFlight = firm.association("clients").loadTarget();
+    firm.association("clients").setTarget([other]);
+    await inFlight;
+
+    expect(firm.association("clients").target).toEqual([other]);
+  });
+});

--- a/packages/activerecord/src/associations/has-many-mid-flight-reassignment.trails.test.ts
+++ b/packages/activerecord/src/associations/has-many-mid-flight-reassignment.trails.test.ts
@@ -13,9 +13,11 @@
 import { describe, it, expect } from "vitest";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { Firm, Client } from "../test-helpers/models/company.js";
+import { Author } from "../test-helpers/models/author.js";
+import { Comment } from "../test-helpers/models/comment.js";
 
 describe("has_many mid-flight reassignment", () => {
-  fixtures(["companies"]);
+  fixtures(["companies", "authors", "posts", "comments"]);
 
   it("a target assigned while the load is in flight is not clobbered by the load", async () => {
     const firm = (await Firm.first()) as Firm;
@@ -26,5 +28,18 @@ describe("has_many mid-flight reassignment", () => {
     await inFlight;
 
     expect(firm.association("clients").target).toEqual([other]);
+  });
+
+  it("a target assigned mid-load survives on a has_many :through", async () => {
+    // HasManyThroughAssociation inherits doAsyncFindTarget from
+    // HasManyAssociation, so it must inherit the guard with it.
+    const author = (await Author.first()) as Author;
+    const other = (await Comment.first()) as Comment;
+
+    const inFlight = author.association("comments").loadTarget();
+    author.association("comments").setTarget([other]);
+    await inFlight;
+
+    expect(author.association("comments").target).toEqual([other]);
   });
 });

--- a/packages/activerecord/src/associations/instance-methods.ts
+++ b/packages/activerecord/src/associations/instance-methods.ts
@@ -59,7 +59,7 @@ function syncAssociationInstance(this: Base, name: string, instance: Association
       // without re-marking loaded.
       instance.target = (cached.target as Base | Base[] | null) ?? null;
     } else {
-      instance.setTarget((cached.target as Base | Base[] | null) ?? null);
+      instance._setTargetFromLoader((cached.target as Base | Base[] | null) ?? null);
     }
     return;
   }
@@ -69,7 +69,7 @@ function syncAssociationInstance(this: Base, name: string, instance: Association
   // a miss, matching `Association#doFindTarget`'s cache semantics.
   const preloaded = _preloadedHolderTarget(this, name);
   if (preloaded) {
-    instance.setTarget(preloaded.value as any);
+    instance._setTargetFromLoader(preloaded.value as any);
   }
 }
 
@@ -157,7 +157,9 @@ export async function loadBelongsTo(this: Base, name: string): Promise<Base | nu
   const result = await bypassStrictLoading.call(this, () =>
     _loadBelongsToOnce(this, name, (assocDef.options ?? {}) as any),
   );
-  association.call(this, name).setTarget(result as any);
+  // Loader writeback: this is the tail of this function's own query, not a
+  // caller replacing the target. See Association#_setTargetFromLoader.
+  association.call(this, name)._setTargetFromLoader(result as any);
   return result as Base | null;
 }
 
@@ -173,7 +175,9 @@ export async function loadHasOne(this: Base, name: string): Promise<Base | null>
   const result = await bypassStrictLoading.call(this, () =>
     _loadHasOneOnce(this, name, (assocDef.options ?? {}) as any),
   );
-  association.call(this, name).setTarget(result as any);
+  // Loader writeback: this is the tail of this function's own query, not a
+  // caller replacing the target. See Association#_setTargetFromLoader.
+  association.call(this, name)._setTargetFromLoader(result as any);
   return result as Base | null;
 }
 

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -1564,7 +1564,7 @@ export class JoinDependency {
           proxy.target.push(child);
         }
       } else {
-        proxy.setTarget(child);
+        proxy._setTargetFromLoader(child);
       }
       proxy._loadedFromPreload = true;
       if (typeof proxy.setInverseInstance === "function") {
@@ -1604,7 +1604,7 @@ export class JoinDependency {
       const proxy = parent.association(node.immediateAssocName);
       if (!proxy || proxy.loaded) return;
       const isCollection = node.assocType === "hasMany";
-      proxy.setTarget(isCollection ? [] : null);
+      proxy._setTargetFromLoader(isCollection ? [] : null);
       proxy._loadedFromPreload = true;
     } catch (e) {
       if (!(e instanceof AssociationNotFoundError)) throw e;

--- a/packages/activerecord/src/associations/preloader/association.ts
+++ b/packages/activerecord/src/associations/preloader/association.ts
@@ -218,7 +218,9 @@ export class Association {
         const owner = owners[i];
         try {
           const association = (owner as any).association(this.reflection.name);
-          association.setTarget(record);
+          // Loader writeback, not an assignment — must not trip the
+          // in-flight guard (see Association#_setTargetFromLoader).
+          association._setTargetFromLoader(record);
           association._loadedFromPreload = true;
           if (i === 0) {
             association.setInverseInstance(record);
@@ -244,10 +246,10 @@ export class Association {
       const currentTarget: Base[] = Array.isArray(association.target) ? association.target : [];
       const notPersistedRecords = currentTarget.filter((r) => !(r as any).isPersisted());
       value = [...records, ...notPersistedRecords];
-      association.setTarget(value);
+      association._setTargetFromLoader(value);
     } else {
       value = records[0] ?? null;
-      association.setTarget(value);
+      association._setTargetFromLoader(value);
     }
     association._loadedFromPreload = true;
 

--- a/packages/activerecord/src/associations/preloader/batch.ts
+++ b/packages/activerecord/src/associations/preloader/batch.ts
@@ -109,7 +109,9 @@ export class Batch {
       try {
         const association = (record as any).association(branch.association);
         if (!association.isLoaded()) {
-          association.setTarget(null);
+          // Loader writeback (preload miss) — must not trip the in-flight
+          // guard. See Association#_setTargetFromLoader.
+          association._setTargetFromLoader(null);
           association._loadedFromPreload = true;
         }
       } catch {

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -187,6 +187,27 @@ export class RecordNotFound extends ActiveRecordError {
   }
 }
 
+/**
+ * Raised when an association's target is replaced while a load for that same
+ * association is still in flight.
+ *
+ * **trails-only — no Rails analogue, deliberately.** Rails cannot reach this
+ * state: `Association#find_target`
+ * (activerecord/lib/active_record/associations/association.rb:248) is
+ * synchronous, so nothing can touch the holder between issuing the query and
+ * assigning its result. Our loader awaits, which opens a window in which an
+ * assignment and a load both claim the target. There is no correct silent
+ * winner — discarding the assignment loses a caller's explicit intent, and
+ * discarding the load hides that a query was wasted — so trails refuses the
+ * race instead of resolving it. Await the load before assigning.
+ */
+export class AssociationTargetReplacedDuringLoad extends ActiveRecordError {
+  constructor(message?: string) {
+    super(message);
+    this.name = "AssociationTargetReplacedDuringLoad";
+  }
+}
+
 export class RecordNotSaved extends ActiveRecordError {
   readonly record?: object;
 

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -267,6 +267,7 @@ export {
   QueryCanceled,
   RangeError,
   AssociationTypeMismatch,
+  AssociationTargetReplacedDuringLoad,
   TableNotSpecified,
   AsynchronousQueryInsideTransactionError,
 } from "./errors.js";

--- a/packages/activerecord/src/test-helpers/seed-association-cache.ts
+++ b/packages/activerecord/src/test-helpers/seed-association-cache.ts
@@ -19,10 +19,13 @@ export function seedAssociationCache(record: Base, name: string, target: unknown
   try {
     const assoc = (
       record as unknown as {
-        association(n: string): { setTarget(t: unknown): void; _explicitTarget: boolean };
+        association(n: string): {
+          _setTargetFromLoader(t: unknown): void;
+          _explicitTarget: boolean;
+        };
       }
     ).association(name);
-    assoc.setTarget(target);
+    assoc._setTargetFromLoader(target);
     assoc._explicitTarget = true;
     return;
   } catch {


### PR DESCRIPTION
## Problem

Replacing a has_many target while a load for it was still in flight silently
clobbered the assignment:

```ts
const inFlight = firm.association("clients").loadTarget();
firm.association("clients").setTarget([other]);
await inFlight;
// target was the 3 loaded rows — the assignment vanished, no diagnostic
```

Rails cannot reach this state: `Association#find_target`
(`activerecord/lib/active_record/associations/association.rb:248`) is
synchronous, so nothing can touch the holder between issuing the query and
assigning its result. trails awaits, which opens the window.

## Approach — refuse the race, don't resolve it

The story originally specified picking a winner (let the assignment win). That
premise was **rejected by the repo owner during review**, and the story has been
amended to match. Silently discarding either side is a footgun: dropping the
assignment loses a caller's explicit intent, dropping the load hides a wasted
query, and neither is diagnosable afterwards.

So `Association#setTarget` now raises the new
`AssociationTargetReplacedDuringLoad` when a load for that association is in
flight. Assigning after the load settles is unaffected.

**This is a deliberate trails-only invention, not a porting gap** — Rails raises
nothing here because the situation cannot arise. Documented as such on the error
class and at the guard.

### Why this is safe to raise on

`Association#_loaderWritebackSuppressed` is incremented around
`HasManyAssociation#doAsyncFindTarget` (exception-safe, `finally`-decremented,
nests correctly for concurrent loads). `loadHasMany`'s tail
`syncToAssociationInstance` bails while it is set, so a loader's own writeback
never reaches `setTarget` and therefore can never trip the guard. Only a genuine
external replacement does. `has_many :through` inherits `doAsyncFindTarget`, and
so inherits the guard.

**Measured before adopting:** throwing breaks **zero** Rails-ported tests.

### What this deleted

Because the clobber now raises at the point of assignment, it can never occur —
so the `_setTargetCount` counter and the guard in
`CollectionAssociation#loadTarget` from the earlier revisions of this PR are
both gone. `collection-association.ts` is untouched by the final diff, which is
smaller and simpler than the version that resolved the race.

## Verification

- 6 new tests: the raise on plain has_many and on `has_many :through`; the
  message naming the association; assignment-after-settle still allowed; and two
  that pin the guard cannot misfire — a sibling `loadHasMany` landing mid-await,
  and concurrent `loadTarget` on one holder, neither of which raises or drops
  rows.
- SQLite: 2001 passed across `associations/` + `associations.test.ts`. Also clean
  on `autosave-association`, `nested-attributes`, `base` (the other `setTarget`
  callers).
- **PostgreSQL and MySQL**, incl. `eager.test.ts` for the preload/hydration path:
  840 passed on each. SQLite timing hides both the bug and bad fixes, so the
  adapter runs are load-bearing here.

## Review round 3

All five confirmed against the code and fixed; two were real correctness bugs.

**1 + 2. The preloader is a loader, and must not raise.** Confirmed:
`preloader/association.ts` `_associateRecordsToOwner` called `setTarget` with no
try/catch, so a preload landing mid-load threw out of the batch; the sibling site
sat inside `catch {}` and silently swallowed the same condition. Both now route
through the new `Association#_setTargetFromLoader`, which assigns without the
guard. Loader-vs-loader is not the race we refuse — both sides are reads of the
same association, so the last one landing is a legitimate result, not lost
intent, and one owner's in-flight load must never abort a whole batch.

**3. Doc comment corrected.** The flag is holder-scoped, not loader-scoped, and
while set it suppresses *every* writeback into that holder — including a
concurrent `loadHasMany` carrying differently-scoped rows, which is dropped from
the holder (it still returns its rows to its own caller). The comment now says
so, and notes what loader-scoping would cost.

**4. The writer path was genuinely unguarded — the important catch.**
`firm.clients = [...]`, `client_ids = [...]` and mass assignment all go through
`CollectionAssociation#replace`, which mutates `target` directly and never calls
`setTarget`. Only the raw `association(name).setTarget(...)` was protected, so
the ordinary user-facing assignment — the actual footgun in the description —
stayed silently clobberable. `replace` now calls the same guard.

**5.** `AssociationTargetReplacedDuringLoad` exported from `index.ts`.

### On test honesty

The first preload test I wrote was **vacuous** — it passed with the fix reverted,
because `Firm.includes(...)` builds fresh owners with their own holders and never
reaches the in-flight one. The second attempt, preloading onto the same instance,
was *also* vacuous: the load's query resolves before the preloader reaches its
associate step, so the window has already closed. The kept test holds the window
open directly and is verified to fail (`AssociationTargetReplacedDuringLoad`
thrown out of the batch) with the fix reverted. The writer test was verified the
same way. Both reverts are recorded in the test comments.

## Verification

- 8 tests. Both new ones proven non-vacuous by reverting each fix in turn.
- SQLite: 2541 passed across `associations/`, `associations.test.ts`,
  `autosave-association`, `nested-attributes`, `base` — `replace` is a hot path,
  so the sweep is wider than the association tree.
- **PostgreSQL and MySQL**: 1005 passed on each, incl. `eager.test.ts` and
  `nested-attributes.test.ts`.

## Review round 4

Three more loader sites called `setTarget` and would now raise/abort — same
defect as round 3, in `join-dependency.ts:1607`, `preloader/batch.ts:112`, and
`instance-methods.ts`. The reviewer also asked about the singular-holder tails.

Rather than fix the three named sites and risk a round 5, I enumerated **every**
`.setTarget(` call in the package and classified each. All ten internal sites
are loader writebacks or internal machinery, none is a caller assignment, so all
ten now go through `_setTargetFromLoader`:

- eager hydration (`join-dependency.ts:1567` **and** :1607 — :1567 was not in the
  review list but is the same hazard), preload miss (`preloader/batch.ts:112`),
  cache/preload hydration and the `loadBelongsTo`/`loadHasOne` tails
  (`instance-methods.ts` ×4), `syncToAssociationInstance` (`associations.ts:1300`),
  inverse-of wiring (`associations.ts:519`), test-helper seeding.

On the reviewer's point 3: the singular tails cannot trip the flag today, but
that is incidental, and the RFC 0063 convergence follow-up bumps the flag for
has_one — so converting them now is what makes that story safe rather than a
regression. Done.

To stop this recurring, a new test walks the source tree and fails on any
non-comment `.setTarget(` outside the guarded definition — `setTarget` is the
caller API, `_setTargetFromLoader` is every internal writeback. Verified it
names the offending `file:line` by reverting one site.

## Verification

- 9 tests. The three behavioural ones proven non-vacuous by reverting each fix;
  the new sweep test proven non-vacuous the same way.
- SQLite: 2542 passed across the association tree + `autosave-association`,
  `nested-attributes`, `base`.
- **PostgreSQL and MySQL**: 1009 passed (PG) incl. `eager.test.ts` and
  `join-dependency-nested-hydration.test.ts`. One MySQL run hit
  `acquireAdvisorySlotMysql: all 6 GET_LOCK slots are held` — host-saturation
  noise (it landed on a different file each run; every file and the guarded pairs
  pass in isolation), not a regression.

## Follow-up

has_one solved this earlier (#5035) with a load-generation token that lets the
assignment win silently, so the two macros now disagree. Registered as
`converge-has-one-has-many-mid-load-replacement-semantics` under RFC 0063 rather
than fanning out from this PR. The has_one measurement has not been done —
singular holders have different mutation patterns, so it should not be assumed
to transfer.

Closes-story: fix-has-many-mid-flight-reassignment-clobber
