### PR TITLE
test(activerecord): port nested-error and standalone-connection test bodies

### DIFF
--- a/packages/activerecord/src/associations/nested-error.test.ts
+++ b/packages/activerecord/src/associations/nested-error.test.ts
@@ -1,31 +1,155 @@
-import { describe, it } from "vitest";
+/**
+ * Faithful port of activerecord/test/cases/associations/nested_error_test.rb.
+ *
+ * Rails' anonymous classes (`Class.new(ActiveRecord::Base) { def self.name;
+ * "Guitar"; end }`) become named classes registered under distinct model names
+ * — registering them as "Guitar"/"Pet" would shadow the canonical models
+ * file-wide — with `foreignKey` passed explicitly where Rails infers it from
+ * the faked `name`.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  Base,
+  registerModel,
+  indexNestedAttributeErrors,
+  setIndexNestedAttributeErrors,
+} from "../index.js";
+import { NestedError } from "./nested-error.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+import type { AssociationProxy } from "./collection-proxy.js";
+import { Guitar } from "../test-helpers/models/guitar.js";
+import { TuningPeg } from "../test-helpers/models/tuning-peg.js";
+import { Owner } from "../test-helpers/models/owner.js";
+import { Pet } from "../test-helpers/models/pet.js";
 
 describe("AssociationsNestedErrorInAssociationOrderTest", () => {
-  it.skip("index in association order", () => {
-    // BLOCKED: Phase G — error indexing requires in-memory nested attribute
-    // records built at assignment time; trails defers nested attribute processing
-    // to save. Also needs index_errors association option and NestedError class.
+  fixtures({ guitars: [Guitar, {}], tuning_pegs: [TuningPeg, {}] });
+
+  it("index in association order", async () => {
+    const guitar = await Guitar.createBang({});
+    await guitar.tuningPegs.createBang({ pitch: 1 });
+    const peg2 = await guitar.tuningPegs.createBang({ pitch: 2 });
+    (peg2 as { pitch: number | null }).pitch = null;
+    await guitar.isValid();
+
+    const error = guitar.errors.objects[0] as NestedError;
+
+    expect(error).toBeInstanceOf(NestedError);
+    expect(error.innerError).toBe(peg2.errors.objects[0]);
+    expect(error.attribute).toBe("tuningPegs[1].pitch");
+    expect(error.type).toBe("not_a_number");
+    expect(error.message).toBe("is not a number");
+    expect(error.base).toBe(guitar);
   });
 });
 
 describe("AssociationsNestedErrorInNestedAttributesOrderTest", () => {
-  it.skip("index in nested attributes order", () => {
-    // BLOCKED: Phase G — error indexing requires in-memory nested attribute
-    // records built at assignment time; trails defers nested attribute processing
-    // to save. Also needs index_errors association option and NestedError class.
+  fixtures({ guitars: [Guitar, {}], tuning_pegs: [TuningPeg, {}] });
+
+  // Rails' anonymous `@guitar_class` (nested_error_test.rb:35): `has_many
+  // :tuning_pegs, index_errors: :nested_attributes_order` keys nested errors
+  // by write order. Rides the canonical `guitars` table and the canonical
+  // `TuningPeg` (`validates_numericality_of :pitch`).
+  class NestedOrderGuitar extends Base {
+    static tableName = "guitars";
+    declare tuningPegs: AssociationProxy<TuningPeg>;
+    static {
+      this.hasMany("tuningPegs", {
+        className: "TuningPeg",
+        foreignKey: "guitar_id",
+        indexErrors: "nestedAttributesOrder",
+      });
+      // Rails: `reject_if: lambda { |attrs| attrs[:pitch]&.odd? }`
+      this.acceptsNestedAttributesFor("tuningPegs", {
+        rejectIf: (attrs: Record<string, unknown>) =>
+          attrs["pitch"] != null && Number(attrs["pitch"]) % 2 === 1,
+      });
+    }
+  }
+
+  it("index in nested attributes order", async () => {
+    const guitar = await NestedOrderGuitar.createBang({});
+    await guitar.tuningPegs.createBang({ pitch: 1 });
+    const peg2 = await guitar.tuningPegs.createBang({ pitch: 2 });
+    await guitar.update({ tuningPegsAttributes: [{ id: peg2.id, pitch: null }] });
+
+    const error = guitar.errors.objects[0] as NestedError;
+
+    expect(error).toBeInstanceOf(NestedError);
+    expect(error.innerError).toBe(peg2.errors.objects[0]);
+    expect(error.attribute).toBe("tuningPegs[0].pitch");
+    expect(error.type).toBe("not_a_number");
+    expect(error.message).toBe("is not a number");
+    expect(error.base).toBe(guitar);
   });
 
-  it.skip("index unaffected by reject_if", () => {
-    // BLOCKED: Phase G — error indexing requires in-memory nested attribute
-    // records built at assignment time; trails defers nested attribute processing
-    // to save. Also needs index_errors association option and NestedError class.
+  it("index unaffected by reject_if", async () => {
+    const guitar = await NestedOrderGuitar.createBang({});
+
+    await guitar.update({
+      tuningPegsAttributes: [
+        { pitch: 1 }, // rejected
+        { pitch: null },
+      ],
+    });
+
+    const error = guitar.errors.objects[0] as NestedError;
+
+    expect(error).toBeInstanceOf(NestedError);
+    expect(error.attribute).toBe("tuningPegs[1].pitch");
+    expect(error.type).toBe("not_a_number");
+    expect(error.message).toBe("is not a number");
+    expect(error.base).toBe(guitar);
   });
 
   describe("AssociationsNestedErrorWithSingularAssociationTest", () => {
-    it.skip("no index when singular association", () => {
-      // BLOCKED: Phase G — error indexing requires in-memory nested attribute
-      // records built at assignment time; trails defers nested attribute processing
-      // to save. Also needs index_errors association option and NestedError class.
+    fixtures({ owners: [Owner, {}], pets: [Pet, {}] });
+
+    // Rails' anonymous `pet_class` / `@owner_class` (nested_error_test.rb:80-94)
+    // on the canonical `pets` / `owners` tables.
+    class ValidatedPet extends Base {
+      static tableName = "pets";
+      declare name: string | null;
+      static {
+        this._primaryKey = "pet_id";
+        this.validates("name", { presence: true });
+      }
+    }
+    class PetOwner extends Base {
+      static tableName = "owners";
+      declare pet: ValidatedPet | null;
+      static {
+        this._primaryKey = "owner_id";
+        this.hasOne("pet", { className: "NestedErrorValidatedPet", foreignKey: "owner_id" });
+        this.acceptsNestedAttributesFor("pet");
+        this.validatesAssociated("pet");
+      }
+    }
+    registerModel("NestedErrorValidatedPet", ValidatedPet);
+    registerModel("NestedErrorPetOwner", PetOwner);
+
+    it("no index when singular association", async () => {
+      const oldAttributeConfig = indexNestedAttributeErrors;
+      setIndexNestedAttributeErrors(true);
+      try {
+        const owner = new PetOwner({ petAttributes: { name: null } });
+        await owner.isValid();
+
+        const error = owner.errors.objects[0] as NestedError;
+        const pet = (owner.association("pet") as unknown as { target?: ValidatedPet }).target!;
+
+        expect(error).toBeInstanceOf(NestedError);
+        // Rails' `assert_equal` goes through ActiveModel::Error#== (semantic
+        // equality on base/attribute/type/options), not object identity —
+        // trails' associated-validation path wraps a duplicated inner error.
+        expect(error.innerError).toStrictEqual(pet.errors.objects[0]);
+        expect(error.attribute).toBe("pet.name");
+        expect(error.type).toBe("blank");
+        expect(error.message).toBe("can't be blank");
+        expect(error.base).toBe(owner);
+      } finally {
+        setIndexNestedAttributeErrors(oldAttributeConfig);
+      }
     });
   });
 });

--- a/packages/activerecord/src/connection-adapters/standalone-connection.test.ts
+++ b/packages/activerecord/src/connection-adapters/standalone-connection.test.ts
@@ -1,24 +1,52 @@
-import { describe, it } from "vitest";
+/**
+ * Faithful port of
+ * activerecord/test/cases/connection_adapters/standalone_connection_test.rb.
+ *
+ * Rails builds the standalone adapter with `db_config.new_connection`; trails'
+ * `DatabaseConfig#newConnection` is the same seam, pre-warmed via
+ * `loadAdapter()` because ESM adapter resolution is async.
+ */
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
+import { Base } from "../index.js";
+import { establishFromTestConfig } from "../test-helpers/test-database-config.js";
+import type { AbstractAdapter } from "./abstract-adapter.js";
 
 describe("StandaloneConnectionTest", () => {
-  it.skip("can query", () => {
-    // BLOCKED: connection-pool — connection pool / handler gap in standalone-connection
-    // ROOT-CAUSE: connection-pool.ts or connection-handler.ts missing Rails parity for StandaloneConnectionTest
-    // SCOPE: ~50–100 LOC fix in connection-pool.ts; affects ~10–24 tests in standalone-connection.test.ts
+  let connection: AbstractAdapter;
+
+  beforeAll(async () => {
+    await establishFromTestConfig();
   });
+
+  beforeEach(async () => {
+    const dbConfig = Base.connectionDbConfig();
+    await dbConfig.loadAdapter();
+    connection = dbConfig.newConnection() as AbstractAdapter;
+  });
+
+  afterEach(async () => {
+    await connection.disconnectBang();
+  });
+
+  it("can query", async () => {
+    const result = await connection.selectAll("SELECT 1");
+    expect(result.rows).toEqual([[1]]);
+  });
+
   it.skip("async fallback", () => {
-    // BLOCKED: connection-pool — connection pool / handler gap in standalone-connection
-    // ROOT-CAUSE: connection-pool.ts or connection-handler.ts missing Rails parity for StandaloneConnectionTest
-    // SCOPE: ~50–100 LOC fix in connection-pool.ts; affects ~10–24 tests in standalone-connection.test.ts
+    // PERMANENT-SKIP: Rails' `select_all("SELECT 1", async: true)` returns a
+    // `FutureResult::Complete` from the load_async infrastructure. Trails has
+    // not ported FutureResult / load_async (selectAll takes no `async` option);
+    // un-skip when that infrastructure lands.
   });
-  it.skip("can throw away", () => {
-    // BLOCKED: connection-pool — connection pool / handler gap in standalone-connection
-    // ROOT-CAUSE: connection-pool.ts or connection-handler.ts missing Rails parity for StandaloneConnectionTest
-    // SCOPE: ~50–100 LOC fix in connection-pool.ts; affects ~10–24 tests in standalone-connection.test.ts
+
+  it("can throw away", () => {
+    connection.throwAwayBang();
+    expect(connection.active).toBe(false);
   });
-  it.skip("can close", () => {
-    // BLOCKED: connection-pool — connection pool / handler gap in standalone-connection
-    // ROOT-CAUSE: connection-pool.ts or connection-handler.ts missing Rails parity for StandaloneConnectionTest
-    // SCOPE: ~50–100 LOC fix in connection-pool.ts; affects ~10–24 tests in standalone-connection.test.ts
+
+  it("can close", async () => {
+    await connection.close();
+    expect(connection.active).toBe(false);
   });
 });


### PR DESCRIPTION
Ports the two 100%-skipped stub files flagged by `test:compare` to faithful test bodies.

## associations/nested-error.test.ts (4/4 un-skipped)

Faithful port of `test/cases/associations/nested_error_test.rb`:

- **index in association order** — canonical `Guitar` (`index_errors: true`) + `TuningPeg`.
- **index in nested attributes order** / **index unaffected by reject_if** — Rails' anonymous `@guitar_class` (`index_errors: :nested_attributes_order` + `reject_if`) becomes `NestedOrderGuitar` on the canonical `guitars` table.
- **no index when singular association** — anonymous pet/owner classes become registered classes on canonical `pets`/`owners`; global `index_nested_attribute_errors` toggled and restored. One accommodation: Rails' `assert_equal` on the inner error goes through `ActiveModel::Error#==` (semantic equality); trails' associated-validation path wraps a duplicated inner error, so that single assertion uses `toStrictEqual` (justified at the call site).

The stubs' original BLOCKED reason (no NestedError class / index_errors option) is stale — both landed since.

## connection-adapters/standalone-connection.test.ts (3/4 un-skipped)

Faithful port of `test/cases/connection_adapters/standalone_connection_test.rb`, building the adapter via `Base.connectionDbConfig().newConnection()` (the `db_config.new_connection` seam), pre-warmed with `loadAdapter()`.

- **can query**, **can throw away**, **can close** — ported and passing.
- **async fallback** — reclassified permanent-skip with recorded reason: Rails asserts a `FutureResult::Complete` from the load_async infrastructure, which trails has not ported (`selectAll` takes no `async` option).

Closes-story: nested-error-standalone-connection-skips
