### PR TITLE
test(activerecord): make nan and permanent-checkout tests visible to test:compare

### DIFF
--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -777,15 +777,17 @@ describe("resolveConfigForConnection / connectsTo with unset configurations", ()
   });
 });
 
-describe("ConnectionHandlingTest common APIs with_connection", () => {
+// Second `ConnectionHandlingTest` block: this test needs `fixtures :posts`
+// while the block above runs fixture-less against a hand-established pool.
+describe("ConnectionHandlingTest", () => {
   // Mirrors Rails `ConnectionHandlingTest` with `fixtures :posts`. The test
   // asserts the pool releases its connection after each common API, so it must
   // run OUTSIDE transactional fixtures (which hold a permanent lease for the
   // wrapping transaction) — opt out by name via `usesTransaction`.
-  const testName =
-    "common APIs don't permanently hold a connection when permanent checkout is deprecated or disallowed";
   fixtures(["posts"], {
-    usesTransaction: [testName],
+    usesTransaction: [
+      "common APIs don't permanently hold a connection when permanent checkout is deprecated or disallowed",
+    ],
   });
 
   afterEach(async () => {
@@ -796,7 +798,7 @@ describe("ConnectionHandlingTest common APIs with_connection", () => {
     await Post.where({ title: "foo" }).deleteAll();
   });
 
-  it(testName, async () => {
+  it("common APIs don't permanently hold a connection when permanent checkout is deprecated or disallowed", async () => {
     setPermanentConnectionCheckout("deprecated");
     Base.releaseConnection();
     expect(Base.connectionPool().activeConnection).toBeNull();

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -809,28 +809,7 @@ describe("ConnectionHandlingTest", () => {
     await Post.first();
     expect(Post.connectionPool().activeConnection).toBeNull();
 
-    await Post.first(2);
-    expect(Post.connectionPool().activeConnection).toBeNull();
-
-    await Post.second();
-    expect(Post.connectionPool().activeConnection).toBeNull();
-
-    await Post.secondToLast();
-    expect(Post.connectionPool().activeConnection).toBeNull();
-
-    await Post.last();
-    expect(Post.connectionPool().activeConnection).toBeNull();
-
-    await Post.last(2);
-    expect(Post.connectionPool().activeConnection).toBeNull();
-
     await Post.count();
-    expect(Post.connectionPool().activeConnection).toBeNull();
-
-    await Post.findBySql("SELECT * FROM posts");
-    expect(Post.connectionPool().activeConnection).toBeNull();
-
-    await Post.countBySql("SELECT COUNT(*) FROM posts");
     expect(Post.connectionPool().activeConnection).toBeNull();
   });
 });

--- a/packages/activerecord/src/numeric-data.test.ts
+++ b/packages/activerecord/src/numeric-data.test.ts
@@ -7,10 +7,6 @@ import { Base } from "./index.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { adapterType } from "./test-adapter.js";
 
-// Rails guards test_numeric_fields_with_nan with current_adapter?(:PostgreSQLAdapter):
-// only PostgreSQL's numeric type stores NaN (SQLite/MySQL reject 'NaN'::numeric).
-const itPg = adapterType === "postgres" ? it : it.skip;
-
 fixtures([]);
 
 beforeAll(async () => {
@@ -93,7 +89,9 @@ describe("NumericDataTest", () => {
     expect((m1!.big_bank_balance as BigDecimal).toString("F")).toBe("234000567.95");
   });
 
-  itPg("numeric fields with nan", async () => {
+  // Rails guards test_numeric_fields_with_nan with current_adapter?(:PostgreSQLAdapter):
+  // only PostgreSQL's numeric type stores NaN (SQLite/MySQL reject 'NaN'::numeric).
+  it.skipIf(adapterType !== "postgres")("numeric fields with nan", async () => {
     // BigDecimal has no NaN form, so BigDecimal("NaN") (passed in as the JS
     // NaN) round-trips as the sentinel "NaN" rather than a BigDecimal — the
     // stand-in for Rails' `nan?` predicate.


### PR DESCRIPTION
`test:compare` reported one missing test in each of `connection-handling.test.ts` and `numeric-data.test.ts`. Both tests were already ported and passing — the extractor just couldn't see them:

- `numeric-data.test.ts` — "numeric fields with nan" was gated behind a bespoke `const itPg = adapterType === "postgres" ? it : it.skip`, which the TS extractor doesn't recognize. Converted to the standard `it.skipIf(adapterType !== "postgres")` form (extractor emits a proper adapter gate).
- `connection-handling.test.ts` — "common APIs don't permanently hold a connection when permanent checkout is deprecated or disallowed" passed its title through a `testName` const (invisible to the extractor) and lived in an invented describe (`ConnectionHandlingTest common APIs with_connection`). Inlined the title literal and renamed the describe to `ConnectionHandlingTest` to match Rails; the block stays separate because it needs `fixtures(["posts"])` with `usesTransaction` opt-out while the main block is fixture-less.

After: both files show Miss 0 and ✓ in `test:compare`, 0 wrong-describe.

Closes-story: missing-singletons-connection-handling-numeric-nan

- Follow-up commit: trimmed the common-APIs lease test to Rails' three calls (`create!`/`first`/`count`) — the extra first(2)/second/last/find_by_sql probes were a trails addition.
