### PR TITLE
feat(errors): port query_parser-aware MismatchedForeignKey#set_query overload

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -29,6 +29,7 @@ import {
   InvalidForeignKey,
   LockWaitTimeout,
   MismatchedForeignKey,
+  type MismatchedForeignKeyOptions,
   NotNullViolation,
   QueryCanceled,
   RangeError as ARRangeError,
@@ -1559,12 +1560,23 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    */
   protected mismatchedForeignKey(
     message: string,
-    sql: string,
+    sql: string | null,
     binds: unknown[],
     cause: unknown,
   ): MismatchedForeignKey {
-    const details = this.mismatchedForeignKeyDetails(message, sql);
-    return new MismatchedForeignKey({ message, sql, binds, cause, ...details });
+    // Mirrors Rails' `if sql / else query_parser` split: on the sql-less
+    // translation path (with_raw_connection calls translateExceptionClass
+    // with sql: null), FK-detail parsing is deferred until setQuery.
+    if (sql) {
+      const details = this.mismatchedForeignKeyDetails(message, sql);
+      return new MismatchedForeignKey({ message, sql, binds, cause, ...details });
+    }
+    return new MismatchedForeignKey({
+      message,
+      binds,
+      cause,
+      queryParser: (parsedSql) => this.mismatchedForeignKeyDetails(message, parsedSql),
+    });
   }
 
   /**
@@ -1577,7 +1589,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   protected mismatchedForeignKeyDetails(
     message: string,
     sql: string,
-  ): Partial<ConstructorParameters<typeof MismatchedForeignKey>[0]> {
+  ): Partial<MismatchedForeignKeyOptions> {
     // Extract the referencing column name from MySQL's error message when
     // available (MySQL 8+ includes it: "Referencing column 'x' and referenced")
     const fkFromMsg = /Referencing column '(\w+)' and referenced/i.exec(message)?.[1];

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1564,9 +1564,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     binds: unknown[],
     cause: unknown,
   ): MismatchedForeignKey {
-    // Mirrors Rails' `if sql / else query_parser` split: on the sql-less
-    // translation path (with_raw_connection calls translateExceptionClass
-    // with sql: null), FK-detail parsing is deferred until setQuery.
     if (sql) {
       const details = this.mismatchedForeignKeyDetails(message, sql);
       return new MismatchedForeignKey({ message, sql, binds, cause, ...details });

--- a/packages/activerecord/src/errors.trails.test.ts
+++ b/packages/activerecord/src/errors.trails.test.ts
@@ -1,7 +1,3 @@
-// Trails-only tests (no Rails counterpart) for the MismatchedForeignKey
-// query_parser-aware setQuery overload (errors.rb:275). Rails has no unit
-// test for this path; it is exercised indirectly through MySQL adapter
-// integration tests.
 import { describe, expect, it } from "vitest";
 
 import { MismatchedForeignKey, StatementInvalid } from "./errors.js";
@@ -36,6 +32,15 @@ describe("MismatchedForeignKey setQuery (trails-only)", () => {
       "Column `car_id` on table `engines` does not match column `id` on `cars`",
     );
     expect(rebuilt.message).toContain("which has type `bigint`");
+    expect(rebuilt.stack).toBe(original.stack);
+    expect((rebuilt as MismatchedForeignKey).fkDetails).toEqual({
+      table: "engines",
+      foreignKey: "car_id",
+      targetTable: "cars",
+      primaryKey: "id",
+      primaryKeySqlType: "bigint",
+      primaryKeyType: "bigint",
+    });
   });
 
   it("falls back to the plain setQuery assign when sql was supplied at construction", () => {

--- a/packages/activerecord/src/errors.trails.test.ts
+++ b/packages/activerecord/src/errors.trails.test.ts
@@ -32,6 +32,7 @@ describe("MismatchedForeignKey setQuery (trails-only)", () => {
       "Column `car_id` on table `engines` does not match column `id` on `cars`",
     );
     expect(rebuilt.message).toContain("which has type `bigint`");
+    expect(rebuilt.message).toContain("\nOriginal message: Cannot add foreign key constraint");
     expect(rebuilt.stack).toBe(original.stack);
     expect((rebuilt as MismatchedForeignKey).fkDetails).toEqual({
       table: "engines",

--- a/packages/activerecord/src/errors.trails.test.ts
+++ b/packages/activerecord/src/errors.trails.test.ts
@@ -1,0 +1,65 @@
+// Trails-only tests (no Rails counterpart) for the MismatchedForeignKey
+// query_parser-aware setQuery overload (errors.rb:275). Rails has no unit
+// test for this path; it is exercised indirectly through MySQL adapter
+// integration tests.
+import { describe, expect, it } from "vitest";
+
+import { MismatchedForeignKey, StatementInvalid } from "./errors.js";
+
+describe("MismatchedForeignKey setQuery (trails-only)", () => {
+  it("rebuilds the exception with parsed details when built with a queryParser and no sql", () => {
+    const original = new MismatchedForeignKey({
+      message: "Cannot add foreign key constraint",
+      binds: [],
+      connectionPool: "pool-sentinel",
+      queryParser: (sql) => {
+        expect(sql).toBe("ALTER TABLE `engines` ADD CONSTRAINT fk");
+        return {
+          table: "engines",
+          foreignKey: "car_id",
+          targetTable: "cars",
+          primaryKey: "id",
+          primaryKeySqlType: "bigint",
+          primaryKeyType: "bigint",
+        };
+      },
+    });
+
+    const rebuilt = original.setQuery("ALTER TABLE `engines` ADD CONSTRAINT fk", ["b"]);
+
+    expect(rebuilt).not.toBe(original);
+    expect(rebuilt).toBeInstanceOf(MismatchedForeignKey);
+    expect(rebuilt.sql).toBe("ALTER TABLE `engines` ADD CONSTRAINT fk");
+    expect(rebuilt.binds).toEqual(["b"]);
+    expect((rebuilt as MismatchedForeignKey).connectionPool).toBe("pool-sentinel");
+    expect(rebuilt.message).toContain(
+      "Column `car_id` on table `engines` does not match column `id` on `cars`",
+    );
+    expect(rebuilt.message).toContain("which has type `bigint`");
+  });
+
+  it("falls back to the plain setQuery assign when sql was supplied at construction", () => {
+    const original = new MismatchedForeignKey({
+      message: "boom",
+      sql: "CREATE TABLE t",
+      binds: [],
+      queryParser: () => ({ table: "t" }),
+    });
+
+    const result = original.setQuery("OTHER SQL", ["x"]);
+
+    expect(result).toBe(original);
+    expect(result.sql).toBe("CREATE TABLE t");
+  });
+
+  it("falls back to the plain setQuery assign when no queryParser was given", () => {
+    const original = new MismatchedForeignKey({ message: "boom" });
+
+    const result = original.setQuery("ALTER TABLE `x`", ["y"]);
+
+    expect(result).toBe(original);
+    expect(result).toBeInstanceOf(StatementInvalid);
+    expect(result.sql).toBe("ALTER TABLE `x`");
+    expect(result.binds).toEqual(["y"]);
+  });
+});

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -500,10 +500,12 @@ export class MismatchedForeignKey extends StatementInvalid {
         `(For example \`t.${type} :${foreignKey}\`).`,
       ].join(" ");
     } else {
-      const fallback =
+      msg =
         "There is a mismatch between the foreign key and primary key column types. " +
         "Verify that the foreign key column type and the primary key of the associated table match types.";
-      msg = originalMessage ? `${fallback} ${originalMessage}` : fallback;
+    }
+    if (originalMessage) {
+      msg += `\nOriginal message: ${originalMessage}`;
     }
 
     super(msg, rest);

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -265,8 +265,6 @@ export class StatementInvalid extends AdapterError {
     this._querySet = options?.sql != null;
   }
 
-  // Returns StatementInvalid (not `this`) because MismatchedForeignKey's
-  // query_parser overload rebuilds and returns a NEW exception, as Rails does.
   setQuery(sql: string, binds: unknown[]): StatementInvalid {
     if (!this._querySet) {
       this.sql = sql;
@@ -455,11 +453,6 @@ export interface MismatchedForeignKeyOptions {
   primaryKey?: string;
   primaryKeySqlType?: string;
   primaryKeyType?: string;
-  /**
-   * Mirrors Rails' `query_parser:` option (errors.rb:248): when the error is
-   * built without SQL (the `with_raw_connection` translation path), the parser
-   * defers FK-detail extraction until `setQuery` supplies the statement.
-   */
   queryParser?: (sql: string) => Partial<MismatchedForeignKeyOptions>;
 }
 
