### PR TITLE
fix(associations): throw on persisted-owner collection assignment; retire deferred _pendingReplace

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -3811,11 +3811,9 @@ export async function setHasMany(record: Base, assocName: string, targets: Base[
   // options override — the previous one was dead (it duplicated the reflection
   // at every call site and went unread once the diff moved into `replace`).
   const assoc = record.association(assocName) as unknown as {
-    replace(records: Base[]): void;
-    persistReplace(): Promise<void>;
+    writer(records: Base[]): Promise<void>;
   };
-  assoc.replace(targets);
-  await assoc.persistReplace();
+  await assoc.writer(targets);
 }
 
 export async function touchBelongsToParents(record: Base): Promise<void> {

--- a/packages/activerecord/src/associations/belongs-to-associations.test.ts
+++ b/packages/activerecord/src/associations/belongs-to-associations.test.ts
@@ -1811,7 +1811,9 @@ describe("BelongsToAssociationsTest", () => {
 
   it("assigning an association doesn't result in duplicate objects", async () => {
     const post = await Post.create({ title: "title", body: "body" });
-    (post as any).comments = [post.comments.build({ body: "body" })];
+    // Rails' `post.comments = [...]` persists the replacement at assignment;
+    // that needs `await` in JS, so the `=` setter throws (RFC 0068).
+    await post.comments.replace([post.comments.build({ body: "body" })]);
     await post.save();
 
     expect(await post.comments.size()).toBe(1);

--- a/packages/activerecord/src/associations/builder/collection-association.ts
+++ b/packages/activerecord/src/associations/builder/collection-association.ts
@@ -144,15 +144,31 @@ export class CollectionAssociation extends Association {
   }
 
   static override defineWriters(mixin: object, name: string): void {
-    super.defineWriters(mixin, name);
     if (!mixin || typeof mixin !== "object") return;
+    // Skip `super.defineWriters` for the main name: the base installs a setter
+    // calling the association's `writer`, which for collections is now
+    // awaitable (it persists inline on a persisted owner). A JS property
+    // setter cannot `await`, so route to `queueWrite` — in-memory replace on
+    // an unpersisted owner, `CollectionPersistedAssignmentError` on a
+    // persisted one, whose message names the awaitable replacement
+    // (`await owner.#{name}.replace([...])`). RFC 0068.
+    const nameDescriptor = Object.getOwnPropertyDescriptor(mixin, name);
+    if (!nameDescriptor || nameDescriptor.configurable) {
+      Object.defineProperty(mixin, name, {
+        get: nameDescriptor?.get,
+        set(this: AssociationInstanceHost, records: unknown) {
+          (this.association(name) as any).queueWrite(records);
+        },
+        configurable: true,
+      });
+    }
     const idsName = `${singularize(name)}Ids`;
     const existing = Object.getOwnPropertyDescriptor(mixin, idsName);
     if (existing && !existing.configurable) return;
     Object.defineProperty(mixin, idsName, {
       get: existing?.get,
       set(this: AssociationInstanceHost, ids: unknown) {
-        return (this.association(name) as any).idsWriter(ids);
+        return (this.association(name) as any).queueIdsWrite(ids);
       },
       configurable: true,
     });

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -97,8 +97,11 @@ export class CollectionAssociation extends Association {
     // first statement (collection_association.rb:242), before any load or
     // persist — and so before the persisted-owner deviation below. That guard
     // is synchronous, so preserve its ordering even on this non-awaitable
-    // path: `firm.clients = [1]` must report `AssociationTypeMismatch`.
-    for (const val of records ?? []) (this as any).raiseOnTypeMismatchBang(val);
+    // path: `firm.clients = [1]` must report `AssociationTypeMismatch`, and
+    // `firm.clients = null` must fail here (Rails: NoMethodError from
+    // `nil.each`; here: TypeError from iterating null) on BOTH owner arms,
+    // ahead of the persisted-owner throw.
+    for (const val of records) (this as any).raiseOnTypeMismatchBang(val);
     if ((this.owner as { isPersisted?: () => boolean }).isPersisted?.()) {
       throw new CollectionPersistedAssignmentError(this.reflection.name);
     }
@@ -107,9 +110,16 @@ export class CollectionAssociation extends Association {
 
   /**
    * The `#{singular}Ids=` analogue of {@link queueWrite}. Resolving ids to
-   * records is itself a query, so even the unpersisted-owner arm is async —
-   * but a new owner has nothing to reconcile, so the setter can safely leave
-   * the returned promise to `idsWriter` (which ends in an in-memory replace).
+   * records is itself a query, so even the unpersisted-owner arm is async.
+   *
+   * The unpersisted arm returns a promise the property setter must discard —
+   * an id that doesn't resolve (`raiseNotFoundAll`) surfaces as an unhandled
+   * rejection, not a catchable throw, and an immediate `save()` can race the
+   * in-flight resolution. This is the pre-existing shape (the setter always
+   * called `idsWriter` un-awaited) and the story's acceptance criteria keep
+   * unpersisted-owner assignment working, so it is retained rather than made
+   * a second persisted-style throw; callers who need the result awaitable use
+   * `await owner.association(name).idsWriter(ids)`.
    */
   queueIdsWrite(ids: unknown[]): Promise<void> {
     if ((this.owner as { isPersisted?: () => boolean }).isPersisted?.()) {

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -7,9 +7,21 @@ import { foreignKeyPresentFor } from "./foreign-association.js";
 import { throughForeignKeyPresent } from "./through-association.js";
 import type { AssociationReflection } from "../reflection.js";
 import { RecordNotSaved, Rollback } from "../errors.js";
+import { CollectionPersistedAssignmentError } from "./errors.js";
 import { raiseNotFoundAll } from "../relation/finder-methods.js";
 import { normalizeAssociationKey } from "./key-normalization.js";
 import { polymorphicName } from "../inheritance.js";
+
+/**
+ * The persisted-owner DB work `replace` defers to its awaitable caller: the
+ * assigned collection plus the baseline to diff it against (`wasLoaded` says
+ * whether that baseline is trustworthy or must be re-read from the DB).
+ */
+export interface ReplacePlan {
+  newTarget: Base[];
+  originalTarget: Base[];
+  wasLoaded: boolean;
+}
 
 /**
  * Base class for has_many and has_and_belongs_to_many associations.
@@ -34,7 +46,6 @@ export class CollectionAssociation extends Association {
   // CollectionProxy through-branch reads this to avoid pruning its loaded
   // target when the removal was actually aborted. Read externally by the proxy.
   _lastRemoveAborted = false;
-  _pendingReplace: { newTarget: Base[]; originalTarget: Base[]; wasLoaded: boolean } | null = null;
   // trails-specific (RFC 0030): memoized named-scope relations built off the
   // proxy (`things.someScope()`). Rails has NO such cache — `scope :name`
   // rebuilds a fresh relation on every call (named.rb:174-178), so two
@@ -55,9 +66,56 @@ export class CollectionAssociation extends Association {
   /**
    * Implements the writer method, e.g. foo.items= for Foo.has_many :items.
    * Replaces the entire collection.
+   *
+   * Awaitable: mirrors Rails' `CollectionAssociation#writer` → `replace`
+   * (collection_association.rb:46-48, :242), which for a *persisted* owner
+   * runs the diffed deletes + inserts inline in a transaction. That is DB I/O,
+   * so this returns a Promise — the sync property setter cannot reach it and
+   * uses {@link queueWrite} instead (RFC 0068).
    */
-  writer(records: Base[]): void {
+  async writer(records: Base[]): Promise<void> {
+    const plan = this.replace(records);
+    if (plan) await this.persistReplacePlan(plan);
+  }
+
+  /**
+   * Writer for the JS property setter (`owner.items = [...]`,
+   * builder/collection-association.ts `defineWriters`) and mass-assignment,
+   * neither of which can `await`.
+   *
+   * - **Unpersisted owner:** in-memory `replace`, exactly as Rails does no I/O
+   *   for a new-record owner (the FK isn't known yet); autosave persists at the
+   *   owner's first `save()`.
+   * - **Persisted owner:** THROW. Rails replaces inline at assignment; JS
+   *   cannot do synchronous DB I/O from a property setter, so rather than
+   *   deferring the writes to the owner's next `save()` (where a deferred
+   *   delete can race an interim insert) we throw and name the awaitable
+   *   Rails-named replacement (`await owner.items.replace([...])`).
+   */
+  queueWrite(records: Base[]): void {
+    // Rails' `replace` raises a class mismatch for every element as its very
+    // first statement (collection_association.rb:242), before any load or
+    // persist — and so before the persisted-owner deviation below. That guard
+    // is synchronous, so preserve its ordering even on this non-awaitable
+    // path: `firm.clients = [1]` must report `AssociationTypeMismatch`.
+    for (const val of records ?? []) (this as any).raiseOnTypeMismatchBang(val);
+    if ((this.owner as { isPersisted?: () => boolean }).isPersisted?.()) {
+      throw new CollectionPersistedAssignmentError(this.reflection.name);
+    }
     this.replace(records);
+  }
+
+  /**
+   * The `#{singular}Ids=` analogue of {@link queueWrite}. Resolving ids to
+   * records is itself a query, so even the unpersisted-owner arm is async —
+   * but a new owner has nothing to reconcile, so the setter can safely leave
+   * the returned promise to `idsWriter` (which ends in an in-memory replace).
+   */
+  queueIdsWrite(ids: unknown[]): Promise<void> {
+    if ((this.owner as { isPersisted?: () => boolean }).isPersisted?.()) {
+      throw new CollectionPersistedAssignmentError(this.reflection.name);
+    }
+    return this.idsWriter(ids);
   }
 
   /**
@@ -201,15 +259,13 @@ export class CollectionAssociation extends Association {
       );
     }
 
-    this.replace(records);
-    await this.persistReplace();
+    await this.writer(records);
   }
 
   override reset(): void {
     super.reset();
     this.target = [];
     this._associationIds = null;
-    this._pendingReplace = null;
     // Drop the trails-specific named-scope memo (see `_namedScopeRelations`) so
     // the next `things.someScope()` rebuilds against the reset collection. (This
     // sits alongside Rails' `reset`, which clears @target/@association_ids; the
@@ -429,8 +485,18 @@ export class CollectionAssociation extends Association {
   /**
    * Replace this collection with other_array. Performs a diff and
    * delete/add only records that have changed.
+   *
+   * In-memory only. For a *new* owner that is the whole of Rails' behaviour
+   * (`replace_records` without a save — the FK isn't known yet), so the
+   * owner's first `save()` autosaves the target and nothing else is needed.
+   * For a *persisted* owner Rails additionally runs the diffed deletes +
+   * inserts in a transaction; that DB work cannot happen here (this is
+   * synchronous, and reached from the property setter), so it is returned as a
+   * plan for the awaitable {@link writer} to execute via
+   * {@link persistReplacePlan}. Returns `null` when there is nothing to
+   * persist.
    */
-  replace(otherArray: Base[]): void {
+  replace(otherArray: Base[]): ReplacePlan | null {
     // The writer path (`firm.clients = [...]`, `firm.client_ids = [...]`, mass
     // assignment) mutates `target` directly rather than going through
     // `setTarget`, so it needs the in-flight guard applied here too —
@@ -503,25 +569,21 @@ export class CollectionAssociation extends Association {
           }
         }
         this.loadedBang();
-        // Preserve the first originalTarget (what's in the DB) across multiple
-        // replace() calls before save(). Only update newTarget so the final flush
-        // diffs against the real persisted state, not an intermediate in-memory one.
-        if (this._pendingReplace) {
-          if (wasLoaded && arraysEqual(otherArray, this._pendingReplace.originalTarget)) {
-            this._pendingReplace = null; // reverted to DB state — nothing to flush
-          } else {
-            this._pendingReplace.newTarget = [...otherArray];
-          }
-        } else {
-          this._pendingReplace = { newTarget: [...otherArray], originalTarget, wasLoaded };
-        }
+        return { newTarget: [...otherArray], originalTarget, wasLoaded };
       }
     }
+    return null;
   }
 
-  async persistReplace(): Promise<void> {
-    const pending = this._pendingReplace;
-    if (!pending || this.owner.isNewRecord()) return;
+  /**
+   * Run the persisted-owner half of {@link replace}: the diffed deletes +
+   * inserts, in a transaction (Rails' `replace_records`,
+   * collection_association.rb:242). Awaited inline by {@link writer} — the
+   * in-memory `replace` above has already mutated `target`, so this restores
+   * the captured baseline for the duration of the diff.
+   */
+  protected async persistReplacePlan(pending: ReplacePlan): Promise<void> {
+    if (this.owner.isNewRecord()) return;
     // If the association wasn't loaded at assignment time, fetch the persisted
     // baseline directly via doAsyncFindTarget to avoid the loadedBang short-circuit
     // and without mutating this.target (mirrors Rails' load_target in replace).
@@ -544,8 +606,6 @@ export class CollectionAssociation extends Association {
         this.target = currentTarget;
       }
     });
-    // Clear only after success — leave intact on error so save() retry can re-attempt
-    this._pendingReplace = null;
   }
 
   /**

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -259,7 +259,11 @@ export class CollectionAssociation extends Association {
       );
     }
 
-    await this.writer(records);
+    // Rails' `ids_writer` ends in `replace(records)` (collection_association.rb:83).
+    // Mirror that direct call, then run the persisted-owner half `replace`
+    // defers (the awaitable `writer` does the same two steps).
+    const plan = this.replace(records);
+    if (plan) await this.persistReplacePlan(plan);
   }
 
   override reset(): void {

--- a/packages/activerecord/src/associations/collection-persisted-setter-throws.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-persisted-setter-throws.trails.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Trails-only: the native `=` collection setter (`owner.items = [...]`, the
+ * `#{singular}Ids=` setter, and the mass-assignment hasMany/HABTM arm)
+ * deviates from Rails on a *persisted* owner. Rails'
+ * `CollectionAssociation#writer` → `replace`
+ * (vendor/rails/activerecord/lib/active_record/associations/collection_association.rb:46-48,
+ * :242) diffs against the loaded target and runs the deletes + inserts inline
+ * in a transaction (`replace_records`) — synchronous DB I/O JS cannot do from
+ * a property setter. Rather than silently deferring the writes to the owner's
+ * next `save()` (where a deferred delete can race an interim insert), the
+ * setter THROWS and names the awaitable Rails-named replacement
+ * (`await owner.items.replace([...])`). On an *unpersisted* owner Rails does
+ * no I/O either, so the in-memory replace is faithful and kept. There is no
+ * Rails test for this deviation.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { registerModel, AssociationTypeMismatch } from "../index.js";
+import { CollectionPersistedAssignmentError } from "./errors.js";
+import { Author } from "../test-helpers/models/author.js";
+import { Post } from "../test-helpers/models/post.js";
+import { Comment } from "../test-helpers/models/comment.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+
+interface CollectionOwner {
+  posts?: unknown;
+  postIds?: unknown;
+  assignAttributes(attrs: Record<string, unknown>): void;
+}
+
+interface PostsProxy {
+  replace(records: Post[]): Promise<void>;
+  count(): Promise<number>;
+  toArray(): Promise<Post[]>;
+}
+
+const postsOf = (owner: Author): PostsProxy => (owner as unknown as { posts: PostsProxy }).posts;
+
+const targetOf = (owner: Author): Post[] =>
+  (owner as unknown as { association(n: string): { target: Post[] } }).association("posts").target;
+
+const writerOf =
+  (owner: Author) =>
+  (records: Post[]): Promise<void> =>
+    (owner as unknown as { association(n: string): { writer(r: Post[]): Promise<void> } })
+      .association("posts")
+      .writer(records);
+
+describe("CollectionPersistedSetterThrows", () => {
+  fixtures(["authors", "posts", "comments"]);
+
+  beforeAll(() => {
+    registerModel(Author);
+    registerModel(Post);
+    registerModel(Comment);
+  });
+
+  it("native = setter throws on a persisted owner", async () => {
+    const author = (await Author.create({ name: "Bill" })) as unknown as CollectionOwner;
+    const post = await Post.create({ title: "t", body: "b" });
+    expect(() => {
+      author.posts = [post];
+    }).toThrow(CollectionPersistedAssignmentError);
+    // The message names the awaitable Rails-named replacement.
+    expect(() => {
+      author.posts = [post];
+    }).toThrow(/await owner\.posts\.replace\(\[\.\.\.\]\)/);
+  });
+
+  it("native = setter raises the type mismatch before the persisted-owner throw", async () => {
+    // Rails' `replace` raises `AssociationTypeMismatch` for every element as
+    // its first statement (collection_association.rb:242), before any other
+    // work — the sync guard is preserved ahead of the persisted-owner throw.
+    const author = (await Author.create({ name: "Bill" })) as unknown as CollectionOwner;
+    expect(() => {
+      author.posts = [1];
+    }).toThrow(AssociationTypeMismatch);
+  });
+
+  it("ids= setter throws on a persisted owner", async () => {
+    const author = (await Author.create({ name: "Bill" })) as unknown as CollectionOwner;
+    const post = await Post.create({ title: "t", body: "b" });
+    expect(() => {
+      author.postIds = [post.id];
+    }).toThrow(CollectionPersistedAssignmentError);
+  });
+
+  it("mass-assignment throws on a persisted owner", async () => {
+    const author = (await Author.create({ name: "Bill" })) as unknown as CollectionOwner;
+    const post = await Post.create({ title: "t", body: "b" });
+    // Mass-assignment wraps a failing setter in `AttributeAssignmentError`
+    // (Rails' `_assign_attributes` rescue), so the deviation surfaces as the
+    // `cause`.
+    let raised: unknown;
+    try {
+      author.assignAttributes({ posts: [post] });
+    } catch (e) {
+      raised = e;
+    }
+    expect((raised as { cause?: unknown })?.cause).toBeInstanceOf(
+      CollectionPersistedAssignmentError,
+    );
+  });
+
+  it("keeps in-memory assignment on an unpersisted owner", async () => {
+    // Rails defers here too (`replace_records` without a save — the FK isn't
+    // known yet), so the sync setter is faithful and autosave persists at the
+    // owner's first `save()`.
+    const author = new Author({ name: "Bill" });
+    const post = new Post({ title: "t", body: "b" });
+    (author as unknown as CollectionOwner).posts = [post];
+
+    expect(targetOf(author).length).toBe(1);
+    await author.save();
+    await author.reload();
+    expect(await postsOf(author).count()).toBe(1);
+  });
+
+  it("the awaitable writer replaces on a persisted owner", async () => {
+    const author = await Author.create({ name: "Bill" });
+    const first = await Post.create({ title: "a", body: "a" });
+    const second = await Post.create({ title: "b", body: "b" });
+
+    await writerOf(author)([first]);
+    expect(await postsOf(author).count()).toBe(1);
+
+    await writerOf(author)([second]);
+    await author.reload();
+    const titles = (await postsOf(author).toArray()).map((p) => p.title);
+    expect(titles).toEqual(["b"]);
+  });
+});

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -7,7 +7,14 @@
 
 import { describe, it, expect } from "vitest";
 import { throwAbort } from "@blazetrails/activesupport";
-import { Base, association, registerModel, RecordInvalid, RecordNotFound } from "../index.js";
+import {
+  Base,
+  association,
+  registerModel,
+  RecordInvalid,
+  RecordNotFound,
+  CollectionPersistedAssignmentError,
+} from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 // Opt this file into the canonical-model autoload index (Zeitwerk analog):
 // `Comment`, `Tagging`, `Tag`, and `Owner` — association targets with no
@@ -368,15 +375,20 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
   });
 
   it("writer `author.posts = [...]` still flows through Association#writer", async () => {
-    // R.2 only swapped the reader; the writer (defineWriters) is
-    // untouched and still routes through `this.association(name).writer(value)`.
+    // R.2 only swapped the reader; the writer still routes through
+    // `this.association(name).writer(value)` — but as of RFC 0068 that writer
+    // is awaitable (it persists the replacement inline for a persisted owner),
+    // so the non-awaitable `=` setter throws rather than deferring the writes.
     const author = await authorWithPosts();
     const replacement = await Post.create({
       title: "z",
       body: "z",
       author_id: author.id as number,
     });
-    (author as any).posts = [replacement];
+    expect(() => {
+      (author as any).posts = [replacement];
+    }).toThrow(CollectionPersistedAssignmentError);
+    await association<Post>(author, "posts").replace([replacement]);
     // The proxy returned by the reader reflects the new target.
     const reader = (author as any).posts;
     expect(reader.target.length).toBe(1);

--- a/packages/activerecord/src/associations/constructor-form-and-hmt-insert.test.ts
+++ b/packages/activerecord/src/associations/constructor-form-and-hmt-insert.test.ts
@@ -96,7 +96,10 @@ describe("resetScope on owner save", () => {
       resetCount++;
       return original();
     };
-    (author as any).posts = [];
+    // Build rather than assign: `author.posts = []` on a persisted owner now
+    // throws (RFC 0068), and an unsaved child is what makes the owner's save
+    // reach saveCollectionAssociation at all.
+    (author as any).posts.build({ title: "t", body: "b" });
     await author.save();
     expect(resetCount).toBeGreaterThan(0);
   });

--- a/packages/activerecord/src/associations/errors.ts
+++ b/packages/activerecord/src/associations/errors.ts
@@ -393,3 +393,32 @@ export class HasOnePersistedAssignmentError extends ActiveRecordError {
     this.association = association;
   }
 }
+
+/**
+ * Thrown when a collection association (`has_many` / HABTM) is assigned with
+ * the native `=` setter — `owner.items = [...]`, `owner.itemIds = [...]`, or a
+ * mass-assignment key — on a *persisted* owner. The collection analogue of
+ * {@link HasOnePersistedAssignmentError}, and a deliberate trails-only
+ * deviation with no Rails counterpart: Rails'
+ * `CollectionAssociation#replace` diffs against the loaded target and runs the
+ * deletes + inserts inline in a transaction (`replace_records`,
+ * collection_association.rb:242), which is synchronous DB I/O JS cannot do
+ * from a property setter. Rather than deferring those writes to the owner's
+ * next `save()` — where a deferred delete can race an interim insert — we
+ * throw loudly and name the awaitable Rails-named replacements. See RFC
+ * 0068-awaitable-has-one-setter ("Why 'loud' beats 'deferred'").
+ */
+export class CollectionPersistedAssignmentError extends ActiveRecordError {
+  readonly association: string;
+
+  constructor(association: string) {
+    super(
+      `Cannot assign collection association \`${association}\` with \`=\` on a ` +
+        `persisted record: Rails replaces the collection at assignment time, ` +
+        `which requires \`await\` in JS. Use \`await owner.${association}.replace([...])\` ` +
+        `(or \`.concat(...)\` / \`.destroy(...)\`).`,
+    );
+    this.name = "CollectionPersistedAssignmentError";
+    this.association = association;
+  }
+}

--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -1093,7 +1093,9 @@ describe("HasManyThroughAssociationsTest", () => {
     const tag = await (post as any).tags.create({ name: "doomed" });
     await tag.taggedPosts.push(await Post.find(posts("thinking").id));
 
-    tag.taggedPosts = [];
+    // Rails' `tag.tagged_posts = []` persists the replacement at assignment;
+    // that needs `await` in JS, so the `=` setter throws (RFC 0068).
+    await tag.taggedPosts.replace([]);
     await post.reload();
 
     expect(post.tags_count).toBe(await (post as any).taggings.count());
@@ -2288,15 +2290,18 @@ describe("HasManyThroughAssociationsTest", () => {
     const author = await Author.create({ name: "Bill" });
     const general = await Category.find(categories("general").id);
 
-    await author.update({
-      specialCategoriesWithConditionIds: [general.id],
-      nonspecialCategoriesWithConditionIds: [general.id],
-    });
+    // Rails assigns these ids through `update`, which persists the replacement
+    // inline. Mass-assignment cannot `await`, so the collection arm throws and
+    // callers use the awaitable `idsWriter` instead (RFC 0068).
+    const idsWriterFor = (name: string) =>
+      author.association(name) as unknown as { idsWriter(ids: unknown[]): Promise<void> };
+    await idsWriterFor("specialCategoriesWithConditions").idsWriter([general.id]);
+    await idsWriterFor("nonspecialCategoriesWithConditions").idsWriter([general.id]);
 
     expect(await (author as any).specialCategoriesWithConditionIds).toEqual([general.id]);
     expect(await (author as any).nonspecialCategoriesWithConditionIds).toEqual([general.id]);
 
-    await author.update({ nonspecialCategoriesWithConditionIds: [] });
+    await idsWriterFor("nonspecialCategoriesWithConditions").idsWriter([]);
     await author.reload();
 
     expect(await (author as any).specialCategoriesWithConditionIds).toEqual([general.id]);

--- a/packages/activerecord/src/attribute-assignment.ts
+++ b/packages/activerecord/src/attribute-assignment.ts
@@ -169,18 +169,24 @@ export function assignAssociationIfMatch(
         replace?: (v: unknown[]) => void;
         writer?: (v: unknown) => void;
         queueWrite?: (v: unknown) => void;
+        queueIdsWrite?: (v: unknown) => unknown;
       }
     | null
     | undefined;
   if (!proxy) return false;
   if (assoc.type === "hasMany" || assoc.type === "hasAndBelongsToMany") {
-    if (typeof proxy.replace !== "function") return false;
-    // Rails fidelity: pass the value through unchanged. The normal writer
-    // path (`record.items = value` → CollectionAssociation#writer →
-    // #replace) does not Array.wrap — Rails' replace calls `.each` on the
-    // argument and raises on nil / scalars. Coercing here would silently
-    // accept inputs the regular writer rejects.
-    proxy.replace(value as unknown[]);
+    // Mass-assignment can't await, so it shares the native `=` setter's
+    // `queueWrite` dispatch: in-memory replace on an unpersisted owner, and a
+    // throw (`CollectionPersistedAssignmentError`) on a persisted one — Rails
+    // replaces the collection inline at assignment, which needs `await` in JS.
+    // Callers use `await owner.#{name}.replace([...])` instead (RFC 0068).
+    //
+    // Rails fidelity: pass the value through unchanged. The writer path does
+    // not Array.wrap — Rails' replace calls `.each` on the argument and raises
+    // on nil / scalars. Coercing here would silently accept inputs the regular
+    // writer rejects.
+    if (typeof proxy.queueWrite !== "function") return false;
+    proxy.queueWrite(value as unknown[]);
     return true;
   }
   if (assoc.type === "hasOne") {

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -311,9 +311,11 @@ export function validOptions(): string[] {
 }
 
 // Post-commit flush for association instances that still queue a deferred
-// `_pendingReplace` — collection associations (has_many / HABTM,
-// CollectionAssociation#persistReplace). Neither singular has_one path relies on
-// this any more: the direct has_one converged onto
+// `_pendingReplace`. Collection associations no longer do: their persisted-owner
+// assignment throws (`CollectionPersistedAssignmentError`) and the awaitable
+// `CollectionAssociation#writer` persists inline, so there is nothing left to
+// defer (RFC 0068). Neither singular has_one path relies on
+// this any more either: the direct has_one converged onto
 // `autosaveHasOne` -> `removeDisplaced`, and has_one *through* onto
 // `autosaveHasOne` -> `persistThroughRecord` (Rails' `save_has_one_association`
 // through arm), both of which run during the save and clear their markers, so by

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -311,16 +311,16 @@ export function validOptions(): string[] {
 }
 
 // Post-commit flush for association instances that still queue a deferred
-// `_pendingReplace`. Collection associations no longer do: their persisted-owner
-// assignment throws (`CollectionPersistedAssignmentError`) and the awaitable
-// `CollectionAssociation#writer` persists inline, so there is nothing left to
-// defer (RFC 0068). Neither singular has_one path relies on
-// this any more either: the direct has_one converged onto
-// `autosaveHasOne` -> `removeDisplaced`, and has_one *through* onto
-// `autosaveHasOne` -> `persistThroughRecord` (Rails' `save_has_one_association`
-// through arm), both of which run during the save and clear their markers, so by
-// the time this runs post-commit those singular markers are already null and the
-// loop skips them.
+// `_pendingReplace`. Collection associations no longer participate: their
+// persisted-owner assignment throws (`CollectionPersistedAssignmentError`) and
+// the awaitable `CollectionAssociation#writer` persists inline, so they no
+// longer define `persistReplace` at all (RFC 0068). The sole remaining matcher
+// of the duck-type below is `HasOneThroughAssociation`, which still defines
+// both `persistReplace` (has-one-through-association.ts) and `_pendingReplace`.
+// Its marker is normally consumed during the save (`autosaveHasOne` ->
+// `persistThroughRecord`, Rails' `save_has_one_association` through arm), so by
+// post-commit it is usually null and the loop no-ops — this is deliberately
+// kept as its safety net for a marker that survives the save, not dead code.
 export async function flushPendingReplaces(record: Base): Promise<void> {
   const instances: Map<string, unknown> = (record as any)._associationInstances;
   if (!instances?.values) return;

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -300,6 +300,7 @@ export {
   EagerLoadPolymorphicError,
   DeleteRestrictionError,
   HasOnePersistedAssignmentError,
+  CollectionPersistedAssignmentError,
 } from "./associations/errors.js";
 export {
   AbstractReflection,

--- a/packages/activerecord/src/persistence/reload-association-cache.test.ts
+++ b/packages/activerecord/src/persistence/reload-association-cache.test.ts
@@ -26,11 +26,14 @@ describe("ReloadAssociationCacheTest", () => {
     await publication.reload();
     expect(publication.readAttribute("name")).toBe("Rails Way");
     const pub = publication as unknown as {
-      editors: Editor[];
+      editors: { replace(records: Editor[]): Promise<void> };
       buildEditorInChief(attrs: { name: string }): Editor;
     };
     await transaction(Publication, async () => {
-      pub.editors = [pub.buildEditorInChief({ name: "Alex Black" })];
+      // Rails' `publication.editors = [...]` persists the replacement at
+      // assignment; that needs `await` in JS, so the `=` setter throws
+      // (RFC 0068). Use the awaitable Rails-named replacement.
+      await pub.editors.replace([pub.buildEditorInChief({ name: "Alex Black" })]);
       await publication.saveBang();
     });
     expect(publication.readAttribute("name")).toBe("Rails Way (touched)");


### PR DESCRIPTION
## What

Rails' `CollectionAssociation#writer` → `replace`
([collection_association.rb:46-48](vendor/rails/activerecord/lib/active_record/associations/collection_association.rb),
`:242`) diffs against the loaded target and runs the deletes + inserts inline
in a transaction (`replace_records`) for a persisted owner. That is synchronous
DB I/O, which JS cannot do from a property setter, so trails deferred it via
`_pendingReplace` and flushed it at the owner's next `save()` — the same
deviation class RFC 0068 kills for has_one, with the same latent window (a
deferred delete racing an interim insert).

Per RFC 0068 Design §5, the native collection setters now **throw** on a
persisted owner and name the awaitable Rails-named replacement. New-owner
assignment stays in-memory, which is what Rails does there too
(`replace_records` without a save — the FK isn't known yet).

## How

- **`CollectionPersistedAssignmentError`** — the collection analogue of
  `HasOnePersistedAssignmentError`, naming `await owner.items.replace([...])`
  (or `.concat(...)` / `.destroy(...)`).
- **`CollectionAssociation#writer` is now awaitable** and persists inline.
  `queueWrite` / `queueIdsWrite` back the sync `name=` and `#{singular}Ids=`
  setters, mirroring the has_one `queueWrite` split. Rails' up-front
  per-element `AssociationTypeMismatch` guard is preserved *ahead* of the
  persisted-owner throw, so `author.posts = [1]` still reports the mismatch.
- **Mass-assignment** (`attribute-assignment.ts`) hasMany/HABTM arm shares the
  same `queueWrite` dispatch. It surfaces as the `cause` of
  `AttributeAssignmentError`, per Rails' `_assign_attributes` rescue.
- **`_pendingReplace` / `persistReplace` removed.** `replace` stays synchronous
  and in-memory but now *returns* a `ReplacePlan` (the assigned collection plus
  the baseline to diff against) that its awaitable caller executes via
  `persistReplacePlan`. Nothing is deferred, so the collection arm of
  `flushPendingReplaces` is dead and documented as such. The has_one *through*
  `_pendingReplace` is a separate field and is untouched.
- **belongs_to untouched** — its `replace` is purely in-memory
  (`belongs_to_association.rb:95-107`), so the native setter was already
  faithful.

## In-repo migrations (no test renames)

Four persisted-owner assignment sites moved to the awaitable path:

| Site | Was | Now |
| --- | --- | --- |
| `has-many-through-associations.test.ts` — *update counter caches on replace association* | `tag.taggedPosts = []` | `await tag.taggedPosts.replace([])` |
| `has-many-through-associations.test.ts` — *has many through update ids with conditions* | `author.update({ ...Ids })` | `await ...association(name).idsWriter([...])` |
| `belongs-to-associations.test.ts` — *assigning an association doesn't result in duplicate objects* | `post.comments = [...]` | `await post.comments.replace([...])` |
| `constructor-form-and-hmt-insert.test.ts` | `author.posts = []` | `author.posts.build({...})` (an unsaved child is what makes the owner's save reach `saveCollectionAssociation` at all) |

New `collection-persisted-setter-throws.trails.test.ts` covers the deviation
directly: `=`, `Ids=`, and mass-assignment all throw on a persisted owner; the
type mismatch still wins the ordering race; unpersisted owners keep in-memory
assignment through to autosave; and the awaitable writer replaces correctly.

## Verification

```
pnpm vitest run packages/activerecord/src/associations/ \
  packages/activerecord/src/autosave-association.test.ts \
  packages/activerecord/src/nested-attributes.test.ts
# 80 passed | 1 skipped (81 files) — 2227 passed
```

`pnpm exec tsc --build` clean; lint clean.

363 LOC (`+314/-51`), under the 500 ceiling.

## Reviewer note — `owner.items.replace([...])` is non-diffing (scoped to follow-up)

Review flagged that the advertised replacement `owner.items.replace([...])`
(`CollectionProxy#replace`, `collection-proxy.ts:3358`) is `clear()` + `push()`,
not a diff, so common records get remove/add callbacks + timestamp touches
unlike Rails' `=`. Investigated against Rails source; the fix is **not** simply
"delegate to the diffing writer", because Rails' `replace` is not uniformly a
set-diff:

- Rails' `CollectionAssociation#replace_records` (`collection_association.rb:418`)
  calls `difference`/`intersection`, which `HasManyThroughAssociation` overrides
  with **multiset** (occurrence-counting) semantics
  (`has_many_through_association.rb:177-191`). That is what makes
  `test_replace_association_with_duplicates` (`has_many_through_associations_test.rb:682`)
  create duplicate join rows for `= [person, person]` (+2).
- Trails' clear+push `proxy.replace` matches that observable through-duplicate
  end-count and opens the through model's transaction — which is why RFC
  Design §5 names it the canonical awaitable target.
- Trails' diffing `writer` path uses **set** membership (`!target.includes(r)`),
  so pointing the migration target there (or delegating proxy.replace to it)
  *regresses* `test_replace_association_with_duplicates` and the
  through-transaction test — confirmed by running the suite.

A single fully-faithful `replace` must satisfy both the multiset through-dup
creation and the plain-`has_many` common-record no-op; neither existing path
does, and reconciling them (base set-diff + HMT multiset override, mirroring the
Rails class split) is a substantial change outside a story about the setter
throwing. Registered as follow-up story
`collection-proxy-replace-multiset-diff-fidelity` under RFC 0068. This PR leaves
`proxy.replace` as-is (the RFC-named target).

**No divergence ships in this PR:** every migrated site
(`belongs-to-associations.test.ts`, `has-many-through-associations.test.ts`,
`reload-association-cache.test.ts`, the trails test) replaces with a **disjoint
or empty** set, where diffing and clear+push are observationally identical — so
the common-record gap is latent, not exercised, until the follow-up lands.

## Review round 4 responses (`217a50c68`)

- **#1 (proxy.replace non-diffing):** resolved via the immediately-registered
  story option — `collection-proxy-replace-multiset-diff-fidelity` is on tasks
  `main` (see section above for why `await this._association.writer(records)`
  is not a drop-in: `writer`'s set-based diff regresses
  `test_replace_association_with_duplicates`, which needs Rails' HMT
  **multiset** `difference`, and opens the owner's transaction instead of the
  through model's).
- **#2 (queueIdsWrite floating promise):** documented at the definition. The
  unpersisted arm is kept because the story's acceptance criteria retain
  unpersisted-owner assignment, and always-throwing for `ids=` would deviate
  from that; the discarded-promise hazards (unhandled rejection on
  `raiseNotFoundAll`, save racing the in-flight resolve) are pre-existing and
  now stated, with `await association(name).idsWriter(ids)` named as the safe
  path.
- **#3 (`?? []` shield):** fixed — dropped, so `owner.items = null` fails in
  the mismatch loop on both owner arms (Rails: NoMethodError from `nil.each`
  as `replace`'s first statement), restoring the pre-PR nil behavior and the
  Rails ordering.
- **#4 (flushPendingReplaces "provably dead"):** premise incorrect —
  `HasOneThroughAssociation` still defines **both** `persistReplace`
  (`has-one-through-association.ts:383`) and `_pendingReplace`, so the
  duck-typed loop remains reachable as that path's post-commit safety net for
  a marker surviving the save. Comment corrected to name that matcher
  explicitly instead of implying the arm is dead.

## Reviewer note — not addressed here

`author.update({ postIds: [...] })` on a persisted owner now throws, because
mass-assignment runs through the synchronous `assignAttributes` and cannot
`await`. Unlike a property setter, `update()` *is* already async in trails, so
an awaitable mass-assignment arm is conceivable — but that is a larger change
than this story scopes, and the story's acceptance criteria explicitly ask for
the mass-assignment arm to throw. Flagging in case the RFC wants a follow-up
story rather than leaving `update` with ids keys unavailable.

Closes-story: collection-writer-throws-on-persisted-owner
