### PR TITLE
refactor(encryption): retire eager _attributeDefinitions wrap; resolve types via typeForAttribute

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1203,13 +1203,13 @@ export class Base extends Model {
     if (name === "id" && Object.prototype.hasOwnProperty.call(this.prototype, "id")) {
       delete (this.prototype as any).id;
     }
-    // Encryption still needs a post-reflection pass: `registerEncryptedType`
-    // defers pushing its `decorateAttributes` decorator until the column is
-    // reflected (it threads the column default into the EncryptedAttributeType),
-    // and this hook also installs the frozen-encryption validator / column-size
-    // checks. `normalizes` / `serialize` push their durable decorator eagerly at
-    // declaration, so — now that `type_for_attribute` / `TypeCaster::Map` resolve
-    // through `attribute_types` (the decorated default attribute set) — they need
+    // Encryption still needs a post-declaration pass — not for type wrapping
+    // (the durable decorator is pushed once at declaration and resolved via
+    // `typeForAttribute`) but for bookkeeping: column-size validation re-runs
+    // and the frozen-encryption validator install. `normalizes` / `serialize`
+    // push their durable decorator eagerly at declaration, so — now that
+    // `type_for_attribute` / `TypeCaster::Map` resolve through
+    // `attribute_types` (the decorated default attribute set) — they need
     // no per-feature `_attributeDefinitions` replay here.
     encryptionHooks.applyPendingEncryptions(this);
   }

--- a/packages/activerecord/src/encrypted-attribute-sti.trails.test.ts
+++ b/packages/activerecord/src/encrypted-attribute-sti.trails.test.ts
@@ -31,10 +31,9 @@ class EncryptedCompany extends Company {}
 class OtherEncryptedCompany extends Company {}
 class ReflectedEncryptedCompany extends Company {}
 
-const defTypeFor = (klass: typeof Company, name: string) =>
-  (
-    klass as unknown as { _attributeDefinitions: Map<string, { type: unknown }> }
-  )._attributeDefinitions.get(name)!.type;
+// Resolve through typeForAttribute — Rails' single lookup surface. The eager
+// `_attributeDefinitions` back-compat view this used to read is retired.
+const defTypeFor = (klass: typeof Company, name: string) => klass.typeForAttribute(name);
 
 const encryptedAttributesOf = (klass: typeof Company) =>
   (klass as unknown as { _encryptedAttributes?: Set<string> })._encryptedAttributes ??

--- a/packages/activerecord/src/encrypted-attribute-sti.trails.test.ts
+++ b/packages/activerecord/src/encrypted-attribute-sti.trails.test.ts
@@ -31,8 +31,6 @@ class EncryptedCompany extends Company {}
 class OtherEncryptedCompany extends Company {}
 class ReflectedEncryptedCompany extends Company {}
 
