### PR TITLE
fix(arel)!: base ToSql IsDistinctFrom emits CASE form, not native syntax

### DIFF
--- a/packages/arel/src/nodes/node.test.ts
+++ b/packages/arel/src/nodes/node.test.ts
@@ -188,7 +188,11 @@ describe("Table.engine", () => {
   it("TreeManager#toSql() compiles through the engine connection's visitor", () => {
     const users = new Table("users");
     const mgr = users.project(users.get("id")).where(users.get("active").isNotDistinctFrom(true));
-    expect(mgr.toSql()).toContain("IS NOT DISTINCT FROM");
+    // The generic base visitor emits the CASE form (to_sql.rb:658), not the
+    // adapter-native `IS NOT DISTINCT FROM` — that is the SQLite/PG override.
+    expect(mgr.toSql()).toContain("CASE WHEN");
+    expect(mgr.toSql()).toContain("END = 0");
+    expect(mgr.toSql()).not.toContain("IS NOT DISTINCT FROM");
     const sqlite = mgr.toSql(sqliteEngine);
     // SQLite emits IS for IS NOT DISTINCT FROM; Quoted(true) inlines as 1 in SQLite.
     expect(sqlite).toContain('"users"."active" IS 1');

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -18,15 +18,16 @@ describe("the to_sql visitor", () => {
   const users = new Table("users");
   const posts = new Table("posts");
   describe("Nodes::IsDistinctFrom", () => {
-    it("should handle nil", () => {
-      const visitor = new Visitors.ToSql(testConnection);
-      const node = users.get("name").isDistinctFrom(null);
-      expect(visitor.compile(node)).toContain("IS NOT NULL");
+    it("should handle column names on both sides", () => {
+      const node = users.get("first_name").isDistinctFrom(users.get("last_name"));
+      expect(new Visitors.ToSql(testConnection).compile(node)).toBe(
+        `CASE WHEN "users"."first_name" = "users"."last_name" OR ("users"."first_name" IS NULL AND "users"."last_name" IS NULL) THEN 0 ELSE 1 END = 1`,
+      );
     });
 
-    it("should handle column names on both sides", () => {
-      const node = users.get("name").isDistinctFrom(users.get("login"));
-      expect(new Visitors.ToSql(testConnection).compile(node)).toContain("IS DISTINCT FROM");
+    it("should handle nil", () => {
+      const node = users.get("name").isDistinctFrom(null);
+      expect(new Visitors.ToSql(testConnection).compile(node)).toBe(`"users"."name" IS NOT NULL`);
     });
   });
 
@@ -232,20 +233,24 @@ describe("the to_sql visitor", () => {
   });
 
   describe("Nodes::IsNotDistinctFrom", () => {
-    it("should handle nil", () => {
-      const node = users.get("name").isNotDistinctFrom(null);
-      const sql = new Visitors.ToSql(testConnection).compile(node);
-      expect(sql).toContain("IS NULL");
-    });
-
     it("should construct a valid generic SQL statement", () => {
-      const node = users.get("name").isNotDistinctFrom(new Nodes.Quoted(1));
-      expect(new Visitors.ToSql(testConnection).compile(node)).toContain("IS NOT DISTINCT FROM");
+      const node = users.get("name").isNotDistinctFrom(new Nodes.Quoted("Aaron Patterson"));
+      expect(new Visitors.ToSql(testConnection).compile(node)).toBe(
+        `CASE WHEN "users"."name" = 'Aaron Patterson' OR ("users"."name" IS NULL AND 'Aaron Patterson' IS NULL) THEN 0 ELSE 1 END = 0`,
+      );
     });
 
     it("should handle column names on both sides", () => {
-      const node = users.get("name").isNotDistinctFrom(users.get("login"));
-      expect(new Visitors.ToSql(testConnection).compile(node)).toContain("IS NOT DISTINCT FROM");
+      const node = users.get("first_name").isNotDistinctFrom(users.get("last_name"));
+      expect(new Visitors.ToSql(testConnection).compile(node)).toBe(
+        `CASE WHEN "users"."first_name" = "users"."last_name" OR ("users"."first_name" IS NULL AND "users"."last_name" IS NULL) THEN 0 ELSE 1 END = 0`,
+      );
+    });
+
+    it("should handle nil", () => {
+      const node = users.get("name").isNotDistinctFrom(null);
+      const sql = new Visitors.ToSql(testConnection).compile(node);
+      expect(sql).toBe(`"users"."name" IS NULL`);
     });
   });
 

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1286,7 +1286,9 @@ export class ToSql extends Visitor {
       collector.append(" IS NULL");
       return collector;
     }
-    return this.visitBinaryOp(node, "IS NOT DISTINCT FROM", collector);
+    collector = this.isDistinctFrom(node, collector);
+    collector.append(" = 0");
+    return collector;
   }
 
   protected visitArelNodesIsDistinctFrom(
@@ -1298,7 +1300,9 @@ export class ToSql extends Visitor {
       collector.append(" IS NOT NULL");
       return collector;
     }
-    return this.visitBinaryOp(node, "IS DISTINCT FROM", collector);
+    collector = this.isDistinctFrom(node, collector);
+    collector.append(" = 1");
+    return collector;
   }
 
   private visitArelNodesNotEqual(node: Nodes.NotEqual, collector: SQLString): SQLString {
@@ -1912,7 +1916,10 @@ export class ToSql extends Visitor {
    * Mirrors `to_sql.rb#is_distinct_from`. CASE-form fallback for adapters
    * that lack native `IS [NOT] DISTINCT FROM`.
    */
-  protected isDistinctFrom(o: { left: Node; right: Node }, collector: SQLString): SQLString {
+  protected isDistinctFrom(
+    o: { left: Nodes.NodeOrValue; right: Nodes.NodeOrValue },
+    collector: SQLString,
+  ): SQLString {
     collector.append("CASE WHEN ");
     this.visit(o.left, collector);
     collector.append(" = ");

--- a/scripts/api-compare/call-mismatches-wide-exclude/arel/visitors/to-sql.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/arel/visitors/to-sql.json
@@ -184,20 +184,6 @@
   {
     "package": "arel",
     "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_IsDistinctFrom",
-    "call": "is_distinct_from",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_IsNotDistinctFrom",
-    "call": "is_distinct_from",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_JoinSource",
     "call": "any?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
## Summary

Base `ToSql` `visit_Arel_Nodes_IsDistinctFrom` / `IsNotDistinctFrom` were
emitting native `IS [NOT] DISTINCT FROM`. Per Rails' base `to_sql.rb:658-676`,
the base visitor emits the **CASE form** via `is_distinct_from` and appends
`" = 1"` / `" = 0"`; native syntax is the PostgreSQL/SQLite override and MySQL
uses `<=>`. Trails had promoted an adapter override into the base visitor, so
any adapter without native support would get SQL it cannot run.

## Changes

- Base `visitArelNodesIsDistinctFrom` / `IsNotDistinctFrom` now route through
  `isDistinctFrom()` and append `" = 1"` / `" = 0"`, preserving the
  `o.right.nil?` early arms (`IS NOT NULL` / `IS NULL`).
- The PostgreSQL, SQLite, and MySQL overrides already emitted their native
  forms — unchanged, verified against `postgresql.rb` / `sqlite.rb` /
  `mysql.rb`.
- Base tests now assert the full emitted SQL (CASE form) per Rails'
  `to_sql_test.rb`, not just node class / substring.
- Widened `isDistinctFrom` param to `NodeOrValue` slots (matches the node).
- Removed the two converged wide-baseline entries in
  `call-mismatches-wide-exclude/arel/visitors/to-sql.json`.

Closes-story: to-sql-base-isdistinctfrom-emits-native-not-case-form
