### PR TITLE
test(activerecord): port remaining eager where-references and from-clause tests

### DIFF
--- a/packages/activerecord/src/associations/eager.test.ts
+++ b/packages/activerecord/src/associations/eager.test.ts
@@ -345,7 +345,7 @@ describe("EagerAssociationTest", () => {
   });
   it("type cast in where references association name", async () => {
     const parent = comments("greetings");
-    const child = await (parent as any).children.create({
+    const child = await (parent as any).children.createBang({
       label: "child",
       body: "hi",
       post_id: parent.post_id,

--- a/packages/activerecord/src/associations/eager.test.ts
+++ b/packages/activerecord/src/associations/eager.test.ts
@@ -343,6 +343,46 @@ describe("EagerAssociationTest", () => {
       expect(eagerMateys.map(mateyAttrs)).toEqual(mateysList.map(mateyAttrs));
     });
   });
+  it("type cast in where references association name", async () => {
+    const parent = comments("greetings");
+    const child = await (parent as any).children.create({
+      label: "child",
+      body: "hi",
+      post_id: parent.post_id,
+    });
+
+    const comment = (await Comment.includes("children")
+      .where({ "children.label": "child" })
+      .last()) as any;
+
+    expect(comment.id).toBe(parent.id);
+    expect((await comment.children.toArray()).map((c: any) => c.id)).toEqual([child.id]);
+  });
+  it("attribute alias in where references association name", async () => {
+    const firm = (await Firm.includes("clients")
+      .where({ "clients.newName": "Summit" })
+      .last()) as any;
+    expect(firm.id).toBe(companies("first_firm").id);
+    expect((await firm.clients.toArray()).map((c: any) => c.id)).toEqual([
+      companies("first_client").id,
+    ]);
+  });
+  it("calculate with string in from and eager loading", async () => {
+    expect(
+      await Post.from("authors, posts")
+        .eagerLoad("comments")
+        .where("posts.author_id = authors.id")
+        .count(),
+    ).toBe(10);
+  });
+  it("with two tables in from without getting double quoted", async () => {
+    const postsArr = await Post.select("posts.*")
+      .from("authors, posts")
+      .eagerLoad("comments")
+      .where("posts.author_id = authors.id")
+      .order("posts.id");
+    expect(await (postsArr[0] as any).comments.length()).toBe(2);
+  });
   it("duplicate middle objects", async () => {
     const commentArr = await Comment.where({ post_id: 1 }).includes({ post: "author" });
     await assertNoQueries(false, () => {


### PR DESCRIPTION
Ports the 4 tests still reported missing in `associations/eager.test.ts` by the fresh `test:compare` run (story `a1-eager-where-references-and-from` shipped a subset):

- type cast in where references association name (eager_test.rb:230)
- attribute alias in where references association name (:240)
- calculate with string in from and eager loading (:246)
- with two tables in from without getting double quoted (:250)

All use canonical models/fixtures already wired in the file; names verbatim. `test:compare` for `eager_test.rb` now shows 0 missing (197 matched ✓).

Closes-story: eager-where-references-from-missing-redux

---

**Review note — `"clients.newName"` vs Rails' `"clients.new_name"`:** trails ports Rails' `alias_attribute :new_name, :name` (`test/models/company.rb:22`) as `aliasAttribute("newName", "name")` (`test-helpers/models/company.ts:73`), per the repo-wide camelCase convention for all attribute/alias names. The test proves the same thing Rails' does — association-qualified attribute-alias resolution in a `where` key — under the trails naming. `"clients.new_name"` is not a registered alias here and would (correctly) fail.
