### PR TITLE
fix(associations): converge composite-FK belongs_to staleState to Rails nil

### DIFF
--- a/packages/activerecord/src/associations/belongs-to-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-association.ts
@@ -209,20 +209,18 @@ export class BelongsToAssociation extends SingularAssociation {
   }
 
   protected override staleState(): unknown {
+    // Rails: `owner._read_attribute(reflection.foreign_key)`
+    // (belongs_to_association.rb:164-166) with NO array branching. For a
+    // composite (array) foreign key, Ruby's `@attributes[Array]` matches no
+    // stored attribute and resolves to `Attribute.null` → nil (verified
+    // against ActiveRecord 8.0.2: composite `stale_state` is nil, so
+    // `stale_target?` never fires and an FK change does NOT reload a loaded
+    // composite-FK belongs_to). Only a scalar FK yields a real state.
     const fks = this.foreignKeyNames();
-    const values = fks.map((fk) =>
-      typeof (this.owner as any)._readAttribute === "function"
-        ? (this.owner as any)._readAttribute(fk)
-        : (this.owner as any)[fk],
-    );
-    if (values.length === 1) return values[0];
-    // BigInt FK components (int8 under PG bigserial) can't go through
-    // JSON.stringify ("Do not know how to serialize a BigInt"); fold to their
-    // decimal string, mirroring CollectionAssociation#recordIdentity. The
-    // single-FK branch returns the raw value, so only the composite path needs
-    // this. The key stays deterministic — same source on every read.
-    const ids = values.map((v) => (typeof v === "bigint" ? v.toString() : v));
-    return JSON.stringify(ids);
+    if (fks.length !== 1) return null;
+    return typeof (this.owner as any)._readAttribute === "function"
+      ? (this.owner as any)._readAttribute(fks[0])
+      : (this.owner as any)[fks[0]];
   }
 
   protected override findTargetNeeded(): boolean {

--- a/packages/activerecord/src/associations/belongs-to-stale-state-bigint-composite-fk.test.ts
+++ b/packages/activerecord/src/associations/belongs-to-stale-state-bigint-composite-fk.test.ts
@@ -86,6 +86,7 @@ describe("belongs_to composite-FK staleState with a BigInt component", () => {
       target: unknown;
       loadedBang(): void;
       isStaleTarget(): boolean;
+      readonly reader: unknown;
     };
     holder.target = post;
     holder.loadedBang();
@@ -93,5 +94,9 @@ describe("belongs_to composite-FK staleState with a BigInt component", () => {
 
     (comment as unknown as Record<string, unknown>).blog_post_id = 2n;
     expect(holder.isStaleTarget()).toBe(false);
+    // The reader keeps the cached target — no stale-reload Promise. Verified
+    // in Rails 8.0.2: `book.order` still returns the originally loaded record
+    // after the composite FK changes.
+    expect(holder.reader).toBe(post);
   });
 });

