### PR TITLE
fix(activerecord): Relation#any?/many?/one? accept the Enumerable pattern arg

### DIFF
--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -649,22 +649,31 @@ export function findOrInitializeBy<T extends typeof Base>(
 /**
  * Mirrors: ActiveRecord::Querying#any? — delegates to all().any?
  */
-export function isAny<T extends typeof Base>(this: T): Promise<boolean> {
-  return this.all().isAny();
+export function isAny<T extends typeof Base>(
+  this: T,
+  ...args: Parameters<ReturnType<T["all"]>["isAny"]>
+): Promise<boolean> {
+  return this.all().isAny(...args);
 }
 
 /**
  * Mirrors: ActiveRecord::Querying#many? — delegates to all().many?
  */
-export function isMany<T extends typeof Base>(this: T): Promise<boolean> {
-  return this.all().isMany();
+export function isMany<T extends typeof Base>(
+  this: T,
+  ...args: Parameters<ReturnType<T["all"]>["isMany"]>
+): Promise<boolean> {
+  return this.all().isMany(...args);
 }
 
 /**
  * Mirrors: ActiveRecord::Querying#one? — delegates to all().one?
  */
-export function isOne<T extends typeof Base>(this: T): Promise<boolean> {
-  return this.all().isOne();
+export function isOne<T extends typeof Base>(
+  this: T,
+  ...args: Parameters<ReturnType<T["all"]>["isOne"]>
+): Promise<boolean> {
+  return this.all().isOne(...args);
 }
 
 /**

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -166,6 +166,15 @@ import { AliasTracker } from "./associations/alias-tracker.js";
 export type LoadedRelation<R> = Omit<R, "then">;
 
 /**
+ * Argument accepted by the `Enumerable` predicate forms (`any?`, `one?`,
+ * `none?`): either Ruby's block (a predicate) or a pattern matched with the
+ * case-equality operator — here a model class, i.e. `instanceof`.
+ */
+export type EnumerablePattern<T extends Base> =
+  | ((record: T) => boolean)
+  | (new (...args: never[]) => Base);
+
+/**
  * Enforce Rails' `extract_options!` shape on variadic `explain(...)`
  * inputs: at most one hash option, and if present it must be the last
  * positional argument. This keeps adapters (especially MySQL, whose
@@ -2249,7 +2258,9 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#any?
    */
-  async isAny(): Promise<boolean> {
+  async isAny(pattern?: EnumerablePattern<T>): Promise<boolean> {
+    if (this._isEmptyRelation()) return false;
+    if (pattern !== undefined) return (await this._countMatching(pattern)) > 0;
     if (this._loaded) return this._records.length > 0;
     return this.exists();
   }
@@ -2257,9 +2268,14 @@ export class Relation<T extends Base> {
   /**
    * Check if there are multiple matching records.
    *
+   * Rails' `many?` takes no pattern argument (only a block), so this accepts a
+   * predicate but not the class-pattern form.
+   *
    * Mirrors: ActiveRecord::Relation#many?
    */
-  async isMany(): Promise<boolean> {
+  async isMany(predicate?: (record: T) => boolean): Promise<boolean> {
+    if (this._isEmptyRelation()) return false;
+    if (predicate !== undefined) return (await this._countMatching(predicate)) > 1;
     if (this._loaded) return this._records.length > 1;
     return (await this.limitedCount()) > 1;
   }
@@ -2269,9 +2285,27 @@ export class Relation<T extends Base> {
    *
    * Mirrors: ActiveRecord::Relation#one?
    */
-  async isOne(): Promise<boolean> {
+  async isOne(pattern?: EnumerablePattern<T>): Promise<boolean> {
+    if (this._isEmptyRelation()) return false;
+    if (pattern !== undefined) return (await this._countMatching(pattern)) === 1;
     if (this._loaded) return this._records.length === 1;
     return (await this.limitedCount()) === 1;
+  }
+
+  /**
+   * Number of loaded records matching an `Enumerable` pattern argument — a
+   * predicate (Ruby's block form) or a model class, which Ruby matches with
+   * the case-equality operator (`Post === record`, i.e. `instanceof`).
+   *
+   * @internal
+   */
+  async _countMatching(pattern: EnumerablePattern<T>): Promise<number> {
+    const records = await this.toArray();
+    if ((pattern as { _isActiveRecordBase?: unknown })._isActiveRecordBase === true) {
+      const klass = pattern as new (...args: never[]) => Base;
+      return records.filter((record) => record instanceof klass).length;
+    }
+    return records.filter(pattern as (record: T) => boolean).length;
   }
 
   /**
@@ -6246,18 +6280,9 @@ export class Relation<T extends Base> {
   /**
    * Mirrors: ActiveRecord::Relation#none?
    */
-  async isNone(
-    pattern?: ((record: T) => boolean) | (new (...args: never[]) => Base),
-  ): Promise<boolean> {
+  async isNone(pattern?: EnumerablePattern<T>): Promise<boolean> {
     if (this._isEmptyRelation()) return true;
-    if (pattern !== undefined) {
-      const records = await this.toArray();
-      if ((pattern as { _isActiveRecordBase?: unknown })._isActiveRecordBase === true) {
-        const klass = pattern as new (...args: never[]) => Base;
-        return !records.some((record) => record instanceof klass);
-      }
-      return !records.some(pattern as (record: T) => boolean);
-    }
+    if (pattern !== undefined) return (await this._countMatching(pattern)) === 0;
     return this.isEmpty();
   }
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2256,7 +2256,7 @@ export class Relation<T extends Base> {
    */
   async isAny(pattern?: EnumerablePattern<T>): Promise<boolean> {
     if (this._isEmptyRelation()) return false;
-    if (pattern !== undefined) return (await this._countMatching(pattern)) > 0;
+    if (pattern !== undefined) return (await this.toArray()).some(this._patternMatcher(pattern));
     if (this._loaded) return this._records.length > 0;
     return this.exists();
   }
@@ -2268,7 +2268,7 @@ export class Relation<T extends Base> {
    */
   async isMany(predicate?: (record: T) => boolean): Promise<boolean> {
     if (this._isEmptyRelation()) return false;
-    if (predicate !== undefined) return (await this._countMatching(predicate)) > 1;
+    if (predicate !== undefined) return (await this._countMatching(predicate, 2)) > 1;
     if (this._loaded) return this._records.length > 1;
     return (await this.limitedCount()) > 1;
   }
@@ -2280,19 +2280,28 @@ export class Relation<T extends Base> {
    */
   async isOne(pattern?: EnumerablePattern<T>): Promise<boolean> {
     if (this._isEmptyRelation()) return false;
-    if (pattern !== undefined) return (await this._countMatching(pattern)) === 1;
+    if (pattern !== undefined) return (await this._countMatching(pattern, 2)) === 1;
     if (this._loaded) return this._records.length === 1;
     return (await this.limitedCount()) === 1;
   }
 
   /** @internal */
-  async _countMatching(pattern: EnumerablePattern<T>): Promise<number> {
-    const records = await this.toArray();
+  _patternMatcher(pattern: EnumerablePattern<T>): (record: T) => boolean {
     if ((pattern as { _isActiveRecordBase?: unknown })._isActiveRecordBase === true) {
       const klass = pattern as new (...args: never[]) => Base;
-      return records.filter((record) => record instanceof klass).length;
+      return (record) => record instanceof klass;
     }
-    return records.filter(pattern as (record: T) => boolean).length;
+    return pattern as (record: T) => boolean;
+  }
+
+  /** @internal */
+  async _countMatching(pattern: EnumerablePattern<T>, limit: number): Promise<number> {
+    const matches = this._patternMatcher(pattern);
+    let count = 0;
+    for (const record of await this.toArray()) {
+      if (matches(record) && ++count === limit) break;
+    }
+    return count;
   }
 
   /**
@@ -6269,7 +6278,7 @@ export class Relation<T extends Base> {
    */
   async isNone(pattern?: EnumerablePattern<T>): Promise<boolean> {
     if (this._isEmptyRelation()) return true;
-    if (pattern !== undefined) return (await this._countMatching(pattern)) === 0;
+    if (pattern !== undefined) return !(await this.toArray()).some(this._patternMatcher(pattern));
     return this.isEmpty();
   }
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -165,11 +165,7 @@ import { AliasTracker } from "./associations/alias-tracker.js";
  */
 export type LoadedRelation<R> = Omit<R, "then">;
 
-/**
- * Argument accepted by the `Enumerable` predicate forms (`any?`, `one?`,
- * `none?`): either Ruby's block (a predicate) or a pattern matched with the
- * case-equality operator — here a model class, i.e. `instanceof`.
- */
+/** @internal */
 export type EnumerablePattern<T extends Base> =
   | ((record: T) => boolean)
   | (new (...args: never[]) => Base);
@@ -2268,9 +2264,6 @@ export class Relation<T extends Base> {
   /**
    * Check if there are multiple matching records.
    *
-   * Rails' `many?` takes no pattern argument (only a block), so this accepts a
-   * predicate but not the class-pattern form.
-   *
    * Mirrors: ActiveRecord::Relation#many?
    */
   async isMany(predicate?: (record: T) => boolean): Promise<boolean> {
@@ -2292,13 +2285,7 @@ export class Relation<T extends Base> {
     return (await this.limitedCount()) === 1;
   }
 
-  /**
-   * Number of loaded records matching an `Enumerable` pattern argument — a
-   * predicate (Ruby's block form) or a model class, which Ruby matches with
-   * the case-equality operator (`Post === record`, i.e. `instanceof`).
-   *
-   * @internal
-   */
+  /** @internal */
   async _countMatching(pattern: EnumerablePattern<T>): Promise<number> {
     const records = await this.toArray();
     if ((pattern as { _isActiveRecordBase?: unknown })._isActiveRecordBase === true) {

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -1383,13 +1383,32 @@ describe("RelationTest", () => {
   });
 
   it("any", async () => {
-    const any = await Post.all().isAny();
-    expect(any).toBe(true);
+    const postsRel = Post.all();
+
+    await assertQueriesCount(3, false, async () => {
+      expect(await postsRel.isAny()).toBe(true); // Uses COUNT()
+      expect(await postsRel.where({ id: null }).isAny()).toBe(false);
+
+      expect(await postsRel.isAny((p) => (p.id as number) > 0)).toBe(true);
+      expect(await postsRel.isAny((p) => (p.id as number) <= 0)).toBe(false);
+
+      expect(await postsRel.isAny(Post)).toBe(true);
+      expect(await postsRel.isAny(Comment)).toBe(false);
+    });
+
+    expect(postsRel.isLoaded).toBe(true);
   });
 
   it("many", async () => {
-    const many = await Post.all().isMany();
-    expect(many).toBe(true);
+    const postsRel = Post.all();
+
+    await assertQueriesCount(2, false, async () => {
+      expect(await postsRel.isMany()).toBe(true); // Uses COUNT()
+      expect(await postsRel.isMany((p) => (p.id as number) > 0)).toBe(true);
+      expect(await postsRel.isMany((p) => (p.id as number) < 2)).toBe(false);
+    });
+
+    expect(postsRel.isLoaded).toBe(true);
   });
 
   it("many with limits", async () => {
@@ -1422,8 +1441,21 @@ describe("RelationTest", () => {
 
   it("one", async () => {
     const postsRel = Post.all();
-    expect(await postsRel.isOne()).toBe(false);
+    await assertQueriesCount(1, false, async () => {
+      expect(await postsRel.isOne()).toBe(false); // Uses COUNT()
+    });
+
     expect(postsRel.isLoaded).toBe(false);
+
+    await assertQueriesCount(1, false, async () => {
+      expect(await postsRel.isOne((p) => (p.id as number) < 3)).toBe(false);
+      expect(await postsRel.isOne((p) => p.id === 1)).toBe(true);
+
+      expect(await postsRel.isOne(Post)).toBe(false);
+      expect(await postsRel.isOne(Comment)).toBe(false);
+    });
+
+    expect(postsRel.isLoaded).toBe(true);
   });
 
   it("one with destroy", async () => {


### PR DESCRIPTION
## Summary

Rails' `Relation#any?`/`one?` (`vendor/rails/activerecord/lib/active_record/relation.rb:386-427`)
`return super if args.present? || block_given?`, deferring to
`Enumerable#any?/one?(pattern)` which matches each element with case-equality
(`Post === record`); `many?` does the same for a block. trails'
`isAny`/`isMany`/`isOne` accepted no argument at all, so `Post.all().isAny(Comment)`
was unreachable. This mirrors the `isNone` fix from #5165.

## Changes

- `Relation#isAny`/`isOne` accept `((record) => boolean) | ModelClass`;
  `isMany` accepts a predicate only — Rails' `many?` has no pattern-arg form.
- All three short-circuit `false` on a null relation, as Rails does (`return false if @none`).
- New `_countMatching` helper does the load-and-match; `isNone` now shares it.
- `Querying.isAny`/`isMany`/`isOne` forward the argument.
- `relations_test`'s `any?`/`many?`/`one?` port Rails' pattern/block assertions
  under `assertQueriesCount`, replacing the previous stubs.

## Testing

`relations.test.ts` (`any`/`many`/`one`/`none?`/`many with limits`/`one with destroy`),
`null-relation.test.ts`, `relation/delegation.test.ts`, `querying.test.ts`,
`querying-methods-delegation.test.ts` pass; workspace typecheck clean;
wide call-mismatch ratchet OK after `api:compare --wide-calls`.

Closes-story: relation-any-many-one-predicate-missing-pattern-arg
