### PR TITLE
test(associations): burn down belongs_to residual skip cluster to zero

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -2256,6 +2256,20 @@ export function computeHasManyWhere(
   if (options.as) {
     const foreignKey = options.foreignKey ?? `${underscore(options.as)}_id`;
     if (Array.isArray(foreignKey)) {
+      // Rails permits an explicit composite FK on a polymorphic `:as`
+      // association when it zips against the owner's composite PK (e.g.
+      // Cpk::Post has_many :comments, as: :commentable,
+      // foreign_key: [:commentable_title, :commentable_author]).
+      if (Array.isArray(primaryKey) && primaryKey.length === foreignKey.length) {
+        const typeCol = `${underscore(options.as)}_type`;
+        const conditions: Record<string, unknown> = { [typeCol]: polymorphicName(ctor) };
+        for (let i = 0; i < foreignKey.length; i++) {
+          const pkValue = record._readAttribute(primaryKey[i]);
+          if (pkValue === null || pkValue === undefined) return null;
+          conditions[foreignKey[i]] = pkValue;
+        }
+        return conditions;
+      }
       // Route through the reflection's canonical checkValidityBang (Rails'
       // single raise site) so the error carries the Rails-faithful message;
       // a no-op for polymorphic `:as` (Rails permits no composite key there).

--- a/packages/activerecord/src/associations/belongs-to-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-association.ts
@@ -5,6 +5,8 @@ import { underscore } from "@blazetrails/activesupport";
 import { belongsToCounterCacheColumn } from "../reflection.js";
 import { hasQueryConstraints, queryConstraintsList } from "../persistence.js";
 import { SingularAssociation } from "./singular-association.js";
+import { Rollback } from "../errors.js";
+import { MissingAttributeError } from "@blazetrails/activemodel";
 
 /**
  * Mirrors: ActiveRecord::Associations::BelongsToAssociation
@@ -33,7 +35,10 @@ export class BelongsToAssociation extends SingularAssociation {
     switch (dependent) {
       case "destroy":
         if (typeof (target as any).destroy === "function") {
-          await (target as any).destroy();
+          // Rails: raise ActiveRecord::Rollback unless target.destroy
+          if ((await (target as any).destroy()) === false) {
+            throw new Rollback();
+          }
         }
         break;
       case "delete":
@@ -219,7 +224,13 @@ export class BelongsToAssociation extends SingularAssociation {
     const fks = this.foreignKeyNames();
     if (fks.length !== 1) return null;
     return typeof (this.owner as any)._readAttribute === "function"
-      ? (this.owner as any)._readAttribute(fks[0])
+      ? // Rails passes `{ |n| owner.send(:missing_attribute, n, caller) }` — a
+        // known-but-unselected FK column raises MissingAttributeError.
+        (this.owner as any)._readAttribute(fks[0], (n: string) => {
+          throw new MissingAttributeError(
+            `missing attribute '${n}' for ${(this.owner.constructor as { name?: string }).name ?? "unknown"}`,
+          );
+        })
       : (this.owner as any)[fks[0]];
   }
 

--- a/packages/activerecord/src/associations/belongs-to-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-association.ts
@@ -35,7 +35,6 @@ export class BelongsToAssociation extends SingularAssociation {
     switch (dependent) {
       case "destroy":
         if (typeof (target as any).destroy === "function") {
-          // Rails: raise ActiveRecord::Rollback unless target.destroy
           if ((await (target as any).destroy()) === false) {
             throw new Rollback();
           }

--- a/packages/activerecord/src/associations/belongs-to-associations.test.ts
+++ b/packages/activerecord/src/associations/belongs-to-associations.test.ts
@@ -14,7 +14,10 @@ import {
   AssociationTypeMismatch,
   modelRegistry,
 } from "../index.js";
-import { assertNoQueries } from "../testing/query-assertions.js";
+import { assertNoQueries, assertQueriesCount } from "../testing/query-assertions.js";
+import { captureSql } from "../testing/sql-capture.js";
+import { MissingAttributeError } from "@blazetrails/activemodel";
+import { throwAbort } from "@blazetrails/activesupport";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { Author, AuthorAddress } from "../test-helpers/models/author.js";
 import { Essay } from "../test-helpers/models/essay.js";
@@ -107,6 +110,32 @@ class WheelPolymorphicName extends Base {
   }
 }
 
+// Mirrors the inline classes in Rails' belongs_to_associations_test.rb
+// (test_dependency_should_halt_parent_destruction*).
+class EssayDestroy extends Base {
+  static _tableName = "essays";
+  static {
+    this.belongsTo("book", { dependent: "destroy", className: "DestroyableBook" });
+  }
+}
+
+class DestroyableBook extends Base {
+  static _tableName = "books";
+  static {
+    this.belongsTo("author", { className: "UndestroyableAuthor", dependent: "destroy" });
+  }
+}
+
+class UndestroyableAuthor extends Base {
+  static _tableName = "authors";
+  static {
+    this.hasOne("book", { className: "DestroyableBook", foreignKey: "author_id" });
+    this.beforeDestroy(function () {
+      throwAbort();
+    });
+  }
+}
+
 for (const m of [
   Author,
   AuthorAddress,
@@ -158,6 +187,9 @@ for (const m of [
   Project,
   AdminUser,
   AdminAccount,
+  EssayDestroy,
+  DestroyableBook,
+  UndestroyableAuthor,
 ]) {
   registerModel(m as any);
 }
@@ -284,7 +316,11 @@ describe("BelongsToAssociationsTest", () => {
     expect(result).toHaveLength(0);
   });
 
-  it.todo("where on polymorphic association with cpk");
+  it("where on polymorphic association with cpk", async () => {
+    const post = await CpkPost.create({ title: "Welcome", author: "Mary" });
+    await (post as any).comments.push(await CpkComment.create({}));
+    expect(await CpkComment.where({ commentable: post }).count()).toBe(1);
+  });
 
   it("assigning belongs to on destroyed object", async () => {
     const client = await Client.create({ name: "Client" });
@@ -306,9 +342,18 @@ describe("BelongsToAssociationsTest", () => {
     expect((client2 as any).firmIdCameFromUser?.()).toBeFalsy();
   });
 
-  it.todo("missing attribute error is raised when no foreign key attribute");
+  it("missing attribute error is raised when no foreign key attribute", async () => {
+    const client = (await Client.select("id").first())!;
+    await expect(client.loadBelongsTo("firm")).rejects.toThrow(MissingAttributeError);
+  });
 
-  it.todo("belongs to does not use order by");
+  it("belongs to does not use order by", async () => {
+    const sqlLog = await captureSql(async () => {
+      const client = await Client.find(3);
+      await client.loadBelongsTo("firm");
+    });
+    expect(sqlLog.every((sql) => !/order by/i.test(sql))).toBe(true);
+  });
 
   it("belongs to with primary key", async () => {
     const firstFirmName = companies("first_firm").name;
@@ -637,7 +682,15 @@ describe("BelongsToAssociationsTest", () => {
     expect(Number(book.order_id)).toBe(Number(orderId));
   });
 
-  it.todo("should set composite foreign key on association when key changes on associated record");
+  it("should set composite foreign key on association when key changes on associated record", async () => {
+    const book = await CpkBook.create({ id: [1, 2], title: "The Well-Grounded Rubyist" });
+    const order = await CpkOrder.create({ id: [1, 2], book });
+
+    (order as any).shop_id = 3;
+    await order.save();
+
+    expect((book as any).shop_id).toBe(3);
+  });
 
   it("building the belonging object with implicit sti base class", async () => {
     const account = Account.new({});
@@ -705,7 +758,34 @@ describe("BelongsToAssociationsTest", () => {
     expect(odegyAccount.firm!.name).toBe("ODEGY");
   });
 
-  it.todo("reload the belonging object with query cache");
+  it("reload the belonging object with query cache", async () => {
+    const odegyAccountId = accounts("odegy_account").id!;
+
+    const connection = (await Base.leaseConnection()) as any;
+    connection.enableQueryCacheBang();
+    connection.clearQueryCache();
+    try {
+      // Populate the cache with a query
+      const odegyAccount = await Account.find(odegyAccountId);
+
+      // Populate the cache with a second query
+      await odegyAccount.loadBelongsTo("firm");
+
+      expect(connection.queryCache.size).toBe(2);
+
+      // Clear the cache and fetch the firm again, populating the cache with a query
+      await assertQueriesCount(1, false, async () => {
+        await (odegyAccount as any).reloadFirm();
+      });
+
+      // This query is not cached anymore, so it should make a real SQL query
+      await assertQueriesCount(1, false, async () => {
+        await Account.find(odegyAccountId);
+      });
+    } finally {
+      connection.disableQueryCacheBang();
+    }
+  });
 
   it("resetting the association", async () => {
     const odegyAccount = accounts("odegy_account");
@@ -1036,7 +1116,22 @@ describe("BelongsToAssociationsTest", () => {
     expect(lineItem).toBeDefined();
   });
 
-  it.todo("belongs to with touch option on touch without updated at attributes");
+  it("belongs to with touch option on touch without updated at attributes", async () => {
+    expect(LineItem.columnNames()).not.toContain("updated_at");
+
+    const lineItem = await LineItem.create({});
+    const invoice = await Invoice.create({ lineItems: [lineItem] });
+    const initial = invoice.updated_at as Temporal.Instant;
+    travelTo(new Date(Date.now() + 1000));
+    try {
+      await lineItem.touch();
+    } finally {
+      travelBack();
+    }
+
+    const reloadedAt = (await invoice.reload()).updated_at as Temporal.Instant;
+    expect(Temporal.Instant.compare(reloadedAt, initial)).not.toBe(0);
+  });
 
   it("belongs to with touch option on touch and removed parent", async () => {
     const lineItem = await LineItem.create({});
@@ -1362,8 +1457,10 @@ describe("BelongsToAssociationsTest", () => {
     expect((essay as any).writer_type).toBeNull();
   });
 
-  it.todo("belongs to proxy should not respond to private methods");
-
+  // "belongs to proxy should not respond to private methods" is excluded in
+  // scripts/api-compare/unported-files.ts: it probes Ruby method visibility
+  // (private_method raising NoMethodError outside `send`), which has no JS
+  // equivalent — TS has no runtime-enforced private dispatch on proxies.
   it("belongs to proxy should respond to private methods via send", async () => {
     const firm = companies("first_firm");
     expect((firm as any)["privateMethod"]()).toBe("I am Jack's innermost fears and aspirations");
@@ -1409,11 +1506,47 @@ describe("BelongsToAssociationsTest", () => {
     expect(AuthorAddress.destroyedAuthorAddressIds).toContain(authorAddress.id);
   });
 
-  it.todo("belongs to invalid dependent option raises exception");
+  it("belongs to invalid dependent option raises exception", async () => {
+    expect(() => {
+      class SpecialAuthor extends Author {
+        static {
+          this.belongsTo("specialAuthorAddress", {
+            dependent: "nullify" as any,
+            className: "AuthorAddress",
+          });
+        }
+      }
+      void SpecialAuthor;
+    }).toThrow(
+      "The :dependent option must be one of destroy, delete, destroyAsync, but is :nullify",
+    );
+  });
 
-  it.todo("dependency should halt parent destruction");
+  it("dependency should halt parent destruction", async () => {
+    const author = await UndestroyableAuthor.create({ name: "Test" });
+    const book = await DestroyableBook.create({ author });
 
-  it.todo("dependency should halt parent destruction with cascaded three levels");
+    const authorCount = await UndestroyableAuthor.count();
+    const bookCount = await DestroyableBook.count();
+    expect(await book.destroy()).toBe(false);
+    expect(await UndestroyableAuthor.count()).toBe(authorCount);
+    expect(await DestroyableBook.count()).toBe(bookCount);
+  });
+
+  it("dependency should halt parent destruction with cascaded three levels", async () => {
+    const author = await UndestroyableAuthor.create({ name: "Test" });
+    const book = await DestroyableBook.create({ author });
+    const essay = await EssayDestroy.create({ book });
+
+    const authorCount = await UndestroyableAuthor.count();
+    const bookCount = await DestroyableBook.count();
+    const essayCount = await EssayDestroy.count();
+    expect(await essay.destroy()).toBe(false);
+    expect(essay.isDestroyed()).toBe(false);
+    expect(await UndestroyableAuthor.count()).toBe(authorCount);
+    expect(await DestroyableBook.count()).toBe(bookCount);
+    expect(await EssayDestroy.count()).toBe(essayCount);
+  });
 
   it("attributes are being set when initialized from belongs to association with where clause", async () => {
     const acc = accounts("signals37");
@@ -1677,9 +1810,21 @@ describe("BelongsToAssociationsTest", () => {
     expect(Number((tagging as any).tag_id)).toBe(Number(tag.id));
   });
 
-  it.todo("should set foreign key on save");
+  it("should set foreign key on save", async () => {
+    const client = await Client.create({ name: "fuu" });
+    const firm = (client as any).buildFirm({ name: "baa" });
 
-  it.todo("should set foreign key on save!");
+    await firm.save();
+    expect((client as any).client_of).toBe(firm.id);
+  });
+
+  it("should set foreign key on save!", async () => {
+    const client = await Client.create({ name: "fuu" });
+    const firm = (client as any).buildFirm({ name: "baa" });
+
+    await firm.saveBang();
+    expect((client as any).client_of).toBe(firm.id);
+  });
 
   it("self referential belongs to with counter cache assigning nil", async () => {
     const comment = await Comment.create({ post: posts("thinking"), body: "fuu" });
@@ -1807,7 +1952,16 @@ describe("BelongsToAssociationsTest", () => {
     expect(await Column.count()).toBe(1);
   });
 
-  it.todo("multiple counter cache with after create update");
+  it("multiple counter cache with after create update", async () => {
+    const post = posts("welcome");
+    const parent = comments("greetings");
+
+    const parentChildrenCount = ((await parent.reload()) as any).children_count as number;
+    const postCommentsCount = ((await post.reload()) as any).comments_count as number;
+    await CommentWithAfterCreateUpdate.create({ body: "foo", post, parent });
+    expect(((await parent.reload()) as any).children_count).toBe(parentChildrenCount + 1);
+    expect(((await post.reload()) as any).comments_count).toBe(postCommentsCount + 1);
+  });
 
   it("assigning an association doesn't result in duplicate objects", async () => {
     const post = await Post.create({ title: "title", body: "body" });

--- a/packages/activerecord/src/associations/belongs-to-associations.test.ts
+++ b/packages/activerecord/src/associations/belongs-to-associations.test.ts
@@ -352,7 +352,7 @@ describe("BelongsToAssociationsTest", () => {
       const client = await Client.find(3);
       await client.loadBelongsTo("firm");
     });
-    expect(sqlLog.every((sql) => !/order by/i.test(sql))).toBe(true);
+    expect(sqlLog.filter((sql) => /order by/i.test(sql))).toEqual([]);
   });
 
   it("belongs to with primary key", async () => {
@@ -1130,7 +1130,7 @@ describe("BelongsToAssociationsTest", () => {
     }
 
     const reloadedAt = (await invoice.reload()).updated_at as Temporal.Instant;
-    expect(Temporal.Instant.compare(reloadedAt, initial)).not.toBe(0);
+    expect(reloadedAt.equals(initial)).toBe(false);
   });
 
   it("belongs to with touch option on touch and removed parent", async () => {

--- a/packages/activerecord/src/associations/builder/belongs-to.ts
+++ b/packages/activerecord/src/associations/builder/belongs-to.ts
@@ -41,6 +41,7 @@ export class BelongsTo extends SingularAssociation {
     const options = reflection.options ?? {};
     const dependent = options.dependent;
     if (dependent) {
+      this.checkDependentOptions(dependent as string, model);
       this.addDestroyCallbacks(model, reflection);
       this.addAfterCommitJobsCallback(model, dependent as string);
     }

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -195,13 +195,16 @@ export class PredicateBuilder {
     attributes: Record<string, unknown>,
   ): Nodes.Node[] {
     if (associatedTable.isPolymorphicAssociation?.()) {
-      const fk = associatedTable.joinForeignKey as string;
+      const fk = associatedTable.joinForeignKey as string | string[];
       const ft = associatedTable.joinForeignType as string;
       const refl = associatedTable.reflection;
-      const pkFor = (klass?: unknown): string =>
-        refl && typeof refl.joinPrimaryKeyFor === "function"
-          ? String(refl.joinPrimaryKeyFor(klass))
-          : String(associatedTable.joinPrimaryKey ?? "id");
+      const pkFor = (klass?: unknown): string | string[] => {
+        const pk =
+          refl && typeof refl.joinPrimaryKeyFor === "function"
+            ? refl.joinPrimaryKeyFor(klass)
+            : (associatedTable.joinPrimaryKey ?? "id");
+        return Array.isArray(pk) ? pk : String(pk);
+      };
       const values = Array.isArray(value) ? value : [value];
       const queries = new PolymorphicArrayValue(
         { joinForeignKey: fk, joinForeignType: ft, joinPrimaryKey: pkFor },

--- a/packages/activerecord/src/relation/predicate-builder/polymorphic-array-value.ts
+++ b/packages/activerecord/src/relation/predicate-builder/polymorphic-array-value.ts
@@ -44,7 +44,10 @@ export class PolymorphicArrayValue {
   queries(): Record<string, unknown>[] {
     const fk = this.associatedTable.joinForeignKey;
     if (this.values.length === 0) {
-      return [{ [Array.isArray(fk) ? fk[0] : fk]: this.values }];
+      if (Array.isArray(fk)) {
+        return [Object.fromEntries(fk.map((col) => [col, this.values]))];
+      }
+      return [{ [fk]: this.values }];
     }
     const result: Record<string, unknown>[] = [];
     for (const [type, ids] of this.typeToIdsMapping()) {

--- a/packages/activerecord/src/relation/predicate-builder/polymorphic-array-value.ts
+++ b/packages/activerecord/src/relation/predicate-builder/polymorphic-array-value.ts
@@ -11,6 +11,8 @@
  */
 import type { Base } from "../../base.js";
 import { polymorphicName } from "../../inheritance.js";
+import { rubyInspectArray } from "../ruby-inspect.js";
+import { ArgumentError } from "@blazetrails/activemodel";
 export class PolymorphicArrayValue {
   private readonly _associatedTable: {
     joinForeignKey: string | string[];
@@ -55,13 +57,21 @@ export class PolymorphicArrayValue {
         // Composite FK: Ruby uses the FK array itself as the hash key
         // (`query[associated_table.join_foreign_key] = ids`), which
         // expand_from_hash later zips per tuple. JS object keys can't be
-        // arrays, so zip each id tuple across the FK columns here — one
-        // query per tuple; queries are ORed by groupingQueries.
+        // arrays, so pre-expand here with the same validation and zip
+        // semantics (predicate_builder.rb:93-96): each ids_set must be an
+        // Array, and `key.zip(ids_set)` iterates only the FK columns —
+        // short tuples pad with nil, extra values are dropped. One query
+        // per tuple; queries are ORed by groupingQueries.
         for (const tuple of ids) {
+          if (!Array.isArray(tuple)) {
+            throw new ArgumentError(
+              `Expected corresponding value for ${rubyInspectArray(fk)} to be an Array`,
+            );
+          }
           const q: Record<string, unknown> = {};
           if (type) q[this.associatedTable.joinForeignType] = type;
-          (tuple as unknown[]).forEach((id, i) => {
-            q[fk[i]] = id;
+          fk.forEach((col, i) => {
+            q[col] = tuple[i] ?? null;
           });
           result.push(q);
         }

--- a/packages/activerecord/src/relation/predicate-builder/polymorphic-array-value.ts
+++ b/packages/activerecord/src/relation/predicate-builder/polymorphic-array-value.ts
@@ -13,17 +13,17 @@ import type { Base } from "../../base.js";
 import { polymorphicName } from "../../inheritance.js";
 export class PolymorphicArrayValue {
   private readonly _associatedTable: {
-    joinForeignKey: string;
+    joinForeignKey: string | string[];
     joinForeignType: string;
-    joinPrimaryKey(klass?: unknown): string;
+    joinPrimaryKey(klass?: unknown): string | string[];
   };
   private readonly _values: unknown[];
 
   constructor(
     associatedTable: {
-      joinForeignKey: string;
+      joinForeignKey: string | string[];
       joinForeignType: string;
-      joinPrimaryKey(klass?: unknown): string;
+      joinPrimaryKey(klass?: unknown): string | string[];
     },
     values: unknown[],
   ) {
@@ -42,14 +42,31 @@ export class PolymorphicArrayValue {
   }
 
   queries(): Record<string, unknown>[] {
+    const fk = this.associatedTable.joinForeignKey;
     if (this.values.length === 0) {
-      return [{ [this.associatedTable.joinForeignKey]: this.values }];
+      return [{ [Array.isArray(fk) ? fk[0] : fk]: this.values }];
     }
     const result: Record<string, unknown>[] = [];
     for (const [type, ids] of this.typeToIdsMapping()) {
+      if (Array.isArray(fk)) {
+        // Composite FK: Ruby uses the FK array itself as the hash key
+        // (`query[associated_table.join_foreign_key] = ids`), which
+        // expand_from_hash later zips per tuple. JS object keys can't be
+        // arrays, so zip each id tuple across the FK columns here — one
+        // query per tuple; queries are ORed by groupingQueries.
+        for (const tuple of ids) {
+          const q: Record<string, unknown> = {};
+          if (type) q[this.associatedTable.joinForeignType] = type;
+          (tuple as unknown[]).forEach((id, i) => {
+            q[fk[i]] = id;
+          });
+          result.push(q);
+        }
+        continue;
+      }
       const q: Record<string, unknown> = {};
       if (type) q[this.associatedTable.joinForeignType] = type;
-      q[this.associatedTable.joinForeignKey] = ids.length === 1 ? ids[0] : ids;
+      q[fk] = ids.length === 1 ? ids[0] : ids;
       result.push(q);
     }
     return result;
@@ -69,7 +86,7 @@ export class PolymorphicArrayValue {
   }
 
   /** @internal */
-  private primaryKey(value: unknown): string {
+  private primaryKey(value: unknown): string | string[] {
     return this.associatedTable.joinPrimaryKey(this.klass(value));
   }
 
@@ -93,6 +110,10 @@ export class PolymorphicArrayValue {
         return (value as any).select(arelTable && !Array.isArray(pk) ? arelTable.get(pk) : pk);
       }
       const pk = this.primaryKey(value);
+      if (Array.isArray(pk)) {
+        // Rails: primary_key.map { |column| value._read_attribute(column) }
+        return pk.map((column) => (value as any)._readAttribute(column));
+      }
       if (pk in value) return (value as any)[pk];
     }
     return value;

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder/polymorphic-array-value.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder/polymorphic-array-value.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation/predicate-builder/polymorphic-array-value.ts",
-    "rubyName": "convert_to_id",
-    "call": "map",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder/polymorphic-array-value.ts",
     "rubyName": "klass",
     "call": "model",
     "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails polymorphic_array_value.rb:36-42 reads `value.model` for Relation inputs; trails polymorphic-array-value.ts:77-81 reads the `_modelClass` field after duck-checking for a relation."
@@ -18,13 +11,6 @@
     "tsFile": "relation/predicate-builder/polymorphic-array-value.ts",
     "rubyName": "queries",
     "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder/polymorphic-array-value.ts",
-    "rubyName": "queries",
-    "call": "map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -518,6 +518,14 @@ export const UNPORTED_FILES: UnportedFile[] = [
     reason: "Ruby Marshal binary serialization — no Node.js equivalent.",
   },
   {
+    testFile: "belongs_to_associations_test.rb",
+    tests: ["belongs to proxy should not respond to private methods"],
+    reason:
+      "Probes Ruby method visibility: `private_method` must raise NoMethodError on a direct " +
+      "call but succeed via `send` (the via-send sibling IS ported). JS has no " +
+      "runtime-enforced private dispatch — a method is either callable or absent.",
+  },
+  {
     testFile: "reaper_test.rb",
     tests: ["connection pool starts reaper in fork"],
     reason: "GVL / Ruby fork() semantics — process forking has no Node.js equivalent.",


### PR DESCRIPTION
Burns the largest residual skip cluster — 13 skipped matched tests in
`associations/belongs-to-associations.test.ts` — down to zero.

## Ported (12)

Straight ports (assertion-only, no impl change needed):

- belongs to does not use order by (`captureSql`)
- should set composite foreign key on association when key changes on associated record
- reload the belonging object with query cache
- belongs to with touch option on touch without updated at attributes
- should set foreign key on save / save!
- multiple counter cache with after create update

Ports that exposed implementation gaps, each fixed against the vendored Rails source:

- **where on polymorphic association with cpk** — `computeHasManyWhere` unconditionally
  raised on a composite FK under `:as`; Rails permits it when it zips against the owner's
  composite PK (`Cpk::Post has_many :comments, as: :commentable`). Also
  `PolymorphicArrayValue#queries` stringified the FK array into a single bogus column;
  Ruby uses the array itself as a hash key which `expand_from_hash` zips per tuple — JS
  object keys can't be arrays, so the tuples are zipped per column at query build.
- **missing attribute error is raised when no foreign key attribute** — `staleState` now
  passes Rails' `missing_attribute` block to `_readAttribute`
  (belongs_to_association.rb:165), so a known-but-unselected FK column raises
  `MissingAttributeError` instead of reading as nil.
- **belongs to invalid dependent option raises exception** — `BelongsTo.defineCallbacks`
  skipped `checkDependentOptions`; the Rails base `define_callbacks` always checks.
- **dependency should halt parent destruction (+ cascaded three levels)** —
  `handleDependency` now raises `Rollback` unless `target.destroy` succeeded
  (belongs_to_association.rb:12), so an aborted cascade rolls back the whole
  destruction and `destroy` returns false. Inline
  `EssayDestroy`/`DestroyableBook`/`UndestroyableAuthor` models mirror Rails'.

## Reclassified (1)

- **belongs to proxy should not respond to private methods** — probes Ruby method
  visibility (`private_method` raising NoMethodError outside `send`; the via-`send`
  sibling IS ported). No JS equivalent — excluded in
  `scripts/api-compare/unported-files.ts` with call-site justification in the test file.

`test:compare --package activerecord --incomplete` no longer lists
belongs_to_associations_test.rb (Skip count 0).

Closes-story: belongs-to-residual-skip-burndown
