### PR TITLE
fix(test-compare): detect quote style via lexer for heredocs and multi-line %q

### DIFF
--- a/scripts/test-compare/extract-ruby-quote-style.test.ts
+++ b/scripts/test-compare/extract-ruby-quote-style.test.ts
@@ -6,9 +6,6 @@ import { describe, expect, it } from "vitest";
 
 const HERE = __dirname;
 
-// Exercises the Ruby extractor's literal expected-VALUE tokens through its real
-// Ripper parser (shelled out), pinning quote-style semantics: double-quoted
-// literals cook escape sequences, single-quoted ones keep them raw.
 describe("Ruby extractor literal quote style", () => {
   const RUBY_SCRIPT = path.join(HERE, "extract-ruby-tests.rb");
 

--- a/scripts/test-compare/extract-ruby-quote-style.test.ts
+++ b/scripts/test-compare/extract-ruby-quote-style.test.ts
@@ -32,6 +32,30 @@ describe("Ruby extractor literal quote style", () => {
     }
   }
 
+  function rubyQuoteStyles(source: string): Array<[number[], string]> {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "quote-rb-"));
+    try {
+      const p = path.join(dir, "source.rb");
+      fs.writeFileSync(p, source);
+      const driver = `
+        require_relative ${JSON.stringify(RUBY_SCRIPT)}
+        require "json"
+        styles = TestExtractor.new.send(:build_quote_styles, File.read(${JSON.stringify(p)}))
+        puts JSON.generate(styles.map { |pos, style| [pos, style.to_s] })
+      `;
+      return JSON.parse(execFileSync("ruby", ["-e", driver], { encoding: "utf-8" }));
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("keeps a dynamic symbol from unbalancing the enclosing literal's stack", () => {
+    // `:"x"` / `%s(y)` close with tstring_end, so they must also open the stack
+    // — otherwise they pop an entry belonging to a still-open outer literal.
+    const styles = rubyQuoteStyles(`x = "a#{:"b"}c"\ny = %s(d)\nz = :e\n`);
+    expect(styles.map(([, style]) => style)).toEqual(["double", "double", "double", "single"]);
+  });
+
   it("keeps escape sequences raw in single-quoted heredocs", () => {
     const v = rubyAssertionValues(
       [

--- a/scripts/test-compare/extract-ruby-quote-style.test.ts
+++ b/scripts/test-compare/extract-ruby-quote-style.test.ts
@@ -1,0 +1,110 @@
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const HERE = __dirname;
+
+// Exercises the Ruby extractor's literal expected-VALUE tokens through its real
+// Ripper parser (shelled out), pinning quote-style semantics: double-quoted
+// literals cook escape sequences, single-quoted ones keep them raw.
+describe("Ruby extractor literal quote style", () => {
+  const RUBY_SCRIPT = path.join(HERE, "extract-ruby-tests.rb");
+
+  function rubyAssertionValues(source: string): Record<string, string[]> {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "quote-rb-"));
+    try {
+      const rel = "cases/foo_test.rb";
+      const p = path.join(dir, rel);
+      fs.mkdirSync(path.dirname(p), { recursive: true });
+      fs.writeFileSync(p, source);
+      const driver = `
+        require_relative ${JSON.stringify(RUBY_SCRIPT)}
+        require "json"
+        ex = TestExtractor.new
+        ex.process_file(File.join(${JSON.stringify(dir)}, ${JSON.stringify(rel)}), ${JSON.stringify(dir)})
+        out = {}
+        ex.test_files.each { |f| f[:testCases].each { |tc| out[tc[:description]] = tc[:assertionValues] } }
+        puts JSON.generate(out)
+      `;
+      const stdout = execFileSync("ruby", ["-e", driver], { encoding: "utf-8" });
+      return JSON.parse(stdout);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("keeps escape sequences raw in single-quoted heredocs", () => {
+    const v = rubyAssertionValues(
+      [
+        "class FooTest < ActiveSupport::TestCase",
+        "  def test_single_heredoc",
+        "    assert_equal(<<~'EOS', x)",
+        "      a\\nb",
+        "    EOS",
+        "  end",
+        "",
+        "  def test_double_heredoc",
+        "    assert_equal(<<~EOS, x)",
+        "      a\\nb",
+        "    EOS",
+        "  end",
+        "end",
+      ].join("\n"),
+    );
+    expect(v["single heredoc"]).toEqual(["s:a\\nb\n"]);
+    expect(v["double heredoc"]).toEqual(["s:a\nb\n"]);
+  });
+
+  it("keeps escape sequences raw in a %q literal whose content starts on a later line", () => {
+    const v = rubyAssertionValues(
+      [
+        "class FooTest < ActiveSupport::TestCase",
+        "  def test_multiline_q",
+        "    assert_equal %q{",
+        "a\\nb",
+        "}, x",
+        "  end",
+        "",
+        "  def test_multiline_bigq",
+        "    assert_equal %Q{",
+        "a\\nb",
+        "}, x",
+        "  end",
+        "end",
+      ].join("\n"),
+    );
+    expect(v["multiline q"]).toEqual(["s:\na\\nb\n"]);
+    expect(v["multiline bigq"]).toEqual(["s:\na\nb\n"]);
+  });
+
+  it("still distinguishes inline single- and double-quoted literals", () => {
+    const v = rubyAssertionValues(
+      [
+        "class FooTest < ActiveSupport::TestCase",
+        "  def test_inline",
+        "    assert_equal 'a\\nb', x",
+        '    assert_equal "a\\nb", y',
+        "  end",
+        "end",
+      ].join("\n"),
+    );
+    expect(v["inline"]).toEqual(["s:a\\nb", "s:a\nb"]);
+  });
+
+  it("attributes the heredoc body past interleaved same-line literals", () => {
+    const v = rubyAssertionValues(
+      [
+        "class FooTest < ActiveSupport::TestCase",
+        "  def test_interleaved",
+        "    assert_equal(<<~'EOS', \"c\\nd\")",
+        "      a\\nb",
+        "    EOS",
+        "  end",
+        "end",
+      ].join("\n"),
+    );
+    expect(v["interleaved"]).toEqual(["s:a\\nb\n"]);
+  });
+});

--- a/scripts/test-compare/extract-ruby-tests.rb
+++ b/scripts/test-compare/extract-ruby-tests.rb
@@ -119,6 +119,7 @@ class TestExtractor
     @class_stack = []
     @test_cases = []
     @source_lines = source.lines
+    @quote_styles = build_quote_styles(source)
     @gate_stack = []
     @file_adapter_gate = dir_adapter_gate(rel_path)
     # Modules that define `def test_*` (e.g. an `ActiveSupport::Concern` mixed
@@ -1190,11 +1191,53 @@ class TestExtractor
   def double_quoted_literal?(node)
     pos = first_tstring_pos(node)
     return true unless pos
+    style = (@quote_styles || {})[pos]
+    return style == :double if style
+    # Fallback for sources Ripper.lex could not tokenize: peek at the source
+    # character preceding the content.
     line, col = pos
     before = @source_lines[line - 1].to_s[0...col]
     return false if before.end_with?("'")
     return false if before.match?(/%q.\z/)
     true
+  end
+
+  # Maps every `tstring_content` token position to the quote style of the
+  # literal that opens it. Ripper's sexp does not record quote style, and the
+  # source character before the content is not enough: a single-quoted heredoc
+  # (`<<~'EOS'`) starts its content at column 0 of a later line, and a `%q`
+  # literal whose content begins on a later line loses its delimiter the same
+  # way. The lexer pass keeps the opening delimiter attached to the content.
+  def build_quote_styles(source)
+    styles = {}
+    open_stack = []
+    heredocs = []
+    Ripper.lex(source).each do |pos, type, tok, _state|
+      case type
+      when :on_tstring_beg, :on_words_beg, :on_qwords_beg,
+           :on_symbols_beg, :on_qsymbols_beg, :on_regexp_beg, :on_backtick
+        open_stack.push(delimiter_style(tok))
+      when :on_tstring_end, :on_label_end, :on_regexp_end
+        open_stack.pop
+      when :on_heredoc_beg
+        heredocs.push(delimiter_style(tok))
+      when :on_heredoc_end
+        heredocs.shift
+      when :on_tstring_content
+        styles[pos] = open_stack.last || heredocs.first || :double
+      end
+    end
+    styles
+  rescue StandardError
+    {}
+  end
+
+  def delimiter_style(tok)
+    return :single if tok.start_with?("'")
+    return :single if tok.match?(/\A%[qwi]/)
+    # Heredoc opener: `<<~'EOS'` / `<<-'EOS'` / `<<'EOS'`.
+    return :single if tok.start_with?("<<") && tok.include?("'")
+    :double
   end
 
   def first_tstring_pos(node)

--- a/scripts/test-compare/extract-ruby-tests.rb
+++ b/scripts/test-compare/extract-ruby-tests.rb
@@ -1203,6 +1203,10 @@ class TestExtractor
       when :on_tstring_beg, :on_words_beg, :on_qwords_beg,
            :on_symbols_beg, :on_qsymbols_beg, :on_regexp_beg, :on_backtick
         open_stack.push(delimiter_style(tok))
+      when :on_symbeg
+        # A bare symbol (`:foo`, token ":") has no closing token; only the
+        # quoting forms (`:"..."`, `:'...'`, `%s(...)`) close with tstring_end.
+        open_stack.push(delimiter_style(tok)) unless tok == ":"
       when :on_tstring_end, :on_label_end, :on_regexp_end
         open_stack.pop
       when :on_heredoc_beg
@@ -1217,8 +1221,8 @@ class TestExtractor
   end
 
   def delimiter_style(tok)
-    return :single if tok.start_with?("'")
-    return :single if tok.match?(/\A%[qwi]/)
+    return :single if tok.start_with?("'", ":'")
+    return :single if tok.match?(/\A%[qwis]/)
     return :single if tok.start_with?("<<") && tok.include?("'")
     :double
   end

--- a/scripts/test-compare/extract-ruby-tests.rb
+++ b/scripts/test-compare/extract-ruby-tests.rb
@@ -1191,23 +1191,9 @@ class TestExtractor
   def double_quoted_literal?(node)
     pos = first_tstring_pos(node)
     return true unless pos
-    style = (@quote_styles || {})[pos]
-    return style == :double if style
-    # Fallback for sources Ripper.lex could not tokenize: peek at the source
-    # character preceding the content.
-    line, col = pos
-    before = @source_lines[line - 1].to_s[0...col]
-    return false if before.end_with?("'")
-    return false if before.match?(/%q.\z/)
-    true
+    @quote_styles.fetch(pos, :double) == :double
   end
 
-  # Maps every `tstring_content` token position to the quote style of the
-  # literal that opens it. Ripper's sexp does not record quote style, and the
-  # source character before the content is not enough: a single-quoted heredoc
-  # (`<<~'EOS'`) starts its content at column 0 of a later line, and a `%q`
-  # literal whose content begins on a later line loses its delimiter the same
-  # way. The lexer pass keeps the opening delimiter attached to the content.
   def build_quote_styles(source)
     styles = {}
     open_stack = []
@@ -1228,14 +1214,11 @@ class TestExtractor
       end
     end
     styles
-  rescue StandardError
-    {}
   end
 
   def delimiter_style(tok)
     return :single if tok.start_with?("'")
     return :single if tok.match?(/\A%[qwi]/)
-    # Heredoc opener: `<<~'EOS'` / `<<-'EOS'` / `<<'EOS'`.
     return :single if tok.start_with?("<<") && tok.include?("'")
     :double
   end


### PR DESCRIPTION
## Summary

`double_quoted_literal?` in the Ruby test extractor decided quote style by
peeking at the source character before a literal's first `@tstring_content`.
That loses the delimiter whenever the content does not start right after it:

- a single-quoted heredoc (`<<~'EOS'`) starts its content at column 0 of a
  later line, so the peek saw nothing and the literal was treated as
  double-quoted — escape sequences got cooked where Ruby keeps them raw;
- a `%q` literal whose content begins on a later line loses its delimiter the
  same way.

Replaces the peek with a `Ripper.lex` pass (`build_quote_styles`) that maps
each `tstring_content` position to the style of the literal that opened it —
a stack for inline literals, a queue for heredocs, whose bodies arrive after
any other tokens on the opener's line. The map is the sole source of truth;
the source peek is gone.

Report-only (`--assertions` value comparison, no CI gate); this is hardening —
no current report mismatch stemmed from it.

## Verification

Dumped `assertionValues` for every test in `vendor/rails/*/test/**/*_test.rb`
(96k lines of tokens) before and after: **byte-identical**, no extraction
errors on either side. So the change is non-regressive across the real corpus
while fixing the constructs that corpus happens not to use yet.

## Tests

New `scripts/test-compare/extract-ruby-quote-style.test.ts` covers the
single-quoted heredoc (fails on baseline — the value came back cooked), its
double-quoted twin, multi-line `%q`/`%Q`, inline `'`/`"`, and a heredoc whose
opener line also carries a double-quoted literal. All existing
`scripts/test-compare/` tests stay green (129 passed).

Closes-story: ruby-literal-quote-style-heredoc-edges
