### PR TITLE
fix(activerecord): converge groupingQueries per-group AND to Rails' pairwise reduce shape

### DIFF
--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -263,11 +263,15 @@ export class PredicateBuilder {
   private groupingQueries(queryGroups: Nodes.Node[][]): Nodes.Node[] {
     if (queryGroups.length === 0) return [];
     if (queryGroups.length === 1) return queryGroups[0];
-    // Rails `grouping_queries`: `Arel::Nodes::Or.new(queries.map!(&:reduce(:and)))`
-    // — an n-ary Or over the full array, wrapped in one Grouping.
-    const reduced = queryGroups.map((inner) =>
-      inner.length === 1 ? inner[0] : new Nodes.And(inner),
-    );
+    // Rails `grouping_queries` (predicate_builder.rb:157-159):
+    // `queries.map! { |query| query.reduce(&:and) }` then an n-ary
+    // `Arel::Nodes::Or.new(queries)` wrapped in one Grouping. `Node#and`
+    // is binary (`And.new [self, right]`), so a 3-predicate group is the
+    // nested chain `And([And([p1, p2]), p3])` — mirrored here via the same
+    // pairwise reduce, not a flat n-ary `And`. SQL is identical either way
+    // (the And visitor joins children without parens), but the AST shape
+    // matches Rails for anything walking the tree.
+    const reduced = queryGroups.map((inner) => inner.reduce((left, right) => left.and(right)));
     return [new Nodes.Grouping(new Nodes.Or(reduced))];
   }
 
@@ -455,15 +459,26 @@ export class PredicateBuilder {
     // expand_from_hash does via `self[key, value]` — dotted keys are
     // not split here (Rails doesn't either).
     const attrs = cols.map((c) => this.table.arelTable.get(c));
+    // Per-tuple AND uses the pairwise `reduce(&:and)` shape (nested
+    // binary `And` chain), matching Rails' `grouping_queries`
+    // (predicate_builder.rb:157) — not a flat n-ary `And`. SQL output
+    // is identical; only the AST shape differs.
+    //
+    // Deviation from the Rails array-key branch's exact tree: Rails'
+    // `grouping_queries` wraps only the outer Or in a single Grouping
+    // (and for a single tuple returns the predicates flat, as separate
+    // where-clause entries). `buildComposite` must return one node, so
+    // each tuple (and the single-tuple case) is wrapped in its own
+    // Grouping — semantically a no-op (AND binds tighter than OR) that
+    // keeps the emitted `(c1 = ? AND c2 = ?) OR (...)` form stable.
     const groupings: Nodes.Node[] = validTuples.map((tuple) => {
       const eqs = attrs.map((attr, i) => attr.eq(this.buildBindAttribute(attr.name, tuple[i])));
-      return new Nodes.Grouping(new Nodes.And(eqs));
+      return new Nodes.Grouping(eqs.reduce((left, right) => left.and(right)));
     });
     if (groupings.length === 1) return groupings[0];
-    // Use n-ary `Or(children[])` (Arel `Nodes::Or` extends `Nary`)
-    // for a flat AST instead of the deeply-nested binary chain
-    // `reduce` would produce. Keeps depth O(1) instead of O(n) for
-    // large tuple lists.
+    // n-ary `Or(children[])` matches Rails: `grouping_queries` builds
+    // `Arel::Nodes::Or.new(queries)` over the whole array (Arel's `Or`
+    // extends `Nary` in Rails 8.0.2 too).
     return new Nodes.Grouping(new Nodes.Or(groupings));
   }
 

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder.json
@@ -212,13 +212,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation/predicate-builder.ts",
-    "rubyName": "grouping_queries",
-    "call": "reduce",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder.ts",
     "rubyName": "handler_for",
     "call": "detect",
     "reason": "Ruby core/Enumerable idiom with a native JS form (e.g. `each` -> for-of, `fetch`/`key?` -> index + `in`, `match?` -> RegExp#test, `clear` -> `length = 0`, `present?`/`blank?` -> truthiness). The port performs the same operation under a JS-native spelling, so no same-named call appears. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."


### PR DESCRIPTION
## Summary

`grouping_queries` per-group AND: trails emitted one flat n-ary `And([...])` per query group; Rails 8.0.2 (`predicate_builder.rb:157`) reduces pairwise via `Node#and` (`Nodes::And.new [self, right]`), so a 3-predicate group is the nested chain `And([And([p1, p2]), p3])`. SQL output is identical (the And visitor joins children without parens), but the AST shape diverged for anything walking/pattern-matching the tree — the class of divergence RFC 0066 burns down.

- `groupingQueries` now reduces each group with `inner.reduce((l, r) => l.and(r))`, matching Rails' `queries.map! { |query| query.reduce(&:and) }`. The n-ary `Or` + single `Grouping` already matched Rails.
- `buildComposite`'s per-tuple AND (the tuple path the story flags for audit) converges to the same pairwise shape. Its n-ary `Or` matches Rails (Arel `Or` extends `Nary` in 8.0.2) — the stale "instead of the nested binary chain reduce would produce" deviation comment is replaced with the Rails citation. The remaining deviation — per-tuple `Grouping` wrappers and the single-tuple `Grouping` (Rails' array-key branch returns single-group predicates flat as separate where-clause entries; `buildComposite` must return one node) — is justified at the call site.

SQL output unchanged; callers (hash expansion, association, composed_of aggregate multi-mapping, composite where) stay green: predicate-builder, composite-where, where, where-clause, aggregations, disable-joins-composite tests all pass locally.

Closes-story: grouping-queries-flat-and-vs-binary-and-reduce
