### PR TITLE
refactor(predicate-builder): delete invented resolveColumn; read attributes off arelTable like expand_from_hash

### DIFF
--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -161,7 +161,10 @@ export class PredicateBuilder {
       } else if (this.table.aggregatedWith(key)) {
         nodes.push(...this.buildFromHashAggregate(key, value, negated));
       } else {
-        const attr = this.resolveColumn(key);
+        // Rails `self[key, value]` (predicate_builder.rb:53-55): the attribute
+        // is read straight off the builder's arel table — dotted keys were
+        // already normalized into nested hashes by convertDotNotationToHash.
+        const attr = this.table.arelTable.get(key);
         nodes.push(negated ? this.buildNegated(attr, value) : this.build(attr, value));
       }
     }
@@ -196,7 +199,7 @@ export class PredicateBuilder {
     const queryGroups: Nodes.Node[][] = values.map((object) =>
       mapping.map(([fieldAttr, aggregateAttr]) =>
         this.build(
-          this.resolveColumn(fieldAttr),
+          this.table.arelTable.get(fieldAttr),
           extractAggregateAttr(object, aggregateAttr, true),
         ),
       ),
@@ -264,7 +267,7 @@ export class PredicateBuilder {
     for (const query of queries) {
       // Cycle guard: prevents infinite recursion when FK name == association name.
       if (isSameHash(query, attributes)) {
-        queryGroups.push([this.build(this.resolveColumn(key), value)]);
+        queryGroups.push([this.build(this.table.arelTable.get(key), value)]);
       } else {
         const inner = this.buildFromHash(query);
         if (inner.length === 0) continue;
@@ -558,7 +561,7 @@ export class PredicateBuilder {
     // identically (or better) on indexed columns.
     if (cols.length === 1) {
       const values = validTuples.map((t) => t[0]);
-      return this.resolveColumn(cols[0]).in(values);
+      return this.table.arelTable.get(cols[0]).in(values);
     }
     // Build equalities through `buildBindAttribute` so each value
     // becomes a `QueryAttribute` (= bind param) rather than an
@@ -566,16 +569,14 @@ export class PredicateBuilder {
     // bypass `compileWithBinds` / prepared-statement caching and
     // mishandle `StatementCache::Substitute` placeholders.
     //
-    // Use the resolved attribute's `.name` (not the raw `c`) when
-    // constructing the bind so qualified column keys
-    // (e.g. `"orders.shop_id"`) resolve to the same column-name
-    // PredicateBuilder.BasicObjectHandler uses for type lookup.
-    //
     // Pre-resolve `Attribute[]` once outside the per-tuple loop —
-    // each `resolveColumn` allocates a fresh `Arel::Attribute` (and
-    // sometimes a `Table`). Reusing the resolved attrs keeps large
-    // tuple lists allocation-light.
-    const attrs = cols.map((c) => this.resolveColumn(c));
+    // each `arelTable.get` allocates a fresh `Arel::Attribute`.
+    // Reusing the resolved attrs keeps large tuple lists
+    // allocation-light. Column names are read straight off the
+    // builder's arel table, the way Rails' array-key branch of
+    // expand_from_hash does via `self[key, value]` — dotted keys are
+    // not split here (Rails doesn't either).
+    const attrs = cols.map((c) => this.table.arelTable.get(c));
     const groupings: Nodes.Node[] = validTuples.map((tuple) => {
       const eqs = attrs.map((attr, i) => attr.eq(this.buildBindAttribute(attr.name, tuple[i])));
       return new Nodes.Grouping(new Nodes.And(eqs));
@@ -586,20 +587,6 @@ export class PredicateBuilder {
     // `reduce` would produce. Keeps depth O(1) instead of O(n) for
     // large tuple lists.
     return new Nodes.Grouping(new Nodes.Or(groupings));
-  }
-
-  resolveColumn(key: string): Nodes.Attribute {
-    // A `"table.column"` key resolves through `resolveArelAttribute`, so the
-    // table carries a caster. Rails reaches the same place from the other side:
-    // convert_dot_notation_to_hash splits on `rindex(".")`
-    // (predicate_builder.rb:171) and routes the table part through
-    // `associated_table` — hence lastIndexOf, matching convertDotNotationToHash
-    // and references() rather than reading `a.b.c` as one column name.
-    if (!key.includes('"')) {
-      const dot = key.lastIndexOf(".");
-      if (dot !== -1) return this.resolveArelAttribute(key.slice(0, dot), key.slice(dot + 1));
-    }
-    return this.table.arelTable.get(key);
   }
 
   registerHandler(


### PR DESCRIPTION
## Summary

`PredicateBuilder#resolveColumn` had no Rails counterpart — there is no `resolve_column` anywhere in `vendor/rails/activerecord/lib/`. It was a trails invention that re-split `"table.column"` keys at attribute-resolution time.

Rails normalizes dotted keys exactly once, on the way in: `convert_dot_notation_to_hash` (`predicate_builder.rb:163-183`) rewrites `"table.column" => v` into `{ "table" => { "column" => v } }`, and `expand_from_hash` then reads attributes straight off the table via `self[key, value]` → `table.arel_table[attr_name]` (`predicate_builder.rb:53-55`).

This PR deletes `resolveColumn` and points its five callers at `this.table.arelTable.get(key)`, matching Rails:

- `buildFromHashInternal` scalar branch (Rails `self[key, value]`, predicate_builder.rb:145)
- `buildFromHashAggregate` multi-mapping branch (Rails `self[field_attr, …]`, predicate_builder.rb:138)
- `buildFromHashAssociation` FK-cycle guard (Rails `self[key, value]`, predicate_builder.rb:122)
- `buildComposite` single-column and multi-column paths (Rails' array-key branch of `expand_from_hash` also reads bare keys — no dot splitting)

Dotted keys are now normalized by `convertDotNotationToHash` only, never re-split at resolution time. No behavior change for the normalized paths: every key reaching the former `resolveColumn` callers is already dot-free (the dotted form is rewritten to the nested-hash form before `buildFromHashInternal` runs). `buildComposite` cols were never dotted at any call site (composite PK columns from `where(cols, tuples)`, DisableJoinsAssociationScope, and the delete path).

## Test plan

- `pnpm vitest run` on `predicate-builder.test.ts`, `predicate-builder.trails.test.ts`, `composite-where.test.ts`, `where.test.ts`, `where-chain.test.ts`, `merging.test.ts`, `aggregations.test.ts`, `disable-joins-composite-key.test.ts`, `disable-joins-composite-nested.test.ts` — all green.
- No test name changes.

Closes-story: predicate-builder-resolvecolumn-is-invented
