### PR TITLE
refactor(has_one_through): drop the duplicated queueWrite override

### DIFF
--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -2,7 +2,6 @@ import type { Base } from "../base.js";
 import type { AssociationDefinition } from "../associations.js";
 import { HasOneAssociation, sameRecord } from "./has-one-association.js";
 import {
-  HasOnePersistedAssignmentError,
   HasOneThroughCantAssociateThroughHasOneOrManyReflection,
   HasOneThroughNestedAssociationsAreReadonly,
 } from "./errors.js";
@@ -29,10 +28,21 @@ export class HasOneThroughAssociation extends HasOneAssociation {
   /**
    * A has_one_through persists its association through a join-model
    * build/create/update/destroy (`createThroughRecord`), not the direct
-   * foreign-key save the base `HasOneAssociation` uses. The through target
-   * therefore keeps its own deferred-replace queue (flushed post-commit by
-   * `flushPendingReplaces` → `persistReplace`); the base has_one converged onto
-   * the single `autosaveHasOne` path and no longer carries this.
+   * foreign-key save the base `HasOneAssociation` uses, so it keeps its own
+   * replace queue. Two roles survive, both Rails-faithful:
+   *
+   *   - **New owner** — Rails' `create_through_record` takes the
+   *     `owner.new_record? || !save` arm and only *builds* the join record
+   *     (has_one_through_association.rb:36-37); the row is written at the
+   *     owner's first `save`. This marker carries that deferral.
+   *   - **Sync `build`/`create` on a persisted owner** — the `!save` half of the
+   *     same arm, reached from non-awaitable builders that cannot `await` the
+   *     join-row reconcile; `persistThroughRecord` drains it inside the save.
+   *
+   * It is NOT a deferral for assignment to a persisted owner: `writer` runs
+   * `persistReplace` inline (clearing the marker before it returns), mirroring
+   * Rails' assignment-time `through_proxy.create` / `through_record.update`
+   * (:30-40).
    */
   _pendingReplace: { record: Base | null; readonly previousTarget: Base | null } | null = null;
 
@@ -96,34 +106,13 @@ export class HasOneThroughAssociation extends HasOneAssociation {
   }
 
   /**
-   * The non-awaitable property-setter / mass-assignment path. Same
-   * throw-or-in-memory dispatch as the base `HasOneAssociation#queueWrite`:
-   * a persisted owner throws (Rails persists the join-row displacement inline
-   * at assignment, which needs `await` in JS — see RFC 0068), and an
-   * unpersisted owner does the in-memory `replace` (which builds the join
-   * record for the owner's next `save()` to persist).
-   */
-  override queueWrite(record: Base | null): void {
-    // Preserve Rails' leading synchronous class-mismatch guard
-    // (has_one_association.rb:59-60) before the persisted-owner throw, matching
-    // the base `HasOneAssociation#queueWrite`.
-    if (record) {
-      (this as unknown as { raiseOnTypeMismatchBang(r: Base): void }).raiseOnTypeMismatchBang(
-        record,
-      );
-    }
-    if ((this.owner as { isPersisted?: () => boolean }).isPersisted?.()) {
-      throw new HasOnePersistedAssignmentError(this.reflection.name);
-    }
-    this.replace(record);
-  }
-
-  /**
    * Mirrors Rails `HasOneThroughAssociation#replace` immediate persist to a
    * saved owner. The base `writer` saves the target's foreign key directly,
    * which is wrong for a through (persistence routes through the join model), so
-   * we override to run the deferred `persistReplace` instead. For a new owner
-   * persistence defers to the owner's next save (`flushPendingReplaces`).
+   * we override to run `persistReplace` — the join-row create/update/destroy of
+   * `create_through_record` (:15-40) — inline, before this returns. For a new
+   * owner Rails takes the `owner.new_record?` build arm (:36-37), so persistence
+   * defers to the owner's next save.
    */
   override writer(record: Base | null): void | Promise<void> {
     this.replace(record);

--- a/packages/activerecord/src/associations/has-one-through-setter.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-through-setter.trails.test.ts
@@ -79,6 +79,11 @@ describe("HasOneThroughSetterTrails", () => {
   it("assigning to a new owner defers the join row to the owner's first save", async () => {
     const member = Member.new({ name: "Unsaved" });
     const club = clubs("boring_club");
+    // Row count, not a `findBy` on `club_id`: four fixture memberships already
+    // point at `boring_club`, so any club-scoped lookup is non-null before we
+    // start. A count delta is what actually pins "the build arm wrote nothing".
+    const rowCount = async () => Number(await CurrentMembership.count());
+    const before = await rowCount();
 
     // A new owner takes Rails' `through_proxy.build` arm (:36-37), which needs
     // no `await` — the plain property setter is the faithful surface here.
@@ -89,9 +94,12 @@ describe("HasOneThroughSetterTrails", () => {
     const built = member.currentMembership;
     expect(built).not.toBeNull();
     expect(built!.isNewRecord()).toBe(true);
-    expect(await CurrentMembership.findBy({ club_id: club.id, member_id: null })).toBeNull();
+    expect(await rowCount()).toBe(before);
 
     await member.save();
+
+    // The deferred build lands exactly one row, at the owner's first save.
+    expect(await rowCount()).toBe(before + 1);
 
     const persisted = await CurrentMembership.findBy({ member_id: member.id });
     expect(persisted).not.toBeNull();

--- a/packages/activerecord/src/associations/has-one-through-setter.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-through-setter.trails.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Trails-only assertions pinning WHEN a has_one_through assignment hits the DB.
+ *
+ * Rails' `HasOneThroughAssociation#replace`
+ * (has_one_through_association.rb:9-13) calls `create_through_record`
+ * synchronously, so for a *persisted* owner the join row is created / updated /
+ * destroyed AT ASSIGNMENT (`through_proxy.create` / `through_record.update` /
+ * `through_record.destroy`, :21-40) — never deferred to the owner's next save.
+ * Only the `owner.new_record? || !save` arm (:36-37) defers, by *building* the
+ * join record for the owner's first save to persist.
+ *
+ * In trails the assignment-time write needs `await`, so it lives on the
+ * awaitable `set#{Name}` setter (RFC 0068). No Rails test pins the *timing*
+ * distinction — Ruby's setter is synchronous, so there is nothing to defer and
+ * nothing to assert. These tests exist so the immediate arms can't silently
+ * regress into save-time deferral (the two-row race RFC 0068 exists to kill),
+ * and so `_pendingReplace` can't quietly reacquire a persisted-owner role.
+ *
+ * Each persisted-owner case asserts against a freshly-`find`ed join row and
+ * never calls `member.save()`, so a deferred implementation fails outright.
+ */
+import { describe, it, expect } from "vitest";
+import { registerModel, enableSti } from "../index.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+import { Member } from "../test-helpers/models/member.js";
+import { Club } from "../test-helpers/models/club.js";
+import { Membership, CurrentMembership } from "../test-helpers/models/membership.js";
+
+type AwaitableClubSetter = { setClub(value: Club | null): Promise<void> };
+
+describe("HasOneThroughSetterTrails", () => {
+  const { members, clubs } = fixtures(["members", "clubs", "memberships"]);
+
+  registerModel(Member);
+  registerModel(Club);
+  enableSti(Membership);
+  registerModel(Membership);
+  registerModel(CurrentMembership);
+
+  it("assigning to a persisted owner updates the existing join row inline", async () => {
+    const member = members("some_other_guy");
+    const membership = await member.loadHasOne("currentMembership");
+    expect(membership).not.toBeNull();
+
+    const newClub = clubs("moustache_club");
+    await (member as unknown as AwaitableClubSetter).setClub(newClub);
+
+    // Rails' `through_record.update(attributes)` arm (:34) — already visible in
+    // the DB, with no `member.save()` anywhere.
+    const reloaded = await CurrentMembership.find(membership!.id);
+    expect(Number(reloaded.readAttribute("club_id"))).toBe(Number(newClub.id));
+  });
+
+  it("assigning to a persisted owner with no join row creates it inline", async () => {
+    const member = await Member.create({ name: "Joinless" });
+    expect(await member.loadHasOne("currentMembership")).toBeNull();
+
+    const club = clubs("boring_club");
+    await (member as unknown as AwaitableClubSetter).setClub(club);
+
+    // Rails' `through_proxy.create(attributes)` arm (:39).
+    const created = await CurrentMembership.findBy({ member_id: member.id });
+    expect(created).not.toBeNull();
+    expect(Number(created!.readAttribute("club_id"))).toBe(Number(club.id));
+  });
+
+  it("assigning nil to a persisted owner destroys the join row inline", async () => {
+    const member = members("some_other_guy");
+    const membership = await member.loadHasOne("currentMembership");
+    expect(membership).not.toBeNull();
+
+    await (member as unknown as AwaitableClubSetter).setClub(null);
+
+    // Rails' `through_record.destroy` arm (:21-22).
+    expect(await CurrentMembership.findBy({ id: membership!.id })).toBeNull();
+    expect(member.club).toBeNull();
+  });
+
+  it("assigning to a new owner defers the join row to the owner's first save", async () => {
+    const member = Member.new({ name: "Unsaved" });
+    const club = clubs("boring_club");
+
+    // A new owner takes Rails' `through_proxy.build` arm (:36-37), which needs
+    // no `await` — the plain property setter is the faithful surface here.
+    member.club = club;
+
+    // Built in memory and readable immediately, but NOT yet in the DB.
+    expect(member.club).toBe(club);
+    const built = member.currentMembership;
+    expect(built).not.toBeNull();
+    expect(built!.isNewRecord()).toBe(true);
+    expect(await CurrentMembership.findBy({ club_id: club.id, member_id: null })).toBeNull();
+
+    await member.save();
+
+    const persisted = await CurrentMembership.findBy({ member_id: member.id });
+    expect(persisted).not.toBeNull();
+    expect(Number(persisted!.readAttribute("club_id"))).toBe(Number(club.id));
+  });
+});


### PR DESCRIPTION
## What

Removes `HasOneThroughAssociation#queueWrite`, whose body was equivalent to the
inherited `HasOneAssociation#queueWrite` (`has-one-association.ts:72-90`): the
same leading `raiseOnTypeMismatchBang` guard (Rails
`has_one_association.rb:59-60`), the same `HasOnePersistedAssignmentError`
throw for a persisted owner, the same `this.replace(record)` for a new owner.
It overrode nothing. Adds the timing coverage that was missing underneath it.

## Why the persisted-owner path needs no deferral

Rails' `HasOneThroughAssociation#replace`
(`has_one_through_association.rb:9-13`) runs `create_through_record` at
assignment; for a persisted owner that reaches `through_proxy.create` /
`through_record.update` / `through_record.destroy` (`:21-40`) — an inline
join-row write. The awaitable `writer` (`:128-133`) already matches this: it
calls `persistReplace` inline and does not return until the join row is
created / updated / destroyed.

So `_pendingReplace` no longer plays any persisted-owner-*assignment* role. Its
two surviving roles are both Rails-faithful, and are now documented in its
JSDoc rather than left to be re-derived:

- **New owner** — Rails takes the `owner.new_record?` arm and only *builds* the
  join record (`:36-37`); the row lands at the owner's first `save`.
- **Sync `build`/`create` on a persisted owner** — the `!save` half of that same
  arm, reached from non-awaitable builders that cannot `await`;
  `persistThroughRecord` drains it inside the save.

`detachDisplacedTarget`'s no-op override stays: a through target has no FK back
to the owner, so displacement is handled entirely by the join-row mutation,
never by nullifying the end record.

## Testing

The persisted-owner arms of `create_through_record` had **no coverage at all**,
so nothing stopped them regressing into save-time deferral — the two-row race
RFC 0068 exists to kill. New `has-one-through-setter.trails.test.ts` pins the
timing: each persisted-owner case asserts against a freshly-`find`ed join row
and never calls `member.save()`, so a deferred implementation fails outright.
It covers all three immediate arms (update `:34` / create `:39` / destroy
`:21-22`) plus the new-owner build arm (`:36-37`) that legitimately defers.

The new-owner case pins its deferral with a `CurrentMembership` row-count
delta — unchanged across the assignment, `+1` after `save`. (A `findBy` on
`club_id` is not usable here: four fixture memberships already point at
`boring_club`, so it is non-null before the test starts.) Verified
load-bearing by negative control — asserting `before + 1` pre-save fails with
`expected 3 to be 4`.

This is a trails-only file because the distinction it pins does not exist in
Ruby — a synchronous setter has nothing to defer, so no Rails test asserts it.

**These new tests pass on baseline `c79a80b1e` as well as on this branch** —
verified by restoring only `has-one-through-association.ts` from `origin/main`
and re-running them. That is the intended result and the actual claim of this
PR: the deletion is behaviour-preserving, now *proven* rather than asserted.
They are guards against future regression, not a demonstration of a fix.

Full affected-suite run — 425 passed, 5 skipped:
`has-one-through-associations` · `has-one-through-build.trails` ·
`has-one-through-setter.trails` · `has-one-associations` ·
`autosave-association` · `nested-through-associations`

## Acceptance criteria

- [x] `queueWrite` override removed; no through path defers a persisted-owner
      replace to save time
- [x] `await owner.set#{Name}(x)` on a persisted owner creates/updates/destroys
      the join row inline, arm for arm with `create_through_record` — now pinned
- [x] New-owner assignment still builds the join record and persists it at the
      owner's first save (`:33-37`) — now pinned
- [x] has_one_through + autosave suites green; `_pendingReplace`'s remaining
      roles documented in its JSDoc

Closes-story: has-one-through-pending-replace-persisted-immediate
