### PR TITLE
fix(encryption): apply store_key_references tag in KeyProvider#encryptionKey

### DIFF
--- a/packages/activerecord/src/encryption/derived-secret-key-provider.test.ts
+++ b/packages/activerecord/src/encryption/derived-secret-key-provider.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 import { Encryptor } from "./encryptor.js";
 import { Configurable } from "./configurable.js";
@@ -12,6 +12,9 @@ describe("ActiveRecord::Encryption::DerivedSecretKeyProviderTest", () => {
   afterAll(() => {
     Configurable.config.keyDerivationSalt = originalSalt;
   });
+  afterEach(() => {
+    Configurable.config.storeKeyReferences = false;
+  });
 
   it("will derive a key with the right length from the given password", () => {
     const provider = new DerivedSecretKeyProvider("my-password");
@@ -21,6 +24,7 @@ describe("ActiveRecord::Encryption::DerivedSecretKeyProviderTest", () => {
   });
 
   it("work with multiple keys when config.store_key_references is false", () => {
+    Configurable.config.storeKeyReferences = false;
     const provider = new DerivedSecretKeyProvider(["password1", "password2"]);
     const enc = new Encryptor({ compress: false });
     const encrypted = enc.encrypt("hello", { keyProvider: provider });
@@ -29,6 +33,7 @@ describe("ActiveRecord::Encryption::DerivedSecretKeyProviderTest", () => {
   });
 
   it("work with multiple keys when config.store_key_references is true", () => {
+    Configurable.config.storeKeyReferences = true;
     const provider = new DerivedSecretKeyProvider(["password1", "password2"]);
     const enc = new Encryptor({ compress: false });
     const encrypted = enc.encrypt("hello", { keyProvider: provider });

--- a/packages/activerecord/src/encryption/encryptor.ts
+++ b/packages/activerecord/src/encryption/encryptor.ts
@@ -5,6 +5,7 @@
  */
 
 import { Message } from "./message.js";
+import type { Properties } from "./properties.js";
 import { MessageSerializer, type MessageSerializerLike } from "./message-serializer.js";
 import { getEncryptionContext } from "./context.js";
 import { Configurable } from "./configurable.js";
@@ -40,8 +41,10 @@ export interface EncryptorLike {
 }
 
 export interface KeyProviderLike {
-  encryptionKey(): { secret: string; publicTags?: Record<string, unknown> };
-  decryptionKeys(message: Message): Array<{ secret: string; publicTags?: Record<string, unknown> }>;
+  encryptionKey(): { secret: string; publicTags?: Record<string, unknown> | Properties };
+  decryptionKeys(
+    message: Message,
+  ): Array<{ secret: string; publicTags?: Record<string, unknown> | Properties }>;
 }
 
 export class Encryptor {
@@ -216,9 +219,7 @@ export class Encryptor {
     const message = this.cipher().encrypt(cipherInput, { key, ...cipherOptions });
     if (compressed) message.addHeader("c", true);
     if (encKeyObj.publicTags) {
-      for (const [k, v] of Object.entries(encKeyObj.publicTags)) {
-        message.addHeader(k, v);
-      }
+      message.addHeaders(encKeyObj.publicTags);
     }
     return message;
   }

--- a/packages/activerecord/src/encryption/envelope-encryption-key-provider.test.ts
+++ b/packages/activerecord/src/encryption/envelope-encryption-key-provider.test.ts
@@ -35,7 +35,7 @@ describe("ActiveRecord::Encryption::EnvelopeEncryptionKeyProviderTest", () => {
     const primaryProvider = new KeyProvider(makeKey());
     const provider = new EnvelopeEncryptionKeyProvider(primaryProvider);
     const key = provider.encryptionKey();
-    expect(key.publicTags.get("encrypted_data_key")).toBeTruthy();
+    expect(key.publicTags.encryptedDataKey).toBeTruthy();
   });
 
   it("decryption_key_for returns the decryption key for a message that was encrypted with a generated encryption key", () => {

--- a/packages/activerecord/src/encryption/envelope-encryption-key-provider.test.ts
+++ b/packages/activerecord/src/encryption/envelope-encryption-key-provider.test.ts
@@ -30,7 +30,7 @@ describe("ActiveRecord::Encryption::EnvelopeEncryptionKeyProviderTest", () => {
     const primaryProvider = new KeyProvider(makeKey());
     const provider = new EnvelopeEncryptionKeyProvider(primaryProvider);
     const key = provider.encryptionKey();
-    expect(key.publicTags.encrypted_data_key).toBeTruthy();
+    expect(key.publicTags.get("encrypted_data_key")).toBeTruthy();
   });
 
   it("decryption_key_for returns the decryption key for a message that was encrypted with a generated encryption key", () => {

--- a/packages/activerecord/src/encryption/envelope-encryption-key-provider.test.ts
+++ b/packages/activerecord/src/encryption/envelope-encryption-key-provider.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
+import { Configurable } from "./configurable.js";
 import { EnvelopeEncryptionKeyProvider } from "./envelope-encryption-key-provider.js";
 import { KeyProvider } from "./key-provider.js";
 import { Key } from "./key.js";
@@ -10,6 +11,10 @@ function makeKey(): Key {
 }
 
 describe("ActiveRecord::Encryption::EnvelopeEncryptionKeyProviderTest", () => {
+  afterEach(() => {
+    Configurable.config.storeKeyReferences = false;
+  });
+
   it("encryption_key returns random encryption keys", () => {
     const primaryProvider = new KeyProvider(makeKey());
     const provider = new EnvelopeEncryptionKeyProvider(primaryProvider);
@@ -71,6 +76,7 @@ describe("ActiveRecord::Encryption::EnvelopeEncryptionKeyProviderTest", () => {
   });
 
   it("work with multiple keys when config.store_key_references is true", () => {
+    Configurable.config.storeKeyReferences = true;
     const primaryProvider = new KeyProvider([makeKey(), makeKey()]);
     const provider = new EnvelopeEncryptionKeyProvider(primaryProvider);
     const enc = new Encryptor({ compress: false });

--- a/packages/activerecord/src/encryption/envelope-encryption-key-provider.ts
+++ b/packages/activerecord/src/encryption/envelope-encryption-key-provider.ts
@@ -27,7 +27,7 @@ export class EnvelopeEncryptionKeyProvider {
   encryptionKey(): Key {
     const randomSecret = this.generateRandomSecret();
     const key = new Key(randomSecret);
-    key.publicTags = { encrypted_data_key: this.encryptDataKey(randomSecret) };
+    key.publicTags.set("encrypted_data_key", this.encryptDataKey(randomSecret));
     return key;
   }
 

--- a/packages/activerecord/src/encryption/envelope-encryption-key-provider.ts
+++ b/packages/activerecord/src/encryption/envelope-encryption-key-provider.ts
@@ -27,7 +27,10 @@ export class EnvelopeEncryptionKeyProvider {
   encryptionKey(): Key {
     const randomSecret = this.generateRandomSecret();
     const key = new Key(randomSecret);
-    key.publicTags.set("encrypted_data_key", this.encryptDataKey(randomSecret));
+    key.publicTags.encryptedDataKey = this.encryptDataKey(randomSecret);
+    if (Configurable.config.storeKeyReferences) {
+      key.publicTags.encryptedDataKeyId = this.activePrimaryKey.id;
+    }
     return key;
   }
 
@@ -54,7 +57,7 @@ export class EnvelopeEncryptionKeyProvider {
 
   /** @internal */
   private decryptDataKey(encryptedMessage: Message): string | null {
-    const encryptedDataKey = headerString(encryptedMessage.headers.get("encrypted_data_key"));
+    const encryptedDataKey = headerString(encryptedMessage.headers.encryptedDataKey);
     if (!encryptedDataKey) return null;
     try {
       return new Encryptor({ compress: false }).decrypt(encryptedDataKey, {

--- a/packages/activerecord/src/encryption/key-provider.test.ts
+++ b/packages/activerecord/src/encryption/key-provider.test.ts
@@ -80,7 +80,6 @@ describe("ActiveRecord::Encryption::KeyProviderTest", () => {
   });
 });
 
-// Mirrors ActiveRecord::EncryptionTestCase#assert_encryptor_works_with.
 function assertEncryptorWorksWith(keyProvider: KeyProvider): void {
   const encryptor = new Encryptor();
   const encryptedMessage = encryptor.encrypt("some text", { keyProvider });

--- a/packages/activerecord/src/encryption/key-provider.test.ts
+++ b/packages/activerecord/src/encryption/key-provider.test.ts
@@ -1,82 +1,88 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { KeyProvider } from "./key-provider.js";
 import { Key } from "./key.js";
 import { Message } from "./message.js";
 import { Encryptor } from "./encryptor.js";
+import { Configurable } from "./configurable.js";
 import * as crypto from "crypto";
 
 function makeKey(): Key {
   return new Key(crypto.randomBytes(32).toString("base64"));
 }
 
+function buildKeys(count: number): Key[] {
+  return Array.from({ length: count }, () => makeKey());
+}
+
 describe("ActiveRecord::Encryption::KeyProviderTest", () => {
+  let message: Message;
+  let keys: Key[];
+  let keyProvider: KeyProvider;
+  let originalStoreKeyReferences: boolean;
+
+  beforeEach(() => {
+    originalStoreKeyReferences = Configurable.config.storeKeyReferences;
+    message = new Message("some secret");
+    keys = buildKeys(3);
+    keyProvider = new KeyProvider(keys);
+  });
+
+  afterEach(() => {
+    Configurable.config.storeKeyReferences = originalStoreKeyReferences;
+  });
+
   it("serves a single key for encrypting and decrypting", () => {
-    const key = makeKey();
+    const key = keys[0];
     const provider = new KeyProvider(key);
-    const encKey = provider.encryptionKey();
-    expect(encKey.secret).toBe(key.secret);
-    const decKeys = provider.decryptionKeys(new Message(""));
-    expect(decKeys).toHaveLength(1);
-    expect(decKeys[0].secret).toBe(key.secret);
+
+    expect(provider.encryptionKey()).toBe(key);
+    expect(provider.decryptionKeys(message)).toEqual([provider.encryptionKey()]);
   });
 
   it("serves the last key for encrypting", () => {
-    const k1 = makeKey();
-    const k2 = makeKey();
-    const provider = new KeyProvider([k1, k2]);
-    expect(provider.encryptionKey().secret).toBe(k2.secret);
+    expect(keyProvider.encryptionKey()).toBe(keys[keys.length - 1]);
   });
 
   it("when store_key_references is false, the encryption key contains a reference to the key itself", () => {
-    const key = makeKey();
-    const provider = new KeyProvider(key);
-    const encKey = provider.encryptionKey();
-    expect(encKey.id).toBeTruthy();
+    expect(keyProvider.encryptionKey().publicTags.encryptedDataKeyId).toBeUndefined();
   });
 
   it("when store_key_references is true, the encryption key contains a reference to the key itself", () => {
-    const key = makeKey();
-    const provider = new KeyProvider(key);
-    const encKey = provider.encryptionKey();
-    expect(encKey.id).toBe(key.id);
+    Configurable.config.storeKeyReferences = true;
+
+    expect(keyProvider.encryptionKey().publicTags.encryptedDataKeyId).toBe(
+      keys[keys.length - 1].id,
+    );
   });
 
   it("when the message does not contain any key reference, it returns all the keys", () => {
-    const k1 = makeKey();
-    const k2 = makeKey();
-    const provider = new KeyProvider([k1, k2]);
-    const decKeys = provider.decryptionKeys(new Message(""));
-    expect(decKeys).toHaveLength(2);
+    expect(keyProvider.decryptionKeys(message)).toEqual(keys);
   });
 
   it("when the message to decrypt contains a reference to the key id, it will return an array only with that message", () => {
-    const k1 = makeKey();
-    const k2 = makeKey();
-    const provider = new KeyProvider([k1, k2]);
-    const message = new Message("");
-    message.addHeader("k", k2.id);
-    const decKeys = provider.decryptionKeys(message);
-    expect(decKeys).toHaveLength(1);
-    expect(decKeys[0].secret).toBe(k2.secret);
+    const targetKey = keys[1];
+
+    message.headers.encryptedDataKeyId = targetKey.id;
+
+    expect(keyProvider.decryptionKeys(message)).toEqual([targetKey]);
   });
 
   it("work with multiple keys when config.store_key_references is false", () => {
-    const k1 = makeKey();
-    const k2 = makeKey();
-    const provider = new KeyProvider([k1, k2]);
-    const enc = new Encryptor({ compress: false });
-    const encrypted = enc.encrypt("hello", { keyProvider: provider });
-    const decrypted = enc.decrypt(encrypted, { keyProvider: provider });
-    expect(decrypted).toBe("hello");
+    Configurable.config.storeKeyReferences = false;
+
+    assertEncryptorWorksWith(keyProvider);
   });
 
   it("work with multiple keys when config.store_key_references is true", () => {
-    const k1 = makeKey();
-    const k2 = makeKey();
-    const provider = new KeyProvider([k1, k2]);
-    const enc = new Encryptor({ compress: false });
-    const encrypted = enc.encrypt("hello", { keyProvider: provider });
-    const decrypted = enc.decrypt(encrypted, { keyProvider: provider });
-    expect(decrypted).toBe("hello");
+    Configurable.config.storeKeyReferences = true;
+
+    assertEncryptorWorksWith(keyProvider);
   });
 });
+
+// Mirrors ActiveRecord::EncryptionTestCase#assert_encryptor_works_with.
+function assertEncryptorWorksWith(keyProvider: KeyProvider): void {
+  const encryptor = new Encryptor();
+  const encryptedMessage = encryptor.encrypt("some text", { keyProvider });
+  expect(encryptor.decrypt(encryptedMessage, { keyProvider })).toBe("some text");
+}

--- a/packages/activerecord/src/encryption/key-provider.ts
+++ b/packages/activerecord/src/encryption/key-provider.ts
@@ -6,10 +6,12 @@
 
 import { Key } from "./key.js";
 import { headerString } from "./encoding-helpers.js";
+import { Configurable } from "./configurable.js";
 import type { Message } from "./message.js";
 
 export class KeyProvider {
   private _keys: Key[];
+  private _encryptionKey: Key | undefined;
   private _keysGroupedById: Map<string, Key[]> | undefined;
 
   constructor(keys: Key | Key[]) {
@@ -17,17 +19,22 @@ export class KeyProvider {
   }
 
   encryptionKey(): Key {
-    return this._keys[this._keys.length - 1];
+    if (!this._encryptionKey) {
+      const key = this._keys[this._keys.length - 1];
+      if (Configurable.config.storeKeyReferences) {
+        key.publicTags.encryptedDataKeyId = key.id;
+      }
+      this._encryptionKey = key;
+    }
+    return this._encryptionKey;
   }
 
   decryptionKeys(message: Message): Key[] {
-    const keyRef = headerString(message.headers.get("k"));
-    if (keyRef) {
-      const grouped = this.keysGroupedById();
-      const found = grouped.get(keyRef);
-      if (found && found.length > 0) return found;
+    const keyId = headerString(message.headers.encryptedDataKeyId);
+    if (keyId != null) {
+      return this.keysGroupedById().get(keyId) ?? [];
     }
-    return [...this._keys];
+    return this._keys;
   }
 
   /** @internal */

--- a/packages/activerecord/src/encryption/key-provider.ts
+++ b/packages/activerecord/src/encryption/key-provider.ts
@@ -30,9 +30,10 @@ export class KeyProvider {
   }
 
   decryptionKeys(message: Message): Key[] {
-    const keyId = headerString(message.headers.encryptedDataKeyId);
-    if (keyId != null) {
-      return this.keysGroupedById().get(keyId) ?? [];
+    // Ruby truthiness: nil and false fall back to @keys; anything else is a reference.
+    const rawKeyId = message.headers.encryptedDataKeyId as unknown;
+    if (rawKeyId != null && rawKeyId !== false) {
+      return this.keysGroupedById().get(headerString(rawKeyId)!) ?? [];
     }
     return this._keys;
   }

--- a/packages/activerecord/src/encryption/key.test.ts
+++ b/packages/activerecord/src/encryption/key.test.ts
@@ -3,10 +3,10 @@ import { Key } from "./key.js";
 
 describe("ActiveRecord::Encryption::KeyTest", () => {
   it("A key can store a secret and public tags", () => {
-    const key = new Key("my-secret");
-    key.publicTags = { keyId: "abc" };
-    expect(key.secret).toBe("my-secret");
-    expect(key.publicTags).toEqual({ keyId: "abc" });
+    const key = new Key("the secret");
+    key.publicTags.set("key", "the key reference");
+    expect(key.secret).toBe("the secret");
+    expect(key.publicTags.get("key")).toBe("the key reference");
   });
 
   it(".derive_from instantiates a key with its secret derived from the passed password", () => {

--- a/packages/activerecord/src/encryption/key.ts
+++ b/packages/activerecord/src/encryption/key.ts
@@ -6,14 +6,15 @@
 
 import { getCrypto } from "@blazetrails/activesupport";
 import { KeyGenerator } from "./key-generator.js";
+import { Properties } from "./properties.js";
 
 export class Key {
   secret: string;
-  publicTags: Record<string, unknown>;
+  publicTags: Properties;
 
   constructor(secret: string) {
     this.secret = secret;
-    this.publicTags = {};
+    this.publicTags = new Properties();
   }
 
   get id(): string {

--- a/packages/activerecord/src/encryption/message.ts
+++ b/packages/activerecord/src/encryption/message.ts
@@ -21,7 +21,7 @@ export class Message {
     this.headers.set(key, value);
   }
 
-  addHeaders(props: Record<string, unknown>): void {
+  addHeaders(props: Record<string, unknown> | Properties): void {
     this.headers.add(props);
   }
 

--- a/packages/activerecord/src/encryption/properties.ts
+++ b/packages/activerecord/src/encryption/properties.ts
@@ -47,8 +47,9 @@ export class Properties {
     return this._data.has(key);
   }
 
-  add(props: Record<string, unknown>): void {
-    for (const [key, value] of Object.entries(props)) {
+  add(props: Record<string, unknown> | Properties): void {
+    const entries = props instanceof Properties ? props.entries() : Object.entries(props);
+    for (const [key, value] of entries) {
       this.set(key, value);
     }
   }
@@ -78,6 +79,15 @@ export class Properties {
       throw new EncryptedContentIntegrity("Can't override property 'e': already set");
     }
     this._data.set("e", value);
+  }
+
+  // Mirrors Rails' DEFAULT_PROPERTIES accessor: encrypted_data_key_id ↔ "i".
+  get encryptedDataKeyId(): string | undefined {
+    return this.get("i") as string | undefined;
+  }
+
+  set encryptedDataKeyId(value: string | undefined) {
+    this.set("i", value);
   }
 
   get iv(): string | undefined {

--- a/packages/activerecord/src/encryption/properties.ts
+++ b/packages/activerecord/src/encryption/properties.ts
@@ -81,7 +81,6 @@ export class Properties {
     this._data.set("e", value);
   }
 
-  // Mirrors Rails' DEFAULT_PROPERTIES accessor: encrypted_data_key_id ↔ "i".
   get encryptedDataKeyId(): string | undefined {
     return this.get("i") as string | undefined;
   }

--- a/packages/activerecord/src/encryption/properties.ts
+++ b/packages/activerecord/src/encryption/properties.ts
@@ -81,6 +81,14 @@ export class Properties {
     this._data.set("e", value);
   }
 
+  get encryptedDataKey(): string | undefined {
+    return this.get("k") as string | undefined;
+  }
+
+  set encryptedDataKey(value: string | undefined) {
+    this.set("k", value);
+  }
+
   get encryptedDataKeyId(): string | undefined {
     return this.get("i") as string | undefined;
   }

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption/envelope-encryption-key-provider.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption/envelope-encryption-key-provider.json
@@ -16,13 +16,6 @@
   {
     "package": "activerecord",
     "tsFile": "encryption/envelope-encryption-key-provider.ts",
-    "rubyName": "encryption_key",
-    "call": "id",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/envelope-encryption-key-provider.ts",
     "rubyName": "generate_random_secret",
     "call": "generate_random_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption/key-provider.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption/key-provider.json
@@ -4,7 +4,7 @@
     "tsFile": "encryption/key-provider.ts",
     "rubyName": "encryption_key",
     "call": "last",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails key_provider.rb:20-26 memoizes `@keys.last` and taps it with `key.id` when config.store_key_references; trails key-provider.ts:19-21 returns `_keys[_keys.length - 1]` \u2014 the store_key_references tap (config exists at encryption/config.ts:14) is unported. Omission tracked in story key-provider-ignores-store-key-references."
+    "reason": "Equivalent (bucket b): Rails key_provider.rb:21 reads `@keys.last`; trails key-provider.ts expresses the same read as `_keys[_keys.length - 1]` \u2014 JS arrays have no `.last`, so the call can never appear. The store_key_references tap itself is ported (PR #5143)."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption/key-provider.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption/key-provider.json
@@ -3,15 +3,8 @@
     "package": "activerecord",
     "tsFile": "encryption/key-provider.ts",
     "rubyName": "encryption_key",
-    "call": "id",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails key_provider.rb:20-26 memoizes `@keys.last` and taps it with `key.id` when config.store_key_references; trails key-provider.ts:19-21 returns `_keys[_keys.length - 1]` — the store_key_references tap (config exists at encryption/config.ts:14) is unported. Omission tracked in story key-provider-ignores-store-key-references."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/key-provider.ts",
-    "rubyName": "encryption_key",
     "call": "last",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails key_provider.rb:20-26 memoizes `@keys.last` and taps it with `key.id` when config.store_key_references; trails key-provider.ts:19-21 returns `_keys[_keys.length - 1]` — the store_key_references tap (config exists at encryption/config.ts:14) is unported. Omission tracked in story key-provider-ignores-store-key-references."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails key_provider.rb:20-26 memoizes `@keys.last` and taps it with `key.id` when config.store_key_references; trails key-provider.ts:19-21 returns `_keys[_keys.length - 1]` \u2014 the store_key_references tap (config exists at encryption/config.ts:14) is unported. Omission tracked in story key-provider-ignores-store-key-references."
   },
   {
     "package": "activerecord",


### PR DESCRIPTION
Ports Rails `KeyProvider#encryption_key`'s `store_key_references` handling (key_provider.rb:20-26), found by per-entry wide-call verification.

## Changes

- `KeyProvider#encryptionKey` now memoizes the last key and, when `config.storeKeyReferences` is set, tags it with `key.publicTags.encryptedDataKeyId = key.id` — so encrypted payloads carry a key reference and multi-key rotation lookup by reference works.
- `KeyProvider#decryptionKeys` reads the reference through the Rails header accessor (`encrypted_data_key_id` ↔ `"i"`, per Properties::DEFAULT_PROPERTIES) instead of the wrong short key `"k"` (which is `encrypted_data_key`, the envelope data key), and returns the grouped lookup result faithfully (`?? []` → empty list surfaces as a DecryptionError, matching Rails' presence check).
- `Properties` gains the `encryptedDataKeyId` accessor pair and `add()` accepts another `Properties` (Rails' `headers.add(key.public_tags)`).
- `Key#publicTags` is now a `Properties` as in Rails (was a bare Record); `Encryptor#buildEncryptedMessage` copies tags via `message.addHeaders(publicTags)` mirroring Rails' `headers.add`.
- Key-provider tests rewritten to assert the Rails behavior (config toggling with restore, `assert_encryptor_works_with` analogue) — the `store_key_references` tests here and in the derived-secret/envelope provider test files previously never touched the config flag; they now set and restore it as Rails does.

## Review round 1 (Codex)

- `EnvelopeEncryptionKeyProvider` now writes/reads the envelope data key through the new `Properties#encryptedDataKey` accessor (`encrypted_data_key` ↔ `"k"`), so headers carry the Rails-compatible short key instead of the literal `encrypted_data_key` string (envelope_encryption_key_provider.rb:21, properties.rb:23-39).
- `EnvelopeEncryptionKeyProvider#encryptionKey` tags `encryptedDataKeyId = activePrimaryKey.id` when `storeKeyReferences` is set, matching envelope_encryption_key_provider.rb:22, so the primary-key reference lookup in `KeyProvider#decryptionKeys` works for envelope encryption too.

Closes-story: key-provider-ignores-store-key-references