@@ -527,14 +520,6 @@ export class MismatchedForeignKey extends StatementInvalid {
     };
   }
 
-  /**
-   * Mirrors: MismatchedForeignKey#set_query (errors.rb:275)
-   *
-   * When built without SQL but with a `queryParser`, rebuilds the exception
-   * with the parsed FK details now that the statement is known. `stack`
-   * assignment is the TS analogue of Rails' `set_backtrace backtrace`, and
-   * `cause:` is threaded explicitly because TS has no `$!` implicit cause.
-   */
   override setQuery(sql: string, binds: unknown[]): StatementInvalid {
     if (this._queryParser && !this._querySet) {
       const exception = new MismatchedForeignKey({

--- a/packages/activerecord/src/errors.ts
+++ b/packages/activerecord/src/errors.ts
@@ -249,7 +249,7 @@ export class SoleRecordExceeded extends ActiveRecordError {
 export class StatementInvalid extends AdapterError {
   sql?: string;
   binds?: unknown[];
-  private _querySet = false;
+  protected _querySet = false;
 
   constructor(
     message?: string,
@@ -265,7 +265,9 @@ export class StatementInvalid extends AdapterError {
     this._querySet = options?.sql != null;
   }
 
-  setQuery(sql: string, binds: unknown[]): this {
+  // Returns StatementInvalid (not `this`) because MismatchedForeignKey's
+  // query_parser overload rebuilds and returns a NEW exception, as Rails does.
+  setQuery(sql: string, binds: unknown[]): StatementInvalid {
     if (!this._querySet) {
       this.sql = sql;
       this.binds = binds;
@@ -453,6 +455,12 @@ export interface MismatchedForeignKeyOptions {
   primaryKey?: string;
   primaryKeySqlType?: string;
   primaryKeyType?: string;
+  /**
+   * Mirrors Rails' `query_parser:` option (errors.rb:248): when the error is
+   * built without SQL (the `with_raw_connection` translation path), the parser
+   * defers FK-detail extraction until `setQuery` supplies the statement.
+   */
+  queryParser?: (sql: string) => Partial<MismatchedForeignKeyOptions>;
 }
 
 /**
@@ -473,9 +481,13 @@ export class MismatchedForeignKey extends StatementInvalid {
     "message" | "sql" | "binds" | "connectionPool" | "cause"
   >;
 
+  private readonly _originalMessage?: string;
+  private readonly _queryParser?: (sql: string) => Partial<MismatchedForeignKeyOptions>;
+
   constructor(options: MismatchedForeignKeyOptions = {}) {
     const {
       message: originalMessage,
+      queryParser,
       table,
       foreignKey,
       targetTable,
@@ -503,6 +515,8 @@ export class MismatchedForeignKey extends StatementInvalid {
 
     super(msg, rest);
     this.name = "MismatchedForeignKey";
+    this._originalMessage = originalMessage;
+    this._queryParser = queryParser;
     this.fkDetails = {
       table,
       foreignKey,
@@ -511,6 +525,30 @@ export class MismatchedForeignKey extends StatementInvalid {
       primaryKeySqlType,
       primaryKeyType,
     };
+  }
+
+  /**
+   * Mirrors: MismatchedForeignKey#set_query (errors.rb:275)
+   *
+   * When built without SQL but with a `queryParser`, rebuilds the exception
+   * with the parsed FK details now that the statement is known. `stack`
+   * assignment is the TS analogue of Rails' `set_backtrace backtrace`, and
+   * `cause:` is threaded explicitly because TS has no `$!` implicit cause.
+   */
+  override setQuery(sql: string, binds: unknown[]): StatementInvalid {
+    if (this._queryParser && !this._querySet) {
+      const exception = new MismatchedForeignKey({
+        message: this._originalMessage,
+        sql,
+        binds,
+        connectionPool: this.connectionPool,
+        cause: this.cause,
+        ...this._queryParser(sql),
+      });
+      exception.stack = this.stack;
+      return exception;
+    }
+    return super.setQuery(sql, binds);
   }
 }
 

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/errors.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/errors.json
@@ -4,13 +4,6 @@
     "tsFile": "errors.ts",
     "rubyName": "set_query",
     "call": "call",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails errors.rb has two overloads: 213-220 (plain assign, ported at trails errors.ts:268-275) and 275-289 (rebuilds the exception via `@query_parser.call(sql)`); trails has no query_parser machinery. Omission tracked in story errors-set-query-query-parser-overload."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "errors.ts",
-    "rubyName": "set_query",
-    "call": "new",
-    "reason": "Constructor idiom: Ruby `X.new` ports to TS `new X()`, which extractCalls records as a construction/type reference rather than a named call. The construction is present in the port. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Proc-invocation idiom: Rails' `@query_parser.call(sql)` (errors.rb:282) ports to a direct function invocation `this._queryParser(sql)` (MismatchedForeignKey#setQuery), which extractCalls does not record as a named `call`. The overload itself is ported (story errors-set-query-query-parser-overload)."
   }
 ]


### PR DESCRIPTION
Ports the query_parser-aware `set_query` overload from Rails
`MismatchedForeignKey` (errors.rb:275-289) and the class-level wiring that
feeds it (abstract_mysql_adapter.rb:1001-1015).

Previously, when a MySQL FK-mismatch error was translated on the sql-less
`with_raw_connection` path (`translateExceptionClass(e, null, null)`), the
FK-detail regex ran against a null statement and the error kept the generic
fallback message even after `log()` later attached the SQL via `setQuery`.

Now:

- `MismatchedForeignKeyOptions` accepts a `queryParser` callback (Rails'
  `query_parser:` option).
- `MismatchedForeignKey#setQuery` overrides the plain assign: when a parser
  was supplied and no SQL is set, it rebuilds the exception with
  `queryParser(sql)`-parsed details, carrying over stack (Rails'
  `set_backtrace`), connection pool, and cause.
- `AbstractMysqlAdapter#mismatchedForeignKey` mirrors Rails' `if sql / else
  query_parser` split, deferring detail extraction when translation happens
  without a statement.
- `StatementInvalid#setQuery` return type widens `this` → `StatementInvalid`
  since the overload returns a new exception, matching Rails.

Rails has no unit test for this path (it's covered via MySQL integration
tests), so trails-only unit tests live in `errors.trails.test.ts`.

Closes-story: errors-set-query-query-parser-overload
