### PR TITLE
fix(relation): converge Relation#aliasTracker to AliasTracker.create

### DIFF
--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -906,9 +906,6 @@ describe("inspect wrapper class name", () => {
 describe("aliasTracker (trails)", () => {
   fixtures([]);
 
-  // Relation#alias_tracker (relation.rb:1307-1309) has no like-named Rails
-  // test; guard the trails convergence from the old bare join-count map to
-  // AliasTracker.create seeded with the relation's table.
   it("returns an AliasTracker seeded with the relation table and joins", () => {
     const tracker = CanonPost.all().aliasTracker();
     expect(tracker).toBeInstanceOf(AliasTracker);
@@ -917,7 +914,6 @@ describe("aliasTracker (trails)", () => {
     const table = new ArelTable("comments");
     const join = new Nodes.InnerJoin(table, new Nodes.On(new Nodes.SqlLiteral("1=1")));
     const seeded = CanonPost.all().aliasTracker([join]);
-    // A seeded join makes the first `comments` visit collide and alias.
     expect(seeded.aliasedTableFor(table, "comments_posts").right).toBe("comments_posts");
   });
 });

--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -15,6 +15,7 @@ import { performMerge } from "./relation/spawn-methods.js";
 import { reverseSqlOrder } from "./relation/query-methods.js";
 import { CpkOrder } from "./test-helpers/models/cpk.js";
 import { AssociationRelation } from "./association-relation.js";
+import { AliasTracker } from "./associations/alias-tracker.js";
 
 import { fixtures } from "./test-helpers/fixtures.js";
 import { Post as CanonPost } from "./test-helpers/models/post.js";
@@ -899,5 +900,24 @@ describe("inspect wrapper class name", () => {
   // flip "" into " DESC".
   it("treats a blank string order as no order when reversing", () => {
     expect(CanonPost.order("").reverseOrder().toSql()).toMatch(/ORDER BY .*\bid\b.* DESC/i);
+  });
+});
+
+describe("aliasTracker (trails)", () => {
+  fixtures([]);
+
+  // Relation#alias_tracker (relation.rb:1307-1309) has no like-named Rails
+  // test; guard the trails convergence from the old bare join-count map to
+  // AliasTracker.create seeded with the relation's table.
+  it("returns an AliasTracker seeded with the relation table and joins", () => {
+    const tracker = CanonPost.all().aliasTracker();
+    expect(tracker).toBeInstanceOf(AliasTracker);
+    expect(tracker.aliases.get("posts")).toBe(1);
+
+    const table = new ArelTable("comments");
+    const join = new Nodes.InnerJoin(table, new Nodes.On(new Nodes.SqlLiteral("1=1")));
+    const seeded = CanonPost.all().aliasTracker([join]);
+    // A seeded join makes the first `comments` visit collide and alias.
+    expect(seeded.aliasedTableFor(table, "comments_posts").right).toBe("comments_posts");
   });
 });

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -6466,12 +6466,11 @@ export class Relation<T extends Base> {
     return this._limitValue !== null || this._offsetValue !== null;
   }
 
-  aliasTracker(): Record<string, number> {
-    const tracker: Record<string, number> = {};
-    for (const join of this._joinClauses) {
-      tracker[join.table] = (tracker[join.table] ?? 0) + 1;
-    }
-    return tracker;
+  /**
+   * Mirrors: ActiveRecord::Relation#alias_tracker (relation.rb:1307-1309)
+   */
+  aliasTracker(joins: unknown[] = [], aliases?: Map<string, number>): AliasTracker {
+    return AliasTracker.create(this.model.connectionPool(), this.table.name, joins, aliases);
   }
 
   preloadAssociations(): AssociationSpec[] {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -6466,10 +6466,7 @@ export class Relation<T extends Base> {
     return this._limitValue !== null || this._offsetValue !== null;
   }
 
-  /**
-   * Mirrors: ActiveRecord::Relation#alias_tracker (relation.rb:1307-1309)
-   */
-  aliasTracker(joins: unknown[] = [], aliases?: Map<string, number>): AliasTracker {
+  aliasTracker(joins: Nodes.Node[] = [], aliases?: Map<string, number>): AliasTracker {
     return AliasTracker.create(this.model.connectionPool(), this.table.name, joins, aliases);
   }
 

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/association-scope.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/association-scope.json
@@ -229,5 +229,12 @@
     "rubyName": "transform_value",
     "call": "call",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/association-scope.ts",
+    "rubyName": "scope",
+    "call": "alias_tracker",
+    "reason": "Rails builds/reads the tracker via Relation#alias_tracker; trails constructs it through its own path at this site (AliasTracker.create / buildMergedJoinAliasTracker / stored _aliasTracker). Routing these sites through the converged Relation#aliasTracker is tracked in story alias-tracker-callsites-bypass-relation-alias-tracker (RFC 0032)."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/disable-joins-association-scope.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/disable-joins-association-scope.json
@@ -19,5 +19,12 @@
     "rubyName": "scope",
     "call": "unscoped",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/disable-joins-association-scope.ts",
+    "rubyName": "scope",
+    "call": "alias_tracker",
+    "reason": "Rails builds/reads the tracker via Relation#alias_tracker; trails constructs it through its own path at this site (AliasTracker.create / buildMergedJoinAliasTracker / stored _aliasTracker). Routing these sites through the converged Relation#aliasTracker is tracked in story alias-tracker-callsites-bypass-relation-alias-tracker (RFC 0032)."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/join-dependency.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/join-dependency.json
@@ -306,5 +306,12 @@
     "rubyName": "walk_tree",
     "call": "each",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/join-dependency.ts",
+    "rubyName": "make_constraints",
+    "call": "alias_tracker",
+    "reason": "Rails builds/reads the tracker via Relation#alias_tracker; trails constructs it through its own path at this site (AliasTracker.create / buildMergedJoinAliasTracker / stored _aliasTracker). Routing these sites through the converged Relation#aliasTracker is tracked in story alias-tracker-callsites-bypass-relation-alias-tracker (RFC 0032)."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
@@ -128,27 +128,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "alias_tracker",
-    "call": "connection_pool",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1307-1309 builds `Associations::AliasTracker.create(model.connection_pool, table.name, joins, aliases)`; trails relation.ts:6465-6471 builds a bare join-count map and never touches the AliasTracker class (which exists at associations/alias-tracker.ts:60). Divergence tracked in story relation-alias-tracker-bypasses-class."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "alias_tracker",
-    "call": "create",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1307-1309 builds `Associations::AliasTracker.create(model.connection_pool, table.name, joins, aliases)`; trails relation.ts:6465-6471 builds a bare join-count map and never touches the AliasTracker class (which exists at associations/alias-tracker.ts:60). Divergence tracked in story relation-alias-tracker-bypasses-class."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "alias_tracker",
-    "call": "model",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1307-1309 builds `Associations::AliasTracker.create(model.connection_pool, table.name, joins, aliases)`; trails relation.ts:6465-6471 builds a bare join-count map and never touches the AliasTracker class (which exists at associations/alias-tracker.ts:60). Divergence tracked in story relation-alias-tracker-bypasses-class."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "all_attributes?",
     "call": "attribute_aliases",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -2482,14 +2461,14 @@
     "tsFile": "relation.ts",
     "rubyName": "none?",
     "call": "empty?",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:378-383 returns true for @none, else falls through to `empty?` (issues a query) or super on args/block (`present?` guard); trails relation.ts:6227-6229 isNone reads only the `_isNone` flag \u2014 the empty?-query fallback is unported. Omission tracked in story relation-none-predicate-misses-empty-fallback."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:378-383 returns true for @none, else falls through to `empty?` (issues a query) or super on args/block (`present?` guard); trails relation.ts:6227-6229 isNone reads only the `_isNone` flag — the empty?-query fallback is unported. Omission tracked in story relation-none-predicate-misses-empty-fallback."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "none?",
     "call": "present?",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:378-383 returns true for @none, else falls through to `empty?` (issues a query) or super on args/block (`present?` guard); trails relation.ts:6227-6229 isNone reads only the `_isNone` flag \u2014 the empty?-query fallback is unported. Omission tracked in story relation-none-predicate-misses-empty-fallback."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:378-383 returns true for @none, else falls through to `empty?` (issues a query) or super on args/block (`present?` guard); trails relation.ts:6227-6229 isNone reads only the `_isNone` flag — the empty?-query fallback is unported. Omission tracked in story relation-none-predicate-misses-empty-fallback."
   },
   {
     "package": "activerecord",
@@ -2671,21 +2650,21 @@
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "call",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1321-1328 concatenates preload_values/includes_values and runs Preloader.new(...).call per spec under the strict_loading_value scope; trails relation.ts:6473-6475 returns the merged `[..._preloadAssociations, ..._includesAssociations]` list and the load path consuming it invokes the preloader \u2014 the value reads are direct field spreads."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1321-1328 concatenates preload_values/includes_values and runs Preloader.new(...).call per spec under the strict_loading_value scope; trails relation.ts:6473-6475 returns the merged `[..._preloadAssociations, ..._includesAssociations]` list and the load path consuming it invokes the preloader — the value reads are direct field spreads."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "each",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1321-1328 concatenates preload_values/includes_values and runs Preloader.new(...).call per spec under the strict_loading_value scope; trails relation.ts:6473-6475 returns the merged `[..._preloadAssociations, ..._includesAssociations]` list and the load path consuming it invokes the preloader \u2014 the value reads are direct field spreads."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1321-1328 concatenates preload_values/includes_values and runs Preloader.new(...).call per spec under the strict_loading_value scope; trails relation.ts:6473-6475 returns the merged `[..._preloadAssociations, ..._includesAssociations]` list and the load path consuming it invokes the preloader — the value reads are direct field spreads."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "includes_values",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1321-1328 concatenates preload_values/includes_values and runs Preloader.new(...).call per spec under the strict_loading_value scope; trails relation.ts:6473-6475 returns the merged `[..._preloadAssociations, ..._includesAssociations]` list and the load path consuming it invokes the preloader \u2014 the value reads are direct field spreads."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1321-1328 concatenates preload_values/includes_values and runs Preloader.new(...).call per spec under the strict_loading_value scope; trails relation.ts:6473-6475 returns the merged `[..._preloadAssociations, ..._includesAssociations]` list and the load path consuming it invokes the preloader — the value reads are direct field spreads."
   },
   {
     "package": "activerecord",
@@ -2699,14 +2678,14 @@
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "preload_values",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1321-1328 concatenates preload_values/includes_values and runs Preloader.new(...).call per spec under the strict_loading_value scope; trails relation.ts:6473-6475 returns the merged `[..._preloadAssociations, ..._includesAssociations]` list and the load path consuming it invokes the preloader \u2014 the value reads are direct field spreads."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1321-1328 concatenates preload_values/includes_values and runs Preloader.new(...).call per spec under the strict_loading_value scope; trails relation.ts:6473-6475 returns the merged `[..._preloadAssociations, ..._includesAssociations]` list and the load path consuming it invokes the preloader — the value reads are direct field spreads."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "strict_loading_value",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1321-1328 concatenates preload_values/includes_values and runs Preloader.new(...).call per spec under the strict_loading_value scope; trails relation.ts:6473-6475 returns the merged `[..._preloadAssociations, ..._includesAssociations]` list and the load path consuming it invokes the preloader \u2014 the value reads are direct field spreads."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1321-1328 concatenates preload_values/includes_values and runs Preloader.new(...).call per spec under the strict_loading_value scope; trails relation.ts:6473-6475 returns the merged `[..._preloadAssociations, ..._includesAssociations]` list and the load path consuming it invokes the preloader — the value reads are direct field spreads."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/query-methods.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/query-methods.json
@@ -1041,5 +1041,12 @@
     "rubyName": "validate_order_args",
     "call": "exclude?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/query-methods.ts",
+    "rubyName": "build_joins",
+    "call": "alias_tracker",
+    "reason": "Rails builds/reads the tracker via Relation#alias_tracker; trails constructs it through its own path at this site (AliasTracker.create / buildMergedJoinAliasTracker / stored _aliasTracker). Routing these sites through the converged Relation#aliasTracker is tracked in story alias-tracker-callsites-bypass-relation-alias-tracker (RFC 0032)."
   }
 ]


### PR DESCRIPTION
## Summary

`Relation#aliasTracker` returned a bespoke `Record<string, number>` join-count
map — never touching the `AliasTracker` class — where Rails' `alias_tracker`
(relation.rb:1307-1309) builds
`Associations::AliasTracker.create(model.connection_pool, table.name, joins, aliases)`.
The count-map shape had zero callers.

- Converge `Relation#aliasTracker(joins = [], aliases?)` to
  `AliasTracker.create(this.model.connectionPool(), this.table.name, joins, aliases)`.
- Remove the now-converged `alias_tracker` entries (`connection_pool`,
  `create`, `model`) from the wide-call ratchet baseline.
- Baseline the four Rails `alias_tracker` call sites the convergence newly
  surfaces (`AssociationScope#scope`, `DisableJoinsAssociationScope#scope`,
  `JoinDependency#make_constraints`, `build_joins`) — each builds its tracker
  through a bespoke path; routing them through the converged method is
  registered as story `alias-tracker-callsites-bypass-relation-alias-tracker`.
- Trails-only regression test (no like-named Rails test exists) guarding the
  AliasTracker return shape and the joins seed.

Closes-story: relation-alias-tracker-bypasses-class


## Review response

**`AliasTracker.create` reads `pool?.tableAliasLength` instead of
`pool.with_connection { |c| c.table_alias_length }`** — known, documented, and
tracked deviation, not introduced here. Rails' `create` (alias_tracker.rb:9-24)
resolves the connection inside a blocking `with_connection`; trails'
`ConnectionPool#withConnection` is async while `create` is called from
synchronous arel-building paths, and the only sync accessor
(`ConnectionPool#leaseConnectionSync`) is documented internal-only ("do not use
on production/query paths"). The fallback and its fix are documented at the
callee (`associations/alias-tracker.ts:85-90`), baselined with the same reason
in `call-mismatches-wide-exclude/activerecord/associations/alias-tracker.json`,
and owned by story
`thread-connection-table-alias-length-into-tracker-construction` (RFC 0051,
currently claimed) — which will fix it for every `create` caller at once. This
PR converges the Rails-visible call shape so that story's fix lands here for
free.
