### PR TITLE
test(arel): converge Rails-named placeholder test bodies to real assertions

### DIFF
--- a/packages/arel/src/attributes.test.ts
+++ b/packages/arel/src/attributes.test.ts
@@ -6,8 +6,8 @@ describe("Attributes", () => {
   it("responds to lower", () => {
     const name = users.get("name");
     const fn = name.lower();
-    expect(fn).toBeInstanceOf(Nodes.NamedFunction);
     expect(fn.name).toBe("LOWER");
+    expect(fn.expressions).toEqual([name]);
   });
 
   describe("equality", () => {

--- a/packages/arel/src/factory-methods.ts
+++ b/packages/arel/src/factory-methods.ts
@@ -34,12 +34,12 @@ export interface FactoryMethodsModule {
   createFalse(): False;
   createTableAlias(relation: Node, name: string | SqlLiteral): TableAlias;
   createJoin(
-    to: Node,
-    constraint?: Node | null,
+    to: Node | string,
+    constraint?: Node | string | null,
     klass?: new (left: Node, right: Node | null) => Join,
   ): Join;
   createStringJoin(to: string | Node): StringJoin;
-  createAnd(clauses: Node[]): And;
+  createAnd(clauses: (Node | string)[]): And;
   createOn(expr: Node): On;
   grouping(expr: Node): Grouping;
   lower(column: unknown): NamedFunction;
@@ -60,13 +60,15 @@ export const FactoryMethods: FactoryMethodsModule = {
     return new TableAlias(relation, name);
   },
 
+  // Rails' create_join/create_and are duck-typed and its own tests exercise
+  // them with bare strings, so the params admit `string` like Table#createJoin.
   createJoin(
-    to: Node,
-    constraint?: Node | null,
+    to: Node | string,
+    constraint?: Node | string | null,
     klass?: new (left: Node, right: Node | null) => Join,
   ): Join {
     const JoinKlass = klass ?? InnerJoin;
-    return new JoinKlass(to, constraint ?? null);
+    return new JoinKlass(to as Node, (constraint ?? null) as Node | null);
   },
 
   createStringJoin(to: string | Node): StringJoin {
@@ -74,8 +76,8 @@ export const FactoryMethods: FactoryMethodsModule = {
     return this.createJoin(node, null, StringJoin) as StringJoin;
   },
 
-  createAnd(clauses: Node[]): And {
-    return new And(clauses);
+  createAnd(clauses: (Node | string)[]): And {
+    return new And(clauses as Node[]);
   },
 
   createOn(expr: Node): On {

--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -468,9 +468,11 @@ describe("SelectManagerTest", () => {
   });
 
   it("should create and nodes", () => {
-    const mgr = new SelectManager(users);
-    const and = mgr.createAnd([users.get("id").eq(1), users.get("name").eq("dean")]);
-    expect(and).toBeInstanceOf(Nodes.And);
+    const mgr = new SelectManager();
+    const children = ["foo", "bar", "baz"];
+    const clause = mgr.createAnd(children);
+    expect(clause).toBeInstanceOf(Nodes.And);
+    expect(clause.children).toEqual(children);
   });
 
   it("should create insert managers", () => {
@@ -480,9 +482,11 @@ describe("SelectManagerTest", () => {
   });
 
   it("should create join nodes", () => {
-    const mgr = new SelectManager(users);
-    const join = mgr.createJoin(posts, users.get("id").eq(posts.get("user_id")));
+    const mgr = new SelectManager();
+    const join = mgr.createJoin("foo", "bar");
     expect(join).toBeInstanceOf(Nodes.InnerJoin);
+    expect(join.left).toBe("foo");
+    expect(join.right).toBe("bar");
   });
 
   describe("join", () => {

--- a/packages/arel/src/table.test.ts
+++ b/packages/arel/src/table.test.ts
@@ -6,23 +6,31 @@ describe("TableTest", () => {
   const users = new Table("users");
   const posts = new Table("posts");
   it("should create join nodes", () => {
-    const join = users.createJoin(posts, users.get("id").eq(posts.get("user_id")));
+    const join = users.createJoin("foo", "bar");
     expect(join).toBeInstanceOf(Nodes.InnerJoin);
+    expect(join.left).toBe("foo");
+    expect(join.right).toBe("bar");
   });
 
   it("should create join nodes with a klass", () => {
     const join = users.createJoin("foo", "bar", Nodes.FullOuterJoin);
     expect(join).toBeInstanceOf(Nodes.FullOuterJoin);
+    expect(join.left).toBe("foo");
+    expect(join.right).toBe("bar");
   });
 
   it("should create join nodes with a klass", () => {
     const join = users.createJoin("foo", "bar", Nodes.OuterJoin);
     expect(join).toBeInstanceOf(Nodes.OuterJoin);
+    expect(join.left).toBe("foo");
+    expect(join.right).toBe("bar");
   });
 
   it("should create join nodes with a klass", () => {
     const join = users.createJoin("foo", "bar", Nodes.RightOuterJoin);
     expect(join).toBeInstanceOf(Nodes.RightOuterJoin);
+    expect(join.left).toBe("foo");
+    expect(join.right).toBe("bar");
   });
 
   describe("createJoin with On constraint", () => {
@@ -98,9 +106,8 @@ describe("TableTest", () => {
 
   describe("new", () => {
     it("should accept a hash", () => {
-      // Table where accepts node conditions
-      const mgr = users.where(users.get("id").eq(1));
-      expect(mgr).toBeInstanceOf(SelectManager);
+      const rel = new Table("users", { as: "foo" });
+      expect(rel.tableAlias).toBe("foo");
     });
 
     it("ignores as if it equals name", () => {
@@ -151,8 +158,10 @@ describe("TableTest", () => {
 
   describe("where", () => {
     it("returns a tree manager", () => {
-      const mgr = users.project(star);
+      const mgr = users.where(users.get("id").eq(1));
+      mgr.project(users.get("id"));
       expect(mgr).toBeInstanceOf(SelectManager);
+      expect(mgr.toSql()).toBe('SELECT "users"."id" FROM "users" WHERE "users"."id" = 1');
     });
   });
 
@@ -169,15 +178,15 @@ describe("TableTest", () => {
 
   describe("equality", () => {
     it("is equal with equal ivars", () => {
-      const a = new Nodes.And([users.get("id").eq(1)]);
-      const b = new Nodes.And([users.get("id").eq(1)]);
-      expect(a.children.length).toBe(b.children.length);
+      const relation1 = new Table("users", { as: "zomg" });
+      const relation2 = new Table("users", { as: "zomg" });
+      expect(relation1.eql(relation2)).toBe(true);
     });
 
     it("is not equal with different ivars", () => {
-      const a = users.get("name");
-      const b = users.get("email");
-      expect(a.name).not.toBe(b.name);
+      const relation1 = new Table("users", { as: "zomg" });
+      const relation2 = new Table("users", { as: "zomg2" });
+      expect(relation1.eql(relation2)).toBe(false);
     });
   });
 
@@ -253,18 +262,6 @@ describe("TableTest", () => {
     const aliased = users.alias("u");
     expect(aliased).toBeInstanceOf(Nodes.TableAlias);
     expect(aliased.name).toBe("u");
-  });
-
-  it("should accept a hash (constructor options)", () => {
-    const t = new Table("users", { as: "u" });
-    expect(t.tableAlias).toBe("u");
-  });
-
-  describe("where", () => {
-    it("returns a tree manager", () => {
-      const mgr = users.project(star);
-      expect(mgr).toBeInstanceOf(SelectManager);
-    });
   });
 
   it("manufactures an attribute", () => {

--- a/packages/arel/src/table.test.ts
+++ b/packages/arel/src/table.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { Table, sql, star, SelectManager, Nodes, Visitors, EmptyJoinError } from "./index.js";
+import {
+  Table,
+  sql,
+  star,
+  SelectManager,
+  TreeManager,
+  Nodes,
+  Visitors,
+  EmptyJoinError,
+} from "./index.js";
 import { testConnection, mysqlTestConnection } from "./test-helpers/connection.js";
 
 describe("TableTest", () => {
@@ -160,7 +169,7 @@ describe("TableTest", () => {
     it("returns a tree manager", () => {
       const mgr = users.where(users.get("id").eq(1));
       mgr.project(users.get("id"));
-      expect(mgr).toBeInstanceOf(SelectManager);
+      expect(mgr).toBeInstanceOf(TreeManager);
       expect(mgr.toSql()).toBe('SELECT "users"."id" FROM "users" WHERE "users"."id" = 1');
     });
   });

--- a/packages/arel/src/table.test.ts
+++ b/packages/arel/src/table.test.ts
@@ -186,15 +186,22 @@ describe("TableTest", () => {
   });
 
   describe("equality", () => {
+    // Rails asserts `array.uniq.size` (table_test.rb:191-202), which exercises
+    // the eql? + hash contract together; JS has no uniq-by-eql, so assert both
+    // halves explicitly.
     it("is equal with equal ivars", () => {
       const relation1 = new Table("users", { as: "zomg" });
       const relation2 = new Table("users", { as: "zomg" });
       expect(relation1.eql(relation2)).toBe(true);
+      expect(relation1.hash()).toBe(relation2.hash());
     });
 
     it("is not equal with different ivars", () => {
       const relation1 = new Table("users", { as: "zomg" });
       const relation2 = new Table("users", { as: "zomg2" });
+      // Rails' Table#hash hashes only @name (table.rb:88-92), so these share a
+      // hash bucket; uniq drops to eql?, which distinguishes them.
+      expect(relation1.hash()).toBe(relation2.hash());
       expect(relation1.eql(relation2)).toBe(false);
     });
   });

--- a/packages/arel/src/visitors/mysql.test.ts
+++ b/packages/arel/src/visitors/mysql.test.ts
@@ -26,29 +26,33 @@ describe("MysqlTest", () => {
 
   describe("Nodes::Regexp", () => {
     it("should know how to visit", () => {
-      const node = users.get("name").matchesRegexp("bar");
+      const node = users.get("name").matchesRegexp("foo.*");
       expect(node).toBeInstanceOf(Nodes.Regexp);
-      expect(node.left).toHaveProperty("name", "name");
+      expect(new Visitors.MySQL().compile(node)).toBe("`users`.`name` REGEXP 'foo.*'");
     });
 
     it("can handle subqueries", () => {
-      const node = users.get("name").matchesRegexp("foo.*");
-      expect(node).toBeInstanceOf(Nodes.Regexp);
-      expect(node.left).toHaveProperty("name", "name");
+      const subquery = users.project("id").where(users.get("name").matchesRegexp("foo.*"));
+      const node = users.get("id").in(subquery);
+      expect(new Visitors.MySQL().compile(node)).toBe(
+        "`users`.`id` IN (SELECT id FROM `users` WHERE `users`.`name` REGEXP 'foo.*')",
+      );
     });
   });
 
   describe("Nodes::NotRegexp", () => {
     it("can handle subqueries", () => {
-      const node = users.get("name").doesNotMatchRegexp("foo.*");
-      expect(node).toBeInstanceOf(Nodes.NotRegexp);
-      expect(node.left).toHaveProperty("name", "name");
+      const subquery = users.project("id").where(users.get("name").doesNotMatchRegexp("foo.*"));
+      const node = users.get("id").in(subquery);
+      expect(new Visitors.MySQL().compile(node)).toBe(
+        "`users`.`id` IN (SELECT id FROM `users` WHERE `users`.`name` NOT REGEXP 'foo.*')",
+      );
     });
 
     it("should know how to visit", () => {
-      const node = users.get("name").doesNotMatchRegexp("bar");
+      const node = users.get("name").doesNotMatchRegexp("foo.*");
       expect(node).toBeInstanceOf(Nodes.NotRegexp);
-      expect(node.left).toHaveProperty("name", "name");
+      expect(new Visitors.MySQL().compile(node)).toBe("`users`.`name` NOT REGEXP 'foo.*'");
     });
   });
 


### PR DESCRIPTION
Sweep of `packages/arel/src/**/*.test.ts` for Rails-named tests whose bodies asserted only tautologies — the detection gap identified in #5029, where `test:compare` counted the tests as matched while the behavior under the name went untested.

## Inventory (all converged in this PR)

| File | Test | Rails source | Problem |
| --- | --- | --- | --- |
| `table.test.ts` | `should create join nodes` (+3 `with a klass` variants) | `table_test.rb:11,18,25,32` | instanceOf only; Rails also asserts `left`/`right` |
| `table.test.ts` | `new > should accept a hash` | `table_test.rb:115` | body was an unrelated `where` + instanceOf; Rails asserts `table_alias == "foo"` |
| `table.test.ts` | `where > returns a tree manager` | `table_test.rb:165` | never called `where`; instanceOf only. Rails builds where+project and asserts SQL |
| `table.test.ts` | `equality > is equal with equal ivars` / `is not equal with different ivars` | `table_test.rb:191,198` | compared unrelated node children lengths / attr names; now uses `Table#eql` mirroring Rails' uniq-based bodies |
| `select-manager.test.ts` | `should create and nodes` | `select_manager_test.rb:487` | missing `children` assertion |
| `select-manager.test.ts` | `should create join nodes` | `select_manager_test.rb:501` | missing `left`/`right` assertions |
| `visitors/mysql.test.ts` | `Nodes::Regexp` / `Nodes::NotRegexp` — `should know how to visit`, `can handle subqueries` (×4) | `visitors/mysql_test.rb:116,124,139,147` | `toHaveProperty("name","name")` on the attribute just built; never compiled SQL. Now assert `REGEXP` / `NOT REGEXP` and the subquery `IN` forms |
| `attributes.test.ts` | `responds to lower` | `attributes_test.rb:7` | missing `expressions` assertion |

Deleted two invented duplicates in `table.test.ts` that shadowed the now-real bodies: `should accept a hash (constructor options)` and the second `where > returns a tree manager` describe block (the dup-below-the-fold pattern).

## Divergence exposed (fixed on main by #5053)

The converged `should create join nodes` initially failed: trails' `SelectManager#createJoin` override wrapped the constraint in an `On` node, with a comment claiming Rails does this — it doesn't (`factory_methods.rb:19` is `klass.new(to, constraint)`). While this PR was open, #5053 converged `SelectManager#join` to Rails' `(relation, klass)` signature and deleted that override on main; after rebasing, this PR no longer touches `select-manager.ts`. What remains here: `FactoryMethods#createJoin`/`createAnd` params widened to admit strings, matching Rails' duck-typed originals (its own tests pass bare `"foo"`/`"bar"`) and `Table#createJoin`'s existing shape.

## Audit notes

The remaining ~300 `toBeInstanceOf` assertions across arel tests mirror Rails' own `assert_kind_of`/`must_be_kind_of` bodies and are faithful — this sweep targeted bodies whose *only* assertion was a tautology. `select_manager_test.rb`'s three `should create join nodes with a … klass` tests have no trails counterpart (2 shown missing by test:compare, pre-existing) — coverage gap, not a placeholder, left for its own story.

A lint heuristic (Rails-matched test whose assertions never reference `toSql()`/`compile()` or node internals) was considered; the surviving instanceOf-only bodies are faithful to Rails' own kind_of-only tests, so the signal-to-noise looked too low to ratchet — noted here rather than shipped.

test:compare after: arel 705/707 (99.7%), all 59 files ✓, delta non-negative (test names unchanged).

Closes-story: arel-tests-rails-named-placeholder-bodies-inflate-test-compare
