### PR TITLE
test(activerecord): converge transaction-isolation level tests to generic dual connections

### DIFF
--- a/packages/activerecord/src/transaction-isolation.test.ts
+++ b/packages/activerecord/src/transaction-isolation.test.ts
@@ -1,9 +1,8 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { Base, TransactionIsolationError } from "./index.js";
-import { adapterType } from "./test-adapter.js";
+import { adapterType, ambientPoolConfiguration } from "./test-adapter.js";
 import { adapterSupports } from "./test-helpers/supports.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { describeIfPg, PG_TEST_URL } from "./adapters/postgresql/test-helper.js";
 
 // Runs when the adapter does NOT support transaction isolation (or is SQLite3).
 // Rails: TransactionIsolationUnsupportedTest
@@ -27,68 +26,22 @@ describe("TransactionIsolationUnsupportedTest", () => {
   });
 });
 
-// Rails: TransactionIsolationTest (joining/nested subtests).
-// Rails guards the full class with `supports_transaction_isolation? &&
-// !current_adapter?(:SQLite3Adapter)` (transaction_isolation_test.rb:20), which the
-// test:compare Ruby extractor renders as adapters=[mysql,postgresql]
-// features=[transaction_isolation]. These two subtests assert that requesting an
-// isolation level while joining/nesting raises — framework-only behavior that holds
-// on both Postgres and MySQL — so the compound guard below mirrors both dimensions of
-// Rails' gate (non-SQLite adapter set + the feature).
+// Rails: TransactionIsolationTest, guarded by `supports_transaction_isolation? &&
+// !current_adapter?(:SQLite3Adapter)` (transaction_isolation_test.rb:20-21), which
+// the test:compare Ruby extractor renders as adapters=[mysql,postgresql]
+// features=[transaction_isolation]. Each subtest carries the compound skipIf below
+// to mirror both dimensions of Rails' gate (non-SQLite adapter set + the feature).
 //
