### PR TITLE
test(query-logs): port Rails escape_sql_comment inputs/outputs verbatim

### DIFF
--- a/packages/activerecord/src/query-logs.test.ts
+++ b/packages/activerecord/src/query-logs.test.ts
@@ -67,17 +67,19 @@ describe("QueryLogsTest", () => {
 
   // Unit tests — Rails' `escape_sql_comment` is exercised directly, no fixtures.
   it("escaping good comment", () => {
-    expect(escapeComment("app:MyApp")).toBe("app:MyApp");
+    expect(escapeComment("app:foo")).toBe("app:foo");
   });
 
   it("escaping good comment with custom separator", () => {
-    expect(escapeComment("app=MyApp")).toBe("app=MyApp");
+    queryLogs.formatter = "sqlcommenter";
+
+    expect(escapeComment("app='foo'")).toBe("app='foo'");
   });
 
   it("escaping bad comments", () => {
-    expect(escapeComment("*/")).toBe("* /");
-    expect(escapeComment("/*")).toBe("/ *");
-    expect(escapeComment("/* evil */")).toBe("/ * evil * /");
+    expect(escapeComment("*/; DROP TABLE USERS;/*")).toBe("* /; DROP TABLE USERS;/ *");
+    expect(escapeComment("**//; DROP TABLE USERS;/*")).toBe("** //; DROP TABLE USERS;/ *");
+    expect(escapeComment("* *//; DROP TABLE USERS;//* *")).toBe("* * //; DROP TABLE USERS;// * *");
   });
 
   // Rails executes `select id from posts`; trails drives the equivalent raw

--- a/packages/activerecord/src/query-logs.ts
+++ b/packages/activerecord/src/query-logs.ts
@@ -311,8 +311,7 @@ export class QueryLogs implements QueryTransformer {
 // (query_logs.rb:219-228). Rails additionally strips a leading
 // `\A\s*/\*\+?\s?` and a trailing `\s?\*/\s*\Z` before escaping; trails
 // intentionally omits that strip so bare-marker inputs round-trip
-// through escape rather than collapsing to an empty string — the
-// existing "escaping bad comments" test cases encode that.
+// through escape rather than collapsing to an empty string.
 export function escapeComment(content: string): string {
   return String(content).replace(/\*\//g, "* /").replace(/\/\*/g, "/ *");
 }

--- a/packages/activerecord/src/query-logs.ts
+++ b/packages/activerecord/src/query-logs.ts
@@ -304,16 +304,12 @@ export class QueryLogs implements QueryTransformer {
   }
 }
 
-// Sanitize a string for safe inclusion in a SQL comment by neutralising
-// any internal "*/" and "/*" sequences (turns them into "* /" / "/ *").
-//
-// Partial port of ActiveRecord::QueryLogs#escape_sql_comment
-// (query_logs.rb:219-228). Rails additionally strips a leading
-// `\A\s*/\*\+?\s?` and a trailing `\s?\*/\s*\Z` before escaping; trails
-// intentionally omits that strip so bare-marker inputs round-trip
-// through escape rather than collapsing to an empty string.
+// Mirrors: ActiveRecord::QueryLogs#escape_sql_comment
 export function escapeComment(content: string): string {
-  return String(content).replace(/\*\//g, "* /").replace(/\/\*/g, "/ *");
+  return String(content)
+    .replace(/^\s*\/\*\+?\s?|\s?\*\/\s*$/g, "")
+    .replace(/\*\//g, "* /")
+    .replace(/\/\*/g, "/ *");
 }
 
 /**


### PR DESCRIPTION
Port Rails' exact `escape_sql_comment` test inputs/outputs to `query-logs.test.ts` (query_logs_test.rb:43-57):

- "escaping good comment": `app:foo` (was `app:MyApp`).
- "escaping good comment with custom separator": sets the sqlcommenter formatter and asserts quoted `app='foo'`, as Rails does.
- "escaping bad comments": Rails' three adversarial payloads, including the `**//` and `* *//...//* *` nesting cases that verify iteration-safe escaping (was three weakened bare-marker cases).

Also converges `escapeComment` to the full Rails implementation: it now strips a leading `/*`/`/*+` and trailing `*/` marker (with optional surrounding whitespace) before neutralising internal `*/` / `/*` sequences, exactly as `escape_sql_comment` does. The previous omission of that strip was a deviation whose only encoding was the weakened test cases this PR replaces.

Closes-story: query-logs-escape-comment-fidelity
