### PR TITLE
fix(arel): MySQL IsDistinctFrom delegates to IsNotDistinctFrom visitor

### DIFF
--- a/packages/arel/src/visitors/mysql.ts
+++ b/packages/arel/src/visitors/mysql.ts
@@ -171,10 +171,7 @@ export class MySQL extends ToSql {
     collector: SQLString,
   ): SQLString {
     collector.append("NOT ");
-    this.visit(node.left, collector);
-    collector.append(" <=> ");
-    this.visit(node.right, collector);
-    return collector;
+    return this.visitArelNodesIsNotDistinctFrom(node, collector);
   }
 
   // MySQL uses `REGEXP` / `NOT REGEXP`, not the SQL-standard `~` /

--- a/scripts/api-compare/call-mismatches-wide-exclude/arel/visitors/mysql.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/arel/visitors/mysql.json
@@ -16,13 +16,6 @@
   {
     "package": "arel",
     "tsFile": "visitors/mysql.ts",
-    "rubyName": "visit_Arel_Nodes_IsDistinctFrom",
-    "call": "visit_Arel_Nodes_IsNotDistinctFrom",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/mysql.ts",
     "rubyName": "visit_Arel_Nodes_NotRegexp",
     "call": "infix_value",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Rails' MySQL visitor routes `IsDistinctFrom` through the `IsNotDistinctFrom` visitor (`vendor/rails/activerecord/lib/arel/visitors/mysql.rb:49-51`):

```ruby
def visit_Arel_Nodes_IsDistinctFrom(o, collector)
  collector << "NOT "
  visit_Arel_Nodes_IsNotDistinctFrom o, collector
end
```

Trails inlined the `<=>` body instead. SQL output is identical (existing mysql.test.ts assertions unchanged), but the call-graph divergence was flagged by the wide-call baseline entry in `scripts/api-compare/call-mismatches-wide-exclude/arel/visitors/mysql.json`.

- `visitArelNodesIsDistinctFrom` now appends `"NOT "` and delegates to `visitArelNodesIsNotDistinctFrom`.
- Removed the converged wide-baseline entry; `API_COMPARE_FORCE=1 pnpm api:compare --wide-calls` + `pnpm api:calls:wide` pass (ratchet OK).

Closes-story: mysql-isdistinctfrom-delegates-to-isnotdistinctfrom