-// Resolve through typeForAttribute — Rails' single lookup surface. The eager
-// `_attributeDefinitions` back-compat view this used to read is retired.
 const defTypeFor = (klass: typeof Company, name: string) => klass.typeForAttribute(name);
 
 const encryptedAttributesOf = (klass: typeof Company) =>

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -271,8 +271,6 @@ export function isEncryptedAttribute(klass: any, attr: string): boolean {
     if (pending?.some((p) => p.name === attr)) return true;
     const defs = current._attributeDefinitions;
     if (defs) {
-      // Unwrap post-encrypts decorators (Serialized may sit on top of the
-      // encrypted type in a decorateAttributes-eager def).
       if (encryptedTypeOf(defs.get(attr)?.type)) return true;
     }
     current = Object.getPrototypeOf(current);
@@ -291,9 +289,6 @@ export function encryptedAttributeQ(record: any, attributeName: string): boolean
   // Resolve attribute aliases (mirrors Rails' attribute_aliases lookup).
   const resolved = klass._attributeAliases?.[attributeName] ?? attributeName;
   if (!klass._encryptedAttributes?.has(resolved)) return false;
-  // Resolve through typeForAttribute and unwrap post-encrypts decorators —
-  // Rails' `type.encrypted?(raw)` reaches the encrypted type through
-  // DelegateClass delegation (encryptable_record.rb:146-153).
   const type = encryptedTypeOf(getAttributeType(klass, resolved));
   if (!type) return false;
   const rawValue = record.readAttributeBeforeTypeCast(resolved);
@@ -361,9 +356,6 @@ export async function decryptRecord(record: any): Promise<void> {
     const type = getAttributeType(klass, attr) as { deserialize?: (v: unknown) => unknown };
     const encryptedType = encryptedTypeOf(type);
     const raw = record.readAttributeBeforeTypeCast(attr);
-    // Deserialize through the FULL resolved type so outer wrappers (a
-    // Serialized coder on top of the encrypted type) apply after decryption —
-    // mirrors Rails' type_for_attribute deserialize (encryptable_record.rb:216).
     if (encryptedType?.isEncrypted(raw) && type?.deserialize) {
       assignments[attr] = type.deserialize(raw);
     } else {

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -271,6 +271,8 @@ export function isEncryptedAttribute(klass: any, attr: string): boolean {
     if (pending?.some((p) => p.name === attr)) return true;
     const defs = current._attributeDefinitions;
     if (defs) {
+      // Mock-model arm: real Base subclasses no longer hold wrapped defs (the
+      // eager view is retired) — their declarations hit the pending arm above.
       if (encryptedTypeOf(defs.get(attr)?.type)) return true;
     }
     current = Object.getPrototypeOf(current);

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -6,11 +6,12 @@
  *
  * In Rails, `encrypts` uses `decorate_attributes` which defers type
  * wrapping via `PendingDecorator` — the actual wrapping happens when
- * `_default_attributes` is first resolved. We mirror this with
- * `_pendingEncryptions`: `encrypts()` records the request, and
- * `applyPendingEncryptions()` runs during construction and after
- * schema reflection, wrapping any attributes that haven't been
- * wrapped yet.
+ * `_default_attributes` is resolved, and `type_for_attribute` is the only
+ * lookup surface. We mirror that directly: `encryptAttribute` pushes the
+ * durable decorator once at declaration time and type inspections resolve
+ * through `typeForAttribute`. The `_pendingEncryptions` buffer only drives
+ * `applyPendingEncryptions()` bookkeeping (column-size validation re-runs
+ * after schema reflection + the frozen-encryption validator install).
  *
  * All actual encryption flows through the Rails-faithful scheme-based
  * `EncryptedAttributeType` under `./encryption/`. A custom `{ encryptor }`
@@ -19,12 +20,15 @@
  */
 
 import { registerEncryptionHooks } from "./encryption-hooks.js";
-import { EncryptedAttributeType } from "./encryption/encrypted-attribute-type.js";
 import { Scheme, type SchemeOptions } from "./encryption/scheme.js";
 import type { EncryptorLike } from "./encryption/encryptor.js";
 import { Aes256Gcm as AesGcmCipher } from "./encryption/cipher/aes256-gcm.js";
 export { Cipher } from "./encryption/cipher.js";
-import { EncryptableRecord } from "./encryption/encryptable-record.js";
+import {
+  EncryptableRecord,
+  getAttributeType,
+  encryptedTypeOf,
+} from "./encryption/encryptable-record.js";
 import { Configurable } from "./encryption/configurable.js";
 import { Contexts } from "./encryption/contexts.js";
 import {
@@ -187,9 +191,9 @@ interface PendingEncryption {
  * defaultEncryptor fallback are preserved on the primary path.
  *
  * The actual type wrapping is deferred (Rails' `decorate_attributes` /
- * PendingDecorator) — `encryptAttribute` records pending encryptions that
- * `applyPendingEncryptions` applies when the attribute definitions are first
- * used and re-applies on every `_defaultAttributes` rebuild.
+ * PendingDecorator) — `encryptAttribute` pushes the durable decorator once at
+ * declaration time; the wrapped type materializes on `_defaultAttributes`
+ * replay and is read through `typeForAttribute`.
  */
 export function encrypts(klass: any, ...args: Array<string | EncryptsOptions>): void {
   let options: EncryptsOptions = {};
@@ -215,30 +219,18 @@ export function encrypts(klass: any, ...args: Array<string | EncryptsOptions>): 
 }
 
 /**
- * Apply any pending encryption decorations to the class's attribute
- * definitions. Wraps the existing cast type with the scheme-based
- * `EncryptedAttributeType`.
+ * Post-declaration / post-reflection bookkeeping for encrypted attributes.
+ *
+ * The type wrapping itself is NOT done here: `encryptAttribute` pushes the
+ * durable PendingDecorator once at declaration time, and every type inspection
+ * resolves through `typeForAttribute` (Rails' single lookup surface) — there is
+ * no eager `_attributeDefinitions` re-wrap to maintain. What remains is the
+ * bookkeeping Rails runs from `load_schema!` / `validate`: column-size
+ * validation re-runs and the frozen-encryption validator install.
  */
 export function applyPendingEncryptions(klass: any): void {
   const pending: PendingEncryption[] | undefined = klass._pendingEncryptions;
   if (!pending || pending.length === 0) return;
-
-  // Copy-on-write so a subclass's pending encryption never mutates an inherited
-  // definitions map. The `decorateAttributes` path does its own copy-on-write
-  // (#4981); this still covers the plain-model branch of registerEncryptedType,
-  // which writes `_attributeDefinitions` directly.
-  if (!Object.prototype.hasOwnProperty.call(klass, "_attributeDefinitions")) {
-    klass._attributeDefinitions = new Map(klass._attributeDefinitions);
-  }
-
-  // Route the actual type wrapping through the shared scheme-based primitive
-  // (mirrors Rails: one EncryptableRecord#encrypts declaration path). On a Base
-  // subclass registerEncryptedType uses the replay-safe decorateAttributes
-  // decorator and skips attributes whose column hasn't been reflected yet — the
-  // persistent _pendingEncryptions buffer re-invokes this once it appears.
-  for (const { name, scheme } of pending) {
-    EncryptableRecord.registerEncryptedType(klass, name, scheme);
-  }
 
   // Re-run column-size validation after schema reflection so limits learned
   // from the DB (not declared via attribute()) are also picked up. Safe even
@@ -279,8 +271,9 @@ export function isEncryptedAttribute(klass: any, attr: string): boolean {
     if (pending?.some((p) => p.name === attr)) return true;
     const defs = current._attributeDefinitions;
     if (defs) {
-      const def = defs.get(attr);
-      if (def?.type instanceof EncryptedAttributeType) return true;
+      // Unwrap post-encrypts decorators (Serialized may sit on top of the
+      // encrypted type in a decorateAttributes-eager def).
+      if (encryptedTypeOf(defs.get(attr)?.type)) return true;
     }
     current = Object.getPrototypeOf(current);
   }
@@ -298,8 +291,11 @@ export function encryptedAttributeQ(record: any, attributeName: string): boolean
   // Resolve attribute aliases (mirrors Rails' attribute_aliases lookup).
   const resolved = klass._attributeAliases?.[attributeName] ?? attributeName;
   if (!klass._encryptedAttributes?.has(resolved)) return false;
-  const type = klass._attributeDefinitions?.get(resolved)?.type;
-  if (!(type instanceof EncryptedAttributeType)) return false;
+  // Resolve through typeForAttribute and unwrap post-encrypts decorators —
+  // Rails' `type.encrypted?(raw)` reaches the encrypted type through
+  // DelegateClass delegation (encryptable_record.rb:146-153).
+  const type = encryptedTypeOf(getAttributeType(klass, resolved));
+  if (!type) return false;
   const rawValue = record.readAttributeBeforeTypeCast(resolved);
   return type.isEncrypted(rawValue);
 }
@@ -362,9 +358,13 @@ export async function decryptRecord(record: any): Promise<void> {
 
   const assignments: Record<string, unknown> = {};
   for (const attr of encryptedAttrs) {
-    const type = klass._attributeDefinitions?.get(attr)?.type;
+    const type = getAttributeType(klass, attr) as { deserialize?: (v: unknown) => unknown };
+    const encryptedType = encryptedTypeOf(type);
     const raw = record.readAttributeBeforeTypeCast(attr);
-    if (type instanceof EncryptedAttributeType && type.isEncrypted(raw)) {
+    // Deserialize through the FULL resolved type so outer wrappers (a
+    // Serialized coder on top of the encrypted type) apply after decryption —
+    // mirrors Rails' type_for_attribute deserialize (encryptable_record.rb:216).
+    if (encryptedType?.isEncrypted(raw) && type?.deserialize) {
       assignments[attr] = type.deserialize(raw);
     } else {
       assignments[attr] = record.readAttribute(attr);

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -568,9 +568,6 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     } as any;
     await Book.loadSchema();
 
-    // Resolve through typeForAttribute — Rails' single lookup surface (the
-    // eager `_attributeDefinitions` view is retired). The durable decorator
-    // resolves the column default from the warm schema cache at replay time.
     const type = Book.typeForAttribute("name");
     expect(type._default).toBe("<untitled>");
 

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -568,7 +568,10 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     } as any;
     await Book.loadSchema();
 
-    const type = Book._attributeDefinitions.get("name").type;
+    // Resolve through typeForAttribute — Rails' single lookup surface (the
+    // eager `_attributeDefinitions` view is retired). The durable decorator
+    // resolves the column default from the warm schema cache at replay time.
+    const type = Book.typeForAttribute("name");
     expect(type._default).toBe("<untitled>");
 
     Configurable.config.supportUnencryptedData = false;

--- a/packages/activerecord/src/encryption/encryptable-record.trails.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.trails.test.ts
@@ -10,7 +10,9 @@ import { fixtures } from "../test-helpers/fixtures.js";
 import {
   EncryptedBookWithSerializedFirstBinary,
   EncryptedBookWithSerializedSecondBinary,
+  EncryptedBookWithSerializedDeterministicName,
 } from "../test-helpers/models/book-encrypted.js";
+import { EncryptableRecord } from "./encryptable-record.js";
 import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
 import { applyPendingEncryptions } from "../encryption.js";
 import { Serialized } from "../type/serialized.js";
@@ -109,5 +111,37 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest (trails)", () => {
       expect((type as Serialized).subtype).toBeInstanceOf(EncryptedAttributeType);
     }
     expect(model._pendingAttributeModifications?.length).toBe(queueLength);
+  });
+
+  // Rails resolves these through `type_for_attribute(name).deterministic?` /
+  // `.encrypted?`, which reach the encrypted type inside a Serialized wrapper
+  // via DelegateClass delegation (encryptable_record.rb:58-62, 146-153). trails
+  // wrappers don't auto-delegate, so `encryptedTypeOf` unwraps explicitly —
+  // these guard that the unwrap keeps working for encrypts-then-serialize.
+  it("includes a Serialized(Encrypted) attribute in deterministicEncryptedAttributes", async () => {
+    await freshAdapter();
+
+    const deterministic = EncryptableRecord.deterministicEncryptedAttributes(
+      EncryptedBookWithSerializedDeterministicName,
+    );
+    expect(deterministic.has("name")).toBe(true);
+    // Non-deterministic Serialized(Encrypted) stays out.
+    expect(
+      EncryptableRecord.deterministicEncryptedAttributes(
+        EncryptedBookWithSerializedSecondBinary,
+      ).has("logo"),
+    ).toBe(false);
+  });
+
+  it("detects ciphertext through the Serialized(Encrypted) wrapper on encryptedAttribute?", async () => {
+    await freshAdapter();
+
+    const book = await EncryptedBookWithSerializedDeterministicName.create({ name: "Dune" });
+
+    // Read back from the DB: before-type-cast is now the stored ciphertext
+    // (on the fresh record it is still the plaintext user input, as in Rails).
+    const reloaded = await EncryptedBookWithSerializedDeterministicName.find(book.id);
+    expect(reloaded.name).toBe("Dune");
+    expect(reloaded.encryptedAttribute("name")).toBe(true);
   });
 });

--- a/packages/activerecord/src/encryption/encryptable-record.trails.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.trails.test.ts
@@ -113,11 +113,6 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest (trails)", () => {
     expect(model._pendingAttributeModifications?.length).toBe(queueLength);
   });
 
