### PR TITLE
test(migration): port assert_queries_count to bulk_alter changing-columns tests

### DIFF
--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -2156,6 +2156,15 @@ describe("MigrationTest", () => {
 // adapter-generic createTable/changeTable surface, exactly like Rails'
 // `@connection.create_table(:delete_me, force: true)` + with_bulk_change_table.
 describeIfSupports("bulk_alter", "BulkAlterTableMigrationsTest", () => {
+  // Mirrors the tests' `{ "Mysql2Adapter" => …, … }.fetch(classname) { raise … }`
+  // expected-query-count hashes (migration_test.rb:1236 et al.).
+  function expectedBulkAlterQueryCount(counts: { mysql: number; postgres: number }): number {
+    if (adapterType !== "mysql" && adapterType !== "postgres") {
+      throw new Error(`need an expected query count for ${adapterType}`);
+    }
+    return counts[adapterType];
+  }
+
   let adapter: DatabaseAdapter;
   beforeEach(async () => {
     adapter = await freshAdapter();
@@ -2174,13 +2183,11 @@ describeIfSupports("bulk_alter", "BulkAlterTableMigrationsTest", () => {
     expect(cols.find((c) => c.name === "name")!.default).toBeFalsy();
     expect(cols.find((c) => c.name === "birthdate")!.type).toBe("date");
 
-    // migration_test.rb:1403 — Mysql2Adapter 3 (columns + primary key + bulk
-    // change), PostgreSQLAdapter 3. Rails' third PG query is a
-    // `SELECT 'character varying'::regtype::oid` type-map miss issued by
-    // quote_default_expression while composing the ALTER; trails' PG type map
-    // is statically initialized and never issues that lookup, so the PG count
-    // here is 2 (bulk change + comment).
-    const expectedQueryCount = { mysql: 3, postgres: 2 }[adapterType as "mysql" | "postgres"];
+    // migration_test.rb:1403 expects 3 on both adapters, but Rails' third PG
+    // query is a `SELECT 'character varying'::regtype::oid` type-map miss from
+    // quote_default_expression (postgresql/schema_creation.rb:102); trails'
+    // statically initialized PG type map never issues it, so PG counts 2.
+    const expectedQueryCount = expectedBulkAlterQueryCount({ mysql: 3, postgres: 2 });
     await assertQueriesCount(expectedQueryCount, true, async () => {
       await adapter.changeTable("delete_me", { bulk: true }, (t: any) => {
         t.change("name", "string", { default: "NONAME" });
@@ -2205,12 +2212,9 @@ describeIfSupports("bulk_alter", "BulkAlterTableMigrationsTest", () => {
     expect(preCols.find((c) => c.name === "name")!.default).toBeFalsy();
     expect(preCols.find((c) => c.name === "birthdate")!.type).toBe("date");
 
-    // migration_test.rb:1433 — Mysql2Adapter 7 (four schema-info queries +
-    // bulk change + UPDATE + NOT NULL), PostgreSQLAdapter 5. As in "changing
-    // columns" above, one of Rails' PG queries is the `::regtype::oid`
-    // type-map miss trails never issues, so the PG count here is 4
-    // (bulk change + columns lookup + UPDATE + NOT NULL).
-    const expectedQueryCount = { mysql: 7, postgres: 4 }[adapterType as "mysql" | "postgres"];
+    // migration_test.rb:1433 expects 7/5; PG counts 4 because trails skips the
+    // `::regtype::oid` type-map miss noted in "changing columns" above.
+    const expectedQueryCount = expectedBulkAlterQueryCount({ mysql: 7, postgres: 4 });
     await assertQueriesCount(expectedQueryCount, true, async () => {
       await adapter.changeTable("delete_me", { bulk: true }, (t: any) => {
         t.change("name", "string", { default: "NONAME" });

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -11,6 +11,7 @@ import { SchemaMigration } from "./schema-migration.js";
 import type { MigrationProxy } from "./migration.js";
 import { ConcurrentMigrationError } from "./migration.js";
 import { adapterType } from "./test-adapter.js";
+import { assertQueriesCount } from "./testing/query-assertions.js";
 import { quoteDefaultExpression } from "./connection-adapters/abstract/quoting.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import { Migration } from "./migration.js";
@@ -2173,9 +2174,18 @@ describeIfSupports("bulk_alter", "BulkAlterTableMigrationsTest", () => {
     expect(cols.find((c) => c.name === "name")!.default).toBeFalsy();
     expect(cols.find((c) => c.name === "birthdate")!.type).toBe("date");
 
-    await adapter.changeTable("delete_me", { bulk: true }, (t: any) => {
-      t.change("name", "string", { default: "NONAME" });
-      t.change("birthdate", "datetime", { comment: "This is a comment" });
+    // migration_test.rb:1403 — Mysql2Adapter 3 (columns + primary key + bulk
+    // change), PostgreSQLAdapter 3. Rails' third PG query is a
+    // `SELECT 'character varying'::regtype::oid` type-map miss issued by
+    // quote_default_expression while composing the ALTER; trails' PG type map
+    // is statically initialized and never issues that lookup, so the PG count
+    // here is 2 (bulk change + comment).
+    const expectedQueryCount = { mysql: 3, postgres: 2 }[adapterType as "mysql" | "postgres"];
+    await assertQueriesCount(expectedQueryCount, true, async () => {
+      await adapter.changeTable("delete_me", { bulk: true }, (t: any) => {
+        t.change("name", "string", { default: "NONAME" });
+        t.change("birthdate", "datetime", { comment: "This is a comment" });
+      });
     });
     cols = await adapter.columns("delete_me");
     const name = cols.find((c) => c.name === "name")!;
@@ -2195,10 +2205,18 @@ describeIfSupports("bulk_alter", "BulkAlterTableMigrationsTest", () => {
     expect(preCols.find((c) => c.name === "name")!.default).toBeFalsy();
     expect(preCols.find((c) => c.name === "birthdate")!.type).toBe("date");
 
-    await adapter.changeTable("delete_me", { bulk: true }, (t: any) => {
-      t.change("name", "string", { default: "NONAME" });
-      t.change("birthdate", "datetime");
-      t.changeNull("age", false, 0);
+    // migration_test.rb:1433 — Mysql2Adapter 7 (four schema-info queries +
+    // bulk change + UPDATE + NOT NULL), PostgreSQLAdapter 5. As in "changing
+    // columns" above, one of Rails' PG queries is the `::regtype::oid`
+    // type-map miss trails never issues, so the PG count here is 4
+    // (bulk change + columns lookup + UPDATE + NOT NULL).
+    const expectedQueryCount = { mysql: 7, postgres: 4 }[adapterType as "mysql" | "postgres"];
+    await assertQueriesCount(expectedQueryCount, true, async () => {
+      await adapter.changeTable("delete_me", { bulk: true }, (t: any) => {
+        t.change("name", "string", { default: "NONAME" });
+        t.change("birthdate", "datetime");
+        t.changeNull("age", false, 0);
+      });
     });
     const cols = await adapter.columns("delete_me");
     expect(String(cols.find((c) => c.name === "name")!.default)).toBe("NONAME");


### PR DESCRIPTION
Ports Rails' `assert_queries_count(…, include_schema: true)` assertions (migration_test.rb:1403-1417, 1433-1449) to the BulkAlterTableMigrationsTest "changing columns" and "changing column null with default" tests that PR #5079 converged without them.

Per-adapter expected counts, branching on `adapterType` like Rails branches on adapter class name:

- **mysql**: 3 / 7 — matches Rails' hash exactly (verified on a local mysql:8 stack).
- **postgres**: 2 / 4 — one lower than Rails' 3 / 5. Verified by running the vendored Rails tests against PG with a `sql.active_record` trace: Rails' extra query is `SELECT 'character varying'::regtype::oid`, a type-map miss issued by `quote_default_expression` in `visit_ChangeColumnDefinition` (postgresql/schema_creation.rb:102). trails' PG type map resolves `character varying` statically and never issues that lookup. The deviation is justified at the call site, and follow-up story `pg-quote-default-regtype-typemap-lookup` (RFC 0032) tracks converging the type-map lookup itself.

sqlite stays gated out via the existing `describeIfSupports("bulk_alter")` (verified: 94 skipped on the sqlite lane). Test names unchanged.

Closes-story: bulk-alter-changing-columns-query-counts
