### PR TITLE
fix(scoping): scope_attributes? includes the default-scope arms

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -587,12 +587,7 @@ async function performClassUpdate(
  * only write scope attrs for keys NOT in the explicit set.
  */
 function _shouldApplyScopeAttributes(ctor: typeof Base): boolean {
-  // `scope_attributes?` (Scoping::Default::ClassMethods) — a default scope
-  // seeds its `where` equalities onto new records too, not only an explicit
-  // current scope. The all_queries flag is irrelevant here: `all` (and thus
-  // `scope_for_create`) applies every default scope, so both all_queries and
-  // non-all_queries `where` conditions propagate on create.
-  return (ctor as any).isScopeAttributes();
+  return ctor.isScopeAttributes();
 }
 
 /**

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -298,7 +298,7 @@ function _withTransactionCallbackOrder(
 import {
   Default as DefaultScoping,
   defaultScope as _defaultScope,
-  hasDefaultScopeOverride,
+  isScopeAttributes as _isScopeAttributes,
   unscoped as _unscoped,
 } from "./scoping/default.js";
 import * as NamedScoping from "./scoping/named.js";
@@ -587,22 +587,12 @@ async function performClassUpdate(
  * only write scope attrs for keys NOT in the explicit set.
  */
 function _shouldApplyScopeAttributes(ctor: typeof Base): boolean {
-  // Mirrors Rails' `Scoping::Default::ClassMethods#scope_attributes?`
-  // (scoping/default.rb): `super || default_scopes.any? || respond_to?(:default_scope)`,
-  // where `super` is `Scoping::ClassMethods#scope_attributes?` (`current_scope`).
-  // A default scope seeds its `where` equalities onto new records too, not only
-  // an explicit current scope. The third term — `respond_to?(:default_scope)` —
-  // is true for a model that defines its own `default_scope` method (the
-  // proc/method form, `def self.default_scope`) rather than registering via the
-  // `default_scope { }` macro (which appends to `defaultScopes`). The macro is
-  // private in Rails, so `respond_to?` is false for ordinary models; only the
-  // method-form override flips it true. `hasDefaultScopeOverride` mirrors that
-  // by walking the static chain for a `defaultScope` that isn't the inherited
-  // macro. The all_queries flag is irrelevant here — `all` (and thus
+  // `scope_attributes?` (Scoping::Default::ClassMethods) — a default scope
+  // seeds its `where` equalities onto new records too, not only an explicit
+  // current scope. The all_queries flag is irrelevant here: `all` (and thus
   // `scope_for_create`) applies every default scope, so both all_queries and
   // non-all_queries `where` conditions propagate on create.
-  const c = ctor as any;
-  return !!c.currentScope || (c.defaultScopes?.length ?? 0) > 0 || hasDefaultScopeOverride(ctor);
+  return (ctor as any).isScopeAttributes();
 }
 
 /**
@@ -2281,6 +2271,11 @@ export class Base extends Model {
    * Mirrors: ActiveRecord::Scoping::ClassMethods#scope_registry
    */
   static scopeRegistry = _scopeRegistry;
+
+  /**
+   * Mirrors: ActiveRecord::Scoping::Default::ClassMethods#scope_attributes?
+   */
+  static isScopeAttributes = _isScopeAttributes;
 
   // -- Finders (class methods) --
 

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -411,6 +411,7 @@ interface CoreHost {
   arelTable?: any;
   prototype: any;
   all(): any;
+  isScopeAttributes(): boolean;
   typeForAttribute(name: string): { cast(value: unknown): unknown };
   ensureSchemaLoaded(): Promise<void>;
 }
@@ -882,7 +883,7 @@ export async function find(this: CoreHost, ...ids: unknown[]): Promise<any> {
   // which applies the default scope's eager joins. Mirrors the `findBy` guard.
   if (
     ids.length === 1 &&
-    !(this as any).isScopeAttributes() &&
+    !this.isScopeAttributes() &&
     this.primaryKey != null &&
     !this.compositePrimaryKey &&
     !Array.isArray(ids[0]) &&
@@ -1081,7 +1082,7 @@ async function findByThroughCache(
   // default scope can add includes/references/order the StatementCache fast path
   // can't reproduce (it builds a bare `where(...).limit(1)`), so defer the whole
   // lookup to the relation path, which applies the default scope's eager joins.
-  if ((this as any).isScopeAttributes()) {
+  if (this.isScopeAttributes()) {
     return this.all().findBy(conditions);
   }
   const keys = Object.keys(conditions);

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -31,7 +31,6 @@ import { Map as TypeCasterMap } from "./type-caster/map.js";
 import { buildPkWhereNode, columnsHash } from "./model-schema.js";
 import { StatementCache } from "./statement-cache.js";
 import { RangeError as ActiveModelRangeError } from "@blazetrails/activemodel";
-import { hasDefaultScopeOverride } from "./scoping/default.js";
 
 /**
  * The Core module interface — methods mixed into every AR model.
@@ -883,9 +882,7 @@ export async function find(this: CoreHost, ...ids: unknown[]): Promise<any> {
   // which applies the default scope's eager joins. Mirrors the `findBy` guard.
   if (
     ids.length === 1 &&
-    !(this as any).currentScope &&
-    ((this as any).defaultScopes?.length ?? 0) === 0 &&
-    !hasDefaultScopeOverride(this) &&
+    !(this as any).isScopeAttributes() &&
     this.primaryKey != null &&
     !this.compositePrimaryKey &&
     !Array.isArray(ids[0]) &&
@@ -1084,8 +1081,7 @@ async function findByThroughCache(
   // default scope can add includes/references/order the StatementCache fast path
   // can't reproduce (it builds a bare `where(...).limit(1)`), so defer the whole
   // lookup to the relation path, which applies the default scope's eager joins.
-  const ctor = this as any;
-  if (ctor.currentScope || (ctor.defaultScopes?.length ?? 0) > 0 || hasDefaultScopeOverride(this)) {
+  if ((this as any).isScopeAttributes()) {
     return this.all().findBy(conditions);
   }
   const keys = Object.keys(conditions);

--- a/packages/activerecord/src/scoping.ts
+++ b/packages/activerecord/src/scoping.ts
@@ -110,13 +110,15 @@ function setValueFor(map: WeakMap<object, any>, modelClass: object, value: any):
 // ---------------------------------------------------------------------------
 
 interface ScopingHost {
-  constructor: { scope_attributes?(): Record<string, unknown>; currentScope?: any };
+  constructor: { isScopeAttributes?(): boolean; currentScope?: any };
   assignAttributes?(attrs: Record<string, unknown>): void;
 }
 
 export function populateWithCurrentScopeAttributes(this: ScopingHost): void {
   const klass = this.constructor as any;
-  if (!klass.currentScope) return;
+  // Rails: `return unless self.class.scope_attributes?` — the Default override
+  // makes this true for a default-scoped model with no current scope too.
+  if (!klass.isScopeAttributes?.()) return;
   const attrs = scopeAttributes.call(klass);
   if (attrs && Object.keys(attrs).length > 0 && this.assignAttributes) {
     this.assignAttributes(attrs);

--- a/packages/activerecord/src/scoping.ts
+++ b/packages/activerecord/src/scoping.ts
@@ -110,15 +110,13 @@ function setValueFor(map: WeakMap<object, any>, modelClass: object, value: any):
 // ---------------------------------------------------------------------------
 
 interface ScopingHost {
-  constructor: { isScopeAttributes?(): boolean; currentScope?: any };
+  constructor: { isScopeAttributes(): boolean };
   assignAttributes?(attrs: Record<string, unknown>): void;
 }
 
 export function populateWithCurrentScopeAttributes(this: ScopingHost): void {
   const klass = this.constructor as any;
-  // Rails: `return unless self.class.scope_attributes?` — the Default override
-  // makes this true for a default-scoped model with no current scope too.
-  if (!klass.isScopeAttributes?.()) return;
+  if (!klass.isScopeAttributes()) return;
   const attrs = scopeAttributes.call(klass);
   if (attrs && Object.keys(attrs).length > 0 && this.assignAttributes) {
     this.assignAttributes(attrs);

--- a/packages/activerecord/src/scoping/default-scoping.trails.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.trails.test.ts
@@ -1,0 +1,39 @@
+/**
+ * TS-only coverage for `scope_attributes?`. Rails has no direct test for the
+ * predicate — it is exercised indirectly through new-record seeding and the
+ * `find`/`find_by` StatementCache guards — so these cases live here rather than
+ * in the ported default_scoping_test.rb file.
+ */
+import { describe, it, expect } from "vitest";
+import "../index.js";
+import { Base } from "../base.js";
+import {
+  Developer,
+  DeveloperOrderedBySalary,
+  ClassMethodDeveloperCalledDavid,
+} from "../test-helpers/models/developer.js";
+
+describe("scopeAttributes?", () => {
+  it("is false for a model with no default scope and no current scope", () => {
+    expect(Developer.isScopeAttributes()).toBe(false);
+  });
+
+  it("is true for a model with a macro default scope", () => {
+    expect(DeveloperOrderedBySalary.isScopeAttributes()).toBe(true);
+  });
+
+  it("is true for a model with a method-form default scope", () => {
+    expect(ClassMethodDeveloperCalledDavid.isScopeAttributes()).toBe(true);
+  });
+
+  it("is true inside a scoping block", async () => {
+    await Developer.where({ name: "David" }).scoping(async () => {
+      expect(Developer.isScopeAttributes()).toBe(true);
+    });
+    expect(Developer.isScopeAttributes()).toBe(false);
+  });
+
+  it("is inherited by Base subclasses", () => {
+    expect(typeof Base.isScopeAttributes).toBe("function");
+  });
+});

--- a/packages/activerecord/src/scoping/default-scoping.trails.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.trails.test.ts
@@ -6,7 +6,6 @@
  */
 import { describe, it, expect } from "vitest";
 import "../index.js";
-import { Base } from "../base.js";
 import {
   Developer,
   DeveloperOrderedBySalary,
@@ -31,9 +30,5 @@ describe("scopeAttributes?", () => {
       expect(Developer.isScopeAttributes()).toBe(true);
     });
     expect(Developer.isScopeAttributes()).toBe(false);
-  });
-
-  it("is inherited by Base subclasses", () => {
-    expect(typeof Base.isScopeAttributes).toBe("function");
   });
 });

--- a/packages/activerecord/src/scoping/default.ts
+++ b/packages/activerecord/src/scoping/default.ts
@@ -194,17 +194,17 @@ export function unscoped<T extends typeof Base, R>(
 }
 
 /**
- * Are there attributes associated with this scope? Overrides the base
- * `Scoping::ClassMethods#scope_attributes?` (current scope only) with the
- * default-scope arms, so a model with a `default_scope` seeds its `where`
- * equalities onto new records even with no current scope. The third arm —
- * Rails' `respond_to?(:default_scope)` — covers the method-form override
- * (`def self.default_scope`) rather than the private `default_scope { }`
- * macro, which instead appends to `defaultScopes`.
+ * Are there attributes associated with this scope? Rails' third arm,
+ * `respond_to?(:default_scope)`, covers only the method-form override
+ * (`def self.default_scope`) — the `default_scope { }` macro is private, so it
+ * registers in `defaultScopes` instead.
  *
  * Mirrors: ActiveRecord::Scoping::Default::ClassMethods#scope_attributes?
  */
-export function isScopeAttributes(this: any): boolean {
+export function isScopeAttributes(this: {
+  currentScope?: unknown;
+  defaultScopes?: DefaultScope[];
+}): boolean {
   return (
     baseIsScopeAttributes.call(this) || isDefaultScopes.call(this) || hasDefaultScopeOverride(this)
   );

--- a/packages/activerecord/src/scoping/default.ts
+++ b/packages/activerecord/src/scoping/default.ts
@@ -1,7 +1,7 @@
 import { ArgumentError } from "@blazetrails/activemodel";
 import type { Base } from "../base.js";
 import type { Relation } from "../relation.js";
-import { ScopeRegistry } from "../scoping.js";
+import { ScopeRegistry, isScopeAttributes as baseIsScopeAttributes } from "../scoping.js";
 
 /**
  * Manages evaluating and applying default scopes.
@@ -191,6 +191,23 @@ export function unscoped<T extends typeof Base, R>(
     return rel.scoping(block);
   }
   return rel;
+}
+
+/**
+ * Are there attributes associated with this scope? Overrides the base
+ * `Scoping::ClassMethods#scope_attributes?` (current scope only) with the
+ * default-scope arms, so a model with a `default_scope` seeds its `where`
+ * equalities onto new records even with no current scope. The third arm —
+ * Rails' `respond_to?(:default_scope)` — covers the method-form override
+ * (`def self.default_scope`) rather than the private `default_scope { }`
+ * macro, which instead appends to `defaultScopes`.
+ *
+ * Mirrors: ActiveRecord::Scoping::Default::ClassMethods#scope_attributes?
+ */
+export function isScopeAttributes(this: any): boolean {
+  return (
+    baseIsScopeAttributes.call(this) || isDefaultScopes.call(this) || hasDefaultScopeOverride(this)
+  );
 }
 
 /**

--- a/packages/activerecord/src/scoping/default.ts
+++ b/packages/activerecord/src/scoping/default.ts
@@ -206,7 +206,9 @@ export function isScopeAttributes(this: {
   defaultScopes?: DefaultScope[];
 }): boolean {
   return (
-    baseIsScopeAttributes.call(this) || isDefaultScopes.call(this) || hasDefaultScopeOverride(this)
+    baseIsScopeAttributes.call(this) ||
+    (this.defaultScopes?.length ?? 0) > 0 ||
+    hasDefaultScopeOverride(this)
   );
 }
 

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/core.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/core.json
@@ -86,13 +86,6 @@
   {
     "package": "activerecord",
     "tsFile": "core.ts",
-    "rubyName": "find",
-    "call": "scope_attributes?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "core.ts",
     "rubyName": "find_by",
     "call": "all?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -242,14 +235,14 @@
     "tsFile": "core.ts",
     "rubyName": "init_internals",
     "call": "define_attribute_methods",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails core.rb:834-849 caches `klass.primary_key` into @primary_key and calls `klass.define_attribute_methods`; trails core.ts:753-771 initializes the same flags but reads primaryKey lazily from the class and defines attribute methods at declare() time — neither call appears in initInternals."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails core.rb:834-849 caches `klass.primary_key` into @primary_key and calls `klass.define_attribute_methods`; trails core.ts:753-771 initializes the same flags but reads primaryKey lazily from the class and defines attribute methods at declare() time \u2014 neither call appears in initInternals."
   },
   {
     "package": "activerecord",
     "tsFile": "core.ts",
     "rubyName": "init_internals",
     "call": "primary_key",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails core.rb:834-849 caches `klass.primary_key` into @primary_key and calls `klass.define_attribute_methods`; trails core.ts:753-771 initializes the same flags but reads primaryKey lazily from the class and defines attribute methods at declare() time — neither call appears in initInternals."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails core.rb:834-849 caches `klass.primary_key` into @primary_key and calls `klass.define_attribute_methods`; trails core.ts:753-771 initializes the same flags but reads primaryKey lazily from the class and defines attribute methods at declare() time \u2014 neither call appears in initInternals."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/scoping.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/scoping.json
@@ -33,12 +33,5 @@
     "rubyName": "populate_with_current_scope_attributes",
     "call": "any?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "scoping.ts",
-    "rubyName": "scope_attributes?",
-    "call": "any?",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails scoping/default.rb:55-57 is `super || default_scopes.any? || respond_to?(:default_scope)`; trails scoping.ts:144-146 isScopeAttributes returns `!!this.currentScope` — only the super (scoping.rb:22-24) arm; the default_scopes.any? arm is unported. Omission tracked in story scope-attributes-predicate-ignores-default-scopes."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/scoping/default.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/scoping/default.json
@@ -30,6 +30,13 @@
   {
     "package": "activerecord",
     "tsFile": "scoping/default.ts",
+    "rubyName": "scope_attributes?",
+    "call": "any?",
+    "reason": "Ruby Array#any? has no ported counterpart: `default_scopes.any?` (scoping/default.rb:56) ports to the `defaultScopes.length` check in isScopeAttributes."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "scoping/default.ts",
     "rubyName": "unscoped",
     "call": "relation",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Rails' `Scoping::Default::ClassMethods#scope_attributes?` (scoping/default.rb:55-57) is `super || default_scopes.any? || respond_to?(:default_scope)`. Trails' `isScopeAttributes` (scoping.ts) returned `!!this.currentScope` only — the base arm — so a model with a default scope and no current scope answered false and `populateWithCurrentScopeAttributes` skipped seeding new records with default-scope attributes.

## Changes

- Add the Default override `isScopeAttributes` in `scoping/default.ts` (Rails layout) and wire it onto `Base`.
- `populateWithCurrentScopeAttributes` now guards on `scope_attributes?` as Rails does, not on `currentScope`.
- Converge the three open-coded copies of the predicate onto it: `base.ts` `_shouldApplyScopeAttributes`, and the `core.ts` `find` / `findByThroughCache` StatementCache guards.
- TS-only coverage in `scoping/default-scoping.trails.test.ts` (Rails has no direct test for the predicate).

Scoping, core, inheritance, relations and base suites pass locally.

Closes-story: scope-attributes-predicate-ignores-default-scopes
