### PR TITLE
fix(model-schema): load own-table descendants under an STI ancestor from their own table

### DIFF
--- a/packages/activerecord/src/model-schema-load-own-table-descendant.trails.test.ts
+++ b/packages/activerecord/src/model-schema-load-own-table-descendant.trails.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { Base } from "./base.js";
+import { registerSubclass } from "./inheritance.js";
+import { loadSchema } from "./model-schema.js";
+
+type Cols = Record<string, { sqlType: string; name: string; default: null }>;
+
+function col(name: string): Cols[string] {
+  return { sqlType: "varchar", name, default: null };
+}
+
+function makeAdapter(tables: Record<string, Cols>, asked: string[]): unknown {
+  return {
+    schemaCache: {
+      isCached: () => true,
+      getCachedColumnsHash: (table: string) => {
+        asked.push(table);
+        return tables[table];
+      },
+      dataSourceExists: async () => true,
+      columnsHash: async (_pool: unknown, table: string) => {
+        asked.push(table);
+        return tables[table];
+      },
+    },
+    lookupCastTypeFromColumn: () => null,
+  };
+}
+
+const tables: Record<string, Cols> = {
+  shapes: { id: col("id"), type: col("type"), sides: col("sides") },
+  tickets: { id: col("id"), subject: col("subject") },
+};
+
+function buildHierarchy(asked: string[]) {
+  class Shape extends Base {
+    static override tableName = "shapes";
+    static {
+      this.inheritanceColumn = "type";
+    }
+  }
+  class Circle extends Shape {}
+  registerSubclass(Circle);
+  class Ticket extends Circle {
+    static override tableName = "tickets";
+  }
+  registerSubclass(Ticket);
+
+  for (const klass of [Shape, Circle, Ticket]) {
+    (klass as unknown as { adapter: unknown }).adapter = makeAdapter(tables, asked);
+  }
+  return { Shape, Circle, Ticket };
+}
+
+describe("loadSchema — own-table descendant under an STI ancestor", () => {
+  it("reflects the descendant's own table, not the STI base's", () => {
+    const asked: string[] = [];
+    const { Ticket } = buildHierarchy(asked);
+
+    const hash = Ticket.columnsHash();
+
+    expect(asked).toContain("tickets");
+    expect(Object.keys(hash).sort()).toEqual(["id", "subject"]);
+    expect(hash).not.toHaveProperty("sides");
+  });
+
+  it("marks the descendant itself schema-loaded rather than the STI base", () => {
+    const asked: string[] = [];
+    const { Shape, Ticket } = buildHierarchy(asked);
+
+    loadSchema.call(Ticket as never);
+
+    expect((Ticket as unknown as { _schemaLoaded: boolean })._schemaLoaded).toBe(true);
+    expect((Shape as unknown as { _schemaLoaded: boolean })._schemaLoaded).toBe(false);
+  });
+
+  it("still redirects a genuine STI subclass to the base's shared table", () => {
+    const asked: string[] = [];
+    const { Shape, Circle } = buildHierarchy(asked);
+
+    const hash = Circle.columnsHash();
+
+    expect(Object.keys(hash).sort()).toEqual(["id", "sides", "type"]);
+    expect(asked).not.toContain("tickets");
+    expect((Shape as unknown as { _schemaLoaded: boolean })._schemaLoaded).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(Circle, "_schemaLoaded")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(Circle, "_attributeDefinitions")).toBe(false);
+  });
+});

--- a/packages/activerecord/src/model-schema-load-own-table-descendant.trails.test.ts
+++ b/packages/activerecord/src/model-schema-load-own-table-descendant.trails.test.ts
@@ -45,11 +45,13 @@ function buildHierarchy(asked: string[]) {
     static override tableName = "tickets";
   }
   registerSubclass(Ticket);
+  class VipTicket extends Ticket {}
+  registerSubclass(VipTicket);
 
