### PR TITLE
test(activerecord): burn down inheritance.test.ts residual skips

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -983,7 +983,9 @@ export class Base extends Model {
   }
 
   static _requireConcreteClass(): void {
-    if (this.abstractClass && !this._suppressAbstractCheck) {
+    // Rails: `abstract_class? || self == Base` (inheritance.rb:57) — Base
+    // itself is not abstract_class? but still cannot be instantiated.
+    if ((this.abstractClass || this === Base) && !this._suppressAbstractCheck) {
       // @nie disposition=keep-as-strategy-hook rails=activerecord/lib/active_record/inheritance.rb:58
       throw new NotImplementedError(
         `${this.name} is an abstract class and cannot be instantiated.`,

--- a/packages/activerecord/src/inheritance.test.ts
+++ b/packages/activerecord/src/inheritance.test.ts
@@ -29,6 +29,7 @@ import {
   GreenCabbage,
   KingCole,
   RedCabbage,
+  YellingVegetable,
 } from "./test-helpers/models/vegetables.js";
 import { Subscriber, SpecialSubscriber } from "./test-helpers/models/subscriber.js";
 import { SelectedMembership } from "./test-helpers/models/membership.js";
@@ -222,23 +223,31 @@ describe("InheritanceTest", () => {
     expect(cabbage).toBeInstanceOf(Cabbage);
   });
 
-  it.skip("becomes sets variables before initialization callbacks", () => {
-    // TRACKED-PENDING-CONVERGENCE: trails becomes() does not trigger afterInitialize
-    // callbacks on the new instance; Rails calls initialize on the becomes() target class
-    // so YellingVegetable.afterInitialize fires and upcases the name. Story:
-    // becomes-after-initialize (RFC 0019).
+  it("becomes sets variables before initialization callbacks", async () => {
+    const vegetable = await Vegetable.createBang({ name: "yelling carrot" });
+    expect(vegetable).toBeInstanceOf(Vegetable);
+    expect(vegetable.name).toBe("yelling carrot");
+
+    const yellingVeggie = vegetable.becomes(YellingVegetable);
+    expect(yellingVeggie.name).toBe("YELLING CARROT");
+    expect(vegetable.name).toBe("YELLING CARROT");
   });
 
-  it.skip("becomes and change tracking for inheritance columns", () => {
-    // TRACKED-PENDING-CONVERGENCE: change tracking for custom inheritance columns (custom_type
-    // on Vegetable) after becomes() is not yet implemented in trails. Story:
-    // becomes-custom-type-change-tracking (RFC 0019).
+  it("becomes and change tracking for inheritance columns", async () => {
+    const cucumber = await Vegetable.find(1);
+    const cabbage = cucumber.becomesBang(Cabbage);
+    expect((cabbage as any).attributeChange("custom_type")).toEqual(["Cucumber", "Cabbage"]);
   });
 
-  it.skip("alt becomes bang resets inheritance type column", () => {
-    // TRACKED-PENDING-CONVERGENCE: trails stores the base class name in the custom_type column
-    // (e.g. "Vegetable") instead of NULL for a base-class instance; Rails stores NULL.
-    // Story: becomes-custom-type-null-base (RFC 0019).
+  it("alt becomes bang resets inheritance type column", async () => {
+    const vegetable = await Vegetable.createBang({ name: "Red Pepper" });
+    expect(vegetable.custom_type).toBeNull();
+
+    const cabbage = vegetable.becomesBang(Cabbage);
+    expect(cabbage.custom_type).toBe("Cabbage");
+
+    cabbage.becomesBang(Vegetable);
+    expect(cabbage.custom_type).toBeNull();
   });
 
   it("inheritance find all", async () => {
@@ -307,10 +316,11 @@ describe("InheritanceTest", () => {
     );
   });
 
-  it.skip("new with ar base", () => {
-    // TRACKED-PENDING-CONVERGENCE: in trails, Base.abstractClass is false (not an abstract
-    // class), so Base.new() does not throw. Rails raises NotImplementedError for
-    // ActiveRecord::Base.new. Story: base-class-new-abstract (RFC 0019).
+  it("new with ar base", () => {
+    expect(() => Base.new()).toThrow(NotImplementedError);
+    // Rails: "ActiveRecord::Base is an abstract class..." — trails has no Ruby
+    // namespace, so the class reads as "Base".
+    expect(() => Base.new()).toThrow("Base is an abstract class and cannot be instantiated.");
   });
 
   it("new with invalid type", () => {
@@ -505,11 +515,15 @@ describe("InheritanceTest", () => {
     expect(error).toBeUndefined();
   });
 
-  it.skip("scope inherited properly", () => {
-    // TRACKED-PENDING-CONVERGENCE: trails' join implementation does not yet support
-    // nested association paths ({ account: "firm" }). The ofFirstFirm scope uses
-    // q.joins({ account: "firm" }) which throws ArgumentError in trails.
-    // Story: scope-inherited-nested-join (RFC 0019).
+  it("scope inherited properly", async () => {
+    let error: unknown;
+    try {
+      await Company.ofFirstFirm();
+      await Client.ofFirstFirm();
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeUndefined();
   });
 
   it("inheritance with default scope", async () => {
@@ -540,10 +554,34 @@ describe("InheritanceComputeTypeTest", () => {
     expect(error).toBeUndefined();
   });
 
-  it.skip("inheritance new with subclass as default", () => {
-    // PERMANENT-SKIP: requires DDL (change_column_default) at runtime.
-    // Rails uses connection.change_column_default + reset_column_information to set a column
-    // default mid-test. Trails does not support live DDL column-default changes in tests.
+  it("inheritance new with subclass as default", async () => {
+    await Company.loadSchema();
+    const originalType = (Company as any).columnsHash()["type"].default;
+    try {
+      await Base.connection.changeColumnDefault("companies", "type", "Firm");
+      (Company as any).resetColumnInformation();
+      await Company.loadSchema();
+
+      let firm = Company.new(); // without arguments
+      expect((firm as any).type).toBe("Firm");
+      expect(firm).toBeInstanceOf(Firm);
+
+      firm = Company.new({ firm_name: "Shri Hans Plastic" }); // with arguments
+      expect((firm as any).type).toBe("Firm");
+      expect(firm).toBeInstanceOf(Firm);
+
+      const client = Client.new();
+      expect((client as any).type).toBe("Client");
+      expect(client).toBeInstanceOf(Client);
+
+      firm = Company.new({ type: "Client" }); // overwrite the default type
+      expect((firm as any).type).toBe("Client");
+      expect(firm).toBeInstanceOf(Client);
+    } finally {
+      await Base.connection.changeColumnDefault("companies", "type", originalType);
+      (Company as any).resetColumnInformation();
+      await Company.loadSchema();
+    }
   });
 });
 

--- a/packages/activerecord/src/persistence.trails.test.ts
+++ b/packages/activerecord/src/persistence.trails.test.ts
@@ -239,3 +239,19 @@ describe("PersistenceTest (trails)", () => {
     expect(aircraft.wingspan).toBeNull();
   });
 });
+
+describe("PersistenceTest (trails)", () => {
+  fixtures(["companies"]);
+
+  // Rails' becomes allocates with `klass.allocate` (persistence.rb:487), which
+  // never enters Inheritance::ClassMethods#new — so the abstract-class / Base
+  // guard `new` enforces (inheritance.rb:57) must not fire for becomes().
+  it("becomes bypasses the Base abstract-instantiation guard", async () => {
+    const { Base } = await import("./index.js");
+    const { Company } = await import("./test-helpers/models/company.js");
+    const company = await Company.first();
+    const asBase = company!.becomes(Base as never);
+    expect(asBase).toBeInstanceOf(Base);
+    expect((asBase as unknown as { id: unknown }).id).toBe(company!.id);
+  });
+});

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -1634,10 +1634,19 @@ export function becomes<
   // Store the class itself, not a boolean: the constructor only skips dispatch
   // when `new.target` *is* this class, so an inherited static never suppresses
   // a nested `new <subclass>()`.
-  const ctor = klass as unknown as { _suppressStiNewDispatch?: unknown };
+  const ctor = klass as unknown as {
+    _suppressStiNewDispatch?: unknown;
+    _suppressAbstractCheck?: boolean;
+  };
   const hadOwn = Object.prototype.hasOwnProperty.call(ctor, "_suppressStiNewDispatch");
   const prev = ctor._suppressStiNewDispatch;
   ctor._suppressStiNewDispatch = klass;
+  // Rails allocates with `klass.allocate`, which never goes through
+  // Inheritance::ClassMethods#new — so the abstract-class / Base guard that
+  // `new` enforces (inheritance.rb:57) does not apply to becomes().
+  const hadOwnAbstract = Object.prototype.hasOwnProperty.call(ctor, "_suppressAbstractCheck");
+  const prevAbstract = ctor._suppressAbstractCheck;
+  ctor._suppressAbstractCheck = true;
   let instance: InstanceType<K>;
   try {
     // Rails passes the variable swap as the `initialize` block, which runs
@@ -1670,6 +1679,8 @@ export function becomes<
   } finally {
     if (hadOwn) ctor._suppressStiNewDispatch = prev;
     else delete ctor._suppressStiNewDispatch;
+    if (hadOwnAbstract) ctor._suppressAbstractCheck = prevAbstract;
+    else delete ctor._suppressAbstractCheck;
   }
   return instance;
 }

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -1622,7 +1622,10 @@ interface BecomesRecord {
  */
 export function becomes<
   T extends BecomesRecord,
-  K extends new (attrs: Record<string, unknown>) => BecomesRecord,
+  K extends new (
+    attrs: Record<string, unknown>,
+    initBlock?: (record: BecomesRecord) => void,
+  ) => BecomesRecord,
 >(this: T, klass: K): InstanceType<K> {
   // Rails: `became = klass.allocate` — construct the exact target class,
   // bypassing `new`'s STI dispatch so becomes(base) is never re-resolved to
@@ -1637,31 +1640,36 @@ export function becomes<
   ctor._suppressStiNewDispatch = klass;
   let instance: InstanceType<K>;
   try {
-    instance = new klass({}) as InstanceType<K>;
+    // Rails passes the variable swap as the `initialize` block, which runs
+    // BEFORE `_run_initialize_callbacks` — so after_initialize hooks on the
+    // target class observe this record's (shared) attributes, not the
+    // throwaway construction-time set.
+    instance = new klass({}, (becoming) => {
+      // Mirrors Rails: `@attributes.reverse_merge!(becoming.@attributes)` — the
+      // new class's default attributes fill in any keys this record is missing
+      // (e.g. attributes declared only on the target subclass), then both
+      // objects share this record's (now merged) attribute set.
+      this._attributes.reverseMergeBang(becoming._attributes);
+      becoming._attributes = this._attributes;
+      becoming._newRecord = this._newRecord;
+      becoming._destroyed = this._destroyed;
+      // Rails: `becoming.instance_variable_set(:@mutations_from_database, ...)`
+      // — share the original's dirty tracker by reference so the became record
+      // reports the same change-set (the throwaway `new klass({})`
+      // construction-time changes, e.g. the STI `type` column, are discarded
+      // with its private attribute set).
+      becoming._dirty = this._dirty;
+      // Rails: `becoming.errors.copy!(errors)` — propagate pending validation
+      // errors across the class swap. Noop if the errors object doesn't expose
+      // a `copy` method (defensive for hosts that stub errors differently).
+      const targetErrors = becoming.errors as { copy?(other: unknown): void };
+      if (typeof targetErrors.copy === "function") {
+        targetErrors.copy(this.errors);
+      }
+    }) as InstanceType<K>;
   } finally {
     if (hadOwn) ctor._suppressStiNewDispatch = prev;
     else delete ctor._suppressStiNewDispatch;
-  }
-  const target = instance as unknown as BecomesRecord;
-  // Mirrors Rails: `@attributes.reverse_merge!(becoming.@attributes)` — the new
-  // class's default attributes fill in any keys this record is missing (e.g.
-  // attributes declared only on the target subclass), then both objects share
-  // this record's (now merged) attribute set.
-  this._attributes.reverseMergeBang(target._attributes);
-  target._attributes = this._attributes;
-  target._newRecord = this._newRecord;
-  target._destroyed = this._destroyed;
-  // Rails: `becoming.instance_variable_set(:@mutations_from_database, ...)` —
-  // share the original's dirty tracker by reference so the became record reports
-  // the same change-set (the throwaway `new klass({})` construction-time changes,
-  // e.g. the STI `type` column, are discarded with its private attribute set).
-  target._dirty = this._dirty;
-  // Rails: `becoming.errors.copy!(errors)` — propagate pending validation
-  // errors across the class swap. Noop if the errors object doesn't expose
-  // a `copy` method (defensive for hosts that stub errors differently).
-  const targetErrors = target.errors as { copy?(other: unknown): void };
-  if (typeof targetErrors.copy === "function") {
-    targetErrors.copy(this.errors);
   }
   return instance;
 }

--- a/packages/activerecord/src/type/integer.test.ts
+++ b/packages/activerecord/src/type/integer.test.ts
@@ -1,16 +1,17 @@
 import { describe, it, expect } from "vitest";
 import { IntegerType } from "@blazetrails/activemodel";
 import { Base } from "../index.js";
+import { Firm } from "../test-helpers/models/company.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 
 fixtures({});
 
 describe("IntegerTest", () => {
-  it("casting ActiveRecord models", () => {
+  it("casting ActiveRecord models", async () => {
     const type = new IntegerType();
     // AR model stringifies to "[object Object]" → parseInt → NaN → null
-    const model = new Base();
-    expect(type.cast(model)).toBeNull();
+    const firm = await Firm.create({ name: "Apple" });
+    expect(type.cast(firm)).toBeNull();
   });
 
   it("values which are out of range can be re-assigned", () => {

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -285,6 +285,46 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "have no JavaScript equivalent.",
   },
   {
+    testFile: "inheritance_test.rb",
+    className: "InheritanceTest",
+    tests: [
+      "compute type no method error",
+      "compute type on undefined method",
+      "compute type argument error",
+    ],
+    reason:
+      "Registers an Object.autoload for a model whose file raises during require, so the " +
+      "exception surfaces from constantize inside compute_type. JS has no autoload/require " +
+      "hook — a module either resolves at import time or the constant simply doesn't exist.",
+  },
+  {
+    testFile: "inheritance_test.rb",
+    className: "InheritanceTest",
+    tests: ["base class activerecord error"],
+    reason:
+      "Asserts `Class.new { include ActiveRecord::Inheritance }` raises ActiveRecordError via " +
+      "Ruby's Module#included hook. Trails mixes modules in statically; there is no runtime " +
+      "include on an arbitrary class to guard.",
+  },
+  {
+    testFile: "inheritance_test.rb",
+    className: "InheritanceTest",
+    tests: ["new with autoload paths"],
+    reason:
+      "Stands up a Zeitwerk loader at runtime so STI dispatch resolves a constant from an " +
+      "autoload path. JS has no runtime constant autoloading; trails resolves subclasses via " +
+      "explicit registerSubclass.",
+  },
+  {
+    testFile: "inheritance_test.rb",
+    className: "InheritanceComputeTypeTest",
+    tests: ["instantiation doesnt try to require corresponding file"],
+    reason:
+      "Exercises Ruby constant-lookup/dependencies integration: a DB type with no top-level " +
+      "constant raises RecordNotFound, then const_set on the test class vs on Firm changes " +
+      "which constant compute_type sees. JS has no const_missing/autoload namespace walk.",
+  },
+  {
     testFile: "modules_test.rb",
     tests: [
       "module spanning associations",


### PR DESCRIPTION
## Summary

Burns down all 12 `matchedSkipped` in `inheritance.test.ts` (RFC 0030 residual-skip campaign).

**Ported (6, now passing):**

- `becomes sets variables before initialization callbacks` — converged `becomes()` to Rails' pattern: the attribute/state swap now runs as the constructor's initialize block, which fires **before** `after_initialize` (Rails `Core#initialize` yields the block first, persistence.rb:487-500). `YellingVegetable`'s hook now observes the shared attributes.
- `becomes and change tracking for inheritance columns`
- `alt becomes bang resets inheritance type column`
- `new with ar base` — `Base.new` now raises `NotImplementedError`, mirroring Rails' `abstract_class? || self == Base` guard (inheritance.rb:57). Message reads `"Base is an abstract class..."` (no Ruby namespace).
- `scope inherited properly` — nested join paths (`joins({ account: "firm" })`) work now; body ported as-is.
- `inheritance new with subclass as default` (InheritanceComputeTypeTest) — `changeColumnDefault` + `resetColumnInformation` are available; ported with the Rails ensure-restore.

**Reclassified permanent (6, recorded in `scripts/api-compare/unported-files.ts` with ROOT-CAUSE reasons):**

- `compute type no method error` / `on undefined method` / `argument error` — `Object.autoload` require-time exception semantics; no JS analogue.
- `base class activerecord error` — Ruby `Module#included` hook on `Class.new { include ... }`.
- `new with autoload paths` — runtime Zeitwerk loader; trails resolves subclasses via `registerSubclass`.
- `instantiation doesnt try to require corresponding file` — `const_missing`/dependencies constant-namespace walk.

`test:compare`: inheritance_test.rb now 67 matched / **0 matchedSkipped**.

Closes-story: inheritance-residual-skip-burndown
