### PR TITLE
fix(activerecord): dump MySQL 8 expression indexes and converge escaping gate

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
@@ -85,4 +85,14 @@ export const supportsDefaultExpression =
   mysqlAvailable &&
   (mariaDb ? _serverVersion?.gte("10.2.1") === true : _serverVersion?.gte("8.0.13") === true);
 
+/**
+ * Mirrors AbstractMysqlAdapter#supports_expression_index?
+ * (abstract_mysql_adapter.rb:104): MySQL ≥ 8.0.13 only; never MariaDB. Feeds
+ * the `expression_index` entry in test-helpers/supports.ts, which cannot bake
+ * the answer into a static adapterType table — the mysql lane may be MySQL 8
+ * (true) or the MariaDB CI stand-in (false).
+ */
+export const supportsExpressionIndex =
+  mysqlAvailable && !mariaDb && _serverVersion?.gte("8.0.13") === true;
+
 export { Mysql2Adapter };

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -291,10 +291,27 @@ describe("SchemaDumperTest", () => {
     line = line.replace(/, \{ name: "company_expression_index" \}\);$/, "");
     if (adapterType === "postgres") {
       expect(line).toMatch(/CASE.+lower\(\(name\)::text\).+END\) DESC"/i);
+    } else if (adapterType === "mysql") {
+      expect(line).toMatch(/CASE.+lower\(`name`\).+END\) DESC"/i);
     } else {
       expect(line).toMatch(/CASE.+lower\(name\).+END\) DESC"/i);
     }
   });
