### PR TITLE
fix(activerecord): filter ignoredColumns at load time, mirroring Rails load_schema!

### DIFF
--- a/packages/activerecord/src/base.trails.test.ts
+++ b/packages/activerecord/src/base.trails.test.ts
@@ -362,6 +362,24 @@ describe("ignored columns follow Rails' value-keyed attribute set (trails)", () 
     ]).not.toContain("author_name");
   });
 
+  it("an STI subclass's own ignoredColumns does not read the base's columns memo", () => {
+    class Company extends Base {
+      static override tableName = "companies";
+      static {
+        this.inheritanceColumn = "type";
+      }
+    }
+    class Firm extends Company {
+      static {
+        this.ignoredColumns = ["rating"];
+      }
+    }
+    expect(Company.columns().map((c: { name: string }) => c.name)).toContain("rating");
+    expect(Firm.columns().map((c: { name: string }) => c.name)).not.toContain("rating");
+    expect(Firm.columnNames()).not.toContain("rating");
+    expect(Company.columns().map((c: { name: string }) => c.name)).toContain("rating");
+  });
+
   it("an ignored column still declared via attribute() casts and responds on SELECT *", async () => {
     const { AttributedDeveloper } = await import("./test-helpers/models/developer.js");
     const dev = await AttributedDeveloper.create();

--- a/packages/activerecord/src/model-schema-load.test.ts
+++ b/packages/activerecord/src/model-schema-load.test.ts
@@ -231,7 +231,10 @@ describe("loadSchemaFromAdapter integration details", () => {
     (Post as unknown as { adapter: unknown }).adapter = adapter;
     await Post.loadSchema();
 
-    expect((Post as unknown as { _columnsHash: unknown })._columnsHash).toBeUndefined();
+    // Rails load_schema! replaces @columns_hash with the freshly filtered hash
+    // (stale entry gone); @columns stays nil until `columns` derives it.
+    const columnsHash = (Post as unknown as { _columnsHash: Record<string, unknown> })._columnsHash;
+    expect(Object.keys(columnsHash)).toEqual(["guid"]);
     expect((Post as unknown as { _columns: unknown })._columns).toBeUndefined();
   });
 

--- a/packages/activerecord/src/model-schema-load.test.ts
+++ b/packages/activerecord/src/model-schema-load.test.ts
@@ -231,8 +231,6 @@ describe("loadSchemaFromAdapter integration details", () => {
     (Post as unknown as { adapter: unknown }).adapter = adapter;
     await Post.loadSchema();
 
-    // Rails load_schema! replaces @columns_hash with the freshly filtered hash
-    // (stale entry gone); @columns stays nil until `columns` derives it.
     const columnsHash = (Post as unknown as { _columnsHash: Record<string, unknown> })._columnsHash;
     expect(Object.keys(columnsHash)).toEqual(["guid"]);
     expect((Post as unknown as { _columns: unknown })._columns).toBeUndefined();

--- a/packages/activerecord/src/model-schema-sync-load.test.ts
+++ b/packages/activerecord/src/model-schema-sync-load.test.ts
@@ -274,8 +274,13 @@ describe("sync loadSchema / columnsHash", () => {
 
     Circle.columnsHash();
 
-    expect((Circle as unknown as { _columnsHash: unknown })._columnsHash).toBeUndefined();
-    expect((Circle as unknown as { _columns: unknown })._columns).toBeUndefined();
+    // The subclass's OWN stale caches are deleted so the base's freshly built
+    // (load-time-filtered) _columnsHash shines through via the prototype chain.
+    expect(Object.prototype.hasOwnProperty.call(Circle, "_columnsHash")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(Circle, "_columns")).toBe(false);
+    expect(
+      Object.keys((Circle as unknown as { _columnsHash: Record<string, unknown> })._columnsHash),
+    ).toEqual(["guid"]);
   });
 
   it("resetColumnInformation on STI subclass resets the STI base", () => {

--- a/packages/activerecord/src/model-schema-sync-load.test.ts
+++ b/packages/activerecord/src/model-schema-sync-load.test.ts
@@ -274,8 +274,6 @@ describe("sync loadSchema / columnsHash", () => {
 
     Circle.columnsHash();
 
-    // The subclass's OWN stale caches are deleted so the base's freshly built
-    // (load-time-filtered) _columnsHash shines through via the prototype chain.
     expect(Object.prototype.hasOwnProperty.call(Circle, "_columnsHash")).toBe(false);
     expect(Object.prototype.hasOwnProperty.call(Circle, "_columns")).toBe(false);
     expect(

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -205,10 +205,6 @@ export function buildWhereNodeFromConstraints(
  *
  * Mirrors: ActiveRecord::ModelSchema::ClassMethods#column_names
  * (`@column_names ||= columns.map(&:name).freeze`, model_schema.rb:478-480).
- * Reads `columnsHash()` keys rather than `columns()` because trails applies
- * the `ignoredColumns` filter at read time in `columnsHash()` (Rails filters
- * at load), and `columns()`' `_columns` memo would bypass it after an
- * `ignoredColumns=` reassignment.
  */
 export function columnNames(this: typeof Base): string[] {
   const host = this as unknown as SchemaHost;
@@ -216,7 +212,7 @@ export function columnNames(this: typeof Base): string[] {
     ? host._columnNamesMemo
     : undefined;
   if (memo && memo.revision === (host._schemaRevision ?? 0)) return memo.names as string[];
-  const names = Object.keys(this.columnsHash());
+  const names = this.columns().map((c: { name: string }) => c.name);
   if (host._schemaLoaded) {
     const frozen = Object.freeze(names);
     host._columnNamesMemo = { revision: host._schemaRevision ?? 0, names: frozen };
@@ -259,6 +255,19 @@ export interface ColumnLike {
 export function columnsHash(this: typeof Base): Record<string, ColumnLike> {
   // load_schema! raises TableNotSpecified for abstract (table-less) classes.
   loadSchema.call(this as SchemaHost);
+
+  // Load-time filtering (Rails load_schema!, model_schema.rb:587-594):
+  // loadSchema populated `_columnsHash` already filtered by `ignoredColumns`,
+  // so a read is just the memo — mirroring Rails' `load_schema unless
+  // @columns_hash; @columns_hash`. Exception: an STI subclass with its OWN
+  // `ignoredColumns` — the memo lives on the STI base, filtered by the base's
+  // set, so the subclass's set must still be honored at read time below.
+  const memoHost = this as unknown as SchemaHost;
+  const hasOwnIgnored =
+    isStiSubclass(this) && Object.prototype.hasOwnProperty.call(this, "_ignoredColumns");
+  if (!hasOwnIgnored && memoHost._columnsHash != null) {
+    return memoHost._columnsHash as Record<string, ColumnLike>;
+  }
 
   // STI-aware adapter + table resolution: adapter may live on the base
   // OR the concrete subclass. Use the same candidate-list logic the
@@ -1161,6 +1170,9 @@ function applyColumnsHash(
   }
 
   const ignored = new Set(host._ignoredColumns ?? []);
+  // Rails load_schema!: `@columns_hash = columns_hash.except(*ignored_columns)`
+  // — the filtered hash is built once here at load time and memoized below.
+  const filteredHash: Record<string, unknown> = {};
   for (const [name, column] of Object.entries(hash)) {
     if (ignored.has(name)) {
       // Remove the prototype accessor unconditionally so `name in record`
@@ -1184,6 +1196,7 @@ function applyColumnsHash(
       }
       continue;
     }
+    filteredHash[name] = column;
     const existing = host._attributeDefinitions.get(name);
     if (existing && (existing.userProvided ?? true)) {
       // A user-declared type override (e.g. an enum) preserves its type across
@@ -1294,6 +1307,10 @@ function applyColumnsHash(
   };
   invalidate(host, { deleteOwn: false });
   if (originatingHost && originatingHost !== host) invalidate(originatingHost, { deleteOwn: true });
+  // Rails load_schema! stores the filtered hash eagerly (`@columns_hash =
+  // columns_hash.except(*ignored_columns)`); `columns` derives lazily from it
+  // (`@columns ||= columns_hash.values`).
+  host._columnsHash = filteredHash;
 
   // Encryption still needs a post-reflection pass — not for type wrapping (the
   // durable decorator was pushed at declaration; `typeForAttribute` resolves it)
@@ -1628,10 +1645,11 @@ export function sequenceName(this: SchemaHost, value?: string | null): string | 
 
 export function ignoredColumns(this: SchemaHost, value?: string[]): string[] {
   if (value !== undefined) {
+    // Rails' ignored_columns= runs reload_schema_from_cache BEFORE storing the
+    // new list (model_schema.rb:366-368), so `columns`/`columns_hash`/
+    // `column_names` all rebuild against it on the next read.
+    reloadSchemaFromCache.call(this);
     this._ignoredColumns = value;
-    // Rails' ignored_columns= runs reload_schema_from_cache
-    // (model_schema.rb:366-368), which nils @attribute_names recursively.
-    clearAttributeNamesMemo(this);
     for (const col of value) {
       if (col in this.prototype) {
         Object.defineProperty(this.prototype, col, {
@@ -1739,13 +1757,41 @@ function initializeLoadSchemaMonitor(this: SchemaHost): void {
   // no-op: JS is single-threaded; no Monitor/Mutex needed
 }
 
-/** @internal */
+/**
+ * Mirrors Rails' `reload_schema_from_cache` (model_schema.rb:553-568): drop the
+ * class-level schema-derived memos on `this` and, recursively, its descendants
+ * so the next read re-runs `loadSchema` — which applies the `ignoredColumns`
+ * filter at load time (`applyColumnsHash`). Unlike `resetColumnInformation`,
+ * this does NOT clear the adapter's schema cache (Rails' reload reads from the
+ * still-warm cache — that's the "from_cache" in the name), so the next load
+ * re-reflects synchronously. Descendants get their own props DELETED (not
+ * assigned) so they re-inherit the freshly rebuilt caches via the prototype
+ * chain, matching the STI invalidation pattern in `resetColumnInformation`.
+ *
+ * @internal
+ */
 function reloadSchemaFromCache(this: SchemaHost, recursive = true): void {
-  resetColumnInformation.call(this);
-  if (recursive) {
-    const subclasses: SchemaHost[] = (this as any).subclasses ?? [];
-    for (const sub of subclasses) {
-      reloadSchemaFromCache.call(sub, true);
+  this._columnsHash = undefined;
+  this._columns = undefined;
+  this._attributesBuilder = undefined;
+  this._returningColumnsForInsertCache = undefined;
+  (this as { _cachedDefaultAttributes?: unknown })._cachedDefaultAttributes = null;
+  this._schemaLoaded = false;
+  (this as { _schemaLoadPromise?: unknown })._schemaLoadPromise = undefined;
+  // Rails nils @attribute_names recursively too.
+  clearAttributeNamesMemo(this);
+  if (!recursive) return;
+  const descendants = (this as { descendants?: SchemaHost[] }).descendants ?? [];
+  for (const sub of descendants) {
+    for (const key of [
+      "_columnsHash",
+      "_columns",
+      "_attributesBuilder",
+      "_returningColumnsForInsertCache",
+      "_cachedDefaultAttributes",
+      "_schemaLoaded",
+    ]) {
+      if (Object.prototype.hasOwnProperty.call(sub, key)) Reflect.deleteProperty(sub, key);
     }
   }
 }

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -256,12 +256,6 @@ export function columnsHash(this: typeof Base): Record<string, ColumnLike> {
   // load_schema! raises TableNotSpecified for abstract (table-less) classes.
   loadSchema.call(this as SchemaHost);
 
-  // Load-time filtering (Rails load_schema!, model_schema.rb:587-594):
-  // loadSchema populated `_columnsHash` already filtered by `ignoredColumns`,
-  // so a read is just the memo — mirroring Rails' `load_schema unless
-  // @columns_hash; @columns_hash`. Exception: an STI subclass with its OWN
-  // `ignoredColumns` — the memo lives on the STI base, filtered by the base's
-  // set, so the subclass's set must still be honored at read time below.
   const memoHost = this as unknown as SchemaHost;
   const hasOwnIgnored =
     isStiSubclass(this) && Object.prototype.hasOwnProperty.call(this, "_ignoredColumns");
@@ -1170,8 +1164,6 @@ function applyColumnsHash(
   }
 
   const ignored = new Set(host._ignoredColumns ?? []);
-  // Rails load_schema!: `@columns_hash = columns_hash.except(*ignored_columns)`
-  // — the filtered hash is built once here at load time and memoized below.
   const filteredHash: Record<string, unknown> = {};
   for (const [name, column] of Object.entries(hash)) {
     if (ignored.has(name)) {
@@ -1307,9 +1299,6 @@ function applyColumnsHash(
   };
   invalidate(host, { deleteOwn: false });
   if (originatingHost && originatingHost !== host) invalidate(originatingHost, { deleteOwn: true });
-  // Rails load_schema! stores the filtered hash eagerly (`@columns_hash =
-  // columns_hash.except(*ignored_columns)`); `columns` derives lazily from it
-  // (`@columns ||= columns_hash.values`).
   host._columnsHash = filteredHash;
 
   // Encryption still needs a post-reflection pass — not for type wrapping (the
@@ -1645,11 +1634,8 @@ export function sequenceName(this: SchemaHost, value?: string | null): string | 
 
 export function ignoredColumns(this: SchemaHost, value?: string[]): string[] {
   if (value !== undefined) {
-    // Rails' ignored_columns= runs reload_schema_from_cache BEFORE storing the
-    // new list (model_schema.rb:366-368), so `columns`/`columns_hash`/
-    // `column_names` all rebuild against it on the next read.
     reloadSchemaFromCache.call(this);
-    this._ignoredColumns = value;
+    this._ignoredColumns = value.map(String);
     for (const col of value) {
       if (col in this.prototype) {
         Object.defineProperty(this.prototype, col, {
@@ -1757,19 +1743,7 @@ function initializeLoadSchemaMonitor(this: SchemaHost): void {
   // no-op: JS is single-threaded; no Monitor/Mutex needed
 }
 
-/**
- * Mirrors Rails' `reload_schema_from_cache` (model_schema.rb:553-568): drop the
- * class-level schema-derived memos on `this` and, recursively, its descendants
- * so the next read re-runs `loadSchema` — which applies the `ignoredColumns`
- * filter at load time (`applyColumnsHash`). Unlike `resetColumnInformation`,
- * this does NOT clear the adapter's schema cache (Rails' reload reads from the
- * still-warm cache — that's the "from_cache" in the name), so the next load
- * re-reflects synchronously. Descendants get their own props DELETED (not
- * assigned) so they re-inherit the freshly rebuilt caches via the prototype
- * chain, matching the STI invalidation pattern in `resetColumnInformation`.
- *
- * @internal
- */
+/** @internal */
 function reloadSchemaFromCache(this: SchemaHost, recursive = true): void {
   this._columnsHash = undefined;
   this._columns = undefined;
@@ -1778,7 +1752,6 @@ function reloadSchemaFromCache(this: SchemaHost, recursive = true): void {
   (this as { _cachedDefaultAttributes?: unknown })._cachedDefaultAttributes = null;
   this._schemaLoaded = false;
   (this as { _schemaLoadPromise?: unknown })._schemaLoadPromise = undefined;
-  // Rails nils @attribute_names recursively too.
   clearAttributeNamesMemo(this);
   if (!recursive) return;
   const descendants = (this as { descendants?: SchemaHost[] }).descendants ?? [];

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -728,6 +728,9 @@ export function attributesBuilder(this: SchemaHost): AttributeSetBuilder {
  * Rails: @columns ||= columns_hash.values.freeze
  */
 export function columns(this: SchemaHost): any[] {
+  if (isStiSubclass(this) && Object.prototype.hasOwnProperty.call(this, "_ignoredColumns")) {
+    return Object.values((this as unknown as typeof Base).columnsHash());
+  }
   if (this._columns) return this._columns;
   loadSchema.call(this);
   const hash = getColumnsHash(this);
@@ -1480,6 +1483,8 @@ async function reflectColumnNames(host: SchemaHost): Promise<Set<string> | null>
           // keeps serving the pre-warm list.
           if (host._schemaLoaded) {
             host._schemaLoaded = false;
+            host._columnsHash = undefined;
+            host._columns = undefined;
             clearAttributeNamesMemo(host);
           }
           return new Set(names);

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/model-schema.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/model-schema.json
@@ -72,27 +72,6 @@
   {
     "package": "activerecord",
     "tsFile": "model-schema.ts",
-    "rubyName": "column_names",
-    "call": "columns",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
-    "rubyName": "column_names",
-    "call": "map",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
-    "rubyName": "columns",
-    "call": "columns_hash",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
     "rubyName": "content_columns",
     "call": "reject",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -130,20 +109,6 @@
     "tsFile": "model-schema.ts",
     "rubyName": "full_table_name_suffix",
     "call": "table_name_suffix",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
-    "rubyName": "ignored_columns=",
-    "call": "map",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
-    "rubyName": "ignored_columns=",
-    "call": "reload_schema_from_cache",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {


### PR DESCRIPTION
## Summary

Rails filters `ignored_columns` at **load time**: `load_schema!` builds `@columns_hash = columns_hash.except(*ignored_columns)` and `ignored_columns=` triggers `reload_schema_from_cache`, so `columns`, `columns_hash`, and `column_names` all agree (`vendor/rails/activerecord/lib/active_record/model_schema.rb:366-368, 587-594`). trails filtered at **read time** in `columnsHash()` instead, so `columns()`'s `_columns` memo leaked ignored columns after an `ignoredColumns=` reassignment (surfaced in #5109).

## Changes

- `applyColumnsHash` now stores the filtered hash into `_columnsHash` eagerly (mirroring `load_schema!`); `columnsHash()` returns the memo, keeping the read-time compute only as the fallback for STI subclasses with their own `ignoredColumns` (whose memo lives on the base, filtered by the base's set).
- `ignoredColumns=` runs the `reload_schema_from_cache` mirror (the previously-vestigial `reloadSchemaFromCache` anchor, rewritten): drops the class-level schema memos on self + descendants **without** clearing the adapter's schema cache — that's the "from_cache" in the name — so the next read re-reflects synchronously from the warm cache.
- `columnNames` is now the literal Rails shape `columns().map(c => c.name)`; the call-site deviation comment justifying the `columnsHash()`-keys workaround is removed.
- Two trails-invented invalidation tests updated: after reflection `_columnsHash` is now the freshly filtered hash (not `undefined`), and an STI subclass's deleted own-caches re-inherit the base's fresh memo via the prototype chain.

## Testing

- `base.test.ts`, `base.trails.test.ts`, `attribute-methods(.trails).test.ts`, `model-schema*.test.ts`, `inheritance.test.ts` — all passing locally (ignored-columns tests unchanged, incl. "when assigning new ignored columns it invalidates cache for column names").

Closes-story: ignored-columns-read-time-filter-vs-rails-load-time