### PR TITLE
fix(postgresql): apply SchemaDumper ignore patterns in exportNameOnSchemaDump

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
@@ -32,6 +32,13 @@ describe("ExclusionConstraintDefinition", () => {
     expect(named.exportNameOnSchemaDump()).toBe(true);
     expect(unnamed.exportNameOnSchemaDump()).toBe(false);
   });
+
+  it("exportNameOnSchemaDump returns false for auto-generated names matching exclIgnorePattern", () => {
+    const autoNamed = new ExclusionConstraintDefinition("t", "x WITH =", {
+      name: "excl_rails_74c9160f55",
+    });
+    expect(autoNamed.exportNameOnSchemaDump()).toBe(false);
+  });
 });
 
 describe("UniqueConstraintDefinition", () => {
@@ -56,6 +63,13 @@ describe("UniqueConstraintDefinition", () => {
     const unnamed = new UniqueConstraintDefinition("t", "col", {});
     expect(named.exportNameOnSchemaDump()).toBe(true);
     expect(unnamed.exportNameOnSchemaDump()).toBe(false);
+  });
+
+  it("exportNameOnSchemaDump returns false for auto-generated names matching uniqueIgnorePattern", () => {
+    const autoNamed = new UniqueConstraintDefinition("t", "col", {
+      name: "uniq_rails_1e07660b77",
+    });
+    expect(autoNamed.exportNameOnSchemaDump()).toBe(false);
   });
 
   it("definedFor matches by name", () => {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -9,6 +9,7 @@
  */
 
 import { NotImplementedError } from "../../errors.js";
+import { SchemaDumper } from "../../schema-dumper.js";
 import { pgDatetimeConfig } from "./pg-datetime-config.js";
 import {
   TableDefinition as AbstractTableDefinition,
@@ -96,7 +97,7 @@ export class ExclusionConstraintDefinition {
   }
 
   exportNameOnSchemaDump(): boolean {
-    return this.name != null;
+    return this.name != null && !SchemaDumper.exclIgnorePattern.test(this.name);
   }
 }
 
@@ -132,7 +133,7 @@ export class UniqueConstraintDefinition {
   }
 
   exportNameOnSchemaDump(): boolean {
-    return this.name != null;
+    return this.name != null && !SchemaDumper.uniqueIgnorePattern.test(this.name);
   }
 
   definedFor(

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.test.ts
@@ -305,6 +305,24 @@ describe("PostgreSQL::SchemaDumper", () => {
       expect(lines[0]).toContain(`using: "gist"`);
       expect(lines[0]).toContain(`name: "excl_rooms_price"`);
     });
+
+    it("omits name for auto-generated names matching exclIgnorePattern", async () => {
+      const { ExclusionConstraintDefinition } = await import("./schema-definitions.js");
+      const adapter = {
+        ...emptySource,
+        exclusionConstraints: async () => [
+          new ExclusionConstraintDefinition("rooms", "price WITH =", {
+            using: "gist",
+            name: "excl_rails_74c9160f55",
+          }),
+        ],
+      };
+      const dumper = new (SchemaDumper as any)(adapter);
+      const lines: string[] = [];
+      await dumper.exclusionConstraintsInCreate("rooms", lines);
+      expect(lines[0]).toContain(`await ctx.addExclusionConstraint("rooms", "price WITH ="`);
+      expect(lines[0]).not.toContain("name:");
+    });
   });
 
   describe("uniqueConstraintsInCreate", () => {
@@ -325,6 +343,23 @@ describe("PostgreSQL::SchemaDumper", () => {
       expect(lines[0]).toContain(`await ctx.addUniqueConstraint("users", ["email"]`);
       expect(lines[0]).toContain(`nullsNotDistinct: true`);
       expect(lines[0]).toContain(`name: "uniq_users_email"`);
+    });
+
+    it("omits name for auto-generated names matching uniqueIgnorePattern", async () => {
+      const { UniqueConstraintDefinition } = await import("./schema-definitions.js");
+      const adapter = {
+        ...emptySource,
+        uniqueConstraints: async () => [
+          new UniqueConstraintDefinition("users", ["email"], {
+            name: "uniq_rails_1e07660b77",
+          }),
+        ],
+      };
+      const dumper = new (SchemaDumper as any)(adapter);
+      const lines: string[] = [];
+      await dumper.uniqueConstraintsInCreate("users", lines);
+      expect(lines[0]).toContain(`await ctx.addUniqueConstraint("users", ["email"]`);
+      expect(lines[0]).not.toContain("name:");
     });
 
     it("emits nothing when no unique constraints", async () => {


### PR DESCRIPTION
Rails' `export_name_on_schema_dump?` on PostgreSQL exclusion- and unique-constraint definitions filters auto-generated names via `SchemaDumper.excl_ignore_pattern` / `unique_ignore_pattern` (vendor/rails/activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb:209-211, 231-233). Trails returned `this.name != null` only, so auto-named constraints dumped their `excl_rails_*` / `uniq_rails_*` names instead of omitting them.

Both `exportNameOnSchemaDump` implementations now apply the corresponding `SchemaDumper` ignore pattern, mirroring Rails.

Closes-story: pg-export-name-ignores-dumper-patterns
