### PR TITLE
fix(encryption): serialize deterministic query expansion through the full resolved type

### DIFF
--- a/packages/activerecord/src/encryption/extended-deterministic-queries.trails.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.trails.test.ts
@@ -5,8 +5,10 @@ import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
 import { Scheme } from "./scheme.js";
 import { Configurable } from "./configurable.js";
 import { installExtendedQueriesIfConfigured } from "./install.js";
-import { ExtendedDeterministicUniquenessValidator } from "./extended-deterministic-uniqueness-validator.js";
-import { EncryptedUniquenessValidator } from "./extended-deterministic-uniqueness-validator.js";
+import {
+  ExtendedDeterministicUniquenessValidator,
+  EncryptedUniquenessValidator,
+} from "./extended-deterministic-uniqueness-validator.js";
 import { UniquenessValidator } from "../validations.js";
 import { getAttributeType } from "./encryptable-record.js";
 // Side-effect: registers encryptionHooks so Base.encrypts() is wired up.

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.trails.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.trails.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { fixtures } from "../test-helpers/fixtures.js";
+import { ExtendedDeterministicQueries } from "./extended-deterministic-queries.js";
+import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
+import { Scheme } from "./scheme.js";
+import { Configurable } from "./configurable.js";
+import { installExtendedQueriesIfConfigured } from "./install.js";
+import { ExtendedDeterministicUniquenessValidator } from "./extended-deterministic-uniqueness-validator.js";
+import { EncryptedUniquenessValidator } from "./extended-deterministic-uniqueness-validator.js";
+import { UniquenessValidator } from "../validations.js";
+import { getAttributeType } from "./encryptable-record.js";
+// Side-effect: registers encryptionHooks so Base.encrypts() is wired up.
+import "../encryption.js";
+import { Base } from "../base.js";
+import { Relation } from "../relation.js";
+
+fixtures([], { useTransactionalTests: false });
+
+// 32 bytes (base64-encoded) for AES-256-GCM, matching the port suite's key.
+const TEST_KEY = Buffer.alloc(32, "x").toString("base64");
+const PREVIOUS_KEY = Buffer.alloc(32, "y").toString("base64");
+
+/**
+ * TS-only guard (Rails has no direct test): a deterministic
+ * Serialized(Encrypted(...)) attribute — `encrypts` then `serialize`, so the
+ * coder dumps BEFORE encryption — must be queryable by plaintext value.
+ * Query expansion has to serialize candidates through the FULL resolved type
+ * (Rails' `owner.type_for_attribute(name)` delegation,
+ * extended_deterministic_queries.rb:58-62), not the bare inner
+ * EncryptedAttributeType, or the expansion ciphertext diverges from the
+ * write path and the lookup silently misses.
+ */
+function buildSerializedBook() {
+  class EncryptedSerializedBook extends Base {
+    static {
+      this._tableName = "books";
+      this.attribute("id", "integer");
+      this.attribute("name", "string");
+      // supportUnencryptedData: false removes the raw-plaintext candidate
+      // from the expansion, so the lookup can only succeed through a
+      // correctly-serialized ciphertext candidate; the previous scheme keeps
+      // `previousTypes` non-empty so expansion actually runs.
+      this.encrypts("name", {
+        deterministic: true,
+        key: TEST_KEY,
+        supportUnencryptedData: false,
+        previousSchemes: [new Scheme({ deterministic: true, key: PREVIOUS_KEY })],
+      });
+      this.serialize("name", { coder: "json" });
+    }
+  }
+  return EncryptedSerializedBook;
+}
+
+describe("ActiveRecord::Encryption::ExtendedDeterministicQueriesTest (trails extras)", () => {
+  let EncryptedSerializedBook: ReturnType<typeof buildSerializedBook>;
+
+  const savedConfig = {
+    extendQueries: Configurable.config.extendQueries,
+    supportUnencryptedData: Configurable.config.supportUnencryptedData,
+    keyDerivationSalt: Configurable.config.keyDerivationSalt,
+    primaryKey: Configurable.config.primaryKey,
+    deterministicKey: Configurable.config.deterministicKey,
+  };
+  const relProto = Relation.prototype as unknown as Record<string, unknown>;
+  const baseStatics = Base as unknown as Record<string, unknown>;
+  const savedMethods: Record<string, unknown> = {};
+
+  beforeAll(async () => {
+    Configurable.config.extendQueries = true;
+    Configurable.config.supportUnencryptedData = true;
+    Configurable.config.keyDerivationSalt = "test-salt";
+    Configurable.config.primaryKey = "test-primary-key";
+    Configurable.config.deterministicKey = "test-deterministic-key";
+
+    savedMethods.where = relProto.where;
+    savedMethods.exists = relProto.exists;
+    savedMethods.scopeForCreate = relProto.scopeForCreate;
+    savedMethods.findBy = baseStatics.findBy;
+    savedMethods.serialize = EncryptedAttributeType.prototype.serialize;
+
+    installExtendedQueriesIfConfigured();
+
+    EncryptedSerializedBook = buildSerializedBook();
+    // Warm the books table once so the first create doesn't race the
+    // test-adapter's schema-recovery path (see the port suite's note).
+    await EncryptedSerializedBook.where("1=1");
+  });
+
+  fixtures([]);
+
+  afterAll(() => {
+    relProto.where = savedMethods.where;
+    relProto.exists = savedMethods.exists;
+    relProto.scopeForCreate = savedMethods.scopeForCreate;
+    baseStatics.findBy = savedMethods.findBy;
+    EncryptedAttributeType.prototype.serialize =
+      savedMethods.serialize as typeof EncryptedAttributeType.prototype.serialize;
+    (ExtendedDeterministicQueries as unknown as Record<string, unknown>)._installed = false;
+    ExtendedDeterministicUniquenessValidator.resetSupport(UniquenessValidator);
+
+    Configurable.config.extendQueries = savedConfig.extendQueries;
+    Configurable.config.supportUnencryptedData = savedConfig.supportUnencryptedData;
+    Configurable.config.keyDerivationSalt = savedConfig.keyDerivationSalt;
+    Configurable.config.primaryKey = savedConfig.primaryKey;
+    Configurable.config.deterministicKey = savedConfig.deterministicKey;
+  });
+
+  it("finds records by plaintext when a deterministic attribute is serialized after encryption", async () => {
+    await EncryptedSerializedBook.create({ name: "Dune" });
+    expect(await EncryptedSerializedBook.findBy({ name: "Dune" })).not.toBeNull();
+    expect(await EncryptedSerializedBook.where("id > 0").findBy({ name: "Dune" })).not.toBeNull();
+    expect(await EncryptedSerializedBook.exists({ name: "Dune" })).toBe(true);
+  });
+
+  it("uniqueness ciphertext generation serializes through the full resolved type", () => {
+    const fullType = getAttributeType(EncryptedSerializedBook, "name") as {
+      serialize(v: unknown): unknown;
+    };
+    // The resolved type is the outer Serialized wrapper, not the bare
+    // EncryptedAttributeType — the delegation the expansion must honor.
+    expect(fullType).not.toBeInstanceOf(EncryptedAttributeType);
+
+    const [current] = EncryptedUniquenessValidator.allCiphertextsFor(
+      EncryptedSerializedBook,
+      "name",
+      "Dune",
+    ) as Array<{ value: unknown }>;
+    // Deterministic encryption: the expansion candidate must equal the
+    // write-path ciphertext (coder dump applied before encryption).
+    expect(current.value).toEqual(fullType.serialize("Dune"));
+  });
+});

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.ts
@@ -3,10 +3,9 @@ import { ADDITIONAL_VALUE_BRAND, EncryptedAttributeType } from "./encrypted-attr
 import { getAttributeType, encryptedTypeOf } from "./encryptable-record.js";
 
 /**
- * The minimal surface AdditionalValue needs from its type. Rails passes the
- * full resolved `type_for_attribute` type here — which for a
- * Serialized(Encrypted(...)) attribute is the outer Type::Serialized, not the
- * inner EncryptedAttributeType — so the field can't be typed as the latter.
+ * What AdditionalValue needs from its type. Rails passes the full resolved
+ * `type_for_attribute` type here — for a Serialized(Encrypted(...)) attribute
+ * that's the outer Type::Serialized, not EncryptedAttributeType.
  */
 export interface SerializableType {
   serialize(value: unknown): unknown;
@@ -130,12 +129,10 @@ export class EncryptedQuery {
     let modified = false;
 
     for (const attrName of encryptedAttrs) {
-      // Rails resolves `type = owner.type_for_attribute(name)` — the FULL
-      // delegated type (extended_deterministic_queries.rb:58-62). For a
-      // Serialized(Encrypted(...)) attribute the coder must dump BEFORE
-      // encryption, matching the write path; `deterministic`/`previous_types`
-      // reach the inner EncryptedAttributeType via DelegateClass delegation
-      // in Rails, via encryptedTypeOf here.
+      // Rails serializes through the FULL `type_for_attribute` type
+      // (extended_deterministic_queries.rb:58-62); `deterministic`/
+      // `previous_types` reach the inner EncryptedAttributeType via
+      // DelegateClass delegation there, via encryptedTypeOf here.
       const fullType = getAttributeType(model, attrName) as SerializableType | undefined;
       const type = encryptedTypeOf(fullType);
       if (!fullType || !type) continue;
@@ -213,9 +210,9 @@ export class EncryptedQuery {
     // still preserving the raw plaintext when unencrypted data remains queryable
     // during migration (support_unencrypted_data).
     // The current-scheme candidate serializes through the FULL resolved type
-    // (coder applied before encryption) so the ciphertext matches the write
-    // path; previous-scheme candidates serialize through the bare previous
-    // EncryptedAttributeTypes, exactly as Rails' delegated `previous_types` do.
+    // (coder dumped before encryption, matching the write path); previous-
+    // scheme candidates use the bare previous EncryptedAttributeTypes, as
+    // Rails' delegated `previous_types` do.
     const results: Array<AdditionalValue | unknown> = [new AdditionalValue(plaintext, fullType)];
     for (const prev of type.previousTypes) {
       results.push(new AdditionalValue(plaintext, prev));

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.ts
@@ -3,6 +3,16 @@ import { ADDITIONAL_VALUE_BRAND, EncryptedAttributeType } from "./encrypted-attr
 import { getAttributeType, encryptedTypeOf } from "./encryptable-record.js";
 
 /**
+ * The minimal surface AdditionalValue needs from its type. Rails passes the
+ * full resolved `type_for_attribute` type here — which for a
+ * Serialized(Encrypted(...)) attribute is the outer Type::Serialized, not the
+ * inner EncryptedAttributeType — so the field can't be typed as the latter.
+ */
+export interface SerializableType {
+  serialize(value: unknown): unknown;
+}
+
+/**
  * Automatically expands encrypted arguments to support querying both
  * encrypted and unencrypted data during encryption migration periods.
  *
@@ -120,13 +130,25 @@ export class EncryptedQuery {
     let modified = false;
 
     for (const attrName of encryptedAttrs) {
-      const type = encryptedTypeOf(getAttributeType(model, attrName));
-      if (!type) continue;
+      // Rails resolves `type = owner.type_for_attribute(name)` — the FULL
+      // delegated type (extended_deterministic_queries.rb:58-62). For a
+      // Serialized(Encrypted(...)) attribute the coder must dump BEFORE
+      // encryption, matching the write path; `deterministic`/`previous_types`
+      // reach the inner EncryptedAttributeType via DelegateClass delegation
+      // in Rails, via encryptedTypeOf here.
+      const fullType = getAttributeType(model, attrName) as SerializableType | undefined;
+      const type = encryptedTypeOf(fullType);
+      if (!fullType || !type) continue;
       if (!type.deterministic) continue;
       if (!type.previousTypes.length) continue;
       const value = result[attrName];
       if (value === undefined) continue;
-      result[attrName] = this.processEncryptedQueryArgument(value, checkForAdditionalValues, type);
+      result[attrName] = this.processEncryptedQueryArgument(
+        value,
+        checkForAdditionalValues,
+        fullType,
+        type,
+      );
       modified = true;
     }
 
@@ -136,6 +158,7 @@ export class EncryptedQuery {
   private static processEncryptedQueryArgument(
     value: unknown,
     checkForAdditionalValues: boolean,
+    fullType: SerializableType,
     type: EncryptedAttributeType,
   ): unknown {
     if (value === null) return value;
@@ -161,10 +184,10 @@ export class EncryptedQuery {
       return value.flatMap((v) => {
         if (v === null) return [v];
         if (checkForAdditionalValues && v instanceof AdditionalValue) return [v];
-        return this.allCiphertextsFor(v, type);
+        return this.allCiphertextsFor(v, fullType, type);
       });
     }
-    return this.allCiphertextsFor(value, type);
+    return this.allCiphertextsFor(value, fullType, type);
   }
 
   /** @internal */
@@ -177,6 +200,7 @@ export class EncryptedQuery {
 
   private static allCiphertextsFor(
     plaintext: unknown,
+    fullType: SerializableType,
     type: EncryptedAttributeType,
   ): Array<AdditionalValue | unknown> {
     // Unlike Rails (which keeps plaintext at index 0 and relies on the
@@ -188,7 +212,11 @@ export class EncryptedQuery {
     // → `ExtendedEncryptableType.serialize` → pre-computed ciphertext, while
     // still preserving the raw plaintext when unencrypted data remains queryable
     // during migration (support_unencrypted_data).
-    const results: Array<AdditionalValue | unknown> = [new AdditionalValue(plaintext, type)];
+    // The current-scheme candidate serializes through the FULL resolved type
+    // (coder applied before encryption) so the ciphertext matches the write
+    // path; previous-scheme candidates serialize through the bare previous
+    // EncryptedAttributeTypes, exactly as Rails' delegated `previous_types` do.
+    const results: Array<AdditionalValue | unknown> = [new AdditionalValue(plaintext, fullType)];
     for (const prev of type.previousTypes) {
       results.push(new AdditionalValue(plaintext, prev));
     }
@@ -270,12 +298,12 @@ export class CoreQueries {
  */
 export class AdditionalValue {
   readonly value: unknown;
-  readonly type: EncryptedAttributeType;
+  readonly type: SerializableType;
   // Brand flag so EncryptedAttributeType.cast can identify AV instances
   // without importing this module (which would be circular).
   readonly [ADDITIONAL_VALUE_BRAND] = true;
 
-  constructor(value: unknown, type: EncryptedAttributeType) {
+  constructor(value: unknown, type: SerializableType) {
     this.type = type;
     this.value = this.process(value);
   }

--- a/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.ts
@@ -1,5 +1,9 @@
 import { EncryptableRecord, getAttributeType, encryptedTypeOf } from "./encryptable-record.js";
-import { AdditionalValue, ExtendedDeterministicQueries } from "./extended-deterministic-queries.js";
+import {
+  AdditionalValue,
+  ExtendedDeterministicQueries,
+  type SerializableType,
+} from "./extended-deterministic-queries.js";
 import { withoutEncryption } from "./context.js";
 
 /**
@@ -115,13 +119,18 @@ export class EncryptedUniquenessValidator {
    * check for duplicates across scheme migrations.
    */
   static allCiphertextsFor(klass: any, attribute: string, value: unknown): unknown[] {
-    const type = encryptedTypeOf(getAttributeType(klass, attribute));
-    if (!type?.deterministic) {
+    // Rails resolves the FULL `type_for_attribute` type — for a
+    // Serialized(Encrypted(...)) attribute the coder dumps BEFORE encryption,
+    // matching the write path. `deterministic`/`previousTypes` reach the inner
+    // EncryptedAttributeType via delegation (encryptedTypeOf here).
+    const fullType = getAttributeType(klass, attribute) as SerializableType | undefined;
+    const type = encryptedTypeOf(fullType);
+    if (!fullType || !type?.deterministic) {
       return [value];
     }
 
     const results: Array<unknown | AdditionalValue> = [];
-    results.push(new AdditionalValue(value, type));
+    results.push(new AdditionalValue(value, fullType));
 
     for (const prevType of type.previousTypes) {
       results.push(new AdditionalValue(value, prevType));

--- a/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.ts
@@ -119,10 +119,10 @@ export class EncryptedUniquenessValidator {
    * check for duplicates across scheme migrations.
    */
   static allCiphertextsFor(klass: any, attribute: string, value: unknown): unknown[] {
-    // Rails resolves the FULL `type_for_attribute` type — for a
-    // Serialized(Encrypted(...)) attribute the coder dumps BEFORE encryption,
-    // matching the write path. `deterministic`/`previousTypes` reach the inner
-    // EncryptedAttributeType via delegation (encryptedTypeOf here).
+    // The current-scheme candidate serializes through the FULL
+    // `type_for_attribute` type (coder dumped before encryption, matching the
+    // write path); gating reaches the inner type via encryptedTypeOf — Rails'
+    // DelegateClass delegation.
     const fullType = getAttributeType(klass, attribute) as SerializableType | undefined;
     const type = encryptedTypeOf(fullType);
     if (!fullType || !type?.deterministic) {

--- a/packages/activerecord/src/type/serialized.ts
+++ b/packages/activerecord/src/type/serialized.ts
@@ -103,6 +103,20 @@ function canonicalKey(value: unknown): string {
  */
 const NONSERIALIZABLE_SENTINEL = "\u0000serialized:";
 
+// Global-registry copy of encryption's ADDITIONAL_VALUE_BRAND
+// (encrypted-attribute-type.ts). Resolved via Symbol.for rather than an
+// import because encrypted-attribute-type.ts imports this module — the same
+// cycle the brand exists to break.
+const ADDITIONAL_VALUE_BRAND = Symbol.for("activerecord.encryption.AdditionalValue");
+
+function isAdditionalValue(value: unknown): boolean {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as Record<symbol, unknown>)[ADDITIONAL_VALUE_BRAND] === true
+  );
+}
+
 /**
  * Recursively unwraps `toHash()`-bearing objects and sorts plain-object keys so
  * the resulting structure has a canonical, insertion-order-independent shape.
@@ -284,6 +298,12 @@ export class Serialized extends ValueType {
   }
 
   cast(value: unknown): unknown {
+    // Encryption AdditionalValue instances pass through cast unchanged so
+    // serialize() can unwrap them — same contract as
+    // EncryptedAttributeType.cast (see the brand's doc there). Needed here
+    // because a Serialized(Encrypted(...)) attribute's resolved type is this
+    // wrapper, so query expansion's AVs hit it first.
+    if (isAdditionalValue(value)) return value;
     // Rails: ActiveModel::Type::Helpers::Mutable#cast is always
     // `deserialize(serialize(value))`. Serializing first means a value the
     // coder can't round-trip (e.g. a non-Hash string like "somedata" through
@@ -294,6 +314,13 @@ export class Serialized extends ValueType {
 
   serialize(value: unknown): unknown {
     if (value === null || value === undefined) return null;
+    // Unwrap encryption AdditionalValues to their pre-computed ciphertext
+    // (computed through this full type at AV construction) instead of
+    // feeding the AV object to the coder. Mirrors what Rails'
+    // ExtendedEncryptableType prepend does for a bare EncryptedAttributeType;
+    // the AV-wrapped current value is a trails invention (Rails keeps the
+    // plaintext raw), so the wrapper type must honor it too.
+    if (isAdditionalValue(value)) return (value as { value: unknown }).value;
     if (this.isDefaultValue(value)) return null;
     const dumped = this.coder.dump(value);
     if (this.subtype.serialize) {

--- a/packages/activerecord/src/type/serialized.ts
+++ b/packages/activerecord/src/type/serialized.ts
@@ -298,11 +298,10 @@ export class Serialized extends ValueType {
   }
 
   cast(value: unknown): unknown {
-    // Encryption AdditionalValue instances pass through cast unchanged so
-    // serialize() can unwrap them — same contract as
-    // EncryptedAttributeType.cast (see the brand's doc there). Needed here
-    // because a Serialized(Encrypted(...)) attribute's resolved type is this
-    // wrapper, so query expansion's AVs hit it first.
+    // Encryption AdditionalValues pass through cast unchanged so serialize()
+    // can unwrap them — the same contract as EncryptedAttributeType.cast,
+    // needed here because a Serialized(Encrypted(...)) attribute's resolved
+    // type is this wrapper.
     if (isAdditionalValue(value)) return value;
     // Rails: ActiveModel::Type::Helpers::Mutable#cast is always
     // `deserialize(serialize(value))`. Serializing first means a value the
@@ -315,10 +314,9 @@ export class Serialized extends ValueType {
   serialize(value: unknown): unknown {
     if (value === null || value === undefined) return null;
     // Unwrap encryption AdditionalValues to their pre-computed ciphertext
-    // (computed through this full type at AV construction) instead of
-    // feeding the AV object to the coder. Mirrors what Rails'
-    // ExtendedEncryptableType prepend does for a bare EncryptedAttributeType;
-    // the AV-wrapped current value is a trails invention (Rails keeps the
+    // instead of feeding the AV object to the coder — mirrors Rails'
+    // ExtendedEncryptableType prepend on the bare EncryptedAttributeType. The
+    // AV-wrapped current-scheme value is a trails invention (Rails keeps the
     // plaintext raw), so the wrapper type must honor it too.
     if (isAdditionalValue(value)) return (value as { value: unknown }).value;
     if (this.isDefaultValue(value)) return null;


### PR DESCRIPTION
## Summary

Deterministic query expansion (`where`/`exists`/`findBy`) and uniqueness ciphertext generation serialized candidate values through the bare inner `EncryptedAttributeType` (`encryptedTypeOf(getAttributeType(...))`). Rails resolves `type = owner.type_for_attribute(name)` — the FULL delegated type (`vendor/rails/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb:58-62`) — so for a deterministic `Serialized(Encrypted(...))` attribute (encrypts-then-serialize) the coder dumps BEFORE encryption, matching the write path. The bare-type serialize produced a different ciphertext and plaintext lookups silently missed.

## Changes

- `EncryptedQuery.processArguments`/`allCiphertextsFor` and `EncryptedUniquenessValidator.allCiphertextsFor` now resolve the full `getAttributeType` result and build the current-scheme `AdditionalValue` with it; previous-scheme candidates keep the bare previous types, exactly as Rails' delegated `previous_types` do. Gating (`deterministic`, `previousTypes`) still reaches the inner type via `encryptedTypeOf` — the TS stand-in for Rails' DelegateClass delegation.
- `AdditionalValue.type` widened to a minimal `SerializableType` (Rails passes the full resolved type here too).
- `Type::Serialized` gains the same AdditionalValue pass-through (`cast`) / unwrap (`serialize`) contract `EncryptedAttributeType.cast` already has, via the shared `Symbol.for` brand (importing would cycle: `encrypted-attribute-type.ts` imports `serialized.ts`). Needed because the AV-wrapped current value is a trails invention (Rails keeps the plaintext raw at index 0) and the wrapper type is what the expansion's AVs hit first.

## Testing

- New TS-only guard `extended-deterministic-queries.trails.test.ts` (Rails has no direct test): a deterministic `Serialized(Encrypted(...))` attribute with `supportUnencryptedData: false` + a previous scheme is queryable by plaintext, and the uniqueness expansion candidate equals the write-path ciphertext. Both tests fail on baseline.
- Port suites for extended-deterministic queries/uniqueness, `serialized-attribute`, `serialized.trails`, message-pack-serialized, and uniqueness-validations all pass.

Closes-story: deterministic-query-expansion-full-type-serialize