### PR TITLE
fix(encryption): encrypts/serialize nesting tracks declaration order

### DIFF
--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -364,11 +364,11 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
   });
 
   it("encrypts serialized attributes where encrypts is declared first", async () => {
-    // _pendingEncryptions defers the wrapping until attribute() is called.
-    // applyPendingEncryptions() then wraps the resolved serialized type, so
-    // declaration order (encrypts before attribute) is transparent. Mirrors
-    // Rails' EncryptedFirstTrafficLight (`encrypts :state` declared before
-    // `serialize :state, type: Array`) on the canonical `traffic_lights` table.
+    // Mirrors Rails' EncryptedFirstTrafficLight (`encrypts :state` declared
+    // before `serialize :state, type: Array`) on the canonical `traffic_lights`
+    // table. Pending decorators replay in declaration order, so the resolved
+    // chain nests Serialized(Encrypted(...)) — serialize, declared second,
+    // wraps the encrypted type (traffic_light_encrypted.rb:10-16).
     const adp = await freshAdapter();
     // `freshAdapter()` already lays the canonical `traffic_lights` table via
     // installEncryptionSchema, so no additional schema setup is needed here.
@@ -376,14 +376,18 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
       static {
         this._tableName = "traffic_lights";
         this.adapter = adp;
-        this.encrypts("state"); // declared BEFORE the serialized type
+        // Raw adapter (schema cache not warmed): declare the columns first —
+        // Rails gets these via schema reflection, which always seeds BEFORE the
+        // pending queue replays. A PendingType declared after encrypts would
+        // replace the decorated type (declaration-order replay), in Rails too.
         this.attribute("id", "integer");
-        this.attribute("state", "json");
-        this.attribute("long_state", "json");
-        // Raw adapter (schema cache not warmed): declare the timestamp columns
-        // the create-time callbacks write, for strict writeFromUser.
+        this.attribute("state", "string");
+        this.attribute("long_state", "string");
         this.attribute("created_at", "datetime");
         this.attribute("updated_at", "datetime");
+        this.encrypts("state"); // declared BEFORE the serialized type
+        this.serialize("state", { type: "Array" });
+        this.serialize("long_state", { type: "Array" });
       }
     } as any;
     new EncryptedFirstTrafficLight();
@@ -681,18 +685,20 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
 
   it("when ignore_case: true is declared before the attributes, the original_<name> reader still decrypts (replay-safe)", async () => {
     const adapter = await freshAdapter();
-    // Declare `encrypts` BEFORE the attribute definitions exist, so both `name`
-    // and its `original_name` counterpart are buffered and only wrapped when the
-    // defs appear — the replay path. If the original_<name> encrypted type is
-    // lost on that replay (the regression this guards), its reader returns raw
-    // ciphertext instead of the decrypted, case-preserved value.
+    // Declare `encrypts` BEFORE the attribute definitions exist (the columns
+    // arrive later via schema reflection), so both `name` and its
+    // `original_name` counterpart are only wrapped on the post-reflection
+    // replay. If the original_<name> encrypted type is lost on that replay (the
+    // regression this guards), its reader returns raw ciphertext instead of the
+    // decrypted, case-preserved value. NOTE: an explicit `attribute()` call
+    // after `encrypts` would REPLACE the encrypted type (declaration-order
+    // replay, as in Rails) — reflection is the only Rails-faithful way for the
+    // columns to appear after the declaration.
     const Book = class extends Base {
       static {
         this._tableName = "encrypted_books";
         this.adapter = adapter;
         this.encrypts("name", { deterministic: true, ignoreCase: true });
-        this.attribute("name", "string");
-        this.attribute("original_name", "string");
       }
     } as unknown as typeof Base & {
       create: (a: object) => Promise<any>;

--- a/packages/activerecord/src/encryption/encryptable-record.trails.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.trails.test.ts
@@ -12,6 +12,7 @@ import {
   EncryptedBookWithSerializedSecondBinary,
 } from "../test-helpers/models/book-encrypted.js";
 import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
+import { applyPendingEncryptions } from "../encryption.js";
 import { Serialized } from "../type/serialized.js";
 import { BinaryType } from "@blazetrails/activemodel";
 
@@ -78,5 +79,35 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest (trails)", () => {
     const subtype = (encrypted as EncryptedAttributeType).castType;
     expect(subtype).toBeInstanceOf(BinaryType);
     expect(subtype).not.toBeInstanceOf(Serialized);
+  });
+
+  it("does not grow the pending-decorator queue or reorder the nesting on _defaultAttributes rebuilds", async () => {
+    await freshAdapter();
+
+    const model = EncryptedBookWithSerializedSecondBinary as unknown as {
+      typeForAttribute(name: string): unknown;
+      _pendingAttributeModifications?: unknown[];
+      _cachedDefaultAttributes?: unknown;
+    };
+    // Force one initial resolution so all pending machinery has run.
+    model.typeForAttribute("logo");
+    const queueLength = model._pendingAttributeModifications?.length;
+    expect(queueLength).toBeGreaterThan(0);
+
+    // Repeated cache invalidation + re-resolution mimics schema reloads. The
+    // old registerEncryptedType pushed a fresh PendingDecorator on each pass,
+    // growing the queue unboundedly AND moving the encryption decorator to the
+    // tail (flipping the nesting to Encrypted(Serialized(...))).
+    for (let i = 0; i < 3; i++) {
+      model._cachedDefaultAttributes = null;
+      // The rebuild paths (defineAttribute, applyColumnsHash, Base statics)
+      // all re-invoke applyPendingEncryptions — the exact call that used to
+      // re-push the encryption decorator onto the queue tail.
+      applyPendingEncryptions(model);
+      const type = model.typeForAttribute("logo");
+      expect(type).toBeInstanceOf(Serialized);
+      expect((type as Serialized).subtype).toBeInstanceOf(EncryptedAttributeType);
+    }
+    expect(model._pendingAttributeModifications?.length).toBe(queueLength);
   });
 });

