### PR TITLE
feat(activerecord): memoize columnNames with ignoredColumns-safe invalidation

### DIFF
--- a/packages/activerecord/src/attribute-methods.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods.trails.test.ts
@@ -271,6 +271,38 @@ describe("AttributeMethodsTest (trails)", () => {
     expect(Topic.attributeNames()).not.toBe(first);
   });
 
+  it("class columnNames is memoized and frozen", async () => {
+    class Topic extends Base {}
+    await Topic.loadSchema();
+    const first = Topic.columnNames();
+    expect(first).toContain("title");
+    expect(Object.isFrozen(first)).toBe(true);
+    expect(Topic.columnNames()).toBe(first);
+  });
+
+  it("ignoredColumns= invalidates the columnNames memo", async () => {
+    class Topic extends Base {}
+    await Topic.loadSchema();
+    const first = Topic.columnNames();
+    expect(first).toContain("approved");
+    Topic.ignoredColumns = ["approved"];
+    const second = Topic.columnNames();
+    expect(second).not.toBe(first);
+    expect(second).not.toContain("approved");
+  });
+
+  it("resetColumnInformation invalidates the class columnNames memo", async () => {
+    class Topic extends Base {}
+    await Topic.loadSchema();
+    const first = Topic.columnNames();
+    (Topic as unknown as { resetColumnInformation(): void }).resetColumnInformation();
+    // Restore the suite's warm-cache invariant for later tests.
+    await Topic.loadSchema();
+    const second = Topic.columnNames();
+    expect(second).not.toBe(first);
+    expect(second).toEqual(first);
+  });
+
   it("subclass does not inherit the parent's attributeNames memo", async () => {
     class Topic extends Base {}
     await Topic.loadSchema();

--- a/packages/activerecord/src/attribute-methods.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods.trails.test.ts
@@ -296,7 +296,6 @@ describe("AttributeMethodsTest (trails)", () => {
     await Topic.loadSchema();
     const first = Topic.columnNames();
     (Topic as unknown as { resetColumnInformation(): void }).resetColumnInformation();
-    // Restore the suite's warm-cache invariant for later tests.
     await Topic.loadSchema();
     const second = Topic.columnNames();
     expect(second).not.toBe(first);

--- a/packages/activerecord/src/model-schema.test.ts
+++ b/packages/activerecord/src/model-schema.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, it, expect, vi } from "vitest";
 import { Base } from "./index.js";
+import { reconcileVirtualAttributes } from "./model-schema.js";
 
 import { fixtures } from "./test-helpers/fixtures.js";
 import { assertNoQueriesMatch } from "./testing/query-assertions.js";
@@ -36,6 +37,31 @@ describe("virtual attribute reconciliation warms the schema cache", () => {
 
     // reconcile reflected through the shared cache, so it is now warm
     expect(conn.schemaCache.getCachedColumnsHash("posts")).toBeDefined();
+  });
+
+  it("warm-cache reconciliation invalidates a columnNames memo taken off the synthesized fallback", async () => {
+    class Post extends Base {
+      static {
+        this.attribute("id", "integer");
+        this.attribute("title", "string");
+        this.attribute("body", "text");
+        this.attribute("virtual_field", "string", { default: "v" });
+      }
+    }
+    const conn = Post.connection;
+    await conn.schemaCache.clearDataSourceCacheBang(conn.pool ?? conn, "posts");
+
+    // Cold cache: loadSchema's synthesized fallback sets `_schemaLoaded` from
+    // the declared attributes, so this memoizes the synthesized list.
+    const cold = Post.columnNames();
+    expect(cold).not.toContain("tags_count");
+
+    // The write path's reconciliation warms the shared cache and clears
+    // `_schemaLoaded` without a `_schemaRevision` bump — the memo must be
+    // dropped with it, not keep serving the pre-warm synthesized list until
+    // some later `loadSchema` happens to bump the revision.
+    await reconcileVirtualAttributes.call(Post as never, true);
+    expect(Post.columnNames()).toContain("tags_count");
   });
 
   it("a second save on a cold-cache virtual-attribute model issues no schema-introspection query", async () => {

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -209,15 +209,6 @@ export function buildWhereNodeFromConstraints(
  * the `ignoredColumns` filter at read time in `columnsHash()` (Rails filters
  * at load), and `columns()`' `_columns` memo would bypass it after an
  * `ignoredColumns=` reassignment.
- *
- * The memo is revision-stamped like `attributeNames`' (attribute-methods.ts):
- * the reset paths that bump `_schemaRevision` (resetColumnInformation,
- * applyColumnsHash) invalidate it — including subclass memos the base's reset
- * can't reach — and the non-bumping paths (`ignoredColumns=`, `tableName=`,
- * `attribute()`) drop it via `clearAttributeNamesMemo`, mirroring Rails'
- * `reload_schema_from_cache` nilling `@column_names` recursively. Cold
- * (pre-load) reads are never memoized: the schema cache can warm without a
- * revision bump to invalidate a memo taken off the synthesized fallback.
  */
 export function columnNames(this: typeof Base): string[] {
   const host = this as unknown as SchemaHost;
@@ -228,8 +219,6 @@ export function columnNames(this: typeof Base): string[] {
   const names = Object.keys(this.columnsHash());
   if (host._schemaLoaded) {
     const frozen = Object.freeze(names);
-    // Re-read the revision: `columnsHash()` above can run the first sync
-    // `loadSchema` → `applyColumnsHash`, which bumps it mid-call.
     host._columnNamesMemo = { revision: host._schemaRevision ?? 0, names: frozen };
     return frozen as string[];
   }

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -204,13 +204,36 @@ export function buildWhereNodeFromConstraints(
  * Return column names for a model, excluding ignored columns.
  *
  * Mirrors: ActiveRecord::ModelSchema::ClassMethods#column_names
- * (`columns.map(&:name)`). Reads `columnsHash()` keys rather than `columns()`
- * because trails applies the `ignoredColumns` filter at read time in
- * `columnsHash()` (Rails filters at load), and `columns()`' `_columns` memo
- * would bypass it after an `ignoredColumns=` reassignment.
+ * (`@column_names ||= columns.map(&:name).freeze`, model_schema.rb:478-480).
+ * Reads `columnsHash()` keys rather than `columns()` because trails applies
+ * the `ignoredColumns` filter at read time in `columnsHash()` (Rails filters
+ * at load), and `columns()`' `_columns` memo would bypass it after an
+ * `ignoredColumns=` reassignment.
+ *
+ * The memo is revision-stamped like `attributeNames`' (attribute-methods.ts):
+ * the reset paths that bump `_schemaRevision` (resetColumnInformation,
+ * applyColumnsHash) invalidate it — including subclass memos the base's reset
+ * can't reach — and the non-bumping paths (`ignoredColumns=`, `tableName=`,
+ * `attribute()`) drop it via `clearAttributeNamesMemo`, mirroring Rails'
+ * `reload_schema_from_cache` nilling `@column_names` recursively. Cold
+ * (pre-load) reads are never memoized: the schema cache can warm without a
+ * revision bump to invalidate a memo taken off the synthesized fallback.
  */
 export function columnNames(this: typeof Base): string[] {
-  return Object.keys(this.columnsHash());
+  const host = this as unknown as SchemaHost;
+  const memo = Object.prototype.hasOwnProperty.call(host, "_columnNamesMemo")
+    ? host._columnNamesMemo
+    : undefined;
+  if (memo && memo.revision === (host._schemaRevision ?? 0)) return memo.names as string[];
+  const names = Object.keys(this.columnsHash());
+  if (host._schemaLoaded) {
+    const frozen = Object.freeze(names);
+    // Re-read the revision: `columnsHash()` above can run the first sync
+    // `loadSchema` → `applyColumnsHash`, which bumps it mid-call.
+    host._columnNamesMemo = { revision: host._schemaRevision ?? 0, names: frozen };
+    return frozen as string[];
+  }
+  return names;
 }
 
 /**
@@ -547,6 +570,8 @@ interface SchemaHost {
   _schemaRevision?: number;
   /** Base `_schemaRevision` this subclass's overlay was built from. @internal */
   _stiOverlaySyncedAt?: number;
+  /** Rails' `@column_names` memo, revision-stamped. @internal */
+  _columnNamesMemo?: { revision: number; names: readonly string[] };
   connection: any;
   prototype: Record<string, unknown>;
   superclass?: SchemaHost;
@@ -554,18 +579,21 @@ interface SchemaHost {
 }
 
 /**
- * Drop the memoized class-level `attributeNames` on `host` and its
- * descendants — Rails' `reload_schema_from_cache` nils `@attribute_names`
- * recursively (model_schema.rb:553-568). Used by the invalidation paths that
- * don't bump `_schemaRevision` (`attribute`, `table_name=`, `ignored_columns=`).
+ * Drop the memoized class-level `attributeNames` and `columnNames` on `host`
+ * and its descendants — Rails' `reload_schema_from_cache` nils
+ * `@attribute_names` and `@column_names` recursively (model_schema.rb:553-568).
+ * Used by the invalidation paths that don't bump `_schemaRevision`
+ * (`attribute`, `table_name=`, `ignored_columns=`).
  *
  * @internal
  */
 export function clearAttributeNamesMemo(host: SchemaHost): void {
   const descendants = (host as { descendants?: SchemaHost[] }).descendants ?? [];
   for (const klass of [host, ...descendants]) {
-    if (Object.prototype.hasOwnProperty.call(klass, "_attributeNamesMemo")) {
-      Reflect.deleteProperty(klass, "_attributeNamesMemo");
+    for (const memo of ["_attributeNamesMemo", "_columnNamesMemo"] as const) {
+      if (Object.prototype.hasOwnProperty.call(klass, memo)) {
+        Reflect.deleteProperty(klass, memo);
+      }
     }
   }
 }

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1467,8 +1467,14 @@ async function reflectColumnNames(host: SchemaHost): Promise<Set<string> | null>
           // that stale view forever — leaving `columnNames()` reading the warm
           // cache's real columns while `attributeNames()` stays minimal. Drop
           // the flag so the next `loadSchema` re-reflects from the warm cache
-          // and merges the real columns into `_attributeDefinitions`.
-          if (host._schemaLoaded) host._schemaLoaded = false;
+          // and merges the real columns into `_attributeDefinitions`. The flag
+          // drop does not bump `_schemaRevision`, so also drop the name memos
+          // stamped against the synthesized view — otherwise `columnNames()`
+          // keeps serving the pre-warm list.
+          if (host._schemaLoaded) {
+            host._schemaLoaded = false;
+            clearAttributeNamesMemo(host);
+          }
           return new Set(names);
         }
       }


### PR DESCRIPTION
Ports Rails' `@column_names` memoization (`@column_names ||= columns.map(&:name).freeze`, model_schema.rb:478-480), deferred from #5116.

## What

- `columnNames()` (model-schema.ts) now memoizes a frozen, per-class own-property list, stamped with `_schemaRevision` — the same pattern as the `attributeNames` memo from #5116. Revision-bumping reset paths (`resetColumnInformation`, `applyColumnsHash`) invalidate it, including subclass memos the base's reset can't reach directly.
- `clearAttributeNamesMemo` now drops the `_columnNamesMemo` too, so the non-bumping invalidation paths (`ignoredColumns=`, `tableName=`, `attribute()`) clear both — mirroring Rails' `reload_schema_from_cache` nilling `@attribute_names` and `@column_names` recursively (model_schema.rb:553-568).
- Cold (pre-load) reads are never memoized: trails applies the `ignoredColumns` filter at read time in `columnsHash()`, and the schema cache can warm without a revision bump, so a memo taken off the synthesized fallback would go stale.

## Tests

- `class columnNames is memoized and frozen` — fails on baseline (recompute-per-call returned fresh arrays).
- `ignoredColumns= invalidates the columnNames memo` — the story's regression: a reassignment after a memoized read must not serve the stale pre-ignore list.
- `resetColumnInformation invalidates the class columnNames memo`.

Closes-story: column-names-memoization-unported