### PR TITLE
fix(globalid,rack): honor explicit null in fetch-defaulted options

### DIFF
--- a/packages/activesupport/src/message-verifier.ts
+++ b/packages/activesupport/src/message-verifier.ts
@@ -40,11 +40,11 @@ interface MessageVerifierOptions {
 interface GenerateOptions {
   expiresIn?: number; // seconds
   expiresAt?: Temporal.Instant;
-  purpose?: string;
+  purpose?: string | null;
 }
 
 interface VerifyOptions {
-  purpose?: string;
+  purpose?: string | null;
 }
 
 export class MessageVerifier {

--- a/packages/globalid/src/signed-global-id.trails.test.ts
+++ b/packages/globalid/src/signed-global-id.trails.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
+import { SignedGlobalID } from "./signed-global-id.js";
+import { setApp, _resetApp } from "./config.js";
+
+// Trails-only coverage: Ruby's `options.fetch :for, DEFAULT_PURPOSE`
+// (signed_global_id.rb:24-26) is key-present — an explicit `for: nil` yields
+// a nil purpose (purpose verification disabled). The upstream suite has no
+// test for the explicit-nil arm, and the idiomatic JS `??` port silently
+// coerces null back to the default, so we pin the semantics here.
+describe("SignedGlobalID pick_purpose explicit-null semantics", () => {
+  const verifier = new MessageVerifier("test-secret", { digest: "sha256", url_safe: true });
+  const person = (id: unknown = 5) => ({ id, constructor: { name: "Person" } });
+
+  beforeEach(() => setApp("bcx"));
+  afterEach(() => _resetApp());
+
+  it("pickPurpose returns null for an explicit for: null", () => {
+    expect(SignedGlobalID.pickPurpose({ for: null })).toBeNull();
+  });
+
+  it("pickPurpose applies the default only when the key is absent", () => {
+    expect(SignedGlobalID.pickPurpose({})).toBe("default");
+    expect(SignedGlobalID.pickPurpose({ for: undefined })).toBe("default");
+    expect(SignedGlobalID.pickPurpose({ for: "login" })).toBe("login");
+  });
+
+  it("an SGID signed with for: null does not verify against the default purpose", () => {
+    const sgid = SignedGlobalID.create(person(5), { verifier, for: null });
+    expect(sgid.purpose).toBeNull();
+    expect(SignedGlobalID.parse(sgid.toString(), { verifier })).toBeNull();
+    expect(SignedGlobalID.parse(sgid.toString(), { verifier, for: null })?.uri).toBe(sgid.uri);
+  });
+});

--- a/packages/globalid/src/signed-global-id.trails.test.ts
+++ b/packages/globalid/src/signed-global-id.trails.test.ts
@@ -3,14 +3,9 @@ import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
 import { SignedGlobalID } from "./signed-global-id.js";
 import { setApp, _resetApp } from "./config.js";
 
-// Trails-only coverage: Ruby's `options.fetch :for, DEFAULT_PURPOSE`
-// (signed_global_id.rb:24-26) is key-present — an explicit `for: nil` yields
-// a nil purpose (purpose verification disabled). The upstream suite has no
-// test for the explicit-nil arm, and the idiomatic JS `??` port silently
-// coerces null back to the default, so we pin the semantics here.
 describe("SignedGlobalID pick_purpose explicit-null semantics", () => {
   const verifier = new MessageVerifier("test-secret", { digest: "sha256", url_safe: true });
-  const person = (id: unknown = 5) => ({ id, constructor: { name: "Person" } });
+  const person = { id: 5, constructor: { name: "Person" } };
 
   beforeEach(() => setApp("bcx"));
   afterEach(() => _resetApp());
@@ -26,7 +21,7 @@ describe("SignedGlobalID pick_purpose explicit-null semantics", () => {
   });
 
   it("an SGID signed with for: null does not verify against the default purpose", () => {
-    const sgid = SignedGlobalID.create(person(5), { verifier, for: null });
+    const sgid = SignedGlobalID.create(person, { verifier, for: null });
     expect(sgid.purpose).toBeNull();
     expect(SignedGlobalID.parse(sgid.toString(), { verifier })).toBeNull();
     expect(SignedGlobalID.parse(sgid.toString(), { verifier, for: null })?.uri).toBe(sgid.uri);

--- a/packages/globalid/src/signed-global-id.ts
+++ b/packages/globalid/src/signed-global-id.ts
@@ -31,8 +31,8 @@ let _classExpiresIn: number | null | undefined;
 
 export interface SignedGlobalIDOptions {
   app?: string;
-  /** Rails-canonical purpose option (`options.fetch :for, DEFAULT_PURPOSE`). */
-  for?: string;
+  /** Rails-canonical purpose option (`options.fetch :for, DEFAULT_PURPOSE`). Explicit `null` disables purpose verification (Rails: `for: nil`). */
+  for?: string | null;
   /** Number of seconds until expiration. `null` explicitly disables expiration (Rails: `expires_in: nil`). */
   expiresIn?: number | null;
   /** Explicit expiration time. `null` explicitly disables expiration (Rails: `expires_at: nil`). */
@@ -50,15 +50,15 @@ export interface SignedGlobalIDOptions {
  * and can't embed `app` or arbitrary extra URI params.
  */
 export interface FromUriOptions {
-  for?: string;
+  for?: string | null;
   expiresIn?: number | null;
   expiresAt?: Temporal.Instant | null;
   verifier?: MessageVerifier;
 }
 
 export interface ParseOptions {
-  /** Rails-canonical purpose option (`options.fetch :for, DEFAULT_PURPOSE`). */
-  for?: string;
+  /** Rails-canonical purpose option (`options.fetch :for, DEFAULT_PURPOSE`). Explicit `null` disables purpose verification (Rails: `for: nil`). */
+  for?: string | null;
   /** Optional — falls back to `SignedGlobalID.verifier` when omitted. */
   verifier?: MessageVerifier;
 }
@@ -69,14 +69,14 @@ export class ExpiredMessage extends Error {}
 /** @internal */
 interface SgidPayload {
   gid: string;
-  purpose: string;
+  purpose: string | null;
   expires_at: string | null;
 }
 
 export class SignedGlobalID {
   /** The raw GID URI string, e.g. `gid://MyApp/User/1` */
   readonly uri: string;
-  readonly purpose: string;
+  readonly purpose: string | null;
   readonly expiresAt: Temporal.Instant | undefined;
 
   private readonly verifier: MessageVerifier;
@@ -87,7 +87,7 @@ export class SignedGlobalID {
 
   private constructor(
     uri: string,
-    purpose: string,
+    purpose: string | null,
     expiresAt: Temporal.Instant | undefined,
     verifier: MessageVerifier,
   ) {
@@ -203,9 +203,14 @@ export class SignedGlobalID {
     return v;
   }
 
-  /** Mirrors: SignedGlobalID.pick_purpose. */
-  static pickPurpose(options: { for?: string }): string {
-    return options.for ?? DEFAULT_PURPOSE;
+  /**
+   * Mirrors: SignedGlobalID.pick_purpose. Ruby's `options.fetch :for,
+   * DEFAULT_PURPOSE` is key-present: an explicit `for: nil` yields a nil
+   * purpose (purpose verification disabled), so only an absent/undefined
+   * key takes the default.
+   */
+  static pickPurpose(options: { for?: string | null }): string | null {
+    return options.for !== undefined ? options.for : DEFAULT_PURPOSE;
   }
 
   // ─── Verify dispatch (Rails private class methods) ────────────────────────

--- a/packages/globalid/src/signed-global-id.ts
+++ b/packages/globalid/src/signed-global-id.ts
@@ -31,7 +31,7 @@ let _classExpiresIn: number | null | undefined;
 
 export interface SignedGlobalIDOptions {
   app?: string;
-  /** Rails-canonical purpose option (`options.fetch :for, DEFAULT_PURPOSE`). Explicit `null` disables purpose verification (Rails: `for: nil`). */
+  /** Rails-canonical purpose option (`options.fetch :for, DEFAULT_PURPOSE`). */
   for?: string | null;
   /** Number of seconds until expiration. `null` explicitly disables expiration (Rails: `expires_in: nil`). */
   expiresIn?: number | null;
@@ -57,7 +57,7 @@ export interface FromUriOptions {
 }
 
 export interface ParseOptions {
-  /** Rails-canonical purpose option (`options.fetch :for, DEFAULT_PURPOSE`). Explicit `null` disables purpose verification (Rails: `for: nil`). */
+  /** Rails-canonical purpose option (`options.fetch :for, DEFAULT_PURPOSE`). */
   for?: string | null;
   /** Optional — falls back to `SignedGlobalID.verifier` when omitted. */
   verifier?: MessageVerifier;
@@ -203,12 +203,7 @@ export class SignedGlobalID {
     return v;
   }
 
-  /**
-   * Mirrors: SignedGlobalID.pick_purpose. Ruby's `options.fetch :for,
-   * DEFAULT_PURPOSE` is key-present: an explicit `for: nil` yields a nil
-   * purpose (purpose verification disabled), so only an absent/undefined
-   * key takes the default.
-   */
+  /** Mirrors: SignedGlobalID.pick_purpose. */
   static pickPurpose(options: { for?: string | null }): string | null {
     return options.for !== undefined ? options.for : DEFAULT_PURPOSE;
   }

--- a/packages/globalid/src/verifier.ts
+++ b/packages/globalid/src/verifier.ts
@@ -17,12 +17,15 @@ export class Verifier {
   }
 
   /** Sign and serialize `data` into a URL-safe token. */
-  generate(data: unknown, options?: { purpose?: string; expiresAt?: Temporal.Instant }): string {
+  generate(
+    data: unknown,
+    options?: { purpose?: string | null; expiresAt?: Temporal.Instant },
+  ): string {
     return this.inner.generate(data, options);
   }
 
   /** Verify a token and return the decoded payload, or null on invalid signature. */
-  verified(message: string, options?: { purpose?: string }): unknown {
+  verified(message: string, options?: { purpose?: string | null }): unknown {
     return this.inner.verified(message, options);
   }
 

--- a/packages/rack/src/deflater.trails.test.ts
+++ b/packages/rack/src/deflater.trails.test.ts
@@ -1,0 +1,15 @@
+import { it, expect } from "vitest";
+import { Deflater } from "./deflater.js";
+
+const app = async () => [200, {}, ["hi"]] as [number, Record<string, any>, any];
+
+// Trails-only coverage: Ruby's `@sync = options.fetch(:sync, true)`
+// (deflater.rb:43) is key-present — an explicit `sync: nil` stays nil
+// (falsy, streaming sync off). The upstream suite only exercises
+// `sync: false`, and the earlier `opts.sync !== false` port coerced every
+// non-false value (including null) to true, so we pin the stored value here.
+it("honors an explicit sync: null as falsy instead of defaulting to true", () => {
+  expect((new Deflater(app, { sync: null }) as any).sync).toBeNull();
+  expect((new Deflater(app, {}) as any).sync).toBe(true);
+  expect((new Deflater(app, { sync: false }) as any).sync).toBe(false);
+});

--- a/packages/rack/src/deflater.trails.test.ts
+++ b/packages/rack/src/deflater.trails.test.ts
@@ -3,11 +3,6 @@ import { Deflater } from "./deflater.js";
 
 const app = async () => [200, {}, ["hi"]] as [number, Record<string, any>, any];
 
-// Trails-only coverage: Ruby's `@sync = options.fetch(:sync, true)`
-// (deflater.rb:43) is key-present — an explicit `sync: nil` stays nil
-// (falsy, streaming sync off). The upstream suite only exercises
-// `sync: false`, and the earlier `opts.sync !== false` port coerced every
-// non-false value (including null) to true, so we pin the stored value here.
 it("honors an explicit sync: null as falsy instead of defaulting to true", () => {
   expect((new Deflater(app, { sync: null }) as any).sync).toBeNull();
   expect((new Deflater(app, {}) as any).sync).toBe(true);

--- a/packages/rack/src/deflater.ts
+++ b/packages/rack/src/deflater.ts
@@ -9,7 +9,8 @@ export interface DeflaterOptions {
     headers: Record<string, any>,
     body: any,
   ) => boolean;
-  sync?: boolean;
+  /** Explicit `null` is honored (falsy — streaming sync off), matching Ruby's key-present `options.fetch(:sync, true)`. */
+  sync?: boolean | null;
 }
 
 export class Deflater {
@@ -23,13 +24,15 @@ export class Deflater {
         body: any,
       ) => boolean)
     | null;
-  private sync: boolean;
+  private sync: boolean | null;
 
   constructor(app: any, opts: DeflaterOptions = {}) {
     this.app = app;
     this.include = opts.include || null;
     this.condition = opts.if || null;
-    this.sync = opts.sync !== false;
+    // Ruby: `@sync = options.fetch(:sync, true)` — key-present semantics, so
+    // an explicit null stays null (falsy); only an absent key takes the default.
+    this.sync = opts.sync !== undefined ? opts.sync : true;
   }
 
   async call(env: Record<string, any>): Promise<[number, Record<string, any>, any]> {

--- a/packages/rack/src/deflater.ts
+++ b/packages/rack/src/deflater.ts
@@ -9,7 +9,6 @@ export interface DeflaterOptions {
     headers: Record<string, any>,
     body: any,
   ) => boolean;
-  /** Explicit `null` is honored (falsy — streaming sync off), matching Ruby's key-present `options.fetch(:sync, true)`. */
   sync?: boolean | null;
 }
 
@@ -30,8 +29,6 @@ export class Deflater {
     this.app = app;
     this.include = opts.include || null;
     this.condition = opts.if || null;
-    // Ruby: `@sync = options.fetch(:sync, true)` — key-present semantics, so
-    // an explicit null stays null (falsy); only an absent key takes the default.
     this.sync = opts.sync !== undefined ? opts.sync : true;
   }
 

--- a/scripts/api-compare/call-mismatches-wide-exclude/globalid/signed-global-id.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/globalid/signed-global-id.json
@@ -32,7 +32,7 @@
     "tsFile": "signed-global-id.ts",
     "rubyName": "pick_purpose",
     "call": "fetch",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails signed_global_id.rb:24-26 uses `options.fetch :for, DEFAULT_PURPOSE` — key-present semantics, so an explicit `for: nil` yields a nil purpose; trails signed-global-id.ts:207-209 uses `options.for ?? DEFAULT_PURPOSE`, which coerces an explicit null back to the default. Divergence tracked in story fetch-nil-presence-divergences-globalid-rack."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails signed_global_id.rb:24-26 uses `options.fetch :for, DEFAULT_PURPOSE` — key-present semantics; trails pickPurpose mirrors it with `options.for !== undefined ? options.for : DEFAULT_PURPOSE`, so an explicit `for: null` yields a null purpose and only an absent key takes the default. Converged; no Hash#fetch analogue in TS, hence the flagged call."
   },
   {
     "package": "globalid",

--- a/scripts/api-compare/call-mismatches-wide-exclude/rack/deflater.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/rack/deflater.json
@@ -67,7 +67,7 @@
     "tsFile": "deflater.ts",
     "rubyName": "initialize",
     "call": "fetch",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails deflater.rb:39-44 stores `@sync = options.fetch(:sync, true)` — key-present semantics, so `sync: nil` stays nil (falsy); trails deflater.ts:28-33 uses `opts.sync !== false`, which coerces every non-false value (including null) to true. Divergence tracked in story fetch-nil-presence-divergences-globalid-rack."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails deflater.rb:39-44 stores `@sync = options.fetch(:sync, true)` — key-present semantics; trails mirrors it with `opts.sync !== undefined ? opts.sync : true`, so an explicit `sync: null` stays null (falsy) and only an absent key takes the default. Converged; no Hash#fetch analogue in TS, hence the flagged call."
   },
   {
     "package": "rack",


### PR DESCRIPTION
Ruby `Hash#fetch(key, default)` applies the default only when the KEY IS ABSENT — an explicitly supplied nil is returned as nil. Two trails ports collapsed that distinction (found by Codex review on PR #5096):

- **`SignedGlobalID.pickPurpose`** (Rails `signed_global_id.rb:24-26`, `options.fetch :for, DEFAULT_PURPOSE`): trails used `options.for ?? DEFAULT_PURPOSE`, coercing an explicit `for: null` back to the default purpose. Now a key-present check — explicit `null` yields a null purpose (purpose verification disabled), matching Rails. Purpose/option types widened to `string | null` through `SignedGlobalID`, `Verifier`, and `MessageVerifier` options.
- **`Rack::Deflater#initialize`** (Rails `deflater.rb:43`, `@sync = options.fetch(:sync, true)`): trails used `opts.sync !== false`, coercing every non-false value (including `null`) to `true`. Now `opts.sync !== undefined ? opts.sync : true` — explicit `null` stays null (falsy).

Regression tests live in new `*.trails.test.ts` files (upstream suites have no explicit-nil coverage); all three new behavioral assertions fail on the baseline sources. The two per-entry wide-exclude reasons are updated to converged wording.

Closes-story: fetch-nil-presence-divergences-globalid-rack