-  // Rails resolves these through `type_for_attribute(name).deterministic?` /
-  // `.encrypted?`, which reach the encrypted type inside a Serialized wrapper
-  // via DelegateClass delegation (encryptable_record.rb:58-62, 146-153). trails
-  // wrappers don't auto-delegate, so `encryptedTypeOf` unwraps explicitly —
-  // these guard that the unwrap keeps working for encrypts-then-serialize.
   it("includes a Serialized(Encrypted) attribute in deterministicEncryptedAttributes", async () => {
     await freshAdapter();
 
@@ -125,7 +120,6 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest (trails)", () => {
       EncryptedBookWithSerializedDeterministicName,
     );
     expect(deterministic.has("name")).toBe(true);
-    // Non-deterministic Serialized(Encrypted) stays out.
     expect(
       EncryptableRecord.deterministicEncryptedAttributes(
         EncryptedBookWithSerializedSecondBinary,
@@ -138,8 +132,6 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest (trails)", () => {
 
     const book = await EncryptedBookWithSerializedDeterministicName.create({ name: "Dune" });
 
-    // Read back from the DB: before-type-cast is now the stored ciphertext
-    // (on the fresh record it is still the plaintext user input, as in Rails).
     const reloaded = await EncryptedBookWithSerializedDeterministicName.find(book.id);
     expect(reloaded.name).toBe("Dune");
     expect(reloaded.encryptedAttribute("name")).toBe(true);

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -179,9 +179,6 @@ export class EncryptableRecord {
   static deterministicEncryptedAttributes(modelClass: any): Set<string> {
     const result = new Set<string>();
     for (const name of this.encryptedAttributes(modelClass)) {
-      // Unwrap post-encrypts decorators (Serialized, Normalized) — Rails'
-      // `type_for_attribute(name).deterministic?` reaches the encrypted type
-      // through DelegateClass delegation (encryptable_record.rb:58-62).
       const type = encryptedTypeOf(getAttributeType(modelClass, name));
       if (type?.deterministic) {
         result.add(name);
@@ -257,13 +254,8 @@ export class EncryptableRecord {
 
   /**
    * Record a pending encryption so `applyPendingEncryptions` (encryption.ts)
-   * re-runs column-size validation and installs the frozen-encryption validator
-   * on every `_defaultAttributes` rebuild (the type wrapping itself is the
-   * durable decorator pushed by `pushEncryptionDecorator`). The `scheme` is
-   * kept in each entry for `encryptFixtureRows` (define-fixtures.ts), which
-   * builds fixture ciphertext before the schema has reflected — at that point
-   * `typeForAttribute` still resolves a plain ValueType. Own-property guarded
-   * like the encrypted-attribute Set.
+   * re-runs its bookkeeping on every `_defaultAttributes` rebuild. The `scheme`
+   * is kept in each entry for `encryptFixtureRows` (define-fixtures.ts).
    * @internal
    */
   static registerPendingEncryption(modelClass: any, name: string, scheme: Scheme): void {
@@ -311,17 +303,10 @@ export class EncryptableRecord {
 
   /**
    * Register the EncryptedAttributeType for a plain mock model (the immediate
-   * path in `encryptAttribute` — callers without `decorateAttributes`). Sets
-   * `_attributeDefinitions` directly, seeding a schema-sourced placeholder when
-   * no def exists yet so `loadSchemaFromAdapter` can supply the real cast type
-   * on the next pass.
-   *
-   * Real Base subclasses never come through here anymore: their wrapping is the
-   * durable PendingDecorator pushed once at declaration time by
-   * `pushEncryptionDecorator`, and every type inspection resolves through
-   * `typeForAttribute` (Rails' single lookup surface,
-   * attribute_registration.rb:66-72) — the eager `_attributeDefinitions`
-   * re-wrap this method used to maintain on rebuild is retired.
+   * path in `encryptAttribute` — callers without `decorateAttributes`). Real
+   * Base subclasses never come through here: their wrapping is the durable
+   * decorator pushed by `pushEncryptionDecorator`, resolved via
+   * `typeForAttribute`.
    * @internal
    */
   static registerEncryptedType(modelClass: any, name: string, scheme: Scheme): void {
@@ -563,8 +548,6 @@ export class EncryptableRecord {
     // Resolve attribute aliases before checking encrypted set.
     const resolvedName = klass._attributeAliases?.[attributeName] ?? attributeName;
     if (!klass._encryptedAttributes?.has(resolvedName)) return false;
-    // Unwrap post-encrypts decorators — Rails' `type.encrypted?(raw)` reaches
-    // the encrypted type through DelegateClass delegation.
     const type = encryptedTypeOf(getAttributeType(klass, resolvedName));
     if (!type) return false;
     const raw = record.readAttributeBeforeTypeCast?.(resolvedName);
@@ -656,10 +639,6 @@ export class EncryptableRecord {
       const raw = record.readAttributeBeforeTypeCast?.(name);
       // Only decrypt if actually encrypted — mirrors Rails' type.deserialize
       // which returns the raw value when support_unencrypted_data is true.
-      // Deserialize through the FULL resolved type (Rails deserializes
-      // `type_for_attribute`'s type, encryptable_record.rb:216-218) so outer
-      // wrappers — a Serialized coder on top of the encrypted type — apply
-      // after decryption.
       if (encryptedType?.isEncrypted(raw) && type?.deserialize) {
         result[name] = type.deserialize(raw);
       } else {
@@ -689,11 +668,8 @@ export class EncryptableRecord {
 }
 
 /**
- * Resolve an attribute's type the way Rails does — through the class's single
- * `type_for_attribute` lookup surface (the replayed default attribute set,
- * attribute_registration.rb:66-72). Falls back to the raw
- * `_attributeDefinitions` entry only for plain mock models that lack the full
- * model machinery (the immediate `registerEncryptedType` path).
+ * Resolve an attribute's type through `typeForAttribute` (Rails' single lookup
+ * surface); falls back to `_attributeDefinitions` for plain mock models.
  */
 export function getAttributeType(klass: any, name: string): unknown {
   if (typeof klass?.typeForAttribute === "function") {
@@ -704,15 +680,8 @@ export function getAttributeType(klass: any, name: string): unknown {
 
 /**
  * Find the EncryptedAttributeType inside a possibly-wrapped resolved type
- * (e.g. `Serialized(Encrypted(binary))` from encrypts-then-serialize).
- *
- * Rails needs no such walk: `Type::Serialized` and `NormalizedValueType`
- * delegate missing methods (`deterministic?`, `encrypted?`, `previous_types`)
- * to their inner type via DelegateClass / delegate_missing_to, so
- * `type_for_attribute(name).deterministic?` reaches the encrypted type through
- * any wrapper. trails wrappers don't auto-delegate, so callers unwrap along the
- * wrappers' inner-type fields (`subtype` for Serialized, `castType` for
- * NormalizedValueType) explicitly.
+ * (e.g. `Serialized(Encrypted(binary))`). Stands in for Rails' DelegateClass
+ * delegation on Type::Serialized / NormalizedValueType.
  */
 export function encryptedTypeOf(type: unknown): EncryptedAttributeType | undefined {
   let current: any = type;

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -179,8 +179,11 @@ export class EncryptableRecord {
   static deterministicEncryptedAttributes(modelClass: any): Set<string> {
     const result = new Set<string>();
     for (const name of this.encryptedAttributes(modelClass)) {
-      const type = getAttributeType(modelClass, name);
-      if (type instanceof EncryptedAttributeType && type.deterministic) {
+      // Unwrap post-encrypts decorators (Serialized, Normalized) — Rails'
+      // `type_for_attribute(name).deterministic?` reaches the encrypted type
+      // through DelegateClass delegation (encryptable_record.rb:58-62).
+      const type = encryptedTypeOf(getAttributeType(modelClass, name));
+      if (type?.deterministic) {
         result.add(name);
       }
     }
@@ -225,8 +228,8 @@ export class EncryptableRecord {
       // (encryptable_record.rb:87-92) and AttributeRegistration replays in
       // declaration order. The decorator resolves the column default at replay
       // time, so it needs no re-push after schema reflection. The
-      // `_pendingEncryptions` buffer remains for the eager
-      // `_attributeDefinitions` view + validator re-runs on rebuild.
+      // `_pendingEncryptions` buffer remains only for validator re-runs +
+      // frozen-validator install on rebuild (applyPendingEncryptions).
       this.registerPendingEncryption(modelClass, name, scheme);
       this.pushEncryptionDecorator(modelClass, name, scheme);
       encryptionHooks.applyPendingEncryptions(modelClass);
@@ -254,8 +257,10 @@ export class EncryptableRecord {
 
   /**
    * Record a pending encryption so `applyPendingEncryptions` (encryption.ts)
-   * decorates the attribute now and re-decorates on every `_defaultAttributes`
-   * rebuild. Own-property guarded like the encrypted-attribute Set.
+   * re-runs column-size validation and installs the frozen-encryption validator
+   * on every `_defaultAttributes` rebuild (the type wrapping itself is the
+   * durable decorator pushed by `pushEncryptionDecorator`). Own-property
+   * guarded like the encrypted-attribute Set.
    * @internal
    */
   static registerPendingEncryption(modelClass: any, name: string, scheme: Scheme): void {
@@ -302,80 +307,21 @@ export class EncryptableRecord {
   }
 
   /**
-   * The single EncryptedAttributeType-wrapping primitive shared by both
-   * declaration paths, so `Base.encrypts` (via `applyPendingEncryptions`) and
-   * the scheme-based `encryptAttribute` register the wrapped type through one
-   * implementation:
+   * Register the EncryptedAttributeType for a plain mock model (the immediate
+   * path in `encryptAttribute` — callers without `decorateAttributes`). Sets
+   * `_attributeDefinitions` directly, seeding a schema-sourced placeholder when
+   * no def exists yet so `loadSchemaFromAdapter` can supply the real cast type
+   * on the next pass.
    *
-   * - Models exposing `decorateAttributes` (real Base subclasses driven by the
-   *   `Base.encrypts` → `applyPendingEncryptions` path) get their eager
-   *   `_attributeDefinitions` view wrapped/corrected here. The durable
-   *   PendingDecorator is NOT pushed from here — `pushEncryptionDecorator`
-   *   pushed it once at declaration time, preserving declaration order in the
-   *   pending queue. Skips when the def isn't present yet — the persistent
-   *   `_pendingEncryptions` buffer re-invokes this once the column is reflected.
-   * - Plain models (the scheme-based / mock-model test path) set
-   *   `_attributeDefinitions` directly, seeding a schema-sourced placeholder
-   *   when no def exists yet so `loadSchemaFromAdapter` can supply the real
-   *   cast type on the next pass.
-   *
-   * The `decorateAttributes` branch skips when the def is absent and does NOT
-   * buffer here — it relies on a persistent `_pendingEncryptions` buffer being
-   * re-applied once the column is reflected. `encryptAttribute` now maintains
-   * that buffer itself (via `registerPendingEncryption` before it calls
-   * `applyPendingEncryptions`), so the scheme path is replay-safe on its own —
-   * completing the RFC 0047 follow-up
-   * `encrypt-route-primary-attribute-through-encrypt-attribute`. This method is
-   * therefore only invoked from `applyPendingEncryptions` (durable path) or
-   * directly by `encryptAttribute` for plain mock models (immediate path).
+   * Real Base subclasses never come through here anymore: their wrapping is the
+   * durable PendingDecorator pushed once at declaration time by
+   * `pushEncryptionDecorator`, and every type inspection resolves through
+   * `typeForAttribute` (Rails' single lookup surface,
+   * attribute_registration.rb:66-72) — the eager `_attributeDefinitions`
+   * re-wrap this method used to maintain on rebuild is retired.
    * @internal
    */
   static registerEncryptedType(modelClass: any, name: string, scheme: Scheme): void {
-    // Mirrors Rails' `default: columns_hash[name.to_s]&.default` — thread the
-    // TRUE DB column default into the encrypted type so a plaintext default
-    // deserializes without an attempted decrypt (see EncryptedAttributeType's
-    // `@default && @default == value` guard in decryptAsText). The default comes
-    // from a query-free peek of the warm schema cache (columnDefaultFor /
-    // cachedColumnDefaultFor), NOT the reflected def's `defaultValue` (which an
-    // `attribute(name, { default })` override would poison) and NOT `columnsHash()`
-    // (which would warm the shared schema cache and perturb sibling tests).
-    if (typeof modelClass.decorateAttributes === "function") {
-      const def = modelClass._attributeDefinitions?.get?.(name);
-      if (!def) return;
-      // Resolve the default Rails threads: `columns_hash[name].default`. When the
-      // schema cache is warm the peek is authoritative (the TRUE column default,
-      // ignoring any `attribute()` override). Before reflection it isn't cached,
-      // so we fall back to the def default as a provisional value and correct it
-      // on the post-reflection replay.
-      const cached = this.cachedColumnDefaultFor(modelClass, name);
-      const authoritative = cached !== NOT_CACHED;
-      const columnDefault = authoritative ? (cached ?? undefined) : (def.defaultValue ?? undefined);
-      if (def.type instanceof EncryptedAttributeType) {
-        // Already wrapped. Re-wrap only to correct a provisional default once the
-        // authoritative column default is known and differs — otherwise stay put.
-        if (!authoritative || def.type._default === columnDefault) return;
-        modelClass._attributeDefinitions.set(name, {
-          ...def,
-          type: new EncryptedAttributeType({
-            scheme,
-            castType: def.type.castType,
-            default: columnDefault,
-          }),
-        });
-        return;
-      }
-      // NOTE: this writes only the eager `_attributeDefinitions` back-compat
-      // view. The durable PendingDecorator was already pushed at declaration
-      // time by `pushEncryptionDecorator` — pushing here (on rebuild) would move
-      // the encryption decorator to the queue tail, breaking declaration-order
-      // nesting relative to `serialize` (the encrypts-first case).
-      modelClass._attributeDefinitions.set(name, {
-        ...def,
-        type: new EncryptedAttributeType({ scheme, castType: def.type, default: columnDefault }),
-      });
-      return;
-    }
-
     // Get existing cast type from attribute definitions if available.
     // If already encrypted, unwrap to avoid double-encryption.
     const existingDef = modelClass._attributeDefinitions?.get?.(name);
@@ -614,8 +560,10 @@ export class EncryptableRecord {
     // Resolve attribute aliases before checking encrypted set.
     const resolvedName = klass._attributeAliases?.[attributeName] ?? attributeName;
     if (!klass._encryptedAttributes?.has(resolvedName)) return false;
-    const type = getAttributeType(klass, resolvedName);
-    if (!(type instanceof EncryptedAttributeType)) return false;
+    // Unwrap post-encrypts decorators — Rails' `type.encrypted?(raw)` reaches
+    // the encrypted type through DelegateClass delegation.
+    const type = encryptedTypeOf(getAttributeType(klass, resolvedName));
+    if (!type) return false;
     const raw = record.readAttributeBeforeTypeCast?.(resolvedName);
     return type.isEncrypted(raw);
   }
@@ -700,11 +648,16 @@ export class EncryptableRecord {
     const klass = record.constructor;
     const result: Record<string, unknown> = {};
     for (const name of klass._encryptedAttributes ?? new Set<string>()) {
-      const type = getAttributeType(klass, name);
+      const type = getAttributeType(klass, name) as { deserialize?: (v: unknown) => unknown };
+      const encryptedType = encryptedTypeOf(type);
       const raw = record.readAttributeBeforeTypeCast?.(name);
       // Only decrypt if actually encrypted — mirrors Rails' type.deserialize
       // which returns the raw value when support_unencrypted_data is true.
-      if (type instanceof EncryptedAttributeType && type.isEncrypted(raw)) {
+      // Deserialize through the FULL resolved type (Rails deserializes
+      // `type_for_attribute`'s type, encryptable_record.rb:216-218) so outer
+      // wrappers — a Serialized coder on top of the encrypted type — apply
+      // after decryption.
+      if (encryptedType?.isEncrypted(raw) && type?.deserialize) {
         result[name] = type.deserialize(raw);
       } else {
         // Plaintext — return the cast value so typed columns (date, JSON, etc.)
@@ -733,9 +686,36 @@ export class EncryptableRecord {
 }
 
 /**
- * Get the attribute type from a model class's _attributeDefinitions.
+ * Resolve an attribute's type the way Rails does — through the class's single
+ * `type_for_attribute` lookup surface (the replayed default attribute set,
+ * attribute_registration.rb:66-72). Falls back to the raw
+ * `_attributeDefinitions` entry only for plain mock models that lack the full
+ * model machinery (the immediate `registerEncryptedType` path).
  */
 export function getAttributeType(klass: any, name: string): unknown {
-  const def = klass._attributeDefinitions?.get?.(name);
-  return def?.type;
+  if (typeof klass?.typeForAttribute === "function") {
+    return klass.typeForAttribute(name);
+  }
+  return klass._attributeDefinitions?.get?.(name)?.type;
+}
+
+/**
+ * Find the EncryptedAttributeType inside a possibly-wrapped resolved type
+ * (e.g. `Serialized(Encrypted(binary))` from encrypts-then-serialize).
+ *
+ * Rails needs no such walk: `Type::Serialized` and `NormalizedValueType`
+ * delegate missing methods (`deterministic?`, `encrypted?`, `previous_types`)
+ * to their inner type via DelegateClass / delegate_missing_to, so
+ * `type_for_attribute(name).deterministic?` reaches the encrypted type through
+ * any wrapper. trails wrappers don't auto-delegate, so callers unwrap along the
+ * wrappers' inner-type fields (`subtype` for Serialized, `castType` for
+ * NormalizedValueType) explicitly.
+ */
+export function encryptedTypeOf(type: unknown): EncryptedAttributeType | undefined {
+  let current: any = type;
+  while (current) {
+    if (current instanceof EncryptedAttributeType) return current;
+    current = current.subtype ?? current.castType;
+  }
+  return undefined;
 }

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -259,8 +259,11 @@ export class EncryptableRecord {
    * Record a pending encryption so `applyPendingEncryptions` (encryption.ts)
    * re-runs column-size validation and installs the frozen-encryption validator
    * on every `_defaultAttributes` rebuild (the type wrapping itself is the
-   * durable decorator pushed by `pushEncryptionDecorator`). Own-property
-   * guarded like the encrypted-attribute Set.
+   * durable decorator pushed by `pushEncryptionDecorator`). The `scheme` is
+   * kept in each entry for `encryptFixtureRows` (define-fixtures.ts), which
+   * builds fixture ciphertext before the schema has reflected — at that point
+   * `typeForAttribute` still resolves a plain ValueType. Own-property guarded
+   * like the encrypted-attribute Set.
    * @internal
    */
   static registerPendingEncryption(modelClass: any, name: string, scheme: Scheme): void {

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -177,6 +177,12 @@ export class EncryptableRecord {
   }
 
   static deterministicEncryptedAttributes(modelClass: any): Set<string> {
+    // Memoized per class like Rails' `@deterministic_encrypted_attributes ||=`
+    // (encryptable_record.rb:58-61); own-property-guarded so STI subclasses
+    // compute their own. Invalidated by `encryptAttribute` on new declarations.
+    if (Object.prototype.hasOwnProperty.call(modelClass, "_deterministicEncryptedAttributes")) {
+      return modelClass._deterministicEncryptedAttributes;
+    }
     const result = new Set<string>();
     for (const name of this.encryptedAttributes(modelClass)) {
       const type = encryptedTypeOf(getAttributeType(modelClass, name));
@@ -184,6 +190,7 @@ export class EncryptableRecord {
         result.add(name);
       }
     }
+    modelClass._deterministicEncryptedAttributes = result;
     return result;
   }
 
@@ -211,6 +218,7 @@ export class EncryptableRecord {
       modelClass._encryptedAttributes = new Set<string>(modelClass._encryptedAttributes ?? []);
     }
     modelClass._encryptedAttributes.add(name);
+    delete modelClass._deterministicEncryptedAttributes;
 
     // Build the per-attribute scheme (mirrors Rails scheme_for) unless the caller
     // supplied one. Each attribute gets its own scheme so per-attribute options
@@ -644,7 +652,8 @@ export class EncryptableRecord {
       } else {
         // Plaintext — return the cast value so typed columns (date, JSON, etc.)
         // keep their in-memory representation rather than the raw DB string.
-        result[name] = record.readAttribute?.(name) ?? raw;
+        result[name] =
+          typeof record.readAttribute === "function" ? record.readAttribute(name) : raw;
       }
     }
     return result;

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
@@ -438,9 +438,6 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::RelationQuerie
       }
     }
     (Contact as any)._encryptedAttributes = new Set(["email"]);
-    // Wire the mock type through the decorator queue so `typeForAttribute` —
-    // the lookup surface scopeForCreate resolves through — returns it (the
-    // eager `_attributeDefinitions` view is retired).
     (Contact as any).decorateAttributes(["email"], () => type);
 
     const avCurrent = new AdditionalValue("plain@example.com", type);

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
@@ -438,8 +438,10 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries::RelationQuerie
       }
     }
     (Contact as any)._encryptedAttributes = new Set(["email"]);
-    const defs = (Contact as any)._attributeDefinitions as Map<string, { type: unknown }>;
-    defs.set("email", { type });
+    // Wire the mock type through the decorator queue so `typeForAttribute` —
+    // the lookup surface scopeForCreate resolves through — returns it (the
+    // eager `_attributeDefinitions` view is retired).
+    (Contact as any).decorateAttributes(["email"], () => type);
 
     const avCurrent = new AdditionalValue("plain@example.com", type);
     const avPrev = new AdditionalValue("plain@example.com", prevType);

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.ts
@@ -1,6 +1,6 @@
 import { prepend } from "@blazetrails/activesupport";
 import { ADDITIONAL_VALUE_BRAND, EncryptedAttributeType } from "./encrypted-attribute-type.js";
-import { getAttributeType } from "./encryptable-record.js";
+import { getAttributeType, encryptedTypeOf } from "./encryptable-record.js";
 
 /**
  * Automatically expands encrypted arguments to support querying both
@@ -120,8 +120,10 @@ export class EncryptedQuery {
     let modified = false;
 
     for (const attrName of encryptedAttrs) {
-      const type = getAttributeType(model, attrName);
-      if (!(type instanceof EncryptedAttributeType)) continue;
+      // Unwrap post-encrypts decorators — query expansion serializes through
+      // the encrypted type itself, like Rails' delegated previous_types.
+      const type = encryptedTypeOf(getAttributeType(model, attrName));
+      if (!type) continue;
       if (!type.deterministic) continue;
       if (!type.previousTypes.length) continue;
       const value = result[attrName];
@@ -234,8 +236,8 @@ export class RelationQueries {
     const scopeAttrs = originalScopeForCreate.call(relation) as Record<string, unknown>;
     const wheres = relation.whereValuesHash();
     for (const attrName of encryptedAttrs) {
-      const type = getAttributeType(model, attrName);
-      if (!(type instanceof EncryptedAttributeType) || !type.deterministic) continue;
+      const type = encryptedTypeOf(getAttributeType(model, attrName));
+      if (!type?.deterministic) continue;
       const values = wheres[attrName];
       if (Array.isArray(values) && values[0] instanceof AdditionalValue) {
         // Our expansion stores AdditionalValue(current) at index 0 (see

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.ts
@@ -120,8 +120,6 @@ export class EncryptedQuery {
     let modified = false;
 
     for (const attrName of encryptedAttrs) {
-      // Unwrap post-encrypts decorators — query expansion serializes through
-      // the encrypted type itself, like Rails' delegated previous_types.
       const type = encryptedTypeOf(getAttributeType(model, attrName));
       if (!type) continue;
       if (!type.deterministic) continue;

--- a/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.ts
@@ -1,5 +1,4 @@
-import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
-import { EncryptableRecord, getAttributeType } from "./encryptable-record.js";
+import { EncryptableRecord, getAttributeType, encryptedTypeOf } from "./encryptable-record.js";
 import { AdditionalValue, ExtendedDeterministicQueries } from "./extended-deterministic-queries.js";
 import { withoutEncryption } from "./context.js";
 
@@ -95,8 +94,8 @@ export class EncryptedUniquenessValidator {
     const deterministicAttrs = EncryptableRecord.deterministicEncryptedAttributes(klass);
     if (!deterministicAttrs.has(attribute)) return;
 
-    const encryptedType = getAttributeType(klass, attribute);
-    if (!(encryptedType instanceof EncryptedAttributeType)) return;
+    const encryptedType = encryptedTypeOf(getAttributeType(klass, attribute));
+    if (!encryptedType) return;
 
     // When ExtendedDeterministicQueries is installed it already expands the
     // WHERE clause to cover all previous-scheme ciphertexts, and buildRelation
@@ -116,8 +115,8 @@ export class EncryptedUniquenessValidator {
    * check for duplicates across scheme migrations.
    */
   static allCiphertextsFor(klass: any, attribute: string, value: unknown): unknown[] {
-    const type = getAttributeType(klass, attribute);
-    if (!(type instanceof EncryptedAttributeType) || !type.deterministic) {
+    const type = encryptedTypeOf(getAttributeType(klass, attribute));
+    if (!type?.deterministic) {
       return [value];
     }
 

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1296,9 +1296,10 @@ function applyColumnsHash(
   invalidate(host, { deleteOwn: false });
   if (originatingHost && originatingHost !== host) invalidate(originatingHost, { deleteOwn: true });
 
-  // Encryption still needs a post-reflection pass (`registerEncryptedType`
-  // defers pushing its decorator until the column reflects, to thread the column
-  // default). `normalizes` / `serialize` push their durable decorator eagerly, so
+  // Encryption still needs a post-reflection pass — not for type wrapping (the
+  // durable decorator was pushed at declaration; `typeForAttribute` resolves it)
+  // but for column-size validation re-runs against the now-known DB limits.
+  // `normalizes` / `serialize` push their durable decorator eagerly, so
   // — now that `type_for_attribute` / `TypeCaster::Map` resolve through
   // `attribute_types` — no per-feature `_attributeDefinitions` replay is needed.
   encryptionHooks.applyPendingEncryptions(host);

--- a/packages/activerecord/src/test-helpers/models/book-encrypted.ts
+++ b/packages/activerecord/src/test-helpers/models/book-encrypted.ts
@@ -138,18 +138,14 @@ export class EncryptedBookWithSerializedSecondBinary extends Base {
   }
 }
 
-// trails-only: no Rails counterpart. Guards that `deterministicEncryptedAttributes`
-// / `encryptedAttribute?` unwrap a post-encrypts `serialize` decorator
-// (Serialized(Encrypted(...))) — Rails gets this for free via DelegateClass
-// delegation on Type::Serialized, which trails wrappers lack.
+// trails-only: no Rails counterpart. Guards Serialized(Encrypted(...)) unwrap
+// in deterministicEncryptedAttributes / encryptedAttribute?.
 export class EncryptedBookWithSerializedDeterministicName extends Base {
   static _tableName = "encrypted_books";
 
   static {
     this.encrypts("name", { deterministic: true });
-    // Lenient JSON coder: the canonical `encrypted_books.name` default
-    // (`<untitled>`) is not valid JSON, and dirty tracking deserializes the
-    // column default through the full Serialized(Encrypted(...)) chain.
+    // Lenient JSON coder: the column default `<untitled>` is not valid JSON.
     this.serialize("name", {
       coder: {
         dump: (value: unknown) => JSON.stringify(value),

--- a/packages/activerecord/src/test-helpers/models/book-encrypted.ts
+++ b/packages/activerecord/src/test-helpers/models/book-encrypted.ts
@@ -138,6 +138,33 @@ export class EncryptedBookWithSerializedSecondBinary extends Base {
   }
 }
 
+// trails-only: no Rails counterpart. Guards that `deterministicEncryptedAttributes`
+// / `encryptedAttribute?` unwrap a post-encrypts `serialize` decorator
+// (Serialized(Encrypted(...))) — Rails gets this for free via DelegateClass
+// delegation on Type::Serialized, which trails wrappers lack.
+export class EncryptedBookWithSerializedDeterministicName extends Base {
+  static _tableName = "encrypted_books";
+
+  static {
+    this.encrypts("name", { deterministic: true });
+    // Lenient JSON coder: the canonical `encrypted_books.name` default
+    // (`<untitled>`) is not valid JSON, and dirty tracking deserializes the
+    // column default through the full Serialized(Encrypted(...)) chain.
+    this.serialize("name", {
+      coder: {
+        dump: (value: unknown) => JSON.stringify(value),
+        load: (value: string) => {
+          try {
+            return JSON.parse(value);
+          } catch {
+            return value;
+          }
+        },
+      },
+    });
+  }
+}
+
 export class EncryptedBookWithCustomCompressor extends Base {
   static _tableName = "encrypted_books";
 


### PR DESCRIPTION
## Summary

Rails has no eager decorated `_attributeDefinitions` view — `type_for_attribute` (the replayed default attribute set, `attribute_registration.rb:66-72`) is the only lookup surface. trails' eager view, maintained by `registerEncryptedType`'s durable branch on every `applyPendingEncryptions` rebuild, wrapped only the encryption decorator, so for encrypts-then-serialize attributes (`EncryptedBookWithSerializedSecondBinary`) it held `Encrypted(binary)` while the resolved type was `Serialized(Encrypted(binary))`.

- `getAttributeType` now delegates to `klass.typeForAttribute` when present; the raw `_attributeDefinitions` read remains only as the fallback for plain mock models (the immediate path — no behavior change there).
- New `encryptedTypeOf` unwraps post-encrypts decorators, standing in for Rails' DelegateClass delegation (`deterministic?` / `encrypted?` / `previous_types` reach the encrypted type through `Type::Serialized` automatically in Rails; trails wrappers don't auto-delegate).
- `registerEncryptedType`'s durable branch (the eager wrap + provisional-default correction) is deleted. The durable path is now exactly Rails': one PendingDecorator pushed at declaration time. `applyPendingEncryptions` shrinks to the bookkeeping that genuinely remains — column-size validation re-runs after reflection + frozen-encryption validator install.
- `buildDecryptAttributeAssignments` / `decryptRecord` deserialize through the FULL resolved type so a `Serialized` coder applies after decryption (Rails `encryptable_record.rb:216-218`).
- trails guards (Rails has no direct test): `deterministicEncryptedAttributes` and instance `encryptedAttribute?` for `Serialized(Encrypted(...))` via the new `EncryptedBookWithSerializedDeterministicName` model.

The `_pendingEncryptions` buffer keeps `{ name, scheme }`: `encryptFixtureRows` (define-fixtures.ts) consumes the scheme to build fixture ciphertext before schema reflection, when `typeForAttribute` still resolves a plain ValueType — justified at the call site. `validateColumnSize`'s `_attributeDefinitions` `limit` read remains: it reads schema metadata, not the type.

Tests updated off the retired view: the STI leak guard and the column-default-threading test now assert through `typeForAttribute`; the `scopeForCreate` integration mock wires its type through `decorateAttributes`.

341 LOC (code), sqlite suites green locally.

Closes-story: encryption-eager-attribute-definitions-view-diverges
