### PR TITLE
refactor(arel)!: make the NodeOrValue operand union load-bearing

### DIFF
--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -110,42 +110,44 @@ export class Attribute extends Node {
   // -- Math --
   //
   // Mirrors Arel::Math: operands pass through unwrapped. The visitor
-  // renders primitive values via `visit` class dispatch.
+  // renders primitive values via `visit` class dispatch. The operand is
+  // typed `NodeOrValue` (not `unknown` + cast) so the union that encodes
+  // what a Rails node slot admits is enforced at the call site.
 
-  add(other: unknown): Grouping {
-    return new Grouping(new Addition(this, other as NodeOrValue));
+  add(other: NodeOrValue): Grouping {
+    return new Grouping(new Addition(this, other));
   }
 
-  subtract(other: unknown): Grouping {
-    return new Grouping(new Subtraction(this, other as NodeOrValue));
+  subtract(other: NodeOrValue): Grouping {
+    return new Grouping(new Subtraction(this, other));
   }
 
-  multiply(other: unknown): Multiplication {
-    return new Multiplication(this, other as NodeOrValue);
+  multiply(other: NodeOrValue): Multiplication {
+    return new Multiplication(this, other);
   }
 
-  divide(other: unknown): Division {
-    return new Division(this, other as NodeOrValue);
+  divide(other: NodeOrValue): Division {
+    return new Division(this, other);
   }
 
-  bitwiseAnd(other: unknown): Grouping {
-    return new Grouping(new BitwiseAnd(this, other as NodeOrValue));
+  bitwiseAnd(other: NodeOrValue): Grouping {
+    return new Grouping(new BitwiseAnd(this, other));
   }
 
-  bitwiseOr(other: unknown): Grouping {
-    return new Grouping(new BitwiseOr(this, other as NodeOrValue));
+  bitwiseOr(other: NodeOrValue): Grouping {
+    return new Grouping(new BitwiseOr(this, other));
   }
 
-  bitwiseXor(other: unknown): Grouping {
-    return new Grouping(new BitwiseXor(this, other as NodeOrValue));
+  bitwiseXor(other: NodeOrValue): Grouping {
+    return new Grouping(new BitwiseXor(this, other));
   }
 
-  bitwiseShiftLeft(other: unknown): Grouping {
-    return new Grouping(new BitwiseShiftLeft(this, other as NodeOrValue));
+  bitwiseShiftLeft(other: NodeOrValue): Grouping {
+    return new Grouping(new BitwiseShiftLeft(this, other));
   }
 
-  bitwiseShiftRight(other: unknown): Grouping {
-    return new Grouping(new BitwiseShiftRight(this, other as NodeOrValue));
+  bitwiseShiftRight(other: NodeOrValue): Grouping {
+    return new Grouping(new BitwiseShiftRight(this, other));
   }
 
   bitwiseNot(): BitwiseNot {

--- a/packages/arel/src/math.ts
+++ b/packages/arel/src/math.ts
@@ -22,34 +22,40 @@ import type { NodeOrValue } from "./nodes/binary.js";
  * result is further chained; `*` and `/` do not — same as Rails. The
  * right-hand operand is passed through raw (Rails does not pre-quote);
  * the visitor renders primitive values via `visit` class dispatch.
+ *
+ * The operand is typed `NodeOrValue` — the union of exactly what a Rails
+ * node slot admits. Ruby's `Arel::Math#*` is untyped only because Ruby has
+ * no types; here the union is the faithful encoding, and typing the
+ * parameter with it (rather than `unknown` + a cast) makes it load-bearing:
+ * a caller that cannot produce a `NodeOrValue` is a finding, not a widen.
  */
 export const Math = {
-  add(this: Node, other: unknown): Grouping {
-    return new Grouping(new Addition(this, other as NodeOrValue));
+  add(this: Node, other: NodeOrValue): Grouping {
+    return new Grouping(new Addition(this, other));
   },
-  subtract(this: Node, other: unknown): Grouping {
-    return new Grouping(new Subtraction(this, other as NodeOrValue));
+  subtract(this: Node, other: NodeOrValue): Grouping {
+    return new Grouping(new Subtraction(this, other));
   },
-  multiply(this: Node, other: unknown): Multiplication {
-    return new Multiplication(this, other as NodeOrValue);
+  multiply(this: Node, other: NodeOrValue): Multiplication {
+    return new Multiplication(this, other);
   },
-  divide(this: Node, other: unknown): Division {
-    return new Division(this, other as NodeOrValue);
+  divide(this: Node, other: NodeOrValue): Division {
+    return new Division(this, other);
   },
-  bitwiseAnd(this: Node, other: unknown): Grouping {
-    return new Grouping(new BitwiseAnd(this, other as NodeOrValue));
+  bitwiseAnd(this: Node, other: NodeOrValue): Grouping {
+    return new Grouping(new BitwiseAnd(this, other));
   },
-  bitwiseOr(this: Node, other: unknown): Grouping {
-    return new Grouping(new BitwiseOr(this, other as NodeOrValue));
+  bitwiseOr(this: Node, other: NodeOrValue): Grouping {
+    return new Grouping(new BitwiseOr(this, other));
   },
-  bitwiseXor(this: Node, other: unknown): Grouping {
-    return new Grouping(new BitwiseXor(this, other as NodeOrValue));
+  bitwiseXor(this: Node, other: NodeOrValue): Grouping {
+    return new Grouping(new BitwiseXor(this, other));
   },
-  bitwiseShiftLeft(this: Node, other: unknown): Grouping {
-    return new Grouping(new BitwiseShiftLeft(this, other as NodeOrValue));
+  bitwiseShiftLeft(this: Node, other: NodeOrValue): Grouping {
+    return new Grouping(new BitwiseShiftLeft(this, other));
   },
-  bitwiseShiftRight(this: Node, other: unknown): Grouping {
-    return new Grouping(new BitwiseShiftRight(this, other as NodeOrValue));
+  bitwiseShiftRight(this: Node, other: NodeOrValue): Grouping {
+    return new Grouping(new BitwiseShiftRight(this, other));
   },
   bitwiseNot(this: Node): BitwiseNot {
     return new BitwiseNot(this);

--- a/packages/arel/src/update-manager.ts
+++ b/packages/arel/src/update-manager.ts
@@ -60,6 +60,16 @@ export class UpdateManager extends TreeManager {
     } else if (values instanceof SqlLiteral || values instanceof BoundSqlLiteral) {
       this.ast.values = [values];
     } else {
+      // Boundary cast — the one that survives the NodeOrValue narrowing.
+      // `UpdateManager#set` is the package edge: ActiveRecord hands over
+      // already-type-cast-for-database column values as
+      // `Record<string, unknown>` (persistence.ts `_updateRecord`), so `val`
+      // is genuinely `unknown` here and cannot be narrowed without pushing a
+      // false type onto AR's DB-value layer. Rails passes these through raw
+      // too; the visitor's Assignment arm quotes a non-Node right rather than
+      // visiting it (to_sql.rb:637-639). This is why `undefined` can still
+      // reach dispatch and the `undefined`→NilClass normalization in
+      // ruby-class.ts / to-sql.ts stays load-bearing.
       this.ast.values = values.map(
         ([col, val]) => new Assignment(new UnqualifiedColumn(col), val as NodeOrValue),
       );

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -71,8 +71,11 @@ function isActiveModelAttribute(v: unknown): boolean {
 // dropped from `NodeOrValue` (binary.ts). The two are complementary rather than
 // contradictory: the union declines to *declare* `undefined` a legal slot
 // occupant, while this normalizes one that arrives anyway. It can still arrive,
-// because `math.ts` / `attribute.ts` / `update-manager.ts` launder values into
-// slots via `as NodeOrValue` casts from `unknown`. The primary normalization is
+// because `update-manager.ts` launders values into a slot via one boundary
+// `as NodeOrValue` cast from `unknown` — the `math.ts` / `attribute.ts` casts
+// were removed once their operands were narrowed to `NodeOrValue`, but
+// `UpdateManager#set` sits on the ActiveRecord edge and cannot be (see the note
+// at its call site). The primary normalization is
 // `rubyClassName` (ruby-class.ts:32), which maps `undefined` to `"NilClass"` at
 // the dispatch boundary so it routes to `visitNilClass`; this helper and
 // `rubyInspect` below just keep the downstream message consistent with that.


### PR DESCRIPTION
## Summary

The 18 operator operands in `math.ts` and `attributes/attribute.ts` were typed
`unknown` and cast into node slots with `as NodeOrValue`, so the union
documented an invariant it did not enforce. That is precisely why the PR #5028
audit — remove an arm, run `pnpm typecheck`, read the fallout — was blind: the
casts launder values from `unknown`, so the compiler never sees what occupies a
slot, and the PR initially dropped `boolean` on a clean typecheck when a bare
boolean actually renders via `UpdateManager#set`.

This narrows those 18 parameters to `NodeOrValue` and deletes the casts. Typing
the parameter with the union is *more* faithful than `unknown` + cast — Ruby's
`Arel::Math#*` is untyped only because Ruby has no types, and `NodeOrValue` is
trails' encoding of what Rails accepts in the slot.

## The surviving boundary cast

`UpdateManager#set` (update-manager.ts) keeps one `as NodeOrValue` cast, now
documented at the call site: it sits on the ActiveRecord edge where
`_updateRecord` hands over already-type-cast-for-database column values as
`Record<string, unknown>`, so `val` is genuinely `unknown` and cannot be
narrowed without pushing a false type onto AR's DB-value layer. One boundary
cast with a reason, not 20 silent ones.

## `undefined` → NilClass normalization stays

Because the `UpdateManager#set` launder survives, an `undefined` can still reach
dispatch, so the normalization in `ruby-class.ts:32` and the downstream
`constructorName` / `rubyInspect` in `to-sql.ts` remain reachable and are kept.
The note at `to-sql.ts` is updated to cite only that path (the math/attribute
casts are gone).

## Verification

Re-running the #5028 experiment — deleting an arm from `NodeOrValue` — now fails
`pnpm typecheck` at real call sites (`math.test.ts`, `predications.test.ts`,
`to-sql.test.ts`, `relation-scoping.test.ts`), which is the point of the story:
the union is an enforced invariant, not decorative. Full typecheck passes with
all arms present; touched arel tests green; api:compare / test:compare neutral
(signatures narrowed, no methods added or removed).

Closes-story: arel-nodeorvalue-casts-make-union-load-bearing
