### PR TITLE
fix(activerecord): remove internal-write bridge; converge _writeAttribute to raise

### DIFF
--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -992,6 +992,7 @@ describe("AssociationScope", () => {
 
       static {
         this._tableName = "pst_galleries";
+        this.attribute("id", "integer");
         this.attribute("pst_gallery_id", "integer");
         this.attribute("imageable_id", "integer");
         this.attribute("imageable_type", "string");

--- a/packages/activerecord/src/associations/source-type-validation.test.ts
+++ b/packages/activerecord/src/associations/source-type-validation.test.ts
@@ -42,6 +42,9 @@ import { fixtures } from "../test-helpers/fixtures.js";
 class StvAuthor extends Base {
   static {
     this._tableName = "stv_authors";
+    // No real table — strict _writeAttribute needs a declared slot for the
+    // dummy `id = 1` assignment below.
+    this.attribute("id", "integer");
   }
 }
 class StvComment extends Base {

--- a/packages/activerecord/src/attribute-methods/write.test.ts
+++ b/packages/activerecord/src/attribute-methods/write.test.ts
@@ -24,12 +24,13 @@ describe("WriteTest", () => {
       }
     }
     const p = new Post({ body: "original" });
-    // _writeAttribute("content", ...) writes to the "content" slot directly.
-    // Neither writeAttribute nor _writeAttribute resolve aliases today;
-    // that redirect will live in a future AR-level writeAttribute override.
-    p._writeAttribute("content", "via alias");
+    // Rails _write_attribute (write.rb:42) skips alias resolution, so the
+    // alias name misses the attribute set and write_from_user raises
+    // MissingAttributeError instead of redirecting to "body".
+    expect(() => p._writeAttribute("content", "via alias")).toThrow(
+      "can't write unknown attribute `content`",
+    );
     expect(p._readAttribute("body")).toBe("original");
-    expect(p._readAttribute("content")).toBe("via alias");
   });
 
   it("_write_attribute bypasses readonly check", () => {

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -1810,7 +1810,10 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
         this._tableName = "pirates";
         this.attribute("catchphrase", "string");
         this.validates("catchphrase", { presence: true });
-        this.hasOne("deepShip", { autosave: true });
+        // The FK derived from the association name would be `deep_pirate_id`;
+        // the real `ships` column is `pirate_id`. The bridge used to swallow
+        // the phantom write; strict _writeAttribute surfaces it.
+        this.hasOne("deepShip", { autosave: true, foreignKey: "pirate_id" });
       }
     }
     registerModel("DeepPirate", DeepPirate);

--- a/packages/activerecord/src/encryption/contexts.test.ts
+++ b/packages/activerecord/src/encryption/contexts.test.ts
@@ -60,6 +60,8 @@ describe("ActiveRecord::Encryption::ContextsTest", () => {
     EncryptedBook = class EncryptedBook extends Base {
       static {
         this._tableName = "encrypted_books";
+        this.attribute("created_at", "datetime");
+        this.attribute("updated_at", "datetime");
         this.attribute("id", "integer");
         this.attribute("name", "string", { default: "<untitled>", limit: 1024 });
         this.encrypts("name", { deterministic: true });

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -531,6 +531,8 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     const Book = class ReflectionOnlyEncryptedBook extends Base {
       static {
         this._tableName = "encrypted_books";
+        this.attribute("created_at", "datetime");
+        this.attribute("updated_at", "datetime");
         this.adapter = adapter;
         this.encrypts("name", { deterministic: true });
       }
@@ -561,6 +563,8 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     const Book = class OverriddenDefaultEncryptedBook extends Base {
       static {
         this._tableName = "encrypted_books";
+        this.attribute("created_at", "datetime");
+        this.attribute("updated_at", "datetime");
         this.adapter = adapter;
         this.attribute("name", "string", { default: "OVERRIDE" });
         this.encrypts("name", { deterministic: true });
@@ -890,6 +894,8 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     const BookDate = class extends Base {
       static {
         this._tableName = "encrypted_books";
+        this.attribute("created_at", "datetime");
+        this.attribute("updated_at", "datetime");
         this.attribute("id", "integer");
         this.attribute("name", "string");
         this.adapter = adp;

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -228,6 +228,8 @@ export function makeEncryptedBook(adapter: DatabaseAdapter) {
   return class EncryptedBook extends Base {
     static {
       this._tableName = "encrypted_books";
+      this.attribute("created_at", "datetime");
+      this.attribute("updated_at", "datetime");
       this.attribute("id", "integer");
       this.attribute("name", "string", { default: "<untitled>" });
       this.adapter = adapter;
@@ -240,6 +242,8 @@ export function makeEncryptedBookWithDowncaseName(adapter: DatabaseAdapter) {
   return class EncryptedBookWithDowncaseName extends Base {
     static {
       this._tableName = "encrypted_books";
+      this.attribute("created_at", "datetime");
+      this.attribute("updated_at", "datetime");
       this.attribute("id", "integer");
       this.attribute("name", "string", { default: "<untitled>" });
       this.adapter = adapter;
@@ -252,6 +256,8 @@ export function makeEncryptedBookThatIgnoresCase(adapter: DatabaseAdapter) {
   return class EncryptedBookThatIgnoresCase extends Base {
     static {
       this._tableName = "encrypted_books";
+      this.attribute("created_at", "datetime");
+      this.attribute("updated_at", "datetime");
       this.attribute("id", "integer");
       this.attribute("name", "string", { default: "<untitled>" });
       this.attribute("original_name", "string");
@@ -289,6 +295,8 @@ export function makeEncryptedBookWithCustomCompressor(adapter: DatabaseAdapter) 
   return class EncryptedBookWithCustomCompressor extends Base {
     static {
       this._tableName = "encrypted_books";
+      this.attribute("created_at", "datetime");
+      this.attribute("updated_at", "datetime");
       this.attribute("id", "integer");
       this.attribute("name", "string");
       this.adapter = adapter;
@@ -313,6 +321,8 @@ export function makeBookThatWillFailToEncryptName(adapter: DatabaseAdapter) {
   return class BookThatWillFailToEncryptName extends Base {
     static {
       this._tableName = "encrypted_books";
+      this.attribute("created_at", "datetime");
+      this.attribute("updated_at", "datetime");
       this.attribute("id", "integer");
       this.attribute("name", "string");
       this.adapter = adapter;
@@ -357,6 +367,8 @@ export function makeEncryptedTrafficLightWithStoreState(adapter: DatabaseAdapter
       this._tableName = "traffic_lights";
       this.attribute("id", "integer");
       this.attribute("state", "json");
+      this.attribute("created_at", "datetime");
+      this.attribute("updated_at", "datetime");
       // Canonical `traffic_lights.long_state` is `text NOT NULL`; the parent
       // Rails TrafficLight serializes it as an Array (traffic_light.rb:4), so the
       // fixture mirrors that with the same serialize/Array coder the canonical
@@ -403,6 +415,8 @@ export function makeMsgPackTextBook(adapter: DatabaseAdapter) {
   return class MsgPackTextBook extends Base {
     static {
       this._tableName = "encrypted_books";
+      this.attribute("created_at", "datetime");
+      this.attribute("updated_at", "datetime");
       this.attribute("id", "integer");
       this.attribute("name", "string", { default: "<untitled>" });
       this.adapter = adapter;
@@ -419,6 +433,8 @@ export function makeUnencryptedBook(adapter: DatabaseAdapter) {
   return class UnencryptedBook extends Base {
     static {
       this._tableName = "encrypted_books";
+      this.attribute("created_at", "datetime");
+      this.attribute("updated_at", "datetime");
       this.attribute("id", "integer");
       this.attribute("name", "string", { default: "<untitled>" });
       this.adapter = adapter;
@@ -434,6 +450,8 @@ export function makeEncryptedBookWithUniquenessValidation(adapter: DatabaseAdapt
   return class EncryptedBookWithUniquenessValidation extends Base {
     static {
       this._tableName = "encrypted_books";
+      this.attribute("created_at", "datetime");
+      this.attribute("updated_at", "datetime");
       this.attribute("id", "integer");
       this.attribute("name", "string", { default: "<untitled>" });
       this.adapter = adapter;
@@ -451,6 +469,8 @@ export function makeEncryptedBookAttribute(adapter: DatabaseAdapter) {
   return class EncryptedBookAttribute extends Base {
     static {
       this._tableName = "encrypted_books";
+      this.attribute("created_at", "datetime");
+      this.attribute("updated_at", "datetime");
       this.attribute("id", "integer");
       this.attribute("name", "date");
       this.adapter = adapter;

--- a/packages/activerecord/src/primary-keys.trails.test.ts
+++ b/packages/activerecord/src/primary-keys.trails.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { CpkBook } from "./test-helpers/models/cpk.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 
 // Rails' `CompositePrimaryKey#id=` guards on `value.is_a?(Enumerable)` and then
 // `@primary_key.zip(value)`. A JS Set is the codebase's Enumerable analogue
@@ -7,6 +8,10 @@ import { CpkBook } from "./test-helpers/models/cpk.js";
 // than raise. Strings and true scalars still raise (see the mirrored Rails
 // test in primary-keys.test.ts).
 describe("CompositePrimaryKey#id= — Enumerable acceptance (trails-only)", () => {
+  // Strict _writeAttribute needs CpkBook's reflected schema warm before the
+  // synchronous `id =` writes below.
+  fixtures({});
+
   it("zips a Set across the key columns like an array", () => {
     const book = new CpkBook();
     book.id = new Set([1, 2]) as unknown as number[];

--- a/packages/activerecord/src/query-cache.test.ts
+++ b/packages/activerecord/src/query-cache.test.ts
@@ -838,6 +838,9 @@ describe("QueryCacheMutableParamTest", () => {
   class JsonObj extends Base {
     static {
       this._tableName = "json_objs";
+      // Declared `payload` suppresses reflection of the scratch table, so the
+      // post-INSERT id write-back needs `id` declared for strict _writeAttribute.
+      this.attribute("id", "integer");
       this.attribute("payload", "json");
     }
   }

--- a/packages/activerecord/src/readonly-attributes.ts
+++ b/packages/activerecord/src/readonly-attributes.ts
@@ -183,32 +183,10 @@ export function _writeAttribute(this: Base, name: string, value: unknown): void 
   }
   // Mirrors Rails `_write_attribute`: skip alias resolution, unlike the public
   // `write_attribute` path above. Rails (write.rb:42) reaches `write_from_user`
-  // and raises for an unknown name, because in Rails the PK/timestamp/locking
-  // columns these internal writers target are always in the attribute set.
-  //
-  // trails' set is NOT always complete: a model on a raw-created table whose
-  // schema cache was never warmed (e.g. the PG/MySQL adapter test suites, which
-  // `adapter.exec("CREATE TABLE …")` then use immediately) cannot reflect its
-  // columns synchronously on an async driver, so the post-INSERT PK write-back
-  // (and timestamp writes) would hit the strict `writeFromUser` and raise.
-  //
-  // BRIDGE (RFC 0046, story remove-internal-write-bridge-converge-write-attribute-strict):
-  // keep the low-level internal path lenient — seed the unreflected real column
-  // directly when `writeFromUser` raises — so the public `writeAttribute` /
-  // `[]=` / mass-assignment paths stay strict (the heart of this story) while
-  // the framework's own writes survive an incomplete set. Removed once every
-  // bespoke test model declares its real columns (RFC 0046).
-  //
-  // A null/undefined name is NOT bridged: that is `id = …` on a key-less table
-  // (`setId` → `_writeAttribute(@primary_key=null, value)`), which must raise
-  // `MissingAttributeError` like Rails. The framework write-backs that rely on
-  // the bridge always target a real (string) column name.
-  try {
-    Model.prototype._writeAttribute.call(this, name, value);
-  } catch (error) {
-    if (!(error instanceof MissingAttributeError) || name == null) throw error;
-    this._attributes.writeCastValue(name, value);
-  }
+  // and raises `MissingAttributeError` for an unknown name — including
+  // `id = …` on a key-less table (`setId` →
+  // `_writeAttribute(@primary_key=null, value)`).
+  Model.prototype._writeAttribute.call(this, name, value);
 }
 
 /**

--- a/packages/activerecord/src/timestamp.test.ts
+++ b/packages/activerecord/src/timestamp.test.ts
@@ -547,6 +547,10 @@ describe("TimestampsWithoutTransactionTest", () => {
       created_at: unknown = null;
       updated_at: unknown = null;
     }
+    // Reflect the raw-created table's `id` column: the virtual attribute
+    // declarations suppress lazy DB reflection, and strict _writeAttribute
+    // (write.rb:42) raises when `id=` misses the attribute set.
+    await TimestampAttributePost.loadSchema();
 
     const post = new TimestampAttributePost({ id: 1 });
     await post.save();


### PR DESCRIPTION
Removes the internal-write bridge (PR #4027) so the low-level `_writeAttribute`
delegates straight to `Model.prototype._writeAttribute` and raises
`MissingAttributeError` for an unknown name, exactly like Rails
`attribute_methods/write.rb:42`.

- `readonly-attributes.ts`: drop the `catch → writeCastValue` fallback.
- `attribute-methods/write.test.ts`: the no-alias-resolution test now asserts
  the Rails-faithful raise (the alias name misses the attribute set) instead of
  the bridged direct slot write.
- `timestamp.test.ts`: `TimestampAttributePost` warms its raw-created table via
  `loadSchema()` so the `id=` write reaches a real attribute (its virtual
  timestamp declarations suppress lazy reflection).

Closes-story: remove-internal-write-bridge-converge-write-attribute-strict
