### PR TITLE
test(activerecord): port the 12 residual enum_test.rb skips to real bodies

### DIFF
--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -593,8 +593,36 @@ describe("EnumTest", () => {
   });
 
   // Rails: anonymous AR class with `validates_uniqueness_of` / inclusion.
-  it.skip("validate uniqueness", () => {});
-  it.skip("validate inclusion of value in array", () => {});
+  it("validate uniqueness", async () => {
+    class Klass extends Base {
+      static _tableName = "books";
+      static {
+        this.enum("status", ["proposed", "written"]);
+        this.validatesUniquenessOf("status");
+      }
+    }
+    registerModel(Klass);
+    await (Klass as any).deleteAll();
+    await Klass.createBang({ status: "proposed" });
+    const book = new Klass({ status: "written" }) as any;
+    expect(await book.isValid()).toBe(true);
+    book.status = "proposed";
+    expect(await book.isValid()).toBe(false);
+  });
+
+  it("validate inclusion of value in array", async () => {
+    class Klass extends Base {
+      static _tableName = "books";
+      static {
+        this.enum("status", ["proposed", "written"]);
+        this.validatesInclusionOf("status", { in: ["written"] });
+      }
+    }
+    const invalidBook = new Klass({ status: "proposed" }) as any;
+    expect(await invalidBook.isValid()).toBe(false);
+    const validBook = new Klass({ status: "written" }) as any;
+    expect(await validBook.isValid()).toBe(true);
+  });
 
   // Rails: `book.status_change` / per-class & inheritable enum redefinition.
   it("enums are distinct per class", async () => {
@@ -896,13 +924,70 @@ describe("EnumTest", () => {
   });
 
   // Rails: the legacy `:_default` / `:_prefix` / `:_suffix` / `:_scopes` /
-  // `:_instance_methods` options must raise — covered behaviorally in
-  // enum.trails.test.ts (assertValidEnumOptions).
-  it.skip(":_default is invalid in the new API", () => {});
-  it.skip(":_prefix is invalid in the new API", () => {});
-  it.skip(":_suffix is invalid in the new API", () => {});
-  it.skip(":_scopes is invalid in the new API", () => {});
-  it.skip(":_instance_methods is invalid in the new API", () => {});
+  // `:_instance_methods` options must raise (assertValidEnumOptions).
+  it(":_default is invalid in the new API", () => {
+    expect(() => {
+      class Klass extends Base {
+        static _tableName = "books";
+        static {
+          this.enum("status", ["proposed", "written", "published"], {
+            _default: "published",
+          } as any);
+        }
+      }
+      void Klass;
+    }).toThrow(/invalid option\(s\): :_default/);
+  });
+
+  it(":_prefix is invalid in the new API", () => {
+    expect(() => {
+      class Klass extends Base {
+        static _tableName = "books";
+        static {
+          this.enum("status", ["proposed", "written", "published"], { _prefix: true } as any);
+        }
+      }
+      void Klass;
+    }).toThrow(/invalid option\(s\): :_prefix/);
+  });
+
+  it(":_suffix is invalid in the new API", () => {
+    expect(() => {
+      class Klass extends Base {
+        static _tableName = "books";
+        static {
+          this.enum("status", ["proposed", "written", "published"], { _suffix: true } as any);
+        }
+      }
+      void Klass;
+    }).toThrow(/invalid option\(s\): :_suffix/);
+  });
+
+  it(":_scopes is invalid in the new API", () => {
+    expect(() => {
+      class Klass extends Base {
+        static _tableName = "books";
+        static {
+          this.enum("status", ["proposed", "written", "published"], { _scopes: false } as any);
+        }
+      }
+      void Klass;
+    }).toThrow(/invalid option\(s\): :_scopes/);
+  });
+
+  it(":_instance_methods is invalid in the new API", () => {
+    expect(() => {
+      class Klass extends Base {
+        static _tableName = "books";
+        static {
+          this.enum("status", ["proposed", "written", "published"], {
+            _instance_methods: false,
+          } as any);
+        }
+      }
+      void Klass;
+    }).toThrow(/invalid option\(s\): :_instance_methods/);
+  });
 
   // Rails: `scopes: false` / `instance_methods: false` opt-outs.
   it("scopes can be disabled by :scopes", () => {
@@ -997,11 +1082,48 @@ describe("EnumTest", () => {
     expect(typeof (K as any).balineseJavanese).toBe("function");
   });
 
-  // Rails: anonymous-class enum names with capitals / unicode / slashes, and
-  // Struct-keyed hash labels — JS-idiom-divergent enum-name surfaces.
-  it.skip("capital characters for enum names", () => {});
-  it.skip("unicode characters for enum names", () => {});
-  it.skip("mangling collision for enum names", () => {});
+  // Rails: anonymous-class enum names with capitals / unicode / slashes. Labels
+  // with characters outside `\w` get the original-form predicate (bracket
+  // notation) alongside the camelized scope, mirroring Rails'
+  // `define_method("Etc/GMT+1?")` surface.
+  it("capital characters for enum names", () => {
+    class Klass extends Base {
+      static _tableName = "computers";
+      static {
+        this.enum("extendedWarranty", ["extendedSilver", "extendedGold"]);
+      }
+    }
+    const computer = (Klass as any).extendedSilver().build();
+    expect(computer.isExtendedSilver()).toBe(true);
+    expect(computer.isExtendedGold()).toBe(false);
+  });
+
+  it("unicode characters for enum names", () => {
+    class Klass extends Base {
+      static _tableName = "books";
+      static {
+        this.enum("language", ["🇺🇸", "🇪🇸", "🇫🇷"]);
+      }
+    }
+    const book = (Klass as any)["🇺🇸"]().build();
+    expect(book["is🇺🇸"]()).toBe(true);
+    expect(book["is🇪🇸"]()).toBe(false);
+  });
+
+  it("mangling collision for enum names", () => {
+    class Klass extends Base {
+      static _tableName = "computers";
+      static {
+        this.enum("timezone", ["Etc/GMT+1", "Etc/GMT-1"]);
+      }
+    }
+    // Rails calls the scope by its literal label (`public_send(:"Etc/GMT+1")`);
+    // trails scope names go through camelize, which maps "/" to "::" —
+    // "Etc/GMT+1" → "etc::GMT+1". The original-form predicates keep the label.
+    const computer = (Klass as any)["etc::GMT+1"]().build();
+    expect(computer["isEtc/GMT+1"]()).toBe(true);
+    expect(computer["isEtc/GMT-1"]()).toBe(false);
+  });
 
   // Rails keys the hash with `Struct.new(:to_s).new("proposed")` objects and
   // asserts `book.status` returns the original key. JS object keys stringify, so
@@ -1021,7 +1143,33 @@ describe("EnumTest", () => {
     expect((b as any).isProposed()).toBe(true);
     expect((b as any).isWritten()).toBe(false);
   });
-  it.skip("serializable? with large number label", () => {});
+  // Rails' out-of-range Integer literals translate to BigInt: an unmapped
+  // number past the column's byte range is not serializable, the string label
+  // is (it maps to 0/1).
+  it("serializable? with large number label", async () => {
+    class Klass extends Base {
+      static _tableName = "books";
+      static {
+        this.enum("status", ["9223372036854775808", "-9223372036854775809"]);
+      }
+    }
+    const type = (Klass as any).typeForAttribute("status");
+
+    expect(type.isSerializable("9223372036854775808")).toBe(true);
+    expect(type.isSerializable("-9223372036854775809")).toBe(true);
+
+    expect(type.isSerializable(9223372036854775808n)).toBe(false);
+    expect(type.isSerializable(-9223372036854775809n)).toBe(false);
+
+    const book1 = await Klass.createBang({ status: "9223372036854775808" });
+    const book2 = await Klass.createBang({ status: "-9223372036854775809" });
+
+    expect((book1 as any).statusForDatabase).toBe(0);
+    expect((book2 as any).statusForDatabase).toBe(1);
+
+    expect((await Klass.where({ status: "9223372036854775808" }).last())?.id).toBe(book1.id);
+    expect((await Klass.where({ status: "-9223372036854775809" }).last())?.id).toBe(book2.id);
+  });
 
   // Rails routes the clash message through the model logger; trails routes it
   // through the `setEnumWarn` sink (default `console.warn`). The exact wording
@@ -1060,8 +1208,22 @@ describe("EnumTest", () => {
     }
   });
 
-  // Rails: `boolean_status` / distinct-clash surface not yet expressible.
-  it.skip("enum doesn't log a warning if no clashes detected", () => {});
+  it("enum doesn't log a warning if no clashes detected", () => {
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      class Klass extends Base {
+        static _tableName = "books";
+        static {
+          this.attribute("status", "integer");
+          this.enum("status", ["notSent"]);
+        }
+      }
+      void Klass;
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
 
   it("enum doesn't log a warning if opting out of scopes", () => {
     const spy = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -8,15 +8,12 @@
  * `Book.published` → `Book.published()`, `@book.written!` → `book.writtenBang()`,
  * `Book.statuses` → `Book.statuses`).
  *
- * Cases the canonical `Book` enum surface cannot yet express are kept under
- * their Rails names and `it.skip`-ped, tracked-pending-convergence under RFC
- * 0023-surfaced-deviations (enum-canonical-book-gaps): frozen `statuses`,
- * `*_before_type_cast` / `*_for_database`, and the
- * conflict-detection / option-validation message surface (the last is covered
- * behaviorally in enum.trails.test.ts). The `cover` string enum, the
- * `boolean_status` boolean enum, and the `last_read` `forgotten: nil` value are
- * now wired on the canonical `Book` model (EnumType supports string/boolean/nil
- * values).
+ * The `cover` string enum, the `boolean_status` boolean enum, and the
+ * `last_read` `forgotten: nil` value are wired on the canonical `Book` model
+ * (EnumType supports string/boolean/nil values). Remaining sub-assertion gaps
+ * on the canonical `Book` surface are tracked under RFC
+ * 0023-surfaced-deviations (enum-canonical-book-gaps) via inline pending
+ * comments below.
  */
 import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
 import { Base, registerModel, Range } from "./index.js";

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -692,6 +692,7 @@ export function _enum(
   const enumMethodNames = enumMethodsHost._enumMethodsModuleNames!;
   const definedNames = new Set<string>();
   const valueMethodNames: string[] = [];
+  const aliasedLabels = new Set<string>();
   for (const [n] of Object.entries(mapping)) {
     const fullName = toCamel(methodName(n));
     const { predicateName, bangName, notScopeName } = enumMethodNamesFor(fullName);
@@ -699,10 +700,17 @@ export function _enum(
 
     // Rails feeds both the value method name and its special-char-stripped
     // friendly alias into detect_negative_enum_conditions! (enum.rb:266-279),
-    // pushing the alias only when it differs and isn't already present.
+    // pushing the alias only when it differs and isn't already present. The
+    // same guard also gates the alias's define_enum_methods call (enum.rb:273):
+    // two labels mangling to one alias (e.g. "Etc/GMT+1" / "Etc/GMT-1") is NOT
+    // a conflict — the alias sticks to the first label and the second label
+    // simply doesn't get one. Record the decision in `aliasedLabels` so the
+    // generation pass below skips the alias for later same-mangling labels too.
     valueMethodNames.push(fullName);
-    if (friendlyName !== fullName && !valueMethodNames.includes(friendlyName)) {
+    const aliasIsNew = friendlyName !== fullName && !valueMethodNames.includes(friendlyName);
+    if (aliasIsNew) {
       valueMethodNames.push(friendlyName);
+      aliasedLabels.add(n);
     }
 
     // Rails runs `detect_enum_conflict!` for the `?`/`!` methods *only* inside
@@ -752,7 +760,7 @@ export function _enum(
       detectEnumConflictBang.call(this, attribute, fullName, true);
       detectEnumConflictBang.call(this, attribute, notScopeName, true);
     }
-    if (friendlyName !== fullName) {
+    if (aliasIsNew) {
       const {
         predicateName: fp,
         bangName: friendlyBang,
@@ -815,7 +823,7 @@ export function _enum(
       scopesEnabled,
       instanceMethodsEnabled,
     );
-    if (friendlyName !== fullName) {
+    if (aliasedLabels.has(n)) {
       methodsModule.defineEnumMethods(
         attrName,
         friendlyName,
@@ -857,7 +865,7 @@ export function _enum(
       const names = enumMethodNamesFor(fullName);
       enumMethodNames.add(names.predicateName);
       enumMethodNames.add(names.bangName);
-      if (friendlyName !== fullName) {
+      if (aliasedLabels.has(n)) {
         const friendlyNames = enumMethodNamesFor(friendlyName);
         enumMethodNames.add(friendlyNames.predicateName);
         enumMethodNames.add(friendlyNames.bangName);


### PR DESCRIPTION
Ports the 12 residual `matchedSkipped` body-less stubs in
`packages/activerecord/src/enum.test.ts` to faithful bodies from
`vendor/rails/activerecord/test/cases/enum_test.rb`:

- **validate uniqueness / validate inclusion of value in array** — anonymous
  books-backed classes with `validatesUniquenessOf` / `validatesInclusionOf`.
- **`:_default` / `:_prefix` / `:_suffix` / `:_scopes` / `:_instance_methods`
  is invalid in the new API** — each asserts the
  `invalid option(s): :_x` ArgumentError from `assertValidEnumOptions`.
- **capital / unicode / mangling-collision enum names** — camelized scope +
  predicate surfaces; special-char labels use the original-form bracket
  predicates (`isEtc/GMT+1`), mirroring Rails' literal `define_method` names.
- **serializable? with large number label** — string labels map through the
  enum; out-of-range BigInts are rejected by the integer subtype; DB roundtrip
  + `statusForDatabase` + where-query assertions.
- **enum doesn't log a warning if no clashes detected**.

Convergence fix surfaced by the mangling-collision port: Rails defines a
label's special-char friendly alias only when no earlier label already
produced it (`!value_method_names.include?(value_method_alias)`,
enum.rb:273), while trails ran the alias conflict check and generation
unconditionally — so `enum("timezone", ["Etc/GMT+1", "Etc/GMT-1"])` raised
"already defined by another enum" where Rails succeeds. `_enum` now records
the alias decision per label (`aliasedLabels`) and gates the conflict pass,
the generation pass, and the `_enumMethodsModuleNames` recording on it: the
alias sticks to the first label, later same-mangling labels simply get none.

`test:compare` now reports enum.test.ts with 0 matchedSkipped (clean ✓, 97
matched). Diff: 192 insertions / 22 deletions.

Closes-story: enum-residual-skip-burndown
