### PR TITLE
test(arel): triage attribute.test.ts type-casting in-describe extras

### DIFF
--- a/packages/arel/src/attributes/attribute.test.ts
+++ b/packages/arel/src/attributes/attribute.test.ts
@@ -818,12 +818,6 @@ describe("AttributeTest", () => {
   });
 
   describe("equality", () => {
-    it("should produce sql", () => {
-      const visitor = new Visitors.ToSql(testConnection);
-      const node = users.get("tags").contains("foo");
-      expect(visitor.compile(node)).toBe('"users"."tags" @> \'foo\'');
-    });
-
     describe("#to_sql", () => {
       it("should produce sql", () => {
         const relation = new Table("users");
@@ -869,48 +863,6 @@ describe("AttributeTest", () => {
 
       expect(table.isAbleToTypeCast()).toBe(true);
       expect(new Visitors.ToSql(testConnection).compile(condition)).toBe('"foo"."id" = (select 1)');
-    });
-
-    it("type casts IN list elements through the attribute", () => {
-      const fakeCaster = {
-        typeCastForDatabase(attrName: string, value: unknown) {
-          return attrName === "id" ? Number(value) : value;
-        },
-      };
-      const table = new Table("foo", { typeCaster: fakeCaster });
-      const condition = table.get("id").in(["1", "2"]);
-
-      expect(new Visitors.ToSql(testConnection).compile(condition)).toBe('"foo"."id" IN (1, 2)');
-    });
-
-    it("type casts NOT IN list elements through the attribute", () => {
-      const fakeCaster = {
-        typeCastForDatabase(attrName: string, value: unknown) {
-          return attrName === "id" ? Number(value) : value;
-        },
-      };
-      const table = new Table("foo", { typeCaster: fakeCaster });
-      const condition = table.get("id").notIn(["1", "2"]);
-
-      expect(new Visitors.ToSql(testConnection).compile(condition)).toBe(
-        '"foo"."id" NOT IN (1, 2)',
-      );
-    });
-
-    it("builds Casted nodes so a null in an IN list casts through the column", () => {
-      const fakeCaster = {
-        typeCastForDatabase(_attrName: string, value: unknown) {
-          return value === null ? 0 : value;
-        },
-      };
-      const table = new Table("foo", { typeCaster: fakeCaster });
-      const attr = table.get("id");
-      const node = attr.in([null]);
-      const right = (node.right as unknown as Nodes.Node[])[0];
-
-      expect(right).toBeInstanceOf(Nodes.Casted);
-      expect((right as Nodes.Casted).attribute).toBe(attr);
-      expect(new Visitors.ToSql(testConnection).compile(node)).toBe('"foo"."id" IN (0)');
     });
   });
 

--- a/packages/arel/src/attributes/attribute.trails.test.ts
+++ b/packages/arel/src/attributes/attribute.trails.test.ts
@@ -108,11 +108,6 @@ describe("AttributeTest (trails)", () => {
     });
   });
 
-  // Rails' `type casting` suite only exercises the caster through #eq
-  // (attributes/attribute_test.rb:1123+); it never pins that #in / #notIn
-  // list elements are wrapped as Casted and rendered through the caster.
-  // The port reimplements that wrapping in predications.ts' array arm, so
-  // these compile-level checks are TS-only coverage.
   describe("type casting", () => {
     it("type casts IN list elements through the attribute", () => {
       const fakeCaster = {

--- a/packages/arel/src/attributes/attribute.trails.test.ts
+++ b/packages/arel/src/attributes/attribute.trails.test.ts
@@ -108,6 +108,55 @@ describe("AttributeTest (trails)", () => {
     });
   });
 
+  // Rails' `type casting` suite only exercises the caster through #eq
+  // (attributes/attribute_test.rb:1123+); it never pins that #in / #notIn
+  // list elements are wrapped as Casted and rendered through the caster.
+  // The port reimplements that wrapping in predications.ts' array arm, so
+  // these compile-level checks are TS-only coverage.
+  describe("type casting", () => {
+    it("type casts IN list elements through the attribute", () => {
+      const fakeCaster = {
+        typeCastForDatabase(attrName: string, value: unknown) {
+          return attrName === "id" ? Number(value) : value;
+        },
+      };
+      const table = new Table("foo", { typeCaster: fakeCaster });
+      const condition = table.get("id").in(["1", "2"]);
+
+      expect(new Visitors.ToSql(testConnection).compile(condition)).toBe('"foo"."id" IN (1, 2)');
+    });
+
+    it("type casts NOT IN list elements through the attribute", () => {
+      const fakeCaster = {
+        typeCastForDatabase(attrName: string, value: unknown) {
+          return attrName === "id" ? Number(value) : value;
+        },
+      };
+      const table = new Table("foo", { typeCaster: fakeCaster });
+      const condition = table.get("id").notIn(["1", "2"]);
+
+      expect(new Visitors.ToSql(testConnection).compile(condition)).toBe(
+        '"foo"."id" NOT IN (1, 2)',
+      );
+    });
+
+    it("builds Casted nodes so a null in an IN list casts through the column", () => {
+      const fakeCaster = {
+        typeCastForDatabase(_attrName: string, value: unknown) {
+          return value === null ? 0 : value;
+        },
+      };
+      const table = new Table("foo", { typeCaster: fakeCaster });
+      const attr = table.get("id");
+      const node = attr.in([null]);
+      const right = (node.right as unknown as Nodes.Node[])[0];
+
+      expect(right).toBeInstanceOf(Nodes.Casted);
+      expect((right as Nodes.Casted).attribute).toBe(attr);
+      expect(new Visitors.ToSql(testConnection).compile(node)).toBe('"foo"."id" IN (0)');
+    });
+  });
+
   describe("relationName", () => {
     it("returns a plain string name unchanged", () => {
       expect(relationName("users")).toBe("users");


### PR DESCRIPTION
Triage the remaining 4 TS-only extras in
`packages/arel/src/attributes/attribute.test.ts` after #5107.

Per the comparison manifests the 4 unmatched tests were:

- `equality > should produce sql` — a verbatim duplicate of
  `#contains > should generate @> in sql` in the same file (Rails'
  `equality` describe has only `#to_sql`). **Deleted.**
- `type casting > type casts IN list elements through the attribute`,
  `... NOT IN list elements ...`, and
  `... builds Casted nodes so a null in an IN list casts through the column`
  — Rails' `type casting` suite only exercises the caster through `#eq`
  (`attributes/attribute_test.rb:1123+`), never IN/NOT IN list elements.
  The port reimplements the Casted wrapping in predications.ts' array arm,
  so these are genuinely TS-only. **Moved to `attribute.trails.test.ts`.**

Note: the story listed "does not type cast SqlLiteral nodes" as an extra,
but it is a Rails test (`attribute_test.rb:1147`) and was already matched —
it stays in place.

`test:compare --package arel`: `attributes/attribute_test.rb →
attribute.test.ts` stays **128/128 matched**, extras drop **4 → 0**.
No test renamed or reworded.

Closes-story: arel-attribute-test-typecasting-extras-triage
