### PR TITLE
fix(reflection): columns() reports the column's own type, not the decorated cast type

### DIFF
--- a/packages/activerecord/src/reflection.test.ts
+++ b/packages/activerecord/src/reflection.test.ts
@@ -1660,23 +1660,8 @@ describe("ReflectionTest", () => {
 describe("ReflectionTest", () => {
   // Rails: test "columns"
   it("columns", () => {
-    class Person extends Base {
-      declare name: string | null;
-      declare age: number | null;
-      declare active: boolean | null;
-
-      static {
-        this._tableName = "people";
-        this.attribute("id", "integer");
-        this.attribute("name", "string");
-        this.attribute("age", "integer");
-        this.attribute("active", "boolean");
-      }
-    }
-
-    const cols = columns(Person);
-    expect(cols.length).toBe(4);
-    expect(cols.map((c) => c.name)).toEqual(["id", "name", "age", "active"]);
+    class Topic extends Base {}
+    expect(columns(Topic).length).toBe(19);
   });
 
   // Rails: test "column_names"

--- a/packages/activerecord/src/reflection.trails.test.ts
+++ b/packages/activerecord/src/reflection.trails.test.ts
@@ -7,7 +7,14 @@
  * counter-cache column helpers exported from reflection.ts.
  */
 import { describe, it, expect } from "vitest";
-import { Base, reflectOnAssociation, registerModel } from "./index.js";
+import { Base, columns, reflectOnAssociation, registerModel } from "./index.js";
+import {
+  configureEncryption,
+  snapshotEncryptionConfig,
+  restoreEncryptionConfig,
+} from "./encryption/test-helpers.js";
+import { EncryptedBookWithSerializedFirstBinary } from "./test-helpers/models/book-encrypted.js";
+import { EncryptedAttributeType } from "./encryption/encrypted-attribute-type.js";
 import { Associations, modelRegistry } from "./associations.js";
 import {
   AssociationReflection,
@@ -386,5 +393,27 @@ describe("ReflectionTest", () => {
     registerModel("SingularOwner", SingularOwner);
     expect(create("hasMany", "comment", null, {}, PluralOwner).pluralName).toBe("comments");
     expect(create("hasMany", "comment", null, {}, SingularOwner).pluralName).toBe("comment");
+  });
+
+  it("columns reports the column's own type, not the decorated cast type", async () => {
+    // Rails' `columns` is `columns_hash.values` (model_schema.rb:432-434) —
+    // schema-sourced, never attribute-decorated. trails previously built it
+    // from `_attributeDefinitions[].type.constructor.name`, so a decorated
+    // column (serialize + encrypts here) reported the wrapper class instead
+    // of the column's own type.
+    const configSnapshot = snapshotEncryptionConfig();
+    configureEncryption();
+    try {
+      await EncryptedBookWithSerializedFirstBinary.loadSchema();
+      const logo = columns(EncryptedBookWithSerializedFirstBinary).find((c) => c.name === "logo");
+      expect(logo?.type).toBe("binary");
+      // The attribute definition stays decorated — only `columns()` reads
+      // the schema column (the encryption idempotence guard depends on it).
+      expect(EncryptedBookWithSerializedFirstBinary.typeForAttribute("logo")).toBeInstanceOf(
+        EncryptedAttributeType,
+      );
+    } finally {
+      restoreEncryptionConfig(configSnapshot);
+    }
   });
 });

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -2387,7 +2387,7 @@ export function clearReflectionsCache(modelClass: typeof Base): void {
 
 export function columns(modelClass: typeof Base): ColumnReflection[] {
   // Rails' `columns` is the database column objects (`columns_hash.values`,
-  // model_schema.rb) — sourced from the schema, never from attribute-level
+  // model_schema.rb:432-434) — sourced from the schema, never from attribute-level
   // decoration. Reading `_attributeDefinitions[].type` here would report the
   // decorated cast-type wrapper (serialize/encrypts/normalizes/enum) instead
   // of the column's own type.

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -2213,10 +2213,10 @@ export class RuntimeReflection extends AbstractReflection {
 
 export class ColumnReflection {
   readonly name: string;
-  readonly type: string;
+  readonly type: string | null;
   readonly defaultValue: unknown;
 
-  constructor(name: string, type: string, defaultValue: unknown) {
+  constructor(name: string, type: string | null, defaultValue: unknown) {
     this.name = name;
     this.type = type;
     this.defaultValue = defaultValue;
@@ -2386,8 +2386,13 @@ export function clearReflectionsCache(modelClass: typeof Base): void {
 // ---------------------------------------------------------------------------
 
 export function columns(modelClass: typeof Base): ColumnReflection[] {
-  return Array.from(modelClass._attributeDefinitions.entries()).map(
-    ([name, def]) => new ColumnReflection(name, def.type.constructor.name, def.defaultValue),
+  // Rails' `columns` is the database column objects (`columns_hash.values`,
+  // model_schema.rb) — sourced from the schema, never from attribute-level
+  // decoration. Reading `_attributeDefinitions[].type` here would report the
+  // decorated cast-type wrapper (serialize/encrypts/normalizes/enum) instead
+  // of the column's own type.
+  return Object.values(modelClass.columnsHash()).map(
+    (col) => new ColumnReflection(col.name, col.type ?? null, col.default),
   );
 }
 


### PR DESCRIPTION
## Summary

`columns()` in `reflection.ts` built its `ColumnReflection` list from
`_attributeDefinitions[].type.constructor.name` — the *decorated cast type* —
so any decorated column (`serialize`, `encrypts`, `normalizes`, enum) reported
the wrapper class name (e.g. `EncryptedAttributeType`) instead of the column's
own type. Rails' `columns` is simply the database column objects
(`columns_hash.values`, `model_schema.rb:432-434`) and never reflects
attribute-level decoration.

## Changes

- `columns(modelClass)` now sources from `modelClass.columnsHash()` (the
  reflected schema columns), mapping each to
  `ColumnReflection(col.name, col.type, col.default)`. `ColumnReflection#type`
  widens to `string | null` (matching `SqlTypeMetadata#type`, nil for unmapped).
- `def.type` stays decorated — the encryption idempotence guard at
  `encryptable-record.ts:311` is untouched; the new regression test asserts
  `typeForAttribute("logo")` is still `EncryptedAttributeType`.
- `reflection.test.ts` "columns" now mirrors Rails' `test_columns`
  (`assert_equal 19, Topic.columns.length`) against the canonical topics
  schema; the previous body asserted a bespoke 4-attribute Person that only
  described the old attribute-definition sourcing.
- New trails-only regression test: `EncryptedBookWithSerializedFirstBinary#logo`
  (serialize + encrypts) reports `"binary"`, not the wrapper class name. Fails
  on baseline (reported `EncryptedAttributeType`).

Caller audit: `columns`/`contentColumns` from `reflection.ts` are consumed only
by `reflection.test.ts` and re-exported from `index.ts`; `contentColumns` keeps
its shape (filters `columns()` by `ModelSchema.contentColumns()` names).

Closes-story: columns-reports-cast-type-not-column-type

## Follow-up registered

`reflection.columnNames()` (and the trio's duplication of the ModelSchema
surface generally) still reads `_attributeDefinitions` — same divergence
family, out of this story's scope. Registered as
`0056-adapter-type-column-reflection-fidelity/reflection-column-helpers-duplicate-model-schema`.
