### PR TITLE
fix(activerecord): bind all write-path column values as prepared-statement params

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/range.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/range.test.ts
@@ -66,6 +66,13 @@ describeIfPg("PostgreSQLAdapter", () => {
         this.attribute("id", "integer");
       }
     }
+    // Mirrors Rails' setup `PostgresqlRange.reset_column_information`
+    // (range_test.rb): the adapter's schema cache still holds the previous
+    // test's columns for `postgresql_ranges`, whose floatrange/stringrange
+    // OIDs were reassigned by the drop+recreate above. Clearing the data-source
+    // cache re-reflects columns against the live catalog so the custom range
+    // types resolve to their current OIDs.
+    PostgresqlRangesCls.resetColumnInformation();
     await PostgresqlRangesCls.loadSchema();
     PostgresqlRanges = PostgresqlRangesCls;
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -845,12 +845,24 @@ function _dispatchAssociationAttrs(
   }
 }
 
-// Column types whose database value is a plain string the driver can bind as
-// an untyped parameter without losing an implicit cast. Used by the write path
-// to decide which values to bind (vs inline) so null-byte strings round-trip.
-const BINDABLE_STRING_TYPES = new Set(["string", "text", "immutable_string"]);
-function isBindableStringColumn(typeName: string | undefined): boolean {
-  return typeName !== undefined && BINDABLE_STRING_TYPES.has(typeName);
+// Build the Arel value node for one write-path column (INSERT VALUES / UPDATE
+// SET). Mirrors Rails' `_insert_record`/`_update_record`, which hand every
+// column to the Arel visitor as an `ActiveModel::Attribute` so
+// `visit_ActiveModel_Attribute → collector.add_bind(o)` binds it as a typed
+// prepared-statement parameter (`type_casted_binds`) — null bytes round-trip
+// and intermediate database values (BinaryData, Temporal, BigDecimal) are
+// finished off by each adapter's bind normalization instead of being inlined
+// via `quote()`. Array columns keep their bespoke inline quoting: their
+// database value is an adapter-specific aggregate literal (`{…}` / `ARRAY[…]`)
+// that the drivers cannot bind as a single scalar parameter — the adapter's
+// `quote` (Rails' `quote(encode_array(value))`) type-casts every element.
+function writePathValueNode(
+  def: { type?: { name?: string } } | undefined,
+  raw: unknown,
+  adapter: { quote(value: unknown): string },
+): InstanceType<typeof Nodes.Node> | unknown {
+  if (def?.type?.name === "array") return arelSql(adapter.quote(raw));
+  return new Nodes.BindParam(raw);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -3557,29 +3569,11 @@ export class Base extends Model {
     const values: unknown[] = columns.map((k) => attrs[k]);
 
     // Build the column→value map for the Rails-faithful `_insert_record` class
-    // method, applying the same per-column node handling the inline INSERT used:
-    // bind string/text-column values as prepared-statement parameters (matching
-    // Rails' type_casted_binds) so a value containing a null byte (\x00)
-    // round-trips rather than truncating the inlined SQL at the C-string
-    // boundary; inline-quote arrays; and pass everything else raw so the
-    // visitor's `quote()` finishes serializing intermediate objects and carries
-    // the implicit cast custom-OID columns (hstore, enum) need.
+    // method: every non-array column value is bound as a prepared-statement
+    // parameter (see writePathValueNode), matching Rails' type_casted_binds.
     const valuesMap: Record<string, unknown> = {};
     columns.forEach((c, i) => {
-      const def = ctor._attributeDefinitions.get(c);
-      const isArray = def?.type?.name === "array";
-      const raw = values[i];
-      valuesMap[c] =
-        !isArray && isBindableStringColumn(def?.type?.name) && typeof raw === "string"
-          ? new Nodes.BindParam(raw)
-          : // Array columns serialize to an OID::Array `Data`; quote it via the
-            // adapter's `quote` (Rails' `quote(encode_array(value))`) so every
-            // element gets `type_cast` — datetimes reach `quoted_date`, binary
-            // gets hex — rather than the bare `String(Data)` an inline literal
-            // would otherwise fall to (which emits ISO-8601 for datetimes).
-            isArray
-            ? arelSql(adapter.quote(raw))
-            : raw;
+      valuesMap[c] = writePathValueNode(ctor._attributeDefinitions.get(c), values[i], adapter);
     });
 
     this._pendingOperation = (async () => {
@@ -3692,22 +3686,10 @@ export class Base extends Model {
     }
 
     const updateValues: [InstanceType<typeof Nodes.Node>, unknown][] = declaredChanges.map(
-      (key) => {
-        const val = dbValues[key];
-        const def = ctor._attributeDefinitions.get(key);
-        const isArray = def?.type?.name === "array";
-        // Bind string/text-column SET values as prepared-statement parameters
-        // (see _performInsert) so null-byte values survive; other types stay
-        // inline.
-        return [
-          table.get(key),
-          !isArray && isBindableStringColumn(def?.type?.name) && typeof val === "string"
-            ? new Nodes.BindParam(val)
-            : isArray
-              ? arelSql(adapter.quote(val))
-              : val,
-        ];
-      },
+      (key) => [
+        table.get(key),
+        writePathValueNode(ctor._attributeDefinitions.get(key), dbValues[key], adapter),
+      ],
     );
 
     // Optimistic locking: include lock column in WHERE and increment it.

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -3718,7 +3718,14 @@ export class Base extends Model {
       const lockIdx = declaredChanges.indexOf(lockCol);
       if (lockIdx !== -1) updateValues.splice(lockIdx, 1);
       this._writeAttribute(lockCol, currentVersion + 1);
-      updateValues.push([table.get(lockCol), currentVersion + 1]);
+      // Rails increments `self[locking_column]` and lets `_update_record` pass
+      // the attribute to Arel like every other SET column (optimistic.rb:
+      // 101-108 → persistence.rb attributes_with_values), so the bumped lock
+      // value is bound, not inlined — route through the same write-path node.
+      updateValues.push([
+        table.get(lockCol),
+        writePathValueNode(ctor._attributeDefinitions.get(lockCol), currentVersion + 1, adapter),
+      ]);
     }
 
     const um = new UpdateManager()

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -852,7 +852,22 @@ function _dispatchAssociationAttrs(
 // prepared-statement parameter (`type_casted_binds`) — null bytes round-trip
 // and intermediate database values (BinaryData, Temporal, BigDecimal) are
 // finished off by each adapter's bind normalization instead of being inlined
-// via `quote()`. Array columns keep their bespoke inline quoting: their
+// via `quote()`.
+//
+// Deviation: the bind carries the pre-extracted `valuesForDatabase()` primitive
+// where Rails' AST carries the Attribute object itself (attribute_methods.rb
+// `attributes_with_values` → persistence.rb `_insert_record`/`_update_record`),
+// keeping type metadata until the adapter's `type_casted_binds`. In trails the
+// Attribute would be resolved to the very same primitive one step later anyway:
+// `toSqlAndBinds` (abstract/database-statements.ts) unwraps every ModelAttribute
+// bind to `valueForDatabase` at compile time — a trails-wide seam shared with
+// the read path and relied on by query-cache keying
+// (`JSON.stringify([sql, binds])`), so threading the Attribute through here is
+// inert. The only driver dispatch keyed off attribute type (SQLite's
+// FloatType → SQLITE_FLOAT for whole-valued floats) is not observable for
+// table writes: a float column's REAL affinity converts an INTEGER-typed bind
+// on storage (verified: `typeof(col)` is 'real' either way).
+// Array columns keep their bespoke inline quoting: their
 // database value is an adapter-specific aggregate literal (`{…}` / `ARRAY[…]`)
 // that the drivers cannot bind as a single scalar parameter — the adapter's
 // `quote` (Rails' `quote(encode_array(value))`) type-casts every element.

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1248,6 +1248,19 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   async reloadTypeMap(): Promise<void> {
     this._typeMap = null;
     await this.loadAdditionalTypes();
+    // A type-map reload signals the database's type universe changed — an
+    // extension or user type (hstore, enum, composite) was created or dropped,
+    // reassigning OIDs. A cached prepared statement that bound or returned one
+    // of those types embeds the now-stale OID in its server-side plan, so
+    // re-executing it raises "cache lookup failed for type <oid>". Drop the
+    // client-side statement map (NOT clearCacheBang) so the next prepare gets a
+    // fresh monotonic name and re-parses against the current OIDs. We
+    // deliberately skip the DEALLOCATE: reloadTypeMap runs mid-DDL-transaction
+    // (e.g. createEnum), and queuing DEALLOCATEs onto the pinned client there
+    // interleaves with the in-flight statement and desyncs the pg protocol.
+    // The orphaned server statements keep their old names — never reused — and
+    // are reclaimed on session reset/close.
+    this._statementPool?.reset();
   }
 
   /**
@@ -3724,6 +3737,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     } else {
       await this.exec(`DROP EXTENSION IF EXISTS ${this.quoteIdentifier(extName)}${cascade}`);
     }
+    // Mirrors Rails' disable_extension, which reloads the type map after the
+    // drop; reloadTypeMap also drops the prepared-statement name map so a later
+    // query doesn't re-execute a plan that referenced the dropped type's OID.
+    await this.reloadTypeMap();
   }
 
   async databaseExists(name: string): Promise<boolean> {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -1640,6 +1640,11 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       : this.pg.quoteIdentifier(enumName);
     const ifExists = options.ifExists ? " IF EXISTS" : "";
     await this.pg.exec(`DROP TYPE${ifExists} ${qualifiedName}`);
+    // Mirrors Rails drop_enum: `internal_exec_query(query).tap { reload_type_map }`
+    // (postgresql_adapter.rb:571-576). reloadTypeMap also drops the
+    // prepared-statement name map so a cached plan referencing the dropped
+    // type's OID is never re-executed ("cache lookup failed for type <oid>").
+    await this.pg.reloadTypeMap();
   }
 
   async renameEnum(name: string, newNameOrOptions: string | { to: string }): Promise<void> {
@@ -1726,6 +1731,15 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       parts.push(`SUBTYPE_DIFF = ${quoteQualifiedIdentifier(options.subtypeDiff, "subtypeDiff")}`);
     }
     await this.pg.exec(`CREATE TYPE ${qualifiedName} AS RANGE (${parts.join(", ")})`);
+    // createRange/dropRange are trails additions (Rails has no range-type DDL
+    // helper), but they follow the pattern of Rails' own type-DDL helpers
+    // (create_enum/drop_enum/rename_enum, postgresql_adapter.rb:541-615), which
+    // all `reload_type_map` after mutating the type universe. reloadTypeMap
+    // also drops the prepared-statement name map, so a cached write-path plan
+    // built against a prior incarnation of the type (drop + recreate reassigns
+    // the OID) is re-prepared instead of raising
+    // "cache lookup failed for type <oid>".
+    await this.pg.reloadTypeMap();
   }
 
   async dropRange(name: string, options: { ifExists?: boolean } = {}): Promise<void> {
@@ -1735,6 +1749,8 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       : this.pg.quoteIdentifier(rangeName);
     const ifExists = options.ifExists ? " IF EXISTS" : "";
     await this.pg.exec(`DROP TYPE${ifExists} ${qualifiedName}`);
+    // See createRange: mirror Rails' type-DDL `reload_type_map` pattern.
+    await this.pg.reloadTypeMap();
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -1660,6 +1660,9 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       ? `${this.pg.quoteIdentifier(schema)}.${this.pg.quoteIdentifier(enumName)}`
       : this.pg.quoteIdentifier(enumName);
     await this.pg.exec(`ALTER TYPE ${qualifiedName} RENAME TO ${this.pg.quoteIdentifier(newName)}`);
+    // Mirrors Rails rename_enum: `exec_query(...).tap { reload_type_map }`
+    // (postgresql_adapter.rb:584).
+    await this.pg.reloadTypeMap();
   }
 
   async addEnumValue(
@@ -1684,6 +1687,9 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     await this.pg.exec(
       `ALTER TYPE ${qualifiedName} ADD VALUE${ifNotExists} ${this.pg.quoteLiteral(value)}${position}`,
     );
+    // Mirrors Rails add_enum_value: `exec_query(...).tap { reload_type_map }`
+    // (postgresql_adapter.rb:602).
+    await this.pg.reloadTypeMap();
   }
 
   async renameEnumValue(name: string, options: { from: string; to: string }): Promise<void> {
@@ -1694,6 +1700,9 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     await this.pg.exec(
       `ALTER TYPE ${qualifiedName} RENAME VALUE ${this.pg.quoteLiteral(options.from)} TO ${this.pg.quoteLiteral(options.to)}`,
     );
+    // Mirrors Rails rename_enum_value: `exec_query(...).tap { reload_type_map }`
+    // (postgresql_adapter.rb:614-616).
+    await this.pg.reloadTypeMap();
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/activerecord/src/write-path-binds.trails.test.ts
+++ b/packages/activerecord/src/write-path-binds.trails.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { Notifications, NotificationEvent as Event } from "@blazetrails/activesupport";
+import { Temporal } from "@blazetrails/activesupport/temporal";
+import { fixtures } from "./test-helpers/fixtures.js";
+import { Task } from "./test-helpers/models/task.js";
+
+/**
+ * Trails-only: no Rails counterpart. Rails' `_insert_record` / `_update_record`
+ * hand every column to Arel as an `ActiveModel::Attribute`, so
+ * `visit_ActiveModel_Attribute → collector.add_bind(o)` makes every write-path
+ * value a typed prepared-statement parameter — there is no inline-vs-bind split
+ * to regress. trails' write path historically inlined every non-string column
+ * via `quote()`; this pins that non-string values (here a datetime) now travel
+ * as binds rather than SQL literals, on INSERT and UPDATE alike.
+ */
+describe("write-path prepared-statement binds", () => {
+  fixtures({});
+
+  it("binds non-string column values on INSERT and UPDATE", async () => {
+    const starting = Temporal.Instant.from("2024-03-05T07:08:09.123456Z");
+    const ending = Temporal.Instant.from("2025-03-05T07:08:09.123456Z");
+    const events: Record<string, unknown>[] = [];
+    const sub = Notifications.subscribe("sql.active_record", (e: Event) =>
+      events.push(e.payload as Record<string, unknown>),
+    );
+
+    let task: Task;
+    try {
+      task = await Task.create({ starting, ending: null });
+      task.ending = ending;
+      await task.save();
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+
+    const insert = events.find((p) => /^INSERT INTO .?tasks.?/i.test(String(p.sql ?? "")));
+    const update = events.find((p) => /^UPDATE .?tasks.?/i.test(String(p.sql ?? "")));
+    expect(insert).toBeDefined();
+    expect(update).toBeDefined();
+
+    for (const payload of [insert!, update!]) {
+      // The datetime never appears as an inline literal…
+      expect(String(payload.sql)).not.toMatch(/202[45]-03-05/);
+      // …because it travels in the bind slot (adapters differ on the wire
+      // format — quoted_date string vs. driver-normalized — so match the
+      // date prefix rather than one adapter's exact rendering).
+      const casted = (
+        typeof payload.type_casted_binds === "function"
+          ? (payload.type_casted_binds as () => unknown[])()
+          : (payload.type_casted_binds as unknown[])
+      ).map(String);
+      expect(casted.some((v) => /202[45]-03-05/.test(v))).toBe(true);
+    }
+
+    const reloaded = await Task.find(task.id);
+    expect(String(reloaded.starting)).toBe(String(task.starting));
+    expect(String(reloaded.ending)).toBe(String(task.ending));
+  });
+});


### PR DESCRIPTION
## Summary

Converges `Base#_performInsert` / `Base#_performUpdate` on Rails' `_insert_record` / `_update_record`: **every** non-array column value is now sent as a prepared-statement bind (Rails' `type_casted_binds`), not just the string/text subset PR #3727 converged. Numbers, dates, binary, json, hstore, enum, and custom PG OID columns all travel through each adapter's bind normalization (`typeCastedBinds` / `_bindForPg` / `mysqlBinds` / `_driverBind`), which since #3727 has grown full Temporal / BigDecimal / `Type::Binary::Data` handling — so no per-type inline-quoting remains on the write path.

Array columns keep their inline `quote()` path: their database value is an adapter-specific aggregate literal (`{…}`) the drivers cannot bind as one scalar parameter.

Also ports the two PG fixes from parked PR #3880 (whose approach this revives, now that prerequisite `pg-pinned-client-write-query-serialization` landed in #4670):

- `reloadTypeMap` drops the client-side prepared-statement name map so a cached plan that embedded a since-reassigned type OID (hstore/enum/composite after extension DDL) isn't re-executed — avoiding `cache lookup failed for type <oid>`. Deliberately no DEALLOCATE: reloadTypeMap runs mid-DDL-transaction and queuing DEALLOCATEs there desyncs the pinned client's protocol.
- `disableExtension` reloads the type map after the drop, mirroring Rails' `disable_extension` (`postgresql_adapter.rb:485-490`).

## Testing

- New trails-only regression test `write-path-binds.trails.test.ts` (Rails has no inline-vs-bind split to regress): asserts a datetime travels as a bind, not an SQL literal, on INSERT and UPDATE. Verified it **fails on origin/main** and passes on this branch, on all three adapters.
- Local runs green on SQLite, PostgreSQL, and MySQL (isolated compose stack): persistence, locking, dirty, timestamp, binary, json-serialization, serialized-attribute, date, time-precision, and the PG custom-type suites (array, bytea, composite, domain, enum, hstore, json, money, uuid).

Closes-story: write-path-bind-all-column-types
