### PR TITLE
fix(activerecord): build RecordNotFound conditions via arel.whereSql

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -930,16 +930,17 @@ describe("CollectionProxy#find — in-memory not-found message fidelity", () => 
       expect(err).toBeInstanceOf(RecordNotFound);
       // Pluralized model name + found/expected suffix + the association scope's
       // `[WHERE …]` conditions clause. Rails' in-memory `find` routes through
-      // `scope.raise_record_not_found_exception!`, so the message carries the
-      // scope's STI type filter + owner FK. Quote characters differ by adapter
-      // (double-quote vs backtick), so `.` stands in for the identifier quotes —
-      // assert structure, not exact quoting.
+      // `scope.raise_record_not_found_exception!`, whose `arel.where_sql(model)`
+      // renders BindParams as `?` placeholders, so the message carries the
+      // scope's STI type filter + owner FK with placeholder values. Quote
+      // characters differ by adapter (double-quote vs backtick), so `.` stands
+      // in for the identifier quotes — assert structure, not exact quoting.
       expect(err.message).toMatch(
         new RegExp(
           `^Couldn't find all Clients with 'id': \\(${realId}, 999999\\) ` +
             `\\[WHERE .companies.\\..type. ` +
-            `IN \\('Client', 'LargeClient', 'SpecialClient', 'VerySpecialClient'\\) ` +
-            `AND .companies.\\..client_of. = ${firm.id}\\] ` +
+            `IN \\(\\?, \\?, \\?, \\?\\) ` +
+            `AND .companies.\\..client_of. = \\?\\] ` +
             `\\(found 1 results, but was looking for 2\\)\\.$`,
         ),
       );

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -931,16 +931,18 @@ describe("CollectionProxy#find — in-memory not-found message fidelity", () => 
       // Pluralized model name + found/expected suffix + the association scope's
       // `[WHERE …]` conditions clause. Rails' in-memory `find` routes through
       // `scope.raise_record_not_found_exception!`, whose `arel.where_sql(model)`
-      // renders BindParams as `?` placeholders, so the message carries the
-      // scope's STI type filter + owner FK with placeholder values. Quote
-      // characters differ by adapter (double-quote vs backtick), so `.` stands
-      // in for the identifier quotes — assert structure, not exact quoting.
+      // renders BindParams as placeholders, so the message carries the scope's
+      // STI type filter + owner FK with placeholder values. Placeholder style
+      // (`?` vs `$N`) and quote characters (double-quote vs backtick) differ by
+      // adapter, so the regex accepts both — assert structure, not exact
+      // rendering.
+      const ph = `(\\?|\\$\\d+)`;
       expect(err.message).toMatch(
         new RegExp(
           `^Couldn't find all Clients with 'id': \\(${realId}, 999999\\) ` +
             `\\[WHERE .companies.\\..type. ` +
-            `IN \\(\\?, \\?, \\?, \\?\\) ` +
-            `AND .companies.\\..client_of. = \\?\\] ` +
+            `IN \\(${ph}, ${ph}, ${ph}, ${ph}\\) ` +
+            `AND .companies.\\..client_of. = ${ph}\\] ` +
             `\\(found 1 results, but was looking for 2\\)\\.$`,
         ),
       );

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -3462,8 +3462,17 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // `[WHERE …]` conditions clause into the not-found raisers. Computed
     // lazily (only when raising) — building the scope relation is wasted
     // work on the hot path where every id is found.
-    const conditionsClause = (): string =>
-      (this.scope() as { _conditionsClause(): string })._conditionsClause();
+    // Built exactly as Rails' raise_record_not_found_exception! does
+    // (finder_methods.rb:418): `" [#{arel.where_sql(model)}]" unless
+    // where_clause.empty?` — off the scope relation, since Rails raises via
+    // `scope.raise_record_not_found_exception!`.
+    const conditionsClause = (): string => {
+      const scope = this.scope() as unknown as {
+        _whereClause: { isEmpty(): boolean };
+        arel(): { whereSql(engine: unknown): string | null };
+      };
+      return scope._whereClause.isEmpty() ? "" : ` [${scope.arel().whereSql(targetModel) ?? ""}]`;
+    };
 
     // Composite + any-multi: always use the "Couldn't find all" shape
     // (matches performFind). Simple-PK single-id uses "with 'pk'=id".

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -6482,36 +6482,6 @@ export class Relation<T extends Base> {
     }
   }
 
-  /**
-   * Rails' not-found `conditions` clause:
-   * `conditions = " [#{arel.where_sql(model)}]" unless where_clause.empty?`
-   * (finder_methods.rb:418), appended to every `raise_record_not_found_exception!`
-   * message. Returns the bracketed `[WHERE …]` suffix (with a leading space) for
-   * a scoped relation, or "" when the where clause is empty.
-   *
-   * The guard is `where_clause.empty?`, but the rendered SQL comes from
-   * `arel.where_sql(model)` — the relation's *full* arel, whose WHERE folds in
-   * the STI `type_condition` and any default-scope predicates, not just the
-   * explicit `where_clause`. So we render the WHERE from the built manager's
-   * constraints (`_buildArel`), matching Arel's `SelectManager#where_sql`
-   * (which prefixes the predicate SQL with `WHERE `), rather than the raw
-   * `_whereClause`. For an STI subclass this includes the `"type" IN (…)`
-   * predicate; for a default-scoped model it includes the scope's WHEREs.
-   *
-   * @internal trails-only helper — Rails inlines this in raise_record_not_found_exception!.
-   */
-  _conditionsClause(): string {
-    if (this._whereClause.isEmpty()) return "";
-    const connection = this._conn();
-    if (!connection?.toSql) return "";
-    const wheres = this._buildArel().constraints;
-    if (wheres.length === 0) return "";
-    const node = wheres.length === 1 ? wheres[0] : new Nodes.And(wheres);
-    const sql = connection.toSql(node);
-    if (sql === "") return "";
-    return ` [WHERE ${sql}]`;
-  }
-
   get isEmptyScope(): boolean {
     // Rails: `@values == klass.unscoped.values`. The unscoped baseline may carry
     // the STI `type_condition`, so a relation whose WHERE matches that baseline

--- a/packages/activerecord/src/relation/finder-methods.test.ts
+++ b/packages/activerecord/src/relation/finder-methods.test.ts
@@ -347,7 +347,7 @@ function makeFindSomeRel(
     _rawOrderClauses: [],
     selectValues: [],
     raiseRecordNotFoundExceptionBang,
-    _conditionsClause: () => "",
+    _whereClause: { isEmpty: () => true },
     where(_cond: any) {
       const rel: any = { toArray: async () => records, select: () => rel };
       return rel;
@@ -454,7 +454,7 @@ function makeFindSomeOrderedRel(
     _rawOrderClauses: [],
     selectValues: [],
     raiseRecordNotFoundExceptionBang,
-    _conditionsClause: () => "",
+    _whereClause: { isEmpty: () => true },
     where(_cond: any) {
       const rel: any = { toArray: async () => records, select: () => rel };
       return rel;
@@ -627,7 +627,7 @@ describe("finder not-found message fidelity", () => {
     const rel: any = {
       _modelClass: { name: "Car", primaryKey: "id" },
       raiseRecordNotFoundExceptionBang,
-      _conditionsClause: () => "",
+      _whereClause: { isEmpty: () => true },
       findBy: async () => null,
     };
     try {
@@ -655,7 +655,7 @@ describe("finder not-found message fidelity", () => {
       _offsetValue: null,
       selectValues: [],
       raiseRecordNotFoundExceptionBang,
-      _conditionsClause: () => "",
+      _whereClause: { isEmpty: () => true },
       where(_cond: any) {
         const inner: any = { toArray: async () => [], select: () => inner };
         return inner;

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -282,8 +282,9 @@ interface FinderRelation {
   _scopeAttributes(): Record<string, unknown>;
   scopeForCreate(): Record<string, unknown>;
   _clone(): any;
-  /** Rails' not-found `conditions` clause: ` [WHERE …]` or "" (relation.ts). */
-  _conditionsClause(): string;
+  _whereClause: { isEmpty(): boolean };
+  /** Relation#arel — the built SelectManager (relation.ts). */
+  arel(): { whereSql(engine: unknown): string | null };
   where(conditions: unknown, ...rest: unknown[]): any;
   limit(n: number): any;
   order(...args: any[]): any;
@@ -309,9 +310,16 @@ export async function performFind(this: FinderRelation, ...args: unknown[]): Pro
   const normalized = normalizeFindArgs(modelName, pk, args);
   if (normalized.emptyArray) return [];
   const { ids, wantArray, tuples } = normalized;
-  // Rails appends the relation's WHERE clause to every not-found message
-  // (`conditions = " [#{arel.where_sql(model)}]" unless where_clause.empty?`).
-  const conditions = this._conditionsClause();
+  // Rails appends the relation's WHERE clause to every not-found message.
+  // Rails builds it inside raise_record_not_found_exception! (finder_methods.rb:418);
+  // trails precomputes it here because the raise paths below go through the
+  // shared raiseNotFoundSingle/raiseNotFoundAll helpers rather than the bang.
+  // The guard is `where_clause.empty?`, but the rendered SQL comes from the
+  // built arel, whose WHERE also folds in the STI type_condition and any
+  // default-scope predicates.
+  const conditions = this._whereClause.isEmpty()
+    ? ""
+    : ` [${this.arel().whereSql(this._modelClass) ?? ""}]`;
 
   // Composite PK: OR over per-tuple WHERE conditions. The
   // `Array.isArray(pk)` guard narrows `pk` to `string[]` via
@@ -669,9 +677,15 @@ export function raiseRecordNotFoundExceptionBang(
   key?: string,
   notFoundIds?: unknown[],
 ): never {
+  // Rails: `conditions = " [#{arel.where_sql(model)}]" unless where_clause.empty?`
+  // (finder_methods.rb:418). `where_sql` returns nil when the manager has no
+  // wheres, which Ruby interpolates as "" — hence the `?? ""`.
+  const conditions = this._whereClause.isEmpty()
+    ? ""
+    : ` [${this.arel().whereSql(this._modelClass) ?? ""}]`;
+
   const name = this._modelClass.name;
   const k = key ?? String(this._modelClass.primaryKey);
-  const conditions = this._conditionsClause();
 
   if (ids === undefined || ids === null) {
     // Rails: `error << " with#{conditions}" if conditions`.

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/finder-methods.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/finder-methods.json
@@ -290,20 +290,6 @@
     "package": "activerecord",
     "tsFile": "relation/finder-methods.ts",
     "rubyName": "raise_record_not_found_exception!",
-    "call": "arel",
-    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "raise_record_not_found_exception!",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "raise_record_not_found_exception!",
     "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -334,12 +320,5 @@
     "rubyName": "raise_record_not_found_exception!",
     "call": "wrap",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "raise_record_not_found_exception!",
-    "call": "where_sql",
-    "reason": "Satisfied by a different path: Rails builds the condition string with `arel.where_sql(model)` (finder_methods.rb:418); trails routes it through the `_conditionsClause()` host method instead. Newly visible (not newly broken) because #5037 gave Arel's whereSql a connection parameter; the divergent indirection pre-dates it. Convergence tracked by story where-sql-wraps-in-and-and-returns-sqlliteral, which also owns removing this entry."
   }
 ]


### PR DESCRIPTION
## Summary

Converges the RecordNotFound `conditions` clause onto Rails' expression
(`finder_methods.rb:418`):

```ruby
conditions = " [#{arel.where_sql(model)}]" unless where_clause.empty?
```

**Where `_conditionsClause` actually lived** (acceptance item 1): the story said
no implementation was found in source — it exists at `relation.ts:6503` (now
deleted). Plain `grep` silently truncates on the 7.8k-line `relation.ts`;
`grep -a` finds it.

**Changes**

- `raiseRecordNotFoundExceptionBang` and `performFind` now build `conditions`
  inline via `this.arel().whereSql(this._modelClass)` behind the
  `where_clause.empty?` guard, with Rails' `" [...]"` wrapping (`?? ""` mirrors
  Ruby nil interpolation).
- `CollectionProxy#find`'s in-memory path builds the same expression off the
  scope relation (Rails raises via `scope.raise_record_not_found_exception!`),
  justified at the call site.
- Deleted `Relation#_conditionsClause` (trails invention). Its
  `connection.toSql` rendering quoted bind values as **literals**; Rails'
  `where_sql` renders BindParams as `?` placeholders. The trails-only
  collection-proxy message-fidelity test expectation is updated accordingly
  (test name unchanged).
- Removed the `raise_record_not_found_exception!` `where_sql`, `arel`, and
  `empty?` entries from the wide call-ratchet baseline — all three now flag as
  stale-converged; `lint-call-mismatches-wide` passes after a forced
  `--wide-calls` re-extract (`OK, 6641 baselined`).

**Testing**: `finder-methods.test.ts`, `finder.test.ts`,
`collection-proxy.test.ts`, `relation.test.ts`,
`has-many-through-associations.test.ts` all pass; tsc + eslint clean on touched
files.

Closes-story: converge-record-not-found-conditions-onto-arel-where-sql
