### PR TITLE
fix(activerecord): keep own-table STI descendant attribute() on the descendant

### DIFF
--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -83,8 +83,10 @@ export function defineAttribute(
   castType: Type,
   options: { default?: unknown; userProvidedDefault?: boolean; limit?: number | null } = {},
 ): void {
-  // STI subclasses share the base's _attributeDefinitions — route to the
-  // base to avoid forking a subclass-local map that drifts from the base.
+  // Shared-table STI subclasses share the schema host's _attributeDefinitions —
+  // route there to avoid forking a subclass-local map that drifts from it. The
+  // host is the STI base for shared-table subclasses, and the receiver itself
+  // once it claims its own table.
   const schemaHost = stiSchemaHost(this as unknown as { tableName: string }) as AnyClass;
   if (schemaHost !== this) {
     schemaHost.defineAttribute(name, castType, options);
@@ -174,10 +176,10 @@ export function _defaultAttributes(this: AnyClass): AttributeSet {
     }
   }
 
-  // For STI subclasses, seed the shared (schema-reflected) set on the STI base
-  // so cache invalidation from Base.attribute/defineAttribute (routed to the
-  // base) stays coherent across siblings. The subclass's own declarations are
-  // layered on afterwards (see below).
+  // For shared-table STI subclasses, seed the shared (schema-reflected) set on
+  // the schema host so cache invalidation from Base.attribute/defineAttribute
+  // (routed to the same host) stays coherent across siblings. The subclass's own
+  // declarations are layered on afterwards (see below).
   const cacheHost = stiSchemaHost(this as unknown as { tableName: string }) as AnyClass;
   const stiSubclass = cacheHost !== this;
 

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -86,9 +86,6 @@ export function defineAttribute(
 ): void {
   // STI subclasses share the base's _attributeDefinitions — route to the
   // base to avoid forking a subclass-local map that drifts from the base.
-  // Only when the table is genuinely shared: an own-table descendant
-  // (`self.table_name = "tickets"` under an STI ancestor) has its own schema,
-  // so its declarations must stay on itself.
   if (sharesStiBaseTable(this)) {
     const stiBase = getStiBase(this);
     (stiBase as AnyClass).defineAttribute(name, castType, options);

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -16,10 +16,9 @@ import {
   resetDefaultAttributes as amResetDefaultAttributes,
   registerWithSuperclass,
 } from "@blazetrails/activemodel";
-import { getStiBase, sharesStiBaseTable } from "./inheritance.js";
 import { encryptionHooks } from "./encryption-hooks.js";
 import { lookup as typeLookup } from "./type.js";
-import { cachedColumnsHash } from "./model-schema.js";
+import { cachedColumnsHash, stiSchemaHost } from "./model-schema.js";
 
 type AnyClass = any;
 
@@ -86,9 +85,9 @@ export function defineAttribute(
 ): void {
   // STI subclasses share the base's _attributeDefinitions — route to the
   // base to avoid forking a subclass-local map that drifts from the base.
-  if (sharesStiBaseTable(this)) {
-    const stiBase = getStiBase(this);
-    (stiBase as AnyClass).defineAttribute(name, castType, options);
+  const schemaHost = stiSchemaHost(this as unknown as { tableName: string }) as AnyClass;
+  if (schemaHost !== this) {
+    schemaHost.defineAttribute(name, castType, options);
     return;
   }
 
@@ -179,8 +178,8 @@ export function _defaultAttributes(this: AnyClass): AttributeSet {
   // so cache invalidation from Base.attribute/defineAttribute (routed to the
   // base) stays coherent across siblings. The subclass's own declarations are
   // layered on afterwards (see below).
-  const stiSubclass = sharesStiBaseTable(this);
-  const cacheHost = stiSubclass ? (getStiBase(this) as AnyClass) : this;
+  const cacheHost = stiSchemaHost(this as unknown as { tableName: string }) as AnyClass;
+  const stiSubclass = cacheHost !== this;
 
   if (!cacheHost._cachedDefaultAttributes) {
     // Register cacheHost with its superclass so resetDefaultAttributes()

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -16,7 +16,7 @@ import {
   resetDefaultAttributes as amResetDefaultAttributes,
   registerWithSuperclass,
 } from "@blazetrails/activemodel";
-import { isStiSubclass, getStiBase } from "./inheritance.js";
+import { getStiBase, sharesStiBaseTable } from "./inheritance.js";
 import { encryptionHooks } from "./encryption-hooks.js";
 import { lookup as typeLookup } from "./type.js";
 import { cachedColumnsHash } from "./model-schema.js";
@@ -86,7 +86,10 @@ export function defineAttribute(
 ): void {
   // STI subclasses share the base's _attributeDefinitions — route to the
   // base to avoid forking a subclass-local map that drifts from the base.
-  if (isStiSubclass(this)) {
+  // Only when the table is genuinely shared: an own-table descendant
+  // (`self.table_name = "tickets"` under an STI ancestor) has its own schema,
+  // so its declarations must stay on itself.
+  if (sharesStiBaseTable(this)) {
     const stiBase = getStiBase(this);
     (stiBase as AnyClass).defineAttribute(name, castType, options);
     return;
@@ -179,7 +182,7 @@ export function _defaultAttributes(this: AnyClass): AttributeSet {
   // so cache invalidation from Base.attribute/defineAttribute (routed to the
   // base) stays coherent across siblings. The subclass's own declarations are
   // layered on afterwards (see below).
-  const stiSubclass = isStiSubclass(this);
+  const stiSubclass = sharesStiBaseTable(this);
   const cacheHost = stiSubclass ? (getStiBase(this) as AnyClass) : this;
 
   if (!cacheHost._cachedDefaultAttributes) {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -42,7 +42,7 @@ import type { Relation } from "./relation.js";
 import {
   getInheritanceColumn,
   inheritanceColumnDisabled,
-  isStiSubclass,
+  sharesStiBaseTable,
   getStiBase,
   instantiateSti,
   stiName,
@@ -1194,8 +1194,11 @@ export class Base extends Model {
     // shared `class_attribute`. Route the registration through the STI
     // base so `Circle.attribute("radius", ...)` lands on `Shape._attributeDefinitions`
     // instead of forking a subclass-local map that later schema
-    // reflection on the base wouldn't see.
-    if (isStiSubclass(this)) {
+    // reflection on the base wouldn't see. Gated on the table actually being
+    // shared: an own-table descendant under an STI ancestor
+    // (`self.table_name = "tickets"`) owns an independent schema, so its
+    // declarations must stay on itself.
+    if (sharesStiBaseTable(this)) {
       const stiBase = getStiBase(this);
       stiBase.attribute(name, typeName, options);
       return;

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -42,7 +42,6 @@ import type { Relation } from "./relation.js";
 import {
   getInheritanceColumn,
   inheritanceColumnDisabled,
-  sharesStiBaseTable,
   getStiBase,
   instantiateSti,
   stiName,
@@ -1195,9 +1194,9 @@ export class Base extends Model {
     // base so `Circle.attribute("radius", ...)` lands on `Shape._attributeDefinitions`
     // instead of forking a subclass-local map that later schema
     // reflection on the base wouldn't see.
-    if (sharesStiBaseTable(this)) {
-      const stiBase = getStiBase(this);
-      stiBase.attribute(name, typeName, options);
+    const schemaHost = ModelSchema.stiSchemaHost(this as unknown as { tableName: string });
+    if ((schemaHost as unknown as typeof Base) !== this) {
+      (schemaHost as unknown as typeof Base).attribute(name, typeName, options);
       return;
     }
     super.attribute(name, typeName, options);

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1194,10 +1194,7 @@ export class Base extends Model {
     // shared `class_attribute`. Route the registration through the STI
     // base so `Circle.attribute("radius", ...)` lands on `Shape._attributeDefinitions`
     // instead of forking a subclass-local map that later schema
-    // reflection on the base wouldn't see. Gated on the table actually being
-    // shared: an own-table descendant under an STI ancestor
-    // (`self.table_name = "tickets"`) owns an independent schema, so its
-    // declarations must stay on itself.
+    // reflection on the base wouldn't see.
     if (sharesStiBaseTable(this)) {
       const stiBase = getStiBase(this);
       stiBase.attribute(name, typeName, options);

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1188,12 +1188,13 @@ export class Base extends Model {
     typeName?: string | Type | AttributeOptions,
     options?: AttributeOptions,
   ): void {
-    // STI subclasses share the base's `_attributeDefinitions` — matching
-    // Rails' `ActiveRecord::Inheritance` where `attribute_types` is a
-    // shared `class_attribute`. Route the registration through the STI
-    // base so `Circle.attribute("radius", ...)` lands on `Shape._attributeDefinitions`
-    // instead of forking a subclass-local map that later schema
-    // reflection on the base wouldn't see.
+    // Shared-table STI subclasses share the schema host's `_attributeDefinitions`
+    // — matching Rails' `ActiveRecord::Inheritance` where `attribute_types` is a
+    // shared `class_attribute`. Route the registration through the schema host so
+    // `Circle.attribute("radius", ...)` lands on `Shape._attributeDefinitions`
+    // instead of forking a subclass-local map that later schema reflection on the
+    // host wouldn't see. An own-table descendant IS its own host, so its
+    // declarations stay on itself.
     const schemaHost = ModelSchema.stiSchemaHost(this as unknown as { tableName: string });
     if ((schemaHost as unknown as typeof Base) !== this) {
       (schemaHost as unknown as typeof Base).attribute(name, typeName, options);

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -514,25 +514,6 @@ export function abstractClass(this: typeof Base, value?: boolean): boolean {
 }
 
 /**
- * Whether a model is an STI descendant that actually shares its STI base's
- * table. A descendant is free to set its own `table_name` (Rails' "own-table
- * descendant" — e.g. `Ticket < Circle < Shape` with `self.table_name =
- * "tickets"`), in which case it owns an independent schema: its columns,
- * attribute declarations and default-attribute cache must NOT be routed to the
- * STI base. `isStiSubclass` alone is true for those, so every base-redirect
- * that is really about a *shared table* must gate on this predicate instead.
- *
- * @internal
- */
-export function sharesStiBaseTable(modelClass: object): boolean {
-  if (!isStiSubclass(modelClass)) return false;
-  const base = getStiBase(modelClass);
-  if (base === modelClass) return false;
-  const own = (modelClass as typeof Base).tableName;
-  return own == null || own === base.tableName;
-}
-
-/**
  * Get the STI base class for a model.
  */
 export function getStiBase(modelClass: object): typeof Base {

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -514,6 +514,25 @@ export function abstractClass(this: typeof Base, value?: boolean): boolean {
 }
 
 /**
+ * Whether a model is an STI descendant that actually shares its STI base's
+ * table. A descendant is free to set its own `table_name` (Rails' "own-table
+ * descendant" — e.g. `Ticket < Circle < Shape` with `self.table_name =
+ * "tickets"`), in which case it owns an independent schema: its columns,
+ * attribute declarations and default-attribute cache must NOT be routed to the
+ * STI base. `isStiSubclass` alone is true for those, so every base-redirect
+ * that is really about a *shared table* must gate on this predicate instead.
+ *
+ * @internal
+ */
+export function sharesStiBaseTable(modelClass: object): boolean {
+  if (!isStiSubclass(modelClass)) return false;
+  const base = getStiBase(modelClass);
+  if (base === modelClass) return false;
+  const own = (modelClass as typeof Base).tableName;
+  return own == null || own === base.tableName;
+}
+
+/**
  * Get the STI base class for a model.
  */
 export function getStiBase(modelClass: object): typeof Base {

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -48,7 +48,7 @@ function reflectionAdapter(klass: any): any {
 // (Shape → Circle → Ticket → VIPTicket, Ticket = "tickets"): the schema host for
 // VIPTicket is Ticket, not Shape. Walk to the topmost ancestor that still shares
 // the receiver's table instead.
-function stiSchemaHost<T extends { tableName: string }>(klass: T): T {
+export function stiSchemaHost<T extends { tableName: string }>(klass: T): T {
   if (!isStiSubclass(klass)) return klass;
   const table = klass.tableName;
   let host = klass;

--- a/packages/activerecord/src/sti-attribute-routing.test.ts
+++ b/packages/activerecord/src/sti-attribute-routing.test.ts
@@ -182,4 +182,26 @@ describe("STI subclass attribute() routing", () => {
     // Inherited (shared-ancestor) declarations remain visible on the descendant.
     expect(Ticket._attributeDefinitions.get("radius")?.type.name).toBe("integer");
   });
+  it("own-table descendant does not clobber the STI base's attributesBuilder cache", () => {
+    class Shape extends Base {
+      static override tableName = "shapes";
+      static {
+        this.inheritanceColumn = "type";
+        this.attribute("radius", "integer");
+      }
+    }
+    class Ticket extends Shape {
+      static override tableName = "tickets";
+      static {
+        this.attribute("priority", "integer");
+      }
+    }
+
+    const shapeBuilder = Shape.attributesBuilder();
+    const ticketBuilder = Ticket.attributesBuilder();
+
+    expect(ticketBuilder).not.toBe(shapeBuilder);
+    expect(Shape.attributesBuilder()).toBe(shapeBuilder);
+    expect(Object.prototype.hasOwnProperty.call(Ticket, "_attributesBuilder")).toBe(true);
+  });
 });

--- a/packages/activerecord/src/sti-attribute-routing.test.ts
+++ b/packages/activerecord/src/sti-attribute-routing.test.ts
@@ -148,4 +148,38 @@ describe("STI subclass attribute() routing", () => {
     expect(Circle._attributeDefinitions.get("radius")?.type.name).toBe("integer");
     expect(Circle._attributeDefinitions.get("guid")?.type.name).toBe("uuid");
   });
+  it("own-table descendant under an STI ancestor keeps attribute() on itself", () => {
+    class Shape extends Base {
+      static override tableName = "shapes";
+      static {
+        this.inheritanceColumn = "type";
+      }
+    }
+    class Circle extends Shape {
+      static {
+        this.attribute("radius", "integer");
+      }
+    }
+    // Rails' own-table descendant: a class under an STI ancestor that names its
+    // own table owns an independent schema, so its declarations must not land
+    // on the STI base (or leak to shared-table siblings).
+    class Ticket extends Circle {
+      static override tableName = "tickets";
+      static {
+        this.attribute("priority", "integer");
+      }
+    }
+
+    expect(Object.prototype.hasOwnProperty.call(Ticket, "_attributeDefinitions")).toBe(true);
+    expect(Ticket._attributeDefinitions.get("priority")?.type.name).toBe("integer");
+    expect(Shape._attributeDefinitions.has("priority")).toBe(false);
+    expect(Circle._attributeDefinitions.has("priority")).toBe(false);
+
+    // The shared-table subclass still routes to the base.
+    expect(Circle._attributeDefinitions).toBe(Shape._attributeDefinitions);
+    expect(Shape._attributeDefinitions.get("radius")?.type.name).toBe("integer");
+
+    // Inherited (shared-ancestor) declarations remain visible on the descendant.
+    expect(Ticket._attributeDefinitions.get("radius")?.type.name).toBe("integer");
+  });
 });


### PR DESCRIPTION
`Base.attribute` / `defineAttribute` / `_defaultAttributes` redirected to the STI
base on bare `isStiSubclass`, so an **own-table descendant** under an STI ancestor
(`Ticket < Shape` with `Ticket.tableName = "tickets"`) had its `attribute()`
declarations land in `Shape._attributeDefinitions` and its default-attributes
cache keyed on `Shape`.

## Change

- Route all three redirects through `stiSchemaHost` — the same walk `main`'s
  schema-load path already uses (the topmost ancestor still on the receiver's
  table). Exported from `model-schema.ts`; no second predicate is introduced.
  Declarations and schema caches now agree on a single owner, including the
  nested `Shape → Circle → Ticket → VIPTicket` case where the host is `Ticket`,
  not `Shape`.
- Regression tests in `sti-attribute-routing.test.ts` (both fail on current
  `main`): an own-table descendant's `attribute()` lands on itself and does not
  leak to base/siblings; its `attributesBuilder` does not clobber the base's.

## Rails

`ActiveModel::AttributeRegistration#attribute`
(`activemodel/lib/active_model/attribute_registration.rb:12`) has no STI redirect
at all — `attribute` is per-class and `_default_attributes` memoizes per class.
The base-redirect is a trails invention; this change narrows it, so it moves
toward Rails. Table resolution matches `model_schema.rb:606` `compute_table_name`:
an explicit `self.table_name=` sticks, otherwise a non-base class cascades to
`base_class.table_name`.

Closes-story: attributes-own-table-descendant-under-sti-routes-to-base