+
+  // Rails: schema_dumper_test.rb:313 — current_adapter?(:Mysql2, :Trilogy)
+  // inside the supports_expression_index? block, asserting the canonical
+  // companies `full_name_index` concat_ws expression round-trips with MySQL's
+  // backtick/charset-literal escaping intact.
+  itIfSupports.skipIf(adapterType !== "mysql")(
+    "expression_index",
+    "schema dump expression indices escaping",
+    async () => {
+      const output = await dumpCanonicalTable("companies");
+      let line = companyIndexLine(output, /full_name_index/);
+      line = line.replace(/, \{ name: "full_name_index" \}\);$/, "");
+      expect(line).toMatch(/concat_ws\(`firm_name`,`name`,_utf8mb4' '\)\)"$/i);
+    },
+  );
 
   it("schema dump includes decimal options", { timeout: FULL_DUMP_TIMEOUT_MS }, async () => {
     // Rails: dump_all_table_schema([/^[^n]/]) — keep only tables starting with
@@ -522,28 +539,6 @@ describe("SchemaDumperTest", () => {
       expect(output).not.toMatch(/addIndex.*test_uc_no_idx.*test_uc_no_idx_position/);
     },
   );
-  // NOT converted to itIfSupports: Rails gates this by current_adapter?(:Mysql2,
-  // :Trilogy) (schema_dumper_test.rb:313, real-MySQL-only, asserts concat_ws
-  // backtick output), not by supports_expression_index?. Our body is a PG/SQLite
-  // port (`lower(a || b)`), so it's a pre-existing divergence — left as-is.
-  it.skipIf(adapterType === "mysql")("schema dump expression indices escaping", async () => {
-    await ctx.createTable("users", { force: true }, (t) => {
-      t.string("first_name");
-      t.string("last_name");
-    });
-    await ctx.addIndex("users", "lower(first_name || ' ' || last_name)", {
-      name: "idx_users_full_name",
-    });
-    const output = await SchemaDumper.dumpTableSchema(Base.connection, "users");
-    expect(output).toContain("idx_users_full_name");
-    // Real introspection returns the backend's stored expression form — sqlite
-    // keeps `lower(first_name || ' ' || last_name)` verbatim, PostgreSQL
-    // normalizes it to `lower((((first_name)::text || ' '::text) || …))`. Assert
-    // the lowercased expression over both columns rather than a byte-exact form,
-    // but still require the quoted `' '` space literal between them so the
-    // escaping is verified (mirrors Rails schema_dumper_test.rb:318).
-    expect(output).toMatch(/lower\(.*first_name.*' '.*last_name.*\).*idx_users_full_name/s);
-  });
   it.skipIf(adapterType !== "mysql")(
     "schema dump includes length for mysql binary fields",
     async () => {

--- a/packages/activerecord/src/test-helpers/canonical-schema.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.ts
@@ -38,6 +38,12 @@ interface ColOpts {
 }
 
 interface IndexOpts {
+  /**
+   * Restrict the index to these adapters, mirroring schema.rb's inline
+   * `if ActiveRecord::TestCase.current_adapter?(...)` gate (e.g. the MySQL-only
+   * `full_name_index`, schema.rb:426). Omitted = all adapters.
+   */
+  adapters?: readonly string[];
   unique?: boolean;
   where?: string;
   name?: string;
@@ -181,6 +187,8 @@ export async function emitTableIndexes(
   for (const { columns, opts } of indexes) {
     const isExpression = typeof columns === "string" && /\W/.test(columns);
     if (isExpression && !(await supportsExpressionIndex(adapter))) continue;
+    // schema.rb's inline current_adapter? gate (e.g. the MySQL-only full_name_index).
+    if (opts.adapters && !opts.adapters.includes(adapter.adapterName)) continue;
     await ss.addIndex(table, columns, {
       unique: opts.unique,
       where: opts.where,
@@ -684,6 +692,11 @@ async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
     t.index("name", { name: "company_name_index", using: "btree" });
     t.index("(CASE WHEN rating > 0 THEN lower(name) END) DESC", {
       name: "company_expression_index",
+    });
+    // schema.rb:426 — MySQL-only functional index (current_adapter?(:Mysql2, :Trilogy)).
+    t.index("(CONCAT_WS(`firm_name`, `name`, _utf8mb4' '))", {
+      name: "full_name_index",
+      adapters: ["mysql"],
     });
   });
 

--- a/packages/activerecord/src/test-helpers/schema-file-generator.test.ts
+++ b/packages/activerecord/src/test-helpers/schema-file-generator.test.ts
@@ -449,6 +449,9 @@ const PARITY_INDEXES: Parameters<typeof emitTableIndexes>[3] = [
     opts: { length: 8, using: "btree", type: "btree", nullsNotDistinct: true },
   },
   { columns: "(lower(external_id))", opts: {} },
+  // Adapter-restricted index (schema.rb's inline current_adapter? gate, e.g.
+  // the MySQL-only full_name_index) — both emitters must apply the same skip.
+  { columns: "body", opts: { name: "idx_probe_mysql_only", adapters: ["mysql"] } },
 ];
 const PARITY_EXPRESSION_INDEX = "(lower(external_id))";
 const GENERATOR_INDEXES: IndexSpec[] = PARITY_INDEXES.map((i) => ({
@@ -477,10 +480,11 @@ describe("generateSchemaFile / canonical-schema.ts index-gating parity", () => {
         generatorIndexes(GENERATOR_SCHEMA, adapter),
         canonicalIndexes(PARITY_INDEXES, adapter, true),
       ]);
-      // All four indexes survive on PG/SQLite (expression kept). Pin the count
-      // so the equality below can't pass vacuously if the schema wrapper stops
-      // being recognized and both sides silently record zero indexes.
-      expect(gen).toHaveLength(PARITY_INDEXES.length);
+      // Everything but the MySQL-only adapters-gated index survives on
+      // PG/SQLite (expression kept). Pin the count so the equality below can't
+      // pass vacuously if the schema wrapper stops being recognized and both
+      // sides silently record zero indexes.
+      expect(gen).toHaveLength(PARITY_INDEXES.length - 1);
       expect(normalizeRecorded(gen)).toBe(normalizeRecorded(canon));
     });
   }
@@ -494,8 +498,9 @@ describe("generateSchemaFile / canonical-schema.ts index-gating parity", () => {
       generatorIndexes(GENERATOR_SCHEMA, "mysql"),
       canonicalIndexes(PARITY_INDEXES, "mysql", false),
     ]);
-    // Only the expression index is dropped, so the other three survive — pin
-    // the count so the equality can't pass vacuously.
+    // Only the expression index is dropped (the adapters-gated MySQL-only
+    // index survives here), so the rest come through — pin the count so the
+    // equality can't pass vacuously.
     expect(gen).toHaveLength(PARITY_INDEXES.length - 1);
     expect(normalizeRecorded(gen)).toBe(normalizeRecorded(canon));
     // Length survives on MySQL (both keep it) and the expression index is

--- a/packages/activerecord/src/test-helpers/schema-file-generator.ts
+++ b/packages/activerecord/src/test-helpers/schema-file-generator.ts
@@ -185,12 +185,17 @@ function generateCode(
       // threads in `supportsExpressionIndex` (resolved from the DB version) to
       // match `emitTableIndexes`' runtime `supportsExpressionIndex(adapter)`
       // check (MySQL >= 8.0.13, SQLite >= 3.9, never MariaDB). When the flag is
-      // omitted, fall back to the coarse `adapterName === "mysql"` skip — exact
-      // for the only live caller today, the PG-only template path
-      // (template-global-setup.ts), where PG always supports expression indexes.
+      // omitted, fall back to the coarse `adapterName === "mysql"` skip — a
+      // last resort for a caller with no live connection. Live callers
+      // (test-setup-dy.ts, template-global-setup.ts) must thread the flag, or
+      // a MySQL-8 worker rebuild strips the canonical expression indexes.
       const dropExpression =
         supportsExpressionIndex !== undefined ? !supportsExpressionIndex : adapterName === "mysql";
       if (isExpression && dropExpression) continue;
+      // schema.rb's inline current_adapter? gate (e.g. the MySQL-only
+      // full_name_index) — mirrors emitTableIndexes' `opts.adapters` skip.
+      if (index.adapters && adapterName !== undefined && !index.adapters.includes(adapterName))
+        continue;
       const optEntries: string[] = [];
       if (index.unique) optEntries.push(`unique: true`);
       if (index.where !== undefined) optEntries.push(`where: ${JSON.stringify(index.where)}`);

--- a/packages/activerecord/src/test-helpers/schema-types.ts
+++ b/packages/activerecord/src/test-helpers/schema-types.ts
@@ -91,6 +91,12 @@ export interface IndexSpec {
   using?: string;
   /** Index type keyword, mirroring Rails' `t.index type:` (e.g. MySQL `"fulltext"`). */
   type?: string;
+  /**
+   * Restrict the index to these adapters, mirroring schema.rb's inline
+   * `if ActiveRecord::TestCase.current_adapter?(...)` gate (e.g. the MySQL-only
+   * `full_name_index`, schema.rb:426). Omitted = all adapters.
+   */
+  adapters?: readonly string[];
 }
 
 export interface WrappedTableSchema {

--- a/packages/activerecord/src/test-helpers/supports.test.ts
+++ b/packages/activerecord/src/test-helpers/supports.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, it } from "vitest";
 import { adapterType } from "../test-adapter.js";
 import { adapterSupports, describeIfSupports, itIfSupports } from "./supports.js";
 
+// Same lane-gated probe supports.ts itself uses — avoids a MySQL connection
+// attempt on the pg/sqlite lanes.
+const mysqlSupportsExpressionIndex =
+  adapterType === "mysql"
+    ? (await import("../adapters/abstract-mysql-adapter/test-helper.js")).supportsExpressionIndex
+    : false;
+
 // Assertions are computed from `adapterType` so they hold on every CI lane
 // (sqlite / postgres / mysql:8), not just the default sqlite run.
 describe("adapterSupports", () => {
@@ -15,9 +22,11 @@ describe("adapterSupports", () => {
   it("reflects the active adapter for backend-specific capabilities", () => {
     expect(adapterSupports("comments")).toBe(adapterType !== "sqlite");
     expect(adapterSupports("insert_conflict_target")).toBe(adapterType !== "mysql");
-    // expression_index: PG + SQLite; MySQL 8 qualifies at the server level but our
-    // schema-dump DDL generator doesn't yet emit correct MySQL 8 syntax (P-9 family).
-    expect(adapterSupports("expression_index")).toBe(adapterType !== "mysql");
+    // expression_index: PG + SQLite always; the MySQL family follows the live
+    // server (MySQL ≥ 8.0.13 true, MariaDB false) via the mysql test-helper probe.
+    expect(adapterSupports("expression_index")).toBe(
+      adapterType !== "mysql" || mysqlSupportsExpressionIndex,
+    );
     // advisory_locks: PG + MySQL, not SQLite (mirrors the old skipIf(=== sqlite)).
     expect(adapterSupports("advisory_locks")).toBe(adapterType !== "sqlite");
     // exclusion/unique constraints: PG only (mirrors skipIf(!== postgres)).

--- a/packages/activerecord/src/test-helpers/supports.ts
+++ b/packages/activerecord/src/test-helpers/supports.ts
@@ -29,6 +29,17 @@ import { adapterType } from "../test-adapter.js";
 const ALL = ["postgres", "mysql", "sqlite"] as const;
 type Backend = (typeof ALL)[number];
 
+// `supports_expression_index?` on the MySQL family is a live-server predicate
+// (`!mariadb? && database_version >= "8.0.13"`, abstract_mysql_adapter.rb:104)
+// that a static adapterType table cannot bake in: the mysql lane runs against
+// MySQL 8 (true) locally but the MariaDB stand-in (false) in CI. Probe the
+// server once, on the mysql lane only — the dynamic import keeps the probe's
+// connection attempt off the pg/sqlite lanes.
+const mysqlExpressionIndex =
+  adapterType === "mysql"
+    ? (await import("../adapters/abstract-mysql-adapter/test-helper.js")).supportsExpressionIndex
+    : false;
+
 const SUPPORTS: Readonly<Record<string, readonly Backend[]>> = {
   // Available on every backend we test (pg17 / mysql:8 / recent sqlite).
   savepoints: ALL,
@@ -51,12 +62,10 @@ const SUPPORTS: Readonly<Record<string, readonly Backend[]>> = {
   // PostgreSQL only (postgresql_adapter.rb:224/228; abstract default false).
   exclusion_constraints: ["postgres"],
   unique_constraints: ["postgres"],
-  // `supports_expression_index?`: `!mariadb? && database_version >= "8.0.13"`.
-  // MySQL 8 qualifies at the server level, but our schema-dump DDL generator
-  // does not yet emit the correct MySQL 8 expression-index syntax (P-9 family).
-  // Unlock "mysql" here once the dump path is fixed. (postgresql_adapter.rb:208,
-  // sqlite3_adapter.rb:155, abstract_mysql_adapter.rb:104)
-  expression_index: ["postgres", "sqlite"],
+  // `supports_expression_index?`: PG + SQLite always; MySQL family per the
+  // live-server probe above (MySQL ≥ 8.0.13, never MariaDB).
+  // (postgresql_adapter.rb:208, sqlite3_adapter.rb:155, abstract_mysql_adapter.rb:104)
+  expression_index: mysqlExpressionIndex ? ALL : ["postgres", "sqlite"],
   // `supports_bulk_alter?`: PostgreSQL + MySQL true, abstract default false.
   // (postgresql_adapter.rb:188, abstract_mysql_adapter.rb:96)
   bulk_alter: ["postgres", "mysql"],

--- a/packages/activerecord/src/test-helpers/test-schema.ts
+++ b/packages/activerecord/src/test-helpers/test-schema.ts
@@ -526,6 +526,12 @@ export const TEST_SCHEMA: Schema = {
         columns: "(CASE WHEN rating > 0 THEN lower(name) END) DESC",
         name: "company_expression_index",
       },
+      // schema.rb:426 — MySQL-only functional index (current_adapter?(:Mysql2, :Trilogy)).
+      {
+        columns: "(CONCAT_WS(`firm_name`, `name`, _utf8mb4' '))",
+        name: "full_name_index",
+        adapters: ["mysql"],
+      },
     ],
   },
 

--- a/packages/activerecord/src/test-setup-dy.ts
+++ b/packages/activerecord/src/test-setup-dy.ts
@@ -35,9 +35,20 @@ import { DatabaseTasks } from "./tasks/database-tasks.js";
 import "./relation.js";
 
 const { adapter, envConfig } = await buildTestDatabaseConfig();
-const schemaFilePath = await generateSchemaFile(TEST_SCHEMA, adapter);
 
 await Base.establishConnection(envConfig.configuration as Record<string, unknown>);
+
+// Resolve `supports_expression_index?` from the live connection BEFORE
+// generating the schema file: without it the generator falls back to its
+// coarse `adapterName === "mysql"` skip and this per-worker rebuild silently
+// strips the canonical expression indexes a MySQL-8 template DB carries
+// (company_expression_index / full_name_index), diverging from schema.rb.
+const { supportsExpressionIndex } = await import("./test-helpers/schema-types.js");
+const schemaFilePath = await generateSchemaFile(
+  TEST_SCHEMA,
+  adapter,
+  await supportsExpressionIndex(Base.connection),
+);
 
 const pgExclusive = adapter === "postgres" && !!process.env.AR_PG_EXCLUSIVE_DB;
 const mysqlExclusive = adapter === "mysql" && !!process.env.AR_MYSQL_EXCLUSIVE_DB;


### PR DESCRIPTION
## Summary

Fixes the P-9 family gap: MySQL 8 canonical expression indexes were silently stripped by the per-worker schema rebuild, so `expression_index` excluded mysql and "schema dump expression indices escaping" carried a wrong-gate (rails `mysql|expression_index` vs ts `postgresql,sqlite`).

- **Root cause:** `test-setup-dy.ts` called `generateSchemaFile(TEST_SCHEMA, adapter)` without the `supportsExpressionIndex` flag, so the generator's coarse `adapterName === "mysql"` fallback dropped every expression index when the worker DB was rebuilt — even though the MySQL 8 template DB (and the adapter's DDL + introspection) already handled them. Now the live `supports_expression_index?` answer is threaded in after `establishConnection`.
- `expression_index` in `test-helpers/supports.ts` now includes mysql per the live server (MySQL ≥ 8.0.13 true; the MariaDB CI stand-in stays false), via a lane-gated probe reusing the mysql test-helper (`supportsExpressionIndex`, mirroring abstract_mysql_adapter.rb:104).
- Added the canonical MySQL-only `full_name_index` (`(CONCAT_WS(...))`, schema.rb:426) via a new `adapters:` index gate mirrored in both emitters (`emitTableIndexes` + `generateSchemaFile`), with a parity-guard fixture entry.
- "schema dump expression indices escaping" is now the Rails mysql body (schema_dumper_test.rb:313-319, canonical companies dump, `concat_ws` backtick/charset-literal assertion) gated `itIfSupports.skipIf(adapterType !== "mysql")("expression_index", …)` — extracted gate matches rails; `test:compare --gates` reports schema_dumper_test.rb 67/67 with no wrong-gate. The former body was a bespoke PG/SQLite invention (bespoke `users` table) — deleted.
- "schema dump expression indices" gained Rails' mysql assertion arm (``lower(`name`)``).

## Testing

- mysql:8 (isolated compose stack): `schema-dumper.test.ts` 44 passed / 24 skipped, both expression-index dump tests green.
- postgres 17: `schema-dumper.test.ts`, `supports.test.ts`, `insert-all.test.ts` — 133 passed.
- sqlite: dumper + supports + generator parity + insert-all + pg-template — 143 passed.
- `pnpm test:compare --gates`: no gate-mismatch for schema_dumper_test.rb.

Closes-story: schema-dumper-mysql-expression-index-dump
