### PR TITLE
fix(activerecord): write raw multiparameter hash and assemble at type cast time

### DIFF
--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -6,10 +6,7 @@ import {
   type DateNegativeInfinity as DateNegativeInfinityType,
 } from "./internal/sentinels.js";
 import { ArgumentError } from "../attribute-assignment.js";
-import {
-  AcceptsMultiparameterTime,
-  isNumericKeyHash,
-} from "./helpers/accepts-multiparameter-time.js";
+import { AcceptsMultiparameterTime, isHash } from "./helpers/accepts-multiparameter-time.js";
 import { configuredTimezone } from "./helpers/timezone.js";
 import { ValueType } from "./value.js";
 
@@ -31,7 +28,7 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
     if (value instanceof Date) {
       return this._applySecondsPrecision(Temporal.Instant.fromEpochMilliseconds(value.getTime()));
     }
-    if (isNumericKeyHash(value)) return this.valueFromMultiparameterAssignment(value);
+    if (isHash(value)) return this.valueFromMultiparameterAssignment(value);
     const str = String(value).trim();
     if (str === "") return null;
     return this.parseString(str);
@@ -122,12 +119,12 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
    * MultiparameterAssignmentErrors at assignment (missing keys 1..3 raise).
    */
   override assertValidValue(value: unknown): void {
-    if (isNumericKeyHash(value)) this.valueFromMultiparameterAssignment(value);
+    if (isHash(value)) this.valueFromMultiparameterAssignment(value);
   }
 
   /** Mirrors: AcceptsMultiparameterTime::InstanceMethods#value_constructed_by_mass_assignment? */
   override isValueConstructedByMassAssignment(value: unknown): boolean {
-    return isNumericKeyHash(value);
+    return isHash(value);
   }
 
   private _applySecondsPrecision(value: Temporal.Instant): Temporal.Instant {

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -117,10 +117,9 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
   }
 
   /**
-   * Mirrors: AcceptsMultiparameterTime::InstanceMethods#assert_valid_value —
-   * a Hash value is validated by assembling it (raising on missing keys /
-   * out-of-range components). Eager: runs at write_from_user time, which is
-   * how Rails surfaces MultiparameterAssignmentErrors at assignment.
+   * Mirrors: AcceptsMultiparameterTime::InstanceMethods#assert_valid_value.
+   * Runs eagerly at write_from_user time — this is how Rails surfaces
+   * MultiparameterAssignmentErrors at assignment (missing keys 1..3 raise).
    */
   override assertValidValue(value: unknown): void {
     if (isNumericKeyHash(value)) this.valueFromMultiparameterAssignment(value);

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -116,6 +116,21 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
     ) as DateTimeCastResult | null;
   }
 
