### PR TITLE
fix(activerecord): recurse expandFromHash raw, matching Rails' expand_from_hash

### DIFF
--- a/packages/activerecord/src/relation/predicate-builder.trails.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.trails.test.ts
@@ -3,6 +3,9 @@ import { testConnection } from "@blazetrails/arel/src/test-helpers/connection.js
 import { IntegerType } from "@blazetrails/activemodel";
 import { Table, Visitors } from "@blazetrails/arel";
 import { Company, Firm } from "../test-helpers/models/company.js";
+import { Author } from "../test-helpers/models/author.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+import { escapeRegExp, quoteTableName, quoteColumnName } from "../test-helpers/quote-regex.js";
 import { PredicateBuilder } from "./predicate-builder.js";
 import { TableMetadata } from "../table-metadata.js";
 
@@ -53,5 +56,25 @@ describe("PredicateBuilder positive-equality bind typing", () => {
     );
     expect(sql).not.toContain("1=0");
     expect(binds).toHaveLength(1);
+  });
+});
+
+// trails-specific regression guard (no Rails counterpart): Rails'
+// expand_from_hash recurses into a nested hash WITHOUT re-running
+// convert_dot_notation_to_hash (predicate_builder.rb:23-26 vs 99-101), so a
+// dotted key inside a nested hash is a literal column name on the associated
+// table — not a second association hop. trails used to recurse through the
+// public buildFromHash, re-splitting `"comments.body"` into a comments join.
+describe("PredicateBuilder nested-hash recursion skips dot re-normalization", () => {
+  fixtures(["authors", "posts", "comments"]);
+
+  it("treats a dotted key inside a nested hash as a literal column on the associated table", () => {
+    const sql = Author.where({ posts: { "comments.body": "hi" } }).toSql();
+    expect(sql).toMatch(
+      new RegExp(
+        `${escapeRegExp(quoteTableName("posts"))}\\.${escapeRegExp(quoteColumnName("comments.body"))}`,
+      ),
+    );
+    expect(sql).not.toContain(quoteTableName("comments.body"));
   });
 });

--- a/packages/activerecord/src/relation/predicate-builder.trails.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.trails.test.ts
@@ -59,12 +59,6 @@ describe("PredicateBuilder positive-equality bind typing", () => {
   });
 });
 
