### PR TITLE
feat(calculations): key expression-grouped calculations by deserialized values

### DIFF
--- a/packages/activerecord/dx-tests/basic-crud.test-d.ts
+++ b/packages/activerecord/dx-tests/basic-crud.test-d.ts
@@ -110,11 +110,9 @@ describe("basic CRUD DX — defining and using a model", () => {
   it("User.count / exists / pluck have concrete return types", () => {
     // Rails' count returns either a scalar or a grouped hash, depending on
     // whether the active scope has a GROUP BY — signature widened to match
-    // Relation#count. Grouping by a belongs_to association keys the hash by the
-    // loaded records, returned as a Map (JS object keys can't be records).
-    expectTypeOf(User.count).returns.resolves.toEqualTypeOf<
-      number | Record<string, number> | Map<unknown, number>
-    >();
+    // Relation#count. Grouped results are a Map keyed by the deserialized
+    // group value (a loaded record for a belongs_to group).
+    expectTypeOf(User.count).returns.resolves.toEqualTypeOf<number | Map<unknown, number>>();
     expectTypeOf(User.exists).returns.resolves.toBeBoolean();
     expectTypeOf(User.pluck).returns.resolves.toEqualTypeOf<unknown[]>();
   });

--- a/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
@@ -14,10 +14,11 @@ import {
 import { SchemaDumper } from "../../connection-adapters/abstract/schema-dumper.js";
 import { DateTime as OidDateTime } from "../../connection-adapters/postgresql/oid/date-time.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
+import { Topic } from "../../test-helpers/models/topic.js";
 import { withTimezoneConfig } from "../../test-helper.js";
 import { Base } from "../../index.js";
 
-fixtures({}, { useTransactionalTests: false });
+fixtures(["topics"], { useTransactionalTests: false });
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
@@ -314,14 +315,14 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
 
   describe("PostgreSQLTimestampFixtureTest", () => {
-    it.skip("group by date", () => {
-      // BLOCKED: grouped-calculation key typing. Rails' Topic.group(...).count
-      // hash keys are type-cast values (`assert_kind_of Time, k`); trails'
-      // groupedAggregate returns Record<string, unknown>, whose keys are
-      // String()-ified even when the group column deserializes to Temporal
-      // (calculations.ts groupedAggregate). Converging needs a typed-Map
-      // result shape for expression groups.
-      // DEFERRED (RFC 0030): tracked by grouped-calculation-typed-keys.
+    it("group by date", async () => {
+      const keys = [
+        ...(
+          (await Topic.group("date_trunc('month', created_at)").count()) as Map<unknown, number>
+        ).keys(),
+      ];
+      expect(keys.length).toBeGreaterThan(0);
+      for (const k of keys) expect(k).toBeInstanceOf(Temporal.Instant);
     });
     it("load infinity and beyond", async () => {
       class Dev extends Base {

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1704,7 +1704,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         const box = await this._djarForCount();
         if (!box) return 0;
         const djar = (box as { djar: unknown }).djar as {
-          count: (column?: string) => Promise<number | Record<string, number>>;
+          count: (column?: string) => Promise<number | Map<unknown, number>>;
         };
         const c = await djar.count(column);
         if (typeof c !== "number") {
@@ -1738,13 +1738,13 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // `COUNT(*)` Rails would.
     const countFn = (
       Relation.prototype as unknown as {
-        count: (this: unknown, column?: string) => Promise<number | Record<string, number>>;
+        count: (this: unknown, column?: string) => Promise<number | Map<unknown, number>>;
       }
     ).count;
     const counted = this._relationStateDiverged()
       ? await countFn.call(this, column)
       : await countFn.call(this.scope(), column);
-    // A grouped count (Record) would mean the caller added a
+    // A grouped count (Map) would mean the caller added a
     // `groupBang(...)` on the proxy — ambiguous for CP#count (which
     // returns a single number). Fail loudly instead of silently
     // collapsing to the group count.
@@ -1759,66 +1759,66 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   // treatment as pluck/pick/count. Without overriding, cp.sum('x') /
   // cp.whereBang({...}); cp.average('y') would both bypass the gate
   // and drop in-place mutations.
-  async sum(column?: string): Promise<number | bigint | Record<string, number | bigint>> {
+  async sum(column?: string): Promise<number | bigint | Map<unknown, number | bigint>> {
     this._checkStrictLoading();
     const fn = (
       Relation.prototype as unknown as {
-        sum: (col?: string) => Promise<number | bigint | Record<string, number | bigint>>;
+        sum: (col?: string) => Promise<number | bigint | Map<unknown, number | bigint>>;
       }
     ).sum;
     if (this._relationStateDiverged()) return fn.call(this, column);
     const s = this.scope();
     return (
       s as unknown as {
-        sum: (col?: string) => Promise<number | bigint | Record<string, number | bigint>>;
+        sum: (col?: string) => Promise<number | bigint | Map<unknown, number | bigint>>;
       }
     ).sum(column);
   }
 
-  async average(column: string): Promise<unknown | null | Record<string, unknown>> {
+  async average(column: string): Promise<unknown | null | Map<unknown, unknown>> {
     this._checkStrictLoading();
     const fn = (
       Relation.prototype as unknown as {
-        average: (col: string) => Promise<unknown | null | Record<string, unknown>>;
+        average: (col: string) => Promise<unknown | null | Map<unknown, unknown>>;
       }
     ).average;
     if (this._relationStateDiverged()) return fn.call(this, column);
     const s = this.scope();
     return (
       s as unknown as {
-        average: (col: string) => Promise<unknown | null | Record<string, unknown>>;
+        average: (col: string) => Promise<unknown | null | Map<unknown, unknown>>;
       }
     ).average(column);
   }
 
-  async minimum(column: string): Promise<unknown | null | Record<string, unknown>> {
+  async minimum(column: string): Promise<unknown | null | Map<unknown, unknown>> {
     this._checkStrictLoading();
     const fn = (
       Relation.prototype as unknown as {
-        minimum: (col: string) => Promise<unknown | null | Record<string, unknown>>;
+        minimum: (col: string) => Promise<unknown | null | Map<unknown, unknown>>;
       }
     ).minimum;
     if (this._relationStateDiverged()) return fn.call(this, column);
     const s = this.scope();
     return (
       s as unknown as {
-        minimum: (col: string) => Promise<unknown | null | Record<string, unknown>>;
+        minimum: (col: string) => Promise<unknown | null | Map<unknown, unknown>>;
       }
     ).minimum(column);
   }
 
-  async maximum(column: string): Promise<unknown | null | Record<string, unknown>> {
+  async maximum(column: string): Promise<unknown | null | Map<unknown, unknown>> {
     this._checkStrictLoading();
     const fn = (
       Relation.prototype as unknown as {
-        maximum: (col: string) => Promise<unknown | null | Record<string, unknown>>;
+        maximum: (col: string) => Promise<unknown | null | Map<unknown, unknown>>;
       }
     ).maximum;
     if (this._relationStateDiverged()) return fn.call(this, column);
     const s = this.scope();
     return (
       s as unknown as {
-        maximum: (col: string) => Promise<unknown | null | Record<string, unknown>>;
+        maximum: (col: string) => Promise<unknown | null | Map<unknown, unknown>>;
       }
     ).maximum(column);
   }
@@ -4071,19 +4071,19 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#calculate
    */
-  async calculate(operation: "count", column?: string): Promise<number | Record<string, number>>;
+  async calculate(operation: "count", column?: string): Promise<number | Map<unknown, number>>;
   async calculate(
     operation: "sum",
     column: string,
-  ): Promise<number | bigint | Record<string, number | bigint>>;
+  ): Promise<number | bigint | Map<unknown, number | bigint>>;
   async calculate(
     operation: "average",
     column: string,
-  ): Promise<unknown | null | Record<string, unknown>>;
+  ): Promise<unknown | null | Map<unknown, unknown>>;
   async calculate(
     operation: "minimum" | "maximum",
     column: string,
-  ): Promise<unknown | null | Record<string, unknown>>;
+  ): Promise<unknown | null | Map<unknown, unknown>>;
   async calculate(operation: string, columnName?: string): Promise<unknown> {
     const op =
       operation === "avg"

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -72,7 +72,14 @@ describe("CalculationsTest", () => {
 
   it("should count with group by qualified name on loaded", async () => {
     const accounts = Account.group("accounts.id");
-    const expected: Record<number, number> = { 1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1 };
+    const expected = new Map([
+      [1, 1],
+      [2, 1],
+      [3, 1],
+      [4, 1],
+      [5, 1],
+      [6, 1],
+    ]);
     expect(await accounts.count()).toEqual(expected);
 
     await accounts.toArray();
@@ -155,25 +162,25 @@ describe("CalculationsTest", () => {
   });
 
   it("should group by field", async () => {
-    const c = await Account.group("firm_id").sum("credit_limit");
-    expect((c as Record<number, number>)[1]).toBeDefined();
-    expect((c as Record<number, number>)[6]).toBeDefined();
-    expect((c as Record<number, number>)[2]).toBeDefined();
+    const c = (await Account.group("firm_id").sum("credit_limit")) as Map<unknown, number>;
+    expect(c.get(1)).toBeDefined();
+    expect(c.get(6)).toBeDefined();
+    expect(c.get(2)).toBeDefined();
   });
 
   it("should group by arel attribute", async () => {
-    const c = await Account.group(Account.arelTable.get("firm_id")).sum(
+    const c = (await Account.group(Account.arelTable.get("firm_id")).sum(
       Account.arelTable.get("credit_limit"),
-    );
-    expect((c as Record<number, number>)[1]).toBeDefined();
-    expect((c as Record<number, number>)[6]).toBeDefined();
-    expect((c as Record<number, number>)[2]).toBeDefined();
+    )) as Map<unknown, number>;
+    expect(c.get(1)).toBeDefined();
+    expect(c.get(6)).toBeDefined();
+    expect(c.get(2)).toBeDefined();
   });
 
   it("should group by multiple fields", async () => {
     const c = await Account.group("firm_id", "credit_limit").count();
     // Rails: 6 unique (firm_id, credit_limit) combos; each count is 1.
-    const total = Object.values(c as object).reduce((sum: number, v) => sum + (v as number), 0);
+    const total = [...(c as Map<unknown, number>).values()].reduce((sum, v) => sum + v, 0);
     expect(total).toBe(6);
   });
 
@@ -185,31 +192,33 @@ describe("CalculationsTest", () => {
 
   it("should group by multiple fields having functions", async () => {
     const c = await Topic.group("author_name", "COALESCE(type, title)").count();
-    expect(typeof c).toBe("object");
+    expect(c).toBeInstanceOf(Map);
     // Rails: 5 topics each with unique (author_name, COALESCE(type,title)) combo
-    const total = Object.values(c as object).reduce((sum: number, v) => sum + (v as number), 0);
+    const total = [...(c as Map<unknown, number>).values()].reduce((sum, v) => sum + v, 0);
     expect(total).toBe(5);
   });
 
   it("should group by summed field", async () => {
-    const expected: Record<string | number, number> = { 1: 50, 2: 60, 6: 105, 9: 53 };
-    const c = (await Account.group("firm_id").sum("credit_limit")) as Record<number, number>;
-    expect(c[null as unknown as number]).toBe(50);
-    expect(c[1]).toBe(50);
-    expect(c[2]).toBe(60);
-    expect(c[6]).toBe(105);
-    expect(c[9]).toBe(53);
-    void expected;
+    // Rails: { nil => 50, 1 => 50, 6 => 105, 2 => 60, 9 => 53 }
+    const expected = new Map<unknown, number>([
+      [null, 50],
+      [1, 50],
+      [6, 105],
+      [2, 60],
+      [9, 53],
+    ]);
+    const c = await Account.group("firm_id").sum("credit_limit");
+    expect(c).toEqual(expected);
   });
 
   it("group by multiple same field", async () => {
     const accounts = Account.group("firm_id");
-    const c = (await accounts.sum("credit_limit")) as Record<number, number>;
-    expect(c[null as unknown as number]).toBe(50);
-    expect(c[1]).toBe(50);
-    expect(c[2]).toBe(60);
-    expect(c[6]).toBe(105);
-    expect(c[9]).toBe(53);
+    const c = (await accounts.sum("credit_limit")) as Map<unknown, number>;
+    expect(c.get(null)).toBe(50);
+    expect(c.get(1)).toBe(50);
+    expect(c.get(2)).toBe(60);
+    expect(c.get(6)).toBe(105);
+    expect(c.get(9)).toBe(53);
   });
 
   it("should generate valid sql with joins and group", async () => {
@@ -228,8 +237,8 @@ describe("CalculationsTest", () => {
     const company = (await Company.where({ id: developer.id }).first())!;
     const c = await (company as any).contracts.group("id").count();
     const totalCount = await (company as any).contracts.count();
-    expect(Object.keys(c as object).length).toBe(totalCount);
-    for (const [, v] of Object.entries(c as Record<string, number>)) {
+    expect((c as Map<unknown, number>).size).toBe(totalCount);
+    for (const [, v] of c as Map<unknown, number>) {
       expect(v).toBe(1);
     }
   });
@@ -237,38 +246,33 @@ describe("CalculationsTest", () => {
   it("should not use alias for grouped field", async () => {
     // Rails: asserts GROUP BY uses accounts.firm_id (not an alias) and order("accounts_firm_id") works.
     // In trails, use the qualified column name for ORDER BY since auto-alias translation may not apply.
-    const c = (await Account.group("firm_id")
-      .order("accounts.firm_id")
-      .sum("credit_limit")) as Record<number, number>;
-    const keys = Object.keys(c)
-      .map(Number)
-      .filter((k) => !isNaN(k));
+    const c = (await Account.group("firm_id").order("accounts.firm_id").sum("credit_limit")) as Map<
+      unknown,
+      number
+    >;
+    const keys = [...c.keys()].filter((k): k is number => typeof k === "number");
     expect(keys.sort((a, b) => a - b)).toEqual([1, 2, 6, 9]);
   });
 
   it("should order by grouped field", async () => {
-    const c = (await Account.group("firm_id").order("firm_id").sum("credit_limit")) as Record<
-      number,
+    const c = (await Account.group("firm_id").order("firm_id").sum("credit_limit")) as Map<
+      unknown,
       number
     >;
-    const keys = Object.keys(c)
-      .map(Number)
-      .filter((k) => !isNaN(k));
+    const keys = [...c.keys()].filter((k): k is number => typeof k === "number");
     expect(keys).toEqual([1, 2, 6, 9]);
   });
 
   it("should order by calculation", async () => {
     const c = (await Account.group("firm_id")
       .order("sum_credit_limit desc, firm_id")
-      .sum("credit_limit")) as Record<number, number>;
-    const values = Object.values(c);
+      .sum("credit_limit")) as Map<unknown, number>;
+    const values = [...c.values()];
     expect(values).toContain(105);
     expect(values).toContain(60);
     expect(values).toContain(53);
     expect(values.filter((v) => v === 50).length).toBe(2);
-    const keys = Object.keys(c)
-      .map(Number)
-      .filter((k) => !isNaN(k));
+    const keys = [...c.keys()].filter((k): k is number => typeof k === "number");
     expect(keys).toEqual(expect.arrayContaining([6, 2, 9, 1]));
   });
 
@@ -277,9 +281,8 @@ describe("CalculationsTest", () => {
       .group("firm_id")
       .order("firm_id")
       .limit(2)
-      .sum("credit_limit")) as Record<number, number>;
-    const keys = Object.keys(c).map(Number);
-    expect(keys).toEqual([1, 2]);
+      .sum("credit_limit")) as Map<unknown, number>;
+    expect([...c.keys()]).toEqual([1, 2]);
   });
 
   it("should limit calculation with offset", async () => {
@@ -288,9 +291,8 @@ describe("CalculationsTest", () => {
       .order("firm_id")
       .limit(2)
       .offset(1)
-      .sum("credit_limit")) as Record<number, number>;
-    const keys = Object.keys(c).map(Number);
-    expect(keys).toEqual([2, 6]);
+      .sum("credit_limit")) as Map<unknown, number>;
+    expect([...c.keys()]).toEqual([2, 6]);
   });
 
   it("order should apply before count", async () => {
@@ -423,18 +425,18 @@ describe("CalculationsTest", () => {
     const result = (await Post.leftJoins("comments")
       .group("comments.post_id")
       .distinct()
-      .count("author_id")) as Record<number, number>;
-    expect(typeof result).toBe("object");
-    expect(Object.keys(result).length).toBeGreaterThan(0);
+      .count("author_id")) as Map<unknown, number>;
+    expect(result).toBeInstanceOf(Map);
+    expect(result.size).toBeGreaterThan(0);
   });
 
   it("distinct count with group by and order and limit", async () => {
     // Rails: Account.group(:firm_id).distinct.order("1 DESC").limit(1).count == { 6 => 2 }
     // firm_id=6 has 2 accounts (ids 3+5); it is the group with the highest count.
-    const result = (await Account.group("firm_id").count()) as Record<number, number>;
+    const result = (await Account.group("firm_id").count()) as Map<unknown, number>;
     // firm_id=6 should have count 2; all others have count 1
-    expect(result[6]).toBe(2);
-    expect(Object.values(result).filter((v) => v === 1).length).toBeGreaterThan(0);
+    expect(result.get(6)).toBe(2);
+    expect([...result.values()].filter((v) => v === 1).length).toBeGreaterThan(0);
   });
 
   it("count for a composite primary key model", async () => {
@@ -445,9 +447,9 @@ describe("CalculationsTest", () => {
   it("group by count for a composite primary key model", async () => {
     const book = cpkBooks("cpk_great_author_first_book");
     const authorId = book.author_id;
-    const expected: Record<number, number> = {
-      [authorId]: (await CpkBook.where({ author_id: authorId }).count()) as number,
-    };
+    const expected = new Map([
+      [authorId, (await CpkBook.where({ author_id: authorId }).count()) as number],
+    ]);
     const result = await CpkBook.where({ author_id: authorId }).group("author_id").count();
     expect(result).toEqual(expected);
   });
@@ -461,11 +463,11 @@ describe("CalculationsTest", () => {
   it("should group by summed field having condition", async () => {
     const c = (await Account.group("firm_id")
       .having("sum(credit_limit) > 50")
-      .sum("credit_limit")) as Record<number, number>;
+      .sum("credit_limit")) as Map<unknown, number>;
     // firm_id=6 sum=105 and firm_id=2 sum=60 satisfy sum > 50
-    expect(c[6]).toBe(105);
-    expect(c[2]).toBe(60);
-    expect(c[9]).toBe(53);
+    expect(c.get(6)).toBe(105);
+    expect(c.get(2)).toBe(60);
+    expect(c.get(9)).toBe(53);
   });
 
   it.skipIf(adapterType === "postgres")(
@@ -474,9 +476,9 @@ describe("CalculationsTest", () => {
       const c = (await Account.select("MIN(credit_limit) AS min_credit_limit")
         .group("firm_id")
         .having("min_credit_limit > 50")
-        .sum("credit_limit")) as Record<number, number>;
-      expect(c[2]).toBe(60);
-      expect(c[9]).toBe(53);
+        .sum("credit_limit")) as Map<unknown, number>;
+      expect(c.get(2)).toBe(60);
+      expect(c.get(9)).toBe(53);
     },
   );
 
@@ -508,46 +510,46 @@ describe("CalculationsTest", () => {
   });
 
   it("should return type casted values with group and expression", async () => {
-    const result = await Account.group("firm_name").sum("0.01 * credit_limit");
-    expect((result as Record<string, number>)["37signals"]).toBeCloseTo(0.5);
+    const result = (await Account.group("firm_name").sum("0.01 * credit_limit")) as Map<
+      unknown,
+      number
+    >;
+    expect(result.get("37signals")).toBeCloseTo(0.5);
   });
 
   it("should group by summed field with conditions", async () => {
-    const c = (await Account.where("firm_id > 1").group("firm_id").sum("credit_limit")) as Record<
-      number,
+    const c = (await Account.where("firm_id > 1").group("firm_id").sum("credit_limit")) as Map<
+      unknown,
       number
     >;
-    expect(c[1]).toBeUndefined();
-    expect(c[6]).toBe(105);
-    expect(c[2]).toBe(60);
+    expect(c.get(1)).toBeUndefined();
+    expect(c.get(6)).toBe(105);
+    expect(c.get(2)).toBe(60);
   });
 
   it("should group by summed field with conditions and having", async () => {
     const c = (await Account.where("firm_id > 1")
       .group("firm_id")
       .having("sum(credit_limit) > 50")
-      .sum("credit_limit")) as Record<number, number>;
-    expect(c[6]).toBe(105);
-    expect(c[2]).toBe(60);
-    expect(c[9]).toBe(53);
-    expect(c[1]).toBeUndefined();
+      .sum("credit_limit")) as Map<unknown, number>;
+    expect(c.get(6)).toBe(105);
+    expect(c.get(2)).toBe(60);
+    expect(c.get(9)).toBe(53);
+    expect(c.get(1)).toBeUndefined();
   });
 
   it("should group by fields with table alias", async () => {
-    const c = (await Account.group("accounts.firm_id").sum("credit_limit")) as Record<
-      number,
-      number
-    >;
-    expect(c[1]).toBe(50);
-    expect(c[6]).toBe(105);
-    expect(c[2]).toBe(60);
+    const c = (await Account.group("accounts.firm_id").sum("credit_limit")) as Map<unknown, number>;
+    expect(c.get(1)).toBe(50);
+    expect(c.get(6)).toBe(105);
+    expect(c.get(2)).toBe(60);
   });
 
   it("should calculate grouped with longer field", async () => {
-    const c = (await Account.group("firm_id").sum("credit_limit")) as Record<number, number>;
-    expect(c[1]).toBe(50);
-    expect(c[6]).toBe(105);
-    expect(c[2]).toBe(60);
+    const c = (await Account.group("firm_id").sum("credit_limit")) as Map<unknown, number>;
+    expect(c.get(1)).toBe(50);
+    expect(c.get(6)).toBe(105);
+    expect(c.get(2)).toBe(60);
   });
 
   it("should calculate with invalid field", async () => {
@@ -556,10 +558,10 @@ describe("CalculationsTest", () => {
   });
 
   it("should calculate grouped with invalid field", async () => {
-    const c = (await Account.group("accounts.firm_id").count()) as Record<number, number>;
-    expect(c[1]).toBe(1);
-    expect(c[6]).toBe(2);
-    expect(c[2]).toBe(1);
+    const c = (await Account.group("accounts.firm_id").count()) as Map<unknown, number>;
+    expect(c.get(1)).toBe(1);
+    expect(c.get(6)).toBe(2);
+    expect(c.get(2)).toBe(1);
   });
 
   it("should calculate grouped association with invalid field", async () => {
@@ -609,19 +611,19 @@ describe("CalculationsTest", () => {
   });
 
   it("should calculate grouped by function", async () => {
-    const c = (await Company.group("UPPER(type)").count()) as Record<string, number>;
-    expect(c[null as unknown as string]).toBe(2);
-    expect(c["DEPENDENTFIRM"]).toBe(1);
-    expect(c["CLIENT"]).toBe(5);
-    expect(c["FIRM"]).toBe(3);
+    const c = (await Company.group("UPPER(type)").count()) as Map<unknown, number>;
+    expect(c.get(null)).toBe(2);
+    expect(c.get("DEPENDENTFIRM")).toBe(1);
+    expect(c.get("CLIENT")).toBe(5);
+    expect(c.get("FIRM")).toBe(3);
   });
 
   it("should calculate grouped by function with table alias", async () => {
-    const c = (await Company.group("UPPER(companies.type)").count()) as Record<string, number>;
-    expect(c[null as unknown as string]).toBe(2);
-    expect(c["DEPENDENTFIRM"]).toBe(1);
-    expect(c["CLIENT"]).toBe(5);
-    expect(c["FIRM"]).toBe(3);
+    const c = (await Company.group("UPPER(companies.type)").count()) as Map<unknown, number>;
+    expect(c.get(null)).toBe(2);
+    expect(c.get("DEPENDENTFIRM")).toBe(1);
+    expect(c.get("CLIENT")).toBe(5);
+    expect(c.get("FIRM")).toBe(3);
   });
 
   it("should not overshadow enumerable sum", async () => {
@@ -652,18 +654,18 @@ describe("CalculationsTest", () => {
   it("should group by scoped field", async () => {
     const rc = companies("rails_core");
     const firm = (await Company.where({ id: rc.id }).first())! as any;
-    const c = (await firm.companies.group("name").sum("id")) as Record<string, number>;
-    expect(Number(c["Leetsoft"])).toBe(7);
-    expect(Number(c["Jadedpixel"])).toBe(8);
+    const c = (await firm.companies.group("name").sum("id")) as Map<unknown, number>;
+    expect(Number(c.get("Leetsoft"))).toBe(7);
+    expect(Number(c.get("Jadedpixel"))).toBe(8);
   });
 
   it("should group by summed field through association and having", async () => {
     const rc = companies("rails_core");
     const firm = (await Company.where({ id: rc.id }).first())! as any;
-    const c = (await firm.companies.group("name").sum("id")) as Record<string, number>;
+    const c = (await firm.companies.group("name").sum("id")) as Map<unknown, number>;
     // Companies under rails_core: Leetsoft (id=7) and Jadedpixel (id=8)
-    expect(Number(c["Leetsoft"])).toBe(7);
-    expect(Number(c["Jadedpixel"])).toBe(8);
+    expect(Number(c.get("Leetsoft"))).toBe(7);
+    expect(Number(c.get("Jadedpixel"))).toBe(8);
   });
 
   it("should count selected field with include", async () => {
@@ -715,16 +717,17 @@ describe("CalculationsTest", () => {
   });
 
   it("should count manual select with group with count all", async () => {
-    const expected: Record<string, number> = { null: 1, "1": 1, "2": 1, "6": 2, "9": 1 };
-    const actual = (await Account.select("DISTINCT accounts.firm_id")
+    const expected = new Map<unknown, number>([
+      [null, 1],
+      [1, 1],
+      [2, 1],
+      [6, 2],
+      [9, 1],
+    ]);
+    const actual = await Account.select("DISTINCT accounts.firm_id")
       .group("accounts.firm_id")
-      .count()) as Record<number, number>;
-    expect(actual[null as unknown as number]).toBe(1);
-    expect(actual[1]).toBe(1);
-    expect(actual[2]).toBe(1);
-    expect(actual[6]).toBe(2);
-    expect(actual[9]).toBe(1);
-    void expected;
+      .count();
+    expect(actual).toEqual(expected);
   });
 
   it("should count manual with count all", async () => {
@@ -786,33 +789,35 @@ describe("CalculationsTest", () => {
   });
 
   it("should count field in joined table with group by", async () => {
-    const c = (await Account.group("accounts.firm_id")
-      .joins("firm")
-      .count("companies.id")) as Record<number, number>;
-    expect(Object.keys(c).map(Number)).toEqual(expect.arrayContaining([1, 6, 2, 9]));
+    const c = (await Account.group("accounts.firm_id").joins("firm").count("companies.id")) as Map<
+      unknown,
+      number
+    >;
+    expect([...c.keys()]).toEqual(expect.arrayContaining([1, 6, 2, 9]));
   });
 
   it("should count field in joined table with group by when tables share column names", async () => {
-    const counts = (await Company.joins("account").group("accounts.status").count()) as Record<
-      string,
+    const counts = (await Company.joins("account").group("accounts.status").count()) as Map<
+      unknown,
       number
     >;
-    expect(counts["active"]).toBe(2);
-    expect(counts["trial"]).toBe(2);
-    expect(counts["suspended"]).toBe(1);
+    expect(counts.get("active")).toBe(2);
+    expect(counts.get("trial")).toBe(2);
+    expect(counts.get("suspended")).toBe(1);
   });
 
   it("should count field of root table with conflicting group by column", async () => {
     // Rails: Post.joins(:comments).group(:post_id).count == { 1=>2, 2=>1, 4=>5, 5=>3, 7=>1 }
     // Also tests group("comments.post_id") which avoids the ambiguous column qualification.
-    const expected = { 1: 2, 2: 1, 4: 5, 5: 3, 7: 1 };
-    const result = (await Post.joins("comments").group("comments.post_id").count()) as Record<
-      number,
-      number
-    >;
-    expect(Object.fromEntries(Object.entries(result).map(([k, v]) => [Number(k), v]))).toEqual(
-      expected,
-    );
+    const expected = new Map([
+      [1, 2],
+      [2, 1],
+      [4, 5],
+      [5, 3],
+      [7, 1],
+    ]);
+    const result = await Post.joins("comments").group("comments.post_id").count();
+    expect(result).toEqual(expected);
   });
 
   it("count with no parameters isnt deprecated", async () => {
@@ -940,11 +945,10 @@ describe("CalculationsTest", () => {
   it("sum with grouped calculation", async () => {
     // Rails: Post.group(:tags_count).sum == { 0 => 0, 1 => 0, 3 => 0 }
     // (posts have tags_count of 0, 1, or 3; sum without a column returns {group => 0})
-    const result = await Post.group("tags_count").count();
-    expect(typeof result).toBe("object");
+    const result = (await Post.group("tags_count").count()) as Map<unknown, number>;
+    expect(result).toBeInstanceOf(Map);
     // tags_count values in fixtures: 0, 1, 3
-    const keys = Object.keys(result as object).map(Number);
-    expect(keys).toEqual(expect.arrayContaining([0, 1, 3]));
+    expect([...result.keys()]).toEqual(expect.arrayContaining([0, 1, 3]));
   });
 
   it("from option with specified index", async () => {
@@ -957,12 +961,12 @@ describe("CalculationsTest", () => {
 
   it("distinct is honored when used with count operation after group", async () => {
     const approvedTopicsCount = (
-      (await Topic.group("approved").count("author_name")) as Record<string, number>
-    )["true"];
+      (await Topic.group("approved").count("author_name")) as Map<unknown, number>
+    ).get(true);
     expect(approvedTopicsCount).toBe(4);
     const distinctAuthorsForApprovedCount = (
-      (await Topic.group("approved").distinct().count("author_name")) as Record<string, number>
-    )["true"];
+      (await Topic.group("approved").distinct().count("author_name")) as Map<unknown, number>
+    ).get(true);
     expect(distinctAuthorsForApprovedCount).toBe(3);
   });
 
@@ -1348,7 +1352,10 @@ describe("CalculationsTest", () => {
   it.skipIf(adapterType !== "postgres")(
     "group by with order by virtual count attribute",
     async () => {
-      const expected = { SpecialPost: 1, StiPost: 2 };
+      const expected = new Map([
+        ["SpecialPost", 1],
+        ["StiPost", 2],
+      ]);
       // Rails `order(:count)`: the Symbol qualifies to `"posts"."count"`, which PG
       // resolves via functional notation as `count(posts.*)` — the "virtual count
       // attribute". A bare string would stay raw SQL and fail to parse.
@@ -1365,8 +1372,8 @@ describe("CalculationsTest", () => {
       .order({ type: "desc" })
       .limit(2)
       .count("comments.id");
-    expect(typeof actual).toBe("object");
-    expect(Object.keys(actual as object).length).toBe(2);
+    expect(actual).toBeInstanceOf(Map);
+    expect((actual as Map<unknown, number>).size).toBe(2);
   });
 
   it("group by with offset", async () => {
@@ -1375,8 +1382,8 @@ describe("CalculationsTest", () => {
       .order({ type: "desc" })
       .offset(1)
       .count("comments.id");
-    expect(typeof actual).toBe("object");
-    expect(Object.keys(actual as object).length).toBeGreaterThanOrEqual(1);
+    expect(actual).toBeInstanceOf(Map);
+    expect((actual as Map<unknown, number>).size).toBeGreaterThanOrEqual(1);
   });
 
   it("group by with limit and offset", async () => {
@@ -1386,16 +1393,15 @@ describe("CalculationsTest", () => {
       .offset(1)
       .limit(1)
       .count("comments.id");
-    expect(typeof actual).toBe("object");
-    expect(Object.keys(actual as object).length).toBe(1);
+    expect(actual).toBeInstanceOf(Map);
+    expect((actual as Map<unknown, number>).size).toBe(1);
   });
 
   it("group by with quoted count and order by alias", async () => {
     // Rails: Post.group(:type).order("count_posts_id").count(Arel.sql('"posts"."id"'))
-    const actual = await Post.group("type").count("posts.id");
-    expect(typeof actual).toBe("object");
-    const keys = Object.keys(actual as object);
-    expect(keys).toEqual(expect.arrayContaining(["Post", "SpecialPost", "StiPost"]));
+    const actual = (await Post.group("type").count("posts.id")) as Map<unknown, number>;
+    expect(actual).toBeInstanceOf(Map);
+    expect([...actual.keys()]).toEqual(expect.arrayContaining(["Post", "SpecialPost", "StiPost"]));
   });
 
   it("pluck not auto table name prefix if column included", async () => {
@@ -1663,18 +1669,17 @@ describe("CalculationsTest", () => {
     });
     const result = (await ShipPart.joins("trinkets")
       .group("ship_parts.name")
-      .sum("ship_parts.id")) as Record<string, number>;
-    expect(Number(result["has trinket"])).toBe(Number(part.id));
+      .sum("ship_parts.id")) as Map<unknown, number>;
+    expect(Number(result.get("has trinket"))).toBe(Number(part.id));
     void treasure;
   });
 
   it("calculation grouped by association doesnt error when no records have association", async () => {
     await Client.updateAll({ client_of: null });
-    const result = (await Client.group("client_of").count()) as Record<string, number>;
+    const result = (await Client.group("client_of").count()) as Map<unknown, number>;
     // All clients have null firm after update; null key maps to total count
     const total = await Client.count();
-    const nilCount = result[null as unknown as string] ?? result["null"] ?? 0;
-    expect(nilCount).toBe(total);
+    expect(result.get(null) ?? 0).toBe(total);
   });
 
   it("should reference correct aliases while joining tables of has many through association", async () => {
@@ -1716,7 +1721,12 @@ describe("CalculationsTest", () => {
 
   it("group by attribute with custom type", async () => {
     const result = await Book.group("status").count();
-    expect(result).toEqual({ proposed: 2, published: 2 });
+    expect(result).toEqual(
+      new Map([
+        ["proposed", 2],
+        ["published", 2],
+      ]),
+    );
   });
 
   it("aggregate attribute on enum type", async () => {
@@ -1726,16 +1736,30 @@ describe("CalculationsTest", () => {
     expect(await Book.sum("difficulty")).toBe(1);
     expect(await Book.minimum("difficulty")).toBe(0);
     expect(await Book.maximum("difficulty")).toBe(1);
-    expect(await Book.group("status").sum("status")).toEqual({ proposed: 0, published: 4 });
-    expect(await Book.group("status").sum("difficulty")).toEqual({ proposed: 0, published: 1 });
-    expect(await Book.group("status").minimum("difficulty")).toEqual({
-      proposed: 0,
-      published: 0,
-    });
-    expect(await Book.group("status").maximum("difficulty")).toEqual({
-      proposed: 0,
-      published: 1,
-    });
+    expect(await Book.group("status").sum("status")).toEqual(
+      new Map([
+        ["proposed", 0],
+        ["published", 4],
+      ]),
+    );
+    expect(await Book.group("status").sum("difficulty")).toEqual(
+      new Map([
+        ["proposed", 0],
+        ["published", 1],
+      ]),
+    );
+    expect(await Book.group("status").minimum("difficulty")).toEqual(
+      new Map([
+        ["proposed", 0],
+        ["published", 0],
+      ]),
+    );
+    expect(await Book.group("status").maximum("difficulty")).toEqual(
+      new Map([
+        ["proposed", 0],
+        ["published", 1],
+      ]),
+    );
   });
 
   it("minimum and maximum on non numeric type", async () => {
@@ -1744,12 +1768,12 @@ describe("CalculationsTest", () => {
     const max = await Topic.maximum("last_read");
     expect(String(min)).toContain("2004-04-15");
     expect(String(max)).toContain("2004-04-15");
-    const minByApproved = (await Topic.group("approved").minimum("last_read")) as Record<
-      string,
+    const minByApproved = (await Topic.group("approved").minimum("last_read")) as Map<
+      unknown,
       unknown
     >;
-    expect(String(minByApproved["false"])).toContain("2004-04-15");
-    expect(minByApproved["true"]).toBeNull();
+    expect(String(minByApproved.get(false))).toContain("2004-04-15");
+    expect(minByApproved.get(true)).toBeNull();
   });
 
   it("minimum and maximum on time attributes", async () => {

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -187,7 +187,7 @@ describe("CalculationsTest", () => {
   it("should group by multiple fields when table name is too long", async () => {
     // Rails: TooLongTableName — canonical Account stands in; asserts multi-field GROUP BY works.
     const res = await Account.group("firm_id", "credit_limit").count();
-    expect(typeof res).toBe("object");
+    expect(res).toBeInstanceOf(Map);
   });
 
   it("should group by multiple fields having functions", async () => {
@@ -199,7 +199,6 @@ describe("CalculationsTest", () => {
   });
 
   it("should group by summed field", async () => {
-    // Rails: { nil => 50, 1 => 50, 6 => 105, 2 => 60, 9 => 53 }
     const expected = new Map<unknown, number>([
       [null, 50],
       [1, 50],

--- a/packages/activerecord/src/calculations.trails.test.ts
+++ b/packages/activerecord/src/calculations.trails.test.ts
@@ -136,3 +136,29 @@ describe("lookupCastTypeFromJoinDependencies integration", () => {
     expect(castType?.constructor.name).not.toBe("ValueType");
   });
 });
+
+// ==========================================================================
+// Grouped-calculation key typing via an Arel attribute's type caster
+//
+// trails-specific regression (no verbatim Rails test): Rails resolves each
+// group column's key type as `col_name.try(:type_caster) || type_for(col_name)`
+// (calculations.rb:567-570), so grouping by an Arel attribute keys the result
+// by the attribute's own decorated type — an enum keys by its labels, not the
+// raw stored integers. Guards the `groupNode instanceof Nodes.Attribute`
+// branch in groupedAggregate.
+// ==========================================================================
+
+describe("grouped calculation keyed via Arel attribute type caster", () => {
+  fixtures(["books"]);
+
+  it("keys an enum group given as an Arel attribute by its labels", async () => {
+    const { Book } = await import("./test-helpers/models/book.js");
+    const result = await Book.group(Book.arelTable.get("status")).count();
+    expect(result).toEqual(
+      new Map([
+        ["proposed", 2],
+        ["published", 2],
+      ]),
+    );
+  });
+});

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -411,13 +411,13 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
    * loading) — except we skip the materialization since count
    * doesn't need it. Net: same result, fewer rows hydrated.
    */
-  async count(column?: string): Promise<number | Record<string, number>> {
+  async count(column?: string): Promise<number | Map<unknown, number>> {
     if (this._chainWalker) {
       const { relation } = await this._walkOnce();
       const merged = this._composeChainedState(relation);
       return (
         merged as unknown as {
-          count: (col?: string) => Promise<number | Record<string, number>>;
+          count: (col?: string) => Promise<number | Map<unknown, number>>;
         }
       ).count(column);
     }
@@ -427,7 +427,7 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
     // override.
     const baseCount = (
       Relation.prototype as unknown as {
-        count: (this: unknown, col?: string) => Promise<number | Record<string, number>>;
+        count: (this: unknown, col?: string) => Promise<number | Map<unknown, number>>;
       }
     ).count;
     return baseCount.call(this, column);

--- a/packages/activerecord/src/null-relation.test.ts
+++ b/packages/activerecord/src/null-relation.test.ts
@@ -98,70 +98,70 @@ describe("NullRelationTest", () => {
   it("null relation count", async () => {
     await assertNoQueries(false, async () => {
       expect(await Comment.none().count("id")).toBe(0);
-      expect(await Comment.none().group("post_id").count("id")).toEqual({});
+      expect(await Comment.none().group("post_id").count("id")).toEqual(new Map());
     });
   });
 
   it("null relation count async", async () => {
     await assertNoQueries(false, async () => {
       expect(await Comment.none().asyncCount("id")).toBe(0);
-      expect(await Comment.none().group("post_id").asyncCount("id")).toEqual({});
+      expect(await Comment.none().group("post_id").asyncCount("id")).toEqual(new Map());
     });
   });
 
   it("null relation sum", async () => {
     await assertNoQueries(false, async () => {
       expect(Number(await Comment.none().sum("id"))).toBe(0);
-      expect(await Comment.none().group("post_id").sum("id")).toEqual({});
+      expect(await Comment.none().group("post_id").sum("id")).toEqual(new Map());
     });
   });
 
   it("null relation sum async", async () => {
     await assertNoQueries(false, async () => {
       expect(Number(await Comment.none().asyncSum("id"))).toBe(0);
-      expect(await Comment.none().group("post_id").asyncSum("id")).toEqual({});
+      expect(await Comment.none().group("post_id").asyncSum("id")).toEqual(new Map());
     });
   });
 
   it("null relation average", async () => {
     await assertNoQueries(false, async () => {
       expect(await Comment.none().average("id")).toBeNull();
-      expect(await Comment.none().group("post_id").average("id")).toEqual({});
+      expect(await Comment.none().group("post_id").average("id")).toEqual(new Map());
     });
   });
 
   it("null relation average async", async () => {
     await assertNoQueries(false, async () => {
       expect(await Comment.none().asyncAverage("id")).toBeNull();
-      expect(await Comment.none().group("post_id").asyncAverage("id")).toEqual({});
+      expect(await Comment.none().group("post_id").asyncAverage("id")).toEqual(new Map());
     });
   });
 
   it("null relation minimum", async () => {
     await assertNoQueries(false, async () => {
       expect(await Comment.none().minimum("id")).toBeNull();
-      expect(await Comment.none().group("post_id").minimum("id")).toEqual({});
+      expect(await Comment.none().group("post_id").minimum("id")).toEqual(new Map());
     });
   });
 
   it("null relation minimum async", async () => {
     await assertNoQueries(false, async () => {
       expect(await Comment.none().asyncMinimum("id")).toBeNull();
-      expect(await Comment.none().group("post_id").asyncMinimum("id")).toEqual({});
+      expect(await Comment.none().group("post_id").asyncMinimum("id")).toEqual(new Map());
     });
   });
 
   it("null relation maximum", async () => {
     await assertNoQueries(false, async () => {
       expect(await Comment.none().maximum("id")).toBeNull();
-      expect(await Comment.none().group("post_id").maximum("id")).toEqual({});
+      expect(await Comment.none().group("post_id").maximum("id")).toEqual(new Map());
     });
   });
 
   it("null relation maximum async", async () => {
     await assertNoQueries(false, async () => {
       expect(await Comment.none().asyncMaximum("id")).toBeNull();
-      expect(await Comment.none().group("post_id").asyncMaximum("id")).toEqual({});
+      expect(await Comment.none().group("post_id").asyncMaximum("id")).toEqual(new Map());
     });
   });
 

--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -469,7 +469,7 @@ export function thirdToLastBang<T extends typeof Base>(this: T): Promise<Instanc
 
 /**
  * Mirrors: ActiveRecord::Querying#count — accepts an optional column name
- * and returns either a number or a grouped `Record<string, number>` when
+ * and returns either a number or a grouped `Map<unknown, number>` when
  * the active scope has a GROUP BY. Parameters/return are derived from
  * `Relation#count` so the signatures stay in sync.
  */

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -551,7 +551,13 @@ describe("RelationTest", () => {
     expect(sql).toContain(`INNER JOIN ${canonicalQuoteTableName("comments")}`);
     expect(sql).toContain(joinString);
 
-    expect(await merged.count()).toEqual({ 2: 1, 4: 3, 5: 1 });
+    expect(await merged.count()).toEqual(
+      new Map([
+        [2, 1],
+        [4, 3],
+        [5, 1],
+      ]),
+    );
   });
 
   it("relation merging with merged joins as symbols", async () => {
@@ -561,7 +567,7 @@ describe("RelationTest", () => {
       .merge(specialCommentsWithRatings);
     const merged = (authors("david") as any).posts.merge(postsWithSpecialCommentsWithRatings);
 
-    expect(await merged.count()).toEqual({ 4: 2 });
+    expect(await merged.count()).toEqual(new Map([[4, 2]]));
   });
 
   it("relation merging with merged symbol joins keeps inner joins", async () => {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3492,23 +3492,23 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#calculate
    */
-  async calculate(operation: "count", column?: string): Promise<number | Record<string, number>>;
+  async calculate(operation: "count", column?: string): Promise<number | Map<unknown, number>>;
   async calculate(
     operation: "sum",
     column: string,
-  ): Promise<number | bigint | Record<string, number | bigint>>;
+  ): Promise<number | bigint | Map<unknown, number | bigint>>;
   async calculate(
     operation: "average",
     column: string,
-  ): Promise<unknown | null | Record<string, unknown>>;
+  ): Promise<unknown | null | Map<unknown, unknown>>;
   async calculate(
     operation: "minimum" | "maximum",
     column: string,
-  ): Promise<unknown | null | Record<string, unknown>>;
+  ): Promise<unknown | null | Map<unknown, unknown>>;
   async calculate(
     operation: "count" | "sum" | "average" | "minimum" | "maximum",
     column?: string,
-  ): Promise<unknown | null | Record<string, unknown>> {
+  ): Promise<unknown | null | Map<unknown, unknown>> {
     switch (operation) {
       case "count":
         return this.count(column);

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -548,20 +548,6 @@ async function groupedAggregate(
     return result;
   }
 
-  // Rails keys the result hash by the group column's deserialized value
-  // (execute_grouped_calculation builds `key_types` from the model's attribute
-  // type, falling back to `calculated_data.column_types` for expressions the
-  // model doesn't own — e.g. `date_trunc('month', created_at)` keys are Time
-  // on PG), so a boolean column yields true/false keys rather than the raw
-  // driver 1/0, and a null group stays a null key.
-  // Rails resolves the key type as `col_name.try(:type_caster) || type_for(col_name)`:
-  // a qualified `other_table.column` group field becomes an Arel attribute of THAT
-  // table via `arel_columns`, so its type_caster wins and the model's own type for a
-  // same-named column is never consulted (calculations_test.rb: grouping Company by
-  // "accounts.status" keeps accounts' string values, not Company's integer enum).
-  // A bare or self-qualified field resolves through the model (`type_for` takes the
-  // last `.`-segment); anything else falls back to the result's column types —
-  // Rails' `calculated_data.column_types.fetch(aliaz, Type.default_value)`.
   const keyFieldName = qualifiedGroupFieldForModel(rel, effectiveGroupCol);
   const keyType = ((keyFieldName === null
     ? null
@@ -583,9 +569,12 @@ async function groupedAggregate(
 }
 
 /**
- * The model-attribute name a group field may resolve its key type through, or
- * null when the field is qualified to a different table (whose own type — via
- * the result's column types — must win) or isn't a plain column reference.
+ * The model-attribute name a group field resolves its key type through, or null
+ * when it must fall through to the result's column types. Mirrors Rails'
+ * `col_name.try(:type_caster) || type_for(col_name)`: a field qualified to a
+ * DIFFERENT table keeps that table's type (grouping Company by "accounts.status"
+ * keys by accounts' strings, not Company's integer enum), while a bare or
+ * self-qualified field resolves through the model by its last `.`-segment.
  */
 function qualifiedGroupFieldForModel(rel: CalculationRelation, field: unknown): string | null {
   if (typeof field !== "string") return null;

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -548,10 +548,12 @@ async function groupedAggregate(
     return result;
   }
 
+  // Rails: `col_name.try(:type_caster) || type_for(col_name) { column_types.fetch(...) }`
+  // (calculations.rb:567-570) — an Arel attribute group field carries its own
+  // table's type caster, ahead of the model lookup and the result's column types.
   const keyFieldName = qualifiedGroupFieldForModel(rel, effectiveGroupCol);
-  const keyType = ((keyFieldName === null
-    ? null
-    : pluckCastTypeForKnownColumn(rel, keyFieldName)) ??
+  const keyType = ((groupNode instanceof Nodes.Attribute ? groupNode.typeCaster : null) ??
+    (keyFieldName === null ? null : pluckCastTypeForKnownColumn(rel, keyFieldName)) ??
     queryResult.columnTypes?.["group_key"] ??
     null) as { deserialize?(v: unknown): unknown } | null;
   const result = new Map<unknown, unknown>();

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -463,7 +463,7 @@ async function groupedAggregate(
   fn: AggFn,
   column: string | Nodes.Node,
   coerceNumeric: boolean = true,
-): Promise<Record<string, unknown> | Map<unknown, unknown>> {
+): Promise<Map<unknown, unknown>> {
   rel._checkEagerLoadable();
   const table = rel._modelClass.arelTable;
   const groupCol = rel._groupColumns[0];
@@ -548,22 +548,51 @@ async function groupedAggregate(
     return result;
   }
 
-  // Rails keys the result by the group column's deserialized value
-  // (execute_grouped_calculation → type_cast_calculated_value on the key), so a
-  // boolean column yields true/false keys rather than the raw driver 1/0.
-  const keyType = pluckCastTypeForKnownColumn(rel, effectiveGroupCol) as {
-    deserialize?(v: unknown): unknown;
-  } | null;
-  const result: Record<string, unknown> = {};
+  // Rails keys the result hash by the group column's deserialized value
+  // (execute_grouped_calculation builds `key_types` from the model's attribute
+  // type, falling back to `calculated_data.column_types` for expressions the
+  // model doesn't own — e.g. `date_trunc('month', created_at)` keys are Time
+  // on PG), so a boolean column yields true/false keys rather than the raw
+  // driver 1/0, and a null group stays a null key.
+  // Rails resolves the key type as `col_name.try(:type_caster) || type_for(col_name)`:
+  // a qualified `other_table.column` group field becomes an Arel attribute of THAT
+  // table via `arel_columns`, so its type_caster wins and the model's own type for a
+  // same-named column is never consulted (calculations_test.rb: grouping Company by
+  // "accounts.status" keeps accounts' string values, not Company's integer enum).
+  // A bare or self-qualified field resolves through the model (`type_for` takes the
+  // last `.`-segment); anything else falls back to the result's column types —
+  // Rails' `calculated_data.column_types.fetch(aliaz, Type.default_value)`.
+  const keyFieldName = qualifiedGroupFieldForModel(rel, effectiveGroupCol);
+  const keyType = ((keyFieldName === null
+    ? null
+    : pluckCastTypeForKnownColumn(rel, keyFieldName)) ??
+    queryResult.columnTypes?.["group_key"] ??
+    null) as { deserialize?(v: unknown): unknown } | null;
+  const result = new Map<unknown, unknown>();
   for (const row of rows) {
     const raw = row.group_key;
     const key =
       raw == null
-        ? "null"
-        : String(typeof keyType?.deserialize === "function" ? keyType.deserialize(raw) : raw);
-    result[key] = aggOf(row[aggAlias]);
+        ? null
+        : typeof keyType?.deserialize === "function"
+          ? keyType.deserialize(raw)
+          : raw;
+    result.set(key, aggOf(row[aggAlias]));
   }
   return result;
+}
+
+/**
+ * The model-attribute name a group field may resolve its key type through, or
+ * null when the field is qualified to a different table (whose own type — via
+ * the result's column types — must win) or isn't a plain column reference.
+ */
+function qualifiedGroupFieldForModel(rel: CalculationRelation, field: unknown): string | null {
+  if (typeof field !== "string") return null;
+  const dot = field.indexOf(".");
+  if (dot === -1) return field;
+  const [table, column] = [field.slice(0, dot), field.slice(dot + 1)];
+  return table === (rel._modelClass as { tableName?: string }).tableName ? column : null;
 }
 
 /**
@@ -689,14 +718,14 @@ function isEmptyCalculationScope(rel: CalculationRelation): boolean {
 export async function performCount(
   this: CalculationRelation,
   column?: string | Nodes.Node,
-): Promise<number | Record<string, number> | Map<unknown, number>> {
+): Promise<number | Map<unknown, number>> {
   if (this._limitValue === 0) return 0;
   // Safe to test contradiction here: every calc method is wrapped by
   // `inQueryConnection`, which awaits `_materializeDeferredDistinctPkPredicates()`
   // before invoking this perform fn — so a deferred distinct-PK marker that
   // resolves to an empty id set is already an empty `IN` (contradiction) by now,
   // same as pluck/exists which materialize inside their own inner functions.
-  if (isEmptyCalculationScope(this)) return this._groupColumns.length > 0 ? {} : 0;
+  if (isEmptyCalculationScope(this)) return this._groupColumns.length > 0 ? new Map() : 0;
 
   // Mirrors calculations.rb:231: `calculate`'s has_include? check precedes the
   // group dispatch. When eager-loading with a group, Rails' `calculate`
@@ -719,12 +748,12 @@ export async function performCount(
         "count",
         column != null && column !== "*" ? column : pk,
         true,
-      ) as Promise<Record<string, number> | Map<unknown, number>>;
+      ) as Promise<Map<unknown, number>>;
     }
   }
 
   if (this._groupColumns.length > 0) {
-    return groupedAggregate(this, "count", column ?? "*", true) as Promise<Record<string, number>>;
+    return groupedAggregate(this, "count", column ?? "*", true) as Promise<Map<unknown, number>>;
   }
   this._checkEagerLoadable();
 
@@ -1157,16 +1186,14 @@ export async function performCount(
 export async function performSum(
   this: CalculationRelation,
   column?: string | Nodes.Node,
-): Promise<number | bigint | Record<string, number | bigint> | Map<unknown, number | bigint>> {
+): Promise<number | bigint | Map<unknown, number | bigint>> {
   if (isEmptyCalculationScope(this)) {
-    if (this._groupColumns.length > 0) return {};
+    if (this._groupColumns.length > 0) return new Map();
     return column && resolveColType(this, column) instanceof BigIntegerType ? 0n : 0;
   }
   if (!column) return 0;
   if (this._groupColumns.length > 0) {
-    return groupedAggregate(this, "sum", column, true) as Promise<
-      Record<string, number | bigint> | Map<unknown, number | bigint>
-    >;
+    return groupedAggregate(this, "sum", column, true) as Promise<Map<unknown, number | bigint>>;
   }
   return ((await singleAggregate(this, "sum", column, true)) as number | bigint) ?? 0;
 }
@@ -1174,14 +1201,14 @@ export async function performSum(
 export async function performAverage(
   this: CalculationRelation,
   column: string | Nodes.Node,
-): Promise<unknown | null | Record<string, unknown> | Map<unknown, unknown>> {
+): Promise<unknown | null | Map<unknown, unknown>> {
   // Returns `unknown` (not just number) because non-numeric column types
   // — interval (Duration), money, time — route through the column type's
   // deserialize and yield a domain object. Rails' AVG return type is
   // similarly polymorphic (BigDecimal for integer/decimal, Duration for
   // interval, etc.). Numeric averages still narrow to JS number at the
   // call site.
-  if (isEmptyCalculationScope(this)) return this._groupColumns.length > 0 ? {} : null;
+  if (isEmptyCalculationScope(this)) return this._groupColumns.length > 0 ? new Map() : null;
   if (this._groupColumns.length > 0) {
     return groupedAggregate(this, "average", column, true);
   }
@@ -1191,8 +1218,8 @@ export async function performAverage(
 export async function performMinimum(
   this: CalculationRelation,
   column: string | Nodes.Node,
-): Promise<unknown | null | Record<string, unknown> | Map<unknown, unknown>> {
-  if (isEmptyCalculationScope(this)) return this._groupColumns.length > 0 ? {} : null;
+): Promise<unknown | null | Map<unknown, unknown>> {
+  if (isEmptyCalculationScope(this)) return this._groupColumns.length > 0 ? new Map() : null;
   if (this._groupColumns.length > 0) {
     return groupedAggregate(this, "minimum", column, false);
   }
@@ -1202,8 +1229,8 @@ export async function performMinimum(
 export async function performMaximum(
   this: CalculationRelation,
   column: string | Nodes.Node,
-): Promise<unknown | null | Record<string, unknown> | Map<unknown, unknown>> {
-  if (isEmptyCalculationScope(this)) return this._groupColumns.length > 0 ? {} : null;
+): Promise<unknown | null | Map<unknown, unknown>> {
+  if (isEmptyCalculationScope(this)) return this._groupColumns.length > 0 ? new Map() : null;
   if (this._groupColumns.length > 0) {
     return groupedAggregate(this, "maximum", column, false);
   }
@@ -1222,15 +1249,11 @@ export async function performMaximum(
  * rules then reject every subclass override.
  */
 export interface CalculationMethods {
-  count(
-    column?: string | Nodes.Node,
-  ): Promise<number | Record<string, number> | Map<unknown, number>>;
-  sum(
-    column?: string | Nodes.Node,
-  ): Promise<number | bigint | Record<string, number | bigint> | Map<unknown, number | bigint>>;
-  average(column: string | Nodes.Node): Promise<unknown | null | Record<string, unknown>>;
-  minimum(column: string | Nodes.Node): Promise<unknown | null | Record<string, unknown>>;
-  maximum(column: string | Nodes.Node): Promise<unknown | null | Record<string, unknown>>;
+  count(column?: string | Nodes.Node): Promise<number | Map<unknown, number>>;
+  sum(column?: string | Nodes.Node): Promise<number | bigint | Map<unknown, number | bigint>>;
+  average(column: string | Nodes.Node): Promise<unknown | null | Map<unknown, unknown>>;
+  minimum(column: string | Nodes.Node): Promise<unknown | null | Map<unknown, unknown>>;
+  maximum(column: string | Nodes.Node): Promise<unknown | null | Map<unknown, unknown>>;
 }
 
 /**
@@ -1394,7 +1417,7 @@ export async function executeGroupedCalculation(
   operation: string,
   columnName: string,
   distinct: boolean,
-): Promise<Record<string, unknown> | Map<unknown, unknown>> {
+): Promise<Map<unknown, unknown>> {
   const fn = operation.toLowerCase() as AggFn;
   // Build a GROUP BY aggregate query via Arel (delegates to the shared groupedAggregate helper).
   const table = rel._modelClass.arelTable as Nodes.Node;

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -389,9 +389,7 @@ describe("RelationTest", () => {
     // while average() yields a number, so coerce both to Number for comparison
     // (Rails compares BigDecimal == Integer loosely).
     const relCounts = (await relation.toArray()).map((r: any) => Number(r.post_count)).sort();
-    const subValues = Object.values((await subquery) as Record<string, number>)
-      .map(Number)
-      .sort();
+    const subValues = [...((await subquery) as Map<unknown, number>).values()].map(Number).sort();
     expect(subValues).toEqual(relCounts);
   });
 
@@ -411,9 +409,7 @@ describe("RelationTest", () => {
       .group("type")
       .average("post_count");
     const relCounts = (await relation.toArray()).map((r: any) => Number(r.post_count)).sort();
-    const subValues = Object.values((await subquery) as Record<string, number>)
-      .map(Number)
-      .sort();
+    const subValues = [...((await subquery) as Map<unknown, number>).values()].map(Number).sort();
     expect(subValues).toEqual(relCounts);
   });
 
@@ -1351,11 +1347,12 @@ describe("RelationTest", () => {
       .where("id is not null")
       .group("author_id")
       .where("legacy_comments_count > 0");
-    const expected: Record<number, number> = { 1: 4, 2: 1 };
-    const result = (await postsRel.count()) as Record<string | number, number>;
-    expect(
-      Object.fromEntries(Object.entries(result).map(([k, v]) => [Number(k), Number(v)])),
-    ).toEqual(expected);
+    const expected = new Map([
+      [1, 4],
+      [2, 1],
+    ]);
+    const result = await postsRel.count();
+    expect(result).toEqual(expected);
   });
 
   it("empty", async () => {

--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -568,8 +568,8 @@ describe("DefaultScopingTest", () => {
 
   it("default scope select ignored by grouped aggregations", async () => {
     const all = await Developer.all();
-    const expected: Record<string, number> = {};
-    for (const d of all as any[]) expected[d.salary] = (expected[d.salary] ?? 0) + 1;
+    const expected = new Map<unknown, number>();
+    for (const d of all as any[]) expected.set(d.salary, (expected.get(d.salary) ?? 0) + 1);
     const received = await DeveloperWithSelect.group("salary").count();
     expect(received).toEqual(expected);
   });

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -537,15 +537,6 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "out of scope (matches the migration/compatibility exclusion). The non-legacy " +
       "schema-dump emission is covered by the passing sibling tests.",
   },
-  // --- Deferred: tracked by focused RFC 0030 stories; remove when they converge ---
-  {
-    testFile: "adapters/postgresql/timestamp_test.rb",
-    tests: ["group by date"],
-    reason:
-      "Deferred: grouped-calculation result keys are String()-ified (Record) while Rails " +
-      "keys are type-cast objects (assert_kind_of Time). Tracked: RFC 0030 story " +
-      "grouped-calculation-typed-keys — remove this entry when it converges.",
-  },
   // --- Permanently not-portable: scattered YAML/Marshal serialization ---
   {
     testFile: "adapters/postgresql/hstore_test.rb",


### PR DESCRIPTION
## Summary

Rails' `execute_grouped_calculation` → `type_cast_calculated_value` keys the grouped-calculation Hash by the **type-cast group value** (`calculations.rb:514-594`): the model's attribute type when the field is its own column, the group field's own Arel `type_caster` when qualified to another table, and `calculated_data.column_types` for expressions the model doesn't own (so `Topic.group("date_trunc('month', created_at)").count` has `Time` keys — `adapters/postgresql/timestamp_test.rb` `test_group_by_date`).

trails' `groupedAggregate` scalar/expression arm ran the key through `deserialize` but then `String()`-ified it into a `Record<string, unknown>`, so typed keys (numbers, booleans, Temporal instants, `null`) could never survive.

## Changes

- **`relation/calculations.ts`**: the scalar/expression arm now returns `Map<unknown, unknown>` (the shape the association-keyed and composite-PK arms already use), keyed by the deserialized value; `null` groups stay a `null` key (Rails' `nil`). Key type resolution mirrors Rails: model attribute type for bare/self-qualified fields (last `.`-segment, per `type_for`), the result's column types otherwise — a field qualified to a *different* table never picks up the model's same-named column type (Rails keeps accounts' strings when grouping `Company` by `"accounts.status"`, not Company's integer enum).
- Grouped empty-scope short-circuits (`none()`, grouped contradiction) return `new Map()` instead of `{}` across count/sum/average/minimum/maximum.
- Signature unions drop `Record<...>` in `relation.ts#calculate`, `CalculationMethods`, `collection-proxy.ts`, `disable-joins-association-relation.ts`.
- **Callers migrated** to the Map shape: `calculations.test.ts`, `relations.test.ts`, `relation.test.ts`, `null-relation.test.ts`, `default-scoping.test.ts` — several tests now assert Rails' concrete hash literals (e.g. `{ nil => 50, 1 => 50, 6 => 105, 2 => 60, 9 => 53 }`) instead of stringly lookups.
- **Un-skipped** `adapters/postgresql/timestamp.test.ts` "group by date": ported from `timestamp_test.rb:123-127`, seeds `topics` fixtures, asserts every key is a `Temporal.Instant` (trails' `Time`). No `unported-files.ts` entry existed for this file, so there was nothing to drop there.

## Testing

- `calculations.test.ts` (229), `relations.test.ts`, `relation.test.ts`, `null-relation.test.ts`, `default-scoping.test.ts`, `or.test.ts`, cpk-eager fold suite + 10 other touching suites green on SQLite.
- `timestamp.test.ts` (27), `calculations.test.ts`, `null-relation.test.ts`, `relation.test.ts`, `default-scoping.test.ts` green under PG (isolated compose stack).

Size note: 595 LOC — over the 500 default; the overage is the caller migration the story requires to land in the same PR as the shape change.

Closes-story: grouped-calculation-typed-keys


## Codex review dispositions

1. **Multi-field groups still collapse to the first field** — confirmed pre-existing divergence (Rails builds `key = group_aliases.map {...}`, calculations.rb:553-589), not introduced here and larger than this story's scalar-arm scope. Registered as story `grouped-calculation-composite-keys` (RFC 0030) with the Rails `file:line` context and the three weak sum-invariant tests to converge alongside it.
2. **Arel group attribute's `typeCaster` not consulted** — fixed in cd54b8dfd: key type resolution now mirrors Rails' `col_name.try(:type_caster) || type_for(col_name) { column_types.fetch(...) }` order, with a trails regression test (`calculations.trails.test.ts`) asserting `Book.group(Book.arelTable.get("status")).count()` keys by enum labels; verified to fail without the branch.
