### PR TITLE
test(sqlite3): converge adapter/virtual-column assertion values to Rails

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
@@ -21,8 +21,6 @@ beforeEach(() => {
   adapter = new BetterSQLite3Adapter(":memory:");
 });
 
-// Rails with_example_table default definition:
-//   id integer PRIMARY KEY AUTOINCREMENT, number integer
 async function createExampleTable(): Promise<void> {
   await adapter.exec(
     `CREATE TABLE "ex" ("id" integer PRIMARY KEY AUTOINCREMENT, "number" integer)`,
@@ -35,7 +33,7 @@ afterEach(async () => {
   // multi-table DROP, so one IF EXISTS statement per name; this balances
   // require-table-teardown and is behavior-neutral on the fresh per-test adapter.
   await adapter.exec(
-    `DROP TABLE IF EXISTS items; DROP TABLE IF EXISTS typed; DROP TABLE IF EXISTS no_pk; DROP TABLE IF EXISTS bin_esc; DROP TABLE IF EXISTS enc_test; DROP TABLE IF EXISTS def_vals; DROP TABLE IF EXISTS strict_items; DROP TABLE IF EXISTS custom_pk_src; DROP TABLE IF EXISTS custom_pk_dest; DROP TABLE IF EXISTS cpk_src; DROP TABLE IF EXISTS cpk_dest; DROP TABLE IF EXISTS custom_pk; DROP TABLE IF EXISTS change_pk; DROP TABLE IF EXISTS add_col_pk; DROP TABLE IF EXISTS barcodes; DROP TABLE IF EXISTS test; DROP TABLE IF EXISTS testings; DROP TABLE IF EXISTS rowid_test; DROP TABLE IF EXISTS rowid_lower; DROP TABLE IF EXISTS text_pk; DROP TABLE IF EXISTS mixed_case; DROP TABLE IF EXISTS auto_inc; DROP TABLE IF EXISTS cpk; DROP TABLE IF EXISTS ex; DROP TABLE IF EXISTS json_defs`,
+    `DROP TABLE IF EXISTS items; DROP TABLE IF EXISTS typed; DROP TABLE IF EXISTS no_pk; DROP TABLE IF EXISTS bin_esc; DROP TABLE IF EXISTS enc_test; DROP TABLE IF EXISTS def_vals; DROP TABLE IF EXISTS strict_items; DROP TABLE IF EXISTS custom_pk_src; DROP TABLE IF EXISTS custom_pk_dest; DROP TABLE IF EXISTS cpk_src; DROP TABLE IF EXISTS cpk_dest; DROP TABLE IF EXISTS custom_pk; DROP TABLE IF EXISTS change_pk; DROP TABLE IF EXISTS barcodes; DROP TABLE IF EXISTS test; DROP TABLE IF EXISTS testings; DROP TABLE IF EXISTS rowid_test; DROP TABLE IF EXISTS rowid_lower; DROP TABLE IF EXISTS text_pk; DROP TABLE IF EXISTS mixed_case; DROP TABLE IF EXISTS auto_inc; DROP TABLE IF EXISTS cpk; DROP TABLE IF EXISTS ex; DROP TABLE IF EXISTS json_defs`,
   );
   await adapter.close();
   Notifications.unsubscribeAll();

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
@@ -21,6 +21,14 @@ beforeEach(() => {
   adapter = new BetterSQLite3Adapter(":memory:");
 });
 
+// Rails with_example_table default definition:
+//   id integer PRIMARY KEY AUTOINCREMENT, number integer
+async function createExampleTable(): Promise<void> {
+  await adapter.exec(
+    `CREATE TABLE "ex" ("id" integer PRIMARY KEY AUTOINCREMENT, "number" integer)`,
+  );
+}
+
 afterEach(async () => {
   // Static teardown for the tables built in-test via raw CREATE TABLE (mostly on
   // throwaway :memory: adapters that are discarded on close). SQLite has no
@@ -131,12 +139,11 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   it("exec insert with quote", async () => {
-    const id = await adapter.executeMutation(
-      `INSERT INTO "items" ("name") VALUES ('it''s a test')`,
-    );
-    expect(id).toBe(1);
-    const rows = await adapter.execute(`SELECT "name" FROM "items" WHERE "id" = 1`);
-    expect(rows[0].name).toBe("it's a test");
+    await createExampleTable();
+    await adapter.executeMutation(`insert into "ex" (number) VALUES (?)`, [10]);
+    const rows = await adapter.execute(`select number from "ex" where number = ?`, [10]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].number).toBe(10);
   });
 
   it("primary key returns nil for no pk", async () => {
@@ -375,9 +382,11 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   it("columns with default", async () => {
-    const cols = await adapter.execute(`PRAGMA table_info("items")`);
-    const activeCol = cols.find((c: any) => c.name === "active");
-    expect(activeCol!.dflt_value).toBe("1");
+    await adapter.exec(
+      `CREATE TABLE "ex" ("id" integer PRIMARY KEY AUTOINCREMENT, "number" integer default 10)`,
+    );
+    const column = (await adapter.columns("ex")).find((x) => x.name === "number")!;
+    expect(column.default).toBe("10");
   });
 
   it("columns with not null", async () => {
@@ -456,44 +465,49 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   itIfSupports("expression_index", "expression index", async () => {
-    await adapter.exec(`CREATE INDEX "expression" ON "items" (max(id, price))`);
-    const indexes = (await adapter.indexes("items")) as any[];
+    await createExampleTable();
+    await adapter.exec(`CREATE INDEX "expression" ON "ex" (max(id, number))`);
+    const indexes = (await adapter.indexes("ex")) as any[];
     const index = indexes.find((idx) => idx.name === "expression");
-    expect(index.columns).toBe("max(id, price)");
+    expect(index.columns).toBe("max(id, number)");
   });
 
   itIfSupports("expression_index", "expression index with trailing comment", async () => {
-    await adapter.exec(`CREATE INDEX expression on items (price % 10) /* comment */`);
-    const indexes = (await adapter.indexes("items")) as any[];
+    await createExampleTable();
+    await adapter.exec(`CREATE INDEX expression on ex (number % 10) /* comment */`);
+    const indexes = (await adapter.indexes("ex")) as any[];
     const index = indexes.find((idx) => idx.name === "expression");
-    expect(index.columns).toBe("price % 10");
+    expect(index.columns).toBe("number % 10");
   });
 
   itIfSupports("expression_index", "expression index with where", async () => {
+    await createExampleTable();
     await adapter.exec(
-      `CREATE INDEX "expression" ON "items" (id % 10, max(id, price)) WHERE id > 1000`,
+      `CREATE INDEX "expression" ON "ex" (id % 10, max(id, number)) WHERE id > 1000`,
     );
-    const indexes = (await adapter.indexes("items")) as any[];
+    const indexes = (await adapter.indexes("ex")) as any[];
     const index = indexes.find((idx) => idx.name === "expression");
-    expect(index.columns).toBe("id % 10, max(id, price)");
+    expect(index.columns).toBe("id % 10, max(id, number)");
     expect(index.where).toBe("id > 1000");
   });
 
   itIfSupports("expression_index", "complicated expression", async () => {
+    await createExampleTable();
     await adapter.exec(
-      `CREATE INDEX expression ON items (id % 10, (CASE WHEN price > 0 THEN max(id, price) END))WHERE(id > 1000)`,
+      `CREATE INDEX expression ON ex (id % 10, (CASE WHEN number > 0 THEN max(id, number) END))WHERE(id > 1000)`,
     );
-    const indexes = (await adapter.indexes("items")) as any[];
+    const indexes = (await adapter.indexes("ex")) as any[];
     const index = indexes.find((idx) => idx.name === "expression");
-    expect(index.columns).toBe("id % 10, (CASE WHEN price > 0 THEN max(id, price) END)");
+    expect(index.columns).toBe("id % 10, (CASE WHEN number > 0 THEN max(id, number) END)");
     expect(index.where).toBe("(id > 1000)");
   });
 
   itIfSupports("expression_index", "not everything an expression", async () => {
-    await adapter.exec(`CREATE INDEX "expression" ON "items" (id, max(id, price))`);
-    const indexes = (await adapter.indexes("items")) as any[];
+    await createExampleTable();
+    await adapter.exec(`CREATE INDEX "expression" ON "ex" (id, max(id, number))`);
+    const indexes = (await adapter.indexes("ex")) as any[];
     const index = indexes.find((idx) => idx.name === "expression");
-    expect(index.columns).toBe("id, max(id, price)");
+    expect(index.columns).toBe("id, max(id, number)");
   });
 
   it("primary key", async () => {
@@ -548,12 +562,17 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   it("add column with custom primary key", async () => {
-    await adapter.exec(`CREATE TABLE "add_col_pk" ("custom_id" INTEGER PRIMARY KEY, "name" TEXT)`);
-    await adapter.exec(`ALTER TABLE "add_col_pk" ADD COLUMN "age" INTEGER`);
-    const cols = await adapter.execute(`PRAGMA table_info("add_col_pk")`);
-    expect(cols.some((c: any) => c.name === "age")).toBe(true);
-    const pkCol = cols.find((c: any) => c.pk === 1);
-    expect(pkCol!.name).toBe("custom_id");
+    await adapter.createTable("barcodes", { id: false, force: true }, (t) => {
+      t.integer("dummy");
+    });
+    await adapter.addColumn("barcodes", "id", "string", { primaryKey: true });
+
+    expect(await adapter.primaryKey("barcodes")).toBe("id");
+
+    const customPk = (await adapter.columns("barcodes")).find((c) => c.name === "id")!;
+
+    expect(customPk.type).toBe("string");
+    expect(customPk.null).toBe(false);
   });
 
   it("remove column preserves index options", async () => {

--- a/packages/activerecord/src/adapters/sqlite3/virtual-column.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/virtual-column.test.ts
@@ -5,94 +5,96 @@ import { expect, beforeEach, afterEach } from "vitest";
 import { describeIfSqlite } from "./test-helper.js";
 import { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";
+import type { Column } from "../../connection-adapters/sqlite3/column.js";
 import { itIfSupports } from "../../test-helpers/supports.js";
 
 let adapter: AbstractSQLite3Adapter;
 
-beforeEach(() => {
+// Rails setup: @connection.create_table :virtual_columns, force: true —
+// the raw DDL below is what that create_table emits on SQLite.
+beforeEach(async () => {
   adapter = new BetterSQLite3Adapter(":memory:");
+  await adapter.exec(
+    `CREATE TABLE "virtual_columns" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar, "upper_name" varchar GENERATED ALWAYS AS (UPPER(name)) STORED, "lower_name" varchar GENERATED ALWAYS AS (LOWER(name)) VIRTUAL, "octet_name" integer GENERATED ALWAYS AS (LENGTH(name)) VIRTUAL, "mutated_name" varchar GENERATED ALWAYS AS (REPLACE(name, 'l', 'L')) VIRTUAL, "column1" integer)`,
+  );
+  // Rails setup: VirtualColumn.create(name: "Rails", column1: 10)
+  await adapter.executeMutation(
+    `INSERT INTO "virtual_columns" ("name", "column1") VALUES ('Rails', 10)`,
+  );
 });
 
 afterEach(async () => {
-  // Throwaway :memory: tables; per-name IF EXISTS drops balance
-  // require-table-teardown (SQLite has no multi-table DROP).
-  await adapter
-    .exec(
-      `DROP TABLE IF EXISTS stored_gen; DROP TABLE IF EXISTS virt_gen; DROP TABLE IF EXISTS impl_virt; DROP TABLE IF EXISTS virt_comma; DROP TABLE IF EXISTS chg_stored; DROP TABLE IF EXISTS chg_virt; DROP TABLE IF EXISTS chg_impl`,
-    )
-    .catch(() => undefined);
+  // Rails teardown: @connection.drop_table :virtual_columns, if_exists: true
+  await adapter.exec(`DROP TABLE IF EXISTS "virtual_columns"`).catch(() => undefined);
   await adapter.close();
 });
+
+async function columnsHash(): Promise<Record<string, Column>> {
+  const hash: Record<string, Column> = {};
+  for (const col of await adapter.columns("virtual_columns")) {
+    hash[col.name] = col as Column;
+  }
+  return hash;
+}
 
 // -- Rails test class: virtual_column_test.rb --
 describeIfSqlite("SQLite3VirtualColumnTest", () => {
   itIfSupports("virtual_columns", "stored column", async () => {
-    await adapter.exec(
-      `CREATE TABLE "stored_gen" ("id" INTEGER PRIMARY KEY, "price" INTEGER, "tax" INTEGER, "total" INTEGER GENERATED ALWAYS AS ("price" + "tax") STORED)`,
-    );
-    await adapter.executeMutation(`INSERT INTO "stored_gen" ("price", "tax") VALUES (100, 10)`);
-    const rows = await adapter.execute(`SELECT "total" FROM "stored_gen"`);
-    expect(rows[0].total).toBe(110);
+    const column = (await columnsHash())["upper_name"];
+    expect(column.isVirtual()).toBe(true);
+    expect(column.isVirtualStored()).toBe(true);
+    const rows = await adapter.execute(`SELECT "upper_name" FROM "virtual_columns" LIMIT 1`);
+    expect(rows[0].upper_name).toBe("RAILS");
   });
 
   itIfSupports("virtual_columns", "explicit virtual column", async () => {
-    await adapter.exec(
-      `CREATE TABLE "virt_gen" ("id" INTEGER PRIMARY KEY, "first" TEXT, "last" TEXT, "full" TEXT GENERATED ALWAYS AS ("first" || ' ' || "last") VIRTUAL)`,
-    );
-    await adapter.executeMutation(
-      `INSERT INTO "virt_gen" ("first", "last") VALUES ('Alice', 'Smith')`,
-    );
-    const rows = await adapter.execute(`SELECT "full" FROM "virt_gen"`);
-    expect(rows[0].full).toBe("Alice Smith");
+    const column = (await columnsHash())["lower_name"];
+    expect(column.isVirtual()).toBe(true);
+    expect(column.isVirtualStored()).toBe(false);
+    const rows = await adapter.execute(`SELECT "lower_name" FROM "virtual_columns" LIMIT 1`);
+    expect(rows[0].lower_name).toBe("rails");
   });
 
   itIfSupports("virtual_columns", "implicit virtual column", async () => {
-    // Without STORED keyword, generated columns are virtual by default
-    await adapter.exec(
-      `CREATE TABLE "impl_virt" ("id" INTEGER PRIMARY KEY, "a" INTEGER, "b" INTEGER, "c" INTEGER GENERATED ALWAYS AS ("a" + "b"))`,
-    );
-    await adapter.executeMutation(`INSERT INTO "impl_virt" ("a", "b") VALUES (3, 4)`);
-    const rows = await adapter.execute(`SELECT "c" FROM "impl_virt"`);
-    expect(rows[0].c).toBe(7);
+    const column = (await columnsHash())["octet_name"];
+    expect(column.isVirtual()).toBe(true);
+    expect(column.isVirtualStored()).toBe(false);
+    const rows = await adapter.execute(`SELECT "octet_name" FROM "virtual_columns" LIMIT 1`);
+    expect(rows[0].octet_name).toBe(5);
   });
 
   itIfSupports("virtual_columns", "virtual column with comma in definition", async () => {
-    await adapter.exec(
-      `CREATE TABLE "virt_comma" ("id" INTEGER PRIMARY KEY, "x" INTEGER, "y" INTEGER, "label" TEXT GENERATED ALWAYS AS (CAST("x" AS TEXT) || ',' || CAST("y" AS TEXT)) VIRTUAL)`,
-    );
-    await adapter.executeMutation(`INSERT INTO "virt_comma" ("x", "y") VALUES (1, 2)`);
-    const rows = await adapter.execute(`SELECT "label" FROM "virt_comma"`);
-    expect(rows[0].label).toBe("1,2");
+    const column = (await columnsHash())["mutated_name"];
+    expect(column.isVirtual()).toBe(true);
+    expect(column.isVirtualStored()).toBe(false);
+    expect(column.defaultFunction).not.toBeNull();
+    const rows = await adapter.execute(`SELECT "mutated_name" FROM "virtual_columns" LIMIT 1`);
+    expect(rows[0].mutated_name).toBe("RaiLs");
   });
 
   itIfSupports("virtual_columns", "change table with stored generated column", async () => {
-    await adapter.exec(
-      `CREATE TABLE "chg_stored" ("id" INTEGER PRIMARY KEY, "x" INTEGER, "y" INTEGER)`,
-    );
-    // SQLite 3.31+ supports ADD COLUMN with generated
-    await adapter.exec(
-      `ALTER TABLE "chg_stored" ADD COLUMN "total" INTEGER GENERATED ALWAYS AS ("x" + "y") STORED`,
-    );
-    await adapter.executeMutation(`INSERT INTO "chg_stored" ("x", "y") VALUES (5, 3)`);
-    const rows = await adapter.execute(`SELECT "total" FROM "chg_stored"`);
-    expect(rows[0].total).toBe(8);
+    await adapter.changeTable("virtual_columns", async (t) => {
+      await t.virtual("decr_column1", { type: "integer", as: "column1 - 1", stored: true });
+    });
+    const column = (await columnsHash())["decr_column1"];
+    expect(column.isVirtual()).toBe(true);
+    expect(column.isVirtualStored()).toBe(true);
+    const rows = await adapter.execute(`SELECT "decr_column1" FROM "virtual_columns" LIMIT 1`);
+    expect(rows[0].decr_column1).toBe(9);
   });
 
   itIfSupports(
     "virtual_columns",
     "change table with explicit virtual generated column",
     async () => {
-      await adapter.exec(
-        `CREATE TABLE "chg_virt" ("id" INTEGER PRIMARY KEY, "first" TEXT, "last" TEXT)`,
-      );
-      await adapter.exec(
-        `ALTER TABLE "chg_virt" ADD COLUMN "full" TEXT GENERATED ALWAYS AS ("first" || ' ' || "last") VIRTUAL`,
-      );
-      await adapter.executeMutation(
-        `INSERT INTO "chg_virt" ("first", "last") VALUES ('John', 'Doe')`,
-      );
-      const rows = await adapter.execute(`SELECT "full" FROM "chg_virt"`);
-      expect(rows[0].full).toBe("John Doe");
+      await adapter.changeTable("virtual_columns", async (t) => {
+        await t.virtual("incr_column1", { type: "integer", as: "column1 + 1", stored: false });
+      });
+      const column = (await columnsHash())["incr_column1"];
+      expect(column.isVirtual()).toBe(true);
+      expect(column.isVirtualStored()).toBe(false);
+      const rows = await adapter.execute(`SELECT "incr_column1" FROM "virtual_columns" LIMIT 1`);
+      expect(rows[0].incr_column1).toBe(11);
     },
   );
 
@@ -100,19 +102,19 @@ describeIfSqlite("SQLite3VirtualColumnTest", () => {
     "virtual_columns",
     "change table with implicit virtual generated column",
     async () => {
-      await adapter.exec(
-        `CREATE TABLE "chg_impl" ("id" INTEGER PRIMARY KEY, "a" INTEGER, "b" INTEGER)`,
-      );
-      await adapter.exec(
-        `ALTER TABLE "chg_impl" ADD COLUMN "c" INTEGER GENERATED ALWAYS AS ("a" * "b")`,
-      );
-      await adapter.executeMutation(`INSERT INTO "chg_impl" ("a", "b") VALUES (4, 5)`);
-      const rows = await adapter.execute(`SELECT "c" FROM "chg_impl"`);
-      expect(rows[0].c).toBe(20);
+      await adapter.changeTable("virtual_columns", async (t) => {
+        await t.virtual("sqr_column1", { type: "integer", as: "pow(column1, 2)" });
+      });
+      const column = (await columnsHash())["sqr_column1"];
+      expect(column.isVirtual()).toBe(true);
+      expect(column.isVirtualStored()).toBe(false);
+      const rows = await adapter.execute(`SELECT "sqr_column1" FROM "virtual_columns" LIMIT 1`);
+      expect(rows[0].sqr_column1).toBe(100);
     },
   );
 
-  // null-overridden: needs schema dump/load infrastructure
+  // null-overridden: needs model layer / schema dump / fixture infrastructure
+  // it.skip("virtual column with full inserts", () => {});
   // it.skip("schema dumping", () => {});
   // it.skip("build fixture sql", () => {});
 });

--- a/packages/activerecord/src/adapters/sqlite3/virtual-column.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/virtual-column.test.ts
@@ -10,21 +10,17 @@ import { itIfSupports } from "../../test-helpers/supports.js";
 
 let adapter: AbstractSQLite3Adapter;
 
-// Rails setup: @connection.create_table :virtual_columns, force: true —
-// the raw DDL below is what that create_table emits on SQLite.
 beforeEach(async () => {
   adapter = new BetterSQLite3Adapter(":memory:");
   await adapter.exec(
     `CREATE TABLE "virtual_columns" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar, "upper_name" varchar GENERATED ALWAYS AS (UPPER(name)) STORED, "lower_name" varchar GENERATED ALWAYS AS (LOWER(name)) VIRTUAL, "octet_name" integer GENERATED ALWAYS AS (LENGTH(name)) VIRTUAL, "mutated_name" varchar GENERATED ALWAYS AS (REPLACE(name, 'l', 'L')) VIRTUAL, "column1" integer)`,
   );
-  // Rails setup: VirtualColumn.create(name: "Rails", column1: 10)
   await adapter.executeMutation(
     `INSERT INTO "virtual_columns" ("name", "column1") VALUES ('Rails', 10)`,
   );
 });
 
 afterEach(async () => {
-  // Rails teardown: @connection.drop_table :virtual_columns, if_exists: true
   await adapter.exec(`DROP TABLE IF EXISTS "virtual_columns"`).catch(() => undefined);
   await adapter.close();
 });

--- a/packages/activerecord/src/adapters/sqlite3/virtual-column.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/virtual-column.trails.test.ts
@@ -1,0 +1,58 @@
+import { it, expect, beforeEach, afterEach } from "vitest";
+import { describeIfSqlite } from "./test-helper.js";
+import { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
+import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";
+import type { Column } from "../../connection-adapters/sqlite3/column.js";
+
+let adapter: AbstractSQLite3Adapter;
+
+beforeEach(async () => {
+  adapter = new BetterSQLite3Adapter(":memory:");
+  await adapter.exec(
+    `CREATE TABLE "virtual_columns" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar, "upper_name" varchar GENERATED ALWAYS AS (UPPER(name)) STORED, "lower_name" varchar GENERATED ALWAYS AS (LOWER(name)) VIRTUAL, "column1" integer)`,
+  );
+  await adapter.executeMutation(
+    `INSERT INTO "virtual_columns" ("name", "column1") VALUES ('Rails', 10)`,
+  );
+});
+
+afterEach(async () => {
+  await adapter.exec(`DROP TABLE IF EXISTS "virtual_columns"`).catch(() => undefined);
+  await adapter.close();
+});
+
+// TS-only regression coverage: Rails' alter_table rebuilds from columns(from)
+// and re-adds generated columns with as:/stored: (sqlite3_adapter.rb:623),
+// but PRAGMA table_info hides them — a table_info-sourced rebuild silently
+// drops every pre-existing generated column.
+describeIfSqlite("SQLite3VirtualColumnTest trails extras", () => {
+  it("alter-table rebuild preserves pre-existing generated columns", async () => {
+    await adapter.changeTable("virtual_columns", async (t) => {
+      await t.virtual("decr_column1", { type: "integer", as: "column1 - 1", stored: true });
+    });
+
+    const columns = (await adapter.columns("virtual_columns")) as Column[];
+    const names = columns.map((c) => c.name);
+    expect(names).toEqual(["id", "name", "upper_name", "lower_name", "column1", "decr_column1"]);
+
+    const upperName = columns.find((c) => c.name === "upper_name")!;
+    expect(upperName.isVirtualStored()).toBe(true);
+    const lowerName = columns.find((c) => c.name === "lower_name")!;
+    expect(lowerName.isVirtual()).toBe(true);
+    expect(lowerName.isVirtualStored()).toBe(false);
+
+    const rows = await adapter.execute(
+      `SELECT "upper_name", "lower_name", "decr_column1" FROM "virtual_columns"`,
+    );
+    expect(rows).toEqual([{ upper_name: "RAILS", lower_name: "rails", decr_column1: 9 }]);
+  });
+
+  it("remove column preserves generated columns", async () => {
+    await adapter.removeColumn("virtual_columns", "column1");
+
+    const columns = (await adapter.columns("virtual_columns")) as Column[];
+    expect(columns.map((c) => c.name)).toEqual(["id", "name", "upper_name", "lower_name"]);
+    const rows = await adapter.execute(`SELECT "upper_name", "lower_name" FROM "virtual_columns"`);
+    expect(rows).toEqual([{ upper_name: "RAILS", lower_name: "rails" }]);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1661,28 +1661,33 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     type: string,
     options?: Record<string, unknown>,
   ): Promise<void> {
+    const baseType = this._baseColumnType(type, options);
+    const generatedAs = typeof options?.as === "string" ? options.as : null;
     if (isInvalidAlterTableType(type, options ?? {})) {
-      const fragment = this._addColumnSqlFragment(type, options);
       const isPk = Boolean(options?.primaryKey) || type === "primary_key";
       await this.alterTable(tableName, (columns) => {
         columns[columnName] = {
           name: columnName,
-          type: fragment,
+          type: baseType,
+          collation: options?.collation ?? null,
+          generatedAs,
+          generatedStored: Boolean(options?.stored),
           notnull: options?.null === false || isPk ? 1 : 0,
           dflt_value:
-            options?.default !== undefined && type !== "virtual"
-              ? this.quoteDefault(
-                  this.serializeDefaultForColumn(options.default, this.typeToSql(type, options)),
-                )
+            options?.default !== undefined && generatedAs === null
+              ? this.quoteDefault(this.serializeDefaultForColumn(options.default, baseType))
               : null,
           pk: isPk ? 1 : 0,
         };
       });
       return;
     }
-    const sqlType = this._addColumnSqlFragment(type, options);
+    const sqlType = baseType;
     let sql = `ALTER TABLE ${quoteTableName(tableName)} ADD COLUMN ${quoteColumnName(columnName)} ${sqlType}`;
     if (options?.collation) sql += ` COLLATE ${quoteColumnName(String(options.collation))}`;
+    if (generatedAs !== null) {
+      sql += ` GENERATED ALWAYS AS (${generatedAs}) ${options?.stored ? "STORED" : "VIRTUAL"}`;
+    }
     if (options?.null === false) sql += " NOT NULL";
     if (options?.default !== undefined) {
       sql += ` DEFAULT ${this.quoteDefault(this.serializeDefaultForColumn(options.default, sqlType))}`;
@@ -1969,18 +1974,12 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     }
   }
 
-  // Mirrors: SQLite3::SchemaCreation#add_column_options! — the GENERATED
-  // clause is keyed off the :as option, with :stored picking STORED/VIRTUAL.
-  private _addColumnSqlFragment(type: string, options?: Record<string, unknown>): string {
-    const base =
-      type === "virtual"
-        ? options?.type
-          ? this.typeToSql(String(options.type), options)
-          : ""
-        : this.typeToSql(type, options);
-    if (typeof options?.as !== "string") return base;
-    const generated = `GENERATED ALWAYS AS (${options.as}) ${options.stored ? "STORED" : "VIRTUAL"}`;
-    return base ? `${base} ${generated}` : generated;
+  // The declared type of a `t.virtual` column comes from its :type option
+  // (SQLite3::TableDefinition resolves :virtual that way; no type when the
+  // option is absent).
+  private _baseColumnType(type: string, options?: Record<string, unknown>): string {
+    if (type !== "virtual") return this.typeToSql(type, options);
+    return options?.type ? this.typeToSql(String(options.type), options) : "";
   }
 
   private typeToSql(type: string, options?: Record<string, unknown>): string {
@@ -2380,14 +2379,30 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     const { schema, bare: bareTable } = this._splitTableName(tableName);
     const pragmaPrefix = schema ? `${quoteColumnName(schema)}.` : "";
     const qTable = quoteTableName(tableName);
+    // table_info hides GENERATED columns; table_xinfo exposes them with
+    // hidden 2 (virtual) / 3 (stored) so the rebuild preserves them (Rails
+    // rebuilds from columns(from) and re-adds them with as:/stored:,
+    // sqlite3_adapter.rb:623).
+    const infoPragma = this.supportsVirtualColumns() ? "table_xinfo" : "table_info";
     const tableInfoStmt = await this.driver.prepare(
-      `PRAGMA ${pragmaPrefix}table_info(${quoteColumnName(bareTable)})`,
+      `PRAGMA ${pragmaPrefix}${infoPragma}(${quoteColumnName(bareTable)})`,
     );
-    const tableInfo = (await tableInfoStmt.all()) as Array<Record<string, unknown>>;
+    const tableInfo = ((await tableInfoStmt.all()) as Array<Record<string, unknown>>).filter(
+      (col) => Number(col.hidden ?? 0) !== 1,
+    );
 
+    const hasGenerated = tableInfo.some((col) => Number(col.hidden ?? 0) >= 2);
+    const reflected = hasGenerated ? await this.columns(tableName) : [];
     const columns: Record<string, Record<string, unknown>> = {};
     for (const col of tableInfo) {
-      columns[col.name as string] = { ...col };
+      const entry: Record<string, unknown> = { ...col };
+      if (Number(col.hidden ?? 0) >= 2) {
+        const meta = reflected.find((r) => r.name === col.name);
+        entry.generatedAs = meta?.defaultFunction ?? null;
+        entry.generatedStored = Number(col.hidden) === 3;
+        entry.dflt_value = null;
+      }
+      columns[col.name as string] = entry;
     }
 
     modify(columns);
@@ -2430,6 +2445,9 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       let def = `${quoteColumnName(name)} ${col.type ?? "TEXT"}`;
       const collation = col.collation === undefined ? existingCollations.get(name) : col.collation;
       if (collation) def += ` COLLATE ${quoteColumnName(String(collation))}`;
+      if (col.generatedAs) {
+        def += ` GENERATED ALWAYS AS (${col.generatedAs})${col.generatedStored ? " STORED" : " VIRTUAL"}`;
+      }
       if (!compositePk && col.pk) def += " PRIMARY KEY";
       if (col.notnull) def += " NOT NULL";
       if (col.dflt_value !== null && col.dflt_value !== undefined) {
@@ -2511,7 +2529,11 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       }
     }
 
+    // Generated columns can't be inserted into — exclude them from the copy
+    // (Rails: columns_to_copy rejects columns with an :as option,
+    // sqlite3_adapter.rb:645).
     const originalColNames = tableInfo
+      .filter((c) => Number(c.hidden ?? 0) < 2)
       .map((c) => c.name as string)
       .filter((n) => colNames.includes(n));
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1661,7 +1661,31 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     type: string,
     options?: Record<string, unknown>,
   ): Promise<void> {
-    const sqlType = this.typeToSql(type, options);
+    // Mirrors: SQLite3Adapter#add_column — ALTER TABLE cannot add a primary
+    // key, a NOT NULL column without a default, or a STORED generated column,
+    // so those route through the full table rebuild (Rails: alter_table).
+    if (isInvalidAlterTableType(type, options ?? {})) {
+      const fragment = this._addColumnSqlFragment(type, options);
+      const isPk = Boolean(options?.primaryKey) || type === "primary_key";
+      await this.alterTable(tableName, (columns) => {
+        columns[columnName] = {
+          name: columnName,
+          type: fragment,
+          // Rails' new_column_definition forces null: false on primary keys
+          // (abstract/schema_definitions.rb:571).
+          notnull: options?.null === false || isPk ? 1 : 0,
+          dflt_value:
+            options?.default !== undefined && type !== "virtual"
+              ? this.quoteDefault(
+                  this.serializeDefaultForColumn(options.default, this.typeToSql(type, options)),
+                )
+              : null,
+          pk: isPk ? 1 : 0,
+        };
+      });
+      return;
+    }
+    const sqlType = this._addColumnSqlFragment(type, options);
     let sql = `ALTER TABLE ${quoteTableName(tableName)} ADD COLUMN ${quoteColumnName(columnName)} ${sqlType}`;
     if (options?.collation) sql += ` COLLATE ${quoteColumnName(String(options.collation))}`;
     if (options?.null === false) sql += " NOT NULL";
@@ -1948,6 +1972,18 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
         binds: [],
       });
     }
+  }
+
+  // Column-definition SQL for addColumn, including the GENERATED clause for
+  // `t.virtual` columns (Rails renders these via SchemaCreation from the
+  // ColumnDefinition's :as/:stored options).
+  private _addColumnSqlFragment(type: string, options?: Record<string, unknown>): string {
+    if (type !== "virtual") return this.typeToSql(type, options);
+    if (typeof options?.as !== "string") {
+      throw new Error("virtual columns require an :as option");
+    }
+    const base = options.type ? `${this.typeToSql(String(options.type), options)} ` : "";
+    return `${base}GENERATED ALWAYS AS (${options.as}) ${options.stored ? "STORED" : "VIRTUAL"}`;
   }
 
   private typeToSql(type: string, options?: Record<string, unknown>): string {
@@ -3145,7 +3181,7 @@ function hasDefaultFunction(defaultValue: unknown, default_: string): boolean {
 function isInvalidAlterTableType(type: string, options: Record<string, unknown>): boolean {
   return (
     type === "primary_key" ||
-    Boolean(options["primary_key"]) ||
+    Boolean(options["primaryKey"]) ||
     (options["null"] === false && options["default"] == null) ||
     (type === "virtual" && Boolean(options["stored"]))
   );

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1661,9 +1661,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     type: string,
     options?: Record<string, unknown>,
   ): Promise<void> {
-    // Mirrors: SQLite3Adapter#add_column — ALTER TABLE cannot add a primary
-    // key, a NOT NULL column without a default, or a STORED generated column,
-    // so those route through the full table rebuild (Rails: alter_table).
     if (isInvalidAlterTableType(type, options ?? {})) {
       const fragment = this._addColumnSqlFragment(type, options);
       const isPk = Boolean(options?.primaryKey) || type === "primary_key";
@@ -1671,8 +1668,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
         columns[columnName] = {
           name: columnName,
           type: fragment,
-          // Rails' new_column_definition forces null: false on primary keys
-          // (abstract/schema_definitions.rb:571).
           notnull: options?.null === false || isPk ? 1 : 0,
           dflt_value:
             options?.default !== undefined && type !== "virtual"
@@ -1974,16 +1969,18 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     }
   }
 
-  // Column-definition SQL for addColumn, including the GENERATED clause for
-  // `t.virtual` columns (Rails renders these via SchemaCreation from the
-  // ColumnDefinition's :as/:stored options).
+  // Mirrors: SQLite3::SchemaCreation#add_column_options! — the GENERATED
+  // clause is keyed off the :as option, with :stored picking STORED/VIRTUAL.
   private _addColumnSqlFragment(type: string, options?: Record<string, unknown>): string {
-    if (type !== "virtual") return this.typeToSql(type, options);
-    if (typeof options?.as !== "string") {
-      throw new Error("virtual columns require an :as option");
-    }
-    const base = options.type ? `${this.typeToSql(String(options.type), options)} ` : "";
-    return `${base}GENERATED ALWAYS AS (${options.as}) ${options.stored ? "STORED" : "VIRTUAL"}`;
+    const base =
+      type === "virtual"
+        ? options?.type
+          ? this.typeToSql(String(options.type), options)
+          : ""
+        : this.typeToSql(type, options);
+    if (typeof options?.as !== "string") return base;
+    const generated = `GENERATED ALWAYS AS (${options.as}) ${options.stored ? "STORED" : "VIRTUAL"}`;
+    return base ? `${base} ${generated}` : generated;
   }
 
   private typeToSql(type: string, options?: Record<string, unknown>): string {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
@@ -10,21 +10,7 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "add_column",
-    "call": "alter_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "add_column",
     "call": "column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "add_column",
-    "call": "invalid_alter_table_type?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {


### PR DESCRIPTION
## Summary

Burns down the 15 assertion-value mismatches across the two sqlite3 adapter
test files by converging their tables and seed data to Rails'
`sqlite3_adapter_test.rb` / `virtual_column_test.rb`:

- **`sqlite3-adapter.test.ts`** — the expression-index family, `columns with
  default`, and `exec insert with quote` now use Rails' `with_example_table`
  (`ex`: `id`, `number`) and assert Rails' values (`max(id, number)`, `"10"`,
  the 10/1-row insert pair). `add column with custom primary key` now mirrors
  Rails' barcodes flow — `create_table id: false` + `add_column :id, :string,
  primary_key: true` — asserting `"id"` / `"string"` / not-null.
- **`virtual-column.test.ts`** — rebuilt on Rails' `virtual_columns` table
  (`name`, `upper_name`, `lower_name`, `octet_name`, `mutated_name`,
  `column1`) seeded with `name: "Rails", column1: 10`, so every generated
  column test asserts Rails' values (`"RAILS"`, `"rails"`, `5`, `"RaiLs"`,
  `9`, `11`, `100`), with the change-table tests going through
  `changeTable` + `t.virtual` like Rails.
- **`sqlite3-adapter.ts`** — ports `SQLite3Adapter#add_column`'s
  `invalid_alter_table_type?` branch (the ported `isInvalidAlterTableType`
  helper was dormant): primary-key, NOT-NULL-without-default, and
  stored-generated column adds route through the `alter_table` rebuild, and
  plain `ADD COLUMN` renders `COLLATE` then the `GENERATED ALWAYS AS (...)`
  clause keyed off `:as` (mirrors `SQLite3::SchemaCreation#add_column_options!`
  ordering). Required for the two tests above (SQLite refuses
  `ADD COLUMN ... PRIMARY KEY`, and refuses `ADD COLUMN ... STORED` on a
  non-empty table).
- **`alterTable` rebuild fidelity** (from review): the rebuild now sources
  columns from `table_xinfo` (`table_info` hides GENERATED columns), re-emits
  `GENERATED ALWAYS AS (...) STORED/VIRTUAL` from the reflected
  `defaultFunction`, and excludes generated columns from the copy — mirroring
  Rails rebuilding from `columns(from)` with `as:`/`stored:` passed through
  and `columns_to_copy` rejecting `:as` columns (`sqlite3_adapter.rb:623`,
  `:645`). `addColumn` carries `:collation` onto the rebuild entry.
  Trails-only regression tests in `virtual-column.trails.test.ts` prove
  generated columns survive `changeTable`/`removeColumn` rebuilds; both fail
  against the origin/main adapter.

`test:compare --assertions` reports 0 value-mismatches for both files.

Closes-story: sqlite3-adapter-virtual-column-value-fidelity
Closes-story: sqlite3-alter-table-drops-generated-columns
