### PR TITLE
fix(activemodel): raise from Type#toJSON so serialized coder dumps of types converge on Rails' as_json raise

### DIFF
--- a/packages/activemodel/src/type/value.ts
+++ b/packages/activemodel/src/type/value.ts
@@ -109,14 +109,6 @@ export abstract class Type<T = unknown> {
     throw new NoMethodError("Unimplemented");
   }
 
-  // `JSON.stringify`'s analogue of the `as_json` hook Rails' JSON encoder
-  // reaches on every nested object: a type buried inside a coder-dumped value
-  // must hit the value.rb:145 raise, not silently dump its internals
-  // (scheme/key material) into the payload.
-  toJSON(): never {
-    return this.asJson();
-  }
-
   /**
    * Mirrors: ActiveModel::Type::Value#cast_value (value.rb:155-157)
    *

--- a/packages/activemodel/src/type/value.ts
+++ b/packages/activemodel/src/type/value.ts
@@ -109,6 +109,16 @@ export abstract class Type<T = unknown> {
     throw new NoMethodError("Unimplemented");
   }
 
+  // Rails' JSON encoder reaches every nested object's `as_json`, so a type
+  // buried inside a value being coder-dumped hits the raise above
+  // (value.rb:145) — e.g. a previous-scheme AdditionalValue reaching
+  // Type::Serialized#serialize. `JSON.stringify`'s analogous hook is
+  // `toJSON`; without it, stringify would silently dump the type's
+  // internals (scheme/key material) into the payload instead of raising.
+  toJSON(): never {
+    return this.asJson();
+  }
+
   /**
    * Mirrors: ActiveModel::Type::Value#cast_value (value.rb:155-157)
    *

--- a/packages/activemodel/src/type/value.ts
+++ b/packages/activemodel/src/type/value.ts
@@ -109,12 +109,10 @@ export abstract class Type<T = unknown> {
     throw new NoMethodError("Unimplemented");
   }
 
-  // Rails' JSON encoder reaches every nested object's `as_json`, so a type
-  // buried inside a value being coder-dumped hits the raise above
-  // (value.rb:145) — e.g. a previous-scheme AdditionalValue reaching
-  // Type::Serialized#serialize. `JSON.stringify`'s analogous hook is
-  // `toJSON`; without it, stringify would silently dump the type's
-  // internals (scheme/key material) into the payload instead of raising.
+  // `JSON.stringify`'s analogue of the `as_json` hook Rails' JSON encoder
+  // reaches on every nested object: a type buried inside a coder-dumped value
+  // must hit the value.rb:145 raise, not silently dump its internals
+  // (scheme/key material) into the payload.
   toJSON(): never {
     return this.asJson();
   }

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.trails.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.trails.test.ts
@@ -122,14 +122,12 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueriesTest (trails ext
     expect(await EncryptedSerializedBook.exists({ name: "Dune" })).toBe(true);
   });
 
-  // Rails-verified (vendored Rails 8.1, sqlite3, extend_queries installed):
-  // a deterministic Serialized(Encrypted) attribute WITH previous schemes
-  // raises NoMethodError on any plaintext lookup — the expansion's
-  // AdditionalValue reaches Type::Serialized#serialize, the JSON coder's
-  // as_json traversal descends into the AV's @type (a bare previous-scheme
-  // EncryptedAttributeType), and ActiveModel::Type::Value#as_json raises
-  // (value.rb:145). No SQL is generated, so no scheme/key material can land
-  // in a bind. Our Type#toJSON mirrors that raise for JSON.stringify.
+  // Rails-verified (vendored Rails, sqlite3, extend_queries installed): with
+  // previous schemes, plaintext lookups raise NoMethodError — the expansion's
+  // AdditionalValue reaches Type::Serialized#serialize and the JSON coder's
+  // as_json traversal hits ActiveModel::Type::Value#as_json (value.rb:145)
+  // via the AV's @type. No SQL is generated, so no scheme/key material can
+  // land in a bind.
   it("raises NoMethodError when a previous-scheme candidate reaches the serialized coder", async () => {
     await expect(PreviousSchemeSerializedBook.findBy({ name: "Dune" })).rejects.toThrow(
       NoMethodError,

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.trails.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.trails.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { ExtendedDeterministicQueries } from "./extended-deterministic-queries.js";
+import { ExtendedDeterministicQueries, AdditionalValue } from "./extended-deterministic-queries.js";
+import { NoMethodError } from "@blazetrails/activemodel";
 import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
 import { Scheme } from "./scheme.js";
 import { Configurable } from "./configurable.js";
@@ -10,7 +11,7 @@ import {
   EncryptedUniquenessValidator,
 } from "./extended-deterministic-uniqueness-validator.js";
 import { UniquenessValidator } from "../validations.js";
-import { getAttributeType } from "./encryptable-record.js";
+import { getAttributeType, encryptedTypeOf } from "./encryptable-record.js";
 // Side-effect: registers encryptionHooks so Base.encrypts() is wired up.
 import "../encryption.js";
 import { Base } from "../base.js";
@@ -32,7 +33,7 @@ const PREVIOUS_KEY = Buffer.alloc(32, "y").toString("base64");
  * EncryptedAttributeType, or the expansion ciphertext diverges from the
  * write path and the lookup silently misses.
  */
