### PR TITLE
refactor(encryption): converge decrypt assignments to unconditional type.deserialize

### DIFF
--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -353,17 +353,7 @@ export async function decryptRecord(record: any): Promise<void> {
   // raises Errors::Configuration when the context is frozen (protected mode).
   EncryptableRecord.validateEncryptionAllowed(record);
 
-  // Mirrors Rails build_decrypt_attribute_assignments
-  // (encryptable_record.rb:214-220): type.deserialize(ciphertext_for(name))
-  // unconditionally — for plaintext rows ciphertextFor returns the
-  // DB-serialized value and deserialize (support_unencrypted_data) passes it
-  // through cast.
-  const assignments: Record<string, unknown> = {};
-  for (const attr of encryptedAttrs) {
-    const type = getAttributeType(klass, attr) as { deserialize?: (v: unknown) => unknown };
-    const encryptedValue = EncryptableRecord.ciphertextFor(record, attr);
-    assignments[attr] = type?.deserialize ? type.deserialize(encryptedValue) : encryptedValue;
-  }
+  const assignments = EncryptableRecord.buildDecryptAttributeAssignments(record);
   await _withoutEncryption(() => record.updateColumns(assignments));
 }
 

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -353,16 +353,16 @@ export async function decryptRecord(record: any): Promise<void> {
   // raises Errors::Configuration when the context is frozen (protected mode).
   EncryptableRecord.validateEncryptionAllowed(record);
 
+  // Mirrors Rails build_decrypt_attribute_assignments
+  // (encryptable_record.rb:214-220): type.deserialize(ciphertext_for(name))
+  // unconditionally — for plaintext rows ciphertextFor returns the
+  // DB-serialized value and deserialize (support_unencrypted_data) passes it
+  // through cast.
   const assignments: Record<string, unknown> = {};
   for (const attr of encryptedAttrs) {
     const type = getAttributeType(klass, attr) as { deserialize?: (v: unknown) => unknown };
-    const encryptedType = encryptedTypeOf(type);
-    const raw = record.readAttributeBeforeTypeCast(attr);
-    if (encryptedType?.isEncrypted(raw) && type?.deserialize) {
-      assignments[attr] = type.deserialize(raw);
-    } else {
-      assignments[attr] = record.readAttribute(attr);
-    }
+    const encryptedValue = EncryptableRecord.ciphertextFor(record, attr);
+    assignments[attr] = type?.deserialize ? type.deserialize(encryptedValue) : encryptedValue;
   }
   await _withoutEncryption(() => record.updateColumns(assignments));
 }

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -642,19 +642,14 @@ export class EncryptableRecord {
     const klass = record.constructor;
     const result: Record<string, unknown> = {};
     for (const name of klass._encryptedAttributes ?? new Set<string>()) {
+      // Mirrors Rails build_decrypt_attribute_assignments
+      // (encryptable_record.rb:214-220): type.deserialize(ciphertext_for(name))
+      // unconditionally — for plaintext rows ciphertextFor returns the
+      // DB-serialized value and deserialize (support_unencrypted_data)
+      // passes it through cast.
       const type = getAttributeType(klass, name) as { deserialize?: (v: unknown) => unknown };
-      const encryptedType = encryptedTypeOf(type);
-      const raw = record.readAttributeBeforeTypeCast?.(name);
-      // Only decrypt if actually encrypted — mirrors Rails' type.deserialize
-      // which returns the raw value when support_unencrypted_data is true.
-      if (encryptedType?.isEncrypted(raw) && type?.deserialize) {
-        result[name] = type.deserialize(raw);
-      } else {
-        // Plaintext — return the cast value so typed columns (date, JSON, etc.)
-        // keep their in-memory representation rather than the raw DB string.
-        result[name] =
-          typeof record.readAttribute === "function" ? record.readAttribute(name) : raw;
-      }
+      const encryptedValue = this.ciphertextFor(record, name);
+      result[name] = type?.deserialize ? type.deserialize(encryptedValue) : encryptedValue;
     }
     return result;
   }

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -642,14 +642,9 @@ export class EncryptableRecord {
     const klass = record.constructor;
     const result: Record<string, unknown> = {};
     for (const name of klass._encryptedAttributes ?? new Set<string>()) {
-      // Mirrors Rails build_decrypt_attribute_assignments
-      // (encryptable_record.rb:214-220): type.deserialize(ciphertext_for(name))
-      // unconditionally — for plaintext rows ciphertextFor returns the
-      // DB-serialized value and deserialize (support_unencrypted_data)
-      // passes it through cast.
-      const type = getAttributeType(klass, name) as { deserialize?: (v: unknown) => unknown };
+      const type = getAttributeType(klass, name) as { deserialize: (v: unknown) => unknown };
       const encryptedValue = this.ciphertextFor(record, name);
-      result[name] = type?.deserialize ? type.deserialize(encryptedValue) : encryptedValue;
+      result[name] = type.deserialize(encryptedValue);
     }
     return result;
   }

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption/encryptable-record.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption/encryptable-record.json
@@ -38,13 +38,6 @@
     "package": "activerecord",
     "tsFile": "encryption/encryptable-record.ts",
     "rubyName": "build_decrypt_attribute_assignments",
-    "call": "ciphertext_for",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/encryptable-record.ts",
-    "rubyName": "build_decrypt_attribute_assignments",
     "call": "encrypted_attributes",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
Converges decrypt-attribute assignments to Rails' shape: `type.deserialize(ciphertext_for(name))` called unconditionally (`build_decrypt_attribute_assignments`, encryptable_record.rb:214-220).

Previously both `EncryptableRecord.buildDecryptAttributeAssignments` and `decryptRecord` branched on `encryptedType?.isEncrypted(raw)` and fell back to `record.readAttribute(name)` for plaintext rows. That was behaviorally equivalent but hid the `support_unencrypted_data` contract that Rails keeps inside the type itself: for an unencrypted value `ciphertextFor` returns the DB-serialized value (`read_attribute_for_database`) and the encrypted type's `deserialize` passes it through cast.

Both sites now resolve the full decorated type via `typeForAttribute` and call `deserialize(ciphertextFor(...))` unconditionally, mirroring Rails line-for-line.

Surfaced in #5097 review (finding 2b). Existing decrypt tests (encryptable-record, encryptable-record-api, contexts, unencrypted-attributes, encryption-schemes) pass unchanged.

Closes-story: decrypt-assignments-unconditional-deserialize