-// The four isolation-LEVEL subtests below (read uncommitted/committed/repeatable
-// read/serializable) are NOT framework-only — they need real cross-connection
-// semantics over two independent physical connections, so they stay in the
-// PG-bodied describeIfPg block and remain a tracked wrong-gate (sub-story
-// transaction-isolation-level-generic-dual-connection: a generic dual-connection
-// body that also runs on MySQL is required before their gate can match Rails'
-// mysql,postgresql adapter set).
+// Tag and Tag2 each establish their own connection to the active lane's primary
+// database (via ambientPoolConfiguration) so their transactions run on independent
+// physical connections — matching Rails' `Tag.establish_connection :arunit` /
+// `Tag2.establish_connection :arunit` pattern, generically across pg + mysql.
 describe("TransactionIsolationTest", () => {
-  fixtures({}, { useTransactionalTests: false });
-
-  it.skipIf(adapterType === "sqlite" || !adapterSupports("transaction_isolation"))(
-    "setting isolation when joining a transaction raises an error",
-    async () => {
-      class Tag extends Base {
-        static {
-          this.attribute("name", "string");
-        }
-      }
-      await Tag.transaction(async () => {
-        await expect(
-          Tag.transaction(async () => {}, { isolation: "serializable" }),
-        ).rejects.toThrow(TransactionIsolationError);
-      });
-    },
-  );
-
-  it.skipIf(adapterType === "sqlite" || !adapterSupports("transaction_isolation"))(
-    "setting isolation when starting a nested transaction raises error",
-    async () => {
-      class Tag extends Base {
-        static {
-          this.attribute("name", "string");
-        }
-      }
-      await Tag.transaction(async () => {
-        await expect(
-          Tag.transaction(async () => {}, { requiresNew: true, isolation: "serializable" }),
-        ).rejects.toThrow(TransactionIsolationError);
-      });
-    },
-  );
-});
-
-// Rails: TransactionIsolationTest, guarded by supports_transaction_isolation? && !SQLite3.
-// Mirrors vendor/rails/activerecord/test/cases/transaction_isolation_test.rb.
-// Tag and Tag2 each establish their own connection to the same database so
-// their transactions run on independent physical connections — matching Rails'
-// `Tag.establish_connection :arunit` / `Tag2.establish_connection :arunit` pattern.
-describeIfPg("TransactionIsolationTest", () => {
   fixtures({}, { useTransactionalTests: false });
 
   class Tag extends Base {
     static {
+      this._tableName = "tags";
       this.attribute("name", "string");
     }
   }
@@ -101,11 +54,13 @@ describeIfPg("TransactionIsolationTest", () => {
   }
 
   beforeAll(async () => {
-    await Tag.establishConnection(PG_TEST_URL);
-    await Tag2.establishConnection(PG_TEST_URL);
+    if (adapterType === "sqlite" || !adapterSupports("transaction_isolation")) return;
+    await Tag.establishConnection(ambientPoolConfiguration());
+    await Tag2.establishConnection(ambientPoolConfiguration());
   });
 
   afterAll(async () => {
+    if (adapterType === "sqlite" || !adapterSupports("transaction_isolation")) return;
     try {
       await Tag.destroyAll();
     } finally {
@@ -115,65 +70,100 @@ describeIfPg("TransactionIsolationTest", () => {
   });
 
   beforeEach(async () => {
+    if (adapterType === "sqlite" || !adapterSupports("transaction_isolation")) return;
     await Tag.destroyAll();
   });
 
   // PG aliases READ UNCOMMITTED to READ COMMITTED — Rails notes this test only
   // asserts that the second connection's auto-committed insert becomes visible.
-  it("read uncommitted", async () => {
-    await Tag.transaction(
-      async () => {
-        expect(await Tag.count()).toBe(0);
-        await Tag2.create({});
-        expect(await Tag.count()).toBe(1);
-      },
-      { isolation: "read_uncommitted" },
-    );
-  });
+  it.skipIf(adapterType === "sqlite" || !adapterSupports("transaction_isolation"))(
+    "read uncommitted",
+    async () => {
+      await Tag.transaction(
+        async () => {
+          expect(await Tag.count()).toBe(0);
+          await Tag2.create({});
+          expect(await Tag.count()).toBe(1);
+        },
+        { isolation: "read_uncommitted" },
+      );
+    },
+  );
 
   // A dirty read must not happen: Tag2's uncommitted insert is invisible to Tag.
-  it("read committed", async () => {
-    await Tag.transaction(
-      async () => {
-        expect(await Tag.count()).toBe(0);
-        await Tag2.transaction(async () => {
-          await Tag2.create({});
+  it.skipIf(adapterType === "sqlite" || !adapterSupports("transaction_isolation"))(
+    "read committed",
+    async () => {
+      await Tag.transaction(
+        async () => {
           expect(await Tag.count()).toBe(0);
-        });
-      },
-      { isolation: "read_committed" },
-    );
-    expect(await Tag.count()).toBe(1);
-  });
+          await Tag2.transaction(async () => {
+            await Tag2.create({});
+            expect(await Tag.count()).toBe(0);
+          });
+        },
+        { isolation: "read_committed" },
+      );
+      expect(await Tag.count()).toBe(1);
+    },
+  );
 
   // A non-repeatable read must not happen: a committed update from the second
   // connection is invisible to the first connection's repeatable-read snapshot.
-  it("repeatable read", async () => {
-    const tag = await Tag.create({ name: "jon" });
+  it.skipIf(adapterType === "sqlite" || !adapterSupports("transaction_isolation"))(
+    "repeatable read",
+    async () => {
+      const tag = await Tag.create({ name: "jon" });
 
-    await Tag.transaction(
-      async () => {
-        await tag.reload();
-        const t2 = await Tag2.find(tag.id);
-        await t2.update({ name: "emily" });
+      await Tag.transaction(
+        async () => {
+          await tag.reload();
+          const t2 = await Tag2.find(tag.id);
+          await t2.update({ name: "emily" });
 
-        await tag.reload();
-        expect(tag.name).toBe("jon");
-      },
-      { isolation: "repeatable_read" },
-    );
+          await tag.reload();
+          expect(tag.name).toBe("jon");
+        },
+        { isolation: "repeatable_read" },
+      );
 
-    await tag.reload();
-    expect(tag.name).toBe("emily");
-  });
+      await tag.reload();
+      expect(tag.name).toBe("emily");
+    },
+  );
 
   // No-error smoke test for serializable — DBs enforce serializability differently.
-  it("serializable", async () => {
-    await Tag.transaction(
-      async () => {
-        await Tag.create({});
-      },
-      { isolation: "serializable" },
-    );
-  });
+  it.skipIf(adapterType === "sqlite" || !adapterSupports("transaction_isolation"))(
+    "serializable",
+    async () => {
+      await Tag.transaction(
+        async () => {
+          await Tag.create({});
+        },
+        { isolation: "serializable" },
+      );
+    },
+  );
+
+  it.skipIf(adapterType === "sqlite" || !adapterSupports("transaction_isolation"))(
+    "setting isolation when joining a transaction raises an error",
+    async () => {
+      await Tag.transaction(async () => {
+        await expect(
+          Tag.transaction(async () => {}, { isolation: "serializable" }),
+        ).rejects.toThrow(TransactionIsolationError);
+      });
+    },
+  );
+
+  it.skipIf(adapterType === "sqlite" || !adapterSupports("transaction_isolation"))(
+    "setting isolation when starting a nested transaction raises error",
+    async () => {
+      await Tag.transaction(async () => {
+        await expect(
+          Tag.transaction(async () => {}, { requiresNew: true, isolation: "serializable" }),
+        ).rejects.toThrow(TransactionIsolationError);
+      });
+    },
+  );
 });

--- a/packages/activerecord/src/transaction-isolation.test.ts
+++ b/packages/activerecord/src/transaction-isolation.test.ts
@@ -3,6 +3,7 @@ import { Base, TransactionIsolationError } from "./index.js";
 import { adapterType, ambientPoolConfiguration } from "./test-adapter.js";
 import { adapterSupports } from "./test-helpers/supports.js";
 import { fixtures } from "./test-helpers/fixtures.js";
+import { transactionIsolationLevels } from "./connection-adapters/abstract/database-statements.js";
 
 // Runs when the adapter does NOT support transaction isolation (or is SQLite3).
 // Rails: TransactionIsolationUnsupportedTest
@@ -76,19 +77,23 @@ describe("TransactionIsolationTest", () => {
 
   // PG aliases READ UNCOMMITTED to READ COMMITTED — Rails notes this test only
   // asserts that the second connection's auto-committed insert becomes visible.
-  it.skipIf(adapterType === "sqlite" || !adapterSupports("transaction_isolation"))(
-    "read uncommitted",
-    async () => {
-      await Tag.transaction(
-        async () => {
-          expect(await Tag.count()).toBe(0);
-          await Tag2.create({});
-          expect(await Tag.count()).toBe(1);
-        },
-        { isolation: "read_uncommitted" },
-      );
-    },
-  );
+  // Rails additionally defines this test only when
+  // `transaction_isolation_levels.include?(:read_uncommitted)`
+  // (transaction_isolation_test.rb:41) — mirrored via the map term below.
+  it.skipIf(
+    adapterType === "sqlite" ||
+      !adapterSupports("transaction_isolation") ||
+      !("read_uncommitted" in transactionIsolationLevels()),
+  )("read uncommitted", async () => {
+    await Tag.transaction(
+      async () => {
+        expect(await Tag.count()).toBe(0);
+        await Tag2.create({});
+        expect(await Tag.count()).toBe(1);
+      },
+      { isolation: "read_uncommitted" },
+    );
+  });
 
   // A dirty read must not happen: Tag2's uncommitted insert is invisible to Tag.
   it.skipIf(adapterType === "sqlite" || !adapterSupports("transaction_isolation"))(
@@ -110,27 +115,31 @@ describe("TransactionIsolationTest", () => {
 
   // A non-repeatable read must not happen: a committed update from the second
   // connection is invisible to the first connection's repeatable-read snapshot.
-  it.skipIf(adapterType === "sqlite" || !adapterSupports("transaction_isolation"))(
-    "repeatable read",
-    async () => {
-      const tag = await Tag.create({ name: "jon" });
+  // Rails additionally defines this test only when
+  // `transaction_isolation_levels.include?(:repeatable_read)`
+  // (transaction_isolation_test.rb:66) — mirrored via the map term below.
+  it.skipIf(
+    adapterType === "sqlite" ||
+      !adapterSupports("transaction_isolation") ||
+      !("repeatable_read" in transactionIsolationLevels()),
+  )("repeatable read", async () => {
+    const tag = await Tag.create({ name: "jon" });
 
-      await Tag.transaction(
-        async () => {
-          await tag.reload();
-          const t2 = await Tag2.find(tag.id);
-          await t2.update({ name: "emily" });
+    await Tag.transaction(
+      async () => {
+        await tag.reload();
+        const t2 = await Tag2.find(tag.id);
+        await t2.update({ name: "emily" });
 
-          await tag.reload();
-          expect(tag.name).toBe("jon");
-        },
-        { isolation: "repeatable_read" },
-      );
+        await tag.reload();
+        expect(tag.name).toBe("jon");
+      },
+      { isolation: "repeatable_read" },
+    );
 
-      await tag.reload();
-      expect(tag.name).toBe("emily");
-    },
-  );
+    await tag.reload();
+    expect(tag.name).toBe("emily");
+  });
 
   // No-error smoke test for serializable — DBs enforce serializability differently.
   it.skipIf(adapterType === "sqlite" || !adapterSupports("transaction_isolation"))(


### PR DESCRIPTION
Converges the four isolation-level subtests of `TransactionIsolationTest` (`read uncommitted`, `read committed`, `repeatable read`, `serializable`) from the PG-only `describeIfPg` block to a generic dual-connection body, resolving their tracked wrong-gate (rails `adapters=[mysql,postgresql] features=[transaction_isolation]` vs ts `adapters=[postgresql]`).

## Changes

- `Tag` / `Tag2` now `establishConnection(ambientPoolConfiguration())` — the active lane's primary config hash already exported from `test-adapter.ts` — instead of the hardcoded `PG_TEST_URL`, mirroring Rails' `Tag.establish_connection :arunit` / `Tag2.establish_connection :arunit` (transaction_isolation_test.rb:33-34) generically across pg + mysql. A hash (not a URL) so socket-configured MySQL runs work.
- Merged the two `TransactionIsolationTest` describes into one, matching Rails' single class and subtest order; every subtest carries the compound `skipIf(adapterType === "sqlite" || !adapterSupports("transaction_isolation"))` guard the joining/nested subtests already used, mirroring both dimensions of Rails' class gate (`supports_transaction_isolation? && !current_adapter?(:SQLite3Adapter)`, transaction_isolation_test.rb:21). Guards are inline for the gate extractor.
- Per review: `read uncommitted` / `repeatable read` also mirror Rails' per-level guards (`transaction_isolation_levels.include?(:read_uncommitted/:repeatable_read)`, transaction_isolation_test.rb:41/:66) as extra `skipIf` terms reading `transactionIsolationLevels()`. Note this map is the constant base map in both Rails (database_statements.rb:420, no adapter overrides) and trails, so the terms are tautologically true for mysql/pg — kept for structural fidelity; gates compare stays clean.
- No SQLite impl gap: Rails itself excludes SQLite3 from this class, and `TransactionIsolationUnsupportedTest` (which runs on SQLite in Rails via the `unless` guard) already asserts the `TransactionIsolationError` raise — trails matches.

## Verification

- `pnpm vitest run packages/activerecord/src/transaction-isolation.test.ts` green on sqlite (6 skipped), postgres (6 passed), and mysql (6 passed, isolated compose stack).
- `pnpm test:compare --package activerecord --gates`: no wrong-gate entries remain for these four tests; match table `transaction_isolation_test.rb` 7/7 OK. Test names unchanged.

Closes-story: transaction-isolation-level-generic-dual-connection
