### PR TITLE
feat(activerecord): Migration[6.1] compatibility — PG :datetime → :timestamp

### DIFF
--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -33,7 +33,12 @@ import { DatabaseConfigurations } from "./database-configurations.js";
 import { DefaultStrategy } from "./migration/default-strategy.js";
 import type { ExecutionStrategy, MigrationLike } from "./migration/execution-strategy.js";
 import type { PendingMigrationConnection } from "./migration/pending-migration-connection.js";
-import { registerVersion, findVersion, CURRENT_VERSION } from "./migration/compatibility.js";
+import {
+  registerVersion,
+  findVersion,
+  installCompatibilityVersions,
+  CURRENT_VERSION,
+} from "./migration/compatibility.js";
 
 export type {
   ReferentialAction,
@@ -441,7 +446,17 @@ export abstract class Migration {
       return;
     }
     const tname = this._pt(name);
-    await this.schema.createTable(tname, optionsOrFn, fn);
+    // Mirrors Rails Migration::Current#create_table — the block's table
+    // definition routes through compatible_table_definition so versioned
+    // compatibility classes (e.g. Migration[6.1]) can patch it.
+    const wrap = (block?: (t: TableDefinition) => void) =>
+      block &&
+      ((t: TableDefinition) => block(this.compatibleTableDefinition(t) as TableDefinition));
+    if (typeof optionsOrFn === "function") {
+      await this.schema.createTable(tname, wrap(optionsOrFn));
+    } else {
+      await this.schema.createTable(tname, optionsOrFn, wrap(fn));
+    }
   }
 
   async dropTable(
@@ -3120,6 +3135,9 @@ export class Current extends Migration {
 
 // Register the current version so Migration.forVersion(1.0) works
 registerVersion(CURRENT_VERSION, Current);
+// Define + register the versioned compatibility classes (e.g. Migration[6.1]) —
+// deferred behind this hook to break the migration ⇄ compatibility import cycle.
+installCompatibilityVersions(Current);
 
 /**
  * Mirrors: ActiveRecord::Migration::CheckPending

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -918,6 +918,18 @@ export abstract class Migration {
     options?: JoinTableOptions | ((t: TableDefinition) => void),
     fn?: (t: TableDefinition) => void,
   ): Promise<void> {
+    // Mirrors Rails Migration::Current#create_join_table — the block's table
+    // definition routes through compatible_table_definition (migration.rb:596),
+    // same as createTable/changeTable. Wrapped before recording, matching Ruby
+    // where `super { |t| yield ... }` hands the recorder the wrapping block.
+    const wrap = (block?: (t: TableDefinition) => void) =>
+      block &&
+      ((t: TableDefinition) => block(this.compatibleTableDefinition(t) as TableDefinition));
+    if (typeof options === "function") {
+      options = wrap(options);
+    } else {
+      fn = wrap(fn);
+    }
     if (this._recording) {
       this._recorder.record("createJoinTable", [table1, table2, options, fn]);
       return;

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -946,13 +946,19 @@ export abstract class Migration {
   ): Promise<void> {
     const options = typeof fnOrOptions === "function" ? {} : (fnOrOptions ?? {});
     const callback = typeof fnOrOptions === "function" ? fnOrOptions : fn;
+    // Mirrors Rails Migration::Current#change_table — the yielded table routes
+    // through compatible_table_definition (migration.rb:588), same as createTable.
+    // Wrapped before recording, matching Ruby where `super { |t| yield ... }`
+    // hands the recorder the already-wrapping block.
+    const wrappedCallback =
+      callback && ((t: Table) => callback(this.compatibleTableDefinition(t) as Table));
     if (this._recording) {
       // Rails: change_table delegates to the CommandRecorder so individual
       // ops inside the block can be inverted (or batched, in the bulk path).
       await this._recorder.changeTable(
         tableName,
         options as Record<string, unknown>,
-        callback as Parameters<CommandRecorder["changeTable"]>[2],
+        wrappedCallback as Parameters<CommandRecorder["changeTable"]>[2],
       );
       return;
     }
@@ -961,7 +967,7 @@ export abstract class Migration {
       // records ops via a Proxy and coalesces into a single ALTER. Apply
       // tableNamePrefix here since SchemaStatements doesn't.
       const tname = this._pt(tableName);
-      await this.schema.changeTable(tname, options, callback);
+      await this.schema.changeTable(tname, options, wrappedCallback);
       return;
     }
     // Build Table against Migration (not SchemaStatements) so that
@@ -974,7 +980,7 @@ export abstract class Migration {
       ).nativeDatabaseTypes?.() ?? {},
     );
     const table = withAdapterColumnMethods(new Table(tableName, this), columnTypes);
-    if (callback) await callback(table);
+    if (wrappedCallback) await wrappedCallback(table);
   }
 
   async renameIndex(tableName: string, oldName: string, newName: string): Promise<void> {

--- a/packages/activerecord/src/migration/compatibility.ts
+++ b/packages/activerecord/src/migration/compatibility.ts
@@ -113,4 +113,103 @@ export interface Compatibility {
   version: string;
 }
 
+/**
+ * Mirrors: ActiveRecord::Migration::Compatibility::V6_1::PostgreSQLCompat
+ */
+export class PostgreSQLCompat {
+  static compatibleTimestampType(type: string, connection: { adapterName: string }): string {
+    if (connection.adapterName === "postgres") {
+      // For Rails <= 6.1, :datetime was aliased to :timestamp
+      // See: https://github.com/rails/rails/blob/v6.1.3.2/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L108
+      // From Rails 7 onwards, you can define what :datetime resolves to (the default is still :timestamp)
+      // See `ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.datetime_type`
+      return type === "datetime" ? "timestamp" : type;
+    }
+    return type;
+  }
+}
+
+/** @internal Shape of a TableDefinition the V6_1 compat layer patches. */
+interface CompatTableDefinition {
+  newColumnDefinition(name: string, type: string, options?: Record<string, unknown>): unknown;
+  column(name: string, type: string, options?: Record<string, unknown>): unknown;
+}
+
+/**
+ * Define and register the versioned compatibility classes.
+ *
+ * Ruby declares `class V6_1 < V7_0` inline in compatibility.rb; here a
+ * top-level `extends Current` would hit the migration.ts ⇄ compatibility.ts
+ * import cycle before `Current` is initialized, so the class bodies are
+ * deferred behind this hook, called from migration.ts once `Current` exists.
+ */
+export function installCompatibilityVersions(current: MigrationClass): void {
+  const CurrentClass = current as abstract new (...args: unknown[]) => Migration;
+
+  /**
+   * Mirrors: ActiveRecord::Migration::Compatibility::V6_1
+   */
+  abstract class V6_1 extends CurrentClass {
+    override async addColumn(
+      tableName: string,
+      columnName: string,
+      type: Parameters<Migration["addColumn"]>[2],
+      options: Parameters<Migration["addColumn"]>[3] = {},
+    ): Promise<void> {
+      if ((type as string) === "datetime" && !("precision" in options)) {
+        options = { ...options, precision: null };
+      }
+      type = PostgreSQLCompat.compatibleTimestampType(
+        type as string,
+        this.connection,
+      ) as typeof type;
+      await super.addColumn(tableName, columnName, type, options);
+    }
+
+    override async changeColumn(
+      tableName: string,
+      columnName: string,
+      type: Parameters<Migration["changeColumn"]>[2],
+      options: Parameters<Migration["changeColumn"]>[3] = {},
+    ): Promise<void> {
+      if ((type as string) === "datetime" && !("precision" in options)) {
+        options = { ...options, precision: null };
+      }
+      type = PostgreSQLCompat.compatibleTimestampType(
+        type as string,
+        this.connection,
+      ) as typeof type;
+      await super.changeColumn(tableName, columnName, type, options);
+    }
+
+    /**
+     * Mirrors: V6_1#compatible_table_definition — Ruby prepends
+     * `V6_1::TableDefinition` to the yielded table definition's singleton
+     * class; here the equivalent is patching the instance's methods so they
+     * run before the prototype's.
+     */
+    override compatibleTableDefinition(t: unknown): unknown {
+      const td = t as CompatTableDefinition;
+      const conn = this.connection;
+      const origNewColumnDefinition = td.newColumnDefinition;
+      // Mirrors: V6_1::TableDefinition#new_column_definition
+      td.newColumnDefinition = function (name, type, options = {}) {
+        type = PostgreSQLCompat.compatibleTimestampType(type, conn);
+        return origNewColumnDefinition.call(this, name, type, options);
+      };
+      const origColumn = td.column;
+      // Mirrors: V6_1::TableDefinition#column — `options[:precision] ||= nil`
+      td.column = function (name, type, options = {}) {
+        if (type === "datetime" && !("precision" in options)) {
+          options = { ...options, precision: null };
+        }
+        return origColumn.call(this, name, type, options);
+      };
+      return super.compatibleTableDefinition(t);
+    }
+  }
+
+  registerVersion("6.1", V6_1 as unknown as MigrationClass);
+}
+
 export { CURRENT_VERSION };

--- a/packages/activerecord/src/migration/compatibility.ts
+++ b/packages/activerecord/src/migration/compatibility.ts
@@ -129,10 +129,11 @@ export class PostgreSQLCompat {
   }
 }
 
-/** @internal Shape of a TableDefinition the V6_1 compat layer patches. */
+/** @internal Shape of a TableDefinition / Table the V6_1 compat layer patches. */
 interface CompatTableDefinition {
-  newColumnDefinition(name: string, type: string, options?: Record<string, unknown>): unknown;
-  column(name: string, type: string, options?: Record<string, unknown>): unknown;
+  newColumnDefinition?(name: string, type: string, options?: Record<string, unknown>): unknown;
+  column?(name: string, type: string, options?: Record<string, unknown>): unknown;
+  change?(name: string, type: string, options?: Record<string, unknown>): unknown;
 }
 
 /**
@@ -187,24 +188,41 @@ export function installCompatibilityVersions(current: MigrationClass): void {
      * `V6_1::TableDefinition` to the yielded table definition's singleton
      * class; here the equivalent is patching the instance's methods so they
      * run before the prototype's.
+     *
+     * @internal
      */
     override compatibleTableDefinition(t: unknown): unknown {
       const td = t as CompatTableDefinition;
       const conn = this.connection;
+      // Ruby prepends V6_1::TableDefinition to both create_table's
+      // TableDefinition and change_table's Table; Table has no
+      // new_column_definition, so each patch is guarded on the method existing.
       const origNewColumnDefinition = td.newColumnDefinition;
-      // Mirrors: V6_1::TableDefinition#new_column_definition
-      td.newColumnDefinition = function (name, type, options = {}) {
-        type = PostgreSQLCompat.compatibleTimestampType(type, conn);
-        return origNewColumnDefinition.call(this, name, type, options);
-      };
+      if (origNewColumnDefinition) {
+        // Mirrors: V6_1::TableDefinition#new_column_definition
+        td.newColumnDefinition = function (name, type, options = {}) {
+          type = PostgreSQLCompat.compatibleTimestampType(type, conn);
+          return origNewColumnDefinition.call(this, name, type, options);
+        };
+      }
+      // Mirrors: V6_1::TableDefinition#column / #change — Ruby's
+      // `options[:precision] ||= nil` marks the key present (suppressing the
+      // Rails 7 datetime precision-6 default) for every column type, since
+      // aliasing can turn e.g. :timestamp into :datetime downstream.
+      const markPrecision = (options: Record<string, unknown>) =>
+        "precision" in options ? options : { ...options, precision: null };
       const origColumn = td.column;
-      // Mirrors: V6_1::TableDefinition#column — `options[:precision] ||= nil`
-      td.column = function (name, type, options = {}) {
-        if (type === "datetime" && !("precision" in options)) {
-          options = { ...options, precision: null };
-        }
-        return origColumn.call(this, name, type, options);
-      };
+      if (origColumn) {
+        td.column = function (name, type, options = {}) {
+          return origColumn.call(this, name, type, markPrecision(options));
+        };
+      }
+      const origChange = td.change;
+      if (origChange) {
+        td.change = function (name, type, options = {}) {
+          return origChange.call(this, name, type, markPrecision(options));
+        };
+      }
       return super.compatibleTableDefinition(t);
     }
   }

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll } from "vitest";
 import { Base } from "./base.js";
