### PR TITLE
fix(predicate-builder): through branch recurses bare like Rails; composite PK routes via array-key zip

### DIFF
--- a/packages/activerecord/src/relation/predicate-builder.trails.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.trails.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { testConnection } from "@blazetrails/arel/src/test-helpers/connection.js";
 import { IntegerType } from "@blazetrails/activemodel";
 import { Nodes, Table, Visitors } from "@blazetrails/arel";
@@ -6,6 +6,13 @@ import { fixtures } from "../test-helpers/fixtures.js";
 import { Company, Firm } from "../test-helpers/models/company.js";
 import { Author } from "../test-helpers/models/author.js";
 import { PriceEstimate } from "../test-helpers/models/price-estimate.js";
+import {
+  CpkBook,
+  CpkChapter,
+  CpkOrderWithSingularBookChapters,
+} from "../test-helpers/models/cpk.js";
+import { registerModel } from "../associations.js";
+import type { Base } from "../index.js";
 import { escapeRegExp, quoteTableName, quoteColumnName } from "../test-helpers/quote-regex.js";
 import { PredicateBuilder } from "./predicate-builder.js";
 import { TableMetadata } from "../table-metadata.js";
@@ -98,6 +105,41 @@ describe("association hash expansion grouping shape", () => {
     expect(or).toBeInstanceOf(Nodes.Or);
     expect(or.children).toHaveLength(2);
     for (const child of or.children) expect(child).toBeInstanceOf(Nodes.And);
+  });
+
+  beforeAll(() => {
+    [CpkOrderWithSingularBookChapters, CpkBook, CpkChapter].forEach((m) =>
+      registerModel(m as unknown as typeof Base),
+    );
+  });
+
+  it("through-association composite primary key routes tuples like Rails' array-key branch", () => {
+    const rel = CpkOrderWithSingularBookChapters.where({
+      chapters: [[1, 2]],
+    }) as unknown as HasWhereClause;
+    // One tuple → one query group → predicates spliced flat, one per PK column.
+    const preds = rel._whereClause.predicates;
+    expect(preds).toHaveLength(2);
+    for (const pred of preds) expect(pred).not.toBeInstanceOf(Nodes.Grouping);
+
+    const multi = CpkOrderWithSingularBookChapters.where({
+      chapters: [
+        [1, 2],
+        [3, 4],
+      ],
+    }) as unknown as HasWhereClause;
+    const multiPreds = multi._whereClause.predicates;
+    expect(multiPreds).toHaveLength(1);
+    expect(multiPreds[0]).toBeInstanceOf(Nodes.Grouping);
+    const or = (multiPreds[0] as Nodes.Grouping).expr as Nodes.Or;
+    expect(or).toBeInstanceOf(Nodes.Or);
+    expect(or.children).toHaveLength(2);
+  });
+
+  it("through-association composite primary key raises on a non-tuple value", () => {
+    expect(() => CpkOrderWithSingularBookChapters.where({ chapters: [1, 2] })).toThrow(
+      'Expected corresponding value for ["author_id", "id"] to be an Array',
+    );
   });
 
   it("through-association single query group stays flat, without an And wrapper", () => {

--- a/packages/activerecord/src/relation/predicate-builder.trails.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.trails.test.ts
@@ -140,6 +140,8 @@ describe("association hash expansion grouping shape", () => {
     expect(() => CpkOrderWithSingularBookChapters.where({ chapters: [1, 2] })).toThrow(
       'Expected corresponding value for ["author_id", "id"] to be an Array',
     );
+    // Ruby `Array(nil)` is [] — a nil value yields zero query groups, not a raise.
+    expect(() => CpkOrderWithSingularBookChapters.where({ chapters: null })).not.toThrow();
   });
 
   it("through-association single query group stays flat, without an And wrapper", () => {

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -218,30 +218,37 @@ export class PredicateBuilder {
       }
       return this.groupingQueries(queryGroups);
     }
-    // Through: delegate with the associated model's primary key (Rails: through_association? path).
+    // Through: bare recursion on the associated builder with the associated
+    // model's primary key (Rails predicate_builder.rb:110-113 — `next
+    // associated_table.predicate_builder.expand_from_hash(primary_key =>
+    // value)`). No value pre-normalization (the recursion's column arm coerces
+    // records/arrays/relations) and no wrapping — `next` inside `flat_map`
+    // splices the predicates flat, keeping each one addressable for
+    // `WhereClause#extract_attributes` / `rewhere`.
     if (associatedTable.isThroughAssociation?.()) {
       const rawPk = associatedTable.klass?.primaryKey ?? "id";
-      if (Array.isArray(rawPk)) {
-        throw new Error(
-          "Through-association with composite primary key is not yet supported (Slot B). " +
-            "Use explicit FK conditions instead.",
-        );
-      }
-      // Normalize value through AssociationQueryValue so records are coerced to their PKs,
-      // arrays of records become id lists, and Relations become subqueries — matching Rails'
-      // build() which does `value = value.id if value.respond_to?(:id)` before dispatching.
-      const normalizedQueries = new AssociationQueryValue(
-        { joinForeignKey: rawPk, joinPrimaryKey: rawPk },
-        value,
-      ).queries();
       const assocPb: PredicateBuilder = associatedTable.predicateBuilder;
-      const queryGroups: Nodes.Node[][] = [];
-      for (const query of normalizedQueries) {
-        const inner = assocPb.expandFromHash(query);
-        if (inner.length === 0) continue;
-        queryGroups.push(inner);
+      if (Array.isArray(rawPk)) {
+        // Composite PK: JS object keys can't be arrays, so mirror the array-key
+        // branch of Rails' expand_from_hash inline (predicate_builder.rb:92-97):
+        // one recursion per ids tuple, zipped against the key columns, then
+        // grouping_queries.
+        const values = Array.isArray(value) ? value : [value];
+        const queryGroups: Nodes.Node[][] = values.map((idsSet) => {
+          if (!Array.isArray(idsSet)) {
+            throw argumentError(
+              `Expected corresponding value for [${rawPk.join(", ")}] to be an Array`,
+            );
+          }
+          const zipped: Record<string, unknown> = {};
+          rawPk.forEach((col, i) => {
+            zipped[col] = idsSet[i];
+          });
+          return assocPb.expandFromHash(zipped);
+        });
+        return assocPb.groupingQueries(queryGroups);
       }
-      return this.groupingQueries(queryGroups);
+      return assocPb.expandFromHash({ [rawPk]: value });
     }
     // Core non-polymorphic, non-through path.
     const queries = new AssociationQueryValue(associatedTable, value).queries();

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -229,7 +229,9 @@ export class PredicateBuilder {
           const flat = Array.isArray(value) ? value.flat(Infinity) : value;
           return assocPb.expandFromHash({ [rawPk[0]]: flat });
         }
-        const values = Array.isArray(value) ? value : [value];
+        // Ruby `Array(value)`: nil → [], array stays, scalar wraps.
+        const values =
+          value === null || value === undefined ? [] : Array.isArray(value) ? value : [value];
         const queryGroups: Nodes.Node[][] = values.map((idsSet) => {
           if (!Array.isArray(idsSet)) {
             throw argumentError(
@@ -244,7 +246,12 @@ export class PredicateBuilder {
         });
         return assocPb.groupingQueries(queryGroups);
       }
-      return assocPb.expandFromHash({ [rawPk]: value });
+      // A klass-less through target makes primaryKey null; Rails passes the
+      // literal `{nil => value}` into the recursion, where the nil key falls
+      // through to `self[nil, value]` and produces degenerate SQL. The JS
+      // computed key coerces null to the string "null" — an equally degenerate
+      // column reference, so no guard beyond this note.
+      return assocPb.expandFromHash({ [rawPk as string]: value });
     }
     // Core non-polymorphic, non-through path.
     const queries = new AssociationQueryValue(associatedTable, value).queries();

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -218,26 +218,22 @@ export class PredicateBuilder {
       }
       return this.groupingQueries(queryGroups);
     }
-    // Through: bare recursion on the associated builder with the associated
-    // model's primary key (Rails predicate_builder.rb:110-113 — `next
-    // associated_table.predicate_builder.expand_from_hash(primary_key =>
-    // value)`). No value pre-normalization (the recursion's column arm coerces
-    // records/arrays/relations) and no wrapping — `next` inside `flat_map`
-    // splices the predicates flat, keeping each one addressable for
-    // `WhereClause#extract_attributes` / `rewhere`.
     if (associatedTable.isThroughAssociation?.()) {
-      const rawPk = associatedTable.klass?.primaryKey ?? "id";
+      const rawPk = associatedTable.primaryKey;
       const assocPb: PredicateBuilder = associatedTable.predicateBuilder;
       if (Array.isArray(rawPk)) {
-        // Composite PK: JS object keys can't be arrays, so mirror the array-key
-        // branch of Rails' expand_from_hash inline (predicate_builder.rb:92-97):
-        // one recursion per ids tuple, zipped against the key columns, then
-        // grouping_queries.
+        // JS object keys can't be arrays, so a composite primary key is routed
+        // to an inline mirror of Rails' array-key branch of expand_from_hash
+        // (predicate_builder.rb:87-97) instead of the recursive call below.
+        if (rawPk.length === 1) {
+          const flat = Array.isArray(value) ? value.flat(Infinity) : value;
+          return assocPb.expandFromHash({ [rawPk[0]]: flat });
+        }
         const values = Array.isArray(value) ? value : [value];
         const queryGroups: Nodes.Node[][] = values.map((idsSet) => {
           if (!Array.isArray(idsSet)) {
             throw argumentError(
-              `Expected corresponding value for [${rawPk.join(", ")}] to be an Array`,
+              `Expected corresponding value for [${rawPk.map((c) => `"${c}"`).join(", ")}] to be an Array`,
             );
           }
           const zipped: Record<string, unknown> = {};


### PR DESCRIPTION
## Summary

Converges the through-association arm of `buildFromHashAssociation` (`packages/activerecord/src/relation/predicate-builder.ts`) on Rails' `expand_from_hash` through branch (predicate_builder.rb:110-113), which is a bare recursion:

```ruby
next associated_table.predicate_builder.expand_from_hash(
  associated_table.primary_key => value
)
```

- **No AssociationQueryValue pre-normalization** — the recursion's column arm already coerces records (`build`'s `value.id if respond_to?(:id)`), arrays, and Relations, matching Rails.
- **Flat splice** — predicates return flat (Rails' `next` inside `flat_map`), keeping each predicate addressable for `WhereClause#extract_attributes` / `rewhere`. (The `Nodes.And` wrapper was already replaced by `groupingQueries` in #5151; this removes the group indirection entirely.)
- **PK sourced from `TableMetadata#primaryKey`** — the exact analogue of Rails' `associated_table.primary_key` (`klass&.primary_key`), replacing the previous `klass?.primaryKey ?? "id"` reach-through.
- **Composite PK no longer throws** the invented "Slot B" error. JS object keys can't be arrays, so Rails' array-key branch of `expand_from_hash` (predicate_builder.rb:87-97) is mirrored inline: the degenerate size-1 key flattens the value and recurses normally; otherwise one recursion per ids tuple zipped against the PK columns, then `groupingQueries` — including Rails' verbatim `ArgumentError` (`Expected corresponding value for ["author_id", "id"] to be an Array`) for a non-array tuple.

## Testing

- New trails-only regression tests in `predicate-builder.trails.test.ts` (both fail on baseline, which threw "Slot B"): composite-PK through tuples route flat for one group / `Grouping(Or)` for multiple, and non-tuple values raise Rails' ArgumentError.
- `pnpm vitest run` on predicate-builder, where, finder-methods, through-association-scope, has-one-through, has-many-through suites — all green (319 passed).

Closes-story: through-branch-prenormalizes-and-wraps-vs-rails-bare-recursion
