### PR TITLE
fix(arel): SelectManager#join takes (relation, klass) only, matching Rails

### DIFF
--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2974,10 +2974,11 @@ export function emitJoinPlan(this: QueryMethodsHost, manager: any, plan: JoinEmi
       : j.table;
     const onNode = typeof j.on === "string" ? arelSql(j.on) : j.on;
     if (j.type === "inner") {
-      manager.join(tableNode, onNode);
+      manager.join(tableNode);
     } else {
-      manager.outerJoin(tableNode, onNode);
+      manager.outerJoin(tableNode);
     }
+    if (onNode != null) manager.on(onNode);
   }
 
   // One AliasTracker shared across every JoinDependency, mirroring Rails' single

--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -550,12 +550,16 @@ describe("SelectManagerTest", () => {
     it("returns inner join sql", () => {
       const mgr = users
         .project(users.get("name"), posts.get("title"))
-        .join(posts, users.get("id").eq(posts.get("user_id")));
+        .join(posts)
+        .on(users.get("id").eq(posts.get("user_id")));
       expect(mgr.toSql()).toContain("INNER JOIN");
     });
 
     it("returns outer join sql", () => {
-      const mgr = users.project(star).outerJoin(posts, users.get("id").eq(posts.get("user_id")));
+      const mgr = users
+        .project(star)
+        .outerJoin(posts)
+        .on(users.get("id").eq(posts.get("user_id")));
       expect(mgr.toSql()).toContain("LEFT OUTER JOIN");
     });
 
@@ -958,7 +962,8 @@ describe("SelectManagerTest", () => {
       expect(
         users
           .project(users.get("name"), posts.get("title"))
-          .join(posts, users.get("id").eq(posts.get("user_id")))
+          .join(posts)
+          .on(users.get("id").eq(posts.get("user_id")))
           .toSql(),
       ).toBe(
         'SELECT "users"."name", "posts"."title" FROM "users" INNER JOIN "posts" ON "users"."id" = "posts"."user_id"',
@@ -969,7 +974,8 @@ describe("SelectManagerTest", () => {
       expect(
         users
           .project(star)
-          .outerJoin(posts, users.get("id").eq(posts.get("user_id")))
+          .outerJoin(posts)
+          .on(users.get("id").eq(posts.get("user_id")))
           .toSql(),
       ).toBe('SELECT * FROM "users" LEFT OUTER JOIN "posts" ON "users"."id" = "posts"."user_id"');
     });
@@ -1164,7 +1170,10 @@ describe("SelectManagerTest", () => {
   });
 
   it("returns join nodes after join()", () => {
-    const manager = users.project("*").join(posts, users.attr("id").eq(posts.attr("user_id")));
+    const manager = users
+      .project("*")
+      .join(posts)
+      .on(users.attr("id").eq(posts.attr("user_id")));
     expect(manager.joinSources.length).toBe(1);
     expect(manager.joinSources[0]).toBeInstanceOf(Nodes.InnerJoin);
   });
@@ -1173,8 +1182,10 @@ describe("SelectManagerTest", () => {
     const comments = new Table("comments");
     const manager = users
       .project("*")
-      .join(posts, users.attr("id").eq(posts.attr("user_id")))
-      .outerJoin(comments, posts.attr("id").eq(comments.attr("post_id")));
+      .join(posts)
+      .on(users.attr("id").eq(posts.attr("user_id")))
+      .outerJoin(comments)
+      .on(posts.attr("id").eq(comments.attr("post_id")));
     expect(manager.joinSources.length).toBe(2);
     expect(manager.joinSources[0]).toBeInstanceOf(Nodes.InnerJoin);
     expect(manager.joinSources[1]).toBeInstanceOf(Nodes.OuterJoin);

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -206,23 +206,9 @@ export class SelectManager extends TreeManager {
    */
   join(
     table: Node | string | null | undefined,
-    klassOrCondition?: (new (left: Node, right: Node | null) => Join) | Node,
+    klass: new (left: Node, right: Node | null) => Join = InnerJoin,
   ): this {
     if (table == null) return this;
-
-    // Rails' signature is `join(relation, klass = Nodes::InnerJoin)` and it
-    // always passes `nil` as create_join's constraint. The second arg here is
-    // overloaded to also accept an ON predicate — a pre-existing trails
-    // extension several activerecord callers rely on positionally (e.g.
-    // query-methods.ts's `manager.join(tableNode, onNode)`), where Rails would
-    // chain `.on(...)`. Narrowing that surface is a separate change.
-    let klass: new (left: Node, right: Node | null) => Join = InnerJoin;
-    let constraint: Node | null = null;
-    if (klassOrCondition && typeof klassOrCondition === "function" && klassOrCondition.prototype) {
-      klass = klassOrCondition as new (left: Node, right: Node | null) => Join;
-    } else if (klassOrCondition instanceof Node) {
-      constraint = klassOrCondition;
-    }
 
     const tableNode = typeof table === "string" ? new SqlLiteral(table) : table;
 
@@ -235,23 +221,16 @@ export class SelectManager extends TreeManager {
       klass = StringJoin as unknown as new (left: Node, right: Node | null) => Join;
     }
 
-    this.core.source.right.push(this.createJoin(tableNode, constraint, klass));
+    this.core.source.right.push(this.createJoin(tableNode, null, klass));
     return this;
   }
 
   /**
    * LEFT OUTER JOIN.
+   *
+   * Mirrors: Arel::SelectManager#outer_join (select_manager.rb:115-117).
    */
-  outerJoin(table: Node | string | null | undefined, onCondition?: Node): this {
-    // Rails: `outer_join(relation) = join(relation, Nodes::OuterJoin)`
-    // (select_manager.rb:115-117). The onCondition arg is a trails extension
-    // used by callers that would otherwise chain `.on(...)`.
-    if (onCondition) {
-      if (table == null) return this;
-      const tableNode = typeof table === "string" ? new SqlLiteral(table) : table;
-      this.core.source.right.push(this.createJoin(tableNode, onCondition, OuterJoin));
-      return this;
-    }
+  outerJoin(table: Node | string | null | undefined): this {
     return this.join(table, OuterJoin);
   }
 
@@ -590,13 +569,10 @@ export class SelectManager extends TreeManager {
   }
 
   // -- FactoryMethods (via TreeManager) --
-  // createTrue/createFalse/createTableAlias/createStringJoin/createAnd/
-  // createOn/grouping/lower/coalesce/cast are mixed in from
+  // createTrue/createFalse/createTableAlias/createJoin/createStringJoin/
+  // createAnd/createOn/grouping/lower/coalesce/cast are mixed in from
   // Arel::FactoryMethods (see ./factory-methods.ts and the include() call
-  // in ./index.ts). createJoin is overridden below because Rails' Arel
-  // wraps the constraint in an `On` node when sourced from a SelectManager.
-
-  private static readonly defaultJoinConstructor = InnerJoin;
+  // in ./index.ts).
 
   /**
    * Build a DeleteManager that applies this SELECT's constraints,
@@ -621,24 +597,6 @@ export class SelectManager extends TreeManager {
     }
     if (havingClause !== null) dm.having(havingClause);
     return dm;
-  }
-
-  private static isJoinConstructor(
-    value: unknown,
-  ): value is new (left: Node, right: Node | null) => Join {
-    return typeof value === "function";
-  }
-
-  createJoin(
-    to: Node,
-    constraint?: Node | null,
-    klass?: new (left: Node, right: Node | null) => Join,
-  ): Join {
-    const JoinKlass =
-      klass && SelectManager.isJoinConstructor(klass)
-        ? klass
-        : SelectManager.defaultJoinConstructor;
-    return new JoinKlass(to, constraint ? new On(constraint) : null);
   }
 
   /**

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -202,7 +202,9 @@ export class SelectManager extends TreeManager {
   }
 
   /**
-   * INNER JOIN.
+   * INNER JOIN (or the join class passed as `klass`).
+   *
+   * Mirrors: Arel::SelectManager#join (select_manager.rb:102-113).
    */
   join(
     table: Node | string | null | undefined,

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -448,7 +448,10 @@ describe("the to_sql visitor", () => {
 
   describe("Nodes::Fragments", () => {
     it("joins subexpressions", () => {
-      const mgr = users.project(star).join(posts, users.get("id").eq(posts.get("user_id")));
+      const mgr = users
+        .project(star)
+        .join(posts)
+        .on(users.get("id").eq(posts.get("user_id")));
       const sql = new Visitors.ToSql(testConnection).compile(mgr.ast);
       expect(sql).toContain("JOIN");
       expect(sql).toContain("ON");


### PR DESCRIPTION
Removes the trails-only overloading of `SelectManager#join`'s second argument, which accepted either a join class or a bare ON predicate. Rails' signature (`select_manager.rb:102-113`) is `join(relation, klass = Nodes::InnerJoin)` and always passes `nil` as `create_join`'s constraint — callers chain `.on(...)`.

- `join(relation, klass = InnerJoin)` only; the positional-predicate arm is gone.
- `outerJoin(relation)` only, matching `select_manager.rb:115-117`.
- `SelectManager`'s divergent `createJoin` override (which wrapped the constraint in `On`) is deleted; the single mixed-in `FactoryMethods.createJoin` now serves all callers, matching Rails' one `create_join`. The `On` wrap stays where Rails puts it — `SelectManager#on`.
- Callers converted to chain `.on(...)`: `emitJoinPlan` in `query-methods.ts` and the arel test call sites. (`association-scope.ts:637` named in the story calls AssociationScope's own private `join` — Rails' `association_scope.rb:54` — not `SelectManager#join`, so it needed no change.)

Verified via the full arel suite (1585 passing, including the to-sql `INNER JOIN`/`LEFT OUTER JOIN`/`ON` emission probes from #5029), plus `association-scope`, `left-outer-join-association`, `join-model`, `relations`, `relation.test`, and the whole `relation/` directory locally.

Closes-story: select-manager-join-positional-condition-arg-extension
