### PR TITLE
test(associations): port has_many through with STI on nested through reflection

### DIFF
--- a/packages/activerecord/src/associations/nested-through-associations.test.ts
+++ b/packages/activerecord/src/associations/nested-through-associations.test.ts
@@ -654,9 +654,19 @@ describe("NestedThroughAssociationsTest", () => {
     expect(subSpecialComment.length).toBeGreaterThan(0);
   });
 
-  // 3-level nested through (specialComments→specialCommentsRatings→taggings) direct-load returns empty.
-  // DEFERRED (RFC 0030): tracked by nested-through-sti-reflection-load.
-  it.todo("has many through with sti on nested through reflection");
+  it("has many through with sti on nested through reflection", async () => {
+    const stiComments = posts("sti_comments");
+    const specialRatingTagging = taggings("special_comment_rating");
+
+    const taggingsResult = await stiComments.specialCommentsRatingsTaggings.toArray();
+    expect(taggingsResult.map((t) => t.id)).toEqual([specialRatingTagging.id]);
+
+    const scope = Post.joins("specialCommentsRatingsTaggings").where({ id: stiComments.id });
+    const emptyComment = await scope.where({ "comments.type": "Comment" });
+    expect(emptyComment).toHaveLength(0);
+    const specialComment = await scope.where({ "comments.type": "SpecialComment" });
+    expect(specialComment.length).toBeGreaterThan(0);
+  });
 
   it("nested has many through writers should raise error", async () => {
     const david = authors("david");

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -546,14 +546,6 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "keys are type-cast objects (assert_kind_of Time). Tracked: RFC 0030 story " +
       "grouped-calculation-typed-keys — remove this entry when it converges.",
   },
-  {
-    testFile: "associations/nested_through_associations_test.rb",
-    tests: ["has many through with sti on nested through reflection"],
-    reason:
-      "Deferred: 3-level nested-through with an STI-scoped intermediate reflection " +
-      "direct-loads empty. Tracked: RFC 0030 story nested-through-sti-reflection-load — " +
-      "remove this entry when it converges.",
-  },
   // --- Permanently not-portable: scattered YAML/Marshal serialization ---
   {
     testFile: "adapters/postgresql/hstore_test.rb",


### PR DESCRIPTION
Ports Rails `test_has_many_through_with_sti_on_nested_through_reflection`
(`associations/nested_through_associations_test.rb:484`): the 3-level
nested-through chain `specialComments` → `specialCommentsRatings` → `taggings`
with an STI-scoped intermediate reflection.

The direct-load gap the deferral noted ("returns empty") has since been fixed
on main — the test now passes as a straight port. This PR converts the
`it.todo` into the ported test and removes the corresponding
`unported-files.ts` deferral entry.

Closes-story: nested-through-sti-reflection-load
