### PR TITLE
fix(arel): visitor dispatch checks respond_to?, not just table membership

### DIFF
--- a/packages/arel/src/visitors/dot.test.ts
+++ b/packages/arel/src/visitors/dot.test.ts
@@ -282,21 +282,18 @@ describe("TestDot", () => {
       );
     });
 
-    it("a mis-registered dispatch method is not reported as an unvisitable value", () => {
-      // The base visitor's "no handler at all" arm already raises Rails'
-      // `TypeError, "Cannot visit ..."` (visitor.rb:39) directly, and Dot lets
-      // it propagate unchanged. That must not be confused with the base
-      // visitor's *other* error — a typo'd method name in the dispatch table —
-      // or a Dot registration bug is indistinguishable from a value Rails
-      // genuinely cannot visit.
+    it("a mis-registered dispatch method falls through to an ancestor's handler", () => {
+      // Mirrors `respond_to?(dispatch[klass], true)` (visitor.rb:36-37): a class
+      // whose own dispatch entry names a missing method does not raise — it
+      // falls through to an ancestor's working handler. Weird extends Unary, so
+      // a typo'd Weird entry resolves upward to `visitArelNodesUnary` and the
+      // node is visited instead of reported as an unvisitable value.
       class Weird extends Nodes.Unary {}
       const v = new Visitors.Dot();
       (v as unknown as { dispatch: Map<unknown, string> }).dispatch.set(Weird, "visitTypoed");
       type Internals = { visit(o: unknown): void };
       v.compile(new Nodes.SqlLiteral("seed"));
-      expect(() => (v as unknown as Internals).visit(new Weird(null))).toThrow(
-        /Dispatch method 'visitTypoed' is not defined on Dot/,
-      );
+      expect(() => (v as unknown as Internals).visit(new Weird(null))).not.toThrow();
     });
 
     it("Temporal values reach visit_Date / visit_Time instead of raising", () => {

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -497,14 +497,14 @@ export class Dot extends Visitor {
     }
     this.nodes.push(node);
     this.withNode(node, () => {
-      // visitor.rb:39 — no ancestor answered the dispatch. Since #5002,
+      // visitor.rb:38 — no ancestor answered the dispatch. Since #5002,
       // Visitor#visit's no-handler arm already throws Ruby's
       // `TypeError, "Cannot visit <Class>"` directly, so it propagates
-      // unchanged. A mis-registered dispatch method (a plain Error from
-      // visitor.ts) likewise propagates as-is — it is a visitor bug, not an
-      // unvisitable value, and must never be relabelled. UnsupportedVisitError
-      // is unreachable here: Dot registers no `unsupported`-aliased handler,
-      // so no super.visit path produces it.
+      // unchanged. A class whose own dispatch entry names a missing method
+      // no longer raises here either: Visitor#visit falls through to an
+      // ancestor's handler (respond_to? check, visitor.rb:36-37).
+      // UnsupportedVisitError is unreachable: Dot registers no
+      // `unsupported`-aliased handler, so no super.visit path produces it.
       super.visit(object);
     });
     return undefined;

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -497,7 +497,7 @@ export class Dot extends Visitor {
     }
     this.nodes.push(node);
     this.withNode(node, () => {
-      // visitor.rb:38 — no ancestor answered the dispatch. Since #5002,
+      // visitor.rb:39 — no ancestor answered the dispatch. Since #5002,
       // Visitor#visit's no-handler arm already throws Ruby's
       // `TypeError, "Cannot visit <Class>"` directly, so it propagates
       // unchanged. A class whose own dispatch entry names a missing method

--- a/packages/arel/src/visitors/visitor.test.ts
+++ b/packages/arel/src/visitors/visitor.test.ts
@@ -69,7 +69,7 @@ describe("Visitor dispatch", () => {
     expect(() => v.accept(new C())).not.toThrow(UnsupportedVisitError);
   });
 
-  it("dispatches properly after failing upwards", () => {
+  it("falls through to an ancestor's handler when its own dispatch entry names a missing method", () => {
     // A class whose own dispatch entry names a missing method falls through to
     // an ancestor's working handler and visits successfully — mirroring Rails'
     // `respond_to?(dispatch[klass], true)` ancestor walk (visitor.rb:36-37),

--- a/packages/arel/src/visitors/visitor.test.ts
+++ b/packages/arel/src/visitors/visitor.test.ts
@@ -69,16 +69,40 @@ describe("Visitor dispatch", () => {
     expect(() => v.accept(new C())).not.toThrow(UnsupportedVisitError);
   });
 
-  it("distinguishes a mis-registered method from an unknown node type", () => {
+  it("dispatches properly after failing upwards", () => {
+    // A class whose own dispatch entry names a missing method falls through to
+    // an ancestor's working handler and visits successfully — mirroring Rails'
+    // `respond_to?(dispatch[klass], true)` ancestor walk (visitor.rb:36-37),
+    // not raising on the mis-registration. B's entry names a typo'd method; A's
+    // works, so `visit(new B())` resolves upward to `visitA`.
+    class FallUpVisitor extends Visitor {
+      visitA(_n: A): string {
+        return "A";
+      }
+      static {
+        this.dispatchCache().set(A, "visitA");
+        this.dispatchCache().set(B, "visitTypoed");
+      }
+    }
+    const v = new FallUpVisitor();
+    expect(v.accept(new B())).toBe("A");
+    // Only the successful ancestor resolution is memoized onto B (visitor.rb:39).
+    expect(FallUpVisitor.dispatchCache().get(B)).toBe("visitA");
+  });
+
+  it("raises TypeError when neither the class nor an ancestor has a responding handler", () => {
+    // Both the class's own entry and every ancestor's name a missing method, so
+    // no handler responds and the terminal is Rails' `TypeError, "Cannot visit
+    // X"` (visitor.rb:38) — not an UnsupportedVisitError for a mis-registration.
     class BadVisitor extends Visitor {
       static {
         this.dispatchCache().set(A, "visitTypoed");
       }
     }
     const v = new BadVisitor();
-    expect(() => v.accept(new A())).toThrow(
-      /Dispatch method 'visitTypoed' is not defined on BadVisitor for node A/,
-    );
+    expect(() => v.accept(new A())).toThrow(TypeError);
+    expect(() => v.accept(new A())).toThrow(/Cannot visit A/);
+    expect(() => v.accept(new A())).not.toThrow(UnsupportedVisitError);
   });
 
   it("propagates the collector argument from accept through to the visit method", () => {

--- a/packages/arel/src/visitors/visitor.test.ts
+++ b/packages/arel/src/visitors/visitor.test.ts
@@ -86,14 +86,14 @@ describe("Visitor dispatch", () => {
     }
     const v = new FallUpVisitor();
     expect(v.accept(new B())).toBe("A");
-    // Only the successful ancestor resolution is memoized onto B (visitor.rb:39).
+    // Only the successful ancestor resolution is memoized onto B (visitor.rb:40).
     expect(FallUpVisitor.dispatchCache().get(B)).toBe("visitA");
   });
 
   it("raises TypeError when neither the class nor an ancestor has a responding handler", () => {
     // Both the class's own entry and every ancestor's name a missing method, so
     // no handler responds and the terminal is Rails' `TypeError, "Cannot visit
-    // X"` (visitor.rb:38) — not an UnsupportedVisitError for a mis-registration.
+    // X"` (visitor.rb:39) — not an UnsupportedVisitError for a mis-registration.
     class BadVisitor extends Visitor {
       static {
         this.dispatchCache().set(A, "visitTypoed");

--- a/packages/arel/src/visitors/visitor.ts
+++ b/packages/arel/src/visitors/visitor.ts
@@ -100,21 +100,15 @@ export abstract class Visitor {
       // `unsupported` and raises UnsupportedVisitError (to_sql.rb:828).
       throw new TypeError(`Cannot visit ${describeClass(object)}`);
     }
-    const fn = (this as unknown as Record<string, unknown>)[methodName];
-    if (typeof fn !== "function") {
-      // Cache hit but the instance has no such method — almost always a
-      // mis-registration (a typo'd method name landed in the dispatch
-      // cache). This is a visitor bug, not an unvisitable value, so it is
-      // a plain Error rather than an UnsupportedVisitError (matching the
-      // same check in to-sql.ts:479). This must stay distinct from the
-      // no-handler terminal above (Rails' `TypeError, "Cannot visit ..."`,
-      // visitor.rb:38), or a typo'd registration masquerades as an
-      // unvisitable value.
-      throw new Error(
-        `Dispatch method '${methodName}' is not defined on ${this.constructor.name} for node ${describeClass(object)}`,
-      );
-    }
-    return (fn as (n: unknown, c?: unknown) => unknown).call(this, object, collector);
+    // `dispatchMethod` only ever returns a name the visitor responds to
+    // (mirroring `respond_to?(dispatch[klass], true)`, visitor.rb:35-37), so a
+    // resolved name always names a real function here — a mis-registered class
+    // resolves to an ancestor's handler or falls out as the TypeError above.
+    const fn = (this as unknown as Record<string, unknown>)[methodName] as (
+      n: unknown,
+      c?: unknown,
+    ) => unknown;
+    return fn.call(this, object, collector);
   }
 
   /**
@@ -144,25 +138,42 @@ export abstract class Visitor {
       }
     }
     const rubyClass = rubyClassName(object);
-    return rubyClass === null ? undefined : `visit${rubyClass}`;
+    if (rubyClass === null) return undefined;
+    const byName = `visit${rubyClass}`;
+    return this.respondsTo(byName) ? byName : undefined;
+  }
+
+  /**
+   * Does this visitor actually have a method named `methodName`? Mirrors
+   * Ruby's `respond_to?(dispatch[klass], true)` (visitor.rb:36-37): a dispatch
+   * entry is only usable when the named method truly resolves to a function on
+   * the visitor instance. `true` includes private methods; in JS every method
+   * on the prototype chain is reachable, so a plain property lookup suffices.
+   */
+  private respondsTo(methodName: string): boolean {
+    return typeof (this as unknown as Record<string, unknown>)[methodName] === "function";
   }
 
   /**
    * Resolve the dispatch method name for `ctor`, walking the JS prototype
    * chain to find an ancestor's handler when there is no direct entry.
-   * Mirrors Ruby's `klass.ancestors.find { |k| respond_to?(dispatch[k]) }`.
-   * Successful lookups are memoized into the cache, matching Rails.
+   * Mirrors Ruby's `klass.ancestors.find { |k| respond_to?(dispatch[k]) }`
+   * (visitor.rb:36-37): a dispatch entry counts only when its named method
+   * actually resolves to a function on the visitor, so a class whose own entry
+   * names a missing method falls through to an ancestor's working handler.
+   * Successful lookups are memoized into the cache, matching Rails
+   * (`dispatch[object.class] = dispatch[superklass]`, visitor.rb:39).
    */
   private resolveDispatch(ctor: NodeCtor): string | undefined {
     const direct = this.dispatch.get(ctor);
-    if (direct) return direct;
+    if (direct && this.respondsTo(direct)) return direct;
     let cur: NodeCtor | null = ctor;
     while (cur) {
       const proto = Object.getPrototypeOf(cur.prototype) as object | null;
       const parent = proto?.constructor as NodeCtor | undefined;
       if (!parent || (parent as unknown) === Object) return undefined;
       const found = this.dispatch.get(parent);
-      if (found) {
+      if (found && this.respondsTo(found)) {
         this.dispatch.set(ctor, found);
         return found;
       }

--- a/packages/arel/src/visitors/visitor.ts
+++ b/packages/arel/src/visitors/visitor.ts
@@ -1,7 +1,7 @@
 import { isHashAnalogue, rubyClassName } from "./ruby-class.js";
 
 // Rails interpolates `object.class` straight into its "Cannot visit" TypeError
-// (visitor.rb:38). The nearest handle here is the Ruby class the value would
+// (visitor.rb:39). The nearest handle here is the Ruby class the value would
 // have had, falling back to the JS constructor for a real class.
 function describeClass(object: unknown): string {
   const rubyClass = rubyClassName(object);
@@ -96,12 +96,12 @@ export abstract class Visitor {
     if (!methodName) {
       // Rails' second failure terminal: no handler on the class or any of its
       // ancestors falls out of `rescue NoMethodError` as a TypeError
-      // (visitor.rb:38), distinct from a class whose handler is aliased to
+      // (visitor.rb:39), distinct from a class whose handler is aliased to
       // `unsupported` and raises UnsupportedVisitError (to_sql.rb:828).
       throw new TypeError(`Cannot visit ${describeClass(object)}`);
     }
     // `dispatchMethod` only ever returns a name the visitor responds to
-    // (mirroring `respond_to?(dispatch[klass], true)`, visitor.rb:35-37), so a
+    // (mirroring `respond_to?(dispatch[klass], true)`, visitor.rb:36-37), so a
     // resolved name always names a real function here — a mis-registered class
     // resolves to an ancestor's handler or falls out as the TypeError above.
     const fn = (this as unknown as Record<string, unknown>)[methodName] as (
@@ -162,7 +162,7 @@ export abstract class Visitor {
    * actually resolves to a function on the visitor, so a class whose own entry
    * names a missing method falls through to an ancestor's working handler.
    * Successful lookups are memoized into the cache, matching Rails
-   * (`dispatch[object.class] = dispatch[superklass]`, visitor.rb:39).
+   * (`dispatch[object.class] = dispatch[superklass]`, visitor.rb:40).
    */
   private resolveDispatch(ctor: NodeCtor): string | undefined {
     const direct = this.dispatch.get(ctor);


### PR DESCRIPTION
## What

`Arel::Visitors::Visitor#visit` (visitor.rb:34-41) resolves a handler with two `respond_to?` checks — the rescue guard and the ancestor `find` block both test whether the visitor actually has the named method, not merely whether the dispatch table has an entry for the class.

trails' `resolveDispatch` walked the JS prototype chain but only checked `this.dispatch.get(parent)` for map membership. A dispatch entry naming a missing method (e.g. a subclass registering a typo'd handler while its parent has a working one) raised `UnsupportedVisitError` instead of falling through to the ancestor's handler as Rails does.

## Changes

- `resolveDispatch` accepts a dispatch entry only when its named method resolves to a function on the visitor instance, mirroring `respond_to?(dispatch[klass], true)` (visitor.rb:36-37).
- A class whose own entry names a missing method now falls through to an ancestor's working handler and visits successfully.
- When neither the class nor any ancestor responds, the terminal is `TypeError, "Cannot visit X"` (visitor.rb:39).
- Only a successful ancestor resolution memoizes `dispatch[object.class] = dispatch[superklass]` (visitor.rb:40).
- The raw-value path is respond-checked too, so the divergent `"Dispatch method '...' is not defined"` Error is retired (base and Dot).
- Tests updated to the Rails semantics, including Dot's mis-registration test (now asserts fallthrough) and a new `visitor.test.ts` case, "falls through to an ancestor's handler when its own dispatch entry names a missing method".

Closes-story: arel-visit-dispatch-respond-to-check
