### PR TITLE
fix(test-infra): honor AR_DB_FORKS by capping the vitest fork pool at root level

### DIFF
--- a/packages/activerecord/src/test-setup-worker-db.ts
+++ b/packages/activerecord/src/test-setup-worker-db.ts
@@ -58,6 +58,23 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// Names BOTH sizing inputs so exhaustion is diagnosable from the message alone.
+// The pool is sized at AR_DB_FORKS + headroom (ar-db-slots.ts), so exhaustion
+// means MORE workers ran concurrently than AR_DB_FORKS promises — historically
+// because the vitest fork cap lived only in per-project poolOptions, which
+// vitest 3's shared pool ignores (see the root poolOptions note in
+// vitest.config.ts) — not that the derivation undercuts the worker count.
+function slotExhaustionMessage(fn: string, lockKind: string, slots: number): string {
+  return (
+    `${fn}: all ${slots} ${lockKind} slots are held after ` +
+    `${SLOT_RETRY_ATTEMPTS} attempts (${(SLOT_RETRY_ATTEMPTS * SLOT_RETRY_DELAY_MS) / 1000}s) ` +
+    `with AR_DB_FORKS=${workerForkCount()} (slot pool = forks + headroom; see ` +
+    `test-helpers/ar-db-slots.ts). More than ${workerForkCount()} workers are competing: ` +
+    `check that the vitest worker cap is honored (root-level poolOptions in ` +
+    `vitest.config.ts), or increase AR_DB_SLOTS, or check for stuck workers.`
+  );
+}
+
 async function acquireAdvisorySlotPg(): Promise<number> {
   if (workerForkCount() <= 1) return 1;
   // Slot pool is sized with headroom over the worker count (see ar-db-slots.ts).
@@ -90,11 +107,7 @@ async function acquireAdvisorySlotPg(): Promise<number> {
   }
 
   await client.end();
-  throw new Error(
-    `acquireAdvisorySlotPg: all ${slots} advisory lock slots are held after ` +
-      `${SLOT_RETRY_ATTEMPTS} attempts (${(SLOT_RETRY_ATTEMPTS * SLOT_RETRY_DELAY_MS) / 1000}s). ` +
-      `Increase AR_DB_SLOTS or check for stuck workers.`,
-  );
+  throw new Error(slotExhaustionMessage("acquireAdvisorySlotPg", "advisory lock", slots));
 }
 
 async function acquireAdvisorySlotMysql(): Promise<number> {
@@ -135,11 +148,7 @@ async function acquireAdvisorySlotMysql(): Promise<number> {
   }
 
   await conn.end();
-  throw new Error(
-    `acquireAdvisorySlotMysql: all ${slots} GET_LOCK slots are held after ` +
-      `${SLOT_RETRY_ATTEMPTS} attempts (${(SLOT_RETRY_ATTEMPTS * SLOT_RETRY_DELAY_MS) / 1000}s). ` +
-      `Increase AR_DB_SLOTS or check for stuck workers.`,
-  );
+  throw new Error(slotExhaustionMessage("acquireAdvisorySlotMysql", "GET_LOCK", slots));
 }
 
 const lane = activeLane();

--- a/packages/activerecord/src/test-setup-worker-db.ts
+++ b/packages/activerecord/src/test-setup-worker-db.ts
@@ -58,20 +58,17 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-// Names BOTH sizing inputs so exhaustion is diagnosable from the message alone.
 // The pool is sized at AR_DB_FORKS + headroom (ar-db-slots.ts), so exhaustion