--- a/packages/activerecord/src/associations/belongs-to-stale-state-bigint-composite-fk.test.ts
+++ b/packages/activerecord/src/associations/belongs-to-stale-state-bigint-composite-fk.test.ts
@@ -1,16 +1,22 @@
 /**
- * Regression guard: `BelongsToAssociation#staleState` composite-FK path folds
- * BigInt FK components before `JSON.stringify`. node-postgres deserializes int8
- * columns (default under PG bigserial) to JS `BigInt`, which `JSON.stringify`
- * rejects ("Do not know how to serialize a BigInt"). The composite-FK branch
- * used a raw `JSON.stringify(values)`, so a `belongs_to` with a composite FK
- * carrying a BigInt component threw on the stale-state check. The single-FK
- * branch returns the raw value, so only the composite path was affected.
- * Mirrors the `CollectionAssociation#recordIdentity` fix (fold `bigint` →
- * `.toString()`).
+ * Convergence guard: `BelongsToAssociation#staleState` for a composite (array)
+ * foreign key matches Rails. Rails' `stale_state`
+ * (belongs_to_association.rb:164-166) is
+ * `owner._read_attribute(reflection.foreign_key)` with no array branching —
+ * when `reflection.foreign_key` is an Array, Ruby's `@attributes[Array]`
+ * matches no stored attribute and resolves to `Attribute.null` → nil.
+ * Verified empirically against ActiveRecord 8.0.2: composite `stale_state` is
+ * nil, `stale_target?` never fires, and an FK change does NOT reload a loaded
+ * composite-FK belongs_to.
  *
- * `staleState` reads the owner's in-memory FK attributes, so this exercises the
- * path with no database round-trip. The models mirror the canonical
+ * trails previously invented a composite key shape
+ * (`JSON.stringify` of the FK components, with BigInt folding — PR #4620);
+ * this file replaces that regression test. The BigInt case is kept: a BigInt
+ * FK component (int8 under PG bigserial) must not throw — trivially true now
+ * that the composite path returns null without serializing anything.
+ *
+ * `staleState` reads the owner's in-memory FK attributes, so this exercises
+ * the path with no database round-trip. The models mirror the canonical
  * `Sharded::Comment` → `blog_post_with_inverse` shape (composite FK
  * `[blog_id, blog_post_id]`); the columns are declared here so the in-memory
  * owner carries the BigInt component without a schema load, following the
@@ -57,7 +63,9 @@ describe("belongs_to composite-FK staleState with a BigInt component", () => {
     expect(() => {
       state = holder.staleState();
     }).not.toThrow();
-    expect(state).toBe(JSON.stringify([1, "9007199254740993"]));
+    // Rails: composite stale_state resolves through the missing-attribute
+    // path to nil — never a real composite value.
+    expect(state).toBeNull();
   });
 
   it("preserves a deterministic key across reads", () => {
@@ -67,5 +75,23 @@ describe("belongs_to composite-FK staleState with a BigInt component", () => {
     };
 
     expect(holder.staleState()).toBe(holder.staleState());
+  });
+
+  it("never marks a loaded composite-FK belongs_to stale on FK change", () => {
+    // Rails (verified on AR 8.0.2): with @stale_state nil, `stale_target?`
+    // stays false after the FK changes, so the loaded target is kept.
+    const post = new BigIntCpkBlogPost({ blog_id: 1 });
+    const comment = new BigIntCpkComment({ blog_id: 1, blog_post_id: 1n });
+    const holder = comment.association("blogPostWithInverse") as unknown as {
+      target: unknown;
+      loadedBang(): void;
+      isStaleTarget(): boolean;
+    };
+    holder.target = post;
+    holder.loadedBang();
+    expect(holder.isStaleTarget()).toBe(false);
+
+    (comment as unknown as Record<string, unknown>).blog_post_id = 2n;
+    expect(holder.isStaleTarget()).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Converges `BelongsToAssociation#staleState` for composite (array) foreign keys to Rails behavior.

Rails' `stale_state` (`belongs_to_association.rb:164-166`) is `owner._read_attribute(reflection.foreign_key)` with no array branching. When the FK is an Array (composite / query_constraints), Ruby's `@attributes[Array]` matches no stored attribute and resolves through `Attribute.null` to `nil`. Verified empirically against ActiveRecord 8.0.2 (sqlite3, `CpkBook belongs_to :order, foreign_key: [:order_shop_id, :order_id]`):

- `stale_state` → `nil`
- `stale_target?` → `false` before AND after an FK change
- the reader keeps returning the stale loaded target after the FK changes

trails instead mapped each FK component and returned `JSON.stringify(values)` — an invented composite key shape with no Rails counterpart (flagged in review of #4620, whose BigInt fold was correct within the invented branch).

## Changes

- `staleState` now returns `null` for a composite FK (Rails' nil), and the raw `_readAttribute` value for a scalar FK — the composite branch and its `JSON.stringify`/BigInt fold are gone.
- The #4620 regression test (`belongs-to-stale-state-bigint-composite-fk.test.ts`) is rewritten to guard the converged behavior: composite `staleState` is `null`, a BigInt FK component doesn't throw, and `isStaleTarget()` stays `false` after a composite-FK change on a loaded association.

## Trade-off (documented)

Rails genuinely never fires staleness for a composite-FK belongs_to: with `@stale_state` nil, `load_target`'s `(@stale_state && stale_target?)` short-circuits, so an in-place FK edit does not reload the association. trails now matches this — that is the converged (and Rails-verified) semantic, not a regression.

Closes-story: belongs-to-composite-fk-stale-state-rails-convergence
