### PR TITLE
test(arel): remaining visitor tests supply an explicit connection

### DIFF
--- a/packages/arel/src/attribute-alignment.test.ts
+++ b/packages/arel/src/attribute-alignment.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "./test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "./index.js";
 
 const users = new Table("users");
-const compile = (n: Nodes.Node): string => new Visitors.ToSql().compile(n);
+const compile = (n: Nodes.Node): string => new Visitors.ToSql(testConnection).compile(n);
 
 // Behavior tests for the attribute-alignment changes — typed-subclass
 // returns from aggregates / contains / overlaps / concat, plus the
@@ -101,7 +102,7 @@ describe("Per-class `as(name)` marks the alias SqlLiteral as retryable", () => {
   // collector.retryable to false.
 
   const collectorIsRetryableAfter = (n: Nodes.Node): boolean =>
-    new Visitors.ToSql().compileWithCollector(n).retryable;
+    new Visitors.ToSql(testConnection).compileWithCollector(n).retryable;
 
   it("Attribute#as keeps the collector retryable", () => {
     expect(collectorIsRetryableAfter(users.attr("id").as("aliased"))).toBe(true);

--- a/packages/arel/src/attributes/attribute.test.ts
+++ b/packages/arel/src/attributes/attribute.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "../test-helpers/connection.js";
 import { Table, star, SelectManager, Nodes, Visitors, relationName } from "../index.js";
 
 describe("AttributeTest", () => {
   const users = new Table("users");
-  const visitor = new Visitors.ToSql();
+  const visitor = new Visitors.ToSql(testConnection);
   describe("#not_eq", () => {
     it("should create a NotEqual node", () => {
       expect(users.project(star).where(users.get("id").notEq(10)).toSql()).toBe(
@@ -19,7 +20,7 @@ describe("AttributeTest", () => {
     it("should handle nil", () => {
       const relation = new Table("users");
       const node = relation.get("id").notEq(null);
-      expect(new Visitors.ToSql().compile(node)).toContain("IS NOT NULL");
+      expect(new Visitors.ToSql(testConnection).compile(node)).toContain("IS NOT NULL");
     });
   });
 
@@ -386,7 +387,7 @@ describe("AttributeTest", () => {
     });
 
     it("should handle nil", () => {
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       const node = users.get("name").eq(null);
       expect(visitor.compile(node)).toBe('"users"."name" IS NULL');
     });
@@ -806,14 +807,14 @@ describe("AttributeTest", () => {
   describe("#not_between", () => {
     it("can be constructed with a standard range", () => {
       const node = users.get("age").notBetween(18, 65);
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       const sql = visitor.compile(node);
       expect(sql).toBe('("users"."age" < 18 OR "users"."age" > 65)');
     });
 
     it("can be constructed with a range starting from -Infinity", () => {
       const node = users.get("age").notBetween(-Infinity, 65);
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       expect(visitor.compile(node)).toBe('"users"."age" > 65');
     });
 
@@ -844,7 +845,7 @@ describe("AttributeTest", () => {
 
     it("can be constructed with an exclusive range", () => {
       const node = users.get("age").notBetween({ begin: 18, end: 65, excludeEnd: true });
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       const result = visitor.compile(node);
       expect(result).toBe('("users"."age" < 18 OR "users"."age" >= 65)');
     });
@@ -860,7 +861,7 @@ describe("AttributeTest", () => {
   describe("#not_in", () => {
     it("can be constructed with a list", () => {
       const node = users.get("id").notIn([1, 2, 3]);
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       expect(visitor.compile(node)).toBe('"users"."id" NOT IN (1, 2, 3)');
     });
 
@@ -926,7 +927,7 @@ describe("AttributeTest", () => {
     });
 
     it("should generate @> in sql", () => {
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       const node = users.get("tags").contains("foo");
       expect(visitor.compile(node)).toBe('"users"."tags" @> \'foo\'');
     });
@@ -934,7 +935,7 @@ describe("AttributeTest", () => {
 
   describe("#overlaps", () => {
     it("should generate && in sql", () => {
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       const node = users.get("tags").overlaps("bar");
       expect(visitor.compile(node)).toBe('"users"."tags" && \'bar\'');
     });
@@ -942,7 +943,7 @@ describe("AttributeTest", () => {
 
   describe("equality", () => {
     it("should produce sql", () => {
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       const node = users.get("tags").contains("foo");
       expect(visitor.compile(node)).toBe('"users"."tags" @> \'foo\'');
     });
@@ -951,7 +952,7 @@ describe("AttributeTest", () => {
       it("should produce sql", () => {
         const relation = new Table("users");
         const node = relation.get("id").eq(10);
-        const visitor = new Visitors.ToSql();
+        const visitor = new Visitors.ToSql(testConnection);
         expect(visitor.compile(node)).toContain('"users"."id" = 10');
       });
     });
@@ -963,7 +964,7 @@ describe("AttributeTest", () => {
       const condition = table.get("id").eq("1");
 
       expect(table.isAbleToTypeCast()).toBe(false);
-      expect(new Visitors.ToSql().compile(condition)).toBe('"foo"."id" = \'1\'');
+      expect(new Visitors.ToSql(testConnection).compile(condition)).toBe('"foo"."id" = \'1\'');
     });
 
     it("type casts when given an explicit caster", () => {
@@ -976,7 +977,7 @@ describe("AttributeTest", () => {
       const condition = table.get("id").eq("1").and(table.get("other_id").eq("2"));
 
       expect(table.isAbleToTypeCast()).toBe(true);
-      expect(new Visitors.ToSql().compile(condition)).toBe(
+      expect(new Visitors.ToSql(testConnection).compile(condition)).toBe(
         '"foo"."id" = 1 AND "foo"."other_id" = \'2\'',
       );
     });
@@ -991,7 +992,7 @@ describe("AttributeTest", () => {
       const condition = table.get("id").eq(new Nodes.SqlLiteral("(select 1)"));
 
       expect(table.isAbleToTypeCast()).toBe(true);
-      expect(new Visitors.ToSql().compile(condition)).toBe('"foo"."id" = (select 1)');
+      expect(new Visitors.ToSql(testConnection).compile(condition)).toBe('"foo"."id" = (select 1)');
     });
 
     it("type casts IN list elements through the attribute", () => {
@@ -1003,7 +1004,7 @@ describe("AttributeTest", () => {
       const table = new Table("foo", { typeCaster: fakeCaster });
       const condition = table.get("id").in(["1", "2"]);
 
-      expect(new Visitors.ToSql().compile(condition)).toBe('"foo"."id" IN (1, 2)');
+      expect(new Visitors.ToSql(testConnection).compile(condition)).toBe('"foo"."id" IN (1, 2)');
     });
 
     it("type casts NOT IN list elements through the attribute", () => {
@@ -1015,7 +1016,9 @@ describe("AttributeTest", () => {
       const table = new Table("foo", { typeCaster: fakeCaster });
       const condition = table.get("id").notIn(["1", "2"]);
 
-      expect(new Visitors.ToSql().compile(condition)).toBe('"foo"."id" NOT IN (1, 2)');
+      expect(new Visitors.ToSql(testConnection).compile(condition)).toBe(
+        '"foo"."id" NOT IN (1, 2)',
+      );
     });
 
     it("builds Casted nodes so a null in an IN list casts through the column", () => {
@@ -1031,7 +1034,7 @@ describe("AttributeTest", () => {
 
       expect(right).toBeInstanceOf(Nodes.Casted);
       expect((right as Nodes.Casted).attribute).toBe(attr);
-      expect(new Visitors.ToSql().compile(node)).toBe('"foo"."id" IN (0)');
+      expect(new Visitors.ToSql(testConnection).compile(node)).toBe('"foo"."id" IN (0)');
     });
   });
 
@@ -1337,7 +1340,7 @@ describe("AttributeTest", () => {
   });
 
   it("should produce sql for attribute", () => {
-    const visitor = new Visitors.ToSql();
+    const visitor = new Visitors.ToSql(testConnection);
     const attr = users.get("name");
     expect(visitor.compile(attr)).toBe('"users"."name"');
   });
@@ -1345,13 +1348,13 @@ describe("AttributeTest", () => {
   it("can be constructed with a subquery for IN", () => {
     const subquery = users.project(users.get("id"));
     const node = users.get("id").in(subquery);
-    const visitor = new Visitors.ToSql();
+    const visitor = new Visitors.ToSql(testConnection);
     expect(visitor.compile(node)).toBe('"users"."id" IN (SELECT "users"."id" FROM "users")');
   });
 
   it("can be constructed with a standard range for between", () => {
     const node = users.get("age").between({ begin: 18, end: 65 });
-    const visitor = new Visitors.ToSql();
+    const visitor = new Visitors.ToSql(testConnection);
     expect(visitor.compile(node)).toBe('"users"."age" BETWEEN 18 AND 65');
   });
 
@@ -1411,7 +1414,7 @@ describe("AttributeTest", () => {
     it("can be constructed with a range starting from -Infinity", () => {
       // Mirrors Rails: not_between(-Inf..end) collapses to gt(end).
       const node = users.get("age").notBetween(-Infinity, 65);
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       expect(visitor.compile(node)).toBe('"users"."age" > 65');
     });
   });
@@ -1421,7 +1424,7 @@ describe("AttributeTest", () => {
       const left = users.get("age").notBetween(18, 30);
       const right = users.get("age").notBetween(40, 50);
       const node = new Nodes.Grouping(new Nodes.Or(left, right));
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       const result = visitor.compile(node);
       expect(result).toContain("OR");
     });
@@ -1439,7 +1442,7 @@ describe("AttributeTest", () => {
       const left = users.get("age").notBetween(18, 65);
       const right = users.get("score").notBetween(1, 100);
       const node = new Nodes.Grouping(new Nodes.And([left, right]));
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       const result = visitor.compile(node);
       expect(result).toContain("AND");
     });
@@ -1448,14 +1451,14 @@ describe("AttributeTest", () => {
   describe("#not_between", () => {
     it("can be constructed with a standard range", () => {
       const node = users.get("id").between([1, 100]);
-      const sql = new Visitors.ToSql().compile(node);
+      const sql = new Visitors.ToSql(testConnection).compile(node);
       expect(sql).toContain("BETWEEN");
       expect(sql).toContain("1 AND 100");
     });
 
     it("can be constructed with a range starting from -Infinity", () => {
       const node = users.get("id").between(-Infinity, 100);
-      const sql = new Visitors.ToSql().compile(node);
+      const sql = new Visitors.ToSql(testConnection).compile(node);
       expect(sql).toContain("<=");
       expect(sql).toContain("100");
     });
@@ -1467,7 +1470,7 @@ describe("AttributeTest", () => {
       const node = new Nodes.Grouping(
         new Nodes.And([users.get("id").gteq(begin), users.get("id").lt(end)]),
       );
-      const sql = new Visitors.ToSql().compile(node);
+      const sql = new Visitors.ToSql(testConnection).compile(node);
       expect(sql).toContain(">=");
       expect(sql).toContain("<");
     });
@@ -1481,7 +1484,7 @@ describe("AttributeTest", () => {
       m2.project(star);
       const union = m1.union(m2);
       expect(union).toBeInstanceOf(Nodes.Union);
-      const sql = new Visitors.ToSql().compile(union);
+      const sql = new Visitors.ToSql(testConnection).compile(union);
       expect(sql).toContain("UNION");
     });
   });
@@ -1489,7 +1492,7 @@ describe("AttributeTest", () => {
   describe("#sum", () => {
     it("should generate the proper SQL", () => {
       const node = users.get("tags").contains("foo");
-      const sql = new Visitors.ToSql().compile(node);
+      const sql = new Visitors.ToSql(testConnection).compile(node);
       expect(sql).toBe('"users"."tags" @> \'foo\'');
     });
   });
@@ -1497,7 +1500,7 @@ describe("AttributeTest", () => {
   describe("#minimum", () => {
     it("should generate proper SQL", () => {
       const node = users.get("tags").overlaps("bar");
-      const sql = new Visitors.ToSql().compile(node);
+      const sql = new Visitors.ToSql(testConnection).compile(node);
       expect(sql).toBe('"users"."tags" && \'bar\'');
     });
   });
@@ -1514,7 +1517,7 @@ describe("AttributeTest", () => {
     it("should produce sql", () => {
       const relation = new Table("users");
       const node = relation.get("id").eq(10);
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       expect(visitor.compile(node)).toContain('"users"."id" = 10');
     });
   });

--- a/packages/arel/src/attributes/attribute.trails.test.ts
+++ b/packages/arel/src/attributes/attribute.trails.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
 
 // TS-only coverage for the `when Enumerable` arm of Attribute#in / #notIn
@@ -8,7 +9,7 @@ import { Table, Nodes, Visitors } from "../index.js";
 // simply Enumerable; the distinction only exists on this side of the port.
 describe("AttributeTest (trails)", () => {
   const users = new Table("users");
-  const visitor = new Visitors.ToSql();
+  const visitor = new Visitors.ToSql(testConnection);
 
   describe("#in", () => {
     it("expands a Set through the Enumerable arm", () => {

--- a/packages/arel/src/attributes/math.test.ts
+++ b/packages/arel/src/attributes/math.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "../test-helpers/connection.js";
 import { Table, Visitors } from "../index.js";
 
 describe("MathTest", () => {
-  const visitor = new Visitors.ToSql();
+  const visitor = new Visitors.ToSql(testConnection);
   const table = new Table("users");
 
   // These test names match the Ruby convention (interpolation-stripped names)
@@ -249,35 +250,35 @@ describe("MathTest", () => {
 
   it("average should be compatible with ", () => {
     const table = new Table("users");
-    const sql = new Visitors.ToSql().compile(table.get("id").average().divide(2));
+    const sql = new Visitors.ToSql(testConnection).compile(table.get("id").average().divide(2));
     expect(sql).toContain("AVG");
     expect(sql).toContain("/");
   });
 
   it("count should be compatible with ", () => {
     const table = new Table("users");
-    const sql = new Visitors.ToSql().compile(table.get("id").count().divide(2));
+    const sql = new Visitors.ToSql(testConnection).compile(table.get("id").count().divide(2));
     expect(sql).toContain("COUNT");
     expect(sql).toContain("/");
   });
 
   it("maximum should be compatible with ", () => {
     const table = new Table("users");
-    const sql = new Visitors.ToSql().compile(table.get("id").maximum().divide(2));
+    const sql = new Visitors.ToSql(testConnection).compile(table.get("id").maximum().divide(2));
     expect(sql).toContain("MAX");
     expect(sql).toContain("/");
   });
 
   it("minimum should be compatible with ", () => {
     const table = new Table("users");
-    const sql = new Visitors.ToSql().compile(table.get("id").minimum().divide(2));
+    const sql = new Visitors.ToSql(testConnection).compile(table.get("id").minimum().divide(2));
     expect(sql).toContain("MIN");
     expect(sql).toContain("/");
   });
 
   it("attribute node should be compatible with ", () => {
     const table = new Table("users");
-    const sql = new Visitors.ToSql().compile(table.get("id").divide(2));
+    const sql = new Visitors.ToSql(testConnection).compile(table.get("id").divide(2));
     expect(sql).toContain("/");
   });
 });

--- a/packages/arel/src/expression-mixins.test.ts
+++ b/packages/arel/src/expression-mixins.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "./test-helpers/connection.js";
 import { Nodes, Visitors } from "./index.js";
 
-const compile = (n: Nodes.Node): string => new Visitors.ToSql().compile(n);
+const compile = (n: Nodes.Node): string => new Visitors.ToSql(testConnection).compile(n);
 
 // Behavior tests for the mixin surface added in this PR — Expressions,
 // AliasPredication, OrderPredications, FilterPredications,

--- a/packages/arel/src/factory-methods.test.ts
+++ b/packages/arel/src/factory-methods.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "./test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "./index.js";
 
 describe("TestFactoryMethods", () => {
@@ -48,14 +49,16 @@ describe("TestFactoryMethods", () => {
   it("lower wraps non-Node arguments via buildQuoted", () => {
     const fn = users.lower("name");
     expect(fn.expressions[0]).toBeInstanceOf(Nodes.Quoted);
-    expect(new Visitors.ToSql().compile(fn)).toBe("LOWER('name')");
+    expect(new Visitors.ToSql(testConnection).compile(fn)).toBe("LOWER('name')");
   });
 
   it("coalesce", () => {
     const fn = users.coalesce(users.get("name"), new Nodes.Quoted("default"));
     expect(fn).toBeInstanceOf(Nodes.NamedFunction);
     expect(fn.name).toBe("COALESCE");
-    expect(new Visitors.ToSql().compile(fn)).toBe('COALESCE("users"."name", \'default\')');
+    expect(new Visitors.ToSql(testConnection).compile(fn)).toBe(
+      'COALESCE("users"."name", \'default\')',
+    );
   });
 
   it("cast", () => {
@@ -65,7 +68,7 @@ describe("TestFactoryMethods", () => {
     // Mirrors Rails: `cast` builds NamedFunction("CAST", [name.as(type)]),
     // not a string-interpolated SqlLiteral. The compiled SQL must reference
     // the column properly rather than "[object Object] AS VARCHAR".
-    expect(new Visitors.ToSql().compile(fn)).toBe('CAST("users"."age" AS VARCHAR)');
+    expect(new Visitors.ToSql(testConnection).compile(fn)).toBe('CAST("users"."age" AS VARCHAR)');
   });
 
   // Mirrors Rails: delegating to `name.as(type)` produces an `As` whose
@@ -83,13 +86,13 @@ describe("TestFactoryMethods", () => {
   it("create true", () => {
     const t = users.createTrue();
     expect(t).toBeInstanceOf(Nodes.True);
-    expect(new Visitors.ToSql().compile(t)).toBe("TRUE");
+    expect(new Visitors.ToSql(testConnection).compile(t)).toBe("TRUE");
   });
 
   it("create false", () => {
     const f = users.createFalse();
     expect(f).toBeInstanceOf(Nodes.False);
-    expect(new Visitors.ToSql().compile(f)).toBe("FALSE");
+    expect(new Visitors.ToSql(testConnection).compile(f)).toBe("FALSE");
   });
 
   // Regression: verifies the include(Node, FactoryMethods) call in index.ts

--- a/packages/arel/src/math.test.ts
+++ b/packages/arel/src/math.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "./test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "./index.js";
 
 describe("Math", () => {
   const users = new Table("users");
-  const visitor = new Visitors.ToSql();
+  const visitor = new Visitors.ToSql(testConnection);
 
   describe("operands pass through raw (no Quoted wrapper)", () => {
     const arg = new Nodes.SqlLiteral("42");

--- a/packages/arel/src/nodes/and.test.ts
+++ b/packages/arel/src/nodes/and.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
 
 describe("And", () => {
@@ -22,7 +23,7 @@ describe("And", () => {
       const caseNode = new Nodes.Case()
         .when(new Nodes.SqlLiteral("1 = 1"), new Nodes.SqlLiteral("'yes'"))
         .as("result");
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       expect(visitor.compile(caseNode)).toBe("CASE WHEN 1 = 1 THEN 'yes' END AS result");
     });
   });

--- a/packages/arel/src/nodes/bin.test.ts
+++ b/packages/arel/src/nodes/bin.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection, mysqlTestConnection } from "../test-helpers/connection.js";
 import { Nodes, Visitors } from "../index.js";
 
 describe("TestBin", () => {
@@ -21,14 +22,14 @@ describe("TestBin", () => {
 
   it("default to sql", () => {
     const node = new Nodes.Bin(new Nodes.SqlLiteral("zomg"));
-    const sql = new Visitors.ToSql().compile(node);
+    const sql = new Visitors.ToSql(testConnection).compile(node);
     expect(sql).toBe("zomg");
   });
 
   it("mysql to sql", () => {
     // Rails MySQL: visit_Arel_Nodes_Bin emits `CAST(... AS BINARY)`.
     const node = new Nodes.Bin(new Nodes.SqlLiteral("zomg"));
-    const sql = new Visitors.MySQL().compile(node);
+    const sql = new Visitors.MySQL(mysqlTestConnection).compile(node);
     expect(sql).toBe("CAST(zomg AS BINARY)");
   });
 });

--- a/packages/arel/src/nodes/case.test.ts
+++ b/packages/arel/src/nodes/case.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
 
 describe("NodesTest", () => {
@@ -19,7 +20,7 @@ describe("NodesTest", () => {
       const caseNode = new Nodes.Case(users.get("status"));
       const withDefault = caseNode.else("unknown");
       expect(withDefault.default).not.toBeNull();
-      expect(new Visitors.ToSql().compile(withDefault)).toContain("ELSE");
+      expect(new Visitors.ToSql(testConnection).compile(withDefault)).toContain("ELSE");
     });
 
     it("clones case, conditions and default", () => {

--- a/packages/arel/src/nodes/casted.test.ts
+++ b/packages/arel/src/nodes/casted.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
 import { buildQuoted } from "./casted.js";
 import { Attribute as AMAttribute, ValueType } from "@blazetrails/activemodel";
@@ -54,7 +55,7 @@ describe("Arel::Nodes.build_quoted", () => {
 
     // compileWithBinds should collect it (not inline it) — matches Rails'
     // visit_ActiveModel_Attribute routing through add_bind.
-    const [sql, binds] = new Visitors.ToSql().compileWithBinds(node);
+    const [sql, binds] = new Visitors.ToSql(testConnection).compileWithBinds(node);
     expect(sql).toBe("?");
     expect(binds).toEqual([amAttr]);
   });
@@ -137,7 +138,9 @@ describe("Arel::Nodes::Casted#nil?", () => {
     expect(new Nodes.Casted(undefined, attr).isNil()).toBe(true);
     expect(new Nodes.Quoted(undefined).isNil()).toBe(true);
 
-    const [sql] = new Visitors.ToSql().compileWithBinds(users.get("id").eq(undefined));
+    const [sql] = new Visitors.ToSql(testConnection).compileWithBinds(
+      users.get("id").eq(undefined),
+    );
     expect(sql).toBe('"users"."id" IS NULL');
   });
 
@@ -145,7 +148,7 @@ describe("Arel::Nodes::Casted#nil?", () => {
   // identically to Casted's, so an undefined-valued Quoted spells IS NULL too.
   it("renders IS NULL for a Quoted(undefined) right-hand side", () => {
     const eq = new Nodes.Equality(users.get("id"), new Nodes.Quoted(undefined));
-    const [sql] = new Visitors.ToSql().compileWithBinds(eq);
+    const [sql] = new Visitors.ToSql(testConnection).compileWithBinds(eq);
     expect(sql).toBe('"users"."id" IS NULL');
   });
 
@@ -170,7 +173,7 @@ describe("Arel::Nodes::Casted#nil?", () => {
     const eq = attr.eq(null);
     expect(eq.right).toBeInstanceOf(Nodes.Casted);
     expect((eq.right as Nodes.Casted).attribute).toBe(attr);
-    const [sql] = new Visitors.ToSql().compileWithBinds(eq);
+    const [sql] = new Visitors.ToSql(testConnection).compileWithBinds(eq);
     expect(sql).toBe('"users"."id" IS NULL');
   });
 });

--- a/packages/arel/src/nodes/comment.test.ts
+++ b/packages/arel/src/nodes/comment.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "../test-helpers/connection.js";
 import { Nodes, Visitors, Table, star } from "../index.js";
 
 describe("CommentTest", () => {
@@ -21,7 +22,7 @@ describe("CommentTest", () => {
       const users = new Table("users");
       const mgr = users.project(star);
       mgr.comment("hello */ DROP TABLE users");
-      const sql = new Visitors.ToSql().compile(mgr.ast);
+      const sql = new Visitors.ToSql(testConnection).compile(mgr.ast);
       // The */ is stripped so the comment stays enclosed
       expect(sql).toContain("/* hello DROP TABLE users */");
       // There should be exactly one block comment pair
@@ -33,7 +34,7 @@ describe("CommentTest", () => {
       const users = new Table("users");
       const mgr = users.project(star);
       mgr.comment("before /* nested */ after");
-      const sql = new Visitors.ToSql().compile(mgr.ast);
+      const sql = new Visitors.ToSql(testConnection).compile(mgr.ast);
       // Both /* and */ stripped from the value
       expect(sql).toContain("/* before nested after */");
     });
@@ -42,7 +43,7 @@ describe("CommentTest", () => {
       const users = new Table("users");
       const mgr = users.project(star);
       mgr.comment("hello   \n  world");
-      const sql = new Visitors.ToSql().compile(mgr.ast);
+      const sql = new Visitors.ToSql(testConnection).compile(mgr.ast);
       expect(sql).toContain("/* hello world */");
     });
   });

--- a/packages/arel/src/nodes/count.test.ts
+++ b/packages/arel/src/nodes/count.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
 
 describe("Arel::Nodes::CountTest", () => {
@@ -7,7 +8,7 @@ describe("Arel::Nodes::CountTest", () => {
     it("should alias the count", () => {
       const count = users.get("id").count();
       const aliased = count.as("user_count");
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       expect(visitor.compile(aliased)).toBe('COUNT("users"."id") AS user_count');
     });
   });

--- a/packages/arel/src/nodes/equality.test.ts
+++ b/packages/arel/src/nodes/equality.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
 
 describe("Arel", () => {
@@ -66,7 +67,7 @@ describe("Arel", () => {
         it("takes an engine", () => {
           const attr = users.get("id");
           const test = attr.eq(10);
-          const sql = new Visitors.ToSql().compile(test);
+          const sql = new Visitors.ToSql(testConnection).compile(test);
           expect(sql).toContain('"users"."id"');
           expect(sql).toContain("10");
         });

--- a/packages/arel/src/nodes/extract.test.ts
+++ b/packages/arel/src/nodes/extract.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
 
 describe("Arel::Nodes::ExtractTest", () => {
@@ -6,7 +7,7 @@ describe("Arel::Nodes::ExtractTest", () => {
   it("should extract field", () => {
     const createdAt = users.get("created_at");
     const node = new Nodes.Extract(createdAt, "YEAR");
-    const visitor = new Visitors.ToSql();
+    const visitor = new Visitors.ToSql(testConnection);
     const sql = visitor.compile(node);
     expect(sql).toBe('EXTRACT(YEAR FROM "users"."created_at")');
   });
@@ -17,7 +18,7 @@ describe("Arel::Nodes::ExtractTest", () => {
     // of how it was constructed.
     const createdAt = users.get("created_at");
     const node = new Nodes.Extract(createdAt, "month");
-    const sql = new Visitors.ToSql().compile(node);
+    const sql = new Visitors.ToSql(testConnection).compile(node);
     expect(sql).toBe('EXTRACT(MONTH FROM "users"."created_at")');
   });
 
@@ -30,14 +31,16 @@ describe("Arel::Nodes::ExtractTest", () => {
     const node = createdAt.extract("year");
     expect(Array.isArray(node.expr)).toBe(true);
     expect((node.expr as Nodes.Node[])[0]).toBe(createdAt);
-    expect(new Visitors.ToSql().compile(node)).toBe('EXTRACT(YEAR FROM "users"."created_at")');
+    expect(new Visitors.ToSql(testConnection).compile(node)).toBe(
+      'EXTRACT(YEAR FROM "users"."created_at")',
+    );
   });
 
   describe("as", () => {
     it("should alias the extract", () => {
       const createdAt = users.get("created_at");
       const node = new Nodes.Extract(createdAt, "MONTH").as("birth_month");
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       const sql = visitor.compile(node);
       expect(sql).toBe('EXTRACT(MONTH FROM "users"."created_at") AS birth_month');
     });

--- a/packages/arel/src/nodes/filter.test.ts
+++ b/packages/arel/src/nodes/filter.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
 
 describe("FilterTest", () => {
@@ -7,7 +8,7 @@ describe("FilterTest", () => {
     it("should add filter to expression", () => {
       const count = new Nodes.NamedFunction("COUNT", [new Nodes.SqlLiteral("*")]);
       const filter = new Nodes.Filter(count, users.get("active").eq(true));
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       expect(visitor.compile(filter)).toBe('COUNT(*) FILTER (WHERE "users"."active" = TRUE)');
     });
 
@@ -23,7 +24,7 @@ describe("FilterTest", () => {
       const w = new Nodes.Window();
       w.order(users.get("id").asc());
       const over = new Nodes.Over(fn, w);
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       const result = visitor.compile(over);
       expect(result).toContain("OVER");
       expect(result).toContain("ORDER BY");
@@ -36,7 +37,7 @@ describe("FilterTest", () => {
         const window = new Nodes.Window();
         window.partition(users.get("year"));
         const over = new Nodes.Over(filter, window);
-        const sql = new Visitors.ToSql().compile(over);
+        const sql = new Visitors.ToSql(testConnection).compile(over);
         expect(sql).toContain("FILTER");
         expect(sql).toContain("OVER");
         expect(sql).toContain("PARTITION BY");
@@ -48,7 +49,7 @@ describe("FilterTest", () => {
         const count = users.get("id").count();
         const filter = new Nodes.Filter(count, users.get("income").gteq(40000));
         const aliased = filter.as("rich_users_count");
-        const sql = new Visitors.ToSql().compile(aliased);
+        const sql = new Visitors.ToSql(testConnection).compile(aliased);
         expect(sql).toContain("FILTER");
         expect(sql).toContain("AS rich_users_count");
       });

--- a/packages/arel/src/nodes/fragments.test.ts
+++ b/packages/arel/src/nodes/fragments.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "../test-helpers/connection.js";
 import { Nodes, Visitors } from "../index.js";
 
 describe("FragmentsTest", () => {
@@ -26,7 +27,7 @@ describe("FragmentsTest", () => {
     it("can be joined with other nodes", () => {
       const a = new Nodes.Fragments([new Nodes.SqlLiteral("foo")]);
       const joined = a.join(new Nodes.SqlLiteral("bar"));
-      const sql = new Visitors.ToSql().compile(joined);
+      const sql = new Visitors.ToSql(testConnection).compile(joined);
       expect(sql).toBe("foo bar");
     });
   });

--- a/packages/arel/src/nodes/function.test.ts
+++ b/packages/arel/src/nodes/function.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
 import { SqlLiteral } from "./sql-literal.js";
 
@@ -66,7 +67,7 @@ describe("Arel::Nodes::ExistsTest", () => {
   it("renders EXISTS(subquery) correctly", () => {
     const inner = users.project(users.get("id")).ast;
     const node = new Nodes.Exists(inner);
-    const sql = new Visitors.ToSql().compile(node);
+    const sql = new Visitors.ToSql(testConnection).compile(node);
     expect(sql).toBe('EXISTS (SELECT "users"."id" FROM "users")');
   });
 });

--- a/packages/arel/src/nodes/grouping.test.ts
+++ b/packages/arel/src/nodes/grouping.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
 
 describe("GroupingTest", () => {
@@ -20,7 +21,7 @@ describe("GroupingTest", () => {
 
   it("should create Equality nodes", () => {
     const grouped = new Nodes.Grouping(users.get("id").eq(1));
-    const sql = new Visitors.ToSql().compile(grouped);
+    const sql = new Visitors.ToSql(testConnection).compile(grouped);
     expect(sql).toBe('("users"."id" = 1)');
   });
 });

--- a/packages/arel/src/nodes/homogeneous-in.test.ts
+++ b/packages/arel/src/nodes/homogeneous-in.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
 import { Attribute as AMAttribute, StringType } from "@blazetrails/activemodel";
 
@@ -24,21 +25,21 @@ describe("Arel::Nodes::HomogeneousInTest", () => {
   const users = new Table("users", { typeCaster: fakePgCaster });
   it("in", () => {
     const node = new Nodes.HomogeneousIn(["Bobby", "Robert"], users.get("name"), "in");
-    const sql = new Visitors.ToSql().compile(node);
+    const sql = new Visitors.ToSql(testConnection).compile(node);
     expect(sql).toBe('"users"."name" IN (?, ?)');
   });
 
   it("custom attribute node", () => {
     const node = new TypedNode("COALESCE", [users.get("nickname"), users.get("name")], STRING_TYPE);
     const expr = new Nodes.HomogeneousIn(["Bobby", "Robert"], node, "in");
-    const sql = new Visitors.ToSql().compile(expr);
+    const sql = new Visitors.ToSql(testConnection).compile(expr);
     expect(sql).toBe('COALESCE("users"."nickname", "users"."name") IN (?, ?)');
   });
 
   describe("HomogeneousIn visitor", () => {
     it("compiles IN with values", () => {
       const node = new Nodes.HomogeneousIn([1, 2, 3], users.get("id"), "in");
-      const sql = new Visitors.ToSql().compile(node);
+      const sql = new Visitors.ToSql(testConnection).compile(node);
       // HomogeneousIn keeps add_binds + bind_block (to_sql.rb:352), so a bare
       // SQLString collector emits `?` placeholders — mirrors Rails test_in.
       expect(sql).toBe('"users"."id" IN (?, ?, ?)');
@@ -46,7 +47,7 @@ describe("Arel::Nodes::HomogeneousInTest", () => {
 
     it("compiles NOT IN with values", () => {
       const node = new Nodes.HomogeneousIn([4, 5], users.get("id"), "notin");
-      const sql = new Visitors.ToSql().compile(node);
+      const sql = new Visitors.ToSql(testConnection).compile(node);
       expect(sql).toBe('"users"."id" NOT IN (?, ?)');
     });
 
@@ -54,13 +55,13 @@ describe("Arel::Nodes::HomogeneousInTest", () => {
       // Mirrors Rails to_sql.rb:347-349 — empty casted_values emits
       // `quote(nil)` inside the parens, not a `1=0` short-circuit.
       const node = new Nodes.HomogeneousIn([], users.get("id"), "in");
-      const sql = new Visitors.ToSql().compile(node);
+      const sql = new Visitors.ToSql(testConnection).compile(node);
       expect(sql).toBe('"users"."id" IN (NULL)');
     });
 
     it("compiles empty NOT IN as NOT IN (NULL)", () => {
       const node = new Nodes.HomogeneousIn([], users.get("id"), "notin");
-      const sql = new Visitors.ToSql().compile(node);
+      const sql = new Visitors.ToSql(testConnection).compile(node);
       expect(sql).toBe('"users"."id" NOT IN (NULL)');
     });
 
@@ -73,13 +74,13 @@ describe("Arel::Nodes::HomogeneousInTest", () => {
       };
       const attr = new Nodes.Attribute(filteringRelation as never, "id");
       const node = new Nodes.HomogeneousIn([1, 2], attr, "in");
-      const sql = new Visitors.ToSql().compile(node);
+      const sql = new Visitors.ToSql(testConnection).compile(node);
       expect(sql).toBe('"users"."id" IN (NULL)');
     });
 
     it("compiles string values", () => {
       const node = new Nodes.HomogeneousIn(["a", "b"], users.get("name"), "in");
-      const sql = new Visitors.ToSql().compile(node);
+      const sql = new Visitors.ToSql(testConnection).compile(node);
       expect(sql).toBe('"users"."name" IN (?, ?)');
     });
   });

--- a/packages/arel/src/nodes/matches.test.ts
+++ b/packages/arel/src/nodes/matches.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "../test-helpers/connection.js";
 import { Table, Nodes } from "../index.js";
 
 describe("MatchesTest", () => {
@@ -27,7 +28,7 @@ describe("MatchesTest", () => {
     it("inlines a string escape literal even in bind-extraction mode", async () => {
       const { Visitors } = await import("../index.js");
       const node = users.get("name").matches("x%", "!");
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       const [sql] = visitor.compileWithBinds(node);
       // ESCAPE value must be inlined ('!'), not turned into a bind placeholder.
       expect(sql).toContain("ESCAPE '!'");

--- a/packages/arel/src/nodes/node.test.ts
+++ b/packages/arel/src/nodes/node.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "../test-helpers/connection.js";
 import { Table, SelectManager, Nodes, Visitors } from "../index.js";
 
 describe("TestNode", () => {
@@ -52,13 +53,13 @@ describe("TestNode", () => {
 
   it("should extract field", () => {
     const node = new Nodes.Extract(users.get("created_at"), "YEAR");
-    const visitor = new Visitors.ToSql();
+    const visitor = new Visitors.ToSql(testConnection);
     expect(visitor.compile(node)).toBe('EXTRACT(YEAR FROM "users"."created_at")');
   });
 
   it("should alias the extract", () => {
     const node = new Nodes.Extract(users.get("created_at"), "MONTH").as("birth_month");
-    const visitor = new Visitors.ToSql();
+    const visitor = new Visitors.ToSql(testConnection);
     expect(visitor.compile(node)).toBe('EXTRACT(MONTH FROM "users"."created_at") AS birth_month');
   });
 
@@ -68,7 +69,7 @@ describe("TestNode", () => {
   });
 
   it("operation ordering via sql", () => {
-    const visitor = new Visitors.ToSql();
+    const visitor = new Visitors.ToSql(testConnection);
     const node = new Nodes.InfixOperation("+", users.get("a"), new Nodes.Quoted(1));
     expect(visitor.compile(node)).toBe('"users"."a" + 1');
   });
@@ -76,7 +77,7 @@ describe("TestNode", () => {
   it("construct with alias via constructor", () => {
     const fn = new Nodes.NamedFunction("SUM", [users.get("age")], "total");
     expect(fn.alias).toBeInstanceOf(Nodes.SqlLiteral);
-    const visitor = new Visitors.ToSql();
+    const visitor = new Visitors.ToSql(testConnection);
     expect(visitor.compile(fn)).toBe('SUM("users"."age") AS total');
   });
 
@@ -174,7 +175,7 @@ describe("Node base polymorphic defaults", () => {
 });
 
 describe("Table.engine", () => {
-  const sqliteEngine = { connection: { visitor: new Visitors.SQLite() } };
+  const sqliteEngine = { connection: { visitor: new Visitors.SQLite(testConnection) } };
 
   it("Node#toSql() compiles through the engine connection's visitor", () => {
     const users = new Table("users");

--- a/packages/arel/src/nodes/over.test.ts
+++ b/packages/arel/src/nodes/over.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
 
 describe("Arel::Nodes::OverTest", () => {
@@ -6,14 +7,16 @@ describe("Arel::Nodes::OverTest", () => {
   describe("as", () => {
     it("should alias the expression", () => {
       const over = users.get("id").count().over().as("foo");
-      expect(new Visitors.ToSql().compile(over)).toBe('COUNT("users"."id") OVER () AS foo');
+      expect(new Visitors.ToSql(testConnection).compile(over)).toBe(
+        'COUNT("users"."id") OVER () AS foo',
+      );
     });
   });
 
   describe("with SQL literal", () => {
     it("should reference the window definition by name", () => {
       const over = users.get("id").count().over(new Nodes.SqlLiteral("foo"));
-      expect(new Visitors.ToSql().compile(over)).toBe('COUNT("users"."id") OVER foo');
+      expect(new Visitors.ToSql(testConnection).compile(over)).toBe('COUNT("users"."id") OVER foo');
     });
   });
 
@@ -21,7 +24,7 @@ describe("Arel::Nodes::OverTest", () => {
     it("should use empty definition", () => {
       const fn = new Nodes.NamedFunction("ROW_NUMBER", []);
       const over = new Nodes.Over(fn);
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       expect(visitor.compile(over)).toBe("ROW_NUMBER() OVER ()");
     });
   });
@@ -32,7 +35,7 @@ describe("Arel::Nodes::OverTest", () => {
       const w = new Nodes.Window();
       w.partition(users.get("department_id"));
       const over = new Nodes.Over(fn, w);
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       const result = visitor.compile(over);
       expect(result).toContain("SUM");
       expect(result).toContain("PARTITION BY");
@@ -55,7 +58,7 @@ describe("Arel::Nodes::OverTest", () => {
 
   describe("with literal", () => {
     it("should reference the window definition by name", () => {
-      const sql = new Visitors.ToSql().compile(users.get("id").count().over("foo"));
+      const sql = new Visitors.ToSql(testConnection).compile(users.get("id").count().over("foo"));
       expect(sql).toBe('COUNT("users"."id") OVER "foo"');
     });
   });

--- a/packages/arel/src/nodes/sql-literal.test.ts
+++ b/packages/arel/src/nodes/sql-literal.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "../test-helpers/connection.js";
 import { Nodes, Visitors } from "../index.js";
 
 describe("SqlLiteralTest", () => {
@@ -14,14 +15,14 @@ describe("SqlLiteralTest", () => {
     it("makes a count node", () => {
       const lit = new Nodes.SqlLiteral("*");
       const count = new Nodes.NamedFunction("COUNT", [lit]);
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       expect(visitor.compile(count)).toBe("COUNT(*)");
     });
 
     it("makes a distinct node", () => {
       const lit = new Nodes.SqlLiteral("zomg");
       const count = new Nodes.NamedFunction("COUNT", [lit], undefined, true);
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       expect(visitor.compile(count)).toBe("COUNT(DISTINCT zomg)");
     });
   });
@@ -30,7 +31,7 @@ describe("SqlLiteralTest", () => {
     it("makes an equality node", () => {
       const lit = new Nodes.SqlLiteral("foo");
       const eq = new Nodes.Equality(lit, new Nodes.Quoted(1));
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       expect(visitor.compile(eq)).toBe("foo = 1");
     });
 
@@ -93,7 +94,7 @@ describe("SqlLiteralTest", () => {
       const b = new Nodes.SqlLiteral("bar");
       const fragments = a.join(b);
       expect(fragments).toBeInstanceOf(Nodes.Fragments);
-      const sql = new Visitors.ToSql().compile(fragments);
+      const sql = new Visitors.ToSql(testConnection).compile(fragments);
       expect(sql).toBe("foo bar");
     });
 
@@ -102,7 +103,7 @@ describe("SqlLiteralTest", () => {
       const b = new Nodes.SqlLiteral("bar");
       const fragments = a.plus(b);
       expect(fragments).toBeInstanceOf(Nodes.Fragments);
-      expect(new Visitors.ToSql().compile(fragments)).toBe("foo bar");
+      expect(new Visitors.ToSql(testConnection).compile(fragments)).toBe("foo bar");
     });
   });
 });

--- a/packages/arel/src/nodes/sum.test.ts
+++ b/packages/arel/src/nodes/sum.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
 
 describe("Arel::Nodes::SumTest", () => {
@@ -7,7 +8,7 @@ describe("Arel::Nodes::SumTest", () => {
     it("should alias the sum", () => {
       const sum = users.get("age").sum();
       const aliased = sum.as("total_age");
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       expect(visitor.compile(aliased)).toBe('SUM("users"."age") AS total_age');
     });
   });

--- a/packages/arel/src/nodes/unary-operation.test.ts
+++ b/packages/arel/src/nodes/unary-operation.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
 
 describe("TestUnaryOperation", () => {
@@ -50,6 +51,6 @@ describe("TestUnaryOperation", () => {
   // is preserved rather than trimmed.
   it("visitor preserves operator whitespace verbatim", () => {
     const node = new Nodes.UnaryOperation("- ", users.get("age"));
-    expect(new Visitors.ToSql().compile(node)).toBe(' -  "users"."age"');
+    expect(new Visitors.ToSql(testConnection).compile(node)).toBe(' -  "users"."age"');
   });
 });

--- a/packages/arel/src/predications-range.test.ts
+++ b/packages/arel/src/predications-range.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "./test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "./index.js";
 
 // Mirrors Rails' Arel attribute_test.rb #between / #not_between blocks.
@@ -123,7 +124,7 @@ describe("Predications range semantics", () => {
   });
 
   describe("#between SQL output", () => {
-    const sql = (n: Nodes.Node) => new Visitors.ToSql().compile(n);
+    const sql = (n: Nodes.Node) => new Visitors.ToSql(testConnection).compile(n);
 
     it("inclusive standard range → BETWEEN", () => {
       expect(sql(id.between({ begin: 1, end: 3 }))).toBe('"users"."id" BETWEEN 1 AND 3');
@@ -149,7 +150,7 @@ describe("Predications range semantics", () => {
   });
 
   describe("#not_between SQL output", () => {
-    const sql = (n: Nodes.Node) => new Visitors.ToSql().compile(n);
+    const sql = (n: Nodes.Node) => new Visitors.ToSql(testConnection).compile(n);
 
     it("inclusive range → (col < b OR col > e)", () => {
       expect(sql(id.notBetween({ begin: 1, end: 3 }))).toBe(

--- a/packages/arel/src/predications.test.ts
+++ b/packages/arel/src/predications.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "./test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "./index.js";
 
 describe("PredicationsMixin", () => {
@@ -8,21 +9,21 @@ describe("PredicationsMixin", () => {
     it("Division#subtract chains via the Math mixin", () => {
       // arel-24: users[:age] / 3 - users[:other]
       const expr = users.get("age").divide(3).subtract(users.get("other"));
-      const sql = new Visitors.ToSql().compile(expr);
+      const sql = new Visitors.ToSql(testConnection).compile(expr);
       expect(sql).toBe('("users"."age" / 3 - "users"."other")');
     });
 
     it("BitwiseAnd#gt produces a GROUP BY / HAVING-style comparison", () => {
       // arel-25: (users[:bitmap] & 16).gt(0)
       const expr = users.get("bitmap").bitwiseAnd(16).gt(0);
-      const sql = new Visitors.ToSql().compile(expr);
+      const sql = new Visitors.ToSql(testConnection).compile(expr);
       expect(sql).toBe('("users"."bitmap" & 16) > 0');
     });
 
     it("BitwiseShiftLeft#gt chains through Predications", () => {
       // arel-28: (users[:bitmap] << 1).gt(0)
       const expr = users.get("bitmap").bitwiseShiftLeft(1).gt(0);
-      const sql = new Visitors.ToSql().compile(expr);
+      const sql = new Visitors.ToSql(testConnection).compile(expr);
       expect(sql).toBe('("users"."bitmap" << 1) > 0');
     });
   });
@@ -31,13 +32,13 @@ describe("PredicationsMixin", () => {
     it("BitwiseNot#gt produces a predicate", () => {
       // arel-30: (~users[:bitmap]).gt(0)
       const expr = new Nodes.BitwiseNot(users.get("bitmap")).gt(0);
-      const sql = new Visitors.ToSql().compile(expr);
+      const sql = new Visitors.ToSql(testConnection).compile(expr);
       expect(sql).toBe(' ~ "users"."bitmap" > 0');
     });
 
     it("BitwiseNot#eq produces an equality predicate", () => {
       const expr = new Nodes.BitwiseNot(users.get("flags")).eq(0);
-      const sql = new Visitors.ToSql().compile(expr);
+      const sql = new Visitors.ToSql(testConnection).compile(expr);
       expect(sql).toBe(' ~ "users"."flags" = 0');
     });
   });
@@ -49,19 +50,19 @@ describe("PredicationsMixin", () => {
       // Rails' `Or.inject` on [] returns nil and the visitor renders
       // NULL — we preserve that, since NULL is not the same as FALSE
       // under SQL three-valued logic.
-      const sql = new Visitors.ToSql().compile(bn.eqAny([]));
+      const sql = new Visitors.ToSql(testConnection).compile(bn.eqAny([]));
       expect(sql).toBe("(NULL)");
     });
 
     it("eqAll([]) does not crash and renders as an empty grouped AND", () => {
       // Matches Attribute#groupedAll: an empty And inside a Grouping
       // visits to `()`, the same as Rails' empty-And rendering.
-      const sql = new Visitors.ToSql().compile(bn.eqAll([]));
+      const sql = new Visitors.ToSql(testConnection).compile(bn.eqAll([]));
       expect(sql).toBe("()");
     });
 
     it("in(scalar) wraps the scalar (Rails quoted_node fallthrough)", () => {
-      const sql = new Visitors.ToSql().compile(bn.in(7));
+      const sql = new Visitors.ToSql(testConnection).compile(bn.in(7));
       expect(sql).toBe(' ~ "users"."flags" IN (7)');
     });
   });
@@ -70,13 +71,13 @@ describe("PredicationsMixin", () => {
     it("count().gt(n) produces HAVING-ready comparison", () => {
       // arel-47: photos[:id].count.gt(5)
       const expr = users.get("id").count().gt(5);
-      const sql = new Visitors.ToSql().compile(expr);
+      const sql = new Visitors.ToSql(testConnection).compile(expr);
       expect(sql).toBe('COUNT("users"."id") > 5');
     });
 
     it("NamedFunction#in accepts a value list", () => {
       const fn = new Nodes.NamedFunction("LOWER", [users.get("name")]);
-      const sql = new Visitors.ToSql().compile(fn.in(["a", "b"]));
+      const sql = new Visitors.ToSql(testConnection).compile(fn.in(["a", "b"]));
       expect(sql).toBe("LOWER(\"users\".\"name\") IN ('a', 'b')");
     });
   });

--- a/packages/arel/src/predications.trails.test.ts
+++ b/packages/arel/src/predications.trails.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "./test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "./index.js";
 
 // The Enumerable-arm distinctions below are trails-only: in Ruby a Set, a Hash
@@ -6,7 +7,7 @@ import { Table, Nodes, Visitors } from "./index.js";
 // to mirror. See attribute.trails.test.ts for the same coverage on Attribute.
 describe("PredicationsMixin in/notIn Enumerable arm", () => {
   const users = new Table("users");
-  const visitor = new Visitors.ToSql();
+  const visitor = new Visitors.ToSql(testConnection);
   // An InfixOperation, not an Attribute — this exercises the Predications
   // mixin's own `in`/`notIn`, which Attribute overrides.
   const expr = () => users.get("bitmap").bitwiseAnd(16);

--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -15,7 +15,7 @@ import { testConnection } from "./test-helpers/connection.js";
 describe("SelectManagerTest", () => {
   const users = new Table("users");
   const posts = new Table("posts");
-  const visitor = new Visitors.ToSql();
+  const visitor = new Visitors.ToSql(testConnection);
   it("join sources", () => {
     const mgr = users.project(star);
     expect(mgr.joinSources).toEqual([]);
@@ -64,7 +64,7 @@ describe("SelectManagerTest", () => {
         const mgr = new SelectManager();
         const as = mgr.as("foo");
         expect(as).toBeInstanceOf(Nodes.TableAlias);
-        const sql = new Visitors.ToSql().compile(as);
+        const sql = new Visitors.ToSql(testConnection).compile(as);
         expect(sql).toContain("foo");
       });
 
@@ -309,7 +309,7 @@ describe("SelectManagerTest", () => {
       const q1 = users.project(users.get("name")).where(users.get("age").gt(21));
       const q2 = users.project(users.get("name")).where(users.get("age").lt(18));
       const union = q1.union(q2);
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       const compiled = visitor.compile(union);
       expect(compiled).toContain("UNION");
     });
@@ -317,7 +317,7 @@ describe("SelectManagerTest", () => {
     it("should union all", () => {
       const q1 = users.project(star);
       const q2 = users.project(star);
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       expect(visitor.compile(q1.unionAll(q2))).toContain("UNION ALL");
     });
   });
@@ -326,7 +326,7 @@ describe("SelectManagerTest", () => {
     it("should intersect two managers", () => {
       const q1 = users.project(star);
       const q2 = users.project(star);
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       expect(visitor.compile(q1.intersect(q2))).toContain("INTERSECT");
     });
   });
@@ -335,7 +335,7 @@ describe("SelectManagerTest", () => {
     it("should except two managers", () => {
       const q1 = users.project(star);
       const q2 = users.project(star);
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       expect(visitor.compile(q1.except(q2))).toContain("EXCEPT");
     });
   });
@@ -344,7 +344,7 @@ describe("SelectManagerTest", () => {
     it("minus aliases except", () => {
       const q1 = users.project(star);
       const q2 = users.project(star);
-      expect(new Visitors.ToSql().compile(q1.minus(q2))).toContain("EXCEPT");
+      expect(new Visitors.ToSql(testConnection).compile(q1.minus(q2))).toContain("EXCEPT");
     });
   });
 
@@ -626,7 +626,7 @@ describe("SelectManagerTest", () => {
       w.order(users.get("id").asc());
       w.frame(new Nodes.Rows(new Nodes.Preceding()));
       const fn = new Nodes.NamedFunction("SUM", [users.get("amount")]);
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       expect(visitor.compile(new Nodes.Over(fn, w))).toContain("ROWS UNBOUNDED PRECEDING");
     });
 
@@ -635,22 +635,22 @@ describe("SelectManagerTest", () => {
       w.order(users.get("id").asc());
       w.frame(new Nodes.Rows(new Nodes.Preceding(new Nodes.Quoted(3))));
       const fn = new Nodes.NamedFunction("SUM", [users.get("amount")]);
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       expect(visitor.compile(new Nodes.Over(fn, w))).toContain("3 PRECEDING");
     });
 
     it("takes a rows frame, unbounded following", () => {
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       expect(visitor.compile(new Nodes.Following())).toBe("UNBOUNDED FOLLOWING");
     });
 
     it("takes a rows frame, bounded following", () => {
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       expect(visitor.compile(new Nodes.Following(new Nodes.Quoted(5)))).toBe("5 FOLLOWING");
     });
 
     it("takes a rows frame, current row", () => {
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       expect(visitor.compile(new Nodes.CurrentRow())).toBe("CURRENT ROW");
     });
 
@@ -659,7 +659,7 @@ describe("SelectManagerTest", () => {
       w.order(users.get("id").asc());
       w.frame(new Nodes.Rows(new Nodes.Between(new Nodes.CurrentRow(), new Nodes.Following())));
       const fn = new Nodes.NamedFunction("SUM", [users.get("amount")]);
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       const result = visitor.compile(new Nodes.Over(fn, w));
       expect(result).toContain("ROWS");
       expect(result).toContain("CURRENT ROW");
@@ -670,7 +670,7 @@ describe("SelectManagerTest", () => {
       w.order(users.get("id").asc());
       w.frame(new Nodes.Range(new Nodes.Preceding()));
       const fn = new Nodes.NamedFunction("SUM", [users.get("amount")]);
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       expect(visitor.compile(new Nodes.Over(fn, w))).toContain("RANGE UNBOUNDED PRECEDING");
     });
 
@@ -679,7 +679,7 @@ describe("SelectManagerTest", () => {
       w.order(users.get("id").asc());
       w.frame(new Nodes.Range(new Nodes.Preceding(new Nodes.Quoted(3))));
       const fn = new Nodes.NamedFunction("SUM", [users.get("amount")]);
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       expect(visitor.compile(new Nodes.Over(fn, w))).toContain("3 PRECEDING");
     });
 
@@ -698,7 +698,7 @@ describe("SelectManagerTest", () => {
       w.order(users.get("id").asc());
       w.frame(new Nodes.Range(new Nodes.CurrentRow()));
       const fn = new Nodes.NamedFunction("SUM", [users.get("amount")]);
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       expect(visitor.compile(new Nodes.Over(fn, w))).toContain("RANGE CURRENT ROW");
     });
 
@@ -1010,7 +1010,7 @@ describe("SelectManagerTest", () => {
       const mgr = new SelectManager(users).project(users.get("id"));
       const lat = mgr.lateral();
       expect(lat).toBeInstanceOf(Nodes.Lateral);
-      const sql = new Visitors.ToSql().compile(lat);
+      const sql = new Visitors.ToSql(testConnection).compile(lat);
       expect(sql).toBe('LATERAL (SELECT "users"."id" FROM "users")');
     });
 
@@ -1022,7 +1022,7 @@ describe("SelectManagerTest", () => {
       const lat = mgr.lateral("u");
       expect(lat).toBeInstanceOf(Nodes.Lateral);
       expect(lat.subquery).toBeInstanceOf(Nodes.TableAlias);
-      const sql = new Visitors.ToSql().compile(lat);
+      const sql = new Visitors.ToSql(testConnection).compile(lat);
       expect(sql).toBe('LATERAL (SELECT "users"."id" FROM "users") u');
     });
   });

--- a/packages/arel/src/table.test.ts
+++ b/packages/arel/src/table.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Table, sql, star, SelectManager, Nodes, Visitors, EmptyJoinError } from "./index.js";
-import { testConnection } from "./test-helpers/connection.js";
+import { testConnection, mysqlTestConnection } from "./test-helpers/connection.js";
 
 describe("TableTest", () => {
   const users = new Table("users");
@@ -221,7 +221,7 @@ describe("TableTest", () => {
   });
 
   it("star routes table-name quoting through the adapter visitor (MySQL=backticks)", () => {
-    const sql = new Visitors.MySQL().compile(users.star);
+    const sql = new Visitors.MySQL(mysqlTestConnection).compile(users.star);
     expect(sql).toBe("`users`.*");
   });
 
@@ -285,7 +285,7 @@ describe("TableTest", () => {
       const aliased = users.as("u");
       expect(aliased).toBeInstanceOf(Nodes.TableAlias);
       expect(aliased.relation).toBe(users);
-      const sql = new Visitors.ToSql().compile(aliased.get("id"));
+      const sql = new Visitors.ToSql(testConnection).compile(aliased.get("id"));
       expect(sql).toBe('"u"."id"');
     });
   });
@@ -308,7 +308,7 @@ describe("TableTest", () => {
       const aliased = users.as("u");
       const attr = users.get("id", aliased);
       expect(attr.relation).toBe(aliased);
-      expect(new Visitors.ToSql().compile(attr)).toBe('"u"."id"');
+      expect(new Visitors.ToSql(testConnection).compile(attr)).toBe('"u"."id"');
     });
   });
 

--- a/packages/arel/src/test-helpers/connection.ts
+++ b/packages/arel/src/test-helpers/connection.ts
@@ -1,7 +1,11 @@
 import type { ArelConnection } from "../visitors/connection.js";
 import type { ArelEngine } from "../nodes/node.js";
 import { ToSql } from "../visitors/to-sql.js";
-import { defaultQuoter } from "../visitors/default-quoter.js";
+import {
+  defaultQuoter,
+  mysqlDefaultQuoter,
+  postgresqlDefaultQuoter,
+} from "../visitors/default-quoter.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 
 /**
@@ -30,6 +34,21 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
  * @internal
  */
 export const testConnection: ArelConnection = defaultQuoter;
+
+/**
+ * The MySQL/PostgreSQL analogues of {@link testConnection}: the adapter-specific
+ * quoters the `MySQL` and `PostgreSQL` visitors otherwise fall back to as their
+ * constructor default (`visitors/mysql.ts`, `visitors/postgresql.ts`). Naming them
+ * at the call site is what lets those defaults be deleted; unlike the generic
+ * `defaultQuoter`, they render adapter-specific forms (PG array literals, MySQL
+ * backticks) the Arel visitor tests assert on.
+ *
+ * @internal
+ */
+export const mysqlTestConnection: ArelConnection = mysqlDefaultQuoter;
+
+/** @internal */
+export const postgresqlTestConnection: ArelConnection = postgresqlDefaultQuoter;
 
 // Stands in for a method FakeRecord does not define. Rails gets this for free —
 // an undefined method on the double raises NoMethodError — so raising here is the

--- a/packages/arel/src/visitors/dispatch-contamination.test.ts
+++ b/packages/arel/src/visitors/dispatch-contamination.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "../test-helpers/connection.js";
 import { Table, Nodes, Visitors } from "../index.js";
 
 describe("DispatchContaminationTest", () => {
@@ -28,8 +29,8 @@ describe("DispatchContaminationTest", () => {
   });
 
   it("is threadsafe when implementing superclass fallback", () => {
-    const v1 = new Visitors.ToSql();
-    const v2 = new Visitors.ToSql();
+    const v1 = new Visitors.ToSql(testConnection);
+    const v2 = new Visitors.ToSql(testConnection);
     const n1 = users.get("id").eq(1);
     const n2 = users.get("id").eq(2);
     expect(v1.compile(n1)).toBe('"users"."id" = 1');

--- a/packages/arel/src/visitors/mysql.test.ts
+++ b/packages/arel/src/visitors/mysql.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection, mysqlTestConnection } from "../test-helpers/connection.js";
 import { Table, star, SelectManager, Nodes, Visitors } from "../index.js";
 
 describe("MysqlTest", () => {
@@ -12,13 +13,13 @@ describe("MysqlTest", () => {
   describe("comment emission", () => {
     it("emits the SelectCore comment in MySQL output", () => {
       const mgr = new SelectManager(users).project(star).comment("trace=mysql");
-      const sql = new Visitors.MySQL().compile(mgr.ast);
+      const sql = new Visitors.MySQL(mysqlTestConnection).compile(mgr.ast);
       expect(sql).toContain("/* trace=mysql */");
     });
 
     it("emits the comment exactly once", () => {
       const mgr = new SelectManager(users).project(star).comment("once");
-      const sql = new Visitors.MySQL().compile(mgr.ast);
+      const sql = new Visitors.MySQL(mysqlTestConnection).compile(mgr.ast);
       expect((sql.match(/\/\* once \*\//g) ?? []).length).toBe(1);
     });
   });
@@ -53,7 +54,7 @@ describe("MysqlTest", () => {
 
   describe("Nodes::IsDistinctFrom", () => {
     it("should handle nil", () => {
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       const node = users.get("name").isDistinctFrom(null);
       expect(visitor.compile(node)).toContain("IS NOT NULL");
     });
@@ -61,25 +62,25 @@ describe("MysqlTest", () => {
 
   describe("Nodes::Ordering", () => {
     it("should handle nulls first", () => {
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       const node = users.get("id").asc().nullsFirst();
       expect(visitor.compile(node)).toContain("NULLS FIRST");
     });
 
     it("should handle nulls last", () => {
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       const node = users.get("id").asc().nullsLast();
       expect(visitor.compile(node)).toContain("NULLS LAST");
     });
 
     it("should handle nulls first reversed", () => {
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       const node = users.get("id").asc().nullsLast().reverse();
       expect(visitor.compile(node)).toContain("NULLS FIRST");
     });
 
     it("should handle nulls last reversed", () => {
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       const node = users.get("id").asc().nullsFirst().reverse();
       expect(visitor.compile(node)).toContain("NULLS LAST");
     });
@@ -87,7 +88,7 @@ describe("MysqlTest", () => {
 
   describe("Nodes::NullsFirst / NullsLast (MySQL emulation)", () => {
     it("emulates NULLS FIRST with IS NOT NULL", () => {
-      const visitor = new Visitors.MySQL();
+      const visitor = new Visitors.MySQL(mysqlTestConnection);
       const node = users.get("id").asc().nullsFirst();
       const sql = visitor.compile(node);
       expect(sql).toContain("`users`.`id` IS NOT NULL");
@@ -95,7 +96,7 @@ describe("MysqlTest", () => {
     });
 
     it("emulates NULLS LAST with IS NULL", () => {
-      const visitor = new Visitors.MySQL();
+      const visitor = new Visitors.MySQL(mysqlTestConnection);
       const node = users.get("id").asc().nullsLast();
       const sql = visitor.compile(node);
       expect(sql).toContain("`users`.`id` IS NULL");
@@ -103,7 +104,7 @@ describe("MysqlTest", () => {
     });
 
     it("emulates NULLS FIRST with DESC ordering", () => {
-      const visitor = new Visitors.MySQL();
+      const visitor = new Visitors.MySQL(mysqlTestConnection);
       const node = users.get("id").desc().nullsFirst();
       const sql = visitor.compile(node);
       expect(sql).toContain("`users`.`id` IS NOT NULL");
@@ -111,7 +112,7 @@ describe("MysqlTest", () => {
     });
 
     it("emulates NULLS LAST with DESC ordering", () => {
-      const visitor = new Visitors.MySQL();
+      const visitor = new Visitors.MySQL(mysqlTestConnection);
       const node = users.get("id").desc().nullsLast();
       const sql = visitor.compile(node);
       expect(sql).toContain("`users`.`id` IS NULL");
@@ -121,7 +122,7 @@ describe("MysqlTest", () => {
 
   it("defaults limit to 18446744073709551615", () => {
     const mgr = users.project(star).skip(5);
-    const sql = new Visitors.MySQL().compile(mgr.ast);
+    const sql = new Visitors.MySQL(mysqlTestConnection).compile(mgr.ast);
     expect(sql).toContain("LIMIT 18446744073709551615");
     expect(sql).toContain("OFFSET 5");
   });
@@ -129,20 +130,20 @@ describe("MysqlTest", () => {
   it("uses DUAL for empty from", () => {
     const mgr = new SelectManager();
     mgr.project("1");
-    const sql = new Visitors.MySQL().compile(mgr.ast);
+    const sql = new Visitors.MySQL(mysqlTestConnection).compile(mgr.ast);
     expect(sql).toContain("FROM DUAL");
   });
 
   describe("locking", () => {
     it("defaults to FOR UPDATE when locking", () => {
       const mgr = users.project(star).lock();
-      const sql = new Visitors.MySQL().compile(mgr.ast);
+      const sql = new Visitors.MySQL(mysqlTestConnection).compile(mgr.ast);
       expect(sql).toContain("FOR UPDATE");
     });
 
     it("allows a custom string to be used as a lock", () => {
       const mgr = users.project(star).lock("LOCK IN SHARE MODE");
-      const sql = new Visitors.MySQL().compile(mgr.ast);
+      const sql = new Visitors.MySQL(mysqlTestConnection).compile(mgr.ast);
       expect(sql).toContain("LOCK IN SHARE MODE");
     });
   });
@@ -150,13 +151,13 @@ describe("MysqlTest", () => {
   describe("concat", () => {
     it("concats columns", () => {
       const node = new Nodes.Concat(users.get("name"), users.get("email"));
-      const sql = new Visitors.MySQL().compile(node);
+      const sql = new Visitors.MySQL(mysqlTestConnection).compile(node);
       expect(sql).toBe(" CONCAT(`users`.`name`, `users`.`email`) ");
     });
 
     it("concats a string", () => {
       const node = new Nodes.Concat(users.get("name"), new Nodes.Quoted("x"));
-      const sql = new Visitors.MySQL().compile(node);
+      const sql = new Visitors.MySQL(mysqlTestConnection).compile(node);
       expect(sql).toBe(" CONCAT(`users`.`name`, 'x') ");
     });
   });
@@ -168,24 +169,28 @@ describe("MysqlTest", () => {
   describe("Nodes::IsNotDistinctFrom", () => {
     it("should handle column names on both sides", () => {
       const node = users.get("id").isNotDistinctFrom(posts.get("user_id"));
-      expect(new Visitors.MySQL().compile(node)).toBe("`users`.`id` <=> `posts`.`user_id`");
+      expect(new Visitors.MySQL(mysqlTestConnection).compile(node)).toBe(
+        "`users`.`id` <=> `posts`.`user_id`",
+      );
     });
 
     it("should handle nil", () => {
       const node = users.get("name").isNotDistinctFrom(null);
-      expect(new Visitors.MySQL().compile(node)).toBe("`users`.`name` <=> NULL");
+      expect(new Visitors.MySQL(mysqlTestConnection).compile(node)).toBe("`users`.`name` <=> NULL");
     });
 
     it("should construct a valid generic SQL statement", () => {
       const node = users.get("name").isNotDistinctFrom(new Nodes.Quoted(1));
-      expect(new Visitors.MySQL().compile(node)).toBe("`users`.`name` <=> 1");
+      expect(new Visitors.MySQL(mysqlTestConnection).compile(node)).toBe("`users`.`name` <=> 1");
     });
   });
 
   describe("Nodes::IsDistinctFrom", () => {
     it("should handle column names on both sides", () => {
       const node = users.get("id").isDistinctFrom(posts.get("user_id"));
-      expect(new Visitors.MySQL().compile(node)).toBe("NOT `users`.`id` <=> `posts`.`user_id`");
+      expect(new Visitors.MySQL(mysqlTestConnection).compile(node)).toBe(
+        "NOT `users`.`id` <=> `posts`.`user_id`",
+      );
     });
   });
 
@@ -193,14 +198,14 @@ describe("MysqlTest", () => {
     it("ignores MATERIALIZED modifiers", () => {
       const cte = new Nodes.Cte("t", users.project(users.get("id")).ast, true);
       const stmt = new SelectManager().with(cte).project("1");
-      const sql = new Visitors.MySQL().compile(stmt.ast);
+      const sql = new Visitors.MySQL(mysqlTestConnection).compile(stmt.ast);
       expect(sql).not.toContain("MATERIALIZED");
     });
 
     it("ignores NOT MATERIALIZED modifiers", () => {
       const cte = new Nodes.Cte("t", users.project(users.get("id")).ast, false);
       const stmt = new SelectManager().with(cte).project("1");
-      const sql = new Visitors.MySQL().compile(stmt.ast);
+      const sql = new Visitors.MySQL(mysqlTestConnection).compile(stmt.ast);
       expect(sql).not.toContain("MATERIALIZED");
     });
   });
@@ -211,7 +216,7 @@ describe("MysqlTest", () => {
 // IsDistinctFrom / IsNotDistinctFrom / Regexp / NotRegexp / Cte).
 describe("MySQL dialect overrides (audit follow-up)", () => {
   const users = new Table("users");
-  const compile = (n: Nodes.Node): string => new Visitors.MySQL().compile(n);
+  const compile = (n: Nodes.Node): string => new Visitors.MySQL(mysqlTestConnection).compile(n);
 
   it("Bin uses CAST(... AS BINARY) (mirrors Rails)", () => {
     expect(compile(new Nodes.Bin(users.get("name")))).toBe("CAST(`users`.`name` AS BINARY)");
@@ -261,7 +266,7 @@ describe("MySQL dialect overrides (audit follow-up)", () => {
 
   describe("prepareUpdateStatement / prepareDeleteStatement (MySQL)", () => {
     const posts = new Table("posts");
-    const visitor = new Visitors.MySQL();
+    const visitor = new Visitors.MySQL(mysqlTestConnection);
     type WithPrepare = {
       prepareUpdateStatement(o: Nodes.UpdateStatement): Nodes.UpdateStatement;
       prepareDeleteStatement(o: Nodes.DeleteStatement): Nodes.DeleteStatement;

--- a/packages/arel/src/visitors/postgres.test.ts
+++ b/packages/arel/src/visitors/postgres.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection, postgresqlTestConnection } from "../test-helpers/connection.js";
 import { Table, star, SelectManager, Nodes, Visitors } from "../index.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 
@@ -6,14 +7,14 @@ describe("PostgresTest", () => {
   const users = new Table("users");
   describe("Nodes::NotRegexp", () => {
     it("should know how to visit", () => {
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       const node = users.get("id").in([1, 2, 3]);
       expect(visitor.compile(node)).toContain("IN");
     });
 
     it("can handle case insensitive", () => {
       const node = users.get("name").doesNotMatchRegexp("foo.*", false);
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("!~*");
     });
 
@@ -22,7 +23,7 @@ describe("PostgresTest", () => {
         .project(users.get("id"))
         .where(users.get("name").doesNotMatchRegexp("foo.*"));
       const node = users.get("id").in(mgr);
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("!~");
     });
   });
@@ -34,14 +35,14 @@ describe("PostgresTest", () => {
 
   describe("Nodes::IsDistinctFrom", () => {
     it("should handle nil", () => {
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       const node = users.get("name").isDistinctFrom(null);
       expect(visitor.compile(node)).toContain("IS NOT NULL");
     });
 
     it("should handle column names on both sides", () => {
       const node = users.get("name").isDistinctFrom(users.get("login"));
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("IS DISTINCT FROM");
     });
   });
@@ -49,20 +50,20 @@ describe("PostgresTest", () => {
   describe("Nodes::DoesNotMatch", () => {
     it("can handle ESCAPE", () => {
       const node = users.get("name").doesNotMatch("foo%", "\\", true);
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       const result = visitor.compile(node);
       expect(result).toContain("NOT LIKE");
     });
 
     it("should know how to visit", () => {
       const node = users.get("name").doesNotMatch("foo%");
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("NOT ILIKE");
     });
 
     it("should know how to visit case sensitive", () => {
       const node = users.get("name").doesNotMatch("foo%", null, true);
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("NOT LIKE");
       expect(sql).not.toContain("ILIKE");
     });
@@ -70,7 +71,7 @@ describe("PostgresTest", () => {
     it("can handle subqueries", () => {
       const mgr = users.project(users.get("id")).where(users.get("name").doesNotMatch("foo%"));
       const node = users.get("id").in(mgr);
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("NOT ILIKE");
     });
   });
@@ -78,33 +79,33 @@ describe("PostgresTest", () => {
   describe("locking", () => {
     it("defaults to FOR UPDATE", () => {
       const mgr = users.project(star).lock();
-      const sql = new Visitors.PostgreSQL().compile(mgr.ast);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(mgr.ast);
       expect(sql).toContain("FOR UPDATE");
     });
 
     it("allows a custom string to be used as a lock", () => {
       const mgr = users.project(star).lock("FOR SHARE");
-      const sql = new Visitors.PostgreSQL().compile(mgr.ast);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(mgr.ast);
       expect(sql).toContain("FOR SHARE");
     });
   });
 
   it("should support DISTINCT ON", () => {
     const mgr = new SelectManager(users).project(star).distinctOn(users.get("id"));
-    const sql = new Visitors.PostgreSQL().compile(mgr.ast);
+    const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(mgr.ast);
     expect(sql).toContain('DISTINCT ON ( "users"."id" )');
   });
 
   it("should support DISTINCT", () => {
     const mgr = new SelectManager(users).project(star).distinct();
-    const sql = new Visitors.PostgreSQL().compile(mgr.ast);
+    const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(mgr.ast);
     expect(sql).toContain("SELECT DISTINCT");
   });
 
   it("encloses LATERAL queries in parens", () => {
     const sub = users.project(users.get("id"));
     const lat = sub.lateral();
-    const sql = new Visitors.PostgreSQL().compile(lat);
+    const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(lat);
     expect(sql).toContain("LATERAL (");
     expect(sql).toContain(")");
   });
@@ -116,7 +117,7 @@ describe("PostgresTest", () => {
     // because Rails' `quote_table_name` returns SqlLiterals unchanged.
     const sub = users.project(users.get("id"));
     const lat = sub.lateral("t");
-    const sql = new Visitors.PostgreSQL().compile(lat);
+    const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(lat);
     expect(sql).toBe('LATERAL (SELECT "users"."id" FROM "users") t');
   });
 
@@ -157,33 +158,33 @@ describe("PostgresTest", () => {
   describe("Nodes::RollUp", () => {
     it("should know how to visit with array arguments", () => {
       const node = users.get("id").in([1, 2, 3]);
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("IN (1, 2, 3)");
     });
 
     it("should know how to visit with CubeDimension Argument", () => {
       const mgr = users.project(star).group(new Nodes.Cube([users.get("id")]));
-      const sql = new Visitors.PostgreSQL().compile(mgr.ast);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(mgr.ast);
       expect(sql).toContain("CUBE(");
     });
 
     it("should know how to generate parenthesis when supplied with many Dimensions", () => {
       const mgr = users.project(star).group(new Nodes.Cube([users.get("id"), users.get("name")]));
-      const sql = new Visitors.PostgreSQL().compile(mgr.ast);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(mgr.ast);
       // Rails Postgres formats grouping elements with spaces inside parens.
       expect(sql).toContain('CUBE( "users"."id", "users"."name" )');
     });
 
     it("should know how to visit with array arguments", () => {
       const node = new Nodes.Rollup([users.get("name"), users.get("bool")]);
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("ROLLUP");
     });
 
     it("should know how to visit with CubeDimension Argument", () => {
       const dim = new Nodes.GroupingElement([users.get("name")]);
       const node = new Nodes.Rollup([dim]);
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("ROLLUP");
     });
 
@@ -191,7 +192,7 @@ describe("PostgresTest", () => {
       const d1 = new Nodes.GroupingElement([users.get("name")]);
       const d2 = new Nodes.GroupingElement([users.get("bool")]);
       const node = new Nodes.Rollup([d1, d2]);
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("ROLLUP");
       expect(sql).toContain("(");
     });
@@ -200,33 +201,33 @@ describe("PostgresTest", () => {
   describe("Nodes::IsNotDistinctFrom", () => {
     it("should handle nil", () => {
       const node = users.get("name").isNotDistinctFrom(null);
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("IS NOT DISTINCT FROM");
     });
 
     it("should construct a valid generic SQL statement", () => {
       const node = users.get("name").isNotDistinctFrom(new Nodes.Quoted(1));
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("IS NOT DISTINCT FROM");
     });
 
     it("should handle column names on both sides", () => {
       const node = users.get("name").isNotDistinctFrom(users.get("login"));
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("IS NOT DISTINCT FROM");
     });
   });
 
   describe("Nodes::InfixOperation", () => {
     it("should handle Contains", () => {
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       const products = new Table("products");
       const node = products.get("metadata").contains('{"foo":"bar"}');
       expect(visitor.compile(node)).toBe(`"products"."metadata" @> '{"foo":"bar"}'`);
     });
 
     it("should handle Overlaps", () => {
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       const products = new Table("products");
       const node = products.get("tags").overlaps("{foo,bar,baz}");
       expect(visitor.compile(node)).toBe(`"products"."tags" && '{foo,bar,baz}'`);
@@ -236,14 +237,14 @@ describe("PostgresTest", () => {
   describe("Nodes::GroupingSet", () => {
     it("should know how to visit with array arguments", () => {
       const node = new Nodes.GroupingSet([users.get("name"), users.get("bool")]);
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("GROUPING SETS");
     });
 
     it("should know how to visit with CubeDimension Argument", () => {
       const dim = new Nodes.GroupingElement([users.get("name"), users.get("bool")]);
       const node = new Nodes.GroupingSet([dim]);
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("GROUPING SETS");
     });
 
@@ -251,7 +252,7 @@ describe("PostgresTest", () => {
       const d1 = new Nodes.GroupingElement([users.get("name")]);
       const d2 = new Nodes.GroupingElement([users.get("bool")]);
       const node = new Nodes.GroupingSet([d1, d2]);
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("GROUPING SETS");
       expect(sql).toContain("(");
     });
@@ -260,14 +261,14 @@ describe("PostgresTest", () => {
   describe("Nodes::Cube", () => {
     it("should know how to visit with array arguments", () => {
       const node = new Nodes.Cube([users.get("name"), users.get("bool")]);
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("CUBE");
     });
 
     it("should know how to visit with CubeDimension Argument", () => {
       const dim = new Nodes.GroupingElement([users.get("name"), users.get("bool")]);
       const node = new Nodes.Cube([dim]);
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("CUBE");
     });
 
@@ -275,7 +276,7 @@ describe("PostgresTest", () => {
       const d1 = new Nodes.GroupingElement([users.get("name")]);
       const d2 = new Nodes.GroupingElement([users.get("bool"), users.get("created_at")]);
       const node = new Nodes.Cube([d1, d2]);
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("CUBE");
       expect(sql).toContain("(");
     });
@@ -284,21 +285,21 @@ describe("PostgresTest", () => {
   describe("Nodes::Regexp", () => {
     it("should know how to visit", () => {
       const node = users.get("name").matchesRegexp("foo.*");
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("~");
       expect(sql).toContain("foo.*");
     });
 
     it("can handle case insensitive", () => {
       const node = users.get("name").matchesRegexp("foo.*", false);
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("~*");
     });
 
     it("can handle subqueries", () => {
       const mgr = users.project(users.get("id")).where(users.get("name").matchesRegexp("foo.*"));
       const node = users.get("id").in(mgr);
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("SELECT");
       expect(sql).toContain("~");
     });
@@ -307,20 +308,20 @@ describe("PostgresTest", () => {
   describe("Nodes::Matches", () => {
     it("should know how to visit", () => {
       const node = users.get("name").matches("foo%");
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("ILIKE");
     });
 
     it("should know how to visit case sensitive", () => {
       const node = users.get("name").matches("foo%", null, true);
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("LIKE");
       expect(sql).not.toContain("ILIKE");
     });
 
     it("can handle ESCAPE", () => {
       const node = users.get("name").matches("foo!%", "!");
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("ILIKE");
       expect(sql).toContain("ESCAPE");
     });
@@ -328,7 +329,7 @@ describe("PostgresTest", () => {
     it("can handle subqueries", () => {
       const mgr = users.project(users.get("id")).where(users.get("name").matches("foo%"));
       const node = users.get("id").in(mgr);
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("ILIKE");
     });
   });
@@ -336,7 +337,7 @@ describe("PostgresTest", () => {
   describe("array quoting", () => {
     it("quotes array values as PG array literals", () => {
       const node = users.get("tags").eq(["a", "b"]);
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("'{a,b}'");
     });
 
@@ -345,13 +346,13 @@ describe("PostgresTest", () => {
         [1, 2],
         [3, 4],
       ]);
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("'{{1,2},{3,4}}'");
     });
 
     it("escapes single quotes in array elements", () => {
       const node = users.get("tags").eq(["O'Reilly"]);
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       // The apostrophe is escaped by the outer single-quoting, not the array
       // encoder — `'` is not in PG::TextEncoder::Array's quote-triggering set,
       // so the element itself stays bare.
@@ -363,22 +364,30 @@ describe("PostgresTest", () => {
       // scalar takes (`when Date, Time then quoted_date`), so the array element
       // must carry the db form the scalar path emits — not ISO-8601.
       const d = Temporal.Instant.from("2026-04-26T14:23:55Z");
-      const scalar = new Visitors.PostgreSQL().compile(users.get("at").eq(d));
+      const scalar = new Visitors.PostgreSQL(postgresqlTestConnection).compile(
+        users.get("at").eq(d),
+      );
       expect(scalar).toContain("'2026-04-26 14:23:55'");
 
-      const sql = new Visitors.PostgreSQL().compile(users.get("ats").eq([d]));
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(
+        users.get("ats").eq([d]),
+      );
       expect(sql).toContain("'{\"2026-04-26 14:23:55\"}'");
     });
 
     it("emits fixed-6 microseconds for a sub-second date array element", () => {
       const d = Temporal.Instant.from("2026-04-26T14:23:55.123Z");
-      const sql = new Visitors.PostgreSQL().compile(users.get("ats").eq([d]));
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(
+        users.get("ats").eq([d]),
+      );
       expect(sql).toContain("'{\"2026-04-26 14:23:55.123000\"}'");
     });
 
     it("quotes date elements of a nested array as db dates", () => {
       const d = Temporal.Instant.from("2026-04-26T14:23:55Z");
-      const sql = new Visitors.PostgreSQL().compile(users.get("ats").eq([[d]]));
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(
+        users.get("ats").eq([[d]]),
+      );
       expect(sql).toContain("'{{\"2026-04-26 14:23:55\"}}'");
     });
 
@@ -387,10 +396,14 @@ describe("PostgresTest", () => {
       // sqlite3/quoting.rb:87 do), so it inherits Ruby true/false and
       // encode_array emits '{true,false}'. The scalar path keeps quoted_true's
       // TRUE — the two pairs legitimately differ.
-      const sql = new Visitors.PostgreSQL().compile(users.get("flags").eq([true, false]));
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(
+        users.get("flags").eq([true, false]),
+      );
       expect(sql).toContain("'{true,false}'");
 
-      const scalar = new Visitors.PostgreSQL().compile(users.get("flag").eq(true));
+      const scalar = new Visitors.PostgreSQL(postgresqlTestConnection).compile(
+        users.get("flag").eq(true),
+      );
       expect(scalar).toContain("TRUE");
     });
   });
@@ -402,7 +415,8 @@ describe("PostgresTest", () => {
 // overrides (behaviorally identical to base, kept for fidelity).
 describe("PostgreSQL dialect overrides (audit follow-up)", () => {
   const users = new Table("users");
-  const compile = (n: Nodes.Node): string => new Visitors.PostgreSQL().compile(n);
+  const compile = (n: Nodes.Node): string =>
+    new Visitors.PostgreSQL(postgresqlTestConnection).compile(n);
 
   it("GroupingElement renders with spaces inside parens", () => {
     const ge = new Nodes.GroupingElement([users.get("a"), users.get("b")]);
@@ -457,19 +471,19 @@ describe("PostgreSQL dialect overrides (audit follow-up)", () => {
   describe("Matches ESCAPE", () => {
     it("hard-quotes a string escape", () => {
       const node = users.get("name").matches("x%", "!");
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("ESCAPE '!'");
     });
 
     it("visits a Node escape", () => {
       const node = users.get("name").matches("x%", new Nodes.Quoted("!"));
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("ESCAPE '!'");
     });
 
     it("visits a Node escape on DoesNotMatch", () => {
       const node = users.get("name").doesNotMatch("x%", new Nodes.Quoted("!"));
-      const sql = new Visitors.PostgreSQL().compile(node);
+      const sql = new Visitors.PostgreSQL(postgresqlTestConnection).compile(node);
       expect(sql).toContain("ESCAPE '!'");
     });
   });
@@ -482,20 +496,28 @@ describe("Temporal array elements", () => {
   // trails' analogue is Temporal.PlainTime, which carries no date to emit.
   it("quotes a time array element as a db time, matching the scalar path", () => {
     const t = Temporal.PlainTime.from("14:23:55");
-    expect(new Visitors.PostgreSQL().compile(users.get("at").eq(t))).toContain("'14:23:55'");
-    expect(new Visitors.PostgreSQL().compile(users.get("ats").eq([t]))).toContain("'{14:23:55}'");
+    expect(
+      new Visitors.PostgreSQL(postgresqlTestConnection).compile(users.get("at").eq(t)),
+    ).toContain("'14:23:55'");
+    expect(
+      new Visitors.PostgreSQL(postgresqlTestConnection).compile(users.get("ats").eq([t])),
+    ).toContain("'{14:23:55}'");
   });
 
   // `when Date, Time then quoted_date` (:103) for the date-only analogue.
   it("quotes a date-only array element without a time part", () => {
     const d = Temporal.PlainDate.from("2026-04-26");
-    expect(new Visitors.PostgreSQL().compile(users.get("ats").eq([d]))).toContain("'{2026-04-26}'");
+    expect(
+      new Visitors.PostgreSQL(postgresqlTestConnection).compile(users.get("ats").eq([d])),
+    ).toContain("'{2026-04-26}'");
   });
 
   // A JS Date is rejected AR-wide (#939): it must not be claimed as a Time.
   it("refuses a JS Date rather than formatting it as a Time", () => {
     const d = new Date("2026-04-26T14:23:55Z");
-    expect(() => new Visitors.PostgreSQL().compile(users.get("at").eq(d))).toThrow(TypeError);
+    expect(() =>
+      new Visitors.PostgreSQL(postgresqlTestConnection).compile(users.get("at").eq(d)),
+    ).toThrow(TypeError);
   });
 });
 
@@ -506,14 +528,16 @@ describe("quotedDate normalisation", () => {
   // serialization zone rather than emitting its own wall clock.
   it("converts a zoned value instead of emitting its wall clock", () => {
     const z = Temporal.Instant.from("2026-04-26T14:23:55Z").toZonedDateTimeISO("America/New_York");
-    expect(new Visitors.PostgreSQL().compile(users.get("at").eq(z))).toContain(
-      "'2026-04-26 14:23:55'",
-    );
+    expect(
+      new Visitors.PostgreSQL(postgresqlTestConnection).compile(users.get("at").eq(z)),
+    ).toContain("'2026-04-26 14:23:55'");
   });
 
   // Rails' `to_fs(:db)` never emits a zero-padded negative year like "00-1".
   it("keeps the sign on a negative year", () => {
     const d = new Temporal.PlainDate(-1, 4, 26);
-    expect(new Visitors.PostgreSQL().compile(users.get("at").eq(d))).toContain("'-1-04-26'");
+    expect(
+      new Visitors.PostgreSQL(postgresqlTestConnection).compile(users.get("at").eq(d)),
+    ).toContain("'-1-04-26'");
   });
 });

--- a/packages/arel/src/visitors/sqlite.test.ts
+++ b/packages/arel/src/visitors/sqlite.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "../test-helpers/connection.js";
 import { Table, star, Nodes, Visitors } from "../index.js";
 
 describe("SqliteTest", () => {
@@ -7,7 +8,7 @@ describe("SqliteTest", () => {
   describe("Nodes::IsDistinctFrom", () => {
     it("should handle nil", () => {
       const node = users.get("name").isDistinctFrom(null);
-      const sql = new Visitors.SQLite().compile(node);
+      const sql = new Visitors.SQLite(testConnection).compile(node);
       // SQLite has no IS DISTINCT FROM; it uses IS NOT for null-aware !=.
       expect(sql).toBe('"users"."name" IS NOT NULL');
     });
@@ -15,19 +16,19 @@ describe("SqliteTest", () => {
 
   it("defaults limit to -1", () => {
     const mgr = users.project(star).skip(5);
-    const sql = new Visitors.SQLite().compile(mgr.ast);
+    const sql = new Visitors.SQLite(testConnection).compile(mgr.ast);
     expect(sql).toContain("LIMIT -1");
     expect(sql).toContain("OFFSET 5");
   });
 
   it("does not support locking", () => {
     const mgr = users.project(star).lock();
-    const sql = new Visitors.SQLite().compile(mgr.ast);
+    const sql = new Visitors.SQLite(testConnection).compile(mgr.ast);
     expect(sql).not.toContain("FOR UPDATE");
   });
 
   it("does not support boolean", () => {
-    const visitor = new Visitors.SQLite();
+    const visitor = new Visitors.SQLite(testConnection);
     expect(visitor.compile(new Nodes.True())).toBe("1");
     expect(visitor.compile(new Nodes.False())).toBe("0");
     // `eq` wraps the raw `true` via quotedNode into a Casted node, which is
@@ -39,20 +40,20 @@ describe("SqliteTest", () => {
   describe("Nodes::IsNotDistinctFrom", () => {
     it("should handle column names on both sides", () => {
       const node = users.get("id").isNotDistinctFrom(posts.get("user_id"));
-      const sql = new Visitors.SQLite().compile(node);
+      const sql = new Visitors.SQLite(testConnection).compile(node);
       // SQLite uses IS for null-aware equality (no IS NOT DISTINCT FROM).
       expect(sql).toBe('"users"."id" IS "posts"."user_id"');
     });
 
     it("should handle nil", () => {
       const node = users.get("name").isNotDistinctFrom(null);
-      const sql = new Visitors.SQLite().compile(node);
+      const sql = new Visitors.SQLite(testConnection).compile(node);
       expect(sql).toBe('"users"."name" IS NULL');
     });
 
     it("should construct a valid generic SQL statement", () => {
       const node = users.get("name").isNotDistinctFrom(new Nodes.Quoted(1));
-      const sql = new Visitors.SQLite().compile(node);
+      const sql = new Visitors.SQLite(testConnection).compile(node);
       expect(sql).toBe('"users"."name" IS 1');
     });
   });
@@ -60,7 +61,7 @@ describe("SqliteTest", () => {
   describe("Nodes::IsDistinctFrom", () => {
     it("should handle column names on both sides", () => {
       const node = users.get("id").isDistinctFrom(posts.get("user_id"));
-      const sql = new Visitors.SQLite().compile(node);
+      const sql = new Visitors.SQLite(testConnection).compile(node);
       expect(sql).toContain('"users"."id"');
       expect(sql).toContain('"posts"."user_id"');
     });
@@ -74,7 +75,7 @@ describe("SqliteTest", () => {
 
     it("UNION strips Grouping wrapped operands", () => {
       const node = new Nodes.Union(new Nodes.Grouping(q1().ast), new Nodes.Grouping(q2().ast));
-      const sql = new Visitors.SQLite().compile(node);
+      const sql = new Visitors.SQLite(testConnection).compile(node);
       expect(sql).not.toContain("((");
       expect(sql).toContain("UNION");
       expect(sql).toBe('( SELECT * FROM "users" UNION SELECT * FROM "users" )');
@@ -82,39 +83,39 @@ describe("SqliteTest", () => {
 
     it("UNION ALL strips Grouping wrapped operands", () => {
       const node = new Nodes.UnionAll(new Nodes.Grouping(q1().ast), new Nodes.Grouping(q2().ast));
-      const sql = new Visitors.SQLite().compile(node);
+      const sql = new Visitors.SQLite(testConnection).compile(node);
       expect(sql).toBe('( SELECT * FROM "users" UNION ALL SELECT * FROM "users" )');
     });
 
     it("INTERSECT strips Grouping wrapped operands", () => {
       const node = new Nodes.Intersect(new Nodes.Grouping(q1().ast), new Nodes.Grouping(q2().ast));
-      const sql = new Visitors.SQLite().compile(node);
+      const sql = new Visitors.SQLite(testConnection).compile(node);
       expect(sql).toBe('( (SELECT * FROM "users") INTERSECT (SELECT * FROM "users") )');
     });
 
     it("EXCEPT strips Grouping wrapped operands", () => {
       const node = new Nodes.Except(new Nodes.Grouping(q1().ast), new Nodes.Grouping(q2().ast));
-      const sql = new Visitors.SQLite().compile(node);
+      const sql = new Visitors.SQLite(testConnection).compile(node);
       expect(sql).toBe('( (SELECT * FROM "users") EXCEPT (SELECT * FROM "users") )');
     });
 
     it("UNION without Grouping operands renders bare SELECTs", () => {
       const node = new Nodes.Union(q1().ast, q2().ast);
-      const sql = new Visitors.SQLite().compile(node);
+      const sql = new Visitors.SQLite(testConnection).compile(node);
       expect(sql).toBe('( SELECT * FROM "users" UNION SELECT * FROM "users" )');
     });
 
     it("nested unions are flattened (Rails-style)", () => {
       const q3 = users.project(star);
       const node = new Nodes.Union(q1().ast, new Nodes.Union(q2().ast, q3.ast));
-      const sql = new Visitors.SQLite().compile(node);
+      const sql = new Visitors.SQLite(testConnection).compile(node);
       expect(sql).toBe(
         '( SELECT * FROM "users" UNION SELECT * FROM "users" UNION SELECT * FROM "users" )',
       );
     });
 
     it("union via SelectManager omits inner parens", () => {
-      const sql = new Visitors.SQLite().compile(q1().union(q2()));
+      const sql = new Visitors.SQLite(testConnection).compile(q1().union(q2()));
       expect(sql).not.toContain("((");
       expect(sql).toContain("UNION");
     });

--- a/packages/arel/src/visitors/to-sql.trails.test.ts
+++ b/packages/arel/src/visitors/to-sql.trails.test.ts
@@ -3,13 +3,15 @@
  * arel/test/visitors/test_to_sql.rb.
  */
 import { describe, it, expect } from "vitest";
+import { testConnection, mysqlTestConnection } from "../test-helpers/connection.js";
 import * as Nodes from "../nodes/index.js";
 import * as Visitors from "./index.js";
 import { Table } from "../table.js";
 
 describe("ToSql Array-named identifiers", () => {
   type ToSqlInternals = { quoteColumnName(name: string | Nodes.SqlLiteral): string };
-  const make = (): ToSqlInternals => new Visitors.ToSql() as unknown as ToSqlInternals;
+  const make = (): ToSqlInternals =>
+    new Visitors.ToSql(testConnection) as unknown as ToSqlInternals;
 
   // Rails' adapters stringify with `name.to_s`, and Ruby's `Array#to_s` is
   // inspect-style rather than JS's comma-join. An Array-named Attribute shows
@@ -24,7 +26,7 @@ describe("ToSql Array-named identifiers", () => {
   it("an Array-named attribute compiles to Rails' Array#to_s column reference", () => {
     const orders = new Table("cpk_orders");
     const attr = orders.get(["shop_id", "id"] as unknown as string);
-    expect(new Visitors.ToSql().compile(new Nodes.Descending(attr))).toBe(
+    expect(new Visitors.ToSql(testConnection).compile(new Nodes.Descending(attr))).toBe(
       '"cpk_orders"."[""shop_id"", ""id""]" DESC',
     );
   });
@@ -75,7 +77,7 @@ describe("ToSql Array-named identifiers", () => {
       ["a", "b"] as unknown as string,
       new Table("t").from().project(new Nodes.SqlLiteral("1")).ast,
     );
-    expect(new Visitors.MySQL().compile(cte)).toContain('`["a", "b"]` AS ');
+    expect(new Visitors.MySQL(mysqlTestConnection).compile(cte)).toContain('`["a", "b"]` AS ');
   });
 });
 
@@ -91,11 +93,11 @@ describe("ToSql raw scalars in quoting slots", () => {
   // union on the strength of that alias alone would contradict this behaviour.
   it("quotes a bare boolean in an Assignment right instead of raising", () => {
     const node = new Nodes.Assignment(users.get("admin"), true);
-    expect(new Visitors.ToSql().compile(node)).toBe('"users"."admin" = TRUE');
+    expect(new Visitors.ToSql(testConnection).compile(node)).toBe('"users"."admin" = TRUE');
   });
 
   it("quotes a bare string in an Assignment right instead of raising", () => {
     const node = new Nodes.Assignment(users.get("name"), "x");
-    expect(new Visitors.ToSql().compile(node)).toBe('"users"."name" = \'x\'');
+    expect(new Visitors.ToSql(testConnection).compile(node)).toBe('"users"."name" = \'x\'');
   });
 });


### PR DESCRIPTION
## What

Follow-up to #5032, which converted `to-sql.test.ts` to name its Arel visitor
connection explicitly. This converts the **remaining** bare visitor
constructions in `packages/arel` — 37 test files — so no visitor silently falls
back to a connection-less default quoter (the invention RFC 0007 is removing).

Rails builds Arel visitors with a real connection
(`Visitors::ToSql.new Table.engine.lease_connection`); it has no
connection-less path. Once every call site names its connection, the visitor
constructor defaults have no remaining reference and can be deleted.

## How

Mechanical single-pattern transformation — add the explicit connection argument:

- `new Visitors.ToSql()` / `new Visitors.SQLite()` → `testConnection`
  (`SQLite` inherits the generic `defaultQuoter` default)
- `new Visitors.PostgreSQL()` → `postgresqlTestConnection`
- `new Visitors.MySQL()` → `mysqlTestConnection`

The only non-mechanical part: `test-helpers/connection.ts` gains
`mysqlTestConnection` / `postgresqlTestConnection`, aliasing the adapter default
quoters exactly as `testConnection` aliases `defaultQuoter`. The PG/MySQL
visitors default to adapter-specific quoters, so their tests must supply those
(otherwise PG array literals / MySQL backticks silently regress to the generic
quoter's output).

`Visitors.Dot()` is intentionally left alone: its constructor takes no
connection (its `quote` is label-escaping, not adapter quoting), so there is no
default-quoter fallback to remove.

## Notes

- **No test names changed** (test:compare delta 0).
- Only `test-helpers/connection.ts` adds two exports; no source parity surface
  changes (api:compare delta non-negative).
- Full `packages/arel` suite green locally (1585 tests).
- **LOC ~569, over the 500 ceiling.** This is a single mechanical arg-add across
  37 files plus ~15 lines adding the two adapter test-connections — the
  mechanical-change exception in CLAUDE.md. Splitting a one-pattern change into
  sibling PRs would double CI/review for no benefit.

Closes-story: convert-remaining-arel-visitor-sites-to-explicit-connection
