### PR TITLE
fix(predicate-builder): preserve deferred excluding ids through DeferredIdsNotIn#invert

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -149,6 +149,7 @@ import { JoinDependency } from "./associations/join-dependency.js";
 import {
   DeferredDistinctPkIn,
   DeferredDistinctPkNotIn,
+  DeferredIdsIn,
   DeferredIdsNotIn,
 } from "./relation/predicate-builder/deferred-distinct-pk-in.js";
 import { invokeScopeLambda } from "./associations/association-scope.js";
@@ -4967,7 +4968,7 @@ export class Relation<T extends Base> {
         const ids = await node.innerRelation._materializeDistinctPkIds();
         predicates[i] =
           node instanceof DeferredDistinctPkNotIn ? attribute.notIn(ids) : attribute.in(ids);
-      } else if (node instanceof DeferredIdsNotIn) {
+      } else if (node instanceof DeferredIdsNotIn || node instanceof DeferredIdsIn) {
         const attribute = node.left as Nodes.Attribute;
         // Rails `excluding`/`without`: one predicate over
         // `records + relations.flat_map(&:ids)` (query_methods.rb:1583-1588).
@@ -4985,7 +4986,9 @@ export class Relation<T extends Base> {
         // (query_methods.rb:1587) — instead of hardcoding `NOT IN`, so the
         // materialized array shares the `where.not` array-negation logic
         // (e.g. the single-id `!=` collapse) rather than diverging.
-        predicates[i] = this.predicateBuilder.build(attribute, ids).invert();
+        // `DeferredIdsIn` (an inverted marker) stays positive: no `.invert()`.
+        const built = this.predicateBuilder.build(attribute, ids);
+        predicates[i] = node instanceof DeferredIdsNotIn ? built.invert() : built;
       }
     }
   }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -4986,7 +4986,6 @@ export class Relation<T extends Base> {
         // (query_methods.rb:1587) — instead of hardcoding `NOT IN`, so the
         // materialized array shares the `where.not` array-negation logic
         // (e.g. the single-id `!=` collapse) rather than diverging.
-        // `DeferredIdsIn` (an inverted marker) stays positive: no `.invert()`.
         const built = this.predicateBuilder.build(attribute, ids);
         predicates[i] = node instanceof DeferredIdsNotIn ? built.invert() : built;
       }

--- a/packages/activerecord/src/relation/predicate-builder/deferred-distinct-pk-in.trails.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder/deferred-distinct-pk-in.trails.test.ts
@@ -21,13 +21,10 @@ describe("DeferredIdsNotIn inversion (trails)", () => {
   it("inverting a WhereClause containing the marker preserves the deferred ids", () => {
     const original = marker();
     const inverted = new WhereClause([original]).invert().predicates[0];
-    // Must not decay to a plain In: the load pipeline materializes only the
-    // marker classes, so a plain node would silently drop literalIds and
-    // innerRelations and leave the display-fallback subquery in the SQL.
     expect(inverted).toBeInstanceOf(DeferredIdsIn);
     const invertedMarker = inverted as DeferredIdsIn;
-    expect(invertedMarker.literalIds).toEqual([1, 2]);
-    expect(invertedMarker.innerRelations).toEqual(original.innerRelations);
+    expect(invertedMarker.literalIds).toBe(original.literalIds);
+    expect(invertedMarker.innerRelations).toBe(original.innerRelations);
     expect(invertedMarker.left).toBe(original.left);
     expect(invertedMarker.right).toBe(original.right);
   });
@@ -36,7 +33,7 @@ describe("DeferredIdsNotIn inversion (trails)", () => {
     const original = marker();
     const roundTripped = original.invert().invert();
     expect(roundTripped).toBeInstanceOf(DeferredIdsNotIn);
-    expect(roundTripped.literalIds).toEqual([1, 2]);
-    expect(roundTripped.innerRelations).toEqual(original.innerRelations);
+    expect(roundTripped.literalIds).toBe(original.literalIds);
+    expect(roundTripped.innerRelations).toBe(original.innerRelations);
   });
 });

--- a/packages/activerecord/src/relation/predicate-builder/deferred-distinct-pk-in.trails.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder/deferred-distinct-pk-in.trails.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Trails-only: the deferred distinct-pk / excluding-ids markers are a trails
+ * invention (Rails materializes ids eagerly inside a synchronous `.where()`),
+ * so these inversion-preservation pins have no Rails counterpart.
+ */
+import { describe, it, expect } from "vitest";
+import { Table, Nodes } from "@blazetrails/arel";
+import { WhereClause } from "../where-clause.js";
+import { DeferredIdsIn, DeferredIdsNotIn } from "./deferred-distinct-pk-in.js";
+
+describe("DeferredIdsNotIn inversion (trails)", () => {
+  const t = new Table("posts");
+
+  function marker(): DeferredIdsNotIn {
+    const attribute = t.get("id");
+    const inlineSubquery = new Nodes.SqlLiteral("SELECT id FROM posts");
+    const innerRelation = { ids: () => Promise.resolve([3, 4]) };
+    return new DeferredIdsNotIn(attribute, inlineSubquery, [1, 2], [innerRelation]);
+  }
+
+  it("inverting a WhereClause containing the marker preserves the deferred ids", () => {
+    const original = marker();
+    const inverted = new WhereClause([original]).invert().predicates[0];
+    // Must not decay to a plain In: the load pipeline materializes only the
+    // marker classes, so a plain node would silently drop literalIds and
+    // innerRelations and leave the display-fallback subquery in the SQL.
+    expect(inverted).toBeInstanceOf(DeferredIdsIn);
+    const invertedMarker = inverted as DeferredIdsIn;
+    expect(invertedMarker.literalIds).toEqual([1, 2]);
+    expect(invertedMarker.innerRelations).toEqual(original.innerRelations);
+    expect(invertedMarker.left).toBe(original.left);
+    expect(invertedMarker.right).toBe(original.right);
+  });
+
+  it("double inversion round-trips back to the excluding marker", () => {
+    const original = marker();
+    const roundTripped = original.invert().invert();
+    expect(roundTripped).toBeInstanceOf(DeferredIdsNotIn);
+    expect(roundTripped.literalIds).toEqual([1, 2]);
+    expect(roundTripped.innerRelations).toEqual(original.innerRelations);
+  });
+});