+  /**
+   * Mirrors: AcceptsMultiparameterTime::InstanceMethods#assert_valid_value —
+   * a Hash value is validated by assembling it (raising on missing keys /
+   * out-of-range components). Eager: runs at write_from_user time, which is
+   * how Rails surfaces MultiparameterAssignmentErrors at assignment.
+   */
+  override assertValidValue(value: unknown): void {
+    if (isNumericKeyHash(value)) this.valueFromMultiparameterAssignment(value);
+  }
+
+  /** Mirrors: AcceptsMultiparameterTime::InstanceMethods#value_constructed_by_mass_assignment? */
+  override isValueConstructedByMassAssignment(value: unknown): boolean {
+    return isNumericKeyHash(value);
+  }
+
   private _applySecondsPrecision(value: Temporal.Instant): Temporal.Instant {
     if (
       this.precision == null ||

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -1,4 +1,8 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
+import {
+  AcceptsMultiparameterTime,
+  isNumericKeyHash,
+} from "./helpers/accepts-multiparameter-time.js";
 import { looseDateParse } from "./helpers/loose-date-parse.js";
 import {
   DateInfinity,
@@ -33,6 +37,9 @@ export class DateType extends ValueType<DateCastResult> {
     if (value instanceof Temporal.PlainDate) return value;
     // Accept PlainDateTime from multiparameter assignment — extract the date part.
     if (value instanceof Temporal.PlainDateTime) return value.toPlainDate();
+    // Numeric-keyed hash written raw by multiparameter assignment — mirrors
+    // AcceptsMultiparameterTime::InstanceMethods#cast's Hash branch.
+    if (isNumericKeyHash(value)) return this.valueFromMultiparameterAssignment(value);
     // boundary: cast accepts Date input from legacy callers / custom types
     // and bridges into Temporal.PlainDate via the UTC calendar components.
     if (value instanceof Date) {
@@ -143,9 +150,27 @@ export class DateType extends ValueType<DateCastResult> {
    * @internal Rails-private helper.
    */
   protected valueFromMultiparameterAssignment(
-    values: Record<number, number | null | undefined>,
+    values: Record<number, unknown>,
   ): Temporal.PlainDate | null {
-    return this.newDate(values[1], values[2], values[3]);
+    // `super` — the AcceptsMultiparameterTime wrapper's Time assembly, which
+    // rolls within-range calendar overflow the way Time.local does (Nov 31 →
+    // Dec 1). The wrapper's `this.type.cast(pdt)` round-trip performs the
+    // `new_date(time.year, time.mon, time.mday)` narrowing via castValue's
+    // PlainDateTime branch.
+    return new AcceptsMultiparameterTime(this).cast(values) as Temporal.PlainDate | null;
+  }
+
+  /**
+   * Mirrors: AcceptsMultiparameterTime::InstanceMethods#assert_valid_value —
+   * a Hash value is validated by assembling it (raising on invalid input).
+   */
+  override assertValidValue(value: unknown): void {
+    if (isNumericKeyHash(value)) this.valueFromMultiparameterAssignment(value);
+  }
+
+  /** Mirrors: AcceptsMultiparameterTime::InstanceMethods#value_constructed_by_mass_assignment? */
+  override isValueConstructedByMassAssignment(value: unknown): boolean {
+    return isNumericKeyHash(value);
   }
 
   /**

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -148,11 +148,10 @@ export class DateType extends ValueType<DateCastResult> {
   protected valueFromMultiparameterAssignment(
     values: Record<number, unknown>,
   ): Temporal.PlainDate | null {
-    // Rails' `super` (AcceptsMultiparameterTime's Time assembly, which rolls
-    // within-range overflow like Time.local: Nov 31 → Dec 1); the wrapper's
-    // cast(pdt) round-trip is the `new_date` narrowing via castValue's
-    // PlainDateTime branch.
-    return new AcceptsMultiparameterTime(this).cast(values) as Temporal.PlainDate | null;
+    // Rails' `super` — AcceptsMultiparameterTime's Time assembly, which rolls
+    // within-range overflow like Time.local (Nov 31 → Dec 1).
+    const time = new AcceptsMultiparameterTime(this).cast(values) as Temporal.PlainDate | null;
+    return time && this.newDate(time.year, time.month, time.day);
   }
 
   /**

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -37,8 +37,7 @@ export class DateType extends ValueType<DateCastResult> {
     if (value instanceof Temporal.PlainDate) return value;
     // Accept PlainDateTime from multiparameter assignment — extract the date part.
     if (value instanceof Temporal.PlainDateTime) return value.toPlainDate();
-    // Numeric-keyed hash written raw by multiparameter assignment — mirrors
-    // AcceptsMultiparameterTime::InstanceMethods#cast's Hash branch.
+    // Mirrors AcceptsMultiparameterTime::InstanceMethods#cast's Hash branch.
     if (isNumericKeyHash(value)) return this.valueFromMultiparameterAssignment(value);
     // boundary: cast accepts Date input from legacy callers / custom types
     // and bridges into Temporal.PlainDate via the UTC calendar components.
@@ -152,10 +151,9 @@ export class DateType extends ValueType<DateCastResult> {
   protected valueFromMultiparameterAssignment(
     values: Record<number, unknown>,
   ): Temporal.PlainDate | null {
-    // `super` — the AcceptsMultiparameterTime wrapper's Time assembly, which
-    // rolls within-range calendar overflow the way Time.local does (Nov 31 →
-    // Dec 1). The wrapper's `this.type.cast(pdt)` round-trip performs the
-    // `new_date(time.year, time.mon, time.mday)` narrowing via castValue's
+    // Rails' `super` (AcceptsMultiparameterTime's Time assembly, which rolls
+    // within-range overflow like Time.local: Nov 31 → Dec 1); the wrapper's
+    // cast(pdt) round-trip is the `new_date` narrowing via castValue's
     // PlainDateTime branch.
     return new AcceptsMultiparameterTime(this).cast(values) as Temporal.PlainDate | null;
   }

--- a/packages/activemodel/src/type/date.ts
+++ b/packages/activemodel/src/type/date.ts
@@ -1,8 +1,5 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import {
-  AcceptsMultiparameterTime,
-  isNumericKeyHash,
-} from "./helpers/accepts-multiparameter-time.js";
+import { AcceptsMultiparameterTime, isHash } from "./helpers/accepts-multiparameter-time.js";
 import { looseDateParse } from "./helpers/loose-date-parse.js";
 import {
   DateInfinity,
@@ -38,7 +35,7 @@ export class DateType extends ValueType<DateCastResult> {
     // Accept PlainDateTime from multiparameter assignment — extract the date part.
     if (value instanceof Temporal.PlainDateTime) return value.toPlainDate();
     // Mirrors AcceptsMultiparameterTime::InstanceMethods#cast's Hash branch.
-    if (isNumericKeyHash(value)) return this.valueFromMultiparameterAssignment(value);
+    if (isHash(value)) return this.valueFromMultiparameterAssignment(value);
     // boundary: cast accepts Date input from legacy callers / custom types
     // and bridges into Temporal.PlainDate via the UTC calendar components.
     if (value instanceof Date) {
@@ -163,12 +160,12 @@ export class DateType extends ValueType<DateCastResult> {
    * a Hash value is validated by assembling it (raising on invalid input).
    */
   override assertValidValue(value: unknown): void {
-    if (isNumericKeyHash(value)) this.valueFromMultiparameterAssignment(value);
+    if (isHash(value)) this.valueFromMultiparameterAssignment(value);
   }
 
   /** Mirrors: AcceptsMultiparameterTime::InstanceMethods#value_constructed_by_mass_assignment? */
   override isValueConstructedByMassAssignment(value: unknown): boolean {
-    return isNumericKeyHash(value);
+    return isHash(value);
   }
 
   /**

--- a/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
+++ b/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
@@ -13,11 +13,15 @@ import { Type } from "../value.js";
  * into a single Temporal.PlainDateTime and delegates to the wrapped type,
  * which extracts what it needs (PlainDate, PlainTime, or PlainDateTime).
  */
-/** @internal */
-export function isNumericKeyHash(value: unknown): value is Record<string, unknown> {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
-  const keys = Object.keys(value as Record<string, unknown>);
-  return keys.length > 0 && keys.every((k) => /^\d+$/.test(k));
+/**
+ * Ruby `value.is_a?(Hash)` analogue — a plain object (including null-prototype
+ * objects, which the multiparameter extractor produces).
+ * @internal
+ */
+export function isHash(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
 }
 
 export class AcceptsMultiparameterTime {
@@ -62,7 +66,7 @@ export class AcceptsMultiparameterTime {
   }
 
   private isMultiparameterHash(value: unknown): boolean {
-    return isNumericKeyHash(value);
+    return isHash(value);
   }
 
   private castFromMultiparameter(hash: Record<string, unknown>): unknown {

--- a/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
+++ b/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
@@ -40,6 +40,28 @@ const MONTH_ABBREVIATIONS = [
   "dec",
 ];
 
+/**
+ * Split non-negative seconds into whole seconds + truncated nanoseconds using
+ * the double's exact binary value (mantissa * 2^exponent), mirroring Ruby
+ * Time's Float → Rational conversion. Negative or non-finite input falls back
+ * to a plain trunc — the caller's domain check raises for it anyway.
+ */
+function exactSecondsToNanoseconds(second: number): { whole: number; ns: number } {
+  if (!(second >= 0) || !Number.isFinite(second)) {
+    return { whole: Math.trunc(second), ns: 0 };
+  }
+  const dv = new DataView(new ArrayBuffer(8));
+  dv.setFloat64(0, second);
+  const bits = dv.getBigUint64(0);
+  const expBits = Number((bits >> 52n) & 0x7ffn);
+  let mantissa = bits & 0xf_ffff_ffff_ffffn;
+  if (expBits !== 0) mantissa |= 1n << 52n;
+  const exponent = expBits === 0 ? -1074 : expBits - 1075;
+  let totalNs = mantissa * 1_000_000_000n;
+  totalNs = exponent >= 0 ? totalNs << BigInt(exponent) : totalNs >> BigInt(-exponent);
+  return { whole: Number(totalNs / 1_000_000_000n), ns: Number(totalNs % 1_000_000_000n) };
+}
+
 export class AcceptsMultiparameterTime {
   readonly type: Type;
   /** @internal */
@@ -128,15 +150,12 @@ export class AcceptsMultiparameterTime {
     const minute = num("5", 0);
     const second = num("6", 0);
 
-    // Decompose fractional seconds into the three Temporal sub-second
-    // components (each 0-999) using integer arithmetic to avoid floating-
-    // point rounding errors. Carry 1e9 ns into wholeSecond explicitly.
-    let wholeSecond = Math.trunc(second);
-    let totalNanoseconds = Math.round((second - wholeSecond) * 1_000_000_000);
-    if (totalNanoseconds === 1_000_000_000) {
-      wholeSecond += 1;
-      totalNanoseconds = 0;
-    }
+    // Ruby converts the seconds Float to an exact Rational and truncates:
+    // Time.utc(...,0.9999999999).nsec == 999_999_999 (never carried into the
+    // next second), and Time.utc(...,0.7).nsec == 699_999_999 because 0.7's
+    // exact binary value is 0.69999999999999995…. Decompose the double's bits
+    // so the truncation operates on that exact value, not an FP product.
+    const { whole: wholeSecond, ns: totalNanoseconds } = exactSecondsToNanoseconds(second);
     const millisecond = Math.trunc(totalNanoseconds / 1_000_000);
     const microsecond = Math.trunc((totalNanoseconds % 1_000_000) / 1_000);
     const nanosecond = totalNanoseconds % 1_000;

--- a/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
+++ b/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
@@ -116,26 +116,36 @@ export class AcceptsMultiparameterTime {
       return this.type.cast(pdt);
     } catch {
       // Rails assembles via ::Time.public_send(default_timezone, *values).
-      // Time.utc/local rolls *within-range* calendar overflow (Nov 31 → Dec 1,
-      // Feb 29 in a common year → Mar 1) but raises ArgumentError outside its
-      // accepted domain (month 13, mday 32, hour 25 — verified on Ruby 3.3),
-      // which AR surfaces as MultiparameterAssignmentErrors. Roll over only
-      // inside that accepted domain; otherwise raise to match Time's strictness.
+      // Time.utc/local rolls *within-range* overflow (Nov 31 → Dec 1, Feb 29
+      // in a common year → Mar 1, hour 24 with 0 min/sec → next midnight,
+      // sec 60 → next minute) but raises ArgumentError outside its accepted
+      // domain (month 13, mday 32, hour 25 — verified on Ruby 3.3), which AR
+      // surfaces as MultiparameterAssignmentErrors. Roll over only inside that
+      // accepted domain; otherwise raise to match Time's strictness.
+      const midnight24 = hour === 24 && minute === 0 && wholeSecond === 0 && totalNanoseconds === 0;
       if (
         month >= 1 &&
         month <= 12 &&
         day >= 1 &&
         day <= 31 &&
-        hour >= 0 &&
-        hour <= 23 &&
+        ((hour >= 0 && hour <= 23) || midnight24) &&
         minute >= 0 &&
         minute <= 59 &&
         wholeSecond >= 0 &&
         wholeSecond <= 60
       ) {
+        // Duration add carries all out-of-range components (day-in-month,
+        // hour 24, leap-second 60) the way Time normalizes them.
         const rolled = Temporal.PlainDate.from({ year, month: 1, day: 1 })
-          .add({ months: month - 1, days: day - 1 })
-          .toPlainDateTime(timeParts);
+          .toPlainDateTime()
+          .add({
+            months: month - 1,
+            days: day - 1,
+            hours: hour,
+            minutes: minute,
+            seconds: wholeSecond,
+            nanoseconds: totalNanoseconds,
+          });
         return this.type.cast(rolled);
       }
       throw new ArgumentError("argument out of range");

--- a/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
+++ b/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
@@ -24,6 +24,22 @@ export function isHash(value: unknown): value is Record<string, unknown> {
   return proto === Object.prototype || proto === null;
 }
 
+// Ruby Time's month-name coercion table (time.c months[]).
+const MONTH_ABBREVIATIONS = [
+  "jan",
+  "feb",
+  "mar",
+  "apr",
+  "may",
+  "jun",
+  "jul",
+  "aug",
+  "sep",
+  "oct",
+  "nov",
+  "dec",
+];
+
 export class AcceptsMultiparameterTime {
   readonly type: Type;
   /** @internal */
@@ -84,12 +100,25 @@ export class AcceptsMultiparameterTime {
     const absent = (k: string) => filled[k] === undefined || filled[k] === null || filled[k] === "";
     if (absent("1") || absent("2") || absent("3")) return null;
 
-    // Extract each slot by key. Rails uses to_i (non-numeric → 0); mirror that for NaN.
+    // Extract each slot by key with ::Time.utc/local's argument coercion
+    // (verified on Ruby 3.3): nil → the slot default; Numeric truncates except
+    // the seconds slot (Time.utc(...,5.5) keeps the fraction); String goes
+    // through strict Integer() — "2004abc", "5.5", and "" all raise
+    // ArgumentError — except the month slot, which also accepts 3-letter
+    // month-name abbreviations case-insensitively ("JAN" works, "june" raises).
     const num = (key: string, fallback: number): number => {
       const v = filled[key];
-      if (v === undefined || v === null || v === "") return fallback;
-      const n = typeof v === "number" ? v : Number(v);
-      return Number.isNaN(n) ? 0 : n;
+      if (v === undefined || v === null) return fallback;
+      if (typeof v === "number") return key === "6" ? v : Math.trunc(v);
+      const s = String(v).trim();
+      if (key === "2") {
+        const monthIndex = MONTH_ABBREVIATIONS.indexOf(s.toLowerCase());
+        if (monthIndex !== -1) return monthIndex + 1;
+      }
+      if (!/^[+-]?\d+$/.test(s)) {
+        throw new ArgumentError(`invalid value for Integer(): ${JSON.stringify(v)}`);
+      }
+      return parseInt(s, 10);
     };
 
     const year = num("1", 0);

--- a/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
+++ b/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
@@ -122,7 +122,9 @@ export class AcceptsMultiparameterTime {
       // domain (month 13, mday 32, hour 25 — verified on Ruby 3.3), which AR
       // surfaces as MultiparameterAssignmentErrors. Roll over only inside that
       // accepted domain; otherwise raise to match Time's strictness.
-      const midnight24 = hour === 24 && minute === 0 && wholeSecond === 0 && totalNanoseconds === 0;
+      // Ruby requires min and whole sec to be 0 at hour 24 but accepts a
+      // fractional second: Time.utc(2004,1,1,24,0,0.1) → 2004-01-02 00:00:00.1.
+      const midnight24 = hour === 24 && minute === 0 && wholeSecond === 0;
       if (
         month >= 1 &&
         month <= 12 &&

--- a/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
+++ b/packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts
@@ -1,4 +1,5 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
+import { ArgumentError } from "../../attribute-assignment.js";
 import { Type } from "../value.js";
 
 /**
@@ -94,36 +95,50 @@ export class AcceptsMultiparameterTime {
     const minute = num("5", 0);
     const second = num("6", 0);
 
+    // Decompose fractional seconds into the three Temporal sub-second
+    // components (each 0-999) using integer arithmetic to avoid floating-
+    // point rounding errors. Carry 1e9 ns into wholeSecond explicitly.
+    let wholeSecond = Math.trunc(second);
+    let totalNanoseconds = Math.round((second - wholeSecond) * 1_000_000_000);
+    if (totalNanoseconds === 1_000_000_000) {
+      wholeSecond += 1;
+      totalNanoseconds = 0;
+    }
+    const millisecond = Math.trunc(totalNanoseconds / 1_000_000);
+    const microsecond = Math.trunc((totalNanoseconds % 1_000_000) / 1_000);
+    const nanosecond = totalNanoseconds % 1_000;
+    const timeParts = { hour, minute, second: wholeSecond, millisecond, microsecond, nanosecond };
     try {
-      // Decompose fractional seconds into the three Temporal sub-second
-      // components (each 0-999) using integer arithmetic to avoid floating-
-      // point rounding errors. Carry 1e9 ns into wholeSecond explicitly.
-      let wholeSecond = Math.trunc(second);
-      let totalNanoseconds = Math.round((second - wholeSecond) * 1_000_000_000);
-      if (totalNanoseconds === 1_000_000_000) {
-        wholeSecond += 1;
-        totalNanoseconds = 0;
-      }
-      const millisecond = Math.trunc(totalNanoseconds / 1_000_000);
-      const microsecond = Math.trunc((totalNanoseconds % 1_000_000) / 1_000);
-      const nanosecond = totalNanoseconds % 1_000;
       const pdt = Temporal.PlainDateTime.from(
-        {
-          year,
-          month,
-          day,
-          hour,
-          minute,
-          second: wholeSecond,
-          millisecond,
-          microsecond,
-          nanosecond,
-        },
+        { year, month, day, ...timeParts },
         { overflow: "reject" },
       );
       return this.type.cast(pdt);
     } catch {
-      return null;
+      // Rails assembles via ::Time.public_send(default_timezone, *values).
+      // Time.utc/local rolls *within-range* calendar overflow (Nov 31 → Dec 1,
+      // Feb 29 in a common year → Mar 1) but raises ArgumentError outside its
+      // accepted domain (month 13, mday 32, hour 25 — verified on Ruby 3.3),
+      // which AR surfaces as MultiparameterAssignmentErrors. Roll over only
+      // inside that accepted domain; otherwise raise to match Time's strictness.
+      if (
+        month >= 1 &&
+        month <= 12 &&
+        day >= 1 &&
+        day <= 31 &&
+        hour >= 0 &&
+        hour <= 23 &&
+        minute >= 0 &&
+        minute <= 59 &&
+        wholeSecond >= 0 &&
+        wholeSecond <= 60
+      ) {
+        const rolled = Temporal.PlainDate.from({ year, month: 1, day: 1 })
+          .add({ months: month - 1, days: day - 1 })
+          .toPlainDateTime(timeParts);
+        return this.type.cast(rolled);
+      }
+      throw new ArgumentError("argument out of range");
     }
   }
 }

--- a/packages/activemodel/src/type/time.ts
+++ b/packages/activemodel/src/type/time.ts
@@ -117,4 +117,17 @@ export class TimeType extends ValueType<Temporal.PlainTime> {
       "5": 0,
     }).cast(values) as Temporal.PlainTime | null;
   }
+
+  /**
+   * Mirrors: AcceptsMultiparameterTime::InstanceMethods#assert_valid_value —
+   * a Hash value is validated by assembling it (raising on invalid input).
+   */
+  override assertValidValue(value: unknown): void {
+    if (isNumericKeyHash(value)) this.valueFromMultiparameterAssignment(value);
+  }
+
+  /** Mirrors: AcceptsMultiparameterTime::InstanceMethods#value_constructed_by_mass_assignment? */
+  override isValueConstructedByMassAssignment(value: unknown): boolean {
+    return isNumericKeyHash(value);
+  }
 }

--- a/packages/activemodel/src/type/time.ts
+++ b/packages/activemodel/src/type/time.ts
@@ -1,9 +1,6 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { looseDateParse } from "./helpers/loose-date-parse.js";
-import {
-  AcceptsMultiparameterTime,
-  isNumericKeyHash,
-} from "./helpers/accepts-multiparameter-time.js";
+import { AcceptsMultiparameterTime, isHash } from "./helpers/accepts-multiparameter-time.js";
 import { ValueType } from "./value.js";
 
 export class TimeType extends ValueType<Temporal.PlainTime> {
@@ -44,7 +41,7 @@ export class TimeType extends ValueType<Temporal.PlainTime> {
     // Accept PlainDateTime from multiparameter assignment — extract the time part.
     if (value instanceof Temporal.PlainDateTime)
       return this._applySecondsPrecision(value.toPlainTime());
-    if (isNumericKeyHash(value)) return this.valueFromMultiparameterAssignment(value);
+    if (isHash(value)) return this.valueFromMultiparameterAssignment(value);
     const str = String(value).trim();
     if (str === "") return null;
     const parts = looseDateParse(str);
@@ -123,11 +120,11 @@ export class TimeType extends ValueType<Temporal.PlainTime> {
    * a Hash value is validated by assembling it (raising on invalid input).
    */
   override assertValidValue(value: unknown): void {
-    if (isNumericKeyHash(value)) this.valueFromMultiparameterAssignment(value);
+    if (isHash(value)) this.valueFromMultiparameterAssignment(value);
   }
 
   /** Mirrors: AcceptsMultiparameterTime::InstanceMethods#value_constructed_by_mass_assignment? */
   override isValueConstructedByMassAssignment(value: unknown): boolean {
-    return isNumericKeyHash(value);
+    return isHash(value);
   }
 }

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -134,6 +134,17 @@ export class TimeZoneConverter extends ValueType<unknown> {
     return this._subtype.serialize(resolved);
   }
 
+  // Rails' DelegateClass(Type::Value) auto-forwards these to the subtype; the
+  // eager assert at write_from_user time is how MultiparameterAssignmentErrors
+  // surface at assignment for zone-aware attributes.
+  override assertValidValue(value: unknown): void {
+    this._subtype.assertValidValue(value);
+  }
+
+  override isValueConstructedByMassAssignment(value: unknown): boolean {
+    return this._subtype.isValueConstructedByMassAssignment(value);
+  }
+
   override isChanged(oldValue: unknown, newValue: unknown, _raw?: unknown): boolean {
     const oldInstant =
       oldValue instanceof TimeWithZone
@@ -240,6 +251,19 @@ function setTimeZoneWithoutConversion(value: unknown): unknown {
   }
   if (value instanceof TimeWithZone) {
     return value.inTimeZone(zone);
+  }
+  if (value instanceof Temporal.PlainTime) {
+    // Time-only columns: the subtype casts the multiparameter hash to a
+    // PlainTime. Rails' Type::Time keeps a full ::Time on the dummy date
+    // 2000-01-01; re-interpret the wall-clock on that dummy date in the
+    // current zone so the aware wrapper still yields a TimeWithZone.
+    const base = zone.local(2000, 1, 1, value.hour, value.minute, value.second, value.millisecond);
+    const subMs = value.microsecond * 1000 + value.nanosecond;
+    if (subMs === 0) return base;
+    return new TimeWithZone(
+      Temporal.Instant.fromEpochNanoseconds(base.utc().epochNanoseconds + BigInt(subMs)),
+      zone,
+    );
   }
   return value;
 }

--- a/packages/activerecord/src/attribute-methods/time-zone-converter.test.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-converter.test.ts
@@ -103,12 +103,12 @@ describe("TimeZoneConverterTest", () => {
     expect(result).toBeInstanceOf(Temporal.Instant);
   });
 
-  it("cast returns null for plain object with non-multiparameter keys", () => {
+  it("cast raises for plain object with non-multiparameter keys", () => {
     setZone("Eastern Time (US & Canada)");
     const converter = new TimeZoneConverter(new DateTime());
-    // A plain object that isn't a valid multiparameter hash → subtype returns null → null
-    const result = converter.cast({ date: "2024-06-15" });
-    expect(result).toBeNull();
+    // Rails: the Hash branch delegates to DateTime#value_from_multiparameter_assignment,
+    // which raises when keys 1/2/3 are missing.
+    expect(() => converter.cast({ date: "2024-06-15" })).toThrow("doesn't contain necessary keys");
   });
 
   it("deserialize wraps Temporal.Instant from subtype in TimeWithZone", () => {

--- a/packages/activerecord/src/multiparameter-attribute-assignment.ts
+++ b/packages/activerecord/src/multiparameter-attribute-assignment.ts
@@ -67,7 +67,11 @@ export function extractMultiparameterCallstack(attrs: Record<string, unknown>): 
       } else {
         castValue = isBlank(value) ? null : value;
       }
-      if (!(name in multiparams)) multiparams[name] = Object.create(null);
+      // Inner parts maps use a normal prototype: their keys are regex-guaranteed
+      // digits (no pollution vector), and the hash is written to the attribute,
+      // where a null-prototype object would make String(hash) throw for
+      // non-date columns (Rails' hash.to_s never raises).
+      if (!(name in multiparams)) multiparams[name] = {};
       multiparams[name][pos] = castValue;
     } else {
       regular[key] = value;

--- a/packages/activerecord/src/multiparameter-attribute-assignment.ts
+++ b/packages/activerecord/src/multiparameter-attribute-assignment.ts
@@ -10,7 +10,6 @@
  * Rails source: activerecord/lib/active_record/attribute_assignment.rb
  */
 
-import { Temporal } from "@blazetrails/activesupport/temporal";
 import { AttributeAssignmentError, MultiparameterAssignmentErrors } from "./errors.js";
 
 // Read _aggregateReflections directly to avoid a circular dependency:
@@ -95,7 +94,7 @@ export function executeMultiparameterAssignment(
       if (aggregation) {
         assignAggregation(instance as any, name, partsMap, aggregation);
       } else {
-        assignDateTimeAttribute(instance, name, partsMap, modelClass);
+        assignDateTimeAttribute(instance, name, partsMap);
       }
     } catch (e) {
       errors.push(
@@ -133,143 +132,14 @@ function assignDateTimeAttribute(
   instance: { writeAttribute(name: string, value: unknown): void },
   name: string,
   partsMap: Record<number, unknown>,
-  modelClass: any,
 ): void {
-  const colType = modelClass.typeForAttribute?.(name);
-  const typeName: string = colType?.type?.() ?? "";
-
-  let maxPos: number;
-  if (typeName === "date") {
-    maxPos = 3;
-  } else if (typeName === "datetime" || typeName === "timestamp" || typeName === "time") {
-    maxPos = 6;
-  } else {
-    maxPos = Math.min(Math.max(...Object.keys(partsMap).map(Number)), MAX_MULTIPARAMETER_INDEX);
-  }
-
-  // Track which positions were explicitly provided (even if blank) vs. absent entirely.
-  // Rails casts blank strings via .to_i → 0 (non-nil), so blank-but-present date parts
-  // trigger a rescued ArgumentError (→ nil). Absent date parts with time parts present
-  // trigger an unrescued TypeError (→ MultiparameterAssignmentErrors). We mirror this by
-  // distinguishing "key in partsMap" (provided, possibly blank) from key absent.
-  const values = Array.from({ length: maxPos }, (_, i) => {
-    const pos = i + 1;
-    return pos in partsMap ? (partsMap[pos] ?? null) : undefined;
-  });
-
-  if (values.every((v) => v === undefined || isBlank(v))) {
-    instance.writeAttribute(name, null);
-    return;
-  }
-
-  const assembled = assembleValue(values, typeName);
-  instance.writeAttribute(name, assembled);
-}
-
-function parseIntStrict(s: string | null, fieldName: string): number | null {
-  if (s === null) return null;
-  const n = parseInt(s, 10);
-  if (isNaN(n)) throw new Error(`Invalid ${fieldName} value: ${JSON.stringify(s)}`);
-  return n;
-}
-
-function buildDate(year: number, month: number, day: number): Temporal.PlainDate {
-  try {
-    return Temporal.PlainDate.from({ year, month, day }, { overflow: "reject" });
-  } catch {
-    // Rails' `read_date` rescues an invalid `Date.new(*set_values)` and falls
-    // back to `instantiate_time_object(set_values).to_date` — i.e. it lets the
-    // overflowing components roll over the way `Time.local` does (Nov 31 → Dec 1,
-    // Feb 29 in a common year → Mar 1). But `Time.utc/local` only accepts month
-    // in 1..12 and mday in 1..31, rolling *within-range* calendar overflow and
-    // raising `ArgumentError` otherwise (verified on Ruby 3.3: mday 0, mday 32,
-    // month 13 all raise "out of range"), which Rails surfaces as a
-    // MultiparameterAssignmentErrors. Roll over only inside that accepted
-    // domain; otherwise re-raise to match Time's strictness.
-    if (month >= 1 && month <= 12 && day >= 1 && day <= 31) {
-      return Temporal.PlainDate.from({ year, month: 1, day: 1 }).add({
-        months: month - 1,
-        days: day - 1,
-      });
-    }
-    throw new Error(`Invalid date: ${year}-${month}-${day}`);
-  }
-}
-
-function buildDateTime(
-  year: number,
-  month: number,
-  day: number,
-  hour: number,
-  min: number,
-  sec: number,
-): Temporal.PlainDateTime {
-  try {
-    return Temporal.PlainDateTime.from(
-      { year, month, day, hour, minute: min, second: sec },
-      { overflow: "reject" },
-    );
-  } catch {
-    throw new Error(`Invalid datetime: ${year}-${month}-${day} ${hour}:${min}:${sec}`);
-  }
-}
-
-function assembleValue(parts: unknown[], typeName: string): unknown {
-  const str = (v: unknown): string | null =>
-    v === null || v === undefined || String(v).trim() === "" ? null : String(v).trim();
-
-  if (typeName === "date") {
-    const [ys, ms, ds] = parts.map(str);
-    if (!ys || !ms || !ds) return null;
-    const year = parseIntStrict(ys, "year"),
-      month = parseIntStrict(ms, "month"),
-      day = parseIntStrict(ds, "day");
-    if (year === null || month === null || day === null) return null;
-    return buildDate(year, month, day);
-  }
-
-  if (typeName === "datetime" || typeName === "timestamp") {
-    // Check raw parts BEFORE str() conversion to distinguish:
-    // - undefined: key was absent from form params (Rails: nil → TypeError → raises)
-    // - null/blank: key present but empty string (Rails: 0 via .to_i → ArgumentError rescued → nil)
-    const datePartsAbsent = parts.slice(0, 3).some((v) => v === undefined);
-    // Check key presence (not value truthiness): blank time parts like (4i)=>""
-    // are cast to null but were still explicitly provided, matching Rails' .to_i → 0 path.
-    const timePartsPresent = parts.slice(3).some((v) => v !== undefined);
-    if (datePartsAbsent && timePartsPresent) {
-      throw new Error(
-        `Multiparameter datetime requires year, month, and day (got ${JSON.stringify(parts)})`,
-      );
-    }
-    const [ys, mos, ds, hs, mis, ss] = parts.map(str);
-    if (!ys || !mos || !ds) return null; // blank date parts → nil (Rails rescued ArgumentError)
-    const year = parseIntStrict(ys, "year")!,
-      month = parseIntStrict(mos, "month")!,
-      day = parseIntStrict(ds, "day")!;
-    const hour = hs !== null ? (parseIntStrict(hs, "hour") ?? 0) : 0;
-    const min = mis !== null ? (parseIntStrict(mis, "minute") ?? 0) : 0;
-    const sec = ss !== null ? (parseIntStrict(ss, "second") ?? 0) : 0;
-    return buildDateTime(year, month, day, hour, min, sec);
-  }
-
-  if (typeName === "time") {
-    const [ys, mos, ds, hs, mis, ss] = parts.map(str);
-    const hour = hs !== null ? (parseIntStrict(hs, "hour") ?? 0) : 0;
-    const min = mis !== null ? (parseIntStrict(mis, "minute") ?? 0) : 0;
-    const sec = ss !== null ? (parseIntStrict(ss, "second") ?? 0) : 0;
-    if (ys && mos && ds) {
-      const year = parseIntStrict(ys, "year"),
-        month = parseIntStrict(mos, "month"),
-        day = parseIntStrict(ds, "day");
-      if (year === null || month === null || day === null) return null;
-      return buildDateTime(year, month, day, hour, min, sec);
-    }
-    // Only time parts → PlainTime (no date context needed for time columns)
-    return Temporal.PlainTime.from({ hour, minute: min, second: sec }, { overflow: "reject" });
-  }
-
-  // Generic: return the first non-blank value
-  return parts.find((v) => !isBlank(v)) ?? null;
+  // Mirrors Rails' execute_callstack_for_multiparameter_attributes: an all-nil
+  // parts hash collapses to nil; otherwise the raw numeric-keyed hash is written
+  // and the type's AcceptsMultiparameterTime cast assembles the value. Writing
+  // the hash (not an assembled Temporal value) keeps valueBeforeTypeCast the
+  // hash, so came_from_user? is false via isValueConstructedByMassAssignment.
+  const values = Object.values(partsMap).every((v) => v === null) ? null : partsMap;
+  instance.writeAttribute(name, values);
 }
 
 function isBlank(v: unknown): boolean {

--- a/packages/activerecord/src/multiparameter-attribute-assignment.ts
+++ b/packages/activerecord/src/multiparameter-attribute-assignment.ts
@@ -133,11 +133,9 @@ function assignDateTimeAttribute(
   name: string,
   partsMap: Record<number, unknown>,
 ): void {
-  // Mirrors Rails' execute_callstack_for_multiparameter_attributes: an all-nil
-  // parts hash collapses to nil; otherwise the raw numeric-keyed hash is written
-  // and the type's AcceptsMultiparameterTime cast assembles the value. Writing
-  // the hash (not an assembled Temporal value) keeps valueBeforeTypeCast the
-  // hash, so came_from_user? is false via isValueConstructedByMassAssignment.
+  // Mirrors execute_callstack_for_multiparameter_attributes: all-nil parts → nil,
+  // else write the raw numeric-keyed hash — the type's AcceptsMultiparameterTime
+  // cast assembles it, keeping valueBeforeTypeCast the hash (came_from_user? false).
   const values = Object.values(partsMap).every((v) => v === null) ? null : partsMap;
   instance.writeAttribute(name, values);
 }

--- a/packages/activerecord/src/multiparameter-attributes.test.ts
+++ b/packages/activerecord/src/multiparameter-attributes.test.ts
@@ -686,13 +686,6 @@ describe("MultiParameterAttributeTest", () => {
       "written_on(4i)": "13",
       "written_on(5i)": "55",
     });
-    // DEVIATION: Rails writes the raw numeric-keyed hash and lets the type's
-    // AcceptsMultiparameterTime cast assemble it, so came_from_user? is false
-    // (value_constructed_by_mass_assignment? sees the hash). Trails assembles
-    // the value in multiparameter-attribute-assignment.ts before writeAttribute,
-    // so the attribute sees a plain user-written Instant → cameFromUser is true.
-    // Converging the assignment path to type-side casting is tracked as a
-    // follow-up story (multiparameter-assignment-type-side-cast).
-    expect(topic.cameFromUser("written_on")).toBe(true);
+    expect(topic.cameFromUser("written_on")).toBe(false);
   });
 });


### PR DESCRIPTION
Converges multiparameter assignment to Rails' type-side cast shape (RFC 0030 residual).

## What

Rails' `execute_callstack_for_multiparameter_attributes` writes the raw numeric-keyed parts hash to the attribute and lets the type's `AcceptsMultiparameterTime` cast assemble it; `came_from_user?` is then false via `value_constructed_by_mass_assignment?`. Trails assembled the Temporal value in AR-land, so `valueBeforeTypeCast` was the assembled value and `cameFromUser` diverged to true.

- `assignDateTimeAttribute` now mirrors `execute_callstack`: all-nil parts → nil, otherwise the raw hash is written; the AR-side `assembleValue`/`buildDate`/`buildDateTime` machinery is deleted.
- `DateType` gains the numeric-key-hash cast dispatch and routes assembly through `AcceptsMultiparameterTime` (Rails' `super` + `new_date` narrowing), preserving Time-style rollover (Nov 31 → Dec 1).
- `Date`/`DateTime`/`Time` types port `assert_valid_value` and `value_constructed_by_mass_assignment?` from the Rails mixin. `DateTimeType`'s eager assert (missing keys 1–3) is what surfaces `MultiparameterAssignmentErrors` at assignment time, as in Rails (`Attribute#with_value_from_user` → `assert_valid_value`).
- `AcceptsMultiparameterTime#castFromMultiparameter` ports `Time.utc/local` semantics: within-range calendar overflow rolls over; out-of-domain components (month 13, mday 32) raise `ArgumentError` instead of silently returning nil.
- `TimeZoneConverter` delegates `assertValidValue` / `isValueConstructedByMassAssignment` to the subtype (Rails `DelegateClass` auto-forwards), and `setTimeZoneWithoutConversion` re-interprets `PlainTime` on Rails' 2000-01-01 dummy date so aware time columns still yield `TimeWithZone`.
- The deviation assertion in `multiparameter-attributes.test.ts` ("multiparameter assigned attributes did not come from user") flips to Rails' expected `false`.

## Testing

- `packages/activerecord/src/multiparameter-attributes.test.ts` — 37 passed
- `packages/activerecord/src/date.test.ts`, `attribute-methods.test.ts`, `attributes.test.ts`, `base.test.ts`, `base.trails.test.ts`, `date-time-precision.test.ts`, `time-zone-converter.test.ts`, `time-zone-conversion.test.ts` — all passed
- activemodel `date`/`date-time`/`time`/`accepts-multiparameter-time-defaults`/`attribute`/`attribute-set`/`attributes`/`user-provided-default`/`numericality-validation` suites — all passed

Closes-story: multiparameter-assignment-type-side-cast


## Follow-ups

- `0023-surfaced-deviations/multiparameter-extra-positions-collapse` — Rails' `values_hash.sort.map!(&:last)` splat makes extra positions collapse positionally (`{1,2,3,7}` → key 7 in the hour slot → raise); trails reads slots 1–6 by key and ignores extras.
