### PR TITLE
fix(postgresql): carry the live Column into ChangeColumnDefaultDefinition

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -1188,7 +1188,8 @@ describeIfPg("PostgreSQLAdapter", () => {
           "id" SERIAL PRIMARY KEY,
           "score" INTEGER DEFAULT 0,
           "created_at" TIMESTAMP WITHOUT TIME ZONE,
-          "tags" TEXT[]
+          "tags" TEXT[],
+          "price" NUMERIC(5,2)
         )
       `);
     });
@@ -1227,14 +1228,21 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("carries the live reflected Column with oid and fmod", async () => {
-      // Rails passes column_for(...)'s live Column straight into
-      // ChangeColumnDefaultDefinition, so the visitor's default quoting
-      // resolves via the (oid, fmod) type-map key — no regtype query.
       const def = await adapter.buildChangeColumnDefaultDefinition("bcd_test", "score", 42);
       const col = def!.column as PgColumn;
       expect(col).toBeInstanceOf(PgColumn);
-      expect(col.oid).toBe(23); // int4
+      expect(col.oid).toBe(23);
       expect(col.fmod).not.toBeNull();
+    });
+
+    it("resolves fmod-dependent types (numeric precision/scale) through the carried column", async () => {
+      const def = await adapter.buildChangeColumnDefaultDefinition("bcd_test", "price", "12.345");
+      const col = def!.column as PgColumn;
+      expect(col.fmod).not.toBeNull();
+      expect(col.precision).toBe(5);
+      expect(col.scale).toBe(2);
+      const sql = await adapter.schemaCreation.accept(def!);
+      expect(sql).toBe(`ALTER COLUMN "price" SET DEFAULT 12.35`);
     });
 
     it("quotes the default via the OID key without a regtype SCHEMA query", async () => {

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -25,6 +25,7 @@ import {
   ValueTooLong,
 } from "../../errors.js";
 import { withSecondAdapter } from "../../test-helpers/second-connection.js";
+import { Column as PgColumn } from "../../connection-adapters/postgresql/column.js";
 
 // Run `fn` with `ext` guaranteed disabled; restore the pre-state (enabled
 // or disabled) on exit even if `fn` throws before tearing down whatever it
@@ -1221,8 +1222,35 @@ describeIfPg("PostgreSQLAdapter", () => {
       const def = await adapter.buildChangeColumnDefaultDefinition("bcd_test", "tags", "{}");
       expect(def).toBeDefined();
       expect(def!.column.name).toBe("tags");
-      expect(def!.column.options.array).toBe(true);
+      expect((def!.column as PgColumn).array).toBe(true);
       expect(def!.column.sqlType).toMatch(/text/i);
+    });
+
+    it("carries the live reflected Column with oid and fmod", async () => {
+      // Rails passes column_for(...)'s live Column straight into
+      // ChangeColumnDefaultDefinition, so the visitor's default quoting
+      // resolves via the (oid, fmod) type-map key — no regtype query.
+      const def = await adapter.buildChangeColumnDefaultDefinition("bcd_test", "score", 42);
+      const col = def!.column as PgColumn;
+      expect(col).toBeInstanceOf(PgColumn);
+      expect(col.oid).toBe(23); // int4
+      expect(col.fmod).not.toBeNull();
+    });
+
+    it("quotes the default via the OID key without a regtype SCHEMA query", async () => {
+      const def = await adapter.buildChangeColumnDefaultDefinition("bcd_test", "score", 42);
+      const spy = vi.spyOn(
+        adapter as unknown as { schemaQuery(sql: string): Promise<unknown[]> },
+        "schemaQuery",
+      );
+      try {
+        const sql = await adapter.schemaCreation.accept(def!);
+        expect(sql).toContain("SET DEFAULT 42");
+        const regtypeQueries = spy.mock.calls.filter(([q]) => /regtype/.test(String(q)));
+        expect(regtypeQueries).toEqual([]);
+      } finally {
+        spy.mockRestore();
+      }
     });
 
     it("extracts :to from a {from:, to:} change hash", async () => {

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -3,6 +3,7 @@ import { Column } from "./mysql/column.js";
 import {
   ChangeColumnDefinition,
   ChangeColumnDefaultDefinition,
+  type ColumnDefinition,
 } from "./abstract/schema-definitions.js";
 import { parseTableOptions } from "./abstract-mysql-adapter.js";
 import { SchemaCreation as MysqlSchemaCreation } from "./mysql/schema-creation.js";
@@ -588,7 +589,7 @@ describe("AbstractMysqlAdapter#buildChangeColumnDefaultDefinition (#1568)", () =
 
   it("preserves the column's null option on the built ColumnDefinition", async () => {
     const cd = await build(makeChangeColumnTextColumn({ null_: false }), "x");
-    expect(cd.column.options.null).toBe(false);
+    expect((cd.column as ColumnDefinition).options.null).toBe(false);
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -3,7 +3,6 @@ import { Column } from "./mysql/column.js";
 import {
   ChangeColumnDefinition,
   ChangeColumnDefaultDefinition,
-  type ColumnDefinition,
 } from "./abstract/schema-definitions.js";
 import { parseTableOptions } from "./abstract-mysql-adapter.js";
 import { SchemaCreation as MysqlSchemaCreation } from "./mysql/schema-creation.js";
@@ -589,7 +588,7 @@ describe("AbstractMysqlAdapter#buildChangeColumnDefaultDefinition (#1568)", () =
 
   it("preserves the column's null option on the built ColumnDefinition", async () => {
     const cd = await build(makeChangeColumnTextColumn({ null_: false }), "x");
-    expect((cd.column as ColumnDefinition).options.null).toBe(false);
+    expect(cd.column.null).toBe(false);
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -71,11 +71,7 @@ import {
   ForeignKeyDefinition,
   IndexDefinition,
 } from "./abstract/schema-definitions.js";
-import type {
-  ColumnType,
-  ColumnOptions,
-  SchemaStatementsLike,
-} from "./abstract/schema-definitions.js";
+import type { ColumnOptions, SchemaStatementsLike } from "./abstract/schema-definitions.js";
 import {
   TableDefinition as MysqlTableDefinition,
   Table as MysqlTable,
@@ -854,17 +850,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     // bare `SET` that quoteDefaultExpression(undefined) → "" would emit.
     // Rails has no nil/undefined split, so this is TS-specific defense.
     const newDefault = extracted === undefined ? null : extracted;
-    // Match the PG adapter's shape: build ColumnDefinition with the
-    // semantic type and set sqlType separately so dumper/visitor paths
-    // see both. visitChangeColumnDefaultDefinition reads name +
-    // options.null, but preserve type metadata for any downstream visitor.
-    const colDef = new ColumnDefinition(
-      column.name,
-      (column.type ?? "string") as ColumnType,
-      { null: column.null } as ColumnOptions,
-    );
-    colDef.sqlType = column.sqlType ?? undefined;
-    return new ChangeColumnDefaultDefinition(colDef, newDefault);
+    return new ChangeColumnDefaultDefinition(column, newDefault);
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1,5 +1,6 @@
 import { ABSTRACT_SCHEMA_QUOTER } from "./quoting.js";
 import type { SchemaQuoter } from "./assert-schema-adapter.js";
+import type { Column } from "../column.js";
 import { singularize, pluralize, getCrypto } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
 
@@ -378,11 +379,15 @@ export class ChangeColumnDefinition {
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::ChangeColumnDefaultDefinition
+ *
+ * Rails' builders pass the live reflected Column (carrying oid/fmod on PG) —
+ * not a synthesized ColumnDefinition — so the visitor's default quoting can
+ * resolve the cast type via the OID key without a regtype query.
  */
 export class ChangeColumnDefaultDefinition {
   readonly default: unknown;
   constructor(
-    readonly column: ColumnDefinition,
+    readonly column: ColumnDefinition | Column,
     defaultValue: unknown,
   ) {
     this.default = defaultValue;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -379,15 +379,11 @@ export class ChangeColumnDefinition {
 
 /**
  * Mirrors: ActiveRecord::ConnectionAdapters::ChangeColumnDefaultDefinition
- *
- * Rails' builders pass the live reflected Column (carrying oid/fmod on PG) —
- * not a synthesized ColumnDefinition — so the visitor's default quoting can
- * resolve the cast type via the OID key without a regtype query.
  */
 export class ChangeColumnDefaultDefinition {
   readonly default: unknown;
   constructor(
-    readonly column: ColumnDefinition | Column,
+    readonly column: Column,
     defaultValue: unknown,
   ) {
     this.default = defaultValue;

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
@@ -11,6 +11,7 @@ import {
   AlterTable,
 } from "../abstract/schema-definitions.js";
 import { TableDefinition as MyTd } from "./schema-definitions.js";
+import { Column } from "./column.js";
 
 describe("MySQL::SchemaCreation", () => {
   const sc = new SchemaCreation();
@@ -47,7 +48,7 @@ describe("MySQL::SchemaCreation", () => {
   });
 
   it("visitChangeColumnDefaultDefinition generates SET DEFAULT", async () => {
-    const col = new ColumnDefinition("status", "string", {});
+    const col = new Column("status", null, { sqlType: "varchar(255)", type: "string" });
     const def = new ChangeColumnDefaultDefinition(col, "active");
     expect(await (sc as any).visitChangeColumnDefaultDefinition(def)).toMatch(
       /ALTER COLUMN `status` SET DEFAULT/,
@@ -55,7 +56,7 @@ describe("MySQL::SchemaCreation", () => {
   });
 
   it("visitChangeColumnDefaultDefinition generates DROP DEFAULT when null:false + null value", async () => {
-    const col = new ColumnDefinition("status", "string", { null: false });
+    const col = new Column("status", null, { sqlType: "varchar(255)", type: "string" }, false);
     const def = new ChangeColumnDefaultDefinition(col, null);
     expect(await (sc as any).visitChangeColumnDefaultDefinition(def)).toBe(
       "ALTER COLUMN `status` DROP DEFAULT",

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -284,10 +284,7 @@ export class SchemaCreation extends AbstractSchemaCreation {
     o: ChangeColumnDefaultDefinition,
   ): Promise<string> {
     let sql = `ALTER COLUMN ${this.adapter.quoteIdentifier(o.column.name)} `;
-    // Rails reads `column.null == false` off the live Column; trails' MySQL
-    // builder still passes a ColumnDefinition, so accept both shapes.
-    const columnNull = "options" in o.column ? o.column.options.null : o.column.null;
-    if (o.default == null && columnNull === false) {
+    if (o.default == null && !o.column.null) {
       sql += "DROP DEFAULT";
     } else {
       sql += `SET DEFAULT ${await this.adapter.quoteDefaultExpression(o.default, o.column)}`;

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -284,7 +284,10 @@ export class SchemaCreation extends AbstractSchemaCreation {
     o: ChangeColumnDefaultDefinition,
   ): Promise<string> {
     let sql = `ALTER COLUMN ${this.adapter.quoteIdentifier(o.column.name)} `;
-    if (o.default == null && o.column.options.null === false) {
+    // Rails reads `column.null == false` off the live Column; trails' MySQL
+    // builder still passes a ColumnDefinition, so accept both shapes.
+    const columnNull = "options" in o.column ? o.column.options.null : o.column.null;
+    if (o.default == null && columnNull === false) {
       sql += "DROP DEFAULT";
     } else {
       sql += `SET DEFAULT ${await this.adapter.quoteDefaultExpression(o.default, o.column)}`;

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { SchemaCreation } from "./schema-creation.js";
 import { quoteDefaultExpression } from "./quoting.js";
 import { ExclusionConstraintDefinition, UniqueConstraintDefinition } from "./schema-definitions.js";
+import { Column } from "./column.js";
 import {
   ForeignKeyDefinition,
   ChangeColumnDefinition,
@@ -103,7 +104,7 @@ describe("PostgreSQL SchemaCreation", () => {
   });
 
   it("visitChangeColumnDefaultDefinition", async () => {
-    const col = new ColumnDefinition("x", "string");
+    const col = new Column("x", null, { sqlType: "character varying", type: "string" });
     expect(
       await s().visitChangeColumnDefaultDefinition(new ChangeColumnDefaultDefinition(col, null)),
     ).toContain("DROP DEFAULT");
@@ -115,7 +116,7 @@ describe("PostgreSQL SchemaCreation", () => {
   it("visitChangeColumnDefaultDefinition: uuid function default stays bare", async () => {
     // postgresql/quoting.rb:159-160 — a `()`-bearing string default on a
     // uuid column must reach the DDL as a call, not as `'uuid_generate_v4()'`.
-    const col = new ColumnDefinition("id", "uuid");
+    const col = new Column("id", null, { sqlType: "uuid", type: "uuid" });
     // The shared stub fakes quoteDefaultExpression; this branch lives in
     // the real one, so wire that in.
     const host = s();

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -1006,11 +1006,6 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     columnName: string,
     defaultOrChanges: unknown,
   ): Promise<ChangeColumnDefaultDefinition | undefined> {
-    // Mirrors PostgreSQL::SchemaStatements#build_change_column_default_definition:
-    // carry the live reflected Column (with oid/fmod) into the definition so
-    // the visitor's quoteDefaultExpression resolves the cast type via the OID
-    // type-map key — no regtype SCHEMA query, and fmod-dependent types
-    // (e.g. numeric precision/scale) keep their modifier.
     const col = (await this.columns(tableName)).find((c) => c.name === columnName);
     if (!col) return undefined;
     const defaultValue = this.extractNewDefaultValue(defaultOrChanges);

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -7,7 +7,6 @@ import {
   ChangeColumnDefinition,
   ChangeColumnDefaultDefinition,
   CheckConstraintDefinition,
-  ColumnDefinition,
   ForeignKeyDefinition,
   TableDefinition as AbstractTableDefinition,
   type AddForeignKeyOptions,
@@ -1007,14 +1006,15 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     columnName: string,
     defaultOrChanges: unknown,
   ): Promise<ChangeColumnDefaultDefinition | undefined> {
+    // Mirrors PostgreSQL::SchemaStatements#build_change_column_default_definition:
+    // carry the live reflected Column (with oid/fmod) into the definition so
+    // the visitor's quoteDefaultExpression resolves the cast type via the OID
+    // type-map key — no regtype SCHEMA query, and fmod-dependent types
+    // (e.g. numeric precision/scale) keep their modifier.
     const col = (await this.columns(tableName)).find((c) => c.name === columnName);
     if (!col) return undefined;
     const defaultValue = this.extractNewDefaultValue(defaultOrChanges);
-    const cd = new ColumnDefinition(columnName, (col.type ?? "string") as ColumnType, {
-      array: col.array || undefined,
-    });
-    cd.sqlType = col.sqlType ?? undefined;
-    return new ChangeColumnDefaultDefinition(cd, defaultValue);
+    return new ChangeColumnDefaultDefinition(col, defaultValue);
   }
 
   override async changeColumnNull(


### PR DESCRIPTION
## What

`buildChangeColumnDefaultDefinition` now passes the live reflected `Column` into `ChangeColumnDefaultDefinition`, mirroring Rails (`postgresql/schema_statements.rb:489-494`, `abstract_mysql_adapter.rb:373-379`). Previously both adapters synthesized a fresh `ColumnDefinition` carrying only type/array/sqlType, dropping the live column's oid/fmod — so on PG the visitor's `quoteDefaultExpression` took the no-OID regtype path (one extra SCHEMA query per change_default vs Rails) and fmod-dependent types (numeric precision/scale) lost their modifier.

## Changes

- `ChangeColumnDefaultDefinition.column` typed as the live `Column`, matching Rails' struct.
- PG and MySQL builders carry the reflected column directly instead of synthesizing a `ColumnDefinition` (net −25 LOC of shim).
- MySQL visitor reads `!o.column.null` off the live column, verbatim Rails (`mysql/schema_creation.rb:27-34`).
- Tests: live-Column shape (oid/fmod carried), a spy asserting SET DEFAULT quoting resolves via the OID type-map key with zero regtype SCHEMA queries, and numeric(5,2) default rounding through the carried fmod.

Closes-story: pg-change-default-definition-carries-live-column