-  for (const klass of [Shape, Circle, Ticket]) {
+  for (const klass of [Shape, Circle, Ticket, VipTicket]) {
     (klass as unknown as { adapter: unknown }).adapter = makeAdapter(tables, asked);
   }
-  return { Shape, Circle, Ticket };
+  return { Shape, Circle, Ticket, VipTicket };
 }
 
 describe("loadSchema — own-table descendant under an STI ancestor", () => {
@@ -84,6 +86,19 @@ describe("loadSchema — own-table descendant under an STI ancestor", () => {
         .map((c: { name: string }) => c.name)
         .sort(),
     ).toEqual(["id", "subject"]);
+  });
+
+  it("redirects a shared-table subclass of an own-table descendant to that descendant", () => {
+    const asked: string[] = [];
+    const { Shape, Ticket, VipTicket } = buildHierarchy(asked);
+
+    const hash = VipTicket.columnsHash();
+
+    expect(Object.keys(hash).sort()).toEqual(["id", "subject"]);
+    expect((Ticket as unknown as { _schemaLoaded: boolean })._schemaLoaded).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(VipTicket, "_schemaLoaded")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(VipTicket, "_attributeDefinitions")).toBe(false);
+    expect((Shape as unknown as { _schemaLoaded: boolean })._schemaLoaded).toBe(false);
   });
 
   it("still redirects a genuine STI subclass to the base's shared table", () => {

--- a/packages/activerecord/src/model-schema-load-own-table-descendant.trails.test.ts
+++ b/packages/activerecord/src/model-schema-load-own-table-descendant.trails.test.ts
@@ -74,6 +74,18 @@ describe("loadSchema — own-table descendant under an STI ancestor", () => {
     expect((Shape as unknown as { _schemaLoaded: boolean })._schemaLoaded).toBe(false);
   });
 
+  it("gives the descendant its own column set for attribute access", () => {
+    const asked: string[] = [];
+    const { Ticket } = buildHierarchy(asked);
+
+    expect([...Ticket.columnNames()].sort()).toEqual(["id", "subject"]);
+    expect(
+      Ticket.columns()
+        .map((c: { name: string }) => c.name)
+        .sort(),
+    ).toEqual(["id", "subject"]);
+  });
+
   it("still redirects a genuine STI subclass to the base's shared table", () => {
     const asked: string[] = [];
     const { Shape, Circle } = buildHierarchy(asked);

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -43,15 +43,29 @@ function reflectionAdapter(klass: any): any {
   return threadedConnectionFor(klass) ?? klass.connection;
 }
 
-function sharesStiBaseTable(klass: { tableName: string }): boolean {
-  const base = getStiBase(klass) as unknown as { tableName: string };
-  return base === klass || base.tableName === klass.tableName;
-}
-
+// `getStiBase` climbs to the TOPMOST `_inheritanceColumn` ancestor, which is the
+// wrong schema host as soon as an intermediate descendant claims its own table
+// (Shape → Circle → Ticket → VIPTicket, Ticket = "tickets"): the schema host for
+// VIPTicket is Ticket, not Shape. Walk to the topmost ancestor that still shares
+// the receiver's table instead.
 function stiSchemaHost<T extends { tableName: string }>(klass: T): T {
-  return isStiSubclass(klass) && sharesStiBaseTable(klass)
-    ? (getStiBase(klass) as unknown as T)
-    : klass;
+  if (!isStiSubclass(klass)) return klass;
+  const table = klass.tableName;
+  let host = klass;
+  let current = Object.getPrototypeOf(klass) as (T & { _abstractClass?: boolean }) | null;
+  while (current && current !== (Function.prototype as unknown)) {
+    if (getAbstractClass.call(current as any)) break;
+    let ancestorTable: string | undefined;
+    try {
+      ancestorTable = current.tableName;
+    } catch {
+      break;
+    }
+    if (ancestorTable !== table) break;
+    host = current;
+    current = Object.getPrototypeOf(current) as typeof current;
+  }
+  return host;
 }
 
 /**

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -43,30 +43,14 @@ function reflectionAdapter(klass: any): any {
   return threadedConnectionFor(klass) ?? klass.connection;
 }
 
-/**
- * True when `klass` sits under an STI base that it actually shares a table
- * with. `isStiSubclass` alone is not that test: `_inheritanceColumn` propagates
- * down the prototype chain, so a descendant that sets its OWN `table_name`
- * (Shape → Circle → Ticket, where Ticket is `tickets`) still reports as an STI
- * subclass. Only a shared table justifies redirecting schema work — reflection,
- * the memo caches, the shared `_attributeDefinitions` overlay — to the base.
- *
- * @internal
- */
-function sharesStiBaseTable(klass: SchemaHost): boolean {
-  const base = getStiBase(klass) as unknown as SchemaHost;
+function sharesStiBaseTable(klass: { tableName: string }): boolean {
+  const base = getStiBase(klass) as unknown as { tableName: string };
   return base === klass || base.tableName === klass.tableName;
 }
 
-/**
- * The class that owns schema work for `klass`: the STI base when the table is
- * genuinely shared, otherwise `klass` itself.
- *
- * @internal
- */
-function stiSchemaHost(klass: SchemaHost): SchemaHost {
+function stiSchemaHost<T extends { tableName: string }>(klass: T): T {
   return isStiSubclass(klass) && sharesStiBaseTable(klass)
-    ? (getStiBase(klass) as unknown as SchemaHost)
+    ? (getStiBase(klass) as unknown as T)
     : klass;
 }
 
@@ -290,12 +274,8 @@ export function columnsHash(this: typeof Base): Record<string, ColumnLike> {
     return memoHost._columnsHash as Record<string, ColumnLike>;
   }
 
-  // STI-aware adapter + table resolution: adapter may live on the base
-  // OR the concrete subclass. Use the same candidate-list logic the
-  // schema loader uses so `Circle.columnsHash()` can still pull the
-  // cached Column objects from Shape's adapter.
   const klass = this;
-  const stiTarget = stiSchemaHost(klass as unknown as SchemaHost) as unknown as typeof Base;
+  const stiTarget = stiSchemaHost(klass);
   const candidates = stiTarget === klass ? [klass] : [stiTarget, klass];
   let adapter: DatabaseAdapterLike | null = null;
   for (const cand of candidates) {
@@ -366,7 +346,7 @@ type DatabaseAdapterLike = { schemaCache?: unknown };
  * columns that carry no client-side default anyway.
  */
 export function cachedColumnsHash(klass: typeof Base): Record<string, ColumnLike> {
-  const target = stiSchemaHost(klass as unknown as SchemaHost) as unknown as typeof Base;
+  const target = stiSchemaHost(klass);
   const cachedFrom = (conn: { schemaCache?: unknown } | null | undefined) => {
     const cache = conn?.schemaCache as
       | { getCachedColumnsHash?: (t: string) => Record<string, ColumnLike> | undefined }
@@ -1094,11 +1074,6 @@ export function loadSchema(this: SchemaHost): void {
     );
   }
 
-  // The class that actually owns the schema load — the STI base when
-  // `this` is a subclass. We set `_schemaLoaded` only on the workHost
-  // so subclasses inherit the flag via the prototype chain. Assigning
-  // on the subclass would shadow the base flag and prevent re-reflection
-  // when the base is reset. Delete any stale own-flag on the subclass.
   const workHost = stiSchemaHost(this);
   if (workHost !== this && Object.prototype.hasOwnProperty.call(this, "_schemaLoaded")) {
     delete this._schemaLoaded;
@@ -1423,10 +1398,6 @@ function applyColumnsHash(
  */
 export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   if (getAbstractClass.call(this as any)) return;
-  // STI subclasses inherit the base's attribute defs — reflect onto the
-  // STI base without forking. Use whichever class has the adapter
-  // configured (base in normal Rails setup, but tolerate subclass-only
-  // configuration).
   const schemaHost = stiSchemaHost(this);
 
   let startingAdapter: SchemaHost["connection"] | undefined;
@@ -1626,9 +1597,6 @@ export async function reconcileVirtualAttributes(this: SchemaHost, reflect = fal
  */
 function loadSchemaFromCacheSync(host: SchemaHost): boolean {
   if (getAbstractClass.call(host as any)) return false;
-  // STI subclasses share the base's table and attribute defs. Reflecting
-  // on a subclass would fork _attributeDefinitions; instead, apply
-  // reflection to the STI base so subclasses inherit it.
   const schemaHost = stiSchemaHost(host);
   // Adapter may be configured on the base OR on the subclass. Try base
   // first (Rails-normal), fall back to the originating host. Access can

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -44,6 +44,33 @@ function reflectionAdapter(klass: any): any {
 }
 
 /**
+ * True when `klass` sits under an STI base that it actually shares a table
+ * with. `isStiSubclass` alone is not that test: `_inheritanceColumn` propagates
+ * down the prototype chain, so a descendant that sets its OWN `table_name`
+ * (Shape → Circle → Ticket, where Ticket is `tickets`) still reports as an STI
+ * subclass. Only a shared table justifies redirecting schema work — reflection,
+ * the memo caches, the shared `_attributeDefinitions` overlay — to the base.
+ *
+ * @internal
+ */
+function sharesStiBaseTable(klass: SchemaHost): boolean {
+  const base = getStiBase(klass) as unknown as SchemaHost;
+  return base === klass || base.tableName === klass.tableName;
+}
+
+/**
+ * The class that owns schema work for `klass`: the STI base when the table is
+ * genuinely shared, otherwise `klass` itself.
+ *
+ * @internal
+ */
+function stiSchemaHost(klass: SchemaHost): SchemaHost {
+  return isStiSubclass(klass) && sharesStiBaseTable(klass)
+    ? (getStiBase(klass) as unknown as SchemaHost)
+    : klass;
+}
+
+/**
  * Schema metadata for ActiveRecord models — table name, primary key,
  * columns, content columns, SQL helpers, and table creation.
  *
@@ -268,7 +295,7 @@ export function columnsHash(this: typeof Base): Record<string, ColumnLike> {
   // schema loader uses so `Circle.columnsHash()` can still pull the
   // cached Column objects from Shape's adapter.
   const klass = this;
-  const stiTarget = isStiSubclass(klass) ? getStiBase(klass) : klass;
+  const stiTarget = stiSchemaHost(klass as unknown as SchemaHost) as unknown as typeof Base;
   const candidates = stiTarget === klass ? [klass] : [stiTarget, klass];
   let adapter: DatabaseAdapterLike | null = null;
   for (const cand of candidates) {
@@ -339,7 +366,7 @@ type DatabaseAdapterLike = { schemaCache?: unknown };
  * columns that carry no client-side default anyway.
  */
 export function cachedColumnsHash(klass: typeof Base): Record<string, ColumnLike> {
-  const target = isStiSubclass(klass) ? getStiBase(klass) : klass;
+  const target = stiSchemaHost(klass as unknown as SchemaHost) as unknown as typeof Base;
   const cachedFrom = (conn: { schemaCache?: unknown } | null | undefined) => {
     const cache = conn?.schemaCache as
       | { getCachedColumnsHash?: (t: string) => Record<string, ColumnLike> | undefined }
@@ -711,7 +738,7 @@ export function attributesBuilder(this: SchemaHost): AttributeSetBuilder {
 
   // STI: write cache to the base so subclasses inherit via prototype
   // chain, and a base reset propagates automatically.
-  const cacheHost = isStiSubclass(this) ? (getStiBase(this) as SchemaHost) : this;
+  const cacheHost = stiSchemaHost(this);
   cacheHost._attributesBuilder = new AttributeSetBuilder(types, defaults);
   // If we are an STI subclass, resetDefaultAttributes() may have placed an
   // own-property shadow of `undefined` on `this` to block stale inheritance.
@@ -734,7 +761,7 @@ export function columns(this: SchemaHost): any[] {
   if (this._columns) return this._columns;
   loadSchema.call(this);
   const hash = getColumnsHash(this);
-  const cacheHost = isStiSubclass(this) ? (getStiBase(this) as SchemaHost) : this;
+  const cacheHost = stiSchemaHost(this);
   cacheHost._columns = Object.values(hash);
   return cacheHost._columns;
 }
@@ -1027,8 +1054,9 @@ function rebuildStiSubclassOverlay(sub: SchemaHost, base: SchemaHost): void {
  * set identical — so key coverage would wrongly report the overlay as fresh.
  */
 export function syncStiSubclassAttributeDefinitions(host: SchemaHost): void {
-  if (!isStiSubclass(host)) return;
-  syncStiSubclassOverlay(host, getStiBase(host) as SchemaHost);
+  const base = stiSchemaHost(host);
+  if (base === host) return;
+  syncStiSubclassOverlay(host, base);
 }
 
 function syncStiSubclassOverlay(sub: SchemaHost, base: SchemaHost): void {
@@ -1071,7 +1099,7 @@ export function loadSchema(this: SchemaHost): void {
   // so subclasses inherit the flag via the prototype chain. Assigning
   // on the subclass would shadow the base flag and prevent re-reflection
   // when the base is reset. Delete any stale own-flag on the subclass.
-  const workHost = isStiSubclass(this) ? (getStiBase(this) as SchemaHost) : this;
+  const workHost = stiSchemaHost(this);
   if (workHost !== this && Object.prototype.hasOwnProperty.call(this, "_schemaLoaded")) {
     delete this._schemaLoaded;
   }
@@ -1399,7 +1427,7 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   // STI base without forking. Use whichever class has the adapter
   // configured (base in normal Rails setup, but tolerate subclass-only
   // configuration).
-  const schemaHost = isStiSubclass(this) ? (getStiBase(this) as SchemaHost) : this;
+  const schemaHost = stiSchemaHost(this);
 
   let startingAdapter: SchemaHost["connection"] | undefined;
   let adapterOwner: SchemaHost | undefined;
@@ -1577,7 +1605,7 @@ async function reflectColumnNames(host: SchemaHost): Promise<Set<string> | null>
  * @internal
  */
 export async function reconcileVirtualAttributes(this: SchemaHost, reflect = false): Promise<void> {
-  const host = isStiSubclass(this) ? (getStiBase(this) as SchemaHost) : this;
+  const host = stiSchemaHost(this);
   if (host._virtualAttributesReconciled) return;
   const real = reflect ? await reflectColumnNames(host) : cachedColumnNames(host);
   if (!real) return;
@@ -1601,7 +1629,7 @@ function loadSchemaFromCacheSync(host: SchemaHost): boolean {
   // STI subclasses share the base's table and attribute defs. Reflecting
   // on a subclass would fork _attributeDefinitions; instead, apply
   // reflection to the STI base so subclasses inherit it.
-  const schemaHost = isStiSubclass(host) ? (getStiBase(host) as SchemaHost) : host;
+  const schemaHost = stiSchemaHost(host);
   // Adapter may be configured on the base OR on the subclass. Try base
   // first (Rails-normal), fall back to the originating host. Access can
   // throw when no pool is configured; treat as "no adapter".


### PR DESCRIPTION
`isStiSubclass` is true for any descendant under an STI base, because
`_inheritanceColumn` propagates down the prototype chain. The schema load path
used that alone to redirect all schema work to `getStiBase(klass)`, so an
own-table descendant (Shape → Circle → Ticket, where Ticket sets
`table_name = "tickets"`) reflected Shape's `shapes` columns onto Shape and
never loaded its own table.

Gate the redirect on the table actually being shared: `stiSchemaHost` walks up
from the receiver to the TOPMOST ancestor that still shares its `tableName`
(stopping at an abstract class or the first table mismatch), instead of jumping
to `getStiBase`. The walk rather than a straight `getStiBase(klass).tableName
=== klass.tableName` comparison matters one level deeper — for
`class VipTicket extends Ticket {}` (no own `tableName`, so `"tickets"`), the
schema host is Ticket, not Shape and not VipTicket itself; comparing against
the STI root would have made VipTicket its own host and lost the sharing of
Ticket's `_schemaLoaded` / `_attributesBuilder` / `_columnsHash`. Applied to `loadSchema`,
`loadSchemaFromCacheSync`, `loadSchemaFromAdapter`, `columnsHash`,
`cachedColumnsHash`, `columns`, `attributesBuilder`,
`reconcileVirtualAttributes`, and the STI overlay sync (an own-table descendant
must not inherit the base's `_attributeDefinitions` overlay — different table,
different columns).

Genuine STI subclasses are unaffected: they still redirect to the base, share
its defs Map, and inherit `_schemaLoaded` through the prototype chain.

Four of the five new tests fail on `origin/main`; the fifth is the shared-table
STI guard and passes on both sides.

Note on fidelity: the schema-host redirect this PR fixes is a trails invention
with no Rails counterpart. Rails' `load_schema!`
(model_schema.rb:587-597) always uses `self.table_name` and stores into the
class's own `@columns_hash`, and `base_class` (inheritance.rb:271-283) has no
table-name logic — Ruby class ivars are not inherited, so each STI subclass
independently re-reads the same warm schema-cache entry. JS statics ARE
inherited, which is why trails needs a host at all. The fidelity target here is
therefore behavioral (an own-table descendant gets its own columns), not
structural; convergence of the redirect itself is tracked separately.

Out of scope, registered as follow-up stories:

- `reloadSchemaFromCache` (the invalidation half) — #5168.
- `attributes.ts` `defineAttribute` / `defaultAttributes` redirect on bare
  `isStiSubclass` too — story
  `attributes-own-table-descendant-under-sti-routes-to-base`.
- Removing the redirect entirely (per-class reflection, as Rails does) — story
  `sti-schema-host-redirect-is-a-trails-invention`.

Closes-story: load-schema-own-table-descendant-under-sti-loads-wrong-table
