### PR TITLE
fix(postgresql): converge quote_default_expression on Rails' regtype OID type-map lookup

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -1163,13 +1163,13 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
 
   describe("buildChangeColumnDefinition", () => {
-    it("returns a ChangeColumnDefinition with correct column name and sqlType", () => {
+    it("returns a ChangeColumnDefinition with correct column name and sqlType", async () => {
       const def = adapter.buildChangeColumnDefinition("users", "age", "integer");
       expect(def.name).toBe("age");
       expect(def.column.name).toBe("age");
       // Like Rails, the builder leaves sqlType unset — the visitor computes it
       // on accept, so the emitted DDL carries the resolved SQL type.
-      expect(adapter.schemaCreation.accept(def)).toContain("TYPE integer");
+      expect(await adapter.schemaCreation.accept(def)).toContain("TYPE integer");
     });
 
     it("reflects using/castAs options on the column definition", () => {

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
@@ -127,8 +127,8 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   // quote_default_expression serializes through the column's cast type exactly
   // once (abstract/quoting.rb:161); a structured json default must not be
   // double-encoded to `'"{}"'` by both a pre-serialize and `super`'s serialize.
-  it("quote default expression serializes a structured json default once", () => {
-    expect(adapter.quoteDefaultExpression({}, { sqlType: "json" })).toEqual("'{}'");
+  it("quote default expression serializes a structured json default once", async () => {
+    expect(await adapter.quoteDefaultExpression({}, { sqlType: "json" })).toEqual("'{}'");
   });
 
   it("exec insert", async () => {

--- a/packages/activerecord/src/column-definition.test.ts
+++ b/packages/activerecord/src/column-definition.test.ts
@@ -28,22 +28,22 @@ class DummyCreation extends SchemaCreation {
 describe("ColumnDefinitionTest", () => {
   const viz = new DummyCreation();
 
-  it("should not include default clause when default is null", () => {
+  it("should not include default clause when default is null", async () => {
     const columnDef = new ColumnDefinition("title", "string", { limit: 20 });
-    expect(viz.accept(columnDef)).toBe("title varchar(20)");
+    expect(await viz.accept(columnDef)).toBe("title varchar(20)");
   });
 
-  it("should include default clause when default is present", () => {
+  it("should include default clause when default is present", async () => {
     const columnDef = new ColumnDefinition("title", "string", { limit: 20, default: "Hello" });
-    expect(viz.accept(columnDef)).toBe("title varchar(20) DEFAULT 'Hello'");
+    expect(await viz.accept(columnDef)).toBe("title varchar(20) DEFAULT 'Hello'");
   });
 
-  it("should specify not null if null option is false", () => {
+  it("should specify not null if null option is false", async () => {
     const columnDef = new ColumnDefinition("title", "string", {
       limit: 20,
       default: "Hello",
       null: false,
     });
-    expect(viz.accept(columnDef)).toBe("title varchar(20) DEFAULT 'Hello' NOT NULL");
+    expect(await viz.accept(columnDef)).toBe("title varchar(20) DEFAULT 'Hello' NOT NULL");
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -834,9 +834,7 @@ export class AbstractAdapter implements Quoting {
     return this.quoteTableName(`${table}.${attr}`);
   }
 
-  // Widened return: PG's override resolves cast types with a live regtype
-  // query (postgresql/quoting.rb:195), so the surface is awaitable; this
-  // base implementation stays synchronous.
+  // Return union: awaitable surface (PG's regtype lookup); this base stays sync.
   quoteDefaultExpression(value: unknown, column?: unknown): string | Promise<string> {
     if (value === undefined) return "";
     if (typeof value === "function") {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -834,7 +834,10 @@ export class AbstractAdapter implements Quoting {
     return this.quoteTableName(`${table}.${attr}`);
   }
 
-  quoteDefaultExpression(value: unknown, column?: unknown): string {
+  // Widened return: PG's override resolves cast types with a live regtype
+  // query (postgresql/quoting.rb:195), so the surface is awaitable; this
+  // base implementation stays synchronous.
+  quoteDefaultExpression(value: unknown, column?: unknown): string | Promise<string> {
     if (value === undefined) return "";
     if (typeof value === "function") {
       const result = (value as () => unknown)();

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -412,7 +412,7 @@ describe("AbstractMysqlAdapter#buildChangeColumnDefinition", () => {
     const col = makeTextColumn({ defaultFunction: "uuid()" });
     const adapter = await makeAdapter(col);
     const cd = await adapter.buildChangeColumnDefinition("users", "uid", "string");
-    const sql = new SchemaCreation().accept(cd);
+    const sql = await new SchemaCreation().accept(cd);
     expect(sql).toContain("DEFAULT uuid()");
     expect(sql).not.toContain("DEFAULT 'uuid()'");
   });
@@ -593,7 +593,7 @@ describe("AbstractMysqlAdapter#buildChangeColumnDefaultDefinition (#1568)", () =
 });
 
 describe("AbstractMysqlAdapter — DROP vs SET DEFAULT fragment (#1568)", () => {
-  function visit(cd: ChangeColumnDefaultDefinition): string {
+  function visit(cd: ChangeColumnDefaultDefinition): Promise<string> {
     return new MysqlSchemaCreation().accept(cd);
   }
 
@@ -608,17 +608,17 @@ describe("AbstractMysqlAdapter — DROP vs SET DEFAULT fragment (#1568)", () => 
 
   it("emits DROP DEFAULT for null default on a NOT NULL column", async () => {
     const cd = await buildFor(makeChangeColumnTextColumn({ null_: false }), null);
-    expect(visit(cd)).toBe("ALTER COLUMN `body` DROP DEFAULT");
+    expect(await visit(cd)).toBe("ALTER COLUMN `body` DROP DEFAULT");
   });
 
   it("emits SET DEFAULT NULL for null default on a nullable column", async () => {
     const cd = await buildFor(makeChangeColumnTextColumn({ null_: true }), null);
-    expect(visit(cd)).toBe("ALTER COLUMN `body` SET DEFAULT NULL");
+    expect(await visit(cd)).toBe("ALTER COLUMN `body` SET DEFAULT NULL");
   });
 
   it("emits SET DEFAULT <literal> for a non-null default", async () => {
     const cd = await buildFor(makeChangeColumnTextColumn({ null_: true }), "world");
-    expect(visit(cd)).toBe("ALTER COLUMN `body` SET DEFAULT 'world'");
+    expect(await visit(cd)).toBe("ALTER COLUMN `body` SET DEFAULT 'world'");
   });
 
   it("undefined → null normalization yields SET DEFAULT NULL, not a bare SET", async () => {
@@ -628,7 +628,7 @@ describe("AbstractMysqlAdapter — DROP vs SET DEFAULT fragment (#1568)", () => 
       from: "a",
       to: undefined,
     });
-    const sql = visit(cd);
+    const sql = await visit(cd);
     expect(sql).toBe("ALTER COLUMN `body` SET DEFAULT NULL");
     expect(sql.endsWith(" SET")).toBe(false);
   });

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -977,7 +977,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   ): Promise<void> {
     const createIndex = await this.buildCreateIndexDefinition(tableName, columnName, options);
     if (!createIndex) return;
-    await this._execMutation(this.schemaStatements().schemaCreation.accept(createIndex));
+    await this._execMutation(await this.schemaStatements().schemaCreation.accept(createIndex));
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract/quoting-interface.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting-interface.ts
@@ -42,8 +42,12 @@ export interface Quoting {
   /** Mirrors: Quoting#quote_table_name_for_assignment (`UPDATE ... SET col = ...`). */
   quoteTableNameForAssignment(table: string, attr: string): string;
 
-  /** Mirrors: Quoting#quote_default_expression (DDL DEFAULT clause). */
-  quoteDefaultExpression(value: unknown, column?: unknown): string;
+  /** Mirrors: Quoting#quote_default_expression (DDL DEFAULT clause).
+   * Awaitable: PG's override resolves the column's cast type with a live
+   * `SELECT '<sql_type>'::regtype::oid` query (postgresql/quoting.rb:195),
+   * so callers must `await` the result; the other adapters return plain
+   * strings. */
+  quoteDefaultExpression(value: unknown, column?: unknown): string | Promise<string>;
 
   /** Mirrors: Quoting#quoted_true. Abstract/PG/MySQL: `"TRUE"`; SQLite: `"1"`. */
   quotedTrue(): string;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -156,10 +156,13 @@ export class SchemaCreation {
     sql += ` ${this.adapter.quoteTableName(o.tableName)}`;
 
     // Rails: `statements = o.columns.map { |c| accept c }` — keep the map call
-    // (the api-compare wide gate tracks it); the promises are awaited in order.
+    // (the api-compare wide gate tracks it) but map to thunks so each column
+    // visit runs only after the previous one settles: Rails' block is
+    // sequential, and PG's default quoting issues a live regtype query per
+    // defaulted column that must not run concurrently.
     const statements: string[] = [];
-    for (const pending of o.columns.map((c) => this.visitColumnDefinition(c))) {
-      statements.push(await pending);
+    for (const visit of o.columns.map((c) => () => this.visitColumnDefinition(c))) {
+      statements.push(await visit());
     }
 
     if (o.compositePrimaryKey && o.compositePrimaryKey.length > 0) {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -103,8 +103,9 @@ export class SchemaCreation {
     return this.adapter.quoteTableName(name);
   }
 
-  /** @internal */
-  protected quoteDefaultExpression(value: unknown, column?: unknown): string {
+  /** @internal Awaitable: PG's quoter resolves cast types with a live
+   * regtype query (postgresql/quoting.rb:195). */
+  protected quoteDefaultExpression(value: unknown, column?: unknown): string | Promise<string> {
     return this.adapter.quoteDefaultExpression(value, column);
   }
 
@@ -135,7 +136,11 @@ export class SchemaCreation {
     return o.map((c) => this.adapter.quoteIdentifier(c)).join(", ");
   }
 
-  accept(o: Definition): string {
+  // Async since the PG quoter's default-expression path issues a live regtype
+  // query (postgresql/quoting.rb:195); Rails' accept is sync only because Ruby
+  // blocks on the query. Visitors that can reach quoteDefaultExpression are
+  // async; the leaf visitors that cannot (indexes, FKs, constraints) stay sync.
+  async accept(o: Definition): Promise<string> {
     if (o instanceof TableDefinition) return this.visitTableDefinition(o);
     if (o instanceof AlterTable) return this.visitAlterTable(o);
     if (o instanceof AddColumnDefinition) return this.visitAddColumnDefinition(o);
@@ -146,12 +151,13 @@ export class SchemaCreation {
     throw new Error(`Unknown definition type: ${(o as any).constructor.name}`);
   }
 
-  protected visitTableDefinition(o: TableDefinition): string {
+  protected async visitTableDefinition(o: TableDefinition): Promise<string> {
     let sql = `CREATE${this.tableModifierInCreate(o)} TABLE`;
     if (o.ifNotExists) sql += " IF NOT EXISTS";
     sql += ` ${this.adapter.quoteTableName(o.tableName)}`;
 
-    const statements: string[] = o.columns.map((c) => this.visitColumnDefinition(c));
+    const statements: string[] = [];
+    for (const c of o.columns) statements.push(await this.visitColumnDefinition(c));
 
     if (o.compositePrimaryKey && o.compositePrimaryKey.length > 0) {
       statements.push(this.visitPrimaryKeyDefinition({ name: o.compositePrimaryKey }));
@@ -197,7 +203,7 @@ export class SchemaCreation {
     return [];
   }
 
-  protected visitColumnDefinition(o: ColumnDefinition): string {
+  protected async visitColumnDefinition(o: ColumnDefinition): Promise<string> {
     // Rails' `visit_ColumnDefinition` (abstract/schema_creation.rb:34) does an
     // unconditional `o.sql_type = type_to_sql(...)`. Trails diverges deliberately:
     // PG/MySQL `TableDefinition` helpers (`t.bit`, `t.inet`, `t.bigserial`,
@@ -222,21 +228,21 @@ export class SchemaCreation {
     }
     let sql = `${this.adapter.quoteIdentifier(o.name)} ${o.sqlType}`;
     if (o.type !== "primary_key") {
-      sql = this.addColumnOptionsBang(sql, this.columnOptions(o) as ColumnOptions);
+      sql = await this.addColumnOptionsBang(sql, this.columnOptions(o) as ColumnOptions);
     }
     return sql;
   }
 
-  protected visitAddColumnDefinition(o: AddColumnDefinition): string {
-    return `ADD ${this.accept(o.column)}`;
+  protected async visitAddColumnDefinition(o: AddColumnDefinition): Promise<string> {
+    return `ADD ${await this.accept(o.column)}`;
   }
 
-  protected visitAlterTable(o: AlterTable): string {
+  protected async visitAlterTable(o: AlterTable): Promise<string> {
     const table = this.adapter.quoteTableName(o.name);
     const parts: string[] = [];
 
     for (const add of o.adds) {
-      parts.push(this.visitAddColumnDefinition(add));
+      parts.push(await this.visitAddColumnDefinition(add));
     }
     for (const fk of o.foreignKeyAdds) {
       parts.push(this.visitAddForeignKey(fk));
@@ -259,7 +265,7 @@ export class SchemaCreation {
         parts.push(`ALTER COLUMN ${col} DROP DEFAULT`);
       } else {
         parts.push(
-          `ALTER COLUMN ${col} SET DEFAULT ${this.adapter.quoteDefaultExpression(change.defaultValue)}`,
+          `ALTER COLUMN ${col} SET DEFAULT ${await this.adapter.quoteDefaultExpression(change.defaultValue)}`,
         );
       }
     }
@@ -344,11 +350,11 @@ export class SchemaCreation {
     return `CONSTRAINT ${this.adapter.quoteIdentifier(o.name)} CHECK (${o.expression})`;
   }
 
-  addColumnOptions(sql: string, options: ColumnOptions): string {
+  async addColumnOptions(sql: string, options: ColumnOptions): Promise<string> {
     if (this.optionsIncludeDefault(options)) {
       // Rails: `sql << " DEFAULT #{quote_default_expression(...)}"`
       // (schema_creation.rb:150) — the keyword lives here, not in the quoter.
-      sql += ` DEFAULT ${this.adapter.quoteDefaultExpression(
+      sql += ` DEFAULT ${await this.adapter.quoteDefaultExpression(
         options.default,
         (options as Record<string, unknown>)["column"],
       )}`;
@@ -581,7 +587,7 @@ export class SchemaCreation {
   }
 
   /** @internal */
-  protected addColumnOptionsBang(sql: string, options: AddColumnOptions): string {
+  protected addColumnOptionsBang(sql: string, options: AddColumnOptions): Promise<string> {
     return this.addColumnOptions(sql, options);
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -103,8 +103,7 @@ export class SchemaCreation {
     return this.adapter.quoteTableName(name);
   }
 
-  /** @internal Awaitable: PG's quoter resolves cast types with a live
-   * regtype query (postgresql/quoting.rb:195). */
+  /** @internal */
   protected quoteDefaultExpression(value: unknown, column?: unknown): string | Promise<string> {
     return this.adapter.quoteDefaultExpression(value, column);
   }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -155,8 +155,12 @@ export class SchemaCreation {
     if (o.ifNotExists) sql += " IF NOT EXISTS";
     sql += ` ${this.adapter.quoteTableName(o.tableName)}`;
 
+    // Rails: `statements = o.columns.map { |c| accept c }` — keep the map call
+    // (the api-compare wide gate tracks it); the promises are awaited in order.
     const statements: string[] = [];
-    for (const c of o.columns) statements.push(await this.visitColumnDefinition(c));
+    for (const pending of o.columns.map((c) => this.visitColumnDefinition(c))) {
+      statements.push(await pending);
+    }
 
     if (o.compositePrimaryKey && o.compositePrimaryKey.length > 0) {
       statements.push(this.visitPrimaryKeyDefinition({ name: o.compositePrimaryKey }));

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
@@ -299,18 +299,18 @@ describe("ReferenceDefinition helpers", () => {
 });
 
 describe("TableDefinition#toSql blank type guard", () => {
-  it("throws a descriptive error for an empty custom type", () => {
+  it("throws a descriptive error for an empty custom type", async () => {
     const td = new TableDefinition("t", { id: false });
     td.column("bad", "" as any);
-    expect(() => new SchemaCreation("sqlite").accept(td)).toThrow(
+    await expect(new SchemaCreation("sqlite").accept(td)).rejects.toThrow(
       /Column "bad" has an empty or blank type/,
     );
   });
 
-  it("throws a descriptive error for a whitespace-only custom type", () => {
+  it("throws a descriptive error for a whitespace-only custom type", async () => {
     const td = new TableDefinition("t", { id: false });
     td.column("bad", "   " as any);
-    expect(() => new SchemaCreation("sqlite").accept(td)).toThrow(
+    await expect(new SchemaCreation("sqlite").accept(td)).rejects.toThrow(
       /Column "bad" has an empty or blank type/,
     );
   });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -227,16 +227,16 @@ describe("SchemaStatements privates (PR 8)", () => {
     expect(frags).toEqual([`DROP COLUMN "updated_at"`, `DROP COLUMN "created_at"`]);
   });
 
-  it("changeColumnDefaultForAlter DROP DEFAULT when null", () => {
+  it("changeColumnDefaultForAlter DROP DEFAULT when null", async () => {
     const ss = makeStatements();
-    expect(ss.changeColumnDefaultForAlter("users", "status", null)).toBe(
+    expect(await ss.changeColumnDefaultForAlter("users", "status", null)).toBe(
       `ALTER COLUMN "status" DROP DEFAULT`,
     );
   });
 
-  it("changeColumnDefaultForAlter SET DEFAULT for value", () => {
+  it("changeColumnDefaultForAlter SET DEFAULT for value", async () => {
     const ss = makeStatements();
-    expect(ss.changeColumnDefaultForAlter("users", "status", "active")).toBe(
+    expect(await ss.changeColumnDefaultForAlter("users", "status", "active")).toBe(
       `ALTER COLUMN "status" SET DEFAULT active`,
     );
   });
@@ -254,17 +254,17 @@ describe("SchemaStatements privates (PR 8)", () => {
     expect(ss.findJoinTableName("cats", "dogs")).toBe("cats_dogs");
   });
 
-  it("addTimestampsForAlter produces ADD fragments with precision when adapter supports it", () => {
+  it("addTimestampsForAlter produces ADD fragments with precision when adapter supports it", async () => {
     const ss = makeStatements({ supportsDatetimeWithPrecision: () => true });
-    const frags = ss.addTimestampsForAlter("users");
+    const frags = await ss.addTimestampsForAlter("users");
     expect(frags).toHaveLength(2);
     expect(frags[0]).toContain("DATETIME(6)");
     expect(frags[1]).toContain("DATETIME(6)");
   });
 
-  it("addTimestampsForAlter respects explicit null option", () => {
+  it("addTimestampsForAlter respects explicit null option", async () => {
     const ss = makeStatements();
-    const frags = ss.addTimestampsForAlter("users", { null: true });
+    const frags = await ss.addTimestampsForAlter("users", { null: true });
     expect(frags[0]).not.toContain("NOT NULL");
   });
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -227,17 +227,25 @@ describe("SchemaStatements privates (PR 8)", () => {
     expect(frags).toEqual([`DROP COLUMN "updated_at"`, `DROP COLUMN "created_at"`]);
   });
 
-  it("changeColumnDefaultForAlter DROP DEFAULT when null", async () => {
+  // Mirrors change_column_default_for_alter (schema_statements.rb:1843): the
+  // abstract helper only routes builder → schema_creation.accept; the SQL
+  // shapes live in the PG/MySQL visitors (visit_ChangeColumnDefaultDefinition).
+  it("changeColumnDefaultForAlter routes the built definition through schema_creation.accept", async () => {
     const ss = makeStatements();
-    expect(await ss.changeColumnDefaultForAlter("users", "status", null)).toBe(
-      `ALTER COLUMN "status" DROP DEFAULT`,
-    );
+    const cd = { marker: true };
+    vi.spyOn(ss, "buildChangeColumnDefaultDefinition").mockResolvedValue(cd as never);
+    vi.spyOn(ss, "schemaCreation", "get").mockReturnValue({
+      accept: async (o: unknown) => (o === cd ? "ACCEPTED" : "WRONG"),
+    } as never);
+    expect(await ss.changeColumnDefaultForAlter("users", "status", "active")).toBe("ACCEPTED");
   });
 
-  it("changeColumnDefaultForAlter SET DEFAULT for value", async () => {
+  it("changeColumnDefaultForAlter raises NotImplementedError without an adapter builder", async () => {
+    // Rails: the abstract build_change_column_default_definition raises
+    // (schema_statements.rb:738-739); only PG/MySQL override it.
     const ss = makeStatements();
-    expect(await ss.changeColumnDefaultForAlter("users", "status", "active")).toBe(
-      `ALTER COLUMN "status" SET DEFAULT active`,
+    await expect(ss.changeColumnDefaultForAlter("users", "status", null)).rejects.toThrow(
+      "build_change_column_default_definition is not implemented",
     );
   });
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -2608,18 +2608,25 @@ export class SchemaStatements {
     return this.schemaCreation.accept(new AddColumnDefinition(cd));
   }
 
-  /** @internal */
+  /** @internal Mirrors change_column_default_for_alter (schema_statements.rb:1843):
+   * routes through the adapter's build_change_column_default_definition (which
+   * attaches the reflected column, so PG's column-aware default quoting fires)
+   * and the schema-creation visitor. The base builder raises NotImplementedError
+   * as in Rails; PG and MySQL override it. */
   async changeColumnDefaultForAlter(
-    _tableName: string,
+    tableName: string,
     columnName: string,
     defaultOrChanges: unknown,
   ): Promise<string> {
-    const newDefault = this.extractNewDefaultValue(defaultOrChanges);
-    const col = this.adapter.quoteIdentifier(columnName);
-    if (newDefault == null) {
-      return `ALTER COLUMN ${col} DROP DEFAULT`;
-    }
-    return `ALTER COLUMN ${col} SET DEFAULT ${await this.adapter.quoteDefaultExpression(newDefault)}`;
+    const cd = await this.buildChangeColumnDefaultDefinition(
+      tableName,
+      columnName,
+      defaultOrChanges,
+    );
+    // ChangeColumnDefaultDefinition is dispatched by the PG/MySQL visitor
+    // subclasses' accept overrides, not the abstract union — same as Rails,
+    // where only those adapters define visit_ChangeColumnDefaultDefinition.
+    return (this.schemaCreation as { accept(o: unknown): Promise<string> }).accept(cd);
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -319,7 +319,7 @@ export class SchemaStatements {
     // supportsIndexSortOrder gate, which yields false on a cold connection
     // (mirrors addIndex's warm-up). Memoized → no-op when already warm.
     await this.adapter.getDatabaseVersion?.();
-    await this.adapter.execute(this.schemaCreation.accept(td));
+    await this.adapter.execute(await this.schemaCreation.accept(td));
 
     // Rails: if supports_comments? && !supports_comments_in_create?
     //   change_table_comment(table_name, comment) if options[:comment].present?
@@ -414,7 +414,7 @@ export class SchemaStatements {
     const addColumnDef = await this.buildAddColumnDefinition(tableName, columnName, type, options);
     if (!addColumnDef) return;
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
-    await this.adapter.execute(this.schemaCreation.accept(addColumnDef));
+    await this.adapter.execute(await this.schemaCreation.accept(addColumnDef));
   }
 
   async removeColumn(
@@ -478,7 +478,7 @@ export class SchemaStatements {
       columns,
       options as Record<string, unknown>,
     );
-    await this.adapter.execute(this.schemaCreation.accept(createIndex));
+    await this.adapter.execute(await this.schemaCreation.accept(createIndex));
   }
 
   async removeIndex(
@@ -551,7 +551,7 @@ export class SchemaStatements {
       const defaultClause =
         options.default === undefined
           ? ""
-          : ` DEFAULT ${this.adapter.quoteDefaultExpression(options.default)}`;
+          : ` DEFAULT ${await this.adapter.quoteDefaultExpression(options.default)}`;
       await this.adapter.execute(
         `ALTER TABLE ${table} MODIFY COLUMN ${col} ${sqlType}${nullable}${defaultClause}`,
       );
@@ -564,7 +564,7 @@ export class SchemaStatements {
       }
       if (options.default !== undefined) {
         clauses.push(
-          `ALTER COLUMN ${col} SET DEFAULT ${this.adapter.quoteDefaultExpression(options.default)}`,
+          `ALTER COLUMN ${col} SET DEFAULT ${await this.adapter.quoteDefaultExpression(options.default)}`,
         );
       }
       await this.adapter.execute(`ALTER TABLE ${table} ${clauses.join(", ")}`);
@@ -573,7 +573,7 @@ export class SchemaStatements {
       const defaultClause =
         options.default === undefined
           ? ""
-          : ` DEFAULT ${this.adapter.quoteDefaultExpression(options.default)}`;
+          : ` DEFAULT ${await this.adapter.quoteDefaultExpression(options.default)}`;
       await this.adapter.execute(
         `ALTER TABLE ${table} ALTER COLUMN ${col} TYPE ${sqlType}${nullable}${defaultClause}`,
       );
@@ -670,7 +670,7 @@ export class SchemaStatements {
     // default like `{ to: 1 }` without :from is the literal default.
     const defaultVal = this.extractNewDefaultValue(options);
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
-    const clause = this.adapter.quoteDefaultExpression(defaultVal);
+    const clause = await this.adapter.quoteDefaultExpression(defaultVal);
     await this.adapter.execute(
       `ALTER TABLE ${this._qi(tableName)} ALTER COLUMN ${this._qi(columnName)} SET DEFAULT ${clause || "NULL"}`,
     );
@@ -683,7 +683,7 @@ export class SchemaStatements {
     defaultValue?: unknown,
   ): Promise<void> {
     if (!allowNull && defaultValue !== undefined) {
-      const quoted = this.adapter.quoteDefaultExpression(defaultValue);
+      const quoted = await this.adapter.quoteDefaultExpression(defaultValue);
       await this.adapter.execute(
         `UPDATE ${this._qi(tableName)} SET ${this._qi(columnName)} = ${quoted} WHERE ${this._qi(columnName)} IS NULL`,
       );
@@ -842,7 +842,7 @@ export class SchemaStatements {
     // table_name_prefix/suffix to to_table and re-runs foreign_key_options
     // idempotently (column/name already filled above), mirroring Rails.
     at.addForeignKey(toTable, opts as Partial<AddForeignKeyOptions>);
-    await this.adapter.execute(this.schemaCreation.accept(at));
+    await this.adapter.execute(await this.schemaCreation.accept(at));
   }
 
   async removeForeignKey(
@@ -891,7 +891,7 @@ export class SchemaStatements {
     // (MySQL/MariaDB `DROP FOREIGN KEY`) rather than a hardcoded `DROP CONSTRAINT`.
     const at = this.createAlterTable(fromTable);
     at.dropForeignKey(fk.name);
-    await this.adapter.execute(this.schemaCreation.accept(at));
+    await this.adapter.execute(await this.schemaCreation.accept(at));
   }
 
   async addCheckConstraint(
@@ -917,7 +917,7 @@ export class SchemaStatements {
     const validate = options.validate !== false;
     const chkDef = new CheckConstraintDefinition(tableName, expression, name, validate);
     await this.adapter.execute(
-      `ALTER TABLE ${this._qi(tableName)} ADD ${this.schemaCreation.accept(chkDef)}`,
+      `ALTER TABLE ${this._qi(tableName)} ADD ${await this.schemaCreation.accept(chkDef)}`,
     );
   }
 
@@ -963,7 +963,7 @@ export class SchemaStatements {
     // (MySQL `DROP CHECK`) rather than a hardcoded `DROP CONSTRAINT`.
     const at = this.createAlterTable(tableName);
     at.dropCheckConstraint(chk.name);
-    await this.adapter.execute(this.schemaCreation.accept(at));
+    await this.adapter.execute(await this.schemaCreation.accept(at));
   }
 
   async addTimestamps(tableName: string, options: ColumnOptions = {}): Promise<void> {
@@ -974,7 +974,7 @@ export class SchemaStatements {
     // the combined ALTER TABLE; non-bulk adapters fall back to two sequential addColumn calls.
     // trails' SQLite3Adapter still defines its own addTimestamps override for direct callers.
     if ((this.adapter as any).supportsBulkAlter?.() === true) {
-      const fragments = this.addTimestampsForAlter(tableName, options);
+      const fragments = await this.addTimestampsForAlter(tableName, options);
       await this.adapter.execute(`ALTER TABLE ${this._qt(tableName)} ${fragments.join(", ")}`);
       return;
     }
@@ -1795,7 +1795,7 @@ export class SchemaStatements {
   async removeConstraint(tableName: string, constraintName: string): Promise<void> {
     const at = new AlterTable(tableName);
     at.dropConstraint(constraintName);
-    await this.adapter.execute(this.schemaCreation.accept(at));
+    await this.adapter.execute(await this.schemaCreation.accept(at));
   }
 
   async dumpSchemaInformation(): Promise<string | null> {
@@ -2602,24 +2602,24 @@ export class SchemaStatements {
     columnName: string,
     type: ColumnType,
     options: ColumnOptions = {},
-  ): string {
+  ): Promise<string> {
     const td = this.createTableDefinition(tableName);
     const cd = td.newColumnDefinition(columnName, type, options);
     return this.schemaCreation.accept(new AddColumnDefinition(cd));
   }
 
   /** @internal */
-  changeColumnDefaultForAlter(
+  async changeColumnDefaultForAlter(
     _tableName: string,
     columnName: string,
     defaultOrChanges: unknown,
-  ): string {
+  ): Promise<string> {
     const newDefault = this.extractNewDefaultValue(defaultOrChanges);
     const col = this.adapter.quoteIdentifier(columnName);
     if (newDefault == null) {
       return `ALTER COLUMN ${col} DROP DEFAULT`;
     }
-    return `ALTER COLUMN ${col} SET DEFAULT ${this.adapter.quoteDefaultExpression(newDefault)}`;
+    return `ALTER COLUMN ${col} SET DEFAULT ${await this.adapter.quoteDefaultExpression(newDefault)}`;
   }
 
   /** @internal */
@@ -2647,15 +2647,15 @@ export class SchemaStatements {
   }
 
   /** @internal */
-  addTimestampsForAlter(tableName: string, options: ColumnOptions = {}): string[] {
+  async addTimestampsForAlter(tableName: string, options: ColumnOptions = {}): Promise<string[]> {
     const opts: ColumnOptions = { ...options };
     if (opts.null == null) opts.null = false;
     if (!("precision" in opts) && (this.adapter as any).supportsDatetimeWithPrecision?.()) {
       opts.precision = 6;
     }
     return [
-      this.addColumnForAlter(tableName, "created_at", "datetime", opts),
-      this.addColumnForAlter(tableName, "updated_at", "datetime", opts),
+      await this.addColumnForAlter(tableName, "created_at", "datetime", opts),
+      await this.addColumnForAlter(tableName, "updated_at", "datetime", opts),
     ];
   }
 

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
@@ -15,70 +15,72 @@ import { TableDefinition as MyTd } from "./schema-definitions.js";
 describe("MySQL::SchemaCreation", () => {
   const sc = new SchemaCreation();
 
-  it("visitDropForeignKey returns DROP FOREIGN KEY sql", () => {
+  it("visitDropForeignKey returns DROP FOREIGN KEY sql", async () => {
     expect((sc as any).visitDropForeignKey("fk_name")).toBe("DROP FOREIGN KEY fk_name");
   });
 
-  it("visitDropCheckConstraint uses CHECK for MySQL", () => {
+  it("visitDropCheckConstraint uses CHECK for MySQL", async () => {
     expect((sc as any).visitDropCheckConstraint("chk")).toBe("DROP CHECK chk");
   });
 
-  it("visitDropCheckConstraint uses CONSTRAINT for MariaDB", () => {
+  it("visitDropCheckConstraint uses CONSTRAINT for MariaDB", async () => {
     const mdb = new SchemaCreation();
     (mdb as any)._mariadb = true;
     expect((mdb as any).visitDropCheckConstraint("chk")).toBe("DROP CONSTRAINT chk");
   });
 
-  it("visitAlterTable routes FK/check drops through the MySQL visitors", () => {
+  it("visitAlterTable routes FK/check drops through the MySQL visitors", async () => {
     const at = new AlterTable("posts");
     at.dropForeignKey("fk_name");
     at.checkConstraintDrops.push("chk");
-    const sql = (sc as any).visitAlterTable(at);
+    const sql = await (sc as any).visitAlterTable(at);
     expect(sql).toContain("DROP FOREIGN KEY fk_name");
     expect(sql).toContain("DROP CHECK chk");
   });
 
-  it("visitChangeColumnDefinition generates CHANGE sql", () => {
+  it("visitChangeColumnDefinition generates CHANGE sql", async () => {
     const col = new ColumnDefinition("email", "string", {});
     const def = new ChangeColumnDefinition(col, "old_name");
-    expect((sc as any).visitChangeColumnDefinition(def)).toMatch(/^CHANGE `old_name` `email` /);
+    expect(await (sc as any).visitChangeColumnDefinition(def)).toMatch(
+      /^CHANGE `old_name` `email` /,
+    );
   });
 
-  it("visitChangeColumnDefaultDefinition generates SET DEFAULT", () => {
+  it("visitChangeColumnDefaultDefinition generates SET DEFAULT", async () => {
     const col = new ColumnDefinition("status", "string", {});
     const def = new ChangeColumnDefaultDefinition(col, "active");
-    expect((sc as any).visitChangeColumnDefaultDefinition(def)).toMatch(
+    expect(await (sc as any).visitChangeColumnDefaultDefinition(def)).toMatch(
       /ALTER COLUMN `status` SET DEFAULT/,
     );
   });
 
-  it("visitChangeColumnDefaultDefinition generates DROP DEFAULT when null:false + null value", () => {
+  it("visitChangeColumnDefaultDefinition generates DROP DEFAULT when null:false + null value", async () => {
     const col = new ColumnDefinition("status", "string", { null: false });
     const def = new ChangeColumnDefaultDefinition(col, null);
-    expect((sc as any).visitChangeColumnDefaultDefinition(def)).toBe(
+    expect(await (sc as any).visitChangeColumnDefaultDefinition(def)).toBe(
       "ALTER COLUMN `status` DROP DEFAULT",
     );
   });
 
-  it("visitIndexDefinition generates inline INDEX sql", () => {
+  it("visitIndexDefinition generates inline INDEX sql", async () => {
     const idx = new IndexDefinition("users", "idx_users_email", false, ["email"]);
     expect((sc as any).visitIndexDefinition(idx, false)).toBe("INDEX `idx_users_email` (`email`)");
   });
 
-  it("visitIndexDefinition generates CREATE UNIQUE INDEX with table", () => {
+  it("visitIndexDefinition generates CREATE UNIQUE INDEX with table", async () => {
     const idx = new IndexDefinition("users", "idx", true, ["email"]);
     expect((sc as any).visitIndexDefinition(idx, true)).toBe(
       "CREATE UNIQUE INDEX `idx` ON `users` (`email`)",
     );
   });
 
-  it("visitCreateIndexDefinition appends algorithm", () => {
+  it("visitCreateIndexDefinition appends algorithm", async () => {
     const idx = new IndexDefinition("users", "idx", false, ["col"]);
     const def = new CreateIndexDefinition(idx, false, "INPLACE");
     expect((sc as any).visitCreateIndexDefinition(def)).toContain("INPLACE");
   });
 
-  it("emits inline index sort order when the adapter supports it", () => {
+  it("emits inline index sort order when the adapter supports it", async () => {
     const host = { supportsIndexSortOrder: () => true };
     const withHost = new SchemaCreation(host as any);
     const idx = new IndexDefinition("users", "idx", false, ["email"], {
@@ -87,7 +89,7 @@ describe("MySQL::SchemaCreation", () => {
     expect((withHost as any).visitIndexDefinition(idx, false)).toBe("INDEX `idx` (`email` DESC)");
   });
 
-  it("drops inline index sort order when the adapter version gate is unsupported", () => {
+  it("drops inline index sort order when the adapter version gate is unsupported", async () => {
     const host = { supportsIndexSortOrder: () => false };
     const withHost = new SchemaCreation(host as any);
     const idx = new IndexDefinition("users", "idx", false, ["email"], {
@@ -96,7 +98,7 @@ describe("MySQL::SchemaCreation", () => {
     expect((withHost as any).visitIndexDefinition(idx, false)).toBe("INDEX `idx` (`email`)");
   });
 
-  it("addTableOptionsBang appends charset and collation", () => {
+  it("addTableOptionsBang appends charset and collation", async () => {
     const td = new TableDefinition("users", { adapterName: "mysql" });
     (td as any).charset = "utf8mb4";
     (td as any).collation = "utf8mb4_unicode_ci";
@@ -105,57 +107,57 @@ describe("MySQL::SchemaCreation", () => {
     expect(result).toContain("COLLATE=utf8mb4_unicode_ci");
   });
 
-  it("addColumnPositionBang appends FIRST", () => {
+  it("addColumnPositionBang appends FIRST", async () => {
     expect((sc as any).addColumnPositionBang("col INTEGER", { first: true })).toBe(
       "col INTEGER FIRST",
     );
   });
 
-  it("addColumnPositionBang appends AFTER", () => {
+  it("addColumnPositionBang appends AFTER", async () => {
     expect((sc as any).addColumnPositionBang("col INTEGER", { after: "name" })).toBe(
       "col INTEGER AFTER `name`",
     );
   });
 
-  it("indexInCreate generates inline index with provided name", () => {
+  it("indexInCreate generates inline index with provided name", async () => {
     const sql = (sc as any).indexInCreate("users", "email", { name: "my_idx" });
     expect(sql).toContain("`my_idx`");
     expect(sql).toContain("`email`");
   });
 
-  it("addColumnOptionsBang emits AUTO_INCREMENT when autoIncrement: true", () => {
+  it("addColumnOptionsBang emits AUTO_INCREMENT when autoIncrement: true", async () => {
     const col = new ColumnDefinition("id", "integer", { autoIncrement: true });
-    const result = (sc as any).addColumnOptionsBang("`id` int(11)", col.options);
+    const result = await (sc as any).addColumnOptionsBang("`id` int(11)", col.options);
     expect(result).toContain("AUTO_INCREMENT");
   });
 
-  it("addColumnOptionsBang does not emit AUTO_INCREMENT when not set", () => {
+  it("addColumnOptionsBang does not emit AUTO_INCREMENT when not set", async () => {
     const col = new ColumnDefinition("id", "integer", {});
-    const result = (sc as any).addColumnOptionsBang("`id` int(11)", col.options);
+    const result = await (sc as any).addColumnOptionsBang("`id` int(11)", col.options);
     expect(result).not.toContain("AUTO_INCREMENT");
   });
 
-  it("addColumn with autoIncrement: true emits AUTO_INCREMENT in DDL", () => {
+  it("addColumn with autoIncrement: true emits AUTO_INCREMENT in DDL", async () => {
     const col = new ColumnDefinition("id", "integer", { autoIncrement: true, null: false });
-    const sql = sc.accept(new AddColumnDefinition(col));
+    const sql = await sc.accept(new AddColumnDefinition(col));
     expect(sql).toMatch(/ADD .+ AUTO_INCREMENT/);
   });
 
-  it("typeToSql emits float(24) for float without limit", () => {
+  it("typeToSql emits float(24) for float without limit", async () => {
     expect(sc.typeToSql("float", {})).toBe("float(24)");
   });
 
-  it("typeToSql emits float(N) for float with limit", () => {
+  it("typeToSql emits float(N) for float with limit", async () => {
     expect(sc.typeToSql("float", { limit: 5 })).toBe("float(5)");
     expect(sc.typeToSql("float", { limit: 53 })).toBe("float(53)");
   });
 
-  it("typeToSql delegates non-float types to super", () => {
+  it("typeToSql delegates non-float types to super", async () => {
     expect(sc.typeToSql("integer", {})).not.toContain("float");
     expect(sc.typeToSql("string", {})).toMatch(/varchar/i);
   });
 
-  it("typeToSql preserves enum/set literal type fragments verbatim", () => {
+  it("typeToSql preserves enum/set literal type fragments verbatim", async () => {
     // Rails' type_to_sql returns an unrecognized type unchanged; the abstract
     // default branch must not uppercase a quoted value list, or enum/set member
     // values get corrupted (e.g. enum('text') -> enum('TEXT')).
@@ -163,15 +165,15 @@ describe("MySQL::SchemaCreation", () => {
     expect(sc.typeToSql("set('a','b')", {})).toBe("set('a','b')");
   });
 
-  it("addColumnOptions emits ON UPDATE when onUpdate is set (MySQL-specific)", () => {
+  it("addColumnOptions emits ON UPDATE when onUpdate is set (MySQL-specific)", async () => {
     const opts: MysqlAddColumnOptions = { onUpdate: "CURRENT_TIMESTAMP" };
-    const result = sc.addColumnOptions("`updated_at` datetime", opts);
+    const result = await sc.addColumnOptions("`updated_at` datetime", opts);
     expect(result).toContain("ON UPDATE CURRENT_TIMESTAMP");
   });
 
-  it("addColumnOptions does not emit ON UPDATE when onUpdate is absent", () => {
+  it("addColumnOptions does not emit ON UPDATE when onUpdate is absent", async () => {
     const col = new ColumnDefinition("updated_at", "datetime", {});
-    const result = sc.addColumnOptions("`updated_at` datetime", col.options);
+    const result = await sc.addColumnOptions("`updated_at` datetime", col.options);
     expect(result).not.toContain("ON UPDATE");
   });
 });
@@ -181,89 +183,89 @@ describe("MySQL::TableDefinition#toSql via SchemaCreation.accept", () => {
   // accepting the TableDefinition into the adapter's SchemaCreation visitor.
   const toSql = (td: MyTd, host?: unknown) => new SchemaCreation(host as any).accept(td);
 
-  it("emits bigint AUTO_INCREMENT PRIMARY KEY for default id column", () => {
+  it("emits bigint AUTO_INCREMENT PRIMARY KEY for default id column", async () => {
     const td = new MyTd("users", {});
     td.string("name");
-    expect(toSql(td)).toBe(
+    expect(await toSql(td)).toBe(
       "CREATE TABLE `users` (`id` bigint NOT NULL AUTO_INCREMENT PRIMARY KEY, `name` varchar(255))",
     );
   });
 
-  it("drops the type for a virtual column with no type option (Rails no-fallback)", () => {
+  it("drops the type for a virtual column with no type option (Rails no-fallback)", async () => {
     const td = new MyTd("t", { id: false });
     td.column("full_name", "virtual" as any, { as: "CONCAT(a, b)" } as any);
     const col = td.columns.find((c) => c.name === "full_name")!;
     expect(col.type).toBeUndefined();
-    const sql = toSql(td);
+    const sql = await toSql(td);
     expect(sql).toContain("`full_name`  AS (CONCAT(a, b))");
     expect(sql).not.toContain("varchar");
   });
 
-  it("honors id: false (no primary key column)", () => {
+  it("honors id: false (no primary key column)", async () => {
     const td = new MyTd("logs", { id: false });
     td.string("body");
-    expect(toSql(td)).toBe("CREATE TABLE `logs` (`body` varchar(255))");
+    expect(await toSql(td)).toBe("CREATE TABLE `logs` (`body` varchar(255))");
   });
 
-  it("appends DEFAULT CHARSET and COLLATE from table options", () => {
+  it("appends DEFAULT CHARSET and COLLATE from table options", async () => {
     const td = new MyTd("posts", { charset: "utf8mb4", collation: "utf8mb4_unicode_ci" });
     td.string("title");
-    const sql = toSql(td);
+    const sql = await toSql(td);
     expect(sql).toContain("DEFAULT CHARSET=utf8mb4");
     expect(sql).toContain("COLLATE=utf8mb4_unicode_ci");
   });
 
-  it("emits IF NOT EXISTS and TEMPORARY modifiers", () => {
+  it("emits IF NOT EXISTS and TEMPORARY modifiers", async () => {
     const td = new MyTd("tmp", { id: false, temporary: true, ifNotExists: true });
     td.integer("n");
-    expect(toSql(td)).toBe("CREATE TEMPORARY TABLE IF NOT EXISTS `tmp` (`n` int)");
+    expect(await toSql(td)).toBe("CREATE TEMPORARY TABLE IF NOT EXISTS `tmp` (`n` int)");
   });
 
-  it("emits composite PRIMARY KEY clause", () => {
+  it("emits composite PRIMARY KEY clause", async () => {
     const td = new MyTd("memberships", { primaryKey: ["user_id", "group_id"] });
     td.bigint("user_id", { null: false });
     td.bigint("group_id", { null: false });
-    const sql = toSql(td);
+    const sql = await toSql(td);
     expect(sql).toContain("PRIMARY KEY (`user_id`, `group_id`)");
   });
 
-  it("inlines indexes when supportsIndexesInCreate (MySQL)", () => {
+  it("inlines indexes when supportsIndexesInCreate (MySQL)", async () => {
     const td = new MyTd("users", {});
     td.string("email");
     td.index(["email"], { unique: true, name: "idx_users_email" });
-    const sql = toSql(td);
+    const sql = await toSql(td);
     expect(sql).toContain("UNIQUE INDEX `idx_users_email` (`email`)");
   });
 
-  it("inlines FOREIGN KEY constraints", () => {
+  it("inlines FOREIGN KEY constraints", async () => {
     const td = new MyTd("posts", {});
     td.bigint("author_id");
     td.foreignKey("authors", { column: "author_id" });
-    const sql = toSql(td);
+    const sql = await toSql(td);
     expect(sql).toContain("CONSTRAINT ");
     expect(sql).toContain("FOREIGN KEY (`author_id`) REFERENCES `authors` (`id`)");
   });
 
-  it("inlines CHECK constraints", () => {
+  it("inlines CHECK constraints", async () => {
     const td = new MyTd("products", {});
     td.integer("price");
     td.checkConstraint("price > 0", { name: "price_positive" });
-    const sql = toSql(td);
+    const sql = await toSql(td);
     expect(sql).toContain("CONSTRAINT `price_positive` CHECK (price > 0)");
   });
 
-  it("appends MySQL COMMENT on table option", () => {
+  it("appends MySQL COMMENT on table option", async () => {
     const td = new MyTd("notes", { comment: "user-supplied" });
     td.string("body");
-    expect(toSql(td)).toContain("COMMENT 'user-supplied'");
+    expect(await toSql(td)).toContain("COMMENT 'user-supplied'");
   });
 
-  it("emits AS clause after table options for CTAS", () => {
+  it("emits AS clause after table options for CTAS", async () => {
     const td = new MyTd("snapshot", { id: false, as: "SELECT 1" });
-    expect(toSql(td)).toMatch(/CREATE TABLE `snapshot`.* AS SELECT 1$/);
+    expect(await toSql(td)).toMatch(/CREATE TABLE `snapshot`.* AS SELECT 1$/);
   });
 
-  it("skips FK emission when host adapter has foreignKeys disabled", () => {
+  it("skips FK emission when host adapter has foreignKeys disabled", async () => {
     const host = {
       supportsForeignKeys: () => true,
       _config: { foreignKeys: false },
@@ -271,14 +273,14 @@ describe("MySQL::TableDefinition#toSql via SchemaCreation.accept", () => {
     const td = new MyTd("posts", { adapter: host });
     td.bigint("author_id");
     td.foreignKey("authors", { column: "author_id" });
-    expect(toSql(td, host)).not.toContain("FOREIGN KEY");
+    expect(await toSql(td, host)).not.toContain("FOREIGN KEY");
   });
 
-  it("skips CHECK emission when host adapter reports !supportsCheckConstraints", () => {
+  it("skips CHECK emission when host adapter reports !supportsCheckConstraints", async () => {
     const host = { supportsCheckConstraints: () => false };
     const td = new MyTd("products", { adapter: host });
     td.integer("price");
     td.checkConstraint("price > 0", { name: "p_pos" });
-    expect(toSql(td, host)).not.toContain("CHECK");
+    expect(await toSql(td, host)).not.toContain("CHECK");
   });
 });

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -234,8 +234,11 @@ export class SchemaCreation extends AbstractSchemaCreation {
     if (o.ifNotExists) sql += " IF NOT EXISTS";
     sql += ` ${this.adapter.quoteTableName(o.tableName)}`;
 
+    // Mirrors the abstract visitor's map-then-await-in-order shape.
     const statements: string[] = [];
-    for (const c of o.columns) statements.push(await this.visitColumnDefinition(c));
+    for (const pending of o.columns.map((c) => this.visitColumnDefinition(c))) {
+      statements.push(await pending);
+    }
     if (o.compositePrimaryKey && o.compositePrimaryKey.length > 0) {
       const cols = o.compositePrimaryKey.map((k) => this.adapter.quoteIdentifier(k)).join(", ");
       statements.push(`PRIMARY KEY (${cols})`);

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -191,9 +191,9 @@ export class SchemaCreation extends AbstractSchemaCreation {
   }
 
   /** @internal */
-  protected override visitAddColumnDefinition(o: AddColumnDefinition): string {
+  protected override async visitAddColumnDefinition(o: AddColumnDefinition): Promise<string> {
     return this.addColumnPositionBang(
-      super.visitAddColumnDefinition(o),
+      await super.visitAddColumnDefinition(o),
       this.columnOptions(o.column) as MysqlColumnOptions,
     );
   }
@@ -229,12 +229,13 @@ export class SchemaCreation extends AbstractSchemaCreation {
    *
    * @internal
    */
-  protected override visitTableDefinition(o: TableDefinition): string {
+  protected override async visitTableDefinition(o: TableDefinition): Promise<string> {
     let sql = `CREATE${this.tableModifierInCreate(o)} TABLE`;
     if (o.ifNotExists) sql += " IF NOT EXISTS";
     sql += ` ${this.adapter.quoteTableName(o.tableName)}`;
 
-    const statements: string[] = o.columns.map((c) => this.visitColumnDefinition(c));
+    const statements: string[] = [];
+    for (const c of o.columns) statements.push(await this.visitColumnDefinition(c));
     if (o.compositePrimaryKey && o.compositePrimaryKey.length > 0) {
       const cols = o.compositePrimaryKey.map((k) => this.adapter.quoteIdentifier(k)).join(", ");
       statements.push(`PRIMARY KEY (${cols})`);
@@ -262,7 +263,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
       | Parameters<AbstractSchemaCreation["accept"]>[0]
       | ChangeColumnDefinition
       | ChangeColumnDefaultDefinition,
-  ): string {
+  ): Promise<string> {
     if (o instanceof ChangeColumnDefinition) return this.visitChangeColumnDefinition(o);
     if (o instanceof ChangeColumnDefaultDefinition)
       return this.visitChangeColumnDefaultDefinition(o);
@@ -270,18 +271,20 @@ export class SchemaCreation extends AbstractSchemaCreation {
   }
 
   /** @internal */
-  protected visitChangeColumnDefinition(o: ChangeColumnDefinition): string {
-    const sql = `CHANGE ${this.adapter.quoteIdentifier(o.name)} ${this.accept(o.column)}`;
+  protected async visitChangeColumnDefinition(o: ChangeColumnDefinition): Promise<string> {
+    const sql = `CHANGE ${this.adapter.quoteIdentifier(o.name)} ${await this.accept(o.column)}`;
     return this.addColumnPositionBang(sql, this.columnOptions(o.column) as MysqlColumnOptions);
   }
 
   /** @internal */
-  protected visitChangeColumnDefaultDefinition(o: ChangeColumnDefaultDefinition): string {
+  protected async visitChangeColumnDefaultDefinition(
+    o: ChangeColumnDefaultDefinition,
+  ): Promise<string> {
     let sql = `ALTER COLUMN ${this.adapter.quoteIdentifier(o.column.name)} `;
     if (o.default == null && o.column.options.null === false) {
       sql += "DROP DEFAULT";
     } else {
-      sql += `SET DEFAULT ${this.adapter.quoteDefaultExpression(o.default, o.column)}`;
+      sql += `SET DEFAULT ${await this.adapter.quoteDefaultExpression(o.default, o.column)}`;
     }
     return sql;
   }
@@ -342,7 +345,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
   }
 
   /** @internal */
-  override addColumnOptions(sql: string, options: ColumnOptions): string {
+  override async addColumnOptions(sql: string, options: ColumnOptions): Promise<string> {
     const mo = options as MysqlColumnOptions;
     const col = mo.column;
     if (col && /^\btimestamp\b/.test(col.sqlType ?? col.type ?? "") && !mo.primaryKey) {
@@ -367,14 +370,14 @@ export class SchemaCreation extends AbstractSchemaCreation {
     const optionsWithoutPk: ColumnOptions = mo.primaryKey
       ? { ...options, primaryKey: false }
       : options;
-    let withBase = super.addColumnOptions(sql, optionsWithoutPk);
+    let withBase = await super.addColumnOptions(sql, optionsWithoutPk);
     if (mo.onUpdate) withBase += ` ON UPDATE ${mo.onUpdate}`;
     if (mo.primaryKey) withBase += " PRIMARY KEY";
     return this.addSqlCommentBang(withBase, mo.comment);
   }
 
   /** @internal */
-  protected override addColumnOptionsBang(sql: string, options: AddColumnOptions): string {
+  protected override addColumnOptionsBang(sql: string, options: AddColumnOptions): Promise<string> {
     return this.addColumnOptions(sql, options);
   }
 

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -234,10 +234,10 @@ export class SchemaCreation extends AbstractSchemaCreation {
     if (o.ifNotExists) sql += " IF NOT EXISTS";
     sql += ` ${this.adapter.quoteTableName(o.tableName)}`;
 
-    // Mirrors the abstract visitor's map-then-await-in-order shape.
+    // Mirrors the abstract visitor's sequential map-to-thunks shape.
     const statements: string[] = [];
-    for (const pending of o.columns.map((c) => this.visitColumnDefinition(c))) {
-      statements.push(await pending);
+    for (const visit of o.columns.map((c) => () => this.visitColumnDefinition(c))) {
+      statements.push(await visit());
     }
     if (o.compositePrimaryKey && o.compositePrimaryKey.length > 0) {
       const cols = o.compositePrimaryKey.map((k) => this.adapter.quoteIdentifier(k)).join(", ");

--- a/packages/activerecord/src/connection-adapters/mysql/schema-quoter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-quoter.ts
@@ -17,7 +17,7 @@ import { quoteDefaultExpression } from "../abstract/quoting.js";
 export interface MysqlSchemaQuoter {
   quoteIdentifier(name: string): string;
   quoteTableName(name: string): string;
-  quoteDefaultExpression(value: unknown, column?: unknown): string;
+  quoteDefaultExpression(value: unknown, column?: unknown): string | Promise<string>;
   quote(value: unknown): string;
   quotedBinary(value: unknown): string;
 }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -60,7 +60,7 @@ export class MysqlSchemaStatements extends BaseSchemaStatements {
       return;
     }
     const createDef = new CreateIndexDefinition(idx, false, algorithmClause);
-    await this.adapter.execute(this.schemaCreation.accept(createDef));
+    await this.adapter.execute(await this.schemaCreation.accept(createDef));
   }
 
   override async dropTable(

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -5459,6 +5459,19 @@ const DEFAULT_FUNCTION_RE = /\w+\(.*\)|\(.*\)::\w+|CURRENT_DATE|CURRENT_TIMESTAM
  * don't have a static registration, so the lookup misses and returns
  * ValueType. Mapping them to the scalar typname (int4) would
  * incorrectly deserialize array values with a scalar type.
+ *
+ * DEVIATION (tracked, pending convergence — RFC 0032 story
+ * converge-pg-lookup-cast-type-regtype-oid-query): Rails' PG
+ * `lookup_cast_type(sql_type)` (postgresql/quoting.rb:195) resolves a
+ * sql_type string to an OID with a live `SELECT '<sql_type>'::regtype::oid`
+ * SCHEMA query before hitting the OID-keyed type map, so every DDL
+ * default-quoting on a ColumnDefinition issues that query. trails resolves
+ * the string statically through this alias table instead: the
+ * quoting/schema-creation visitor chain is synchronous and cannot await a
+ * query. Consequence: the bulk-alter tests in migration.test.ts count one
+ * fewer PG SCHEMA query than migration_test.rb (3→2, 5→4), and custom
+ * types (enums/domains) that only Rails' regtype round-trip would resolve
+ * fall through to ValueType here.
  */
 function normalizeFormatType(sqlType: string): string {
   if (/\[\]\s*$/.test(sqlType)) return sqlType;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3605,12 +3605,28 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   /**
+   * Mirrors: PostgreSQL::Quoting#lookup_cast_type (postgresql/quoting.rb:195).
+   * Resolves a sql_type string to its OID with a live
+   * `SELECT '<sql_type>'::regtype::oid` SCHEMA query, then looks the OID up in
+   * the type map (Rails' `super` = abstract `type_map.lookup(oid)`). The PG
+   * type map is keyed by OID and short typname, so DDL-formatted names like
+   * `character varying` resolve only through this regtype round-trip — which
+   * also handles typmods (`(255)`), `[]` array suffixes, enums, and domains.
+   * @internal
+   */
+  private async lookupCastType(sqlType: string): Promise<Type> {
+    const rows = await this.schemaQuery(`SELECT ${this.quote(sqlType)}::regtype::oid`);
+    return this.typeMap.lookup(Number(rows[0]?.oid));
+  }
+
+  /**
    * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::Quoting#quote_default_expression.
    * Routes through the array- and typeMap-aware `pgQuoteDefaultExpression`
    * so DEFAULT clauses on array columns and OID-backed types serialize
-   * correctly.
+   * correctly. Async: a ColumnDefinition (no OID) resolves its cast type via
+   * `lookupCastType`'s live regtype query, as Rails does.
    */
-  override quoteDefaultExpression(value: unknown, column?: unknown): string {
+  override quoteDefaultExpression(value: unknown, column?: unknown): Promise<string> {
     const col = column as
       | {
           sqlType?: string | null;
@@ -3633,7 +3649,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         sqlType?: string | null;
         oid?: number | null;
         fmod?: number | null;
-      }): { serialize?(v: unknown): unknown } | null {
+      }):
+        | { serialize?(v: unknown): unknown }
+        | null
+        | Promise<{ serialize?(v: unknown): unknown } | null> {
         // A live Column carries an OID, so hand it straight through: Rails
         // keys the lookup on (oid, fmod, sql_type) (quoting.rb:191), and for
         // an array column that OID resolves to OID::Array(subtype) — an
@@ -3644,16 +3663,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
             serialize?(v: unknown): unknown;
           } | null;
         }
-        // No OID means a ColumnDefinition from a DDL path, whose sqlType is
-        // the `[]`-suffixed form typeToSql emitted (`integer[]`). Strip it so
-        // the element typname resolves — normalizeFormatType deliberately
-        // preserves `[]` for the type-casting path, so the strip belongs
-        // here at the call site rather than in the shared helper. The
-        // element subtype is then wrapped in OidArray downstream.
-        const base = (c.sqlType ?? "").replace(/\[\]\s*$/, "");
-        return self.lookupCastTypeFromColumn({ sqlType: base }) as {
-          serialize?(v: unknown): unknown;
-        } | null;
+        // No OID means a ColumnDefinition from a DDL path: Rails resolves its
+        // sql_type with the live regtype query (postgresql/quoting.rb:195),
+        // which handles typmods and `[]` array suffixes server-side — an
+        // array sql_type resolves to the array type's OID directly.
+        return self.lookupCastType(c.sqlType ?? "");
       },
     };
     return pgQuoteDefaultExpression.call(
@@ -4848,18 +4862,18 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   /** @internal */
-  addColumnForAlter(
+  async addColumnForAlter(
     tableName: string,
     columnName: string,
     type: string,
     options: Record<string, unknown> = {},
-  ): unknown {
+  ): Promise<unknown> {
     const col = this.createTableDefinition(tableName).newColumnDefinition(
       columnName,
       type,
       options,
     );
-    const sql = `ADD COLUMN ${this.schemaCreation.accept(col)}`;
+    const sql = `ADD COLUMN ${await this.schemaCreation.accept(col)}`;
     return "comment" in options
       ? [
           sql,
@@ -4869,19 +4883,19 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   /** @internal */
-  changeColumnForAlter(
+  async changeColumnForAlter(
     tableName: string,
     columnName: string,
     type: string,
     options: Record<string, unknown> = {},
-  ): unknown[] {
+  ): Promise<unknown[]> {
     const changeDef = this.buildChangeColumnDefinition(
       tableName,
       columnName,
       type,
       options as Parameters<typeof this.buildChangeColumnDefinition>[3],
     );
-    const sqls: unknown[] = [this.schemaCreation.accept(changeDef)];
+    const sqls: unknown[] = [await this.schemaCreation.accept(changeDef)];
     if ("comment" in options)
       sqls.push(() =>
         this.changeColumnComment(tableName, columnName, options.comment as string | null),
@@ -5459,19 +5473,6 @@ const DEFAULT_FUNCTION_RE = /\w+\(.*\)|\(.*\)::\w+|CURRENT_DATE|CURRENT_TIMESTAM
  * don't have a static registration, so the lookup misses and returns
  * ValueType. Mapping them to the scalar typname (int4) would
  * incorrectly deserialize array values with a scalar type.
- *
- * DEVIATION (tracked, pending convergence — RFC 0032 story
- * converge-pg-lookup-cast-type-regtype-oid-query): Rails' PG
- * `lookup_cast_type(sql_type)` (postgresql/quoting.rb:195) resolves a
- * sql_type string to an OID with a live `SELECT '<sql_type>'::regtype::oid`
- * SCHEMA query before hitting the OID-keyed type map, so every DDL
- * default-quoting on a ColumnDefinition issues that query. trails resolves
- * the string statically through this alias table instead: the
- * quoting/schema-creation visitor chain is synchronous and cannot await a
- * query. Consequence: the bulk-alter tests in migration.test.ts count one
- * fewer PG SCHEMA query than migration_test.rb (3→2, 5→4), and custom
- * types (enums/domains) that only Rails' regtype round-trip would resolve
- * fall through to ValueType here.
  */
 function normalizeFormatType(sqlType: string): string {
   if (/\[\]\s*$/.test(sqlType)) return sqlType;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.type-map.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.type-map.test.ts
@@ -1,4 +1,5 @@
-import { StringType, ValueType } from "@blazetrails/activemodel";
+import { IntegerType, StringType, ValueType } from "@blazetrails/activemodel";
+import { Array as OidArray } from "./postgresql/oid/array.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { HashLookupTypeMap } from "../type/hash-lookup-type-map.js";
@@ -94,28 +95,40 @@ describe("PostgreSQLAdapter#quoteDefaultExpression", () => {
     await adapter.close().catch(() => undefined);
   });
 
-  it("reads `array` from ColumnDefinition.options for DDL paths", () => {
+  /** Stub Rails' `SELECT '<sql_type>'::regtype::oid` round-trip
+   * (postgresql/quoting.rb:195) with a warmed type map: `integer[]` resolves
+   * to the `_int4` array OID (1007), registered as OID::Array(integer) the way
+   * the type-map initializer's array pass would. */
+  function stubRegtypeLookup(): void {
+    adapter.typeMap.registerType(1007, new OidArray(new IntegerType()) as never);
+    vi.spyOn(adapter, "schemaQuery").mockResolvedValue([{ oid: 1007 }]);
+  }
+
+  it("reads `array` from ColumnDefinition.options for DDL paths", async () => {
     // Simulates a ColumnDefinition built by addColumn/changeColumn:
     // array lives on `.options`, sqlType is the `[]`-suffixed form.
+    stubRegtypeLookup();
     const columnDef = { sqlType: "integer[]", options: { array: true } };
-    expect(adapter.quoteDefaultExpression([1, 2, 3], columnDef)).toBe("'{1,2,3}'");
+    expect(await adapter.quoteDefaultExpression([1, 2, 3], columnDef)).toBe("'{1,2,3}'");
   });
 
-  it("reads `array` from a live Column instance", () => {
+  it("reads `array` from a live Column instance", async () => {
+    stubRegtypeLookup();
     const column = { sqlType: "integer", array: true };
-    expect(adapter.quoteDefaultExpression([4, 5, 6], column)).toBe("'{4,5,6}'");
+    expect(await adapter.quoteDefaultExpression([4, 5, 6], column)).toBe("'{4,5,6}'");
   });
 
-  it("normalizes `integer[]` sqlType so the integer subtype resolves", () => {
-    // If normalization were missing, the `integer[]` lookup would
-    // miss and the element subtype would fall back to ValueType,
-    // emitting the floats verbatim ('{1.7,2.3}'). IntegerType#serialize
-    // truncates to integers, so '{1,2}' confirms the subtype lookup hit.
+  it("normalizes `integer[]` sqlType so the integer subtype resolves", async () => {
+    // The regtype round-trip resolves `integer[]` to the array OID whose
+    // registered type is OID::Array(integer). If it fell to ValueType instead,
+    // the floats would be emitted verbatim ('{1.7,2.3}'); IntegerType#serialize
+    // truncates to integers, so '{1,2}' confirms the subtype resolved.
+    stubRegtypeLookup();
     const columnDef = { sqlType: "integer[]", options: { array: true } };
-    expect(adapter.quoteDefaultExpression([1.7, 2.3], columnDef)).toBe("'{1,2}'");
+    expect(await adapter.quoteDefaultExpression([1.7, 2.3], columnDef)).toBe("'{1,2}'");
   });
 
-  it("resolves a live column's cast type by oid/fmod, not by formatted name", () => {
+  it("resolves a live column's cast type by oid/fmod, not by formatted name", async () => {
     // Rails keys lookup_cast_type_from_column on (oid, fmod, sql_type)
     // (postgresql/quoting.rb:191). Registering a distinguishable type under
     // an OID whose sqlType would otherwise resolve elsewhere proves the OID
@@ -125,10 +138,10 @@ describe("PostgreSQLAdapter#quoteDefaultExpression", () => {
       serialize: () => "99",
     } as never);
     const column = { oid: 918_273, fmod: -1, sqlType: "numeric", array: false };
-    expect(adapter.quoteDefaultExpression(1.5, column)).toBe("'99'");
+    expect(await adapter.quoteDefaultExpression(1.5, column)).toBe("'99'");
   });
 
-  it("forwards fmod so precision-carrying types resolve", () => {
+  it("forwards fmod so precision-carrying types resolve", async () => {
     // fmod is how numeric(10,2) recovers its precision/scale; dropping it
     // would silently hand the factory -1.
     let seen: number | undefined;
@@ -142,7 +155,7 @@ describe("PostgreSQLAdapter#quoteDefaultExpression", () => {
       seen = fmod;
       return { serialize: (v: unknown) => v };
     }) as never);
-    adapter.quoteDefaultExpression("x", { oid: 918_274, fmod: 655_366, sqlType: "numeric" });
+    await adapter.quoteDefaultExpression("x", { oid: 918_274, fmod: 655_366, sqlType: "numeric" });
     expect(seen).toBe(655_366);
     spy.mockRestore();
   });

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
@@ -69,7 +69,7 @@ describe("PostgreSQL quoting", () => {
     expect(quote(Infinity)).toBe("'Infinity'");
   });
 
-  it("quotes arrays through the encoder's delimiter, not a hardcoded comma", () => {
+  it("quotes arrays through the encoder's delimiter, not a hardcoded comma", async () => {
     // box[] uses a `;` element delimiter; routing quote/typeCast through
     // encodeArray (which calls the OID encoder) keeps it type-correct rather
     // than diverging on a hardcoded `,`.
@@ -104,7 +104,7 @@ describe("PostgreSQL quoting", () => {
     expect(quote(new Range("2020-01-01", null, true))).toBe("'[2020-01-01,)'");
   });
 
-  it("serializes defaults for any PostgreSQL column, not only array columns", () => {
+  it("serializes defaults for any PostgreSQL column, not only array columns", async () => {
     const column = { sqlType: "integer", array: false };
     const typeMap = {
       lookupCastTypeFromColumn(col: { sqlType?: string | null }) {
@@ -113,70 +113,75 @@ describe("PostgreSQL quoting", () => {
       },
     };
 
-    expect(quoteDefaultExpression.call(HOST, 41, column, typeMap)).toBe("42");
+    expect(await quoteDefaultExpression.call(HOST, 41, column, typeMap)).toBe("42");
   });
 
-  it("quotes a binary default through PG's quotedBinary", () => {
+  it("quotes a binary default through PG's quotedBinary", async () => {
     // Binary self-dispatches through the host, so it must reach the bytea escape
     // form, not the abstract byte-string fallback. Cover both shapes here —
     // the raw Uint8Array trails' BinaryType#serialize actually returns, and the
     // BinaryData Rails' Binary#serialize returns (activemodel/.../binary.rb:31).
-    expect(quoteDefaultExpression.call(HOST, new Uint8Array([0x1f, 0x8b]))).toBe("'\\x1f8b'");
-    expect(quoteDefaultExpression.call(HOST, new BinaryData(new Uint8Array([0x1f, 0x8b])))).toBe(
-      "'\\x1f8b'",
-    );
+    expect(await quoteDefaultExpression.call(HOST, new Uint8Array([0x1f, 0x8b]))).toBe("'\\x1f8b'");
+    expect(
+      await quoteDefaultExpression.call(HOST, new BinaryData(new Uint8Array([0x1f, 0x8b]))),
+    ).toBe("'\\x1f8b'");
   });
 
-  it("quotes a BC date default through PG's quotedDate", () => {
+  it("quotes a BC date default through PG's quotedDate", async () => {
     // Dates self-dispatch through the host, so they must reach PG's BC-suffixing
     // quotedDate (postgresql/quoting.rb:143), not the abstract formatter which
     // drops " BC".
-    expect(quoteDefaultExpression.call(HOST, Temporal.PlainDate.from("-000043-03-15"))).toBe(
+    expect(await quoteDefaultExpression.call(HOST, Temporal.PlainDate.from("-000043-03-15"))).toBe(
       "'0044-03-15 BC'",
     );
   });
 
-  it("quotes a binary default produced by BinaryType#serialize", () => {
+  it("quotes a binary default produced by BinaryType#serialize", async () => {
     // Guards the real quoteDefaultExpression path: whatever the type map's
     // serialize emits must still reach PG's bytea form.
     // `array` must be present: the serialize branch is gated on `"array" in column`.
     const column = { sqlType: "bytea", array: false };
     const typeMap = { lookupCastTypeFromColumn: () => new BinaryType() };
-    expect(quoteDefaultExpression.call(HOST, "ab", column, typeMap)).toBe("'\\x6162'");
+    expect(await quoteDefaultExpression.call(HOST, "ab", column, typeMap)).toBe("'\\x6162'");
   });
 
-  it("serializes array defaults via fallback OidArray when type map misses", () => {
+  it("serializes array defaults via fallback OidArray when type map misses", async () => {
     const column = { sqlType: "text[]", array: true };
     const nullTypeMap = {
       lookupCastTypeFromColumn() {
         return null;
       },
     };
-    expect(quoteDefaultExpression.call(HOST, [], column, nullTypeMap)).toBe("'{}'");
-    expect(quoteDefaultExpression.call(HOST, ["a", "b"], column, nullTypeMap)).toBe("'{a,b}'");
+    expect(await quoteDefaultExpression.call(HOST, [], column, nullTypeMap)).toBe("'{}'");
+    expect(await quoteDefaultExpression.call(HOST, ["a", "b"], column, nullTypeMap)).toBe(
+      "'{a,b}'",
+    );
   });
 
-  it("does not quote function default values for UUID columns", () => {
+  it("does not quote function default values for UUID columns", async () => {
     // Rails postgresql/quoting.rb:159-160. Both pgcrypto and uuid-ossp spellings
     // are exercised (uuid_test.rb:16 picks between them by extension support).
     const column = { type: "uuid", sqlType: "uuid" };
-    expect(quoteDefaultExpression.call(HOST, "gen_random_uuid()", column)).toBe(
+    expect(await quoteDefaultExpression.call(HOST, "gen_random_uuid()", column)).toBe(
       "gen_random_uuid()",
     );
-    expect(quoteDefaultExpression.call(HOST, "uuid_generate_v4()", column)).toBe(
+    expect(await quoteDefaultExpression.call(HOST, "uuid_generate_v4()", column)).toBe(
       "uuid_generate_v4()",
     );
     // A non-function string default on a uuid column is still quoted.
-    expect(quoteDefaultExpression.call(HOST, "11111111-1111-1111-1111-111111111111", column)).toBe(
-      "'11111111-1111-1111-1111-111111111111'",
-    );
+    expect(
+      await quoteDefaultExpression.call(HOST, "11111111-1111-1111-1111-111111111111", column),
+    ).toBe("'11111111-1111-1111-1111-111111111111'");
     // The branch is uuid-only — the same string on a text column is quoted.
     expect(
-      quoteDefaultExpression.call(HOST, "gen_random_uuid()", { type: "text", sqlType: "text" }),
+      await quoteDefaultExpression.call(HOST, "gen_random_uuid()", {
+        type: "text",
+        sqlType: "text",
+      }),
     ).toBe("'gen_random_uuid()'");
   });
 
-  it("does not apply array fallback when column.array is false", () => {
+  it("does not apply array fallback when column.array is false", async () => {
     const column = { sqlType: "text", array: false };
     const nullTypeMap = {
       lookupCastTypeFromColumn() {
@@ -184,10 +189,10 @@ describe("PostgreSQL quoting", () => {
       },
     };
     // A plain string value should still round-trip normally
-    expect(quoteDefaultExpression.call(HOST, "hello", column, nullTypeMap)).toBe("'hello'");
+    expect(await quoteDefaultExpression.call(HOST, "hello", column, nullTypeMap)).toBe("'hello'");
   });
 
-  it("serializes array defaults through the type map", () => {
+  it("serializes array defaults through the type map", async () => {
     const arrayType = new OidArray(stringSubtype);
     const column = { sqlType: "text[]", array: true };
     const typeMap = {
@@ -196,10 +201,10 @@ describe("PostgreSQL quoting", () => {
       },
     };
 
-    expect(quoteDefaultExpression.call(HOST, ["a", "b"], column, typeMap)).toBe("'{a,b}'");
+    expect(await quoteDefaultExpression.call(HOST, ["a", "b"], column, typeMap)).toBe("'{a,b}'");
   });
 
-  it("serializes array defaults via an element subtype (per-element coercion)", () => {
+  it("serializes array defaults via an element subtype (per-element coercion)", async () => {
     // Mirrors Rails postgresql/quoting.rb:161-163 where
     // lookup_cast_type_from_column returns OID::Array(IntegerType) and
     // serialize walks each element through Integer#serialize. Trails'
@@ -211,10 +216,12 @@ describe("PostgreSQL quoting", () => {
         return { cast: (v: unknown) => v, serialize: (v: unknown) => Number(v) + 100 };
       },
     };
-    expect(quoteDefaultExpression.call(HOST, [1, 2, 3], column, typeMap)).toBe("'{101,102,103}'");
+    expect(await quoteDefaultExpression.call(HOST, [1, 2, 3], column, typeMap)).toBe(
+      "'{101,102,103}'",
+    );
   });
 
-  it("passes raw array-literal string defaults through without scalar coercion", () => {
+  it("passes raw array-literal string defaults through without scalar coercion", async () => {
     // Regression: when the value is a PG array literal string (e.g.
     // `"{}"`) on an array column, the element-subtype lookup must NOT
     // run — IntegerType#serialize("{}") would coerce to NaN. Rails
@@ -226,8 +233,8 @@ describe("PostgreSQL quoting", () => {
         return { serialize: (v: unknown) => Number(v) };
       },
     };
-    expect(quoteDefaultExpression.call(HOST, "{}", column, typeMap)).toBe("'{}'");
-    expect(quoteDefaultExpression.call(HOST, "{1,2,3}", column, typeMap)).toBe("'{1,2,3}'");
+    expect(await quoteDefaultExpression.call(HOST, "{}", column, typeMap)).toBe("'{}'");
+    expect(await quoteDefaultExpression.call(HOST, "{1,2,3}", column, typeMap)).toBe("'{1,2,3}'");
   });
 
   it("supports nested function calls up to 2 levels deep", () => {

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -167,9 +167,8 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
   return abstractQuote.call(this, value);
 }
 
-// Async: the ColumnDefinition (no-OID) lookup path resolves the sql_type with
-// a live `SELECT '<sql_type>'::regtype::oid` query (postgresql/quoting.rb:195);
-// Ruby blocks on it, we await it.
+// Async: the ColumnDefinition (no-OID) path awaits the live regtype lookup
+// (postgresql/quoting.rb:195) that Ruby blocks on.
 export async function quoteDefaultExpression(
   this: QuotingDispatchHost,
   value: unknown,

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -73,9 +73,12 @@ export interface DefaultExpressionColumn {
  * branch actually uses.
  */
 export interface CastTypeLookup {
-  lookupCastTypeFromColumn(column: DefaultExpressionColumn): {
-    serialize?(value: unknown): unknown;
-  } | null;
+  lookupCastTypeFromColumn(
+    column: DefaultExpressionColumn,
+  ):
+    | { serialize?(value: unknown): unknown }
+    | null
+    | Promise<{ serialize?(value: unknown): unknown } | null>;
 }
 
 export function quoteTableName(name: string): string {
@@ -164,12 +167,15 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
   return abstractQuote.call(this, value);
 }
 
-export function quoteDefaultExpression(
+// Async: the ColumnDefinition (no-OID) lookup path resolves the sql_type with
+// a live `SELECT '<sql_type>'::regtype::oid` query (postgresql/quoting.rb:195);
+// Ruby blocks on it, we await it.
+export async function quoteDefaultExpression(
   this: QuotingDispatchHost,
   value: unknown,
   column?: DefaultExpressionColumn | null,
   castTypeLookup?: CastTypeLookup | null,
-): string {
+): Promise<string> {
   if (value === undefined) return "";
   if (typeof value === "function") {
     const result = (value as () => unknown)();
@@ -191,7 +197,7 @@ export function quoteDefaultExpression(
 
   let serialized: unknown = value;
   if (column != null && "array" in column) {
-    const castType = castTypeLookup?.lookupCastTypeFromColumn(column) ?? null;
+    const castType = (await castTypeLookup?.lookupCastTypeFromColumn(column)) ?? null;
     if (column.array === true && globalThis.Array.isArray(value)) {
       // Rails routes JS arrays through OID::Array.serialize so each
       // element is cast by the element subtype before quoting. Trails'

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.test.ts
@@ -102,17 +102,17 @@ describe("PostgreSQL SchemaCreation", () => {
     ).toMatch(/^ADD CONSTRAINT/);
   });
 
-  it("visitChangeColumnDefaultDefinition", () => {
+  it("visitChangeColumnDefaultDefinition", async () => {
     const col = new ColumnDefinition("x", "string");
     expect(
-      s().visitChangeColumnDefaultDefinition(new ChangeColumnDefaultDefinition(col, null)),
+      await s().visitChangeColumnDefaultDefinition(new ChangeColumnDefaultDefinition(col, null)),
     ).toContain("DROP DEFAULT");
     expect(
-      s().visitChangeColumnDefaultDefinition(new ChangeColumnDefaultDefinition(col, "v")),
+      await s().visitChangeColumnDefaultDefinition(new ChangeColumnDefaultDefinition(col, "v")),
     ).toContain("SET DEFAULT");
   });
 
-  it("visitChangeColumnDefaultDefinition: uuid function default stays bare", () => {
+  it("visitChangeColumnDefaultDefinition: uuid function default stays bare", async () => {
     // postgresql/quoting.rb:159-160 — a `()`-bearing string default on a
     // uuid column must reach the DDL as a call, not as `'uuid_generate_v4()'`.
     const col = new ColumnDefinition("id", "uuid");
@@ -122,25 +122,27 @@ describe("PostgreSQL SchemaCreation", () => {
     host.adapter.quoteDefaultExpression = (v: unknown, c: unknown) =>
       quoteDefaultExpression.call(null as never, v, c as never);
     expect(
-      host.visitChangeColumnDefaultDefinition(
+      await host.visitChangeColumnDefaultDefinition(
         new ChangeColumnDefaultDefinition(col, "uuid_generate_v4()"),
       ),
     ).toBe('ALTER COLUMN "id" SET DEFAULT uuid_generate_v4()');
   });
 
-  it("visitChangeColumnDefinition: ALTER COLUMN TYPE", () => {
+  it("visitChangeColumnDefinition: ALTER COLUMN TYPE", async () => {
     const col = new ColumnDefinition("price", "decimal", { precision: 10, scale: 2 });
-    expect(s().visitChangeColumnDefinition(new ChangeColumnDefinition(col, "price"))).toMatch(
+    expect(await s().visitChangeColumnDefinition(new ChangeColumnDefinition(col, "price"))).toMatch(
       /ALTER COLUMN "price" TYPE/,
     );
   });
 
-  it("addColumnOptionsBang: COLLATE + STORED + throws for virtual", () => {
+  it("addColumnOptionsBang: COLLATE + STORED + throws for virtual", async () => {
     const col = new ColumnDefinition("n", "string");
-    expect(s().addColumnOptionsBang("n", { collation: "en_US" })).toContain('COLLATE "en_US"');
-    expect(s().addColumnOptionsBang("n", { as: "a||b", stored: true, column: col })).toContain(
-      "STORED",
+    expect(await s().addColumnOptionsBang("n", { collation: "en_US" })).toContain(
+      'COLLATE "en_US"',
     );
+    expect(
+      await s().addColumnOptionsBang("n", { as: "a||b", stored: true, column: col }),
+    ).toContain("STORED");
     expect(() => s().addColumnOptionsBang("n", { as: "a||b", stored: false, column: col })).toThrow(
       "VIRTUAL",
     );
@@ -170,7 +172,7 @@ describe("PostgreSQL SchemaCreation", () => {
     expect(sql).not.toContain("CONSTRAINT");
   });
 
-  it("visitAlterTable: constraint validations and exclusion adds are comma-separated from FK adds", () => {
+  it("visitAlterTable: constraint validations and exclusion adds are comma-separated from FK adds", async () => {
     const fk = new ForeignKeyDefinition(
       "users",
       "posts",
@@ -185,7 +187,7 @@ describe("PostgreSQL SchemaCreation", () => {
     const at = new AlterTable("users") as any;
     at.foreignKeyAdds.push(fk);
     at.constraintValidations = ["some_constraint"];
-    const sql = s().visitAlterTable(at);
+    const sql = await s().visitAlterTable(at);
     expect(sql).toContain("ADD CONSTRAINT");
     expect(sql).toContain(", VALIDATE CONSTRAINT");
   });

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.test.ts
@@ -143,9 +143,12 @@ describe("PostgreSQL SchemaCreation", () => {
     expect(
       await s().addColumnOptionsBang("n", { as: "a||b", stored: true, column: col }),
     ).toContain("STORED");
-    expect(() => s().addColumnOptionsBang("n", { as: "a||b", stored: false, column: col })).toThrow(
-      "VIRTUAL",
-    );
+    // async wrapper: the visitor surface is Promise-returning, but the
+    // VIRTUAL guard (_pgGeneratedClause) currently throws synchronously —
+    // rejects.toThrow covers both shapes.
+    await expect(async () =>
+      s().addColumnOptionsBang("n", { as: "a||b", stored: false, column: col }),
+    ).rejects.toThrow("VIRTUAL");
   });
 
   it("visitExclusionConstraintDefinition: deferrable true → DEFERRABLE without INITIALLY", () => {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
@@ -97,8 +97,8 @@ export class SchemaCreation extends AbstractSchemaCreation {
   }
 
   /** @internal */
-  protected override visitAlterTable(o: any): string {
-    let sql = super.visitAlterTable(o);
+  protected override async visitAlterTable(o: any): Promise<string> {
+    let sql = await super.visitAlterTable(o);
     const pgParts: string[] = [];
     if (Array.isArray(o.constraintValidations)) {
       for (const name of o.constraintValidations) pgParts.push(this.visitValidateConstraint(name));
@@ -203,7 +203,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
       | Parameters<AbstractSchemaCreation["accept"]>[0]
       | ChangeColumnDefinition
       | ChangeColumnDefaultDefinition,
-  ): string {
+  ): Promise<string> {
     if (o instanceof ChangeColumnDefinition) return this.visitChangeColumnDefinition(o);
     if (o instanceof ChangeColumnDefaultDefinition)
       return this.visitChangeColumnDefaultDefinition(o);
@@ -211,7 +211,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
   }
 
   /** @internal */
-  protected visitChangeColumnDefinition(o: ChangeColumnDefinition): string {
+  protected async visitChangeColumnDefinition(o: ChangeColumnDefinition): Promise<string> {
     const column = o.column;
     column.sqlType = this.typeToSql(column.type, column.options);
     const quotedName = this.adapter.quoteIdentifier(o.name);
@@ -237,7 +237,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
         // Mirrors Rails postgresql/schema_creation.rb:99 — pass column to
         // quote_default_expression so array/typeMap-aware serialization
         // is preserved on ALTER COLUMN SET DEFAULT.
-        sql += `, ALTER COLUMN ${quotedName} SET DEFAULT ${this.adapter.quoteDefaultExpression(options["default"], column)}`;
+        sql += `, ALTER COLUMN ${quotedName} SET DEFAULT ${await this.adapter.quoteDefaultExpression(options["default"], column)}`;
       }
     }
 
@@ -249,19 +249,21 @@ export class SchemaCreation extends AbstractSchemaCreation {
   }
 
   /** @internal */
-  protected visitChangeColumnDefaultDefinition(o: ChangeColumnDefaultDefinition): string {
+  protected async visitChangeColumnDefaultDefinition(
+    o: ChangeColumnDefaultDefinition,
+  ): Promise<string> {
     const col = this.adapter.quoteIdentifier(o.column.name);
     // Mirrors Rails postgresql/schema_creation.rb:110 — column is passed
     // to quote_default_expression so PG's typeMap/array branch fires.
     const action =
       o.default == null
         ? "DROP DEFAULT"
-        : `SET DEFAULT ${this.adapter.quoteDefaultExpression(o.default, o.column)}`;
+        : `SET DEFAULT ${await this.adapter.quoteDefaultExpression(o.default, o.column)}`;
     return `ALTER COLUMN ${col} ${action}`;
   }
 
   /** @internal */
-  protected override addColumnOptionsBang(sql: string, options: AddColumnOptions): string {
+  protected override addColumnOptionsBang(sql: string, options: AddColumnOptions): Promise<string> {
     const opts = options as Record<string, unknown>;
     if (opts["collation"]) {
       sql += ` COLLATE ${this.adapter.quoteIdentifier(String(opts["collation"]))}`;

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
@@ -10,7 +10,7 @@ import {
 import { SchemaCreation as PgSchemaCreation } from "./schema-creation.js";
 
 describe("ExclusionConstraintDefinition", () => {
-  it("exposes options as accessors", () => {
+  it("exposes options as accessors", async () => {
     const defn = new ExclusionConstraintDefinition("products", "price WITH =, range WITH &&", {
       name: "price_check",
       using: "gist",
@@ -160,107 +160,107 @@ describe("AlterTable", () => {
 describe("TableDefinition#toSql", () => {
   // Rails generates CREATE TABLE SQL by accepting the TableDefinition into the
   // adapter's SchemaCreation visitor; there is no TableDefinition#to_sql.
-  const toSql = (td: TableDefinition): string => {
+  const toSql = (td: TableDefinition): Promise<string> => {
     const adapter = (td as any)._adapter;
     return new PgSchemaCreation("typeToSql" in adapter ? adapter : undefined).accept(td);
   };
 
-  it("emits UNLOGGED when unlogged: true", () => {
+  it("emits UNLOGGED when unlogged: true", async () => {
     const td = new TableDefinition("products", { id: false, unlogged: true });
     td.string("name");
-    expect(toSql(td)).toMatch(/^CREATE UNLOGGED TABLE/);
+    expect(await toSql(td)).toMatch(/^CREATE UNLOGGED TABLE/);
   });
 
-  it("does not emit UNLOGGED by default", () => {
+  it("does not emit UNLOGGED by default", async () => {
     const td = new TableDefinition("products", { id: false });
     td.string("name");
-    expect(toSql(td)).toMatch(/^CREATE TABLE/);
-    expect(toSql(td)).not.toContain("UNLOGGED");
+    expect(await toSql(td)).toMatch(/^CREATE TABLE/);
+    expect(await toSql(td)).not.toContain("UNLOGGED");
   });
 
-  it("drops the type for a virtual column with no type option (Rails no-fallback)", () => {
+  it("drops the type for a virtual column with no type option (Rails no-fallback)", async () => {
     const td = new TableDefinition("articles", { id: false });
     td.column("full_name", "virtual" as any, { as: "a || b", stored: true } as any);
     const col = td.columns.find((c) => c.name === "full_name")!;
     expect(col.type).toBeUndefined();
-    const sql = toSql(td);
+    const sql = await toSql(td);
     expect(sql).toContain('"full_name"  GENERATED ALWAYS AS (a || b) STORED');
     expect(sql).not.toContain("varchar");
   });
 
-  it("emits exclusion constraint in CREATE TABLE", () => {
+  it("emits exclusion constraint in CREATE TABLE", async () => {
     const td = new TableDefinition("meetings", { id: false });
     td.exclusionConstraint("room WITH =, during WITH &&", { name: "no_overlap", using: "gist" });
-    const sql = toSql(td);
+    const sql = await toSql(td);
     expect(sql).toContain(
       'CONSTRAINT "no_overlap" EXCLUDE USING gist (room WITH =, during WITH &&)',
     );
   });
 
-  it("emits unique constraint in CREATE TABLE", () => {
+  it("emits unique constraint in CREATE TABLE", async () => {
     const td = new TableDefinition("orders", { id: false });
     td.uniqueConstraint("position", { name: "unique_pos", deferrable: "deferred" });
-    const sql = toSql(td);
+    const sql = await toSql(td);
     expect(sql).toContain(
       'CONSTRAINT "unique_pos" UNIQUE ("position") DEFERRABLE INITIALLY DEFERRED',
     );
   });
 
-  it("emits unique constraint with nulls not distinct", () => {
+  it("emits unique constraint with nulls not distinct", async () => {
     const td = new TableDefinition("orders", { id: false });
     td.uniqueConstraint("position", { name: "unique_pos", nullsNotDistinct: true });
-    const sql = toSql(td);
+    const sql = await toSql(td);
     expect(sql).toContain("NULLS NOT DISTINCT");
   });
 
-  it("emits unique constraint using index", () => {
+  it("emits unique constraint using index", async () => {
     const td = new TableDefinition("orders", { id: false });
     td.uniqueConstraint("position", { name: "unique_pos", usingIndex: "orders_pos_idx" });
-    const sql = toSql(td);
+    const sql = await toSql(td);
     expect(sql).toContain('USING INDEX "orders_pos_idx"');
   });
 
-  it("emits DEFERRABLE without INITIALLY clause when deferrable: true", () => {
+  it("emits DEFERRABLE without INITIALLY clause when deferrable: true", async () => {
     const td = new TableDefinition("orders", { id: false });
     td.uniqueConstraint("position", { name: "unique_pos", deferrable: true });
-    const sql = toSql(td);
+    const sql = await toSql(td);
     expect(sql).toContain('CONSTRAINT "unique_pos" UNIQUE ("position") DEFERRABLE');
     expect(sql).not.toContain("INITIALLY TRUE");
     expect(sql).not.toContain("INITIALLY");
   });
 
-  it("emits exclusion constraint without CONSTRAINT clause when name is omitted", () => {
+  it("emits exclusion constraint without CONSTRAINT clause when name is omitted", async () => {
     const td = new TableDefinition("meetings", { id: false });
     td.exclusionConstraint("room WITH =", { using: "gist" });
-    const sql = toSql(td);
+    const sql = await toSql(td);
     expect(sql).toContain("EXCLUDE USING gist (room WITH =)");
     expect(sql).not.toContain('CONSTRAINT ""');
   });
 
-  it("emits unique constraint without CONSTRAINT clause when name is omitted", () => {
+  it("emits unique constraint without CONSTRAINT clause when name is omitted", async () => {
     const td = new TableDefinition("orders", { id: false });
     td.uniqueConstraint("position");
-    const sql = toSql(td);
+    const sql = await toSql(td);
     expect(sql).toContain('UNIQUE ("position")');
     expect(sql).not.toContain('CONSTRAINT ""');
   });
 
-  it("handles constraint-only table with no columns (id: false)", () => {
+  it("handles constraint-only table with no columns (id: false)", async () => {
     const td = new TableDefinition("link_table", { id: false });
     td.uniqueConstraint("ref", { name: "unique_ref" });
-    const sql = toSql(td);
+    const sql = await toSql(td);
     expect(sql).not.toContain("(,");
     expect(sql).toContain('UNIQUE ("ref")');
   });
 
-  it("injects constraints before trailing table options clause", () => {
+  it("injects constraints before trailing table options clause", async () => {
     const td = new TableDefinition("logs", {
       id: false,
       options: "WITH (autovacuum_enabled = false)",
     });
     td.string("message");
     td.uniqueConstraint("message", { name: "unique_msg" });
-    const sql = toSql(td);
+    const sql = await toSql(td);
     // Constraint must appear inside the column list, before the trailing WITH clause
     const constraintPos = sql.indexOf('CONSTRAINT "unique_msg"');
     const withPos = sql.indexOf("WITH (");
@@ -268,18 +268,18 @@ describe("TableDefinition#toSql", () => {
     expect(constraintPos).toBeLessThan(withPos);
   });
 
-  it("skips constraint injection for CREATE TABLE ... AS queries", () => {
+  it("skips constraint injection for CREATE TABLE ... AS queries", async () => {
     const td = new TableDefinition("archived_orders", {
       id: false,
       as: "SELECT (1) AS id, amount FROM orders WHERE archived = true",
     });
     td.uniqueConstraint("id", { name: "unique_id" });
-    const sql = toSql(td);
+    const sql = await toSql(td);
     expect(sql).not.toContain("CONSTRAINT");
     expect(sql).toContain("AS SELECT");
   });
 
-  it("emits PG-specific long-tail column SQL types verbatim from pgColumn helpers (no-adapter fallback)", () => {
+  it("emits PG-specific long-tail column SQL types verbatim from pgColumn helpers (no-adapter fallback)", async () => {
     // No adapter provided → PgSchemaCreation falls back to abstract typeToSql,
     // whose default branch returns an unrecognized type verbatim (Rails parity:
     // `type.to_s` — it never uppercases). This matches the real-PostgreSQLAdapter
@@ -297,7 +297,7 @@ describe("TableDefinition#toSql", () => {
     td.money("price");
     td.oid("oid_col");
     td.tsrange("during");
-    const sql = toSql(td);
+    const sql = await toSql(td);
     expect(sql).toContain('"net" cidr');
     expect(sql).toContain('"addr" inet');
     expect(sql).toContain('"props" hstore');
@@ -313,7 +313,7 @@ describe("TableDefinition#toSql", () => {
     expect(sql).toContain('"during" tsrange');
   });
 
-  it("emits PG-specific long-tail column SQL types lowercase when adapter provides typeToSql", () => {
+  it("emits PG-specific long-tail column SQL types lowercase when adapter provides typeToSql", async () => {
     // Stub adapter mirrors PostgreSQLAdapter.NATIVE_DATABASE_TYPES lowercase
     // output — verifies that the visitor delegates to the adapter's typeToSql.
     const stubAdapter = {
@@ -329,7 +329,7 @@ describe("TableDefinition#toSql", () => {
     td.macaddr("mac");
     td.tsvector("doc");
     td.money("price");
-    const sql = toSql(td);
+    const sql = await toSql(td);
     expect(sql).toContain('"net" cidr');
     expect(sql).toContain('"addr" inet');
     expect(sql).toContain('"props" hstore');
@@ -338,11 +338,11 @@ describe("TableDefinition#toSql", () => {
     expect(sql).toContain('"price" money');
   });
 
-  it("handles default values containing doubled single-quotes without mis-parsing", () => {
+  it("handles default values containing doubled single-quotes without mis-parsing", async () => {
     const td = new TableDefinition("messages", { id: false });
     td.string("body", { default: "Bob's" });
     td.uniqueConstraint("body", { name: "unique_body" });
-    const sql = toSql(td);
+    const sql = await toSql(td);
     expect(sql).toContain("Bob''s");
     expect(sql).toContain('CONSTRAINT "unique_body"');
   });

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -915,7 +915,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     // string; the only proc Rails appends here is the :comment change.
     this.pg.clearCacheBang();
     const changeColDef = this.buildChangeColumnDefinition(tableName, columnName, type, options);
-    const clause = this.pg.schemaCreation.accept(changeColDef);
+    const clause = await this.pg.schemaCreation.accept(changeColDef);
     // Route DDL through the public `execute` (not the raw `exec`) so the
     // dirties_query_cache wrapper clears the query cache on schema changes.
     await this.adapter.execute(`ALTER TABLE ${this._qt(tableName)} ${clause}`);
@@ -981,7 +981,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       );
     } else {
       const col = (await this.columns(tableName)).find((c) => c.name === columnName);
-      const expr = this.adapter.quoteDefaultExpression(defaultValue, col);
+      const expr = await this.adapter.quoteDefaultExpression(defaultValue, col);
       await this.adapter.execute(
         `ALTER TABLE ${quotedTable} ALTER COLUMN ${quotedCol} SET DEFAULT ${expr}`,
       );
@@ -1044,7 +1044,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       // Rails guards the pre-ALTER UPDATE with `if column` — skip it when the
       // column can't be found rather than quoting against an undefined column.
       if (col) {
-        const expr = this.adapter.quoteDefaultExpression(defaultValue, col);
+        const expr = await this.adapter.quoteDefaultExpression(defaultValue, col);
         await this.adapter.execute(
           `UPDATE ${quotedTable} SET ${quotedCol} = ${expr} WHERE ${quotedCol} IS NULL`,
         );
@@ -1257,7 +1257,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     // (now converged): it applies table_name_prefix/suffix and re-runs
     // foreign_key_options idempotently (column/name already filled above).
     at.addForeignKey(toTable, fkOptions as Partial<AddForeignKeyOptions>);
-    await this.pg.exec(this.pg.schemaCreation.accept(at));
+    await this.pg.exec(await this.pg.schemaCreation.accept(at));
   }
 
   override async checkConstraints(tableName: string): Promise<CheckConstraintDefinition[]> {
@@ -1454,7 +1454,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     const opts = this.uniqueConstraintOptions(tableName, columnName, options);
     const at = this.pg.createAlterTable(tableName) as PgAlterTable;
     at.addUniqueConstraint(columnName as string | string[], opts);
-    await this.pg.exec(this.pg.schemaCreation.accept(at));
+    await this.pg.exec(await this.pg.schemaCreation.accept(at));
   }
 
   async removeUniqueConstraint(

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1031,7 +1031,9 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   // with side effects is not double-evaluated. In Rails `SqlLiteral < String`, so
   // a SqlLiteral result runs through the same `match?` regex — unwrap to its
   // string and apply the same paren-wrap branch rather than special-casing it.
-  override quoteDefaultExpression(value: unknown, column?: unknown): string {
+  // Return type carries the widened base union for the super call; this
+  // implementation itself never returns a Promise.
+  override quoteDefaultExpression(value: unknown, column?: unknown): string | Promise<string> {
     if (typeof value === "function") {
       const result = (value as () => unknown)();
       const str = typeof result === "string" ? result : isSqlLiteral(result) ? result.value : null;

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-creation.test.ts
@@ -9,7 +9,7 @@ import {
 describe("SQLite3::SchemaCreation", () => {
   const sc = new SchemaCreation("sqlite");
 
-  it("appends DEFERRABLE INITIALLY DEFERRED when deferrable is 'deferred'", () => {
+  it("appends DEFERRABLE INITIALLY DEFERRED when deferrable is 'deferred'", async () => {
     const fk = new ForeignKeyDefinition(
       "orders",
       "customers",
@@ -20,10 +20,10 @@ describe("SQLite3::SchemaCreation", () => {
       undefined,
       "deferred",
     );
-    expect(sc.accept(fk)).toContain("DEFERRABLE INITIALLY DEFERRED");
+    expect(await sc.accept(fk)).toContain("DEFERRABLE INITIALLY DEFERRED");
   });
 
-  it("omits DEFERRABLE when not set", () => {
+  it("omits DEFERRABLE when not set", async () => {
     const fk = new ForeignKeyDefinition(
       "orders",
       "customers",
@@ -31,32 +31,32 @@ describe("SQLite3::SchemaCreation", () => {
       "id",
       "fk_orders_customers",
     );
-    expect(sc.accept(fk)).not.toContain("DEFERRABLE");
+    expect(await sc.accept(fk)).not.toContain("DEFERRABLE");
   });
 
-  it("omits USING clause from CREATE INDEX (no index-using support)", () => {
+  it("omits USING clause from CREATE INDEX (no index-using support)", async () => {
     const td = new TableDefinition("articles", { adapterName: "sqlite" });
     td.index(["title"], { using: "btree" });
-    expect(sc.accept(new CreateIndexDefinition(td.indexes[0]))).not.toContain("USING");
+    expect(await sc.accept(new CreateIndexDefinition(td.indexes[0]))).not.toContain("USING");
   });
 
-  it("appends COLLATE clause when collation option is set", () => {
+  it("appends COLLATE clause when collation option is set", async () => {
     const td = new TableDefinition("articles", { adapterName: "sqlite" });
     td.column("title", "string", { collation: "BINARY" } as any);
-    expect(sc.accept(td)).toContain('COLLATE "BINARY"');
+    expect(await sc.accept(td)).toContain('COLLATE "BINARY"');
   });
 
-  it("appends GENERATED ALWAYS AS VIRTUAL for virtual columns", () => {
+  it("appends GENERATED ALWAYS AS VIRTUAL for virtual columns", async () => {
     const td = new TableDefinition("articles", { adapterName: "sqlite" });
     td.column("full_name", "string", { as: "first_name || ' ' || last_name" } as any);
-    const sql = sc.accept(td);
+    const sql = await sc.accept(td);
     expect(sql).toContain("GENERATED ALWAYS AS");
     expect(sql).toContain("VIRTUAL");
   });
 
-  it("appends STORED for stored virtual columns", () => {
+  it("appends STORED for stored virtual columns", async () => {
     const td = new TableDefinition("articles", { adapterName: "sqlite" });
     td.column("full_name", "string", { as: "first_name || ' ' || last_name", stored: true } as any);
-    expect(sc.accept(td)).toContain("STORED");
+    expect(await sc.accept(td)).toContain("STORED");
   });
 });

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-creation.ts
@@ -24,7 +24,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
   }
 
   /** @internal */
-  override addColumnOptions(sql: string, options: ColumnOptions): string {
+  override addColumnOptions(sql: string, options: ColumnOptions): Promise<string> {
     const opts = options as Record<string, unknown>;
     if (opts["collation"]) {
       sql += ` COLLATE "${opts["collation"]}"`;
@@ -37,7 +37,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
   }
 
   /** @internal */
-  protected override addColumnOptionsBang(sql: string, options: ColumnOptions): string {
+  protected override addColumnOptionsBang(sql: string, options: ColumnOptions): Promise<string> {
     return this.addColumnOptions(sql, options);
   }
 }

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.test.ts
@@ -29,22 +29,22 @@ describe("SQLite3::TableDefinition", () => {
     expect(col.type).toBe("string");
   });
 
-  it("drops the type for a virtual column with no type option (Rails no-fallback)", () => {
+  it("drops the type for a virtual column with no type option (Rails no-fallback)", async () => {
     const td = new TableDefinition("articles", { id: false });
     td.column("full_name", "virtual" as any, { as: "a || b" } as any);
     const col = td.columns.find((c) => c.name === "full_name")!;
     expect(col.type).toBeUndefined();
-    const sql = new SchemaCreation("sqlite", (td as any)._adapter).accept(td);
+    const sql = await new SchemaCreation("sqlite", (td as any)._adapter).accept(td);
     expect(sql).toContain('"full_name"  GENERATED ALWAYS AS (a || b)');
     expect(sql).not.toContain("varchar");
     expect(sql).not.toContain("VARCHAR");
   });
 
-  it("emits GENERATED ALWAYS AS ... STORED via visitor", () => {
+  it("emits GENERATED ALWAYS AS ... STORED via visitor", async () => {
     const td = new TableDefinition("items", { id: false });
     td.column("x", "integer");
     td.column("expr", "integer", { as: "x + 1", stored: true } as any);
-    const sql = new SchemaCreation("sqlite", (td as any)._adapter).accept(td);
+    const sql = await new SchemaCreation("sqlite", (td as any)._adapter).accept(td);
     expect(sql).toContain("GENERATED ALWAYS AS (x + 1) STORED");
   });
 });

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -2232,9 +2232,12 @@ describeIfSupports("bulk_alter", "BulkAlterTableMigrationsTest", () => {
     expect(cols.find((c) => c.name === "birthdate")!.type).toBe("date");
 
     // migration_test.rb:1403 expects 3 on both adapters, but Rails' third PG
-    // query is a `SELECT 'character varying'::regtype::oid` type-map miss from
-    // quote_default_expression (postgresql/schema_creation.rb:102); trails'
-    // statically initialized PG type map never issues it, so PG counts 2.
+    // query is the `SELECT 'character varying'::regtype::oid` lookup that PG's
+    // lookup_cast_type (postgresql/quoting.rb:195) issues from
+    // quote_default_expression (postgresql/schema_creation.rb:102); trails
+    // resolves the sql_type statically (see normalizeFormatType in
+    // postgresql-adapter.ts — tracked deviation, RFC 0032 story
+    // converge-pg-lookup-cast-type-regtype-oid-query), so PG counts 2.
     const expectedQueryCount = expectedBulkAlterQueryCount({ mysql: 3, postgres: 2 });
     await assertQueriesCount(expectedQueryCount, true, async () => {
       await adapter.changeTable("delete_me", { bulk: true }, (t: any) => {
@@ -2261,7 +2264,8 @@ describeIfSupports("bulk_alter", "BulkAlterTableMigrationsTest", () => {
     expect(preCols.find((c) => c.name === "birthdate")!.type).toBe("date");
 
     // migration_test.rb:1433 expects 7/5; PG counts 4 because trails skips the
-    // `::regtype::oid` type-map miss noted in "changing columns" above.
+    // `::regtype::oid` lookup noted in "changing columns" above (tracked
+    // deviation, RFC 0032 story converge-pg-lookup-cast-type-regtype-oid-query).
     const expectedQueryCount = expectedBulkAlterQueryCount({ mysql: 7, postgres: 4 });
     await assertQueriesCount(expectedQueryCount, true, async () => {
       await adapter.changeTable("delete_me", { bulk: true }, (t: any) => {

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -23,7 +23,7 @@ import { SchemaCreation as PgSchemaCreation } from "./connection-adapters/postgr
 import { SchemaCreation as MysqlSchemaCreation } from "./connection-adapters/mysql/schema-creation.js";
 import { SchemaCreation as SQLite3SchemaCreation } from "./connection-adapters/sqlite3/schema-creation.js";
 
-function emitTableSql(td: TableDefinition): string {
+function emitTableSql(td: TableDefinition): Promise<string> {
   const adapterName = (td as any)._adapterName;
   const adapter = (td as any)._adapter;
   // PG and SQLite visitors take a SchemaQuoter for identifier/default quoting, so
@@ -254,10 +254,10 @@ describe("MigrationTest", () => {
     }
   });
 
-  it("decimal scale without precision should raise", () => {
+  it("decimal scale without precision should raise", async () => {
     const td = new TableDefinition("products");
     td.decimal("price", { scale: 2 });
-    expect(() => emitTableSql(td)).toThrow(
+    await expect(emitTableSql(td)).rejects.toThrow(
       "Error adding decimal column: precision cannot be empty if scale is specified",
     );
   });
@@ -2231,14 +2231,7 @@ describeIfSupports("bulk_alter", "BulkAlterTableMigrationsTest", () => {
     expect(cols.find((c) => c.name === "name")!.default).toBeFalsy();
     expect(cols.find((c) => c.name === "birthdate")!.type).toBe("date");
 
-    // migration_test.rb:1403 expects 3 on both adapters, but Rails' third PG
-    // query is the `SELECT 'character varying'::regtype::oid` lookup that PG's
-    // lookup_cast_type (postgresql/quoting.rb:195) issues from
-    // quote_default_expression (postgresql/schema_creation.rb:102); trails
-    // resolves the sql_type statically (see normalizeFormatType in
-    // postgresql-adapter.ts — tracked deviation, RFC 0032 story
-    // converge-pg-lookup-cast-type-regtype-oid-query), so PG counts 2.
-    const expectedQueryCount = expectedBulkAlterQueryCount({ mysql: 3, postgres: 2 });
+    const expectedQueryCount = expectedBulkAlterQueryCount({ mysql: 3, postgres: 3 });
     await assertQueriesCount(expectedQueryCount, true, async () => {
       await adapter.changeTable("delete_me", { bulk: true }, (t: any) => {
         t.change("name", "string", { default: "NONAME" });
@@ -2263,10 +2256,7 @@ describeIfSupports("bulk_alter", "BulkAlterTableMigrationsTest", () => {
     expect(preCols.find((c) => c.name === "name")!.default).toBeFalsy();
     expect(preCols.find((c) => c.name === "birthdate")!.type).toBe("date");
 
-    // migration_test.rb:1433 expects 7/5; PG counts 4 because trails skips the
-    // `::regtype::oid` lookup noted in "changing columns" above (tracked
-    // deviation, RFC 0032 story converge-pg-lookup-cast-type-regtype-oid-query).
-    const expectedQueryCount = expectedBulkAlterQueryCount({ mysql: 7, postgres: 4 });
+    const expectedQueryCount = expectedBulkAlterQueryCount({ mysql: 7, postgres: 5 });
     await assertQueriesCount(expectedQueryCount, true, async () => {
       await adapter.changeTable("delete_me", { bulk: true }, (t: any) => {
         t.change("name", "string", { default: "NONAME" });

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1712,7 +1712,7 @@ export class MigrationContext {
         `Adapter ${this.connection.adapterName} does not expose schemaCreation; cannot render CREATE TABLE DDL.`,
       );
     }
-    await this.connection.execute(schemaCreation.accept(td));
+    await this.connection.execute(await schemaCreation.accept(td));
     if (options?.comment != null && options.comment.trim().length > 0) {
       const adapterWithComments = this.connection as {
         supportsComments?: () => boolean;

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
@@ -233,20 +233,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "change_column_default_for_alter",
-    "call": "accept",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "change_column_default_for_alter",
-    "call": "build_change_column_default_definition",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "check_constraint_exists?",
     "call": "check_constraint_for",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
## Summary

Converges trails' PG `quote_default_expression` on Rails' live regtype OID type-map lookup.

Rails' PG `lookup_cast_type(sql_type)` (postgresql/quoting.rb:195) resolves a sql_type string to an OID with a live `SELECT '<sql_type>'::regtype::oid` SCHEMA query before hitting the OID-keyed type map, so every DDL default-quoting on a `ColumnDefinition` (which carries no OID) issues that query. trails previously resolved the string statically via `FORMAT_TYPE_ALIASES` and never issued it, leaving its PG bulk-alter query counts one below Rails'.

## Changes

- **`PostgreSQLAdapter#lookupCastType`** (new, mirrors postgresql/quoting.rb:195): issues the regtype query and looks the resulting OID up in the type map.
- **`quoteDefaultExpression` is now awaitable** across the Quoting surface; the PG override is async, the abstract/MySQL/SQLite implementations stay synchronous under the widened `string | Promise<string>` return.
- **`SchemaCreation.accept` and the default-reaching visitors are async** (abstract + MySQL + PG + SQLite subclasses); leaf visitors (indexes, FKs, constraints) stay sync. Rails' visitors are sync only because Ruby blocks on the query — all production callers were already in async DDL methods.
- **Deleted the `[]`-strip invention** in the PG DDL lookup shim: regtype resolves array sql_types (`integer[]`) to the array type's OID server-side, exactly as Rails does.
- **`migration.test.ts` bulk-alter PG expected counts return to Rails' 3/5** (migration_test.rb:1403/1433) and the deviation comments are removed.

## Testing

- Unit/visitor suites (sqlite): migration, column-definition, sql-default, schema-creation ×4, schema-definitions ×3, schema-statements-privates, type-map — all green.
- Live PG (isolated compose stack): `migration.test.ts` (91 passed), defaults, ddl-through-execute, postgresql-adapter.trails, type-map — all green; the two bulk-alter tests now count Rails' 3/5 with the regtype query observed.
- Live MySQL (isolated stack): migration + MySQL visitor suites green (counts unchanged, 3/7).

The follow-up story `converge-pg-lookup-cast-type-regtype-oid-query` registered earlier in this branch's life is closed as superseded — this PR implements it.

Closes-story: pg-quote-default-regtype-typemap-lookup
