### PR TITLE
test(arel): strengthen gt_any/not_eq_all/not_eq_any toContain assertions to exact Rails SQL

### DIFF
--- a/packages/arel/src/attributes/attribute.test.ts
+++ b/packages/arel/src/attributes/attribute.test.ts
@@ -1247,7 +1247,9 @@ describe("AttributeTest", () => {
       const relation = new Table("users");
       const mgr = relation.project(relation.get("id"));
       mgr.where(relation.get("id").gtAny([1, 2]));
-      expect(mgr.toSql()).toContain("OR");
+      expect(mgr.toSql()).toBe(
+        `SELECT "users"."id" FROM "users" WHERE ("users"."id" > 1 OR "users"."id" > 2)`,
+      );
     });
   });
 
@@ -1261,7 +1263,9 @@ describe("AttributeTest", () => {
       const relation = new Table("users");
       const mgr = relation.project(relation.get("id"));
       mgr.where(relation.get("id").notEqAll([1, 2]));
-      expect(mgr.toSql()).toContain("AND");
+      expect(mgr.toSql()).toBe(
+        `SELECT "users"."id" FROM "users" WHERE ("users"."id" != 1 AND "users"."id" != 2)`,
+      );
     });
   });
 
@@ -1275,7 +1279,9 @@ describe("AttributeTest", () => {
       const relation = new Table("users");
       const mgr = relation.project(relation.get("id"));
       mgr.where(relation.get("id").notEqAny([1, 2]));
-      expect(mgr.toSql()).toContain("OR");
+      expect(mgr.toSql()).toBe(
+        `SELECT "users"."id" FROM "users" WHERE ("users"."id" != 1 OR "users"."id" != 2)`,
+      );
     });
   });
 });


### PR DESCRIPTION
Strengthens the three surviving weak `toContain("OR"/"AND")` assertions in `packages/arel/src/attributes/attribute.test.ts` to Rails' exact `must_be_like` SQL (attribute_test.rb:39-46, 55-62, 109-116):

- `#gt_any` "should generate ORs in sql"
- `#not_eq_all` "should generate ANDs in sql"
- `#not_eq_any` "should generate ORs in sql"

No test renamed; test:compare matched count unchanged.

Closes-story: arel-attribute-test-weak-tocontain-assertions
