### PR TITLE
chore(api-compare): per-entry verify value-accessor-read + core-idiom wide-call entries

### DIFF
--- a/scripts/api-compare/call-mismatches-wide-exclude/actioncontroller/metal.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actioncontroller/metal.json
@@ -60,6 +60,6 @@
     "tsFile": "metal.ts",
     "rubyName": "performed?",
     "call": "response_body",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails metal.rb:245-247 reads `response_body || response.committed?`; trails metal.ts:294-296 isPerformed reads the recorded `this.performed` flag (set by the responseBody setter) plus `response?.committed` — the body read is a direct field, so no responseBody call is recorded."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/actioncontroller/metal/etag-with-template-digest.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actioncontroller/metal/etag-with-template-digest.json
@@ -74,13 +74,13 @@
     "tsFile": "metal/etag-with-template-digest.ts",
     "rubyName": "pick_template_for_etag",
     "call": "find_all",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails etag_with_template_digest.rb:49-53 resolves the template via `lookup_context.find_all(action_name, _prefixes).first&.virtual_path`; trails etag-with-template-digest.ts:60-66 falls back to `controller.actionName` directly — there is no ActionView lookup-context layer in trails, so find_all/first never appear. Omission (missing template-resolver fallback) tracked in story actionpack-omissions-from-wide-verify."
   },
   {
     "package": "actioncontroller",
     "tsFile": "metal/etag-with-template-digest.ts",
     "rubyName": "pick_template_for_etag",
     "call": "first",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails etag_with_template_digest.rb:49-53 resolves the template via `lookup_context.find_all(action_name, _prefixes).first&.virtual_path`; trails etag-with-template-digest.ts:60-66 falls back to `controller.actionName` directly — there is no ActionView lookup-context layer in trails, so find_all/first never appear. Omission (missing template-resolver fallback) tracked in story actionpack-omissions-from-wide-verify."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/actioncontroller/metal/live.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actioncontroller/metal/live.json
@@ -4,7 +4,7 @@
     "tsFile": "metal/live.ts",
     "rubyName": "abort",
     "call": "clear",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails live.rb:220-225 calls `@buf.clear`; trails live.ts:117-119 empties the buffer with the JS-native `this._buf.length = 0` spelling."
   },
   {
     "package": "actioncontroller",

--- a/scripts/api-compare/call-mismatches-wide-exclude/actioncontroller/metal/request-forgery-protection.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actioncontroller/metal/request-forgery-protection.json
@@ -123,7 +123,7 @@
     "tsFile": "metal/request-forgery-protection.ts",
     "rubyName": "reset",
     "call": "delete",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request_forgery_protection.rb:328-330/361-363 call `session.delete`/`cookie_jar.delete`; trails request-forgery-protection.ts:138-140/160-162 use the JS `delete obj[key]` operator, which records no call."
   },
   {
     "package": "actioncontroller",

--- a/scripts/api-compare/call-mismatches-wide-exclude/actioncontroller/renderer.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actioncontroller/renderer.json
@@ -4,14 +4,14 @@
     "tsFile": "renderer.ts",
     "rubyName": "env_for_request",
     "call": "key?",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails renderer.rb:153-159 uses `@env.key?` and `default_env.merge(@env)`; trails renderer.ts:107-117 uses the `\"HTTP_HOST\" in this._env` operator and object spread `{...routes.defaultEnv, ...this._env}`."
   },
   {
     "package": "actioncontroller",
     "tsFile": "renderer.ts",
     "rubyName": "env_for_request",
     "call": "merge",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails renderer.rb:153-159 uses `@env.key?` and `default_env.merge(@env)`; trails renderer.ts:107-117 uses the `\"HTTP_HOST\" in this._env` operator and object spread `{...routes.defaultEnv, ...this._env}`."
   },
   {
     "package": "actioncontroller",

--- a/scripts/api-compare/call-mismatches-wide-exclude/actioncontroller/test-case.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actioncontroller/test-case.json
@@ -95,7 +95,7 @@
     "tsFile": "test-case.ts",
     "rubyName": "controller_class_name",
     "call": "anonymous?",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails test_case.rb:552-554 branches on `@controller.class.anonymous?`; trails test-case.ts:132-134 returns `controllerClass?.name ?? \"\"` with no anonymous-controller handling. Omission tracked in story actionpack-omissions-from-wide-verify."
   },
   {
     "package": "actioncontroller",

--- a/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/http/mime-type.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/http/mime-type.json
@@ -102,7 +102,7 @@
     "tsFile": "http/mime-type.ts",
     "rubyName": "ref",
     "call": "to_s",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails mime_type.rb:285-287 returns `symbol || to_s`; trails mime-type.ts:194-196 returns `this.symbol` only — the to_s fallback for symbol-less types is unported. Omission tracked in story actionpack-omissions-from-wide-verify."
   },
   {
     "package": "actiondispatch",
@@ -137,7 +137,7 @@
     "tsFile": "http/mime-type.ts",
     "rubyName": "to_str",
     "call": "to_s",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails mime_type.rb:277-279 defines the string-duck `to_str` as `to_s`; trails' toString (mime-type.ts:181-183) serves both roles — Ruby's implicit-conversion protocol has no JS analogue, so no separate to_s call exists."
   },
   {
     "package": "actiondispatch",

--- a/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/http/request.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/http/request.json
@@ -32,7 +32,7 @@
     "tsFile": "http/request.ts",
     "rubyName": "engine_script_name=",
     "call": "routes",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:180-182 setter writes `set_header(routes.env_key, ...)`; trails request.ts:804-806 ports only the getter overload (engineScriptName reads `this.env[routes.envKey]`) — the setter used by engine mounting is unported, so no routes call is recorded."
   },
   {
     "package": "actiondispatch",
@@ -53,7 +53,7 @@
     "tsFile": "http/request.ts",
     "rubyName": "GET",
     "call": "action_encoding_template",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:395-404 parses query params through CustomParamEncoder.action_encoding_template + ParamBuilder.from_query_string under fetch_header memoization; trails request.ts:944-946 returns `this.queryParameters` — trails parses query strings in that accessor without the encoding-template/ParamBuilder machinery (unported by design; plain UTF-8 params only)."
   },
   {
     "package": "actiondispatch",
@@ -67,7 +67,7 @@
     "tsFile": "http/request.ts",
     "rubyName": "GET",
     "call": "from_query_string",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:395-404 parses query params through CustomParamEncoder.action_encoding_template + ParamBuilder.from_query_string under fetch_header memoization; trails request.ts:944-946 returns `this.queryParameters` — trails parses query strings in that accessor without the encoding-template/ParamBuilder machinery (unported by design; plain UTF-8 params only)."
   },
   {
     "package": "actiondispatch",
@@ -81,7 +81,7 @@
     "tsFile": "http/request.ts",
     "rubyName": "GET",
     "call": "path_parameters",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:395-404 parses query params through CustomParamEncoder.action_encoding_template + ParamBuilder.from_query_string under fetch_header memoization; trails request.ts:944-946 returns `this.queryParameters` — trails parses query strings in that accessor without the encoding-template/ParamBuilder machinery (unported by design; plain UTF-8 params only)."
   },
   {
     "package": "actiondispatch",
@@ -165,7 +165,7 @@
     "tsFile": "http/request.ts",
     "rubyName": "POST",
     "call": "action_encoding_template",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:408-434 runs the body through parse_formatted_parameters/params_parsers and ParamBuilder.from_pairs/from_hash with encoding templates; trails request.ts:949-951 returns `this.requestParameters` — body parsing happens in that accessor without the encoding-template/ParamBuilder machinery (unported by design)."
   },
   {
     "package": "actiondispatch",
@@ -179,14 +179,14 @@
     "tsFile": "http/request.ts",
     "rubyName": "POST",
     "call": "from_hash",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:408-434 runs the body through parse_formatted_parameters/params_parsers and ParamBuilder.from_pairs/from_hash with encoding templates; trails request.ts:949-951 returns `this.requestParameters` — body parsing happens in that accessor without the encoding-template/ParamBuilder machinery (unported by design)."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "POST",
     "call": "from_pairs",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:408-434 runs the body through parse_formatted_parameters/params_parsers and ParamBuilder.from_pairs/from_hash with encoding templates; trails request.ts:949-951 returns `this.requestParameters` — body parsing happens in that accessor without the encoding-template/ParamBuilder machinery (unported by design)."
   },
   {
     "package": "actiondispatch",
@@ -200,21 +200,21 @@
     "tsFile": "http/request.ts",
     "rubyName": "POST",
     "call": "params_parsers",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:408-434 runs the body through parse_formatted_parameters/params_parsers and ParamBuilder.from_pairs/from_hash with encoding templates; trails request.ts:949-951 returns `this.requestParameters` — body parsing happens in that accessor without the encoding-template/ParamBuilder machinery (unported by design)."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "POST",
     "call": "parse_formatted_parameters",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:408-434 runs the body through parse_formatted_parameters/params_parsers and ParamBuilder.from_pairs/from_hash with encoding templates; trails request.ts:949-951 returns `this.requestParameters` — body parsing happens in that accessor without the encoding-template/ParamBuilder machinery (unported by design)."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "POST",
     "call": "path_parameters",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:408-434 runs the body through parse_formatted_parameters/params_parsers and ParamBuilder.from_pairs/from_hash with encoding templates; trails request.ts:949-951 returns `this.requestParameters` — body parsing happens in that accessor without the encoding-template/ParamBuilder machinery (unported by design)."
   },
   {
     "package": "actiondispatch",

--- a/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/journey/nodes/node.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/journey/nodes/node.json
@@ -4,7 +4,7 @@
     "tsFile": "journey/nodes/node.ts",
     "rubyName": "glob?",
     "call": "any?",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails node.rb:38-40 reads `stars.any?`; trails node.ts:276-278 isGlob reads `this.stars.length > 0`."
   },
   {
     "package": "actiondispatch",

--- a/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/middleware/cookies.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/middleware/cookies.json
@@ -81,7 +81,7 @@
     "tsFile": "middleware/cookies.ts",
     "rubyName": "serializer",
     "call": "cookies_serializer",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails cookies.rb:574-586 switches on `request.cookies_serializer`; trails cookies.ts:746-765 reads the same env slot directly (`request.env[\"action_dispatch.cookies_serializer\"]`) so object serializers stay visible — the narrowing cookiesSerializer accessor is bypassed, hence no same-named call."
   },
   {
     "package": "actiondispatch",

--- a/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/middleware/exception-wrapper.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/middleware/exception-wrapper.json
@@ -4,28 +4,28 @@
     "tsFile": "middleware/exception-wrapper.ts",
     "rubyName": "build_backtrace",
     "call": "each",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails exception_wrapper.rb:254-275 decorates backtrace locations with compiled ActionView template methods (each/map/key?/to_s/method_name over PathRegistry resolvers); trails exception-wrapper.ts:297-299 returns `this.traces` — there are no compiled template methods in trails, so the whole decoration loop is inapplicable."
   },
   {
     "package": "actiondispatch",
     "tsFile": "middleware/exception-wrapper.ts",
     "rubyName": "build_backtrace",
     "call": "key?",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails exception_wrapper.rb:254-275 decorates backtrace locations with compiled ActionView template methods (each/map/key?/to_s/method_name over PathRegistry resolvers); trails exception-wrapper.ts:297-299 returns `this.traces` — there are no compiled template methods in trails, so the whole decoration loop is inapplicable."
   },
   {
     "package": "actiondispatch",
     "tsFile": "middleware/exception-wrapper.ts",
     "rubyName": "build_backtrace",
     "call": "map",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails exception_wrapper.rb:254-275 decorates backtrace locations with compiled ActionView template methods (each/map/key?/to_s/method_name over PathRegistry resolvers); trails exception-wrapper.ts:297-299 returns `this.traces` — there are no compiled template methods in trails, so the whole decoration loop is inapplicable."
   },
   {
     "package": "actiondispatch",
     "tsFile": "middleware/exception-wrapper.ts",
     "rubyName": "build_backtrace",
     "call": "method_name",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails exception_wrapper.rb:254-275 decorates backtrace locations with compiled ActionView template methods (each/map/key?/to_s/method_name over PathRegistry resolvers); trails exception-wrapper.ts:297-299 returns `this.traces` — there are no compiled template methods in trails, so the whole decoration loop is inapplicable."
   },
   {
     "package": "actiondispatch",
@@ -39,7 +39,7 @@
     "tsFile": "middleware/exception-wrapper.ts",
     "rubyName": "build_backtrace",
     "call": "to_s",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails exception_wrapper.rb:254-275 decorates backtrace locations with compiled ActionView template methods (each/map/key?/to_s/method_name over PathRegistry resolvers); trails exception-wrapper.ts:297-299 returns `this.traces` — there are no compiled template methods in trails, so the whole decoration loop is inapplicable."
   },
   {
     "package": "actiondispatch",

--- a/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/middleware/session/abstract-store.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/middleware/session/abstract-store.json
@@ -4,6 +4,6 @@
     "tsFile": "middleware/session/abstract-store.ts",
     "rubyName": "initialize_sid",
     "call": "delete",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails abstract_store.rb:35-38 calls `@default_options.delete` twice; trails abstract-store.ts:124-127 uses the JS `delete this.defaultOptions.*` operator."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/middleware/session/mem-cache-store.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/middleware/session/mem-cache-store.json
@@ -4,6 +4,6 @@
     "tsFile": "middleware/session/mem-cache-store.ts",
     "rubyName": "initialize_sid",
     "call": "delete",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Same body as abstract_store.rb:35-38 (mem_cache_store.rb defines no initialize_sid of its own; the flag comes from the shared Compatibility body); trails mem-cache-store.ts inherits abstract-store.ts:124-127, which uses the JS `delete` operator."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/middleware/stack.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/middleware/stack.json
@@ -81,7 +81,7 @@
     "tsFile": "middleware/stack.ts",
     "rubyName": "last",
     "call": "middlewares",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails stack.rb:89-91 reads the `middlewares` accessor; trails stack.ts:48-50 reads the backing `this.entries` array directly."
   },
   {
     "package": "actiondispatch",

--- a/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/routing/mapper.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/routing/mapper.json
@@ -627,7 +627,7 @@
     "tsFile": "routing/mapper.ts",
     "rubyName": "nested_scope?",
     "call": "nested?",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails mapper.rb:1831-1833 reads `@scope.nested?`; trails mapper.ts:1243-1245 isNestedScope inlines the scope-object predicate as `this.scopeStack.length > 1`."
   },
   {
     "package": "actiondispatch",

--- a/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/system-testing/driver.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/system-testing/driver.json
@@ -4,28 +4,28 @@
     "tsFile": "system-testing/driver.ts",
     "rubyName": "browser_options",
     "call": "compact",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails driver.rb:51-53 merges `@browser.options` into @options and compacts; trails driver.ts:89-91 returns `{...this._options}` — trails has no selenium Browser object to merge, and JS object spread drops nothing (compact N/A). Browser-option merge gap tracked in story actionpack-omissions-from-wide-verify."
   },
   {
     "package": "actiondispatch",
     "tsFile": "system-testing/driver.ts",
     "rubyName": "browser_options",
     "call": "merge",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails driver.rb:51-53 merges `@browser.options` into @options and compacts; trails driver.ts:89-91 returns `{...this._options}` — trails has no selenium Browser object to merge, and JS object spread drops nothing (compact N/A). Browser-option merge gap tracked in story actionpack-omissions-from-wide-verify."
   },
   {
     "package": "actiondispatch",
     "tsFile": "system-testing/driver.ts",
     "rubyName": "browser_options",
     "call": "options",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails driver.rb:51-53 merges `@browser.options` into @options and compacts; trails driver.ts:89-91 returns `{...this._options}` — trails has no selenium Browser object to merge, and JS object spread drops nothing (compact N/A). Browser-option merge gap tracked in story actionpack-omissions-from-wide-verify."
   },
   {
     "package": "actiondispatch",
     "tsFile": "system-testing/driver.ts",
     "rubyName": "initialize",
     "call": "delete",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails driver.rb:10-25 pops the name with `@options.delete(:name)`; trails driver.ts:47-55 uses the JS `delete opts.name` operator on a spread copy."
   },
   {
     "package": "actiondispatch",

--- a/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/testing/assertions/routing.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/testing/assertions/routing.json
@@ -144,13 +144,13 @@
     "tsFile": "testing/assertions/routing.ts",
     "rubyName": "reset_routes",
     "call": "app",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails routing.rb has two overloads: 72-77 (integration: app.instance_variable_set + singleton_class.redefine_method) and 298-303 (functional: plain restore); trails routing.ts:270-277 ports the functional overload only — JS has no singleton classes, so the app/redefine_method arm has no analogue."
   },
   {
     "package": "actiondispatch",
     "tsFile": "testing/assertions/routing.ts",
     "rubyName": "reset_routes",
     "call": "redefine_method",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails routing.rb has two overloads: 72-77 (integration: app.instance_variable_set + singleton_class.redefine_method) and 298-303 (functional: plain restore); trails routing.ts:270-277 ports the functional overload only — JS has no singleton classes, so the app/redefine_method arm has no analogue."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/testing/integration.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/testing/integration.json
@@ -256,27 +256,27 @@
     "tsFile": "testing/integration.ts",
     "rubyName": "url_options",
     "call": "controller",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails integration.rb:140-150 reverse-merges controller.url_options and @app.routes.default_url_options into the memo; trails integration.ts:186-195 merges only defaults + host/protocol — the controller and app-routes merges are unported. Omission tracked in story actionpack-omissions-from-wide-verify."
   },
   {
     "package": "actiondispatch",
     "tsFile": "testing/integration.ts",
     "rubyName": "url_options",
     "call": "default_url_options",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails integration.rb:140-150 reverse-merges controller.url_options and @app.routes.default_url_options into the memo; trails integration.ts:186-195 merges only defaults + host/protocol — the controller and app-routes merges are unported. Omission tracked in story actionpack-omissions-from-wide-verify."
   },
   {
     "package": "actiondispatch",
     "tsFile": "testing/integration.ts",
     "rubyName": "url_options",
     "call": "reverse_merge!",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails integration.rb:140-150 reverse-merges controller.url_options and @app.routes.default_url_options into the memo; trails integration.ts:186-195 merges only defaults + host/protocol — the controller and app-routes merges are unported. Omission tracked in story actionpack-omissions-from-wide-verify."
   },
   {
     "package": "actiondispatch",
     "tsFile": "testing/integration.ts",
     "rubyName": "url_options",
     "call": "routes",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails integration.rb:140-150 reverse-merges controller.url_options and @app.routes.default_url_options into the memo; trails integration.ts:186-195 merges only defaults + host/protocol — the controller and app-routes merges are unported. Omission tracked in story actionpack-omissions-from-wide-verify."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activemodel/attribute-methods.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activemodel/attribute-methods.json
@@ -46,14 +46,14 @@
     "tsFile": "attribute-methods.ts",
     "rubyName": "attribute_alias",
     "call": "attribute_aliases",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails attribute_methods.rb:245-247 reads `attribute_aliases[name.to_s]`; trails attribute-methods.ts:367-369 reads `host._attributeAliases[name]` directly — JS string keys need no to_s coercion."
   },
   {
     "package": "activemodel",
     "tsFile": "attribute-methods.ts",
     "rubyName": "attribute_alias",
     "call": "to_s",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails attribute_methods.rb:245-247 reads `attribute_aliases[name.to_s]`; trails attribute-methods.ts:367-369 reads `host._attributeAliases[name]` directly — JS string keys need no to_s coercion."
   },
   {
     "package": "activemodel",
@@ -256,7 +256,7 @@
     "tsFile": "attribute-methods.ts",
     "rubyName": "generated_attribute_methods",
     "call": "include",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails attribute_methods.rb:400-402 lazily builds `Module.new.tap { include mod }`; trails attribute-methods.ts:466-468 returns the `_generatedMethods` Set — there is no module system to include into, the Set is the holder."
   },
   {
     "package": "activemodel",
@@ -284,14 +284,14 @@
     "tsFile": "attribute-methods.ts",
     "rubyName": "resolve_attribute_name",
     "call": "attribute_aliases",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails attribute_methods.rb:396-398 uses `attribute_aliases.fetch(super, &:itself)`; trails attribute-methods.ts:461-463 reads `this._attributeAliases?.[name] ?? name`."
   },
   {
     "package": "activemodel",
     "tsFile": "attribute-methods.ts",
     "rubyName": "resolve_attribute_name",
     "call": "fetch",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails attribute_methods.rb:396-398 uses `attribute_aliases.fetch(super, &:itself)`; trails attribute-methods.ts:461-463 reads `this._attributeAliases?.[name] ?? name`."
   },
   {
     "package": "activemodel",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activemodel/attribute-set.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activemodel/attribute-set.json
@@ -18,7 +18,7 @@
     "tsFile": "attribute-set.ts",
     "rubyName": "cast_types",
     "call": "transform_values",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails attribute_set.rb:24-26 uses `attributes.transform_values(&:type)`; trails attribute-set.ts:60-66 builds the record with a for-of loop over `this.attributes`."
   },
   {
     "package": "activemodel",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activemodel/dirty.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activemodel/dirty.json
@@ -4,7 +4,7 @@
     "tsFile": "dirty.ts",
     "rubyName": "as_json",
     "call": "merge",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails dirty.rb:264-268 merges mutation-tracker ivars into `options[:except]` and defers to the model serializer via super; trails dirty.ts:111-113 returns `this.changes` — the mixin has no super() JSON pipeline. Contract divergence tracked in story activesupport-activemodel-omissions-from-wide-verify."
   },
   {
     "package": "activemodel",
@@ -60,14 +60,14 @@
     "tsFile": "dirty.ts",
     "rubyName": "attribute_previous_change",
     "call": "change_to_attribute",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails dirty.rb:404-406 calls `mutations_before_last_save.change_to_attribute(attr_name.to_s)`; trails dirty.ts:76-81 reads the `previousChanges` record directly by string key."
   },
   {
     "package": "activemodel",
     "tsFile": "dirty.ts",
     "rubyName": "attribute_previous_change",
     "call": "to_s",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails dirty.rb:404-406 calls `mutations_before_last_save.change_to_attribute(attr_name.to_s)`; trails dirty.ts:76-81 reads the `previousChanges` record directly by string key."
   },
   {
     "package": "activemodel",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activemodel/type/value.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activemodel/type/value.json
@@ -4,6 +4,6 @@
     "tsFile": "type/value.ts",
     "rubyName": "initialize",
     "call": "serialize_cast_value_compatible?",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails serialize_cast_value.rb:41-44 eagerly computes `serialize_cast_value_compatible?` in initialize as a warm-up; trails value.ts computes it lazily with per-class memoization in the static serializeCastValueCompatible (value.ts:168+) — the eager constructor call is a Ruby-only perf priming."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/association.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/association.json
@@ -249,7 +249,7 @@
     "tsFile": "associations/association.ts",
     "rubyName": "marshal_dump",
     "call": "map",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails association.rb:206-209 maps over instance_variables to build the ivar list; trails association.ts:529-537 dumps the fixed `{loaded, target}` shape — Marshal introspection has no JS analogue, the shape is explicit."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/attribute-methods.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/attribute-methods.json
@@ -487,7 +487,7 @@
     "tsFile": "attribute-methods.ts",
     "rubyName": "initialize_generated_modules",
     "call": "include",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails attribute_methods.rb:42-50 does `include @generated_attribute_methods`; trails attribute-methods.ts:257-259 assigns a GeneratedAttributeMethods holder instance — no Module#include in TS, the holder is consulted directly."
   },
   {
     "package": "activerecord",
@@ -515,7 +515,7 @@
     "tsFile": "attribute-methods.ts",
     "rubyName": "method_defined_within?",
     "call": "owner",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails attribute_methods.rb:187-197 compares `instance_method(name).owner` across class and superclass; trails attribute-methods.ts:508-517 uses `name in klass.prototype` vs `name in superklass.prototype` — the prototype chain check replaces Method#owner introspection."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/attribute-methods/dirty.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/attribute-methods/dirty.json
@@ -32,14 +32,14 @@
     "tsFile": "attribute-methods/dirty.ts",
     "rubyName": "attribute_change_to_be_saved",
     "call": "change_to_attribute",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails dirty.rb:152-154 calls `mutations_from_database.change_to_attribute(attr_name.to_s)`; trails attribute-methods/dirty.ts:83-90 reads `record.changes[attr]` directly by string key."
   },
   {
     "package": "activerecord",
     "tsFile": "attribute-methods/dirty.ts",
     "rubyName": "attribute_change_to_be_saved",
     "call": "to_s",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails dirty.rb:152-154 calls `mutations_from_database.change_to_attribute(attr_name.to_s)`; trails attribute-methods/dirty.ts:83-90 reads `record.changes[attr]` directly by string key."
   },
   {
     "package": "activerecord",
@@ -67,14 +67,14 @@
     "tsFile": "attribute-methods/dirty.ts",
     "rubyName": "saved_change_to_attribute",
     "call": "change_to_attribute",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails dirty.rb:98-100 calls `mutations_before_last_save.change_to_attribute(attr_name.to_s)`; trails attribute-methods/dirty.ts:34-39 reads `record.previousChanges[attr]` directly by string key."
   },
   {
     "package": "activerecord",
     "tsFile": "attribute-methods/dirty.ts",
     "rubyName": "saved_change_to_attribute",
     "call": "to_s",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails dirty.rb:98-100 calls `mutations_before_last_save.change_to_attribute(attr_name.to_s)`; trails attribute-methods/dirty.ts:34-39 reads `record.previousChanges[attr]` directly by string key."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/attribute-methods/primary-key.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/attribute-methods/primary-key.json
@@ -74,14 +74,14 @@
     "tsFile": "attribute-methods/primary-key.ts",
     "rubyName": "instance_method_already_implemented?",
     "call": "include?",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails primary_key.rb:69-71 is `super || primary_key && ID_ATTRIBUTE_METHODS.include?(method_name)`; trails primary-key.ts:274-279 answers via `methodName in this.prototype` — the prototype chain already contains the id methods the Rails guard enumerates."
   },
   {
     "package": "activerecord",
     "tsFile": "attribute-methods/primary-key.ts",
     "rubyName": "instance_method_already_implemented?",
     "call": "primary_key",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails primary_key.rb:69-71 is `super || primary_key && ID_ATTRIBUTE_METHODS.include?(method_name)`; trails primary-key.ts:274-279 answers via `methodName in this.prototype` — the prototype chain already contains the id methods the Rails guard enumerates."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
@@ -235,7 +235,7 @@
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "extended_type_map_key",
     "call": "emulate_booleans",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails abstract_mysql_adapter.rb:762-768 pairs @default_timezone with the emulate_booleans accessor; trails abstract-mysql-adapter.ts:1733-1743 reads the `_emulateBooleans` field directly."
   },
   {
     "package": "activerecord",
@@ -298,7 +298,7 @@
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "mariadb?",
     "call": "match?",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails abstract_mysql_adapter.rb:92-94 runs `/mariadb/i.match?(full_version)` live; trails isMariadb (abstract-mysql-adapter.ts:422-424) returns the `_mariadb` flag computed once at connect by the same regex (mysql2-adapter.ts:1864)."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/connection-pool.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/connection-pool.json
@@ -74,7 +74,7 @@
     "tsFile": "connection-adapters/abstract/connection-pool.ts",
     "rubyName": "clear_reloadable_connections",
     "call": "disconnect!",
-    "reason": "clearReloadableConnections is now async (converge-connection-pool-lifecycle-async); it delegates the synchronous reload-clear \u2014 including `conn.disconnectBang()` \u2014 to the private `_clearReloadableConnections` core so the public method can await the returned async-close drains. Same call, moved into the shared sync helper."
+    "reason": "clearReloadableConnections is now async (converge-connection-pool-lifecycle-async); it delegates the synchronous reload-clear — including `conn.disconnectBang()` — to the private `_clearReloadableConnections` core so the public method can await the returned async-close drains. Same call, moved into the shared sync helper."
   },
   {
     "package": "activerecord",
@@ -109,7 +109,7 @@
     "tsFile": "connection-adapters/abstract/connection-pool.ts",
     "rubyName": "connected?",
     "call": "any?",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails connection_pool.rb:427-429 is `@connections.any?(&:connected?)`; trails connection-pool.ts:570-572 isConnected checks `_connections.length > 0` — pool membership stands in for the per-connection connected? probe (part of the pool async/sync convergence surface)."
   },
   {
     "package": "activerecord",
@@ -186,7 +186,7 @@
     "tsFile": "connection-adapters/abstract/connection-pool.ts",
     "rubyName": "flush",
     "call": "disconnect!",
-    "reason": "flush is now async (converge-connection-pool-lifecycle-async); it delegates the synchronous eviction \u2014 including `conn.disconnectBang()` \u2014 to the private `_flush` core so the public method can await the returned async-close drains. Same call, moved into the shared sync helper."
+    "reason": "flush is now async (converge-connection-pool-lifecycle-async); it delegates the synchronous eviction — including `conn.disconnectBang()` — to the private `_flush` core so the public method can await the returned async-close drains. Same call, moved into the shared sync helper."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/connection-pool/queue.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/connection-pool/queue.json
@@ -25,7 +25,7 @@
     "tsFile": "connection-adapters/abstract/connection-pool/queue.ts",
     "rubyName": "can_remove_no_wait?",
     "call": "size",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails queue.rb:93-95 reads `@queue.size`; trails queue.ts:278-280 reads `this._queue.length`."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/query-cache.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/query-cache.json
@@ -11,14 +11,14 @@
     "tsFile": "connection-adapters/abstract/query-cache.ts",
     "rubyName": "query_cache",
     "call": "compute_if_absent",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails query_cache.rb:187-191 calls `@thread_query_caches.compute_if_absent(IsolatedExecutionState.context)`; trails query-cache.ts:318-322 calls the same computeIfAbsent with `executionContextId()` standing in for IsolatedExecutionState.context — the getter form keeps the extractor from crediting the calls."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/query-cache.ts",
     "rubyName": "query_cache",
     "call": "context",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails query_cache.rb:187-191 calls `@thread_query_caches.compute_if_absent(IsolatedExecutionState.context)`; trails query-cache.ts:318-322 calls the same computeIfAbsent with `executionContextId()` standing in for IsolatedExecutionState.context — the getter form keeps the extractor from crediting the calls."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/query-cache.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/query-cache.json
@@ -11,14 +11,14 @@
     "tsFile": "connection-adapters/abstract/query-cache.ts",
     "rubyName": "query_cache",
     "call": "compute_if_absent",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails query_cache.rb:187-191 calls `@thread_query_caches.compute_if_absent(IsolatedExecutionState.context)`; trails query-cache.ts:318-322 calls the same computeIfAbsent with `executionContextId()` standing in for IsolatedExecutionState.context — the getter form keeps the extractor from crediting the calls."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails query_cache.rb:187-191 calls `@thread_query_caches.compute_if_absent(IsolatedExecutionState.context)`; trails query-cache.ts:318-322 makes the same computeIfAbsent call with `executionContextId()` standing in for IsolatedExecutionState.context — the TS method is a getter, and the extractor records no calls for getters (its ts-api record carries no call set), so both reads go uncredited."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/query-cache.ts",
     "rubyName": "query_cache",
     "call": "context",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails query_cache.rb:187-191 calls `@thread_query_caches.compute_if_absent(IsolatedExecutionState.context)`; trails query-cache.ts:318-322 calls the same computeIfAbsent with `executionContextId()` standing in for IsolatedExecutionState.context — the getter form keeps the extractor from crediting the calls."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails query_cache.rb:187-191 calls `@thread_query_caches.compute_if_absent(IsolatedExecutionState.context)`; trails query-cache.ts:318-322 makes the same computeIfAbsent call with `executionContextId()` standing in for IsolatedExecutionState.context — the TS method is a getter, and the extractor records no calls for getters (its ts-api record carries no call set), so both reads go uncredited."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-creation.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-creation.json
@@ -18,7 +18,7 @@
     "tsFile": "connection-adapters/abstract/schema-creation.ts",
     "rubyName": "column_options",
     "call": "merge",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails schema_creation.rb:146-148 is `o.options.merge(column: o)`; trails schema-creation.ts:579-581 uses object spread `{...o.options, column: o}`."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
@@ -137,7 +137,7 @@
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "conditional_options",
     "call": "slice",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails schema_definitions.rb:254-256 is `options.slice(:if_exists, :if_not_exists)`; trails schema-definitions.ts:675-680 picks the two keys explicitly."
   },
   {
     "package": "activerecord",
@@ -200,14 +200,14 @@
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "integer_like_primary_key?",
     "call": "include?",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails schema_definitions.rb:605-607 uses `[:integer, :bigint].include?(type)` and `options.key?(:default)`; trails schema-definitions.ts:1031-1037 inlines the type equality checks and tests `options.default === undefined`."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "integer_like_primary_key?",
     "call": "key?",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails schema_definitions.rb:605-607 uses `[:integer, :bigint].include?(type)` and `options.key?(:default)`; trails schema-definitions.ts:1031-1037 inlines the type equality checks and tests `options.default === undefined`."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
@@ -200,14 +200,14 @@
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "integer_like_primary_key?",
     "call": "include?",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails schema_definitions.rb:605-607 uses `[:integer, :bigint].include?(type)` and `options.key?(:default)`; trails schema-definitions.ts:1031-1037 inlines the type equality checks and tests `options.default === undefined`."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails schema_definitions.rb:605-607 uses `[:integer, :bigint].include?(type)` and `!options.key?(:default)`; trails schema-definitions.ts:1031-1037 inlines the type equality checks and tests `options.default === undefined`. The presence check is preserved under the nil↔null mapping: an explicit `default: null` is !== undefined, so it disables the rewrite exactly as Rails' key?-present nil does; the only unmatched shape is an explicit `default: undefined`, which has no Ruby analogue and conventionally means absent in JS."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "integer_like_primary_key?",
     "call": "key?",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails schema_definitions.rb:605-607 uses `[:integer, :bigint].include?(type)` and `options.key?(:default)`; trails schema-definitions.ts:1031-1037 inlines the type equality checks and tests `options.default === undefined`."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails schema_definitions.rb:605-607 uses `[:integer, :bigint].include?(type)` and `!options.key?(:default)`; trails schema-definitions.ts:1031-1037 inlines the type equality checks and tests `options.default === undefined`. The presence check is preserved under the nil↔null mapping: an explicit `default: null` is !== undefined, so it disables the rewrite exactly as Rails' key?-present nil does; the only unmatched shape is an explicit `default: undefined`, which has no Ruby analogue and conventionally means absent in JS."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
@@ -620,7 +620,7 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "foreign_keys_enabled?",
     "call": "fetch",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails schema_statements.rb:1783-1785 is `@config.fetch(:foreign_keys, true)`; trails schema-statements.ts:2487-2493 reads `adapter._config?.foreignKeys !== false` — the default-true fetch becomes a !== false check."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails schema_statements.rb:1783-1785 is `@config.fetch(:foreign_keys, true)` — key-present semantics, so an explicitly configured nil stays falsy; trails schema-statements.ts:2487-2493 reads `adapter._config?.foreignKeys !== false`, which coerces null (and any non-false value) to true. Divergence tracked in story fetch-nil-presence-divergences-globalid-rack."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
@@ -550,7 +550,7 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "extract_new_default_value",
     "call": "has_key?",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails schema_statements.rb:1820-1826 uses `has_key?(:from)/has_key?(:to)`; trails schema-statements.ts:2569-2579 uses the JS `in` operator."
   },
   {
     "package": "activerecord",
@@ -620,7 +620,7 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "foreign_keys_enabled?",
     "call": "fetch",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails schema_statements.rb:1783-1785 is `@config.fetch(:foreign_keys, true)`; trails schema-statements.ts:2487-2493 reads `adapter._config?.foreignKeys !== false` — the default-true fetch becomes a !== false check."
   },
   {
     "package": "activerecord",
@@ -809,7 +809,7 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "options_include_default?",
     "call": "include?",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails schema_statements.rb:1517-1519 uses `options.include?(:default)`; trails schema-statements.ts:2040-2042 uses the JS `\"default\" in options` operator."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/mysql/column.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/mysql/column.json
@@ -4,13 +4,13 @@
     "tsFile": "connection-adapters/mysql/column.ts",
     "rubyName": "unsigned?",
     "call": "match?",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails mysql/column.rb:9-11 runs the unsigned regex against sql_type on every call; trails mysql/column.ts:12 stores `unsigned` as a readonly boolean computed when the adapter builds columns from SHOW FULL FIELDS."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql/column.ts",
     "rubyName": "virtual?",
     "call": "match?",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails mysql/column.rb:22-24 runs the VIRTUAL/STORED/PERSISTENT regex against extra on every call; trails mysql/column.ts:14 stores `virtual` as a readonly boolean computed at column construction."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/mysql/schema-dumper.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/mysql/schema-dumper.json
@@ -11,21 +11,21 @@
     "tsFile": "connection-adapters/mysql/schema-dumper.ts",
     "rubyName": "extract_expression_for_virtual_column",
     "call": "query_value",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails mysql/schema_dumper.rb:74-93 queries information_schema (query_value/quote/quote_column_name) per column; trails schema-dumper.ts:275-280 reads `virtualExpressionCache` which the adapter pre-populates with the same information_schema query before column iteration."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql/schema-dumper.ts",
     "rubyName": "extract_expression_for_virtual_column",
     "call": "quote",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails mysql/schema_dumper.rb:74-93 queries information_schema (query_value/quote/quote_column_name) per column; trails schema-dumper.ts:275-280 reads `virtualExpressionCache` which the adapter pre-populates with the same information_schema query before column iteration."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql/schema-dumper.ts",
     "rubyName": "extract_expression_for_virtual_column",
     "call": "quote_column_name",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails mysql/schema_dumper.rb:74-93 queries information_schema (query_value/quote/quote_column_name) per column; trails schema-dumper.ts:275-280 reads `virtualExpressionCache` which the adapter pre-populates with the same information_schema query before column iteration."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
@@ -606,7 +606,7 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "supports_optimizer_hints?",
     "call": "extension_available?",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails postgresql_adapter.rb:444-449 memoizes `extension_available?(\"pg_hint_plan\")`; trails postgresql-adapter.ts:3442-3444 returns the `_hasOptimizerHints` flag populated by the same pg_extension count query (postgresql-adapter.ts:3257-3271)."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql/column.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql/column.json
@@ -4,6 +4,6 @@
     "tsFile": "connection-adapters/postgresql/column.ts",
     "rubyName": "virtual?",
     "call": "present?",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails postgresql/column.rb:28-31 reads `@generated.present?`; trails postgresql/column.ts:104-106 isVirtual checks `this.generated !== null && this.generated !== \"\"` — the explicit spelling of present?."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql/database-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql/database-statements.json
@@ -4,7 +4,7 @@
     "tsFile": "connection-adapters/postgresql/database-statements.ts",
     "rubyName": "affected_rows",
     "call": "clear",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails postgresql/database_statements.rb:189-193 reads cmd_tuples then `result.clear`s the libpq buffer; trails database-statements.ts:231-233 returns `result.rowCount ?? 0` — node-postgres results are GC'd, there is no clear to call."
   },
   {
     "package": "activerecord",
@@ -95,7 +95,7 @@
     "tsFile": "connection-adapters/postgresql/database-statements.ts",
     "rubyName": "returning_column_values",
     "call": "first",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails postgresql/database_statements.rb:208-210 reads `result.rows.first`; trails database-statements.ts:307-309 reads `result.rows[0]`."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql/schema-definitions.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql/schema-definitions.json
@@ -25,7 +25,7 @@
     "tsFile": "connection-adapters/postgresql/schema-definitions.ts",
     "rubyName": "export_name_on_schema_dump?",
     "call": "match?",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails postgresql/schema_definitions.rb:209-211/231-233 filter via SchemaDumper.excl_ignore_pattern/unique_ignore_pattern.match?; trails schema-definitions.ts:98-100/134-136 return `this.name != null` only — the ignore-pattern filtering (patterns exist at schema-dumper.ts:346-348) is unported. Omission tracked in story pg-export-name-ignores-dumper-patterns."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql/utils.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql/utils.json
@@ -11,6 +11,6 @@
     "tsFile": "connection-adapters/postgresql/utils.ts",
     "rubyName": "to_s",
     "call": "join",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails postgresql/utils.rb:18-20 is `parts.join(SEPARATOR)`; trails utils.ts:17-22 toString template-joins schema and identifier explicitly."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3/database-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3/database-statements.json
@@ -102,7 +102,7 @@
     "tsFile": "connection-adapters/sqlite3/database-statements.ts",
     "rubyName": "returning_column_values",
     "call": "first",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails sqlite3/database_statements.rb:135-137 reads `result.rows.first`; trails sqlite3/database-statements.ts:285-287 reads `result.rows[0]`."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/core.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/core.json
@@ -46,7 +46,7 @@
     "tsFile": "core.ts",
     "rubyName": "connection_class?",
     "call": "connection_class",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails core.rb:234-236 delegates to the connection_class reader (core.rb:230-232); trails core.ts:535-539 is a combined accessor reading the `_connectionClass` field directly."
   },
   {
     "package": "activerecord",
@@ -242,14 +242,14 @@
     "tsFile": "core.ts",
     "rubyName": "init_internals",
     "call": "define_attribute_methods",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails core.rb:834-849 caches `klass.primary_key` into @primary_key and calls `klass.define_attribute_methods`; trails core.ts:753-771 initializes the same flags but reads primaryKey lazily from the class and defines attribute methods at declare() time — neither call appears in initInternals."
   },
   {
     "package": "activerecord",
     "tsFile": "core.ts",
     "rubyName": "init_internals",
     "call": "primary_key",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails core.rb:834-849 caches `klass.primary_key` into @primary_key and calls `klass.define_attribute_methods`; trails core.ts:753-771 initializes the same flags but reads primaryKey lazily from the class and defines attribute methods at declare() time — neither call appears in initInternals."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/database-configurations/hash-config.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/database-configurations/hash-config.json
@@ -4,7 +4,7 @@
     "tsFile": "database-configurations/hash-config.ts",
     "rubyName": "database_tasks?",
     "call": "fetch",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails hash_config.rb:161-163 uses `configuration_hash.fetch(:database_tasks, true)`; trails hash-config.ts:97-101 reads the key with an explicit undefined-defaults-true check."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption.json
@@ -18,14 +18,14 @@
     "tsFile": "encryption.ts",
     "rubyName": "context",
     "call": "default_context",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails contexts.rb:62-64 returns `current_custom_context || default_context`; trails encryption.ts:449-451 delegates to Contexts.context (encryption/context.ts), which performs the same custom-else-default read internally."
   },
   {
     "package": "activerecord",
     "tsFile": "encryption.ts",
     "rubyName": "current_custom_context",
     "call": "last",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails contexts.rb:66-68 reads `custom_contexts&.last`; trails encryption.ts:454-456 delegates to Contexts.currentCustomContext, which reads the stack tail inside encryption/context.ts."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption/encryptable-record.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption/encryptable-record.json
@@ -186,14 +186,14 @@
     "tsFile": "encryption/encryptable-record.ts",
     "rubyName": "has_encrypted_attributes?",
     "call": "encrypted_attributes",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails encryptable_record.rb:204-206 reads `self.class.encrypted_attributes.present?`; trails encryptable-record.ts:165-167 reads `modelClass._encryptedAttributes?.size > 0`."
   },
   {
     "package": "activerecord",
     "tsFile": "encryption/encryptable-record.ts",
     "rubyName": "has_encrypted_attributes?",
     "call": "present?",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails encryptable_record.rb:204-206 reads `self.class.encrypted_attributes.present?`; trails encryptable-record.ts:165-167 reads `modelClass._encryptedAttributes?.size > 0`."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption/encrypted-attribute-type.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption/encrypted-attribute-type.json
@@ -18,14 +18,14 @@
     "tsFile": "encryption/encrypted-attribute-type.ts",
     "rubyName": "decryption_options",
     "call": "compact",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails encrypted_attribute_type.rb:158-160 builds `{key_provider:}.compact`; trails encrypted-attribute-type.ts:368-373 inserts the key conditionally instead of compacting."
   },
   {
     "package": "activerecord",
     "tsFile": "encryption/encrypted-attribute-type.ts",
     "rubyName": "encryption_options",
     "call": "compact",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails encrypted_attribute_type.rb:154-156 builds the options hash and `.compact`s; trails encrypted-attribute-type.ts:361-366 inserts keyProvider conditionally instead of compacting."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption/key-provider.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption/key-provider.json
@@ -4,14 +4,14 @@
     "tsFile": "encryption/key-provider.ts",
     "rubyName": "encryption_key",
     "call": "id",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails key_provider.rb:20-26 memoizes `@keys.last` and taps it with `key.id` when config.store_key_references; trails key-provider.ts:19-21 returns `_keys[_keys.length - 1]` — the store_key_references tap (config exists at encryption/config.ts:14) is unported. Omission tracked in story key-provider-ignores-store-key-references."
   },
   {
     "package": "activerecord",
     "tsFile": "encryption/key-provider.ts",
     "rubyName": "encryption_key",
     "call": "last",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails key_provider.rb:20-26 memoizes `@keys.last` and taps it with `key.id` when config.store_key_references; trails key-provider.ts:19-21 returns `_keys[_keys.length - 1]` — the store_key_references tap (config exists at encryption/config.ts:14) is unported. Omission tracked in story key-provider-ignores-store-key-references."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/errors.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/errors.json
@@ -4,7 +4,7 @@
     "tsFile": "errors.ts",
     "rubyName": "set_query",
     "call": "call",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails errors.rb has two overloads: 213-220 (plain assign, ported at trails errors.ts:268-275) and 275-289 (rebuilds the exception via `@query_parser.call(sql)`); trails has no query_parser machinery. Omission tracked in story errors-set-query-query-parser-overload."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/insert-all.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/insert-all.json
@@ -130,7 +130,7 @@
     "tsFile": "insert-all.ts",
     "rubyName": "resolve_attribute_alias",
     "call": "attribute_alias",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails insert_all.rb:125-127 calls `model.attribute_alias(attribute)`; trails insert-all.ts:401-404 reads `model._attributeAliases` directly."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/locking/optimistic.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/locking/optimistic.json
@@ -46,14 +46,14 @@
     "tsFile": "locking/optimistic.ts",
     "rubyName": "locking_column=",
     "call": "reload_schema_from_cache",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails optimistic.rb:165-168 calls `reload_schema_from_cache` before assigning `value.to_s`; trails setLockingColumn (optimistic.ts:28-30) assigns the field only — the schema-cache reload (exists at attributes.ts:296) is skipped, and the TS signature already takes a string. Omission tracked in story locking-column-setter-skips-schema-reload."
   },
   {
     "package": "activerecord",
     "tsFile": "locking/optimistic.ts",
     "rubyName": "locking_column=",
     "call": "to_s",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails optimistic.rb:165-168 calls `reload_schema_from_cache` before assigning `value.to_s`; trails setLockingColumn (optimistic.ts:28-30) assigns the field only — the schema-cache reload (exists at attributes.ts:296) is skipped, and the TS signature already takes a string. Omission tracked in story locking-column-setter-skips-schema-reload."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration.json
@@ -613,7 +613,7 @@
     "tsFile": "migration.ts",
     "rubyName": "reverting?",
     "call": "connection",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails migration.rb:869-871 probes `connection.respond_to?(:reverting) && connection.reverting`; trails migration.ts:1208-1210 isReverting reads the local `_recording && _recorder.reverting` state — the recorder is held on the migration, not looked up through the connection."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/no-touching.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/no-touching.json
@@ -25,6 +25,6 @@
     "tsFile": "no-touching.ts",
     "rubyName": "no_touching?",
     "call": "applied_to?",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails no_touching.rb:53-55 calls `NoTouching.applied_to?(self.class)`; trails no-touching.ts:51+ isNoTouching reads the module-level `_noTouchingDepth` map directly."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
@@ -130,21 +130,21 @@
     "tsFile": "relation.ts",
     "rubyName": "alias_tracker",
     "call": "connection_pool",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1307-1309 builds `Associations::AliasTracker.create(model.connection_pool, table.name, joins, aliases)`; trails relation.ts:6465-6471 builds a bare join-count map and never touches the AliasTracker class (which exists at associations/alias-tracker.ts:60). Divergence tracked in story relation-alias-tracker-bypasses-class."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "alias_tracker",
     "call": "create",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1307-1309 builds `Associations::AliasTracker.create(model.connection_pool, table.name, joins, aliases)`; trails relation.ts:6465-6471 builds a bare join-count map and never touches the AliasTracker class (which exists at associations/alias-tracker.ts:60). Divergence tracked in story relation-alias-tracker-bypasses-class."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "alias_tracker",
     "call": "model",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1307-1309 builds `Associations::AliasTracker.create(model.connection_pool, table.name, joins, aliases)`; trails relation.ts:6465-6471 builds a bare join-count map and never touches the AliasTracker class (which exists at associations/alias-tracker.ts:60). Divergence tracked in story relation-alias-tracker-bypasses-class."
   },
   {
     "package": "activerecord",
@@ -2503,14 +2503,14 @@
     "tsFile": "relation.ts",
     "rubyName": "none?",
     "call": "empty?",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:378-383 returns true for @none, else falls through to `empty?` (issues a query) or super on args/block (`present?` guard); trails relation.ts:6227-6229 isNone reads only the `_isNone` flag — the empty?-query fallback is unported. Omission tracked in story relation-none-predicate-misses-empty-fallback."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "none?",
     "call": "present?",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:378-383 returns true for @none, else falls through to `empty?` (issues a query) or super on args/block (`present?` guard); trails relation.ts:6227-6229 isNone reads only the `_isNone` flag — the empty?-query fallback is unported. Omission tracked in story relation-none-predicate-misses-empty-fallback."
   },
   {
     "package": "activerecord",
@@ -2692,21 +2692,21 @@
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "call",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1321-1328 concatenates preload_values/includes_values and runs Preloader.new(...).call per spec under the strict_loading_value scope; trails relation.ts:6473-6475 returns the merged `[..._preloadAssociations, ..._includesAssociations]` list and the load path consuming it invokes the preloader — the value reads are direct field spreads."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "each",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1321-1328 concatenates preload_values/includes_values and runs Preloader.new(...).call per spec under the strict_loading_value scope; trails relation.ts:6473-6475 returns the merged `[..._preloadAssociations, ..._includesAssociations]` list and the load path consuming it invokes the preloader — the value reads are direct field spreads."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "includes_values",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1321-1328 concatenates preload_values/includes_values and runs Preloader.new(...).call per spec under the strict_loading_value scope; trails relation.ts:6473-6475 returns the merged `[..._preloadAssociations, ..._includesAssociations]` list and the load path consuming it invokes the preloader — the value reads are direct field spreads."
   },
   {
     "package": "activerecord",
@@ -2720,14 +2720,14 @@
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "preload_values",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1321-1328 concatenates preload_values/includes_values and runs Preloader.new(...).call per spec under the strict_loading_value scope; trails relation.ts:6473-6475 returns the merged `[..._preloadAssociations, ..._includesAssociations]` list and the load path consuming it invokes the preloader — the value reads are direct field spreads."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "strict_loading_value",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1321-1328 concatenates preload_values/includes_values and runs Preloader.new(...).call per spec under the strict_loading_value scope; trails relation.ts:6473-6475 returns the merged `[..._preloadAssociations, ..._includesAssociations]` list and the load path consuming it invokes the preloader — the value reads are direct field spreads."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/merger.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/merger.json
@@ -172,63 +172,63 @@
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
     "call": "empty?",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails merger.rb:96-115; trails merger.ts:92-94 delegates to foldMergePreloads (relation/merge-preloads.ts), which performs the same body: length===0 empty? guards, same-model union via unionAppend, else reflectOnAllAssociations().find on className with preload/includes nesting — the reads happen on `_preloadAssociations`/`_includesAssociations` fields inside the helper."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
     "call": "find",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails merger.rb:96-115; trails merger.ts:92-94 delegates to foldMergePreloads (relation/merge-preloads.ts), which performs the same body: length===0 empty? guards, same-model union via unionAppend, else reflectOnAllAssociations().find on className with preload/includes nesting — the reads happen on `_preloadAssociations`/`_includesAssociations` fields inside the helper."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
     "call": "includes_values",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails merger.rb:96-115; trails merger.ts:92-94 delegates to foldMergePreloads (relation/merge-preloads.ts), which performs the same body: length===0 empty? guards, same-model union via unionAppend, else reflectOnAllAssociations().find on className with preload/includes nesting — the reads happen on `_preloadAssociations`/`_includesAssociations` fields inside the helper."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
     "call": "includes!",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails merger.rb:96-115; trails merger.ts:92-94 delegates to foldMergePreloads (relation/merge-preloads.ts), which performs the same body: length===0 empty? guards, same-model union via unionAppend, else reflectOnAllAssociations().find on className with preload/includes nesting — the reads happen on `_preloadAssociations`/`_includesAssociations` fields inside the helper."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
     "call": "model",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails merger.rb:96-115; trails merger.ts:92-94 delegates to foldMergePreloads (relation/merge-preloads.ts), which performs the same body: length===0 empty? guards, same-model union via unionAppend, else reflectOnAllAssociations().find on className with preload/includes nesting — the reads happen on `_preloadAssociations`/`_includesAssociations` fields inside the helper."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
     "call": "preload_values",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails merger.rb:96-115; trails merger.ts:92-94 delegates to foldMergePreloads (relation/merge-preloads.ts), which performs the same body: length===0 empty? guards, same-model union via unionAppend, else reflectOnAllAssociations().find on className with preload/includes nesting — the reads happen on `_preloadAssociations`/`_includesAssociations` fields inside the helper."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
     "call": "preload!",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails merger.rb:96-115; trails merger.ts:92-94 delegates to foldMergePreloads (relation/merge-preloads.ts), which performs the same body: length===0 empty? guards, same-model union via unionAppend, else reflectOnAllAssociations().find on className with preload/includes nesting — the reads happen on `_preloadAssociations`/`_includesAssociations` fields inside the helper."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
     "call": "reflect_on_all_associations",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails merger.rb:96-115; trails merger.ts:92-94 delegates to foldMergePreloads (relation/merge-preloads.ts), which performs the same body: length===0 empty? guards, same-model union via unionAppend, else reflectOnAllAssociations().find on className with preload/includes nesting — the reads happen on `_preloadAssociations`/`_includesAssociations` fields inside the helper."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
     "call": "relation",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails merger.rb:96-115; trails merger.ts:92-94 delegates to foldMergePreloads (relation/merge-preloads.ts), which performs the same body: length===0 empty? guards, same-model union via unionAppend, else reflectOnAllAssociations().find on className with preload/includes nesting — the reads happen on `_preloadAssociations`/`_includesAssociations` fields inside the helper."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder.json
@@ -221,14 +221,14 @@
     "tsFile": "relation/predicate-builder.ts",
     "rubyName": "handler_for",
     "call": "detect",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails predicate_builder.rb:185-187 is `@handlers.detect { klass === object }.last`; trails predicate-builder.ts:605-611 iterates the pairs with for-of + instanceof and returns the handler directly."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/predicate-builder.ts",
     "rubyName": "handler_for",
     "call": "last",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails predicate_builder.rb:185-187 is `@handlers.detect { klass === object }.last`; trails predicate-builder.ts:605-611 iterates the pairs with for-of + instanceof and returns the handler directly."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder/polymorphic-array-value.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder/polymorphic-array-value.json
@@ -11,7 +11,7 @@
     "tsFile": "relation/predicate-builder/polymorphic-array-value.ts",
     "rubyName": "klass",
     "call": "model",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails polymorphic_array_value.rb:36-42 reads `value.model` for Relation inputs; trails polymorphic-array-value.ts:77-81 reads the `_modelClass` field after duck-checking for a relation."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/scoping.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/scoping.json
@@ -39,6 +39,6 @@
     "tsFile": "scoping.ts",
     "rubyName": "scope_attributes?",
     "call": "any?",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails scoping/default.rb:55-57 is `super || default_scopes.any? || respond_to?(:default_scope)`; trails scoping.ts:144-146 isScopeAttributes returns `!!this.currentScope` — only the super (scoping.rb:22-24) arm; the default_scopes.any? arm is unported. Omission tracked in story scope-attributes-predicate-ignores-default-scopes."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/tasks/mysql-database-tasks.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/tasks/mysql-database-tasks.json
@@ -11,7 +11,7 @@
     "tsFile": "tasks/mysql-database-tasks.ts",
     "rubyName": "collation",
     "call": "connection",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails mysql_database_tasks.rb:36-38 reads the live `connection.collation`; trails mysql-database-tasks.ts:120-122 reads `configurationHash.collation` — configured value, not the database's. Divergence tracked in story database-tasks-collation-reads-config."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/tasks/postgresql-database-tasks.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/tasks/postgresql-database-tasks.json
@@ -11,7 +11,7 @@
     "tsFile": "tasks/postgresql-database-tasks.ts",
     "rubyName": "collation",
     "call": "connection",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails postgresql_database_tasks.rb:36-38 reads the live `connection.collation`; trails postgresql-database-tasks.ts:127-129 reads `configurationHash.collation` — configured value, not the database's. Divergence tracked in story database-tasks-collation-reads-config."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/type.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/type.json
@@ -4,13 +4,13 @@
     "tsFile": "type.ts",
     "rubyName": "adapter_name_from",
     "call": "adapter",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails type.rb:49-51 reads `model.connection_db_config.adapter.to_sym`; trails type.ts:127-133 reads `model.connection?.adapterName` — the adapter name comes off the live connection instead of the db config object."
   },
   {
     "package": "activerecord",
     "tsFile": "type.ts",
     "rubyName": "adapter_name_from",
     "call": "connection_db_config",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails type.rb:49-51 reads `model.connection_db_config.adapter.to_sym`; trails type.ts:127-133 reads `model.connection?.adapterName` — the adapter name comes off the live connection instead of the db config object."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/validations.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/validations.json
@@ -4,7 +4,7 @@
     "tsFile": "validations.ts",
     "rubyName": "custom_validation_context?",
     "call": "exclude?",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails validations.rb:77-79 uses `[:create, :update].exclude?(validation_context)`; trails validations.ts:168-171 inlines the two !== comparisons."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activesupport/cache.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activesupport/cache.json
@@ -88,28 +88,28 @@
     "tsFile": "cache.ts",
     "rubyName": "namespace_key",
     "call": "call",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails cache.rb:948-968 supports per-call :namespace overrides (call_options.key?) and callable namespaces (namespace.call); trails cache/entry-record.ts:19-21 namespaceKey takes an already-resolved string namespace — callers resolve options first, and callable namespaces are unported. Gap tracked in story activesupport-activemodel-omissions-from-wide-verify."
   },
   {
     "package": "activesupport",
     "tsFile": "cache.ts",
     "rubyName": "namespace_key",
     "call": "key?",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails cache.rb:948-968 supports per-call :namespace overrides (call_options.key?) and callable namespaces (namespace.call); trails cache/entry-record.ts:19-21 namespaceKey takes an already-resolved string namespace — callers resolve options first, and callable namespaces are unported. Gap tracked in story activesupport-activemodel-omissions-from-wide-verify."
   },
   {
     "package": "activesupport",
     "tsFile": "cache.ts",
     "rubyName": "normalize_options",
     "call": "each",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails cache.rb:901-910 loops OPTION_ALIASES with each/key?; trails cache/store.ts:451-463 inlines the single expires_in alias family with explicit null checks."
   },
   {
     "package": "activesupport",
     "tsFile": "cache.ts",
     "rubyName": "normalize_options",
     "call": "key?",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails cache.rb:901-910 loops OPTION_ALIASES with each/key?; trails cache/store.ts:451-463 inlines the single expires_in alias family with explicit null checks."
   },
   {
     "package": "activesupport",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activesupport/callbacks.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activesupport/callbacks.json
@@ -74,7 +74,7 @@
     "tsFile": "callbacks.ts",
     "rubyName": "duplicates?",
     "call": "matches?",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails callbacks.rb:272-279 delegates to `matches?(other.kind, other.filter)` for Symbol filters; trails callbacks.ts:629-634 isDuplicates inlines the kind/filter equality for string filters."
   },
   {
     "package": "activesupport",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activesupport/duration.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activesupport/duration.json
@@ -46,14 +46,14 @@
     "tsFile": "duration.ts",
     "rubyName": "initialize",
     "call": "any?",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails duration.rb:226-234 rejects zero parts and computes @variable via `parts.any? { VARIABLE_PARTS.include?(part) }`; trails duration.ts:54-65 stores a fixed normalized parts record — variable-duration tracking is unported. Gap tracked in story activesupport-activemodel-omissions-from-wide-verify."
   },
   {
     "package": "activesupport",
     "tsFile": "duration.ts",
     "rubyName": "initialize",
     "call": "include?",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails duration.rb:226-234 rejects zero parts and computes @variable via `parts.any? { VARIABLE_PARTS.include?(part) }`; trails duration.ts:54-65 stores a fixed normalized parts record — variable-duration tracking is unported. Gap tracked in story activesupport-activemodel-omissions-from-wide-verify."
   },
   {
     "package": "activesupport",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activesupport/encrypted-file.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activesupport/encrypted-file.json
@@ -46,7 +46,7 @@
     "tsFile": "encrypted-file.ts",
     "rubyName": "read_env_key",
     "call": "presence",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails encrypted_file.rb:117-119 reads `ENV[env_key].presence`; trails encrypted-file.ts:192-195 spells presence as an explicit empty-string check."
   },
   {
     "package": "activesupport",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activesupport/error-reporter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activesupport/error-reporter.json
@@ -67,7 +67,7 @@
     "tsFile": "error-reporter.ts",
     "rubyName": "set_context",
     "call": "set",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails error_reporter.rb:201-203 forwards to `ActiveSupport::ExecutionContext.set(...)`; trails error-reporter.ts:66-68 merges into the reporter's own executionContext field — there is no global ExecutionContext singleton in trails."
   },
   {
     "package": "activesupport",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activesupport/number-helper/number-to-phone-converter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activesupport/number-helper/number-to-phone-converter.json
@@ -11,6 +11,6 @@
     "tsFile": "number-helper/number-to-phone-converter.ts",
     "rubyName": "country_code",
     "call": "blank?",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails number_to_phone_converter.rb:47-49 tests `code.blank?`; trails number-to-phone-converter.ts:44-47 spells it as explicit undefined/null/empty-string checks."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/globalid/signed-global-id.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/globalid/signed-global-id.json
@@ -32,7 +32,7 @@
     "tsFile": "signed-global-id.ts",
     "rubyName": "pick_purpose",
     "call": "fetch",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails signed_global_id.rb:24-26 is `options.fetch :for, DEFAULT_PURPOSE`; trails signed-global-id.ts:207-209 is `options.for ?? DEFAULT_PURPOSE`."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails signed_global_id.rb:24-26 uses `options.fetch :for, DEFAULT_PURPOSE` — key-present semantics, so an explicit `for: nil` yields a nil purpose; trails signed-global-id.ts:207-209 uses `options.for ?? DEFAULT_PURPOSE`, which coerces an explicit null back to the default. Divergence tracked in story fetch-nil-presence-divergences-globalid-rack."
   },
   {
     "package": "globalid",

--- a/scripts/api-compare/call-mismatches-wide-exclude/globalid/signed-global-id.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/globalid/signed-global-id.json
@@ -32,7 +32,7 @@
     "tsFile": "signed-global-id.ts",
     "rubyName": "pick_purpose",
     "call": "fetch",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails signed_global_id.rb:24-26 is `options.fetch :for, DEFAULT_PURPOSE`; trails signed-global-id.ts:207-209 is `options.for ?? DEFAULT_PURPOSE`."
   },
   {
     "package": "globalid",

--- a/scripts/api-compare/call-mismatches-wide-exclude/globalid/uri/gid.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/globalid/uri/gid.json
@@ -46,7 +46,7 @@
     "tsFile": "uri/gid.ts",
     "rubyName": "to_s",
     "call": "query",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails uri/gid.rb:104-107 reassembles from app/path/query; trails uri/gid.ts:222-224 toString returns the stored canonical `this.uri` string built at parse time — no query re-read needed."
   },
   {
     "package": "globalid",

--- a/scripts/api-compare/call-mismatches-wide-exclude/rack/cascade.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/rack/cascade.json
@@ -18,13 +18,13 @@
     "tsFile": "cascade.ts",
     "rubyName": "initialize",
     "call": "add",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails cascade.rb:21-27 iterates `apps.each { add app }`; trails cascade.ts:8-12 copies via spread and fills cascadeFor with a for-of loop — add()'s bookkeeping is inlined."
   },
   {
     "package": "rack",
     "tsFile": "cascade.ts",
     "rubyName": "initialize",
     "call": "each",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails cascade.rb:21-27 iterates `apps.each { add app }`; trails cascade.ts:8-12 copies via spread and fills cascadeFor with a for-of loop — add()'s bookkeeping is inlined."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/rack/deflater.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/rack/deflater.json
@@ -67,7 +67,7 @@
     "tsFile": "deflater.ts",
     "rubyName": "initialize",
     "call": "fetch",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails deflater.rb:39-44 uses `options.fetch(:sync, true)`; trails deflater.ts:28-33 spells the default as `opts.sync !== false`."
   },
   {
     "package": "rack",

--- a/scripts/api-compare/call-mismatches-wide-exclude/rack/deflater.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/rack/deflater.json
@@ -67,7 +67,7 @@
     "tsFile": "deflater.ts",
     "rubyName": "initialize",
     "call": "fetch",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails deflater.rb:39-44 uses `options.fetch(:sync, true)`; trails deflater.ts:28-33 spells the default as `opts.sync !== false`."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails deflater.rb:39-44 stores `@sync = options.fetch(:sync, true)` — key-present semantics, so `sync: nil` stays nil (falsy); trails deflater.ts:28-33 uses `opts.sync !== false`, which coerces every non-false value (including null) to true. Divergence tracked in story fetch-nil-presence-divergences-globalid-rack."
   },
   {
     "package": "rack",

--- a/scripts/api-compare/call-mismatches-wide-exclude/rack/mock-response.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/rack/mock-response.json
@@ -4,7 +4,7 @@
     "tsFile": "mock-response.ts",
     "rubyName": "cookie",
     "call": "fetch",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails mock_response.rb:73-75 is `cookies.fetch(name, nil)`; trails mock-response.ts:66-68 is an index read returning undefined when absent."
   },
   {
     "package": "rack",

--- a/scripts/api-compare/call-mismatches-wide-exclude/rack/request.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/rack/request.json
@@ -25,7 +25,7 @@
     "tsFile": "request.ts",
     "rubyName": "delete_header",
     "call": "delete",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:140-142 calls `@env.delete name`; trails request.ts:154-158 uses the JS `delete this.env[key]` operator (returning the prior value)."
   },
   {
     "package": "rack",

--- a/scripts/api-compare/call-mismatches-wide-exclude/trailties/engine/configuration.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/trailties/engine/configuration.json
@@ -4,7 +4,7 @@
     "tsFile": "engine/configuration.ts",
     "rubyName": "all_eager_load_paths",
     "call": "eager_load",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails engine/configuration.rb:133-135 unions `eager_load_paths + paths.eager_load`; trails engine/configuration.ts:99-101 returns only `[...this.eagerLoadPaths]` — the Paths#eager_load contribution is unported (trails' paths registry carries no eager-load flags). Gap tracked in story activesupport-activemodel-omissions-from-wide-verify."
   },
   {
     "package": "trailties",

--- a/scripts/api-compare/call-mismatches-wide-exclude/trailties/generators/rails/script/script-generator.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/trailties/generators/rails/script/script-generator.json
@@ -4,6 +4,6 @@
     "tsFile": "generators/rails/script/script-generator.ts",
     "rubyName": "depth",
     "call": "size",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails script_generator.rb:13-15 reads `class_path.size + 1`; trails script-generator.ts:23-25 reads `classPathParts.length + 1`."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/trailties/generators/resource-helpers.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/trailties/generators/resource-helpers.json
@@ -11,6 +11,6 @@
     "tsFile": "generators/resource-helpers.ts",
     "rubyName": "controller_file_path",
     "call": "join",
-    "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails resource_helpers.rb:46-48 joins `(controller_class_path + [controller_file_name]).join(\"/\")`; trails resource-helpers.ts:38-39 performs the identical `[...].join(\"/\")` — flagged only because the extractor does not credit calls inside concise arrow-function exports."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/trailties/generators/resource-helpers.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/trailties/generators/resource-helpers.json
@@ -11,6 +11,6 @@
     "tsFile": "generators/resource-helpers.ts",
     "rubyName": "controller_file_path",
     "call": "join",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails resource_helpers.rb:46-48 joins `(controller_class_path + [controller_file_name]).join(\"/\")`; trails resource-helpers.ts:38-39 performs the identical `[...].join(\"/\")` — flagged only because the extractor does not credit calls inside concise arrow-function exports."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails resource_helpers.rb:46-48 joins `(controller_class_path + [controller_file_name]).join(\"/\")`; trails resource-helpers.ts:38-39 performs the identical `[...].join(\"/\")` — the extractor credits the controllerClassPath/controllerFileName reads but not calls whose receiver is an array literal, so `join` goes unrecorded (confirmed against output/ts-api.json)."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/trailties/paths.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/trailties/paths.json
@@ -74,6 +74,6 @@
     "tsFile": "paths.ts",
     "rubyName": "initialize",
     "call": "eager_load!",
-    "reason": "Ruby-side value-accessor read: the flagged name is an attr/getter read that only became gate-subject once extractCalls credited property reads. trails reads the corresponding state directly as a property or getter, frequently under a different field name (e.g. `preload_values` -> `_preloadAssociations`), so no same-named call is recorded. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails paths.rb:119-130 dispatches option flags through bang methods (eager_load!/skip_eager_load! etc.); trails paths.ts:64-70 constructor assigns the corresponding booleans directly from options — the flag-bang indirection is inlined."
   }
 ]


