### PR TITLE
fix(activerecord): probe per-connection connected state in ConnectionPool#isConnected

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -568,7 +568,7 @@ export class ConnectionPool implements ReapablePool {
   }
 
   isConnected(): boolean {
-    return this._connections != null && this._connections.length > 0;
+    return this._connections != null && this._connections.some((conn) => conn.isConnected());
   }
 
   get connections(): DatabaseAdapter[] {

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -35,6 +35,10 @@ class TransactionAwareTestAdapter extends AbstractAdapter implements DatabaseAda
   isNoDatabaseError(_error: unknown): boolean {
     return false;
   }
+  constructor() {
+    super();
+    this._connection = this;
+  }
   // This double has no real raw connection; report active so checkout's
   // verify! is a no-op (mirroring Rails, where the pinned connection is
   // active and verify! returns without reconnecting). Backed by a mutable
@@ -479,6 +483,16 @@ it("pin connection connected?", async () => {
   await pool.pinConnectionBang();
   expect(pool.isConnected()).toBe(true);
   await pool.unpinConnectionBang();
+});
+
+it("isConnected probes each pooled connection's connected state", async () => {
+  const pool = makePool();
+  const conn = await pool.checkout();
+  expect(pool.isConnected()).toBe(true);
+  pool.checkin(conn);
+  conn.disconnectBang();
+  expect(pool.connections.length).toBe(1);
+  expect(pool.isConnected()).toBe(false);
 });
 
 it("pin connection opens a transaction", async () => {

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -486,7 +486,7 @@ it("pin connection connected?", async () => {
 });
 
 it("isConnected probes each pooled connection's connected state", async () => {
-  const pool = makePool();
+  const pool = makeTransactionAwarePool();
   const conn = await pool.checkout();
   expect(pool.isConnected()).toBe(true);
   pool.checkin(conn);

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/connection-pool.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/connection-pool.json
@@ -109,7 +109,7 @@
     "tsFile": "connection-adapters/abstract/connection-pool.ts",
     "rubyName": "connected?",
     "call": "any?",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails connection_pool.rb:427-429 is `@connections.any?(&:connected?)`; trails connection-pool.ts:570-572 isConnected checks `_connections.length > 0` — pool membership stands in for the per-connection connected? probe (part of the pool async/sync convergence surface)."
+    "reason": "Verified equivalent: Rails connection_pool.rb:427-429 `@connections.any?(&:connected?)` is ported as `_connections.some((conn) => conn.isConnected())` — JS Array#some is the any? analogue; the extractor has no some→any? mapping."
   },
   {
     "package": "activerecord",


### PR DESCRIPTION
Converges `ConnectionPool#isConnected` with Rails `ConnectionPool#connected?`
(connection_pool.rb:427-429), which is `synchronize { @connections.any?(&:connected?) }`
— a per-connection probe. Trails checked `_connections.length > 0` (pool
membership only), so a pool holding only disconnected adapters still reported
connected.

- `isConnected` now returns `_connections.some((conn) => conn.isConnected())`.
- Regression test (fails on baseline): a checked-in pooled connection that is
  `disconnectBang()`-ed leaves the pool not-connected while still a member.
- The `TransactionAwareTestAdapter` double now plants a stand-in raw-connection
  handle so adapter-level `isConnected()` (Rails `connected?` =
  `!@raw_connection.nil?`) reports true, as a real connected adapter would.
- Wide-exclude reason for `connected?`/`any?` updated to verified-equivalent
  wording (JS `Array#some` is the `any?` analogue; the extractor has no
  some→any? mapping, so the entry itself must stay).

Closes-story: pool-connected-predicate-skips-per-connection-probe
