### PR TITLE
fix(postgresql): route changeColumnDefault through changeColumnDefaultForAlter

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -970,12 +970,9 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     // Invalidate the cached reflection before mutating (matching the other DDL
     // methods, e.g. addColumn) so a subsequent columnsHash()/columnDefaults read
     // sees the new default rather than a stale (always-warm) entry. Safe to clear
-    // first: the column lookup below queries pg_catalog directly, not the cache.
+    // first: buildChangeColumnDefaultDefinition's column lookup queries
+    // pg_catalog directly, not the cache.
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
-    // Mirrors postgresql/schema_statements.rb:486: route through
-    // change_column_default_for_alter so the non-bulk path shares the
-    // builder + visit_ChangeColumnDefaultDefinition machinery with bulk
-    // change_table.
     await this.adapter.execute(
       `ALTER TABLE ${this._qt(tableName)} ${await this.changeColumnDefaultForAlter(tableName, columnName, defaultOrChanges)}`,
     );

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -972,20 +972,13 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     // sees the new default rather than a stale (always-warm) entry. Safe to clear
     // first: the column lookup below queries pg_catalog directly, not the cache.
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
-    const quotedTable = this._qt(tableName);
-    const quotedCol = this._qi(columnName);
-    const defaultValue = this.extractNewDefaultValue(defaultOrChanges);
-    if (defaultValue == null) {
-      await this.adapter.execute(
-        `ALTER TABLE ${quotedTable} ALTER COLUMN ${quotedCol} DROP DEFAULT`,
-      );
-    } else {
-      const col = (await this.columns(tableName)).find((c) => c.name === columnName);
-      const expr = await this.adapter.quoteDefaultExpression(defaultValue, col);
-      await this.adapter.execute(
-        `ALTER TABLE ${quotedTable} ALTER COLUMN ${quotedCol} SET DEFAULT ${expr}`,
-      );
-    }
+    // Mirrors postgresql/schema_statements.rb:486: route through
+    // change_column_default_for_alter so the non-bulk path shares the
+    // builder + visit_ChangeColumnDefaultDefinition machinery with bulk
+    // change_table.
+    await this.adapter.execute(
+      `ALTER TABLE ${this._qt(tableName)} ${await this.changeColumnDefaultForAlter(tableName, columnName, defaultOrChanges)}`,
+    );
   }
 
   buildChangeColumnDefinition(


### PR DESCRIPTION
## Summary

PG `changeColumnDefault` hand-rolled the `ALTER COLUMN ... DROP/SET DEFAULT` SQL and called `quoteDefaultExpression` directly, bypassing the `buildChangeColumnDefaultDefinition` + `visitChangeColumnDefaultDefinition` machinery that #5150 wired for the bulk path.

Rails' PG `change_column_default` (postgresql/schema_statements.rb:486) executes `ALTER TABLE ... #{change_column_default_for_alter(...)}`, so the non-bulk path shares the builder + visitor. This PR converges: PG `changeColumnDefault` now routes through `changeColumnDefaultForAlter`.

## Testing

- `pnpm vitest run` on PG (isolated compose stack, ARCONN=postgresql): `postgresql/schema-statements.test.ts`, `postgresql/schema-statements-class.test.ts` (78 passed), `defaults.test.ts`, `migration.test.ts`, `invertible-migration.test.ts`, `adapters/postgresql/array.test.ts` (174 passed, 16 skipped).

Closes-story: pg-change-column-default-route-through-for-alter
