### PR TITLE
fix(activerecord): run UpdateableViewTest insert under Rails' partial_inserts default

### DIFF
--- a/packages/activerecord/src/view.test.ts
+++ b/packages/activerecord/src/view.test.ts
@@ -225,6 +225,19 @@ describe("UpdateableViewTest", () => {
   class PrintedBook extends Base {
     static override _tableName = "printed_books";
     static override _primaryKey = "id";
+    // Rails' AR test suite runs with the class default `partial_inserts = true`
+    // (helper.rb never flips it — only a `config.load_defaults 7.0+` app does),
+    // while our test-setup-ar.ts deliberately runs loadDefaults("7.0"), i.e.
+    // partialInserts=false. That difference is fatal here on MySQL only: the
+    // updatable view reports its NOT-NULL `id` with a fabricated default "0"
+    // (SHOW FULL FIELDS strips `auto_increment` from Extra, so the column is
+    // not auto-populated and survives the full-insert column set), and with
+    // NO_AUTO_VALUE_ON_ZERO in sql_mode the INSERT stores literal 0 instead of
+    // letting the underlying `books` table auto-assign. Rails under
+    // partial_inserts=false fails identically — there is no adapter gap — so
+    // restore Rails' own test-suite setting for this model: the unchanged `id`
+    // then stays out of the INSERT column list and MySQL auto-assigns.
+    static override partialInserts = true;
   }
 
   beforeAll(rebuildBooksTables);
@@ -253,16 +266,8 @@ describe("UpdateableViewTest", () => {
   });
 
   // Rails gates this `features=[views]` (runs on mysql + postgresql; SQLite views
-  // do not support DML). Match that static gate with `skipIf(sqlite)` and skip
-  // MySQL at runtime via ctx.skip so the extracted gate stays `mysql,postgresql|
-  // views` without a false green:
-  //   BLOCKED (MySQL): the updatable view reports its NOT-NULL `id` with default
-  //   "0" (via SHOW FULL FIELDS) and NO_AUTO_VALUE_ON_ZERO keeps id=0 in
-  //   attributesForCreate, so the INSERT stores literal 0 instead of letting the
-  //   underlying books table auto-assign. PG/Trilogy are unaffected.
-  //   Sub-story: view-insert-mysql-no-auto-value-on-zero.
-  itIfSupports.skipIf(adapterType === "sqlite")("views", "insert record", async (ctx) => {
-    ctx.skip(adapterType === "mysql");
+  // do not support DML).
+  itIfSupports.skipIf(adapterType === "sqlite")("views", "insert record", async () => {
     await PrintedBook.createBang({ name: "Rails in Action", status: 0, format: "paperback" });
     const newBook = await PrintedBook.last();
     expect((newBook as any).name).toBe("Rails in Action");


### PR DESCRIPTION
## Summary

Fixes the MySQL skip on `UpdateableViewTest` "insert record" (`view.test.ts`) — the test now runs and passes on the mysql lane, with the gate unchanged (`mysql,postgresql|views`).

## Diagnosis: no adapter gap — a test-env config divergence

The story hypothesized an impl gap in the MySQL view-insert path. Local reproduction (isolated mysql:8 + general_log) shows our reflection and dirty tracking match Rails exactly:

- The updatable view reports its NOT-NULL `id` with a fabricated default `"0"` and Extra stripped of `auto_increment` (MySQL server behavior for views; verified with raw `SHOW FULL FIELDS`). Our `newColumnFromField` parses it exactly as Rails' `MySQL::Column` would: `default: "0"`, `autoIncrement: false`.
- The dirty set for the new record is `["name", "format"]` — `id` is correctly *not* changed (from-database default, same as Rails).
- The INSERT still carried `id = 0` because our suite runs `loadDefaults("7.0")` (`test-setup-ar.ts`), i.e. `partialInserts = false`, so the full-insert branch keeps every non-auto-populated column — and the view's `id` is not auto-populated (`Extra` is empty). With `NO_AUTO_VALUE_ON_ZERO` in sql_mode (which Rails sets, and we converged on), MySQL stores literal `0`.

Rails' own AR test suite runs with the **class default** `partial_inserts = true` (`dirty.rb:50`; `test/cases/helper.rb` never flips it — `partial_inserts = false` only comes from the railties app config `load_defaults 7.0`, `railties/lib/rails/application/configuration.rb:263`). Under `partial_inserts = false`, real Rails inserts `id = 0` through the view identically — verified by tracing `attribute_names_for_partial_inserts` → `attributes_for_create` (`id` is `0`, not nil, so the pk-drop doesn't fire, and `Column#auto_populated?` is false for the view column).

## Fix

Restore Rails' actual test-suite setting for this one model: `static override partialInserts = true` on `PrintedBook`, justified at the call site. The unchanged `id` then stays out of the INSERT column list and the underlying `books` table auto-assigns, on every adapter.

- `ctx.skip(adapterType === "mysql")` and the BLOCKED note are removed; the static gate expression is untouched, so the extracted gate stays `mysql,postgresql|views`. Test name unchanged.

## Testing

- mysql2 (isolated mysql:8): `view.test.ts` 20 passed / 1 skipped (was: "insert record" failing with id=0 once unskipped).
- postgresql (pg 17): 21 passed.
- sqlite: 17 passed / 4 skipped.
- `scripts/test-compare/gate-mismatch.test.ts` + `extract-ts-gates.test.ts`: pass.

Closes-story: view-insert-mysql-no-auto-value-on-zero