-function buildSerializedBook() {
+function buildSerializedBook({ previousSchemes = false } = {}) {
   class EncryptedSerializedBook extends Base {
     static {
       this._tableName = "books";
@@ -40,13 +41,17 @@ function buildSerializedBook() {
       this.attribute("name", "string");
       // supportUnencryptedData: false removes the raw-plaintext candidate
       // from the expansion, so the lookup can only succeed through a
-      // correctly-serialized ciphertext candidate; the previous scheme keeps
-      // `previousTypes` non-empty so expansion actually runs.
+      // correctly-serialized ciphertext candidate. A previous scheme makes
+      // `previousTypes` non-empty so query expansion actually runs — but in
+      // Rails that combination RAISES (see the raise test below), so the
+      // lookup tests use the no-previous-schemes variant.
       this.encrypts("name", {
         deterministic: true,
         key: TEST_KEY,
         supportUnencryptedData: false,
-        previousSchemes: [new Scheme({ deterministic: true, key: PREVIOUS_KEY })],
+        ...(previousSchemes
+          ? { previousSchemes: [new Scheme({ deterministic: true, key: PREVIOUS_KEY })] }
+          : {}),
       });
       this.serialize("name", { coder: "json" });
     }
@@ -56,6 +61,7 @@ function buildSerializedBook() {
 
 describe("ActiveRecord::Encryption::ExtendedDeterministicQueriesTest (trails extras)", () => {
   let EncryptedSerializedBook: ReturnType<typeof buildSerializedBook>;
+  let PreviousSchemeSerializedBook: ReturnType<typeof buildSerializedBook>;
 
   const savedConfig = {
     extendQueries: Configurable.config.extendQueries,
@@ -84,6 +90,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueriesTest (trails ext
     installExtendedQueriesIfConfigured();
 
     EncryptedSerializedBook = buildSerializedBook();
+    PreviousSchemeSerializedBook = buildSerializedBook({ previousSchemes: true });
     // Warm the books table once so the first create doesn't race the
     // test-adapter's schema-recovery path (see the port suite's note).
     await EncryptedSerializedBook.where("1=1");
@@ -115,8 +122,36 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueriesTest (trails ext
     expect(await EncryptedSerializedBook.exists({ name: "Dune" })).toBe(true);
   });
 
+  // Rails-verified (vendored Rails 8.1, sqlite3, extend_queries installed):
+  // a deterministic Serialized(Encrypted) attribute WITH previous schemes
+  // raises NoMethodError on any plaintext lookup — the expansion's
+  // AdditionalValue reaches Type::Serialized#serialize, the JSON coder's
+  // as_json traversal descends into the AV's @type (a bare previous-scheme
+  // EncryptedAttributeType), and ActiveModel::Type::Value#as_json raises
+  // (value.rb:145). No SQL is generated, so no scheme/key material can land
+  // in a bind. Our Type#toJSON mirrors that raise for JSON.stringify.
+  it("raises NoMethodError when a previous-scheme candidate reaches the serialized coder", async () => {
+    await expect(PreviousSchemeSerializedBook.findBy({ name: "Dune" })).rejects.toThrow(
+      NoMethodError,
+    );
+    await expect(PreviousSchemeSerializedBook.where({ name: "Dune" }).first()).rejects.toThrow(
+      NoMethodError,
+    );
+
+    // The mechanism, pinned directly: Serialized#serialize(AV) raises inside
+    // coder.dump before any payload exists — the dumped-AV JSON (which would
+    // embed previous-scheme internals) is never produced.
+    const fullType = getAttributeType(PreviousSchemeSerializedBook, "name") as {
+      serialize(v: unknown): unknown;
+    };
+    const prevType = encryptedTypeOf(getAttributeType(PreviousSchemeSerializedBook, "name"))!
+      .previousTypes[0];
+    const av = new AdditionalValue("Dune", prevType);
+    expect(() => fullType.serialize(av)).toThrow(NoMethodError);
+  });
+
   it("uniqueness ciphertext generation serializes through the full resolved type", () => {
-    const fullType = getAttributeType(EncryptedSerializedBook, "name") as {
+    const fullType = getAttributeType(PreviousSchemeSerializedBook, "name") as {
       serialize(v: unknown): unknown;
     };
     // The resolved type is the outer Serialized wrapper, not the bare
@@ -124,7 +159,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueriesTest (trails ext
     expect(fullType).not.toBeInstanceOf(EncryptedAttributeType);
 
     const candidates = EncryptedUniquenessValidator.allCiphertextsFor(
-      EncryptedSerializedBook,
+      PreviousSchemeSerializedBook,
       "name",
       "Dune",
     );
@@ -137,7 +172,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueriesTest (trails ext
     // resolved type, so the raw candidate encrypts to the write-path
     // ciphertext (coder dump applied before encryption).
     const arelAttr = (
-      EncryptedSerializedBook as unknown as {
+      PreviousSchemeSerializedBook as unknown as {
         arelTable: { get(name: string): { typeCaster: unknown } };
       }
     ).arelTable.get("name");

--- a/packages/activesupport/src/json.ts
+++ b/packages/activesupport/src/json.ts
@@ -46,6 +46,13 @@ function asJsonValue(value: unknown, options: NormalizedOptions): unknown {
 
   if (Array.isArray(value)) return value.map((v) => asJsonValue(v, options));
 
+  // HashWithIndifferentAccess is a Hash subclass in Ruby, so it takes the
+  // Hash#as_json path; unwrap via toHash() so its contents — not its
+  // Map-backed internals — are traversed.
+  if (typeof (value as { toHash?: unknown }).toHash === "function") {
+    return asJsonValue((value as { toHash(): unknown }).toHash(), options);
+  }
+
   // Only true Hashes (plain objects / Maps) get `only`/`except` key filtering.
   // Other objects (Date, RegExp, BigNumber-likes, …) carry their own `as_json`
   // string form, so leave them for `JSON.stringify` to serialize via `toJSON`
@@ -62,6 +69,18 @@ function asJsonValue(value: unknown, options: NormalizedOptions): unknown {
       if (keep.has(k)) out[String(k)] = asJsonValue(v, options);
     }
     return out;
+  }
+
+  // Rails' `Object#as_json` is `instance_values.as_json(options)` — a generic
+  // object becomes a hash of its instance variables and the traversal recurses
+  // into each of them (core_ext/object/json.rb:62-64). Objects carrying their
+  // own `toJSON` (Date, …) keep their native JSON form, as above. This
+  // recursion is what lets a nested type instance hit `Type#asJson`'s raise
+  // (value.rb:145) — e.g. an encryption AdditionalValue's `type` reaching a
+  // serialized coder's dump — instead of stringify silently dumping the
+  // type's internals.
+  if (typeof value === "object" && typeof (value as { toJSON?: unknown }).toJSON !== "function") {
+    return asJsonValue({ ...value }, options);
   }
 
   return value;
@@ -91,8 +110,11 @@ function filterHashKeys(keys: unknown[], options: NormalizedOptions): Set<unknow
 }
 
 export namespace ActiveSupportJSON {
+  // Rails: `ActiveSupport::JSON.encode` runs the `as_json` traversal
+  // unconditionally, options or not (encoding.rb:22-25) — the options-only
+  // shortcut would skip `asJson` raises (e.g. Type#asJson) on nested objects.
   export function encode(value: unknown, options?: EncodeOptions): string {
-    const resolved = options === undefined ? value : asJsonValue(value, normalizeOptions(options));
+    const resolved = asJsonValue(value, normalizeOptions(options ?? {}));
     return JSON.stringify(resolved) ?? "null";
   }
 


### PR DESCRIPTION
## Summary

Story: previous-scheme `AdditionalValue` for a deterministic
Serialized(Encrypted(...)) attribute reaches `Serialized.serialize`, and the
hypothesis was that (like Rails) the coder dumps the AV into a garbage IN
candidate → silent miss + possible scheme internals in a bind.

**Rails-verified finding (vendored Rails, sqlite3, `extend_queries`
installed via `ExtendedDeterministicQueries.install_support`):** Rails does
NOT produce a garbage candidate — it **raises `NoMethodError`**. The JSON
coder's `as_json` traversal descends into the AV's `@type` (the bare
previous-scheme `EncryptedAttributeType`) and hits
`ActiveModel::Type::Value#as_json`, which deliberately raises
(activemodel value.rb:145). `where`, `find_by`, and `to_sql` all raise; no
SQL is ever generated, so no scheme/key material can land in a bind.

(Earlier repros that "found" the record did so only because
`install_support` never ran outside a railtie boot — no expansion happened
at all, and `serialize_with_oldest?` made the single candidate match.)

Trails diverged: `JSON.stringify(AV)` silently dumped the AV — including
its `type`'s scheme internals — into an encrypted garbage candidate
(silent miss). Per the story's acceptance criteria, converge to Rails.

## Changes

- `ActiveSupportJSON.encode` (activesupport json.ts) — the raise lives in
  the `as_json` traversal, exactly where Rails has it: `encode` now runs
  the traversal unconditionally (Rails encoding.rb:22-25, previously
  skipped without options); generic objects recurse as their instance
  values (`Object#as_json`, core_ext/object/json.rb:62-64), which is what
  lets a nested type instance hit `Type#asJson`'s `NoMethodError`
  (value.rb:145); HWIA unwraps via `toHash` (it is a Hash subclass in
  Ruby, so it takes `Hash#as_json`). Objects with their own `toJSON`
  (Date, …) keep their native JSON form.
  A first iteration put the raise in a global `Type#toJSON`; CI showed
  that breaks the preloader's `LoaderQuery#hashKey`, which
  `JSON.stringify`s scope values containing types — Rails hashes
  `values_for_queries` with Ruby `#hash`, no `as_json` involved, so bare
  `JSON.stringify` must stay safe and only the encode/coder path raises.
- `extended-deterministic-queries.trails.test.ts` — new guard pinning the
  raise on `findBy`/`where` and directly on `Serialized#serialize(AV)`
  (fails on baseline: previously resolved silently). The existing lookup
  guard now uses a no-previous-schemes model (with previous schemes the
  Rails-faithful behavior is the raise, not a successful lookup); the
  uniqueness-candidates guard keeps the previous-schemes model.

## Testing

- `pnpm vitest run packages/activerecord/src/encryption/extended-deterministic-queries.trails.test.ts` — 3 passed; new test fails on baseline.
- Adjacent suites (type/value, coders/json, json-encoding, serialized-attribute, serialization, json-serialization, attribute-inspection, encryptable-record.trails, extended-deterministic-queries) — all pass.
- `pnpm typecheck`, eslint, prettier — clean.

Closes-story: serialized-outer-previous-scheme-av-coder-dump
