### PR TITLE
refactor(arel): type to-sql's visitActiveModelAttribute as ModelAttribute

### DIFF
--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1922,8 +1922,11 @@ describe("the to_sql visitor", () => {
       const v = new NumberedVisitor();
       const collector = new Collectors.SQLString();
       (
-        v as unknown as { visitActiveModelAttribute(o: unknown, c: unknown): void }
-      ).visitActiveModelAttribute({ value: "x" }, collector);
+        v as unknown as { visitActiveModelAttribute(o: AMAttribute, c: Collectors.SQLString): void }
+      ).visitActiveModelAttribute(
+        AMAttribute.fromDatabase("name", "x", new StringType()),
+        collector,
+      );
       // bindIndex starts at 1; the block receives 1, so `$1`
       expect(collector.value).toBe("$1");
     });

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1426,7 +1426,7 @@ export class ToSql extends Visitor {
    * Rails calls `collector.add_bind(o, &bind_block)` — always emits an
    * unbound placeholder; the dispatch never delegates to the BindParam visitor.
    */
-  protected visitActiveModelAttribute(o: unknown, collector: SQLString): SQLString {
+  protected visitActiveModelAttribute(o: ModelAttribute, collector: SQLString): SQLString {
     collector.addBind(o, this.bindBlock());
     return collector;
   }


### PR DESCRIPTION
Types `to-sql.ts`'s `visitActiveModelAttribute` as `ModelAttribute`, matching
the sibling `dot.ts` port. The `unknown` was forced by the old dispatch-table
typing, which could not express a non-`Node` class key; #5013 widened
`NodeCtor` to `object`, so the honest signature now compiles.

Rails: `to_sql.rb:756` `visit_ActiveModel_Attribute(o, collector)` →
`collector.add_bind(o, &bind_block)`.

The test's structural cast stays only because the method is `protected` — its
`o` is now typed `AMAttribute` and the test passes a real
`Attribute.fromDatabase(...)` instead of a `{ value: "x" }` stand-in. No body
narrowing existed to remove.

Closes-story: to-sql-visitactivemodelattribute-untyped-param
