### PR TITLE
fix(activerecord): converge calculations/relations adapter gates with Rails

### DIFF
--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -271,9 +271,7 @@ describe("CalculationsTest", () => {
     expect(keys).toEqual(expect.arrayContaining([6, 2, 9, 1]));
   });
 
-  it.skipIf(adapterType !== "sqlite")("should limit calculation", async () => {
-    // group+order+limit+sum returning ordered keys works on SQLite; PG/MySQL wrap
-    // in a subquery that drops the outer ORDER BY — trails implementation gap.
+  it("should limit calculation", async () => {
     const c = (await Account.where("firm_id IS NOT NULL")
       .group("firm_id")
       .order("firm_id")
@@ -283,7 +281,7 @@ describe("CalculationsTest", () => {
     expect(keys).toEqual([1, 2]);
   });
 
-  it.skipIf(adapterType !== "sqlite")("should limit calculation with offset", async () => {
+  it("should limit calculation with offset", async () => {
     const c = (await Account.where("firm_id IS NOT NULL")
       .group("firm_id")
       .order("firm_id")
@@ -549,9 +547,7 @@ describe("CalculationsTest", () => {
     expect(c[2]).toBe(60);
   });
 
-  it.skipIf(adapterType !== "sqlite")("should calculate with invalid field", async () => {
-    // Rails: both "*" and :all are treated as COUNT(*). In trails, calculate("count", "all")
-    // generates COUNT(all) which is invalid SQL on PG/MySQL — implementation gap.
+  it("should calculate with invalid field", async () => {
     expect(await Account.calculate("count", "*")).toBe(6);
     expect(await Account.calculate("count", "all")).toBe(6);
   });
@@ -1346,13 +1342,19 @@ describe("CalculationsTest", () => {
     ]);
   });
 
-  it.skip(// Rails: PG-only. In trails, maximum("comments_count") fails because the Post model
-  // aliases it as "commentsCount" and the snake_case alias isn't resolved in calculations.
-  "group by with order by virtual count attribute", async () => {
-    const expected = { SpecialPost: 1, StiPost: 2 };
-    const actual = await Post.group("type").order("count").limit(2).maximum("comments_count");
-    expect(actual).toEqual(expected);
-  });
+  it.skipIf(adapterType !== "postgres")(
+    "group by with order by virtual count attribute",
+    async () => {
+      const expected = { SpecialPost: 1, StiPost: 2 };
+      // Rails `order(:count)`: the Symbol qualifies to `"posts"."count"`, which PG
+      // resolves via functional notation as `count(posts.*)` — the "virtual count
+      // attribute". A bare string would stay raw SQL and fail to parse.
+      const actual = await (Post.group("type").order(Symbol.for("count") as any) as any)
+        .limit(2)
+        .maximum("comments_count");
+      expect(actual).toEqual(expected);
+    },
+  );
 
   it("group by with limit", async () => {
     const actual = await Post.includes("comments")

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -214,8 +214,10 @@ function buildAggNode(
   distinct: boolean,
 ): any {
   const sqlName = SQL_FN_NAMES[fn];
-  if (column === "*" || column instanceof Nodes.SqlLiteral) {
-    const lit = column === "*" ? new Nodes.SqlLiteral("*") : column;
+  // "all" is the JS analogue of Rails' :all symbol — aggregate_column maps it
+  // to Arel.star (calculations.rb:414-423), i.e. COUNT(*), not a column ref.
+  if (column === "*" || column === "all" || column instanceof Nodes.SqlLiteral) {
+    const lit = column instanceof Nodes.SqlLiteral ? column : new Nodes.SqlLiteral("*");
     return new Nodes.NamedFunction(sqlName, [lit], undefined, distinct);
   }
   // Arel node (e.g. arelTable.get("col")) — use it directly without string resolution.
@@ -304,9 +306,9 @@ function needsBigintCast(rel: CalculationRelation): boolean {
  * needsBigintCast() is true. Aliases are quoted to match SQLite's
  * identifier quoting convention.
  */
-function wrapBigintAgg(innerSql: string, grouped = false): string {
+function wrapBigintAgg(innerSql: string, grouped = false, aggAlias = "val"): string {
   if (grouped) {
-    return `SELECT "group_key", CAST("val" AS TEXT) AS "val" FROM (${innerSql}) AS "_bigint_agg"`;
+    return `SELECT "group_key", CAST("${aggAlias}" AS TEXT) AS "${aggAlias}" FROM (${innerSql}) AS "_bigint_agg"`;
   }
   return `SELECT CAST("val" AS TEXT) AS "val" FROM (${innerSql}) AS "_bigint_agg"`;
 }
@@ -480,7 +482,14 @@ async function groupedAggregate(
   const groupNode = arelColumns.call(rel as never, [effectiveGroupCol])[0] as Nodes.Node;
   const aggNode = buildAggNode(rel, fn, column, rel._isDistinct);
   const groupKeyAlias = new Nodes.As(groupNode, new Nodes.SqlLiteral("group_key"));
-  const manager = table.project(groupKeyAlias, aggNode.as("val"));
+  // Rails aliases the aggregate as `column_alias_for("#{operation} #{column_name}")`
+  // — e.g. `sum_credit_limit`, `count_all` — so order("sum_credit_limit desc")
+  // can reference it (calculations.rb:537). A raw Arel node keeps "val".
+  const aggAlias =
+    typeof column === "string"
+      ? columnAliasFor(`${fn} ${column.toLowerCase()}`.replace(/\*/g, "all"))
+      : "val";
+  const manager = table.project(groupKeyAlias, aggNode.as(aggAlias));
   // Rails `calculate` (calculations.rb:217-238) folds the eager JoinDependency
   // into `joins_values` via `apply_join_dependency` before dispatching to the
   // grouped/simple calculation. Fold it into the shared `build_joins` port so
@@ -495,6 +504,10 @@ async function groupedAggregate(
   rel._applyWheresToManager(manager, table);
   applyFromToManager(rel, manager);
   manager.group(groupNode);
+  // Rails `execute_grouped_calculation` runs `select_all` on the relation's own
+  // arel, which retains order_values — without the ORDER BY, LIMIT/OFFSET pick
+  // arbitrary groups on PG/MySQL.
+  rel._applyOrderToManager(manager, table);
 
   if (rel._limitValue !== null) manager.take(rel._limitValue);
   if (rel._offsetValue !== null) manager.skip(rel._offsetValue);
@@ -504,7 +517,7 @@ async function groupedAggregate(
   const [withCtes, ctedBinds] = prependCtes(rel, rawSql, managerBinds);
   const sql =
     isBigintColumn(rel, fn, column) && needsBigintCast(rel)
-      ? wrapBigintAgg(withCtes, true)
+      ? wrapBigintAgg(withCtes, true, aggAlias)
       : withCtes;
   const opName = fn.charAt(0).toUpperCase() + fn.slice(1);
   const queryResult = await rel
@@ -530,7 +543,7 @@ async function groupedAggregate(
     const byId = new Map(records.map((r) => [String(r.id), r]));
     const result = new Map<unknown, unknown>();
     for (const row of rows) {
-      result.set(byId.get(String(row.group_key)) ?? null, aggOf(row.val));
+      result.set(byId.get(String(row.group_key)) ?? null, aggOf(row[aggAlias]));
     }
     return result;
   }
@@ -548,7 +561,7 @@ async function groupedAggregate(
       raw == null
         ? "null"
         : String(typeof keyType?.deserialize === "function" ? keyType.deserialize(raw) : raw);
-    result[key] = aggOf(row.val);
+    result[key] = aggOf(row[aggAlias]);
   }
   return result;
 }
@@ -1047,7 +1060,9 @@ export async function performCount(
 
   // `table` and `project` (alias-aware) were resolved above the limit/offset
   // branch so every count path shares them.
-  const effectiveColumn = column === "*" ? undefined : column;
+  // "all" is the JS analogue of Rails' :all symbol — aggregate_column maps both
+  // it and "*" to Arel.star, i.e. COUNT(*) (calculations.rb:414-423).
+  const effectiveColumn = column === "*" || column === "all" ? undefined : column;
 
   // Rails: when no explicit column, check if select_values has a single Arel attribute
   // and use it as the count column (mirrors calculations.rb#execute_simple_calculation).

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -697,18 +697,15 @@ describe("RelationTest", () => {
     expect(sql).toContain("body");
   });
 
-  it.skipIf(adapterType === "mysql")("finding with sanitized order", () => {
-    const q1 = Tag.order([arelSql("field(id, ?)"), [1, 3, 2]]).toSql();
-    expect(q1).toMatch(/field\(id, 1,\s*3,\s*2\)/);
-    const q2 = Tag.order([arelSql("field(id, ?)"), []]).toSql();
-    expect(q2).toMatch(/field\(id, NULL\)/);
-    const q3 = Tag.order([arelSql("field(id, ?)"), null as any]).toSql();
-    expect(q3).toMatch(/field\(id, NULL\)/);
-  });
+  // Mirrors Rails' inline `current_adapter?(:Mysql2Adapter, :TrilogyAdapter)`
+  // branch (relations_test.rb:476); kept out of the test body so
+  // vitest/no-conditional-in-test stays happy.
+  const sanitizedOrderRe =
+    adapterType === "mysql" ? /field\(id, '1',\s*'3',\s*'2'\)/ : /field\(id, 1,\s*3,\s*2\)/;
 
-  it.skipIf(adapterType !== "mysql")("finding with sanitized order (mysql)", () => {
+  it("finding with sanitized order", () => {
     const q1 = Tag.order([arelSql("field(id, ?)"), [1, 3, 2]]).toSql();
-    expect(q1).toMatch(/field\(id, '1',\s*'3',\s*'2'\)/);
+    expect(q1).toMatch(sanitizedOrderRe);
     const q2 = Tag.order([arelSql("field(id, ?)"), []]).toSql();
     expect(q2).toMatch(/field\(id, NULL\)/);
     const q3 = Tag.order([arelSql("field(id, ?)"), null as any]).toSql();


### PR DESCRIPTION
Converges the 5 gate mismatches in `calculations.test.ts` / `relations.test.ts` flagged by `test:compare --gates` (22 → 17 activerecord gate mismatches).

## Over-gated → un-gated

- **"finding with sanitized order"** — deleted the trails-invented `"(mysql)"` twin and merged back to one unconditional test; the mysql/other regex branch mirrors Rails' inline `current_adapter?(:Mysql2Adapter, :TrilogyAdapter)` (relations_test.rb:476), hoisted out of the test body for `vitest/no-conditional-in-test`.
- **"should limit calculation"** / **"should limit calculation with offset"** — the `skipIf(!sqlite)` gate was papering over `groupedAggregate` dropping `order_values`: Rails' `execute_grouped_calculation` runs `select_all` on the relation's own arel, which keeps the ORDER BY, so LIMIT/OFFSET pick ordered groups. Now applied via `_applyOrderToManager`. This required aliasing the aggregate Rails-style (`column_alias_for("#{operation} #{column_name}")` → `sum_credit_limit`, `count_all`; calculations.rb:537) instead of the invented `"val"`, so `order("sum_credit_limit desc")` ("should order by calculation") still resolves once ORDER BY is actually emitted.
- **"should calculate with invalid field"** — `calculate("count", "all")` emitted `COUNT(all)`; `"all"` (the JS analogue of Rails' `:all` symbol) now maps to Arel.star → `COUNT(*)` per `aggregate_column` (calculations.rb:414-423).

## Should-gate → gated

- **"group by with order by virtual count attribute"** — was `it.skip`; now `skipIf(adapterType !== "postgres")`, matching Rails' `if current_adapter?(:PostgreSQLAdapter)` (calculations_test.rb:1202), and passing on the PG lane. The old skip comment blamed alias resolution, but the real reason it's PG-only is Rails' `order(:count)`: the Symbol qualifies to `"posts"."count"`, which PG resolves via functional notation as `count(posts.*)`. Ported with the Symbol order arg (`order(Symbol.for("count"))`) — a bare string stays raw SQL per the converged order semantics and fails to parse.

## Verification

- SQLite, PG, and MySQL lanes: both files fully green locally (isolated compose stack).
- `test:compare --gates`: no mismatch remains for any of the 5; count dropped 22 → 17.

Closes-story: calculations-relations-overgate-convergence
