### PR TITLE
test(activerecord): port abstract_mysql_adapter concurrency tests (RFC 0030)

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/count-deleted-rows-with-lock.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/count-deleted-rows-with-lock.test.ts
@@ -1,10 +1,11 @@
 /**
- * Trails-specific invariant for the MySQL adapter: deleting rows in one
- * connection while another connection concurrently inserts must report the
- * correct deleted-row count. Relocated from
- * count-deleted-rows-with-lock.test.ts (RFC 0043) -- the paired Rails file
- * adapters/abstract_mysql_adapter/count_deleted_rows_with_lock_test.rb is an
- * adapter-gated case that maps zero in test:compare.
+ * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/count_deleted_rows_with_lock_test.rb
+ *
+ * Rails races `Bulb.unscoped.delete_all` against `Author.create!` on two Ruby
+ * Threads and asserts the delete reports 1 row (MySQL row-count-under-lock
+ * behavior). This port drives the same race at the adapter level on two
+ * connections; the tables use a `test_` prefix so the DROP/CREATE cycle stays
+ * off the shared canonical `bulbs`/`authors` tables that parallel workers own.
  */
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/count-deleted-rows-with-lock.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/count-deleted-rows-with-lock.test.ts
@@ -1,12 +1,3 @@
-/**
- * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/count_deleted_rows_with_lock_test.rb
- *
- * Rails races `Bulb.unscoped.delete_all` against `Author.create!` on two Ruby
- * Threads and asserts the delete reports 1 row (MySQL row-count-under-lock
- * behavior). This port drives the same race at the adapter level on two
- * connections; the tables use a `test_` prefix so the DROP/CREATE cycle stays
- * off the shared canonical `bulbs`/`authors` tables that parallel workers own.
- */
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
 

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/nested-deadlock.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/nested-deadlock.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/nested_deadlock_test.rb
+ *
+ * Rails provokes a real InnoDB deadlock by running competing nested
+ * (savepoint) transactions on two Ruby Threads synchronized with a
+ * Concurrent::CyclicBarrier. This port drives the same interleave on two
+ * adapter connections raced with Promise.allSettled and an async barrier.
+ * Rails' own test creates the `samples` table inline, so the inline
+ * DROP/CREATE here is faithful.
+ */
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+import { Deadlocked, Rollback } from "../../errors.js";
+import { SavepointTransaction } from "../../connection-adapters/abstract/transaction.js";
+
+function createBarrier(n: number): { wait: () => Promise<void> } {
+  let count = 0;
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return {
+    wait: () => {
+      count++;
+      if (count >= n) resolve();
+      return promise;
+    },
+  };
+}
+
+/** Mirrors Rails' `make_parent_transaction_dirty` which runs `Sample.take`. */
+async function makeParentDirty(a: Mysql2Adapter): Promise<void> {
+  await a.execQuery("SELECT * FROM `samples` LIMIT 1");
+}
+
+/** Mirrors `assert_current_transaction_is_savepoint_transaction`. */
+function assertSavepoint(a: Mysql2Adapter): void {
+  expect(a.currentTransaction()).toBeInstanceOf(SavepointTransaction);
+}
+
+describeIfMysql("Mysql2Adapter", () => {
+  let adapter: Mysql2Adapter;
+  beforeEach(async () => {
+    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
+  });
+  afterEach(async () => {
+    await adapter.close();
+  });
+
+  describe("NestedDeadlockTest", () => {
+    let s1id: number;
+    let s2id: number;
+
+    beforeEach(async () => {
+      await adapter.execute("DROP TABLE IF EXISTS `samples`");
+      await adapter.execute(
+        "CREATE TABLE `samples` (id INT AUTO_INCREMENT PRIMARY KEY, value INT)",
+      );
+      await adapter.execute("INSERT INTO `samples` (value) VALUES (1)");
+      await adapter.execute("INSERT INTO `samples` (value) VALUES (2)");
+      const rows = await adapter.execute("SELECT id FROM `samples` ORDER BY id");
+      s1id = Number(rows[0]["id"]);
+      s2id = Number(rows[1]["id"]);
+    });
+    afterEach(async () => {
+      await adapter.execute("DROP TABLE IF EXISTS `samples`").catch(() => {});
+    });
+
+    /**
+     * The shared interleave: each connection opens a parent transaction,
+     * dirties it (forcing the nested `requiresNew` transaction onto a
+     * savepoint), row-locks its own sample, waits at the barrier, then
+     * updates the other's row — guaranteeing InnoDB detects a deadlock on
+     * exactly one side. `onDeadlock` mirrors each Rails test's rescue
+     * placement: undefined lets Deadlocked propagate out of the nested
+     * transaction and doom the whole block.
+     */
+    async function raceNestedTransactions(
+      adapter2: Mysql2Adapter,
+      onDeadlock?: "rollback" | "swallow",
+    ): Promise<{ results: PromiseSettledResult<void>[]; deadlocks: number }> {
+      const barrier = createBarrier(2);
+      let deadlocks = 0;
+
+      const side = async (
+        a: Mysql2Adapter,
+        lockId: number,
+        updateId: number,
+        value: number,
+      ): Promise<void> => {
+        await a.transaction(async () => {
+          await makeParentDirty(a);
+          const nested = a.transaction({ requiresNew: true }, async () => {
+            assertSavepoint(a);
+            await a.execute(`SELECT * FROM \`samples\` WHERE id = ${lockId} FOR UPDATE`);
+            await barrier.wait();
+            try {
+              await a.executeMutation(
+                `UPDATE \`samples\` SET value = ${value} WHERE id = ${updateId}`,
+              );
+            } catch (e) {
+              if (onDeadlock === "rollback" && e instanceof Deadlocked) {
+                deadlocks++;
+                throw new Rollback();
+              }
+              throw e;
+            }
+          });
+          if (onDeadlock === "swallow") {
+            try {
+              await nested;
+            } catch (e) {
+              if (!(e instanceof Deadlocked)) throw e;
+              deadlocks++;
+            }
+          } else {
+            await nested;
+          }
+          // Rails' first test ends at the nested transaction; only the
+          // recovery tests follow it with the outer `update value: 10`.
+          if (onDeadlock !== undefined) {
+            await a.executeMutation(`UPDATE \`samples\` SET value = 10 WHERE id = ${updateId}`);
+          }
+        });
+      };
+
+      const results = await Promise.allSettled([
+        side(adapter, s1id, s2id, onDeadlock ? 4 : 1),
+        side(adapter2, s2id, s1id, onDeadlock ? 3 : 2),
+      ]);
+      return { results, deadlocks };
+    }
+
+    async function expectFinalValues(values: number[]): Promise<void> {
+      const finalRows = await adapter.execute("SELECT value FROM `samples` ORDER BY id");
+      expect(finalRows.map((r) => Number(r["value"]))).toEqual(values);
+    }
+
+    it("deadlock correctly raises Deadlocked inside nested SavepointTransaction", async () => {
+      const adapter2 = new Mysql2Adapter(MYSQL_TEST_URL);
+      try {
+        const { results } = await raceNestedTransactions(adapter2);
+
+        const errors = results.filter((r) => r.status === "rejected").map((r) => r.reason);
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toBeInstanceOf(Deadlocked);
+
+        expect(adapter.active).toBe(true);
+        expect(adapter2.active).toBe(true);
+      } finally {
+        await adapter2.close();
+      }
+    });
+
+    it("rollback exception is swallowed after a rollback", async () => {
+      const adapter2 = new Mysql2Adapter(MYSQL_TEST_URL);
+      try {
+        const { results, deadlocks } = await raceNestedTransactions(adapter2, "rollback");
+
+        expect(results[0].status).toBe("fulfilled");
+        expect(results[1].status).toBe("fulfilled");
+        expect(deadlocks).toBe(1);
+        await expectFinalValues([10, 10]);
+      } finally {
+        await adapter2.close();
+      }
+    });
+
+    it("deadlock inside nested SavepointTransaction is recoverable", async () => {
+      const adapter2 = new Mysql2Adapter(MYSQL_TEST_URL);
+      try {
+        const { results, deadlocks } = await raceNestedTransactions(adapter2, "swallow");
+
+        expect(results[0].status).toBe("fulfilled");
+        expect(results[1].status).toBe("fulfilled");
+        expect(deadlocks).toBe(1);
+        await expectFinalValues([10, 10]);
+      } finally {
+        await adapter2.close();
+      }
+    });
+  });
+});

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/nested-deadlock.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/nested-deadlock.test.ts
@@ -1,13 +1,3 @@
-/**
- * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/nested_deadlock_test.rb
- *
- * Rails provokes a real InnoDB deadlock by running competing nested
- * (savepoint) transactions on two Ruby Threads synchronized with a
- * Concurrent::CyclicBarrier. This port drives the same interleave on two
- * adapter connections raced with Promise.allSettled and an async barrier.
- * Rails' own test creates the `samples` table inline, so the inline
- * DROP/CREATE here is faithful.
- */
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
 import { Deadlocked, Rollback } from "../../errors.js";
