### PR TITLE
test(activerecord): feature-gate CTE merging, insert/upsert-all cache, and partial-index tests

### DIFF
--- a/packages/activerecord/src/query-cache.test.ts
+++ b/packages/activerecord/src/query-cache.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import { registerModel } from "./index.js"; // also eager-loads CollectionProxy for association()
 import { fixtures } from "./test-helpers/fixtures.js";
+import { itIfSupports } from "./test-helpers/supports.js";
 import { Base } from "./base.js";
 import { Task } from "./test-helpers/models/task.js";
 import { Topic } from "./test-helpers/models/topic.js";
@@ -952,9 +953,7 @@ describe("QueryCacheExpiryTest", () => {
     });
   });
 
-  // Rails guards with `skip unless supports_insert_on_duplicate_skip?`; every
-  // trails adapter (sqlite/postgresql/mysql2) supports it, so run unconditionally.
-  it("insert all", async () => {
+  itIfSupports("insert_on_duplicate_skip", "insert all", async () => {
     await Task.cache(async () => {
       await assertClears(1, async () => {
         await Task.insert({ starting: new Date().toISOString() });
@@ -978,9 +977,7 @@ describe("QueryCacheExpiryTest", () => {
     });
   });
 
-  // Rails guards with `skip unless supports_insert_on_duplicate_update?`; every
-  // trails adapter supports it, so run unconditionally.
-  it("upsert all", async () => {
+  itIfSupports("insert_on_duplicate_update", "upsert all", async () => {
     await Task.cache(async () => {
       await assertClears(1, async () => {
         await Task.upsert({ starting: new Date().toISOString() });

--- a/packages/activerecord/src/relation/merging.test.ts
+++ b/packages/activerecord/src/relation/merging.test.ts
@@ -9,6 +9,7 @@ import { sql as arelSql } from "@blazetrails/arel";
 
 import { registerModel, Range } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
+import { itIfSupports } from "../test-helpers/supports.js";
 import { assertQueriesCount, assertQueriesMatch } from "../testing/query-assertions.js";
 import { quoteTableName, escapeRegExp } from "../test-helpers/quote-regex.js";
 import { Author } from "../test-helpers/models/author.js";
@@ -496,40 +497,52 @@ describe("MergingDifferentRelationsTest", () => {
     expect(await ids((dev as any).ratings)).toEqual([rating1.id]);
   });
 
-  it("merging relation with common table expression", async () => {
-    const postsWithTags = Post.with({
-      posts_with_tags: Post.where("tags_count > 0"),
-    }).from("posts_with_tags AS posts");
-    const postsWithComments = Post.where("legacy_comments_count > 0");
-    const relation = postsWithComments.merge(postsWithTags).order("posts.id");
+  itIfSupports(
+    "common_table_expressions",
+    "merging relation with common table expression",
+    async () => {
+      const postsWithTags = Post.with({
+        posts_with_tags: Post.where("tags_count > 0"),
+      }).from("posts_with_tags AS posts");
+      const postsWithComments = Post.where("legacy_comments_count > 0");
+      const relation = postsWithComments.merge(postsWithTags).order("posts.id");
 
-    expect((await relation.pluck("id")).map(Number)).toEqual([1, 2, 7]);
-  });
+      expect((await relation.pluck("id")).map(Number)).toEqual([1, 2, 7]);
+    },
+  );
 
-  it("merging multiple relations with common table expression", async () => {
-    const postsWithTags = Post.with({ posts_with_tags: Post.where("tags_count > 0") });
-    const postsWithComments = Post.with({
-      posts_with_comments: Post.where("legacy_comments_count > 0"),
-    });
-    const relation = postsWithComments
-      .merge(postsWithTags)
-      .joins(
-        "JOIN posts_with_tags pwt ON pwt.id = posts.id JOIN posts_with_comments pwc ON pwc.id = posts.id",
-      )
-      .order("posts.id");
+  itIfSupports(
+    "common_table_expressions",
+    "merging multiple relations with common table expression",
+    async () => {
+      const postsWithTags = Post.with({ posts_with_tags: Post.where("tags_count > 0") });
+      const postsWithComments = Post.with({
+        posts_with_comments: Post.where("legacy_comments_count > 0"),
+      });
+      const relation = postsWithComments
+        .merge(postsWithTags)
+        .joins(
+          "JOIN posts_with_tags pwt ON pwt.id = posts.id JOIN posts_with_comments pwc ON pwc.id = posts.id",
+        )
+        .order("posts.id");
 
-    expect((await relation.pluck("id")).map(Number)).toEqual([1, 2, 7]);
-  });
+      expect((await relation.pluck("id")).map(Number)).toEqual([1, 2, 7]);
+    },
+  );
 
-  it("relation merger leaves to database to decide what to do when multiple CTEs with same alias are passed", async () => {
-    const postsWithTags = Post.with({ popular_posts: Post.where("tags_count > 0") });
-    const postsWithComments = Post.with({
-      popular_posts: Post.where("legacy_comments_count > 0"),
-    });
-    const relation = postsWithTags
-      .merge(postsWithComments)
-      .joins("JOIN popular_posts pp ON pp.id = posts.id");
+  itIfSupports(
+    "common_table_expressions",
+    "relation merger leaves to database to decide what to do when multiple CTEs with same alias are passed",
+    async () => {
+      const postsWithTags = Post.with({ popular_posts: Post.where("tags_count > 0") });
+      const postsWithComments = Post.with({
+        popular_posts: Post.where("legacy_comments_count > 0"),
+      });
+      const relation = postsWithTags
+        .merge(postsWithComments)
+        .joins("JOIN popular_posts pp ON pp.id = posts.id");
 
-    await expect(relation.toArray()).rejects.toThrow();
-  });
+      await expect(relation.toArray()).rejects.toThrow();
+    },
+  );
 });

--- a/packages/activerecord/src/validations/uniqueness-validation.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.test.ts
@@ -15,6 +15,7 @@ import { Base } from "../index.js";
 import { registerModel } from "../associations.js";
 import { registerSubclass } from "../inheritance.js";
 import { adapterType } from "../test-adapter.js";
+import { itIfSupports } from "../test-helpers/supports.js";
 import { assertQueriesCount, assertNoQueries } from "../testing/query-assertions.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { Topic } from "../test-helpers/models/topic.js";
@@ -833,10 +834,7 @@ describe("UniquenessValidationWithIndexTest", () => {
     });
   });
 
-  // Rails `skip unless @connection.supports_partial_index?` — MySQL is the only
-  // adapter whose `supportsPartialIndex()` is false, and the vitest lint rule
-  // forbids a runtime conditional inside the test body.
-  it.skipIf(adapterType === "mysql")("partial index", async () => {
+  itIfSupports("partial_index", "partial index", async () => {
     Topic.validatesUniqueness("title");
     await Base.connection.addIndex("topics", "title", {
       unique: true,


### PR DESCRIPTION
Converts six tests from unconditional or adapter-gated to `itIfSupports` so the extracted `adapterFeatureKey` matches Rails' `supports_*` gates (`test:compare --gates` rows from 2026-07-22):

- `relation/merging.test.ts` — the three CTE merging tests now gate on `common_table_expressions` (Rails: `supports_common_table_expressions?`).
- `query-cache.test.ts` — "insert all" gates on `insert_on_duplicate_skip`, "upsert all" on `insert_on_duplicate_update` (Rails body-skips).
- `validations/uniqueness-validation.test.ts` — "partial index" replaces the `skipIf(adapterType === "mysql")` adapter gate with `itIfSupports("partial_index", …)`, matching Rails' `supports_partial_index?`.

All feature keys already existed in `test-helpers/supports.ts` with Rails-faithful coverage — no new keys needed. Test names and bodies are unchanged apart from gating. After this change `test:compare --gates` no longer reports these six tests (16 remaining mismatches are other stories' rows).

Closes-story: feature-gate-missing-cte-upsert-partial-index
