### PR TITLE
test(fidelity): converge divergent test data to Rails literals across encryption, multiparameter, reflection, quoting, reaper

### DIFF
--- a/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
+++ b/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
@@ -56,7 +56,7 @@ export class AcceptsMultiparameterTime {
     this.type.cast(value);
   }
 
-  valueConstructedByMassAssignment(value: unknown): boolean {
+  isValueConstructedByMassAssignment(value: unknown): boolean {
     return this.isMultiparameterHash(value);
   }
 
@@ -136,5 +136,5 @@ export interface InstanceMethods {
   serializeCastValue(value: unknown): unknown;
   cast(value: unknown): unknown;
   assertValidValue(value: unknown): void;
-  valueConstructedByMassAssignment(value: unknown): boolean;
+  isValueConstructedByMassAssignment(value: unknown): boolean;
 }

--- a/packages/activerecord/src/adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/quoting.test.ts
@@ -39,13 +39,13 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("quote float nan", async () => {
-      const rows = await adapter.execute("SELECT 'NaN'::float AS val");
-      expect(rows[0].val).toBeNaN();
+      const nan = 0.0 / 0;
+      expect(adapter.quote(nan)).toBe("'NaN'");
     });
 
     it("quote float infinity", async () => {
-      const rows = await adapter.execute("SELECT 'Infinity'::float AS val");
-      expect(rows[0].val).toBe(Infinity);
+      const infinity = 1.0 / 0;
+      expect(adapter.quote(infinity)).toBe("'Infinity'");
     });
 
     it("quote string", async () => {
@@ -111,7 +111,6 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("quote integer", async () => {
-      // Rails: @conn.quote(42) returns the SQL literal text "42".
       expect(adapter.quote(42)).toBe("42");
     });
 

--- a/packages/activerecord/src/adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/quoting.test.ts
@@ -49,8 +49,10 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("quote string", async () => {
-      const rows = await adapter.execute("SELECT ? AS val", ["hello"]);
-      expect(rows[0].val).toBe("hello");
+      // Rails asserts quote_string("'") == "''" (escaped content, no wrapping
+      // quotes). Trails' quoteString wraps — round-trip the same "'" datum.
+      const rows = await adapter.execute("SELECT ? AS val", ["'"]);
+      expect(rows[0].val).toBe("'");
     });
 
     it("quote column name", async () => {
@@ -109,8 +111,8 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("quote integer", async () => {
-      const rows = await adapter.execute("SELECT 42::integer AS val");
-      expect(rows[0].val).toBe(42);
+      // Rails: @conn.quote(42) returns the SQL literal text "42".
+      expect(adapter.quote(42)).toBe("42");
     });
 
     it("quote big decimal", async () => {

--- a/packages/activerecord/src/adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/quoting.test.ts
@@ -26,10 +26,12 @@ afterEach(async () => {
 // -- Rails test class: quoting_test.rb --
 describeIfSqlite("SQLite3QuotingTest", () => {
   it("quote string", async () => {
+    // Rails asserts quote_string("'") == "''" (escaped content, no wrapping
+    // quotes). Trails' quoteString wraps — round-trip the same "'" datum.
     await adapter.exec(`CREATE TABLE "quote_test" ("id" INTEGER PRIMARY KEY, "val" TEXT)`);
-    await adapter.executeMutation(`INSERT INTO "quote_test" ("val") VALUES ('it''s')`);
+    await adapter.executeMutation(`INSERT INTO "quote_test" ("val") VALUES ('''')`);
     const rows = await adapter.execute(`SELECT "val" FROM "quote_test"`);
-    expect(rows[0].val).toBe("it's");
+    expect(rows[0].val).toBe("'");
   });
 
   it("quote column name", async () => {

--- a/packages/activerecord/src/encryption/configurable.test.ts
+++ b/packages/activerecord/src/encryption/configurable.test.ts
@@ -102,11 +102,11 @@ describe("ActiveRecord::Encryption::ConfigurableTest", () => {
 
     try {
       // Named class: filter key is "underscore(ClassName).attribute"
-      class EncryptedPost {}
-      const modelClass = Object.assign(EncryptedPost, { _attributeDefinitions: new Map() });
-      EncryptableRecord.encrypts(modelClass, "title");
+      class NamedPirate {}
+      const modelClass = Object.assign(NamedPirate, { _attributeDefinitions: new Map() });
+      EncryptableRecord.encrypts(modelClass, "catchphrase");
 
-      expect(filterParameters).toContain("encrypted_post.title");
+      expect(filterParameters).toContain("named_pirate.catchphrase");
     } finally {
       dispose();
     }
@@ -124,9 +124,9 @@ describe("ActiveRecord::Encryption::ConfigurableTest", () => {
     try {
       // Truly anonymous class (empty .name): filter key is just the attribute name
       const modelClass = Object.assign(class {}, { _attributeDefinitions: new Map() });
-      EncryptableRecord.encrypts(modelClass, "secret");
+      EncryptableRecord.encrypts(modelClass, "catchphrase");
 
-      expect(filterParameters).toContain("secret");
+      expect(filterParameters).toContain("catchphrase");
       expect(filterParameters.every((f) => !f.includes("."))).toBe(true);
     } finally {
       dispose();
@@ -134,7 +134,7 @@ describe("ActiveRecord::Encryption::ConfigurableTest", () => {
   });
 
   it("exclude the installation of autofiltered params", () => {
-    Configurable.config.addToFilterParameters = false;
+    Configurable.config.excludeFromFilterParameters = ["catchphrase"];
 
     const filterParameters: string[] = [];
     const autoFilteredParameters = new AutoFilteredParameters(filterParameters);
@@ -145,14 +145,13 @@ describe("ActiveRecord::Encryption::ConfigurableTest", () => {
     });
 
     try {
-      class AnotherModel {}
-      const modelClass = Object.assign(AnotherModel, { _attributeDefinitions: new Map() });
-      EncryptableRecord.encrypts(modelClass, "email");
+      const modelClass = Object.assign(class {}, { _attributeDefinitions: new Map() });
+      EncryptableRecord.encrypts(modelClass, "catchphrase");
 
-      // addToFilterParameters = false → nothing is added
-      expect(filterParameters).toHaveLength(0);
+      expect(filterParameters).toEqual([]);
     } finally {
       dispose();
+      Configurable.config.excludeFromFilterParameters = [];
     }
   });
 

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -471,7 +471,11 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
   });
 
   it("forced encoding for deterministic attributes will replace invalid characters", async () => {
-    // ASCII encoding replaces chars > 0x7F with "?".
+    // Rails feeds invalid UTF-8 bytes ("Hello \x93\xfa".b) and expects U+FFFD
+    // replacement. JS strings are always valid UTF-16 — invalid byte sequences
+    // cannot exist — so the UTF-8 forced encoding is a no-op here. The ASCII
+    // path exercises the same replacement machinery: like Ruby's
+    // String#encode("US-ASCII", replace), chars > 0x7F become "?".
     Configurable.config.forcedEncodingForDeterministicEncryption = "ASCII";
     const Book = makeEncryptedBook(await freshAdapter());
     new Book();
@@ -788,7 +792,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     const Post = makeEncryptedPost(await freshAdapter());
     new Post();
     expect(Book.typeForAttribute("name").type()).toBe("string");
-    expect(Post.typeForAttribute("body").type()).toBe("string");
+    expect(Post.typeForAttribute("body").type()).toBe("text");
   });
 
   it("encrypts normalized data", async () => {

--- a/packages/activerecord/src/encryption/encrypting-only-encryptor.test.ts
+++ b/packages/activerecord/src/encryption/encrypting-only-encryptor.test.ts
@@ -10,17 +10,17 @@ function generateKey(): string {
 describe("ActiveRecord::Encryption::EncryptingOnlyEncryptorTest", () => {
   it("decrypt returns the passed data", () => {
     const enc = new EncryptingOnlyEncryptor();
-    expect(enc.decrypt("hello")).toBe("hello");
+    expect(enc.decrypt("Some data")).toBe("Some data");
   });
 
   it("encrypt encrypts the passed data", () => {
     const enc = new EncryptingOnlyEncryptor();
     const key = generateKey();
-    const encrypted = enc.encrypt("hello", { key });
-    expect(encrypted).not.toBe("hello");
+    const encrypted = enc.encrypt("Some data", { key });
+    expect(encrypted).not.toBe("Some data");
     const realEnc = new Encryptor();
     const decrypted = realEnc.decrypt(encrypted, { key });
-    expect(decrypted).toBe("hello");
+    expect(decrypted).toBe("Some data");
   });
 
   it("extends Encryptor", () => {

--- a/packages/activerecord/src/encryption/encryption-schemes.test.ts
+++ b/packages/activerecord/src/encryption/encryption-schemes.test.ts
@@ -282,7 +282,7 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
     Configurable.config.previousSchemes = [];
     Configurable.config.previous = [
       { encryptor: new TestEncryptor({ det: "cipher_det" }), deterministic: true } as SchemeOptions,
-      { encryptor: new TestEncryptor({ nondet: "cipher_nondet" }) } as SchemeOptions,
+      { encryptor: new TestEncryptor({ "STEPHEN KING": "cipher_nondet" }) } as SchemeOptions,
     ];
 
     const modelClass = { _attributeDefinitions: new Map() };
@@ -293,7 +293,7 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
 
     const type = modelClass._attributeDefinitions.get("name")?.type as EncryptedAttributeType;
     expect(type.previousTypes).toHaveLength(1);
-    expect(type.deserialize("cipher_nondet")).toBe("nondet");
+    expect(type.deserialize("cipher_nondet")).toBe("STEPHEN KING");
     expect(() => type.deserialize("cipher_det")).toThrow(DecryptionError);
   });
 
@@ -392,7 +392,10 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
     Configurable.config.supportUnencryptedData = false;
     Configurable.config.previousSchemes = [];
     Configurable.config.previous = [
-      { encryptor: new TestEncryptor({ det: "cipher_det" }), deterministic: true } as SchemeOptions,
+      {
+        encryptor: new TestEncryptor({ "STEPHEN KING": "cipher_det" }),
+        deterministic: true,
+      } as SchemeOptions,
       { encryptor: new TestEncryptor({ nondet: "cipher_nondet" }) } as SchemeOptions,
     ];
 
@@ -406,7 +409,7 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
     const type = modelClass._attributeDefinitions.get("name")?.type as EncryptedAttributeType;
     // Only the deterministic global previous scheme is wired in.
     expect(type.previousTypes).toHaveLength(1);
-    expect(type.deserialize("cipher_det")).toBe("det");
+    expect(type.deserialize("cipher_det")).toBe("STEPHEN KING");
     expect(() => type.deserialize("cipher_nondet")).toThrow(DecryptionError);
   });
 });

--- a/packages/activerecord/src/encryption/key-generator.test.ts
+++ b/packages/activerecord/src/encryption/key-generator.test.ts
@@ -5,18 +5,19 @@ import { Configurable } from "./configurable.js";
 describe("ActiveRecord::Encryption::KeyGeneratorTest", () => {
   it("generate_random_key generates random keys with the cipher key length by default", () => {
     const gen = new KeyGenerator();
-    const key = gen.generateRandomKey();
-    expect(Buffer.from(key, "base64").length).toBe(32);
+    expect(gen.generateRandomKey()).not.toBe(gen.generateRandomKey());
+    expect(Buffer.from(gen.generateRandomKey(), "base64").length).toBe(32);
   });
 
   it("generate_random_key generates random keys with a custom length", () => {
     const gen = new KeyGenerator();
-    const key = gen.generateRandomKey(16);
-    expect(Buffer.from(key, "base64").length).toBe(16);
+    expect(gen.generateRandomKey(10)).not.toBe(gen.generateRandomKey(10));
+    expect(Buffer.from(gen.generateRandomKey(10), "base64").length).toBe(10);
   });
 
   it("generate_random_hex_key generates random hexadecimal keys with the cipher key length by default", () => {
     const gen = new KeyGenerator();
+    expect(gen.generateRandomHexKey()).not.toBe(gen.generateRandomHexKey());
     const key = gen.generateRandomHexKey();
     expect(key.length).toBe(64);
     expect(key).toMatch(/^[0-9a-f]+$/);
@@ -24,31 +25,32 @@ describe("ActiveRecord::Encryption::KeyGeneratorTest", () => {
 
   it("generate_random_hex_key generates random hexadecimal keys with a custom length", () => {
     const gen = new KeyGenerator();
-    const key = gen.generateRandomHexKey(16);
-    expect(key.length).toBe(32);
+    expect(gen.generateRandomHexKey(10)).not.toBe(gen.generateRandomHexKey(10));
+    const key = gen.generateRandomHexKey(10);
+    expect(key.length).toBe(20);
     expect(key).toMatch(/^[0-9a-f]+$/);
   });
 
   it("derive keys using the configured digest algorithm", () => {
     const gen256 = new KeyGenerator("SHA256");
     const genSha1 = new KeyGenerator("SHA1");
-    const k1 = gen256.deriveKey("password");
-    const k2 = genSha1.deriveKey("password");
+    const k1 = gen256.deriveKey("some secret");
+    const k2 = genSha1.deriveKey("some secret");
     expect(k1).not.toBe(k2);
   });
 
   it("derive_key derives a key with from the provided password with the cipher key length by default", () => {
     const gen = new KeyGenerator();
-    const key = gen.deriveKey("password");
-    expect(Buffer.from(key, "base64").length).toBe(32);
-    const key2 = gen.deriveKey("password");
-    expect(key2).toBe(key);
+    expect(gen.deriveKey("some password")).toBe(gen.deriveKey("some password"));
+    expect(gen.deriveKey("some password")).not.toBe(gen.deriveKey("some other password"));
+    expect(Buffer.from(gen.deriveKey("some password"), "base64").length).toBe(32);
   });
 
   it("derive_key derives a key with a custom length", () => {
     const gen = new KeyGenerator();
-    const key = gen.deriveKey("password", 16);
-    expect(Buffer.from(key, "base64").length).toBe(16);
+    expect(gen.deriveKey("some password", 12)).toBe(gen.deriveKey("some password", 12));
+    expect(gen.deriveKey("some password", 12)).not.toBe(gen.deriveKey("some other password", 12));
+    expect(Buffer.from(gen.deriveKey("some password", 12), "base64").length).toBe(12);
   });
 
   it("hash_digest_class reflects the configured digest", () => {

--- a/packages/activerecord/src/encryption/message.test.ts
+++ b/packages/activerecord/src/encryption/message.test.ts
@@ -4,28 +4,31 @@ import { EncryptedContentIntegrity, ForbiddenClass } from "./errors.js";
 
 describe("ActiveRecord::Encryption::MessageTest", () => {
   it("add_header lets you add headers", () => {
-    const message = new Message("payload");
-    message.addHeader("key", "value");
-    expect(message.headers.get("key")).toBe("value");
+    const message = new Message();
+    message.addHeader("header_1", "value 1");
+    expect(message.headers.get("header_1")).toBe("value 1");
   });
 
   it("add_headers lets you add multiple headers", () => {
-    const message = new Message("payload");
-    message.addHeaders({ a: "1", b: "2" });
-    expect(message.headers.get("a")).toBe("1");
-    expect(message.headers.get("b")).toBe("2");
+    const message = new Message();
+    message.addHeaders({ header_1: "value 1", header_2: "value 2" });
+    expect(message.headers.get("header_1")).toBe("value 1");
+    expect(message.headers.get("header_2")).toBe("value 2");
   });
 
   it("headers can't be overridden", () => {
-    const message = new Message("payload");
-    message.addHeader("key", "value");
-    expect(() => message.addHeader("key", "other")).toThrow(EncryptedContentIntegrity);
+    const message = new Message();
+    message.addHeaders({ header_1: "value 1" });
+    expect(() => message.addHeaders({ header_1: "value 1" })).toThrow(EncryptedContentIntegrity);
+    expect(() => message.addHeaders({ header_1: "value 1" })).toThrow(EncryptedContentIntegrity);
   });
 
   it("validates that payloads are either nil or strings", () => {
-    expect(() => new Message(42 as any)).toThrow(ForbiddenClass);
-    expect(() => new Message(null)).not.toThrow();
-    expect(() => new Message(undefined)).not.toThrow();
-    expect(() => new Message("hello")).not.toThrow();
+    // Rails uses Date.new / []; Temporal.PlainDate has no zero-arg analogue, so
+    // an array stands in for the non-string payload.
+    expect(() => new Message([] as any)).toThrow(ForbiddenClass);
+    expect(() => new Message()).not.toThrow();
+    expect(() => new Message("")).not.toThrow();
+    expect(() => new Message("Some payload")).not.toThrow();
   });
 });

--- a/packages/activerecord/src/encryption/null-encryptor.test.ts
+++ b/packages/activerecord/src/encryption/null-encryptor.test.ts
@@ -4,17 +4,17 @@ import { NullEncryptor } from "./null-encryptor.js";
 describe("ActiveRecord::Encryption::NullEncryptorTest", () => {
   it("encrypt returns the passed data", () => {
     const enc = new NullEncryptor();
-    expect(enc.encrypt("hello")).toBe("hello");
+    expect(enc.encrypt("Some data")).toBe("Some data");
   });
 
   it("decrypt returns the passed data", () => {
     const enc = new NullEncryptor();
-    expect(enc.decrypt("hello")).toBe("hello");
+    expect(enc.decrypt("Some data")).toBe("Some data");
   });
 
   it("encrypted? returns false", () => {
     const enc = new NullEncryptor();
-    expect(enc.isEncrypted("hello")).toBe(false);
+    expect(enc.isEncrypted("Some data")).toBe(false);
   });
 
   it("binary? returns false", () => {

--- a/packages/activerecord/src/encryption/properties.test.ts
+++ b/packages/activerecord/src/encryption/properties.test.ts
@@ -4,32 +4,32 @@ import { EncryptedContentIntegrity, ForbiddenClass } from "./errors.js";
 
 describe("ActiveRecord::EncryptionPropertiesTest", () => {
   it("behaves like a hash", () => {
-    const props = new Properties({ a: "1", b: "2" });
-    expect(props.get("a")).toBe("1");
-    expect(props.get("b")).toBe("2");
-    expect(props.has("a")).toBe(true);
-    expect(props.has("c")).toBe(false);
+    const props = new Properties();
+    props.set("key_1", "value 1");
+    props.set("key_2", "value 2");
+    expect(props.get("key_1")).toBe("value 1");
+    expect(props.get("key_2")).toBe("value 2");
   });
 
   it("defines custom accessors for some default properties", () => {
+    const authTag = "some auth tag";
     const props = new Properties();
-    props.set("iv", "test-iv");
-    props.set("at", "test-at");
-    expect(props.iv).toBe("test-iv");
-    expect(props.authTag).toBe("test-at");
+    props.set("at", authTag);
+    expect(props.authTag).toBe(authTag);
+    expect(props.get("at")).toBe(authTag);
   });
 
   it("raises EncryptedContentIntegrity when trying to override properties", () => {
     const props = new Properties();
-    props.set("key", "value");
-    expect(() => props.set("key", "other")).toThrow(EncryptedContentIntegrity);
+    props.set("key_1", "value 1");
+    expect(() => props.set("key_1", "value 1")).toThrow(EncryptedContentIntegrity);
   });
 
   it("add will add all the properties passed", () => {
     const props = new Properties();
-    props.add({ a: "1", b: "2" });
-    expect(props.get("a")).toBe("1");
-    expect(props.get("b")).toBe("2");
+    props.add({ key_1: "value 1", key_2: "value 2" });
+    expect(props.get("key_1")).toBe("value 1");
+    expect(props.get("key_2")).toBe("value 2");
   });
 
   it("validate allowed types on creation", () => {

--- a/packages/activerecord/src/encryption/read-only-null-encryptor.test.ts
+++ b/packages/activerecord/src/encryption/read-only-null-encryptor.test.ts
@@ -5,16 +5,16 @@ import { EncryptionError } from "./errors.js";
 describe("ActiveRecord::Encryption::ReadOnlyNullEncryptorTest", () => {
   it("decrypt returns the encrypted message", () => {
     const enc = new ReadOnlyNullEncryptor();
-    expect(enc.decrypt("hello")).toBe("hello");
+    expect(enc.decrypt("some text")).toBe("some text");
   });
 
   it("encrypt raises an Encryption", () => {
     const enc = new ReadOnlyNullEncryptor();
-    expect(() => enc.encrypt("hello")).toThrow(EncryptionError);
+    expect(() => enc.encrypt("some text")).toThrow(EncryptionError);
   });
 
   it("encrypted? returns false", () => {
-    expect(new ReadOnlyNullEncryptor().isEncrypted("hello")).toBe(false);
+    expect(new ReadOnlyNullEncryptor().isEncrypted("some text")).toBe(false);
   });
 
   it("binary? returns false", () => {

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -212,7 +212,9 @@ export function makeEncryptedPost(adapter: DatabaseAdapter) {
       this._tableName = "posts";
       this.attribute("id", "integer");
       this.attribute("title", "string");
-      this.attribute("body", "string");
+      // Rails' posts.body is a text column — keep the declared type faithful so
+      // type_for_attribute(:body).type reflects :text.
+      this.attribute("body", "text");
       this.adapter = adapter;
       this.encrypts("title");
       this.encrypts("body");

--- a/packages/activerecord/src/multiparameter-attributes.test.ts
+++ b/packages/activerecord/src/multiparameter-attributes.test.ts
@@ -168,7 +168,13 @@ describe("MultiParameterAttributeTest", () => {
     });
     const dt = topic.written_on as Temporal.Instant;
     expect(dt).toBeInstanceOf(Temporal.Instant);
+    // Rails asserts the full to_fs(:db) representation: "1850-06-24 16:24:00".
     expect(utc(dt).year).toBe(1850);
+    expect(utc(dt).month).toBe(6);
+    expect(utc(dt).day).toBe(24);
+    expect(utc(dt).hour).toBe(16);
+    expect(utc(dt).minute).toBe(24);
+    expect(utc(dt).second).toBe(0);
   });
 
   it("multiparameter attributes on time will raise on big time if missing date parts", () => {
@@ -440,64 +446,61 @@ describe("MultiParameterAttributeTest", () => {
   });
 
   it("multiparameter attributes setting date attribute", () => {
-    const topic = new Topic();
-    (topic as any).attributes = {
-      "last_read(1i)": "2004",
-      "last_read(2i)": "6",
-      "last_read(3i)": "24",
-    };
-    const d = topic.last_read;
-    expect(d.year).toBe(2004);
-    expect(d.month).toBe(6);
-    expect(d.day).toBe(24);
+    const topic = new Topic({
+      "written_on(1i)": "1952",
+      "written_on(2i)": "3",
+      "written_on(3i)": "11",
+    });
+    const dt = topic.written_on as Temporal.Instant;
+    expect(utc(dt).year).toBe(1952);
+    expect(utc(dt).month).toBe(3);
+    expect(utc(dt).day).toBe(11);
   });
 
   it("create with multiparameter attributes setting date attribute", () => {
-    // Rails: Topic.new(attrs) calls assign_attributes internally
+    // Rails: Topic.create_with(attrs).new — the create_with scope threads the
+    // multiparameter attrs into new, which assign_attributes handles the same way.
     const topic = new Topic({
-      title: "test",
-      "last_read(1i)": "2004",
-      "last_read(2i)": "6",
-      "last_read(3i)": "24",
+      "written_on(1i)": "1952",
+      "written_on(2i)": "3",
+      "written_on(3i)": "11",
     });
-    const d = topic.last_read;
-    expect(d.year).toBe(2004);
-    expect(d.month).toBe(6);
-    expect(d.day).toBe(24);
+    const dt = topic.written_on as Temporal.Instant;
+    expect(utc(dt).year).toBe(1952);
+    expect(utc(dt).month).toBe(3);
+    expect(utc(dt).day).toBe(11);
   });
 
   it("multiparameter attributes setting date and time attribute", () => {
-    const topic = new Topic();
-    topic.assignAttributes({
-      "last_read(1i)": "2004",
-      "last_read(2i)": "6",
-      "last_read(3i)": "24",
-      "written_on(1i)": "2004",
-      "written_on(2i)": "6",
-      "written_on(3i)": "24",
-      "written_on(4i)": "16",
-      "written_on(5i)": "24",
-      "written_on(6i)": "0",
+    const topic = new Topic({
+      "written_on(1i)": "1952",
+      "written_on(2i)": "3",
+      "written_on(3i)": "11",
+      "written_on(4i)": "13",
+      "written_on(5i)": "55",
     });
-    const d = topic.last_read;
-    expect(d.year).toBe(2004);
     const dt = topic.written_on as Temporal.Instant;
-    expect(utc(dt).hour).toBe(16);
+    expect(utc(dt).year).toBe(1952);
+    expect(utc(dt).month).toBe(3);
+    expect(utc(dt).day).toBe(11);
+    expect(utc(dt).hour).toBe(13);
+    expect(utc(dt).minute).toBe(55);
   });
 
   it("create with multiparameter attributes setting date and time attribute", () => {
     const topic = new Topic({
-      title: "test",
-      "written_on(1i)": "2004",
-      "written_on(2i)": "6",
-      "written_on(3i)": "24",
-      "written_on(4i)": "16",
-      "written_on(5i)": "24",
-      "written_on(6i)": "0",
+      "written_on(1i)": "1952",
+      "written_on(2i)": "3",
+      "written_on(3i)": "11",
+      "written_on(4i)": "13",
+      "written_on(5i)": "55",
     });
     const dt = topic.written_on as Temporal.Instant;
-    expect(utc(dt).year).toBe(2004);
-    expect(utc(dt).hour).toBe(16);
+    expect(utc(dt).year).toBe(1952);
+    expect(utc(dt).month).toBe(3);
+    expect(utc(dt).day).toBe(11);
+    expect(utc(dt).hour).toBe(13);
+    expect(utc(dt).minute).toBe(55);
   });
 
   it("multiparameter attributes setting time but not date on date field", () => {
@@ -679,15 +682,20 @@ describe("MultiParameterAttributeTest", () => {
   });
 
   it("multiparameter assigned attributes did not come from user", () => {
-    const topic = new Topic();
-    topic.assignAttributes({
-      "last_read(1i)": "2004",
-      "last_read(2i)": "6",
-      "last_read(3i)": "24",
+    const topic = new Topic({
+      "written_on(1i)": "1952",
+      "written_on(2i)": "3",
+      "written_on(3i)": "11",
+      "written_on(4i)": "13",
+      "written_on(5i)": "55",
     });
-    const d = topic.last_read;
-    expect(d.year).toBe(2004);
-    expect(d.month).toBe(6);
-    expect(d.day).toBe(24);
+    // DEVIATION: Rails writes the raw numeric-keyed hash and lets the type's
+    // AcceptsMultiparameterTime cast assemble it, so came_from_user? is false
+    // (value_constructed_by_mass_assignment? sees the hash). Trails assembles
+    // the value in multiparameter-attribute-assignment.ts before writeAttribute,
+    // so the attribute sees a plain user-written Instant → cameFromUser is true.
+    // Converging the assignment path to type-side casting is tracked as a
+    // follow-up story (multiparameter-assignment-type-side-cast).
+    expect(topic.cameFromUser("written_on")).toBe(true);
   });
 });

--- a/packages/activerecord/src/multiparameter-attributes.test.ts
+++ b/packages/activerecord/src/multiparameter-attributes.test.ts
@@ -168,7 +168,6 @@ describe("MultiParameterAttributeTest", () => {
     });
     const dt = topic.written_on as Temporal.Instant;
     expect(dt).toBeInstanceOf(Temporal.Instant);
-    // Rails asserts the full to_fs(:db) representation: "1850-06-24 16:24:00".
     expect(utc(dt).year).toBe(1850);
     expect(utc(dt).month).toBe(6);
     expect(utc(dt).day).toBe(24);
@@ -458,13 +457,11 @@ describe("MultiParameterAttributeTest", () => {
   });
 
   it("create with multiparameter attributes setting date attribute", () => {
-    // Rails: Topic.create_with(attrs).new — the create_with scope threads the
-    // multiparameter attrs into new, which assign_attributes handles the same way.
-    const topic = new Topic({
+    const topic = Topic.createWith({
       "written_on(1i)": "1952",
       "written_on(2i)": "3",
       "written_on(3i)": "11",
-    });
+    }).new();
     const dt = topic.written_on as Temporal.Instant;
     expect(utc(dt).year).toBe(1952);
     expect(utc(dt).month).toBe(3);
@@ -488,13 +485,13 @@ describe("MultiParameterAttributeTest", () => {
   });
 
   it("create with multiparameter attributes setting date and time attribute", () => {
-    const topic = new Topic({
+    const topic = Topic.createWith({
       "written_on(1i)": "1952",
       "written_on(2i)": "3",
       "written_on(3i)": "11",
       "written_on(4i)": "13",
       "written_on(5i)": "55",
-    });
+    }).new();
     const dt = topic.written_on as Temporal.Instant;
     expect(utc(dt).year).toBe(1952);
     expect(utc(dt).month).toBe(3);

--- a/packages/activerecord/src/reaper.test.ts
+++ b/packages/activerecord/src/reaper.test.ts
@@ -61,8 +61,8 @@ describe("ReaperTest", () => {
 
   it("reaping frequency configuration", () => {
     const pool = makePool();
-    const reaper = new Reaper(pool, 100);
-    expect(reaper.frequency).toBe(100);
+    const reaper = new Reaper(pool, 10.01);
+    expect(reaper.frequency).toBe(10.01);
   });
 
   it("connection pool starts reaper", () => {

--- a/packages/activerecord/src/reflection.test.ts
+++ b/packages/activerecord/src/reflection.test.ts
@@ -32,6 +32,8 @@ import { create as createReflection } from "./reflection.js";
 import { Customer } from "./test-helpers/models/customer.js";
 import { Organization } from "./test-helpers/models/organization.js";
 import { Author } from "./test-helpers/models/author.js";
+import { Hotel as CanonicalHotel } from "./test-helpers/models/hotel.js";
+import { ShardedComment } from "./test-helpers/models/sharded.js";
 
 import { UnknownPrimaryKey, NameError } from "./errors.js";
 import { ArgumentError } from "@blazetrails/activemodel";
@@ -983,16 +985,14 @@ describe("ReflectionTest", () => {
     expect(hotels).toHaveLength(1);
   });
   it("reflect on association accepts symbols", () => {
-    const { Author } = makeModels();
-    const ref = reflectOnAssociation(Author, "books");
+    const ref = reflectOnAssociation(CanonicalHotel, "departments");
     expect(ref).not.toBeNull();
-    expect(ref!.name).toBe("books");
+    expect(ref!.name).toBe("departments");
   });
   it("reflect on association accepts strings", () => {
-    const { Author } = makeModels();
-    const ref = reflectOnAssociation(Author, "books");
+    const ref = reflectOnAssociation(CanonicalHotel, "departments");
     expect(ref).not.toBeNull();
-    expect(ref!.name).toBe("books");
+    expect(ref!.name).toBe("departments");
   });
   it("reflect on missing source assocation raise exception", () => {
     // Mirrors Rails test/cases/reflection_test.rb: Hotel has_many :lost_items,
@@ -1080,18 +1080,11 @@ describe("ReflectionTest", () => {
     expect(Object.keys(cols).length).toBeGreaterThan(0);
   });
 
-  it("human name for column", () => {
-    class Article extends Base {
-      declare body_text: string | null;
-
-      static {
-        this._tableName = "refl_articles";
-        this.attribute("body_text", "string");
-      }
-    }
-    const cols = (Article as any).columnsHash();
-    expect(cols["body_text"]).toBeDefined();
-    expect(cols["body_text"].name).toBe("body_text");
+  it("human name for column", async () => {
+    await CanonicalTopic.loadSchema();
+    expect((CanonicalTopic as any).columnForAttribute("author_name").humanName()).toBe(
+      "Author name",
+    );
   });
 
   it("integer columns", () => {
@@ -1632,17 +1625,9 @@ describe("ReflectionTest", () => {
   });
 
   it("association primary key uses explicit primary key option as first priority", () => {
-    class Author extends Base {
-      declare name: string | null;
-
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    Associations.hasMany.call(Author, "books", { primaryKey: "custom_id" });
-    const ref = reflectOnAssociation(Author, "books");
+    const ref = reflectOnAssociation(ShardedComment, "blogPostById");
     expect(ref).not.toBeNull();
-    expect(ref!.options.primaryKey).toBe("custom_id");
+    expect(ref!.associationPrimaryKey).toBe("id");
   });
 
   it("belongs to reflection with query constraints infers correct foreign key", () => {


### PR DESCRIPTION
Literal-fidelity sweep converging trails tests that were semantically
equivalent to Rails but ran on invented data (flagged by `--assertions`
value mismatches). ~30 entries across:

- **encryption/**: null_encryptor / read_only_null_encryptor /
  encrypting_only_encryptor ("Some data" / "some text"), message + properties
  (`header_1`/`key_1` → "value 1"/"value 2"), key_generator custom lengths
  (10 for random keys, 12 for derive — the length IS threaded through, Rails'
  custom values now asserted), configurable (NamedPirate.catchphrase filter
  params; the exclude test now uses `excludeFromFilterParameters` like Rails'
  `excluded_from_filter_parameters` instead of `addToFilterParameters=false`),
  encryption_schemes ("STEPHEN KING").
- **multiparameter_attributes**: 1952/3/11 (+13:55) written_on payloads
  restored; the create-with tests now go through `createWith(...).new()`
  exactly like Rails' `create_with(...).new`; "old date" asserts the full
  `1850-06-24 16:24:00` representation.
- **reflection**: accepts symbols/strings now reflect canonical
  `Hotel#departments`; "human name for column" asserts
  `columnForAttribute("author_name").humanName() === "Author name"`;
  association-primary-key-first-priority uses `ShardedComment#blogPostById`
  → `associationPrimaryKey === "id"`.
- **quoting**: PG "quote integer" / "quote float nan" / "quote float infinity"
  now assert `quote()`'s SQL text (`"42"`, `"'NaN'"`, `"'Infinity'"`) like
  Rails — quote already returned text; the old tests asserted DB round-trips.
  PG/sqlite3 "quote string" round-trip Rails' `"'"` datum.
- **reaper**: frequency 10.01.

Genuine divergences found while restoring:

- `EncryptedPost.body` was declared `string`; Rails' posts.body is text.
  Declared `text` so `type_for_attribute(:body).type` reflects `:text`
  (impl was fine — the helper's declaration was the divergence).
- activemodel's multiparameter wrapper defined
  `valueConstructedByMassAssignment`, but `Attribute.FromUser.cameFromUser`
  calls `isValueConstructedByMassAssignment` — the override was dead code
  under the wrong name. Renamed to actually override.
- `came_from_user?` after multiparameter assignment: Rails is false (type-side
  hash cast); trails assembles the value in AR-land before `writeAttribute`,
  so it's true. Deviation justified at the call site; follow-up story
  `multiparameter-assignment-type-side-cast` registered.
- Forced-encoding replacement: Rails feeds invalid UTF-8 bytes (U+FFFD
  replacement); JS strings can't hold invalid byte sequences, so the ASCII
  path ("?" replacement, matching Ruby's `encode("US-ASCII", replace)`) is the
  faithful analogue — justified in a call-site comment.

Closes-story: divergent-test-data-fidelity-sweep
