### PR TITLE
test(activerecord): un-skip adapter notifications/pk-zero and sqlite explain eager-loading

### DIFF
--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach, afterAll } from "vitest";
 import { Nodes } from "@blazetrails/arel";
+import { Notifications } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import { AbstractAdapter } from "./connection-adapters/abstract-adapter.js";
@@ -262,12 +263,11 @@ describe("AdapterTest", () => {
     expect(b.name).toBe("my other \x00 book");
   });
 
-  it.skip("create record with pk as zero", () => {
-    // BLOCKED: schema-gen. defineSchema emits the canonical `books` PK as an
-    // auto-increment/identity column (PG GENERATED AS IDENTITY, MySQL AUTO_INCREMENT
-    // treats inserted 0 as "next value"), so explicit `id: 0` is overridden and
-    // `Book.find(0)` misses. Rails declares `books` with `id: :integer` (plain integer
-    // PK that honours 0). Skipped until defineSchema can mirror that.
+  it("create record with pk as zero", async () => {
+    await Book.create({ id: 0 });
+    expect((await Book.find(0)).id).toBe(0);
+    // assert_nothing_raised: a throw here fails the test.
+    await Book.destroy(0);
   });
 
   it("valid column", () => {
@@ -458,11 +458,17 @@ describe("AdapterTest", () => {
     },
   );
 
-  it.skip("exceptions from notifications are not translated", () => {
-    // BLOCKED: notifications. activesupport Notifications._notify swallows subscriber
-    // errors on the instrument()/instrumentAsync() path (only publish() with
-    // propagate=true re-raises), so a subscriber raising inside sql.active_record never
-    // bubbles to the caller. Needs Notifications to re-raise from instrumented blocks.
+  it("exceptions from notifications are not translated", async () => {
+    const originalError = new Error("This StandardError shouldn't get translated");
+    const subscriber = Notifications.subscribe("sql.active_record", () => {
+      throw originalError;
+    });
+    try {
+      const actualError = await Base.connection.execute("SELECT * FROM posts").catch((e) => e);
+      expect(actualError).toBe(originalError);
+    } finally {
+      Notifications.unsubscribe(subscriber);
+    }
   });
 
   it("database related exceptions are translated to statement invalid", async () => {
@@ -1239,14 +1245,9 @@ function twoWeeksAgo(): string {
     .slice(0, 19);
 }
 
-describe("AdapterThreadSafetyTest", () => {
-  it.skip("#active? is synchronized", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — gvl
-  });
-  it.skip("#verify! is synchronized", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — gvl
-  });
-});
+// Rails' AdapterThreadSafetyTest ("#active? is synchronized" / "#verify! is
+// synchronized") is Ruby-only (Thread.new/GVL interleaving) and registered as
+// unported in scripts/api-compare/unported-files.ts.
 
 // MySQL-only: invalidateTransaction fires only when
 // isSavepointErrorsInvalidateTransactions() is true (Mysql2Adapter override);

--- a/packages/activerecord/src/adapters/sqlite3/explain.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/explain.test.ts
@@ -6,7 +6,9 @@ import "../../index.js";
 import { describeIfSqlite } from "./test-helper.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
 import { Author } from "../../test-helpers/models/author.js";
-import "../../test-helpers/models/post.js";
+// Opt into the canonical-model autoload index so `Author.has_many :posts`
+// resolves `Post` by name on first reference.
+import "../../test-helpers/canonical-model-index.js";
 
 // -- Rails test class: explain_test.rb (ActiveRecord::SQLite3TestCase) --
 // Pinned to the SQLite backend: the `EXPLAIN for: … "authors" …` header quoting
@@ -25,9 +27,17 @@ describeIfSqlite("SQLite3ExplainTest", () => {
     expect(explain).toMatch(/(SEARCH )?(TABLE )?authors USING (INTEGER )?PRIMARY KEY/);
   });
 
-  it.skip("explain with eager loading", () => {
-    // BLOCKED: adapter-sqlite — SQLite-specific adapter gap in explain
-    // ROOT-CAUSE: adapters/sqlite3/explain.ts missing Rails parity
-    // SCOPE: ~30–100 LOC fix in adapters/sqlite3/explain.ts; affects ~1–17 tests in explain.test.ts
+  it("explain with eager loading", async () => {
+    const explain = await Author.where({ id: authors("david").id })
+      .includes("posts")
+      .explain();
+    expect(explain).toMatch(
+      /EXPLAIN for: SELECT "authors"\.\* FROM "authors" WHERE "authors"\."id" = (?:\? \[\["id", 1\]\]|\? \[1\]|1)/,
+    );
+    expect(explain).toMatch(/(SEARCH )?(TABLE )?authors USING (INTEGER )?PRIMARY KEY/);
+    expect(explain).toMatch(
+      /EXPLAIN for: SELECT "posts"\.\* FROM "posts" WHERE "posts"\."author_id" = (?:\? \[\["author_id", 1\]\]|\? \[1\]|1)/,
+    );
+    expect(explain).toMatch(/(SEARCH |(SCAN )?(TABLE ))posts/);
   });
 });

--- a/packages/activerecord/src/test-helpers/canonical-schema.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.ts
@@ -1234,7 +1234,11 @@ async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
   });
 
   await define("posts", {}, (t) => {
+    // Rails: `t.references :author` — references default `index: true`, so
+    // schema.rb emits index_posts_on_author_id (load-bearing for the SQLite
+    // explain eager-loading plan: SEARCH posts USING INDEX, not SCAN).
     t.integer("author_id");
+    t.index("author_id", { name: "index_posts_on_author_id" });
     t.string("title", { null: false });
     t.text("body", { null: false });
     t.string("type");

--- a/packages/activerecord/src/test-helpers/test-schema.ts
+++ b/packages/activerecord/src/test-helpers/test-schema.ts
@@ -1201,17 +1201,23 @@ export const TEST_SCHEMA: Schema = {
   },
 
   posts: {
-    author_id: "integer",
-    title: { type: "string", null: false },
-    body: { type: "text", null: false },
-    type: "string",
-    legacy_comments_count: { type: "integer", default: 0 },
-    taggings_with_delete_all_count: { type: "integer", default: 0 },
-    taggings_with_destroy_count: { type: "integer", default: 0 },
-    tags_count: { type: "integer", default: 0 },
-    indestructible_tags_count: { type: "integer", default: 0 },
-    tags_with_destroy_count: { type: "integer", default: 0 },
-    tags_with_nullify_count: { type: "integer", default: 0 },
+    columns: {
+      author_id: "integer",
+      title: { type: "string", null: false },
+      body: { type: "text", null: false },
+      type: "string",
+      legacy_comments_count: { type: "integer", default: 0 },
+      taggings_with_delete_all_count: { type: "integer", default: 0 },
+      taggings_with_destroy_count: { type: "integer", default: 0 },
+      tags_count: { type: "integer", default: 0 },
+      indestructible_tags_count: { type: "integer", default: 0 },
+      tags_with_destroy_count: { type: "integer", default: 0 },
+      tags_with_nullify_count: { type: "integer", default: 0 },
+    },
+    // Rails: `t.references :author` — references default `index: true`, so
+    // schema.rb emits index_posts_on_author_id (load-bearing for the SQLite
+    // explain eager-loading plan: SEARCH posts USING INDEX, not SCAN).
+    indexes: [{ columns: "author_id", name: "index_posts_on_author_id" }],
   },
 
   postesques: {


### PR DESCRIPTION
Part of RFC 0030-ar-test-compare-residual-burndown (adapter cluster, story E4).

## What

Un-skips the story's `it.skip` targets in `adapter.test.ts` and
`adapters/sqlite3/explain.test.ts`:

- **exceptions from notifications are not translated** — the recorded blocker
  (Notifications swallowing subscriber errors) was resolved by the RFC 0023
  Fanout convergence (#4903/#4913): `instrument` now re-raises subscriber
  errors. Test body ported from `adapter_test.rb:245` and passes as-is.
- **create record with pk as zero** — the recorded blocker no longer holds:
  SQLite honours an explicit 0 rowid, PG serial accepts explicit ids, and the
  mysql2 adapter sets `NO_AUTO_VALUE_ON_ZERO` like Rails
  (`mysql2-adapter.ts:2070` ↔ `abstract_mysql_adapter.rb:936`).
- **explain with eager loading** (sqlite3) — Rails' plan regex
  `(SEARCH |(SCAN )?(TABLE ))posts` requires the `index_posts_on_author_id`
  index that schema.rb gets implicitly from `t.references :author`
  (references default `index: true`); our posts table lacked it, so SQLite
  planned `SCAN posts`. Added the index to both schema sources
  (`canonical-schema.ts` and `TEST_SCHEMA`) and mirrored the Rails test body.
- **#active? / #verify! is synchronized** — deleted the `it.skip` stubs: the
  Ruby tests are Thread.new/GVL-only and are already registered as unported in
  `scripts/api-compare/unported-files.ts` (AdapterThreadSafetyTest entry), so
  the stubs only produced `matchedSkipped` noise.
- **update prepared statement** — already un-skipped on main (gated
  `skipIf(postgres)` mirroring Rails' adapter gate); verified passing.

`adapters/postgresql/explain.test.ts` and `mysql-explain.test.ts` verified:
their counted skips are `describeIfPg`/`describeIfMysql` gates, no `it.skip`.

Residual: `disconnect and recover on #configure_connection failure` stays
skipped — it is a surfaced deviation tracked by RFC 0023 story
`adapter-configure-connection-failure-propagation`, not on this story's list.

`test:compare` now reports 1 matchedSkipped for `adapter_test.rb` (the tracked
residual above) and 0 for the explain files.

Closes-story: e4-adapter-explain-notifications
