### PR TITLE
feat(pg): converge lookupCastType on Rails' live regtype OID query

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -254,17 +254,17 @@ describe("SchemaStatements privates (PR 8)", () => {
     expect(ss.findJoinTableName("cats", "dogs")).toBe("cats_dogs");
   });
 
-  it("addTimestampsForAlter produces ADD fragments with precision when adapter supports it", () => {
+  it("addTimestampsForAlter produces ADD fragments with precision when adapter supports it", async () => {
     const ss = makeStatements({ supportsDatetimeWithPrecision: () => true });
-    const frags = ss.addTimestampsForAlter("users");
+    const frags = await ss.addTimestampsForAlter("users");
     expect(frags).toHaveLength(2);
     expect(frags[0]).toContain("DATETIME(6)");
     expect(frags[1]).toContain("DATETIME(6)");
   });
 
-  it("addTimestampsForAlter respects explicit null option", () => {
+  it("addTimestampsForAlter respects explicit null option", async () => {
     const ss = makeStatements();
-    const frags = ss.addTimestampsForAlter("users", { null: true });
+    const frags = await ss.addTimestampsForAlter("users", { null: true });
     expect(frags[0]).not.toContain("NOT NULL");
   });
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -319,9 +319,7 @@ export class SchemaStatements {
     // supportsIndexSortOrder gate, which yields false on a cold connection
     // (mirrors addIndex's warm-up). Memoized → no-op when already warm.
     await this.adapter.getDatabaseVersion?.();
-    await (
-      this.adapter as { preResolveDefaultCastTypes?: (columns: unknown[]) => Promise<void> }
-    ).preResolveDefaultCastTypes?.(td.columns);
+    await this.preResolveDefaultCastTypes(td.columns);
     await this.adapter.execute(this.schemaCreation.accept(td));
 
     // Rails: if supports_comments? && !supports_comments_in_create?
@@ -417,10 +415,19 @@ export class SchemaStatements {
     const addColumnDef = await this.buildAddColumnDefinition(tableName, columnName, type, options);
     if (!addColumnDef) return;
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
-    await (
-      this.adapter as { preResolveDefaultCastTypes?: (columns: unknown[]) => Promise<void> }
-    ).preResolveDefaultCastTypes?.(addColumnDef.adds.map((add) => add.column));
+    await this.preResolveDefaultCastTypes(addColumnDef.adds.map((add) => add.column));
     await this.adapter.execute(this.schemaCreation.accept(addColumnDef));
+  }
+
+  // PG resolves each pending DEFAULT's cast type with a live `::regtype::oid`
+  // query (postgresql/quoting.rb:195) that the synchronous SchemaCreation
+  // visitor cannot await; its adapter pre-resolves through this optional hook.
+  private async preResolveDefaultCastTypes(columns: ColumnDefinition[]): Promise<void> {
+    await (
+      this.adapter as {
+        preResolveDefaultCastTypes?: (columns: ColumnDefinition[]) => Promise<void>;
+      }
+    ).preResolveDefaultCastTypes?.(columns);
   }
 
   async removeColumn(

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -987,7 +987,7 @@ export class SchemaStatements {
     // the combined ALTER TABLE; non-bulk adapters fall back to two sequential addColumn calls.
     // trails' SQLite3Adapter still defines its own addTimestamps override for direct callers.
     if ((this.adapter as any).supportsBulkAlter?.() === true) {
-      const fragments = this.addTimestampsForAlter(tableName, options);
+      const fragments = await this.addTimestampsForAlter(tableName, options);
       await this.adapter.execute(`ALTER TABLE ${this._qt(tableName)} ${fragments.join(", ")}`);
       return;
     }
@@ -2660,15 +2660,18 @@ export class SchemaStatements {
   }
 
   /** @internal */
-  addTimestampsForAlter(tableName: string, options: ColumnOptions = {}): string[] {
+  async addTimestampsForAlter(tableName: string, options: ColumnOptions = {}): Promise<string[]> {
     const opts: ColumnOptions = { ...options };
     if (opts.null == null) opts.null = false;
     if (!("precision" in opts) && (this.adapter as any).supportsDatetimeWithPrecision?.()) {
       opts.precision = 6;
     }
+    // Await both fragments: `this` may be the SchemaStatements mixin host
+    // (sync addColumnForAlter) or the PG adapter itself, whose
+    // addColumnForAlter is async (regtype default pre-resolution).
     return [
-      this.addColumnForAlter(tableName, "created_at", "datetime", opts),
-      this.addColumnForAlter(tableName, "updated_at", "datetime", opts),
+      await this.addColumnForAlter(tableName, "created_at", "datetime", opts),
+      await this.addColumnForAlter(tableName, "updated_at", "datetime", opts),
     ];
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -319,6 +319,13 @@ export class SchemaStatements {
     // supportsIndexSortOrder gate, which yields false on a cold connection
     // (mirrors addIndex's warm-up). Memoized → no-op when already warm.
     await this.adapter.getDatabaseVersion?.();
+    // PG resolves each pending DEFAULT's cast type with a live
+    // `::regtype::oid` query (postgresql/quoting.rb:195) that the
+    // synchronous visitor cannot await, so its adapter pre-resolves them
+    // here (optional hook; absent — a no-op — on the other adapters).
+    await (
+      this.adapter as { preResolveDefaultCastTypes?: (columns: unknown[]) => Promise<void> }
+    ).preResolveDefaultCastTypes?.(td.columns);
     await this.adapter.execute(this.schemaCreation.accept(td));
 
     // Rails: if supports_comments? && !supports_comments_in_create?
@@ -414,6 +421,10 @@ export class SchemaStatements {
     const addColumnDef = await this.buildAddColumnDefinition(tableName, columnName, type, options);
     if (!addColumnDef) return;
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
+    // Same PG regtype pre-resolution hook as createTable (quoting.rb:195).
+    await (
+      this.adapter as { preResolveDefaultCastTypes?: (columns: unknown[]) => Promise<void> }
+    ).preResolveDefaultCastTypes?.(addColumnDef.adds.map((add) => add.column));
     await this.adapter.execute(this.schemaCreation.accept(addColumnDef));
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -319,7 +319,7 @@ export class SchemaStatements {
     // supportsIndexSortOrder gate, which yields false on a cold connection
     // (mirrors addIndex's warm-up). Memoized → no-op when already warm.
     await this.adapter.getDatabaseVersion?.();
-    await this.preResolveDefaultCastTypes(td.columns);
+    await this.preResolvePendingDefaultCastTypes(td.columns);
     await this.adapter.execute(this.schemaCreation.accept(td));
 
     // Rails: if supports_comments? && !supports_comments_in_create?
@@ -415,14 +415,14 @@ export class SchemaStatements {
     const addColumnDef = await this.buildAddColumnDefinition(tableName, columnName, type, options);
     if (!addColumnDef) return;
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
-    await this.preResolveDefaultCastTypes(addColumnDef.adds.map((add) => add.column));
+    await this.preResolvePendingDefaultCastTypes(addColumnDef.adds.map((add) => add.column));
     await this.adapter.execute(this.schemaCreation.accept(addColumnDef));
   }
 
   // PG resolves each pending DEFAULT's cast type with a live `::regtype::oid`
   // query (postgresql/quoting.rb:195) that the synchronous SchemaCreation
   // visitor cannot await; its adapter pre-resolves through this optional hook.
-  private async preResolveDefaultCastTypes(columns: ColumnDefinition[]): Promise<void> {
+  private async preResolvePendingDefaultCastTypes(columns: ColumnDefinition[]): Promise<void> {
     await (
       this.adapter as {
         preResolveDefaultCastTypes?: (columns: ColumnDefinition[]) => Promise<void>;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -319,10 +319,6 @@ export class SchemaStatements {
     // supportsIndexSortOrder gate, which yields false on a cold connection
     // (mirrors addIndex's warm-up). Memoized → no-op when already warm.
     await this.adapter.getDatabaseVersion?.();
-    // PG resolves each pending DEFAULT's cast type with a live
-    // `::regtype::oid` query (postgresql/quoting.rb:195) that the
-    // synchronous visitor cannot await, so its adapter pre-resolves them
-    // here (optional hook; absent — a no-op — on the other adapters).
     await (
       this.adapter as { preResolveDefaultCastTypes?: (columns: unknown[]) => Promise<void> }
     ).preResolveDefaultCastTypes?.(td.columns);
@@ -421,7 +417,6 @@ export class SchemaStatements {
     const addColumnDef = await this.buildAddColumnDefinition(tableName, columnName, type, options);
     if (!addColumnDef) return;
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
-    // Same PG regtype pre-resolution hook as createTable (quoting.rb:195).
     await (
       this.adapter as { preResolveDefaultCastTypes?: (columns: unknown[]) => Promise<void> }
     ).preResolveDefaultCastTypes?.(addColumnDef.adds.map((add) => add.column));

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -989,6 +989,67 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   /**
+   * Mirrors: PostgreSQL::Quoting#lookup_cast_type (postgresql/quoting.rb:195):
+   * `super(query_value("SELECT #{quote(sql_type)}::regtype::oid", "SCHEMA").to_i)`
+   * — resolves a sql_type string to its OID with a live regtype round-trip,
+   * then looks up the OID-keyed type map (the abstract lookup_cast_type is
+   * `type_map.lookup(key)`). Async where Rails is sync; the synchronous
+   * SchemaCreation visitor chain consumes the result through
+   * {@link preResolveDefaultCastTypes} at the async DDL entry points.
+   * @internal
+   */
+  async lookupCastType(sqlType: string): Promise<Type> {
+    const rows = await this.schemaQuery(`SELECT ${this.quote(sqlType)}::regtype::oid`);
+    const first = rows[0];
+    const oid = first == null ? Number.NaN : Number(Object.values(first)[0]);
+    return this.typeMap.lookup(oid);
+  }
+
+  /**
+   * Cast types resolved ahead of a DDL statement build, keyed by the
+   * ColumnDefinition whose DEFAULT clause will consume them. Stands in for
+   * Rails calling lookup_cast_type live inside quote_default_expression
+   * (abstract/quoting.rb:161): trails' SchemaCreation visitor chain is
+   * synchronous, so the async DDL entry points resolve each type up front —
+   * the same regtype query, still issued while the statement is being built —
+   * and quoteDefaultExpression reads it back from here.
+   */
+  private readonly preResolvedDefaultCastTypes = new WeakMap<object, Type>();
+
+  /**
+   * Pre-resolves the regtype cast type for each ColumnDefinition whose
+   * DEFAULT clause the synchronous SchemaCreation visitor is about to
+   * quote, issuing one `SELECT '<sql_type>'::regtype::oid` query per
+   * default — exactly the queries Rails' quote_default_expression →
+   * lookup_cast_type path issues on DDL over ColumnDefinitions. The guards
+   * mirror the visitor's: primary_key columns never reach
+   * addColumnOptions, and optionsIncludeDefault treats an undefined
+   * default (or null-with-NOT-NULL) as absent.
+   * @internal
+   */
+  async preResolveDefaultCastTypes(
+    columns: Iterable<{
+      type?: unknown;
+      sqlType?: string | null;
+      options?: object;
+    }>,
+  ): Promise<void> {
+    for (const column of columns) {
+      if (column.type === "primary_key") continue;
+      const options = (column.options ?? {}) as { default?: unknown; null?: boolean | null };
+      if (options.default === undefined) continue;
+      if (options.null === false && options.default === null) continue;
+      const sqlType =
+        column.sqlType ??
+        this.typeToSql(
+          String(column.type),
+          options as Parameters<PostgreSQLAdapter["typeToSql"]>[1],
+        );
+      this.preResolvedDefaultCastTypes.set(column, await this.lookupCastType(sqlType));
+    }
+  }
+
+  /**
    * Mirrors: PostgreSQLAdapter#case_insensitive_comparison (via AbstractAdapter).
    * Async override: looks up the column type and checks pg_proc before emitting LOWER.
    * @internal
@@ -3644,12 +3705,20 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
             serialize?(v: unknown): unknown;
           } | null;
         }
-        // No OID means a ColumnDefinition from a DDL path, whose sqlType is
-        // the `[]`-suffixed form typeToSql emitted (`integer[]`). Strip it so
-        // the element typname resolves — normalizeFormatType deliberately
-        // preserves `[]` for the type-casting path, so the strip belongs
-        // here at the call site rather than in the shared helper. The
-        // element subtype is then wrapped in OidArray downstream.
+        // No OID means a ColumnDefinition from a DDL path. Rails resolves
+        // its sql_type with a live `::regtype::oid` query — lookup_cast_type
+        // (postgresql/quoting.rb:195) — which the async DDL entry points
+        // replicate up front via preResolveDefaultCastTypes; consume that
+        // resolution here.
+        const pre = col != null ? self.preResolvedDefaultCastTypes.get(col) : undefined;
+        if (pre) return pre as { serialize?(v: unknown): unknown };
+        // Static fallback for direct synchronous callers that skipped
+        // pre-resolution (unit-level visitor tests, non-DDL paths): the
+        // sqlType is the `[]`-suffixed form typeToSql emitted (`integer[]`).
+        // Strip it so the element typname resolves — normalizeFormatType
+        // deliberately preserves `[]` for the type-casting path, so the
+        // strip belongs here at the call site rather than in the shared
+        // helper. The element subtype is then wrapped in OidArray downstream.
         const base = (c.sqlType ?? "").replace(/\[\]\s*$/, "");
         return self.lookupCastTypeFromColumn({ sqlType: base }) as {
           serialize?(v: unknown): unknown;
@@ -4847,18 +4916,25 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     );
   }
 
-  /** @internal */
-  addColumnForAlter(
+  /**
+   * Rails' add_column_for_alter is synchronous; async here so the pending
+   * DEFAULT's regtype cast type can be pre-resolved (postgresql/quoting.rb:195)
+   * before the synchronous visitor quotes it — bulkChangeTable awaits every
+   * *ForAlter result, so the signature change is absorbed there.
+   * @internal
+   */
+  async addColumnForAlter(
     tableName: string,
     columnName: string,
     type: string,
     options: Record<string, unknown> = {},
-  ): unknown {
+  ): Promise<unknown> {
     const col = this.createTableDefinition(tableName).newColumnDefinition(
       columnName,
       type,
       options,
     );
+    await this.preResolveDefaultCastTypes([col]);
     const sql = `ADD COLUMN ${this.schemaCreation.accept(col)}`;
     return "comment" in options
       ? [
@@ -4868,19 +4944,28 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       : sql;
   }
 
-  /** @internal */
-  changeColumnForAlter(
+  /**
+   * Rails' change_column_for_alter is synchronous; async for the same
+   * regtype pre-resolution reason as addColumnForAlter above. Unlike the
+   * add path, the visitor only quotes a non-nil default (nil emits DROP
+   * DEFAULT), so nil skips the query — as in Rails.
+   * @internal
+   */
+  async changeColumnForAlter(
     tableName: string,
     columnName: string,
     type: string,
     options: Record<string, unknown> = {},
-  ): unknown[] {
+  ): Promise<unknown[]> {
     const changeDef = this.buildChangeColumnDefinition(
       tableName,
       columnName,
       type,
       options as Parameters<typeof this.buildChangeColumnDefinition>[3],
     );
+    if (changeDef.column.options.default != null) {
+      await this.preResolveDefaultCastTypes([changeDef.column]);
+    }
     const sqls: unknown[] = [this.schemaCreation.accept(changeDef)];
     if ("comment" in options)
       sqls.push(() =>

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -989,13 +989,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   /**
-   * Mirrors: PostgreSQL::Quoting#lookup_cast_type (postgresql/quoting.rb:195):
-   * `super(query_value("SELECT #{quote(sql_type)}::regtype::oid", "SCHEMA").to_i)`
-   * — resolves a sql_type string to its OID with a live regtype round-trip,
-   * then looks up the OID-keyed type map (the abstract lookup_cast_type is
-   * `type_map.lookup(key)`). Async where Rails is sync; the synchronous
-   * SchemaCreation visitor chain consumes the result through
-   * {@link preResolveDefaultCastTypes} at the async DDL entry points.
+   * Mirrors: PostgreSQL::Quoting#lookup_cast_type (postgresql/quoting.rb:195).
    * @internal
    */
   async lookupCastType(sqlType: string): Promise<Type> {
@@ -1005,28 +999,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return this.typeMap.lookup(oid);
   }
 
-  /**
-   * Cast types resolved ahead of a DDL statement build, keyed by the
-   * ColumnDefinition whose DEFAULT clause will consume them. Stands in for
-   * Rails calling lookup_cast_type live inside quote_default_expression
-   * (abstract/quoting.rb:161): trails' SchemaCreation visitor chain is
-   * synchronous, so the async DDL entry points resolve each type up front —
-   * the same regtype query, still issued while the statement is being built —
-   * and quoteDefaultExpression reads it back from here.
-   */
   private readonly preResolvedDefaultCastTypes = new WeakMap<object, Type>();
 
-  /**
-   * Pre-resolves the regtype cast type for each ColumnDefinition whose
-   * DEFAULT clause the synchronous SchemaCreation visitor is about to
-   * quote, issuing one `SELECT '<sql_type>'::regtype::oid` query per
-   * default — exactly the queries Rails' quote_default_expression →
-   * lookup_cast_type path issues on DDL over ColumnDefinitions. The guards
-   * mirror the visitor's: primary_key columns never reach
-   * addColumnOptions, and optionsIncludeDefault treats an undefined
-   * default (or null-with-NOT-NULL) as absent.
-   * @internal
-   */
+  /** @internal */
   async preResolveDefaultCastTypes(
     columns: Iterable<{
       type?: unknown;
@@ -3705,20 +3680,14 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
             serialize?(v: unknown): unknown;
           } | null;
         }
-        // No OID means a ColumnDefinition from a DDL path. Rails resolves
-        // its sql_type with a live `::regtype::oid` query — lookup_cast_type
-        // (postgresql/quoting.rb:195) — which the async DDL entry points
-        // replicate up front via preResolveDefaultCastTypes; consume that
-        // resolution here.
         const pre = col != null ? self.preResolvedDefaultCastTypes.get(col) : undefined;
         if (pre) return pre as { serialize?(v: unknown): unknown };
-        // Static fallback for direct synchronous callers that skipped
-        // pre-resolution (unit-level visitor tests, non-DDL paths): the
-        // sqlType is the `[]`-suffixed form typeToSql emitted (`integer[]`).
-        // Strip it so the element typname resolves — normalizeFormatType
-        // deliberately preserves `[]` for the type-casting path, so the
-        // strip belongs here at the call site rather than in the shared
-        // helper. The element subtype is then wrapped in OidArray downstream.
+        // No OID means a ColumnDefinition from a DDL path, whose sqlType is
+        // the `[]`-suffixed form typeToSql emitted (`integer[]`). Strip it so
+        // the element typname resolves — normalizeFormatType deliberately
+        // preserves `[]` for the type-casting path, so the strip belongs
+        // here at the call site rather than in the shared helper. The
+        // element subtype is then wrapped in OidArray downstream.
         const base = (c.sqlType ?? "").replace(/\[\]\s*$/, "");
         return self.lookupCastTypeFromColumn({ sqlType: base }) as {
           serialize?(v: unknown): unknown;
@@ -4916,13 +4885,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     );
   }
 
-  /**
-   * Rails' add_column_for_alter is synchronous; async here so the pending
-   * DEFAULT's regtype cast type can be pre-resolved (postgresql/quoting.rb:195)
-   * before the synchronous visitor quotes it — bulkChangeTable awaits every
-   * *ForAlter result, so the signature change is absorbed there.
-   * @internal
-   */
+  /** @internal */
   async addColumnForAlter(
     tableName: string,
     columnName: string,
@@ -4944,13 +4907,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       : sql;
   }
 
-  /**
-   * Rails' change_column_for_alter is synchronous; async for the same
-   * regtype pre-resolution reason as addColumnForAlter above. Unlike the
-   * add path, the visitor only quotes a non-nil default (nil emits DROP
-   * DEFAULT), so nil skips the query — as in Rails.
-   * @internal
-   */
+  /** @internal */
   async changeColumnForAlter(
     tableName: string,
     columnName: string,

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -994,32 +994,23 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    */
   async lookupCastType(sqlType: string): Promise<Type> {
     const rows = await this.schemaQuery(`SELECT ${this.quote(sqlType)}::regtype::oid`);
-    const first = rows[0];
-    const oid = first == null ? Number.NaN : Number(Object.values(first)[0]);
-    return this.typeMap.lookup(oid);
+    return this.typeMap.lookup(Number(Object.values(rows[0] ?? {})[0]));
   }
 
   private readonly preResolvedDefaultCastTypes = new WeakMap<object, Type>();
 
   /** @internal */
   async preResolveDefaultCastTypes(
-    columns: Iterable<{
-      type?: unknown;
-      sqlType?: string | null;
-      options?: object;
-    }>,
+    columns: Iterable<{ type?: string; sqlType?: string | null; options?: ColumnOptions }>,
   ): Promise<void> {
     for (const column of columns) {
       if (column.type === "primary_key") continue;
-      const options = (column.options ?? {}) as { default?: unknown; null?: boolean | null };
+      const options = column.options ?? {};
       if (options.default === undefined) continue;
       if (options.null === false && options.default === null) continue;
       const sqlType =
         column.sqlType ??
-        this.typeToSql(
-          String(column.type),
-          options as Parameters<PostgreSQLAdapter["typeToSql"]>[1],
-        );
+        this.typeToSql(column.type ?? "", options as Parameters<PostgreSQLAdapter["typeToSql"]>[1]);
       this.preResolvedDefaultCastTypes.set(column, await this.lookupCastType(sqlType));
     }
   }

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -68,6 +68,8 @@ interface PgSchemaAdapter {
     sqlType?: string | null;
     name?: string;
   }): Type;
+  // Optional so lighter test doubles need not implement it.
+  preResolveDefaultCastTypes?(columns: Iterable<ColumnDefinition>): Promise<void>;
   reloadTypeMap(): Promise<void>;
   serialFromDefaultFunction(
     tableName: string,
@@ -915,6 +917,12 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     // string; the only proc Rails appends here is the :comment change.
     this.pg.clearCacheBang();
     const changeColDef = this.buildChangeColumnDefinition(tableName, columnName, type, options);
+    // Rails quotes a non-nil new DEFAULT through lookup_cast_type's live
+    // `::regtype::oid` query (postgresql/quoting.rb:195); the visitor below
+    // is synchronous, so pre-resolve the cast type before accept.
+    if (changeColDef.column.options.default != null) {
+      await this.pg.preResolveDefaultCastTypes?.([changeColDef.column]);
+    }
     const clause = this.pg.schemaCreation.accept(changeColDef);
     // Route DDL through the public `execute` (not the raw `exec`) so the
     // dirties_query_cache wrapper clears the query cache on schema changes.

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -68,7 +68,6 @@ interface PgSchemaAdapter {
     sqlType?: string | null;
     name?: string;
   }): Type;
-  // Optional so lighter test doubles need not implement it.
   preResolveDefaultCastTypes?(columns: Iterable<ColumnDefinition>): Promise<void>;
   reloadTypeMap(): Promise<void>;
   serialFromDefaultFunction(
@@ -917,9 +916,6 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     // string; the only proc Rails appends here is the :comment change.
     this.pg.clearCacheBang();
     const changeColDef = this.buildChangeColumnDefinition(tableName, columnName, type, options);
-    // Rails quotes a non-nil new DEFAULT through lookup_cast_type's live
-    // `::regtype::oid` query (postgresql/quoting.rb:195); the visitor below
-    // is synchronous, so pre-resolve the cast type before accept.
     if (changeColDef.column.options.default != null) {
       await this.pg.preResolveDefaultCastTypes?.([changeColDef.column]);
     }

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -2231,11 +2231,10 @@ describeIfSupports("bulk_alter", "BulkAlterTableMigrationsTest", () => {
     expect(cols.find((c) => c.name === "name")!.default).toBeFalsy();
     expect(cols.find((c) => c.name === "birthdate")!.type).toBe("date");
 
-    // migration_test.rb:1403 expects 3 on both adapters, but Rails' third PG
-    // query is a `SELECT 'character varying'::regtype::oid` type-map miss from
-    // quote_default_expression (postgresql/schema_creation.rb:102); trails'
-    // statically initialized PG type map never issues it, so PG counts 2.
-    const expectedQueryCount = expectedBulkAlterQueryCount({ mysql: 3, postgres: 2 });
+    // migration_test.rb:1403 — PG's third query is the
+    // `SELECT 'character varying'::regtype::oid` lookup that lookup_cast_type
+    // (postgresql/quoting.rb:195) issues from quote_default_expression.
+    const expectedQueryCount = expectedBulkAlterQueryCount({ mysql: 3, postgres: 3 });
     await assertQueriesCount(expectedQueryCount, true, async () => {
       await adapter.changeTable("delete_me", { bulk: true }, (t: any) => {
         t.change("name", "string", { default: "NONAME" });
@@ -2260,9 +2259,9 @@ describeIfSupports("bulk_alter", "BulkAlterTableMigrationsTest", () => {
     expect(preCols.find((c) => c.name === "name")!.default).toBeFalsy();
     expect(preCols.find((c) => c.name === "birthdate")!.type).toBe("date");
 
-    // migration_test.rb:1433 expects 7/5; PG counts 4 because trails skips the
-    // `::regtype::oid` type-map miss noted in "changing columns" above.
-    const expectedQueryCount = expectedBulkAlterQueryCount({ mysql: 7, postgres: 4 });
+    // migration_test.rb:1433 expects 7/5 (the PG count includes the
+    // `::regtype::oid` lookup noted in "changing columns" above).
+    const expectedQueryCount = expectedBulkAlterQueryCount({ mysql: 7, postgres: 5 });
     await assertQueriesCount(expectedQueryCount, true, async () => {
       await adapter.changeTable("delete_me", { bulk: true }, (t: any) => {
         t.change("name", "string", { default: "NONAME" });

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -2231,9 +2231,6 @@ describeIfSupports("bulk_alter", "BulkAlterTableMigrationsTest", () => {
     expect(cols.find((c) => c.name === "name")!.default).toBeFalsy();
     expect(cols.find((c) => c.name === "birthdate")!.type).toBe("date");
 
-    // migration_test.rb:1403 — PG's third query is the
-    // `SELECT 'character varying'::regtype::oid` lookup that lookup_cast_type
-    // (postgresql/quoting.rb:195) issues from quote_default_expression.
     const expectedQueryCount = expectedBulkAlterQueryCount({ mysql: 3, postgres: 3 });
     await assertQueriesCount(expectedQueryCount, true, async () => {
       await adapter.changeTable("delete_me", { bulk: true }, (t: any) => {
@@ -2259,8 +2256,6 @@ describeIfSupports("bulk_alter", "BulkAlterTableMigrationsTest", () => {
     expect(preCols.find((c) => c.name === "name")!.default).toBeFalsy();
     expect(preCols.find((c) => c.name === "birthdate")!.type).toBe("date");
 
-    // migration_test.rb:1433 expects 7/5 (the PG count includes the
-    // `::regtype::oid` lookup noted in "changing columns" above).
     const expectedQueryCount = expectedBulkAlterQueryCount({ mysql: 7, postgres: 5 });
     await assertQueriesCount(expectedQueryCount, true, async () => {
       await adapter.changeTable("delete_me", { bulk: true }, (t: any) => {


### PR DESCRIPTION
## Summary

Rails' PG `lookup_cast_type(sql_type)` (postgresql/quoting.rb:195) resolves a sql_type string to a cast type with a live `SELECT '<sql_type>'::regtype::oid` SCHEMA query, then looks up the OID-keyed type map. Every DDL default-quoting on a `ColumnDefinition` (no OID) routes through it. trails resolved the string statically via `normalizeFormatType` because the `SchemaCreation` visitor chain is synchronous.

This converges via the story's sanctioned alternative: **pre-resolution in the async DDL entry points**.

- `PostgreSQLAdapter.lookupCastType(sqlType)` — the live regtype query into the OID-keyed type map, mirroring quoting.rb:195 (`super(query_value(...).to_i)` → `type_map.lookup(oid)`).
- `preResolveDefaultCastTypes(columns)` — issues one regtype query per pending DEFAULT (the exact queries Rails issues from `quote_default_expression`) and stashes the resolved type per `ColumnDefinition` in a WeakMap; the synchronous `quoteDefaultExpression` closure consumes it on the no-OID path. Guards mirror the visitor (`primary_key` skip, `optionsIncludeDefault`, change-path nil → DROP DEFAULT, no query).
- Wired at: abstract `createTable` / `addColumn` (optional adapter hook before `accept`, no-op on other adapters), PG `changeColumn`, and PG `addColumnForAlter` / `changeColumnForAlter` (now async — `bulkChangeTable` already awaits every `*ForAlter` result).
- The static `normalizeFormatType` path remains only as the fallback for direct synchronous visitor callers (unit-level tests); DDL now takes the regtype round-trip, so custom types (enums/domains) registered in the type map resolve in DDL default quoting.

PG bulk-alter query counts return to Rails' 3/5 (migration_test.rb:1403/1433) and the deviation comments are removed. (The DEVIATION block commit 12179577b lives on an unmerged sibling branch, so on main only the test-count comments existed.)

## Testing

Isolated compose stack (PG 16 / MySQL 8):

- PG: migration.test.ts (91 passed), postgresql schema-statements / schema-statements-class / schema-creation / quoting / schema-definitions, defaults, sql-default, column-definition, array, uuid, type-map — all green.
- MySQL: migration.test.ts (86 passed).
- sqlite lane: migration, abstract schema-creation / schema-statements-privates, defaults — green.

Closes-story: converge-pg-lookup-cast-type-regtype-oid-query
