### PR TITLE
refactor(activerecord): PredicateBuilder holds a TableMetadata, not an Arel Table

### DIFF
--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -676,9 +676,7 @@ export function predicateBuilder(this: CoreHost): PredicateBuilder {
     return this._predicateBuilder;
   const table = this.arelTable;
   const metadata = new TableMetadata(this as any, table);
-  const pb = new PredicateBuilder(table);
-  pb.setTableContext(metadata);
-  this._predicateBuilder = pb;
+  this._predicateBuilder = new PredicateBuilder(metadata);
   return this._predicateBuilder;
 }
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -6387,8 +6387,7 @@ export class Relation<T extends Base> {
     if (modelPb && typeof modelPb.with === "function") {
       pb = modelPb.with(metadata);
     } else {
-      pb = new PredicateBuilder(this.table);
-      pb.setTableContext(metadata);
+      pb = new PredicateBuilder(metadata);
     }
     this._predicateBuilder = pb;
     return pb;

--- a/packages/activerecord/src/relation/predicate-builder.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.test.ts
@@ -158,7 +158,7 @@ describe("PredicateBuilderTest", () => {
     const compile = (node: Nodes.Node) => new Visitors.ToSql().compile(node);
 
     it("builds equality for scalars", () => {
-      const builder = new PredicateBuilder(table);
+      const builder = new PredicateBuilder(new TableMetadata(null, table));
       const [node] = builder.buildFromHash({ title: "hello" });
       expect(compile(node)).toContain('"posts"."title"');
       // Value is a BindParam → rendered as `?`, not inlined (Rails parity).
@@ -166,25 +166,25 @@ describe("PredicateBuilderTest", () => {
     });
 
     it("builds IS NULL for null values", () => {
-      const builder = new PredicateBuilder(table);
+      const builder = new PredicateBuilder(new TableMetadata(null, table));
       const [node] = builder.buildFromHash({ title: null });
       expect(compile(node)).toMatch(/IS NULL/);
     });
 
     it("builds IN for arrays", () => {
-      const builder = new PredicateBuilder(table);
+      const builder = new PredicateBuilder(new TableMetadata(null, table));
       const [node] = builder.buildFromHash({ id: [1, 2, 3] });
       expect(compile(node)).toMatch(/IN \(\?, \?, \?\)/);
     });
 
     it("builds IN for Set values (mirrors Rails registering Set => ArrayHandler)", () => {
-      const builder = new PredicateBuilder(table);
+      const builder = new PredicateBuilder(new TableMetadata(null, table));
       const [node] = builder.buildFromHash({ id: new Set([1, 2, 3]) });
       expect(compile(node)).toMatch(/IN \(\?, \?, \?\)/);
     });
 
     it("builds IN for Set values when a custom handler is also registered", () => {
-      const builder = new PredicateBuilder(table);
+      const builder = new PredicateBuilder(new TableMetadata(null, table));
       builder.registerHandler(Date, {
         call: (attr, _v) => attr.eq(0),
       });
@@ -193,7 +193,7 @@ describe("PredicateBuilderTest", () => {
     });
 
     it("builds BETWEEN for ranges", () => {
-      const builder = new PredicateBuilder(table);
+      const builder = new PredicateBuilder(new TableMetadata(null, table));
       const [node] = builder.buildFromHash({ age: new Range(18, 65) });
       expect(compile(node)).toMatch(/BETWEEN 18 AND 65/);
     });
@@ -204,7 +204,7 @@ describe("PredicateBuilderTest", () => {
     // `respond_to?(:id)` (Object#id was removed in 1.9), so `where(col: { id: 5 })`
     // routes the Hash to a handler rather than dereferencing it to `5`.
     it("does not dereference a plain object literal to its id", () => {
-      const builder = new PredicateBuilder(table);
+      const builder = new PredicateBuilder(new TableMetadata(null, table));
       const node = builder.build(table.get("title"), { id: 5 });
       const [sql, binds] = new Visitors.ToSql().compileWithBinds(node);
       expect(sql).toContain('"posts"."title" = ?');
@@ -213,7 +213,7 @@ describe("PredicateBuilderTest", () => {
     });
 
     it("does not dereference a plain object literal inside an array", () => {
-      const builder = new PredicateBuilder(table);
+      const builder = new PredicateBuilder(new TableMetadata(null, table));
       const node = builder.build(table.get("title"), [{ id: 5 }]);
       const [, binds] = new Visitors.ToSql().compileWithBinds(node);
       expect((binds[0] as { value: unknown }).value).toEqual({ id: 5 });
@@ -227,7 +227,7 @@ describe("PredicateBuilderTest", () => {
       class NotARecord {
         constructor(public id: number) {}
       }
-      const builder = new PredicateBuilder(table);
+      const builder = new PredicateBuilder(new TableMetadata(null, table));
       const node = builder.build(table.get("id"), [new NotARecord(5), new NotARecord(7)]);
       const sql = new Visitors.ToSql().compile(node);
       // The objects flow into HomogeneousIn untouched — they are NOT flattened
@@ -236,7 +236,7 @@ describe("PredicateBuilderTest", () => {
     });
 
     it("handles exclusive ranges", () => {
-      const builder = new PredicateBuilder(table);
+      const builder = new PredicateBuilder(new TableMetadata(null, table));
       const [node] = builder.buildFromHash({ age: new Range(18, 65, true) });
       const sql = compile(node);
       expect(sql).toMatch(/>= 18/);
@@ -251,14 +251,16 @@ describe("PredicateBuilderTest", () => {
     // dispatch, so an array never reaches ArrayHandler → `IN (...)`. This is the
     // PG-array case (`where(arrayCol: [1, 2])` → `arr = '{1,2}'`) at unit level.
     it("forces equality for a force-equality type instead of dispatching to a handler", () => {
-      const builder = new PredicateBuilder(table);
       const forceEqType = {
         isForceEquality: (v: unknown) => Array.isArray(v),
         cast: (v: unknown) => v,
         serialize: (v: unknown) => v,
       };
-      (builder as any)._tableContext = { typeForAttribute: () => forceEqType };
-      const node = builder.build(table.get("tags"), [1, 2]);
+      // The metadata's table caster answers the force-equality type — the
+      // `table.type(attribute.name)` lookup Rails' build performs.
+      const feTable = new Table("posts", { typeCaster: { typeForAttribute: () => forceEqType } });
+      const builder = new PredicateBuilder(new TableMetadata(null, feTable));
+      const node = builder.build(feTable.get("tags"), [1, 2]);
       const [sql, binds] = new Visitors.ToSql().compileWithBinds(node);
       // Single equality bind, NOT `IN (?, ?)`.
       expect(sql).toContain('"posts"."tags" = ?');
@@ -273,25 +275,25 @@ describe("PredicateBuilderTest", () => {
     const compile = (node: Nodes.Node) => new Visitors.ToSql().compile(node);
 
     it("builds IS NOT NULL for null values", () => {
-      const builder = new PredicateBuilder(table);
+      const builder = new PredicateBuilder(new TableMetadata(null, table));
       const [node] = builder.buildNegatedFromHash({ title: null });
       expect(compile(node)).toMatch(/IS NOT NULL/);
     });
 
     it("builds NOT IN for arrays", () => {
-      const builder = new PredicateBuilder(table);
+      const builder = new PredicateBuilder(new TableMetadata(null, table));
       const [node] = builder.buildNegatedFromHash({ id: [1, 2, 3] });
       expect(compile(node)).toMatch(/NOT IN \(\?, \?, \?\)/);
     });
 
     it("builds NOT IN for Set values in negated predicates", () => {
-      const builder = new PredicateBuilder(table);
+      const builder = new PredicateBuilder(new TableMetadata(null, table));
       const [node] = builder.buildNegatedFromHash({ id: new Set([1, 2]) });
       expect(compile(node)).toMatch(/NOT IN \(\?, \?\)/);
     });
 
     it("builds correct negation for exclusive ranges", () => {
-      const builder = new PredicateBuilder(table);
+      const builder = new PredicateBuilder(new TableMetadata(null, table));
       const [node] = builder.buildNegatedFromHash({ age: new Range(18, 65, true) });
       const sql = compile(node);
       expect(sql).toMatch(/< 18/);
@@ -299,7 +301,7 @@ describe("PredicateBuilderTest", () => {
     });
 
     it("does not dereference a plain object literal to its id when negated", () => {
-      const builder = new PredicateBuilder(table);
+      const builder = new PredicateBuilder(new TableMetadata(null, table));
       const node = builder.buildNegated(table.get("title"), { id: 5 });
       const sql = new Visitors.ToSql().compile(node);
       // Negation binds the RHS (Rails inverts a positively-built, bound
@@ -318,7 +320,7 @@ describe("PredicateBuilderTest", () => {
       class NotARecord {
         constructor(public id: number) {}
       }
-      const builder = new PredicateBuilder(table);
+      const builder = new PredicateBuilder(new TableMetadata(null, table));
       const [node] = builder.buildNegatedFromHash({
         id: [new NotARecord(5), new NotARecord(7)],
       });
@@ -330,7 +332,7 @@ describe("PredicateBuilderTest", () => {
   describe("QueryAttribute bind handling", () => {
     it("buildBindAttribute creates a QueryAttribute", () => {
       const table = castedTable("users");
-      const builder = new PredicateBuilder(table);
+      const builder = new PredicateBuilder(new TableMetadata(null, table));
       const qa = builder.buildBindAttribute("name", "alice");
       expect(qa.name).toBe("name");
       expect(qa.value).toBe("alice");
@@ -338,7 +340,7 @@ describe("PredicateBuilderTest", () => {
 
     it("BasicObjectHandler routes through buildBindAttribute", () => {
       const table = castedTable("users");
-      const builder = new PredicateBuilder(table);
+      const builder = new PredicateBuilder(new TableMetadata(null, table));
       const node = builder.build(table.get("name"), "alice");
       const visitor = new Visitors.ToSql();
       const [sql, binds] = visitor.compileWithBinds(node);
@@ -348,7 +350,7 @@ describe("PredicateBuilderTest", () => {
 
     it("Substitute flows through as BindParam via QueryAttribute", () => {
       const table = castedTable("users");
-      const builder = new PredicateBuilder(table);
+      const builder = new PredicateBuilder(new TableMetadata(null, table));
       const node = builder.build(table.get("name"), new Substitute());
       const visitor = new Visitors.ToSql();
       const [sql, binds] = visitor.compileWithBinds(node);
@@ -361,7 +363,7 @@ describe("PredicateBuilderTest", () => {
 
     it("compile inlines QueryAttribute values for display SQL", () => {
       const table = castedTable("users");
-      const builder = new PredicateBuilder(table);
+      const builder = new PredicateBuilder(new TableMetadata(null, table));
       const node = builder.build(table.get("name"), "alice");
       const visitor = new Visitors.ToSql();
       // The value is wrapped in a BindParam, so raw Arel compile emits `?`

--- a/packages/activerecord/src/relation/predicate-builder.trails.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.trails.test.ts
@@ -3,6 +3,7 @@ import { IntegerType } from "@blazetrails/activemodel";
 import { Table, Visitors } from "@blazetrails/arel";
 import { Company, Firm } from "../test-helpers/models/company.js";
 import { PredicateBuilder } from "./predicate-builder.js";
+import { TableMetadata } from "../table-metadata.js";
 
 // trails-specific regression guard (no Rails counterpart): Base.predicateBuilder
 // is now TableMetadata-backed, and that metadata is bound to the class. The memo
@@ -40,7 +41,7 @@ describe("PredicateBuilder positive-equality bind typing", () => {
     const table = new Table("posts", {
       typeCaster: { typeForAttribute: () => undefined },
     });
-    const builder = new PredicateBuilder(table);
+    const builder = new PredicateBuilder(new TableMetadata(null, table));
     const joined = new Table("authors", { typeCaster: { typeForAttribute: () => int8 } });
     return builder.build(joined.get("id"), value);
   };

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -1,4 +1,4 @@
-import { Table, Nodes, sql as arelSql } from "@blazetrails/arel";
+import { Nodes, sql as arelSql } from "@blazetrails/arel";
 import { Range } from "../connection-adapters/postgresql/oid/range.js";
 import { QueryAttribute } from "./query-attribute.js";
 import { ArrayHandler } from "./predicate-builder/array-handler.js";
@@ -10,8 +10,8 @@ import { AssociationQueryValue } from "./predicate-builder/association-query-val
 import { Substitute } from "../statement-cache.js";
 import { PolymorphicArrayValue } from "./predicate-builder/polymorphic-array-value.js";
 import { argumentError } from "./query-methods.js";
-import { Connection as TypeCasterConnection } from "../type-caster/connection.js";
 import { attributeRelationOf } from "./predicate-builder/attribute-relation.js";
+import type { TableMetadata } from "../table-metadata.js";
 
 interface BoundType {
   cast?(x: unknown): unknown;
@@ -37,14 +37,14 @@ const IDENTITY_CAST_TYPE = {
  * Mirrors: ActiveRecord::PredicateBuilder
  */
 export class PredicateBuilder {
-  private _table: Table;
+  private _table: TableMetadata;
 
   /** @internal */
-  get table(): Table {
+  get table(): TableMetadata {
     return this._table;
   }
 
-  protected set table(value: Table) {
+  protected set table(value: TableMetadata) {
     this._table = value;
   }
   private arrayHandler: ArrayHandler;
@@ -52,9 +52,8 @@ export class PredicateBuilder {
   private basicObjectHandler: BasicObjectHandler;
   private relationHandler: RelationHandler;
   private handlers: Array<[any, { call(attr: Nodes.Attribute, value: any): Nodes.Node }]> = [];
-  private _tableContext: any = null;
 
-  constructor(table: Table) {
+  constructor(table: TableMetadata) {
     this._table = table;
     this.arrayHandler = new ArrayHandler(this);
     this.rangeHandler = new RangeHandler((attribute, v) => {
@@ -117,9 +116,9 @@ export class PredicateBuilder {
 
   /**
    * Resolves the column type for a range bound, preferring the attribute's own
-   * relation typeCaster (covers joined/aliased tables), then the predicate
-   * builder's table/model context, then the arel table. Mirrors the cascade
-   * Rails' `build_bind_attribute` gets for free via `table.type(column_name)`.
+   * relation typeCaster (covers joined/aliased tables), then the builder's
+   * TableMetadata. Mirrors the cascade Rails' `build_bind_attribute` gets for
+   * free via `table.type(column_name)`.
    */
   private resolveBoundType(attribute: Nodes.Attribute): BoundType | undefined {
     return this.resolveColumnType(attribute.name, attributeRelationOf(attribute)) as
@@ -130,14 +129,13 @@ export class PredicateBuilder {
   /**
    * The single type-resolution cascade every bind-building path shares: the
    * attribute's own relation typeCaster (covers joined/aliased tables), then
-   * the predicate builder's table/model context, then the arel table. Returns
+   * the builder's TableMetadata (Rails' `table.type(column_name)`). Returns
    * the first candidate `accept` approves.
    *
    * `accept` is what lets the force-equality scan share this cascade: it probes
    * every level for `isForceEquality?(value)` rather than stopping at the first
    * type that merely exists. Each level is evaluated lazily and only until
-   * `accept` is satisfied — the arel-table leg throws on a caster-less table,
-   * so it must stay unreached when an earlier level answers.
+   * `accept` is satisfied.
    *
    * Written as a straight-line cascade rather than a generator or a lookup
    * array on purpose: positive single-value equality is the hottest path in the
@@ -153,9 +151,7 @@ export class PredicateBuilder {
   ): TypeCandidate {
     const relationType = (relation as TypeCaster | undefined)?.typeForAttribute?.(columnName);
     if (accept(relationType)) return relationType;
-    const contextType = (this._tableContext as TypeCaster | null)?.typeForAttribute?.(columnName);
-    if (accept(contextType)) return contextType;
-    const tableType = this.table.typeForAttribute(columnName) as TypeCandidate;
+    const tableType = this.table.type(columnName) as TypeCandidate;
     if (accept(tableType)) return tableType;
     return undefined;
   }
@@ -164,7 +160,8 @@ export class PredicateBuilder {
    * First existing type in the cascade, or undefined.
    *
    * Note this is byte-compatible with the old `this.table`-only lookup for
-   * plain (non-joined) columns: `table.get(col).relation` IS `this.table`, so
+   * plain (non-joined) columns: `table.get(col).relation` IS the metadata's
+   * arel table, so
    * the first leg answers with exactly the type the narrow lookup would have
    * returned. The extra levels only come into play for joined/aliased
    * attributes, which is precisely where the narrow lookup was wrong.
@@ -209,12 +206,7 @@ export class PredicateBuilder {
     }
     const nodes: Nodes.Node[] = [];
     for (const [key, value] of Object.entries(conditions)) {
-      if (
-        isPlainObject(value) &&
-        this._tableContext &&
-        typeof this._tableContext.associatedTable === "function" &&
-        !this._tableContext.hasColumn?.(key)
-      ) {
+      if (isPlainObject(value) && !this.table.hasColumn(key)) {
         // Mirrors Rails PredicateBuilder#expand_from_hash: pass the
         // join-dependency resolver block to associatedTable so a nested-hash key
         // that is not a direct reflection (e.g. a join table name) still
@@ -223,35 +215,24 @@ export class PredicateBuilder {
         // caller relation's join deps by table name and has no valid context
         // against the now-resolved associated table (Rails passes &block only to
         // associated_table, then calls expand_from_hash with no block).
-        const assocPb: PredicateBuilder = this._tableContext.associatedTable(
+        const assocPb: PredicateBuilder = this.table.associatedTable(
           key,
-          block,
+          block as (name: string) => never,
         ).predicateBuilder;
         const innerNodes = negated
           ? assocPb.buildNegatedFromHash(value)
           : assocPb.buildFromHash(value);
         nodes.push(...innerNodes);
-      } else if (
-        !isPlainObject(value) &&
-        this._tableContext &&
-        typeof this._tableContext.isAssociatedWith === "function" &&
-        typeof this._tableContext.associatedTable === "function" &&
-        this._tableContext.isAssociatedWith(key) &&
-        !this._tableContext.hasColumn?.(key)
-      ) {
+      } else if (this.table.isAssociatedWith(key) && !this.table.hasColumn(key)) {
         const assocNodes = this.buildFromHashAssociation(
-          this._tableContext.associatedTable(key),
+          this.table.associatedTable(key),
           key,
           value,
           negated,
           conditions,
         );
         nodes.push(...assocNodes);
-      } else if (
-        this._tableContext &&
-        typeof this._tableContext.aggregatedWith === "function" &&
-        this._tableContext.aggregatedWith(key)
-      ) {
+      } else if (this.table.aggregatedWith(key)) {
         nodes.push(...this.buildFromHashAggregate(key, value, negated));
       } else {
         const attr = this.resolveColumn(key);
@@ -270,7 +251,7 @@ export class PredicateBuilder {
    * @internal
    */
   private buildFromHashAggregate(key: string, value: unknown, negated: boolean): Nodes.Node[] {
-    const reflection = this._tableContext.reflectOnAggregation(key);
+    const reflection = this.table.reflectOnAggregation(key);
     const mapping: [string, string][] = reflection.mapping();
     // Rails: `values = value.nil? ? [nil] : Array.wrap(value)`.
     const values =
@@ -576,12 +557,10 @@ export class PredicateBuilder {
    * `type_for_attribute(name).cast(value)`.
    */
   private normalizeQueryValue(columnName: string, value: unknown): unknown {
-    const klass = (this.table as { klass?: { _normalizations?: Map<string, unknown> } }).klass;
+    const klass = this.table.klass as { _normalizations?: Map<string, unknown> } | null;
     const normalizations = klass?._normalizations;
     if (!normalizations || !normalizations.has(columnName)) return value;
-    const type = this.table.typeForAttribute(columnName) as
-      | { cast?(v: unknown): unknown }
-      | undefined;
+    const type = this.table.type(columnName) as { cast?(v: unknown): unknown } | undefined;
     return type?.cast ? type.cast(value) : value;
   }
 
@@ -702,7 +681,7 @@ export class PredicateBuilder {
       const dot = key.lastIndexOf(".");
       if (dot !== -1) return this.resolveArelAttribute(key.slice(0, dot), key.slice(dot + 1));
     }
-    return this.table.get(key);
+    return this.table.arelTable.get(key);
   }
 
   registerHandler(
@@ -747,38 +726,15 @@ export class PredicateBuilder {
     // associated_table had to alias to the hash key (table-metadata.ts:83-84,
     // mirroring table_metadata.rb:44) — both answer `get`, neither is
     // `instanceof Table`.
-    const ctx = this._tableContext as {
-      associatedTable?: (
-        n: string,
-        f?: (name: string) => unknown,
-      ) => { arelTable: Table | Nodes.TableAlias };
-    };
-    if (typeof ctx?.associatedTable === "function") {
-      return ctx.associatedTable(tableName, fallback).arelTable.get(columnName);
-    }
-    // Rails' PredicateBuilder always holds a TableMetadata, so `associated_table`
-    // is always reachable and never yields a caster-less table; trails' holds the
-    // raw Arel table plus the metadata as `_tableContext`, so a builder
-    // constructed without one lands here. Attach a caster the way the no-klass
-    // branch of associated_table does (table_metadata.rb:47-48) — with
-    // type_for_attribute delegating bare, a bare table would raise.
-    const klass = (this._tableContext as { klass?: unknown })?.klass ?? null;
-    return new Table(tableName, {
-      typeCaster: new TypeCasterConnection(klass as never, tableName),
-    }).get(columnName);
+    return this.table
+      .associatedTable(tableName, fallback as (name: string) => never)
+      .arelTable.get(columnName);
   }
 
-  with(context: any): PredicateBuilder {
-    const table = context?.arelTable ?? this.table;
+  with(table: TableMetadata): PredicateBuilder {
     const builder = new PredicateBuilder(table);
     builder.handlers = [...this.handlers];
-    builder._tableContext = context;
     return builder;
-  }
-
-  /** Set context without cloning — use only when constructing a fresh builder. */
-  setTableContext(context: any): void {
-    this._tableContext = context;
   }
 
   /**

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -223,7 +223,7 @@ export class PredicateBuilder {
           ? assocPb.buildNegatedFromHash(value)
           : assocPb.buildFromHash(value);
         nodes.push(...innerNodes);
-      } else if (this.table.isAssociatedWith(key) && !this.table.hasColumn(key)) {
+      } else if (this.table.isAssociatedWith(key)) {
         const assocNodes = this.buildFromHashAssociation(
           this.table.associatedTable(key),
           key,
@@ -732,8 +732,12 @@ export class PredicateBuilder {
   }
 
   with(table: TableMetadata): PredicateBuilder {
+    // Rails: `other = dup; other.table = table` — dup shares the @handlers
+    // ARRAY OBJECT, so handlers registered on the model builder later are
+    // visible to builders already derived for associated metadata (and vice
+    // versa). A `[...this.handlers]` snapshot would leave them stale.
     const builder = new PredicateBuilder(table);
-    builder.handlers = [...this.handlers];
+    builder.handlers = this.handlers;
     return builder;
   }
 

--- a/packages/activerecord/src/table-metadata.ts
+++ b/packages/activerecord/src/table-metadata.ts
@@ -121,9 +121,7 @@ export class TableMetadata {
         null;
       if (modelPb && typeof modelPb.with === "function") return modelPb.with(this);
     }
-    const pb = new PredicateBuilder(this._arelTable);
-    pb.setTableContext(this);
-    return pb;
+    return new PredicateBuilder(this);
   }
 
   get arelTable(): Table | any {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder.json
@@ -250,12 +250,5 @@
     "rubyName": "references",
     "call": "sql",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder.ts",
-    "rubyName": "resolve_arel_attribute",
-    "call": "table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]


### PR DESCRIPTION
## Summary

Rails' `PredicateBuilder#initialize(table)` takes a **TableMetadata** and stores it as `@table` (`predicate_builder.rb:12-13`) — every `table.` call in the class (`associated_table`, `type`, `has_column?`) is a TableMetadata call. trails held the raw Arel `Table` plus the metadata as a side `_tableContext` (set via `setTableContext` / `with`), so a builder could exist with a table but no metadata.

This converges the class's internal shape (the entry point was already fixed by #4846):

- `PredicateBuilder`'s `table` is now a `TableMetadata` (type-only import, no runtime cycle); `_tableContext` and `setTableContext` are gone.
- `resolveArelAttribute`'s no-context fallback (hand-built `TypeCaster::Connection`, surfaced by #4889) is deleted — `associatedTable` is always reachable, as in Rails (`table_metadata.rb:43-48`).
- The shared type cascade (`buildBindAttribute` et al.) reads `table.type(name)` on the metadata, matching `predicate_builder.rb:20-22`; the separate context leg collapses away.
- `buildFromHashInternal`'s `_tableContext`-presence / typeof guards reduce to direct metadata calls, mirroring `expand_from_hash`.
- `with(table)` now takes the TableMetadata directly, like Rails' `with`.
- Callers updated: `core.ts` `predicateBuilder`, `table-metadata.ts` `predicateBuilder`, `relation.ts` `predicateBuilder`, and both predicate-builder test files construct with `new TableMetadata(...)`. No test name changes.

Closes-story: predicate-builder-table-is-arel-table-not-tablemetadata
