### PR TITLE
test(activerecord): port disconnected_test.rb

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -216,7 +216,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   override get active(): boolean {
-    return !this._closed && this._pgClientOptions != null;
+    // Rails' active? starts with `return false unless @raw_connection`
+    // (postgresql_adapter.rb); the ping half can't run in a sync getter.
+    return this._rawConnection !== null && !this._closed && this._pgClientOptions != null;
   }
 
   // Mirrors Rails' `PostgreSQLAdapter#connected?`
@@ -3072,7 +3074,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     this._statementPool = null;
     this._needsDeallocateAll = false;
     this._inTransaction = false;
-    this._closed = true;
+    // Rails' disconnect! is NOT terminal: with_raw_connection's
+    // `connect! if @raw_connection.nil?` (abstract_adapter.rb:985) lazily
+    // reopens on the next query (cases/disconnected_test.rb). `_closed = true`
+    // is reserved for close()/discardBang(), which ARE terminal.
     // If a connect is in flight, bump its generation so it tears down (end()s,
     // not adopts) its socket when it resolves — even if a racing reconnect
     // clears _closed first — and so a later reconnect opens a fresh acquire

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -456,8 +456,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     name: string = "SQL",
   ): Promise<Record<string, unknown>[]> {
     sql = this.preprocessQuery(sql);
-    // Rails order in with_raw_connection: lazy connect! first, then
-    // materialize_transactions (abstract_adapter.rb:985-987).
     await this.ensureConnected();
     await this.materializeTransactions();
 
@@ -620,7 +618,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     // preprocessQuery runs Rails' check_if_write_query, which raises
     // ReadOnlyError while writes are prevented — see isPreventingWrites below.
     sql = this.preprocessQuery(sql);
-    // Same lazy connect!-before-materialize order as `execute` above.
     await this.ensureConnected();
     await this.materializeTransactions();
     const payload = this._notificationPayload(sql, binds, name);
@@ -2891,11 +2888,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
    */
   private async ensureConnected(): Promise<void> {
     if (this._asyncConnectPending) await this.completeAsyncConnect();
-    // Mirrors with_raw_connection's `connect! if @raw_connection.nil? &&
-    // reconnect_can_restore_state?` (abstract_adapter.rb:985): the sqlite
-    // execute path bypasses withRawConnection, so the lazy reconnect after
-    // `disconnect!` lands here. `driver` plays @raw_connection — a closed
-    // handle is its nil state — and connect! is verify! (abstract_adapter.rb:778).
     else if (!this.isActive() && this.isReconnectCanRestoreState()) await this.verifyBang();
   }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -456,6 +456,9 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     name: string = "SQL",
   ): Promise<Record<string, unknown>[]> {
     sql = this.preprocessQuery(sql);
+    // Rails order in with_raw_connection: lazy connect! first, then
+    // materialize_transactions (abstract_adapter.rb:985-987).
+    await this.ensureConnected();
     await this.materializeTransactions();
 
     const payload = this._notificationPayload(sql, binds, name);
@@ -617,6 +620,8 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     // preprocessQuery runs Rails' check_if_write_query, which raises
     // ReadOnlyError while writes are prevented — see isPreventingWrites below.
     sql = this.preprocessQuery(sql);
+    // Same lazy connect!-before-materialize order as `execute` above.
+    await this.ensureConnected();
     await this.materializeTransactions();
     const payload = this._notificationPayload(sql, binds, name);
     const driverBinds = binds.map(_driverBind, this) as SqliteBinds;
@@ -2886,6 +2891,12 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
    */
   private async ensureConnected(): Promise<void> {
     if (this._asyncConnectPending) await this.completeAsyncConnect();
+    // Mirrors with_raw_connection's `connect! if @raw_connection.nil? &&
+    // reconnect_can_restore_state?` (abstract_adapter.rb:985): the sqlite
+    // execute path bypasses withRawConnection, so the lazy reconnect after
+    // `disconnect!` lands here. `driver` plays @raw_connection — a closed
+    // handle is its nil state — and connect! is verify! (abstract_adapter.rb:778).
+    else if (!this.isActive() && this.isReconnectCanRestoreState()) await this.verifyBang();
   }
 
   /** @internal */

--- a/packages/activerecord/src/disconnected.test.ts
+++ b/packages/activerecord/src/disconnected.test.ts
@@ -4,15 +4,7 @@ import { Base } from "./index.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { adapterType, inMemoryDb } from "./test-adapter.js";
 
-// Ports activerecord/test/cases/disconnected_test.rb. Rails gates the single
-// case `unless in_memory_db?` — disconnecting an in-memory SQLite database
-// would drop the schema with it.
 describe.skipIf(inMemoryDb())("TestDisconnectedAdapter", () => {
-  // Rails declares no fixtures; the case only needs the canonical `products`
-  // table to exist. The disconnect/reconnect lifecycle is meaningless inside a
-  // wrapping transaction (the disconnect would sever it mid-flight), so the
-  // case opts out via `usesTransaction`, like AdapterConnectionTest's
-  // disconnect cases in adapter.test.ts.
   fixtures([], {
     usesTransaction: ["reconnects to execute statements when disconnected"],
   });
@@ -20,16 +12,9 @@ describe.skipIf(inMemoryDb())("TestDisconnectedAdapter", () => {
   let connection: AbstractAdapter;
 
   beforeEach(() => {
-    // Rails: `@connection = ActiveRecord::Base.lease_connection`.
     connection = Base.connection;
   });
 
-  // Rails reads the private `@raw_connection` ivar via `instance_variable_get`
-  // and compares `__id__`s; object identity stands in for `__id__`. PG and
-  // MySQL keep the raw handle in the base `_connection` slot; sqlite keeps it
-  // in `driver`, where a closed handle plays `@raw_connection = nil` (the
-  // adapter closes in place rather than nil-ing the field), so a closed
-  // driver maps to null here.
   function rawConnection(conn: AbstractAdapter): unknown {
     const sqlite = conn as unknown as { driver?: { isOpen(): boolean } };
     if (adapterType === "sqlite") {

--- a/packages/activerecord/src/disconnected.test.ts
+++ b/packages/activerecord/src/disconnected.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { AbstractAdapter } from "./connection-adapters/abstract-adapter.js";
+import { Base } from "./index.js";
+import { fixtures } from "./test-helpers/fixtures.js";
+import { adapterType, inMemoryDb } from "./test-adapter.js";
+
+// Ports activerecord/test/cases/disconnected_test.rb. Rails gates the single
+// case `unless in_memory_db?` — disconnecting an in-memory SQLite database
+// would drop the schema with it.
+describe.skipIf(inMemoryDb())("TestDisconnectedAdapter", () => {
+  // Rails declares no fixtures; the case only needs the canonical `products`
+  // table to exist. The disconnect/reconnect lifecycle is meaningless inside a
+  // wrapping transaction (the disconnect would sever it mid-flight), so the
+  // case opts out via `usesTransaction`, like AdapterConnectionTest's
+  // disconnect cases in adapter.test.ts.
+  fixtures([], {
+    usesTransaction: ["reconnects to execute statements when disconnected"],
+  });
+
+  let connection: AbstractAdapter;
+
+  beforeEach(() => {
+    // Rails: `@connection = ActiveRecord::Base.lease_connection`.
+    connection = Base.connection;
+  });
+
+  // Rails reads the private `@raw_connection` ivar via `instance_variable_get`
+  // and compares `__id__`s; object identity stands in for `__id__`. PG and
+  // MySQL keep the raw handle in the base `_connection` slot; sqlite keeps it
+  // in `driver`, where a closed handle plays `@raw_connection = nil` (the
+  // adapter closes in place rather than nil-ing the field), so a closed
+  // driver maps to null here.
+  function rawConnection(conn: AbstractAdapter): unknown {
+    const sqlite = conn as unknown as { driver?: { isOpen(): boolean } };
+    if (adapterType === "sqlite") {
+      return sqlite.driver?.isOpen() ? sqlite.driver : null;
+    }
+    return (conn as unknown as { _connection: unknown })._connection;
+  }
+
+  it("reconnects to execute statements when disconnected", async () => {
+    await connection.execute("SELECT count(*) from products");
+    const firstConnection = rawConnection(connection);
+
+    connection.disconnectBang();
+    expect(rawConnection(connection)).toBeNull();
+
+    await connection.execute("SELECT count(*) from products");
+    const secondConnection = rawConnection(connection);
+
+    expect(secondConnection).not.toBe(firstConnection);
+  });
+});


### PR DESCRIPTION
Ports `disconnected_test.rb` — `test:compare --package activerecord` marked it ✗ with no TS counterpart.

- `packages/activerecord/src/disconnected.test.ts`: the single Rails case "reconnects to execute statements when disconnected", asserting raw-connection identity changes across `disconnect!` + re-execute, gated `unless in_memory_db?` via `describe.skipIf(inMemoryDb())`. Runs non-transactional (`usesTransaction`) since a wrapping transaction would be severed by the disconnect.
- The port surfaced a sqlite divergence: the sqlite `execute`/`executeMutation` path (which bypasses `withRawConnection` — the known deviation) lacked Rails' lazy reconnect (`connect! if @raw_connection.nil? && reconnect_can_restore_state?`, abstract_adapter.rb:985). `ensureConnected` now mirrors that guard via `verifyBang` (Rails `connect!` = `verify!`, abstract_adapter.rb:778), invoked before `materializeTransactions` to match with_raw_connection's order.

`test:compare` now shows `disconnected_test.rb → disconnected.test.ts ✓`.

Closes-story: port-disconnected-test
