### PR TITLE
fix(activerecord): read SchemaDumper ignore patterns in abstract export-name getters

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
@@ -1,0 +1,43 @@
+// TS-only unit coverage: the abstract definition getters must read the
+// configurable SchemaDumper ignore patterns at call time (Rails'
+// export_name_on_schema_dump? reads SchemaDumper.fk_ignore_pattern /
+// .chk_ignore_pattern), not a hardcoded copy of the default regex.
+import { describe, it, expect, afterEach } from "vitest";
+import { ForeignKeyDefinition, CheckConstraintDefinition } from "./schema-definitions.js";
+import { SchemaDumper } from "../../schema-dumper.js";
+
+const originalFkPattern = SchemaDumper.fkIgnorePattern;
+const originalChkPattern = SchemaDumper.chkIgnorePattern;
+
+afterEach(() => {
+  SchemaDumper.fkIgnorePattern = originalFkPattern;
+  SchemaDumper.chkIgnorePattern = originalChkPattern;
+});
+
+describe("ForeignKeyDefinition#export_name_on_schema_dump?", () => {
+  const fk = (name: string): ForeignKeyDefinition =>
+    new ForeignKeyDefinition("astronauts", "rockets", "rocket_id", "id", name);
+
+  it("honors a custom SchemaDumper.fkIgnorePattern at call time", () => {
+    expect(fk("ignored_fk_astronauts_rockets").isExportNameOnSchemaDump).toBe(true);
+    expect(fk("fk_rails_0123456789").isExportNameOnSchemaDump).toBe(false);
+
+    SchemaDumper.fkIgnorePattern = /^ignored_/;
+    expect(fk("ignored_fk_astronauts_rockets").isExportNameOnSchemaDump).toBe(false);
+    expect(fk("fk_rails_0123456789").isExportNameOnSchemaDump).toBe(true);
+  });
+});
+
+describe("CheckConstraintDefinition#export_name_on_schema_dump?", () => {
+  const chk = (name: string): CheckConstraintDefinition =>
+    new CheckConstraintDefinition("trades", "price > 0", name);
+
+  it("honors a custom SchemaDumper.chkIgnorePattern at call time", () => {
+    expect(chk("ignored_chk_trades_price").isExportNameOnSchemaDump).toBe(true);
+    expect(chk("chk_rails_0123456789").isExportNameOnSchemaDump).toBe(false);
+
+    SchemaDumper.chkIgnorePattern = /^ignored_/;
+    expect(chk("ignored_chk_trades_price").isExportNameOnSchemaDump).toBe(false);
+    expect(chk("chk_rails_0123456789").isExportNameOnSchemaDump).toBe(true);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
@@ -1,7 +1,3 @@
-// TS-only unit coverage: the abstract definition getters must read the
-// configurable SchemaDumper ignore patterns at call time (Rails'
-// export_name_on_schema_dump? reads SchemaDumper.fk_ignore_pattern /
-// .chk_ignore_pattern), not a hardcoded copy of the default regex.
 import { describe, it, expect, afterEach } from "vitest";
 import { ForeignKeyDefinition, CheckConstraintDefinition } from "./schema-definitions.js";
 import { SchemaDumper } from "../../schema-dumper.js";

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
@@ -22,6 +22,13 @@ describe("ForeignKeyDefinition#export_name_on_schema_dump?", () => {
     expect(fk("ignored_fk_astronauts_rockets").isExportNameOnSchemaDump).toBe(false);
     expect(fk("fk_rails_0123456789").isExportNameOnSchemaDump).toBe(true);
   });
+
+  it("stays stable across repeated calls with a g-flagged pattern", () => {
+    SchemaDumper.fkIgnorePattern = /^ignored_/g;
+    const definition = fk("ignored_fk_astronauts_rockets");
+    expect(definition.isExportNameOnSchemaDump).toBe(false);
+    expect(definition.isExportNameOnSchemaDump).toBe(false);
+  });
 });
 
 describe("CheckConstraintDefinition#export_name_on_schema_dump?", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -11,6 +11,20 @@ import { SchemaDumper } from "../../schema-dumper.js";
  * like `COLLATE \`utf8mb4_bin\``. This regex substitutes for quoting: only
  * safe charset/collation names pass.
  */
+/**
+ * @internal RegExp#test with a g/y-flagged pattern mutates shared lastIndex
+ * state across calls (Ruby's Regexp#match? has no such statefulness), so a
+ * user-configured ignore pattern with those flags would alternate results.
+ * schema-dumper.ts strips the flags the same way in its fallback paths.
+ */
+function statelessTest(pattern: RegExp, value: string): boolean {
+  const stateless =
+    pattern.global || pattern.sticky
+      ? new RegExp(pattern.source, pattern.flags.replace(/[gy]/g, ""))
+      : pattern;
+  return stateless.test(value);
+}
+
 export function assertSafeMysqlIdentifier(value: string, kind: string): void {
   if (!/^[A-Za-z0-9_]+$/.test(value)) {
     throw new ArgumentError(`Invalid MySQL ${kind}: ${JSON.stringify(value)}`);
@@ -280,7 +294,7 @@ export class ForeignKeyDefinition {
 
   // Mirrors: ActiveRecord::ConnectionAdapters::ForeignKeyDefinition#export_name_on_schema_dump?
   get isExportNameOnSchemaDump(): boolean {
-    return !SchemaDumper.fkIgnorePattern.test(this.name);
+    return !statelessTest(SchemaDumper.fkIgnorePattern, this.name);
   }
 
   isDefinedFor(options: ForeignKeyLookupOptions = {}): boolean {
@@ -351,7 +365,7 @@ export class CheckConstraintDefinition {
   }
 
   get isExportNameOnSchemaDump(): boolean {
-    return this.name ? !SchemaDumper.chkIgnorePattern.test(this.name) : false;
+    return this.name ? !statelessTest(SchemaDumper.chkIgnorePattern, this.name) : false;
   }
 
   isDefinedFor(options: { name: string; expression?: string; validate?: boolean }): boolean {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -2,6 +2,7 @@ import { ABSTRACT_SCHEMA_QUOTER } from "./quoting.js";
 import type { SchemaQuoter } from "./assert-schema-adapter.js";
 import { singularize, pluralize, getCrypto } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
+import { SchemaDumper } from "../../schema-dumper.js";
 
 /**
  * @internal Shared identifier guard for MySQL bare-identifier emission
@@ -279,7 +280,7 @@ export class ForeignKeyDefinition {
 
   // Mirrors: ActiveRecord::ConnectionAdapters::ForeignKeyDefinition#export_name_on_schema_dump?
   get isExportNameOnSchemaDump(): boolean {
-    return !/^fk_rails_[0-9a-f]{10}$/.test(this.name);
+    return !SchemaDumper.fkIgnorePattern.test(this.name);
   }
 
   isDefinedFor(options: ForeignKeyLookupOptions = {}): boolean {
@@ -350,7 +351,7 @@ export class CheckConstraintDefinition {
   }
 
   get isExportNameOnSchemaDump(): boolean {
-    return this.name ? !/^chk_rails_[0-9a-f]{10}$/.test(this.name) : false;
+    return this.name ? !SchemaDumper.chkIgnorePattern.test(this.name) : false;
   }
 
   isDefinedFor(options: { name: string; expression?: string; validate?: boolean }): boolean {


### PR DESCRIPTION
## Summary

Rails' `ForeignKeyDefinition#export_name_on_schema_dump?` and
`CheckConstraintDefinition#export_name_on_schema_dump?` read the configurable
class attributes `ActiveRecord::SchemaDumper.fk_ignore_pattern` /
`.chk_ignore_pattern` at call time
(vendor/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb:150-152,185-187).
Trails hardcoded the default regexes in both abstract getters, so a
user-configured pattern was ignored — while the PG definitions
(`ExclusionConstraintDefinition` / `UniqueConstraintDefinition`) already read
`SchemaDumper.exclIgnorePattern` / `.uniqueIgnorePattern` dynamically.

Both abstract getters now read `SchemaDumper.fkIgnorePattern` /
`.chkIgnorePattern` at call time. No import cycle: schema-dumper.ts does not
import the abstract schema-definitions module, and the PG schema-definitions
file already imports SchemaDumper the same way.

## Test plan

- New `schema-definitions.trails.test.ts` (TS-only unit coverage): setting a
  custom `SchemaDumper.fkIgnorePattern` / `chkIgnorePattern` flips the getter
  result; patterns restored in `afterEach`.
- Existing `schema-definitions.test.ts` and `schema-dumper.test.ts` pass.

Closes-story: fk-chk-export-name-hardcodes-ignore-pattern
