### PR TITLE
test(activerecord): restore Rails concrete-value assertions in weakened-assertion cluster

### DIFF
--- a/packages/activerecord/src/active-record-schema.test.ts
+++ b/packages/activerecord/src/active-record-schema.test.ts
@@ -4,7 +4,8 @@
  */
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from "vitest";
 import { Base, Migration, Schema, TableDefinition } from "./index.js";
-import { MigrationContext } from "./migration.js";
+import { MigrationContext, Migrator } from "./migration.js";
+import { SchemaMigration } from "./schema-migration.js";
 
 import { adapterType } from "./test-adapter.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
@@ -46,16 +47,20 @@ describe("ActiveRecordSchemaTest", () => {
   });
 
   it("has primary key", async () => {
-    await Schema.define(adapter, async (schema) => {
-      await schema.createTable("pk_test", (t) => {
-        t.string("name");
-      });
-    });
-    // Verify table exists and has auto-incrementing id
-    await adapter.executeMutation(`INSERT INTO "pk_test" ("name") VALUES ('test')`);
-    const rows = await adapter.execute(`SELECT * FROM "pk_test"`);
-    expect(rows.length).toBe(1);
-    expect(rows[0].id).toBeDefined();
+    const oldPrimaryKeyPrefixType = Base.primaryKeyPrefixType;
+    Base.primaryKeyPrefixType = "table_name_with_underscore";
+    const schemaMigration = new SchemaMigration(adapter);
+    try {
+      expect(schemaMigration.primaryKey).toBe("version");
+
+      await schemaMigration.createTable();
+      const before = await schemaMigration.count();
+      await schemaMigration.createVersion("12");
+      expect(await schemaMigration.count()).toBe(before + 1);
+    } finally {
+      await schemaMigration.deleteVersion("12");
+      Base.primaryKeyPrefixType = oldPrimaryKeyPrefixType;
+    }
   });
 
   it("schema without version is the current version schema", () => {
@@ -94,15 +99,16 @@ describe("ActiveRecordSchemaTest", () => {
     const saved = Base.tableNamePrefix;
     Base.tableNamePrefix = "nep_";
     try {
-      await Schema.define(adapter, async (schema) => {
+      await Schema.define(adapter, { version: 7 }, async (schema) => {
         await schema.createTable("fruits", (t) => {
           t.string("color");
         });
       });
-      await adapter.executeMutation(`INSERT INTO "nep_fruits" ("color") VALUES ('red')`);
-      const rows = await adapter.execute(`SELECT * FROM "nep_fruits"`);
-      expect(rows.length).toBe(1);
+      expect(await new Migrator(adapter, []).currentVersion()).toBe(7);
     } finally {
+      // Rails ensure: drop_table :nep_schema_migrations (dropTable resolves the
+      // still-prefixed table name).
+      await new SchemaMigration(adapter).dropTable();
       Base.tableNamePrefix = saved;
     }
   });

--- a/packages/activerecord/src/adapters/postgresql/uuid.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/uuid.test.ts
@@ -486,11 +486,12 @@ describeIfPg("PostgreSQLAdapter", () => {
         )
       `);
       try {
-        const rows = await adapter.execute(`
-          INSERT INTO uuid_column_default_test DEFAULT VALUES
-          RETURNING guid
-        `);
-        expect(isValidUuid(rows[0].guid as string)).toBe(true);
+        const cols = (await adapter.columns("uuid_column_default_test")) as {
+          name: string;
+          defaultFunction?: string;
+        }[];
+        const column = cols.find((c) => c.name === "guid");
+        expect(column!.defaultFunction).toBe("gen_random_uuid()");
       } finally {
         await adapter.exec(`DROP TABLE IF EXISTS uuid_column_default_test`);
       }

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -4,6 +4,7 @@ import "./encryption.js";
 import { describe, it, expect } from "vitest";
 import { sql as arelSql, star as arelStar } from "@blazetrails/arel";
 import { adapterType } from "./test-adapter.js";
+import { captureSql } from "./testing/sql-capture.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 // Opt into the canonical-model autoload index so association targets resolve by
 // name on first reference — no manual `registerModel`.
@@ -97,8 +98,8 @@ describe("CalculationsTest", () => {
 
   it("should return integer average if db returns such", async () => {
     const value = await Book.average("status");
-    expect(typeof value).toBe("number");
-    expect(value).toBeCloseTo(1.0);
+    expect(value).toBe(1.0);
+    expect(value).toBeTypeOf("number");
   });
 
   it("should return float average if db returns such", async () => {
@@ -299,11 +300,10 @@ describe("CalculationsTest", () => {
   });
 
   it("limit should apply before count", async () => {
-    // Rails: Account.order(:id).limit(4).count(:firm_id) == 3
     // accounts 1..4: account 2 has null firm_id → count(:firm_id) = 3
     const accounts = Account.order("id").limit(4);
-    expect(await accounts.count()).toBe(4);
     expect(await accounts.count("firm_id")).toBe(3);
+    expect(await accounts.select("firm_id").count()).toBe(3);
   });
 
   it("limit should apply before count arel attribute", async () => {
@@ -340,8 +340,11 @@ describe("CalculationsTest", () => {
   });
 
   it("no order by when counting all", async () => {
-    const count = await Account.order({ id: "desc" }).limit(10).count();
-    expect(typeof count).toBe("number");
+    const queries = await captureSql(async () => {
+      await Account.order({ id: "desc" }).limit(10).count();
+    });
+    expect(queries.length).toBe(1);
+    expect(queries[0]).not.toMatch(/ORDER BY/);
   });
 
   it("count on invalid columns raises", async () => {

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -95,9 +95,10 @@ export class TransactionState {
     return this.isCompleted();
   }
 
-  rollbackBang(): void {
+  rollbackBang(): "rolledback" {
     this._children?.forEach((c) => c.rollbackBang());
     this._state = "rolledback";
+    return "rolledback";
   }
 
   fullRollbackBang(): void {
@@ -110,16 +111,18 @@ export class TransactionState {
     this._state = "invalidated";
   }
 
-  commitBang(): void {
+  commitBang(): "committed" {
     this._state = "committed";
+    return "committed";
   }
 
   fullCommitBang(): void {
     this._state = "fully_committed";
   }
 
-  nullifyBang(): void {
+  nullifyBang(): null {
     this._state = null;
+    return null;
   }
 }
 

--- a/packages/activerecord/src/connection-adapters/abstract/transaction.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/transaction.ts
@@ -101,14 +101,16 @@ export class TransactionState {
     return "rolledback";
   }
 
-  fullRollbackBang(): void {
+  fullRollbackBang(): "fully_rolledback" {
     this._children?.forEach((c) => c.rollbackBang());
     this._state = "fully_rolledback";
+    return "fully_rolledback";
   }
 
-  invalidateBang(): void {
+  invalidateBang(): "invalidated" {
     this._children?.forEach((c) => c.invalidateBang());
     this._state = "invalidated";
+    return "invalidated";
   }
 
   commitBang(): "committed" {
@@ -116,8 +118,9 @@ export class TransactionState {
     return "committed";
   }
 
-  fullCommitBang(): void {
+  fullCommitBang(): "fully_committed" {
     this._state = "fully_committed";
+    return "fully_committed";
   }
 
   nullifyBang(): null {

--- a/packages/activerecord/src/connection-adapters/schema-cache.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.test.ts
@@ -244,10 +244,13 @@ describe("SchemaCacheTest", () => {
 
   it("columns for existent table", async () => {
     const cache = new SchemaCache();
-    cache.setColumns("users", [makeColumn("id", "integer"), makeColumn("name", "text")]);
-    const cols = await cache.columns(null, "users");
-    expect(cols).toHaveLength(2);
-    expect(cols![0].name).toBe("id");
+    cache.setColumns("courses", [
+      makeColumn("id", "integer"),
+      makeColumn("name", "text"),
+      makeColumn("college_id", "integer"),
+    ]);
+    const cols = await cache.columns(null, "courses");
+    expect(cols!.length).toBe(3);
   });
 
   it("columns for non existent table", () => {
@@ -259,11 +262,13 @@ describe("SchemaCacheTest", () => {
 
   it("columns hash for existent table", async () => {
     const cache = new SchemaCache();
-    cache.setColumns("users", [makeColumn("id", "integer"), makeColumn("name", "text")]);
-    const hash = await cache.columnsHash(null, "users");
-    expect(hash).toBeDefined();
-    expect(hash!["id"]).toBeInstanceOf(Column);
-    expect(hash!["name"].sqlType).toBe("text");
+    cache.setColumns("courses", [
+      makeColumn("id", "integer"),
+      makeColumn("name", "text"),
+      makeColumn("college_id", "integer"),
+    ]);
+    const hash = await cache.columnsHash(null, "courses");
+    expect(Object.keys(hash!).length).toBe(3);
   });
 
   it("columns hash for non existent table", () => {

--- a/packages/activerecord/src/finder.test.ts
+++ b/packages/activerecord/src/finder.test.ts
@@ -34,6 +34,8 @@ import { Tagging as CanonicalTagging } from "./test-helpers/models/tagging.js";
 import { Subscriber as CanonicalSubscriber } from "./test-helpers/models/subscriber.js";
 import { Developer as CanonicalDeveloper } from "./test-helpers/models/developer.js";
 import { Tag as CanonicalTag } from "./test-helpers/models/tag.js";
+import { Car as CanonicalCar } from "./test-helpers/models/car.js";
+import { Toy } from "./test-helpers/models/toy.js";
 import {
   Company as CanonicalCompany,
   Firm as CanonicalFirm,
@@ -694,20 +696,15 @@ describe("FinderTest", () => {
   });
 
   it("find one message on primary key", async () => {
-    class Topic extends Base {
-      static {
-        this.attribute("title", "string");
-      }
-    }
     try {
-      await Topic.find(0);
+      await CanonicalCar.find(0);
       expect.unreachable("should throw");
     } catch (e: any) {
       expect(e).toBeInstanceOf(RecordNotFound);
       expect(e.id).toBe(0);
       expect(e.primaryKey).toBe("id");
-      expect(e.model).toBe("Topic");
-      expect(e.message).toBe("Couldn't find Topic with 'id'=0");
+      expect(e.model).toBe("Car");
+      expect(e.message).toBe("Couldn't find Car with 'id'=0");
     }
   });
 
@@ -1125,11 +1122,17 @@ describe("FinderTest", () => {
     expect(found).toBeDefined();
   });
   it("find some message with custom primary key", async () => {
-    const { Post } = makeModel();
-    const p1 = await Post.create({ title: "cpk_a" });
-    const p2 = await Post.create({ title: "cpk_b" });
-    const results = await Post.where({ id: [p1.id, p2.id] });
-    expect(results.length).toBe(2);
+    class MercedesCar extends Toy {
+      static _primaryKey = "name";
+    }
+    const e = await MercedesCar.find("Hello", "World!").then(
+      () => null,
+      (err: unknown) => err,
+    );
+    expect(e).toBeInstanceOf(RecordNotFound);
+    expect((e as Error).message).toBe(
+      "Couldn't find all MercedesCars with 'name': (Hello, World!) (found 0 results, but was looking for 2).",
+    );
   });
   it("#skip_query_cache! for #exists?", async () => {
     const { Post } = makeModel();

--- a/packages/activerecord/src/json-serialization.test.ts
+++ b/packages/activerecord/src/json-serialization.test.ts
@@ -306,13 +306,12 @@ describe("DatabaseConnectedJsonEncodingTest", () => {
     const david = await getDavid();
     (david as unknown as { favoriteQuote: () => string }).favoriteQuote = () =>
       "Constraints are liberating";
-    const json = await david.asJson({ include: "posts", methods: ["favoriteQuote"] });
+    const json = JSON.stringify(
+      await david.asJson({ include: "posts", methods: ["favoriteQuote"] }),
+    );
 
-    expect(json.favoriteQuote).toBe("Constraints are liberating");
-    const posts = json.posts as Array<Record<string, unknown>>;
-    for (const p of posts) {
-      expect(p.favoriteQuote).toBeUndefined();
-    }
+    expect(json).toMatch(/"favoriteQuote":"Constraints are liberating"/);
+    expect(json.match(/"favoriteQuote":/g)!.length).toBe(1);
   });
 
   it("should allow only option for list of authors", async () => {

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -227,7 +227,7 @@ describe("MigrationTest", () => {
   });
 
   it("rename table with prefix and suffix", async () => {
-    const { ctx } = await freshContext();
+    const { adapter, ctx } = await freshContext();
     ctx.tableNamePrefix = "pre_";
     ctx.tableNameSuffix = "_suf";
     // Own the scratch tables for the whole test: with the global reset shielded
@@ -236,12 +236,19 @@ describe("MigrationTest", () => {
     await ctx.dropTable("pre_old_suf", "pre_new_suf", { ifExists: true });
     try {
       await ctx.createTable("pre_old_suf", {}, (t) => {
-        t.string("value");
+        t.string("content");
       });
+      await adapter.executeMutation(
+        `INSERT INTO ${adapter.quoteTableName("pre_old_suf")} (${adapter.quoteColumnName("content")}) VALUES ('hello world')`,
+      );
+      const before = await adapter.execute(
+        `SELECT * FROM ${adapter.quoteTableName("pre_old_suf")}`,
+      );
+      expect(before[0].content).toBe("hello world");
 
       await ctx.renameTable("old", "new");
-      expect(await ctx.tableExists("pre_old_suf")).toBe(false);
-      expect(await ctx.tableExists("pre_new_suf")).toBe(true);
+      const after = await adapter.execute(`SELECT * FROM ${adapter.quoteTableName("pre_new_suf")}`);
+      expect(after[0].content).toBe("hello world");
     } finally {
       await ctx.dropTable("pre_old_suf", "pre_new_suf", { ifExists: true });
     }
@@ -729,8 +736,12 @@ describe("MigrationTest", () => {
       },
     ];
     const migrator = new Migrator(adapter, migrations);
-    const pending = await migrator.pendingMigrations();
-    expect(pending.length).toBe(1);
+    try {
+      await migrator.schemaMigration.dropTable();
+      expect(await migrator.needsMigration()).toBe(true);
+    } finally {
+      await migrator.schemaMigration.createTable();
+    }
   });
 
   it("any migrations", async () => {
@@ -1008,9 +1019,9 @@ describe("MigrationTest", () => {
     expect(err).toBeInstanceOf(Error);
     // Without a DDL transaction, the column is not rolled back
     expect(columnAdded).toBe(true);
-    // Error message matches Rails format (no "this and" because no transaction)
-    expect(err.message).toMatch(/An error has occurred, all later migrations canceled/);
-    expect(err.message).not.toContain("this and");
+    expect(err.message).toBe(
+      "An error has occurred, all later migrations canceled:\n\nSomething broke",
+    );
     // The failed no-transaction migration leaves `wtx_test` behind (that is the
     // point of the test); drop it so it does not leak past the shielded reset.
     await adapter.dropTable("wtx_test", { ifExists: true });
@@ -1109,8 +1120,12 @@ describe("MigrationTest", () => {
     const { InternalMetadata } = await import("./internal-metadata.js");
     const im = new InternalMetadata(adapter);
     await im.createTable();
-    await im.set("foo", "bar");
-    expect(await im.get("foo")).toBe("bar");
+    try {
+      await im.set("version", "foo");
+      expect(await im.get("version")).toBe("foo");
+    } finally {
+      await im.deleteAllEntries();
+    }
   });
 
   it("updating an existing entry into internal metadata", async () => {
@@ -1170,8 +1185,8 @@ describe("MigrationTest", () => {
     await adapter.beginTransaction();
     try {
       await sm.createTable();
-      expect(await sm.tableExists()).toBe(true);
-      await sm.createVersion("foo");
+      expect(await sm.tableExists()).toBeTruthy();
+      expect(await sm.createVersion("foo")).toBe("foo");
       await adapter.commit();
     } catch (e) {
       await adapter.rollback();
@@ -1185,8 +1200,8 @@ describe("MigrationTest", () => {
     await adapter.beginTransaction();
     try {
       await sm.createTable();
-      expect(await sm.tableExists()).toBe(true);
-      await sm.createVersion("bar");
+      expect(await sm.tableExists()).toBeTruthy();
+      expect(await sm.createVersion("bar")).toBe("bar");
       await adapter.commit();
     } catch (e) {
       await adapter.rollback();
@@ -2139,12 +2154,45 @@ describe("MigrationTest", () => {
         expect(new NoTs().version).toBe("99999999999999");
       });
 
-      it("copied migrations at timestamp boundary are valid", () => {
-        class Boundary extends Migration {
-          static version = "20231231235959";
-          async change() {}
+      it("copied migrations at timestamp boundary are valid", async () => {
+        const fs = await import("node:fs");
+        const path = await import("node:path");
+        const os = await import("node:os");
+        const { Temporal } = await import("@blazetrails/activesupport/temporal");
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), "trails-mig-boundary-"));
+        const src = path.join(root, "temp_source");
+        const dst = path.join(root, "temp_dest");
+        fs.mkdirSync(src, { recursive: true });
+        fs.mkdirSync(dst, { recursive: true });
+        for (const f of [
+          "20180101010101_test_migration.ts",
+          "20180101010102_test_migration_two.ts",
+          "20180101010103_test_migration_three.ts",
+        ]) {
+          fs.writeFileSync(path.join(src, f), "// temp migration\n");
         }
-        expect(new Boundary().version).toBe("20231231235959");
+        // Rails travel_to(Time.utc(2023, 12, 1, 10, 10, 59)): freeze the clock
+        // so next_migration_number renumbers past the seconds boundary
+        // (…101059, …101060, …101061).
+        const nowSpy = vi
+          .spyOn(Temporal.Now, "instant")
+          .mockReturnValue(Temporal.Instant.from("2023-12-01T10:10:59Z"));
+        try {
+          const copied = await Migration.copy(dst, { temp: src });
+
+          expect(fs.existsSync(path.join(dst, "20231201101059_test_migration.temp.ts"))).toBe(true);
+          expect(fs.existsSync(path.join(dst, "20231201101060_test_migration_two.temp.ts"))).toBe(
+            true,
+          );
+          expect(fs.existsSync(path.join(dst, "20231201101061_test_migration_three.temp.ts"))).toBe(
+            true,
+          );
+
+          expect(Number(copied[copied.length - 1].version)).toBe(20231201101061);
+        } finally {
+          nowSpy.mockRestore();
+          fs.rmSync(root, { recursive: true, force: true });
+        }
       });
     }); // MigrationValidationTest
   }); // CopyMigrationsTest

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2803,7 +2803,9 @@ export class Migrator {
     } catch (e) {
       // Mirrors: ActiveRecord::Migrator#execute_migration_in_transaction rescue block
       const useTx = this._useTransaction(migration);
-      const msg = `An error has occurred, ${useTx ? "this and " : ""}all later migrations canceled:\n\n${e}`;
+      // Ruby's `#{e}` interpolates Exception#to_s — the bare message, without
+      // the `Error: ` prefix JS String(e) would add.
+      const msg = `An error has occurred, ${useTx ? "this and " : ""}all later migrations canceled:\n\n${e instanceof Error ? e.message : e}`;
       throw Object.assign(new Error(msg), { cause: e });
     }
 

--- a/packages/activerecord/src/primary-keys.test.ts
+++ b/packages/activerecord/src/primary-keys.test.ts
@@ -401,8 +401,8 @@ describe("PrimaryKeysTest", () => {
     }[];
     const col = cols.find((c) => c.name === "monkeyID");
     expect(col).toBeDefined();
-    expect(col!.defaultFunction).toMatch(/nextval/);
-    expect(col!.serial).toBe(true);
+    expect(col!.defaultFunction).toBe("nextval('\"mixed_case_monkeys_monkeyID_seq\"'::regclass)");
+    expect(col!.serial).toBeTruthy();
   });
 
   it.skipIf(adapterType !== "postgres")("serial with unquoted sequence name", async () => {
@@ -416,8 +416,8 @@ describe("PrimaryKeysTest", () => {
     }[];
     const col = cols.find((c) => c.name === "id");
     expect(col).toBeDefined();
-    expect(col!.defaultFunction).toMatch(/nextval/);
-    expect(col!.serial).toBe(true);
+    expect(col!.defaultFunction).toBe("nextval('topics_id_seq'::regclass)");
+    expect(col!.serial).toBeTruthy();
   });
 });
 

--- a/packages/activerecord/src/primary-keys.test.ts
+++ b/packages/activerecord/src/primary-keys.test.ts
@@ -389,8 +389,6 @@ describe("PrimaryKeysTest", () => {
   });
 
   it.skipIf(adapterType !== "postgres")("serial with quoted sequence name", async () => {
-    // Rails: assert_equal "nextval('"mixed_case_monkeys_monkeyID_seq"'::regclass)", column.default_function
-    //        assert_predicate column, :serial?
     // columnsHash() reads from the model's schema cache which is cleared by
     // clearSchemaCache after each test; use connection.columns() directly so the
     // PG adapter's full column introspection (with defaultFunction) is always fresh.
@@ -406,9 +404,8 @@ describe("PrimaryKeysTest", () => {
   });
 
   it.skipIf(adapterType !== "postgres")("serial with unquoted sequence name", async () => {
-    // Rails: assert_equal "nextval('topics_id_seq'::regclass)", column.default_function
-    //        assert_predicate column, :serial?
-    // Same issue as above — use connection.columns() for fresh PG introspection.
+    // Same schema-cache issue as above — use connection.columns() for fresh PG
+    // introspection.
     const cols = (await (Base.connection as any).columns("topics")) as {
       name: string;
       defaultFunction?: string;

--- a/packages/activerecord/src/readonly.test.ts
+++ b/packages/activerecord/src/readonly.test.ts
@@ -53,10 +53,10 @@ describe("ReadOnlyTest", () => {
 
   it("cant save readonly record", async () => {
     const dev = await Developer.find(developers("david").id);
-    expect(dev.isReadonly()).toBe(false);
+    expect(dev.isReadonly()).toBeFalsy();
 
     dev.readonlyBang();
-    expect(dev.isReadonly()).toBe(true);
+    expect(dev.isReadonly()).toBeTruthy();
 
     // In-memory writes remain allowed; only persistence is blocked. The
     // 25-char name violates Developer's `length: { in: [3, 20] }` validation,
@@ -65,12 +65,20 @@ describe("ReadOnlyTest", () => {
     // rather than raising ReadOnlyRecord. Resetting to a valid name then
     // surfaces the readonly guard.
     (dev as Record<string, unknown>).name = "Luscious forbidden fruit.";
-    expect(await dev.save()).toBe(false);
+    expect(await dev.save()).toBeFalsy();
     (dev as Record<string, unknown>).name = "Forbidden.";
 
-    await expect(dev.save()).rejects.toThrow("Developer is marked as readonly");
-    await expect(dev.saveBang()).rejects.toThrow("Developer is marked as readonly");
-    await expect(dev.destroy()).rejects.toThrow("Developer is marked as readonly");
+    const catchError = (p: Promise<unknown>) =>
+      p.then(
+        () => null,
+        (err: unknown) => err as Error,
+      );
+    let e = await catchError(dev.save());
+    expect(e?.message).toBe("Developer is marked as readonly");
+    e = await catchError(dev.saveBang());
+    expect(e?.message).toBe("Developer is marked as readonly");
+    e = await catchError(dev.destroy());
+    expect(e?.message).toBe("Developer is marked as readonly");
   });
 
   it("cant touch readonly record", async () => {

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -985,10 +985,16 @@ export async function performCount(
     // Inherit select-value column when no explicit column is provided (same logic
     // as the non-limit path below — mirrors Rails execute_simple_calculation).
     const selectColsLimited = (this as any)._selectColumns as unknown[] | null | undefined;
+    // A single plain-identifier string select (`select("firm_id")`) counts that
+    // column too — Rails' select_for_count compiles string select values via
+    // arel_columns. Raw SQL fragments (commas/spaces) stay out: Rails raises on
+    // those and trails' divergence there is tracked separately.
     const singleSelectColLimited =
       !rawEffectiveCol &&
       selectColsLimited?.length === 1 &&
-      selectColsLimited[0] instanceof Nodes.Node
+      (selectColsLimited[0] instanceof Nodes.Node ||
+        (typeof selectColsLimited[0] === "string" &&
+          /^[a-zA-Z_][a-zA-Z0-9_.]*$/.test(selectColsLimited[0])))
         ? selectColsLimited[0]
         : null;
     const effectiveCol = rawEffectiveCol ?? singleSelectColLimited ?? undefined;

--- a/packages/activerecord/src/sanitize.test.ts
+++ b/packages/activerecord/src/sanitize.test.ts
@@ -51,8 +51,8 @@ describe("SanitizeTest", () => {
         this.attribute("title", "string");
       }
     }
-    const sql = Post.sanitizeSqlArray("SELECT 1");
-    expect(sql).toBe("SELECT 1");
+    const sql = Post.sanitizeSqlArray("");
+    expect(sql).toBe("");
   });
 
   it("sanitize sql like", () => {

--- a/packages/activerecord/src/schema-migration.ts
+++ b/packages/activerecord/src/schema-migration.ts
@@ -61,10 +61,13 @@ export class SchemaMigration {
     await this._adapter.dropTable(this.tableName, { ifExists: true });
   }
 
-  async createVersion(version: string): Promise<void> {
+  // Rails: connection.insert(im, "...", primary_key, version) — returns the
+  // supplied id value, i.e. the version (schema_migration.rb:19-25).
+  async createVersion(version: string): Promise<string> {
     const im = new InsertManager(this.arelTable);
     im.insert([[this.arelTable.get(this.primaryKey), version]]);
     await this._adapter.execute(this._adapter.toSql(im));
+    return version;
   }
 
   async deleteVersion(version: string): Promise<void> {
@@ -113,7 +116,7 @@ export class SchemaMigration {
   }
 
   async recordVersion(version: string): Promise<void> {
-    return this.createVersion(version);
+    await this.createVersion(version);
   }
 
   static normalizeMigrationNumber(number: string | number): string {

--- a/packages/activerecord/src/strict-loading.test.ts
+++ b/packages/activerecord/src/strict-loading.test.ts
@@ -809,6 +809,7 @@ describe("StrictLoadingTest", () => {
     developer!.strictLoadingBang();
 
     setActionOnStrictLoadingViolation("log");
+    expect(actionOnStrictLoadingViolation).toBe("log");
     let logged = false;
     const sub = Notifications.subscribe("strict_loading_violation.active_record", () => {
       logged = true;

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -544,7 +544,11 @@ describe("TransactionTest", () => {
     };
 
     first.approved = true;
-    await expect(first.save()).rejects.toThrow("Make the transaction rollback");
+    const e = await first.save().then(
+      () => null,
+      (err: unknown) => err,
+    );
+    expect((e as Error).message).toBe("Make the transaction rollback");
     expect(((await Topic.find(1)) as any).approved).toBe(false);
   });
 
@@ -1253,8 +1257,7 @@ describe("TransactionTest", () => {
 
     await txn.rollback();
 
-    txn.state.commitBang();
-    expect(txn.state.committed).toBe(true);
+    expect(txn.state.commitBang()).toBe("committed");
   });
 
   it("mark transaction state as rolledback", async () => {
@@ -1264,8 +1267,7 @@ describe("TransactionTest", () => {
 
     await txn.commit();
 
-    txn.state.rollbackBang();
-    expect(txn.state.rolledBack).toBe(true);
+    expect(txn.state.rollbackBang()).toBe("rolledback");
   });
 
   it("mark transaction state as nil", async () => {
@@ -1275,9 +1277,7 @@ describe("TransactionTest", () => {
 
     await txn.commit();
 
-    // Rails asserts `transaction.state.nullify!` returns nil; nullifyBang()
-    // returns void — the TS equivalent of nil.
-    expect(txn.state.nullifyBang()).toBeUndefined();
+    expect(txn.state.nullifyBang()).toBeNull();
   });
 });
 

--- a/packages/activerecord/src/validations/absence-validation.test.ts
+++ b/packages/activerecord/src/validations/absence-validation.test.ts
@@ -5,6 +5,9 @@
 import { describe, it, expect } from "vitest";
 import { Base } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
+import { Human } from "../test-helpers/models/human.js";
+import { Face } from "../test-helpers/models/face.js";
+import { seedAssociationCache } from "../test-helpers/seed-association-cache.js";
 
 fixtures({});
 
@@ -25,9 +28,19 @@ describe("AbsenceValidationTest", () => {
     expect(await t.isValid()).toBe(false);
   });
   it("has one marked for destruction", async () => {
-    const { Topic } = makeModel();
-    const t = new Topic({ body: "" });
-    expect(await t.isValid()).toBe(true);
+    class Boy extends Human {
+      static name = "Boy";
+    }
+    Boy.validatesAbsenceOf("face");
+
+    const boy = new Boy();
+    const face = new Face();
+    seedAssociationCache(boy, "face", face);
+    expect(await boy.isValid()).toBe(false);
+    expect(boy.errors.get("face").length).toBe(1);
+
+    face.markForDestruction();
+    expect(await boy.isValid()).toBe(true);
   });
   it("has many marked for destruction", async () => {
     const { Topic } = makeModel();


### PR DESCRIPTION
Restores Rails' concrete expected values in the weakened-assertion cluster surfaced by `test:compare --assertions` (RFC 0030 residual burndown). Every listed value-mismatch entry for the target files is cleared; the only remaining entries are the documented-benign numeric-literal formatting class (`n:53.0` vs `n:53`).

## Test restorations

- **transactions**: `TransactionState` bang methods now return the new state (mirroring Ruby's implicit assignment return, transaction.rb:51-76), so `mark transaction state as committed/rolledback/nil` assert `"committed"` / `"rolledback"` / `null`; `raising exception in callback rollbacks in save` asserts the exact `"Make the transaction rollback"` message.
- **readonly**: the three `ReadOnlyRecord` raises now assert `"Developer is marked as readonly"` message equality (readonly_test.rb:30-37).
- **strict-loading**: asserts `actionOnStrictLoadingViolation === "log"` after set (strict_loading_test.rb:656).
- **primary-keys (PG)**: exact `nextval('topics_id_seq'::regclass)` / `nextval('"mixed_case_monkeys_monkeyID_seq"'::regclass)` default-function values.
- **adapters/postgresql/uuid**: `uuid column default` asserts `column.defaultFunction === "gen_random_uuid()"` via adapter.columns() (uuid_test.rb:52).
- **schema-cache**: `columns (hash) for existent table` use Rails' `courses` table with 3 columns and assert size 3.
- **calculations**: `limit should apply before count` restored to Rails' two `=== 3` assertions; `no order by when counting all` captures SQL and asserts 1 query without ORDER BY; integer average asserts `1.0`.
- **finder**: `find one message on primary key` converged from bespoke Topic to canonical `Car` (finder_test.rb:1718); `find some message with custom primary key` ports the MercedesCar-over-Toy custom-pk model and asserts the full `RecordNotFound` message.
- **active-record-schema**: `has primary key` asserts `schemaMigration.primaryKey === "version"` + count delta; `schema define with table name prefix` passes `version: 7` and asserts `currentVersion() === 7`.
- **sanitize**: `sanitizeSqlArray("")` returns `""` (sanitize_test.rb:58-61).
- **json-serialization**: asserts `"favoriteQuote":"Constraints are liberating"` appears exactly once in the JSON string.
- **absence-validation**: faithful Boy/Face port — invalid with a face, exactly one error, valid after `markForDestruction()`.
- **migration**: `migration detection without schema migration table` drops the table and asserts `needsMigration() === true`; `migration without transaction` asserts the exact full error message; internal-metadata test uses Rails' `version = "foo"`; `schema migration create table wont be affected by schema cache` asserts `createVersion` returns its version; `rename table with prefix and suffix` round-trips `"hello world"` through the rename; `copied migrations at timestamp boundary are valid` is now a real copy test with the Temporal clock frozen at 2023-12-01 10:10:59 asserting the …101059/…101060/…101061 renumbering and final version `20231201101061`.

## Impl convergences the restored assertions forced

- `TransactionState` bang methods return the state (Ruby implicit return).
- `SchemaMigration#createVersion` returns the version (Rails `connection.insert(im, …, primary_key, version)` returns the supplied id).
- Migrator error interpolation uses `e.message` instead of `String(e)` — Ruby's `#{e}` is `Exception#to_s`, without JS's `Error: ` prefix.
- Limited `count()` now inherits a single plain-string select value (`select("firm_id").limit(4).count`) as the counted column, matching Rails' `select_for_count`; raw SQL fragments stay excluded (that divergence is tracked separately).

Local runs: all touched suites pass on sqlite3 (PG-gated tests covered by CI).

Closes-story: weakened-assertion-restoration-sweep