-// means MORE workers ran concurrently than AR_DB_FORKS promises — historically
-// because the vitest fork cap lived only in per-project poolOptions, which
-// vitest 3's shared pool ignores (see the root poolOptions note in
-// vitest.config.ts) — not that the derivation undercuts the worker count.
+// means more workers ran concurrently than AR_DB_FORKS promises — name both
+// numbers so that reads as a worker-cap bug, not a schema-setup regression.
 function slotExhaustionMessage(fn: string, lockKind: string, slots: number): string {
   return (
     `${fn}: all ${slots} ${lockKind} slots are held after ` +
     `${SLOT_RETRY_ATTEMPTS} attempts (${(SLOT_RETRY_ATTEMPTS * SLOT_RETRY_DELAY_MS) / 1000}s) ` +
-    `with AR_DB_FORKS=${workerForkCount()} (slot pool = forks + headroom; see ` +
+    `with AR_DB_FORKS=${workerForkCount()} (slot pool = forks + headroom, see ` +
     `test-helpers/ar-db-slots.ts). More than ${workerForkCount()} workers are competing: ` +
     `check that the vitest worker cap is honored (root-level poolOptions in ` +
-    `vitest.config.ts), or increase AR_DB_SLOTS, or check for stuck workers.`
+    `vitest.config.ts), increase AR_DB_SLOTS, or check for stuck workers.`
   );
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "vitest/config";
 import path from "path";
+import os from "os";
 
 // AR_DB_FORKS (read in test-setup-worker-db.ts) sets the vitest worker count
 // via TEST_FORKS below. The advisory-lock slot pool is sized SEPARATELY, with
@@ -80,7 +81,18 @@ const SQLITE_DRIVER_TESTS = [
 ];
 
 const _parsedForks = parseInt(process.env.TRAILS_TEST_FORKS ?? process.env.AR_DB_FORKS ?? "", 10);
-const TEST_FORKS = Number.isFinite(_parsedForks) && _parsedForks > 0 ? _parsedForks : 6;
+// Clamp to vitest's own host-derived ceiling (numCpus - 1): while the root
+// maxForks cap was a per-project no-op, that ceiling is what every run
+// actually used, and the suite's timeouts are tuned to it — on the 4-vCPU CI
+// runner, honoring AR_DB_FORKS=8 outright oversubscribes PG enough to push
+// the full-DB schema-dump tests past their 5s timeout. The env vars can only
+// lower the cap, never raise it past the host. The advisory-slot pool still
+// sizes from AR_DB_FORKS (ar-db-slots.ts), so it can only over-provision.
+const _hostForkCap = Math.max(os.availableParallelism() - 1, 1);
+const TEST_FORKS = Math.min(
+  Number.isFinite(_parsedForks) && _parsedForks > 0 ? _parsedForks : 6,
+  _hostForkCap,
+);
 
 const alias = {
   "@blazetrails/activesupport/message-verifier": path.resolve(

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -284,14 +284,12 @@ export default defineConfig({
   resolve: { alias },
   test: {
     globals: true,
-    // The worker cap MUST live at the ROOT config: vitest 3's shared fork pool
-    // sizes itself from `vitest.config.poolOptions.forks.maxForks` (see
-    // createForksPool in vitest/dist) and never consults the per-project
-    // `poolOptions`, so a project-level `maxForks` is a silent no-op and the
-    // effective cap becomes `numCpus - 1`. On a many-core host that let every
-    // test file fork at once, exhausting the AR_DB advisory-slot pool (first
-    // N files pin all N slots; every later file fails setup with
-    // "all N GET_LOCK slots are held").
+    // MUST live at the ROOT config: vitest 3's shared fork pool sizes itself
+    // from the root `poolOptions.forks.maxForks` only (createForksPool never
+    // consults per-project poolOptions — a project-level `maxForks` is a
+    // silent no-op and the cap falls back to `numCpus - 1`, which on a
+    // many-core host forks every file at once and exhausts the AR_DB
+    // advisory-slot pool: "all N GET_LOCK slots are held").
     poolOptions: { forks: { maxForks: TEST_FORKS } },
     // In the isolated trails-tsc coverage run, the build-views/watch tests are
     // CPU-pegged in tsc under v8 instrumentation long enough to starve vitest's
@@ -379,7 +377,6 @@ export default defineConfig({
           // tracking removal).
           hookTimeout: 30_000,
           pool: "forks",
-          poolOptions: { forks: { maxForks: TEST_FORKS } },
         },
       },
       {
@@ -391,7 +388,6 @@ export default defineConfig({
           name: "sqlite-drivers",
           include: SQLITE_DRIVER_TESTS,
           exclude: [...SHARED_EXCLUDE],
-          poolOptions: { forks: { maxForks: TEST_FORKS } },
         },
       },
       {
@@ -418,7 +414,6 @@ export default defineConfig({
           // Arel's suite needs `Arel::Table.engine` set, exactly as Rails' does
           // (it runs under activerecord, where the engine is ActiveRecord::Base).
           setupFiles: ["./packages/arel/src/test-setup-engine.ts"],
-          poolOptions: { forks: { maxForks: TEST_FORKS } },
         },
       },
     ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -284,6 +284,15 @@ export default defineConfig({
   resolve: { alias },
   test: {
     globals: true,
+    // The worker cap MUST live at the ROOT config: vitest 3's shared fork pool
+    // sizes itself from `vitest.config.poolOptions.forks.maxForks` (see
+    // createForksPool in vitest/dist) and never consults the per-project
+    // `poolOptions`, so a project-level `maxForks` is a silent no-op and the
+    // effective cap becomes `numCpus - 1`. On a many-core host that let every
+    // test file fork at once, exhausting the AR_DB advisory-slot pool (first
+    // N files pin all N slots; every later file fails setup with
+    // "all N GET_LOCK slots are held").
+    poolOptions: { forks: { maxForks: TEST_FORKS } },
     // In the isolated trails-tsc coverage run, the build-views/watch tests are
     // CPU-pegged in tsc under v8 instrumentation long enough to starve vitest's
     // reporter heartbeat, surfacing a `Timeout calling "onTaskUpdate"` worker


### PR DESCRIPTION
## Problem

Any sizeable MySQL slice at `AR_DB_FORKS=4` failed ~34/41 suites at setup with
`acquireAdvisorySlotMysql: all 6 GET_LOCK slots are held` — deterministically:
first 6 files passed, everything after failed, zero failing assertions.

## Root cause

vitest 3's shared fork pool sizes itself **only from the root config**:
`createForksPool` reads `vitest.config.poolOptions?.forks` and never consults
per-project `poolOptions`. Our `maxForks: TEST_FORKS` lived inside each
project entry, so it was a silent no-op and the effective cap was
`numCpus - 1` (23 on a 24-core host). Every test file forked at once;
instrumentation showed **6 worker processes acquiring slots in the same
millisecond** with `AR_DB_FORKS=4`. The first 6 workers pinned all
6 slots (forks + 2 headroom) for their process lifetimes, and every later
file's worker exhausted the 5s bounded retry. Lock release on worker exit is
fine — this was pure over-forking.

## Fix

- Declare `poolOptions: { forks: { maxForks: TEST_FORKS } }` at the root
  `test` config (with a comment explaining why it must live there).
- Slot-exhaustion errors now name `AR_DB_FORKS` and the pool derivation, and
  point at the worker cap first — so a recurrence is diagnosable from the
  message instead of reading as an opaque schema-setup regression (this cost
  real time on #4977).

## Verification

Against a fresh isolated `mysql:8` container, the 14-file
`connection-adapters/mysql{,2}` slice at `AR_DB_FORKS=4`:

- baseline: 8 failed / 6 passed (the story's signature)
- with fix: **14 passed / 228 tests green** (twice)

`node scripts/typecheck.mjs` clean; `ar-db-slots.test.ts` green.

Closes-story: mysql-advisory-slot-exhaustion-at-four-forks


## Update: host fork ceiling

The first CI runs failed the 3 full-DB `SchemaDumperTest` dump tests (5s
timeout) twice, deterministically: honoring `AR_DB_FORKS=8` for the first
time oversubscribed the 4-vCPU PG runner — the per-project no-op meant every
prior run actually used vitest's `numCpus - 1` fallback, and the suite's
timeouts are tuned to that. `TEST_FORKS` is now clamped to
`min(env, numCpus - 1)`, so the env caps can only lower concurrency below the
host ceiling, never raise it past what the host supports. The advisory-slot
pool still sizes from `AR_DB_FORKS` and can only over-provision.
