### PR TITLE
refactor(model-schema): drop columnNames abstract-class fallback invention

### DIFF
--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -81,8 +81,8 @@ function getModelColumns(modelClass: any): string[] {
       ch = undefined;
     }
   }
-  // columnNames() is now plain `Object.keys(columnsHash())`, so when
-  // columnsHash() threw above (abstract / no table) it would throw here too.
+  // No columnNames() fallback: it would throw exactly like the caught
+  // columnsHash() above (abstract / no table).
   const cols: string[] = ch ? Object.keys(ch) : [];
   // A falsy primaryKey ("" / null) marks a no-primary-key model — there is no
   // PK column to fold into the SELECT list, so leave the columns as-is.

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -81,7 +81,9 @@ function getModelColumns(modelClass: any): string[] {
       ch = undefined;
     }
   }
-  const cols: string[] = ch ? Object.keys(ch) : (modelClass.columnNames?.() ?? []);
+  // columnNames() is now plain `Object.keys(columnsHash())`, so when
+  // columnsHash() threw above (abstract / no table) it would throw here too.
+  const cols: string[] = ch ? Object.keys(ch) : [];
   // A falsy primaryKey ("" / null) marks a no-primary-key model — there is no
   // PK column to fold into the SELECT list, so leave the columns as-is.
   const pk = modelClass.primaryKey;

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -611,6 +611,7 @@ export function pkAttribute(this: InstanceMethodHost, name: string): boolean {
 
 interface AttributeNamesHost {
   _attributeDefinitions: { keys(): Iterable<string>; has(name: string): boolean };
+  abstractClass?: boolean;
   columnNames?(): string[];
 }
 
@@ -629,7 +630,7 @@ interface AttributeNamesHost {
 export function attributeNames(this: AttributeNamesHost): string[] {
   // Rails attribute_methods.rb:236-241: `if !abstract_class? && table_exists?`
   // — an abstract class has no attribute names at all.
-  if ((this as { abstractClass?: boolean }).abstractClass) return [];
+  if (this.abstractClass) return [];
   const declared = [...this._attributeDefinitions.keys()];
   const columnNames = this.columnNames?.() ?? [];
   if (columnNames.length === 0) return declared;

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -15,6 +15,7 @@ import { queryAttribute as _queryAttribute } from "./attribute-methods/query.js"
 // toKey/id: inline to avoid a circular dependency (primary-key.ts imports
 // dangerousAttributeMethods from this file)
 import { reload as _reload } from "./persistence.js";
+import { cachedTableExists } from "./model-schema.js";
 import {
   serializableHash as _serializableHash,
   attributeNamesForSerialization as _attrNamesForSerialization,
@@ -628,12 +629,12 @@ interface AttributeNamesHost {
  * declaration order.
  */
 export function attributeNames(this: AttributeNamesHost): string[] {
-  // Rails attribute_methods.rb:236-241: `if !abstract_class? && table_exists?`
-  // — an abstract class has no attribute names at all. The table_exists? half
-  // is unportable here (trails' tableExists is async); an absent table's
-  // columnsHash is empty, so Rails' NonExistentTable case (base_test.rb:1638)
-  // still yields [] via the declared/columnNames merge below.
-  if (this.abstractClass) return [];
+  // Rails attribute_methods.rb:236-241: `if !abstract_class? && table_exists?`.
+  // trails' tableExists is async, so the table_exists? half runs off the
+  // schema cache's already-resolved answer — `false` only after a
+  // dataSourceExists miss; a cold/unknown table falls through (fail-open,
+  // where Rails' sync DB hit would return []).
+  if (this.abstractClass || cachedTableExists.call(this as never) === false) return [];
   const declared = [...this._attributeDefinitions.keys()];
   const columnNames = this.columnNames?.() ?? [];
   if (columnNames.length === 0) return declared;

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -629,7 +629,10 @@ interface AttributeNamesHost {
  */
 export function attributeNames(this: AttributeNamesHost): string[] {
   // Rails attribute_methods.rb:236-241: `if !abstract_class? && table_exists?`
-  // — an abstract class has no attribute names at all.
+  // — an abstract class has no attribute names at all. The table_exists? half
+  // is unportable here (trails' tableExists is async); an absent table's
+  // columnsHash is empty, so Rails' NonExistentTable case (base_test.rb:1638)
+  // still yields [] via the declared/columnNames merge below.
   if (this.abstractClass) return [];
   const declared = [...this._attributeDefinitions.keys()];
   const columnNames = this.columnNames?.() ?? [];

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -627,6 +627,9 @@ interface AttributeNamesHost {
  * declaration order.
  */
 export function attributeNames(this: AttributeNamesHost): string[] {
+  // Rails attribute_methods.rb:236-241: `if !abstract_class? && table_exists?`
+  // — an abstract class has no attribute names at all.
+  if ((this as { abstractClass?: boolean }).abstractClass) return [];
   const declared = [...this._attributeDefinitions.keys()];
   const columnNames = this.columnNames?.() ?? [];
   if (columnNames.length === 0) return declared;

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -1612,7 +1612,9 @@ describe("BasicsTest", () => {
         this.attribute("name", "string");
       }
     }
-    expect(AbstractModel.attributeNames()).toContain("name");
+    // Rails base_test.rb test_attribute_names_on_abstract_class:
+    // `assert_equal [], AbstractCompany.attribute_names`.
+    expect(AbstractModel.attributeNames()).toEqual([]);
   });
   it("table name with 2 abstract subclasses", () => {
     class AbstractBase extends Base {

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -1615,6 +1615,11 @@ describe("BasicsTest", () => {
     // Rails: `assert_equal [], AbstractCompany.attribute_names` (base_test.rb:1642).
     expect(AbstractModel.attributeNames()).toEqual([]);
   });
+  it("attribute names on table not exists", () => {
+    // Rails: `assert_equal [], NonExistentTable.attribute_names` (base_test.rb:1638).
+    class NonExistentTable extends Base {}
+    expect(NonExistentTable.attributeNames()).toEqual([]);
+  });
   it("table name with 2 abstract subclasses", () => {
     class AbstractBase extends Base {
       static {

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -1612,8 +1612,7 @@ describe("BasicsTest", () => {
         this.attribute("name", "string");
       }
     }
-    // Rails base_test.rb test_attribute_names_on_abstract_class:
-    // `assert_equal [], AbstractCompany.attribute_names`.
+    // Rails: `assert_equal [], AbstractCompany.attribute_names` (base_test.rb:1642).
     expect(AbstractModel.attributeNames()).toEqual([]);
   });
   it("table name with 2 abstract subclasses", () => {

--- a/packages/activerecord/src/base.trails.test.ts
+++ b/packages/activerecord/src/base.trails.test.ts
@@ -299,6 +299,23 @@ describe("BasicsTest (trails)", () => {
   });
 });
 
+describe("attribute_names table_exists? guard (trails)", () => {
+  fixtures([]);
+
+  it("attributeNames is [] for a declared attribute once the cache resolves the table absent", async () => {
+    class DeclaredNonExistent extends Base {
+      static tableName = "non_existent_tables";
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    // Populate the schema cache's dataSourceExists=false entry — the sync
+    // stand-in for Rails' table_exists? DB hit (attribute_methods.rb:236-241).
+    expect(await DeclaredNonExistent.tableExists()).toBe(false);
+    expect(DeclaredNonExistent.attributeNames()).toEqual([]);
+  });
+});
+
 // Rails removes ignored columns only from schema/default `attribute_types`
 // (`columns_hash.except(*ignored_columns)`), NOT from a raw result row: a
 // `SELECT *` that projects an ignored column still lands it in `@attributes`

--- a/packages/activerecord/src/base.trails.test.ts
+++ b/packages/activerecord/src/base.trails.test.ts
@@ -285,9 +285,8 @@ describe("BasicsTest (trails)", () => {
   });
 
   it("columnNames raises TableNotSpecified on an abstract class", () => {
-    // Rails column_names is `columns.map(&:name)` with no abstract-class
-    // fallback — load_schema! raises TableNotSpecified (model_schema.rb:444-446,
-    // 561). Guards against reintroducing the invented attribute-walk branch.
+    // Rails column_names has no abstract-class fallback — load_schema! raises
+    // TableNotSpecified. Guards against reintroducing the attribute-walk branch.
     class AbstractIntrospected extends Base {
       static {
         this.abstractClass = true;

--- a/packages/activerecord/src/base.trails.test.ts
+++ b/packages/activerecord/src/base.trails.test.ts
@@ -283,6 +283,21 @@ describe("BasicsTest (trails)", () => {
     const exists = await Ghost.tableExists();
     expect(exists).toBe(true);
   });
+
+  it("columnNames raises TableNotSpecified on an abstract class", () => {
+    // Rails column_names is `columns.map(&:name)` with no abstract-class
+    // fallback — load_schema! raises TableNotSpecified (model_schema.rb:444-446,
+    // 561). Guards against reintroducing the invented attribute-walk branch.
+    class AbstractIntrospected extends Base {
+      static {
+        this.abstractClass = true;
+        this.attribute("name", "string");
+      }
+    }
+    expect(() => AbstractIntrospected.columnNames()).toThrow(
+      "AbstractIntrospected has no table configured",
+    );
+  });
 });
 
 // Rails removes ignored columns only from schema/default `attribute_types`

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -289,6 +289,16 @@ export class SchemaCache {
   }
 
   /**
+   * Synchronous, query-free read of an already-resolved data-source existence
+   * check. `undefined` when this table has never been checked (a warm cache
+   * only seeds `true` for tables it saw — an unchecked absent table is not
+   * `false` here until `dataSourceExists` misses on it).
+   */
+  getCachedDataSourceExists(name: string): boolean | undefined {
+    return this._dataSourceExists.get(name);
+  }
+
+  /**
    * Synchronous, query-free read of an already-cached primary key. Returns
    * `undefined` when the table's primary key has not been reflected yet (the
    * caller should fall back to the convention default), or the cached value

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1604,6 +1604,26 @@ export function columnDefaults(this: SchemaHost): Record<string, unknown> {
   return this._defaultAttributes().deepDup().toHash();
 }
 
+/**
+ * Synchronous, cache-only view of `tableExists`: `false` only when the schema
+ * cache has already resolved this table as absent, `undefined` when unknown
+ * (cold cache / no adapter). Sync callers of Rails' `table_exists?` guard
+ * (class-level `attribute_names`) use this since `tableExists` is async.
+ *
+ * @internal
+ */
+export function cachedTableExists(this: SchemaHost): boolean | undefined {
+  let conn: any;
+  try {
+    conn = reflectionAdapter(this);
+  } catch {
+    return undefined;
+  }
+  const cache = conn?.schemaCache;
+  if (!cache || typeof cache.getCachedDataSourceExists !== "function") return undefined;
+  return cache.getCachedDataSourceExists(this.tableName);
+}
+
 export async function tableExists(this: SchemaHost): Promise<boolean> {
   const conn = reflectionAdapter(this);
   const cache = conn.schemaCache;

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -205,7 +205,10 @@ export function buildWhereNodeFromConstraints(
  * Return column names for a model, excluding ignored columns.
  *
  * Mirrors: ActiveRecord::ModelSchema::ClassMethods#column_names
- * (`columns.map(&:name)`, i.e. the `columns_hash` keys).
+ * (`columns.map(&:name)`). Reads `columnsHash()` keys rather than `columns()`
+ * because trails applies the `ignoredColumns` filter at read time in
+ * `columnsHash()` (Rails filters at load), and `columns()`' `_columns` memo
+ * would bypass it after an `ignoredColumns=` reassignment.
  */
 export function columnNames(this: typeof Base): string[] {
   return Object.keys(this.columnsHash());

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -208,19 +208,6 @@ export function buildWhereNodeFromConstraints(
  * (`columns.map(&:name)`, i.e. the `columns_hash` keys).
  */
 export function columnNames(this: typeof Base): string[] {
-  // Abstract classes have no concrete table, and `columnsHash` throws for them.
-  // Fall back to the declared (non-virtual) attribute names so introspecting an
-  // abstract model doesn't blow up — matches the pre-columnsHash behavior.
-  if (this.abstractClass) {
-    const ignored = new Set(this.ignoredColumns ?? []);
-    const out: string[] = [];
-    for (const [name, def] of this._attributeDefinitions) {
-      if (ignored.has(name)) continue;
-      if ((def as { virtual?: boolean }).virtual) continue;
-      out.push(name);
-    }
-    return out;
-  }
   return Object.keys(this.columnsHash());
 }
 


### PR DESCRIPTION
Rails' `column_names` is just `@column_names ||= columns.map(&:name)` (`model_schema.rb:444-446`) with no abstract-class special case — calling it on an abstract class raises `TableNotSpecified` via `load_schema!`. trails' `ModelSchema.columnNames` carried an invented fallback that walked `_attributeDefinitions` for abstract classes instead of raising.

Changes:

- `model-schema.ts`: `columnNames` is now plain `Object.keys(columnsHash())` — raises `TableNotSpecified` for abstract classes like Rails.
- `attribute-methods.ts`: class-level `attributeNames` gains Rails' abstract guard (`attribute_methods.rb:236-241`) returning `[]` — this was the one caller that leaned on the fallback (via `base.test.ts` "attribute names on abstract class", whose assertion now matches Rails' `test_attribute_names_on_abstract_class`: `assert_equal [], AbstractCompany.attribute_names`).
- `join-dependency.ts`: `getModelColumns`'s `columnNames()` fallback after a caught `columnsHash()` throw would now throw identically — replaced with `[]`.
- Regression test in `base.trails.test.ts` asserting `columnNames` raises on an abstract class (fails on baseline, which returned attribute names).

Other callers (`classHasAttribute`, timestamps, encryption) either already guard `abstractClass` or only run on concrete models.

Closes-story: columnnames-abstract-class-fallback-invention

**Codex review — `table_exists?` half of the `attribute_names` guard:** trails' `tableExists` is async (`model-schema.ts:1607`), so the guard can't call it synchronously. Rails' covered scenario (`test_attribute_names_on_table_not_exists`, `base_test.rb:1638`) still yields `[]` here: an absent table has an empty `columnsHash` and no declared attributes, so the declared/columnNames merge returns `[]`. Ported that Rails test verbatim to `base.test.ts` and documented the deviation at the call site.

**Codex round 2 — declared-attribute leak:** fixed rather than justified. The `table_exists?` half now runs off a new sync, query-free `SchemaCache#getCachedDataSourceExists` (reads the `_dataSourceExists` map `dataSourceExists` already maintains), surfaced as `ModelSchema.cachedTableExists`. `attributeNames` returns `[]` when the cache has resolved the table absent; a cold/unchecked table fails open (trails cannot make Rails' sync DB hit). Covered by a new trails test: declared attribute + `await tableExists()` (caches `false`) → `attributeNames() === []`.
