### PR TITLE
fix(mysql2): re-run MismatchedForeignKey enrichment after queryParser setQuery rebuild

### DIFF
--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.mismatched-fk-enrichment.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.mismatched-fk-enrichment.trails.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { Mysql2Adapter } from "./mysql2-adapter.js";
+import { MismatchedForeignKey } from "../errors.js";
+
+// Trails-specific guards (no Rails counterpart): Rails'
+// mismatched_foreign_key_details resolves the referenced column's type
+// synchronously via column_for, so the exception message is always fully
+// detailed. Trails defers that lookup to the async
+// _enrichMismatchedForeignKey, which _translateAndEnrich must run AFTER the
+// queryParser setQuery rebuild on the sql-less translation path
+// (translateExceptionClass(e, null, null) inside withRawConnection) — the
+// rebuild parses the FK names the enrichment needs. These run offline —
+// constructing the adapter does not open a connection, and columns() is
+// stubbed.
+const FK_SQL =
+  "ALTER TABLE `wheels` ADD CONSTRAINT `fk_wheels_vehicles` " +
+  "FOREIGN KEY (`wheelable_id`) REFERENCES `vehicles` (`id`)";
+
+function fkDriverError(): Error {
+  const e = new Error("Cannot add foreign key constraint") as Error & { errno: number };
+  e.errno = 1215; // ER_CANNOT_ADD_FOREIGN
+  return e;
+}
+
+function makeAdapter(): Mysql2Adapter {
+  const adapter = new Mysql2Adapter({ host: "localhost" });
+  (adapter as unknown as { columns: unknown }).columns = async () => [
+    { name: "id", sqlTypeMetadata: { sqlType: "bigint", type: "integer" } },
+  ];
+  return adapter;
+}
+
+describe("Mysql2Adapter#_translateAndEnrich (queryParser rebuild ordering)", () => {
+  it("sql-less translation yields a MismatchedForeignKey with the generic fallback message", async () => {
+    const adapter = makeAdapter();
+    const translated = adapter.translateExceptionClass(fkDriverError(), null, null);
+    expect(translated).toBeInstanceOf(MismatchedForeignKey);
+    expect((translated as MismatchedForeignKey).message).toContain(
+      "There is a mismatch between the foreign key and primary key column types",
+    );
+    expect((translated as MismatchedForeignKey).fkDetails.targetTable).toBeUndefined();
+    await adapter.close();
+  });
+
+  it("re-enriches a sql-less MismatchedForeignKey after the setQuery rebuild", async () => {
+    const adapter = makeAdapter();
+    // The sql-less withRawConnection translation path builds the queryParser
+    // variant; _translateAndEnrich must rebuild it with the statement sql and
+    // THEN run enrichment so the referenced column type lands in the message.
+    const sqlLess = adapter.translateExceptionClass(
+      fkDriverError(),
+      null,
+      null,
+    ) as MismatchedForeignKey;
+    const enriched = await (
+      adapter as unknown as {
+        _translateAndEnrich(e: unknown, sql: string, binds: unknown[]): Promise<Error>;
+      }
+    )._translateAndEnrich(sqlLess, FK_SQL, []);
+    expect(enriched).toBeInstanceOf(MismatchedForeignKey);
+    expect(enriched.message).toContain(
+      "Column `wheelable_id` on table `wheels` does not match column `id` on `vehicles`, " +
+        "which has type `bigint`.",
+    );
+    expect(enriched.message).toContain("`t.bigint :wheelable_id`");
+    expect((enriched as MismatchedForeignKey).sql).toBe(FK_SQL);
+    await adapter.close();
+  });
+
+  it("re-translates from the driver cause when the catch site unwraps it", async () => {
+    const adapter = makeAdapter();
+    // Mirrors the execute()/internalExecute() catch sites: a sql-less
+    // MismatchedForeignKey thrown by the withRawConnection loop is re-run
+    // through _translateAndEnrich via its raw driver cause plus the sql.
+    const sqlLess = adapter.translateExceptionClass(
+      fkDriverError(),
+      null,
+      null,
+    ) as MismatchedForeignKey;
+    const enriched = await (
+      adapter as unknown as {
+        _translateAndEnrich(e: unknown, sql: string, binds: unknown[]): Promise<Error>;
+      }
+    )._translateAndEnrich(sqlLess.cause ?? sqlLess, FK_SQL, []);
+    expect(enriched).toBeInstanceOf(MismatchedForeignKey);
+    expect(enriched.message).toContain("which has type `bigint`");
+    await adapter.close();
+  });
+});

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.mismatched-fk-enrichment.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.mismatched-fk-enrichment.trails.test.ts
@@ -2,23 +2,13 @@ import { describe, it, expect } from "vitest";
 import { Mysql2Adapter } from "./mysql2-adapter.js";
 import { MismatchedForeignKey } from "../errors.js";
 