--- a/packages/activerecord/src/relation/predicate-builder/deferred-distinct-pk-in.ts
+++ b/packages/activerecord/src/relation/predicate-builder/deferred-distinct-pk-in.ts
@@ -93,4 +93,45 @@ export class DeferredIdsNotIn extends Nodes.NotIn {
   ) {
     super(attribute, inlineSubquery);
   }
+
+  // Inherited NotIn#invert would build a plain In carrying only the
+  // display-fallback pk-select subquery, dropping literalIds/innerRelations —
+  // the load pipeline would never materialize the ids, and on MySQL the
+  // leftover `IN (SELECT ... LIMIT ...)` display shape is exactly what the
+  // marker exists to avoid. Nothing builds an inverted excluding marker today,
+  // but `WhereClause#invert` is the single negation mechanism (#5064), so any
+  // future invert of a merged/rewhere'd clause reaches here.
+  invert(): DeferredIdsIn {
+    return new DeferredIdsIn(
+      this.left as Nodes.Attribute,
+      this.right as Nodes.Node,
+      this.literalIds,
+      this.innerRelations,
+    );
+  }
+}
+
+/**
+ * Positive counterpart produced only by `DeferredIdsNotIn#invert` — no builder
+ * records it directly. Carries the same deferred payload so the load pipeline
+ * materializes it to a literal `attribute.in([...ids])`.
+ */
+export class DeferredIdsIn extends Nodes.In {
+  constructor(
+    attribute: Nodes.Attribute,
+    inlineSubquery: Nodes.Node,
+    readonly literalIds: unknown[],
+    readonly innerRelations: { ids(): Promise<unknown[]> }[],
+  ) {
+    super(attribute, inlineSubquery);
+  }
+
+  invert(): DeferredIdsNotIn {
+    return new DeferredIdsNotIn(
+      this.left as Nodes.Attribute,
+      this.right as Nodes.Node,
+      this.literalIds,
+      this.innerRelations,
+    );
+  }
 }

--- a/packages/activerecord/src/relation/predicate-builder/deferred-distinct-pk-in.ts
+++ b/packages/activerecord/src/relation/predicate-builder/deferred-distinct-pk-in.ts
@@ -95,12 +95,8 @@ export class DeferredIdsNotIn extends Nodes.NotIn {
   }
 
   // Inherited NotIn#invert would build a plain In carrying only the
-  // display-fallback pk-select subquery, dropping literalIds/innerRelations —
-  // the load pipeline would never materialize the ids, and on MySQL the
-  // leftover `IN (SELECT ... LIMIT ...)` display shape is exactly what the
-  // marker exists to avoid. Nothing builds an inverted excluding marker today,
-  // but `WhereClause#invert` is the single negation mechanism (#5064), so any
-  // future invert of a merged/rewhere'd clause reaches here.
+  // display-fallback subquery and drop literalIds/innerRelations, so the load
+  // pipeline would never materialize the ids (see DeferredDistinctPkIn#invert).
   invert(): DeferredIdsIn {
     return new DeferredIdsIn(
       this.left as Nodes.Attribute,


### PR DESCRIPTION
## Summary

`DeferredIdsNotIn` (the `excluding`/`without` deferred-ids marker in
`deferred-distinct-pk-in.ts`) had no `invert()` override: the inherited
`NotIn#invert` built a plain `In` carrying only the display-fallback
pk-select subquery, silently dropping `literalIds` and `innerRelations`.
The load pipeline (`relation.ts` `_materializeDeferredDistinctPkPredicates`)
would then never materialize the ids, and on MySQL the leftover
`IN (SELECT ... LIMIT ...)` display shape is exactly what the marker exists
to avoid. Unreached today, but `WhereClause#invert` is the single negation
mechanism after #5064, so any future invert of a merged/rewhere'd clause
containing the marker would trip it silently.

Mirrors the `DeferredDistinctPkIn`/`NotIn` pair from #5064:

- `DeferredIdsNotIn#invert` returns a new `DeferredIdsIn` (positive
  counterpart, produced only by inversion — no builder records it directly)
  carrying the same `literalIds` + `innerRelations`; `DeferredIdsIn#invert`
  round-trips back.
- `_materializeDeferredDistinctPkPredicates` handles the positive marker
  too: same in-order id concatenation, substituted positively
  (`predicateBuilder.build(attribute, ids)` without `.invert()`).

## Tests

New `deferred-distinct-pk-in.trails.test.ts` (trails-only — the deferred
markers are a trails invention; Rails materializes ids eagerly in its
synchronous `.where()`): inverting a `WhereClause` containing the marker
preserves the deferred payload instead of decaying to a plain `In`, and
double inversion round-trips. Fails on baseline (`inverted` is a plain
`Nodes.In` with no `literalIds`). `excluding.test.ts`,
`where-clause.test.ts`, and `where-chain.trails.test.ts` stay green.

Closes-story: deferred-ids-notin-invert-drops-marker
