### PR TITLE
test(arel): converge select-manager chains/distinct_on bodies to Rails

### DIFF
--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -5,7 +5,6 @@ import {
   star,
   SelectManager,
   InsertManager,
-  UpdateManager,
   Nodes,
   Visitors,
   EmptyJoinError,
@@ -425,9 +424,9 @@ describe("SelectManagerTest", () => {
 
   describe("order", () => {
     it("chains", () => {
-      const mgr = new UpdateManager();
-      mgr.table(users);
-      expect(mgr.where(users.get("id").eq(1))).toBe(mgr);
+      const table = new Table("users");
+      const mgr = new SelectManager();
+      expect(mgr.order(table.get("id"))).toBe(mgr);
     });
   });
 
@@ -630,8 +629,9 @@ describe("SelectManagerTest", () => {
     });
 
     it("chains", () => {
-      const mgr = users.project(star);
-      expect(mgr.where(users.get("id").eq(1))).toBe(mgr);
+      const table = new Table("users");
+      const mgr = new SelectManager();
+      expect(mgr.group(table.get("id"))).toBe(mgr);
     });
   });
 
@@ -899,9 +899,8 @@ describe("SelectManagerTest", () => {
 
   describe("take", () => {
     it("chains", () => {
-      const um = new UpdateManager();
-      const result = um.table(users);
-      expect(result).toBe(um);
+      const mgr = new SelectManager();
+      expect(mgr.take(1)).toBe(mgr);
     });
   });
 
@@ -923,13 +922,19 @@ describe("SelectManagerTest", () => {
       const mgr = users.project(star).where(sub);
       expect(mgr.toSql()).toContain("WHERE");
     });
+
+    it("chains", () => {
+      const table = new Table("users");
+      const mgr = new SelectManager();
+      mgr.from(table);
+      expect(mgr.project(table.get("id")).where(table.get("id").eq(1))).toBe(mgr);
+    });
   });
 
   describe("comment", () => {
     it("chains", () => {
-      const mgr = new SelectManager(users);
-      const result = mgr.project(star);
-      expect(result).toBe(mgr);
+      const mgr = new SelectManager();
+      expect(mgr.comment("selecting")).toBe(mgr);
     });
   });
 
@@ -937,6 +942,13 @@ describe("SelectManagerTest", () => {
     it("makes sql", () => {
       const mgr = users.project(star);
       expect(mgr.toSql()).toBe('SELECT * FROM "users"');
+    });
+
+    it("chains", () => {
+      const table = new Table("users");
+      const mgr = new SelectManager();
+      expect(mgr.from(table).project(table.get("id"))).toBe(mgr);
+      expect(mgr.toSql()).toBe('SELECT "users"."id" FROM "users"');
     });
   });
 
@@ -957,13 +969,34 @@ describe("SelectManagerTest", () => {
       mgr.distinct(false);
       expect(mgr.ast.cores[mgr.ast.cores.length - 1].setQuantifier).toBeNull();
     });
+
+    it("chains", () => {
+      const mgr = new SelectManager();
+      expect(mgr.distinct()).toBe(mgr);
+      expect(mgr.distinct(false)).toBe(mgr);
+    });
   });
 
   describe("distinct_on", () => {
     it("sets the quantifier", () => {
-      const mgr = users.project(star);
-      mgr.distinct();
-      expect(mgr.toSql()).toContain("DISTINCT");
+      const mgr = new SelectManager();
+      const table = new Table("users");
+
+      mgr.distinctOn(table.get("id"));
+      expect(mgr.ast.cores[mgr.ast.cores.length - 1].setQuantifier).toEqual(
+        new Nodes.DistinctOn(table.get("id")),
+      );
+
+      mgr.distinctOn(false);
+      expect(mgr.ast.cores[mgr.ast.cores.length - 1].setQuantifier).toBeNull();
+    });
+
+    it("chains", () => {
+      const mgr = new SelectManager();
+      const table = new Table("users");
+
+      expect(mgr.distinctOn(table.get("id"))).toBe(mgr);
+      expect(mgr.distinctOn(false)).toBe(mgr);
     });
   });
 

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -318,8 +318,8 @@ export class SelectManager extends TreeManager {
    *
    * Mirrors: Arel::SelectManager#distinct_on
    */
-  distinctOn(value: Node): this {
-    this.core.setQuantifier = new DistinctOn(value);
+  distinctOn(value: Node | false | null): this {
+    this.core.setQuantifier = value === false || value == null ? null : new DistinctOn(value);
     return this;
   }
 


### PR DESCRIPTION
Several `select-manager.test.ts` tests fuzzy-matched Rails test names while
their bodies exercised a different method entirely. This converges them to the
Rails bodies (`vendor/rails/activerecord/test/cases/arel/select_manager_test.rb`).

- `group > chains` (rb:702) chained `where`, not `group`.
- `order > chains` (rb:425) built an `UpdateManager` and chained `where`.
- `take > chains` (rb:1143) built an `UpdateManager` and chained `table`.
- `comment > chains` (rb:1216) chained `project`.
- `distinct_on > sets the quantifier` (rb:1195) called `distinct()` and grepped
  the SQL for `DISTINCT`; it never touched `distinctOn`. Now asserts
  `setQuantifier` equals `DistinctOn(table["id"])` and is null after
  `distinctOn(false)`.
- Ported the missing `distinct > chains` (rb:1187), `distinct_on > chains`
  (rb:1206), `from > chains` (rb:1161) and `where > chains` (rb:1143) tests.

`SelectManager#distinctOn` gained the falsy branch from Rails'
`distinct_on(value)` — a false/nil argument clears the set quantifier instead of
wrapping it in a `DistinctOn` node.

Closes-story: select-manager-fuzzy-matched-divergent-chain-quantifier-bodies
