### PR TITLE
test(arel): clarify Map-iterator test name in predications.trails

### DIFF
--- a/packages/arel/src/predications.trails.test.ts
+++ b/packages/arel/src/predications.trails.test.ts
@@ -26,7 +26,7 @@ describe("PredicationsMixin in/notIn Enumerable arm", () => {
       expect(visitor.compile(expr().in(ids()))).toBe('("users"."bitmap" & 16) IN (1, 2)');
     });
 
-    it("expands a Map through the Enumerable arm", () => {
+    it("expands an iterator taken off a Map through the Enumerable arm", () => {
       expect(visitor.compile(expr().in(new Map([[1, 2]]).keys()))).toBe(
         '("users"."bitmap" & 16) IN (1)',
       );


### PR DESCRIPTION
`packages/arel/src/predications.trails.test.ts` had a test named "expands a Map
through the Enumerable arm" that passed `new Map([[1, 2]]).keys()` — a Map
Iterator, not a Map. It therefore exercised the same generator/Enumerable arm as
the neighbouring generator test and never touched the Hash analogue its name
implied.

This renames it to "expands an iterator taken off a Map through the Enumerable
arm", saying what it actually exercises. The Hash-analogue pair-expansion
coverage added by #5004 ("expands a Map into pairs, matching Ruby's Enumerable
Hash") keeps the "Map" name.

Trails-only test file with no Rails counterpart, so renaming is permitted.

Closes-story: arel-predications-trails-map-test-uses-keys-iterator