### PR DESCRIPTION
## What

Per-entry verification of the two largest cluster-vetted wide-call exclude
clusters from #4997 — value-accessor read (66 entries) and core/Enumerable
idiom (86 entries). Every one of the 152 entries was line-checked against the
vendored Rails body (resolved via the wide artifact's `rubyFile`), and its
cluster-level reason replaced with a per-entry reason citing the Rails
`file:line` it was checked against and what the trails body does instead.

## Real omissions found

The extrapolation concern from the story was warranted: 20 method sites
(spanning ~33 of the 152 entries) hid real divergences, now registered as
eleven RFC 0032 stories (referenced from the
corresponding entry reasons):

- `relation-none-predicate-misses-empty-fallback` — isNone() reads only the
  `_isNone` flag; Rails `none?` falls through to `empty?`.
- `relation-alias-tracker-bypasses-class` — bare join-count map instead of
  `AliasTracker.create(model.connection_pool, ...)`.
- `pg-export-name-ignores-dumper-patterns` — excl/uniq ignore patterns exist
  but are never consulted by exportNameOnSchemaDump.
- `errors-set-query-query-parser-overload` — errors.rb:275-289 overload
  (query_parser exception enrichment) unported.
- `key-provider-ignores-store-key-references` — encryption key never tagged
  with its id despite config.storeKeyReferences existing.
- `locking-column-setter-skips-schema-reload` — reload_schema_from_cache
  skipped on locking_column= despite the helper existing.
- `database-tasks-collation-reads-config` — collation read from config hash,
  not the live connection (MySQL + PG).
- `scope-attributes-predicate-ignores-default-scopes` — the
  `default_scopes.any?` arm of scoping/default.rb:55-57 is missing.
- `actionpack-omissions-from-wide-verify` — bundle: controller_class_name
  anonymous?, integration url_options merges, Mime#ref to_s fallback,
  pick_template_for_etag lookup path, driver browser_options merge.
- `fetch-nil-presence-divergences-globalid-rack` — Ruby `fetch` key-present
  semantics (explicit nil honored) collapsed by `??`/`!== false` in
  SignedGlobalID.pickPurpose, Rack Deflater, and AR foreign_keys_enabled?
  (from Codex review).
- `activesupport-activemodel-omissions-from-wide-verify` — bundle: AM
  Dirty#as_json contract, Duration variable parts, cache namespace_key
  callable/override support, all_eager_load_paths paths union.

## Verification

- `pnpm api:calls:wide` green (6639 baselined; baseline unchanged in count,
  no new entries — reasons only).
- Reason-only diff: one reason line swapped per entry across 77 exclude files;
  no exclude entries added or removed.
- Extractor-behavior claims in two reasons (getter call sets, array-literal
  receivers) were confirmed against `output/ts-api.json`, not inferred.

Closes-story: verify-value-accessor-read-wide-entries-per-entry
