### PR TITLE
fix(activerecord): route alias_tracker call sites through Relation#aliasTracker

### DIFF
--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -6,9 +6,7 @@ import { AliasTracker, aliasedArelTableForReflection } from "./alias-tracker.js"
 import { polymorphicName } from "../inheritance.js";
 import { CompositePrimaryKeyMismatchError } from "./errors.js";
 import { routeThroughCheckValidity } from "./validate-through-reflection.js";
-import type { Quoting } from "../connection-adapters/abstract/quoting-interface.js";
 import { constructJoinDependency, structuralUnionEq } from "../relation/query-methods.js";
-import { threadedConnectionFor } from "../connection-handling.js";
 
 /**
  * Lambda applied to each FK/type bind value before it reaches the
@@ -261,32 +259,26 @@ export class AssociationScope {
    */
   scope(association: AssociationScopeable): unknown {
     const { owner, reflection, klass } = association;
-    // Prefer the connection threaded by the enclosing `withConnection` wrap over
-    // the deprecated `.connection` getter (which flips the lease permanent under
-    // `permanent_connection_checkout = :deprecated|:disallowed`), matching the
-    // resolution in join-dependency.ts and merged-join-alias-tracker.ts.
-    const connection = threadedConnectionFor(klass) ?? klass.connection;
-    const quoter = connection as unknown as Quoting;
     // Rails: `klass.unscoped` (association_scope.rb:23). Rails' unscoped
     // bypasses default_scope but STILL applies the STI `type_condition`
     // because `relation()` adds it for `finder_needs_type_condition?`
     // classes (`core.rb:431-435`). `Base.unscoped` now wires STI through
     // `_buildUnscopedRelation`, so no compensation is needed here.
-    let scope: unknown = klass.unscoped();
-    // Per-scope-build AliasTracker. Rails seeds it from
-    // `scope.alias_tracker` (associations/association_scope.rb:26);
-    // we don't expose one on Relation yet, so create a fresh tracker
-    // here seeded with the owning klass's table name (matches Rails'
-    // default seeding with `klass.arel_table`). The tracker is
-    // shared across the chain walk within this call so repeated
-    // joins to the same table get unique aliases.
-    // Rails builds the tracker with the connection (association_scope.rb:26),
-    // so its alias cap is the connection's `table_alias_length` (256 on MySQL,
-    // 63 on PG). Pass the resolved connection — `create` reads its
-    // `tableAliasLength` — rather than `null`, which would fall back to the 64
-    // default.
-    const tracker = AliasTracker.create(quoter, klass.arelTable.name, [], undefined, quoter);
-    const chain = this.getChain(reflection, tracker);
+    const scopeRelation = klass.unscoped() as {
+      aliasTracker: () => AliasTracker;
+    };
+    let scope: unknown = scopeRelation;
+    // Rails: `get_chain(reflection, association, scope.alias_tracker)`
+    // (association_scope.rb:26) — the tracker comes from the relation's
+    // converged `aliasTracker()` (relation.rb:1307-1309), seeded with the
+    // klass's table name. The tracker is shared across the chain walk within
+    // this call so repeated joins to the same table get unique aliases. The
+    // alias cap comes from `AliasTracker.create`'s pool arg; until the
+    // connection is threaded into `create` (RFC 0051,
+    // thread-connection-table-alias-length-into-tracker-construction) it falls
+    // back to the 64 default — a documented `create`-side deviation, not a
+    // call-site one.
+    const chain = this.getChain(reflection, scopeRelation.aliasTracker());
     // Rails: `scope.extending! reflection.extensions` (association_scope.rb:28).
     // Mix any `extend:`-declared modules onto the relation so extension
     // methods are available on the loaded association's relation.

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -1,3 +1,4 @@
+import type { AliasTracker } from "./alias-tracker.js";
 import {
   AssociationScope,
   ReflectionProxy,
@@ -117,8 +118,17 @@ export class DisableJoinsAssociationScope extends AssociationScope {
     // never cross an `await` boundary, or Promise/A+ unwraps it via
     // the Relation thenable (`.then` → `toArray`). Build sync, box,
     // return the box.
+    // Rails: `unscoped = association.klass.unscoped` then
+    // `get_chain(source_reflection, association, unscoped.alias_tracker)`
+    // (disable_joins_association_scope.rb:9-10) — the tracker comes from the
+    // converged `Relation#aliasTracker` (relation.rb:1307-1309). DJAS never
+    // emits joins, so the tracker only names repeat-visit `ReflectionProxy`
+    // aliased tables during the chain walk.
+    const unscoped = klass.unscoped() as { aliasTracker: () => AliasTracker };
     return DisableJoinsAssociationRelation.deferred(klass, async () => {
-      const reverseChain = this.getChain(sourceReflection).slice().reverse();
+      const reverseChain = this.getChain(sourceReflection, unscoped.aliasTracker())
+        .slice()
+        .reverse();
       const [lastReflection, lastOrdered, lastJoinIds] = await this._lastScopeChain(
         reverseChain,
         owner,

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -843,6 +843,7 @@ export class JoinDependency {
     parent: JoinPart,
     child: JoinPart,
     joinType: typeof Nodes.InnerJoin | typeof Nodes.OuterJoin,
+    tracker: AliasTracker,
   ): void {
     if (child.throughGroup) {
       this._resolveThroughGroup(parent, child.throughGroup, joinType);
@@ -883,7 +884,7 @@ export class JoinDependency {
     const referenced = this._references.get(child.immediateAssocName);
     const lookupName = referenced ?? child.tableName;
     const parentTableName = (parent.baseKlass as any)?.tableName ?? (parent as any).table;
-    const alias = this._aliasTracker.aliasNameForTable(lookupName, () =>
+    const alias = tracker.aliasNameForTable(lookupName, () =>
       child.reflection.aliasCandidate(parentTableName),
     );
     this._rebuildChildJoin(parent, child, alias ?? lookupName);
@@ -1076,7 +1077,11 @@ export class JoinDependency {
     child: JoinPart,
     joinType: typeof Nodes.InnerJoin | typeof Nodes.OuterJoin,
   ): Nodes.Join[] {
-    this._resolveChildAlias(parent, child, joinType);
+    // Rails passes the `alias_tracker` attr_reader into
+    // `child.join_constraints(..., alias_tracker)` (join_dependency.rb:193);
+    // `_resolveChildAlias` is our emit-time port of that call's aliasing
+    // block, so thread the same reader through it.
+    this._resolveChildAlias(parent, child, joinType, this.aliasTracker);
     const joins: Nodes.Join[] = [];
     const arelJoin = child.arelJoin;
     if (arelJoin) {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3327,13 +3327,22 @@ export class Relation<T extends Base> {
     // too (`buckets[:named_join] = left_joins` with an empty `left_joins`); the
     // empty-named early return emits the same SQL as the stash-fold path.
     // Rails: `alias_tracker = alias_tracker(leading_joins + join_nodes, aliases)`
-    // (query_methods.rb:1894) — the converged `Relation#aliasTracker`. Built once
-    // here (this method is the live-path half of the `build_joins` split) and
-    // threaded through either emit below. The `_joinClauses` seeding is
-    // trails-only compensation for raw join clauses living outside
-    // `joins_values` (see merged-join-alias-tracker.ts).
-    const tracker = this.aliasTracker([...leadingJoins, ...joinNodes], aliases?.aliases);
-    seedJoinClauseAliases(this as any, tracker);
+    // (query_methods.rb:1894) — the converged `Relation#aliasTracker`, built
+    // once here (this method is the live-path half of the `build_joins` split)
+    // and threaded through either emit below. Lazy behind the same
+    // `unless named_joins.empty? && stashed_joins.empty?` guard Rails builds it
+    // under (see JoinEmissionPlan#tracker) — a joinless relation on a
+    // connectionless model must not touch `connectionPool()`. The
+    // `_joinClauses` seeding is trails-only compensation for raw join clauses
+    // living outside `joins_values` (see merged-join-alias-tracker.ts).
+    let memoTracker: AliasTracker | undefined;
+    const tracker = (): AliasTracker => {
+      if (!memoTracker) {
+        memoTracker = this.aliasTracker([...leadingJoins, ...joinNodes], aliases?.aliases);
+        seedJoinClauseAliases(this as any, memoTracker);
+      }
+      return memoTracker;
+    };
     if (pureLeftOuter && this._leftOuterJoinsValues.length > 0) {
       _qm.emitJoinPlan.call(this as any, manager, {
         leadingJoins,

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -70,6 +70,7 @@ import {
   type OrderArg,
 } from "./relation/query-methods.js";
 import * as _qm from "./relation/query-methods.js";
+import { seedJoinClauseAliases } from "./relation/merged-join-alias-tracker.js";
 import {
   Batches,
   ensureValidOptionsForBatchingBang as _ensureValidOptionsForBatchingBang,
@@ -3325,6 +3326,14 @@ export class Relation<T extends Base> {
     // a CTE symbol, already routed into `joinNodes` above. Rails returns early there
     // too (`buckets[:named_join] = left_joins` with an empty `left_joins`); the
     // empty-named early return emits the same SQL as the stash-fold path.
+    // Rails: `alias_tracker = alias_tracker(leading_joins + join_nodes, aliases)`
+    // (query_methods.rb:1894) — the converged `Relation#aliasTracker`. Built once
+    // here (this method is the live-path half of the `build_joins` split) and
+    // threaded through either emit below. The `_joinClauses` seeding is
+    // trails-only compensation for raw join clauses living outside
+    // `joins_values` (see merged-join-alias-tracker.ts).
+    const tracker = this.aliasTracker([...leadingJoins, ...joinNodes], aliases?.aliases);
+    seedJoinClauseAliases(this as any, tracker);
     if (pureLeftOuter && this._leftOuterJoinsValues.length > 0) {
       _qm.emitJoinPlan.call(this as any, manager, {
         leadingJoins,
@@ -3332,6 +3341,7 @@ export class Relation<T extends Base> {
         stashedJoins: [...leftStashed],
         namedJoins: leftAssociations as any,
         aliases,
+        tracker,
       });
       return;
     }
@@ -3356,6 +3366,7 @@ export class Relation<T extends Base> {
       stashedJoins,
       namedJoins: [],
       aliases,
+      tracker,
     });
   }
 

--- a/packages/activerecord/src/relation/merged-join-alias-tracker.ts
+++ b/packages/activerecord/src/relation/merged-join-alias-tracker.ts
@@ -1,63 +1,36 @@
 /**
- * Shared AliasTracker construction for cross-klass merged joins.
+ * Trails-specific alias seeding for the shared `build_joins` AliasTracker.
  *
- * Rails shares one `alias_tracker` across every join dependency in
- * `build_joins`, so a `merge` that brings an association join onto a table the
- * outer relation already joins is aliased (`authors_categorizations`). This
- * builds that single tracker — seeded with the base table (Rails
- * `AliasTracker.create(connection, table_name, joins)`), the manual joins, and
- * the resolved `_joinClauses` tables — and threads it through every
- * `JoinDependency#joinConstraints` in the live SelectManager path
- * (`_applyJoinsToManager`) and the `from`-subquery path (`buildJoins`). Each
+ * Rails shares one `alias_tracker(leading_joins + join_nodes, aliases)`
+ * (query_methods.rb:1894) across every join dependency in `build_joins`, so a
+ * `merge` that brings an association join onto a table the outer relation
+ * already joins is aliased (`authors_categorizations`). Trails builds that
+ * tracker through the converged `Relation#aliasTracker` at each `build_joins`
+ * call site (`buildJoins` / `_applyJoinsToManager`) and then seeds it here
+ * with the resolved `_joinClauses` tables — a trails-only step: Rails has no
+ * `_joinClauses` (its raw join clauses ride `joins_values` as Arel nodes and
+ * are counted by `initial_count_for`), so their pre-resolved tables must be
+ * claimed explicitly for a later association/merged join to collide. Each
  * dependency then claims and aliases its tables lazily at emit-time in
  * `makeConstraints`, so a duplicate join collides naturally — no separate
  * seed/re-align pass.
  */
-import { Nodes } from "@blazetrails/arel";
 import { underscore, pluralize } from "@blazetrails/activesupport";
-import { AliasTracker } from "../associations/alias-tracker.js";
-import { threadedConnectionFor } from "../connection-handling.js";
-import type { Quoting } from "../connection-adapters/abstract/quoting-interface.js";
+import type { AliasTracker } from "../associations/alias-tracker.js";
 
 interface MergedJoinAliasHost {
   _modelClass: {
     tableName: string;
-    connection: Quoting & { tableAliasLength(): number };
   };
   _joinClauses: Array<{ table: string; assoc?: string }>;
 }
 
 /**
- * Build the AliasTracker shared across a relation's join dependencies. Mirrors
- * Rails `build_joins`' `alias_tracker(leading_joins + join_nodes, aliases)`
- * (query_methods.rb:1891): seeded with the base table (Rails
- * `AliasTracker.create(connection, table_name, joins)`), the `leadingJoins +
- * joinNodes` raw Arel join nodes (so `initialCountFor` counts a table already
- * claimed by a leading/raw join — forcing a same-table association join to its
- * `alias_candidate`), and the resolved `_joinClauses` tables. `existingAliases`
- * is the alias map threaded in from `build_from` (Rails' `aliases` argument);
- * its counts are folded in first. Each JoinDependency then claims and aliases
- * its own tables at emit-time in `makeConstraints`.
+ * Claim the host's resolved `_joinClauses` tables into `tracker` so a later
+ * association/merged join onto the same table is detected as a collision.
  */
-export function buildMergedJoinAliasTracker(
-  host: MergedJoinAliasHost,
-  joinNodes: Nodes.Join[],
-  existingAliases?: Map<string, number>,
-): AliasTracker {
-  // Prefer the connection threaded by the enclosing `withQueryConnection` wrap
-  // (Rails threads the `with_connection` connection through join building)
-  // rather than the deprecated `.connection` getter, which would flip the lease
-  // permanent under `permanent_connection_checkout = :deprecated|:disallowed`.
-  const connection = (threadedConnectionFor(
-    host._modelClass as unknown as Parameters<typeof threadedConnectionFor>[0],
-  ) ?? host._modelClass.connection) as Quoting & { tableAliasLength(): number };
-  const aliasLength = connection.tableAliasLength();
-  const seededAliases = existingAliases ? new Map(existingAliases) : new Map<string, number>();
-  const tracker = new AliasTracker(aliasLength, seededAliases, joinNodes, connection);
+export function seedJoinClauseAliases(host: MergedJoinAliasHost, tracker: AliasTracker): void {
   const ownerTable = host._modelClass.tableName;
-  // Seed the base table (Rails AliasTracker.create sets aliases[initial_table] = 1)
-  // so an association that joins back onto the relation's own table collides.
-  tracker.aliases.set(ownerTable, 1);
   for (const c of host._joinClauses) {
     if (c.assoc) {
       // Association where-join (whereAssociated / associated): mirror the
@@ -74,5 +47,4 @@ export function buildMergedJoinAliasTracker(
       tracker.aliases.set(c.table, 1);
     }
   }
-  return tracker;
 }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -3013,8 +3013,14 @@ export function emitJoinPlan(this: QueryMethodsHost, manager: any, plan: JoinEmi
   // `joinConstraints` makes a merged join onto an already-joined table collide
   // and alias. `plan.aliases` is the tracker threaded in from `build_from`
   // (Rails' `aliases` argument), whose counts the caller folded in. Invoked
-  // lazily (see JoinEmissionPlan#tracker) only where a JoinDependency emits.
-  const sharedTracker = plan.tracker;
+  // lazily (see JoinEmissionPlan#tracker) only where a JoinDependency emits;
+  // `trackerWasBuilt` records that a forcing site actually ran, gating the
+  // aliases writeback below.
+  let trackerWasBuilt = false;
+  const sharedTracker = (): AliasTracker => {
+    trackerWasBuilt = true;
+    return plan.tracker();
+  };
   const references = (this as any)._aliasableReferences();
 
   // Rails build_joins (query_methods.rb:1881-1897) emits ALL named association
@@ -3098,7 +3104,14 @@ export function emitJoinPlan(this: QueryMethodsHost, manager: any, plan: JoinEmi
   // source and a sibling explicit `:post` join in the SAME outer JoinDependency
   // would both re-alias `posts` to the same candidate and collide — the outer
   // tracker must learn what the nested scope build already claimed.
-  if (plan.aliases) {
+  // Only when a JoinDependency emission actually forced the tracker: Rails'
+  // `build_joins` skips `alias_tracker` entirely when the
+  // `named_joins.empty? && stashed_joins.empty?` guard fails, even with
+  // `aliases` supplied (query_methods.rb:1893) — a joinless nested
+  // `join_scope.arel(aliases)` build claims nothing in the caller's hash, and
+  // forcing the thunk here would re-open the `connectionPool()` raise on a
+  // connectionless model that the lazy tracker exists to avoid.
+  if (plan.aliases && trackerWasBuilt) {
     for (const [name, count] of sharedTracker().aliases) {
       if (count > (plan.aliases.aliases.get(name) ?? 0)) plan.aliases.aliases.set(name, count);
     }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -33,7 +33,7 @@ import { sanitizeLimit } from "../connection-adapters/abstract/database-statemen
 import { columnNameWithOrderMatcher as abstractOrderMatcher } from "../connection-adapters/abstract/sql-formatting.js";
 import { JoinDependency } from "../associations/join-dependency.js";
 import type { AliasTracker } from "../associations/alias-tracker.js";
-import { buildMergedJoinAliasTracker } from "./merged-join-alias-tracker.js";
+import { seedJoinClauseAliases } from "./merged-join-alias-tracker.js";
 import { threadedConnectionFor } from "../connection-handling.js";
 import { wrapWithScopeProxy } from "./delegation.js";
 import { foreignKey } from "@blazetrails/activesupport";
@@ -197,6 +197,9 @@ interface QueryMethodsHost {
   // are read-only getters derived from it via `_isNamedJoinValue`.
   _joinsValues: (AssociationSpec | string | Nodes.Join)[];
   joinsValues: (AssociationSpec | string | Nodes.Join)[];
+  // Converged Rails `Relation#alias_tracker(joins, aliases)` (relation.rb:1307);
+  // `buildJoins` reads it to build the shared `build_joins` tracker.
+  aliasTracker(joins?: Nodes.Node[], aliases?: Map<string, number>): AliasTracker;
   _isNamedJoinValue(v: unknown): boolean;
   readonly _joinValues: (string | Nodes.Join)[];
   _leftOuterJoinsValues: AssociationSpec[];
@@ -2953,6 +2956,13 @@ export interface JoinEmissionPlan {
   namedJoins: AssociationSpec[];
   /** Tracker threaded in from `build_from`; absent on the live path. */
   aliases?: AliasTracker;
+  /**
+   * The shared tracker built by the caller via the converged
+   * `Relation#aliasTracker(leading_joins + join_nodes, aliases)`
+   * (query_methods.rb:1894) and seeded with the resolved `_joinClauses`
+   * tables (`seedJoinClauseAliases`).
+   */
+  tracker: AliasTracker;
 }
 
 /**
@@ -2987,18 +2997,17 @@ export function emitJoinPlan(this: QueryMethodsHost, manager: any, plan: JoinEmi
 
   // One AliasTracker shared across every JoinDependency, mirroring Rails' single
   // `build_joins` `alias_tracker(leading_joins + join_nodes, aliases)`
-  // (query_methods.rb:1891). Seeding it with the leading-join + join-node tables
-  // means a JoinDependency joining a table already claimed by a leading/raw join
-  // node is re-aliased to its `alias_candidate`. Each dependency claims and
-  // aliases its tables lazily at emit-time in `makeConstraints`, so threading
-  // this one tracker through every `joinConstraints` makes a merged join onto an
-  // already-joined table collide and alias. `plan.aliases` is the tracker
-  // threaded in from `build_from` (Rails' `aliases` argument), folded in below.
-  const sharedTracker = buildMergedJoinAliasTracker(
-    this as any,
-    [...plan.leadingJoins, ...plan.joinNodes],
-    plan.aliases?.aliases,
-  );
+  // (query_methods.rb:1891). Built by the caller (`buildJoins` /
+  // `_applyJoinsToManager`, the two halves of the `build_joins` split) via the
+  // converged `Relation#aliasTracker` and threaded in on the plan. Seeding it
+  // with the leading-join + join-node tables means a JoinDependency joining a
+  // table already claimed by a leading/raw join node is re-aliased to its
+  // `alias_candidate`. Each dependency claims and aliases its tables lazily at
+  // emit-time in `makeConstraints`, so threading this one tracker through every
+  // `joinConstraints` makes a merged join onto an already-joined table collide
+  // and alias. `plan.aliases` is the tracker threaded in from `build_from`
+  // (Rails' `aliases` argument), whose counts the caller folded in.
+  const sharedTracker = plan.tracker;
   const references = (this as any)._aliasableReferences();
 
   // Rails build_joins (query_methods.rb:1881-1897) emits ALL named association
@@ -3105,12 +3114,21 @@ export function buildJoins(this: QueryMethodsHost, arel: any, aliases?: AliasTra
   // Subquery path: buckets fold eager into stashed_join. Delegate emission to
   // the shared `build_joins` port.
   const buckets = buildJoinBuckets.call(this);
+  const leadingJoins = buckets.leading_join as Nodes.Join[];
+  const joinNodes = buckets.join_node as Nodes.Join[];
+  // Rails: `alias_tracker = alias_tracker(leading_joins + join_nodes, aliases)`
+  // (query_methods.rb:1894) — the converged `Relation#aliasTracker`. The
+  // `_joinClauses` seeding is trails-only compensation for raw join clauses
+  // living outside `joins_values` (see merged-join-alias-tracker.ts).
+  const tracker = this.aliasTracker([...leadingJoins, ...joinNodes], aliases?.aliases);
+  seedJoinClauseAliases(this, tracker);
   emitJoinPlan.call(this, arel, {
-    leadingJoins: buckets.leading_join as Nodes.Join[],
-    joinNodes: buckets.join_node as Nodes.Join[],
+    leadingJoins,
+    joinNodes,
     stashedJoins: buckets.stashed_join as JoinDependency[],
     namedJoins: buckets.named_join as AssociationSpec[],
     aliases,
+    tracker,
   });
 }
 

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2957,12 +2957,18 @@ export interface JoinEmissionPlan {
   /** Tracker threaded in from `build_from`; absent on the live path. */
   aliases?: AliasTracker;
   /**
-   * The shared tracker built by the caller via the converged
+   * The shared tracker, built by the caller via the converged
    * `Relation#aliasTracker(leading_joins + join_nodes, aliases)`
    * (query_methods.rb:1894) and seeded with the resolved `_joinClauses`
-   * tables (`seedJoinClauseAliases`).
+   * tables (`seedJoinClauseAliases`). A memoized thunk, not an instance:
+   * Rails only builds `alias_tracker` inside the
+   * `unless named_joins.empty? && stashed_joins.empty?` guard
+   * (query_methods.rb:1893), so a relation with no join dependencies to emit
+   * must never touch it — `Relation#aliasTracker` reads
+   * `model.connectionPool()`, which raises `ConnectionNotDefined` on a
+   * connectionless model.
    */
-  tracker: AliasTracker;
+  tracker: () => AliasTracker;
 }
 
 /**
@@ -3006,7 +3012,8 @@ export function emitJoinPlan(this: QueryMethodsHost, manager: any, plan: JoinEmi
   // emit-time in `makeConstraints`, so threading this one tracker through every
   // `joinConstraints` makes a merged join onto an already-joined table collide
   // and alias. `plan.aliases` is the tracker threaded in from `build_from`
-  // (Rails' `aliases` argument), whose counts the caller folded in.
+  // (Rails' `aliases` argument), whose counts the caller folded in. Invoked
+  // lazily (see JoinEmissionPlan#tracker) only where a JoinDependency emits.
   const sharedTracker = plan.tracker;
   const references = (this as any)._aliasableReferences();
 
@@ -3057,7 +3064,7 @@ export function emitJoinPlan(this: QueryMethodsHost, manager: any, plan: JoinEmi
         : ([[] as AssociationSpec[], Nodes.InnerJoin] as const);
   if (namedJoins.length > 0 || plan.stashedJoins.length > 0) {
     const jd = constructJoinDependency.call(this, namedJoins, joinType);
-    for (const node of jd.joinConstraints(plan.stashedJoins, sharedTracker, references))
+    for (const node of jd.joinConstraints(plan.stashedJoins, sharedTracker(), references))
       manager.appendJoinNode(node);
   }
 
@@ -3065,13 +3072,13 @@ export function emitJoinPlan(this: QueryMethodsHost, manager: any, plan: JoinEmi
   // same shared tracker, so a join onto an already-joined table aliases at
   // emit-time in makeConstraints (`authors_categorizations`).
   for (const jd of this._namedInnerJoinDeps) {
-    for (const node of jd.joinConstraints([], sharedTracker)) manager.appendJoinNode(node);
+    for (const node of jd.joinConstraints([], sharedTracker())) manager.appendJoinNode(node);
   }
 
   // Cross-klass merged left-outer JoinDependencies (Rails merge_outer_joins):
   // emitted against the same shared tracker.
   for (const jd of this._leftOuterJoinDeps) {
-    for (const node of jd.joinConstraints([], sharedTracker)) manager.appendJoinNode(node);
+    for (const node of jd.joinConstraints([], sharedTracker())) manager.appendJoinNode(node);
   }
 
   // Rails' single `buckets[:join_node]` array is populated raw joins_values Join
@@ -3092,7 +3099,7 @@ export function emitJoinPlan(this: QueryMethodsHost, manager: any, plan: JoinEmi
   // would both re-alias `posts` to the same candidate and collide — the outer
   // tracker must learn what the nested scope build already claimed.
   if (plan.aliases) {
-    for (const [name, count] of sharedTracker.aliases) {
+    for (const [name, count] of sharedTracker().aliases) {
       if (count > (plan.aliases.aliases.get(name) ?? 0)) plan.aliases.aliases.set(name, count);
     }
   }
@@ -3117,11 +3124,19 @@ export function buildJoins(this: QueryMethodsHost, arel: any, aliases?: AliasTra
   const leadingJoins = buckets.leading_join as Nodes.Join[];
   const joinNodes = buckets.join_node as Nodes.Join[];
   // Rails: `alias_tracker = alias_tracker(leading_joins + join_nodes, aliases)`
-  // (query_methods.rb:1894) — the converged `Relation#aliasTracker`. The
+  // (query_methods.rb:1894) — the converged `Relation#aliasTracker`, built
+  // lazily behind the same `unless named_joins.empty? && stashed_joins.empty?`
+  // guard Rails builds it under (see JoinEmissionPlan#tracker). The
   // `_joinClauses` seeding is trails-only compensation for raw join clauses
   // living outside `joins_values` (see merged-join-alias-tracker.ts).
-  const tracker = this.aliasTracker([...leadingJoins, ...joinNodes], aliases?.aliases);
-  seedJoinClauseAliases(this, tracker);
+  let memoTracker: AliasTracker | undefined;
+  const tracker = (): AliasTracker => {
+    if (!memoTracker) {
+      memoTracker = this.aliasTracker([...leadingJoins, ...joinNodes], aliases?.aliases);
+      seedJoinClauseAliases(this, memoTracker);
+    }
+    return memoTracker;
+  };
   emitJoinPlan.call(this, arel, {
     leadingJoins,
     joinNodes,

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/association-scope.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/association-scope.json
@@ -229,12 +229,5 @@
     "rubyName": "transform_value",
     "call": "call",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association-scope.ts",
-    "rubyName": "scope",
-    "call": "alias_tracker",
-    "reason": "Rails builds/reads the tracker via Relation#alias_tracker; trails constructs it through its own path at this site (AliasTracker.create / buildMergedJoinAliasTracker / stored _aliasTracker). Routing these sites through the converged Relation#aliasTracker is tracked in story alias-tracker-callsites-bypass-relation-alias-tracker (RFC 0032)."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/disable-joins-association-scope.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/disable-joins-association-scope.json
@@ -12,19 +12,5 @@
     "rubyName": "scope",
     "call": "last_scope_chain",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/disable-joins-association-scope.ts",
-    "rubyName": "scope",
-    "call": "unscoped",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/disable-joins-association-scope.ts",
-    "rubyName": "scope",
-    "call": "alias_tracker",
-    "reason": "Rails builds/reads the tracker via Relation#alias_tracker; trails constructs it through its own path at this site (AliasTracker.create / buildMergedJoinAliasTracker / stored _aliasTracker). Routing these sites through the converged Relation#aliasTracker is tracked in story alias-tracker-callsites-bypass-relation-alias-tracker (RFC 0032)."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/join-dependency.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/join-dependency.json
@@ -306,12 +306,5 @@
     "rubyName": "walk_tree",
     "call": "each",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/join-dependency.ts",
-    "rubyName": "make_constraints",
-    "call": "alias_tracker",
-    "reason": "Rails builds/reads the tracker via Relation#alias_tracker; trails constructs it through its own path at this site (AliasTracker.create / buildMergedJoinAliasTracker / stored _aliasTracker). Routing these sites through the converged Relation#aliasTracker is tracked in story alias-tracker-callsites-bypass-relation-alias-tracker (RFC 0032)."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/query-methods.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/query-methods.json
@@ -550,7 +550,7 @@
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_where_clause",
     "call": "map",
-    "reason": "Rails' `build_where_clause` `map` is `key.map { |k| attribute_aliases[k] }` inside `transform_keys` for composite ARRAY keys; JS object keys can't be arrays, so trails resolves single-key aliases via `aliases[key] ?? key` and composite keys via `PredicateBuilder#buildComposite` — no `map` over keys applies."
+    "reason": "Rails' `build_where_clause` `map` is `key.map { |k| attribute_aliases[k] }` inside `transform_keys` for composite ARRAY keys; JS object keys can't be arrays, so trails resolves single-key aliases via `aliases[key] ?? key` and composite keys via `PredicateBuilder#buildComposite` \u2014 no `map` over keys applies."
   },
   {
     "package": "activerecord",
@@ -1041,12 +1041,5 @@
     "rubyName": "validate_order_args",
     "call": "exclude?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_joins",
-    "call": "alias_tracker",
-    "reason": "Rails builds/reads the tracker via Relation#alias_tracker; trails constructs it through its own path at this site (AliasTracker.create / buildMergedJoinAliasTracker / stored _aliasTracker). Routing these sites through the converged Relation#aliasTracker is tracked in story alias-tracker-callsites-bypass-relation-alias-tracker (RFC 0032)."
   }
 ]


### PR DESCRIPTION
## Summary

Follow-up to #5154, which converged `Relation#aliasTracker` to Rails'
`AliasTracker.create(model.connection_pool, table.name, joins, aliases)`
(relation.rb:1307-1309). Four Rails `alias_tracker` call sites still built or
read trackers through bespoke paths; each now routes through the converged
method:

- **`AssociationScope#scope`** (association_scope.rb:26): takes the tracker
  from `klass.unscoped().aliasTracker()` instead of a bespoke
  `AliasTracker.create(quoter, ...)`. The connection-derived alias cap
  (256 MySQL / 63 PG) temporarily falls back to `create`'s 64 default — the
  already-baselined `create`-side deviation owned by RFC 0051
  (`thread-connection-table-alias-length-into-tracker-construction`), which
  restores it for every `create` caller at once.
- **`DisableJoinsAssociationScope#scope`**
  (disable_joins_association_scope.rb:10): now passes
  `unscoped.aliasTracker()` into `getChain` — previously no tracker was
  threaded at all (repeat-visit `ReflectionProxy` tables kept bare names).
  This also converges the previously-baselined `unscoped` call, so that
  entry is removed too.
- **`JoinDependency#makeConstraints`** (join_dependency.rb:193): threads the
  `aliasTracker` reader into `_resolveChildAlias` (our port of the
  `join_constraints(..., alias_tracker)` aliasing block) instead of that
  helper reading the stored `_aliasTracker` field.
- **`build_joins`** (query_methods.rb:1894): `buildJoins` and the live-path
  `_applyJoinsToManager` (the two halves of the `build_joins` split) now build
  the shared tracker via
  `this.aliasTracker([...leadingJoins, ...joinNodes], aliases?.aliases)` and
  thread it to `emitJoinPlan` on the plan. The trails-only `_joinClauses`
  seeding (raw join clauses live outside `joins_values`, so Rails'
  `initial_count_for` never sees them) is split into `seedJoinClauseAliases`;
  `buildMergedJoinAliasTracker` is deleted.

The four `alias-tracker-callsites-bypass-relation-alias-tracker` baseline
entries in `call-mismatches-wide-exclude` are removed (plus the stale DJAS
`scope`/`unscoped` entry the gate now reports as converged);
`pnpm api:calls:wide` is green.

## Testing

- `association-scope-alias-tracker`, `association-scope`,
  `disable-joins-association-scope`, `alias-tracker`,
  `join-dependency-alias-tracker`, `join-dependency-alias-length.trails`,
  `eager-shared-alias-tracker`, `join-dependency-through-aliasing`,
  `join-dependency-quoting`, `build-joins-from-subquery-dedup`,
  `cpk-eager-count-aggregate-build-joins-fold.trails`, `relation.trails`,
  `relations`, `through-association-scope`, `apply-association-scope` — all
  green locally.
- `API_COMPARE_FORCE=1 pnpm api:compare --wide-calls && pnpm api:calls:wide` —
  OK.

Closes-story: alias-tracker-callsites-bypass-relation-alias-tracker
