### PR TITLE
refactor(encryption): retire AV-wrapping of current-scheme expansion candidate

### DIFF
--- a/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
@@ -522,11 +522,9 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries.installSupport"
       rel.where({ email: "a@x" });
       const captured = rel._lastWhere.email as unknown[];
       expect(Array.isArray(captured)).toBe(true);
-      // See allCiphertextsFor: our expansion puts AV(current) at [0] (not
-      // plaintext like Rails) because our PredicateBuilder bypasses
-      // EncryptedAttributeType.serialize for raw scalars in IN arrays.
-      expect(captured[0]).toBeInstanceOf(AdditionalValue);
-      expect((captured[0] as AdditionalValue).value).toBeDefined();
+      // Rails shape: raw plaintext at [0] (the PredicateBuilder serializes it
+      // through the resolved type), previous-scheme AVs after it.
+      expect(captured[0]).toBe("a@x");
       expect(captured[1]).toBeInstanceOf(AdditionalValue);
     });
   });
@@ -570,7 +568,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueries.installSupport"
       (Contact as any).findBy({ email: "x" });
       const captured = (Contact as any)._lastFindBy.email as unknown[];
       expect(Array.isArray(captured)).toBe(true);
-      expect(captured[0]).toBeInstanceOf(AdditionalValue);
+      expect(captured[0]).toBe("x");
       expect(captured[1]).toBeInstanceOf(AdditionalValue);
     });
   });

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.trails.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.trails.test.ts
@@ -123,13 +123,27 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueriesTest (trails ext
     // EncryptedAttributeType — the delegation the expansion must honor.
     expect(fullType).not.toBeInstanceOf(EncryptedAttributeType);
 
-    const [current] = EncryptedUniquenessValidator.allCiphertextsFor(
+    const candidates = EncryptedUniquenessValidator.allCiphertextsFor(
       EncryptedSerializedBook,
       "name",
       "Dune",
-    ) as Array<{ value: unknown }>;
-    // Deterministic encryption: the expansion candidate must equal the
-    // write-path ciphertext (coder dump applied before encryption).
-    expect(current.value).toEqual(fullType.serialize("Dune"));
+    );
+    // Rails shape: raw plaintext first, AdditionalValues only for previous
+    // schemes. The current-scheme candidate is serialized downstream by the
+    // PredicateBuilder through the attribute's resolved type.
+    expect(candidates[0]).toBe("Dune");
+    expect(candidates.length).toBeGreaterThan(1);
+    // The type the PredicateBuilder serializes IN-list scalars through
+    // (HomogeneousIn#castedValues → attribute typeCaster) must be the full
+    // resolved type, so the candidate matches the write-path ciphertext
+    // (coder dump applied before encryption). Deterministic encryption makes
+    // the equality check meaningful.
+    const arelAttr = (
+      EncryptedSerializedBook as unknown as {
+        arelTable: { get(name: string): { typeCaster: unknown } };
+      }
+    ).arelTable.get("name");
+    const caster = arelAttr.typeCaster as { serialize(v: unknown): unknown };
+    expect(caster.serialize("Dune")).toEqual(fullType.serialize("Dune"));
   });
 });

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.trails.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.trails.test.ts
@@ -129,15 +129,13 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueriesTest (trails ext
       "Dune",
     );
     // Rails shape: raw plaintext first, AdditionalValues only for previous
-    // schemes. The current-scheme candidate is serialized downstream by the
-    // PredicateBuilder through the attribute's resolved type.
+    // schemes.
     expect(candidates[0]).toBe("Dune");
     expect(candidates.length).toBeGreaterThan(1);
     // The type the PredicateBuilder serializes IN-list scalars through
     // (HomogeneousIn#castedValues → attribute typeCaster) must be the full
