### PR TITLE
test(transactions): un-skip the 4 counted transactions_test.rb residual skips

### DIFF
--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -1572,8 +1572,6 @@ describe("TransactionTest", () => {
   });
 
   it("prepared statement materializes transaction", async (ctx) => {
-    // Rails wraps this in `if lease_connection.prepared_statements`
-    // (transactions_test.rb:1562); mirror the guard at runtime.
     const conn = (await Topic.leaseConnection()) as any;
     ctx.skip(!conn.preparedStatements);
     await Topic.first();

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -82,6 +82,7 @@ describe("TransactionTest", () => {
       "rollback dirty changes",
       "rollback dirty changes multiple saves",
       "rollback dirty changes then retry save",
+      "rollback dirty changes then retry save on new record with autosave association",
       "rolling back in a callback rollbacks before save",
       "restore frozen state after double destroy",
       "restore new record after double save",

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -51,6 +51,8 @@ for (const klass of [
   CpkOrder,
   CpkAuthor,
   CpkChapter,
+  Author,
+  Book,
 ]) {
   registerModel(klass as any);
 }
@@ -377,8 +379,18 @@ describe("TransactionTest", () => {
     expect((await topic.reload()).title).toBe(topic.title);
   });
 
-  it.skip("rollback dirty changes then retry save on new record with autosave association", () => {
-    // Autosave collection associations (`author.books << book`) not yet ported.
+  it("rollback dirty changes then retry save on new record with autosave association", async () => {
+    const author = Author.new({ name: "DHH" }) as any;
+    const book = (await Book.createBang({})) as any;
+    await author.books.push(book);
+
+    await author.transaction(async () => {
+      await author.saveBang();
+      throw new Rollback();
+    });
+
+    await author.saveBang();
+    expect((await (await book.reload()).author).id).toBe(author.id);
   });
 
   it("persisted in a model with custom primary key after failed save", async () => {
@@ -584,13 +596,21 @@ describe("TransactionTest", () => {
     expect(author.isNewRecord()).toBe(false);
   });
 
-  it.skip("update should rollback on failure", () => {
-    // Autosave collection assignment (`author.update(post_ids: [])`) not yet
-    // ported — relies on has_many collection replacement + autosave rollback.
+  it("update should rollback on failure", async () => {
+    const author = (await Author.find(1)) as any;
+    const postsCount = await author.posts.size();
+    expect(postsCount).toBeGreaterThan(0);
+    const status = await author.update({ name: null, postIds: [] });
+    expect(status).toBeFalsy();
+    expect(await (await author.posts.reload()).size()).toBe(postsCount);
   });
 
-  it.skip("update should rollback on failure!", () => {
-    // See "update should rollback on failure" — same autosave collection gap.
+  it("update should rollback on failure!", async () => {
+    const author = (await Author.find(1)) as any;
+    const postsCount = await author.posts.size();
+    expect(postsCount).toBeGreaterThan(0);
+    await expect(author.updateBang({ name: null, postIds: [] })).rejects.toThrow(RecordInvalid);
+    expect(await (await author.posts.reload()).size()).toBe(postsCount);
   });
 
   it("cancellation from before destroy rollbacks in destroy", async () => {
@@ -1399,6 +1419,7 @@ describe("TransactionTest", () => {
       "releasing named savepoints",
       "empty transaction is not materialized",
       "unprepared statement materializes transaction",
+      "prepared statement materializes transaction",
       "nested transactions skip excess savepoints",
       "nested transactions after disable lazy transactions",
       "savepoint does not materialize transaction",
@@ -1550,8 +1571,18 @@ describe("TransactionTest", () => {
     expectedQueries.forEach((expected, i) => expect(actualQueries[i]).toMatch(expected));
   });
 
-  it.skip("prepared statement materializes transaction", () => {
-    // Requires prepared_statements-gated query monitoring not modeled here.
+  it("prepared statement materializes transaction", async (ctx) => {
+    // Rails wraps this in `if lease_connection.prepared_statements`
+    // (transactions_test.rb:1562); mirror the guard at runtime.
+    const conn = (await Topic.leaseConnection()) as any;
+    ctx.skip(!conn.preparedStatements);
+    await Topic.first();
+
+    await assertQueriesMatch(/BEGIN|COMMIT/i, undefined, true, async () => {
+      await Topic.transaction(async () => {
+        await Topic.first();
+      });
+    });
   });
 
   it("savepoint does not materialize transaction", async () => {

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -83,6 +83,8 @@ describe("TransactionTest", () => {
       "rollback dirty changes multiple saves",
       "rollback dirty changes then retry save",
       "rollback dirty changes then retry save on new record with autosave association",
+      "update should rollback on failure",
+      "update should rollback on failure!",
       "rolling back in a callback rollbacks before save",
       "restore frozen state after double destroy",
       "restore new record after double save",


### PR DESCRIPTION
Un-skips the 4 counted residual skips in `transactions.test.ts` (RFC 0030 burndown). The other 7 `it.skip`s in the file were already classified out in `unported-files.ts` (thread/GVL, Ruby throw/catch, multidb).

- **rollback dirty changes then retry save on new record with autosave association** (transactions_test.rb:417) — autosave collection push on a new record now works; ported directly.
- **update should rollback on failure / failure!** (:686/:695) — `update({ name: null, postIds: [] })` routes the `postIds` writer through the setter inside `withTransactionReturningStatus`; validation failure rolls the collection write back. Ported directly.
- **prepared statement materializes transaction** (:1563) — Rails wraps this in `if lease_connection.prepared_statements`; mirrored as a runtime `ctx.skip(!conn.preparedStatements)` (same pattern as bind-parameter.test.ts), and added to the `usesTransaction` opt-out list like its `unprepared` sibling so real BEGIN/COMMIT are observable.

Also registers `Author`/`Book` in the file's model registry so `Author#books` resolves.

`test:compare --incomplete` no longer lists transactions_test.rb (Skip count 0).

Verified locally on all three adapters (isolated compose stack): sqlite 95 passed, PostgreSQL 93 passed (prepared-statement test exercised), MySQL 92 passed (prepared-statement guard skips, matching Rails' gate — MySQL defaults prepared statements off).

Closes-story: transactions-residual-skips
