### PR TITLE
feat(api-compare): interleave class and instance methods by source line

### DIFF
--- a/packages/activemodel/src/attribute.ts
+++ b/packages/activemodel/src/attribute.ts
@@ -57,6 +57,40 @@ export abstract class Attribute {
     this._hasValueForDatabase = false;
   }
 
+  // --- Factory methods ---
+
+  static fromDatabase(name: string, value: unknown, type: Type, castValue?: unknown): FromDatabase {
+    if (arguments.length >= 4) {
+      return new FromDatabase(name, value, type, null, castValue);
+    }
+    return new FromDatabase(name, value, type, null);
+  }
+
+  static fromUser(
+    name: string,
+    value: unknown,
+    type: Type,
+    originalAttribute: Attribute | null = null,
+  ): FromUser {
+    return new FromUser(name, value, type, originalAttribute);
+  }
+
+  withCastValue(value: unknown): Attribute {
+    return new WithCastValue(this.name, value, this.type);
+  }
+
+  static withCastValue(name: string, value: unknown, type: Type): WithCastValue {
+    return new WithCastValue(name, value, type);
+  }
+
+  static null(name: string): Null {
+    return new Null(name);
+  }
+
+  static uninitialized(name: string, type: Type): Uninitialized {
+    return new Uninitialized(name, type);
+  }
+
   get valueBeforeTypeCast(): unknown {
     return this._valueBeforeTypeCast;
   }
@@ -120,14 +154,6 @@ export abstract class Attribute {
     return Attribute.fromDatabase(this.name, value, this.type);
   }
 
