### PR TITLE
refactor(arel): converge the Hash analogue into rubyClassName

### DIFF
--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -6,6 +6,7 @@ import { UnsupportedVisitError } from "../errors.js";
 import { PlainString } from "../collectors/plain-string.js";
 import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 import { temporalClassName } from "../temporal-tag.js";
+import { isHashAnalogue } from "./ruby-class.js";
 
 type AppendableCollector = { append(s: string): unknown; value: string };
 
@@ -497,14 +498,6 @@ export class Dot extends Visitor {
     }
     this.nodes.push(node);
     this.withNode(node, () => {
-      // Residue over the shared class dispatch: `rubyClassName` names a value
-      // `Hash` only when its prototype is Object.prototype, but Ruby's
-      // ancestor walk (visitor.rb:36-41) reaches `visit_Hash` for any Hash
-      // descendant — in JS, any record derived from a plain record (isHash).
-      if (this.isHash(object)) {
-        this.visitHash(object as Record<string, unknown>);
-        return;
-      }
       try {
         super.visit(object);
       } catch (e) {
@@ -610,67 +603,15 @@ export class Dot extends Visitor {
   }
 
   /**
-   * The trails analogue of Ruby's `o.is_a?(Hash)`.
-   *
-   * Rails' `Visitor#visit` (visitor.rb:36-41) walks `object.class.ancestors`
-   * for a visitable class, so `class MyHash < Hash` reaches `visit_Hash`
-   * while `class Config < Object` finds no handler and raises TypeError.
-   * JS has no Hash class — the object literal *is* the Hash — so the
-   * equivalent of that ancestor split is whether the prototype chain is
-   * made only of plain objects:
-   *
-   *   - `{ a: 1 }` and `Object.create(null)` are Hashes;
-   *   - `Object.create({ a: 1 })` is the JS way to derive a record from
-   *     another record — Ruby's `MyHash < Hash` — so it's a Hash too;
-   *   - a class instance (including `class Config extends Object`) has a
-   *     prototype whose `constructor` is that class, which is Ruby's
-   *     `Config < Object`: no ancestor handler, so it does not route here.
-   *
-   * `visitHash` reads `Object.entries`, which sees only own enumerable
-   * string keys — inherited and symbol keys are not walked, matching the
-   * fields Rails' `each_with_index` over a Hash would yield for the
-   * derived record's own pairs.
-   */
-  private isHash(o: unknown): boolean {
-    if (!o || typeof o !== "object") return false;
-    if (Array.isArray(o)) return false;
-    // Node covers Table (which extends Node).
-    if (o instanceof Node) return false;
-    for (
-      let proto = Object.getPrototypeOf(o);
-      proto !== null;
-      proto = Object.getPrototypeOf(proto)
-    ) {
-      if (proto === Object.prototype) return true;
-      // What marks a *class* prototype is the back-reference: `class C {}`
-      // installs `C.prototype.constructor === C`, so the own `constructor`
-      // is a function pointing back at this very object. Anything else —
-      // absent, a non-function, or a function whose `.prototype` is some
-      // other object — leaves the value a record, so keep walking. A literal
-      // `constructor` key (`{ constructor: "x" }`) fails the identity, and
-      // its name is irrelevant to dispatch anyway: Ruby dispatches by
-      // ancestry (visitor.rb:36-41), so a Hash with a `:constructor` key is
-      // still a Hash and reaches visit_Hash (dot.rb:220).
-      const ctor = Object.getOwnPropertyDescriptor(proto, "constructor")?.value as
-        | { prototype?: unknown }
-        | undefined;
-      if (typeof ctor === "function" && ctor.prototype === proto) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  /**
    * Rails: `o.class.name`. We use the JS ctor name for objects and emit
    * Rails-style class names for primitives and nil values — `String`,
    * `Integer`, `Float`, `TrueClass`, `FalseClass`, `NilClass`, `Symbol`,
    * `Time` — so leaf nodes match Rails' shape.
    *
-   * Values matching the Hash analogue (see isHash) are named `Hash` rather
+   * Values matching the Hash analogue (see isHashAnalogue) are named `Hash` rather
    * than JS's ctor name `Object`. Rails labels the node `o.class.name`
    * (dot.rb:253), so a *named* Hash subclass would be "MyHash" — but no
-   * value reaching this arm can supply such a name: isHash admits only
+   * value reaching this arm can supply such a name: isHashAnalogue admits only
    * object literals, `Object.create(null)`, and records derived from those,
    * every one of which reports a ctor name of `Object`. Class instances,
    * the only objects with a distinct ctor name, are Ruby's `Config < Object`
@@ -688,7 +629,7 @@ export class Dot extends Visitor {
     if (o instanceof Date) return "Time";
     const temporalClass = temporalClassName(o);
     if (temporalClass) return temporalClass;
-    if (this.isHash(o)) return "Hash";
+    if (isHashAnalogue(o)) return "Hash";
     const ctor = (o as { constructor?: { name?: string } }).constructor;
     return ctor?.name ?? "Object";
   }

--- a/packages/arel/src/visitors/ruby-class.ts
+++ b/packages/arel/src/visitors/ruby-class.ts
@@ -35,17 +35,47 @@ export function rubyClassName(v: unknown): string | null {
   if (typeof v === "symbol") return "Symbol";
   const dateTime = dateTimeClassName(v);
   if (dateTime !== null) return dateTime;
-  if (isPlainObject(v)) return "Hash";
+  if (isHashAnalogue(v)) return "Hash";
   return null;
 }
 
-// The analogue of Ruby's Hash — an object literal, i.e. one whose prototype is
-// Object.prototype (or null). Anything else is an instance of some other class
-// and dispatches on that class in Rails, not on Hash.
-function isPlainObject(v: unknown): boolean {
+/**
+ * The analogue of Ruby's Hash — the class `Visitor#visit` would dispatch a
+ * record on.
+ *
+ * Rails' `Visitor#visit` walks `object.class.ancestors` (visitor.rb:36-41), so
+ * every `Hash` descendant reaches `visit_Hash` for *any* visitor, not just one.
+ * JS has no Hash class — the record literal *is* the Hash — so the equivalent
+ * of that ancestor split is whether the prototype chain is made only of plain
+ * records:
+ *
+ *   - `{ a: 1 }` and `Object.create(null)` are Hashes;
+ *   - `Object.create({ a: 1 })` is the JS way to derive a record from another
+ *     record — Ruby's `class MyHash < Hash` — so it's a Hash too;
+ *   - a class instance (including `class Config extends Object`) has a prototype
+ *     whose own `constructor` points back at the class, which is Ruby's
+ *     `Config < Object`: no ancestor handler, so it is not a Hash.
+ *
+ * What marks a *class* prototype is that back-reference: `class C {}` installs
+ * `C.prototype.constructor === C`, so the own `constructor` is a function
+ * pointing back at this very object. Anything else — absent, a non-function, or
+ * a function whose `.prototype` is some other object — leaves the value a
+ * record, so keep walking. A literal `constructor` key (`{ constructor: "x" }`)
+ * fails the identity, and its name is irrelevant to dispatch anyway: Ruby
+ * dispatches by ancestry, so a Hash with a `:constructor` key is still a Hash.
+ */
+export function isHashAnalogue(v: unknown): boolean {
   if (typeof v !== "object" || v === null) return false;
-  const proto = Object.getPrototypeOf(v);
-  return proto === Object.prototype || proto === null;
+  for (let proto = Object.getPrototypeOf(v); proto !== null; proto = Object.getPrototypeOf(proto)) {
+    if (proto === Object.prototype) return true;
+    const ctor = Object.getOwnPropertyDescriptor(proto, "constructor")?.value as
+      | { prototype?: unknown }
+      | undefined;
+    if (typeof ctor === "function" && ctor.prototype === proto) {
+      return false;
+    }
+  }
+  return true;
 }
 
 // The Ruby class Rails would dispatch a date/time value on, all three of which

--- a/packages/arel/src/visitors/visitor.test.ts
+++ b/packages/arel/src/visitors/visitor.test.ts
@@ -108,7 +108,15 @@ describe("Visitor dispatch", () => {
     // raw values and nodes share one method table and one entry point — there
     // is no separate raw-value path. These pin that the same `accept` that
     // dispatches a Node also resolves a bare JS value to `visit<RubyClass>`.
+    // A real class registered in the ctor-keyed dispatch cache. A Hash whose
+    // `constructor` property happens to point here must still dispatch as Hash,
+    // not be hijacked onto this handler.
+    class Registered {}
+
     class ValueVisitor extends Visitor {
+      visitRegistered(): string {
+        return "Registered";
+      }
       visitInteger(o: number | bigint): string {
         return `Integer:${o}`;
       }
@@ -132,6 +140,9 @@ describe("Visitor dispatch", () => {
       }
       visitTime(): string {
         return "Time";
+      }
+      static {
+        this.dispatchCache().set(Registered, "visitRegistered");
       }
     }
 
@@ -160,6 +171,28 @@ describe("Visitor dispatch", () => {
       ["record derived from a null-prototype record", Object.create(Object.create(null))],
       ["record inheriting a literal constructor key", Object.create({ constructor: "x" })],
     ])("classifies a %s as Hash on a non-Dot visitor", (_label, value) => {
+      expect(new ValueVisitor().accept(value)).toBe("Hash");
+    });
+
+    it.each([
+      // Rails reads `object.class` (visitor.rb:28) before it looks inside, and a
+      // Hash's `:constructor` key can't change its class. A JS record's
+      // `constructor` — whether an own data key on a null-prototype record or an
+      // inherited one — must not hijack dispatch to that (registered) ctor's
+      // handler; the record is a Hash and routes to visit_Hash regardless.
+      [
+        "own constructor key pointing at a registered ctor",
+        (() => {
+          const h: Record<string, unknown> = Object.create(null);
+          h.constructor = Registered;
+          return h;
+        })(),
+      ],
+      [
+        "inherited constructor key pointing at a registered ctor",
+        Object.create({ constructor: Registered }),
+      ],
+    ])("a Hash whose %s still dispatches as Hash", (_label, value) => {
       expect(new ValueVisitor().accept(value)).toBe("Hash");
     });
 

--- a/packages/arel/src/visitors/visitor.test.ts
+++ b/packages/arel/src/visitors/visitor.test.ts
@@ -152,6 +152,17 @@ describe("Visitor dispatch", () => {
       expect(new ValueVisitor().accept(value)).toBe(expected);
     });
 
+    it.each([
+      // Rails' `visit` walks object.class.ancestors (visitor.rb:36-41), so any
+      // record derived from a plain record reaches visit_Hash on every visitor,
+      // not just Dot. These are the JS analogues of `class MyHash < Hash`.
+      ["record derived from a plain record", Object.create({ inherited: "x" })],
+      ["record derived from a null-prototype record", Object.create(Object.create(null))],
+      ["record inheriting a literal constructor key", Object.create({ constructor: "x" })],
+    ])("classifies a %s as Hash on a non-Dot visitor", (_label, value) => {
+      expect(new ValueVisitor().accept(value)).toBe("Hash");
+    });
+
     it("raises when the value's class has no handler", () => {
       class Arbitrary {}
       expect(() => new ValueVisitor().accept(new Arbitrary())).toThrow(TypeError);

--- a/packages/arel/src/visitors/visitor.ts
+++ b/packages/arel/src/visitors/visitor.ts
@@ -1,4 +1,4 @@
-import { rubyClassName } from "./ruby-class.js";
+import { isHashAnalogue, rubyClassName } from "./ruby-class.js";
 
 // Rails interpolates `object.class` straight into its "Cannot visit" TypeError
 // (visitor.rb:38). The nearest handle here is the Ruby class the value would
@@ -128,15 +128,21 @@ export abstract class Visitor {
    * entry point for raw values.
    */
   private dispatchMethod(object: unknown): string | undefined {
-    // A record can carry a non-function `constructor` — an inherited literal
-    // key (`Object.create({ constructor: "x" })`) — which is not a dispatch
-    // class. Only a real constructor function keys the ctor cache; anything
-    // else falls through to `rubyClassName`, where the ancestor walk still
-    // classifies the record as a Hash.
-    const ctor = (object as { constructor?: NodeCtor } | null | undefined)?.constructor;
-    if (typeof ctor === "function") {
-      const byCtor = this.resolveDispatch(ctor);
-      if (byCtor) return byCtor;
+    // Rails reads `object.class` (visitor.rb:28) — an intrinsic that a Hash's
+    // contents can't shadow — before it ever looks inside. A JS record's
+    // `constructor` is not that intrinsic: it can be an own or inherited data
+    // key (`Object.create(null)` then `h.constructor = Set`, or
+    // `Object.create({ constructor: Set })`), which would wrongly route the
+    // record to that ctor's handler instead of `visit_Hash`. So the
+    // ctor-cache path is for genuine class instances only; a Hash analogue
+    // skips it and is classified by `rubyClassName`'s ancestor walk, exactly
+    // as Ruby dispatches every Hash descendant to `visit_Hash`.
+    if (!isHashAnalogue(object)) {
+      const ctor = (object as { constructor?: NodeCtor } | null | undefined)?.constructor;
+      if (typeof ctor === "function") {
+        const byCtor = this.resolveDispatch(ctor);
+        if (byCtor) return byCtor;
+      }
     }
     const rubyClass = rubyClassName(object);
     return rubyClass === null ? undefined : `visit${rubyClass}`;

--- a/packages/arel/src/visitors/visitor.ts
+++ b/packages/arel/src/visitors/visitor.ts
@@ -128,8 +128,13 @@ export abstract class Visitor {
    * entry point for raw values.
    */
   private dispatchMethod(object: unknown): string | undefined {
+    // A record can carry a non-function `constructor` — an inherited literal
+    // key (`Object.create({ constructor: "x" })`) — which is not a dispatch
+    // class. Only a real constructor function keys the ctor cache; anything
+    // else falls through to `rubyClassName`, where the ancestor walk still
+    // classifies the record as a Hash.
     const ctor = (object as { constructor?: NodeCtor } | null | undefined)?.constructor;
-    if (ctor) {
+    if (typeof ctor === "function") {
       const byCtor = this.resolveDispatch(ctor);
       if (byCtor) return byCtor;
     }


### PR DESCRIPTION
## What

PR #5003 routed `Dot`'s raw values onto the inherited `Visitor#visit` class
dispatch, except for one residue arm that survived in `Dot#visit`:

```ts
if (this.isHash(object)) { this.visitHash(...); return; }
```

The residue existed because two Hash analogues disagreed: `rubyClassName`'s
`isPlainObject` answered `"Hash"` only when the prototype was `Object.prototype`
or `null`, while `Dot#isHash` walked the whole prototype chain, so a record
derived from another record (`Object.create({a:1})`, the JS analogue of
`class MyHash < Hash`) was a Hash only under `Dot`.

Rails needs no such split: `Visitor#visit` walks `object.class.ancestors`
(visitor.rb:36-41), so any `Hash` descendant reaches `visit_Hash` for **every**
visitor. Since `rubyClassName` is the shared raw-value dispatch used by
`ToSql` / `Mysql` / `PostgreSQL`, the stricter definition classified a derived
record inconsistently depending on which visitor saw it.

## How

- Move the prototype-chain ancestor walk from `Dot#isHash` into `ruby-class.ts`
  as the shared, exported `isHashAnalogue` helper; `rubyClassName` uses it, so
  every visitor now classifies a derived record as `Hash`.
- Guard the ctor-keyed dispatch path in `Visitor#dispatchMethod` against a
  non-function constructor — an inherited literal `constructor` key
  (`Object.create({ constructor: "x" })`) now reaches `Visitor#visit` directly
  instead of being intercepted by `Dot`'s pre-dispatch arm, and must not be
  treated as a dispatch class.
- Delete the `isHash` pre-dispatch arm in `Dot#visit` and `Dot#isHash`;
  `Dot#classNameOf` reuses the shared helper.
- Add non-Dot (`Visitor`) coverage: a record derived from a plain record, from
  a null-prototype record, and one inheriting a literal `constructor` key all
  classify as `Hash`. On `ToSql` such a record now reaches `visitHash` →
  `unsupported`, the same terminal a plain hash already hit.

`dot.test.ts` stays green with no test renamed (the five shapes at
`dot.test.ts:472-520`).

Closes-story: converge-hash-analogue-into-rubyclassname
