### PR TITLE
fix(eslint): conditional constructor carve-out + static/instance method-order slots

### DIFF
--- a/eslint/rails-file-structure-method-order.mjs
+++ b/eslint/rails-file-structure-method-order.mjs
@@ -26,6 +26,14 @@
  * unmatched class body with the sole unmatched bucket. Anything more
  * ambiguous is left unordered.
  *
+ * A manifest entry is `name` for a Ruby instance method and `static name`
+ * for a Ruby class method. Staticness discriminates only when it has to:
+ * a slot prefers a member of matching staticness, and falls back to a
+ * mismatched one when the container declares nothing with the expected
+ * staticness (the common port that flipped instance↔static). A same-named
+ * member of the OTHER staticness, when Rails defines only one of the two,
+ * is a trails invention and stays in the unmapped tail.
+ *
  * Autofix carries leading JSDoc / line comments with each declaration
  * (a comment is attached if it ends on the line immediately preceding
  * the next attached comment or the declaration itself).
@@ -218,55 +226,82 @@ function groupUnits(members) {
   const units = [];
   for (const m of members) {
     const name = memberName(m);
+    const isStatic = m.static === true;
     const prev = units[units.length - 1];
-    if (prev && prev.name === name && name !== null) {
+    // Staticness is part of the grouping key: an adjacent `static foo` /
+    // `foo` pair are two distinct members that map to two distinct Rails
+    // definitions, so they must not collapse into one movable unit.
+    if (prev && prev.name === name && prev.isStatic === isStatic && name !== null) {
       prev.members.push(m);
     } else {
-      units.push({ name, members: [m] });
+      units.push({ name, isStatic, members: [m] });
     }
   }
   return units;
 }
 
-function computeTargetOrder(currentNodes, expectedOrder) {
-  const names = currentNodes.map((u) => u.name);
-  const expectedSet = new Set(expectedOrder);
-  // Mapped subset in current order — used to detect "already correct"
-  // without rebuilding when nothing maps.
-  const mappedIdxByName = new Map();
-  names.forEach((n, i) => {
-    if (n && expectedSet.has(n) && !mappedIdxByName.has(n)) mappedIdxByName.set(n, i);
-  });
-  if (mappedIdxByName.size === 0) return currentNodes;
+// Manifest entries are `name` (instance) or `static name` (Rails class method).
+function parseExpected(entry) {
+  return entry.startsWith("static ")
+    ? { name: entry.slice(7), isStatic: true }
+    : { name: entry, isStatic: false };
+}
 
-  // Target: for each expected name, take ALL same-named nodes (in their
-  // current relative order) and place them together at the manifest
-  // position. Keeps getter/setter pairs and TS overload signatures
-  // grouped — splitting them would corrupt the class.
-  // Then append remaining unmapped nodes in their current order.
+// `declaredKeys` holds `static name` / `name` for EVERY member the container
+// declares, including ones that are not themselves orderable. `Arel::Table`'s
+// `static engine` is a PropertyDefinition (a field, not a method), so it never
+// becomes a unit — but it is still the member that owns the Rails
+// `static engine` slot, and its presence is what disqualifies the invented
+// instance `get engine()` from being moved into that slot.
+function computeTargetOrder(currentNodes, expectedOrder, declaredKeys) {
+  const expected = expectedOrder.map(parseExpected);
+  const names = currentNodes.map((u) => u.name);
+  const expectedNames = new Set(expected.map((e) => e.name));
+  // Does anything map at all? Used to detect "nothing to do" without
+  // rebuilding. Staticness only ever narrows which unit fills a slot, so
+  // a name-level check is the right coarse gate here.
+  if (!names.some((n) => n && expectedNames.has(n))) return currentNodes;
+
   const used = new Array(currentNodes.length).fill(false);
   const target = [];
 
-  // Constructor carve-out: TS class `constructor` always sorts first
-  // even when not in the manifest. Some Rails classes inherit from
-  // Struct (no explicit `initialize`), so the manifest omits
-  // `constructor` entirely; without this carve-out the constructor
-  // falls into the unmapped tail (visually unusual).
-  for (let i = 0; i < currentNodes.length; i++) {
-    if (!used[i] && names[i] === "constructor") {
-      target.push(currentNodes[i]);
-      used[i] = true;
-    }
-  }
-
-  for (const name of expectedOrder) {
-    if (name === "constructor") continue;
+  // Constructor carve-out: some Rails classes inherit from Struct and have
+  // no explicit `initialize`, so the manifest omits `constructor` and it
+  // would land in the unmapped tail (visually unusual) — hoist it in that
+  // case only. When the manifest DOES list `constructor`, Rails has a real
+  // `initialize` with a real source position, and honoring that position is
+  // the whole point of the manifest: `ActiveModel::Error` defines
+  // `def self.full_message` (error.rb:15) and `def self.generate_message`
+  // (:64) BEFORE `initialize` (:103). An unconditional hoist made those
+  // files lint clean while ordered wrongly.
+  if (!expectedNames.has("constructor")) {
     for (let i = 0; i < currentNodes.length; i++) {
-      if (used[i]) continue;
-      if (names[i] === name) {
+      if (!used[i] && names[i] === "constructor") {
         target.push(currentNodes[i]);
         used[i] = true;
       }
+    }
+  }
+
+  // Fill each expected slot. Prefer units whose staticness matches the Rails
+  // definition. Fall back to a staticness-mismatched unit only when the
+  // container declares NO member with the expected staticness — that is the
+  // common, benign case of a port that legitimately flipped instance↔static,
+  // and matching it keeps those files ordered exactly as before.
+  //
+  // When the expected member IS declared, a differently-scoped same-named
+  // member is a trails invention with no Rails counterpart, so it stays in the
+  // unmapped tail rather than being moved into a slot that belongs to its
+  // sibling. `Arel::Table` is the case: Rails has only the class-level
+  // `attr_accessor :engine` (table.rb:9); trails' extra instance
+  // `get engine()` is an invention and gets no Rails-derived position.
+  for (const { name, isStatic } of expected) {
+    const exactDeclared = declaredKeys.has(isStatic ? `static ${name}` : name);
+    for (let i = 0; i < currentNodes.length; i++) {
+      if (used[i] || names[i] !== name) continue;
+      if (exactDeclared && currentNodes[i].isStatic !== isStatic) continue;
+      target.push(currentNodes[i]);
+      used[i] = true;
     }
   }
   for (let i = 0; i < currentNodes.length; i++) {
@@ -371,7 +406,13 @@ const rule = {
         if (name) allClassNames.add(name);
         const orderable = node.body.filter(isOrderableClassMember);
         if (orderable.length < 2) return;
-        classCandidates.push({ node, name, members: orderable });
+        // Every declared member, orderable or not — see computeTargetOrder.
+        const declaredKeys = new Set();
+        for (const m of node.body) {
+          const n = memberName(m);
+          if (n) declaredKeys.add(m.static === true ? `static ${n}` : n);
+        }
+        classCandidates.push({ node, name, members: orderable, declaredKeys });
       },
       "Program:exit"(programNode) {
         // Assign each class body its manifest bucket. Exact TS-name match
@@ -408,7 +449,11 @@ const rule = {
         }
         for (const cand of classCandidates) {
           if (cand.expectedOrder) {
-            containers.push({ members: cand.members, expectedOrder: cand.expectedOrder });
+            containers.push({
+              members: cand.members,
+              expectedOrder: cand.expectedOrder,
+              declaredKeys: cand.declaredKeys,
+            });
           }
         }
 
@@ -419,6 +464,8 @@ const rule = {
             container: programNode,
             members: topLevel,
             expectedOrder: functionOrder,
+            // Top-level functions have no staticness; every name is "instance".
+            declaredKeys: new Set(topLevel.map(memberName).filter(Boolean)),
           });
         }
 
@@ -441,12 +488,12 @@ const rule = {
         let firstMismatch = null; // { node, expectedName, beforeName }
         let mismatchCount = 0;
 
-        for (const { members, expectedOrder } of containers) {
+        for (const { members, expectedOrder, declaredKeys } of containers) {
           // Collapse consecutive same-named members into units before
           // reorder, so TS overload groups (and class accessor pairs
           // where the pair is already adjacent) move as a single block.
           const units = groupUnits(members);
-          const target = computeTargetOrder(units, expectedOrder);
+          const target = computeTargetOrder(units, expectedOrder, declaredKeys);
           if (!ordersDiffer(units, target)) continue;
 
           // Each unit's slot spans from the first member's extended

--- a/eslint/rails-file-structure-method-order.test.mjs
+++ b/eslint/rails-file-structure-method-order.test.mjs
@@ -68,6 +68,21 @@ const fixture = {
       classes: { S: ["static first", "second"] },
       functions: [],
     },
+    // Rails defines a CLASS method (`static first`), and the port implemented
+    // it as an INSTANCE method (a legitimate instance↔static flip). With no
+    // `static first` declared, the slot falls back to the instance member so
+    // the file still orders — the common port, not an invention.
+    "packages/arel/src/fixture-flip.ts": {
+      classes: { F: ["static first", "second"] },
+      functions: [],
+    },
+    // Both a static and an instance member of the same name, each with its own
+    // Rails definition (`static kind` at validator.rb:103, `kind` at :116).
+    // Two distinct slots; each is filled by the matching-staticness member.
+    "packages/arel/src/fixture-both.ts": {
+      classes: { B2: ["static first", "constructor", "first"] },
+      functions: [],
+    },
   },
 };
 function restoreManifest() {
@@ -90,6 +105,8 @@ const ambiguousFile = path.join(REPO_ROOT, "packages/arel/src/fixture-ambiguous.
 const noEvidenceFile = path.join(REPO_ROOT, "packages/arel/src/fixture-noevidence.ts");
 const ctorFile = path.join(REPO_ROOT, "packages/arel/src/fixture-ctor.ts");
 const staticFile = path.join(REPO_ROOT, "packages/arel/src/fixture-static.ts");
+const flipFile = path.join(REPO_ROOT, "packages/arel/src/fixture-flip.ts");
+const bothFile = path.join(REPO_ROOT, "packages/arel/src/fixture-both.ts");
 
 const tester = new RuleTester({
   languageOptions: {
@@ -334,6 +351,34 @@ try {
         errors: [{ messageId: "outOfOrder" }],
         output:
           `class S {\n` + `  static first() {}\n` + `  second() {}\n` + `  first() {}\n` + `}\n`,
+      },
+      // Fallback: Rails has `static first` but the port made it an INSTANCE
+      // method (no static declared). The slot fills with the instance member
+      // — the legitimate instance↔static flip — so it still orders.
+      {
+        filename: flipFile,
+        code: `class F {\n` + `  second() {}\n` + `  first() {}\n` + `}\n`,
+        errors: [{ messageId: "outOfOrder" }],
+        output: `class F {\n` + `  first() {}\n` + `  second() {}\n` + `}\n`,
+      },
+      // Both declared: `static first` and instance `first` each fill their own
+      // slot by matching staticness, with the constructor between them —
+      // exactly the validator.rb `self.kind` / `initialize` / `kind` layout.
+      {
+        filename: bothFile,
+        code:
+          `class B2 {\n` +
+          `  first() {}\n` +
+          `  constructor() {}\n` +
+          `  static first() {}\n` +
+          `}\n`,
+        errors: [{ messageId: "outOfOrder" }],
+        output:
+          `class B2 {\n` +
+          `  static first() {}\n` +
+          `  constructor() {}\n` +
+          `  first() {}\n` +
+          `}\n`,
       },
       // Duplicate-named members (getter/setter pairs, TS overload
       // signatures) stay grouped under reorder. The manifest lists each

--- a/eslint/rails-file-structure-method-order.test.mjs
+++ b/eslint/rails-file-structure-method-order.test.mjs
@@ -54,6 +54,20 @@ const fixture = {
       classes: { Zzz: sharedClassOrder },
       functions: [],
     },
+    // `constructor` IS in the manifest, at a non-zero index — Rails defines
+    // `initialize` AFTER other members (ActiveModel::Error's
+    // `def self.full_message` at error.rb:15 vs `initialize` at :103). The
+    // carve-out must NOT hoist it past `first`.
+    "packages/arel/src/fixture-ctor.ts": {
+      classes: { C: ["first", "constructor", "third"] },
+      functions: [],
+    },
+    // A Rails CLASS method (`static first`) alongside a same-named instance
+    // member that Rails does not define — the Arel::Table `engine` shape.
+    "packages/arel/src/fixture-static.ts": {
+      classes: { S: ["static first", "second"] },
+      functions: [],
+    },
   },
 };
 function restoreManifest() {
@@ -74,6 +88,8 @@ const multiFile = path.join(REPO_ROOT, "packages/arel/src/fixture-multi.ts");
 const renameFile = path.join(REPO_ROOT, "packages/arel/src/fixture-rename.ts");
 const ambiguousFile = path.join(REPO_ROOT, "packages/arel/src/fixture-ambiguous.ts");
 const noEvidenceFile = path.join(REPO_ROOT, "packages/arel/src/fixture-noevidence.ts");
+const ctorFile = path.join(REPO_ROOT, "packages/arel/src/fixture-ctor.ts");
+const staticFile = path.join(REPO_ROOT, "packages/arel/src/fixture-static.ts");
 
 const tester = new RuleTester({
   languageOptions: {
@@ -293,6 +309,31 @@ try {
           `  second() {}\n` +
           `  third() {}\n` +
           `}\n`,
+      },
+      // …but the carve-out is CONDITIONAL. When the manifest DOES list
+      // `constructor`, Rails has a real `initialize` at a real source
+      // position and that position wins — `first` must end up BEFORE it.
+      // An unconditional hoist let error.ts / attribute.ts lint clean while
+      // their Rails-preceding members sat after the constructor.
+      {
+        filename: ctorFile,
+        code: `class C {\n` + `  constructor() {}\n` + `  third() {}\n` + `  first() {}\n` + `}\n`,
+        errors: [{ messageId: "outOfOrder" }],
+        output:
+          `class C {\n` + `  first() {}\n` + `  constructor() {}\n` + `  third() {}\n` + `}\n`,
+      },
+      // A Rails class method and a same-named instance member are distinct.
+      // `static first` fills the Rails slot; the instance `first()` is a
+      // trails invention with no Rails counterpart, so it is NOT ordered —
+      // it stays in the unmapped tail rather than being moved into the slot
+      // that belongs to the static.
+      {
+        filename: staticFile,
+        code:
+          `class S {\n` + `  second() {}\n` + `  first() {}\n` + `  static first() {}\n` + `}\n`,
+        errors: [{ messageId: "outOfOrder" }],
+        output:
+          `class S {\n` + `  static first() {}\n` + `  second() {}\n` + `  first() {}\n` + `}\n`,
       },
       // Duplicate-named members (getter/setter pairs, TS overload
       // signatures) stay grouped under reorder. The manifest lists each

--- a/packages/activemodel/src/attribute-set.ts
+++ b/packages/activemodel/src/attribute-set.ts
@@ -12,10 +12,6 @@ export class AttributeSet {
   private attributes: Map<string, Attribute>;
   private _frozen = false;
 
-  constructor(attributes: Map<string, Attribute> = new Map()) {
-    this.attributes = attributes;
-  }
-
   /**
    * Yield each underlying Attribute value.
    *
@@ -55,6 +51,10 @@ export class AttributeSet {
       if (!drop.has(name)) result.set(name, attr);
     }
     return result;
+  }
+
+  constructor(attributes: Map<string, Attribute> = new Map()) {
+    this.attributes = attributes;
   }
 
   castTypes(): Record<string, import("./type/value.js").Type> {

--- a/packages/activemodel/src/attribute-set/builder.ts
+++ b/packages/activemodel/src/attribute-set/builder.ts
@@ -111,20 +111,6 @@ export class LazyAttributeHash {
   private additionalTypes: Map<string, Type>;
   private defaultAttributes: Map<string, Attribute>;
 
-  constructor(
-    types: Map<string, Type>,
-    values: Record<string, unknown>,
-    additionalTypes: Map<string, Type> = new Map(),
-    defaultAttributes: Map<string, Attribute> = new Map(),
-    delegateHash: Map<string, Attribute> = new Map(),
-  ) {
-    this.types = types;
-    this.values = values;
-    this.additionalTypes = additionalTypes;
-    this.defaultAttributes = defaultAttributes;
-    this.delegate = delegateHash;
-  }
-
   /**
    * Return a new map applying `fn` to each materialized Attribute.
    *
@@ -177,6 +163,20 @@ export class LazyAttributeHash {
       if (!drop.has(name)) result.set(name, attr);
     }
     return result;
+  }
+
+  constructor(
+    types: Map<string, Type>,
+    values: Record<string, unknown>,
+    additionalTypes: Map<string, Type> = new Map(),
+    defaultAttributes: Map<string, Attribute> = new Map(),
+    delegateHash: Map<string, Attribute> = new Map(),
+  ) {
+    this.types = types;
+    this.values = values;
+    this.additionalTypes = additionalTypes;
+    this.defaultAttributes = defaultAttributes;
+    this.delegate = delegateHash;
   }
 
   isKey(key: string): boolean {

--- a/packages/activemodel/src/attribute.ts
+++ b/packages/activemodel/src/attribute.ts
@@ -34,6 +34,40 @@ export abstract class Attribute {
   private _cachedValueForDatabase: unknown;
   private _hasValueForDatabase: boolean;
 
+  // --- Factory methods ---
+
+  static fromDatabase(name: string, value: unknown, type: Type, castValue?: unknown): FromDatabase {
+    if (arguments.length >= 4) {
+      return new FromDatabase(name, value, type, null, castValue);
+    }
+    return new FromDatabase(name, value, type, null);
+  }
+
+  static fromUser(
+    name: string,
+    value: unknown,
+    type: Type,
+    originalAttribute: Attribute | null = null,
+  ): FromUser {
+    return new FromUser(name, value, type, originalAttribute);
+  }
+
+  static withCastValue(name: string, value: unknown, type: Type): WithCastValue {
+    return new WithCastValue(name, value, type);
+  }
+
+  static null(name: string): Null {
+    return new Null(name);
+  }
+
+  static uninitialized(name: string, type: Type): Uninitialized {
+    return new Uninitialized(name, type);
+  }
+
+  get valueBeforeTypeCast(): unknown {
+    return this._valueBeforeTypeCast;
+  }
+
   constructor(
     name: string,
     valueBeforeTypeCast: unknown,
@@ -55,44 +89,6 @@ export abstract class Attribute {
     }
     this._cachedValueForDatabase = undefined;
     this._hasValueForDatabase = false;
-  }
-
-  // --- Factory methods ---
-
-  static fromDatabase(name: string, value: unknown, type: Type, castValue?: unknown): FromDatabase {
-    if (arguments.length >= 4) {
-      return new FromDatabase(name, value, type, null, castValue);
-    }
-    return new FromDatabase(name, value, type, null);
-  }
-
-  static fromUser(
-    name: string,
-    value: unknown,
-    type: Type,
-    originalAttribute: Attribute | null = null,
-  ): FromUser {
-    return new FromUser(name, value, type, originalAttribute);
-  }
-
-  withCastValue(value: unknown): Attribute {
-    return new WithCastValue(this.name, value, this.type);
-  }
-
-  static withCastValue(name: string, value: unknown, type: Type): WithCastValue {
-    return new WithCastValue(name, value, type);
-  }
-
-  static null(name: string): Null {
-    return new Null(name);
-  }
-
-  static uninitialized(name: string, type: Type): Uninitialized {
-    return new Uninitialized(name, type);
-  }
-
-  get valueBeforeTypeCast(): unknown {
-    return this._valueBeforeTypeCast;
   }
 
   get value(): unknown {
@@ -152,6 +148,10 @@ export abstract class Attribute {
 
   withValueFromDatabase(value: unknown): Attribute {
     return Attribute.fromDatabase(this.name, value, this.type);
+  }
+
+  withCastValue(value: unknown): Attribute {
+    return new WithCastValue(this.name, value, this.type);
   }
 
   withType(type: Type): Attribute {

--- a/packages/activemodel/src/error.ts
+++ b/packages/activemodel/src/error.ts
@@ -83,30 +83,6 @@ export class Error {
   readonly rawType: string;
   readonly options: Record<string, unknown>;
 
-  constructor(
-    base: ModelBase,
-    attribute: string,
-    type: string = "invalid",
-    options: Record<string, unknown> = {},
-    rawType?: string,
-  ) {
-    this.base = base;
-    this.attribute = attribute;
-    // Rails `NestedError#initialize` keeps `@raw_type = inner_error.raw_type`
-    // while allowing `@type` to be overridden via `override_options[:type]`
-    // (activemodel/lib/active_model/nested_error.rb:8-15). Message
-    // generation keys off `raw_type` so i18n lookups still resolve the
-    // original error's key even when the surface `type` has been renamed.
-    // `rawType` defaults to `type` for the common case where they match.
-    this.rawType = rawType ?? type;
-    this.type = type || "invalid";
-    this.options = options;
-  }
-
-  get fullMessage(): string {
-    return Error.fullMessage(this.attribute, this.message, this.base);
-  }
-
   static fullMessage(attribute: string, message: string, base: ModelBase): string {
     if (attribute === "base") return message;
     const modelClass = base?.constructor as ModelClass | undefined;
@@ -246,6 +222,26 @@ export class Error {
     });
   }
 
+  constructor(
+    base: ModelBase,
+    attribute: string,
+    type: string = "invalid",
+    options: Record<string, unknown> = {},
+    rawType?: string,
+  ) {
+    this.base = base;
+    this.attribute = attribute;
+    // Rails `NestedError#initialize` keeps `@raw_type = inner_error.raw_type`
+    // while allowing `@type` to be overridden via `override_options[:type]`
+    // (activemodel/lib/active_model/nested_error.rb:8-15). Message
+    // generation keys off `raw_type` so i18n lookups still resolve the
+    // original error's key even when the surface `type` has been renamed.
+    // `rawType` defaults to `type` for the common case where they match.
+    this.rawType = rawType ?? type;
+    this.type = type || "invalid";
+    this.options = options;
+  }
+
   get message(): string {
     // Rails error.rb:136-141: dispatch on raw_type shape — Symbol → generate_message, else → literal.
     // TS has no Symbol type; identifier-shaped strings (no spaces/punctuation) are the equivalent.
@@ -281,6 +277,10 @@ export class Error {
 
   get detail(): Record<string, unknown> {
     return this.details;
+  }
+
+  get fullMessage(): string {
+    return Error.fullMessage(this.attribute, this.message, this.base);
   }
 
   /**

--- a/packages/activemodel/src/errors.ts
+++ b/packages/activemodel/src/errors.ts
@@ -23,10 +23,6 @@ export class Errors<TBase extends object = object> {
   private _errors: ActiveModelError[] = [];
   private _base: TBase | null;
 
-  constructor(base: TBase | null) {
-    this._base = base;
-  }
-
   get errors(): this {
     return this;
   }
@@ -38,6 +34,10 @@ export class Errors<TBase extends object = object> {
    */
   get objects(): ActiveModelError[] {
     return this._errors;
+  }
+
+  constructor(base: TBase | null) {
+    this._base = base;
   }
 
   /**

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -100,6 +100,68 @@ export class ModelName {
   private _humanFallback: string;
   private _klass: ModelLike | null;
 
+  get cacheKey(): string {
+    return this.collection;
+  }
+
+  /**
+   * Mirrors Rails `@name.match?(regexp)`. Returns whether the class
+   * name matches the given regex (boolean — this is `match?` semantic,
+   * not the integer position that Ruby `=~` returns).
+   *
+   * Preserves `pattern.lastIndex` so repeated calls with `/g` or `/y`
+   * regexes stay stable — `RegExp.prototype.test` advances `lastIndex`
+   * on stateful flags, but Ruby `match?` is stateless.
+   */
+  match(pattern: unknown): boolean {
+    if (!(pattern instanceof RegExp)) {
+      throw new ArgumentError("ModelName#match requires a RegExp");
+    }
+    const savedLastIndex = pattern.lastIndex;
+    try {
+      return pattern.test(this.name);
+    } finally {
+      pattern.lastIndex = savedLastIndex;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // String-ness — Rails `ActiveModel::Name < String` (naming.rb:10, :151-152):
+  //   include Comparable
+  //   delegate :==, :===, :<=>, :=~, :"!~", :eql?, :match?, :to_s,
+  //            :to_str, :as_json, to: :name
+  //
+  // JS can't overload operators, so we expose methods + the one coercion
+  // hook JS does have: `Symbol.toPrimitive`. That covers IMPLICIT string
+  // coercion only — `String(modelName)`, template literals, `modelName +
+  // ""`, and loose `==` against a string. It does NOT trigger on strict
+  // `===` / `Object.is` / matchers that use strict identity without
+  // coercion; for those, callers use `mn.name` or `mn.equals(other)`.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Mirrors Rails `to_s` / `to_str` delegated to `@name`
+   * (naming.rb:131-152). Rails' `@name` is the full constant path
+   * (`"Blog::Post"`). TS class names carry no `::`, so we reconstruct the
+   * qualified path from the namespace segments in the constructor; `toString`
+   * returns that full path (`"Blog::Post"`) to match Rails.
+   */
+  toString(): string {
+    return this.name;
+  }
+
+  /**
+   * Mirrors Rails `@name.as_json` — `String#as_json` just returns the
+   * string (and accepts an ignored `options` Hash). Returns `this.name`
+   * as-is; accepts (but ignores) an options argument so callers match
+   * Rails' signature and the rest of this codebase's `asJson(options?)`
+   * conventions. Lets `JSON.stringify(mn)` emit the plain class name
+   * rather than `{}` / the object form.
+   */
+  asJson(_options?: unknown): string {
+    return this.name;
+  }
+
   /**
    * Construct a ModelName.
    *
@@ -217,68 +279,6 @@ export class ModelName {
     if (uncountable) routeKey = `${routeKey}_index`;
     this.routeKey = routeKey;
     this.singularRouteKey = singularize(this.routeKey);
-  }
-
-  get cacheKey(): string {
-    return this.collection;
-  }
-
-  /**
-   * Mirrors Rails `@name.match?(regexp)`. Returns whether the class
-   * name matches the given regex (boolean — this is `match?` semantic,
-   * not the integer position that Ruby `=~` returns).
-   *
-   * Preserves `pattern.lastIndex` so repeated calls with `/g` or `/y`
-   * regexes stay stable — `RegExp.prototype.test` advances `lastIndex`
-   * on stateful flags, but Ruby `match?` is stateless.
-   */
-  match(pattern: unknown): boolean {
-    if (!(pattern instanceof RegExp)) {
-      throw new ArgumentError("ModelName#match requires a RegExp");
-    }
-    const savedLastIndex = pattern.lastIndex;
-    try {
-      return pattern.test(this.name);
-    } finally {
-      pattern.lastIndex = savedLastIndex;
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // String-ness — Rails `ActiveModel::Name < String` (naming.rb:10, :151-152):
-  //   include Comparable
-  //   delegate :==, :===, :<=>, :=~, :"!~", :eql?, :match?, :to_s,
-  //            :to_str, :as_json, to: :name
-  //
-  // JS can't overload operators, so we expose methods + the one coercion
-  // hook JS does have: `Symbol.toPrimitive`. That covers IMPLICIT string
-  // coercion only — `String(modelName)`, template literals, `modelName +
-  // ""`, and loose `==` against a string. It does NOT trigger on strict
-  // `===` / `Object.is` / matchers that use strict identity without
-  // coercion; for those, callers use `mn.name` or `mn.equals(other)`.
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Mirrors Rails `to_s` / `to_str` delegated to `@name`
-   * (naming.rb:131-152). Rails' `@name` is the full constant path
-   * (`"Blog::Post"`). TS class names carry no `::`, so we reconstruct the
-   * qualified path from the namespace segments in the constructor; `toString`
-   * returns that full path (`"Blog::Post"`) to match Rails.
-   */
-  toString(): string {
-    return this.name;
-  }
-
-  /**
-   * Mirrors Rails `@name.as_json` — `String#as_json` just returns the
-   * string (and accepts an ignored `options` Hash). Returns `this.name`
-   * as-is; accepts (but ignores) an options argument so callers match
-   * Rails' signature and the rest of this codebase's `asJson(options?)`
-   * conventions. Lets `JSON.stringify(mn)` emit the plain class name
-   * rather than `{}` / the object form.
-   */
-  asJson(_options?: unknown): string {
-    return this.name;
   }
 
   /** Implicit coercion hook so `String(mn)`, `"${mn}"`, `mn + ""` all work. */

--- a/packages/activemodel/src/validator.ts
+++ b/packages/activemodel/src/validator.ts
@@ -77,14 +77,14 @@ export function shouldValidate(record: ValidatableRecord, options: ConditionalOp
 export abstract class Validator<TBase extends object = object> {
   readonly options: Record<string, unknown>;
 
-  constructor(options: Record<string, unknown> = {}) {
-    const { class: _cls, ...rest } = options;
-    this.options = Object.freeze(rest);
-  }
-
   static get kind(): string {
     const name = underscore(this.name);
     return name.endsWith("_validator") ? name.slice(0, -"_validator".length) : name;
+  }
+
+  constructor(options: Record<string, unknown> = {}) {
+    const { class: _cls, ...rest } = options;
+    this.options = Object.freeze(rest);
   }
 
   get kind(): string {

--- a/packages/arel/src/collectors/composite.ts
+++ b/packages/arel/src/collectors/composite.ts
@@ -20,11 +20,6 @@ export class Composite {
   private right: CollectorLike;
   preparable = true;
 
-  constructor(left: CollectorLike, right: CollectorLike) {
-    this.left = left;
-    this.right = right;
-  }
-
   get retryable(): boolean {
     if ("retryable" in this.left && this.left.retryable === false) return false;
     if ("retryable" in this.right && this.right.retryable === false) return false;
@@ -36,6 +31,11 @@ export class Composite {
       (this.left as CollectorLike & { retryable: boolean }).retryable = value;
     if ("retryable" in this.right)
       (this.right as CollectorLike & { retryable: boolean }).retryable = value;
+  }
+
+  constructor(left: CollectorLike, right: CollectorLike) {
+    this.left = left;
+    this.right = right;
   }
 
   addBind(value: unknown, block?: (index: number) => string): this {

--- a/packages/arel/src/nodes/casted.ts
+++ b/packages/arel/src/nodes/casted.ts
@@ -57,14 +57,14 @@ export class Casted extends NodeExpression {
   readonly value: unknown;
   readonly attribute: Attribute;
 
+  valueBeforeTypeCast(): unknown {
+    return this.value;
+  }
+
   constructor(value: unknown, attribute: Attribute) {
     super();
     this.value = value;
     this.attribute = attribute;
-  }
-
-  valueBeforeTypeCast(): unknown {
-    return this.value;
   }
 
   /**

--- a/packages/arel/src/nodes/function.ts
+++ b/packages/arel/src/nodes/function.ts
@@ -10,19 +10,19 @@ export class Function extends NodeExpression {
   distinct: boolean;
   private _alias: Node | null;
 
-  constructor(expressions: Node[], aliasNode: Node | string | null = null) {
-    super();
-    this.expressions = expressions;
-    this._alias = typeof aliasNode === "string" ? new SqlLiteral(aliasNode) : aliasNode;
-    this.distinct = false;
-  }
-
   get alias(): Node | null {
     return this._alias;
   }
 
   set alias(value: Node | string | null) {
     this._alias = typeof value === "string" ? new SqlLiteral(value) : value;
+  }
+
+  constructor(expressions: Node[], aliasNode: Node | string | null = null) {
+    super();
+    this.expressions = expressions;
+    this._alias = typeof aliasNode === "string" ? new SqlLiteral(aliasNode) : aliasNode;
+    this.distinct = false;
   }
 
   as(aliasName: string): this {

--- a/packages/arel/src/nodes/sql-literal.ts
+++ b/packages/arel/src/nodes/sql-literal.ts
@@ -15,16 +15,16 @@ export class SqlLiteral extends Node {
   readonly value: string;
   retryableFlag = false;
 
+  get retryable(): boolean {
+    return this.retryableFlag;
+  }
+
   constructor(value: string, options?: { retryable?: boolean }) {
     super();
     this.value = value;
     if (options?.retryable) {
       this.retryableFlag = true;
     }
-  }
-
-  get retryable(): boolean {
-    return this.retryableFlag;
   }
 
   fetchAttribute(_block?: (attr: Node) => unknown): unknown {

--- a/packages/arel/src/nodes/unary.ts
+++ b/packages/arel/src/nodes/unary.ts
@@ -4,14 +4,14 @@ import { NodeExpression } from "./node-expression.js";
 export class Unary extends NodeExpression {
   readonly expr: unknown;
 
-  constructor(expr: unknown) {
-    super();
-    this.expr = expr;
-  }
-
   // Mirrors Rails `alias :value :expr` (unary.rb:7).
   get value(): unknown {
     return this.expr;
+  }
+
+  constructor(expr: unknown) {
+    super();
+    this.expr = expr;
   }
 
   accept<T>(visitor: NodeVisitor<T>): T {

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -31,19 +31,6 @@ export interface TypeCaster {
  */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Table extends Node {
-  constructor(name: string, options?: { as?: string; klass?: TableKlass; typeCaster?: unknown }) {
-    super();
-    this.name = name;
-    const as = options?.as ?? null;
-    this.tableAlias = as === name ? null : as;
-    this.klass = options?.klass;
-    this.typeCaster = options?.typeCaster ?? null;
-  }
-
-  readonly name: string;
-  readonly tableAlias: string | null;
-  readonly klass?: TableKlass;
-
   /** Mirrors: `Arel::Table.engine` (table.rb:8-9, `class << self; attr_accessor
    *  :engine`). Rails assigns `ActiveRecord::Base` from
    *  `active_record.rb:562-564`; trails assigns it at the bottom of
@@ -55,6 +42,19 @@ export class Table extends Node {
 
   static set engine(value: ArelEngine | null) {
     _engine.current = value;
+  }
+
+  readonly name: string;
+  readonly tableAlias: string | null;
+  readonly klass?: TableKlass;
+
+  constructor(name: string, options?: { as?: string; klass?: TableKlass; typeCaster?: unknown }) {
+    super();
+    this.name = name;
+    const as = options?.as ?? null;
+    this.tableAlias = as === name ? null : as;
+    this.klass = options?.klass;
+    this.typeCaster = options?.typeCaster ?? null;
   }
 
   /**

--- a/scripts/build-rails-file-structure-manifest.ts
+++ b/scripts/build-rails-file-structure-manifest.ts
@@ -68,6 +68,11 @@ interface RubyEntity {
   instanceMethods?: RubyMethod[];
   classMethods?: RubyMethod[];
 }
+type TaggedMethod = RubyMethod & { isStatic: boolean };
+// Attach staticness to each method so it survives the source-line merge — the
+// manifest needs to know whether the interleaved entry was a class method.
+const tagStatic = (methods: RubyMethod[] = [], isStatic: boolean): TaggedMethod[] =>
+  methods.map((m) => ({ ...m, isStatic }));
 
 const railsApi = JSON.parse(fs.readFileSync(RAILS_API_PATH, "utf8"));
 
@@ -121,13 +126,23 @@ const ORDER_ONLY_CANDIDATES: Record<string, string[]> = {
 // alternate spelling becomes "unmapped" and skips ordering. The rule filters
 // each container's expected names to those actually present, so emitting both
 // is a safe no-op for whichever spelling wasn't used.
-const pushMethod = (list: string[], seen: Set<string>, name: string) => {
+// `isStatic` records whether the Ruby method was a CLASS method, emitted as a
+// `static ` prefix on the manifest entry. Without it, a Ruby class that defines
+// both `def foo` and `def self.foo` — or a TS class that adds an instance member
+// alongside a real Rails class method — collapses to ONE expected slot, and the
+// rule moves whichever member it happens to match. `Arel::Table` is the live
+// case: `engine` exists only as a class-level `attr_accessor` (table.rb:9), but
+// trails also has an invented instance `get engine()`; a bare `engine` entry let
+// that invention be repositioned against the class accessor's slot. Entries in
+// the `functions` bucket stay bare — top-level functions have no staticness.
+const pushMethod = (list: string[], seen: Set<string>, name: string, isStatic: boolean) => {
   const candidates = rubyMethodToTs(name) ?? ORDER_ONLY_CANDIDATES[name];
   if (!candidates || candidates.length === 0) return;
   for (const ts of candidates) {
-    if (seen.has(ts)) continue;
-    seen.add(ts);
-    list.push(ts);
+    const entry = isStatic ? `static ${ts}` : ts;
+    if (seen.has(entry)) continue;
+    seen.add(entry);
+    list.push(entry);
   }
 };
 
@@ -188,23 +203,28 @@ for (const [pkg, rubyPkg] of Object.entries<any>(railsApi.packages)) {
       if (!host.file) continue;
       const className = host.fqn.split("::").pop() ?? host.fqn;
       // Order by source line rather than appending classMethods after
-      // instanceMethods — see mergeBySourceLine for why. Bucketing by `file`
-      // happens below, after ordering; the merge is a total order on `line`, so
-      // each file's slice is still ascending.
-      for (const m of mergeBySourceLine(host.instanceMethods, host.classMethods)) {
+      // instanceMethods — see mergeBySourceLine for why. Tag each method with
+      // `isStatic` BEFORE merging so the interleaved order keeps the class-vs-
+      // instance distinction the manifest needs (`static name` vs `name`).
+      // Bucketing by `file` happens below, after ordering; the merge is a total
+      // order on `line`, so each file's slice is still ascending.
+      for (const m of mergeBySourceLine(tagStatic(host.instanceMethods, false), tagStatic(host.classMethods, true))) {
         const file = m.file ?? host.file;
         noteClass(file, className, host.fqn);
         const b = bucketFor(file, className);
-        pushMethod(b.names, b.seen, m.name);
+        pushMethod(b.names, b.seen, m.name, m.isStatic);
       }
     }
   };
   const visitModules = (entities: Record<string, RubyEntity>) => {
     for (const host of Object.values(entities)) {
       if (!host.file) continue;
-      for (const m of mergeBySourceLine(host.instanceMethods, host.classMethods)) {
+      // Modules port to top-level functions, which have no staticness — every
+      // entry stays bare regardless of whether Ruby declared it on the module
+      // or its singleton.
+      for (const m of mergeBySourceLine(tagStatic(host.instanceMethods, false), tagStatic(host.classMethods, true))) {
         const b = bucketFor(m.file ?? host.file, FUNCTIONS_KEY);
-        pushMethod(b.names, b.seen, m.name);
+        pushMethod(b.names, b.seen, m.name, false);
       }
     }
   };

--- a/scripts/build-rails-file-structure-manifest.ts
+++ b/scripts/build-rails-file-structure-manifest.ts
@@ -208,7 +208,10 @@ for (const [pkg, rubyPkg] of Object.entries<any>(railsApi.packages)) {
       // instance distinction the manifest needs (`static name` vs `name`).
       // Bucketing by `file` happens below, after ordering; the merge is a total
       // order on `line`, so each file's slice is still ascending.
-      for (const m of mergeBySourceLine(tagStatic(host.instanceMethods, false), tagStatic(host.classMethods, true))) {
+      for (const m of mergeBySourceLine(
+        tagStatic(host.instanceMethods, false),
+        tagStatic(host.classMethods, true),
+      )) {
         const file = m.file ?? host.file;
         noteClass(file, className, host.fqn);
         const b = bucketFor(file, className);
@@ -222,7 +225,10 @@ for (const [pkg, rubyPkg] of Object.entries<any>(railsApi.packages)) {
       // Modules port to top-level functions, which have no staticness — every
       // entry stays bare regardless of whether Ruby declared it on the module
       // or its singleton.
-      for (const m of mergeBySourceLine(tagStatic(host.instanceMethods, false), tagStatic(host.classMethods, true))) {
+      for (const m of mergeBySourceLine(
+        tagStatic(host.instanceMethods, false),
+        tagStatic(host.classMethods, true),
+      )) {
         const b = bucketFor(m.file ?? host.file, FUNCTIONS_KEY);
         pushMethod(b.names, b.seen, m.name, false);
       }


### PR DESCRIPTION
## What

Closes two ways a `rails-file-structure-method-order`-clean file could still be
unfaithful to Rails' layout (surfaced by review of #5039).

### 1. Conditional constructor carve-out

The rule force-hoisted any `constructor` to index 0 and skipped it in the
expected-order loop, so a manifest that placed members **before** the
constructor could not be expressed — the file linted clean while ordered
wrongly. Now the carve-out fires **only when `constructor` is absent** from the
expected list (the Struct-subclass case it was written for); when the manifest
lists it, its position is honored.

- `error.ts` converges: `static fullMessage` (error.rb:15) / `static
  generateMessage` (:64) precede the constructor (`initialize` at :103).
- `attribute.ts` converges: the five `class << self` factories (attribute.rb:7-24)
  precede the constructor (:33).
- `validator.ts` converges: `static kind` (:103) → constructor (:108) →
  `kind` (:116).

### 2. Static vs instance members are distinguishable

The manifest builder now records staticness (`static name` vs `name`), threaded
through #5039's source-line interleave so both ordering and the class/instance
distinction survive. A slot prefers a matching-staticness member and only falls
back to a mismatch when the container declares nothing with the expected
staticness (the common instance↔static port). A differently-scoped same-named
member that Rails does **not** define is a trails invention with no Rails
counterpart and stays in the unmapped tail rather than hijacking its sibling's
slot — `Arel::Table`'s invented instance `get engine()` no longer moves into the
class-level `attr_accessor :engine` (table.rb:9) slot.

## Testing

- New rule unit cases (fail on the pre-fix rule): conditional carve-out honors a
  non-zero manifest `constructor` index; a Rails class method and same-named
  instance invention resolve to distinct slots.
- `packages/arel/src` + `packages/activemodel/src` lint clean (CI-equivalent
  method-order run).
- `pnpm typecheck` clean; arel + activemodel suites (3551 tests) pass.

Closes-story: rails-file-structure-method-order-constructor-carveout

## Dependency & size note

Branched after #5039 (source-line interleave) merged and rebased onto it; the
merge tags each Ruby method with its staticness **before** #5039's
`mergeBySourceLine`, so both the line ordering and the class/instance
distinction survive into the manifest.

The diff is ~585 LOC, above the 500 default, but **169/169 of it is pure
mechanical member relocation** (`eslint --fix` output, balanced insert/delete)
across the 13 files the now-faithful manifest reorders. The rule goes live in CI
for `arel` + `activemodel`, so those moves **must** ship in the same PR —
splitting would leave CI red on the un-reordered files. The non-mechanical
surface (rule + manifest builder + tests) is ~247 lines.
