### PR TITLE
fix(relation): invert assembled WhereClause instead of threading negation through PredicateBuilder

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -819,7 +819,9 @@ export class Relation<T extends Base> {
       // predicate added (matches Rails' `where.not(...)` no-op for
       // empty hashes).
       if (node !== null) {
-        rel._whereClause.predicates.push(new Nodes.Not(new Nodes.Grouping(node)));
+        // Rails builds the positive predicate and inverts it (WhereClause#invert
+        // → node.invert): `IN` → `NOT IN`, a grouped tuple-OR → `NOT (...)`.
+        rel._whereClause.predicates.push(node.invert());
       }
       return rel;
     }
@@ -839,16 +841,14 @@ export class Relation<T extends Base> {
     // Values pass to PredicateBuilder raw, like Rails — the QueryAttribute
     // bind owns casting/serialization at compile time (predicate_builder.rb:57-69).
     //
-    // Mirrors Rails' WhereClause#invert — branches on the actual predicate count,
-    // not the key count, since one key can expand to multiple predicates:
-    // - 1 predicate → invert_predicate (NOT NULL, !=, NOT BETWEEN, NOT IN, etc.)
-    // - 2+ predicates → NOT(p1 AND p2 AND ...) — semantically different from p1 != AND p2 !=
-    const positiveNodes = this.predicateBuilder.buildFromHash(conditions);
-    if (positiveNodes.length <= 1) {
-      rel._whereClause.predicates.push(...this.predicateBuilder.buildNegatedFromHash(conditions));
-    } else {
-      rel._whereClause.predicates.push(new Nodes.Not(new Nodes.And(positiveNodes)));
-    }
+    // Mirrors Rails WhereChain#not → `build_where_clause(opts).invert`
+    // (query_methods.rb:49): the predicate builder is always positive;
+    // negation is a single WhereClause#invert over the assembled clause —
+    // 1 predicate → node.invert() (`!=`, `IS NOT NULL`, `NOT IN`, ...),
+    // 2+ predicates → NOT(p1 AND p2 AND ...).
+    rel._whereClause.predicates.push(
+      ...new WhereClause(this.predicateBuilder.buildFromHash(conditions)).invert().predicates,
+    );
     return rel;
   }
 
@@ -4982,12 +4982,12 @@ export class Relation<T extends Base> {
         for (const rel of node.innerRelations) {
           ids.push(...(await rel.ids()));
         }
-        // Route through the negated predicate builder — trails' equivalent of
-        // Rails `predicate_builder[primary_key, records].invert`
+        // Build positively and invert — Rails
+        // `predicate_builder[primary_key, records].invert`
         // (query_methods.rb:1587) — instead of hardcoding `NOT IN`, so the
-        // materialized array shares the loaded/`where.not` array-negation logic
-        // (e.g. an eventual single-id `!=` collapse) rather than diverging.
-        predicates[i] = this.predicateBuilder.buildNegated(attribute, ids);
+        // materialized array shares the `where.not` array-negation logic
+        // (e.g. the single-id `!=` collapse) rather than diverging.
+        predicates[i] = this.predicateBuilder.build(attribute, ids).invert();
       }
     }
   }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -838,17 +838,15 @@ export class Relation<T extends Base> {
       rel._whereClause.predicates.push(...clause.invert().predicates);
       return rel;
     }
-    // Values pass to PredicateBuilder raw, like Rails — the QueryAttribute
-    // bind owns casting/serialization at compile time (predicate_builder.rb:57-69).
-    //
     // Mirrors Rails WhereChain#not → `build_where_clause(opts).invert`
-    // (query_methods.rb:49): the predicate builder is always positive;
-    // negation is a single WhereClause#invert over the assembled clause —
-    // 1 predicate → node.invert() (`!=`, `IS NOT NULL`, `NOT IN`, ...),
-    // 2+ predicates → NOT(p1 AND p2 AND ...).
-    rel._whereClause.predicates.push(
-      ...new WhereClause(this.predicateBuilder.buildFromHash(conditions)).invert().predicates,
-    );
+    // (query_methods.rb:49): the hash routes through the same
+    // `build_where_clause` as `where` — which resolves attribute aliases and
+    // passes the join-dependency lookup block before `build_from_hash`
+    // (query_methods.rb:1631-1644) — then a single WhereClause#invert over the
+    // assembled clause: 1 predicate → node.invert() (`!=`, `IS NOT NULL`,
+    // `NOT IN`, ...), 2+ predicates → NOT(p1 AND p2 AND ...).
+    const clause = rel.buildWhereClause(conditions) as WhereClause;
+    rel._whereClause.predicates.push(...clause.invert().predicates);
     return rel;
   }
 

--- a/packages/activerecord/src/relation/predicate-builder.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { testConnection } from "@blazetrails/arel/src/test-helpers/connection.js";
 import { Table, Visitors, Nodes } from "@blazetrails/arel";
 import { PredicateBuilder } from "./predicate-builder.js";
