### PR TITLE
fix(relation): drop eager where-value pre-cast, defer to QueryAttribute bind

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -836,19 +836,16 @@ export class Relation<T extends Base> {
       rel._whereClause.predicates.push(...clause.invert().predicates);
       return rel;
     }
-    const castConditions: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(conditions)) {
-      castConditions[key] = this._castWhereValue(key, value);
-    }
+    // Values pass to PredicateBuilder raw, like Rails — the QueryAttribute
+    // bind owns casting/serialization at compile time (predicate_builder.rb:57-69).
+    //
     // Mirrors Rails' WhereClause#invert — branches on the actual predicate count,
     // not the key count, since one key can expand to multiple predicates:
     // - 1 predicate → invert_predicate (NOT NULL, !=, NOT BETWEEN, NOT IN, etc.)
     // - 2+ predicates → NOT(p1 AND p2 AND ...) — semantically different from p1 != AND p2 !=
-    const positiveNodes = this.predicateBuilder.buildFromHash(castConditions);
+    const positiveNodes = this.predicateBuilder.buildFromHash(conditions);
     if (positiveNodes.length <= 1) {
-      rel._whereClause.predicates.push(
-        ...this.predicateBuilder.buildNegatedFromHash(castConditions),
-      );
+      rel._whereClause.predicates.push(...this.predicateBuilder.buildNegatedFromHash(conditions));
     } else {
       rel._whereClause.predicates.push(new Nodes.Not(new Nodes.And(positiveNodes)));
     }
@@ -885,13 +882,8 @@ export class Relation<T extends Base> {
     if (conditions.length === 0) return this;
     if (conditions.length === 1) return this.where(conditions[0]);
 
-    const buildClause = (cond: Record<string, unknown>): WhereClause => {
-      const cast: Record<string, unknown> = {};
-      for (const [key, value] of Object.entries(cond)) {
-        cast[key] = value instanceof Relation ? value : this._castWhereValue(key, value);
-      }
-      return new WhereClause(this.predicateBuilder.buildFromHash(cast));
-    };
+    const buildClause = (cond: Record<string, unknown>): WhereClause =>
+      new WhereClause(this.predicateBuilder.buildFromHash(cond));
 
     let combined = buildClause(conditions[0]);
     for (let i = 1; i < conditions.length; i++) {
@@ -5757,61 +5749,6 @@ export class Relation<T extends Base> {
         }
       }
     }