-// trails-specific regression guard (no Rails counterpart): Rails'
-// expand_from_hash recurses into a nested hash WITHOUT re-running
-// convert_dot_notation_to_hash (predicate_builder.rb:23-26 vs 99-101), so a
-// dotted key inside a nested hash is a literal column name on the associated
-// table — not a second association hop. trails used to recurse through the
-// public buildFromHash, re-splitting `"comments.body"` into a comments join.
 describe("PredicateBuilder nested-hash recursion skips dot re-normalization", () => {
   fixtures(["authors", "posts", "comments"]);
 

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -102,10 +102,6 @@ export class PredicateBuilder {
     return this.expandFromHash(this.convertDotNotationToHash(conditions), block);
   }
 
-  // Mirrors Rails' protected PredicateBuilder#expand_from_hash
-  // (predicate_builder.rb:84-155): every internal recursion re-enters here
-  // directly, so convertDotNotationToHash runs exactly once per buildFromHash
-  // entry — a dotted key inside a nested hash stays a literal column name.
   protected expandFromHash(
     conditions: Record<string, unknown>,
     block?: (tableName: string) => unknown,
@@ -137,9 +133,6 @@ export class PredicateBuilder {
           key,
           block as (name: string) => never,
         ).predicateBuilder;
-        // Rails recurses via expand_from_hash (predicate_builder.rb:99-101), NOT
-        // build_from_hash — dot notation was already normalized at entry, so a
-        // dotted key here is a literal column name, not another hop.
         nodes.push(...assocPb.expandFromHash(value));
       } else if (this.table.isAssociatedWith(key)) {
         const assocNodes = this.buildFromHashAssociation(
@@ -179,8 +172,6 @@ export class PredicateBuilder {
       const [columnName, aggregateAttr] = mapping[0];
       // Rails: `object.respond_to?(aggr) ? object.public_send(aggr) : object`.
       const mapped = values.map((object) => extractAggregateAttr(object, aggregateAttr, false));
-      // Rails: `self[column_name, values]` (predicate_builder.rb:131) — the
-      // column is read straight off the arel table, no dot re-normalization.
       return [this.build(this.table.arelTable.get(columnName), mapped)];
     }
     // Multi-mapping: one AND-group per object over every mapped column, ORed

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -99,10 +99,14 @@ export class PredicateBuilder {
     conditions: Record<string, unknown>,
     block?: (tableName: string) => unknown,
   ): Nodes.Node[] {
-    return this.buildFromHashInternal(this.convertDotNotationToHash(conditions), block);
+    return this.expandFromHash(this.convertDotNotationToHash(conditions), block);
   }
 
-  private buildFromHashInternal(
+  // Mirrors Rails' protected PredicateBuilder#expand_from_hash
+  // (predicate_builder.rb:84-155): every internal recursion re-enters here
+  // directly, so convertDotNotationToHash runs exactly once per buildFromHash
+  // entry — a dotted key inside a nested hash stays a literal column name.
+  protected expandFromHash(
     conditions: Record<string, unknown>,
     block?: (tableName: string) => unknown,
   ): Nodes.Node[] {
@@ -133,7 +137,10 @@ export class PredicateBuilder {
           key,
           block as (name: string) => never,
         ).predicateBuilder;
-        nodes.push(...assocPb.buildFromHash(value));
+        // Rails recurses via expand_from_hash (predicate_builder.rb:99-101), NOT
+        // build_from_hash — dot notation was already normalized at entry, so a
+        // dotted key here is a literal column name, not another hop.
+        nodes.push(...assocPb.expandFromHash(value));
       } else if (this.table.isAssociatedWith(key)) {
         const assocNodes = this.buildFromHashAssociation(
           this.table.associatedTable(key),
@@ -172,7 +179,9 @@ export class PredicateBuilder {
       const [columnName, aggregateAttr] = mapping[0];
       // Rails: `object.respond_to?(aggr) ? object.public_send(aggr) : object`.
       const mapped = values.map((object) => extractAggregateAttr(object, aggregateAttr, false));
-      return this.buildFromHash({ [columnName]: mapped });
+      // Rails: `self[column_name, values]` (predicate_builder.rb:131) — the
+      // column is read straight off the arel table, no dot re-normalization.
+      return [this.build(this.table.arelTable.get(columnName), mapped)];
     }
     // Multi-mapping: one AND-group per object over every mapped column, ORed
     // together (grouping_queries), mirroring expand_from_hash.
@@ -212,7 +221,7 @@ export class PredicateBuilder {
       ).queries();
       const queryGroups: Nodes.Node[][] = [];
       for (const query of queries) {
-        const inner = this.buildFromHash(query);
+        const inner = this.expandFromHash(query);
         if (inner.length === 0) continue;
         queryGroups.push(inner);
       }
@@ -235,7 +244,7 @@ export class PredicateBuilder {
         value,
       ).queries();
       const assocPb: PredicateBuilder = associatedTable.predicateBuilder;
-      const inner = normalizedQueries.flatMap((q) => assocPb.buildFromHash(q));
+      const inner = normalizedQueries.flatMap((q) => assocPb.expandFromHash(q));
       if (inner.length === 0) return [];
       return [inner.length === 1 ? inner[0] : new Nodes.And(inner)];
     }
@@ -247,7 +256,7 @@ export class PredicateBuilder {
       if (isSameHash(query, attributes)) {
         queryGroups.push([this.build(this.table.arelTable.get(key), value)]);
       } else {
-        const inner = this.buildFromHash(query);
+        const inner = this.expandFromHash(query);
         if (inner.length === 0) continue;
         queryGroups.push(inner);
       }
@@ -578,13 +587,6 @@ export class PredicateBuilder {
     return (
       typeof value === "object" && value !== null && "_modelClass" in value && "toArel" in value
     );
-  }
-
-  protected expandFromHash(
-    attributes: Record<string, unknown>,
-    block?: (key: string) => any,
-  ): Nodes.Node[] {
-    return this.buildFromHash(attributes);
   }
 
   private convertDotNotationToHash(attributes: Record<string, unknown>): Record<string, unknown> {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder.json
@@ -30,13 +30,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation/predicate-builder.ts",
-    "rubyName": "build_from_hash",
-    "call": "expand_from_hash",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder.ts",
     "rubyName": "convert_dot_notation_to_hash",
     "call": "merge!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -47,27 +40,6 @@
     "rubyName": "convert_dot_notation_to_hash",
     "call": "rindex",
     "reason": "Name-collision false positive (story relation-delegation-rails-named-methods): exposing the `delegate ... to: :records` set under Rails names made `split`/`reverse`/`rindex` recognized ported method names, so this unrelated call to String#split / Array#reverse / String#rindex on a non-Relation receiver is flagged by the name-based wide call-set check."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder.ts",
-    "rubyName": "expand_from_hash",
-    "call": "aggregated_with?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder.ts",
-    "rubyName": "expand_from_hash",
-    "call": "associated_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder.ts",
-    "rubyName": "expand_from_hash",
-    "call": "associated_with?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -101,13 +73,6 @@
     "package": "activerecord",
     "tsFile": "relation/predicate-builder.ts",
     "rubyName": "expand_from_hash",
-    "call": "has_column?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder.ts",
-    "rubyName": "expand_from_hash",
     "call": "map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -116,13 +81,6 @@
     "tsFile": "relation/predicate-builder.ts",
     "rubyName": "expand_from_hash",
     "call": "new",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder.ts",
-    "rubyName": "expand_from_hash",
-    "call": "predicate_builder",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -151,13 +109,6 @@
     "tsFile": "relation/predicate-builder.ts",
     "rubyName": "expand_from_hash",
     "call": "stringify_keys",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder.ts",
-    "rubyName": "expand_from_hash",
-    "call": "table",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {


### PR DESCRIPTION
Rails' `expand_from_hash` recurses raw: the nested-hash branch calls the associated builder's `expand_from_hash` directly (predicate_builder.rb:99-101), so `convert_dot_notation_to_hash` runs exactly once, at the `build_from_hash` entry (predicate_builder.rb:23-26). trails' nested branch recursed through the public `buildFromHash`, re-normalizing the nested hash — `where(posts: { "comments.body": v })` re-split `"comments.body"` into a second association hop instead of treating it as a literal column on the posts table.

Changes:

- Rename `buildFromHashInternal` → protected `expandFromHash` (the Rails api:compare target), deleting the vestigial `expandFromHash` stub that delegated back to `buildFromHash`.
- All internal recursions (nested hash, through, association query loop) now re-enter `expandFromHash` directly, matching Rails.
- Aggregate single-mapping branch uses the `self[column_name, values]` shape (`build(arelTable.get(col), mapped)`) instead of round-tripping through `buildFromHash` (predicate_builder.rb:131).
- Regression test in `predicate-builder.trails.test.ts` (fails on baseline): a dotted key inside a nested hash stays a literal column name.

Closes-story: nested-hash-recursion-renormalizes-dot-notation