+import { WhereClause } from "./where-clause.js";
 import { Substitute } from "../statement-cache.js";
 import { Range } from "../connection-adapters/postgresql/oid/range.js";
 import { TableMetadata } from "../table-metadata.js";
@@ -271,58 +272,64 @@ describe("PredicateBuilderTest", () => {
     });
   });
 
+  // Negation is Rails-shaped: the builder is always positive; `where.not`
+  // inverts the assembled clause (WhereClause#invert → node.invert()).
   describe("buildNegatedFromHash", () => {
     const table = castedTable("posts");
     const compile = (node: Nodes.Node) => new Visitors.ToSql(testConnection).compile(node);
+    const buildInverted = (builder: PredicateBuilder, hash: Record<string, unknown>) =>
+      new WhereClause(builder.buildFromHash(hash)).invert().predicates;
 
     it("builds IS NOT NULL for null values", () => {
       const builder = new PredicateBuilder(new TableMetadata(null, table));
-      const [node] = builder.buildNegatedFromHash({ title: null });
+      const [node] = buildInverted(builder, { title: null });
       expect(compile(node)).toMatch(/IS NOT NULL/);
     });
 
     it("builds NOT IN for arrays", () => {
       const builder = new PredicateBuilder(new TableMetadata(null, table));
-      const [node] = builder.buildNegatedFromHash({ id: [1, 2, 3] });
+      const [node] = buildInverted(builder, { id: [1, 2, 3] });
       expect(compile(node)).toMatch(/NOT IN \(\?, \?, \?\)/);
     });
 
     it("builds NOT IN for Set values in negated predicates", () => {
       const builder = new PredicateBuilder(new TableMetadata(null, table));
-      const [node] = builder.buildNegatedFromHash({ id: new Set([1, 2]) });
+      const [node] = buildInverted(builder, { id: new Set([1, 2]) });
       expect(compile(node)).toMatch(/NOT IN \(\?, \?\)/);
     });
 
     it("builds correct negation for exclusive ranges", () => {
+      // Rails: positive `gteq(begin).and(lt(end))`, inverted via Node#invert →
+      // `NOT (age >= 18 AND age < 65)` (And has no invert override).
       const builder = new PredicateBuilder(new TableMetadata(null, table));
-      const [node] = builder.buildNegatedFromHash({ age: new Range(18, 65, true) });
+      const [node] = buildInverted(builder, { age: new Range(18, 65, true) });
       const sql = compile(node);
-      expect(sql).toMatch(/< 18/);
-      expect(sql).toMatch(/>= 65/);
+      expect(sql).toMatch(/^NOT \(/);
+      expect(sql).toMatch(/>= 18/);
+      expect(sql).toMatch(/< 65/);
     });
 
     it("does not dereference a plain object literal to its id when negated", () => {
       const builder = new PredicateBuilder(new TableMetadata(null, table));
-      const node = builder.buildNegated(table.get("title"), { id: 5 });
+      const node = builder.build(table.get("title"), { id: 5 }).invert();
       const sql = new Visitors.ToSql(testConnection).compile(node);
-      // Negation binds the RHS (Rails inverts a positively-built, bound
-      // predicate), so the value rides a QueryAttribute bind rather than being
-      // inlined.
+      // Rails inverts a positively-built, bound predicate, so the value rides a
+      // QueryAttribute bind rather than being inlined.
       expect(sql).toContain('"posts"."title" !=');
       // The whole object is bound, not the dereferenced `5`.
       const bound = (node as unknown as { right: { value: { value: unknown } } }).right.value.value;
       expect(bound).toEqual({ id: 5 });
     });
 
-    // Mirror of the positive ArrayHandler convergence on the negated per-element
-    // path: non-Base objects carrying an `id` are not collapsed into a
+    // Mirror of the positive ArrayHandler convergence on the inverted path:
+    // non-Base objects carrying an `id` are not collapsed into a
     // `NOT IN (5, 7)` PK list the way real AR records would be.
     it("does not dereference non-Base objects carrying an id inside a negated array", () => {
       class NotARecord {
         constructor(public id: number) {}
       }
       const builder = new PredicateBuilder(new TableMetadata(null, table));
-      const [node] = builder.buildNegatedFromHash({
+      const [node] = buildInverted(builder, {
         id: [new NotARecord(5), new NotARecord(7)],
       });
       const sql = new Visitors.ToSql(testConnection).compile(node);
@@ -425,7 +432,8 @@ describe("PredicateBuilderTest", () => {
     it("negated form expands whereNot({authors: {name: 'Rails'}}) to NOT \"authors\".\"name\" = 'Rails'", () => {
       const meta = new TableMetadata(PbTestPost as any, (PbTestPost as any).arelTable);
       const builder = meta.predicateBuilder;
-      const nodes = builder.buildNegatedFromHash({ authors: { name: "Rails" } });
+      const nodes = new WhereClause(builder.buildFromHash({ authors: { name: "Rails" } })).invert()
+        .predicates;
       const sql = nodes.map((n) => new Visitors.ToSql(testConnection).compile(n)).join(" AND ");
       expect(sql).toContain('"authors"."name"');
       // Negation binds the RHS, so 'Rails' rides a QueryAttribute bind.

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -2,7 +2,6 @@ import { Nodes, sql as arelSql } from "@blazetrails/arel";
 import { Range } from "../connection-adapters/postgresql/oid/range.js";
 import { QueryAttribute } from "./query-attribute.js";
 import { ArrayHandler } from "./predicate-builder/array-handler.js";
-import { isBaseInstance } from "./predicate-builder/is-base-instance.js";
 import { RangeHandler, UnboundableBound } from "./predicate-builder/range-handler.js";
 import { BasicObjectHandler } from "./predicate-builder/basic-object-handler.js";
 import { RelationHandler } from "./predicate-builder/relation-handler.js";
@@ -69,7 +68,7 @@ export class PredicateBuilder {
    * `serializable? { |v| @_unboundable = v <=> 0 }` (query_attribute.rb:46-50),
    * driven by the ActiveModelRangeError raised on serialize. Reusing it (rather
    * than a second sign computation) keeps this in lockstep with the
-   * equality/negation single-value paths, and handles non-numeric out-of-range
+   * equality single-value path, and handles non-numeric out-of-range
    * bounds (e.g. custom types) type-agnostically.
    *
    * Callers pass the type from {@link typeOf} so sign detection uses the same
@@ -100,19 +99,11 @@ export class PredicateBuilder {
     conditions: Record<string, unknown>,
     block?: (tableName: string) => unknown,
   ): Nodes.Node[] {
-    return this.buildFromHashInternal(this.convertDotNotationToHash(conditions), false, block);
-  }
-
-  buildNegatedFromHash(
-    conditions: Record<string, unknown>,
-    block?: (tableName: string) => unknown,
-  ): Nodes.Node[] {
-    return this.buildFromHashInternal(this.convertDotNotationToHash(conditions), true, block);
+    return this.buildFromHashInternal(this.convertDotNotationToHash(conditions), block);
   }
 
   private buildFromHashInternal(
     conditions: Record<string, unknown>,
-    negated: boolean,
     block?: (tableName: string) => unknown,
   ): Nodes.Node[] {
     // Mirrors Rails PredicateBuilder#expand_from_hash: `return ["1=0"] if
@@ -121,14 +112,11 @@ export class PredicateBuilder {
     // `where(sink: {})` (empty hash, no foreign key) match nothing. Top-level
     // `where({})` never reaches here — it short-circuits as a blank argument in
     // `Relation#where` (like Rails' `args.first.blank?`), so this fires only for
-    // the nested/associated recursion.
-    //
-    // Under negation (`where.not(sink: {})`) trails threads `negated` into the
-    // recursion (Rails builds positively then inverts the WhereClause), so the
-    // contradiction inverts to the `1=1` tautology — `NOT (1=0)` matches every
-    // row, mirroring `WhereClause#invert` over Rails' `["1=0"]`.
+    // the nested/associated recursion. Like Rails, expansion is always
+    // positive: `where.not(...)` inverts the assembled WhereClause one level
+    // up (WhereClause#invert), so `where.not(sink: {})` becomes `NOT (1=0)`.
     if (Object.keys(conditions).length === 0) {
-      return [arelSql(negated ? "1=1" : "1=0")];
+      return [arelSql("1=0")];
     }
     const nodes: Nodes.Node[] = [];
     for (const [key, value] of Object.entries(conditions)) {
@@ -145,27 +133,22 @@ export class PredicateBuilder {
           key,
           block as (name: string) => never,
         ).predicateBuilder;
-        const innerNodes = negated
-          ? assocPb.buildNegatedFromHash(value)
-          : assocPb.buildFromHash(value);
-        nodes.push(...innerNodes);
+        nodes.push(...assocPb.buildFromHash(value));
       } else if (this.table.isAssociatedWith(key)) {
         const assocNodes = this.buildFromHashAssociation(
           this.table.associatedTable(key),
           key,
           value,
-          negated,
           conditions,
         );
         nodes.push(...assocNodes);
       } else if (this.table.aggregatedWith(key)) {
-        nodes.push(...this.buildFromHashAggregate(key, value, negated));
+        nodes.push(...this.buildFromHashAggregate(key, value));
       } else {
         // Rails `self[key, value]` (predicate_builder.rb:53-55): the attribute
         // is read straight off the builder's arel table — dotted keys were
         // already normalized into nested hashes by convertDotNotationToHash.
-        const attr = this.table.arelTable.get(key);
-        nodes.push(negated ? this.buildNegated(attr, value) : this.build(attr, value));
+        nodes.push(this.build(this.table.arelTable.get(key), value));
       }
     }
     return nodes;
@@ -179,7 +162,7 @@ export class PredicateBuilder {
    *
    * @internal
    */
-  private buildFromHashAggregate(key: string, value: unknown, negated: boolean): Nodes.Node[] {
+  private buildFromHashAggregate(key: string, value: unknown): Nodes.Node[] {
     const reflection = this.table.reflectOnAggregation(key);
     const mapping: [string, string][] = reflection.mapping();
     // Rails: `values = value.nil? ? [nil] : Array.wrap(value)`.
@@ -189,13 +172,10 @@ export class PredicateBuilder {
       const [columnName, aggregateAttr] = mapping[0];
       // Rails: `object.respond_to?(aggr) ? object.public_send(aggr) : object`.
       const mapped = values.map((object) => extractAggregateAttr(object, aggregateAttr, false));
-      return negated
-        ? this.buildNegatedFromHash({ [columnName]: mapped })
-        : this.buildFromHash({ [columnName]: mapped });
+      return this.buildFromHash({ [columnName]: mapped });
     }
     // Multi-mapping: one AND-group per object over every mapped column, ORed
-    // together (grouping_queries). Each column is built positively; negation is
-    // applied once at the group level, mirroring expand_from_hash.
+    // together (grouping_queries), mirroring expand_from_hash.
     const queryGroups: Nodes.Node[][] = values.map((object) =>
       mapping.map(([fieldAttr, aggregateAttr]) =>
         this.build(
@@ -204,7 +184,7 @@ export class PredicateBuilder {
         ),
       ),
     );
-    return this.groupingQueries(queryGroups, negated);
+    return this.groupingQueries(queryGroups);
   }
 
   /** @internal */
@@ -212,7 +192,6 @@ export class PredicateBuilder {
     associatedTable: any,
     key: string,
     value: unknown,
-    negated: boolean,
     attributes: Record<string, unknown>,
   ): Nodes.Node[] {
     if (associatedTable.isPolymorphicAssociation?.()) {
@@ -234,11 +213,9 @@ export class PredicateBuilder {
         if (inner.length === 0) continue;
         queryGroups.push(inner);
       }
-      return this.groupingQueries(queryGroups, negated);
+      return this.groupingQueries(queryGroups);
     }
     // Through: delegate with the associated model's primary key (Rails: through_association? path).
-    // Always build positively — negation is applied once at the group level below (mirrors Rails
-    // expand_from_hash which never recurses with negation).
     if (associatedTable.isThroughAssociation?.()) {
       const rawPk = associatedTable.klass?.primaryKey ?? "id";
       if (Array.isArray(rawPk)) {
@@ -257,11 +234,9 @@ export class PredicateBuilder {
       const assocPb: PredicateBuilder = associatedTable.predicateBuilder;
       const inner = normalizedQueries.flatMap((q) => assocPb.buildFromHash(q));
       if (inner.length === 0) return [];
-      const group = inner.length === 1 ? inner[0] : new Nodes.And(inner);
-      return negated ? [new Nodes.Not(new Nodes.Grouping(group))] : [group];
+      return [inner.length === 1 ? inner[0] : new Nodes.And(inner)];
     }
     // Core non-polymorphic, non-through path.
-    // Rails expand_from_hash is always positive; negation is applied once at the group level.
     const queries = new AssociationQueryValue(associatedTable, value).queries();
     const queryGroups: Nodes.Node[][] = [];
     for (const query of queries) {
@@ -274,123 +249,26 @@ export class PredicateBuilder {
         queryGroups.push(inner);
       }
     }
-    return this.groupingQueries(queryGroups, negated);
+    return this.groupingQueries(queryGroups);
   }
 
   /**
    * Mirrors PredicateBuilder#grouping_queries: a single query group's predicates
    * are returned *flat* (so each column stays an addressable predicate, which
    * `WhereClause#extract_attributes` — and thus `rewhere` — relies on); multiple
-   * groups are each AND-reduced and ORed inside a Grouping. Negation wraps the
-   * group(s) in `NOT (...)` rather than negating each predicate independently.
+   * groups are each AND-reduced and ORed inside a Grouping.
    *
    * @internal
    */
-  private groupingQueries(queryGroups: Nodes.Node[][], negated: boolean): Nodes.Node[] {
+  private groupingQueries(queryGroups: Nodes.Node[][]): Nodes.Node[] {
     if (queryGroups.length === 0) return [];
-    if (queryGroups.length === 1) {
-      const inner = queryGroups[0];
-      if (!negated) return inner;
-      const node = inner.length === 1 ? inner[0] : new Nodes.And(inner);
-      return [new Nodes.Not(new Nodes.Grouping(node))];
-    }
+    if (queryGroups.length === 1) return queryGroups[0];
     // Rails `grouping_queries`: `Arel::Nodes::Or.new(queries.map!(&:reduce(:and)))`
     // — an n-ary Or over the full array, wrapped in one Grouping.
     const reduced = queryGroups.map((inner) =>
       inner.length === 1 ? inner[0] : new Nodes.And(inner),
     );
-    const grouping = new Nodes.Grouping(new Nodes.Or(reduced));
-    return negated ? [new Nodes.Not(grouping)] : [grouping];
-  }
-
-  buildNegated(attribute: Nodes.Attribute, value: unknown): Nodes.Node {
-    // Mirror build()'s deref (predicate_builder.rb:58). In Rails the deref lives in
-    // build() and negation is the inversion of a positively-built predicate, so
-    // `value = value.id if value.respond_to?(:id)` always applies — `where.not(col: record)`
-    // must compare against record.id, not the whole record object.
-    if (respondsToId(value)) {
-      value = (value as { id: unknown }).id;
-    }
-    if (value === null || value === undefined) {
-      return attribute.notEq(null);
-    }
-    if (value instanceof Set) {
-      value = Array.from(value);
-    }
-    if (value instanceof Range) {
-      return this.rangeHandler.callNegated(attribute, value);
-    }
-    if (Array.isArray(value)) {
-      return this.buildNegatedArray(attribute, value);
-    }
-    if (this.isRelation(value)) {
-      return this.relationHandler.callNegated(attribute, value);
-    }
-    // Build a bind attribute (as the positive BasicObjectHandler path does)
-    // rather than passing the raw value: Rails builds negation by inverting a
-    // positively-built predicate, so the RHS is a QueryAttribute bind. This
-    // also lets an out-of-range value report `unboundable?` at the visitor
-    // (`!=` → `1=1`) instead of raising ActiveModelRangeError when bound.
-    return attribute.notEq(this.buildBindAttribute(attribute.name, value));
-  }
-
-  private buildNegatedArray(attribute: Nodes.Attribute, value: unknown[]): Nodes.Node {
-    if (value.length === 0) return attribute.notIn([]);
-
-    const scalarValues: unknown[] = [];
-    let hasNull = false;
-    const ranges: Range[] = [];
-    const nonScalarValues: unknown[] = [];
-
-    for (const item of value) {
-      if (item === null || item === undefined) {
-        hasNull = true;
-      } else if (item instanceof Range) {
-        ranges.push(item);
-      } else if (isBaseInstance(item)) {
-        // Rails ArrayHandler: `x.is_a?(Base) ? x.id : x` — only genuine AR
-        // records deref to their PK; a non-Base object carrying an `id` does not.
-        scalarValues.push(item.id);
-      } else if (typeof item === "object" || typeof item === "function") {
-        nonScalarValues.push(item);
-      } else {
-        scalarValues.push(item);
-      }
-    }
-
-    const parts: Nodes.Node[] = [];
-
-    // Mirror Rails `ArrayHandler#call` (array_handler.rb:18-23) followed by
-    // `.invert`: a length-1 value array builds the scalar predicate
-    // (`build(attribute, values.first)` → Equality) and inverts to `!=`, only
-    // multi-value arrays use `IN` (→ `NOT IN` here). The positive
-    // `ArrayHandler.call` already collapses the single-value case via
-    // `predicateBuilder.build`; mirror its inverse here with `buildNegated` so
-    // both paths agree (`where.not`, `excluding`).
-    if (scalarValues.length === 1) {
-      parts.push(this.buildNegated(attribute, scalarValues[0]));
-    } else if (scalarValues.length > 1) {
-      // Mirror Rails `ArrayHandler#call` + `.invert`: the multi-value case is a
-      // `HomogeneousIn` node, inverted to `:notin`. Its `castedValues` drops
-      // out-of-range values, matching the positive IN path.
-      parts.push(new Nodes.HomogeneousIn(scalarValues, attribute, "notin"));
-    }
-
-    if (hasNull) {
-      parts.push(attribute.notEq(null));
-    }
-
-    for (const range of ranges) {
-      parts.push(this.buildNegated(attribute, range));
-    }
-
-    for (const v of nonScalarValues) {
-      parts.push(this.buildNegated(attribute, v));
-    }
-
-    if (parts.length === 0) return attribute.notIn([]);
-    if (parts.length === 1) return parts[0];
-    return new Nodes.And(parts);
+    return [new Nodes.Grouping(new Nodes.Or(reduced))];
   }
 
   build(attribute: Nodes.Attribute, value: unknown): Nodes.Node {

--- a/packages/activerecord/src/relation/predicate-builder/deferred-distinct-pk-in.ts
+++ b/packages/activerecord/src/relation/predicate-builder/deferred-distinct-pk-in.ts
@@ -30,6 +30,18 @@ export class DeferredDistinctPkIn extends Nodes.In {
   ) {
     super(attribute, inlineSubquery);
   }
+
+  // Inherited In#invert would build a plain NotIn and drop the deferred
+  // innerRelation, so the load pipeline would never materialize the ids.
+  // `where.not(col: relationWithLimit)` reaches the negated marker through
+  // here (WhereClause#invert over the positively-built predicate).
+  invert(): DeferredDistinctPkNotIn {
+    return new DeferredDistinctPkNotIn(
+      this.left as Nodes.Attribute,
+      this.right as Nodes.Node,
+      this.innerRelation,
+    );
+  }
 }
 
 export class DeferredDistinctPkNotIn extends Nodes.NotIn {
@@ -39,6 +51,14 @@ export class DeferredDistinctPkNotIn extends Nodes.NotIn {
     readonly innerRelation: { _materializeDistinctPkIds(): Promise<unknown[]> },
   ) {
     super(attribute, inlineSubquery);
+  }
+
+  invert(): DeferredDistinctPkIn {
+    return new DeferredDistinctPkIn(
+      this.left as Nodes.Attribute,
+      this.right as Nodes.Node,
+      this.innerRelation,
+    );
   }
 }
 

--- a/packages/activerecord/src/relation/predicate-builder/range-handler.ts
+++ b/packages/activerecord/src/relation/predicate-builder/range-handler.ts
@@ -62,29 +62,6 @@ export class RangeHandler {
     return attribute.between({ begin: beginVal, end: endVal, excludeEnd: value.excludeEnd });
   }
 
-  callNegated(attribute: Nodes.Attribute, value: Range): Nodes.Node {
-    const [beginVal, endVal] = this._castBounds(attribute, value);
-    const node = attribute.between({
-      begin: beginVal,
-      end: endVal,
-      excludeEnd: value.excludeEnd,
-    });
-    // When `between` returns an `And` (exclusive-end with both bounds
-    // non-open), prefer the explicit `(col < begin OR col >= end)` shape
-    // — `Not(And(gteq, lt))` would lose the ordering AR callers (and
-    // parity tests) match on. Branching on the node class rather than the
-    // bound values catches every non-open-ended case (incl. NaN bounds).
-    if (node instanceof Nodes.And) {
-      return new Nodes.Grouping(new Nodes.Or(attribute.lt(beginVal), attribute.gteq(endVal)));
-    }
-    // Mirrors Rails WhereClause#invert: call `.invert()` on the Arel node so
-    // collapsed predicates (`lteq` → `gt`, `gteq` → `lt`, `In([])` →
-    // `NotIn([])`) become canonical, instead of double-wrapping `Not(...)` over
-    // a simpler form. For full BETWEEN this still yields `Not(Between(...))`
-    // (Node#invert default), matching AR-level `where.not(col: 1..5)` exactly.
-    return node.invert();
-  }
-
   private _castBounds(attribute: Nodes.Attribute, value: Range): [unknown, unknown] {
     // Rails RangeHandler skips no bounds: `build_bind_attribute` wraps even
     // nil / Float::INFINITY. We mirror the intent by passing those through

--- a/packages/activerecord/src/relation/predicate-builder/relation-handler.ts
+++ b/packages/activerecord/src/relation/predicate-builder/relation-handler.ts
@@ -2,7 +2,7 @@ import { Nodes } from "@blazetrails/arel";
 import { ArgumentError } from "@blazetrails/activemodel";
 
 import { rubyInspectArray } from "../ruby-inspect.js";
-import { DeferredDistinctPkIn, DeferredDistinctPkNotIn } from "./deferred-distinct-pk-in.js";
+import { DeferredDistinctPkIn } from "./deferred-distinct-pk-in.js";
 
 /**
  * Handles Relation values in where conditions by converting them to
@@ -16,17 +16,10 @@ import { DeferredDistinctPkIn, DeferredDistinctPkNotIn } from "./deferred-distin
  */
 export class RelationHandler {
   call(attribute: Nodes.Attribute, value: any): Nodes.Node {
-    const deferred = this.deferDistinctPkMaterialization(attribute, value, false);
+    const deferred = this.deferDistinctPkMaterialization(attribute, value);
     if (deferred) return deferred;
     const relation = this.injectPrimaryKeySelect(attribute, this.applyJoinDependency(value));
     return attribute.in(relation.toArel());
-  }
-
-  callNegated(attribute: Nodes.Attribute, value: any): Nodes.Node {
-    const deferred = this.deferDistinctPkMaterialization(attribute, value, true);
-    if (deferred) return deferred;
-    const relation = this.injectPrimaryKeySelect(attribute, this.applyJoinDependency(value));
-    return attribute.notIn(relation.toArel());
   }
 
   // Rails routes an eager-loading subquery with a limit/offset over a collection
@@ -40,14 +33,13 @@ export class RelationHandler {
   private deferDistinctPkMaterialization(
     attribute: Nodes.Attribute,
     value: any,
-    negated: boolean,
   ): Nodes.Node | null {
     if (typeof value?._isDeferredDistinctPkSubquery !== "function") return null;
     if (!value._isDeferredDistinctPkSubquery()) return null;
     const inlineSubquery = value._buildDeferredDistinctPkInlineSubquery();
-    return negated
-      ? new DeferredDistinctPkNotIn(attribute, inlineSubquery, value)
-      : new DeferredDistinctPkIn(attribute, inlineSubquery, value);
+    // Always positive — `where.not(...)` reaches the negated marker via
+    // `DeferredDistinctPkIn#invert` (WhereClause#invert).
+    return new DeferredDistinctPkIn(attribute, inlineSubquery, value);
   }
 
   // Mirrors Rails `if value.eager_loading? value = value.send(:apply_join_dependency) end`

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1592,8 +1592,12 @@ function excludingBang(this: QueryMethodsHost, records: any[]): any {
   // predicate exactly as Rails does (array handler dereferences AR records to
   // their ids).
   if (unloadedRelations.length === 0) {
+    // Rails `predicate_builder[primary_key, records].invert` — `#[]` reads the
+    // attribute straight off the builder's arel table (predicate_builder.rb:53-55).
     this._whereClause.predicates.push(
-      this.predicateBuilder.build(this.predicateBuilder.resolveColumn(pk), literalRecords).invert(),
+      this.predicateBuilder
+        .build(this.predicateBuilder.table.arelTable.get(pk), literalRecords)
+        .invert(),
     );
     return this;
   }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1593,7 +1593,7 @@ function excludingBang(this: QueryMethodsHost, records: any[]): any {
   // their ids).
   if (unloadedRelations.length === 0) {
     this._whereClause.predicates.push(
-      ...this.predicateBuilder.buildNegatedFromHash({ [pk]: literalRecords }),
+      this.predicateBuilder.build(this.predicateBuilder.resolveColumn(pk), literalRecords).invert(),
     );
     return this;
   }
@@ -1611,9 +1611,10 @@ function excludingBang(this: QueryMethodsHost, records: any[]): any {
   const attribute = (this._modelClass as any).arelTable.get(pk);
   // Mirror the array handler's `x.is_a?(Base) ? x.id : x` deref.
   const literalIds = literalRecords.map((r) => (isBaseInstance(r) ? (r as any).id : r));
-  const inlineSubquery = (
-    this.predicateBuilder.buildNegated(attribute, unloadedRelations[0]) as Nodes.NotIn
-  ).right as Nodes.Node;
+  // Build the positive `IN (subquery)` (Rails builds positively and inverts);
+  // only its subquery `right` is needed for the marker's display fallback.
+  const inlineSubquery = (this.predicateBuilder.build(attribute, unloadedRelations[0]) as Nodes.In)
+    .right as Nodes.Node;
   this._whereClause.predicates.push(
     new DeferredIdsNotIn(attribute, inlineSubquery, literalIds, unloadedRelations),
   );

--- a/packages/activerecord/src/relation/where-chain.trails.test.ts
+++ b/packages/activerecord/src/relation/where-chain.trails.test.ts
@@ -12,6 +12,8 @@ import { fixtures } from "../test-helpers/fixtures.js";
 import { Post } from "../test-helpers/models/post.js";
 import { Author } from "../test-helpers/models/author.js";
 import { Comment } from "../test-helpers/models/comment.js";
+import { Customer } from "../test-helpers/models/customer.js";
+import { Range } from "../connection-adapters/postgresql/oid/range.js";
 
 registerModel(Post);
 registerModel(Author);
@@ -55,6 +57,53 @@ describe("WhereChain associated join guard (trails)", () => {
     const loj = Comment.leftOuterJoins("children").where().associated("children").toSql();
     expect(joinCount(loj)).toBe(1);
     expect(loj).toMatch(/["`]?children["`]?\.["`]?id["`]?\s+IS NOT NULL/i);
+  });
+});
+
+// `where.not` is a single WhereClause#invert over the positively-built clause
+// (query_methods.rb:49, where_clause.rb:85-92) — never per-branch negation
+// threaded through the predicate builder. These pin the inversion shapes the
+// old threading got structurally different (Rails-shape SQL + row semantics).
+describe("WhereChain not inversion shapes (trails)", () => {
+  fixtures(["posts", "authors", "authorAddresses", "customers"]);
+
+  it("inverts an array containing null as NOT (IN ... OR IS NULL)", async () => {
+    const relation = Post.whereNot({
+      title: [null, "Welcome to the weblog", "So I was thinking"],
+    });
+    // Positive ArrayHandler shape `(title IN (...) OR title IS NULL)`, inverted
+    // once at the clause level — not the threaded `NOT IN ... AND IS NOT NULL`.
+    expect(relation.toSql()).toMatch(/NOT \(.*IN \(.*\).*OR.*IS NULL\)/is);
+    const posts = await relation;
+    expect(posts.length).toBeGreaterThan(0);
+    for (const post of posts) {
+      expect(post.title).not.toBeNull();
+      expect(post.title).not.toBe("Welcome to the weblog");
+    }
+  });
+
+  it("inverts a multi-column aggregate group as one NOT over the AND group", async () => {
+    const david = await Customer.find(1);
+    const relation = Customer.whereNot({ address: david.address });
+    // expand_from_hash builds the three mapped-column equalities positively;
+    // WhereClause#invert wraps them in a single NOT(...) group.
+    expect(relation.toSql()).toMatch(
+      /NOT \(.*address_street.*AND.*address_city.*AND.*address_country.*\)/is,
+    );
+    // The flat positive predicates invert via NOT(ast) — no per-branch
+    // Grouping double-wrap (`NOT ((...))`) like the old negation threading.
+    expect(relation.toSql()).not.toMatch(/NOT \(\(/);
+    const customers = await relation;
+    expect(customers.length).toBeGreaterThan(0);
+    expect(ids(customers)).not.toContain(1);
+  });
+
+  it("inverts an exclusive range as NOT over the positive bound pair", () => {
+    // Arel builds `gteq(begin) AND lt(end)`; And has no invert override, so
+    // Node#invert yields `NOT (id >= 1 AND id < 5)` — not a re-derived
+    // `(id < 1 OR id >= 5)`.
+    const sql = Post.whereNot({ id: new Range(1, 5, true) }).toSql();
+    expect(sql).toMatch(/NOT \(.*id.*>=.*AND.*id.*<.*\)/is);
   });
 });
 

--- a/packages/activerecord/src/relation/where-chain.trails.test.ts
+++ b/packages/activerecord/src/relation/where-chain.trails.test.ts
@@ -13,6 +13,7 @@ import { Post } from "../test-helpers/models/post.js";
 import { Author } from "../test-helpers/models/author.js";
 import { Comment } from "../test-helpers/models/comment.js";
 import { Customer } from "../test-helpers/models/customer.js";
+import { Company } from "../test-helpers/models/company.js";
 import { Range } from "../connection-adapters/postgresql/oid/range.js";
 
 registerModel(Post);
@@ -104,6 +105,15 @@ describe("WhereChain not inversion shapes (trails)", () => {
     // `(id < 1 OR id >= 5)`.
     const sql = Post.whereNot({ id: new Range(1, 5, true) }).toSql();
     expect(sql).toMatch(/NOT \(.*id.*>=.*AND.*id.*<.*\)/is);
+  });
+
+  it("resolves attribute aliases before inversion like build_where_clause", () => {
+    // Rails WhereChain#not routes through build_where_clause (query_methods.rb:49),
+    // which resolves alias_attribute keys before expand_from_hash — so
+    // `where.not(newName: ...)` lands on the real `name` column, inverted.
+    const sql = Company.whereNot({ newName: "37signals" }).toSql();
+    expect(sql).toMatch(/["`]name["`]\s*!=/);
+    expect(sql).not.toMatch(/newName/);
   });
 });
 


### PR DESCRIPTION
## Summary

Rails' `PredicateBuilder` is always positive — `expand_from_hash` never negates. `where.not` builds the positive clause and applies a single `WhereClause#invert` (`node.invert()` for one predicate, `NOT(ast)` for several) one level up (query_methods.rb:49, where_clause.rb:85-92). trails instead threaded a `negated: boolean` through the whole hash-expansion path (`buildNegatedFromHash` / `buildNegated` / `buildNegatedArray`, plus `callNegated` on the range and relation handlers), re-implementing negation locally in every branch.

This PR converges on Rails' single-inversion shape and deletes the threading:

- `Relation#whereNot` builds positively and pushes `WhereClause#invert`'s predicates; the composite-key form inverts the built node (single-column now emits `NOT IN` instead of `NOT (id IN (...))`).
- `excluding!`/`without` and the deferred-ids materialization use `build(...).invert()`, mirroring `predicate_builder[primary_key, records].invert` (query_methods.rb:1587).
- `PredicateBuilder` loses the `negated` threading entirely; empty nested hashes always expand to `1=0` and invert to `NOT (1=0)` like Rails (previously a bespoke `1=1` literal).
- `RelationHandler` always defers the positive `DeferredDistinctPkIn`; the deferred markers gain `invert()` overrides so inversion preserves the deferred `innerRelation` instead of decaying to a plain `In`/`NotIn` (the inherited `In#invert` would have dropped it).
- `where.not` on an exclusive range now emits Rails' `NOT (col >= a AND col < b)` (And has no invert override → `Node#invert` → `Not`) instead of the bespoke `(col < a OR col >= b)`.

Net: −140 LOC of invented negation machinery.

## Tests

- `predicate-builder.test.ts` negation tests rewritten to exercise the converged positive-build + invert path (names unchanged); the exclusive-range expectation updated to Rails' `NOT (...)` shape.
- All Rails `where_chain_test.rb` `not`/`rewhere` cases were already ported and stay green, as do where/excluding/composite-where/or/merging/enum/uniqueness/finder/relations/default-scoping/eager/through/HABTM suites locally (audit found no un-ported Rails `where.not` tests).
- New trails-only pinning tests in `where-chain.trails.test.ts` for the story's tricky cases, each failing on the old threading: array-with-null inverts as `NOT (IN ... OR IS NULL)` (single 3-valued-logic inversion, not `NOT IN ... AND IS NOT NULL`), multi-column `composed_of` groups invert as one `NOT (...)` over the flat AND group (no per-branch `NOT ((...))` double-wrap — the flat predicates also keep `extract_attributes`/`rewhere` addressing), and exclusive ranges invert as `NOT (col >= a AND col < b)`.

Closes-story: predicate-builder-negation-threading-vs-whereclause-invert
