### PR TITLE
refactor(arel): delete deprecated ArelQuoter type alias

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -2064,7 +2064,7 @@ export function buildFixtureSql(
   // quoting is dialect-correct rather than using the global default quoter.
   const visitor =
     ((this as any)?.visitor as Visitors.ToSql | undefined) ??
-    new Visitors.ToSql(this as unknown as Visitors.ArelQuoter);
+    new Visitors.ToSql(this as unknown as Visitors.ArelConnection);
   return visitor.compile(manager.ast);
 }
 

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -782,7 +782,7 @@ export class Builder implements InsertBuilder {
   private _visitor(): Visitors.ToSql {
     const v = this._insertAll.connection.visitor;
     if (v) return v;
-    const q = this._insertAll.connection as unknown as Visitors.ArelQuoter;
+    const q = this._insertAll.connection as unknown as Visitors.ArelConnection;
     if (this._dialect === "mysql") return new Visitors.MySQL(q);
     if (this._dialect === "postgres") return new Visitors.PostgreSQL(q);
     return new Visitors.SQLite(q);

--- a/packages/arel/src/visitors/index.ts
+++ b/packages/arel/src/visitors/index.ts
@@ -1,4 +1,4 @@
-export { ToSql, type ArelConnection, type ArelQuoter } from "./to-sql.js";
+export { ToSql, type ArelConnection } from "./to-sql.js";
 export { substituteBoundValues } from "./substitute-bound-values.js";
 export {
   splitSchemaQualifiedName,

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -2287,7 +2287,7 @@ describe("ArelQuoter / defaultQuoter wiring", () => {
   });
 
   it("stub quoter: quoteTableName output appears in compiled SQL", () => {
-    const stubQuoter: Visitors.ArelQuoter = {
+    const stubQuoter: Visitors.ArelConnection = {
       quoteTableName: (name) => `<<${name}>>`,
       quoteColumnName: (name) => `<<${name}>>`,
       quoteString: (s) => s.replace(/'/g, "''"),

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -20,20 +20,6 @@ export type { ArelConnection } from "./connection.js";
 import type { ArelConnection } from "./connection.js";
 
 /**
- * Connection-quoting surface exposed to the Arel visitor.
- *
- * Mirrors Rails' `@connection` object passed to `Arel::Visitors::ToSql`.
- * Rails dispatches every quoting decision through the connection so adapters
- * can specialise (PG hex-escapes binary, MySQL backtick-quotes identifiers,
- * etc.).  We accept this subset so `arel` stays dependency-free from
- * `activerecord`; `AbstractAdapter` is a structural superset and always
- * satisfies this interface.
- *
- * @deprecated Use `ArelConnection` — this alias will be removed in a future release.
- */
-export type ArelQuoter = ArelConnection;
-
-/**
  * Resolve a bind's database value. QueryAttribute exposes
  * `valueForDatabase` as a method; ActiveModel::Attribute (TS port)
  * exposes it as a getter. A normal property read handles both shapes —


### PR DESCRIPTION
Deletes the deprecated `ArelQuoter` type alias (`export type ArelQuoter = ArelConnection`) from `packages/arel/src/visitors/to-sql.ts` and its re-export in `visitors/index.ts`. Rails has no such name — the `ToSql#initialize` parameter (`to_sql.rb:12`) is just the adapter connection, which trails names `ArelConnection`. With the default quoters removed in #5067, this alias was the last vestige of the pre-RFC-0007 "quoter" framing.

All importers switched to `ArelConnection`:

- `packages/arel/src/visitors/to-sql.test.ts` (stub annotation only; test names unchanged)
- `packages/activerecord/src/insert-all.ts`
- `packages/activerecord/src/connection-adapters/abstract/database-statements.ts`

Closes-story: delete-deprecated-arelquoter-alias
