### PR TITLE
test(activerecord): port prepared_statement_status_test.rb

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -21,7 +21,7 @@ import {
   NotImplementedError,
   type SQLWarning,
 } from "../errors.js";
-import { Notifications } from "@blazetrails/activesupport";
+import { IsolatedExecutionState, Notifications } from "@blazetrails/activesupport";
 import type { EventPayload } from "@blazetrails/activesupport";
 import { disablePreparedStatements } from "../ar-config.js";
 import { Result, type ColumnTypes } from "../result.js";
@@ -974,7 +974,7 @@ export class AbstractAdapter implements Quoting {
   }
 
   get preparedStatements(): boolean {
-    return this._preparedStatements;
+    return this._preparedStatements && !this.preparedStatementsDisabledCache.has(this);
   }
 
   set preparedStatements(value: boolean) {
@@ -1434,12 +1434,17 @@ export class AbstractAdapter implements Quoting {
   }
 
   async unpreparedStatement<T>(fn: () => Promise<T> | T): Promise<T> {
-    const was = this._preparedStatements;
-    this._preparedStatements = false;
+    // Rails' `cache = prepared_statements_disabled_cache.add?(object_id) if
+    // @prepared_statements` — `Set#add?` returns nil when already present, so
+    // only the outermost block clears the entry on exit.
+    let cache: Set<unknown> | undefined;
+    if (this._preparedStatements && !this.preparedStatementsDisabledCache.has(this)) {
+      cache = this.preparedStatementsDisabledCache.add(this);
+    }
     try {
       return await fn();
     } finally {
-      this._preparedStatements = was;
+      cache?.delete(this);
     }
   }
 
@@ -1710,10 +1715,12 @@ export class AbstractAdapter implements Quoting {
     return new Visitors.ToSql(this);
   }
 
-  private _preparedStatementsDisabledCache = new Set<unknown>();
-
   get preparedStatementsDisabledCache(): Set<unknown> {
-    return this._preparedStatementsDisabledCache;
+    // Rails: `IsolatedExecutionState[:active_record_prepared_statements_disabled_cache] ||= Set.new`
+    return IsolatedExecutionState.fetch(
+      "active_record_prepared_statements_disabled_cache",
+      () => new Set<unknown>(),
+    );
   }
 
   // --- Lifecycle ---

--- a/packages/activerecord/src/prepared-statement-status.test.ts
+++ b/packages/activerecord/src/prepared-statement-status.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from "vitest";
+import { IsolatedExecutionState } from "@blazetrails/activesupport";
 import "./index.js";
 import { Base } from "./base.js";
 import { fixtures } from "./test-helpers/fixtures.js";
@@ -33,30 +34,25 @@ describe.skipIf(!isSqliteRun())("PreparedStatementStatusTest", () => {
 
     // eslint-disable-next-line vitest/no-conditional-in-test
     if ((await Base.leaseConnection()).preparedStatements) {
-      const t1 = (async () => {
+      const t1 = IsolatedExecutionState.run(async () => {
         await courseConn.unpreparedStatement(async () => {
           inside.set();
           await preventing.wait;
           expect(courseConn.preparedStatements).toBe(false);
-          expect(entrantConn.preparedStatements).toBe(false);
+          expect(entrantConn.preparedStatements).toBe(true);
+          finished.set();
         });
-        expect(courseConn.preparedStatements).toBe(true);
-        expect(entrantConn.preparedStatements).toBe(false);
-        finished.set();
-      })();
+      });
 
-      const t2 = (async () => {
-        await inside.wait;
+      const t2 = IsolatedExecutionState.run(async () => {
         await entrantConn.unpreparedStatement(async () => {
-          expect(courseConn.preparedStatements).toBe(false);
+          await inside.wait;
+          expect(courseConn.preparedStatements).toBe(true);
           expect(entrantConn.preparedStatements).toBe(false);
           preventing.set();
           await finished.wait;
-          expect(courseConn.preparedStatements).toBe(true);
-          expect(entrantConn.preparedStatements).toBe(false);
         });
-        expect(entrantConn.preparedStatements).toBe(true);
-      })();
+      });
 
       await t1;
       await t2;

--- a/packages/activerecord/src/prepared-statement-status.test.ts
+++ b/packages/activerecord/src/prepared-statement-status.test.ts
@@ -1,0 +1,85 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import "./index.js";
+import { Base } from "./base.js";
+import { fixtures } from "./test-helpers/fixtures.js";
+import { setupSecondPool } from "./test-helpers/setup-second-pool.js";
+import { isSqliteRun } from "./test-helpers/sqlite-template.js";
+import { Course } from "./test-helpers/models/course.js";
+import { Entrant } from "./test-helpers/models/entrant.js";
+
+// Ruby's Concurrent::Event: a one-shot latch with `set` / `wait`.
+function event(): { set: () => void; wait: Promise<void> } {
+  let set!: () => void;
+  const wait = new Promise<void>((resolve) => {
+    set = resolve;
+  });
+  return { set, wait };
+}
+
+// Rails runs this test against two real databases (arunit / arunit2) so
+// Course and Entrant lease connections from distinct pools. Like
+// MultipleDbTest, we reproduce the split with `setupSecondPool`, which only
+// self-provisions on the sqlite run — hence the gate.
+describe.skipIf(!isSqliteRun())("PreparedStatementStatusTest", () => {
+  fixtures({}, { useTransactionalTests: false });
+  beforeAll(async () => {
+    await setupSecondPool();
+  });
+
+  it("prepared statement status is thread and instance specific", async () => {
+    const courseConn = await Course.leaseConnection();
+    const entrantConn = await Entrant.leaseConnection();
+
+    const inside = event();
+    const preventing = event();
+    const finished = event();
+
+    expect(courseConn).not.toBe(entrantConn);
+
+    // eslint-disable-next-line vitest/no-conditional-in-test -- mirrors Rails' inline `if ActiveRecord::Base.lease_connection.prepared_statements` branch
+    if ((await Base.leaseConnection()).preparedStatements) {
+      // Rails interleaves two Threads and relies on `unprepared_statement`
+      // tracking the disabled set per *thread*: each thread sees the other
+      // connection still prepared even while that connection sits inside its
+      // own `unprepared_statement` block. Single-threaded JS has no
+      // thread-local state — trails' `unpreparedStatement` flips the instance
+      // flag — so the thread-specific half collapses: while both blocks are
+      // live, both flags read false. We keep Rails' event-driven interleave
+      // and assert the *instance*-specific half: each connection's block
+      // never touches the other instance, and each flag is restored on exit
+      // of its own block regardless of the other block still being live.
+      const t1 = (async () => {
+        await courseConn.unpreparedStatement(async () => {
+          inside.set();
+          await preventing.wait;
+          expect(courseConn.preparedStatements).toBe(false);
+          expect(entrantConn.preparedStatements).toBe(false);
+        });
+        // courseConn's exit restores its own flag; entrantConn is still
+        // inside its block and stays off — instance isolation both ways.
+        expect(courseConn.preparedStatements).toBe(true);
+        expect(entrantConn.preparedStatements).toBe(false);
+        finished.set();
+      })();
+
+      const t2 = (async () => {
+        await inside.wait;
+        await entrantConn.unpreparedStatement(async () => {
+          expect(courseConn.preparedStatements).toBe(false);
+          expect(entrantConn.preparedStatements).toBe(false);
+          preventing.set();
+          await finished.wait;
+          expect(courseConn.preparedStatements).toBe(true);
+          expect(entrantConn.preparedStatements).toBe(false);
+        });
+        expect(entrantConn.preparedStatements).toBe(true);
+      })();
+
+      await t1;
+      await t2;
+    } else {
+      expect(courseConn.preparedStatements).toBe(false);
+      expect(entrantConn.preparedStatements).toBe(false);
+    }
+  });
+});

--- a/packages/activerecord/src/prepared-statement-status.test.ts
+++ b/packages/activerecord/src/prepared-statement-status.test.ts
@@ -7,7 +7,6 @@ import { isSqliteRun } from "./test-helpers/sqlite-template.js";
 import { Course } from "./test-helpers/models/course.js";
 import { Entrant } from "./test-helpers/models/entrant.js";
 
-// Ruby's Concurrent::Event: a one-shot latch with `set` / `wait`.
 function event(): { set: () => void; wait: Promise<void> } {
   let set!: () => void;
   const wait = new Promise<void>((resolve) => {
@@ -16,10 +15,6 @@ function event(): { set: () => void; wait: Promise<void> } {
   return { set, wait };
 }
 
-// Rails runs this test against two real databases (arunit / arunit2) so
-// Course and Entrant lease connections from distinct pools. Like
-// MultipleDbTest, we reproduce the split with `setupSecondPool`, which only
-// self-provisions on the sqlite run — hence the gate.
 describe.skipIf(!isSqliteRun())("PreparedStatementStatusTest", () => {
   fixtures({}, { useTransactionalTests: false });
   beforeAll(async () => {
@@ -36,18 +31,8 @@ describe.skipIf(!isSqliteRun())("PreparedStatementStatusTest", () => {
 
     expect(courseConn).not.toBe(entrantConn);
 
-    // eslint-disable-next-line vitest/no-conditional-in-test -- mirrors Rails' inline `if ActiveRecord::Base.lease_connection.prepared_statements` branch
+    // eslint-disable-next-line vitest/no-conditional-in-test
     if ((await Base.leaseConnection()).preparedStatements) {
-      // Rails interleaves two Threads and relies on `unprepared_statement`
-      // tracking the disabled set per *thread*: each thread sees the other
-      // connection still prepared even while that connection sits inside its
-      // own `unprepared_statement` block. Single-threaded JS has no
-      // thread-local state — trails' `unpreparedStatement` flips the instance
-      // flag — so the thread-specific half collapses: while both blocks are
-      // live, both flags read false. We keep Rails' event-driven interleave
-      // and assert the *instance*-specific half: each connection's block
-      // never touches the other instance, and each flag is restored on exit
-      // of its own block regardless of the other block still being live.
       const t1 = (async () => {
         await courseConn.unpreparedStatement(async () => {
           inside.set();
@@ -55,8 +40,6 @@ describe.skipIf(!isSqliteRun())("PreparedStatementStatusTest", () => {
           expect(courseConn.preparedStatements).toBe(false);
           expect(entrantConn.preparedStatements).toBe(false);
         });
-        // courseConn's exit restores its own flag; entrantConn is still
-        // inside its block and stays off — instance isolation both ways.
         expect(courseConn.preparedStatements).toBe(true);
         expect(entrantConn.preparedStatements).toBe(false);
         finished.set();

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-adapter.json
@@ -387,20 +387,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "unprepared_statement",
-    "call": "add?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "unprepared_statement",
-    "call": "delete",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
     "rubyName": "verify!",
     "call": "synchronize",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Ports `vendor/rails/activerecord/test/cases/prepared_statement_status_test.rb` (one test: "prepared statement status is thread and instance specific").

Two distinct pools (Course via `setupSecondPool`'s arunit2, Entrant via primary); Rails' `Concurrent::Event` → promise latches, `Thread.new` → `IsolatedExecutionState.run` (a fresh per-task execution state, the analogue of Ruby's per-thread state). Assertions are Rails-verbatim. Gated to the sqlite run like `MultipleDbTest` (second pool self-provisions only there).

To make the verbatim assertions hold, converges the implementation to Rails: `unprepared_statement` now tracks disabled connections in a per-execution-context cache (`IsolatedExecutionState`, mirroring `abstract_adapter.rb`'s `prepared_statements_disabled_cache`) and `prepared_statements?` consults it, replacing the previous invented instance-flag flip and the vestigial instance-level `_preparedStatementsDisabledCache`.

`test:compare --package activerecord` now shows the file ✓.

Closes-story: port-prepared-statement-status-test
