### PR TITLE
fix(predicate-builder): route PK-normalized through-association groups via groupingQueries

### DIFF
--- a/packages/activerecord/src/relation/predicate-builder.trails.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.trails.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { testConnection } from "@blazetrails/arel/src/test-helpers/connection.js";
 import { IntegerType } from "@blazetrails/activemodel";
-import { Table, Visitors } from "@blazetrails/arel";
+import { Nodes, Table, Visitors } from "@blazetrails/arel";
+import { fixtures } from "../test-helpers/fixtures.js";
 import { Company, Firm } from "../test-helpers/models/company.js";
 import { Author } from "../test-helpers/models/author.js";
-import { fixtures } from "../test-helpers/fixtures.js";
+import { PriceEstimate } from "../test-helpers/models/price-estimate.js";
 import { escapeRegExp, quoteTableName, quoteColumnName } from "../test-helpers/quote-regex.js";
 import { PredicateBuilder } from "./predicate-builder.js";
 import { TableMetadata } from "../table-metadata.js";
@@ -70,5 +71,40 @@ describe("PredicateBuilder nested-hash recursion skips dot re-normalization", ()
       ),
     );
     expect(sql).not.toContain(quoteTableName("comments.body"));
+  });
+});
+
+type HasWhereClause = { _whereClause: { predicates: Nodes.Node[] } };
+
+describe("association hash expansion grouping shape", () => {
+  const { treasures, cars, comments } = fixtures([
+    "authors",
+    "authorAddresses",
+    "posts",
+    "comments",
+    "treasures",
+    "cars",
+    "priceEstimates",
+  ]);
+
+  it("multi-type polymorphic value emits OR of AND-reduced groups in one Grouping", () => {
+    const rel = PriceEstimate.where({
+      estimateOf: [treasures("diamond"), cars("honda")],
+    }) as unknown as HasWhereClause;
+    const preds = rel._whereClause.predicates;
+    expect(preds).toHaveLength(1);
+    expect(preds[0]).toBeInstanceOf(Nodes.Grouping);
+    const or = (preds[0] as Nodes.Grouping).expr as Nodes.Or;
+    expect(or).toBeInstanceOf(Nodes.Or);
+    expect(or.children).toHaveLength(2);
+    for (const child of or.children) expect(child).toBeInstanceOf(Nodes.And);
+  });
+
+  it("through-association single query group stays flat, without an And wrapper", () => {
+    const rel = Author.where({ comments: comments("greetings") }) as unknown as HasWhereClause;
+    const preds = rel._whereClause.predicates;
+    expect(preds).toHaveLength(1);
+    expect(preds[0]).not.toBeInstanceOf(Nodes.And);
+    expect(preds[0]).not.toBeInstanceOf(Nodes.Grouping);
   });
 });

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -235,9 +235,13 @@ export class PredicateBuilder {
         value,
       ).queries();
       const assocPb: PredicateBuilder = associatedTable.predicateBuilder;
-      const inner = normalizedQueries.flatMap((q) => assocPb.expandFromHash(q));
-      if (inner.length === 0) return [];
-      return [inner.length === 1 ? inner[0] : new Nodes.And(inner)];
+      const queryGroups: Nodes.Node[][] = [];
+      for (const query of normalizedQueries) {
+        const inner = assocPb.expandFromHash(query);
+        if (inner.length === 0) continue;
+        queryGroups.push(inner);
+      }
+      return this.groupingQueries(queryGroups);
     }
     // Core non-polymorphic, non-through path.
     const queries = new AssociationQueryValue(associatedTable, value).queries();


### PR DESCRIPTION
## Summary

Story context: the polymorphic/PK-normalized association branch of `expandFromHash` bypassed `grouping_queries`. Since #5098 the polymorphic branch itself already routes through `groupingQueries`; the remaining flat-And was the **through/PK-normalized** branch (the story's cited `predicate-builder.ts:230-237`), which flattened all `AssociationQueryValue#queries()` results with `flatMap` and wrapped them in one flat `new Nodes.And(inner)`.

Rails (`predicate_builder.rb:118-125`) maps each query group through `expand_from_hash` separately and routes the groups through `grouping_queries`:

- a **single** query group returns FLAT — separate, addressable where-clause entries, which `WhereClause#extract_attributes` / `rewhere` rely on;
- **multiple** groups become pairwise-reduced Ands ORed inside one Grouping.

This PR converges the through branch to per-query `buildFromHash` groups routed through `groupingQueries`, matching the sibling polymorphic and core branches.

## Tests

- New trails-only shape guards in `predicate-builder.trails.test.ts` (Rails' `where_test.rb` coverage is membership-only, so no Rails-named counterpart exists):
  - multi-type polymorphic value → one `Grouping(Or(And, And))` (pins the OR-of-AND grouping per the story AC);
  - through-association single query group → flat predicates, no `And` wrapper.
- Existing association/polymorphic coverage stays green: `where.test.ts` (incl. "polymorphic array where multiple types", "where with through association"), `predicate-builder.test.ts`, `where-clause.test.ts`, `where-chain.trails.test.ts` — 127 passed locally.

Closes-story: poly-association-branch-flat-and-bypasses-grouping-queries
