### PR TITLE
refactor(arel): delete default quoters from production surface; visitors require a connection

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql/oid/array-encode-parity.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/array-encode-parity.trails.test.ts
@@ -1,16 +1,17 @@
 import { describe, it, expect } from "vitest";
-import { Visitors } from "@blazetrails/arel";
+import { postgresqlTestConnection } from "@blazetrails/arel/src/test-helpers/connection.js";
 import { Array as OidArray, Data as ArrayData } from "./array.js";
 import { StringType } from "@blazetrails/activemodel";
 
-// trails-only: the connection-less Arel quoter (`postgresqlDefaultQuoter`)
+// trails-only: arel's PG test quoter (`postgresqlTestConnection`, formerly the
+// production `postgresqlDefaultQuoter` — RFC 0007 moved it to test-helpers)
 // re-implements the array literal that the adapter builds via
 // `quote(ArrayData)` -> `encode_array`. Three PRs (#4867, #4869, #4872) each had
 // to re-converge the copy after it drifted. Both now share
 // `encodeArrayElement`; this pins that they agree byte-for-byte.
 describe("PostgreSQL array literal encoding", () => {
   const encoder = new OidArray(new StringType());
-  const arelQuoter = Visitors.postgresqlDefaultQuoter;
+  const arelQuoter = postgresqlTestConnection;
 
   const cases: [string, unknown[]][] = [
     ["strings", ["a", "b"]],

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -5474,8 +5474,11 @@ export class Relation<T extends Base> {
   }
 
   private _arelVisitor(): Visitors.ToSql {
-    const adapter = this._resolveAdapter();
-    return adapter?.visitor ?? new Visitors.ToSql(adapter ?? undefined);
+    // `_conn()` (not `_resolveAdapter()`) so an unconnected model raises
+    // ConnectionNotEstablished, as Rails does — the connection-less ANSI
+    // fallback this used to reach was the invention RFC 0007 deleted.
+    const adapter = this._conn();
+    return adapter.visitor ?? new Visitors.ToSql(adapter);
   }
 
   /** Returns the adapter's visitor when defined, or null. */
@@ -5485,7 +5488,6 @@ export class Relation<T extends Base> {
 
   /**
    * Compile a SelectManager's AST through the adapter visitor (`_arelVisitor`).
-   * Falls back to the default ANSI ToSql when no connection is established.
    * Sets _lastSelectRetryable and _lastSelectBinds for the execution call sites.
    */
   /**

--- a/packages/activerecord/src/relation/predicate-builder.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { testConnection } from "@blazetrails/arel/src/test-helpers/connection.js";
 import { Table, Visitors, Nodes } from "@blazetrails/arel";
 import { PredicateBuilder } from "./predicate-builder.js";
 import { Substitute } from "../statement-cache.js";
@@ -135,7 +136,7 @@ describe("PredicateBuilderTest", () => {
     const [node] = Topic.predicateBuilder.buildFromHash({
       "schema.table.column": "value",
     });
-    const sql = new Visitors.ToSql().compile(node);
+    const sql = new Visitors.ToSql(testConnection).compile(node);
     // Arel resolves "schema.table" as schema.table identifier, producing:
     // "schema"."table"."column" = ?  (the value is a BindParam, not inlined —
     // Rails parity, see Arel BindParam#toSql).
@@ -155,7 +156,7 @@ describe("PredicateBuilderTest", () => {
 
   describe("buildFromHash", () => {
     const table = castedTable("posts");
-    const compile = (node: Nodes.Node) => new Visitors.ToSql().compile(node);
+    const compile = (node: Nodes.Node) => new Visitors.ToSql(testConnection).compile(node);
 
     it("builds equality for scalars", () => {
       const builder = new PredicateBuilder(new TableMetadata(null, table));
@@ -206,7 +207,7 @@ describe("PredicateBuilderTest", () => {
     it("does not dereference a plain object literal to its id", () => {
       const builder = new PredicateBuilder(new TableMetadata(null, table));
       const node = builder.build(table.get("title"), { id: 5 });
-      const [sql, binds] = new Visitors.ToSql().compileWithBinds(node);
+      const [sql, binds] = new Visitors.ToSql(testConnection).compileWithBinds(node);
       expect(sql).toContain('"posts"."title" = ?');
       // The whole object is bound, not the dereferenced `5`.
       expect((binds[0] as { value: unknown }).value).toEqual({ id: 5 });
@@ -215,7 +216,7 @@ describe("PredicateBuilderTest", () => {
     it("does not dereference a plain object literal inside an array", () => {
       const builder = new PredicateBuilder(new TableMetadata(null, table));
       const node = builder.build(table.get("title"), [{ id: 5 }]);
-      const [, binds] = new Visitors.ToSql().compileWithBinds(node);
+      const [, binds] = new Visitors.ToSql(testConnection).compileWithBinds(node);
       expect((binds[0] as { value: unknown }).value).toEqual({ id: 5 });
     });
 
@@ -229,7 +230,7 @@ describe("PredicateBuilderTest", () => {
       }
       const builder = new PredicateBuilder(new TableMetadata(null, table));
       const node = builder.build(table.get("id"), [new NotARecord(5), new NotARecord(7)]);
-      const sql = new Visitors.ToSql().compile(node);
+      const sql = new Visitors.ToSql(testConnection).compile(node);
       // The objects flow into HomogeneousIn untouched — they are NOT flattened
       // to `IN (5, 7)` the way a real AR record would be.
       expect(sql).not.toMatch(/IN \(5, 7\)/);
@@ -261,7 +262,7 @@ describe("PredicateBuilderTest", () => {
       const feTable = new Table("posts", { typeCaster: { typeForAttribute: () => forceEqType } });
       const builder = new PredicateBuilder(new TableMetadata(null, feTable));
       const node = builder.build(feTable.get("tags"), [1, 2]);
-      const [sql, binds] = new Visitors.ToSql().compileWithBinds(node);
+      const [sql, binds] = new Visitors.ToSql(testConnection).compileWithBinds(node);
       // Single equality bind, NOT `IN (?, ?)`.
       expect(sql).toContain('"posts"."tags" = ?');
       expect(sql).not.toMatch(/IN \(/);
@@ -272,7 +273,7 @@ describe("PredicateBuilderTest", () => {
 
   describe("buildNegatedFromHash", () => {
     const table = castedTable("posts");
-    const compile = (node: Nodes.Node) => new Visitors.ToSql().compile(node);
+    const compile = (node: Nodes.Node) => new Visitors.ToSql(testConnection).compile(node);
 
     it("builds IS NOT NULL for null values", () => {
       const builder = new PredicateBuilder(new TableMetadata(null, table));
@@ -303,7 +304,7 @@ describe("PredicateBuilderTest", () => {
     it("does not dereference a plain object literal to its id when negated", () => {
       const builder = new PredicateBuilder(new TableMetadata(null, table));
       const node = builder.buildNegated(table.get("title"), { id: 5 });
-      const sql = new Visitors.ToSql().compile(node);
+      const sql = new Visitors.ToSql(testConnection).compile(node);
       // Negation binds the RHS (Rails inverts a positively-built, bound
       // predicate), so the value rides a QueryAttribute bind rather than being
       // inlined.
@@ -324,7 +325,7 @@ describe("PredicateBuilderTest", () => {
       const [node] = builder.buildNegatedFromHash({
         id: [new NotARecord(5), new NotARecord(7)],
       });
-      const sql = new Visitors.ToSql().compile(node);
+      const sql = new Visitors.ToSql(testConnection).compile(node);
       expect(sql).not.toMatch(/NOT IN \(5, 7\)/);
     });
   });
@@ -342,7 +343,7 @@ describe("PredicateBuilderTest", () => {
       const table = castedTable("users");
       const builder = new PredicateBuilder(new TableMetadata(null, table));
       const node = builder.build(table.get("name"), "alice");
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       const [sql, binds] = visitor.compileWithBinds(node);
       expect(sql).toContain('"users"."name" = ?');
       expect(binds).toHaveLength(1);
@@ -352,7 +353,7 @@ describe("PredicateBuilderTest", () => {
       const table = castedTable("users");
       const builder = new PredicateBuilder(new TableMetadata(null, table));
       const node = builder.build(table.get("name"), new Substitute());
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       const [sql, binds] = visitor.compileWithBinds(node);
       expect(sql).toContain('"users"."name" = ?');
       expect(binds).toHaveLength(1);
@@ -365,7 +366,7 @@ describe("PredicateBuilderTest", () => {
       const table = castedTable("users");
       const builder = new PredicateBuilder(new TableMetadata(null, table));
       const node = builder.build(table.get("name"), "alice");
-      const visitor = new Visitors.ToSql();
+      const visitor = new Visitors.ToSql(testConnection);
       // The value is wrapped in a BindParam, so raw Arel compile emits `?`
       // (mirrors Rails); the value is carried as a bind, not inlined.
       expect(visitor.compile(node)).toBe('"users"."name" = ?');
@@ -403,7 +404,7 @@ describe("PredicateBuilderTest", () => {
       const meta = new TableMetadata(PbTestPost as any, (PbTestPost as any).arelTable);
       const builder = meta.predicateBuilder;
       const nodes = builder.buildFromHash({ authors: { name: "Rails" } });
-      const sql = nodes.map((n) => new Visitors.ToSql().compile(n)).join(" AND ");
+      const sql = nodes.map((n) => new Visitors.ToSql(testConnection).compile(n)).join(" AND ");
       expect(sql).toContain('"authors"."name"');
       expect(sql).toContain("= ?");
       expect(sql).not.toContain('"posts"."authors"');
@@ -416,7 +417,7 @@ describe("PredicateBuilderTest", () => {
       const meta = new TableMetadata(PbTestPost as any, (PbTestPost as any).arelTable);
       const builder = meta.predicateBuilder;
       const nodes = builder.buildFromHash({ writer: { name: "Rails" } });
-      const sql = nodes.map((n) => new Visitors.ToSql().compile(n)).join(" AND ");
+      const sql = nodes.map((n) => new Visitors.ToSql(testConnection).compile(n)).join(" AND ");
       expect(sql).toContain('"writer"."name"');
       expect(sql).toContain("= ?");
     });
@@ -425,7 +426,7 @@ describe("PredicateBuilderTest", () => {
       const meta = new TableMetadata(PbTestPost as any, (PbTestPost as any).arelTable);
       const builder = meta.predicateBuilder;
       const nodes = builder.buildNegatedFromHash({ authors: { name: "Rails" } });
-      const sql = nodes.map((n) => new Visitors.ToSql().compile(n)).join(" AND ");
+      const sql = nodes.map((n) => new Visitors.ToSql(testConnection).compile(n)).join(" AND ");
       expect(sql).toContain('"authors"."name"');
       // Negation binds the RHS, so 'Rails' rides a QueryAttribute bind.
       const bound = (nodes[0] as unknown as { right: { value: { value: unknown } } }).right.value
@@ -449,7 +450,7 @@ describe("PredicateBuilderTest", () => {
         const meta = new TableMetadata(PbTestProduct as any, (PbTestProduct as any).arelTable);
         const builder = meta.predicateBuilder;
         const nodes = builder.buildFromHash({ price: { foo: "bar" } });
-        const sql = nodes.map((n) => new Visitors.ToSql().compile(n)).join(" AND ");
+        const sql = nodes.map((n) => new Visitors.ToSql(testConnection).compile(n)).join(" AND ");
         expect(sql).toContain('"products"."price"');
         expect(sql).not.toContain('"price"."foo"');
       } finally {

--- a/packages/activerecord/src/relation/predicate-builder.trails.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.trails.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { testConnection } from "@blazetrails/arel/src/test-helpers/connection.js";
 import { IntegerType } from "@blazetrails/activemodel";
 import { Table, Visitors } from "@blazetrails/arel";
 import { Company, Firm } from "../test-helpers/models/company.js";
@@ -47,12 +48,14 @@ describe("PredicateBuilder positive-equality bind typing", () => {
   };
 
   it("collapses a joined out-of-range equality to 1=0", () => {
-    const sql = new Visitors.ToSql().compile(buildJoinedEquality(OUT_OF_RANGE));
+    const sql = new Visitors.ToSql(testConnection).compile(buildJoinedEquality(OUT_OF_RANGE));
     expect(sql).toBe("1=0");
   });
 
   it("leaves an in-range joined equality as a bound predicate", () => {
-    const [sql, binds] = new Visitors.ToSql().compileWithBinds(buildJoinedEquality(7n));
+    const [sql, binds] = new Visitors.ToSql(testConnection).compileWithBinds(
+      buildJoinedEquality(7n),
+    );
     expect(sql).not.toContain("1=0");
     expect(binds).toHaveLength(1);
   });

--- a/packages/arel/src/quote-array.test.ts
+++ b/packages/arel/src/quote-array.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { quoteArrayLiteral } from "./quote-array.js";
-import { defaultQuoter } from "./visitors/default-quoter.js";
+import { defaultQuoter } from "./test-helpers/default-quoter.js";
 import { BinaryData } from "@blazetrails/activemodel";
 import { BigDecimal } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";

--- a/packages/arel/src/quote-array.ts
+++ b/packages/arel/src/quote-array.ts
@@ -112,7 +112,7 @@ function typeCastArrayElement(
   // connection.ts) carries no `quotedDate`/`quotedTime` to dispatch onto —
   // Rails' Arel does no value formatting, so those live on the adapter — which
   // is exactly what `formatElement` exists to supply: the only caller,
-  // `postgresqlDefaultQuoter.quote` (visitors/default-quoter.ts:231), routes
+  // `postgresqlDefaultQuoter.quote` (test-helpers/default-quoter.ts), routes
   // date-likes through its `quotedDate` before the value reaches here. A
   // Temporal value (trails' `Type::Time::Value` analogue) has no `toISOString`
   // and so is NOT covered by that hook; it raises here rather than silently

--- a/packages/arel/src/test-helpers/connection.ts
+++ b/packages/arel/src/test-helpers/connection.ts
@@ -1,11 +1,7 @@
 import type { ArelConnection } from "../visitors/connection.js";
 import type { ArelEngine } from "../nodes/node.js";
 import { ToSql } from "../visitors/to-sql.js";
-import {
-  defaultQuoter,
-  mysqlDefaultQuoter,
-  postgresqlDefaultQuoter,
-} from "../visitors/default-quoter.js";
+import { defaultQuoter, mysqlDefaultQuoter, postgresqlDefaultQuoter } from "./default-quoter.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 
 /**
@@ -26,20 +22,17 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
  * adapter as Rails does.
  *
  * The point of routing through this module is that the connection is *explicit at
- * the call site*: no visitor silently falls back to a default. The underlying
- * `defaultQuoter` values are the invention RFC 0007 is deleting — once every call
- * site names its connection, the visitor constructor defaults go away and these
- * bindings become the only reference, at which point they collapse into this file.
+ * the call site*: no visitor falls back to a default — the constructor defaults
+ * (and the production `defaultQuoter` surface) were deleted by RFC 0007. The
+ * quoting hosts now live next door in `test-helpers/default-quoter.ts`, a
+ * permanent test-only stub (see its header for why the package split forces it).
  *
  * @internal
  */
 export const testConnection: ArelConnection = defaultQuoter;
 
 /**
- * The MySQL/PostgreSQL analogues of {@link testConnection}: the adapter-specific
- * quoters the `MySQL` and `PostgreSQL` visitors otherwise fall back to as their
- * constructor default (`visitors/mysql.ts`, `visitors/postgresql.ts`). Naming them
- * at the call site is what lets those defaults be deleted; unlike the generic
+ * The MySQL/PostgreSQL analogues of {@link testConnection}. Unlike the generic
  * `defaultQuoter`, they render adapter-specific forms (PG array literals, MySQL
  * backticks) the Arel visitor tests assert on.
  *

--- a/packages/arel/src/test-helpers/default-quoter.ts
+++ b/packages/arel/src/test-helpers/default-quoter.ts
@@ -1,11 +1,11 @@
-import type { ArelConnection } from "./connection.js";
-import { quoteSchemaQualifiedName } from "./split-schema-qualified-name.js";
+import type { ArelConnection } from "../visitors/connection.js";
+import { quoteSchemaQualifiedName } from "../visitors/split-schema-qualified-name.js";
 import { quoteArrayLiteral } from "../quote-array.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 
-// Standalone comment sanitize for connection-less `Node#toSql()` (debug aid):
-// strips block-comment delimiters (leaving `--` alone, like Rails' abstract
-// sanitize). Real adapters override via `AbstractAdapter#sanitizeAsSqlComment`.
+// Standalone comment sanitize for these test hosts: strips block-comment
+// delimiters (leaving `--` alone, like Rails' abstract sanitize). Real
+// adapters override via `AbstractAdapter#sanitizeAsSqlComment`.
 function defaultSanitizeAsSqlComment(value: string): string {
   return String(value)
     .replace(/[\r\n]+/g, " ")
@@ -32,7 +32,7 @@ type TemporalDateLike =
 // reached through `@connection.quote`. Real adapters own the authoritative,
 // timezone-aware version in
 // packages/activerecord/src/connection-adapters/abstract/quoting.ts; this copy
-// only serves the connection-less `Node#toSql()` debug path.
+// only serves arel's own test suite.
 //
 // `quoted_date`/`quoted_time` deliberately stay OFF `ArelConnection`: Rails puts
 // them on the adapter (`ConnectionAdapters::Quoting`), and Arel reaches them only
@@ -169,8 +169,9 @@ function quoteScalar(this: ArelConnection, value: unknown): string {
 }
 
 /**
- * MySQL default quoter: backtick-quoted identifiers, same escaping as the abstract adapter.
- * Used when `new MySQL()` is constructed without a connection quoter (test / debug use).
+ * MySQL test quoter: backtick-quoted identifiers, same escaping as the abstract
+ * adapter. Test-only — surfaced as `mysqlTestConnection` (connection.ts); no
+ * visitor falls back to it.
  */
 export const mysqlDefaultQuoter: ArelConnection = {
   quoteTableName(name: string): string {
@@ -232,12 +233,15 @@ export const mysqlDefaultQuoter: ArelConnection = {
 };
 
 /**
- * Default connection used when no adapter is passed to a visitor.
- * Emits ANSI double-quoted identifiers and single-quoted strings —
- * matches the Rails abstract-adapter defaults.
+ * Generic test connection: ANSI double-quoted identifiers and single-quoted
+ * strings, matching the Rails abstract-adapter defaults.
  *
- * `Node#toSql()` (no connection in scope) uses this; treat its output
- * as a debug aid, not production SQL — same as Rails.
+ * Test-only, and permanently so as long as `packages/arel` ships its own suite:
+ * Rails' Arel tests reach a real adapter via `Table.engine.lease_connection`
+ * (one gem, no cycle), but `@blazetrails/activerecord` depends on
+ * `@blazetrails/arel`, so arel-side tests cannot import a real adapter without
+ * a circular dependency. This host stands in for that adapter; production code
+ * always passes a real connection (RFC 0007) — no visitor defaults to this.
  */
 export const defaultQuoter: ArelConnection = {
   quoteTableName(name: string): string {
@@ -293,12 +297,12 @@ export const defaultQuoter: ArelConnection = {
 };
 
 /**
- * PostgreSQL quoter used when `new PostgreSQL()` is constructed without a
- * connection (test / debug use). Rails' `Arel::Visitors::PostgreSQL` has no
- * `quote` override — array literals are formatted by the adapter
- * (`quote(OID::Array::Data)` → `encode_array`, postgresql/quoting.rb:221-226).
- * Trails' connection-less visitors have no adapter to reach, so this host
- * carries the minimal array-literal encoding in the adapter's place.
+ * PostgreSQL test quoter, surfaced as `postgresqlTestConnection`
+ * (connection.ts). Rails' `Arel::Visitors::PostgreSQL` has no `quote` override
+ * — array literals are formatted by the adapter (`quote(OID::Array::Data)` →
+ * `encode_array`, postgresql/quoting.rb:221-226). Arel-side tests have no
+ * adapter to reach (see `defaultQuoter`), so this host carries the minimal
+ * array-literal encoding in the adapter's place.
  */
 export const postgresqlDefaultQuoter: ArelConnection = {
   ...defaultQuoter,

--- a/packages/arel/src/test-setup-engine.ts
+++ b/packages/arel/src/test-setup-engine.ts
@@ -8,5 +8,5 @@ import { fakeRecordEngine } from "./test-helpers/connection.js";
 // compiles through `Table.engine`, installing that double suite-wide is what
 // makes every bare `.toSql()` render `'t'`/`'f'` for booleans, exactly as Rails'
 // arel suite does. This replaces the earlier generic `Visitors::ToSql`, which
-// anchored the suite on the connection-less `defaultQuoter` RFC 0007 is deleting.
+// anchored the suite on the connection-less `defaultQuoter` RFC 0007 deleted.
 Table.engine = fakeRecordEngine;

--- a/packages/arel/src/visitors/index.ts
+++ b/packages/arel/src/visitors/index.ts
@@ -1,5 +1,4 @@
 export { ToSql, type ArelConnection, type ArelQuoter } from "./to-sql.js";
-export { defaultQuoter, mysqlDefaultQuoter, postgresqlDefaultQuoter } from "./default-quoter.js";
 export { substituteBoundValues } from "./substitute-bound-values.js";
 export {
   splitSchemaQualifiedName,

--- a/packages/arel/src/visitors/mysql.test.ts
+++ b/packages/arel/src/visitors/mysql.test.ts
@@ -28,13 +28,15 @@ describe("MysqlTest", () => {
     it("should know how to visit", () => {
       const node = users.get("name").matchesRegexp("foo.*");
       expect(node).toBeInstanceOf(Nodes.Regexp);
-      expect(new Visitors.MySQL().compile(node)).toBe("`users`.`name` REGEXP 'foo.*'");
+      expect(new Visitors.MySQL(mysqlTestConnection).compile(node)).toBe(
+        "`users`.`name` REGEXP 'foo.*'",
+      );
     });
 
     it("can handle subqueries", () => {
       const subquery = users.project("id").where(users.get("name").matchesRegexp("foo.*"));
       const node = users.get("id").in(subquery);
-      expect(new Visitors.MySQL().compile(node)).toBe(
+      expect(new Visitors.MySQL(mysqlTestConnection).compile(node)).toBe(
         "`users`.`id` IN (SELECT id FROM `users` WHERE `users`.`name` REGEXP 'foo.*')",
       );
     });
@@ -44,7 +46,7 @@ describe("MysqlTest", () => {
     it("can handle subqueries", () => {
       const subquery = users.project("id").where(users.get("name").doesNotMatchRegexp("foo.*"));
       const node = users.get("id").in(subquery);
-      expect(new Visitors.MySQL().compile(node)).toBe(
+      expect(new Visitors.MySQL(mysqlTestConnection).compile(node)).toBe(
         "`users`.`id` IN (SELECT id FROM `users` WHERE `users`.`name` NOT REGEXP 'foo.*')",
       );
     });
@@ -52,7 +54,9 @@ describe("MysqlTest", () => {
     it("should know how to visit", () => {
       const node = users.get("name").doesNotMatchRegexp("foo.*");
       expect(node).toBeInstanceOf(Nodes.NotRegexp);
-      expect(new Visitors.MySQL().compile(node)).toBe("`users`.`name` NOT REGEXP 'foo.*'");
+      expect(new Visitors.MySQL(mysqlTestConnection).compile(node)).toBe(
+        "`users`.`name` NOT REGEXP 'foo.*'",
+      );
     });
   });
 

--- a/packages/arel/src/visitors/mysql.ts
+++ b/packages/arel/src/visitors/mysql.ts
@@ -3,7 +3,6 @@ import * as Nodes from "../nodes/index.js";
 import { SQLString } from "../collectors/sql-string.js";
 import { ToSql, cteRelationSelfWraps } from "./to-sql.js";
 import type { ArelConnection } from "./connection.js";
-import { mysqlDefaultQuoter } from "./default-quoter.js";
 
 /**
  * MySQL visitor — dialect tweaks on top of generic ToSql.
@@ -11,7 +10,7 @@ import { mysqlDefaultQuoter } from "./default-quoter.js";
  * Mirrors: Arel::Visitors::MySQL
  */
 export class MySQL extends ToSql {
-  constructor(connection: ArelConnection = mysqlDefaultQuoter) {
+  constructor(connection: ArelConnection) {
     super(connection);
   }
 

--- a/packages/arel/src/visitors/mysql.ts
+++ b/packages/arel/src/visitors/mysql.ts
@@ -2,7 +2,6 @@ import { Node } from "../nodes/node.js";
 import * as Nodes from "../nodes/index.js";
 import { SQLString } from "../collectors/sql-string.js";
 import { ToSql, cteRelationSelfWraps } from "./to-sql.js";
-import type { ArelConnection } from "./connection.js";
 
 /**
  * MySQL visitor — dialect tweaks on top of generic ToSql.
@@ -10,10 +9,6 @@ import type { ArelConnection } from "./connection.js";
  * Mirrors: Arel::Visitors::MySQL
  */
 export class MySQL extends ToSql {
-  constructor(connection: ArelConnection) {
-    super(connection);
-  }
-
   // Mirrors Rails' MySQL visitor: `CAST(expr AS BINARY)` (the explicit
   // cast form) rather than the prefix-`BINARY ` operator the previous
   // Trails impl used. Both force binary comparison; this matches Rails'

--- a/packages/arel/src/visitors/postgres.test.ts
+++ b/packages/arel/src/visitors/postgres.test.ts
@@ -123,7 +123,7 @@ describe("PostgresTest", () => {
 
   describe("Nodes::BindParam", () => {
     it("increments each bind param", () => {
-      const visitor = new Visitors.PostgreSQLWithBinds();
+      const visitor = new Visitors.PostgreSQLWithBinds(postgresqlTestConnection);
       const a = users.get("id").eq(new Nodes.BindParam());
       const b = users.get("name").eq(new Nodes.BindParam());
       const sql = visitor.compile(new Nodes.And([a, b]));
@@ -132,7 +132,7 @@ describe("PostgresTest", () => {
     });
 
     it("compileWithBinds extracts values with $N placeholders", () => {
-      const visitor = new Visitors.PostgreSQLWithBinds();
+      const visitor = new Visitors.PostgreSQLWithBinds(postgresqlTestConnection);
       const a = users.get("id").eq(new Nodes.BindParam(42));
       const b = users.get("name").eq(new Nodes.BindParam("alice"));
       const [sql, binds] = visitor.compileWithBinds(new Nodes.And([a, b]));
@@ -144,7 +144,7 @@ describe("PostgresTest", () => {
     });
 
     it("compileWithBinds uses $N placeholders for Quoted Date values", () => {
-      const visitor = new Visitors.PostgreSQLWithBinds();
+      const visitor = new Visitors.PostgreSQLWithBinds(postgresqlTestConnection);
       const d = Temporal.Instant.from("2020-01-02T12:00:00.000Z");
       const node = users.get("created_at").eq(new Nodes.Quoted(d));
       const [sql, binds] = visitor.compileWithBinds(node);

--- a/packages/arel/src/visitors/postgresql.ts
+++ b/packages/arel/src/visitors/postgresql.ts
@@ -2,8 +2,6 @@ import { Node } from "../nodes/node.js";
 import * as Nodes from "../nodes/index.js";
 import { SQLString } from "../collectors/sql-string.js";
 import { ToSql } from "./to-sql.js";
-import { postgresqlDefaultQuoter } from "./default-quoter.js";
-import type { ArelConnection } from "./connection.js";
 
 /**
  * PostgreSQL visitor — extends generic ToSql with PostgreSQL-specific features.
@@ -11,17 +9,6 @@ import type { ArelConnection } from "./connection.js";
  * Mirrors: Arel::Visitors::PostgreSQL
  */
 export class PostgreSQL extends ToSql {
-  // Rails' Arel::Visitors::PostgreSQL defines no constructor — it inherits
-  // ToSql's, and @connection is always a real adapter. Trails constructs
-  // visitors with no connection (Node#toSql(), visitor unit tests), so the
-  // default has to name a PG-flavoured quoting host rather than the ANSI one.
-  // This is the only Rails-absent member here; the quote override it replaces
-  // was the larger deviation (Rails formats arrays in the adapter's quote —
-  // postgresql/quoting.rb:221-226 — never in the visitor).
-  constructor(connection: ArelConnection = postgresqlDefaultQuoter) {
-    super(connection);
-  }
-
   protected override visitArelNodesMatches(node: Nodes.Matches, collector: SQLString): SQLString {
     this.visit(node.left, collector);
     collector.append(node.caseSensitive ? " LIKE " : " ILIKE ");

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -1911,7 +1911,7 @@ describe("the to_sql visitor", () => {
         }
       }
       const tbl = new Table("users");
-      const v = new NumberedVisitor();
+      const v = new NumberedVisitor(testConnection);
       // Only BindParam routes through addBind (and therefore bindBlock); Casted
       // and Quoted values inline their quoted literal (Rails to_sql.rb:87-88).
       const [sql] = v.compileWithBinds(
@@ -1944,7 +1944,7 @@ describe("the to_sql visitor", () => {
           return (i: number) => `$${i}`;
         }
       }
-      const v = new NumberedVisitor();
+      const v = new NumberedVisitor(testConnection);
       const collector = new Collectors.SQLString();
       (
         v as unknown as { visitActiveModelAttribute(o: AMAttribute, c: Collectors.SQLString): void }

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -16,7 +16,6 @@ import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 // here so api:compare finds it where Rails defines it.
 export { UnsupportedVisitError };
 
-import { defaultQuoter } from "./default-quoter.js";
 export type { ArelConnection } from "./connection.js";
 import type { ArelConnection } from "./connection.js";
 
@@ -183,7 +182,7 @@ function hex4(code: number): string {
 export class ToSql extends Visitor {
   protected readonly connection: ArelConnection;
 
-  constructor(connection: ArelConnection = defaultQuoter) {
+  constructor(connection: ArelConnection) {
     super();
     this.connection = connection;
   }
@@ -1669,8 +1668,7 @@ export class ToSql extends Visitor {
    * Mirrors `to_sql.rb#quote` (to_sql.rb:867-870): SqlLiteral passes through,
    * everything else is handed to the connection. Rails' Arel does no value
    * formatting of its own — every date/array/binary decision lives in the
-   * adapter's `quote`. Connection-less visitors reach the default quoters in
-   * `default-quoter.ts`, which stand in for an adapter.
+   * adapter's `quote`.
    */
   protected quote(value: unknown): string {
     if (value instanceof Nodes.SqlLiteral) return value.value;

--- a/packages/arel/src/visitors/visitor.ts
+++ b/packages/arel/src/visitors/visitor.ts
@@ -24,7 +24,12 @@ function describeClass(object: unknown): string {
  * reject any ctor with a more-specific parameter type.
  */
 export type NodeCtor = abstract new (...args: never[]) => object;
-type VisitorCtor = typeof Visitor;
+// Structural, not `typeof Visitor`: concrete visitors now take a required
+// `ArelConnection` constructor argument (RFC 0007 deleted the defaults), so
+// their constructor signatures are not assignable to the abstract base's.
+// Only the static dispatch surface matters here, never construction.
+type VisitorCtor = (abstract new (...args: never[]) => Visitor) &
+  Pick<typeof Visitor, "dispatchCache">;
 
 const PER_CLASS_CACHE = new WeakMap<VisitorCtor, Map<NodeCtor, string>>();
 


### PR DESCRIPTION
Final phase of RFC 0007: delete the connection-less default-quoter invention from arel's production surface.

## What

- **Moved** `packages/arel/src/visitors/default-quoter.ts` → `packages/arel/src/test-helpers/default-quoter.ts`, bodies unchanged (the shape pinned in #5032 review — no rewrite). It is a **permanent** test-only stub, not a transitional one: Rails' Arel tests reach a real adapter via `Table.engine.lease_connection` (one gem), but `@blazetrails/activerecord` depends on `@blazetrails/arel`, so arel-side tests cannot import a real adapter without a cycle. What RFC 0007 eliminates is the *production* surface, not the existence of a test connection. Rails anchor documented in the file header (`to_sql.rb:867-870`; adapter twin in `connection-adapters/abstract/quoting.ts`).
- **Deleted the constructor defaults**: `ToSql` and `MySQL` now require an `ArelConnection`; no visitor supplies a fallback.
- **Deleted the `PostgreSQL` constructor entirely** — Rails' `arel/visitors/postgresql.rb` declares none; it existed only to name the default.
- **Dropped the `Visitors.*DefaultQuoter` re-exports** from `visitors/index.ts` — arel tests reach the hosts via `test-helpers/connection.ts` (`testConnection` / `mysqlTestConnection` / `postgresqlTestConnection`).
- `Relation#_arelVisitor` no longer degrades to a connection-less ANSI `ToSql` on an unconnected model — it resolves through `_conn()` and raises `ConnectionNotEstablished`, as Rails' `to_sql` does.
- `array-encode-parity.trails.test.ts` **repointed** at the moved quoter (`postgresqlTestConnection` via the `@blazetrails/arel/src` test alias) — it keeps pinning the PG quoter byte-for-byte against `OID::Array#encode` until `delete-arel-quote-array-adapter-owns-array-encoding` retires the duplication.
- `VisitorCtor` is now structural (`abstract new (...args: never[])`) because concrete visitors' required-arg constructors are no longer assignable to `typeof Visitor`.

## Testing

- `pnpm typecheck` clean.
- Arel visitor suites (to-sql, postgres, mysql, sqlite, dot, visitor, dispatch-contamination, quote-array): 534 tests pass.
- predicate-builder (+ trails) and array-encode-parity: 45 tests pass.

Closes-story: delete-arel-default-quoters-and-constructor-defaults
