### PR TITLE
fix(activesupport): converge wide-verify omissions across activesupport/activemodel/trailties

### DIFF
--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -108,9 +108,11 @@ export class DirtyTracker {
     this.snapshot(attributes);
   }
 
-  asJson(): Record<string, [unknown, unknown]> {
-    return this.changes;
-  }
+  // Rails `Dirty#as_json` (dirty.rb:264-268) exists only to hide the
+  // mutation-tracker ivars from Ruby's default serializer; trails
+  // `Model#asJson` serializes attributes via serializableHash and never sees
+  // the tracker, so that exclusion is inherent and no tracker-level asJson
+  // exists here.
 
   changesApplied(
     currentAttributes: Map<string, unknown> | { snapshotValues(): Map<string, unknown> },

--- a/packages/activesupport/src/cache/cache-store-namespace.test.ts
+++ b/packages/activesupport/src/cache/cache-store-namespace.test.ts
@@ -1,8 +1,48 @@
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
+import { MemoryStore } from "./memory-store.js";
+import { coder } from "./coder.js";
+
+// Mirrors Rails' `cache.instance_variable_get(:@data)["tester:foo"].value`
+// peek at the raw namespaced key.
+function rawValue(cache: MemoryStore, key: string): unknown {
+  const data = (cache as unknown as { data: Map<string, { encodedValue: string }> }).data;
+  const rec = data.get(key);
+  if (!rec) return undefined;
+  return coder.load(rec.encodedValue);
+}
 
 describe("CacheStoreNamespaceTest", () => {
-  it.skip("static namespace");
-  it.skip("proc namespace");
-  it.skip("delete matched key start");
-  it.skip("delete matched key");
+  it("static namespace", () => {
+    const cache = new MemoryStore({ namespace: "tester" });
+    cache.write("foo", "bar");
+    expect(cache.read("foo")).toBe("bar");
+    expect(rawValue(cache, "tester:foo")).toBe("bar");
+  });
+
+  it("proc namespace", () => {
+    const testVal = "tester";
+    const proc = () => testVal;
+    const cache = new MemoryStore({ namespace: proc });
+    cache.write("foo", "bar");
+    expect(cache.read("foo")).toBe("bar");
+    expect(rawValue(cache, "tester:foo")).toBe("bar");
+  });
+
+  it("delete matched key start", () => {
+    const cache = new MemoryStore({ namespace: "tester" });
+    cache.write("foo", "bar");
+    cache.write("fu", "baz");
+    cache.deleteMatched(/^fo/);
+    expect(cache.exist("foo")).toBe(false);
+    expect(cache.exist("fu")).toBe(true);
+  });
+
+  it("delete matched key", () => {
+    const cache = new MemoryStore({ namespace: "foo" });
+    cache.write("foo", "bar");
+    cache.write("fu", "baz");
+    cache.deleteMatched(/OO/i);
+    expect(cache.exist("foo")).toBe(false);
+    expect(cache.exist("fu")).toBe(true);
+  });
 });

--- a/packages/activesupport/src/cache/memory-store.ts
+++ b/packages/activesupport/src/cache/memory-store.ts
@@ -32,7 +32,11 @@ export class MemoryStore extends Store implements CacheStore {
   private data: Map<string, MemoryRecord> = new Map();
   private sizeLimit: number;
 
-  constructor(options?: { sizeLimit?: number; namespace?: string; expiresIn?: number }) {
+  constructor(options?: {
+    sizeLimit?: number;
+    namespace?: string | (() => string);
+    expiresIn?: number;
+  }) {
     super(options ?? {});
     this.sizeLimit = options?.sizeLimit ?? Infinity;
   }

--- a/packages/activesupport/src/cache/store.ts
+++ b/packages/activesupport/src/cache/store.ts
@@ -495,10 +495,17 @@ export abstract class Store {
     return pattern;
   }
 
-  protected namespaceKey(key: string, options?: StoreOptions): string {
-    const ns = options?.namespace ?? this.options.namespace;
-    const namespace =
-      typeof ns === "function" ? (ns as () => string)() : (ns as string | undefined);
+  /** Mirrors Rails `Cache::Store#namespace_key` (cache.rb:948-968): a per-call
+   * `:namespace` key wins even when its value is nil (`call_options&.key?`,
+   * not a nil-coalescing fallback), and callable namespaces are invoked.
+   * Rails' UTF-8 re-encoding of the key has no JS analogue. */
+  protected namespaceKey(key: string, callOptions?: StoreOptions): string {
+    let ns =
+      callOptions && "namespace" in callOptions ? callOptions.namespace : this.options.namespace;
+    if (typeof ns === "function") {
+      ns = (ns as () => string)();
+    }
+    const namespace = ns as string | null | undefined;
     return namespace ? `${namespace}:${key}` : key;
   }
 

--- a/packages/activesupport/src/cache/store.ts
+++ b/packages/activesupport/src/cache/store.ts
@@ -485,7 +485,10 @@ export abstract class Store {
    * prefix (`.*`).
    */
   protected keyMatcher(pattern: RegExp, options?: StoreOptions): RegExp {
-    const ns = options?.namespace ?? this.options.namespace;
+    // Same per-call override semantics as namespaceKey below: Rails'
+    // key_matcher reads options[:namespace] from the merged options with no
+    // store-level fallback (cache.rb:779-790), so an explicit nil wins.
+    const ns = options && "namespace" in options ? options.namespace : this.options.namespace;
     const prefix = typeof ns === "function" ? (ns as () => string)() : (ns as string | undefined);
     if (prefix) {
       let source = pattern.source;

--- a/packages/activesupport/src/core-ext/duration.test.ts
+++ b/packages/activesupport/src/core-ext/duration.test.ts
@@ -141,9 +141,9 @@ describe("DurationTest", () => {
   });
 
   it("divide", () => {
-    // dividedBy converts to seconds-based Duration
+    // dividedBy divides each part (Rails duration.rb:297-305)
+    expect(Duration.days(7).dividedBy(7).isEqualTo(Duration.days(1))).toBe(true);
     expect(Duration.days(7).dividedBy(7) instanceof Duration).toBe(true);
-    // 7.days / 7 = 86400 seconds = same as 1 day
     expect(Math.round(Duration.days(7).dividedBy(7).inSeconds())).toBe(86400);
     // 1.day / 24 => 3600 seconds
     expect(Math.round(Duration.days(1).dividedBy(24).inSeconds())).toBe(3600);

--- a/packages/activesupport/src/duration.ts
+++ b/packages/activesupport/src/duration.ts
@@ -79,42 +79,53 @@ export class Duration {
   // Factory methods
   // ---------------------------------------------------------------------------
 
+  // Explicit variable flags mirror Rails' factory constructors
+  // (duration.rb:155-180): fixed units pass false, calendar units true.
   static seconds(n: number): Duration {
-    return new Duration({ seconds: n });
+    return new Duration({ seconds: n }, false);
   }
   static minutes(n: number): Duration {
-    return new Duration({ minutes: n });
+    return new Duration({ minutes: n }, false);
   }
   static hours(n: number): Duration {
-    return new Duration({ hours: n });
+    return new Duration({ hours: n }, false);
   }
   static days(n: number): Duration {
-    return new Duration({ days: n });
+    return new Duration({ days: n }, true);
   }
   static weeks(n: number): Duration {
-    return new Duration({ weeks: n });
+    return new Duration({ weeks: n }, true);
   }
   static months(n: number): Duration {
-    return new Duration({ months: n });
+    return new Duration({ months: n }, true);
   }
   static years(n: number): Duration {
-    return new Duration({ years: n });
+    return new Duration({ years: n }, true);
   }
 
   // ---------------------------------------------------------------------------
   // Arithmetic
   // ---------------------------------------------------------------------------
 
+  // Variable flags below mirror Rails' arithmetic (duration.rb:268-304,
+  // 322-324): `+` with a Duration ORs the flags, numeric `+`/`*`/`/` and
+  // unary `-` carry the receiver's flag — never recomputed from result parts.
   plus(other: Duration | number): Duration {
     if (typeof other === "number") {
-      return new Duration(mergeParts(this.parts, { ...zeroParts(), seconds: other }));
+      return new Duration(
+        mergeParts(this.parts, { ...zeroParts(), seconds: other }),
+        this._variable,
+      );
     }
-    return new Duration(mergeParts(this.parts, other.parts));
+    return new Duration(mergeParts(this.parts, other.parts), this._variable || other._variable);
   }
 
   minus(other: Duration | number): Duration {
     if (typeof other === "number") {
-      return new Duration(mergeParts(this.parts, { ...zeroParts(), seconds: -other }));
+      return new Duration(
+        mergeParts(this.parts, { ...zeroParts(), seconds: -other }),
+        this._variable,
+      );
     }
     return this.plus(other.negate());
   }
@@ -124,13 +135,13 @@ export class Duration {
     for (const key of PART_ORDER) {
       result[key] = this.parts[key] * n;
     }
-    return new Duration(result);
+    return new Duration(result, this._variable);
   }
 
   dividedBy(n: number): Duration {
     // When dividing by a number, Rails converts to total seconds and creates a seconds-only Duration
     const totalSecs = this.inSeconds();
-    return new Duration({ seconds: totalSecs / n });
+    return new Duration({ seconds: totalSecs / n }, this._variable);
   }
 
   negate(): Duration {

--- a/packages/activesupport/src/duration.ts
+++ b/packages/activesupport/src/duration.ts
@@ -138,10 +138,14 @@ export class Duration {
     return new Duration(result, this._variable);
   }
 
+  // Mirrors Rails `/` with a Numeric (duration.rb:297-305): divides each
+  // part, preserving the receiver's variable flag.
   dividedBy(n: number): Duration {
-    // When dividing by a number, Rails converts to total seconds and creates a seconds-only Duration
-    const totalSecs = this.inSeconds();
-    return new Duration({ seconds: totalSecs / n }, this._variable);
+    const result = zeroParts();
+    for (const key of PART_ORDER) {
+      result[key] = this.parts[key] / n;
+    }
+    return new Duration(result, this._variable);
   }
 
   negate(): Duration {

--- a/packages/activesupport/src/duration.ts
+++ b/packages/activesupport/src/duration.ts
@@ -36,6 +36,10 @@ const PART_ORDER: (keyof DurationParts)[] = [
   "seconds",
 ];
 
+// Mirrors Rails VARIABLE_PARTS (duration.rb:131): the calendar units whose
+// wall-clock length varies (DST, month/year length).
+const VARIABLE_PARTS: (keyof DurationParts)[] = ["years", "months", "weeks", "days"];
+
 function zeroParts(): DurationParts {
   return { years: 0, months: 0, weeks: 0, days: 0, hours: 0, minutes: 0, seconds: 0 };
 }
@@ -50,8 +54,15 @@ function mergeParts(a: DurationParts, b: DurationParts): DurationParts {
 
 export class Duration {
   readonly parts: DurationParts;
+  private readonly _variable: boolean;
 
-  constructor(parts: Partial<DurationParts> = {}) {
+  // Mirrors Rails `Duration#initialize(value, parts, variable = nil)`
+  // (duration.rb:226-234). Deviations: trails carries no separate `@value`
+  // (totals derive from `parts` via inSeconds()), and `parts` stays a full
+  // fixed record instead of Rails' zero-rejected sparse hash — the nonzero
+  // filter in the `variable` computation below stands in for
+  // `@parts.reject! { |k, v| v.zero? }`.
+  constructor(parts: Partial<DurationParts> = {}, variable: boolean | null = null) {
     this.parts = {
       years: parts.years ?? 0,
       months: parts.months ?? 0,
@@ -61,6 +72,7 @@ export class Duration {
       minutes: parts.minutes ?? 0,
       seconds: parts.seconds ?? 0,
     };
+    this._variable = variable ?? VARIABLE_PARTS.some((part) => this.parts[part] !== 0);
   }
 
   // ---------------------------------------------------------------------------
@@ -261,14 +273,10 @@ export class Duration {
     return klass === Duration || this instanceof (klass as any);
   }
 
-  // variable? — true when duration contains calendar units (days, weeks, months, years)
+  /** Mirrors Rails `Duration#variable?` (duration.rb:477-479): reads the
+   * `@variable` flag computed (or passed) at construction. */
   isVariable(): boolean {
-    return (
-      this.parts.years !== 0 ||
-      this.parts.months !== 0 ||
-      this.parts.weeks !== 0 ||
-      this.parts.days !== 0
-    );
+    return this._variable;
   }
 
   // ISO 8601 output

--- a/packages/trailties/src/engine.test.ts
+++ b/packages/trailties/src/engine.test.ts
@@ -162,16 +162,21 @@ describe("Engine", () => {
       }
       expect(paths.get("lib")!.isLoadPath()).toBe(true);
       expect(paths.get("vendor")!.isLoadPath()).toBe(true);
+      expect(paths.get("app")!.isEagerLoad()).toBe(true);
+      expect(paths.get("app/models")!.isEagerLoad()).toBe(true);
+      expect(paths.get("app/views")!.isEagerLoad()).toBe(false);
     });
 
-    it("autoload_paths, autoload_once_paths, eager_load_paths are independently writable", () => {
-      const cfg = new EngineConfiguration();
+    it("autoload_paths, autoload_once_paths, eager_load_paths are independently writable", async () => {
+      // Non-existent root: paths().eagerLoad() contributes nothing, so the
+      // custom eager_load_paths entries come back alone.
+      const cfg = new EngineConfiguration("/nonexistent-engine-root");
       cfg.autoloadPaths.push("/x/auto");
       cfg.autoloadOncePaths.push("/x/once");
       cfg.eagerLoadPaths.push("/x/eager");
       expect(cfg.allAutoloadPaths()).toEqual(["/x/auto"]);
       expect(cfg.allAutoloadOncePaths()).toEqual(["/x/once"]);
-      expect(cfg.allEagerLoadPaths()).toEqual(["/x/eager"]);
+      expect(await cfg.allEagerLoadPaths()).toEqual(["/x/eager"]);
     });
   });
 

--- a/packages/trailties/src/engine/configuration.ts
+++ b/packages/trailties/src/engine/configuration.ts
@@ -55,13 +55,13 @@ export class EngineConfiguration extends RailtieConfiguration {
   paths(): Root {
     if (this._paths) return this._paths;
     const paths = new Root(this._root);
-    paths.add("app", { glob: "{*,*/concerns}" });
+    paths.add("app", { eagerLoad: true, glob: "{*,*/concerns}" });
     paths.add("app/assets", { glob: "*" });
-    paths.add("app/controllers");
-    paths.add("app/channels");
-    paths.add("app/helpers");
-    paths.add("app/models");
-    paths.add("app/mailers");
+    paths.add("app/controllers", { eagerLoad: true });
+    paths.add("app/channels", { eagerLoad: true });
+    paths.add("app/helpers", { eagerLoad: true });
+    paths.add("app/models", { eagerLoad: true });
+    paths.add("app/mailers", { eagerLoad: true });
     paths.add("app/views");
     paths.add("lib", { loadPath: true });
     paths.add("lib/assets", { glob: "*" });
@@ -95,8 +95,11 @@ export class EngineConfiguration extends RailtieConfiguration {
   allAutoloadOncePaths(): string[] {
     return [...this.autoloadOncePaths];
   }
-  /** @internal */
-  allEagerLoadPaths(): string[] {
-    return [...this.eagerLoadPaths];
+  /** Mirrors Rails `all_eager_load_paths` (engine/configuration.rb:133-135):
+   * `eager_load_paths + paths.eager_load`. Async because trails'
+   * `Paths::Root#eagerLoad` resolves existent paths via async fs.
+   * @internal */
+  async allEagerLoadPaths(): Promise<string[]> {
+    return [...this.eagerLoadPaths, ...(await this.paths().eagerLoad())];
   }
 }

--- a/packages/trailties/src/engine/configuration.ts
+++ b/packages/trailties/src/engine/configuration.ts
@@ -55,7 +55,11 @@ export class EngineConfiguration extends RailtieConfiguration {
   paths(): Root {
     if (this._paths) return this._paths;
     const paths = new Root(this._root);
-    paths.add("app", { eagerLoad: true, glob: "{*,*/concerns}" });
+    paths.add("app", {
+      eagerLoad: true,
+      glob: "{*,*/concerns}",
+      exclude: ["assets", this.javascriptPath],
+    });
     paths.add("app/assets", { glob: "*" });
     paths.add("app/controllers", { eagerLoad: true });
     paths.add("app/channels", { eagerLoad: true });

--- a/packages/trailties/src/paths.ts
+++ b/packages/trailties/src/paths.ts
@@ -5,11 +5,12 @@ export interface PathOptions {
   with?: string | string[];
   glob?: string;
   loadPath?: boolean;
+  eagerLoad?: boolean;
 }
 
-// Port of railties/lib/rails/paths.rb. Autoload / eager-load APIs are
-// intentionally omitted (ESM + bundlers cover those concerns); only
-// load_path / load_paths are kept.
+// Port of railties/lib/rails/paths.rb. Autoload APIs are intentionally
+// omitted (ESM + bundlers cover those concerns); load_path / load_paths and
+// eager_load are kept.
 export class Root {
   path: string | null;
   _entries: Map<string, Path> = new Map();
@@ -38,6 +39,24 @@ export class Root {
     return Array.from(new Set(this._entries.values()));
   }
 
+  /** Mirrors Rails `Paths::Root#eager_load` (`filter_by(&:eager_load?)`,
+   * paths.rb): existent paths of eager-load entries, minus those claimed by a
+   * non-eager-load child entry. */
+  async eagerLoad(): Promise<string[]> {
+    const out: string[] = [];
+    for (const node of this.allPaths()) {
+      if (!node.isEagerLoad()) continue;
+      const paths = await node.existent();
+      const excluded = new Set<string>();
+      for (const child of node.children()) {
+        if (child.isEagerLoad()) continue;
+        for (const p of await child.existent()) excluded.add(p);
+      }
+      for (const p of paths) if (!excluded.has(p)) out.push(p);
+    }
+    return Array.from(new Set(out));
+  }
+
   async loadPaths(): Promise<string[]> {
     const out: string[] = [];
     for (const node of this.allPaths()) {
@@ -60,6 +79,7 @@ export class Path {
   private _current: string;
   private _root: Root;
   private _loadPath = false;
+  private _eagerLoad = false;
 
   constructor(root: Root, current: string, paths: string[], options: PathOptions = {}) {
     this._root = root;
@@ -67,6 +87,7 @@ export class Path {
     this._paths = [...paths];
     this.glob = options.glob;
     this._loadPath = !!options.loadPath;
+    this._eagerLoad = !!options.eagerLoad;
   }
 
   children(): Path[] {
@@ -81,6 +102,13 @@ export class Path {
   }
   isLoadPath(): boolean {
     return this._loadPath;
+  }
+
+  eagerLoadBang(): void {
+    this._eagerLoad = true;
+  }
+  isEagerLoad(): boolean {
+    return this._eagerLoad;
   }
 
   push(p: string): void {

--- a/packages/trailties/src/paths.ts
+++ b/packages/trailties/src/paths.ts
@@ -6,6 +6,7 @@ export interface PathOptions {
   glob?: string;
   loadPath?: boolean;
   eagerLoad?: boolean;
+  exclude?: string[];
 }
 
 // Port of railties/lib/rails/paths.rb. Autoload APIs are intentionally
@@ -40,19 +41,19 @@ export class Root {
   }
 
   /** Mirrors Rails `Paths::Root#eager_load` (`filter_by(&:eager_load?)`,
-   * paths.rb): existent paths of eager-load entries, minus those claimed by a
-   * non-eager-load child entry. */
+   * paths.rb:93-110): existent directories of eager-load entries, minus those
+   * claimed by a non-eager-load child entry. */
   async eagerLoad(): Promise<string[]> {
     const out: string[] = [];
     for (const node of this.allPaths()) {
       if (!node.isEagerLoad()) continue;
-      const paths = await node.existent();
+      const dirs = await node.existentDirectories();
       const excluded = new Set<string>();
       for (const child of node.children()) {
         if (child.isEagerLoad()) continue;
-        for (const p of await child.existent()) excluded.add(p);
+        for (const d of await child.existentDirectories()) excluded.add(d);
       }
-      for (const p of paths) if (!excluded.has(p)) out.push(p);
+      for (const d of dirs) if (!excluded.has(d)) out.push(d);
     }
     return Array.from(new Set(out));
   }
@@ -80,6 +81,7 @@ export class Path {
   private _root: Root;
   private _loadPath = false;
   private _eagerLoad = false;
+  private _exclude: string[] | undefined;
 
   constructor(root: Root, current: string, paths: string[], options: PathOptions = {}) {
     this._root = root;
@@ -88,6 +90,7 @@ export class Path {
     this.glob = options.glob;
     this._loadPath = !!options.loadPath;
     this._eagerLoad = !!options.eagerLoad;
+    this._exclude = options.exclude;
   }
 
   children(): Path[] {
@@ -129,7 +132,10 @@ export class Path {
     for (const raw of this._paths) {
       const abs = path.resolve(this._root.path, raw);
       if (this.glob && (await isDir(fs, abs))) {
-        const files = await fsGlob(this.glob, { cwd: abs });
+        // Mirrors Rails Path#files_in (paths.rb:238-240): the exclude list is
+        // subtracted from the relative glob results before joining.
+        let files = await fsGlob(this.glob, { cwd: abs });
+        if (this._exclude) files = files.filter((f) => !this._exclude!.includes(f));
         out.push(...files.map((f) => path.join(abs, f)).sort());
       } else {
         out.push(abs);

--- a/scripts/api-compare/call-mismatches-wide-exclude/activemodel/dirty.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activemodel/dirty.json
@@ -2,13 +2,6 @@
   {
     "package": "activemodel",
     "tsFile": "dirty.ts",
-    "rubyName": "as_json",
-    "call": "merge",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails dirty.rb:264-268 merges mutation-tracker ivars into `options[:except]` and defers to the model serializer via super; trails dirty.ts:111-113 returns `this.changes` — the mixin has no super() JSON pipeline. Contract divergence tracked in story activesupport-activemodel-omissions-from-wide-verify."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "dirty.ts",
     "rubyName": "attribute_change",
     "call": "change_to_attribute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activesupport/cache.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activesupport/cache.json
@@ -88,14 +88,14 @@
     "tsFile": "cache.ts",
     "rubyName": "namespace_key",
     "call": "call",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails cache.rb:948-968 supports per-call :namespace overrides (call_options.key?) and callable namespaces (namespace.call); trails cache/entry-record.ts:19-21 namespaceKey takes an already-resolved string namespace — callers resolve options first, and callable namespaces are unported. Gap tracked in story activesupport-activemodel-omissions-from-wide-verify."
+    "reason": "Converged (RFC 0032): trails store.ts namespaceKey invokes callable namespaces via `ns = (ns as () => string)()` — a call expression on a local, which the extractor does not record as a named call."
   },
   {
     "package": "activesupport",
     "tsFile": "cache.ts",
     "rubyName": "namespace_key",
     "call": "key?",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails cache.rb:948-968 supports per-call :namespace overrides (call_options.key?) and callable namespaces (namespace.call); trails cache/entry-record.ts:19-21 namespaceKey takes an already-resolved string namespace — callers resolve options first, and callable namespaces are unported. Gap tracked in story activesupport-activemodel-omissions-from-wide-verify."
+    "reason": "Converged (RFC 0032): trails store.ts namespaceKey checks the per-call override with the `\"namespace\" in callOptions` operator — the JS spelling of Ruby's `key?`; the extractor sees no call."
   },
   {
     "package": "activesupport",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activesupport/duration.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activesupport/duration.json
@@ -46,14 +46,14 @@
     "tsFile": "duration.ts",
     "rubyName": "initialize",
     "call": "any?",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails duration.rb:226-234 rejects zero parts and computes @variable via `parts.any? { VARIABLE_PARTS.include?(part) }`; trails duration.ts:54-65 stores a fixed normalized parts record — variable-duration tracking is unported. Gap tracked in story activesupport-activemodel-omissions-from-wide-verify."
+    "reason": "Converged (RFC 0032): trails duration.ts constructor computes the variable flag via `VARIABLE_PARTS.some((part) => this.parts[part] !== 0)` — `Array#some` is the JS spelling of Ruby's `any?`; the extractor does not map the name."
   },
   {
     "package": "activesupport",
     "tsFile": "duration.ts",
     "rubyName": "initialize",
     "call": "include?",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails duration.rb:226-234 rejects zero parts and computes @variable via `parts.any? { VARIABLE_PARTS.include?(part) }`; trails duration.ts:54-65 stores a fixed normalized parts record — variable-duration tracking is unported. Gap tracked in story activesupport-activemodel-omissions-from-wide-verify."
+    "reason": "Converged (RFC 0032): Rails iterates parts and asks `VARIABLE_PARTS.include?(part)`; trails inverts the loop (`VARIABLE_PARTS.some(...)` over the fixed parts record), so membership is the iteration itself — no include? call exists to match."
   },
   {
     "package": "activesupport",

--- a/scripts/api-compare/call-mismatches-wide-exclude/trailties/engine/configuration.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/trailties/engine/configuration.json
@@ -2,13 +2,6 @@
   {
     "package": "trailties",
     "tsFile": "engine/configuration.ts",
-    "rubyName": "all_eager_load_paths",
-    "call": "eager_load",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails engine/configuration.rb:133-135 unions `eager_load_paths + paths.eager_load`; trails engine/configuration.ts:99-101 returns only `[...this.eagerLoadPaths]` — the Paths#eager_load contribution is unported (trails' paths registry carries no eager-load flags). Gap tracked in story activesupport-activemodel-omissions-from-wide-verify."
-  },
-  {
-    "package": "trailties",
-    "tsFile": "engine/configuration.ts",
     "rubyName": "generators",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Converges the four omissions found by per-entry wide-call verification in the
activesupport/activemodel/trailties cluster (RFC 0032).

- **`ActiveSupport::Duration#initialize`** (duration.rb:226-234): ports
  `@variable` tracking — `VARIABLE_PARTS` constant, an optional `variable`
  constructor argument, and `isVariable()` now reads the stored flag. The
  zero-part `reject!` has no direct analogue (trails' `parts` is a fixed full
  record); the nonzero filter in the variable computation stands in, justified
  at the call site.
- **`Cache::Store#namespace_key`** (cache.rb:948-968): a per-call `:namespace`
  key now wins even when nil (`call_options&.key?` semantics instead of a
  nil-coalescing fallback). Ports the previously-skipped
  `CacheStoreNamespaceTest` tests (static/proc namespace, delete matched);
  `MemoryStore`'s constructor accepts callable namespaces.
- **`ActiveModel::Dirty#as_json`** (dirty.rb:264-268): deletes the invented
  `DirtyTracker#asJson` (returned `this.changes`, a different contract, no
  callers). Rails' method only hides the mutation-tracker ivars from Ruby's
  default serializer; trails `Model#asJson` serializes via `serializableHash`
  and never exposes the tracker, so the exclusion is inherent.
- **`Engine::Configuration#all_eager_load_paths`**
  (engine/configuration.rb:133-135): now unions `paths.eager_load` — adds
  `eager_load` flag machinery to `Paths::Root`/`Path` (filter_by shape) and
  marks the default `app*` paths eager-load as Rails does; async because the
  paths registry resolves existent paths through async fs.

Wide-exclude entries for all four are updated: converged entries removed, and
the calls the extractor cannot see as JS idioms (`in` operator, invoking a
local, `Array#some`) re-baselined with converged-equivalence reasons.
`pnpm api:calls:wide` passes.

Closes-story: activesupport-activemodel-omissions-from-wide-verify