--- a/packages/activerecord/src/encryption/encryptable-record.trails.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.trails.test.ts
@@ -40,19 +40,17 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest (trails)", () => {
     restoreEncryptionConfig(configSnapshot);
   });
 
-  // Rails resolves `serialize :logo, coder: JSON` + `encrypts :logo` to
-  // EncryptedAttributeType(Serialized(<binary column type>)) — the pending
-  // decorators replay over a seed built from `type_for_column`
-  // (activemodel/lib/active_model/attribute_registration.rb:23-34,
-  // activerecord/lib/active_record/attributes.rb:241-245), so each decorator
-  // is applied exactly once.
-  it.each([
-    ["serialize before encrypts", EncryptedBookWithSerializedFirstBinary],
-    ["encrypts before serialize", EncryptedBookWithSerializedSecondBinary],
-  ])("resolves logo to Encrypted(Serialized(binary)) — %s", async (_label, model) => {
+  // Rails replays pending decorators in declaration order
+  // (activemodel/lib/active_model/attribute_registration.rb:66-72) over a seed
+  // built from `type_for_column`, so `serialize` + `encrypts` nest in the order
+  // they were declared: serialize-then-encrypts →
+  // EncryptedAttributeType(Serialized(binary)), encrypts-then-serialize →
+  // Serialized(EncryptedAttributeType(binary)). Each decorator applies exactly
+  // once (the seed carries no EncryptedAttributeType).
+  it("resolves logo to Encrypted(Serialized(binary)) — serialize before encrypts", async () => {
     await freshAdapter();
 
-    const encrypted = model.typeForAttribute("logo");
+    const encrypted = EncryptedBookWithSerializedFirstBinary.typeForAttribute("logo");
     expect(encrypted).toBeInstanceOf(EncryptedAttributeType);
 
     const serialized = (encrypted as EncryptedAttributeType).castType;
@@ -63,5 +61,22 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest (trails)", () => {
     const subtype = (serialized as Serialized).subtype;
     expect(subtype).toBeInstanceOf(BinaryType);
     expect(subtype).not.toBeInstanceOf(EncryptedAttributeType);
+  });
+
+  it("resolves logo to Serialized(Encrypted(binary)) — encrypts before serialize", async () => {
+    await freshAdapter();
+
+    const serialized = EncryptedBookWithSerializedSecondBinary.typeForAttribute("logo");
+    expect(serialized).toBeInstanceOf(Serialized);
+
+    const encrypted = (serialized as Serialized).subtype;
+    expect(encrypted).toBeInstanceOf(EncryptedAttributeType);
+
+    // Declaration-order replay: the encryption decorator was pushed at
+    // `encrypts` time, before `serialize`'s — a rebuild-time re-push would land
+    // it after and flip the nesting back to Encrypted(Serialized(binary)).
+    const subtype = (encrypted as EncryptedAttributeType).castType;
+    expect(subtype).toBeInstanceOf(BinaryType);
+    expect(subtype).not.toBeInstanceOf(Serialized);
   });
 });

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -218,13 +218,17 @@ export class EncryptableRecord {
     const scheme = prebuiltScheme ?? schemeFor(options);
 
     if (typeof modelClass.decorateAttributes === "function") {
-      // Durable path (real model classes): buffer the pending encryption in the
-      // class's own `_pendingEncryptions` and apply it now — and again on every
-      // `_defaultAttributes` rebuild / schema load. This gives the scheme path
-      // its own replay buffer (the RFC 0047 follow-up registerEncryptedType's
-      // doc references), so the encrypted type survives replay even though
-      // `Base.encrypts` declares at static-init before the schema is loaded.
+      // Durable path (real model classes): push the durable PendingDecorator NOW,
+      // at declaration time, so its position in the pending queue tracks
+      // declaration order relative to `serialize` / `normalizes` — mirroring
+      // Rails, where `encrypts` calls `decorate_attributes` inline
+      // (encryptable_record.rb:87-92) and AttributeRegistration replays in
+      // declaration order. The decorator resolves the column default at replay
+      // time, so it needs no re-push after schema reflection. The
+      // `_pendingEncryptions` buffer remains for the eager
+      // `_attributeDefinitions` view + validator re-runs on rebuild.
       this.registerPendingEncryption(modelClass, name, scheme);
+      this.pushEncryptionDecorator(modelClass, name, scheme);
       encryptionHooks.applyPendingEncryptions(modelClass);
     } else {
       // Immediate path (plain-object callers without decoration machinery, e.g.
@@ -262,16 +266,54 @@ export class EncryptableRecord {
   }
 
   /**
+   * Push the durable encryption PendingDecorator, exactly once per `encrypts`
+   * declaration — mirroring Rails' `decorate_attributes([name]) { ... }` in
+   * encryptable_record.rb:87-92. Pushing at declaration time (not on the first
+   * post-reflection rebuild, as before) keeps the decorator's queue position —
+   * and therefore the resolved nesting relative to `serialize` — in declaration
+   * order, and bounds the queue: repeated `_defaultAttributes` rebuilds never
+   * re-push (`registerEncryptedType` no longer touches the queue).
+   *
+   * The column default is resolved inside the decorator at replay time
+   * (mirrors Rails' `default: columns_hash[name.to_s]&.default`, evaluated in
+   * the block), so a replay after schema reflection picks up the authoritative
+   * DB default without any re-push.
+   * @internal
+   */
+  static pushEncryptionDecorator(modelClass: any, name: string, scheme: Scheme): void {
+    modelClass.decorateAttributes([name], (attrName: string, castType: Type, host?: unknown) => {
+      // Idempotence guard for the eager immediate-apply pass (a fresh-seed
+      // replay applies each queued decorator once, but `decorateAttributes`
+      // also applies eagerly to a possibly already-wrapped definitions view).
+      if (castType instanceof EncryptedAttributeType) return null as unknown as Type;
+      const target = host ?? modelClass;
+      return new EncryptedAttributeType({
+        scheme,
+        castType,
+        default: this.columnDefaultFor(
+          target,
+          attrName,
+          (target as { _attributeDefinitions?: Map<string, unknown> })._attributeDefinitions?.get?.(
+            attrName,
+          ),
+        ),
+      });
+    });
+  }
+
+  /**
    * The single EncryptedAttributeType-wrapping primitive shared by both
    * declaration paths, so `Base.encrypts` (via `applyPendingEncryptions`) and
    * the scheme-based `encryptAttribute` register the wrapped type through one
    * implementation:
    *
    * - Models exposing `decorateAttributes` (real Base subclasses driven by the
-   *   `Base.encrypts` → `applyPendingEncryptions` path) get a replay-safe
-   *   PendingDecorator so `_defaultAttributes` re-wraps after schema reflection.
-   *   Skips when the def isn't present yet — the persistent `_pendingEncryptions`
-   *   buffer re-invokes this once the column is reflected — or already encrypted.
+   *   `Base.encrypts` → `applyPendingEncryptions` path) get their eager
+   *   `_attributeDefinitions` view wrapped/corrected here. The durable
+   *   PendingDecorator is NOT pushed from here — `pushEncryptionDecorator`
+   *   pushed it once at declaration time, preserving declaration order in the
+   *   pending queue. Skips when the def isn't present yet — the persistent
+   *   `_pendingEncryptions` buffer re-invokes this once the column is reflected.
    * - Plain models (the scheme-based / mock-model test path) set
    *   `_attributeDefinitions` directly, seeding a schema-sourced placeholder
    *   when no def exists yet so `loadSchemaFromAdapter` can supply the real
@@ -310,23 +352,26 @@ export class EncryptableRecord {
       const columnDefault = authoritative ? (cached ?? undefined) : (def.defaultValue ?? undefined);
       if (def.type instanceof EncryptedAttributeType) {
         // Already wrapped. Re-wrap only to correct a provisional default once the
-        // authoritative column default is known and differs — otherwise stay put
-        // so the PendingDecorator queue doesn't grow on every replay. The
-        // immediate apply below updates def.type, so the next replay early-returns.
+        // authoritative column default is known and differs — otherwise stay put.
         if (!authoritative || def.type._default === columnDefault) return;
-      }
-      modelClass.decorateAttributes([name], (_attrName: string, castType: Type) => {
-        if (castType instanceof EncryptedAttributeType) {
-          if (!authoritative || (castType as any)._default === columnDefault) {
-            return null as unknown as Type;
-          }
-          return new EncryptedAttributeType({
+        modelClass._attributeDefinitions.set(name, {
+          ...def,
+          type: new EncryptedAttributeType({
             scheme,
-            castType: castType.castType,
+            castType: def.type.castType,
             default: columnDefault,
-          });
-        }
-        return new EncryptedAttributeType({ scheme, castType, default: columnDefault });
+          }),
+        });
+        return;
+      }
+      // NOTE: this writes only the eager `_attributeDefinitions` back-compat
+      // view. The durable PendingDecorator was already pushed at declaration
+      // time by `pushEncryptionDecorator` — pushing here (on rebuild) would move
+      // the encryption decorator to the queue tail, breaking declaration-order
+      // nesting relative to `serialize` (the encrypts-first case).
+      modelClass._attributeDefinitions.set(name, {
+        ...def,
+        type: new EncryptedAttributeType({ scheme, castType: def.type, default: columnDefault }),
       });
       return;
     }

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -170,17 +170,6 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
     return this.castType.type();
   }
 
-  // Deviation from Rails' `binary?` (false on EncryptedAttributeType): Ruby's
-  // Binary#deserialize returns a binary-encoded STRING, so a wrapping coder's
-  // `load` works on it directly. trails' BinaryType yields bytes, and
-  // Serialized#deserialize's bytes→utf8 compensation (type/serialized.ts) is
-  // gated on `subtype.isBinary()` — for the encrypts-before-serialize nesting
-  // (Serialized(Encrypted(Binary))) that subtype is this type, so delegate to
-  // the cast type like `type()` above or the compensation never fires.
-  override isBinary(): boolean {
-    return this.castType.isBinary();
-  }
-
   get previousTypes(): EncryptedAttributeType[] {
     // Key on both supportUnencryptedData and the global-previous version counter
     // so the list is recomputed whenever config changes (e.g. configure() called

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -170,6 +170,17 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
     return this.castType.type();
   }
 
+  // Deviation from Rails' `binary?` (false on EncryptedAttributeType): Ruby's
+  // Binary#deserialize returns a binary-encoded STRING, so a wrapping coder's
+  // `load` works on it directly. trails' BinaryType yields bytes, and
+  // Serialized#deserialize's bytes→utf8 compensation (type/serialized.ts) is
+  // gated on `subtype.isBinary()` — for the encrypts-before-serialize nesting
+  // (Serialized(Encrypted(Binary))) that subtype is this type, so delegate to
+  // the cast type like `type()` above or the compensation never fires.
+  override isBinary(): boolean {
+    return this.castType.isBinary();
+  }
+
   get previousTypes(): EncryptedAttributeType[] {
     // Key on both supportUnencryptedData and the global-previous version counter
     // so the list is recomputed whenever config changes (e.g. configure() called

--- a/packages/activerecord/src/type/serialized.ts
+++ b/packages/activerecord/src/type/serialized.ts
@@ -271,9 +271,13 @@ export class Serialized extends ValueType {
     // Rails: binary subtypes (bytea) return a binary-encoded Ruby String; JS
     // returns a Uint8Array. BinaryType.serialize pipes coder.dump() output
     // through TextEncoder (UTF-8), so the bridge must invert with UTF-8 to
-    // recover the string coder.load() expects.
+    // recover the string coder.load() expects. Gated on `type()`, not
+    // `isBinary()`: an EncryptedAttributeType subtype (encrypts-then-serialize
+    // nesting) delegates `type` — but NOT `binary?` — to its binary cast type
+    // (encrypted_attribute_type.rb:16, value.rb:77-79), and its deserialize
+    // yields the cast type's bytes, which need the same inversion.
     const forCoder =
-      this.subtype.isBinary() && deserialized instanceof Uint8Array
+      this.subtype.type?.() === "binary" && deserialized instanceof Uint8Array
         ? Buffer.from(deserialized).toString("utf8")
         : deserialized;
     return this.coder.load(forCoder);


### PR DESCRIPTION
## Summary

`encrypts`-then-`serialize` now resolves to `Serialized(Encrypted(<column type>))`, matching Rails' declaration-order decorator replay (`attribute_registration.rb:66-72`); `serialize`-then-`encrypts` stays `Encrypted(Serialized(<column type>))`.

**Cause**: `registerEncryptedType` pushed a fresh `PendingDecorator` on every `_defaultAttributes` rebuild, landing the encryption decorator at the queue tail regardless of where `encrypts()` was declared — both orders resolved to `Encrypted(Serialized(...))`.

## Changes

- **`pushEncryptionDecorator`**: the durable decorator is pushed exactly once, at `encrypts()` time — mirroring Rails' inline `decorate_attributes` (`encryptable_record.rb:87-92`). The column default is resolved *inside* the decorator at replay time (mirrors Rails' `default: columns_hash[name.to_s]&.default` evaluated in the block), so no re-push is needed after schema reflection and the queue never grows across rebuilds.
- **`registerEncryptedType`** (durable branch) now only maintains the eager `_attributeDefinitions` back-compat view (wrap + provisional-default correction) and never touches the queue.
- **`Serialized#deserialize`'s bytes→utf8 bridge** now gates on `subtype.type() === "binary"` instead of `subtype.isBinary()`. Rails' `EncryptedAttributeType` delegates only `:accessor, :type` to `cast_type` (`encrypted_attribute_type.rb:16`) and keeps `binary? == false` (`value.rb:77-79`) — so `isBinary` stays un-delegated (Rails-faithful), while the delegated `type` predicate lets the `Serialized(Encrypted(Binary))` nesting still invert its cast type's bytes for `coder.load` (`serialized binary data can be encrypted` covers it).
- Two tests that declared `attribute()` *after* `encrypts` were made Rails-faithful (columns before decorators / via reflection): a `PendingType` replayed after the decorator replaces the decorated type — in Rails too.
- Guard tests (`encryptable-record.trails.test.ts`) now assert the two **different** chains for `EncryptedBookWithSerializedFirstBinary` / `...SecondBinary`, plus queue-length + nesting stability across repeated `applyPendingEncryptions` / `_defaultAttributes` rebuilds (the no-unbounded-growth invariant).

## Testing

- New/updated guard tests verified to **fail on baseline** (`origin/main` @ c218c4550: SecondBinary resolves `EncryptedAttributeType`, not `Serialized`).
- `encryptable-record.test.ts` + `encryptable-record.trails.test.ts`: 79 passed.
- Encryption suite + `serialized-attribute` / `serialization` / `store` / `binary`: 36 files, 433 passed.
- `type/` + `attributes.test.ts`: 122 passed.
- Swept `instanceof EncryptedAttributeType` / `isBinary()` call sites: Rails' equivalents also check the top-level type, so `Serialized(Encrypted)` attributes behave shape-identically to Rails.

Closes-story: encrypts-serialize-nesting-ignores-declaration-order