-  }
-
-  private _castWhereValue(key: string, value: unknown): unknown {
-    if (value === null || value === undefined || value instanceof Range) return value;
-    let attrKey = key;
-    const firstDot = key.indexOf(".");
-    if (firstDot !== -1 && key.indexOf(".", firstDot + 1) === -1 && !key.includes('"')) {
-      const tablePrefix = key.slice(0, firstDot);
-      if (tablePrefix === this._modelClass.arelTable.name) {
-        attrKey = key.slice(firstDot + 1);
-      }
-    }
-    if (Array.isArray(value)) {
-      // A `where(col: [...])` array is one of two things: an `IN (...)` list of
-      // scalars (element-cast each through the column type) or — on a
-      // force-equality column (PG array / range / serialized) — a single
-      // force-equality value the predicate builder binds whole. `force_equality?`
-      // on the column type distinguishes them. Element-casting a whole array
-      // through an OID::Array column would run the string-only
-      // `_castAttributeValue` per element and parse each scalar as its own array
-      // literal (`'black'` → `[]`), corrupting `['black','blue']` → `[[],[]]`;
-      // leave the array intact and let the predicate builder's force-equality
-      // bind serialize it via the column type. Non-force-equality columns keep
-      // the element-wise IN-list cast.
-      const type = this._modelClass.typeForAttribute?.(attrKey) as
-        | { isForceEquality?(v: unknown): boolean }
-        | undefined;
-      if (type?.isForceEquality?.(value)) return value;
-      return value.map((v) => this._castPreservingUncastable(attrKey, v));
-    }
-    return this._castPreservingUncastable(attrKey, value);
-  }
-
-  /**
-   * Cast a scalar `where` value through its column type, but preserve the raw
-   * value when the cast collapses a non-null input to `null`.
-   *
-   * Rails never pre-casts a `where` value to nil: an un-castable string
-   * (`where(parent_id: "not-a-number")`, `where(written_on: "")`, or such an
-   * element inside `where(parent_id: ["not-a-number"])`) keeps its raw value and
-   * the QueryAttribute bind serializes to NULL at compile time — yielding
-   * `col = NULL` / `col IN (NULL)` (matches nothing), not the `IS NULL` path
-   * (matches nulls). Collapsing to nil here would misroute BOTH the scalar
-   * (Equality → `rightIsNull`) and array (ArrayHandler's `values.compact!`
-   * nil-partition, array_handler.rb:16) paths onto explicit-nil handling. So the
-   * bind — evaluated by the visitor via `nil?`/`unboundable?` — decides
-   * nullness, not this pre-cast. A genuinely null input stays null (routes to
-   * `IS NULL`), matching Rails treating only real `nil` as null.
-   */
-  private _castPreservingUncastable(attrKey: string, value: unknown): unknown {
-    const cast = this._modelClass._castAttributeValue(attrKey, value);
-    if ((cast === null || cast === undefined) && value !== null && value !== undefined) {
-      return value;
-    }
-    return cast;
   }
 
   private _qualifiedCol(table: Table, key: string): { tbl: string; col: string } {

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -234,7 +234,6 @@ interface QueryMethodsHost {
   _skipQueryCache: boolean | undefined;
   _modelClass: typeof import("../base.js").Base;
   predicateBuilder: import("./predicate-builder.js").PredicateBuilder;
-  _castWhereValue(key: string, value: unknown): unknown;
 }
 
 // ---------------------------------------------------------------------------
@@ -1044,10 +1043,14 @@ export function buildWhereClause(
     referencesBang.call(this, ...referencesFromConditions(opts));
     const mc = (this as any)._modelClass;
     const aliases: Record<string, string> = mc?._attributeAliases ?? {};
+    // Rails never pre-casts hash values here — build_where_clause hands them
+    // raw to PredicateBuilder, whose QueryAttribute bind casts/serializes at
+    // compile time (predicate_builder.rb:57-69 → build_bind_attribute →
+    // value_for_database).
     const normalized: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(opts)) {
       const resolved = aliases[key] ?? key;
-      normalized[resolved] = isRelationLike(value) ? value : this._castWhereValue(resolved, value);
+      normalized[resolved] = value;
     }
     const block = (tableName: string) => lookupTableKlassFromJoinDependencies.call(this, tableName);
     const parts = this.predicateBuilder.buildFromHash(normalized, block);
@@ -1361,11 +1364,7 @@ function havingBang(
     throw argumentError(`Unsupported argument type for having: ${typeof opts} (${String(opts)})`);
   }
 
-  const cast: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(opts)) {
-    cast[key] = isRelationLike(value) ? value : this._castWhereValue(key, value);
-  }
-  this._havingClause.predicates.push(...this.predicateBuilder.buildFromHash(cast));
+  this._havingClause.predicates.push(...this.predicateBuilder.buildFromHash(opts));
   return this;
 }
 

--- a/packages/activerecord/src/relation/where-raw-bind-defer.trails.test.ts
+++ b/packages/activerecord/src/relation/where-raw-bind-defer.trails.test.ts
@@ -1,0 +1,53 @@
+/**
+ * trails-specific regression guard (no Rails counterpart): `Relation#where` /
+ * `whereNot` / `whereAny` / `having` hand hash values RAW to PredicateBuilder,
+ * like Rails' build_where_clause (query_methods.rb) — the QueryAttribute bind
+ * owns casting/serialization at compile time (predicate_builder.rb:57-69 →
+ * build_bind_attribute → value_for_database). An earlier trails invention
+ * (`Relation#_castWhereValue`, removed by RFC 0067) eagerly pre-cast string
+ * values up front; these tests pin the deferred-bind behavior on every entry
+ * point that used it, for the un-castable inputs the pre-cast used to mangle:
+ * an un-castable string must serialize to NULL in the bind (`col = NULL` /
+ * `IN (NULL)`, matches nothing) — never route onto the explicit-nil
+ * `IS NULL` / `IS NOT NULL` path (matches nulls).
+ */
+import { describe, it, expect } from "vitest";
+import "../index.js";
+import { registerModel } from "../associations.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+import { Topic } from "../test-helpers/models/topic.js";
+
+registerModel(Topic);
+
+describe("where value defer-to-bind casting", () => {
+  const { topics } = fixtures(["topics"]);
+
+  it("whereNot with an un-castable string binds it instead of IS NOT NULL", async () => {
+    const first = topics("first");
+    await first.update({ parent_id: 0 });
+    const rel = Topic.whereNot({ parent_id: "not-a-number" });
+    expect(rel.toSql()).not.toMatch(/IS NOT NULL/i);
+    // `parent_id != NULL` matches nothing — including rows whose parent_id IS NULL.
+    expect(await rel).toHaveLength(0);
+  });
+
+  it("whereAny with an un-castable string binds it instead of IS NULL", async () => {
+    const rel = Topic.all().whereAny({ parent_id: "not-a-number" }, { written_on: "" });
+    expect(rel.toSql()).not.toMatch(/IS NULL/i);
+    expect(await rel).toHaveLength(0);
+  });
+
+  it("having with an un-castable string binds it instead of IS NULL", async () => {
+    const rel = Topic.group("parent_id").having({ parent_id: "not-a-number" });
+    expect(rel.toSql()).not.toMatch(/IS NULL/i);
+    expect(await rel).toHaveLength(0);
+  });
+
+  it("non-string scalars for a numeric column take the same bind path as strings", async () => {
+    // The retired pre-cast only touched `typeof value === "string"`; a raw
+    // number and its string spelling must compile to the same predicate shape.
+    const numeric = Topic.where({ parent_id: 1 }).toSql();
+    const stringy = Topic.where({ parent_id: "1" }).toSql();
+    expect(stringy).toBe(numeric);
+  });
+});