-    // resolved type, so the candidate matches the write-path ciphertext
-    // (coder dump applied before encryption). Deterministic encryption makes
-    // the equality check meaningful.
+    // resolved type, so the raw candidate encrypts to the write-path
+    // ciphertext (coder dump applied before encryption).
     const arelAttr = (
       EncryptedSerializedBook as unknown as {
         arelTable: { get(name: string): { typeCaster: unknown } };

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.ts
@@ -140,12 +140,7 @@ export class EncryptedQuery {
       if (!type.previousTypes.length) continue;
       const value = result[attrName];
       if (value === undefined) continue;
-      result[attrName] = this.processEncryptedQueryArgument(
-        value,
-        checkForAdditionalValues,
-        fullType,
-        type,
-      );
+      result[attrName] = this.processEncryptedQueryArgument(value, checkForAdditionalValues, type);
       modified = true;
     }
 
@@ -155,11 +150,8 @@ export class EncryptedQuery {
   private static processEncryptedQueryArgument(
     value: unknown,
     checkForAdditionalValues: boolean,
-    fullType: SerializableType,
     type: EncryptedAttributeType,
   ): unknown {
-    if (value === null) return value;
-
     // Rails' process_encrypted_query_argument short-circuits when the
     // caller is a Relation (`where`/`exists?`) and the value is already
     // an expanded array whose last element is an AdditionalValue — that
@@ -177,14 +169,25 @@ export class EncryptedQuery {
       return value;
     }
 
-    if (Array.isArray(value)) {
-      return value.flatMap((v) => {
-        if (v === null) return [v];
-        if (checkForAdditionalValues && v instanceof AdditionalValue) return [v];
-        return this.allCiphertextsFor(v, fullType, type);
-      });
+    // Rails (extended_deterministic_queries.rb:73-86): only String/Array
+    // arguments expand; anything else passes through untouched. Plaintext
+    // candidates stay raw at the head of the list — the PredicateBuilder
+    // serializes them through the attribute's resolved type
+    // (HomogeneousIn#castedValues), which encrypts with the current scheme.
+    // Only previous-scheme candidates are AdditionalValue-wrapped; the
+    // support_unencrypted_data cleartext candidate arrives as one of those
+    // (previousTypes appends a clean-text scheme).
+    if (typeof value === "string" || Array.isArray(value)) {
+      const list = Array.isArray(value) ? value : [value];
+      return [
+        ...list,
+        ...list.flatMap((eachValue) => {
+          if (checkForAdditionalValues && eachValue instanceof AdditionalValue) return [eachValue];
+          return this.additionalValuesFor(eachValue, type);
+        }),
+      ];
     }
-    return this.allCiphertextsFor(value, fullType, type);
+    return value;
   }
 
   /** @internal */
@@ -193,34 +196,6 @@ export class EncryptedQuery {
     type: EncryptedAttributeType,
   ): AdditionalValue[] {
     return type.previousTypes.map((additionalType) => new AdditionalValue(value, additionalType));
-  }
-
-  private static allCiphertextsFor(
-    plaintext: unknown,
-    fullType: SerializableType,
-    type: EncryptedAttributeType,
-  ): Array<AdditionalValue | unknown> {
-    // Unlike Rails (which keeps plaintext at index 0 and relies on the
-    // PredicateBuilder type-casting scalars to encrypt them), our
-    // PredicateBuilder only type-casts objects via `build`/`QueryAttribute`.
-    // Plain scalars in an IN array bypass `EncryptedAttributeType.serialize`
-    // and land in the SQL unencrypted. Wrapping encrypted candidates in
-    // AdditionalValue ensures those elements go through `predicateBuilder.build`
-    // → `ExtendedEncryptableType.serialize` → pre-computed ciphertext, while
-    // still preserving the raw plaintext when unencrypted data remains queryable
-    // during migration (support_unencrypted_data).
-    // The current-scheme candidate serializes through the FULL resolved type
-    // (coder dumped before encryption, matching the write path); previous-
-    // scheme candidates use the bare previous EncryptedAttributeTypes, as
-    // Rails' delegated `previous_types` do.
-    const results: Array<AdditionalValue | unknown> = [new AdditionalValue(plaintext, fullType)];
-    for (const prev of type.previousTypes) {
-      results.push(new AdditionalValue(plaintext, prev));
-    }
-    if (type.supportUnencryptedData) {
-      results.push(plaintext);
-    }
-    return results;
   }
 }
 
@@ -262,13 +237,15 @@ export class RelationQueries {
       const type = encryptedTypeOf(getAttributeType(model, attrName));
       if (!type?.deterministic) continue;
       const values = wheres[attrName];
-      if (Array.isArray(values) && values[0] instanceof AdditionalValue) {
-        // Our expansion stores AdditionalValue(current) at index 0 (see
-        // allCiphertextsFor). Keep the AV reference — when the new record
-        // saves, EncryptedAttributeType.serialize (patched via
-        // ExtendedEncryptableType) unwraps it to the ciphertext without
-        // re-encrypting. Writing values[0].value directly would serialize
-        // the ciphertext as plaintext, producing a double-encrypted blob.
+      // Rails (extended_deterministic_queries.rb:114-117): an expanded list
+      // is raw plaintext at [0] followed only by AdditionalValues — collapse
+      // it back to the plaintext so the new record encrypts through the
+      // normal write path.
+      if (
+        Array.isArray(values) &&
+        values.length > 0 &&
+        values.slice(1).every((v) => v instanceof AdditionalValue)
+      ) {
         scopeAttrs[attrName] = values[0];
       }
     }

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.ts
@@ -3,9 +3,9 @@ import { ADDITIONAL_VALUE_BRAND, EncryptedAttributeType } from "./encrypted-attr
 import { getAttributeType, encryptedTypeOf } from "./encryptable-record.js";
 
 /**
- * What AdditionalValue needs from its type. Rails passes the full resolved
- * `type_for_attribute` type here — for a Serialized(Encrypted(...)) attribute
- * that's the outer Type::Serialized, not EncryptedAttributeType.
+ * What AdditionalValue needs from its type — one of the attribute's
+ * `previousTypes` (bare previous-scheme EncryptedAttributeTypes, as Rails'
+ * delegated `previous_types`).
  */
 export interface SerializableType {
   serialize(value: unknown): unknown;
@@ -169,14 +169,11 @@ export class EncryptedQuery {
       return value;
     }
 
-    // Rails (extended_deterministic_queries.rb:73-86): only String/Array
-    // arguments expand; anything else passes through untouched. Plaintext
-    // candidates stay raw at the head of the list — the PredicateBuilder
+    // Only String/Array arguments expand (extended_deterministic_queries.rb:74).
+    // Plaintexts stay raw at the head of the list — the PredicateBuilder
     // serializes them through the attribute's resolved type
-    // (HomogeneousIn#castedValues), which encrypts with the current scheme.
-    // Only previous-scheme candidates are AdditionalValue-wrapped; the
-    // support_unencrypted_data cleartext candidate arrives as one of those
-    // (previousTypes appends a clean-text scheme).
+    // (HomogeneousIn#castedValues), encrypting with the current scheme; only
+    // previous-scheme candidates are AdditionalValue-wrapped.
     if (typeof value === "string" || Array.isArray(value)) {
       const list = Array.isArray(value) ? value : [value];
       return [
@@ -237,10 +234,13 @@ export class RelationQueries {
       const type = encryptedTypeOf(getAttributeType(model, attrName));
       if (!type?.deterministic) continue;
       const values = wheres[attrName];
-      // Rails (extended_deterministic_queries.rb:114-117): an expanded list
-      // is raw plaintext at [0] followed only by AdditionalValues — collapse
-      // it back to the plaintext so the new record encrypts through the
-      // normal write path.
+      // An expanded list is raw plaintext at [0] followed only by
+      // AdditionalValues — collapse it back to the plaintext so the new
+      // record encrypts through the normal write path
+      // (extended_deterministic_queries.rb:115-117). The length guard is
+      // ours: `[].slice(1).every(...)` is vacuously true and would copy
+      // `undefined` into the scope for an empty (unreachable in Rails,
+      // where `[][1..]` is nil) where-list.
       if (
         Array.isArray(values) &&
         values.length > 0 &&

--- a/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.ts
@@ -114,16 +114,18 @@ export class EncryptedUniquenessValidator {
   }
 
   /**
-   * Returns all ciphertext variants for a value across current and
-   * previous encryption schemes. Used by uniqueness validation to
-   * check for duplicates across scheme migrations.
+   * Returns the query candidates for a value across current and previous
+   * encryption schemes: the raw plaintext (current scheme, encrypted
+   * downstream by the PredicateBuilder) plus an AdditionalValue per previous
+   * scheme. Used by uniqueness validation to check for duplicates across
+   * scheme migrations.
    */
   static allCiphertextsFor(klass: any, attribute: string, value: unknown): unknown[] {
-    // Rails shape: the current-scheme candidate stays as raw plaintext at
-    // index 0 (the PredicateBuilder serializes it through the attribute's
-    // resolved type); only previous-scheme candidates are
-    // AdditionalValue-wrapped. Gating reaches the inner type via
-    // encryptedTypeOf — Rails' DelegateClass delegation.
+    // The current-scheme candidate stays as raw plaintext at index 0 — the
+    // PredicateBuilder serializes it through the attribute's resolved type;
+    // only previous-scheme candidates are AdditionalValue-wrapped. Gating
+    // reaches the inner type via encryptedTypeOf (Rails' DelegateClass
+    // delegation).
     const fullType = getAttributeType(klass, attribute) as SerializableType | undefined;
     const type = encryptedTypeOf(fullType);
     if (!fullType || !type?.deterministic) {

--- a/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.ts
@@ -119,23 +119,17 @@ export class EncryptedUniquenessValidator {
    * check for duplicates across scheme migrations.
    */
   static allCiphertextsFor(klass: any, attribute: string, value: unknown): unknown[] {
-    // The current-scheme candidate serializes through the FULL
-    // `type_for_attribute` type (coder dumped before encryption, matching the
-    // write path); gating reaches the inner type via encryptedTypeOf — Rails'
-    // DelegateClass delegation.
+    // Rails shape: the current-scheme candidate stays as raw plaintext at
+    // index 0 (the PredicateBuilder serializes it through the attribute's
+    // resolved type); only previous-scheme candidates are
+    // AdditionalValue-wrapped. Gating reaches the inner type via
+    // encryptedTypeOf — Rails' DelegateClass delegation.
     const fullType = getAttributeType(klass, attribute) as SerializableType | undefined;
     const type = encryptedTypeOf(fullType);
     if (!fullType || !type?.deterministic) {
       return [value];
     }
 
-    const results: Array<unknown | AdditionalValue> = [];
-    results.push(new AdditionalValue(value, fullType));
-
-    for (const prevType of type.previousTypes) {
-      results.push(new AdditionalValue(value, prevType));
-    }
-
-    return results;
+    return [value, ...type.previousTypes.map((prevType) => new AdditionalValue(value, prevType))];
   }
 }

--- a/packages/activerecord/src/type/serialized.ts
+++ b/packages/activerecord/src/type/serialized.ts
@@ -103,20 +103,6 @@ function canonicalKey(value: unknown): string {
  */
 const NONSERIALIZABLE_SENTINEL = "\u0000serialized:";
 
-// Global-registry copy of encryption's ADDITIONAL_VALUE_BRAND
-// (encrypted-attribute-type.ts). Resolved via Symbol.for rather than an
-// import because encrypted-attribute-type.ts imports this module — the same
-// cycle the brand exists to break.
-const ADDITIONAL_VALUE_BRAND = Symbol.for("activerecord.encryption.AdditionalValue");
-
-function isAdditionalValue(value: unknown): boolean {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    (value as Record<symbol, unknown>)[ADDITIONAL_VALUE_BRAND] === true
-  );
-}
-
 /**
  * Recursively unwraps `toHash()`-bearing objects and sorts plain-object keys so
  * the resulting structure has a canonical, insertion-order-independent shape.
@@ -298,11 +284,6 @@ export class Serialized extends ValueType {
   }
 
   cast(value: unknown): unknown {
-    // Encryption AdditionalValues pass through cast unchanged so serialize()
-    // can unwrap them — the same contract as EncryptedAttributeType.cast,
-    // needed here because a Serialized(Encrypted(...)) attribute's resolved
-    // type is this wrapper.
-    if (isAdditionalValue(value)) return value;
     // Rails: ActiveModel::Type::Helpers::Mutable#cast is always
     // `deserialize(serialize(value))`. Serializing first means a value the
     // coder can't round-trip (e.g. a non-Hash string like "somedata" through
@@ -313,12 +294,6 @@ export class Serialized extends ValueType {
 
   serialize(value: unknown): unknown {
     if (value === null || value === undefined) return null;
-    // Unwrap encryption AdditionalValues to their pre-computed ciphertext
-    // instead of feeding the AV object to the coder — mirrors Rails'
-    // ExtendedEncryptableType prepend on the bare EncryptedAttributeType. The
-    // AV-wrapped current-scheme value is a trails invention (Rails keeps the
-    // plaintext raw), so the wrapper type must honor it too.
-    if (isAdditionalValue(value)) return (value as { value: unknown }).value;
     if (this.isDefaultValue(value)) return null;
     const dumped = this.coder.dump(value);
     if (this.subtype.serialize) {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption/extended-deterministic-queries.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption/extended-deterministic-queries.json
@@ -80,13 +80,6 @@
     "package": "activerecord",
     "tsFile": "encryption/extended-deterministic-queries.ts",
     "rubyName": "process_encrypted_query_argument",
-    "call": "additional_values_for",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/extended-deterministic-queries.ts",
-    "rubyName": "process_encrypted_query_argument",
     "call": "last",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
Retires the trails invention that wrapped the current-scheme expansion candidate in an `AdditionalValue`, converging deterministic encrypted-query expansion to Rails.

## Changes

- **`ExtendedDeterministicQueries.processEncryptedQueryArgument`** now mirrors Rails (`extended_deterministic_queries.rb:71-93`): only String/Array arguments expand, raw plaintext stays at the head of the list, and the previously-dead `additionalValuesFor` is the live path — `AdditionalValue` wrapping is reserved for previous-scheme candidates. The PredicateBuilder already serializes plain IN-list scalars through the attribute's resolved type (`HomogeneousIn#castedValues` → attribute `typeCaster` → `TypeCasterMap` → `typeForAttribute`), which encrypts the raw candidate with the current scheme — the machinery Rails relies on.
- **`RelationQueries.scopeForCreate`** collapses an expanded list back to its raw plaintext head, mirroring Rails' `values[1..].all?(AdditionalValue) → values.first`, so the new record encrypts through the normal write path (no AV copy-through needed).
- **`EncryptedUniquenessValidator.allCiphertextsFor`** follows the same Rails shape: raw value first, previous-scheme AVs after.
- **`type/serialized.ts`**: the `ADDITIONAL_VALUE_BRAND` pass-through/unwrap added in #5135 (Symbol.for brand copy, `cast`/`serialize` special cases) is deleted — no `AdditionalValue` reaches the wrapper type anymore.

The `Serialized(Encrypted(...))` guard in `extended-deterministic-queries.trails.test.ts` stays green: the current-scheme candidate is now serialized by the PredicateBuilder through the full resolved type (coder dump before encryption, matching the write path).

## Tests

- `encryption/` suite (34 files, 343 tests) green locally; `serialized-attribute.test.ts` green.
- Unit assertions that encoded the old AV-at-[0] shape updated to the Rails shape (test names unchanged).

Closes-story: current-scheme-av-wrap-invention-retire
