### PR TITLE
fix(test-compare): stop collapsing Trilogy into the mysql adapter family

### DIFF
--- a/scripts/test-compare/extract-ruby-gates.test.ts
+++ b/scripts/test-compare/extract-ruby-gates.test.ts
@@ -87,6 +87,38 @@ describe("Ruby extractor gate detection", () => {
     expect(g["pg and ps"]).toEqual({ guards: ["prepared_statements"], source: ["class"] });
   });
 
+  it("folds statically-false Trilogy predicates out of gate conditions", () => {
+    const g = rubyGates({
+      // Mirrors abstract_mysql_adapter/connection_test.rb:144 — an `unless
+      // TrilogyAdapter` wrapper inside a mysql-dir file must not collapse to
+      // `mysql AND !mysql` = the empty adapter set.
+      "cases/adapters/abstract_mysql_adapter/connection_test.rb": `
+        unless current_adapter?(:TrilogyAdapter)
+          def test_passing_arbitrary_flags_to_adapter; end
+        end
+      `,
+      // Mirrors base_test.rb:871 — Trilogy drops out of the disjunction.
+      "cases/base_test.rb": `
+        unless current_adapter?(:PostgreSQLAdapter) || current_adapter?(:TrilogyAdapter)
+          def test_no_pg_no_trilogy; end
+        end
+        if current_adapter?(:TrilogyAdapter)
+          def test_trilogy_only; end
+        end
+      `,
+    });
+    expect(g["passing arbitrary flags to adapter"]).toEqual({
+      adapters: ["mysql"],
+      source: ["dir"],
+    });
+    expect(g["no pg no trilogy"]).toEqual({
+      adapters: ["mysql", "sqlite"],
+      source: ["class"],
+    });
+    // A Trilogy-only positive gate runs nowhere in trails: explicit empty set.
+    expect(g["trilogy only"]).toEqual({ adapters: [], source: ["class"] });
+  });
+
   it("captures a negated current_adapter? exclusion in a compound trailing-if", () => {
     const g = rubyGates({
       // Mirrors persistence_test.rb:1614 — `end if supports_X? && !current_adapter?(:SQLite3Adapter)`.

--- a/scripts/test-compare/extract-ruby-tests.rb
+++ b/scripts/test-compare/extract-ruby-tests.rb
@@ -617,6 +617,9 @@ class TestExtractor
     gate = {}
     # A condition that is ONLY Trilogy-positive runs nowhere in trails: emit the
     # explicit empty adapter set (distinct from "no gate" = runs everywhere).
+    # Restricted to pure adapter conditions: a compound like `if Trilogy &&
+    # supports_x?` keeps its feature/guard gate instead — conservative, but
+    # comparable, and no such compound exists in the Rails suite today.
     if trilogy_only && positive && acc[:features].empty? && acc[:guards].empty?
       gate[:adapters] = []
     end

--- a/scripts/test-compare/extract-ruby-tests.rb
+++ b/scripts/test-compare/extract-ruby-tests.rb
@@ -85,8 +85,13 @@ ADAPTER_SYMBOL_MAP = {
   "PostgreSQL" => "postgresql",
   "Mysql2Adapter" => "mysql",
   "Mysql2" => "mysql",
-  "TrilogyAdapter" => "mysql",
-  "Trilogy" => "mysql",
+  # Trilogy is a distinct MySQL DRIVER, not a member of trails' adapter set —
+  # trails' mysql family runs the mysql2 driver, so `current_adapter?(:Trilogy*)`
+  # is statically false here. Mapped to a pseudo family (not in ALL_ADAPTERS)
+  # that gate_from_run_condition folds away, so `unless TrilogyAdapter` inside a
+  # mysql-dir file no longer collapses to `mysql AND !mysql` = the empty set.
+  "TrilogyAdapter" => "trilogy",
+  "Trilogy" => "trilogy",
   "AbstractMysqlAdapter" => "mysql",
   "SQLite3Adapter" => "sqlite",
   "SQLite3" => "sqlite",
@@ -602,7 +607,19 @@ class TestExtractor
 
     adapters = acc[:adapter_syms].map { |s| ADAPTER_SYMBOL_MAP[s] }.compact.uniq
     neg_adapters = acc[:neg_adapter_syms].map { |s| ADAPTER_SYMBOL_MAP[s] }.compact.uniq
+    # `current_adapter?(:Trilogy*)` is statically false in trails (see
+    # ADAPTER_SYMBOL_MAP): an exclusion (`unless Trilogy`) excludes nothing and
+    # a disjunct (`if Mysql2 || Trilogy`) reduces to the remaining adapters, so
+    # fold the pseudo family out of both sets before deriving the gate.
+    trilogy_only = !adapters.empty? && (adapters - ["trilogy"]).empty?
+    adapters -= ["trilogy"]
+    neg_adapters -= ["trilogy"]
     gate = {}
+    # A condition that is ONLY Trilogy-positive runs nowhere in trails: emit the
+    # explicit empty adapter set (distinct from "no gate" = runs everywhere).
+    if trilogy_only && positive && acc[:features].empty? && acc[:guards].empty?
+      gate[:adapters] = []
+    end
     # A POSITIVE adapter set isn't sound — and must be dropped — when the
     # condition mixes it with a feature/guard (`supports_X? && current_adapter?`
     # could be `&&` or `||`; the run-on set differs), or with a negated adapter


### PR DESCRIPTION
## Summary

Fixes the last extractor-artifact `wrong-gate` rows from RFC 0032's gate-fidelity burndown (follow-up to `gate-wrong-gate-body-convergence`). Test bodies are untouched — they gate correctly; the extracted railsGate was wrong.

- **Mysql2/Trilogy collapse**: `ADAPTER_SYMBOL_MAP` mapped both `Mysql2Adapter` and `TrilogyAdapter` to `mysql`, so the `unless current_adapter?(:TrilogyAdapter)` wrapper in `abstract_mysql_adapter/connection_test.rb:144` collapsed to `mysql AND !mysql` = the empty adapter set, flagging "passing arbitrary flags to adapter" and "passing flags by array to adapter". Trilogy is a distinct MySQL *driver* trails doesn't have — `current_adapter?(:Trilogy*)` is statically false here. It now maps to a pseudo family that `gate_from_run_condition` folds out: exclusions drop away, disjuncts (`unless PG || Trilogy`, base_test.rb:871) reduce to the remaining adapters, and a Trilogy-only positive gate emits the explicit empty set.
- **`!prepared_statements` over-exclusion** ("update prepared statement"): already resolved on main — the extractor records the runtime predicate as a `prepared_statements` guard (extract-ruby-tests.rb `scan_run_condition`), which makes the compound non-comparable rather than over-excluding SQLite. Verified not flagged; covered by the existing "treats prepared_statements as a guard" unit test.

`test:compare --package activerecord --gates`: the two connection.test.ts rows are gone (10 → 8 wrong-gate), no new mismatch rows, "update prepared statement" clean.

Closes-story: gate-extractor-mysql2-trilogy-prepared-artifacts
