### PR TITLE
test(arel): tighten #not_in Union test to exact Rails SQL assertion

### DIFF
--- a/packages/arel/src/attributes/attribute.test.ts
+++ b/packages/arel/src/attributes/attribute.test.ts
@@ -650,7 +650,6 @@ describe("AttributeTest", () => {
       const mgr1 = users.project(users.get("id"));
       const mgr2 = users.project(users.get("id"));
       const union = mgr1.union(mgr2);
-      // Rails' #not_in Union test itself calls #in and asserts IN — mirror it.
       const node = users.get("id").in(union);
       expect(visitor.compile(node)).toBe(
         '"users"."id" IN (( SELECT "users"."id" FROM "users" UNION SELECT "users"."id" FROM "users" ))',

--- a/packages/arel/src/attributes/attribute.test.ts
+++ b/packages/arel/src/attributes/attribute.test.ts
@@ -650,12 +650,10 @@ describe("AttributeTest", () => {
       const mgr1 = users.project(users.get("id"));
       const mgr2 = users.project(users.get("id"));
       const union = mgr1.union(mgr2);
-      expect(union).toBeInstanceOf(Nodes.Union);
+      // Rails' #not_in Union test itself calls #in and asserts IN — mirror it.
       const node = users.get("id").in(union);
-      const sql = visitor.compile(node);
-      expect(sql).toContain('"users"."id" IN (');
-      expect(sql).toContain(
-        'SELECT "users"."id" FROM "users" UNION SELECT "users"."id" FROM "users"',
+      expect(visitor.compile(node)).toBe(
+        '"users"."id" IN (( SELECT "users"."id" FROM "users" UNION SELECT "users"."id" FROM "users" ))',
       );
     });
 


### PR DESCRIPTION
## Summary

Story `arel-attribute-test-not-in-union-uses-in` claimed the `#not_in` "can be constructed with a Union" test should call `notIn(union)` per Rails. The vendored source contradicts that premise: Rails' own test (`vendor/rails/activerecord/test/cases/arel/attributes/attribute_test.rb:958`, inside the `#not_in` describe) calls `relation[:id].in(union)` and asserts `IN (...)` — the `#in`-under-`#not_in` quirk is upstream Rails, and our test already mirrors it. Switching to `notIn` would deviate from Rails.

What this PR does instead (faithful convergence, same pattern as #5106):

- Drop the invented `expect(union).toBeInstanceOf(Nodes.Union)` assertion (no Rails counterpart).
- Replace the two loose `toContain` checks with the exact `must_be_like` SQL: `"users"."id" IN (( SELECT "users"."id" FROM "users" UNION SELECT "users"."id" FROM "users" ))`.
- Comment at the call site notes why `#in` is correct here.

test:compare matched count for attribute_test.rb is unchanged (test name untouched).

Closes-story: arel-attribute-test-not-in-union-uses-in
