### PR TITLE
fix(arel): route With/WithRecursive visitors through collectCtes

### DIFF
--- a/packages/arel/src/nodes/cte.trails.test.ts
+++ b/packages/arel/src/nodes/cte.trails.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { Table, Nodes, Visitors } from "../index.js";
+import { testConnection } from "../test-helpers/connection.js";
+
+// TS-only: no Rails counterpart. Pins that a `Cte` whose name is a
+// `SqlLiteral` (as produced by `TableAlias#toCte`) preserves the literal
+// through `toTable()`, matching Rails' `Arel::Table.new(name)` pass-through
+// (cte.rb:31-32) — the resulting table name renders bare, not quoted.
+describe("Cte#toTable", () => {
+  it("preserves a SqlLiteral name as a bare table name", () => {
+    const cte = new Nodes.Cte(
+      new Nodes.SqlLiteral("expr1"),
+      new Table("bar").project(new Nodes.SqlLiteral("*")).ast,
+    );
+    const sql = new Visitors.ToSql(testConnection).compile(cte.toTable());
+    expect(sql).toBe("expr1");
+  });
+
+  it("quotes a plain-string name as an identifier", () => {
+    const cte = new Nodes.Cte("expr1", new Table("bar").project(new Nodes.SqlLiteral("*")).ast);
+    const sql = new Visitors.ToSql(testConnection).compile(cte.toTable());
+    expect(sql).toBe('"expr1"');
+  });
+});

