### PR TITLE
refactor(arel): remove stale UnsupportedVisitError translation in Dot#visit

### DIFF
--- a/packages/arel/src/visitors/dot.test.ts
+++ b/packages/arel/src/visitors/dot.test.ts
@@ -283,11 +283,12 @@ describe("TestDot", () => {
     });
 
     it("a mis-registered dispatch method is not reported as an unvisitable value", () => {
-      // Dot translates the base visitor's "no handler at all" error into
-      // Rails' `TypeError, "Cannot visit ..."` (visitor.rb:39). That must not
-      // also swallow the base visitor's *other* error — a typo'd method name
-      // in the dispatch table — or a Dot registration bug is indistinguishable
-      // from a value Rails genuinely cannot visit.
+      // The base visitor's "no handler at all" arm already raises Rails'
+      // `TypeError, "Cannot visit ..."` (visitor.rb:39) directly, and Dot lets
+      // it propagate unchanged. That must not be confused with the base
+      // visitor's *other* error — a typo'd method name in the dispatch table —
+      // or a Dot registration bug is indistinguishable from a value Rails
+      // genuinely cannot visit.
       class Weird extends Nodes.Unary {}
       const v = new Visitors.Dot();
       (v as unknown as { dispatch: Map<unknown, string> }).dispatch.set(Weird, "visitTypoed");

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -2,7 +2,6 @@ import { Node } from "../nodes/node.js";
 import * as Nodes from "../nodes/index.js";
 import { Table } from "../table.js";
 import { Visitor, type NodeCtor } from "./visitor.js";
-import { UnsupportedVisitError } from "../errors.js";
 import { PlainString } from "../collectors/plain-string.js";
 import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 import { temporalClassName } from "../temporal-tag.js";
@@ -498,24 +497,15 @@ export class Dot extends Visitor {
     }
     this.nodes.push(node);
     this.withNode(node, () => {
-      try {
-        super.visit(object);
-      } catch (e) {
-        // visitor.rb:39 — no ancestor answered the dispatch. Dot has always
-        // reported that as Ruby's TypeError with the value's class name.
-        //
-        // `cause` has no counterpart in `raise TypeError, "Cannot visit ..."`
-        // because Ruby chains the active exception into `#cause` implicitly;
-        // JS does not, so passing it is what keeps the two equivalent. It is
-        // also required here by the `preserve-caught-error` lint rule. The
-        // class and message still match visitor.rb:39 exactly.
-        if (e instanceof UnsupportedVisitError) {
-          throw new TypeError(`Cannot visit ${this.classNameOf(object)}`, { cause: e });
-        }
-        // A mis-registered dispatch method (a plain Error from visitor.ts) is
-        // a bug in this visitor, not an unvisitable value — never relabel it.
-        throw e;
-      }
+      // visitor.rb:39 — no ancestor answered the dispatch. Since #5002,
+      // Visitor#visit's no-handler arm already throws Ruby's
+      // `TypeError, "Cannot visit <Class>"` directly, so it propagates
+      // unchanged. A mis-registered dispatch method (a plain Error from
+      // visitor.ts) likewise propagates as-is — it is a visitor bug, not an
+      // unvisitable value, and must never be relabelled. UnsupportedVisitError
+      // is unreachable here: Dot registers no `unsupported`-aliased handler,
+      // so no super.visit path produces it.
+      super.visit(object);
     });
     return undefined;
   }

--- a/packages/arel/src/visitors/visitor.ts
+++ b/packages/arel/src/visitors/visitor.ts
@@ -106,10 +106,9 @@ export abstract class Visitor {
       // mis-registration (a typo'd method name landed in the dispatch
       // cache). This is a visitor bug, not an unvisitable value, so it is
       // a plain Error rather than an UnsupportedVisitError (matching the
-      // same check in to-sql.ts:479). Subclasses that translate the
-      // "no entry at all" case into their own error — Dot re-raises it as
-      // Rails' `TypeError, "Cannot visit ..."` (visitor.rb:39) — must not
-      // swallow this one, or a typo'd registration masquerades as an
+      // same check in to-sql.ts:479). This must stay distinct from the
+      // no-handler terminal above (Rails' `TypeError, "Cannot visit ..."`,
+      // visitor.rb:38), or a typo'd registration masquerades as an
       // unvisitable value.
       throw new Error(
         `Dispatch method '${methodName}' is not defined on ${this.constructor.name} for node ${describeClass(object)}`,


### PR DESCRIPTION
## What

Since #5002, `Visitor#visit`'s no-handler arm throws Ruby's
`TypeError, "Cannot visit <Class>"` directly (visitor.rb:38) instead of
`UnsupportedVisitError`. `Dot#visit` still wrapped `super.visit` in a
try/catch that translated `UnsupportedVisitError` into that same `TypeError`
with a `{ cause }` — a layer that is now stale:

- **Vestigial:** the live no-handler path produces the `TypeError` itself and
  fell through to the bare `throw e`, propagating unchanged. The
  `instanceof UnsupportedVisitError` branch was never taken.
- **Wrong if reached:** `UnsupportedVisitError` is the *other* Rails terminal
  (`unsupported`-aliased handlers, to_sql.rb:828). Relabelling it as
  `Cannot visit X` would re-collapse inside Dot the two terminals #5002 split.

## Reachability finding

`UnsupportedVisitError` is **not reachable** from `super.visit` inside `Dot`.
Dot registers no `unsupported`-aliased handler, so no dispatch path within it
raises `UnsupportedVisitError`; a class with no handler at all hits the
no-handler arm, which now throws `TypeError` directly.

## Change

Remove the dead try/catch and let the base visitor's `TypeError` propagate
unchanged. The mis-registered-dispatch plain `Error` still propagates as-is
(never relabelled). `classNameOf` remains (used for `DotNode` names);
`describeClass` in `visitor.ts` is the sole name derivation for the message,
matching visitor.rb:38. Stale `{ cause }`/visitor.rb:39 comment removed; test
comment updated. Coverage retained: dot.test.ts still asserts a handler-less
class reaches Dot and gets `TypeError, "Cannot visit X"`, plus the
mis-registered passthrough.

Closes-story: dot-visit-unsupported-translation-stale-after-typeerror