--- a/packages/activerecord/src/relation/where-raw-bind-defer.trails.test.ts
+++ b/packages/activerecord/src/relation/where-raw-bind-defer.trails.test.ts
@@ -38,7 +38,8 @@ describe("where value defer-to-bind casting", () => {
   });
 
   it("having with an un-castable string binds it instead of IS NULL", async () => {
-    const rel = Topic.group("parent_id").having({ parent_id: "not-a-number" });
+    // Select only the grouped column — PG rejects an ungrouped `topics.*`.
+    const rel = Topic.select("parent_id").group("parent_id").having({ parent_id: "not-a-number" });
     expect(rel.toSql()).not.toMatch(/IS NULL/i);
     expect(await rel).toHaveLength(0);
   });


### PR DESCRIPTION
## Summary

Removes the eager `where`-value pre-cast machinery (`Relation#_castWhereValue`
/ `_castPreservingUncastable`, a trails invention with no Rails analog) and
lets the `QueryAttribute` bind own all casting/serialization at compile time,
matching Rails' design.

## Audit (acceptance criterion 1)

Rails' `build_where_clause` hands hash values raw to `PredicateBuilder`;
casting happens only in the bind (`predicate_builder.rb:57-69` →
`build_bind_attribute` → `QueryAttribute#value_for_database`). trails
duplicated that cast up front, string-only, at four entry points:

- `buildWhereClause` (where hash path, `relation/query-methods.ts`)
- `havingBang` (`relation/query-methods.ts`)
- `whereNot` hash path (`relation.ts`)
- `whereAny` (`relation.ts`)

trails' `PredicateBuilder` already resolves each bound's column type via the
same relation/context/table cascade Rails gets from `table.type(column_name)`,
and its `QueryAttribute` casts (`typeCast`) and serializes
(`valueForDatabase`) at compile time. Every constraint the pre-cast was
thought to carry is already owned downstream:

- **force-equality arrays** (PG array / serialized): the pre-cast explicitly
  skipped them; the builder's force-equality scan binds the array whole.
- **un-castable strings** (#4848's `_castPreservingUncastable`): the bind
  serializes them to NULL — `col = NULL` / `IN (NULL)` (matches nothing) —
  and `isNil()` keys off `valueBeforeTypeCast`, so the `IS NULL` path is
  never misrouted.
- **PK int8→BigInt**: `IntegerType#cast` in the bind's resolved type handles
  it; `Base._castAttributeValue` remains for the `find`-path callers
  (core.ts, inheritance.ts), which are out of scope here.

So nothing needs to remain: the machinery is deleted entirely — no
SKIP_GROUPS rationale required (criterion's preferred outcome).

## Shape (criterion 2)

No pre-cast remains, so no string-only routing and no collapse-to-nil.
Non-string scalars and strings now take the identical bind path (pinned by
test).

## Coverage (criterion 3)

- Rails' `where_test.rb` numeric/boolean/decimal/duration-for-string-column
  and integer/emoji-for-binary-column tests were already ported and still
  pass on the bind-only path.
- New `where-raw-bind-defer.trails.test.ts` pins the deferred-bind behavior
  at each former pre-cast entry point (`whereNot` / `whereAny` / `having`
  with un-castable strings never emit `IS [NOT] NULL`; a raw number and its
  string spelling compile to the same SQL). These are convergence pins — the
  refactor is intentionally behavior-preserving after #4848, so they pass on
  baseline too.

## Testing

`where`, `where-chain(+trails)`, `where-clause`, `predicate-builder(+trails)`,
`query-attribute`, `or`, `and`, `merging`, `composite-where`, `relation`,
`finder-methods`, `calculations`, `enum`, `mutation`, `unscope-coverage`,
`has-many-associations`, `value-accessor-semantics` — all green locally;
`pnpm typecheck` and eslint clean.

Closes-story: relation-where-value-eager-precast-vs-rails-defer
