### PR TITLE
fix(arel): render Temporal.Instant/ZonedDateTime as Ruby Time#to_s in FakeRecord quote

### DIFF
--- a/packages/arel/src/attributes/attribute.test.ts
+++ b/packages/arel/src/attributes/attribute.test.ts
@@ -230,11 +230,11 @@ describe("AttributeTest", () => {
       expect(mgr.toSql()).toContain(`"users"."name" <= 'fake_name'`);
 
       // Rails compares against Time.now; a fixed value keeps the assertion
-      // deterministic. PlainDateTime reaches the quoter's DateTime arm, whose
-      // space-separated form matches Rails' quoted_date shape.
-      const currentTime = Temporal.PlainDateTime.from("2024-01-01T00:00:00");
+      // deterministic. Instant is the Time analogue and reaches FakeRecord's
+      // `else` arm, which renders Ruby's `Time#to_s` shape.
+      const currentTime = Temporal.Instant.from("2024-01-01T00:00:00Z");
       mgr.where(relation.get("created_at").lteq(currentTime));
-      expect(mgr.toSql()).toContain(`"users"."created_at" <= '2024-01-01 00:00:00'`);
+      expect(mgr.toSql()).toContain(`"users"."created_at" <= '2024-01-01 00:00:00 +0000'`);
     });
   });
 

--- a/packages/arel/src/test-helpers/connection.ts
+++ b/packages/arel/src/test-helpers/connection.ts
@@ -61,7 +61,9 @@ function unreachableOnFakeRecord(name: string): () => never {
 // `else` arm below for the Time analogues, whose own `toString` is ISO.
 function rubyTimeToS(zdt: Temporal.ZonedDateTime): string {
   const p = (n: number): string => String(n).padStart(2, "0");
-  const offsetMinutes = zdt.offsetNanoseconds / 60_000_000_000;
+  // Truncate to whole minutes: Ruby's `%z` drops sub-minute seconds from
+  // historical LMT offsets (Europe/Paris 1900, `+00:09:21`, renders `+0009`).
+  const offsetMinutes = Math.trunc(zdt.offsetNanoseconds / 60_000_000_000);
   const sign = offsetMinutes < 0 ? "-" : "+";
   const abs = Math.abs(offsetMinutes);
   const offset = `${sign}${p(Math.floor(abs / 60))}${p(abs % 60)}`;

--- a/packages/arel/src/test-helpers/connection.ts
+++ b/packages/arel/src/test-helpers/connection.ts
@@ -56,6 +56,18 @@ function unreachableOnFakeRecord(name: string): () => never {
   };
 }
 
+// Ruby `Time#to_s` — `"YYYY-MM-DD HH:MM:SS +ZZZZ"` (space-separated, no
+// fractional seconds, four-digit zone offset). Used by the FakeRecord double's
+// `else` arm below for the Time analogues, whose own `toString` is ISO.
+function rubyTimeToS(zdt: Temporal.ZonedDateTime): string {
+  const p = (n: number): string => String(n).padStart(2, "0");
+  const offsetMinutes = zdt.offsetNanoseconds / 60_000_000_000;
+  const sign = offsetMinutes < 0 ? "-" : "+";
+  const abs = Math.abs(offsetMinutes);
+  const offset = `${sign}${p(Math.floor(abs / 60))}${p(abs % 60)}`;
+  return `${String(zdt.year).padStart(4, "0")}-${p(zdt.month)}-${p(zdt.day)} ${p(zdt.hour)}:${p(zdt.minute)}:${p(zdt.second)} ${offset}`;
+}
+
 /**
  * Port of the Arel suite's `FakeRecord::Connection` quoting
  * (`test/cases/arel/support/fake_record.rb:55-90`).
@@ -113,6 +125,19 @@ export const fakeRecordConnection: ArelConnection = {
     if (thing instanceof Temporal.PlainDateTime) {
       const p = (n: number): string => String(n).padStart(2, "0");
       return `'${String(thing.year).padStart(4, "0")}-${p(thing.month)}-${p(thing.day)} ${p(thing.hour)}:${p(thing.minute)}:${p(thing.second)}'`;
+    }
+    // fake_record.rb has no explicit `Time` arm: a Ruby `Time` falls to `else`
+    // and renders via `to_s` — `"2024-01-01 00:00:00 +0000"` (attribute_test.rb:273
+    // interpolates `'#{current_time}'` and asserts that shape). The Temporal
+    // analogues stringify as ISO (`2024-01-01T00:00:00Z`), so `String(thing)`
+    // in the fallback would diverge; hand-render Ruby's `Time#to_s` shape
+    // instead. An Instant carries no zone and renders in UTC (`+0000`), like a
+    // `Time` under `TZ=UTC`.
+    if (thing instanceof Temporal.Instant) {
+      return `'${rubyTimeToS(thing.toZonedDateTimeISO("UTC"))}'`;
+    }
+    if (thing instanceof Temporal.ZonedDateTime) {
+      return `'${rubyTimeToS(thing)}'`;
     }
     return `'${String(thing).replace(/'/g, "\\'")}'`;
   },

--- a/packages/arel/src/test-helpers/connection.ts
+++ b/packages/arel/src/test-helpers/connection.ts
@@ -67,7 +67,10 @@ function rubyTimeToS(zdt: Temporal.ZonedDateTime): string {
   const sign = offsetMinutes < 0 ? "-" : "+";
   const abs = Math.abs(offsetMinutes);
   const offset = `${sign}${p(Math.floor(abs / 60))}${p(abs % 60)}`;
-  return `${String(zdt.year).padStart(4, "0")}-${p(zdt.month)}-${p(zdt.day)} ${p(zdt.hour)}:${p(zdt.minute)}:${p(zdt.second)} ${offset}`;
+  // Ruby renders BCE years sign-then-zero-padded: `Time.new(-1, ...).to_s` is
+  // `-0001-01-01 ...`; a bare padStart on the signed string would emit `00-1`.
+  const year = `${zdt.year < 0 ? "-" : ""}${String(Math.abs(zdt.year)).padStart(4, "0")}`;
+  return `${year}-${p(zdt.month)}-${p(zdt.day)} ${p(zdt.hour)}:${p(zdt.minute)}:${p(zdt.second)} ${offset}`;
 }
 
 /**


### PR DESCRIPTION
Quoting a `Temporal.Instant` through the arel suite's `toSql()` path fell to FakeRecord's `else` string-fallback arm, whose `String(thing)` renders ISO (`'2024-01-01T00:00:00Z'`). In Ruby, a `Time` hitting `fake_record.rb`'s `else` arm renders `to_s` = `'2024-01-01 00:00:00 +0000'` (space-separated, four-digit offset), so the trails fallback shape diverged for the Time analogue — #5057 worked around it by substituting `PlainDateTime` in the `#lteq` test.

- `fakeRecordConnection.quote` now hand-renders the Ruby `Time#to_s` shape for `Instant` (UTC, `+0000`) and `ZonedDateTime` (its own offset), with the deviation justified at the call site — `String(thing)` would emit ISO where Ruby's `to_s` does not.
- The `#lteq` "should accept various data types." test now uses `Instant` directly, matching Rails `attribute_test.rb:268-276` (`Time.now` interpolated via `to_s`).

Closes-story: arel-fake-connection-instant-stringifies-iso