### PR TITLE
test(activerecord): express insert-returning trigger gate inline for the gate extractor

### DIFF
--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -2143,7 +2143,10 @@ describe("PersistenceTest", () => {
     await Base.connection.dropTable("pk_autopopulated_by_a_trigger_records", { ifExists: true });
   });
 
-  it.skipIf(!supportsTrigger)(
+  // Inline De-Morgan'd skip form of Rails' `if supports_insert_returning? &&
+  // !current_adapter?(:SQLite3Adapter)` — kept inline (not the `supportsTrigger`
+  // const) so the gate extractor reads adapters+features off the expression.
+  it.skipIf(adapterType === "sqlite" || !adapterSupports("insert_returning"))(
     "model with no auto populated fields still returns primary key after insert",
     async () => {
       const record = (await PkAutopopulatedByATriggerRecord.create()) as any;


### PR DESCRIPTION
## Summary

`test:compare --gates` flagged persistence.test.ts "model with no auto populated fields still returns primary key after insert" as `[missing-gate]`: Rails gates it `adapters=[mysql,postgresql] features=[insert_returning]`, but our `it.skipIf(!supportsTrigger)` hides the condition behind a const the gate extractor can't read, so it extracted as `guards=[unknown]`.

Fix: inline the De-Morgan'd skip expression at the test site — `it.skipIf(adapterType === "sqlite" || !adapterSupports("insert_returning"))` — the exact idiom `scripts/test-compare/gates.ts` `gateFromGuardExpr` documents, which yields `adapters=[mysql,postgresql] features=[insert_returning]`, matching the Rails gate. The `supportsTrigger` const stays for the beforeAll/afterAll DDL guards. Test name and body unchanged.

Verified: `pnpm test:compare -- --gates` no longer emits a row for this test; persistence.test.ts passes locally (156 passed, 5 skipped).

Closes-story: persistence-insert-returning-gate