-  withCastValue(value: unknown): Attribute {
-    return new WithCastValue(this.name, value, this.type);
-  }
-
-  static withCastValue(name: string, value: unknown, type: Type): WithCastValue {
-    return new WithCastValue(name, value, type);
-  }
-
   withType(type: Type): Attribute {
     if (this.changedInPlace()) {
       return this.withValueFromUser(this.value).withType(type);
@@ -144,6 +170,8 @@ export abstract class Attribute {
   isInitialized(): boolean {
     return true;
   }
+
+  abstract typeCast(value: unknown): unknown;
 
   cameFromUser(): boolean {
     return false;
@@ -164,8 +192,6 @@ export abstract class Attribute {
     return this.originalAttribute !== null;
   }
 
-  abstract typeCast(value: unknown): unknown;
-
   private changedFromAssignment(): boolean {
     if (!this.isAssigned()) return false;
     return this.type.isChanged(this.originalValue, this.value, this.valueBeforeTypeCast);
@@ -179,32 +205,6 @@ export abstract class Attribute {
   /** @internal */
   protected _originalValueForDatabase(): unknown {
     return this.type.serialize(this.originalValue);
-  }
-
-  // --- Factory methods ---
-
-  static fromDatabase(name: string, value: unknown, type: Type, castValue?: unknown): FromDatabase {
-    if (arguments.length >= 4) {
-      return new FromDatabase(name, value, type, null, castValue);
-    }
-    return new FromDatabase(name, value, type, null);
-  }
-
-  static fromUser(
-    name: string,
-    value: unknown,
-    type: Type,
-    originalAttribute: Attribute | null = null,
-  ): FromUser {
-    return new FromUser(name, value, type, originalAttribute);
-  }
-
-  static null(name: string): Null {
-    return new Null(name);
-  }
-
-  static uninitialized(name: string, type: Type): Uninitialized {
-    return new Uninitialized(name, type);
   }
 
   /**

--- a/packages/activemodel/src/error.ts
+++ b/packages/activemodel/src/error.ts
@@ -103,43 +103,6 @@ export class Error {
     this.options = options;
   }
 
-  get message(): string {
-    // Rails error.rb:136-141: dispatch on raw_type shape — Symbol → generate_message, else → literal.
-    // TS has no Symbol type; identifier-shaped strings (no spaces/punctuation) are the equivalent.
-    if (IDENTIFIER_RE.test(this.rawType)) {
-      const opts: Record<string, unknown> = {};
-      for (const [k, v] of Object.entries(this.options)) {
-        if (!CALLBACKS_OPTIONS.has(k)) opts[k] = v;
-      }
-      return Error.generateMessage(this.attribute, this.rawType, this.base, opts);
-    }
-    return this.rawType;
-  }
-
-  get details(): Record<string, unknown> {
-    const result: Record<string, unknown> = { error: this.rawType };
-    for (const [key, value] of Object.entries(this.options)) {
-      if (
-        key !== "if" &&
-        key !== "unless" &&
-        key !== "on" &&
-        key !== "allow_nil" &&
-        key !== "allow_blank" &&
-        key !== "allowNil" &&
-        key !== "allowBlank" &&
-        key !== "strict" &&
-        key !== "message"
-      ) {
-        result[key] = value;
-      }
-    }
-    return result;
-  }
-
-  get detail(): Record<string, unknown> {
-    return this.details;
-  }
-
   get fullMessage(): string {
     return Error.fullMessage(this.attribute, this.message, this.base);
   }
@@ -201,64 +164,6 @@ export class Error {
     }
 
     return format;
-  }
-
-  /**
-   * See if this error matches `attribute`, `type`, and `options`. Mirrors
-   * Rails `Error#match?` (activemodel/lib/active_model/error.rb:166-174):
-   * subset match — every key in `options` must equal (Ruby `==`, i.e.
-   * structural for Array/Hash, value-equal for primitives) the
-   * corresponding value in `this.options`; extra keys on the error are
-   * ignored. Not Ruby's case-equality (`===`), which would imply
-   * RegExp/Range-style matching — Rails' `match?` uses `!=`.
-   */
-  match(attribute: string, type?: string, options?: Record<string, unknown>): boolean {
-    if (this.attribute !== attribute) return false;
-    if (type !== undefined && this.type !== type) return false;
-    if (options) {
-      for (const [key, value] of Object.entries(options)) {
-        if (!optionsEqual(this.options[key], value)) return false;
-      }
-    }
-    return true;
-  }
-
-  /**
-   * Strict match — Rails `Error#strict_match?`
-   * (activemodel/lib/active_model/error.rb:184-188): attribute/type must
-   * match and `options` must equal the error's `@options` with
-   * `CALLBACKS_OPTIONS` and `MESSAGE_OPTIONS` stripped.
-   */
-  strictMatch(attribute: string, type: string, options?: Record<string, unknown>): boolean {
-    if (!this.match(attribute, type)) return false;
-    const expected = options ?? {};
-    const own: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(this.options)) {
-      if (!CALLBACKS_OPTIONS.has(k) && !MESSAGE_OPTIONS.has(k)) own[k] = v;
-    }
-    const expectedKeys = Object.keys(expected);
-    const ownKeys = Object.keys(own);
-    if (expectedKeys.length !== ownKeys.length) return false;
-    for (const k of expectedKeys) {
-      if (!Object.prototype.hasOwnProperty.call(own, k) || !optionsEqual(own[k], expected[k]))
-        return false;
-    }
-    return true;
-  }
-
-  /**
-   * Identity tuple used by `==` and `hash`. Mirrors Rails
-   * `attributes_for_hash` (activemodel/lib/active_model/error.rb:204-206):
-   * `[@base, @attribute, @raw_type, @options.except(*CALLBACKS_OPTIONS)]`.
-   *
-   * @internal Rails-private helper.
-   */
-  protected attributesForHash(): [ModelBase, string, string, Record<string, unknown>] {
-    const own: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(this.options)) {
-      if (!CALLBACKS_OPTIONS.has(k)) own[k] = v;
-    }
-    return [this.base, this.attribute, this.rawType, own];
   }
 
   /**
@@ -339,6 +244,101 @@ export class Error {
       defaults: defaults.slice(1),
       defaultValue: type,
     });
+  }
+
+  get message(): string {
+    // Rails error.rb:136-141: dispatch on raw_type shape — Symbol → generate_message, else → literal.
+    // TS has no Symbol type; identifier-shaped strings (no spaces/punctuation) are the equivalent.
+    if (IDENTIFIER_RE.test(this.rawType)) {
+      const opts: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(this.options)) {
+        if (!CALLBACKS_OPTIONS.has(k)) opts[k] = v;
+      }
+      return Error.generateMessage(this.attribute, this.rawType, this.base, opts);
+    }
+    return this.rawType;
+  }
+
+  get details(): Record<string, unknown> {
+    const result: Record<string, unknown> = { error: this.rawType };
+    for (const [key, value] of Object.entries(this.options)) {
+      if (
+        key !== "if" &&
+        key !== "unless" &&
+        key !== "on" &&
+        key !== "allow_nil" &&
+        key !== "allow_blank" &&
+        key !== "allowNil" &&
+        key !== "allowBlank" &&
+        key !== "strict" &&
+        key !== "message"
+      ) {
+        result[key] = value;
+      }
+    }
+    return result;
+  }
+
+  get detail(): Record<string, unknown> {
+    return this.details;
+  }
+
+  /**
+   * See if this error matches `attribute`, `type`, and `options`. Mirrors
+   * Rails `Error#match?` (activemodel/lib/active_model/error.rb:166-174):
+   * subset match — every key in `options` must equal (Ruby `==`, i.e.
+   * structural for Array/Hash, value-equal for primitives) the
+   * corresponding value in `this.options`; extra keys on the error are
+   * ignored. Not Ruby's case-equality (`===`), which would imply
+   * RegExp/Range-style matching — Rails' `match?` uses `!=`.
+   */
+  match(attribute: string, type?: string, options?: Record<string, unknown>): boolean {
+    if (this.attribute !== attribute) return false;
+    if (type !== undefined && this.type !== type) return false;
+    if (options) {
+      for (const [key, value] of Object.entries(options)) {
+        if (!optionsEqual(this.options[key], value)) return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Strict match — Rails `Error#strict_match?`
+   * (activemodel/lib/active_model/error.rb:184-188): attribute/type must
+   * match and `options` must equal the error's `@options` with
+   * `CALLBACKS_OPTIONS` and `MESSAGE_OPTIONS` stripped.
+   */
+  strictMatch(attribute: string, type: string, options?: Record<string, unknown>): boolean {
+    if (!this.match(attribute, type)) return false;
+    const expected = options ?? {};
+    const own: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(this.options)) {
+      if (!CALLBACKS_OPTIONS.has(k) && !MESSAGE_OPTIONS.has(k)) own[k] = v;
+    }
+    const expectedKeys = Object.keys(expected);
+    const ownKeys = Object.keys(own);
+    if (expectedKeys.length !== ownKeys.length) return false;
+    for (const k of expectedKeys) {
+      if (!Object.prototype.hasOwnProperty.call(own, k) || !optionsEqual(own[k], expected[k]))
+        return false;
+    }
+    return true;
+  }
+
+  /**
+   * Identity tuple used by `==` and `hash`. Mirrors Rails
+   * `attributes_for_hash` (activemodel/lib/active_model/error.rb:204-206):
+   * `[@base, @attribute, @raw_type, @options.except(*CALLBACKS_OPTIONS)]`.
+   *
+   * @internal Rails-private helper.
+   */
+  protected attributesForHash(): [ModelBase, string, string, Record<string, unknown>] {
+    const own: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(this.options)) {
+      if (!CALLBACKS_OPTIONS.has(k)) own[k] = v;
+    }
+    return [this.base, this.attribute, this.rawType, own];
   }
 
   /**

--- a/packages/activemodel/src/translation.ts
+++ b/packages/activemodel/src/translation.ts
@@ -36,6 +36,13 @@ const MISSING_TRANSLATION = "\x00__MISSING_TRANSLATION__\x00";
 
 let _raiseOnMissingTranslations = false;
 
+export function raiseOnMissingTranslations(value?: boolean): boolean {
+  if (value !== undefined) {
+    _raiseOnMissingTranslations = value;
+  }
+  return _raiseOnMissingTranslations;
+}
+
 /**
  * Walk the class prototype chain collecting constructors that expose a
  * modelName static (i.e. those that include ActiveModel::Naming in Rails).
@@ -99,13 +106,6 @@ export function humanAttributeName(
     }
     return result;
   }
-}
-
-export function raiseOnMissingTranslations(value?: boolean): boolean {
-  if (value !== undefined) {
-    _raiseOnMissingTranslations = value;
-  }
-  return _raiseOnMissingTranslations;
 }
 
 function _callI18n(

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -50,6 +50,10 @@ export class Table extends Node {
     this.typeCaster = options?.typeCaster ?? null;
   }
 
+  get engine(): unknown {
+    return Table.engine;
+  }
+
   /**
    * Create an alias for this table.
    *
@@ -184,10 +188,6 @@ export class Table extends Node {
 
   isAbleToTypeCast(): boolean {
     return this.typeCaster != null;
-  }
-
-  get engine(): unknown {
-    return Table.engine;
   }
 
   get(name: string, table?: Attribute["relation"]): Attribute {

--- a/packages/arel/src/visitors/visitor.ts
+++ b/packages/arel/src/visitors/visitor.ts
@@ -62,6 +62,26 @@ export abstract class Visitor {
   }
 
   /**
+   * Per-class dispatch cache. Each subclass gets its own map seeded from
+   * its parent (mirrors Rails' `@dispatch_cache ||= ...` per-class ivar).
+   *
+   * @internal
+   */
+  static dispatchCache(this: VisitorCtor): Map<NodeCtor, string> {
+    let cache = PER_CLASS_CACHE.get(this);
+    if (!cache) {
+      const parent = Object.getPrototypeOf(this) as VisitorCtor | null;
+      const inherited =
+        parent && typeof parent.dispatchCache === "function" && parent !== this
+          ? parent.dispatchCache()
+          : undefined;
+      cache = new Map(inherited);
+      PER_CLASS_CACHE.set(this, cache);
+    }
+    return cache;
+  }
+
+  /**
    * Instance-side accessor mirroring Rails' private `get_dispatch_cache`.
    * Returns the class-level dispatch cache for `this.constructor`.
    */
@@ -96,26 +116,6 @@ export abstract class Visitor {
       );
     }
     return (fn as (n: unknown, c?: unknown) => unknown).call(this, object, collector);
-  }
-
-  /**
-   * Per-class dispatch cache. Each subclass gets its own map seeded from
-   * its parent (mirrors Rails' `@dispatch_cache ||= ...` per-class ivar).
-   *
-   * @internal
-   */
-  static dispatchCache(this: VisitorCtor): Map<NodeCtor, string> {
-    let cache = PER_CLASS_CACHE.get(this);
-    if (!cache) {
-      const parent = Object.getPrototypeOf(this) as VisitorCtor | null;
-      const inherited =
-        parent && typeof parent.dispatchCache === "function" && parent !== this
-          ? parent.dispatchCache()
-          : undefined;
-      cache = new Map(inherited);
-      PER_CLASS_CACHE.set(this, cache);
-    }
-    return cache;
   }
 
   /**

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -423,6 +423,14 @@ class ApiExtractor
     # method carries a position. Without it `class << self` blocks placed above
     # the instance methods (e.g. active_model/attribute.rb:7-24) can't be
     # interleaved back into Rails source order by manifest consumers.
+    #
+    # INVARIANT: a recorder must read `@current_line` BEFORE walking children.
+    # This is set on the way IN and never restored on the way OUT, so after a
+    # nested walk it holds the deepest line last visited, not the line of the
+    # construct being recorded. Every recorder today satisfies this (process_def
+    # /process_defs use non-walking helpers for deps/calls/digest; the
+    # process_command and method_add_block codegen recorders all fire before
+    # descending) — keep it that way, or capture the line into a local first.
     line = first_line(node)
     @current_line = line if line
 
@@ -1860,17 +1868,26 @@ class ApiExtractor
 
   # ---- Helpers ----
 
-  # Earliest source line under `node`. Ripper's scanner events carry a
+  # Earliest source line under `node`. Ripper's SCANNER events carry a
   # `[lineno, column]` tuple as their last element (e.g.
   # `[:@ident, "from_database", [7, 8]]`); parser events don't, so recurse
   # until one turns up.
+  #
+  # The scanner-event gate (`:@`-prefixed head) is what makes this exact rather
+  # than a guess: shape alone ("last element is a 2-Integer array") would also
+  # match any parser event that happened to end in one, and silently yield a
+  # line from the wrong subtree. Only scanner events ever carry positions, so
+  # checking the head costs nothing and removes the ambiguity.
   def first_line(node)
     return nil unless node.is_a?(Array)
 
-    tail = node.last
-    if tail.is_a?(Array) && tail.length == 2 &&
-       tail[0].is_a?(Integer) && tail[1].is_a?(Integer)
-      return tail[0]
+    head = node[0]
+    if head.is_a?(Symbol) && head.to_s.start_with?("@")
+      tail = node.last
+      if tail.is_a?(Array) && tail.length == 2 &&
+         tail[0].is_a?(Integer) && tail[1].is_a?(Integer)
+        return tail[0]
+      end
     end
 
     node.each do |child|

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -326,6 +326,7 @@ class ApiExtractor
     end
 
     @current_file = rel_path
+    @current_line = 0
     walk(sexp)
 
     # Handle dynamic class creation via const_set:
@@ -417,6 +418,13 @@ class ApiExtractor
 
   def walk(node)
     return unless node.is_a?(Array)
+
+    # Track the source line of the construct being visited so every recorded
+    # method carries a position. Without it `class << self` blocks placed above
+    # the instance methods (e.g. active_model/attribute.rb:7-24) can't be
+    # interleaved back into Rails source order by manifest consumers.
+    line = first_line(node)
+    @current_line = line if line
 
     case node[0]
     when :module
@@ -570,6 +578,7 @@ class ApiExtractor
       visibility: vis.to_s,
       params: params,
       file: @current_file,
+      line: @current_line,
     }
     method_info[:deps] = dep_info[:deps] unless dep_info[:deps].empty?
     method_info[:depRefs] = dep_info[:depRefs] unless dep_info[:depRefs].empty?
@@ -621,6 +630,7 @@ class ApiExtractor
       visibility: vis.to_s,
       params: params,
       file: @current_file,
+      line: @current_line,
     }
     method_info[:deps] = dep_info[:deps] unless dep_info[:deps].empty?
     method_info[:depRefs] = dep_info[:depRefs] unless dep_info[:depRefs].empty?
@@ -895,7 +905,7 @@ class ApiExtractor
     names = extract_symbol_args(args)
     names.each do |name|
       if kind == :reader || kind == :accessor
-        entry = { name: name, visibility: vis.to_s, params: [], file: file }
+        entry = { name: name, visibility: vis.to_s, params: [], file: file, line: @current_line }
         entry[:umbrellaConfig] = true if redirect_fqn
         target[bucket] << entry
       end
@@ -905,6 +915,7 @@ class ApiExtractor
           visibility: vis.to_s,
           params: [{ name: "value", kind: "required" }],
           file: file,
+          line: @current_line,
         }
         entry[:umbrellaConfig] = true if redirect_fqn
         target[bucket] << entry
@@ -944,6 +955,7 @@ class ApiExtractor
           visibility: vis.to_s,
           params: [],
           file: @current_file,
+          line: @current_line,
         }
       end
       if kind == :writer || kind == :accessor
@@ -952,6 +964,7 @@ class ApiExtractor
           visibility: vis.to_s,
           params: [{ name: "value", kind: "required" }],
           file: @current_file,
+          line: @current_line,
         }
       end
       maybe_update_module_file(fqn, target)
@@ -974,6 +987,7 @@ class ApiExtractor
       visibility: vis.to_s,
       params: [],
       file: @current_file,
+      line: @current_line,
       notes: "alias",
     }
     # Record the aliased target so resolve_aliases! can copy its real param
@@ -1005,6 +1019,7 @@ class ApiExtractor
       visibility: current_visibility.to_s,
       params: [],
       file: @current_file,
+      line: @current_line,
       notes: "alias",
     }
     # Record the aliased target so resolve_aliases! can copy its real param
@@ -1212,6 +1227,7 @@ class ApiExtractor
       visibility: "public",
       params: params,
       file: @current_file,
+      line: @current_line,
       notes: "class_attribute",
     }
     target[:classMethods] << info if on_class
@@ -1252,6 +1268,7 @@ class ApiExtractor
       visibility: "public",
       params: [],
       file: @current_file,
+      line: @current_line,
       notes: "scope",
     }
   end
@@ -1269,6 +1286,7 @@ class ApiExtractor
       visibility: "public",
       params: [],
       file: @current_file,
+      line: @current_line,
       notes: "scope",
     }
   end
@@ -1326,6 +1344,7 @@ class ApiExtractor
         visibility: "public",
         params: [],
         file: @current_file,
+        line: @current_line,
         notes: "delegate",
       }
     end
@@ -1356,6 +1375,7 @@ class ApiExtractor
         visibility: "public",
         params: params,
         file: @current_file,
+        line: @current_line,
         notes: "define_column_methods",
       }
     end
@@ -1415,6 +1435,7 @@ class ApiExtractor
             visibility: "public",
             params: form == :writer ? [{ name: "value", kind: "required" }] : [],
             file: @current_file,
+            line: @current_line,
             notes: "class_eval",
           }
         end
@@ -1838,6 +1859,26 @@ class ApiExtractor
   end
 
   # ---- Helpers ----
+
+  # Earliest source line under `node`. Ripper's scanner events carry a
+  # `[lineno, column]` tuple as their last element (e.g.
+  # `[:@ident, "from_database", [7, 8]]`); parser events don't, so recurse
+  # until one turns up.
+  def first_line(node)
+    return nil unless node.is_a?(Array)
+
+    tail = node.last
+    if tail.is_a?(Array) && tail.length == 2 &&
+       tail[0].is_a?(Integer) && tail[1].is_a?(Integer)
+      return tail[0]
+    end
+
+    node.each do |child|
+      line = first_line(child)
+      return line if line
+    end
+    nil
+  end
 
   def new_class_info(name, fqn)
     {

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -736,3 +736,77 @@ describe("Ruby extractor body digest (source-hash pinning)", () => {
     expect(edited["Foo#save"]).not.toBe(base["Foo#save"]);
   });
 });
+
+// Per-method source lines let consumers (the file-structure method-order
+// manifest) interleave classMethods back into Rails source order instead of
+// appending them after instanceMethods — which inverts every Rails file that
+// opens with a `class << self` block (active_model/attribute.rb:7-24).
+describe("Ruby extractor method source lines", () => {
+  const RUBY_SCRIPT = path.join(HERE, "extract-ruby-api.rb");
+
+  // Returns "<fqn>#<method>" -> [bucket, line].
+  function rubyLines(src: string): Record<string, [string, number]> {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lines-rb-"));
+    try {
+      fs.writeFileSync(path.join(dir, "a.rb"), src);
+      const driver = `
+        require_relative ${JSON.stringify(RUBY_SCRIPT)}
+        require "json"
+        ex = ApiExtractor.new
+        ex.process_file(File.join(${JSON.stringify(dir)}, "a.rb"), ${JSON.stringify(dir)})
+        out = {}
+        ex.classes.each do |fqn, info|
+          %i[instanceMethods classMethods].each do |bucket|
+            info[bucket].each { |m| out["#{fqn}##{m[:name]}"] = [bucket.to_s, m[:line]] }
+          end
+        end
+        puts JSON.generate(out)
+      `;
+      return JSON.parse(execFileSync("ruby", ["-e", driver], { encoding: "utf-8" }));
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("records a leading `class << self` block ahead of the instance methods", () => {
+    const lines = rubyLines(
+      [
+        "class Attribute",
+        "  class << self",
+        "    def from_database(value)",
+        "      new(value)",
+        "    end",
+        "  end",
+        "",
+        "  attr_reader :value",
+        "",
+        "  def initialize(value)",
+        "    @value = value",
+        "  end",
+        "end",
+      ].join("\n"),
+    );
+    expect(lines["Attribute#from_database"]).toEqual(["classMethods", 3]);
+    expect(lines["Attribute#value"]).toEqual(["instanceMethods", 8]);
+    expect(lines["Attribute#initialize"]).toEqual(["instanceMethods", 10]);
+  });
+
+  it("records a line for `def self.` singleton methods and aliases", () => {
+    const lines = rubyLines(
+      [
+        "class Foo",
+        "  def bar",
+        "  end",
+        "",
+        "  alias baz bar",
+        "",
+        "  def self.qux",
+        "  end",
+        "end",
+      ].join("\n"),
+    );
+    expect(lines["Foo#bar"]).toEqual(["instanceMethods", 2]);
+    expect(lines["Foo#baz"]).toEqual(["instanceMethods", 5]);
+    expect(lines["Foo#qux"]).toEqual(["classMethods", 7]);
+  });
+});

--- a/scripts/api-compare/source-order.test.ts
+++ b/scripts/api-compare/source-order.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { mergeBySourceLine } from "./source-order.js";
+
+const m = (name: string, line?: number) => ({ name, line });
+const names = (list: { name: string }[]) => list.map((x) => x.name);
+
+describe("mergeBySourceLine", () => {
+  it("puts a leading `class << self` block ahead of the instance methods", () => {
+    // active_model/attribute.rb: factories at :8-:24, attr_reader at :29,
+    // initialize at :33.
+    const instance = [m("name", 29), m("value_before_type_cast", 29), m("initialize", 33)];
+    const klass = [m("from_database", 8), m("from_user", 12), m("null", 20)];
+    expect(names(mergeBySourceLine(instance, klass))).toEqual([
+      "from_database",
+      "from_user",
+      "null",
+      "name",
+      "value_before_type_cast",
+      "initialize",
+    ]);
+  });
+
+  it("keeps a trailing `class << self` block after the instance methods", () => {
+    const instance = [m("initialize", 5), m("call", 9)];
+    const klass = [m("build", 20)];
+    expect(names(mergeBySourceLine(instance, klass))).toEqual(["initialize", "call", "build"]);
+  });
+
+  it("interleaves class methods defined between instance methods", () => {
+    const instance = [m("a", 5), m("c", 25)];
+    const klass = [m("b", 15)];
+    expect(names(mergeBySourceLine(instance, klass))).toEqual(["a", "b", "c"]);
+  });
+
+  it("preserves bucket order for methods sharing a line (multi-name attr_accessor)", () => {
+    // `attr_accessor :singular, :plural` records every name at the statement's
+    // first line; their declared order is the only signal.
+    const instance = [m("singular", 12), m("plural", 12), m("element", 12)];
+    expect(names(mergeBySourceLine(instance, []))).toEqual(["singular", "plural", "element"]);
+  });
+
+  it("sorts line-less entries last, preserving instance-then-class append order", () => {
+    const instance = [m("i1"), m("i2")];
+    const klass = [m("c1")];
+    expect(names(mergeBySourceLine(instance, klass))).toEqual(["i1", "i2", "c1"]);
+  });
+
+  it("orders positioned entries ahead of line-less ones", () => {
+    const instance = [m("unpositioned"), m("positioned", 3)];
+    expect(names(mergeBySourceLine(instance, []))).toEqual(["positioned", "unpositioned"]);
+  });
+
+  it("defaults both buckets to empty", () => {
+    expect(mergeBySourceLine()).toEqual([]);
+  });
+});

--- a/scripts/api-compare/source-order.ts
+++ b/scripts/api-compare/source-order.ts
@@ -1,0 +1,46 @@
+/**
+ * Source-order merge for a Rails entity's two method buckets.
+ *
+ * `rails-api.json` splits an entity's methods into `instanceMethods` and
+ * `classMethods`. Consumers that care about *file layout* (the
+ * `rails-file-structure-method-order` manifest) must not simply concatenate
+ * them: a Rails class whose `class << self` block sits at the TOP of the file
+ * would have its factory methods demanded LAST. `activemodel/lib/
+ * active_model/attribute.rb:7-24` defines `from_database` / `from_user` /
+ * `with_cast_value` / `null` / `uninitialized` before `initialize` (:33).
+ *
+ * Constraints: no `node:` specifiers, no `process` references.
+ */
+
+/** The subset of a `rails-api.json` method entry this module needs. */
+export interface SourcePositioned {
+  /** 1-based source line, as recorded by `extract-ruby-api.rb`. */
+  line?: number;
+}
+
+/**
+ * Merge `instanceMethods` + `classMethods` into one list ordered by source
+ * line.
+ *
+ * Entries without a `line` sort last while keeping their relative order, which
+ * reproduces the historical instance-then-class append for any consumer reading
+ * a `rails-api.json` written before the `line` field existed.
+ *
+ * The sort is stable and total, so restricting the result to the methods of any
+ * single source file still yields that file's methods in ascending-line order —
+ * which is what the manifest needs, since it buckets by `file` after ordering
+ * (an entity's methods can span files when Rails reopens a class).
+ */
+export function mergeBySourceLine<T extends SourcePositioned>(
+  instanceMethods: readonly T[] = [],
+  classMethods: readonly T[] = [],
+): T[] {
+  return [...instanceMethods, ...classMethods]
+    .map((m, i) => ({ m, i }))
+    .sort((a, b) => {
+      const al = a.m.line ?? Infinity;
+      const bl = b.m.line ?? Infinity;
+      return al === bl ? a.i - b.i : al - bl;
+    })
+    .map(({ m }) => m);
+}

--- a/scripts/build-rails-file-structure-manifest.ts
+++ b/scripts/build-rails-file-structure-manifest.ts
@@ -59,6 +59,7 @@ interface RubyMethod {
   name: string;
   visibility: "public" | "private" | "protected";
   file?: string;
+  line?: number;
 }
 interface RubyEntity {
   fqn: string;
@@ -129,6 +130,22 @@ const pushMethod = (list: string[], seen: Set<string>, name: string) => {
   }
 };
 
+// An entity's methods in Rails SOURCE order, rather than instanceMethods then
+// classMethods. A `class << self` block at the TOP of a Rails file
+// (active_model/attribute.rb:7-24 defines from_database/from_user/… before
+// `initialize` at :33) would otherwise be demanded LAST, inverting Rails order.
+// Methods without a `line` (a rails-api.json predating the field) sort last,
+// reproducing the historical instance-then-class append.
+const orderBySourceLine = (host: RubyEntity): RubyMethod[] =>
+  [...(host.instanceMethods ?? []), ...(host.classMethods ?? [])]
+    .map((m, i) => ({ m, i }))
+    .sort((a, b) => {
+      const al = a.m.line ?? Infinity;
+      const bl = b.m.line ?? Infinity;
+      return al === bl ? a.i - b.i : al - bl;
+    })
+    .map(({ m }) => m);
+
 // A TS container: `{ file, key }` where `key` is a class name or the sentinel
 // `FUNCTIONS_KEY` for the file's top-level functions. Ruby methods are bucketed
 // per (rubyFile, container) so each class keeps its own dedup scope.
@@ -185,13 +202,7 @@ for (const [pkg, rubyPkg] of Object.entries<any>(railsApi.packages)) {
     for (const host of Object.values(entities)) {
       if (!host.file) continue;
       const className = host.fqn.split("::").pop() ?? host.fqn;
-      for (const m of host.instanceMethods ?? []) {
-        const file = m.file ?? host.file;
-        noteClass(file, className, host.fqn);
-        const b = bucketFor(file, className);
-        pushMethod(b.names, b.seen, m.name);
-      }
-      for (const m of host.classMethods ?? []) {
+      for (const m of orderBySourceLine(host)) {
         const file = m.file ?? host.file;
         noteClass(file, className, host.fqn);
         const b = bucketFor(file, className);
@@ -202,11 +213,7 @@ for (const [pkg, rubyPkg] of Object.entries<any>(railsApi.packages)) {
   const visitModules = (entities: Record<string, RubyEntity>) => {
     for (const host of Object.values(entities)) {
       if (!host.file) continue;
-      for (const m of host.instanceMethods ?? []) {
-        const b = bucketFor(m.file ?? host.file, FUNCTIONS_KEY);
-        pushMethod(b.names, b.seen, m.name);
-      }
-      for (const m of host.classMethods ?? []) {
+      for (const m of orderBySourceLine(host)) {
         const b = bucketFor(m.file ?? host.file, FUNCTIONS_KEY);
         pushMethod(b.names, b.seen, m.name);
       }

--- a/scripts/build-rails-file-structure-manifest.ts
+++ b/scripts/build-rails-file-structure-manifest.ts
@@ -26,6 +26,7 @@ import * as path from "path";
 import { fileURLToPath } from "url";
 import { rubyMethodToTs, rubyFileToTs } from "./api-compare/conventions.js";
 import { writeJsonManifest } from "./api-compare/write-json-manifest.js";
+import { mergeBySourceLine } from "./api-compare/source-order.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
@@ -130,22 +131,6 @@ const pushMethod = (list: string[], seen: Set<string>, name: string) => {
   }
 };
 
-// An entity's methods in Rails SOURCE order, rather than instanceMethods then
-// classMethods. A `class << self` block at the TOP of a Rails file
-// (active_model/attribute.rb:7-24 defines from_database/from_user/… before
-// `initialize` at :33) would otherwise be demanded LAST, inverting Rails order.
-// Methods without a `line` (a rails-api.json predating the field) sort last,
-// reproducing the historical instance-then-class append.
-const orderBySourceLine = (host: RubyEntity): RubyMethod[] =>
-  [...(host.instanceMethods ?? []), ...(host.classMethods ?? [])]
-    .map((m, i) => ({ m, i }))
-    .sort((a, b) => {
-      const al = a.m.line ?? Infinity;
-      const bl = b.m.line ?? Infinity;
-      return al === bl ? a.i - b.i : al - bl;
-    })
-    .map(({ m }) => m);
-
 // A TS container: `{ file, key }` where `key` is a class name or the sentinel
 // `FUNCTIONS_KEY` for the file's top-level functions. Ruby methods are bucketed
 // per (rubyFile, container) so each class keeps its own dedup scope.
@@ -202,7 +187,11 @@ for (const [pkg, rubyPkg] of Object.entries<any>(railsApi.packages)) {
     for (const host of Object.values(entities)) {
       if (!host.file) continue;
       const className = host.fqn.split("::").pop() ?? host.fqn;
-      for (const m of orderBySourceLine(host)) {
+      // Order by source line rather than appending classMethods after
+      // instanceMethods — see mergeBySourceLine for why. Bucketing by `file`
+      // happens below, after ordering; the merge is a total order on `line`, so
+      // each file's slice is still ascending.
+      for (const m of mergeBySourceLine(host.instanceMethods, host.classMethods)) {
         const file = m.file ?? host.file;
         noteClass(file, className, host.fqn);
         const b = bucketFor(file, className);
@@ -213,7 +202,7 @@ for (const [pkg, rubyPkg] of Object.entries<any>(railsApi.packages)) {
   const visitModules = (entities: Record<string, RubyEntity>) => {
     for (const host of Object.values(entities)) {
       if (!host.file) continue;
-      for (const m of orderBySourceLine(host)) {
+      for (const m of mergeBySourceLine(host.instanceMethods, host.classMethods)) {
         const b = bucketFor(m.file ?? host.file, FUNCTIONS_KEY);
         pushMethod(b.names, b.seen, m.name);
       }


### PR DESCRIPTION
Surfaced by review of PR #5030.

`build-rails-file-structure-manifest.ts` walked a Rails entity's
`instanceMethods` then `classMethods`, so class methods were always appended
AFTER instance methods. When a Rails class opens with a `class << self` block
this inverts Rails order — `activemodel/lib/active_model/attribute.rb:7-24`
defines `from_database` / `from_user` / `with_cast_value` / `null` /
`uninitialized` before `initialize` (:33), yet the manifest demanded them last.

Root cause: `extract-ruby-api.rb` recorded `file` per method but not the source
line, so there was no way to interleave the two lists by position.

## Changes

- `extract-ruby-api.rb`: `first_line` walks the Ripper AST for the first
  `[lineno, col]` scanner tuple; `walk` threads it as `@current_line`, and every
  method-recording site (`def`, `defs`, `attr_*`, `alias`/`alias_method`,
  `scope`, `delegate`, `class_attribute`, `class_eval` codegen) emits `line`.
- `api-compare/source-order.ts`: `mergeBySourceLine` merges both buckets into
  one source-ordered list via a stable sort on `line`. Entries without a line
  sort last, reproducing the historical instance-then-class append for any
  `rails-api.json` written before the field existed.
- `build-rails-file-structure-manifest.ts` calls it instead of concatenating.

Split into a pure module rather than left inline because the builder runs at
import and is eslint-ignored, and the CI lint/test jobs have no Ruby — so they
never build the manifest. A pure module is the only way to pin the interleave
(and the line-less fallback) in CI.

## Verification

- `attribute.ts` now expects `fromDatabase, fromUser, withCastValue, null,
  uninitialized` BEFORE `name, valueBeforeTypeCast, type, constructor, …`,
  matching attribute.rb. 168 of 1043 manifest files change order.
- **Every one of the 16,009 extracted methods carries an integer `line`** (no
  nulls). Cross-checking each against the vendored Rails source, all 13,991
  non-synthetic methods resolve to a line whose text contains the method name;
  the only 116 apparent misses are multi-line `attr_accessor` lists, where the
  recorded line is the statement's first line — which is the correct anchor for
  ordering.
- Extraction wall time is unchanged (~5.4s, `API_COMPARE_FORCE=1`, 3 paired
  runs).
- The refactor commit is byte-identical in manifest output to the commit before
  it.
- `line` is additive — existing `rails-api.json` consumers ignore it, and the
  Ruby cache is content-keyed on the extractor so it self-busts.

## Rebased onto #5030

#5030 (the PR that surfaced this story) merged while this was open, and it
changed both things this PR depends on: the builder now keys order per class
(`visitClasses`/`visitModules`) instead of per file, and **the rule is now live
in CI**. Rebased onto it — the interleave is applied in both visitors, and
`attribute.ts`'s `Attribute` class still expects `fromDatabase, fromUser,
withCastValue, null, uninitialized` ahead of the instance members.

That second change invalidated this PR's original "not in scope" note. With the
rule enforcing, the more-faithful manifest makes five ports fail, so they are
fixed here: `activemodel/attribute.ts`, `error.ts`, `translation.ts`,
`arel/table.ts`, `arel/visitors/visitor.ts`. Applied with `eslint --fix`, then
verified **pure movement** — sorted non-blank lines identical to `origin/main` in
all five — with all 249 tests in the touched files passing. `origin/main` lints
clean with its own builder, so these five are attributable to this change.

### These are lint-driven moves, not verified fidelity wins

Review correctly caught me overclaiming here; the commit message is corrected and
no member is now claimed to land on a Rails-anchored position. Two pre-existing
rule limits (both from #5030) mean a clean file is not a converged one:

- **The constructor carve-out** (`rails-file-structure-method-order.mjs:250-260`)
  hoists `constructor` to index 0 and skips it in the expected-order loop, so
  nothing can precede it even when the manifest says otherwise. `error.ts` is the
  clearest victim: the manifest wants `fullMessage` (error.rb:15) and
  `generateMessage` (:64) ahead of the constructor, matching Rails where both
  precede `initialize` (:103) — the rule cannot express it, so they stay after it
  at :110/:172 and the file merely goes quiet. Same for `attribute.ts`: the
  manifest puts `constructor` at index 8, but the file still leads with it.
- **Same-named static + instance members collapse to one manifest entry.** In
  `table.ts` what moved is the *instance* `get engine()` — a trails invention;
  table.rb:8-9 has only `@engine = nil` + `class << self; attr_accessor :engine`
  and no `def engine`. `static engine` did not move (already above the
  constructor on main). An invented member was repositioned against a Rails line
  belonging to a different member. Harmless but unanchored.

Both are registered as
`0025-fidelity-verification-tooling/rails-file-structure-method-order-constructor-carveout`
rather than fixed here — they are rule bugs, not manifest bugs, and this PR's
acceptance criteria are all manifest-level and met.

## LOC

405/175 including the reordering. The reorder is 162 insertions against 162
deletions of the same lines (mechanical, `--fix`-generated, verified as pure
movement); net of it the PR is ~250 LOC. Flagging since it crosses the 500
default.

Closes-story: method-order-interleave-class-instance-methods-by-line



