### PR TITLE
refactor(activerecord): defer find-path id casting to the bind, remove Base._castAttributeValue

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -3420,20 +3420,18 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
 
     // Cast incoming ids through the target model's attribute types so
     // in-memory find matches Relation.find's WHERE-condition casting
-    // (e.g. proxy.find("1") on an integer PK). For composite keys,
-    // cast each tuple element by its PK column.
-    const castFn = (
-      targetModel as typeof Base & {
-        _castAttributeValue?: (attributeName: string, value: unknown) => unknown;
-      }
-    )._castAttributeValue;
+    // (e.g. proxy.find("1") on an integer PK — the DB path's QueryAttribute
+    // bind casts at compile time, so the loaded-target path must cast too).
+    // For composite keys, cast each tuple element by its PK column.
+    const typeFor = (col: string): { cast(value: unknown): unknown } =>
+      targetModel.typeForAttribute(col);
     const castId = (id: unknown): unknown => {
       if (composite) {
         const cols = pk;
         const values = id as unknown[];
-        return castFn ? cols.map((c, i) => castFn.call(targetModel, c, values[i])) : values;
+        return cols.map((c, i) => typeFor(c).cast(values[i]));
       }
-      return castFn ? castFn.call(targetModel, pk, id) : id;
+      return typeFor(pk).cast(id);
     };
 
     // Index records by PK once — O(records + ids) instead of

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2284,23 +2284,6 @@ export class Base extends Model {
 
   // -- Finders (class methods) --
 
-  /** @internal Cast a value through its attribute's adapter-resolved type. */
-  static _castAttributeValue(key: string, value: unknown): unknown {
-    if (typeof value !== "string") return value;
-    let def = this._attributeDefinitions.get(key);
-    if (!def && typeof this.primaryKey === "string" && key === this.primaryKey) {
-      // Mirror Rails: `find` casts the id through the column type that
-      // `load_schema!` always populates (model_schema.rb load_schema!). The
-      // schema cache is always warm (RFC 0031), so this sync (re)load reflects
-      // the PK's real adapter-resolved type, keeping input-cast aligned with
-      // the read path (PG int8→BigInt, not number) without a DB query.
-      (ModelSchema.loadSchema as any).call(this);
-      def = this._attributeDefinitions.get(key);
-    }
-    if (def) return def.type.cast(value);
-    return value;
-  }
-
   // Overloads match Rails' behavior:
   //   find(id)          → single record
   //   find([id, ...])   → array of records (plural PK)

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -412,7 +412,7 @@ interface CoreHost {
   arelTable?: any;
   prototype: any;
   all(): any;
-  _castAttributeValue(key: string, value: unknown): unknown;
+  typeForAttribute(name: string): { cast(value: unknown): unknown };
   ensureSchemaLoaded(): Promise<void>;
 }
 
@@ -1006,9 +1006,10 @@ export async function find(this: CoreHost, ...ids: unknown[]): Promise<any> {
       // (not the aggregate "in [...]"), and a hit is wrapped back into a
       // 1-element array because `expects_array` is true.
       const single = compactedIds[0];
-      const castSingle = this._castAttributeValue(this.primaryKey as string, single);
+      // Rails find_one passes the id raw — `where(primary_key => id)`; the
+      // QueryAttribute bind owns casting at compile time (predicate_builder.rb).
       const record = await this.all()
-        .where({ [this.primaryKey as string]: castSingle })
+        .where({ [this.primaryKey as string]: single })
         .first();
       if (!record) {
         throw new RecordNotFound(
@@ -1020,10 +1021,15 @@ export async function find(this: CoreHost, ...ids: unknown[]): Promise<any> {
       }
       return [record];
     }
-    const castIds = compactedIds.map((i) => this._castAttributeValue(this.primaryKey as string, i));
+    // Rails find_some_ordered passes the ids raw to `where(primary_key => ids)`
+    // (the bind casts); only the in_order_of step below casts, via
+    // `ids.map { model.type_for_attribute(primary_key).cast(id) }`
+    // (finder_methods.rb:576).
     const records = await this.all()
-      .where({ [this.primaryKey as string]: castIds })
+      .where({ [this.primaryKey as string]: compactedIds })
       .toArray();
+    const pkType = this.typeForAttribute(this.primaryKey as string);
+    const castIds = compactedIds.map((i) => pkType.cast(i));
     // Key by pkMatchKey so a BigInt PK matches the number/string id passed in
     // (a raw-value Map would miss `1n` vs `1` and spuriously raise below).
     const idToRecord = new Map<unknown, any>();
@@ -1041,9 +1047,10 @@ export async function find(this: CoreHost, ...ids: unknown[]): Promise<any> {
     // in_order_of: return in input order
     return castIds.map((cid) => idToRecord.get(pkMatchKey(cid))!);
   }
-  const castId = this._castAttributeValue(this.primaryKey as string, id);
+  // Rails find_one: the id flows raw into `where(primary_key => id)` — the
+  // QueryAttribute bind casts/serializes at compile time (predicate_builder.rb).
   const record = await this.all()
-    .where({ [this.primaryKey as string]: castId })
+    .where({ [this.primaryKey as string]: id })
     .first();
   if (!record) {
     throw new RecordNotFound(

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -1006,8 +1006,6 @@ export async function find(this: CoreHost, ...ids: unknown[]): Promise<any> {
       // (not the aggregate "in [...]"), and a hit is wrapped back into a
       // 1-element array because `expects_array` is true.
       const single = compactedIds[0];
-      // Rails find_one passes the id raw — `where(primary_key => id)`; the
-      // QueryAttribute bind owns casting at compile time (predicate_builder.rb).
       const record = await this.all()
         .where({ [this.primaryKey as string]: single })
         .first();
@@ -1021,13 +1019,12 @@ export async function find(this: CoreHost, ...ids: unknown[]): Promise<any> {
       }
       return [record];
     }
-    // Rails find_some_ordered passes the ids raw to `where(primary_key => ids)`
-    // (the bind casts); only the in_order_of step below casts, via
-    // `ids.map { model.type_for_attribute(primary_key).cast(id) }`
-    // (finder_methods.rb:576).
     const records = await this.all()
       .where({ [this.primaryKey as string]: compactedIds })
       .toArray();
+    // Rails find_some_ordered casts only for the in_order_of mapping:
+    // `ids.map { model.type_for_attribute(primary_key).cast(id) }`
+    // (finder_methods.rb:576) — the WHERE ids stay raw for the bind to cast.
     const pkType = this.typeForAttribute(this.primaryKey as string);
     const castIds = compactedIds.map((i) => pkType.cast(i));
     // Key by pkMatchKey so a BigInt PK matches the number/string id passed in
@@ -1047,8 +1044,6 @@ export async function find(this: CoreHost, ...ids: unknown[]): Promise<any> {
     // in_order_of: return in input order
     return castIds.map((cid) => idToRecord.get(pkMatchKey(cid))!);
   }
-  // Rails find_one: the id flows raw into `where(primary_key => id)` — the
-  // QueryAttribute bind casts/serializes at compile time (predicate_builder.rb).
   const record = await this.all()
     .where({ [this.primaryKey as string]: id })
     .first();

--- a/packages/activerecord/src/finder.trails.test.ts
+++ b/packages/activerecord/src/finder.trails.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Trails-only finder pins (no Rails counterpart test names).
+ *
+ * Pins the find-path defer-to-bind casting: `find` passes the id raw into
+ * `where(primary_key => id)` (Rails core.rb / finder_methods.rb design) and
+ * the QueryAttribute bind owns the cast at compile time — so a PK slug like
+ * "1-foo" still resolves to id 1 through the bind's IntegerType cast, with no
+ * eager pre-cast on the find path.
+ */
+import { describe, it, expect } from "vitest";
+import "./index.js";
+import { registerModel } from "./associations.js";
+import { fixtures } from "./test-helpers/fixtures.js";
+import { Post } from "./test-helpers/models/post.js";
+
+registerModel(Post);
+
+describe("FinderTrailsTest", () => {
+  const { posts } = fixtures(["posts"]);
+
+  it("find with pk slug string casts through the bind", async () => {
+    const welcome = posts("welcome");
+    const found = await Post.find("1-foo");
+    expect(found.id).toStrictEqual(welcome.id);
+  });
+
+  it("find with array of pk slug strings casts through the bind", async () => {
+    const welcome = posts("welcome");
+    const thinking = posts("thinking");
+    const found = (await Post.find(["1-foo", "2-bar"])) as Post[];
+    expect(found.map((r) => r.id)).toStrictEqual([welcome.id, thinking.id]);
+  });
+});

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -22,13 +22,11 @@ function castInheritanceColumnValue(
 ): unknown {
   // Rails: type_for_attribute(inheritCol).cast(value) — handles non-string
   // inputs (numbers/booleans) by coercing through the column's type.
-  // Falls back to Base._castAttributeValue (string-only) for compatibility.
-  const attrType = modelClass.typeForAttribute(inheritCol) as {
-    cast(value: unknown): unknown;
-  } | null;
-  const casted = attrType
-    ? attrType.cast(value)
-    : modelClass._castAttributeValue(inheritCol, value);
+  // typeForAttribute is total (unknown names yield a Value-default type),
+  // so no fallback is needed.
+  const casted = (
+    modelClass.typeForAttribute(inheritCol) as { cast(value: unknown): unknown }
+  ).cast(value);
   if (casted == null) return casted;
   // Normalize to a primitive string (handles String wrapper objects) so
   // findStiClass downstream can match against modelRegistry keys.

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -22,8 +22,6 @@ function castInheritanceColumnValue(
 ): unknown {
   // Rails: type_for_attribute(inheritCol).cast(value) — handles non-string
   // inputs (numbers/booleans) by coercing through the column's type.
-  // typeForAttribute is total (unknown names yield a Value-default type),
-  // so no fallback is needed.
   const casted = (
     modelClass.typeForAttribute(inheritCol) as { cast(value: unknown): unknown }
   ).cast(value);

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1017,16 +1017,17 @@ export function loadSchema(this: SchemaHost): void {
 
   // Cache-miss path: with the schema cache always warm (RFC 0031), a
   // table-backed model reflects from the persistent cache entry above and
-  // returns — so the int8→BigInt PK divergence that the old `_castAttributeValue`
-  // parseInt fallback worried about cannot arise on this path. Reaching here
+  // returns — so the int8→BigInt PK divergence that the removed eager id
+  // pre-cast (`_castAttributeValue`) worried about cannot arise on this path.
+  // Reaching here
   // means a genuinely tableless attribute-only model (the synthesize fallback
   // below builds its `columnsHash` from declared attributes), which has no
   // adapter-resolved PK type at all. If such a model still lacks a typed
   // primary-key def, do NOT mark the load terminal: leaving `_schemaLoaded`
   // unset lets a later load replace the synthesized view with real reflected
-  // columns once a cache entry exists. `_castAttributeValue` returning the raw
-  // string id for a tableless model in the meantime is harmless — there is no
-  // DB column type to cast through.
+  // columns once a cache entry exists. The find path passing the raw string id
+  // to the bind for a tableless model in the meantime is harmless — there is
+  // no DB column type to cast through.
   let pkStillMissing = false;
   if (workHost._attributeDefinitions.size > 0) {
     const pks = Array.isArray(workHost.primaryKey)


### PR DESCRIPTION
## Summary

Removes `Base._castAttributeValue` — the find-path sibling of the eager
`where`-value pre-cast deleted in #5065 — so ids flow raw into
`where(primary_key => id)` and the QueryAttribute bind owns casting at compile
time, matching Rails' design (core.rb / finder_methods.rb,
predicate_builder.rb:57-69).

- `core.ts` find family: single-id and multi-id paths now pass raw ids to
  `where` (Rails `find_one` / `find_some_ordered`). The in-order-of mapping
  keeps Rails' one legitimate cast — `type_for_attribute(primary_key).cast(id)`
  (finder_methods.rb:576) — via `typeForAttribute`.
- `base.ts`: `_castAttributeValue` deleted, including its trails-only sync
  `ModelSchema.loadSchema` side effect on the query path.
- `inheritance.ts`: the STI discriminator fallback to `_castAttributeValue` was
  dead — `typeForAttribute` is total (unknown names yield a Value-default
  type) — so the helper now casts through `typeForAttribute` unconditionally,
  which is exactly Rails' `type_for_attribute(inheritCol).cast(value)`.
- `collection-proxy.ts` loaded-target `find`: routes its in-memory id cast
  through `typeForAttribute` directly (same cast the DB path's bind performs).
- New `finder.trails.test.ts` pins PK-slug ids (`"1-foo"`, single + array
  forms) resolving through the bind cast; int8→BigInt is already pinned by
  `bigint-roundtrip.test.ts`.

## Testing

- `finder.test.ts` (269), `relation/finder-methods.test.ts` (44),
  `inheritance.test.ts` (73), `collection-proxy.test.ts` (61),
  `bigint-roundtrip.test.ts`, `relation/where.test.ts` (slug pin),
  `preloader-bigint-number-key-match.test.ts` — all green.
- New `finder.trails.test.ts` (2) green.

Closes-story: find-path-cast-attribute-value-eager-precast-vs-rails-defer
