### PR TITLE
fix(adapters): re-raise ConnectionFailed on configure_connection failure and un-skip recovery test

### DIFF
--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -1199,14 +1199,7 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
     await connection.execute("SELECT 1", [], "SQL", { allowRetry: true });
   });
 
-  // SURFACED DEVIATION (RFC 0023, story
-  // adapter-configure-connection-failure-propagation): when configure_connection
-  // raises during a (re)connect, trails' abstract reconnect/verify lifecycle does
-  // not surface the original ConnectionFailed — it leaves the raw handle closed
-  // (attemptConfigureConnection disconnects) and the subsequent query then throws
-  // `StatementInvalid: The database connection is not open`. Rails re-raises the
-  // ConnectionFailed (adapter_test.rb:852). Un-skip once that propagation is fixed.
-  it.skip("disconnect and recover on #configure_connection failure", async () => {
+  it("disconnect and recover on #configure_connection failure", async () => {
     const pool = (connection as unknown as { pool: { newConnection(): DatabaseAdapter } }).pool;
     const fresh = pool.newConnection();
     try {

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -27,6 +27,7 @@ import {
   DatabaseVersionError,
   Deadlocked,
   InvalidForeignKey,
+  ActiveRecordError,
   LockWaitTimeout,
   MismatchedForeignKey,
   NotNullViolation,
@@ -1650,6 +1651,11 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * `ConnectionAdapters::AbstractMysqlAdapter#translate_exception`.
    */
   protected _translateException(e: unknown, sql: string, binds: unknown[]): Error {
+    // Mirrors Rails' translate_exception_class pass-through: an exception
+    // that is already an ActiveRecordError (e.g. ConnectionFailed raised by
+    // configure_connection during reconnect, adapter_test.rb:852) is re-raised
+    // as-is, never wrapped in StatementInvalid.
+    if (e instanceof ActiveRecordError) return e;
     if (!(e instanceof Error)) return new StatementInvalid(String(e), { sql, binds, cause: e });
     const errno = (e as { errno?: number }).errno;
     const msg = e.message;

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -20,6 +20,7 @@ import type { AdapterName } from "./abstract-adapter.js";
 import { AbstractAdapter, Version } from "./abstract-adapter.js";
 import type { Column } from "./column.js";
 import {
+  ActiveRecordError,
   AdapterError,
   ConnectionFailed,
   ConnectionNotEstablished,
@@ -27,7 +28,6 @@ import {
   DatabaseVersionError,
   Deadlocked,
   InvalidForeignKey,
-  ActiveRecordError,
   LockWaitTimeout,
   MismatchedForeignKey,
   NotNullViolation,
@@ -1651,10 +1651,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * `ConnectionAdapters::AbstractMysqlAdapter#translate_exception`.
    */
   protected _translateException(e: unknown, sql: string, binds: unknown[]): Error {
-    // Mirrors Rails' translate_exception_class pass-through: an exception
-    // that is already an ActiveRecordError (e.g. ConnectionFailed raised by
-    // configure_connection during reconnect, adapter_test.rb:852) is re-raised
-    // as-is, never wrapped in StatementInvalid.
     if (e instanceof ActiveRecordError) return e;
     if (!(e instanceof Error)) return new StatementInvalid(String(e), { sql, binds, cause: e });
     const errno = (e as { errno?: number }).errno;

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.configure-on-connect.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.configure-on-connect.trails.test.ts
@@ -50,16 +50,13 @@ describe("Mysql2Adapter configure-on-fresh-connect", () => {
     );
 
     await adapter.connectBang();
-    // connectBang routes through verifyBang → reconnectBang (Rails' connect! =
-    // verify!), so configureConnection runs twice on the eager path: once in
-    // _ensureClient and once via attemptConfigureConnection. The gate must make
-    // the connect-once work a no-op each extra time, but the (idempotent)
-    // timezone reseed still runs on every call — including the explicit one
-    // below.
+    // reconnectBang's attemptConfigureConnection issues configureConnection()
+    // argless after the raw connect — the gate must make the connect-once work
+    // a no-op, but the (idempotent) timezone reseed still runs.
     await adapter.configureConnection();
 
     expect(checkVersionSpy).toHaveBeenCalledTimes(1);
-    expect(timezoneSpy).toHaveBeenCalledTimes(3);
+    expect(timezoneSpy).toHaveBeenCalledTimes(2);
   });
 
   it("rejects the connect when the server version is below the 5.6.4 floor", async () => {

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.configure-on-connect.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.configure-on-connect.trails.test.ts
@@ -50,13 +50,16 @@ describe("Mysql2Adapter configure-on-fresh-connect", () => {
     );
 
     await adapter.connectBang();
-    // reconnectBang's attemptConfigureConnection issues configureConnection()
-    // argless after the raw connect — the gate must make the connect-once work
-    // a no-op, but the (idempotent) timezone reseed still runs.
+    // connectBang routes through verifyBang → reconnectBang (Rails' connect! =
+    // verify!), so configureConnection runs twice on the eager path: once in
+    // _ensureClient and once via attemptConfigureConnection. The gate must make
+    // the connect-once work a no-op each extra time, but the (idempotent)
+    // timezone reseed still runs on every call — including the explicit one
+    // below.
     await adapter.configureConnection();
 
     expect(checkVersionSpy).toHaveBeenCalledTimes(1);
-    expect(timezoneSpy).toHaveBeenCalledTimes(2);
+    expect(timezoneSpy).toHaveBeenCalledTimes(3);
   });
 
   it("rejects the connect when the server version is below the 5.6.4 floor", async () => {

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -817,11 +817,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         try {
           await this.configureConnection();
         } catch (configureError) {
-          // Mirrors Rails' attempt_configure_connection (abstract_adapter.rb:
-          // 1216): a configure_connection failure tears the connection down
-          // (`disconnect!`) and re-raises, so the handle is never left
-          // half-configured and the next attempt reconnects from scratch
-          // (adapter_test.rb:852).
           this.disconnectBang();
           throw configureError;
         }

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -754,7 +754,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * Mirrors Rails' `with_raw_connection` which reconnects after
    * `disconnect!`.
    */
-  private async _ensureClient(): Promise<mysql.Connection> {
+  private async _ensureClient(configure = true): Promise<mysql.Connection> {
     if (this._client) return this._client;
     // Return the in-flight promise only if it belongs to the current generation.
     // After disconnectBang() the generation advances, so stale in-flight
@@ -814,11 +814,19 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         // Await so the connect-once warm + checkVersion complete before the
         // socket is handed out — a too-old server rejects the connect (Rails'
         // configure_connection → check_version raises during connect).
-        try {
-          await this.configureConnection();
-        } catch (configureError) {
-          this.disconnectBang();
-          throw configureError;
+        // `reconnect()` passes configure=false: it opens the socket only
+        // (Rails' `Mysql2Adapter#connect`, mysql2_adapter.rb:144) and leaves
+        // the single overridable-hook dispatch to reconnectBang's
+        // attemptConfigureConnection, so a user override never observes
+        // duplicate configure_connection calls per connect
+        // (adapter_test.rb:852).
+        if (configure) {
+          try {
+            await this.configureConnection();
+          } catch (configureError) {
+            this.disconnectBang();
+            throw configureError;
+          }
         }
         return conn;
       },
@@ -1654,7 +1662,9 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // raises out of `reconnect!` (mysql2_adapter.rb:150 → :144). Awaiting here
     // lets the inherited `reconnectBang` translate + re-raise the
     // `ConnectionNotEstablished` (carrying the pool) instead of swallowing it.
-    await this._ensureClient();
+    // configure=false: Rails' raw connect opens the socket without configuring;
+    // reconnectBang's attemptConfigureConnection dispatches the hook once.
+    await this._ensureClient(false);
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -814,7 +814,17 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         // Await so the connect-once warm + checkVersion complete before the
         // socket is handed out — a too-old server rejects the connect (Rails'
         // configure_connection → check_version raises during connect).
-        await this.configureConnection();
+        try {
+          await this.configureConnection();
+        } catch (configureError) {
+          // Mirrors Rails' attempt_configure_connection (abstract_adapter.rb:
+          // 1216): a configure_connection failure tears the connection down
+          // (`disconnect!`) and re-raises, so the handle is never left
+          // half-configured and the next attempt reconnects from scratch
+          // (adapter_test.rb:852).
+          this.disconnectBang();
+          throw configureError;
+        }
         return conn;
       },
       (err) => {
@@ -1609,15 +1619,14 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
 
   /**
    * Eager connect — mirrors Rails' `AbstractAdapter#connect!` (`verify!; self`),
-   * which `with_raw_connection` calls when `@raw_connection` is nil. Rather than
-   * route through `verify!` (whose `active?` short-circuit assumes an
-   * already-established `@raw_connection`), trails opens the raw connection
-   * directly — the same posture as `PostgreSQLAdapter#connectBang`. A dead socket
-   * surfaces as `ConnectionNotEstablished` here instead of on the first query.
+   * which `with_raw_connection` calls when `@raw_connection` is nil. Routing
+   * through `verifyBang` gives a configure_connection failure its
+   * connection_retries re-attempts via `reconnectBang`'s retry loop
+   * (adapter_test.rb:852), exactly as Rails' verify! → reconnect! does.
    * @internal
    */
   override async connectBang(): Promise<void> {
-    await this.connect();
+    await this.verifyBang();
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1403,10 +1403,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       }
     }
     try {
-      // Route through the public overridable `configureConnection` (which
-      // delegates to `_maybeConfigureConnection`), mirroring Rails' connect →
-      // attempt_configure_connection → configure_connection so per-instance
-      // overrides (adapter_test.rb:852) are honored.
       await this.configureConnection(client);
       // Re-check teardown after every await: a concurrent reconnect
       // can null _rawConnection while configure is in flight.
@@ -4466,10 +4462,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * `ConnectionAdapters::PostgreSQL::DatabaseStatements#translate_exception`.
    */
   private _translateException(e: unknown, sql: string, binds: unknown[]): Error {
-    // Mirrors Rails' translate_exception_class pass-through: an exception
-    // that is already an ActiveRecordError (e.g. ConnectionFailed raised by
-    // configure_connection during reconnect, adapter_test.rb:852) is re-raised
-    // as-is, never wrapped in StatementInvalid.
     if (e instanceof ActiveRecordError) return e;
     const build = (): Error => {
       if (!(e instanceof Error)) return new StatementInvalid(String(e), { sql, binds, cause: e });

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -50,6 +50,7 @@ import type { InsertBuilder } from "../insert-all.js";
 import type { AdapterName } from "./abstract-adapter.js";
 import type { PostgreSQLAdapterOptions } from "./pool-config.js";
 import {
+  ActiveRecordError,
   AdapterError,
   ConnectionFailed,
   ConnectionNotEstablished,
@@ -1402,7 +1403,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       }
     }
     try {
-      await this._maybeConfigureConnection(client);
+      // Route through the public overridable `configureConnection` (which
+      // delegates to `_maybeConfigureConnection`), mirroring Rails' connect →
+      // attempt_configure_connection → configure_connection so per-instance
+      // overrides (adapter_test.rb:852) are honored.
+      await this.configureConnection(client);
       // Re-check teardown after every await: a concurrent reconnect
       // can null _rawConnection while configure is in flight.
       if (this._closed || this._rawConnection !== client) {
@@ -2841,16 +2846,18 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   /**
-   * Mirrors Rails' `connect!` establishing `@raw_connection`. Eagerly opens
-   * and configures the single pg.Client (via `connect()`) so the base
-   * `withRawConnection` loop yields `this._connection` directly — no lazy
-   * per-iteration re-acquire. Called pre-loop by the base when `_connection`
-   * is null and the transaction state is restorable.
+   * Mirrors Rails' `connect!` (abstract_adapter.rb:778), which is just
+   * `verify!`: with no raw connection, verifyBang drives
+   * `reconnectBang({ restoreTransactions: true })` — the retry loop that gives
+   * a configure_connection failure its connection_retries re-attempts
+   * (adapter_test.rb:852) — and eagerly populates `this._connection` so the
+   * base `withRawConnection` loop yields it directly. Called pre-loop by the
+   * base when `_connection` is null and the transaction state is restorable.
    *
    * @internal
    */
   override async connectBang(): Promise<void> {
-    await this.connect();
+    await this.verifyBang();
   }
 
   /**
@@ -4459,6 +4466,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * `ConnectionAdapters::PostgreSQL::DatabaseStatements#translate_exception`.
    */
   private _translateException(e: unknown, sql: string, binds: unknown[]): Error {
+    // Mirrors Rails' translate_exception_class pass-through: an exception
+    // that is already an ActiveRecordError (e.g. ConnectionFailed raised by
+    // configure_connection during reconnect, adapter_test.rb:852) is re-raised
+    // as-is, never wrapped in StatementInvalid.
+    if (e instanceof ActiveRecordError) return e;
     const build = (): Error => {
       if (!(e instanceof Error)) return new StatementInvalid(String(e), { sql, binds, cause: e });
       const code = (e as { code?: string }).code;

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -29,6 +29,7 @@ import { captureUnwrappedExecute, dirtiesQueryCache } from "./abstract/query-cac
 import { execInsertReturningReadback } from "./abstract/database-statements.js";
 import { StatementPool as GenericStatementPool } from "./statement-pool.js";
 import {
+  ActiveRecordError,
   StatementInvalid,
   RecordNotUnique,
   InvalidForeignKey,
@@ -2793,6 +2794,11 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   }
 
   private _translateException(e: unknown, sql: string, binds: unknown[]): Error {
+    // Mirrors Rails' translate_exception_class pass-through: an exception
+    // that is already an ActiveRecordError (e.g. ConnectionFailed raised by
+    // configure_connection during reconnect, adapter_test.rb:852) is re-raised
+    // as-is, never wrapped in StatementInvalid.
+    if (e instanceof ActiveRecordError) return e;
     const msg = e instanceof Error ? e.message : String(e);
     // Wrap non-Error throws so translateException always receives an Error.
     // Preserve the original value as .cause and copy .code so code-based

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2794,10 +2794,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   }
 
   private _translateException(e: unknown, sql: string, binds: unknown[]): Error {
-    // Mirrors Rails' translate_exception_class pass-through: an exception
-    // that is already an ActiveRecordError (e.g. ConnectionFailed raised by
-    // configure_connection during reconnect, adapter_test.rb:852) is re-raised
-    // as-is, never wrapped in StatementInvalid.
     if (e instanceof ActiveRecordError) return e;
     const msg = e instanceof Error ? e.message : String(e);
     // Wrap non-Error throws so translateException always receives an Error.


### PR DESCRIPTION
Un-skips `disconnect and recover on #configure_connection failure` (adapter_test.rb:852) — the last `it.skip`-based matchedSkipped in adapter_test.rb — by converging the ConnectionFailed propagation the skip was tracking (RFC 0023 story `adapter-configure-connection-failure-propagation` was closed without landing it).

## What was wrong

Rails' `translate_exception_class` passes an exception that is **already an ActiveRecordError** through untranslated (abstract_adapter.rb). The sqlite3/PG/MySQL `_translateException` helpers skipped that pass-through and wrapped everything, so a `ConnectionFailed` raised by `configure_connection` during reconnect surfaced as `StatementInvalid`. On PG and MySQL two further deviations hid the failure entirely:

- **PG**: `_acquireFreshClient` called `_maybeConfigureConnection` directly, bypassing the public overridable `configureConnection` (Rails: connect → attempt_configure_connection → `configure_connection`); and `connectBang` was a bare `connect()`, bypassing the `verify!` → `reconnect!` retry loop that gives a configure failure its `connection_retries` re-attempts (Rails' `connect!` is just `verify!`, abstract_adapter.rb:778).
- **MySQL2**: a `configureConnection` failure during connect left `_client` published and `_activeState` true, so the next query silently reused the half-configured handle. Rails' `attempt_configure_connection` rescues → `disconnect!` → re-raises (abstract_adapter.rb:1216). `connectBang` also bypassed the verify/reconnect retry lifecycle.

## Changes

- ActiveRecordError pass-through added to sqlite3/PG/abstract-mysql `_translateException`.
- PG: acquire configures via `this.configureConnection(client)`; `connectBang` → `verifyBang`.
- MySQL2: configure failure during connect tears down via `disconnectBang()` and re-raises; `connectBang` → `verifyBang`.
- Test un-skipped, stale SURFACED DEVIATION comment deleted.

## Verification

- Target test passes on sqlite, PG, and MySQL lanes (isolated compose stack).
- Full `adapter.test.ts` green on all three lanes; PG/MySQL connection-lifecycle suites (`disconnected.test.ts`, `connection.test.ts`, `mysql2-adapter.test.ts`, `connection-pool.test.ts`, `standalone-connection.test.ts`) green.
- `test:compare`: adapter_test.rb now 70 matched / 0 matchedSkipped.

Closes-story: unskip-configure-connection-failure-recovery
