### PR TITLE
fix(tasks): read charset from the live database in MySQL/PG database tasks

### DIFF
--- a/packages/activerecord/src/tasks/mysql-database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.test.ts
@@ -12,12 +12,15 @@ function config(overrides: Record<string, unknown> = {}): HashConfig {
 }
 
 describe("MySQLDatabaseTasks", () => {
-  it("test_charset_defaults_to_utf8mb4", () => {
-    expect(new MySQLDatabaseTasks(config()).charset()).toBe("utf8mb4");
-  });
-
-  it("test_charset_reads_encoding_from_config", () => {
-    expect(new MySQLDatabaseTasks(config({ encoding: "latin1" })).charset()).toBe("latin1");
+  it("test_db_retrieves_charset", async () => {
+    const tasks = new MySQLDatabaseTasks(config());
+    const charsetMock = vi.fn(async () => "utf8mb4");
+    vi.spyOn(
+      tasks as unknown as { connection(): Promise<unknown> },
+      "connection",
+    ).mockResolvedValue({ charset: charsetMock });
+    await expect(tasks.charset()).resolves.toBe("utf8mb4");
+    expect(charsetMock).toHaveBeenCalledOnce();
   });
 
   it("test_db_retrieves_collation", async () => {

--- a/packages/activerecord/src/tasks/mysql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/mysql-database-tasks.ts
@@ -113,8 +113,8 @@ export class MySQLDatabaseTasks {
     await this.create(saved);
   }
 
-  charset(): string {
-    return String(this.configurationHash.encoding ?? "utf8mb4");
+  async charset(): Promise<string> {
+    return (await this.connection()).charset();
   }
 
   async collation(): Promise<string> {

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.test.ts
@@ -12,12 +12,15 @@ function config(overrides: Record<string, unknown> = {}): HashConfig {
 }
 
 describe("PostgreSQLDatabaseTasks", () => {
-  it("test_charset_defaults_to_utf8", () => {
-    expect(new PostgreSQLDatabaseTasks(config()).charset()).toBe("utf8");
-  });
-
-  it("test_charset_reads_encoding_from_config", () => {
-    expect(new PostgreSQLDatabaseTasks(config({ encoding: "UTF8" })).charset()).toBe("UTF8");
+  it("test_db_retrieves_charset", async () => {
+    const tasks = new PostgreSQLDatabaseTasks(config());
+    const encodingMock = vi.fn(async () => "UTF8");
+    vi.spyOn(
+      tasks as unknown as { connection(): Promise<unknown> },
+      "connection",
+    ).mockResolvedValue({ encoding: encodingMock });
+    await expect(tasks.charset()).resolves.toBe("UTF8");
+    expect(encodingMock).toHaveBeenCalledOnce();
   });
 
   it("test_db_retrieves_collation", async () => {

--- a/packages/activerecord/src/tasks/postgresql-database-tasks.ts
+++ b/packages/activerecord/src/tasks/postgresql-database-tasks.ts
@@ -121,8 +121,8 @@ export class PostgreSQLDatabaseTasks {
     );
   }
 
-  charset(): string {
-    return this.encoding();
+  async charset(): Promise<string> {
+    return (await this.connection()).encoding();
   }
 
   async collation(): Promise<string> {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/tasks/mysql-database-tasks.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/tasks/mysql-database-tasks.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "tasks/mysql-database-tasks.ts",
-    "rubyName": "charset",
-    "call": "connection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/mysql-database-tasks.ts",
     "rubyName": "configuration_hash_without_database",
     "call": "merge",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/tasks/postgresql-database-tasks.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/tasks/postgresql-database-tasks.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "tasks/postgresql-database-tasks.ts",
-    "rubyName": "charset",
-    "call": "connection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/postgresql-database-tasks.ts",
     "rubyName": "create",
     "call": "create_database",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
## Summary

Same deviation shape as #5111 (collation), but for charset. Rails' database tasks read charset from the live database — `connection.charset` (`mysql_database_tasks.rb:32-34`) and `connection.encoding` (`postgresql_database_tasks.rb:32-34`) — but trails read config (`configurationHash.encoding` with a default), so `charset()` never reflected actual database state.

Both tasks' `charset()` now lease a connection and delegate to the adapter — MySQL `charset()` (`SHOW VARIABLES ... character_set_database`), PG `encoding()` (via pgSchemaStatements) — matching Rails. The PG task's private `encoding()` (config-based, used by `create()`) is unchanged, mirroring Rails' private `encoding` method.

Removed the two stale `charset → connection` wide-ratchet baseline entries.

## Tests

Replaced the config-reading unit tests with `test_db_retrieves_charset` (mirroring Rails' MySQL/PG rake tests), stubbing `connection` and asserting the adapter method is called. Ran both files against an isolated PG/MySQL compose stack — all pass.

Closes-story: database-tasks-charset-reads-config
