### PR TITLE
fix(activerecord): YAML coder safe-dump raises Psych::DisallowedClass on previous-scheme AdditionalValue

### DIFF
--- a/packages/activerecord/src/attribute-methods/serialization.ts
+++ b/packages/activerecord/src/attribute-methods/serialization.ts
@@ -9,7 +9,7 @@
 
 import { JSON as CodersJSON } from "../coders/json.js";
 import { ColumnSerializer as CodersColumnSerializer } from "../coders/column-serializer.js";
-import { YAMLColumn } from "../coders/yaml-column.js";
+import { YAMLColumn, type YamlColumnOptions } from "../coders/yaml-column.js";
 
 export interface Serialization {
   serialize(attribute: string, options?: { coder?: unknown }): void;
@@ -101,16 +101,15 @@ export function buildColumnSerializer(
   attrName: string,
   coder: unknown,
   type: unknown,
-  _yaml?: Record<string, unknown>,
+  yaml?: YamlColumnOptions,
 ): unknown {
   const resolvedCoder = coder === globalThis.JSON ? CodersJSON : coder;
 
   // Mirrors Rails' `coder == ::YAML || coder == Coders::YAMLColumn`. The string
   // "YAML" is the trails analog of Ruby's `::YAML` module constant. Rails forwards
-  // `**(yaml || {})` (permitted_classes/unsafe_load) into the YAMLColumn ctor; those
-  // Psych safe-load keywords have no JS analog, so the `_yaml` option set is dropped.
+  // `**(yaml || {})` (permitted_classes/unsafe_load) into the YAMLColumn ctor.
   if (resolvedCoder === "YAML" || resolvedCoder === YAMLColumn) {
-    return new YAMLColumn(attrName, type as new (...args: unknown[]) => unknown);
+    return new YAMLColumn(attrName, type as new (...args: unknown[]) => unknown, yaml ?? {});
   }
 
   if (typeof resolvedCoder === "function" && !("load" in resolvedCoder)) {

--- a/packages/activerecord/src/coders/yaml-column.test.ts
+++ b/packages/activerecord/src/coders/yaml-column.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { YAMLColumn, DisallowedClass } from "./yaml-column.js";
 import { setUseYamlUnsafeLoad } from "../ar-config.js";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 
-// Trails-only round-trip coverage. The YAMLColumnTest / YAMLColumnTestWithSafeLoad
-// blocks below stay Ruby-only (Psych safe-load / permitted-classes have no JS
-// analog); these assert the dump/load contract the store coder relies on.
+// Trails-only round-trip coverage plus the ported safe-dump restriction. The
+// remaining YAMLColumnTest / YAMLColumnTestWithSafeLoad skips stay Ruby-only
+// (Psych safe-LOAD / permitted-classes-on-load have no JS analog).
 describe("YAMLColumn round-trip", () => {
   it("dumps and loads a plain hash", () => {
     const coder = new YAMLColumn("params");
@@ -88,8 +89,11 @@ describe("YAMLColumnTestWithSafeLoad", () => {
   it.skip("yaml column permitted classes are consumed by safe load", () => {
     // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — yaml
   });
-  it.skip("yaml column permitted classes are consumed by safe dump", () => {
-    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — yaml
+  it("yaml column permitted classes are consumed by safe dump", () => {
+    // Rails: `assert_raises(Psych::DisallowedClass) { coder.dump([Time.new]) }`.
+    // Temporal is the trails Time analog; it's outside the permitted set.
+    const coder = new YAMLColumn("attr_name");
+    expect(() => coder.dump([Temporal.Now.instant()])).toThrow(DisallowedClass);
   });
   it.skip("yaml column permitted classes option", () => {
     // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — yaml

--- a/packages/activerecord/src/coders/yaml-column.test.ts
+++ b/packages/activerecord/src/coders/yaml-column.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest";
-import { YAMLColumn } from "./yaml-column.js";
+import { describe, it, expect, afterEach } from "vitest";
+import { YAMLColumn, DisallowedClass } from "./yaml-column.js";
+import { setUseYamlUnsafeLoad } from "../ar-config.js";
 
 // Trails-only round-trip coverage. The YAMLColumnTest / YAMLColumnTestWithSafeLoad
 // blocks below stay Ruby-only (Psych safe-load / permitted-classes have no JS
@@ -23,6 +24,33 @@ describe("YAMLColumn round-trip", () => {
     const coder = new YAMLColumn("params");
     const value = { a: [1, 2, { b: "x" }], c: { d: true } };
     expect(coder.load(coder.dump(value))).toEqual(value);
+  });
+
+  // Rails-verified (vendored Rails, Psych >= 5.1): safe_dump raises
+  // Psych::DisallowedClass on any class instance outside the permitted set —
+  // top-level or nested — while `ActiveRecord.use_yaml_unsafe_load = true`
+  // switches to the unrestricted `::YAML.dump` branch (yaml_column.rb:15-24).
+  describe("safe dump", () => {
+    afterEach(() => setUseYamlUnsafeLoad(false));
+
+    class Unpermitted {
+      secret = "s3cret";
+    }
+
+    it("raises DisallowedClass when dumping an unpermitted class instance", () => {
+      const coder = new YAMLColumn("params");
+      expect(() => coder.dump(new Unpermitted())).toThrow(DisallowedClass);
+      expect(() => coder.dump(new Unpermitted())).toThrow(
+        /Tried to dump unspecified class: Unpermitted/,
+      );
+      expect(() => coder.dump({ nested: [new Unpermitted()] })).toThrow(DisallowedClass);
+    });
+
+    it("dumps unpermitted class instances when use_yaml_unsafe_load is set", () => {
+      setUseYamlUnsafeLoad(true);
+      const coder = new YAMLColumn("params");
+      expect(coder.dump(new Unpermitted())).toContain("s3cret");
+    });
   });
 });
 

--- a/packages/activerecord/src/coders/yaml-column.ts
+++ b/packages/activerecord/src/coders/yaml-column.ts
@@ -1,21 +1,43 @@
 import { parse as yamlParse, stringify as yamlStringify } from "@blazetrails/activesupport/yaml";
+import { useYamlUnsafeLoad, yamlColumnPermittedClasses } from "../ar-config.js";
 import { ColumnSerializer } from "./column-serializer.js";
 
 type ClassLike = new (...args: unknown[]) => unknown;
 
 /**
+ * Mirror of `Psych::DisallowedClass` — raised when `safe_dump` (or
+ * `safe_load`) encounters a class instance outside the permitted set. Rails
+ * hits this when an arbitrary object reaches a YAML column's coder, e.g. an
+ * encryption previous-scheme `AdditionalValue` reaching `Serialized#serialize`
+ * during extended deterministic query expansion — the raise fires before any
+ * payload exists, so no scheme/key material can leak into a dumped candidate.
+ */
+export class DisallowedClass extends globalThis.Error {
+  constructor(action: string, klassName: string) {
+    super(`Tried to ${action} unspecified class: ${klassName}`);
+    this.name = "Psych::DisallowedClass";
+  }
+}
+
+/**
  * Inner coder that does the raw YAML encode/decode. Rails wraps Psych's
- * safe_load/safe_dump with permitted-classes / unsafe-load options; those guard
- * against deserializing arbitrary Ruby objects and have no analog in trails
- * (the `yaml` package only ever produces plain JS values), so this degenerates
- * to a plain parse/stringify pair.
+ * safe_load/safe_dump with permitted-classes / unsafe-load options. The
+ * safe_load side has no analog in trails (the `yaml` package only ever
+ * produces plain JS values), so `load` degenerates to a plain parse — but the
+ * safe_dump side does: dumping a class instance that isn't in the permitted
+ * set raises `Psych::DisallowedClass`, exactly like Psych's `safe_dump`.
+ * `ActiveRecord.use_yaml_unsafe_load` switches to the unrestricted dump, like
+ * Rails' `::YAML.dump` branch.
  *
  * Mirrors: ActiveRecord::Coders::YAMLColumn::SafeCoder
  *
  * @internal
  */
 class SafeCoder {
+  constructor(private readonly permittedClasses: unknown[] = []) {}
+
   dump(object: unknown): string {
+    if (!useYamlUnsafeLoad) this.assertDumpable(object);
     return yamlStringify(object, { directives: true });
   }
 
@@ -26,6 +48,31 @@ class SafeCoder {
     // non-string never reaches here; like Rails (which raises on a non-String/IO
     // argument) we don't silently coerce bad input.
     return yamlParse(payload as string);
+  }
+
+  /**
+   * Psych `safe_dump` visitor analog: scalars, arrays, and plain hashes are
+   * always dumpable; any other object must be an instance of a permitted
+   * class (`permitted_classes` + `ActiveRecord.yaml_column_permitted_classes`)
+   * or the dump raises `Psych::DisallowedClass`.
+   */
+  private assertDumpable(value: unknown, seen = new Set<object>()): void {
+    if (value === null || typeof value !== "object") return;
+    if (seen.has(value)) return;
+    seen.add(value);
+    if (Array.isArray(value)) {
+      for (const element of value) this.assertDumpable(element, seen);
+      return;
+    }
+    const proto = Object.getPrototypeOf(value);
+    if (proto === Object.prototype || proto === null) {
+      for (const element of Object.values(value)) this.assertDumpable(element, seen);
+      return;
+    }
+    for (const permitted of [...this.permittedClasses, ...yamlColumnPermittedClasses]) {
+      if (typeof permitted === "function" && value instanceof permitted) return;
+    }
+    throw new DisallowedClass("dump", value.constructor?.name ?? "Object");
   }
 }
 

--- a/packages/activerecord/src/coders/yaml-column.ts
+++ b/packages/activerecord/src/coders/yaml-column.ts
@@ -34,10 +34,13 @@ export class DisallowedClass extends globalThis.Error {
  * @internal
  */
 class SafeCoder {
-  constructor(private readonly permittedClasses: unknown[] = []) {}
+  constructor(
+    private readonly permittedClasses: unknown[] = [],
+    private readonly unsafeLoad: boolean | null = null,
+  ) {}
 
   dump(object: unknown): string {
-    if (!useYamlUnsafeLoad) this.assertDumpable(object);
+    if (!(this.unsafeLoad ?? useYamlUnsafeLoad)) this.assertDumpable(object);
     return yamlStringify(object, { directives: true });
   }
 
@@ -93,7 +96,21 @@ class SafeCoder {
  * @internal
  */
 export class YAMLColumn extends ColumnSerializer {
-  constructor(attrName: string, objectClass: ClassLike = Object as unknown as ClassLike) {
-    super(attrName, new SafeCoder(), objectClass);
+  constructor(
+    attrName: string,
+    objectClass: ClassLike = Object as unknown as ClassLike,
+    { permittedClasses = [], unsafeLoad = null }: YamlColumnOptions = {},
+  ) {
+    super(attrName, new SafeCoder(permittedClasses ?? [], unsafeLoad), objectClass);
   }
+}
+
+/**
+ * The `yaml:` option set Rails' `serialize` forwards into the YAMLColumn ctor
+ * (`**(yaml || {})`, serialization.rb:215) — camelCase analogs of Psych's
+ * `permitted_classes:` / `unsafe_load:` keywords.
+ */
+export interface YamlColumnOptions {
+  permittedClasses?: unknown[];
+  unsafeLoad?: boolean | null;
 }

--- a/packages/activerecord/src/coders/yaml-column.ts
+++ b/packages/activerecord/src/coders/yaml-column.ts
@@ -69,6 +69,11 @@ class SafeCoder {
     }
     const proto = Object.getPrototypeOf(value);
     if (proto === Object.prototype || proto === null) {
+      // Only values are recursed, not keys: unlike Psych's mapping-node visit
+      // (which checks both), a plain-object key in JS is always a string scalar,
+      // so no disallowed class can hide there. A Map or other non-plain object
+      // isn't Object.prototype-proto'd and falls through to the permitted-class
+      // check below, raising just like an unpermitted value would.
       for (const element of Object.values(value)) this.assertDumpable(element, seen);
       return;
     }

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.trails.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.trails.test.ts
@@ -16,6 +16,7 @@ import { getAttributeType, encryptedTypeOf } from "./encryptable-record.js";
 import "../encryption.js";
 import { Base } from "../base.js";
 import { Relation } from "../relation.js";
+import { DisallowedClass } from "../coders/yaml-column.js";
 
 fixtures([], { useTransactionalTests: false });
 
@@ -33,7 +34,7 @@ const PREVIOUS_KEY = Buffer.alloc(32, "y").toString("base64");
  * EncryptedAttributeType, or the expansion ciphertext diverges from the
  * write path and the lookup silently misses.
  */
-function buildSerializedBook({ previousSchemes = false } = {}) {
+function buildSerializedBook({ previousSchemes = false, coder = "json" } = {}) {
   class EncryptedSerializedBook extends Base {
     static {
       this._tableName = "books";
@@ -53,7 +54,7 @@ function buildSerializedBook({ previousSchemes = false } = {}) {
           ? { previousSchemes: [new Scheme({ deterministic: true, key: PREVIOUS_KEY })] }
           : {}),
       });
-      this.serialize("name", { coder: "json" });
+      this.serialize("name", { coder });
     }
   }
   return EncryptedSerializedBook;
@@ -62,6 +63,7 @@ function buildSerializedBook({ previousSchemes = false } = {}) {
 describe("ActiveRecord::Encryption::ExtendedDeterministicQueriesTest (trails extras)", () => {
   let EncryptedSerializedBook: ReturnType<typeof buildSerializedBook>;
   let PreviousSchemeSerializedBook: ReturnType<typeof buildSerializedBook>;
+  let PreviousSchemeYamlBook: ReturnType<typeof buildSerializedBook>;
 
   const savedConfig = {
     extendQueries: Configurable.config.extendQueries,
@@ -91,6 +93,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueriesTest (trails ext
 
     EncryptedSerializedBook = buildSerializedBook();
     PreviousSchemeSerializedBook = buildSerializedBook({ previousSchemes: true });
+    PreviousSchemeYamlBook = buildSerializedBook({ previousSchemes: true, coder: "YAML" });
     // Warm the books table once so the first create doesn't race the
     // test-adapter's schema-recovery path (see the port suite's note).
     await EncryptedSerializedBook.where("1=1");
@@ -146,6 +149,29 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueriesTest (trails ext
       .previousTypes[0];
     const av = new AdditionalValue("Dune", prevType);
     expect(() => fullType.serialize(av)).toThrow(NoMethodError);
+  });
+
+  // Rails-verified (vendored Rails, sqlite3, extend_queries installed): with
+  // the YAML coder, the previous-scheme AdditionalValue reaches
+  // Coders::YAMLColumn#dump and Psych's safe_dump raises
+  // `Psych::DisallowedClass: Tried to dump unspecified class:
+  // ActiveRecord::Encryption::ExtendedDeterministicQueries::AdditionalValue`.
+  // Like the JSON path, the raise fires before any payload or SQL exists, so
+  // no scheme/key material can land in a bind.
+  it("raises Psych::DisallowedClass when a previous-scheme candidate reaches the YAML coder", async () => {
+    await expect(PreviousSchemeYamlBook.findBy({ name: "Dune" })).rejects.toThrow(DisallowedClass);
+    await expect(PreviousSchemeYamlBook.where({ name: "Dune" }).first()).rejects.toThrow(
+      DisallowedClass,
+    );
+
+    const fullType = getAttributeType(PreviousSchemeYamlBook, "name") as {
+      serialize(v: unknown): unknown;
+    };
+    const prevType = encryptedTypeOf(getAttributeType(PreviousSchemeYamlBook, "name"))!
+      .previousTypes[0];
+    const av = new AdditionalValue("Dune", prevType);
+    expect(() => fullType.serialize(av)).toThrow(DisallowedClass);
+    expect(() => fullType.serialize(av)).toThrow(/Tried to dump unspecified class/);
   });
 
   it("uniqueness ciphertext generation serializes through the full resolved type", () => {

--- a/packages/activerecord/src/serialize.ts
+++ b/packages/activerecord/src/serialize.ts
@@ -7,6 +7,7 @@ import {
   isTypeIncompatibleWithSerialize,
   buildColumnSerializer,
 } from "./attribute-methods/serialization.js";
+import type { YamlColumnOptions } from "./coders/yaml-column.js";
 
 interface InnerCoder {
   dump(value: unknown): string | null;
@@ -52,6 +53,8 @@ type CoderOption = "json" | "array" | "hash" | InnerCoder | (new (...args: any[]
 export interface SerializeOptions {
   coder?: CoderOption;
   type?: "Array" | "Hash" | typeof Array | typeof Object | (new (...args: any[]) => any);
+  /** Rails `serialize :x, coder: YAML, yaml: { permitted_classes: [...] }`. */
+  yaml?: YamlColumnOptions;
 }
 
 /**
@@ -113,7 +116,7 @@ function resolveSerializer(
     objectType = t;
   }
 
-  const coder = buildColumnSerializer(attribute, rawCoder, objectType) as Coder;
+  const coder = buildColumnSerializer(attribute, rawCoder, objectType, options.yaml) as Coder;
   return { coder, coderIdentity, objectType };
 }
 

--- a/packages/activerecord/src/serialized-attribute.test.ts
+++ b/packages/activerecord/src/serialized-attribute.test.ts
@@ -3,7 +3,8 @@
  * Test names are chosen to match Ruby test names from the Rails test suite.
  * Mirrors: activerecord/test/cases/serialized_attribute_test.rb
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+import { setUseYamlUnsafeLoad } from "./ar-config.js";
 import { ValueType, MissingAttributeError } from "@blazetrails/activemodel";
 import { Base, serialize, SerializationTypeMismatch } from "./index.js";
 import { HashObject } from "./serialize.js";
@@ -37,6 +38,12 @@ class MyObject {
 
 describe("SerializedAttributeTest", () => {
   const { topics, posts } = fixtures(["topics", "posts"]);
+
+  // Rails: `setup { ActiveRecord.use_yaml_unsafe_load = true }`
+  // (serialized_attribute_test.rb:10) — the default YAML coder safe-dumps, and
+  // these tests serialize non-permitted classes like MyObject.
+  beforeEach(() => setUseYamlUnsafeLoad(true));
+  afterAll(() => setUseYamlUnsafeLoad(false));
 
   it("serialize does not eagerly load columns", () => {
     // Rails: assert_no_queries { Topic.serialize(:content) }

--- a/packages/activerecord/src/store.ts
+++ b/packages/activerecord/src/store.ts
@@ -2,6 +2,7 @@ import { ConfigurationError } from "./errors.js";
 import type { Base } from "./base.js";
 import { HashWithIndifferentAccess } from "@blazetrails/activesupport";
 import { buildColumnSerializer } from "./attribute-methods/serialization.js";
+import type { YamlColumnOptions } from "./coders/yaml-column.js";
 import { getOrCreateModuleCarrier } from "./module-carrier.js";
 
 // Injected by base.ts to break the store→serialize→json→store circular dep.
@@ -324,7 +325,7 @@ export interface StoreOptions {
   prefix?: boolean | string;
   suffix?: boolean | string;
   coder?: unknown;
-  yaml?: Record<string, unknown>;
+  yaml?: YamlColumnOptions;
 }
 
 /**

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -109,10 +109,11 @@ export const UNPORTED_FILES: UnportedFile[] = [
     pattern: "coders/yaml_column.rb",
     testFile: "coders/yaml_column_test.rb",
     reason:
-      "YAML column coder. The store-column dump/load path is ported (coders/yaml-column.ts, " +
-      'backed by the `yaml` package — `store :col, coder: "YAML"`), but the Psych-specific ' +
-      "safe-load machinery (permitted_classes, unsafe_load, type-mismatch-on-Ruby-class) has " +
-      "no JS analog; those test cases stay Ruby-only.",
+      "YAML column coder. The store-column dump/load path and the Psych safe-dump class " +
+      "restriction are ported (coders/yaml-column.ts, backed by the `yaml` package — " +
+      '`store :col, coder: "YAML"`), but the Psych-specific safe-LOAD machinery ' +
+      "(permitted_classes on load, type-mismatch-on-Ruby-class) has no JS analog; those " +
+      "test cases stay Ruby-only.",
   },
   {
     pattern: "fixtures.rb",


### PR DESCRIPTION
## Summary

Story: **yaml-coder-previous-scheme-av-dump** (RFC 0055-serialization-fidelity).

PR #5155 converged the JSON-coder path (previous-scheme `AdditionalValue` reaching `Serialized#serialize` raises `NoMethodError` via as_json). The YAML-coder path was unverified: trails' `YamlColumn` SafeCoder was a plain `yaml.stringify`, so an AV reaching it was **silently dumped** — previous-scheme type internals serialized into an encrypted garbage candidate.

### Rails verification

Reproduced in vendored Rails (sqlite3, `encrypts` + `serialize coder: YAML` + `previous:` + `ExtendedDeterministicQueries.install_support`):

```
find_by raised:      Psych::DisallowedClass: Tried to dump unspecified class: ActiveRecord::Encryption::ExtendedDeterministicQueries::AdditionalValue
where raised:        Psych::DisallowedClass: (same)
serialize(AV) raised: Psych::DisallowedClass: (same)
```

The raise fires inside Psych `safe_dump` before any payload or SQL exists — no scheme/key material can land in a bind.

### Convergence

- `coders/yaml-column.ts`: SafeCoder now emulates Psych `safe_dump` — scalars, arrays, and plain hashes dump; any other class instance raises the new `DisallowedClass` (`Psych::DisallowedClass`, "Tried to dump unspecified class: X") unless permitted via `yamlColumnPermittedClasses` or `useYamlUnsafeLoad` is set (mirrors yaml_column.rb:15-24 branch structure). Load side unchanged (safe_load still has no JS analog).
- `serialized-attribute.test.ts`: mirrors Rails' `setup { ActiveRecord.use_yaml_unsafe_load = true }` (serialized_attribute_test.rb:10) — those tests serialize non-permitted classes like `MyObject` through the default YAML coder.

### Guard tests (fail on baseline — verified)

- `extended-deterministic-queries.trails.test.ts`: yaml-coder variant of the previous-scheme raise test — `findBy`/`where`/direct `serialize(AV)` all raise `DisallowedClass` before any SQL.
- `yaml-column.test.ts`: coder-level pins — unpermitted instance (top-level and nested) raises; `useYamlUnsafeLoad` restores the unrestricted dump.

Closes-story: yaml-coder-previous-scheme-av-dump
