### PR TITLE
fix(persistence): route collection ids/writer assignment through awaitable replace in #update

### DIFF
--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -776,7 +776,9 @@ describe("HasManyAssociationsTest", () => {
 
   it("replace with new", async () => {
     const firm = (await HmFirm.first()) as any;
-    firm.clients = [companies("second_client"), Client.new({ name: "New Client" })];
+    await firm
+      .association("clients")
+      .writer([companies("second_client"), Client.new({ name: "New Client" })]);
     await firm.save();
     await firm.reload();
     const clients = await firm.clients;

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -624,12 +624,6 @@ async function assignUpdateAttributes(self: any, attrs: Record<string, unknown>)
   if (pending.length) await Promise.all(pending);
 }
 
-/**
- * If `key` is a collection association's plural writer (`posts=`) or ids writer
- * (`postIds=`), return the awaitable replace promise; otherwise `undefined`.
- * Used by `#update`/`#update!` to bypass the throwing sync property setter and
- * persist the replace inline inside the update transaction (see call site).
- */
 function collectionWriterPromise(
   self: any,
   key: string,
@@ -666,16 +660,6 @@ function assignUpdateAttribute(self: any, key: string, value: unknown): Promise<
     self.id = value;
     return;
   }
-  // Collection association writers (`posts=`, `postIds=`). Rails routes these
-  // through `public_send` → `replace`, which for a *persisted* owner runs the
-  // diffed deletes + inserts inline (collection_association.rb:242). The JS
-  // property setter cannot `await` that DB I/O, so `defineWriters` installs a
-  // setter that throws `CollectionPersistedAssignmentError` on a persisted
-  // owner (RFC 0068). But `#update`/`#update!` already run inside
-  // `with_transaction_returning_status` and can `await`, so route straight to
-  // the awaitable `writer`/`idsWriter` here — the replace joins the update
-  // transaction and rolls back with it if the subsequent `save` fails, exactly
-  // as `author.update(name: nil, post_ids: [])` does in Rails.
   const collectionWrite = collectionWriterPromise(self, key, value);
   if (collectionWrite) return collectionWrite;
   // Dispatch through prototype setter for generated writers (e.g. *Ids writers

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -631,8 +631,8 @@ function collectionWriterPromise(
 ): Promise<void> | undefined {
   const ctor = self.constructor as typeof Base;
   for (const ref of reflectOnAllAssociations(ctor)) {
-    if (!ref.isCollection?.()) continue;
-    const name = String((ref as any).nameString ?? ref.name);
+    if (!ref.isCollection()) continue;
+    const name = String(ref.name);
     if (key === name) {
       return self.association(name).writer(value);
     }

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -6,6 +6,9 @@
  */
 
 import { Temporal } from "@blazetrails/activesupport/temporal";
+import { singularize } from "@blazetrails/activesupport";
+import { reflectOnAllAssociations } from "./reflection.js";
+import type { Base } from "./base.js";
 import {
   ArgumentError,
   sanitizeForMassAssignment,
@@ -621,6 +624,31 @@ async function assignUpdateAttributes(self: any, attrs: Record<string, unknown>)
   if (pending.length) await Promise.all(pending);
 }
 
+/**
+ * If `key` is a collection association's plural writer (`posts=`) or ids writer
+ * (`postIds=`), return the awaitable replace promise; otherwise `undefined`.
+ * Used by `#update`/`#update!` to bypass the throwing sync property setter and
+ * persist the replace inline inside the update transaction (see call site).
+ */
+function collectionWriterPromise(
+  self: any,
+  key: string,
+  value: unknown,
+): Promise<void> | undefined {
+  const ctor = self.constructor as typeof Base;
+  for (const ref of reflectOnAllAssociations(ctor)) {
+    if (!ref.isCollection?.()) continue;
+    const name = String((ref as any).nameString ?? ref.name);
+    if (key === name) {
+      return self.association(name).writer(value);
+    }
+    if (key === `${singularize(name)}Ids`) {
+      return self.association(name).idsWriter(value);
+    }
+  }
+  return undefined;
+}
+
 function assignUpdateAttribute(self: any, key: string, value: unknown): Promise<void> | void {
   const configs = self.constructor?._nestedAttributeConfigs as
     | { associationName: string }[]
@@ -638,6 +666,18 @@ function assignUpdateAttribute(self: any, key: string, value: unknown): Promise<
     self.id = value;
     return;
   }
+  // Collection association writers (`posts=`, `postIds=`). Rails routes these
+  // through `public_send` → `replace`, which for a *persisted* owner runs the
+  // diffed deletes + inserts inline (collection_association.rb:242). The JS
+  // property setter cannot `await` that DB I/O, so `defineWriters` installs a
+  // setter that throws `CollectionPersistedAssignmentError` on a persisted
+  // owner (RFC 0068). But `#update`/`#update!` already run inside
+  // `with_transaction_returning_status` and can `await`, so route straight to
+  // the awaitable `writer`/`idsWriter` here — the replace joins the update
+  // transaction and rolls back with it if the subsequent `save` fails, exactly
+  // as `author.update(name: nil, post_ids: [])` does in Rails.
+  const collectionWrite = collectionWriterPromise(self, key, value);
+  if (collectionWrite) return collectionWrite;
   // Dispatch through prototype setter for generated writers (e.g. *Ids writers
   // from CollectionAssociation builder). Mirrors Rails' public_send("#{key}=").
   // *Ids writers are async (they query the DB to resolve records); return the


### PR DESCRIPTION
## Summary

`TransactionTest > update should rollback on failure` (and `...!`) went red on
`main @a31fb712` (Active Record PostgreSQL Tests (1)). Root cause is the
interaction between `#update` and #5042 (RFC 0068): the generated collection
property setters (`posts=`, `postIds=`) now **throw**
`CollectionPersistedAssignmentError` on a persisted owner, because a synchronous
JS setter cannot perform the inline replace DB I/O that Rails' `replace` does.

`author.update({ name: null, postIds: [] })` therefore threw
`CollectionPersistedAssignmentError` instead of running the `post_ids=` replace
inside the update transaction and rolling it back when the `name` presence
validation fails.

## Fix

`#update`/`#update!` already run inside `with_transaction_returning_status` and
**can** `await`. During the update assignment loop, route collection-writer keys
(`posts`, `postIds`) straight to the awaitable `writer`/`idsWriter` instead of
the throwing sync property setter — matching Rails' `assign_attributes` →
`public_send("post_ids=")` → `replace` running inline inside the update
transaction. The replace joins the transaction and rolls back with it on the
subsequent `save` failure.

The throwing sync setters remain for direct `author.posts = [...]` /
`author.postIds = [...]` assignment (covered by
`collection-persisted-setter-throws.trails.test.ts`, still green).

## Verification

- `transactions.test.ts` — both formerly-failing tests pass; full file green.
- `collection-persisted-setter-throws.trails.test.ts`, `persistence.test.ts`,
  `nested-attributes.test.ts` — green.
- typecheck + eslint clean.

Closes-story: red-a31fb712