### PR TITLE
fix(attribute-methods): port class attributeNames memoization; never memoize the cold-cache fail-open answer

### DIFF
--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1805,8 +1805,8 @@ export class Model {
    * Mirrors: ActiveModel::AttributeMethods#attribute_names (instance)
    */
   attributeNames(): string[] {
-    // Copy: the class-level result is Rails-frozen (memoized), while Rails'
-    // instance method returns a fresh mutable `@attributes.keys` array.
+    // Copy: the class-level result is frozen (memoized); Rails' instance
+    // method returns a fresh mutable `@attributes.keys` array.
     return [...(this.constructor as typeof Model).attributeNames()];
   }
 

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1805,7 +1805,9 @@ export class Model {
    * Mirrors: ActiveModel::AttributeMethods#attribute_names (instance)
    */
   attributeNames(): string[] {
-    return (this.constructor as typeof Model).attributeNames();
+    // Copy: the class-level result is Rails-frozen (memoized), while Rails'
+    // instance method returns a fresh mutable `@attributes.keys` array.
+    return [...(this.constructor as typeof Model).attributeNames()];
   }
 
   get attributes(): Record<string, unknown> {

--- a/packages/activerecord/src/attribute-methods.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods.trails.test.ts
@@ -226,9 +226,6 @@ describe("AttributeMethodsTest (trails)", () => {
     expect((w as { color: unknown }).color).toBe("fixed");
   });
 
-  // Rails' class-level `attribute_names` is `@attribute_names ||= ...freeze`
-  // (attribute_methods.rb:236-241), invalidated by reload_schema_from_cache.
-  // These guard the trails port of that memo and its cold-cache carve-out.
   it("class attributeNames is memoized and frozen", async () => {
     class Topic extends Base {}
     await Topic.loadSchema();
@@ -243,9 +240,8 @@ describe("AttributeMethodsTest (trails)", () => {
     await Topic.loadSchema();
     const first = Topic.attributeNames();
     (Topic as unknown as { resetColumnInformation(): void }).resetColumnInformation();
-    // The reset also drops the shared cache's per-table entry; re-reflect so
-    // the comparison sees real columns (and the suite's warm-cache invariant
-    // is restored for later tests).
+    // The reset drops the shared cache's per-table entry; re-reflect so the
+    // suite's warm-cache invariant is restored for later tests.
     await Topic.loadSchema();
     const second = Topic.attributeNames();
     expect(second).not.toBe(first);
@@ -257,8 +253,6 @@ describe("AttributeMethodsTest (trails)", () => {
     await Topic.loadSchema();
     const parentNames = Topic.attributeNames();
     class ImportantTopic extends Topic {}
-    // Rails nils @attribute_names in `inherited`; the subclass memoizes its
-    // own array rather than reading the parent's.
     expect(ImportantTopic.attributeNames()).not.toBe(parentNames);
   });
 
@@ -268,12 +262,10 @@ describe("AttributeMethodsTest (trails)", () => {
         this.attribute("name", "string");
       }
     }
-    // Cold cache: the table has never hit a dataSourceExists check, so the
-    // table_exists? half of the guard fails open (documented inherent
-    // deviation — Rails' sync DB hit would return []).
+    // Cold cache fails open (documented inherent deviation — Rails' sync DB
+    // hit would return []); loadSchema seeds dataSourceExists=false, and the
+    // cold answer must not have been memoized, so the guard then closes.
     expect(NonExistentTable.attributeNames()).toEqual(["name"]);
-    // The async pipeline records dataSourceExists=false; the cold answer
-    // must not have been memoized, so the guard now closes.
     await NonExistentTable.loadSchema();
     expect(NonExistentTable.attributeNames()).toEqual([]);
   });

--- a/packages/activerecord/src/attribute-methods.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods.trails.test.ts
@@ -225,4 +225,56 @@ describe("AttributeMethodsTest (trails)", () => {
     const w = new Widget({});
     expect((w as { color: unknown }).color).toBe("fixed");
   });
+
+  // Rails' class-level `attribute_names` is `@attribute_names ||= ...freeze`
+  // (attribute_methods.rb:236-241), invalidated by reload_schema_from_cache.
+  // These guard the trails port of that memo and its cold-cache carve-out.
+  it("class attributeNames is memoized and frozen", async () => {
+    class Topic extends Base {}
+    await Topic.loadSchema();
+    const first = Topic.attributeNames();
+    expect(first).toContain("title");
+    expect(Object.isFrozen(first)).toBe(true);
+    expect(Topic.attributeNames()).toBe(first);
+  });
+
+  it("resetColumnInformation invalidates the class attributeNames memo", async () => {
+    class Topic extends Base {}
+    await Topic.loadSchema();
+    const first = Topic.attributeNames();
+    (Topic as unknown as { resetColumnInformation(): void }).resetColumnInformation();
+    // The reset also drops the shared cache's per-table entry; re-reflect so
+    // the comparison sees real columns (and the suite's warm-cache invariant
+    // is restored for later tests).
+    await Topic.loadSchema();
+    const second = Topic.attributeNames();
+    expect(second).not.toBe(first);
+    expect(second).toEqual(first);
+  });
+
+  it("subclass does not inherit the parent's attributeNames memo", async () => {
+    class Topic extends Base {}
+    await Topic.loadSchema();
+    const parentNames = Topic.attributeNames();
+    class ImportantTopic extends Topic {}
+    // Rails nils @attribute_names in `inherited`; the subclass memoizes its
+    // own array rather than reading the parent's.
+    expect(ImportantTopic.attributeNames()).not.toBe(parentNames);
+  });
+
+  it("does not memoize the cold-cache fail-open attributeNames answer", async () => {
+    class NonExistentTable extends Base {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    // Cold cache: the table has never hit a dataSourceExists check, so the
+    // table_exists? half of the guard fails open (documented inherent
+    // deviation — Rails' sync DB hit would return []).
+    expect(NonExistentTable.attributeNames()).toEqual(["name"]);
+    // The async pipeline records dataSourceExists=false; the cold answer
+    // must not have been memoized, so the guard now closes.
+    await NonExistentTable.loadSchema();
+    expect(NonExistentTable.attributeNames()).toEqual([]);
+  });
 });

--- a/packages/activerecord/src/attribute-methods.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods.trails.test.ts
@@ -10,6 +10,7 @@
 import { describe, it, expect } from "vitest";
 import { Base, ReadonlyAttributeError, registerModel } from "./index.js";
 import { formatForInspect } from "./attribute-inspection.js";
+import { registerSubclass } from "./inheritance.js";
 
 import { fixtures } from "./test-helpers/fixtures.js";
 import { Minivan } from "./test-helpers/models/minivan.js";
@@ -246,6 +247,28 @@ describe("AttributeMethodsTest (trails)", () => {
     const second = Topic.attributeNames();
     expect(second).not.toBe(first);
     expect(second).toEqual(first);
+  });
+
+  it("tableName= invalidates the attributeNames memo on descendants", async () => {
+    class Topic extends Base {}
+    class ImportantTopic extends Topic {
+      static {
+        registerSubclass(this);
+      }
+    }
+    await Topic.loadSchema();
+    Topic.attributeNames();
+    const subNames = ImportantTopic.attributeNames();
+    Topic.tableName = "posts";
+    expect(ImportantTopic.attributeNames()).not.toBe(subNames);
+  });
+
+  it("ignoredColumns= invalidates the attributeNames memo", async () => {
+    class Topic extends Base {}
+    await Topic.loadSchema();
+    const first = Topic.attributeNames();
+    Topic.ignoredColumns = ["approved"];
+    expect(Topic.attributeNames()).not.toBe(first);
   });
 
   it("subclass does not inherit the parent's attributeNames memo", async () => {

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -614,6 +614,8 @@ interface AttributeNamesHost {
   _attributeDefinitions: { keys(): Iterable<string>; has(name: string): boolean };
   abstractClass?: boolean;
   columnNames?(): string[];
+  _schemaRevision?: number;
+  _attributeNamesMemo?: { revision: number; names: readonly string[] };
 }
 
 /**
@@ -629,19 +631,56 @@ interface AttributeNamesHost {
  * declaration order.
  */
 export function attributeNames(this: AttributeNamesHost): string[] {
+  // Rails' `@attribute_names ||=` memo, per-class like a Ruby ivar: an own
+  // property only (a subclass never reads its parent's memo — Rails nils
+  // `@attribute_names` in `inherited`). Stamped with the STI base's
+  // `_schemaRevision` so the reset paths that clear `_columns`/`_columnsHash`
+  // (resetColumnInformation, applyColumnsHash) invalidate it — including
+  // subclass memos the base's reset can't reach — without extra bookkeeping.
+  const revision = this._schemaRevision ?? 0;
+  const memo = Object.prototype.hasOwnProperty.call(this, "_attributeNamesMemo")
+    ? this._attributeNamesMemo
+    : undefined;
+  if (memo && memo.revision === revision) return memo.names as string[];
   // Rails attribute_methods.rb:236-241: `if !abstract_class? && table_exists?`.
   // trails' tableExists is async, so the table_exists? half runs off the
   // schema cache's already-resolved answer — `false` only after a
-  // dataSourceExists miss; a cold/unknown table falls through (fail-open,
-  // where Rails' sync DB hit would return []).
-  if (this.abstractClass || cachedTableExists.call(this as never) === false) return [];
+  // dataSourceExists miss; a cold/unknown table (`undefined`) falls through
+  // (fail-open, where Rails' sync DB hit would return []). Inherent
+  // deviation: a sync API cannot make the DB hit, and failing closed would
+  // break every adapter-less attribute-only model. The async schema pipeline
+  // (loadSchemaFromAdapter → dataSourceExists) seeds the negative entry, so
+  // the guard closes once `loadSchema()` has been awaited.
+  const exists = cachedTableExists.call(this as never);
+  if (this.abstractClass || exists === false) {
+    this._attributeNamesMemo = { revision, names: Object.freeze([]) };
+    return [];
+  }
   const declared = [...this._attributeDefinitions.keys()];
   const columnNames = this.columnNames?.() ?? [];
-  if (columnNames.length === 0) return declared;
-  const columnSet = new Set(columnNames);
-  const orderedColumns = columnNames.filter((name) => this._attributeDefinitions.has(name));
-  const virtuals = declared.filter((name) => !columnSet.has(name));
-  return [...orderedColumns, ...virtuals];
+  let names: string[];
+  if (columnNames.length === 0) {
+    names = declared;
+  } else {
+    const columnSet = new Set(columnNames);
+    const orderedColumns = columnNames.filter((name) => this._attributeDefinitions.has(name));
+    const virtuals = declared.filter((name) => !columnSet.has(name));
+    names = [...orderedColumns, ...virtuals];
+  }
+  // Never memoize the fail-open cold-cache answer (`exists === undefined`):
+  // a later `loadSchema()` can resolve the table as absent without bumping
+  // `_schemaRevision` (loadSchemaFromAdapter returns before applyColumnsHash
+  // on a dataSourceExists miss), which would pin the wrong names forever.
+  if (exists !== undefined) {
+    // Rails freezes the memoized array; return the same frozen instance.
+    // Re-read the revision: computing `columnNames()` above can run the
+    // first sync `loadSchema` → `applyColumnsHash`, which bumps it —
+    // stamping the entry value keeps the memo valid for the next call.
+    const frozen = Object.freeze(names);
+    this._attributeNamesMemo = { revision: this._schemaRevision ?? 0, names: frozen };
+    return frozen as string[];
+  }
+  return names;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -631,30 +631,30 @@ interface AttributeNamesHost {
  * declaration order.
  */
 export function attributeNames(this: AttributeNamesHost): string[] {
-  // Rails' `@attribute_names ||=` memo, per-class like a Ruby ivar: an own
-  // property only (a subclass never reads its parent's memo — Rails nils
-  // `@attribute_names` in `inherited`). Stamped with the STI base's
-  // `_schemaRevision` so the reset paths that clear `_columns`/`_columnsHash`
-  // (resetColumnInformation, applyColumnsHash) invalidate it — including
-  // subclass memos the base's reset can't reach — without extra bookkeeping.
-  const revision = this._schemaRevision ?? 0;
+  // Rails' `@attribute_names ||= ...freeze` memo, own-property per class (a
+  // subclass never reads its parent's memo — Rails nils `@attribute_names` in
+  // `inherited`), revision-stamped so the reset paths that clear
+  // `_columns`/`_columnsHash` (resetColumnInformation, applyColumnsHash)
+  // invalidate it, including subclass memos the base's reset can't reach.
   const memo = Object.prototype.hasOwnProperty.call(this, "_attributeNamesMemo")
     ? this._attributeNamesMemo
     : undefined;
-  if (memo && memo.revision === revision) return memo.names as string[];
+  if (memo && memo.revision === (this._schemaRevision ?? 0)) return memo.names as string[];
   // Rails attribute_methods.rb:236-241: `if !abstract_class? && table_exists?`.
-  // trails' tableExists is async, so the table_exists? half runs off the
-  // schema cache's already-resolved answer — `false` only after a
-  // dataSourceExists miss; a cold/unknown table (`undefined`) falls through
-  // (fail-open, where Rails' sync DB hit would return []). Inherent
-  // deviation: a sync API cannot make the DB hit, and failing closed would
-  // break every adapter-less attribute-only model. The async schema pipeline
-  // (loadSchemaFromAdapter → dataSourceExists) seeds the negative entry, so
-  // the guard closes once `loadSchema()` has been awaited.
+  // trails' tableExists is async, so the table_exists? half runs off the schema
+  // cache's already-resolved answer — `false` only after a dataSourceExists
+  // miss; a cold/unknown table (`undefined`) falls through. Accepted inherent
+  // deviation from Rails' sync-DB-hit `[]`: a sync API cannot make the DB hit,
+  // and failing closed would break every adapter-less attribute-only model.
+  // The async pipeline (loadSchemaFromAdapter → dataSourceExists) seeds the
+  // negative entry, closing the guard once `loadSchema()` has been awaited —
+  // which is why the fail-open answer must never be memoized: that resolution
+  // happens without a `_schemaRevision` bump to invalidate it.
   const exists = cachedTableExists.call(this as never);
   if (this.abstractClass || exists === false) {
-    this._attributeNamesMemo = { revision, names: Object.freeze([]) };
-    return [];
+    const frozen = Object.freeze([] as string[]);
+    this._attributeNamesMemo = { revision: this._schemaRevision ?? 0, names: frozen };
+    return frozen as string[];
   }
   const declared = [...this._attributeDefinitions.keys()];
   const columnNames = this.columnNames?.() ?? [];
@@ -667,16 +667,10 @@ export function attributeNames(this: AttributeNamesHost): string[] {
     const virtuals = declared.filter((name) => !columnSet.has(name));
     names = [...orderedColumns, ...virtuals];
   }
-  // Never memoize the fail-open cold-cache answer (`exists === undefined`):
-  // a later `loadSchema()` can resolve the table as absent without bumping
-  // `_schemaRevision` (loadSchemaFromAdapter returns before applyColumnsHash
-  // on a dataSourceExists miss), which would pin the wrong names forever.
   if (exists !== undefined) {
-    // Rails freezes the memoized array; return the same frozen instance.
-    // Re-read the revision: computing `columnNames()` above can run the
-    // first sync `loadSchema` → `applyColumnsHash`, which bumps it —
-    // stamping the entry value keeps the memo valid for the next call.
     const frozen = Object.freeze(names);
+    // Re-read the revision: `columnNames()` above can run the first sync
+    // `loadSchema` → `applyColumnsHash`, which bumps it mid-call.
     this._attributeNamesMemo = { revision: this._schemaRevision ?? 0, names: frozen };
     return frozen as string[];
   }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1201,9 +1201,8 @@ export class Base extends Model {
       return;
     }
     super.attribute(name, typeName, options);
-    // Rails' `attribute` ends in `reload_schema_from_cache` (attributes.rb),
-    // which nils `@attribute_names` recursively; drop the memo on this class
-    // and its descendants so the new declaration is visible.
+    // Rails' `attribute` ends in `reload_schema_from_cache`, which nils
+    // `@attribute_names` recursively.
     for (const klass of [this, ...this.descendants]) {
       if (Object.prototype.hasOwnProperty.call(klass, "_attributeNamesMemo")) {
         Reflect.deleteProperty(klass, "_attributeNamesMemo");

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1201,6 +1201,14 @@ export class Base extends Model {
       return;
     }
     super.attribute(name, typeName, options);
+    // Rails' `attribute` ends in `reload_schema_from_cache` (attributes.rb),
+    // which nils `@attribute_names` recursively; drop the memo on this class
+    // and its descendants so the new declaration is visible.
+    for (const klass of [this, ...this.descendants]) {
+      if (Object.prototype.hasOwnProperty.call(klass, "_attributeNamesMemo")) {
+        Reflect.deleteProperty(klass, "_attributeNamesMemo");
+      }
+    }
     // A newly declared attribute may be virtual (no DB column); force the next
     // ensureSchemaLoaded to re-run virtual reconciliation (model-schema.ts
     // reconcileVirtualAttributes) instead of skipping it via the one-shot guard.

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1203,11 +1203,7 @@ export class Base extends Model {
     super.attribute(name, typeName, options);
     // Rails' `attribute` ends in `reload_schema_from_cache`, which nils
     // `@attribute_names` recursively.
-    for (const klass of [this, ...this.descendants]) {
-      if (Object.prototype.hasOwnProperty.call(klass, "_attributeNamesMemo")) {
-        Reflect.deleteProperty(klass, "_attributeNamesMemo");
-      }
-    }
+    ModelSchema.clearAttributeNamesMemo(this as never);
     // A newly declared attribute may be virtual (no DB column); force the next
     // ensureSchemaLoaded to re-run virtual reconciliation (model-schema.ts
     // reconcileVirtualAttributes) instead of skipping it via the one-shot guard.

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -554,6 +554,23 @@ interface SchemaHost {
   hookAttributeType?(name: string, type: Type): Type;
 }
 
+/**
+ * Drop the memoized class-level `attributeNames` on `host` and its
+ * descendants — Rails' `reload_schema_from_cache` nils `@attribute_names`
+ * recursively (model_schema.rb:553-568). Used by the invalidation paths that
+ * don't bump `_schemaRevision` (`attribute`, `table_name=`, `ignored_columns=`).
+ *
+ * @internal
+ */
+export function clearAttributeNamesMemo(host: SchemaHost): void {
+  const descendants = (host as { descendants?: SchemaHost[] }).descendants ?? [];
+  for (const klass of [host, ...descendants]) {
+    if (Object.prototype.hasOwnProperty.call(klass, "_attributeNamesMemo")) {
+      Reflect.deleteProperty(klass, "_attributeNamesMemo");
+    }
+  }
+}
+
 export function deriveJoinTableName(this: SchemaHost, otherTableName: string): string {
   const tables = [underscore(this.name), otherTableName].sort();
   return tables.join("_");
@@ -1552,11 +1569,10 @@ export function tableName(this: SchemaHost, value?: string): string {
       // chain and would otherwise never reflect its own table. Shadow the
       // inherited flag with an own `false` so the next load re-reflects.
       (this as { _schemaLoaded?: boolean })._schemaLoaded = false;
-      // Rails' reset_column_information also nils @attribute_names; drop the
-      // memo now so reads before the next load don't see the old table's names.
-      if (Object.prototype.hasOwnProperty.call(this, "_attributeNamesMemo")) {
-        Reflect.deleteProperty(this, "_attributeNamesMemo");
-      }
+      // Rails' reset_column_information also nils @attribute_names (on the
+      // class and, recursively, its descendants); drop the memos now so reads
+      // before the next load don't see the old table's names.
+      clearAttributeNamesMemo(this);
     }
   }
   return resolveTableName.call(this as any);
@@ -1590,6 +1606,9 @@ export function sequenceName(this: SchemaHost, value?: string | null): string | 
 export function ignoredColumns(this: SchemaHost, value?: string[]): string[] {
   if (value !== undefined) {
     this._ignoredColumns = value;
+    // Rails' ignored_columns= runs reload_schema_from_cache
+    // (model_schema.rb:366-368), which nils @attribute_names recursively.
+    clearAttributeNamesMemo(this);
     for (const col of value) {
       if (col in this.prototype) {
         Object.defineProperty(this.prototype, col, {

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1553,9 +1553,7 @@ export function tableName(this: SchemaHost, value?: string): string {
       // inherited flag with an own `false` so the next load re-reflects.
       (this as { _schemaLoaded?: boolean })._schemaLoaded = false;
       // Rails' reset_column_information also nils @attribute_names; drop the
-      // memo now (rather than waiting for the reload's revision bump) so
-      // reads between the rename and the next load don't see the old table's
-      // names.
+      // memo now so reads before the next load don't see the old table's names.
       if (Object.prototype.hasOwnProperty.call(this, "_attributeNamesMemo")) {
         Reflect.deleteProperty(this, "_attributeNamesMemo");
       }

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1552,6 +1552,13 @@ export function tableName(this: SchemaHost, value?: string): string {
       // chain and would otherwise never reflect its own table. Shadow the
       // inherited flag with an own `false` so the next load re-reflects.
       (this as { _schemaLoaded?: boolean })._schemaLoaded = false;
+      // Rails' reset_column_information also nils @attribute_names; drop the
+      // memo now (rather than waiting for the reload's revision bump) so
+      // reads between the rename and the next load don't see the old table's
+      // names.
+      if (Object.prototype.hasOwnProperty.call(this, "_attributeNamesMemo")) {
+        Reflect.deleteProperty(this, "_attributeNamesMemo");
+      }
     }
   }
   return resolveTableName.call(this as any);


### PR DESCRIPTION
## Summary

Story `attribute-names-table-exists-fail-open-cold-cache` (RFC 0056): port Rails' class-level `attribute_names` memoization and settle the cold-cache `table_exists?` fail-open as an accepted inherent deviation, recorded at the guard.

Rails (`attribute_methods.rb:236-241`) is `@attribute_names ||= if !abstract_class? && table_exists? ... end.freeze`.

- **Memoization** — per-class own property (a subclass never reads its parent's memo, mirroring Rails nil-ing `@attribute_names` in `inherited`), stamped with the STI base's `_schemaRevision` so the reset paths that clear `_columns`/`_columnsHash` (`resetColumnInformation`, `applyColumnsHash`) invalidate it — including subclass memos the base's recursive Rails reset would reach. Rails' other clears are covered too: `attribute()` (ends in `reload_schema_from_cache`) drops the memo on the class and descendants; `table_name=` drops it eagerly. The array is frozen like Rails'.
- **Cold-cache fail-open** — a sync API cannot make Rails' synchronous DB hit, and failing closed would break every adapter-less attribute-only model; the async pipeline (`loadSchemaFromAdapter` → `dataSourceExists`) already seeds the negative entry so the guard closes once `loadSchema()` has been awaited. Justification recorded at the guard. Crucially, the fail-open answer is **never memoized**: `loadSchemaFromAdapter` returns before `applyColumnsHash` (no revision bump) on a `dataSourceExists` miss, so memoizing the cold answer would pin the wrong names forever.
- **Instance `attributeNames()`** now copies the class array — Rails' instance variant returns a fresh mutable `@attributes.keys`.

## Testing

New tests in `attribute-methods.trails.test.ts` (trails-internal memo mechanics, no verbatim Rails counterparts): memoized+frozen result, `resetColumnInformation` invalidation, subclass memo isolation, and the cold-cache no-memoize rule. The memoization tests fail on baseline. Existing Rails-ported guards (`caches are cleared` in attributes.test.ts, `read attribute names` in reflection.test.ts) exercised the `attribute()`-invalidation and instance-copy paths.

Closes-story: attribute-names-table-exists-fail-open-cold-cache
