### PR TITLE
fix(arel)!: add SelectManager#lock's true arm and SqlLiteral pass-through

### DIFF
--- a/packages/arel/src/select-manager.trails.test.ts
+++ b/packages/arel/src/select-manager.trails.test.ts
@@ -34,4 +34,35 @@ describe("SelectManagerTest (trails)", () => {
     mgr.join("comments ON comments.user_id = users.id");
     expect(mgr.joinSources[0]).toBeInstanceOf(Nodes.StringJoin);
   });
+
+  // Trails-only coverage for Arel::SelectManager#lock's `case` arms
+  // (select_manager.rb:52-63). Rails' select_manager_test.rb pins only the
+  // no-arg default ("adds a lock node"); the `true`, bare-String, and
+  // pass-through-SqlLiteral arms each need their own pin here.
+  describe("lock arms", () => {
+    const star = new Nodes.SqlLiteral("*");
+
+    it("maps true to FOR UPDATE", () => {
+      const mgr = new SelectManager(users).project(star);
+      expect(mgr.lock(true).toSql()).toBe('SELECT * FROM "users" FOR UPDATE');
+    });
+
+    it("wraps a bare string in a SqlLiteral", () => {
+      const mgr = new SelectManager(users).project(star);
+      expect(mgr.lock("FOR SHARE").toSql()).toBe('SELECT * FROM "users" FOR SHARE');
+    });
+
+    it("passes a SqlLiteral through unwrapped", () => {
+      const mgr = new SelectManager(users).project(star);
+      const literal = new Nodes.SqlLiteral("FOR UPDATE NOWAIT");
+      mgr.lock(literal);
+      expect((mgr.locked as Nodes.Lock).expr).toBe(literal);
+      expect(mgr.toSql()).toBe('SELECT * FROM "users" FOR UPDATE NOWAIT');
+    });
+
+    it("defaults to FOR UPDATE with no argument", () => {
+      const mgr = new SelectManager(users).project(star);
+      expect(mgr.lock().toSql()).toBe('SELECT * FROM "users" FOR UPDATE');
+    });
+  });
 });

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -124,14 +124,22 @@ export class SelectManager extends TreeManager {
 
   /**
    * Add a lock clause (FOR UPDATE by default).
+   *
+   * Mirrors: Arel::SelectManager#lock (select_manager.rb:52-63). Rails'
+   * `case`: `true` and the no-arg default both become `Arel.sql("FOR
+   * UPDATE")`, a `SqlLiteral` passes through unwrapped (empty `when` branch),
+   * and a bare `String` is wrapped. `true` is how ActiveRecord's `lock!` /
+   * `with_lock` express the default lock.
    */
-  lock(lockClause?: string | Node): this {
+  lock(lockClause: string | Node | boolean = true): this {
     const expr =
-      lockClause === undefined
+      lockClause === true
         ? new SqlLiteral("FOR UPDATE")
-        : typeof lockClause === "string"
-          ? new SqlLiteral(lockClause)
-          : lockClause;
+        : lockClause instanceof SqlLiteral
+          ? lockClause
+          : typeof lockClause === "string"
+            ? new SqlLiteral(lockClause)
+            : lockClause;
     this.ast.lock = new Lock(expr);
     return this;
   }


### PR DESCRIPTION
## Summary

Rails' `Arel::SelectManager#lock` (`select_manager.rb:52-63`) has a `case`
with a `true` arm that trails' `lock()` lacked:

```ruby
def lock(locking = Arel.sql("FOR UPDATE"))
  case locking
  when true          then locking = Arel.sql("FOR UPDATE")
  when Arel::Nodes::SqlLiteral  # pass through
  when String        then locking = Arel.sql locking
  end
  @ast.lock = Nodes::Lock.new(locking)
  self
end
```

Trails' parameter type did not admit `true`, and an already-`SqlLiteral`
argument was rewrapped rather than passed through (Rails' empty `when`
branch). This widens the parameter to accept `true`, maps it (and the no-arg
default) to `SqlLiteral("FOR UPDATE")`, and keeps the `SqlLiteral` arm a
pass-through.

`lock(true)` is how ActiveRecord's `lock!`/`with_lock` express a default
lock (`lock_value = locks || true`, then `arel.lock(lock_value)` in
`query_methods.rb:1768`).

## AR callers passing `true`

Per the acceptance criteria, grepped AR for `.lock(` callers reaching Arel:
the only one is `packages/activerecord/src/relation/query-methods.ts:2724`
(`arel.lock(this._lockValue)`). Trails' `lockBang` (`query-methods.ts:1390`)
already normalizes `true` → `"FOR UPDATE"` before storing `_lockValue`
(typed `string | null`), so **no AR caller passes `true` to Arel today** —
this is a surface-fidelity gap, not a live bug. (Rails does pass `true`
through; trails pre-converts earlier.)

## Tests

Rails' `select_manager_test.rb` pins only the no-arg default (kept as-is in
`select-manager.test.ts`). The `true`, bare-`String`, and pass-through
`SqlLiteral` arms are trails-distinct branches, pinned in
`select-manager.trails.test.ts` asserting emitted SQL for each.

Closes-story: select-manager-lock-missing-true-arm