-// Trails-specific guards (no Rails counterpart): Rails'
-// mismatched_foreign_key_details resolves the referenced column's type
-// synchronously via column_for, so the exception message is always fully
-// detailed. Trails defers that lookup to the async
-// _enrichMismatchedForeignKey, which _translateAndEnrich must run AFTER the
-// queryParser setQuery rebuild on the sql-less translation path
-// (translateExceptionClass(e, null, null) inside withRawConnection) — the
-// rebuild parses the FK names the enrichment needs. These run offline —
-// constructing the adapter does not open a connection, and columns() is
-// stubbed.
 const FK_SQL =
   "ALTER TABLE `wheels` ADD CONSTRAINT `fk_wheels_vehicles` " +
   "FOREIGN KEY (`wheelable_id`) REFERENCES `vehicles` (`id`)";
 
 function fkDriverError(): Error {
   const e = new Error("Cannot add foreign key constraint") as Error & { errno: number };
-  e.errno = 1215; // ER_CANNOT_ADD_FOREIGN
+  e.errno = 1215;
   return e;
 }
 
@@ -28,6 +18,14 @@ function makeAdapter(): Mysql2Adapter {
     { name: "id", sqlTypeMetadata: { sqlType: "bigint", type: "integer" } },
   ];
   return adapter;
