### PR TITLE
refactor(predicate-builder): retire buildBindAttribute wide-gate baseline; inline table.type read

### DIFF
--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -501,7 +501,7 @@ export class PredicateBuilder {
    * — single-source `table.type(column_name)`, no fallback.
    */
   buildBindAttribute(columnName: string, value: unknown): QueryAttribute {
-    return new QueryAttribute(columnName, value, this.typeOf(columnName));
+    return new QueryAttribute(columnName, value, this.table.type(columnName) as BoundType);
   }
 
   resolveArelAttribute(

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -496,12 +496,8 @@ export class PredicateBuilder {
     this.handlers.unshift([klass, handler]);
   }
 
-  /**
-   * Mirrors: `PredicateBuilder#build_bind_attribute` (predicate_builder.rb:67-69)
-   * — single-source `table.type(column_name)`, no fallback.
-   */
   buildBindAttribute(columnName: string, value: unknown): QueryAttribute {
-    return new QueryAttribute(columnName, value, this.table.type(columnName) as BoundType);
+    return new QueryAttribute(columnName, value, this.table.type(columnName));
   }
 
   resolveArelAttribute(

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder.json
@@ -30,20 +30,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation/predicate-builder.ts",
-    "rubyName": "build_bind_attribute",
-    "call": "table",
-    "reason": "Adapted through the shared type cascade (story unify-predicate-builder-type-resolution-cascades): Rails' build_bind_attribute reads `table.type(column_name)` inline and unconditionally (predicate_builder.rb:67-68). trails resolves the same type through _resolveTypeBy, a shared relation -> _tableContext -> this.table cascade that returns the first level to answer, so `this.table` is the fallback leg rather than an unconditional read. This is equivalent for plain columns because `table.get(col).relation` IS `this.table`, so the relation leg returns exactly what Rails' inline read would; for joined/aliased attributes an earlier level intentionally answers first, which is the divergence this story exists to introduce (Rails gets the same effect by re-rooting PredicateBuilder#table per association, which trails cannot do). Either way the wide gate is name-based and inspects only the Rails-mapped method body, so it cannot see the read in the shared resolver."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder.ts",
-    "rubyName": "build_bind_attribute",
-    "call": "type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder.ts",
     "rubyName": "build_from_hash",
     "call": "expand_from_hash",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Scheduled cleanup of debt from #4963 (RFC 0067 `retire-predicate-builder-relation-param-and-wide-gate-baseline`).

The prerequisite convergence already landed on main (#5062 made `PredicateBuilder#table` a TableMetadata; #5063 collapsed the type cascade to single-source `table.type`), which also removed `buildBindAttribute`'s invented third `relation` parameter — it is already the Rails-faithful `(columnName, value)` with no caller passing a relation.

What remained was the wide-gate debt:

- `buildBindAttribute` now reads `this.table.type(columnName)` **inline**, matching Rails' literal `table.type(column_name)` (predicate_builder.rb:67-69), instead of going through the private `typeOf` helper the name-based wide gate cannot see into.
- Deleted the `build_bind_attribute -> table` and `build_bind_attribute -> type` baseline entries from `call-mismatches-wide-exclude/activerecord/relation/predicate-builder.json`. `pnpm exec tsx scripts/api-compare/lint-call-mismatches-wide.ts` passes with them gone (re-extracted, not re-baselined) — the gate now sees both reads in the mapped body again.

The #4963 SQL-level guards in `predicate-builder.trails.test.ts` ("collapses a joined out-of-range equality to 1=0" and its in-range control) pass unchanged, as do the ported `predicate-builder.test.ts` tests (34/34).

Closes-story: retire-predicate-builder-relation-param-and-wide-gate-baseline