@@ -28,12 +18,10 @@ function createBarrier(n: number): { wait: () => Promise<void> } {
   };
 }
 
-/** Mirrors Rails' `make_parent_transaction_dirty` which runs `Sample.take`. */
 async function makeParentDirty(a: Mysql2Adapter): Promise<void> {
   await a.execQuery("SELECT * FROM `samples` LIMIT 1");
 }
 
-/** Mirrors `assert_current_transaction_is_savepoint_transaction`. */
 function assertSavepoint(a: Mysql2Adapter): void {
   expect(a.currentTransaction()).toBeInstanceOf(SavepointTransaction);
 }
@@ -66,15 +54,6 @@ describeIfMysql("Mysql2Adapter", () => {
       await adapter.execute("DROP TABLE IF EXISTS `samples`").catch(() => {});
     });
 
-    /**
-     * The shared interleave: each connection opens a parent transaction,
-     * dirties it (forcing the nested `requiresNew` transaction onto a
-     * savepoint), row-locks its own sample, waits at the barrier, then
-     * updates the other's row — guaranteeing InnoDB detects a deadlock on
-     * exactly one side. `onDeadlock` mirrors each Rails test's rescue
-     * placement: undefined lets Deadlocked propagate out of the nested
-     * transaction and doom the whole block.
-     */
     async function raceNestedTransactions(
       adapter2: Mysql2Adapter,
       onDeadlock?: "rollback" | "swallow",
@@ -116,8 +95,6 @@ describeIfMysql("Mysql2Adapter", () => {
           } else {
             await nested;
           }
-          // Rails' first test ends at the nested transaction; only the
-          // recovery tests follow it with the outer `update value: 10`.
           if (onDeadlock !== undefined) {
             await a.executeMutation(`UPDATE \`samples\` SET value = 10 WHERE id = ${updateId}`);
           }

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/nested-deadlock.trails.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/nested-deadlock.trails.test.ts
@@ -1,20 +1,11 @@
-/**
- * Trails-specific (TS-only) extra for the MySQL adapter's nested-deadlock
- * suite. The Rails-named tests from
- * adapters/abstract_mysql_adapter/nested_deadlock_test.rb live in
- * nested-deadlock.test.ts; this file keeps the adapter-level savepoint
- * promotion check that has no Rails counterpart.
- */
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
 import { SavepointTransaction } from "../../connection-adapters/abstract/transaction.js";
 
-/** Mirrors Rails' `make_parent_transaction_dirty` which runs `Sample.take`. */
 async function makeParentDirty(a: Mysql2Adapter): Promise<void> {
   await a.execQuery("SELECT * FROM `samples` LIMIT 1");
 }
 
-/** Mirrors `assert_current_transaction_is_savepoint_transaction`. */
 function assertSavepoint(a: Mysql2Adapter): void {
   expect(a.currentTransaction()).toBeInstanceOf(SavepointTransaction);
 }

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/nested-deadlock.trails.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/nested-deadlock.trails.test.ts
@@ -1,33 +1,13 @@
 /**
- * Trails-specific deadlock invariants for the MySQL adapter.
- *
- * The Rails counterpart `adapters/abstract_mysql_adapter/nested_deadlock_test.rb`
- * is formally unported (see scripts/api-compare/unported-files.ts): it provokes a
- * real database deadlock across two Ruby Threads synchronized with a
- * `Concurrent::CyclicBarrier`, which single-threaded Ruby concurrency cannot be
- * mirrored 1:1 in JS. These tests instead exercise the same trails invariants
- * (savepoint promotion + Deadlocked/Rollback handling) using two separate adapter
- * connections driven concurrently with `Promise.allSettled` and an async barrier.
+ * Trails-specific (TS-only) extra for the MySQL adapter's nested-deadlock
+ * suite. The Rails-named tests from
+ * adapters/abstract_mysql_adapter/nested_deadlock_test.rb live in
+ * nested-deadlock.test.ts; this file keeps the adapter-level savepoint
+ * promotion check that has no Rails counterpart.
  */
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
-import { Deadlocked, Rollback } from "../../errors.js";
 import { SavepointTransaction } from "../../connection-adapters/abstract/transaction.js";
-
-function createBarrier(n: number): { wait: () => Promise<void> } {
-  let count = 0;
-  let resolve!: () => void;
-  const promise = new Promise<void>((r) => {
-    resolve = r;
-  });
-  return {
-    wait: () => {
-      count++;
-      if (count >= n) resolve();
-      return promise;
-    },
-  };
-}
 
 /** Mirrors Rails' `make_parent_transaction_dirty` which runs `Sample.take`. */
 async function makeParentDirty(a: Mysql2Adapter): Promise<void> {
@@ -66,132 +46,6 @@ describeIfMysql("Mysql2Adapter", () => {
           assertSavepoint(adapter);
         });
       });
-    });
-
-    it("deadlock correctly raises Deadlocked inside nested SavepointTransaction", async () => {
-      await adapter.execute("INSERT INTO `samples` (value) VALUES (1)");
-      await adapter.execute("INSERT INTO `samples` (value) VALUES (2)");
-      const rows = await adapter.execute("SELECT id FROM `samples` ORDER BY id");
-      const s1id = Number(rows[0]["id"]);
-      const s2id = Number(rows[1]["id"]);
-
-      const adapter2 = new Mysql2Adapter(MYSQL_TEST_URL);
-      try {
-        const barrier = createBarrier(2);
-
-        const [result1, result2] = await Promise.allSettled([
-          (async () => {
-            await adapter.transaction(async () => {
-              await makeParentDirty(adapter);
-              await adapter.transaction({ requiresNew: true }, async () => {
-                assertSavepoint(adapter);
-                await adapter.execute(`SELECT * FROM \`samples\` WHERE id = ${s1id} FOR UPDATE`);
-                await barrier.wait();
-                await adapter.executeMutation(
-                  `UPDATE \`samples\` SET value = 1 WHERE id = ${s2id}`,
-                );
-              });
-            });
-          })(),
-          (async () => {
-            await adapter2.transaction(async () => {
-              await makeParentDirty(adapter2);
-              await adapter2.transaction({ requiresNew: true }, async () => {
-                assertSavepoint(adapter2);
-                await adapter2.execute(`SELECT * FROM \`samples\` WHERE id = ${s2id} FOR UPDATE`);
-                await barrier.wait();
-                await adapter2.executeMutation(
-                  `UPDATE \`samples\` SET value = 2 WHERE id = ${s1id}`,
-                );
-              });
-            });
-          })(),
-        ]);
-
-        const errors = [result1, result2]
-          .filter((r) => r.status === "rejected")
-          .map((r) => r.reason);
-
-        expect(errors).toHaveLength(1);
-        expect(errors[0]).toBeInstanceOf(Deadlocked);
-
-        expect(adapter.active).toBe(true);
-        expect(adapter2.active).toBe(true);
-      } finally {
-        await adapter2.close();
-      }
-    });
-
-    it("rollback exception is swallowed after a rollback", async () => {
-      await adapter.execute("INSERT INTO `samples` (value) VALUES (1)");
-      await adapter.execute("INSERT INTO `samples` (value) VALUES (2)");
-      const rows = await adapter.execute("SELECT id FROM `samples` ORDER BY id");
-      const s1id = Number(rows[0]["id"]);
-      const s2id = Number(rows[1]["id"]);
-
-      const adapter2 = new Mysql2Adapter(MYSQL_TEST_URL);
-      try {
-        const barrier = createBarrier(2);
-        let deadlocks = 0;
-
-        const [result1, result2] = await Promise.allSettled([
-          (async () => {
-            await adapter.transaction(async () => {
-              await makeParentDirty(adapter);
-              await adapter.transaction({ requiresNew: true }, async () => {
-                assertSavepoint(adapter);
-                await adapter.execute(`SELECT * FROM \`samples\` WHERE id = ${s1id} FOR UPDATE`);
-                await barrier.wait();
-                try {
-                  await adapter.executeMutation(
-                    `UPDATE \`samples\` SET value = 4 WHERE id = ${s2id}`,
-                  );
-                } catch (e) {
-                  if (e instanceof Deadlocked) {
-                    deadlocks++;
-                    throw new Rollback();
-                  }
-                  throw e;
-                }
-              });
-              await adapter.executeMutation(`UPDATE \`samples\` SET value = 10 WHERE id = ${s2id}`);
-            });
-          })(),
-          (async () => {
-            await adapter2.transaction(async () => {
-              await makeParentDirty(adapter2);
-              await adapter2.transaction({ requiresNew: true }, async () => {
-                assertSavepoint(adapter2);
-                await adapter2.execute(`SELECT * FROM \`samples\` WHERE id = ${s2id} FOR UPDATE`);
-                await barrier.wait();
-                try {
-                  await adapter2.executeMutation(
-                    `UPDATE \`samples\` SET value = 3 WHERE id = ${s1id}`,
-                  );
-                } catch (e) {
-                  if (e instanceof Deadlocked) {
-                    deadlocks++;
-                    throw new Rollback();
-                  }
-                  throw e;
-                }
-              });
-              await adapter2.executeMutation(
-                `UPDATE \`samples\` SET value = 10 WHERE id = ${s1id}`,
-              );
-            });
-          })(),
-        ]);
-
-        expect(result1.status).toBe("fulfilled");
-        expect(result2.status).toBe("fulfilled");
-        expect(deadlocks).toBe(1);
-
-        const finalRows = await adapter.execute("SELECT value FROM `samples` ORDER BY id");
-        expect(finalRows.map((r) => Number(r["value"]))).toEqual([10, 10]);
-      } finally {
-        await adapter2.close();
-      }
     });
   });
 });

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -913,33 +913,6 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "concurrency test with no single-threaded JS equivalent.",
   },
   {
-    testFile: "adapters/abstract_mysql_adapter/count_deleted_rows_with_lock_test.rb",
-    tests: ["delete and create in different threads synchronize correctly"],
-    reason:
-      "Two Ruby Threads racing a DELETE and CREATE under a row lock to assert " +
-      "MySQL-side synchronization. GVL / shared-memory Thread model has no " +
-      "Node.js equivalent.",
-  },
-  // --- Concurrent-thread deadlock detection ---
-  // Listed in both the MySQL and PostgreSQL sibling files so the shared-test
-  // detector keeps them balanced (an asymmetric exclusion would mis-flag the
-  // surviving sibling as "misplaced").
-  {
-    testFile: "adapters/abstract_mysql_adapter/nested_deadlock_test.rb",
-    tests: [
-      "deadlock correctly raises Deadlocked inside nested SavepointTransaction",
-      "deadlock inside nested SavepointTransaction is recoverable",
-      "rollback exception is swallowed after a rollback",
-    ],
-    reason:
-      "Provokes a real database deadlock by running competing transactions on " +
-      "two Ruby Threads synchronized with a Concurrent::CyclicBarrier " +
-      "(nested_deadlock_test.rb:36-160); 'rollback exception is swallowed after " +
-      "a rollback' (:81) asserts `deadlocks == 1, \"deadlock is required for " +
-      'the test setup"`. A deadlock requires genuine concurrency; ' +
-      "single-threaded JS cannot reproduce it.",
-  },
-  {
     testFile: "adapters/postgresql/transaction_nested_test.rb",
     tests: [
       "deadlock inside nested SavepointTransaction is recoverable",


### PR DESCRIPTION
Ports the two `abstract_mysql_adapter` concurrency files that `test:compare --incomplete` marked ✗ (no TS counterpart):

- `count_deleted_rows_with_lock_test.rb` → `count-deleted-rows-with-lock.test.ts`: races a DELETE against an unrelated INSERT on two connections; asserts the delete reports 1 row. Relocated from the `.trails` extras file (deleted) so it maps in test:compare.
- `nested_deadlock_test.rb` → `nested-deadlock.test.ts`: all three Rails tests, provoking a real InnoDB deadlock across two adapter connections with an async barrier standing in for Rails' `Concurrent::CyclicBarrier`. Two tests relocated from the `.trails` extras file (deduped into a shared `raceNestedTransactions` interleave); the previously unported "deadlock inside nested SavepointTransaction is recoverable" is newly ported. The `.trails` file keeps only the TS-only savepoint-promotion extra.
- Drops both files' `unported-files.ts` exclusions — the concurrency argument no longer holds (the PG sibling `transaction-nested.test.ts` already set the precedent).

Verified locally against an isolated MySQL 8 stack: all 5 tests pass; both files now show ✓ in `test:compare --package activerecord`.

Closes-story: port-abstract-mysql-concurrency-tests
