### PR TITLE
fix(tasks): read collation from the live database in MySQL/PG database tasks

### DIFF
--- a/packages/activerecord/src/tasks/mysql-database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.test.ts
@@ -20,14 +20,15 @@ describe("MySQLDatabaseTasks", () => {
     expect(new MySQLDatabaseTasks(config({ encoding: "latin1" })).charset()).toBe("latin1");
   });
 
-  it("test_collation_reads_from_config", () => {
-    expect(new MySQLDatabaseTasks(config({ collation: "utf8mb4_general_ci" })).collation()).toBe(
-      "utf8mb4_general_ci",
-    );
-  });
-
-  it("test_collation_returns_null_when_unset", () => {
-    expect(new MySQLDatabaseTasks(config()).collation()).toBeNull();
+  it("test_db_retrieves_collation", async () => {
+    const tasks = new MySQLDatabaseTasks(config());
+    const collationMock = vi.fn(async () => "utf8mb4_general_ci");
+    vi.spyOn(
+      tasks as unknown as { connection(): Promise<unknown> },
+      "connection",
+    ).mockResolvedValue({ collation: collationMock });
+    await expect(tasks.collation()).resolves.toBe("utf8mb4_general_ci");
+    expect(collationMock).toHaveBeenCalledOnce();
   });
 
   it("test_using_database_configurations_is_true", () => {

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -117,8 +117,11 @@ export class MySQLDatabaseTasks {
     return String(this.configurationHash.encoding ?? "utf8mb4");
   }
 
-  collation(): string | null {
-    return (this.configurationHash.collation as string) ?? null;
+  async collation(): Promise<string> {
+    const conn = (await this.connection()) as DatabaseAdapter & {
+      collation(): Promise<string>;
+    };
+    return conn.collation();
   }
 
   async structureDump(filename: string, extraFlags?: string | string[] | null): Promise<void> {

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -5,7 +5,7 @@
  */
 
 import { getFs, getChildProcessAsync, type SpawnSyncResult } from "@blazetrails/activesupport";
-import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
+import type { Mysql2Adapter } from "../connection-adapters/mysql2-adapter.js";
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
 import { DatabaseAlreadyExists } from "../errors.js";
 import { Base } from "../base.js";
@@ -118,10 +118,7 @@ export class MySQLDatabaseTasks {
   }
 
   async collation(): Promise<string> {
-    const conn = (await this.connection()) as DatabaseAdapter & {
-      collation(): Promise<string>;
-    };
-    return conn.collation();
+    return (await this.connection()).collation();
   }
 
   async structureDump(filename: string, extraFlags?: string | string[] | null): Promise<void> {
@@ -320,8 +317,8 @@ export class MySQLDatabaseTasks {
     return env;
   }
 
-  private async connection(): Promise<DatabaseAdapter> {
-    return Base.connectionPool().leaseConnection();
+  private async connection(): Promise<Mysql2Adapter> {
+    return (await Base.connectionPool().leaseConnection()) as Mysql2Adapter;
   }
 
   private async runCmd(cmd: string, args: string[], action: string, stdin?: string): Promise<void> {

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.test.ts
@@ -20,12 +20,15 @@ describe("PostgreSQLDatabaseTasks", () => {
     expect(new PostgreSQLDatabaseTasks(config({ encoding: "UTF8" })).charset()).toBe("UTF8");
   });
 
-  it("test_collation_reads_from_config", () => {
-    expect(new PostgreSQLDatabaseTasks(config({ collation: "C" })).collation()).toBe("C");
-  });
-
-  it("test_collation_returns_null_when_unset", () => {
-    expect(new PostgreSQLDatabaseTasks(config()).collation()).toBeNull();
+  it("test_db_retrieves_collation", async () => {
+    const tasks = new PostgreSQLDatabaseTasks(config());
+    const collationMock = vi.fn(async () => "en_US.UTF-8");
+    vi.spyOn(
+      tasks as unknown as { connection(): Promise<unknown> },
+      "connection",
+    ).mockResolvedValue({ collation: collationMock });
+    await expect(tasks.collation()).resolves.toBe("en_US.UTF-8");
+    expect(collationMock).toHaveBeenCalledOnce();
   });
 
   it("test_using_database_configurations_is_true", () => {

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -12,6 +12,7 @@ import {
   type SpawnSyncResult,
 } from "@blazetrails/activesupport";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
+import type { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
 import type { DatabaseConfig } from "../database-configurations/database-config.js";
 import { DatabaseAlreadyExists } from "../errors.js";
 import { Base } from "../base.js";
@@ -125,10 +126,7 @@ export class PostgreSQLDatabaseTasks {
   }
 
   async collation(): Promise<string> {
-    const conn = (await this.connection()) as DatabaseAdapter & {
-      collation(): Promise<string>;
-    };
-    return conn.collation();
+    return (await this.connection()).collation();
   }
 
   async purge(): Promise<void> {
@@ -275,8 +273,8 @@ export class PostgreSQLDatabaseTasks {
     return String(this.configurationHash.encoding ?? defaultEncoding());
   }
 
-  private async connection(): Promise<DatabaseAdapter> {
-    return Base.connectionPool().leaseConnection();
+  private async connection(): Promise<PostgreSQLAdapter> {
+    return (await Base.connectionPool().leaseConnection()) as PostgreSQLAdapter;
   }
 
   private async closeAdapter(adapter: DatabaseAdapter): Promise<void> {

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -124,8 +124,11 @@ export class PostgreSQLDatabaseTasks {
     return this.encoding();
   }
 
-  collation(): string | null {
-    return (this.configurationHash.collation as string) ?? null;
+  async collation(): Promise<string> {
+    const conn = (await this.connection()) as DatabaseAdapter & {
+      collation(): Promise<string>;
+    };
+    return conn.collation();
   }
 
   async purge(): Promise<void> {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/tasks/mysql-database-tasks.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/tasks/mysql-database-tasks.json
@@ -9,13 +9,6 @@
   {
     "package": "activerecord",
     "tsFile": "tasks/mysql-database-tasks.ts",
-    "rubyName": "collation",
-    "call": "connection",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails mysql_database_tasks.rb:36-38 reads the live `connection.collation`; trails mysql-database-tasks.ts:120-122 reads `configurationHash.collation` — configured value, not the database's. Divergence tracked in story database-tasks-collation-reads-config."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/mysql-database-tasks.ts",
     "rubyName": "configuration_hash_without_database",
     "call": "merge",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/tasks/postgresql-database-tasks.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/tasks/postgresql-database-tasks.json
@@ -9,13 +9,6 @@
   {
     "package": "activerecord",
     "tsFile": "tasks/postgresql-database-tasks.ts",
-    "rubyName": "collation",
-    "call": "connection",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails postgresql_database_tasks.rb:36-38 reads the live `connection.collation`; trails postgresql-database-tasks.ts:127-129 reads `configurationHash.collation` — configured value, not the database's. Divergence tracked in story database-tasks-collation-reads-config."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/postgresql-database-tasks.ts",
     "rubyName": "create",
     "call": "create_database",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
## Summary

Rails' database tasks read collation from the live database (`connection.collation`,
`mysql_database_tasks.rb:36-38` / `postgresql_database_tasks.rb:36-38`), but trails read
the configured value (`configurationHash.collation`), so `collation()` reported nothing
for databases whose collation wasn't set in config and never reflected actual DB state.

Both tasks' `collation()` now lease a connection and delegate to the adapter's
`collation()` (already ported: MySQL `SHOW VARIABLES ... collation_database`, PG
`datcollate` from `pg_database`), matching Rails.

## Tests

Replaced the config-reading unit tests with `test_db_retrieves_collation` (mirroring
Rails' MySQL/PG rake tests), asserting the connection's `collation` is called. Ran both
files against an isolated PG/MySQL compose stack — all pass.

Closes-story: database-tasks-collation-reads-config
