### PR TITLE
fix(activerecord): gate checkParts name on chkIgnorePattern

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -348,8 +348,9 @@ export class CheckConstraintDefinition {
     return this.validate;
   }
 
+  // Mirrors: ActiveRecord::ConnectionAdapters::CheckConstraintDefinition#export_name_on_schema_dump?
   get isExportNameOnSchemaDump(): boolean {
-    return true;
+    return this.name ? !/^chk_rails_[0-9a-f]{10}$/.test(this.name) : false;
   }
 
   isDefinedFor(options: { name: string; expression?: string; validate?: boolean }): boolean {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -58,6 +58,7 @@ export type ReferentialAction = "cascade" | "nullify" | "restrict" | "no_action"
 export interface ForeignKeyOptionsAdapter {
   tableNamePrefix?: string;
   tableNameSuffix?: string;
+  /** @internal */
   foreignKeyOptions(
     fromTable: string,
     toTable: string,
@@ -348,7 +349,6 @@ export class CheckConstraintDefinition {
     return this.validate;
   }
 
-  // Mirrors: ActiveRecord::ConnectionAdapters::CheckConstraintDefinition#export_name_on_schema_dump?
   get isExportNameOnSchemaDump(): boolean {
     return this.name ? !/^chk_rails_[0-9a-f]{10}$/.test(this.name) : false;
   }

--- a/packages/activerecord/src/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/schema-dumper.trails.test.ts
@@ -184,6 +184,24 @@ describe("SchemaDumper trails-only cases", () => {
     const customOutput = await SchemaDumper.dump(mkSource(customName) as any);
     expect(customOutput).toContain(`name: "${customName}"`);
   });
+
+  it("chkIgnorePattern suppresses name for matching check constraint names, includes name for non-matching", async () => {
+    const mkSource = (chkName: string) => ({
+      tables: async () => ["products"],
+      columns: async (_t: string) => [{ name: "price", type: "decimal" }],
+      indexes: async () => [],
+      checkConstraints: async () => [{ expression: "price > 0", name: chkName }],
+    });
+    // auto-generated Rails name → name: omitted (export_name_on_schema_dump? == false)
+    const autoName = "chk_rails_abc123def4";
+    const autoOutput = await SchemaDumper.dump(mkSource(autoName) as any);
+    expect(autoOutput).toContain("t.checkConstraint");
+    expect(autoOutput).not.toContain(`"${autoName}"`);
+    // custom name → name: included
+    const customChkName = "products_price_check";
+    const customOutput = await SchemaDumper.dump(mkSource(customChkName) as any);
+    expect(customOutput).toContain(`name: "${customChkName}"`);
+  });
 });
 
 describe("SchemaDumperAdapterTest", () => {

--- a/packages/activerecord/src/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/schema-dumper.trails.test.ts
@@ -192,12 +192,10 @@ describe("SchemaDumper trails-only cases", () => {
       indexes: async () => [],
       checkConstraints: async () => [{ expression: "price > 0", name: chkName }],
     });
-    // auto-generated Rails name → name: omitted (export_name_on_schema_dump? == false)
     const autoName = "chk_rails_abc123def4";
     const autoOutput = await SchemaDumper.dump(mkSource(autoName) as any);
     expect(autoOutput).toContain("t.checkConstraint");
     expect(autoOutput).not.toContain(`"${autoName}"`);
-    // custom name → name: included
     const customChkName = "products_price_check";
     const customOutput = await SchemaDumper.dump(mkSource(customChkName) as any);
     expect(customOutput).toContain(`name: "${customChkName}"`);

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -1050,9 +1050,6 @@ export class SchemaDumper {
       rawChkPattern.global || rawChkPattern.sticky
         ? new RegExp(rawChkPattern.source, rawChkPattern.flags.replace(/[gy]/g, ""))
         : rawChkPattern;
-    // Mirrors Rails' export_name_on_schema_dump? — delegate to the constraint
-    // object when available (CheckConstraintDefinition incorporates the
-    // chk_rails_ ignore-pattern check), else fall back.
     const exportName =
       "isExportNameOnSchemaDump" in (check as object)
         ? (check as unknown as { isExportNameOnSchemaDump: boolean }).isExportNameOnSchemaDump

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -1045,7 +1045,19 @@ export class SchemaDumper {
   /** @internal */
   checkParts(check: { expression: string; name?: string; validate?: boolean }): string[] {
     const parts: string[] = [JSON.stringify(check.expression)];
-    if (check.name) parts.push(`name: ${JSON.stringify(check.name)}`);
+    const rawChkPattern = (this.constructor as typeof SchemaDumper).chkIgnorePattern;
+    const chkIgnorePattern =
+      rawChkPattern.global || rawChkPattern.sticky
+        ? new RegExp(rawChkPattern.source, rawChkPattern.flags.replace(/[gy]/g, ""))
+        : rawChkPattern;
+    // Mirrors Rails' export_name_on_schema_dump? — delegate to the constraint
+    // object when available (CheckConstraintDefinition incorporates the
+    // chk_rails_ ignore-pattern check), else fall back.
+    const exportName =
+      "isExportNameOnSchemaDump" in (check as object)
+        ? (check as unknown as { isExportNameOnSchemaDump: boolean }).isExportNameOnSchemaDump
+        : check.name != null && !chkIgnorePattern.test(check.name);
+    if (exportName && check.name) parts.push(`name: ${JSON.stringify(check.name)}`);
     if (check.validate === false) parts.push("validate: false");
     return parts;
   }


### PR DESCRIPTION
Rails `SchemaDumper#check_parts` gates the `name:` option on `check.export_name_on_schema_dump?` (schema_dumper.rb:311), which applies `SchemaDumper.chk_ignore_pattern` (schema_definitions.rb:185-187) so auto-generated `chk_rails_*` check constraint names are omitted from the dump.

Trails `checkParts` pushed `name:` whenever `check.name` was set, so auto-generated names dumped. This mirrors the FK path (schema-dumper.ts:1085-1088): delegate to `isExportNameOnSchemaDump` when the constraint object provides it, fall back to `chkIgnorePattern` otherwise. Also fixes `CheckConstraintDefinition.isExportNameOnSchemaDump`, which hardcoded `true` instead of applying the `chk_rails_` pattern (Rails schema_definitions.rb:185-187).

Dumper-level test shows an auto-named `chk_rails_[0-9a-f]{10}` constraint dumps without `name:` while an explicitly named one keeps it.

Closes-story: check-parts-name-ignores-chk-pattern