### PR TITLE
fix(tasks): mirror index-level effective status; pin postponed-RFC override

### DIFF
--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -204,6 +204,28 @@ describe("ready", () => {
     expect(ready(idx).map((s) => s.id)).toEqual(["active"]);
   });
 
+  it("never surfaces a story build-index downgraded under a postponed RFC", () => {
+    // build-index.mjs (tasks repo) emits effective status: a `ready` story
+    // under a non-active RFC arrives here as `draft` with the authored value
+    // in raw_status. Pin that neither ready() nor listFiltered's status
+    // filter resurrects it as claimable from the raw value.
+    const idx = index([
+      story({ id: "active", rfc: "0001-r", raw_status: "ready" }),
+      story({ id: "downgraded", rfc: "0004-r", status: "draft", raw_status: "ready" }),
+    ]);
+    idx.rfcs.push({
+      id: "0004-r",
+      title: "R4",
+      status: "postponed",
+      owner: "@x",
+      packages: [],
+      clusters: ["c1"],
+      file_path: "0004-r/README.md",
+    });
+    expect(ready(idx).map((s) => s.id)).toEqual(["active"]);
+    expect(listFiltered(idx, { status: "ready" }).map((s) => s.id)).toEqual(["active"]);
+  });
+
   it("excludes a ready story whose RFC is null-status or absent from the index", () => {
     const idx = index([
       story({ id: "active", rfc: "0001-r" }), // active → included

--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -439,6 +439,24 @@ describe("isIndexStale", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  it("detects edits under a legacy draft-slug RFC dir (indexed by RFC_DIR_RE too)", () => {
+    const { dir, index, setAge } = checkout();
+    mkdirSync(join(dir, "rfcs", "draft-r", "stories"), { recursive: true });
+    writeFileSync(join(dir, "rfcs", "draft-r", "stories", "s.md"), "x");
+    setAge("rfcs/draft-r/stories/s.md", 200);
+    expect(isIndexStale(index, dir)).toBe(true);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("ignores 0000-template (excluded from the index, so it can't stale it)", () => {
+    const { dir, index, setAge } = checkout();
+    mkdirSync(join(dir, "rfcs", "0000-template", "stories"), { recursive: true });
+    writeFileSync(join(dir, "rfcs", "0000-template", "README.md"), "x");
+    setAge("rfcs/0000-template/README.md", 200);
+    expect(isIndexStale(index, dir)).toBe(false);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
   it("detects a build script newer than the index (derivation changes must reindex)", () => {
     const { dir, index, setAge } = checkout();
     setAge("scripts/build-index.mjs", 200);

--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -1,4 +1,12 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -20,6 +28,7 @@ afterEach(() => {
 
 import {
   bestBundle,
+  isIndexStale,
   __setLockDirForTest,
   acquireTasksLock,
   buildRfcContent,
@@ -376,6 +385,65 @@ describe("nextBundle", () => {
     const bundle = nextBundle(idx, { maxLoc: 250 });
     // Both clusters tie at 100; either may win, but never both together.
     expect(bundle.length).toBe(1);
+  });
+});
+
+describe("isIndexStale", () => {
+  // Lay out a minimal tasks checkout: rfcs/0001-r/{README.md,stories/s.md},
+  // scripts/build-index.mjs, and index.json, all with controlled mtimes so
+  // each staleness trigger can be exercised independently.
+  function checkout(): { dir: string; index: string; setAge: (rel: string, sec: number) => void } {
+    const dir = mkdtempSync(join(tmpdir(), "tasks-stale-"));
+    mkdirSync(join(dir, "rfcs", "0001-r", "stories"), { recursive: true });
+    mkdirSync(join(dir, "scripts"), { recursive: true });
+    for (const rel of [
+      "rfcs/0001-r/README.md",
+      "rfcs/0001-r/stories/s.md",
+      "scripts/build-index.mjs",
+      "index.json",
+    ]) {
+      writeFileSync(join(dir, rel), "x");
+    }
+    const setAge = (rel: string, sec: number): void => {
+      // utimes takes seconds; positive sec = newer than the epoch base below.
+      utimesSync(join(dir, rel), 1_000_000 + sec, 1_000_000 + sec);
+    };
+    // Baseline: everything older than the index → fresh.
+    for (const rel of [
+      "rfcs/0001-r/README.md",
+      "rfcs/0001-r/stories/s.md",
+      "scripts/build-index.mjs",
+    ])
+      setAge(rel, 0);
+    setAge("index.json", 100);
+    return { dir, index: join(dir, "index.json"), setAge };
+  }
+
+  it("reports fresh when the index is newest", () => {
+    const { dir, index } = checkout();
+    expect(isIndexStale(index, dir)).toBe(false);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("detects a story file newer than the index (rfcs/ layout, not repo root)", () => {
+    const { dir, index, setAge } = checkout();
+    setAge("rfcs/0001-r/stories/s.md", 200);
+    expect(isIndexStale(index, dir)).toBe(true);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("detects an RFC README newer than the index (status flips live there)", () => {
+    const { dir, index, setAge } = checkout();
+    setAge("rfcs/0001-r/README.md", 200);
+    expect(isIndexStale(index, dir)).toBe(true);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("detects a build script newer than the index (derivation changes must reindex)", () => {
+    const { dir, index, setAge } = checkout();
+    setAge("scripts/build-index.mjs", 200);
+    expect(isIndexStale(index, dir)).toBe(true);
+    rmSync(dir, { recursive: true, force: true });
   });
 });
 

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -170,10 +170,14 @@ export function isIndexStale(indexPath: string, tasksDir: string = TASKS_DIR): b
   }
   // RFC dirs live under rfcs/ (post repo-rename layout); scanning the repo
   // root here — as this function originally did — finds no `NNNN-` dirs and
-  // silently reports every index fresh forever.
+  // silently reports every index fresh forever. The dir predicate mirrors
+  // RFC_DIR_RE in the tasks repo's scripts/lib.mjs: numbered `NNNN-slug`,
+  // unnumbered `0000-slug` placeholders, and legacy `draft-slug` all feed the
+  // index (0000-template is excluded there too), so an edit under any of them
+  // must invalidate the cache.
   const rfcsRoot = join(tasksDir, "rfcs");
   for (const rfcDir of readdirSync(rfcsRoot)) {
-    if (!/^\d{4}-/.test(rfcDir)) continue;
+    if (!/^(?!0000-template$)(?:\d{4}|draft)-[a-z0-9][a-z0-9-]*$/.test(rfcDir)) continue;
     // The RFC README's frontmatter feeds the index too (status, clusters,
     // packages, owner — and clusters drive `deps_rfc` resolution). A
     // README edit without a story touch must invalidate the cache.

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -105,7 +105,14 @@ export interface StoryEntry {
   id: string;
   rfc: string;
   title: string | null;
+  // The EFFECTIVE status: build-index.mjs downgrades `ready` to `draft` when
+  // the parent RFC is not active (effectiveStoryStatus in validate-lib.mjs),
+  // so no index.json consumer can surface such a story as claimable. The
+  // ready() gate below re-checks the RFC status anyway — belt and suspenders.
   status: StoryStatus | null;
+  // The authored frontmatter status, before the parent-RFC override. Optional:
+  // absent from index.json files built before the override existed.
+  raw_status?: string | null;
   cluster: string | null;
   deps: string[];
   deps_rfc: string[];

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -149,19 +149,40 @@ export function loadIndex(): Index {
   return JSON.parse(readFileSync(indexPath, "utf8")) as Index;
 }
 
-function isIndexStale(indexPath: string): boolean {
+export function isIndexStale(indexPath: string, tasksDir: string = TASKS_DIR): boolean {
   const indexMtime = statSync(indexPath).mtimeMs;
-  for (const rfcDir of readdirSync(TASKS_DIR)) {
+  // index.json is DERIVED by scripts/*.mjs (build-index.mjs plus the lib/
+  // validate-lib modules it imports). A script change with no content edit —
+  // e.g. the effective-status derivation that downgrades `ready` under a
+  // non-active RFC — must invalidate an index the old code built, or every
+  // consumer keeps serving the old shape until some story file happens to
+  // change.
+  const scriptsDir = join(tasksDir, "scripts");
+  let scriptNames: string[];
+  try {
+    scriptNames = readdirSync(scriptsDir);
+  } catch {
+    scriptNames = [];
+  }
+  for (const name of scriptNames) {
+    if (!name.endsWith(".mjs")) continue;
+    if (statSync(join(scriptsDir, name)).mtimeMs > indexMtime) return true;
+  }
+  // RFC dirs live under rfcs/ (post repo-rename layout); scanning the repo
+  // root here — as this function originally did — finds no `NNNN-` dirs and
+  // silently reports every index fresh forever.
+  const rfcsRoot = join(tasksDir, "rfcs");
+  for (const rfcDir of readdirSync(rfcsRoot)) {
     if (!/^\d{4}-/.test(rfcDir)) continue;
     // The RFC README's frontmatter feeds the index too (status, clusters,
     // packages, owner — and clusters drive `deps_rfc` resolution). A
     // README edit without a story touch must invalidate the cache.
     try {
-      if (statSync(join(TASKS_DIR, rfcDir, "README.md")).mtimeMs > indexMtime) return true;
+      if (statSync(join(rfcsRoot, rfcDir, "README.md")).mtimeMs > indexMtime) return true;
     } catch {
       /* missing README — validate step will catch */
     }
-    const storiesDir = join(TASKS_DIR, rfcDir, "stories");
+    const storiesDir = join(rfcsRoot, rfcDir, "stories");
     let entries: string[];
     try {
       entries = readdirSync(storiesDir);


### PR DESCRIPTION
## Summary

Companion to tasks-repo commit `f13ebab93` ("fix(index): non-active RFC status overrides story ready status"): `build-index.mjs` now derives each story's emitted `status` — `ready` under a non-active (draft/postponed/superseded/closed) RFC downgrades to `draft`, with the authored value preserved as `raw_status` — so every `index.json` consumer (`pnpm tasks list`, the dashboard/backlog page, the spawn loop) agrees with the CLI `ready()` gate from one authoritative source.

Trails side:

- `StoryEntry` mirrors the new optional `raw_status` field and documents that `status` is the effective (post-override) value; the `ready()` RFC-status gate stays as belt-and-suspenders.
- **`isIndexStale()` repaired**: it scanned the tasks-repo *root* for `NNNN-` dirs, but RFCs live under `rfcs/` since the repo rename — the loop matched nothing, so every existing `index.json` was reported fresh forever and the new index shape would never have reached consumers without a manual rebuild. It now scans `rfcs/`, and also treats an index older than any `scripts/*.mjs` as stale, so a derivation change alone forces a reindex.
- New tests: the postponed-override invariant (a downgraded story — `status: draft`, `raw_status: ready` — never surfaces from `ready()` or `listFiltered({ status: "ready" })`), plus 4 `isIndexStale` cases (fresh / story touch / README touch / script touch).

Before: `index.json` showed 10 ready stories under `0023-surfaced-deviations` (postponed). After reindex: 0; `pnpm tasks ready` and `pnpm tasks list --status ready` show none.

## Testing

- `pnpm vitest run scripts/tasks/cli.test.ts` — 247 passed
- tasks repo: `pnpm test` (validate-lib tests incl. new `effectiveStoryStatus` cases), `pnpm validate`, index rebuilt
