### PR TITLE
fix(postgresql): route excl/unique exportName getters through stateless g/y-strip test

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { SchemaDumper } from "../../schema-dumper.js";
 import {
   ExclusionConstraintDefinition,
   UniqueConstraintDefinition,
@@ -39,9 +40,29 @@ describe("ExclusionConstraintDefinition", () => {
     });
     expect(autoNamed.exportNameOnSchemaDump()).toBe(false);
   });
+
+  describe("with a g-flagged exclIgnorePattern", () => {
+    afterEach(() => {
+      SchemaDumper.exclIgnorePattern = /^excl_rails_[0-9a-f]{10}$/;
+    });
+
+    it("exportNameOnSchemaDump is stable across repeated calls", () => {
+      SchemaDumper.exclIgnorePattern = /^excl_rails_[0-9a-f]{10}$/g;
+      const autoNamed = new ExclusionConstraintDefinition("t", "x WITH =", {
+        name: "excl_rails_74c9160f55",
+      });
+      expect(autoNamed.exportNameOnSchemaDump()).toBe(false);
+      expect(autoNamed.exportNameOnSchemaDump()).toBe(false);
+      expect(autoNamed.exportNameOnSchemaDump()).toBe(false);
+    });
+  });
 });
 
 describe("UniqueConstraintDefinition", () => {
+  afterEach(() => {
+    SchemaDumper.uniqueIgnorePattern = /^uniq_rails_[0-9a-f]{10}$/;
+  });
+
   it("exposes options as accessors", () => {
     const defn = new UniqueConstraintDefinition("orders", "position", {
       name: "unique_position",
@@ -69,6 +90,16 @@ describe("UniqueConstraintDefinition", () => {
     const autoNamed = new UniqueConstraintDefinition("t", "col", {
       name: "uniq_rails_1e07660b77",
     });
+    expect(autoNamed.exportNameOnSchemaDump()).toBe(false);
+  });
+
+  it("exportNameOnSchemaDump is stable across repeated calls with a g-flagged uniqueIgnorePattern", () => {
+    SchemaDumper.uniqueIgnorePattern = /^uniq_rails_[0-9a-f]{10}$/g;
+    const autoNamed = new UniqueConstraintDefinition("t", "col", {
+      name: "uniq_rails_1e07660b77",
+    });
+    expect(autoNamed.exportNameOnSchemaDump()).toBe(false);
+    expect(autoNamed.exportNameOnSchemaDump()).toBe(false);
     expect(autoNamed.exportNameOnSchemaDump()).toBe(false);
   });
 

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
@@ -59,10 +59,6 @@ describe("ExclusionConstraintDefinition", () => {
 });
 
 describe("UniqueConstraintDefinition", () => {
-  afterEach(() => {
-    SchemaDumper.uniqueIgnorePattern = /^uniq_rails_[0-9a-f]{10}$/;
-  });
-
   it("exposes options as accessors", () => {
     const defn = new UniqueConstraintDefinition("orders", "position", {
       name: "unique_position",
@@ -93,14 +89,20 @@ describe("UniqueConstraintDefinition", () => {
     expect(autoNamed.exportNameOnSchemaDump()).toBe(false);
   });
 
-  it("exportNameOnSchemaDump is stable across repeated calls with a g-flagged uniqueIgnorePattern", () => {
-    SchemaDumper.uniqueIgnorePattern = /^uniq_rails_[0-9a-f]{10}$/g;
-    const autoNamed = new UniqueConstraintDefinition("t", "col", {
-      name: "uniq_rails_1e07660b77",
+  describe("with a g-flagged uniqueIgnorePattern", () => {
+    afterEach(() => {
+      SchemaDumper.uniqueIgnorePattern = /^uniq_rails_[0-9a-f]{10}$/;
     });
-    expect(autoNamed.exportNameOnSchemaDump()).toBe(false);
-    expect(autoNamed.exportNameOnSchemaDump()).toBe(false);
-    expect(autoNamed.exportNameOnSchemaDump()).toBe(false);
+
+    it("exportNameOnSchemaDump is stable across repeated calls", () => {
+      SchemaDumper.uniqueIgnorePattern = /^uniq_rails_[0-9a-f]{10}$/g;
+      const autoNamed = new UniqueConstraintDefinition("t", "col", {
+        name: "uniq_rails_1e07660b77",
+      });
+      expect(autoNamed.exportNameOnSchemaDump()).toBe(false);
+      expect(autoNamed.exportNameOnSchemaDump()).toBe(false);
+      expect(autoNamed.exportNameOnSchemaDump()).toBe(false);
+    });
   });
 
   it("definedFor matches by name", () => {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -9,7 +9,7 @@
  */
 
 import { NotImplementedError } from "../../errors.js";
-import { SchemaDumper } from "../../schema-dumper.js";
+import { SchemaDumper, statelessTest } from "../../schema-dumper.js";
 import { pgDatetimeConfig } from "./pg-datetime-config.js";
 import {
   TableDefinition as AbstractTableDefinition,
@@ -97,7 +97,7 @@ export class ExclusionConstraintDefinition {
   }
 
   exportNameOnSchemaDump(): boolean {
-    return this.name != null && !SchemaDumper.exclIgnorePattern.test(this.name);
+    return this.name != null && !statelessTest(SchemaDumper.exclIgnorePattern, this.name);
   }
 }
 
@@ -133,7 +133,7 @@ export class UniqueConstraintDefinition {
   }
 
   exportNameOnSchemaDump(): boolean {
-    return this.name != null && !SchemaDumper.uniqueIgnorePattern.test(this.name);
+    return this.name != null && !statelessTest(SchemaDumper.uniqueIgnorePattern, this.name);
   }
 
   definedFor(

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -331,13 +331,6 @@ class AdapterSchemaSource implements SchemaSource {
   }
 }
 
-/**
- * Runs `pattern.test(value)` without the g/y-flag `lastIndex` footgun. A
- * `global`/`sticky` regex advances `lastIndex` on each `.test()`, so repeated
- * calls with a user-configured ignore pattern would alternate true/false;
- * strip those flags into a fresh regex so the test is stateless. Mirrors Rails'
- * `Regexp#match?`, which never mutates match state.
- */
 export function statelessTest(pattern: RegExp, value: string): boolean {
   const safe =
     pattern.global || pattern.sticky

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -332,6 +332,21 @@ class AdapterSchemaSource implements SchemaSource {
 }
 
 /**
+ * Runs `pattern.test(value)` without the g/y-flag `lastIndex` footgun. A
+ * `global`/`sticky` regex advances `lastIndex` on each `.test()`, so repeated
+ * calls with a user-configured ignore pattern would alternate true/false;
+ * strip those flags into a fresh regex so the test is stateless. Mirrors Rails'
+ * `Regexp#match?`, which never mutates match state.
+ */
+export function statelessTest(pattern: RegExp, value: string): boolean {
+  const safe =
+    pattern.global || pattern.sticky
+      ? new RegExp(pattern.source, pattern.flags.replace(/[gy]/g, ""))
+      : pattern;
+  return safe.test(value);
+}
+
+/**
  * Generates the schema DSL string from a SchemaSource. Mirrors
  * Rails' base `ActiveRecord::SchemaDumper` class.
  */
@@ -1045,15 +1060,11 @@ export class SchemaDumper {
   /** @internal */
   checkParts(check: { expression: string; name?: string; validate?: boolean }): string[] {
     const parts: string[] = [JSON.stringify(check.expression)];
-    const rawChkPattern = (this.constructor as typeof SchemaDumper).chkIgnorePattern;
-    const chkIgnorePattern =
-      rawChkPattern.global || rawChkPattern.sticky
-        ? new RegExp(rawChkPattern.source, rawChkPattern.flags.replace(/[gy]/g, ""))
-        : rawChkPattern;
+    const chkIgnorePattern = (this.constructor as typeof SchemaDumper).chkIgnorePattern;
     const exportName =
       "isExportNameOnSchemaDump" in (check as object)
         ? (check as unknown as { isExportNameOnSchemaDump: boolean }).isExportNameOnSchemaDump
-        : check.name != null && !chkIgnorePattern.test(check.name);
+        : check.name != null && !statelessTest(chkIgnorePattern, check.name);
     if (exportName && check.name) parts.push(`name: ${JSON.stringify(check.name)}`);
     if (check.validate === false) parts.push("validate: false");
     return parts;
@@ -1076,12 +1087,7 @@ export class SchemaDumper {
       deferrable?: boolean | string;
       validate?: boolean;
     };
-    const rawFkPattern = (this.constructor as typeof SchemaDumper).fkIgnorePattern;
-    // Strip g/y flags to avoid mutating shared lastIndex state across iterations.
-    const fkIgnorePattern =
-      rawFkPattern.global || rawFkPattern.sticky
-        ? new RegExp(rawFkPattern.source, rawFkPattern.flags.replace(/[gy]/g, ""))
-        : rawFkPattern;
+    const fkIgnorePattern = (this.constructor as typeof SchemaDumper).fkIgnorePattern;
     for (const fk of fks as Fk[]) {
       const fromExpr = JSON.stringify(this.removePrefixAndSuffix(fk.fromTable ?? tableName));
       const toExpr = JSON.stringify(this.removePrefixAndSuffix(fk.toTable));
@@ -1093,7 +1099,7 @@ export class SchemaDumper {
       const exportName =
         "isExportNameOnSchemaDump" in (fk as object)
           ? (fk as unknown as { isExportNameOnSchemaDump: boolean }).isExportNameOnSchemaDump
-          : fk.name != null && !fkIgnorePattern.test(fk.name);
+          : fk.name != null && !statelessTest(fkIgnorePattern, fk.name);
       if (exportName && fk.name) opts.push(`name: ${JSON.stringify(fk.name)}`);
       if (fk.onUpdate) opts.push(`onUpdate: ${JSON.stringify(fk.onUpdate)}`);
       if (fk.onDelete) opts.push(`onDelete: ${JSON.stringify(fk.onDelete)}`);


### PR DESCRIPTION
Follow-up to #5163. The two PostgreSQL constraint getters
`ExclusionConstraintDefinition.exportNameOnSchemaDump` and
`UniqueConstraintDefinition.exportNameOnSchemaDump` still called `.test()` on the
raw stored `SchemaDumper.exclIgnorePattern` / `uniqueIgnorePattern`. A
user-configured pattern carrying a `g`/`y` flag advances `lastIndex` on each
`.test()`, so repeated getter calls alternate true/false — the exact footgun
#5163 fixed for the abstract getters. Rails' `export_name_on_schema_dump?` uses
`Regexp#match?`, which is stateless.

## Changes

- Hoist a shared `statelessTest(pattern, value)` helper into `schema-dumper.ts`
  that strips `g`/`y` flags into a fresh regex before `.test()`.
- Route both PG getters through it, and replace the two inline flag-strip blocks
  in `SchemaDumper#checkParts` / `#foreignKeys` with the shared helper (no second
  copy).
- Tests: a custom `exclIgnorePattern` / `uniqueIgnorePattern` with a `g` flag now
  yields stable results across repeated getter calls; reset in `afterEach`.

Closes-story: pg-excl-unique-export-name-flag-strip
