### PR TITLE
feat(calculations): group by every field and key multi-field grouped calculations by tuples

### DIFF
--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -193,8 +193,9 @@ describe("CalculationsTest", () => {
 
   it("should group by multiple fields when table name is too long", async () => {
     // Rails: TooLongTableName — canonical Account stands in (the canonical schema
-    // has no toooooooo_long_* table); the point is that a multi-field GROUP BY
-    // keys by the full tuple rather than collapsing on the first field.
+    // has no toooooooo_long_* table). trails aliases group keys `group_key_<i>`
+    // rather than deriving them from the column, so table-name length can never
+    // overflow an alias; what survives porting is the tuple-keying assertion.
     const res = await Account.group("firm_id", "credit_limit").count();
     expect([...(res as Map<unknown, number>).entries()]).toContainEqual([[6, 50], 1]);
     expect([...(res as Map<unknown, number>).entries()]).toContainEqual([[6, 55], 1]);

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -178,24 +178,38 @@ describe("CalculationsTest", () => {
   });
 
   it("should group by multiple fields", async () => {
-    const c = await Account.group("firm_id", "credit_limit").count();
-    // Rails: 6 unique (firm_id, credit_limit) combos; each count is 1.
-    const total = [...(c as Map<unknown, number>).values()].reduce((sum, v) => sum + v, 0);
-    expect(total).toBe(6);
+    const c = await Account.group("firm_id", "credit_limit").count("*");
+    for (const firmAndLimit of [
+      [null, 50],
+      [1, 50],
+      [6, 50],
+      [6, 55],
+      [9, 53],
+      [2, 60],
+    ]) {
+      expect([...(c as Map<unknown, number>).keys()]).toContainEqual(firmAndLimit);
+    }
   });
 
   it("should group by multiple fields when table name is too long", async () => {
-    // Rails: TooLongTableName — canonical Account stands in; asserts multi-field GROUP BY works.
+    // Rails: TooLongTableName — canonical Account stands in (the canonical schema
+    // has no toooooooo_long_* table); the point is that a multi-field GROUP BY
+    // keys by the full tuple rather than collapsing on the first field.
     const res = await Account.group("firm_id", "credit_limit").count();
-    expect(res).toBeInstanceOf(Map);
+    expect([...(res as Map<unknown, number>).entries()]).toContainEqual([[6, 50], 1]);
+    expect([...(res as Map<unknown, number>).entries()]).toContainEqual([[6, 55], 1]);
   });
 
   it("should group by multiple fields having functions", async () => {
-    const c = await Topic.group("author_name", "COALESCE(type, title)").count();
-    expect(c).toBeInstanceOf(Map);
-    // Rails: 5 topics each with unique (author_name, COALESCE(type,title)) combo
-    const total = [...(c as Map<unknown, number>).values()].reduce((sum, v) => sum + v, 0);
-    expect(total).toBe(5);
+    const c = (await Topic.group("author_name", "COALESCE(type, title)").count("*")) as Map<
+      unknown,
+      number
+    >;
+    const entries = [...c.entries()];
+    expect(entries).toContainEqual([["Carl", "The Third Topic of the day"], 1]);
+    expect(entries).toContainEqual([["Mary", "Reply"], 1]);
+    expect(entries).toContainEqual([["David", "The First Topic"], 1]);
+    expect(entries).toContainEqual([["Carl", "Reply"], 1]);
   });
 
   it("should group by summed field", async () => {

--- a/packages/activerecord/src/calculations.trails.test.ts
+++ b/packages/activerecord/src/calculations.trails.test.ts
@@ -162,3 +162,37 @@ describe("grouped calculation keyed via Arel attribute type caster", () => {
     );
   });
 });
+
+// ==========================================================================
+// Multi-field grouped-calculation key shape
+//
+// trails-specific regression (no verbatim Rails test asserts these two rules
+// in isolation): Rails uniqs group_fields only when there is more than one
+// (calculations.rb:516), and unwraps the key tuple to a scalar only when a
+// single group field survives (calculations.rb:583-584). Guards against a
+// regression to the old single-field collapse, where every non-association
+// grouped calculation reduced to `_groupColumns[0]`.
+// ==========================================================================
+
+describe("multi-field grouped calculation key shape", () => {
+  fixtures(["companies", "accounts"]);
+
+  it("uniqs repeated group fields and keys by a scalar", async () => {
+    const { Account } = await import("./test-helpers/models/account.js");
+    const result = (await Account.group("firm_id", "firm_id").count()) as Map<unknown, number>;
+    // Both fields collapse to one, so keys stay scalar rather than [n, n].
+    expect([...result.keys()].every((k) => !Array.isArray(k))).toBe(true);
+    expect(result.get(6)).toBe(2);
+  });
+
+  it("does not collapse distinct groups sharing their first field", async () => {
+    const { Account } = await import("./test-helpers/models/account.js");
+    const single = (await Account.group("firm_id").count()) as Map<unknown, number>;
+    const multi = (await Account.group("firm_id", "credit_limit").count()) as Map<unknown, number>;
+    expect(single.get(6)).toBe(2);
+    // firm 6's two accounts have distinct credit limits, so they split in two.
+    const firmSix = [...multi.entries()].filter(([k]) => (k as unknown[])[0] === 6);
+    expect(firmSix.map(([, v]) => v)).toEqual([1, 1]);
+    expect(firmSix.map(([k]) => (k as unknown[])[1]).sort()).toEqual([50, 55]);
+  });
+});

--- a/packages/activerecord/src/calculations.trails.test.ts
+++ b/packages/activerecord/src/calculations.trails.test.ts
@@ -196,3 +196,37 @@ describe("multi-field grouped calculation key shape", () => {
     expect(firmSix.map(([k]) => (k as unknown[])[1]).sort()).toEqual([50, 55]);
   });
 });
+
+// ==========================================================================
+// Multi-field grouped SUM over a bigint column
+//
+// trails-specific regression (no Rails analogue — Ruby has no Number
+// precision cliff): SQLite returns a large SUM as a lossy double, so
+// groupedAggregate wraps the query in a CAST(... AS TEXT) that must re-project
+// EVERY group key alias. Guards wrapBigintAgg's grouped branch against
+// dropping the trailing keys once there is more than one group field.
+// ==========================================================================
+
+describe("multi-field grouped bigint sum", () => {
+  fixtures([]);
+
+  it("carries every group key through the bigint text-cast wrap", async () => {
+    const { NumericData } = await import("./test-helpers/models/numeric-data.js");
+    await NumericData.create({ world_population: 2n ** 62n, my_house_population: 1n });
+    await NumericData.create({ world_population: 2n ** 62n, my_house_population: 2n });
+
+    const result = (await NumericData.group("my_house_population", "world_population").sum(
+      "atoms_in_universe",
+    )) as Map<unknown, unknown>;
+
+    const keys = [...result.keys()] as unknown[][];
+    expect(keys).toHaveLength(2);
+    // Both key components survive the wrap — the old single-alias wrap would
+    // have dropped world_population and collapsed the tuple.
+    expect(keys.every((k) => Array.isArray(k) && k.length === 2)).toBe(true);
+    // BigIntegerType only widens to bigint past the safe-integer range, so the
+    // small key stays a Number while the 2^62 key comes back as a bigint.
+    expect(keys.map((k) => k[0]).sort()).toEqual([1, 2]);
+    expect(keys.every((k) => k[1] === 2n ** 62n)).toBe(true);
+  });
+});

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -472,14 +472,12 @@ async function groupedAggregate(
   rel._checkEagerLoadable();
   const table = rel._modelClass.arelTable;
   // Rails `execute_grouped_calculation` (calculations.rb:515-522) keeps EVERY
-  // group field, uniq'ing them only when there is more than one, and reflects a
-  // belongs_to association only from a lone field — which then expands to that
-  // association's (possibly composite) foreign key.
+  // group field, uniq'ing only when there is more than one. A belongs_to
+  // reflection is attempted from a LONE field, which then expands to that
+  // association's foreign key; the result is keyed by the loaded associated
+  // records rather than by the raw key values.
   let groupFields: unknown[] = rel._groupColumns;
   if (groupFields.length > 1) groupFields = [...new Set(groupFields)];
-  // Rails: a single group field that reflects to a belongs_to association
-  // groups by the association's foreign key, then maps the result keys back to
-  // the loaded associated records (calculations.rb:execute_grouped_calculation).
   const association =
     groupFields.length === 1 ? resolveGroupAssociation(rel, groupFields[0]) : null;
   if (association && Array.isArray(association.foreignKey)) {
@@ -491,11 +489,12 @@ async function groupedAggregate(
   // column unqualified (matching the subquery alias) instead of pinning it to
   // the original model table, and a raw Arel node passes straight through.
   const groupNodes = arelColumns.call(rel as never, groupFields) as Nodes.Node[];
-  // A lone group field keeps the bare `group_key` alias; multiple fields get one
-  // alias each, mirroring Rails' per-field `column_alias_tracker.alias_for`.
-  const aliases = groupNodes.map((_, i) =>
-    groupNodes.length === 1 ? "group_key" : `group_key_${i}`,
-  );
+  // One alias per field, standing in for Rails' `column_alias_tracker.alias_for`.
+  // A lone field keeps the bare `group_key` the belongs_to arm below reads by
+  // name; these aliases are fixed-length, so unlike Rails they never need
+  // truncating for a long table name.
+  const aliases =
+    groupNodes.length === 1 ? ["group_key"] : groupNodes.map((_, i) => `group_key_${i}`);
   const aggNode = buildAggNode(rel, fn, column, rel._isDistinct);
   const groupKeyAliases = groupNodes.map(
     (n, i) => new Nodes.As(n, new Nodes.SqlLiteral(aliases[i])),

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -306,9 +306,14 @@ function needsBigintCast(rel: CalculationRelation): boolean {
  * needsBigintCast() is true. Aliases are quoted to match SQLite's
  * identifier quoting convention.
  */
-function wrapBigintAgg(innerSql: string, grouped = false, aggAlias = "val"): string {
-  if (grouped) {
-    return `SELECT "group_key", CAST("${aggAlias}" AS TEXT) AS "${aggAlias}" FROM (${innerSql}) AS "_bigint_agg"`;
+function wrapBigintAgg(
+  innerSql: string,
+  groupAliases: string[] | null = null,
+  aggAlias = "val",
+): string {
+  if (groupAliases) {
+    const keys = groupAliases.map((a) => `"${a}"`).join(", ");
+    return `SELECT ${keys}, CAST("${aggAlias}" AS TEXT) AS "${aggAlias}" FROM (${innerSql}) AS "_bigint_agg"`;
   }
   return `SELECT CAST("val" AS TEXT) AS "val" FROM (${innerSql}) AS "_bigint_agg"`;
 }
@@ -466,22 +471,35 @@ async function groupedAggregate(
 ): Promise<Map<unknown, unknown>> {
   rel._checkEagerLoadable();
   const table = rel._modelClass.arelTable;
-  const groupCol = rel._groupColumns[0];
+  // Rails `execute_grouped_calculation` (calculations.rb:515-522) keeps EVERY
+  // group field, uniq'ing them only when there is more than one, and reflects a
+  // belongs_to association only from a lone field — which then expands to that
+  // association's (possibly composite) foreign key.
+  let groupFields: unknown[] = rel._groupColumns;
+  if (groupFields.length > 1) groupFields = [...new Set(groupFields)];
   // Rails: a single group field that reflects to a belongs_to association
   // groups by the association's foreign key, then maps the result keys back to
   // the loaded associated records (calculations.rb:execute_grouped_calculation).
-  const association = resolveGroupAssociation(rel, groupCol);
+  const association =
+    groupFields.length === 1 ? resolveGroupAssociation(rel, groupFields[0]) : null;
   if (association && Array.isArray(association.foreignKey)) {
     return groupedCompositeAssoc(rel, association, fn, column, coerceNumeric);
   }
-  const effectiveGroupCol = association ? (association.foreignKey as string) : groupCol;
+  if (association) groupFields = [association.foreignKey as string];
   // Mirror Rails `execute_grouped_calculation`, which resolves group fields via
   // the plural `arel_columns` — so a `from(subquery, alias)` leaves the group
   // column unqualified (matching the subquery alias) instead of pinning it to
   // the original model table, and a raw Arel node passes straight through.
-  const groupNode = arelColumns.call(rel as never, [effectiveGroupCol])[0] as Nodes.Node;
+  const groupNodes = arelColumns.call(rel as never, groupFields) as Nodes.Node[];
+  // A lone group field keeps the bare `group_key` alias; multiple fields get one
+  // alias each, mirroring Rails' per-field `column_alias_tracker.alias_for`.
+  const aliases = groupNodes.map((_, i) =>
+    groupNodes.length === 1 ? "group_key" : `group_key_${i}`,
+  );
   const aggNode = buildAggNode(rel, fn, column, rel._isDistinct);
-  const groupKeyAlias = new Nodes.As(groupNode, new Nodes.SqlLiteral("group_key"));
+  const groupKeyAliases = groupNodes.map(
+    (n, i) => new Nodes.As(n, new Nodes.SqlLiteral(aliases[i])),
+  );
   // Rails aliases the aggregate as `column_alias_for("#{operation} #{column_name}")`
   // — e.g. `sum_credit_limit`, `count_all` — so order("sum_credit_limit desc")
   // can reference it (calculations.rb:537). A raw Arel node keeps "val".
@@ -489,7 +507,7 @@ async function groupedAggregate(
     typeof column === "string"
       ? columnAliasFor(`${fn} ${column.toLowerCase()}`.replace(/\*/g, "all"))
       : "val";
-  const manager = table.project(groupKeyAlias, aggNode.as(aggAlias));
+  const manager = table.project(...groupKeyAliases, aggNode.as(aggAlias));
   // Rails `calculate` (calculations.rb:217-238) folds the eager JoinDependency
   // into `joins_values` via `apply_join_dependency` before dispatching to the
   // grouped/simple calculation. Fold it into the shared `build_joins` port so
@@ -503,7 +521,7 @@ async function groupedAggregate(
   rel._applyJoinsToManager(manager, eagerJdGa);
   rel._applyWheresToManager(manager, table);
   applyFromToManager(rel, manager);
-  manager.group(groupNode);
+  for (const n of groupNodes) manager.group(n);
   // Rails `execute_grouped_calculation` runs `select_all` on the relation's own
   // arel, which retains order_values — without the ORDER BY, LIMIT/OFFSET pick
   // arbitrary groups on PG/MySQL.
@@ -517,7 +535,7 @@ async function groupedAggregate(
   const [withCtes, ctedBinds] = prependCtes(rel, rawSql, managerBinds);
   const sql =
     isBigintColumn(rel, fn, column) && needsBigintCast(rel)
-      ? wrapBigintAgg(withCtes, true, aggAlias)
+      ? wrapBigintAgg(withCtes, aliases, aggAlias)
       : withCtes;
   const opName = fn.charAt(0).toUpperCase() + fn.slice(1);
   const queryResult = await rel
@@ -549,23 +567,31 @@ async function groupedAggregate(
   }
 
   // Rails: `col_name.try(:type_caster) || type_for(col_name) { column_types.fetch(...) }`
-  // (calculations.rb:567-570) — an Arel attribute group field carries its own
-  // table's type caster, ahead of the model lookup and the result's column types.
-  const keyFieldName = qualifiedGroupFieldForModel(rel, effectiveGroupCol);
-  const keyType = ((groupNode instanceof Nodes.Attribute ? groupNode.typeCaster : null) ??
-    (keyFieldName === null ? null : pluckCastTypeForKnownColumn(rel, keyFieldName)) ??
-    queryResult.columnTypes?.["group_key"] ??
-    null) as { deserialize?(v: unknown): unknown } | null;
+  // (calculations.rb:567-570), resolved per group field — an Arel attribute group
+  // field carries its own table's type caster, ahead of the model lookup and the
+  // result's column types.
+  const keyTypes = groupNodes.map((node, i) => {
+    const fieldName = qualifiedGroupFieldForModel(rel, groupFields[i]);
+    return ((node instanceof Nodes.Attribute ? node.typeCaster : null) ??
+      (fieldName === null ? null : pluckCastTypeForKnownColumn(rel, fieldName)) ??
+      queryResult.columnTypes?.[aliases[i]] ??
+      null) as { deserialize?(v: unknown): unknown } | null;
+  });
   const result = new Map<unknown, unknown>();
   for (const row of rows) {
-    const raw = row.group_key;
-    const key =
-      raw == null
+    // Rails `key = group_aliases.map { ... }; key = key.first if key.size == 1`
+    // (calculations.rb:583-584). JS arrays compare by reference as Map keys, so
+    // callers locate a multi-field key by its component values, not identity.
+    const key = aliases.map((alias, i) => {
+      const raw = row[alias];
+      const keyType = keyTypes[i];
+      return raw == null
         ? null
         : typeof keyType?.deserialize === "function"
           ? keyType.deserialize(raw)
           : raw;
-    result.set(key, aggOf(row[aggAlias]));
+    });
+    result.set(key.length === 1 ? key[0] : key, aggOf(row[aggAlias]));
   }
   return result;
 }
@@ -591,8 +617,8 @@ function qualifiedGroupFieldForModel(rel: CalculationRelation, field: unknown): 
  * Rails' `model._reflect_on_association(field).belongs_to?` guard — only
  * belongs_to associations are grouped by foreign key and keyed by record.
  */
-function resolveGroupAssociation(rel: CalculationRelation, groupCol: string): any {
-  if (rel._groupColumns.length !== 1 || typeof groupCol !== "string") return null;
+function resolveGroupAssociation(rel: CalculationRelation, groupCol: unknown): any {
+  if (typeof groupCol !== "string") return null;
   const reflection = (rel._modelClass as any)._reflectOnAssociation?.(groupCol);
   if (!reflection || !reflection.belongsTo?.()) return null;
   // Rails (calculations.rb:521) does `group_fields = Array(association.foreign_key)`


### PR DESCRIPTION
## Problem

trails' `groupedAggregate` (`packages/activerecord/src/relation/calculations.ts`,
scalar/expression arm) reduced every non-association grouped calculation to
`rel._groupColumns[0]`: it projected a single `group_key` alias and emitted
`GROUP BY` on that one node only. Distinct groups that shared the first field
silently collapsed into a single entry.

Rails' `execute_grouped_calculation`
(`vendor/rails/activerecord/lib/active_record/relation/calculations.rb:515-534`,
`:553-589`) keeps **all** group fields: `group_fields = group_values` (uniq'd
when `size > 1`), aliases and type-casts each via `key_types`, groups by every
field, and builds `key = group_aliases.map { |aliaz| row[aliaz] }` — unwrapping
to a scalar only when there is a single group field.

## Change

- `groupFields` is the full group list, uniq'd only when >1
  (`calculations.rb:516`). The belongs_to reflection is attempted only from a
  lone field (`calculations.rb:518`), then expands to its foreign key.
- One `group_key_<i>` alias per field, reusing the projection pattern
  `groupedCompositeAssoc` already established; a lone field keeps the bare
  `group_key` that the belongs_to arm reads by name.
- `GROUP BY` every group node.
- Key type resolved **per field** (Arel `typeCaster` → model lookup → result
  `columnTypes`); the result `Map` is keyed by the per-field deserialized
  tuple, unwrapped to a scalar for a single field (`calculations.rb:583-584`).
- `wrapBigintAgg`'s grouped branch takes the alias list, so SQLite's
  `CAST(... AS TEXT)` re-projects every group key instead of only `group_key`.

JS arrays compare by reference as `Map` keys, so callers locate a multi-field
key by its component values — the same convention the composite belongs_to arm
already documents.

## Tests

The three ported multi-field tests previously passed only because
`SUM(counts)` is invariant under group collapse. They now assert Rails' literal
grouped shapes:

- `should group by multiple fields` — each of Rails' six
  `[firm_id, credit_limit]` key tuples is present.
- `should group by multiple fields when table name is too long` — `[6, 50] => 1`
  and `[6, 55] => 1` are distinct entries (the two rows that used to collapse).
  Canonical `Account` stands in for Rails' `TooLongTableName`, which the
  canonical schema does not have; trails' aliases are fixed-length, so the
  alias-truncation concern the Rails test targets cannot arise here.
- `should group by multiple fields having functions` — Rails' four concrete
  `[author_name, COALESCE(type, title)] => 1` entries.

Plus three trails-only guards in `calculations.trails.test.ts` (no Rails
analogue) covering the uniq rule, the single-field scalar unwrap, and the
multi-alias bigint text-cast wrap.

Verified against the pre-fix implementation: all three ported tests, the
collapse guard, and the bigint-wrap guard fail on `origin/main`'s
`calculations.ts` and pass with the change.

Closes-story: grouped-calculation-composite-keys