--- a/packages/arel/src/nodes/cte.ts
+++ b/packages/arel/src/nodes/cte.ts
@@ -29,7 +29,11 @@ export class Cte extends Binary {
   }
 
   toTable(): Table {
-    return new Table(this.name instanceof SqlLiteral ? this.name.value : this.name);
+    // Rails `Arel::Table.new(name)` passes the name through unchanged, so a
+    // `SqlLiteral` name stays a literal and the Table visitor renders it bare
+    // (visit_Arel_Table visits a Node name). `Table` types `name` as `string`;
+    // a smuggled `SqlLiteral` is cast, matching visit_Arel_Table's convention.
+    return new Table(this.name as unknown as string);
   }
 
   accept<T>(visitor: NodeVisitor<T>): T {

--- a/packages/arel/src/nodes/cte.ts
+++ b/packages/arel/src/nodes/cte.ts
@@ -1,5 +1,6 @@
 import { Node, NodeVisitor } from "./node.js";
 import { Binary } from "./binary.js";
+import { SqlLiteral } from "./sql-literal.js";
 import { Table } from "../table.js";
 
 /**
@@ -8,11 +9,15 @@ import { Table } from "../table.js";
  * Mirrors: Arel::Nodes::Cte
  */
 export class Cte extends Binary {
-  readonly name: string;
+  // Rails: `SelectManager#as` builds a `TableAlias` whose name is a
+  // `Nodes::SqlLiteral` (rendered bare), so `TableAlias#to_cte` passes that
+  // literal straight through to `Cte.new`. A plain-string name (e.g. a directly
+  // constructed `Cte`) is quoted. Accept both.
+  readonly name: string | SqlLiteral;
   readonly relation: Node;
   readonly materialized: boolean | null;
 
-  constructor(name: string, relation: Node, materialized: boolean | null = null) {
+  constructor(name: string | SqlLiteral, relation: Node, materialized: boolean | null = null) {
     super(name, relation);
     this.name = name;
     this.relation = relation;
@@ -24,7 +29,7 @@ export class Cte extends Binary {
   }
 
   toTable(): Table {
-    return new Table(this.name);
+    return new Table(this.name instanceof SqlLiteral ? this.name.value : this.name);
   }
 
   accept<T>(visitor: NodeVisitor<T>): T {

--- a/packages/arel/src/nodes/table-alias.ts
+++ b/packages/arel/src/nodes/table-alias.ts
@@ -59,7 +59,7 @@ export class TableAlias extends Binary {
   }
 
   toCte(): Cte {
-    return new Cte(this.nameString, this.relation);
+    return new Cte(this.name, this.relation);
   }
 
   /** The alias as a bare string, unwrapping a `SqlLiteral` name. */

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -387,27 +387,38 @@ describe("the to_sql visitor", () => {
   });
 
   describe("Nodes::With", () => {
-    it("handles Cte nodes", () => {
-      const cte = new Nodes.Cte("t", users.project(users.get("id")).ast);
-      const sql = new Visitors.ToSql(testConnection).compile(cte);
-      expect(sql).toContain('"t" AS (');
+    it("handles table aliases", () => {
+      const manager = new Table("foo").project(star).from(new Nodes.SqlLiteral("expr2"));
+      const expr1 = new Table("bar").project(star).as("expr1");
+      const expr2 = new Table("baz").project(star).as("expr2");
+      manager.with(expr1, expr2);
+      const sql = new Visitors.ToSql(testConnection).compile(manager.ast);
+      expect(sql).toBe(
+        'WITH expr1 AS (SELECT * FROM "bar"), expr2 AS (SELECT * FROM "baz") SELECT * FROM expr2',
+      );
     });
 
-    it("handles table aliases", () => {
-      const mgr = users.project(star);
-      const asNode = new Nodes.As(mgr.ast, new Nodes.SqlLiteral("foo"));
-      const node = new Nodes.With([asNode]);
-      const sql = new Visitors.ToSql(testConnection).compile(node);
-      expect(sql).toContain("WITH");
-      expect(sql).toContain("foo");
+    it("handles Cte nodes", () => {
+      const cte = new Nodes.Cte("expr1", new Table("bar").project(star).ast);
+      const manager = new Table("foo")
+        .project(star)
+        .with(cte)
+        .from(cte.toTable())
+        .where(cte.toTable().get("score").gt(5));
+      const sql = new Visitors.ToSql(testConnection).compile(manager.ast);
+      expect(sql).toBe(
+        'WITH "expr1" AS (SELECT * FROM "bar") SELECT * FROM "expr1" WHERE "expr1"."score" > 5',
+      );
     });
   });
 
   describe("Nodes::WithRecursive", () => {
     it("handles table aliases", () => {
-      const aliased = new Nodes.TableAlias(users, "u");
-      const sql = new Visitors.ToSql(testConnection).compile(aliased);
-      expect(sql).toBe('"users" "u"');
+      const manager = new Table("foo").project(star).from(new Nodes.SqlLiteral("expr1"));
+      const expr1 = new Table("bar").project(star).as("expr1");
+      manager.withRecursive(expr1);
+      const sql = new Visitors.ToSql(testConnection).compile(manager.ast);
+      expect(sql).toBe('WITH RECURSIVE expr1 AS (SELECT * FROM "bar") SELECT * FROM expr1');
     });
   });
 

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -687,14 +687,12 @@ export class ToSql extends Visitor {
 
   private visitArelNodesWith(node: Nodes.With, collector: SQLString): SQLString {
     collector.append("WITH ");
-    this.injectJoin(node.children, ", ", collector);
-    return collector;
+    return this.collectCtes(node.children, collector);
   }
 
   private visitArelNodesWithRecursive(node: Nodes.WithRecursive, collector: SQLString): SQLString {
     collector.append("WITH RECURSIVE ");
-    this.injectJoin(node.children, ", ", collector);
-    return collector;
+    return this.collectCtes(node.children, collector);
   }
 
   // -- Set operations --

--- a/scripts/api-compare/call-mismatches-wide-exclude/arel/visitors/to-sql.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/arel/visitors/to-sql.json
@@ -345,20 +345,6 @@
   {
     "package": "arel",
     "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_With",
-    "call": "collect_ctes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_WithRecursive",
-    "call": "collect_ctes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Array",
     "call": "inject_join",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
## What

`visitArelNodesWith` / `visitArelNodesWithRecursive` inject-joined their raw
children directly, bypassing the already-written `collectCtes` and never
calling `child.toCte()`. Rails `to_sql.rb:198-206` routes both through
`collect_ctes`, which visits `child.to_cte` (to_sql.rb:1023-1030) — so any
child whose `to_cte` differs from itself (`As`, `TableAlias`) rendered wrong.

## Changes

- `visitArelNodesWith` / `visitArelNodesWithRecursive` now route through
  `collectCtes`, matching to_sql.rb:198-206.
- `TableAlias.toCte` passes its `SqlLiteral` name straight through (Rails
  `Cte.new(name, relation)`) instead of unwrapping to a bare string, so a
  `SelectManager#as` CTE name renders bare (`WITH expr1 AS …`) as in Rails.
  `Cte` accepts a `string | SqlLiteral` name accordingly (bare literal vs
  quoted plain string).
- Ports the Rails `Nodes::With` / `Nodes::WithRecursive` "handles table
  aliases" and "handles Cte nodes" tests verbatim. The table-alias cases
  exercise the non-identity `to_cte` path the old code skipped — a same-node
  test would pass regardless.
- Removes the two converged wide-baseline entries
  (`visit_Arel_Nodes_With -> collect_ctes`,
  `visit_Arel_Nodes_WithRecursive -> collect_ctes`).

Closes-story: to-sql-with-visitors-bypass-collect-ctes
