### PR TITLE
test(activerecord): un-skip statement cache with sql string literal

### DIFF
--- a/packages/activerecord/src/bind-parameter.test.ts
+++ b/packages/activerecord/src/bind-parameter.test.ts
@@ -242,19 +242,21 @@ describe("BindParameterTest", () => {
     expect(statementCacheKeys(conn)).not.toContain(conn.sqlKey(cap.sqls.at(-1)));
   });
 
-  // DEVIATION (tracked): Rails asserts the SQL string literal IS cached
-  // (bind_parameter_test.rb:100-107, `assert_includes`): `sanitize_sql` bakes the
-  // value into an `Arel::Nodes::SqlLiteral`, leaving `collector.preparable = true`
-  // (no unpreparable node), so a no-bind-but-preparable SELECT is pooled. The
-  // `collector.preparable` threading (Composite default-true, SqlLiteral
-  // non-preparable, `compileWithBinds` 4-tuple, `opts.preparable` into selectAll)
-  // is now restored, but un-skipping this case ALSO needs `where("col = ?", val)`
-  // to route through `BoundSqlLiteral` (preparable) instead of a plain
-  // `SqlLiteral` (non-preparable). That `build_where_clause` → `BoundSqlLiteral`
-  // wiring is deferred to the `converge-build-where-clause-bound-sql-literal`
-  // story (see the NOTE in relation/query-methods.ts), so this case stays skipped
-  // until that lands and is un-skipped there.
-  it.skip("statement cache with sql string literal", () => {});
+  it("statement cache with sql string literal", async (ctx) => {
+    const conn = (await Topic.leaseConnection()) as any;
+    ctx.skip(!conn.preparedStatements);
+    conn.clearCache();
+
+    const cap = captureSelectSql();
+    // Rails: `Topic.where("topics.id = ?", 1)` — the `?` fragment routes through
+    // BoundSqlLiteral (preparable), so the statement IS pooled (assert_includes,
+    // bind_parameter_test.rb:100-107).
+    const topics = Topic.where("topics.id = ?", 1);
+    expect((await topics.toArray()).map((t: any) => Number(t.id))).toEqual([1]);
+    cap.stop();
+
+    expect(statementCacheKeys(conn)).toContain(conn.sqlKey(cap.sqls.at(-1)));
+  });
 
   it("too many binds", async () => {
     const conn = (await Topic.leaseConnection()) as any;


### PR DESCRIPTION
Un-skips the last remaining `it.skip` in `bind-parameter.test.ts`: **statement cache with sql string literal** (bind_parameter_test.rb:100-107).

The skip was blocked on `where("col = ?", val)` routing through `BoundSqlLiteral` (preparable) instead of a plain `SqlLiteral`. That `build_where_clause` → `BoundSqlLiteral` wiring has since landed in `relation/query-methods.ts`, so the test now passes as Rails writes it: the sanitized string-literal SELECT is preparable and enters the statement pool (`assert_includes`).

The other 6 tests on the story's un-skip list (statement cache, with query cache, with find, with find by, with in clause, binds are logged) were already un-skipped on main by earlier PRs — the story snapshot (2026-06-15) predates them. This PR clears the file's last `matchedSkipped`.

Verified on SQLite and PostgreSQL (isolated stack); prepared-statements gate (`ctx.skip`) mirrors Rails' class-level `if prepared_statements` wrapper for MySQL/MariaDB.

Closes-story: e1-bind-parameter