-import { MigrationContext } from "./migration.js";
+import { Migration, MigrationContext } from "./migration.js";
 import { SchemaDumper } from "./connection-adapters/abstract/schema-dumper.js";
 import type { SchemaSource } from "./schema-dumper.js";
 import { adapterType } from "./test-adapter.js";
@@ -887,17 +887,66 @@ describe("SchemaDumperTest", () => {
       });
     },
   );
-  it.skipIf(adapterType !== "postgres")("timestamps schema dump before rails 7", (ctx) => {
-    ctx.skip();
-    // BLOCKED: needs Migration version compatibility (Migration[6.1]).
-    // Tracked: rfcs/0030-ar-test-compare-residual-burndown/stories/c1-schema-dumper-residual-gaps.md
+  it.skipIf(adapterType !== "postgres")("timestamps schema dump before rails 7", async () => {
+    class TimestampsMigration extends Migration.forVersion(6.1) {
+      override write(): void {}
+      override async up(): Promise<void> {
+        await this.createTable("timestamps", (t) => {
+          t.datetime("this_should_remain_datetime");
+          t.timestamp("this_is_an_alias_of_datetime");
+          t.column("this_is_also_an_alias_of_datetime", "timestamp");
+        });
+      }
+      override async down(): Promise<void> {
+        await this.dropTable("timestamps");
+      }
+    }
+    const migration = new TimestampsMigration();
+    try {
+      await migration.migrate("up");
+      const output = await SchemaDumper.dumpTableSchema(Base.connection, "timestamps");
+      expect(output).toContain('t.datetime("this_should_remain_datetime"');
+      expect(output).toContain('t.datetime("this_is_an_alias_of_datetime"');
+      expect(output).toContain('t.datetime("this_is_also_an_alias_of_datetime"');
+    } finally {
+      await migration.migrate("down");
+    }
   });
   it.skipIf(adapterType !== "postgres")(
     "timestamps schema dump before rails 7 with timestamptz setting",
-    (ctx) => {
-      ctx.skip();
-      // BLOCKED: needs Migration version compatibility + datetime_type-aware dump.
-      // Tracked: rfcs/0030-ar-test-compare-residual-burndown/stories/c1-schema-dumper-residual-gaps.md
+    async () => {
+      await withPostgresqlDatetimeType("timestamptz", async () => {
+        class TimestampsMigration extends Migration.forVersion(6.1) {
+          override write(): void {}
+          override async up(): Promise<void> {
+            await this.createTable("timestamps", (t) => {
+              t.datetime("this_should_change_to_timestamp");
+              t.timestamp("this_should_stay_as_timestamp");
+              t.column("this_should_also_stay_as_timestamp", "timestamp");
+            });
+          }
+          override async down(): Promise<void> {
+            await this.dropTable("timestamps");
+          }
+        }
+        const migration = new TimestampsMigration();
+        try {
+          await migration.migrate("up");
+          const output = await SchemaDumper.dumpTableSchema(Base.connection, "timestamps");
+          // Normally we'd write `t.datetime` here. But because you've changed the `datetime_type`
+          // to something else, `t.datetime` now means `:timestamptz`. To ensure that old columns
+          // are still created as a `:timestamp` we need to change what is written to the schema dump.
+          //
+          // Typically in Rails we handle this through Migration versioning (`ActiveRecord::Migration::Compatibility`)
+          // but that doesn't work here because the schema dumper is not aware of which migration
+          // a column was added in.
+          expect(output).toContain('t.timestamp("this_should_change_to_timestamp"');
+          expect(output).toContain('t.timestamp("this_should_stay_as_timestamp"');
+          expect(output).toContain('t.timestamp("this_should_also_stay_as_timestamp"');
+        } finally {
+          await migration.migrate("down");
+        }
+      });
     },
   );
   it.skipIf(adapterType !== "postgres")(
@@ -954,18 +1003,63 @@ describe("SchemaDumperTest", () => {
 
   it.skipIf(adapterType !== "postgres")(
     "schema dump with correct timestamp types via add column before rails 7",
-    (ctx) => {
-      ctx.skip();
-      // BLOCKED: needs Migration version compatibility (Migration[6.1]).
-      // Tracked: rfcs/0030-ar-test-compare-residual-burndown/stories/c1-schema-dumper-residual-gaps.md
+    async () => {
+      class TimestampsMigration extends Migration.forVersion(6.1) {
+        override write(): void {}
+        override async up(): Promise<void> {
+          await this.createTable("timestamps");
+          await this.addColumn("timestamps", "default_format", "datetime");
+          await this.addColumn("timestamps", "without_time_zone", "datetime");
+          await this.addColumn("timestamps", "also_without_time_zone", "timestamp");
+        }
+        override async down(): Promise<void> {
+          await this.dropTable("timestamps");
+        }
+      }
+      const migration = new TimestampsMigration();
+      try {
+        await migration.migrate("up");
+        const output = await SchemaDumper.dumpTableSchema(Base.connection, "timestamps");
+        expect(output).toContain('t.datetime("default_format"');
+        expect(output).toContain('t.datetime("without_time_zone"');
+        expect(output).toContain('t.datetime("also_without_time_zone"');
+      } finally {
+        await migration.migrate("down");
+      }
     },
   );
   it.skipIf(adapterType !== "postgres")(
     "schema dump with correct timestamp types via add column before rails 7 with timestamptz setting",
-    (ctx) => {
-      ctx.skip();
-      // BLOCKED: needs Migration version compatibility + datetime_type-aware dump.
-      // Tracked: rfcs/0030-ar-test-compare-residual-burndown/stories/c1-schema-dumper-residual-gaps.md
+    async () => {
+      await withPostgresqlDatetimeType("timestamptz", async () => {
+        class TimestampsMigration extends Migration.forVersion(6.1) {
+          override write(): void {}
+          override async up(): Promise<void> {
+            await this.createTable("timestamps");
+            await this.addColumn("timestamps", "this_should_change_to_timestamp", "datetime");
+            await this.addColumn("timestamps", "this_should_stay_as_timestamp", "timestamp");
+          }
+          override async down(): Promise<void> {
+            await this.dropTable("timestamps");
+          }
+        }
+        const migration = new TimestampsMigration();
+        try {
+          await migration.migrate("up");
+          const output = await SchemaDumper.dumpTableSchema(Base.connection, "timestamps");
+          // Normally we'd write `t.datetime` here. But because you've changed the `datetime_type`
+          // to something else, `t.datetime` now means `:timestamptz`. To ensure that old columns
+          // are still created as a `:timestamp` we need to change what is written to the schema dump.
+          //
+          // Typically in Rails we handle this through Migration versioning (`ActiveRecord::Migration::Compatibility`)
+          // but that doesn't work here because the schema dumper is not aware of which migration
+          // a column was added in.
+          expect(output).toContain('t.timestamp("this_should_change_to_timestamp"');
+          expect(output).toContain('t.timestamp("this_should_stay_as_timestamp"');
+        } finally {
+          await migration.migrate("down");
+        }
+      });
     },
   );
 

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration.json
@@ -23,13 +23,6 @@
   {
     "package": "activerecord",
     "tsFile": "migration.ts",
-    "rubyName": "change_table",
-    "call": "compatible_table_definition",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
     "rubyName": "check_all_pending!",
     "call": "any?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -109,20 +102,6 @@
     "tsFile": "migration.ts",
     "rubyName": "copy",
     "call": "to_s",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
-    "rubyName": "create_join_table",
-    "call": "compatible_table_definition",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
-    "rubyName": "create_table",
-    "call": "compatible_table_definition",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {


### PR DESCRIPTION
Implements `Migration[6.1]` (`Compatibility::V6_1`) with the PostgreSQL `compatible_timestamp_type` override, un-skipping the 4 remaining schema-dumper tests split off from `c1-schema-dumper-timestamptz-version-compat`.

## What

- `migration/compatibility.ts`: `PostgreSQLCompat.compatibleTimestampType` (`:datetime` → `:timestamp` on PG, mirrors `compatibility.rb:165-178`) and a `V6_1` class overriding `addColumn` / `changeColumn` and `compatibleTableDefinition` (patching the yielded table definition's `newColumnDefinition` / `column`, the TS analogue of Ruby's singleton-class `prepend`). Registered as version `"6.1"`, so `Migration.forVersion(6.1)` resolves it.
  - Ruby declares `class V6_1 < V7_0` inline; a top-level `extends Current` here would hit the migration.ts ⇄ compatibility.ts import cycle before `Current` initializes, so the class body is deferred behind `installCompatibilityVersions(Current)`, called from migration.ts.
- `migration.ts`: `Migration#createTable` now routes the block's table definition through `compatibleTableDefinition` (mirrors `Migration::Current#create_table`, `migration.rb:580-586`; previously the hook existed but was never invoked).
- `schema-dumper.test.ts`: un-skips the 4 PG-gated tests (Rails `schema_dumper_test.rb:675/701/827/853`), each porting Rails' anonymous `ActiveRecord::Migration[6.1]` subclass with `up`/`down` and `migrate(:down)` cleanup:
  - `timestamps schema dump before rails 7`
  - `timestamps schema dump before rails 7 with timestamptz setting`
  - `schema dump with correct timestamp types via add column before rails 7`
  - `schema dump with correct timestamp types via add column before rails 7 with timestamptz setting`

## Why it works

Under `Migration[6.1]`, `:datetime` is rewritten to `:timestamp` at column-definition / `add_column` time, so the physical column is `timestamp without time zone` even when `datetime_type = :timestamptz`. The dump side (datetime_type-aware via #3433) then reports physical `timestamp` as `:timestamp` under the timestamptz setting, else `:datetime` — exactly what the 4 tests assert.

## Testing

- All 4 new tests pass on an isolated PG stack; full `schema-dumper.test.ts` + `invertible-migration.test.ts` + `migrator.trails.test.ts` + `migration.test.ts` pass on PG and SQLite.
- `pnpm typecheck` clean; 251 LOC (≤ 300 ceiling).

Closes-story: c1-schema-dumper-migration-version-compat
