### PR TITLE
refactor(postgresql): drop static FORMAT_TYPE_ALIASES string-lookup path

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
@@ -146,36 +146,14 @@ describe("PostgreSQLAdapter#lookupCastTypeFromColumn", () => {
     expect(type).toBeInstanceOf(Uuid);
   });
 
-  it("falls back to sqlType lookup when oid is missing", () => {
-    const type = adapter.lookupCastTypeFromColumn({
-      oid: null,
-      sqlType: "uuid",
-      name: "guid",
-    });
-    expect(type).toBeInstanceOf(Uuid);
+  it("returns a ValueType when oid is missing", () => {
+    const type = adapter.lookupCastTypeFromColumn({ oid: null, sqlType: "uuid", name: "guid" });
+    expect(type).toBeInstanceOf(ValueType);
   });
 
   it("returns a ValueType when neither oid nor sqlType is available", () => {
     const type = adapter.lookupCastTypeFromColumn({});
     expect(type).toBeInstanceOf(ValueType);
-  });
-
-  it("normalizes format_type output to typname for the sqlType fallback", () => {
-    // pg_catalog.format_type returns "integer", "character varying(255)",
-    // etc. Our type_map is keyed by typname (int4, varchar). The
-    // fallback needs to map between them so the well-known types
-    // resolve when oid is missing. Check for specific resolved types
-    // rather than `not ValueType` — concrete types now extend
-    // ValueType, so every typed instance is also an instanceof ValueType.
-    const integer = adapter.lookupCastTypeFromColumn({ oid: null, sqlType: "integer" });
-    expect(integer.constructor).not.toBe(ValueType);
-    const varchar = adapter.lookupCastTypeFromColumn({
-      oid: null,
-      sqlType: "character varying(255)",
-    });
-    expect(varchar.constructor).not.toBe(ValueType);
-    const bigint = adapter.lookupCastTypeFromColumn({ oid: null, sqlType: "bigint" });
-    expect(bigint.constructor).not.toBe(ValueType);
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -963,19 +963,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     name?: string;
   }): Type {
     const oid = column.oid;
-    if (oid == null) {
-      if (column.sqlType) {
-        // Pass the original sqlType + fmod so registerClassWithLimit /
-        // numeric / interval factories can still extract limit /
-        // precision / scale from the modifier.
-        return this.typeMap.lookup(
-          normalizeFormatType(column.sqlType),
-          column.fmod ?? -1,
-          column.sqlType,
-        );
-      }
-      return new ValueType();
-    }
+    // Rails keys this lookup on (oid, fmod, sql_type) only — a column without
+    // an OID (a bare ColumnDefinition) resolves via `lookupCastType`'s live
+    // regtype query instead (quoting.rb:195), never through a string map.
+    if (oid == null) return new ValueType();
     // Rails' lookup_cast_type_from_column only *looks up* — it never
     // mutates the type_map on miss. Registering a fallback here would
     // poison the map: subsequent getOidType calls would see
@@ -5460,43 +5451,6 @@ export function splitPgDefault(raw: string | null): { literal: unknown; fn: stri
  * unrecognized expression and does not populate Column#default_function.
  */
 const DEFAULT_FUNCTION_RE = /\w+\(.*\)|\(.*\)::\w+|CURRENT_DATE|CURRENT_TIMESTAMP/;
-
-/**
- * Normalize a `pg_catalog.format_type(...)` string to the typname the
- * static type_map is keyed by. PG returns human-friendly forms like
- * "integer" / "character varying(255)" / "bigint", but we register
- * "int4" / "varchar" / "int8". Strip size modifiers and alias common
- * formatted names so the fallback path in lookupCastTypeFromColumn
- * resolves well-known *scalar* types.
- *
- * Array types (e.g. "integer[]") are deliberately left as-is — they
- * don't have a static registration, so the lookup misses and returns
- * ValueType. Mapping them to the scalar typname (int4) would
- * incorrectly deserialize array values with a scalar type.
- */
-function normalizeFormatType(sqlType: string): string {
-  if (/\[\]\s*$/.test(sqlType)) return sqlType;
-  const base = sqlType
-    .replace(/\(.*\)/, "")
-    .trim()
-    .toLowerCase();
-  return FORMAT_TYPE_ALIASES[base] ?? base;
-}
-
-const FORMAT_TYPE_ALIASES: Record<string, string> = {
-  smallint: "int2",
-  integer: "int4",
-  bigint: "int8",
-  real: "float4",
-  "double precision": "float8",
-  "character varying": "varchar",
-  character: "bpchar",
-  "timestamp without time zone": "timestamp",
-  "timestamp with time zone": "timestamptz",
-  "time without time zone": "time",
-  "time with time zone": "timetz",
-  boolean: "bool",
-};
 
 (PostgreSQLAdapter.prototype as any).performQuery = performQuery;
 (PostgreSQLAdapter.prototype as any).castResult = castResult;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -963,9 +963,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     name?: string;
   }): Type {
     const oid = column.oid;
-    // Rails keys this lookup on (oid, fmod, sql_type) only — a column without
-    // an OID (a bare ColumnDefinition) resolves via `lookupCastType`'s live
-    // regtype query instead (quoting.rb:195), never through a string map.
     if (oid == null) return new ValueType();
     // Rails' lookup_cast_type_from_column only *looks up* — it never
     // mutates the type_map on miss. Registering a fallback here would

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
@@ -138,37 +138,6 @@ export class SchemaDumper extends AbstractSchemaDumper {
       : !!(column as any).virtual;
   }
 
-  /**
-   * Since `new_column_from_field` stores the raw default literal (Rails'
-   * extract_value_from_default), an array column's `column.default` arrives as a
-   * PG array literal string (`"{}"`, `"{1,2,3}"`, `"{t,f}"`). The inherited
-   * `schemaDefault` deserializes via `lookupCastTypeFromColumn`, but the dumper's
-   * `ColumnInfo` carries no OID, so the lookup resolves the *array* sqlType
-   * (`"integer[]"`) and can't turn `"{}"` into `[]`. Parse the literal, then run
-   * each element through the *element* cast type's `deserialize` +
-   * `typeCastForSchema` — exactly how Rails' OID::Array dumps array defaults
-   * (e.g. `t`/`f` → `true`/`false`, `1.5` → quoted decimal, `4` → bare integer).
-   * @internal
-   */
-  protected override schemaDefault(column: ColumnInfo): string | undefined {
-    if (column.array && typeof column.default === "string" && /^\{.*\}$/.test(column.default)) {
-      const elements = parsePgArrayLiteral(column.default);
-      if (elements.length === 0) return "[]";
-      const elementType = this.pgAdapter()?.lookupCastTypeFromColumn?.({
-        sqlType: (column.sqlType ?? "").replace(/\[\]\s*$/, ""),
-        fmod: (column as any).fmod ?? -1,
-        name: column.name,
-      });
-      const rendered =
-        typeof elementType?.deserialize === "function" &&
-        typeof elementType?.typeCastForSchema === "function"
-          ? elements.map((el) => elementType.typeCastForSchema(elementType.deserialize(el)))
-          : elements.map((el) => JSON.stringify(el));
-      return `[${rendered.join(", ")}]`;
-    }
-    return super.schemaDefault(column as any);
-  }
-
   /** @internal */
   protected override schemaExpression(column: ColumnInfo): string | undefined {
     if (column.isSerial) return undefined;
@@ -320,31 +289,4 @@ export class SchemaDumper extends AbstractSchemaDumper {
   private pgAdapter(): any {
     return this._adapter();
   }
-}
-
-/**
- * Parse a PG array literal (`"{}"`, `"{1,2,3}"`, `'{"a,b",c}'`) into its string
- * elements, unwrapping double quotes and unescaping `\"` / `\\`.
- */
-function parsePgArrayLiteral(literal: string): string[] {
-  const inner = literal.slice(1, -1);
-  if (inner === "") return [];
-  const elements: string[] = [];
-  let buf = "";
-  let inQuotes = false;
-  for (let i = 0; i < inner.length; i++) {
-    const ch = inner[i];
-    if (ch === "\\") {
-      buf += inner[++i] ?? "";
-    } else if (ch === '"') {
-      inQuotes = !inQuotes;
-    } else if (ch === "," && !inQuotes) {
-      elements.push(buf);
-      buf = "";
-    } else {
-      buf += ch;
-    }
-  }
-  elements.push(buf);
-  return elements;
 }

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -56,6 +56,15 @@ export interface ColumnInfo {
    * `schemaPrecision`) can inspect the raw declaration on live columns.
    */
   sqlType?: string | null;
+  /**
+   * PG type OID (with its modifier) from the live column. Rails' dumper hands the
+   * real Column to `lookup_cast_type_from_column`, which is keyed on
+   * `(oid, fmod, sql_type)` — carry both so `schemaDefault` resolves the same
+   * OID-registered type (e.g. OID::Array for array columns) instead of a
+   * string-keyed fallback.
+   */
+  oid?: number | null;
+  fmod?: number | null;
   primaryKey?: boolean;
   null?: boolean;
   default?: unknown;
@@ -260,6 +269,8 @@ class AdapterSchemaSource implements SchemaSource {
         // than coalescing to the raw sqlType name.
         type: col.type ?? null,
         sqlType: col.sqlType ?? undefined,
+        oid: (col as any).oid ?? undefined,
+        fmod: (col as any).fmod ?? undefined,
         primaryKey: col.primaryKey,
         null: col.null,
         // A virtual column has no user-visible default (Rails Column#has_default?

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -56,13 +56,6 @@ export interface ColumnInfo {
    * `schemaPrecision`) can inspect the raw declaration on live columns.
    */
   sqlType?: string | null;
-  /**
-   * PG type OID (with its modifier) from the live column. Rails' dumper hands the
-   * real Column to `lookup_cast_type_from_column`, which is keyed on
-   * `(oid, fmod, sql_type)` — carry both so `schemaDefault` resolves the same
-   * OID-registered type (e.g. OID::Array for array columns) instead of a
-   * string-keyed fallback.
-   */
   oid?: number | null;
   fmod?: number | null;
   primaryKey?: boolean;


### PR DESCRIPTION
## What

Rails' PG type map is keyed on `(oid, fmod, sql_type)` only; a bare `sql_type`
resolves via the live regtype query (`postgresql/quoting.rb:195`, ported in
#5150), never through a string-keyed alias table. trails still carried an
invented `normalizeFormatType` + `FORMAT_TYPE_ALIASES` fallback consumed by the
`oid == null` branch of `lookupCastTypeFromColumn`, plus a PG-dumper
`schemaDefault` override that leaned on it (a `[]`-stripped scalar `sqlType`)
because the dumper's `ColumnInfo` dropped the OID.

## Audit — callers reaching `lookupCastTypeFromColumn` with `oid == null`

- **DDL default quoting** (`quoteDefaultExpression`, adapter:3648): already
  routes the no-OID (ColumnDefinition) case through `lookupCastType`'s regtype
  query — never touched the alias branch.
- **Schema dumper** (`abstract/schema-dumper.ts schemaDefault`): the *only* real
  consumer of the alias branch, because `AdapterSchemaSource` built `ColumnInfo`
  without the OID. The PG dumper worked around this with a bespoke
  `schemaDefault` override for array defaults.
- Type-caster / model-schema reflection paths always carry a live Column (OID
  present).

## Change

- Carry `oid`/`fmod` through `ColumnInfo` from the live Column so the shared
  `schemaDefault` resolves the real OID-registered type (`OID::Array` for array
  columns) — the same array-default dumping the bespoke override reproduced.
- `oid == null` branch now returns `ValueType`.
- Delete `FORMAT_TYPE_ALIASES`, `normalizeFormatType`, the PG `schemaDefault`
  override, and `parsePgArrayLiteral`.

## Testing

PG (isolated stack): `array.test.ts` (43), `defaults.test.ts`,
`schema-dumper.test.ts`, `uuid`/`json` — all green, including array-default
schema-dump paths. Sync unit dumper tests green.

Closes-story: pg-remove-static-format-type-aliases-lookup