+}
+
+function translateAndEnrich(adapter: Mysql2Adapter, e: unknown, sql: string): Promise<Error> {
+  return (
+    adapter as unknown as {
+      _translateAndEnrich(e: unknown, sql: string, binds: unknown[]): Promise<Error>;
+    }
+  )._translateAndEnrich(e, sql, []);
 }
 
 describe("Mysql2Adapter#_translateAndEnrich (queryParser rebuild ordering)", () => {
@@ -44,19 +42,12 @@ describe("Mysql2Adapter#_translateAndEnrich (queryParser rebuild ordering)", () 
 
   it("re-enriches a sql-less MismatchedForeignKey after the setQuery rebuild", async () => {
     const adapter = makeAdapter();
-    // The sql-less withRawConnection translation path builds the queryParser
-    // variant; _translateAndEnrich must rebuild it with the statement sql and
-    // THEN run enrichment so the referenced column type lands in the message.
     const sqlLess = adapter.translateExceptionClass(
       fkDriverError(),
       null,
       null,
     ) as MismatchedForeignKey;
-    const enriched = await (
-      adapter as unknown as {
-        _translateAndEnrich(e: unknown, sql: string, binds: unknown[]): Promise<Error>;
-      }
-    )._translateAndEnrich(sqlLess, FK_SQL, []);
+    const enriched = await translateAndEnrich(adapter, sqlLess, FK_SQL);
     expect(enriched).toBeInstanceOf(MismatchedForeignKey);
     expect(enriched.message).toContain(
       "Column `wheelable_id` on table `wheels` does not match column `id` on `vehicles`, " +
@@ -69,19 +60,12 @@ describe("Mysql2Adapter#_translateAndEnrich (queryParser rebuild ordering)", () 
 
   it("re-translates from the driver cause when the catch site unwraps it", async () => {
     const adapter = makeAdapter();
-    // Mirrors the execute()/internalExecute() catch sites: a sql-less
-    // MismatchedForeignKey thrown by the withRawConnection loop is re-run
-    // through _translateAndEnrich via its raw driver cause plus the sql.
     const sqlLess = adapter.translateExceptionClass(
       fkDriverError(),
       null,
       null,
     ) as MismatchedForeignKey;
-    const enriched = await (
-      adapter as unknown as {
-        _translateAndEnrich(e: unknown, sql: string, binds: unknown[]): Promise<Error>;
-      }
-    )._translateAndEnrich(sqlLess.cause ?? sqlLess, FK_SQL, []);
+    const enriched = await translateAndEnrich(adapter, sqlLess.cause ?? sqlLess, FK_SQL);
     expect(enriched).toBeInstanceOf(MismatchedForeignKey);
     expect(enriched.message).toContain("which has type `bigint`");
     await adapter.close();

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -909,7 +909,17 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * enrich it with the referenced column's type via an async columns() call.
    */
   private async _translateAndEnrich(e: unknown, sql: string, binds: unknown[]): Promise<Error> {
-    let translated = this._translateException(e, sql, binds);
+    let translated: Error = this._translateException(e, sql, binds);
+    if (translated instanceof MismatchedForeignKey) {
+      // A MismatchedForeignKey translated on the sql-less withRawConnection
+      // path (translateExceptionClass(e, null, null)) defers FK-name parsing
+      // to a queryParser rebuild in setQuery. Run that rebuild before the
+      // enrichment so the async column-type lookup sees the parsed names —
+      // Rails resolves the type synchronously inside
+      // mismatched_foreign_key_details, so its rebuilt message is always
+      // fully detailed. setQuery is a no-op when sql was already attached.
+      translated = translated.setQuery(sql, binds);
+    }
     if (translated instanceof MismatchedForeignKey) {
       translated = await this._enrichMismatchedForeignKey(translated);
     }
@@ -1315,10 +1325,14 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         } catch (e: any) {
           // The loop already translated for its retry classification; guard
           // against re-translating an ActiveRecordError (see execute()).
+          // A MismatchedForeignKey from the loop's sql-less translation still
+          // needs the sql-aware re-translate + enrichment — same as execute().
           const translated =
-            e instanceof ActiveRecordError
-              ? e
-              : await this._translateAndEnrich(e, driverSql, driverBinds);
+            e instanceof MismatchedForeignKey
+              ? await this._translateAndEnrich(e.cause ?? e, driverSql, driverBinds)
+              : e instanceof ActiveRecordError
+                ? e
+                : await this._translateAndEnrich(e, driverSql, driverBinds);
           throw translated;
         }
       });

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -911,13 +911,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   private async _translateAndEnrich(e: unknown, sql: string, binds: unknown[]): Promise<Error> {
     let translated: Error = this._translateException(e, sql, binds);
     if (translated instanceof MismatchedForeignKey) {
-      // A MismatchedForeignKey translated on the sql-less withRawConnection
-      // path (translateExceptionClass(e, null, null)) defers FK-name parsing
-      // to a queryParser rebuild in setQuery. Run that rebuild before the
-      // enrichment so the async column-type lookup sees the parsed names —
-      // Rails resolves the type synchronously inside
-      // mismatched_foreign_key_details, so its rebuilt message is always
-      // fully detailed. setQuery is a no-op when sql was already attached.
       translated = translated.setQuery(sql, binds);
     }
     if (translated instanceof MismatchedForeignKey) {
@@ -1325,8 +1318,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         } catch (e: any) {
           // The loop already translated for its retry classification; guard
           // against re-translating an ActiveRecordError (see execute()).
-          // A MismatchedForeignKey from the loop's sql-less translation still
-          // needs the sql-aware re-translate + enrichment — same as execute().
           const translated =
             e instanceof MismatchedForeignKey
               ? await this._translateAndEnrich(e.cause ?? e, driverSql, driverBinds)


### PR DESCRIPTION
## What

PR #5134 ported the query_parser-aware `MismatchedForeignKey#set_query` overload, but on the sql-less translation path (`translateExceptionClass(e, null, null)` inside `withRawConnection`) the rebuilt exception got FK **names** from `mismatchedForeignKeyDetails` and never the referenced column's SQL type: the async `_enrichMismatchedForeignKey` ran at translate time — before the `setQuery` rebuild — when `fkDetails` was still empty, so enrichment was skipped and the exception kept the generic fallback message. Rails' `mismatched_foreign_key_details` (abstract_mysql_adapter.rb:978-999) resolves `primary_key_column` synchronously, so its rebuilt message is always fully detailed.

Fix (mysql2-adapter.ts, errors.ts untouched):

- `_translateAndEnrich` now runs the queryParser `setQuery(sql, binds)` rebuild **before** enrichment, so the async column-type lookup sees the parsed names. `setQuery` is a no-op when sql was already attached.
- `internalExecute`'s catch gains the same `e instanceof MismatchedForeignKey → _translateAndEnrich(e.cause ?? e, …)` arm its siblings (`execQuery`, `execute`, `executeMutation`) already had, so the sql-less variant thrown by the retry loop no longer escapes un-enriched through the `ActiveRecordError` passthrough.

## Tests

`mysql2-adapter.mismatched-fk-enrichment.trails.test.ts` (trails-only — Rails has no async-enrichment seam): offline adapter with stubbed `columns()`, covering the sql-less translation producing the queryParser variant, the setQuery-rebuild-then-enrich ordering (fails on baseline), and the cause-unwrap catch-site path.

Closes-story: mismatched-fk-query-parser-rebuild-enrichment
