### PR TITLE
fix(model-schema): reload own-table descendants under STI subclasses

### DIFF
--- a/packages/activerecord/src/model-schema-reload-recursion.trails.test.ts
+++ b/packages/activerecord/src/model-schema-reload-recursion.trails.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { ValueType } from "@blazetrails/activemodel";
+import { Base } from "./base.js";
+import { reloadSchemaFromCache } from "./model-schema.js";
+import { registerSubclass } from "./inheritance.js";
+
+class UuidType extends ValueType {
+  override readonly name = "uuid" as unknown as "value";
+}
+
+function makeAdapter(columns: Record<string, unknown>): unknown {
+  return {
+    schemaCache: {
+      isCached: () => true,
+      getCachedColumnsHash: () => columns,
+      dataSourceExists: async () => true,
+      columnsHash: async () => columns,
+    },
+    lookupCastTypeFromColumn(column: { sqlType: string }) {
+      return column.sqlType === "uuid" ? new UuidType() : null;
+    },
+  };
+}
+
+const own = <T>(host: object, key: string): T | undefined =>
+  Object.prototype.hasOwnProperty.call(host, key) ? (host as Record<string, T>)[key] : undefined;
+
+describe("reloadSchemaFromCache recursion — non-STI descendant under STI", () => {
+  // trails fidelity gap: Rails' reload_schema_from_cache recurses `subclasses.each`
+  // reaching EVERY descendant. A subclass that owns its `table_name` sits under an
+  // STI subclass but carries an independent schema, so it must be reloaded in full
+  // — not merely have its local STI overlay caches cleared, which leaves its own
+  // `_schemaLoadPromise` / `_schemaRevision` memos stale.
+  it("invalidates an own-table descendant's schema memos when an STI ancestor reloads", async () => {
+    class Shape extends Base {
+      static override tableName = "shapes";
+      static {
+        this.inheritanceColumn = "type";
+      }
+    }
+    class Circle extends Shape {}
+    registerSubclass(Circle);
+    class Ticket extends Circle {
+      static override tableName = "tickets";
+    }
+    registerSubclass(Ticket);
+
+    const cols = { guid: { sqlType: "uuid", name: "guid", default: null } };
+    for (const klass of [Shape, Circle, Ticket]) {
+      (klass as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
+    }
+
+    // Reflect on the own-table descendant FIRST, so it owns its schema-load
+    // promise (rather than inheriting the base's).
+    await Ticket.loadSchema();
+    expect(own<Promise<void>>(Ticket, "_schemaLoadPromise")).toBeDefined();
+    const revisionBefore = own<number>(Ticket, "_schemaRevision");
+
+    // Reload from an STI ancestor (Rails: a `lockingColumn=` / `ignoredColumns=`
+    // change on Shape drives this). Every descendant must be invalidated.
+    reloadSchemaFromCache.call(Shape as never);
+
+    // On current main the own-table descendant only gets its local caches
+    // cleared, so its load-promise memo survives and it never re-reflects.
+    expect(own<Promise<void>>(Ticket, "_schemaLoadPromise")).toBeUndefined();
+    expect(own<number>(Ticket, "_schemaRevision")).toBe((revisionBefore ?? 0) + 1);
+  });
+});

--- a/packages/activerecord/src/model-schema-reload-recursion.trails.test.ts
+++ b/packages/activerecord/src/model-schema-reload-recursion.trails.test.ts
@@ -26,11 +26,6 @@ const own = <T>(host: object, key: string): T | undefined =>
   Object.prototype.hasOwnProperty.call(host, key) ? (host as Record<string, T>)[key] : undefined;
 
 describe("reloadSchemaFromCache recursion — non-STI descendant under STI", () => {
-  // trails fidelity gap: Rails' reload_schema_from_cache recurses `subclasses.each`
-  // reaching EVERY descendant. A subclass that owns its `table_name` sits under an
-  // STI subclass but carries an independent schema, so it must be reloaded in full
-  // — not merely have its local STI overlay caches cleared, which leaves its own
-  // `_schemaLoadPromise` / `_schemaRevision` memos stale.
   it("invalidates an own-table descendant's schema memos when an STI ancestor reloads", async () => {
     class Shape extends Base {
       static override tableName = "shapes";
@@ -50,19 +45,43 @@ describe("reloadSchemaFromCache recursion — non-STI descendant under STI", () 
       (klass as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
     }
 
-    // Reflect on the own-table descendant FIRST, so it owns its schema-load
-    // promise (rather than inheriting the base's).
     await Ticket.loadSchema();
     expect(own<Promise<void>>(Ticket, "_schemaLoadPromise")).toBeDefined();
     const revisionBefore = own<number>(Ticket, "_schemaRevision");
 
-    // Reload from an STI ancestor (Rails: a `lockingColumn=` / `ignoredColumns=`
-    // change on Shape drives this). Every descendant must be invalidated.
     reloadSchemaFromCache.call(Shape as never);
 
-    // On current main the own-table descendant only gets its local caches
-    // cleared, so its load-promise memo survives and it never re-reflects.
     expect(own<Promise<void>>(Ticket, "_schemaLoadPromise")).toBeUndefined();
     expect(own<number>(Ticket, "_schemaRevision")).toBe((revisionBefore ?? 0) + 1);
+  });
+
+  it("reloads an own-table descendant in full when it is the reload target, without redirecting to the STI base", async () => {
+    class Shape extends Base {
+      static override tableName = "shapes";
+      static {
+        this.inheritanceColumn = "type";
+      }
+    }
+    class Circle extends Shape {}
+    registerSubclass(Circle);
+    class Ticket extends Circle {
+      static override tableName = "tickets";
+    }
+    registerSubclass(Ticket);
+
+    const cols = { guid: { sqlType: "uuid", name: "guid", default: null } };
+    for (const klass of [Shape, Circle, Ticket]) {
+      (klass as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
+    }
+
+    await Ticket.loadSchema();
+    const ticketRevisionBefore = own<number>(Ticket, "_schemaRevision");
+    const shapeRevisionBefore = own<number>(Shape, "_schemaRevision");
+
+    reloadSchemaFromCache.call(Ticket as never);
+
+    expect(own<Promise<void>>(Ticket, "_schemaLoadPromise")).toBeUndefined();
+    expect(own<number>(Ticket, "_schemaRevision")).toBe((ticketRevisionBefore ?? 0) + 1);
+    expect(own<number>(Shape, "_schemaRevision")).toBe(shapeRevisionBefore);
   });
 });

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -868,13 +868,6 @@ function clearStiSubclassLocalCaches(sub: SchemaHost): void {
   if (Object.prototype.hasOwnProperty.call(sub, "_attributeDefinitions")) {
     scrubSchemaSourcedDefinitions(sub);
   }
-  // Rails' recursion reaches every descendant; deeper STI subclasses fork
-  // the same way, so walk them too. A descendant that owns its `table_name`
-  // (breaking out of the shared STI table) is NOT a forked overlay of the
-  // base's schema — clearing its local caches would leave its own `_schemaLoaded`
-  // / `_schemaRevision` / load-promise memos stale. Re-enter the full reload for
-  // it instead (safe: `reloadSchemaMemosAndRecurse` only walks down, never
-  // redirects back up to the shared base, so no loop).
   for (const deeper of (sub as { subclasses?: SchemaHost[] }).subclasses ?? []) {
     if (sharesStiBaseTable(deeper)) {
       clearStiSubclassLocalCaches(deeper);
@@ -884,17 +877,9 @@ function clearStiSubclassLocalCaches(sub: SchemaHost): void {
   }
 }
 
-/**
- * True when `klass` shares its STI base's table (a genuine STI overlay whose
- * schema is the base's). False when `klass` (or an intermediate ancestor) sets
- * its own `table_name`, so it carries an independent schema even though an STI
- * ancestor exists — such a class must be reloaded in full, not treated as a
- * forked overlay.
- */
 function sharesStiBaseTable(klass: SchemaHost): boolean {
-  const base = getStiBase(klass as unknown as object) as unknown as typeof Base;
-  if ((base as unknown as SchemaHost) === klass) return true;
-  return (klass as unknown as typeof Base).tableName === base.tableName;
+  const base = getStiBase(klass) as unknown as SchemaHost;
+  return base === klass || base.tableName === klass.tableName;
 }
 
 /**
@@ -913,19 +898,8 @@ function scrubSchemaSourcedDefinitions(host: SchemaHost): void {
   }
 }
 
-/**
- * @internal
- * Mirrors: ActiveRecord::ModelSchema#reload_schema_from_cache — the narrow,
- * cache-preserving invalidation (nils the class-level schema memos so the next
- * load re-reflects, from the still-warm schema cache), recursing over tracked
- * subclasses as Rails does (`subclasses.each`, model_schema.rb:566).
- */
+/** @internal */
 export function reloadSchemaFromCache(this: SchemaHost): void {
-  // STI subclasses share the base's defs. Redirect the reload to the base
-  // so schema-sourced defs and accessors are actually cleared; clear the
-  // subclass-local caches too so any forked metadata is dropped. A descendant
-  // that owns its `table_name` does NOT share the base's schema, so it must
-  // reload in full rather than redirect (which would loop back to the base).
   if (isStiSubclass(this) && sharesStiBaseTable(this)) {
     clearStiSubclassLocalCaches(this);
     reloadSchemaFromCache.call(getStiBase(this) as SchemaHost);
@@ -934,12 +908,6 @@ export function reloadSchemaFromCache(this: SchemaHost): void {
   reloadSchemaMemosAndRecurse(this);
 }
 
-/**
- * The reload body proper: nil this class's schema memos, bump the revision so
- * subclass overlays resync, and recurse over tracked subclasses (Rails'
- * `subclasses.each`). Split out from {@link reloadSchemaFromCache} so the
- * own-table branch can re-enter it directly without the STI redirect.
- */
 function reloadSchemaMemosAndRecurse(host: SchemaHost): void {
   host._columnsHash = undefined;
   host._columns = undefined;
@@ -947,27 +915,13 @@ function reloadSchemaMemosAndRecurse(host: SchemaHost): void {
   host._attributesBuilder = undefined;
   host._schemaLoaded = false;
   host._virtualAttributesReconciled = false;
-  // Invalidate every STI subclass overlay built from the pre-reset definitions.
-  // The defs Map below is mutated IN PLACE, so neither map identity nor key
-  // coverage can detect that a subclass's overlay is stale — only this counter
-  // can. Mirrors Rails resetting the class and its descendants.
   host._schemaRevision = (host._schemaRevision ?? 0) + 1;
   (host as SchemaHost & { _cachedDefaultAttributes?: unknown })._cachedDefaultAttributes = null;
   (host as SchemaHost & { _schemaLoadPromise?: Promise<void> })._schemaLoadPromise = undefined;
-  // Rails' reload_schema_from_cache also nils @attribute_names / @column_names
-  // (on the class and, via recursion, its descendants); the helper clears the
-  // memos for the receiver and every descendant in one pass.
   clearAttributeNamesMemo(host);
   if (Object.prototype.hasOwnProperty.call(host, "_attributeDefinitions")) {
     scrubSchemaSourcedDefinitions(host);
   }
-  // Rails: `subclasses.each { |descendant| descendant.send(:reload_schema_from_cache) }`.
-  // A subclass that shares this base's STI table gets its local forks cleared
-  // directly rather than via a recursive call — recursing into one would
-  // redirect right back to this base (the branch above) and loop; its
-  // shared-overlay resync rides the `_schemaRevision` bump. Any other subclass
-  // (non-STI, or an STI descendant with its own `table_name`) carries an
-  // independent schema and recurses in full, as in Rails.
   for (const sub of (host as { subclasses?: SchemaHost[] }).subclasses ?? []) {
     if (isStiSubclass(sub) && sharesStiBaseTable(sub)) {
       clearStiSubclassLocalCaches(sub);

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -872,7 +872,7 @@ function clearStiSubclassLocalCaches(sub: SchemaHost): void {
     if (sharesStiBaseTable(deeper)) {
       clearStiSubclassLocalCaches(deeper);
     } else {
-      reloadSchemaMemosAndRecurse(deeper);
+      reloadSchemaFromCache.call(deeper);
     }
   }
 }
@@ -905,28 +905,24 @@ export function reloadSchemaFromCache(this: SchemaHost): void {
     reloadSchemaFromCache.call(getStiBase(this) as SchemaHost);
     return;
   }
-  reloadSchemaMemosAndRecurse(this);
-}
-
-function reloadSchemaMemosAndRecurse(host: SchemaHost): void {
-  host._columnsHash = undefined;
-  host._columns = undefined;
-  host._returningColumnsForInsertCache = undefined;
-  host._attributesBuilder = undefined;
-  host._schemaLoaded = false;
-  host._virtualAttributesReconciled = false;
-  host._schemaRevision = (host._schemaRevision ?? 0) + 1;
-  (host as SchemaHost & { _cachedDefaultAttributes?: unknown })._cachedDefaultAttributes = null;
-  (host as SchemaHost & { _schemaLoadPromise?: Promise<void> })._schemaLoadPromise = undefined;
-  clearAttributeNamesMemo(host);
-  if (Object.prototype.hasOwnProperty.call(host, "_attributeDefinitions")) {
-    scrubSchemaSourcedDefinitions(host);
+  this._columnsHash = undefined;
+  this._columns = undefined;
+  this._returningColumnsForInsertCache = undefined;
+  this._attributesBuilder = undefined;
+  this._schemaLoaded = false;
+  this._virtualAttributesReconciled = false;
+  this._schemaRevision = (this._schemaRevision ?? 0) + 1;
+  (this as SchemaHost & { _cachedDefaultAttributes?: unknown })._cachedDefaultAttributes = null;
+  (this as SchemaHost & { _schemaLoadPromise?: Promise<void> })._schemaLoadPromise = undefined;
+  clearAttributeNamesMemo(this);
+  if (Object.prototype.hasOwnProperty.call(this, "_attributeDefinitions")) {
+    scrubSchemaSourcedDefinitions(this);
   }
-  for (const sub of (host as { subclasses?: SchemaHost[] }).subclasses ?? []) {
+  for (const sub of (this as { subclasses?: SchemaHost[] }).subclasses ?? []) {
     if (isStiSubclass(sub) && sharesStiBaseTable(sub)) {
       clearStiSubclassLocalCaches(sub);
     } else {
-      reloadSchemaMemosAndRecurse(sub);
+      reloadSchemaFromCache.call(sub);
     }
   }
 }

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -869,10 +869,32 @@ function clearStiSubclassLocalCaches(sub: SchemaHost): void {
     scrubSchemaSourcedDefinitions(sub);
   }
   // Rails' recursion reaches every descendant; deeper STI subclasses fork
-  // the same way, so walk them too.
+  // the same way, so walk them too. A descendant that owns its `table_name`
+  // (breaking out of the shared STI table) is NOT a forked overlay of the
+  // base's schema — clearing its local caches would leave its own `_schemaLoaded`
+  // / `_schemaRevision` / load-promise memos stale. Re-enter the full reload for
+  // it instead (safe: `reloadSchemaMemosAndRecurse` only walks down, never
+  // redirects back up to the shared base, so no loop).
   for (const deeper of (sub as { subclasses?: SchemaHost[] }).subclasses ?? []) {
-    clearStiSubclassLocalCaches(deeper);
+    if (sharesStiBaseTable(deeper)) {
+      clearStiSubclassLocalCaches(deeper);
+    } else {
+      reloadSchemaMemosAndRecurse(deeper);
+    }
   }
+}
+
+/**
+ * True when `klass` shares its STI base's table (a genuine STI overlay whose
+ * schema is the base's). False when `klass` (or an intermediate ancestor) sets
+ * its own `table_name`, so it carries an independent schema even though an STI
+ * ancestor exists — such a class must be reloaded in full, not treated as a
+ * forked overlay.
+ */
+function sharesStiBaseTable(klass: SchemaHost): boolean {
+  const base = getStiBase(klass as unknown as object) as unknown as typeof Base;
+  if ((base as unknown as SchemaHost) === klass) return true;
+  return (klass as unknown as typeof Base).tableName === base.tableName;
 }
 
 /**
@@ -901,42 +923,56 @@ function scrubSchemaSourcedDefinitions(host: SchemaHost): void {
 export function reloadSchemaFromCache(this: SchemaHost): void {
   // STI subclasses share the base's defs. Redirect the reload to the base
   // so schema-sourced defs and accessors are actually cleared; clear the
-  // subclass-local caches too so any forked metadata is dropped.
-  if (isStiSubclass(this)) {
+  // subclass-local caches too so any forked metadata is dropped. A descendant
+  // that owns its `table_name` does NOT share the base's schema, so it must
+  // reload in full rather than redirect (which would loop back to the base).
+  if (isStiSubclass(this) && sharesStiBaseTable(this)) {
     clearStiSubclassLocalCaches(this);
     reloadSchemaFromCache.call(getStiBase(this) as SchemaHost);
     return;
   }
-  this._columnsHash = undefined;
-  this._columns = undefined;
-  this._returningColumnsForInsertCache = undefined;
-  this._attributesBuilder = undefined;
-  this._schemaLoaded = false;
-  this._virtualAttributesReconciled = false;
+  reloadSchemaMemosAndRecurse(this);
+}
+
+/**
+ * The reload body proper: nil this class's schema memos, bump the revision so
+ * subclass overlays resync, and recurse over tracked subclasses (Rails'
+ * `subclasses.each`). Split out from {@link reloadSchemaFromCache} so the
+ * own-table branch can re-enter it directly without the STI redirect.
+ */
+function reloadSchemaMemosAndRecurse(host: SchemaHost): void {
+  host._columnsHash = undefined;
+  host._columns = undefined;
+  host._returningColumnsForInsertCache = undefined;
+  host._attributesBuilder = undefined;
+  host._schemaLoaded = false;
+  host._virtualAttributesReconciled = false;
   // Invalidate every STI subclass overlay built from the pre-reset definitions.
   // The defs Map below is mutated IN PLACE, so neither map identity nor key
   // coverage can detect that a subclass's overlay is stale — only this counter
   // can. Mirrors Rails resetting the class and its descendants.
-  this._schemaRevision = (this._schemaRevision ?? 0) + 1;
-  (this as SchemaHost & { _cachedDefaultAttributes?: unknown })._cachedDefaultAttributes = null;
-  (this as SchemaHost & { _schemaLoadPromise?: Promise<void> })._schemaLoadPromise = undefined;
+  host._schemaRevision = (host._schemaRevision ?? 0) + 1;
+  (host as SchemaHost & { _cachedDefaultAttributes?: unknown })._cachedDefaultAttributes = null;
+  (host as SchemaHost & { _schemaLoadPromise?: Promise<void> })._schemaLoadPromise = undefined;
   // Rails' reload_schema_from_cache also nils @attribute_names / @column_names
   // (on the class and, via recursion, its descendants); the helper clears the
   // memos for the receiver and every descendant in one pass.
-  clearAttributeNamesMemo(this);
-  if (Object.prototype.hasOwnProperty.call(this, "_attributeDefinitions")) {
-    scrubSchemaSourcedDefinitions(this);
+  clearAttributeNamesMemo(host);
+  if (Object.prototype.hasOwnProperty.call(host, "_attributeDefinitions")) {
+    scrubSchemaSourcedDefinitions(host);
   }
   // Rails: `subclasses.each { |descendant| descendant.send(:reload_schema_from_cache) }`.
-  // STI subclasses get their local forks cleared directly rather than via a
-  // recursive call — recursing into one would redirect right back to this base
-  // (the branch above) and loop; their shared-overlay resync rides the
-  // `_schemaRevision` bump. Non-STI subclasses (own table) recurse as in Rails.
-  for (const sub of (this as { subclasses?: SchemaHost[] }).subclasses ?? []) {
-    if (isStiSubclass(sub)) {
+  // A subclass that shares this base's STI table gets its local forks cleared
+  // directly rather than via a recursive call — recursing into one would
+  // redirect right back to this base (the branch above) and loop; its
+  // shared-overlay resync rides the `_schemaRevision` bump. Any other subclass
+  // (non-STI, or an STI descendant with its own `table_name`) carries an
+  // independent schema and recurses in full, as in Rails.
+  for (const sub of (host as { subclasses?: SchemaHost[] }).subclasses ?? []) {
+    if (isStiSubclass(sub) && sharesStiBaseTable(sub)) {
       clearStiSubclassLocalCaches(sub);
     } else {
-      reloadSchemaFromCache.call(sub);
+      reloadSchemaMemosAndRecurse(sub);
     }
   }
 }


### PR DESCRIPTION
## Summary

Rails' `reload_schema_from_cache` recurses `subclasses.each`, reaching every
descendant. trails reloads non-STI subclasses fully and clears STI subclasses'
local overlay caches, but a subclass that owns its `table_name` (breaking out
of the shared STI table) while nested under an STI subclass was only ever
reached by `clearStiSubclassLocalCaches`. That path clears its local caches but
does **not** bump `_schemaRevision`, clear `_schemaLoadPromise`, or run
`clearAttributeNamesMemo` — so its own schema memos stay stale after an ancestor
`lockingColumn=` / `ignoredColumns=` reload, and it never re-reflects.

## Fix

- Add `sharesStiBaseTable(klass)` — true only when the class shares its STI
  base's table (a genuine forked overlay). A descendant whose `tableName`
  differs carries an independent schema.
- Split the reload body into `reloadSchemaMemosAndRecurse`, which only walks
  **down** the subclass tree and never redirects up to the shared base, so
  re-entering it for an own-table descendant cannot loop.
- Both the STI-redirect branch and the recursive subclass walk now dispatch
  own-table descendants into the full reload instead of the local-cache clear.

## Rails source / deviation note

Mirrors `ActiveRecord::ModelSchema#reload_schema_from_cache`
(`activerecord/lib/active_record/model_schema.rb:553-571`). Rails' method has
**no** STI-vs-own-table branching — it unconditionally resets ivars on `self`
then recurses into every subclass with the same call (`model_schema.rb:566-570`).
The `clearStiSubclassLocalCaches` / `sharesStiBaseTable` / redirect-to-base
apparatus is a trails invention required by the shared-`_attributeDefinitions`-Map
overlay design (STI subclasses share the base's defs Map rather than forking it).
Recorded here rather than as a code comment per the review-cycle instruction to
drop inline commentary; the `@internal` tag is retained because `api-compare`
uses it to keep the exported helper off the public-surface comparison.

## Test

`model-schema-reload-recursion.trails.test.ts` — two cases, both fail on current
`main`, pass with the fix:

1. an own-table descendant under an STI subclass loads its schema (owning
   `_schemaLoadPromise`); an STI **ancestor** reloads; the descendant's
   `_schemaLoadPromise` / `_schemaRevision` memos are asserted invalidated.
2. reloading **directly** on the own-table descendant reloads it in full (bumps
   its own revision, clears its promise) without redirecting up to the STI base
   (the base's revision is unchanged).

## Follow-up: the load path shares the same conflation (out of scope)

Review correctly flagged that the **load** path has the identical own-table
redirect and is untouched here: `loadSchema` (model-schema.ts:1064) and
`loadSchemaFromCacheSync` (model-schema.ts:1594) both do
`isStiSubclass(host) ? getStiBase(host) : host`, so an own-table descendant
reflects the STI base's table onto the base rather than loading its own table's
columns. That is a pre-existing bug on `main` in a different method, and fixing
it means gating the load-path redirect on `sharesStiBaseTable` and untangling
whether an own-table descendant should share the base's defs Map at all — a
riskier change that touches the STI overlay invariant. Per the repo's
one-story-per-PR rule it is tracked separately rather than bundled here:

- Story: `load-schema-own-table-descendant-under-sti-loads-wrong-table`
  (RFC 0032-ar-gate-fidelity-burndown).

This is why this PR's test asserts only invalidation and does not assert the
adapter is queried with `"tickets"` — that assertion belongs with the load-path
story (it would fail today, since the load path is unfixed). The invalidation
this PR adds is still load-order-meaningful: clearing the descendant's
`_schemaLoadPromise` is what forces the next `loadSchema()` to re-reflect at all
instead of short-circuiting on the stale resolved promise.

Closes-story: reload-schema-recursion-misses-non-sti-under-sti
