### PR TITLE
test(sqlite3): drive virtual-column tests through a model like Rails

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3/virtual-column.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/virtual-column.test.ts
@@ -7,6 +7,7 @@ import { Base } from "../../index.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 import { FixtureSet } from "../../test-helpers/fixture-set.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
+import { virtualColumnFixtureData } from "../../test-helpers/fixtures/virtual-columns.js";
 import { itIfSupports } from "../../test-helpers/supports.js";
 import type { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import type { Column } from "../../connection-adapters/sqlite3/column.js";
@@ -19,9 +20,6 @@ afterAll(() => {
   vi.unstubAllEnvs();
 });
 
-// `virtual_columns` is not part of the canonical schema: Rails' own test builds
-// it inline in `setup` via `@connection.create_table :virtual_columns`, so we
-// mirror that rather than reaching for a canonical table.
 fixtures([], { useTransactionalTests: false });
 
 let adapter: AbstractSQLite3Adapter;
@@ -29,8 +27,6 @@ let adapter: AbstractSQLite3Adapter;
 class VirtualColumn extends Base {
   static tableName = "virtual_columns";
   static {
-    // Declare the real PK so strict writeFromUser's post-INSERT id write-back
-    // has a known column (mirrors the PG virtual-column test).
     this.attribute("id", "integer");
   }
 }
@@ -54,8 +50,6 @@ afterEach(async () => {
   VirtualColumn.resetColumnInformation();
 });
 
-// `take()` is nullable in TS; every call site here runs against the row created
-// in `beforeEach`, so unwrap once rather than asserting non-null per test.
 async function take(): Promise<Record<string, unknown>> {
   return (await VirtualColumn.take()) as unknown as Record<string, unknown>;
 }
@@ -160,10 +154,11 @@ describeIfSqlite("SQLite3VirtualColumnTest", () => {
   });
 
   itIfSupports("virtual_columns", "build fixture sql", async () => {
-    const created = await FixtureSet.createFixtures(adapter, VirtualColumn, {
-      one: { name: "hello" },
-      two: { name: "world" },
-    });
+    const created = await FixtureSet.createFixtures(
+      adapter,
+      VirtualColumn,
+      virtualColumnFixtureData,
+    );
     expect(Object.keys(created).length).toBe(2);
   });
 });

--- a/packages/activerecord/src/adapters/sqlite3/virtual-column.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/virtual-column.test.ts
@@ -1,82 +1,125 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/sqlite3/virtual_column_test.rb
  */
-import { expect, beforeEach, afterEach } from "vitest";
+import { expect, beforeAll, beforeEach, afterEach, afterAll, vi } from "vitest";
 import { describeIfSqlite } from "./test-helper.js";
-import { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
-import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";
-import type { Column } from "../../connection-adapters/sqlite3/column.js";
+import { Base } from "../../index.js";
+import { SchemaDumper } from "../../schema-dumper.js";
+import { FixtureSet } from "../../test-helpers/fixture-set.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import { itIfSupports } from "../../test-helpers/supports.js";
+import type { AbstractSQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
+import type { Column } from "../../connection-adapters/sqlite3/column.js";
+
+beforeAll(() => {
+  vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
+});
+
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
+
+// `virtual_columns` is not part of the canonical schema: Rails' own test builds
+// it inline in `setup` via `@connection.create_table :virtual_columns`, so we
+// mirror that rather than reaching for a canonical table.
+fixtures([], { useTransactionalTests: false });
 
 let adapter: AbstractSQLite3Adapter;
 
+class VirtualColumn extends Base {
+  static tableName = "virtual_columns";
+  static {
+    // Declare the real PK so strict writeFromUser's post-INSERT id write-back
+    // has a known column (mirrors the PG virtual-column test).
+    this.attribute("id", "integer");
+  }
+}
+
 beforeEach(async () => {
-  adapter = new BetterSQLite3Adapter(":memory:");
-  await adapter.exec(
-    `CREATE TABLE "virtual_columns" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar, "upper_name" varchar GENERATED ALWAYS AS (UPPER(name)) STORED, "lower_name" varchar GENERATED ALWAYS AS (LOWER(name)) VIRTUAL, "octet_name" integer GENERATED ALWAYS AS (LENGTH(name)) VIRTUAL, "mutated_name" varchar GENERATED ALWAYS AS (REPLACE(name, 'l', 'L')) VIRTUAL, "column1" integer)`,
-  );
-  await adapter.executeMutation(
-    `INSERT INTO "virtual_columns" ("name", "column1") VALUES ('Rails', 10)`,
-  );
+  adapter = Base.connection as AbstractSQLite3Adapter;
+  await adapter.createTable("virtual_columns", { force: true }, (t) => {
+    t.string("name");
+    t.virtual("upper_name", { type: "string", as: "UPPER(name)", stored: true });
+    t.virtual("lower_name", { type: "string", as: "LOWER(name)", stored: false });
+    t.virtual("octet_name", { type: "integer", as: "LENGTH(name)" });
+    t.virtual("mutated_name", { type: "string", as: "REPLACE(name, 'l', 'L')" });
+    t.integer("column1");
+  });
+  await reloadColumnInformation();
+  await VirtualColumn.create({ name: "Rails", column1: 10 });
 });
 
 afterEach(async () => {
-  await adapter.exec(`DROP TABLE IF EXISTS "virtual_columns"`).catch(() => undefined);
-  await adapter.close();
+  await adapter.dropTable("virtual_columns", { ifExists: true }).catch(() => undefined);
+  VirtualColumn.resetColumnInformation();
 });
 
-async function columnsHash(): Promise<Record<string, Column>> {
-  const hash: Record<string, Column> = {};
-  for (const col of await adapter.columns("virtual_columns")) {
-    hash[col.name] = col as Column;
-  }
-  return hash;
+// `take()` is nullable in TS; every call site here runs against the row created
+// in `beforeEach`, so unwrap once rather than asserting non-null per test.
+async function take(): Promise<Record<string, unknown>> {
+  return (await VirtualColumn.take()) as unknown as Record<string, unknown>;
+}
+
+function columnFor(name: string): Column {
+  return VirtualColumn.columnsHash()[name] as unknown as Column;
+}
+
+async function reloadColumnInformation(): Promise<void> {
+  adapter.schemaCache?.clear();
+  VirtualColumn.resetColumnInformation();
+  await VirtualColumn.loadSchema();
 }
 
 // -- Rails test class: virtual_column_test.rb --
 describeIfSqlite("SQLite3VirtualColumnTest", () => {
+  itIfSupports("virtual_columns", "virtual column with full inserts", async () => {
+    const partialInsertsWas = VirtualColumn.partialInserts;
+    VirtualColumn.partialInserts = false;
+    try {
+      await expect(VirtualColumn.createBang({ name: "Rails" })).resolves.toBeTruthy();
+    } finally {
+      VirtualColumn.partialInserts = partialInsertsWas;
+    }
+  });
+
   itIfSupports("virtual_columns", "stored column", async () => {
-    const column = (await columnsHash())["upper_name"];
+    const column = columnFor("upper_name");
     expect(column.isVirtual()).toBe(true);
     expect(column.isVirtualStored()).toBe(true);
-    const rows = await adapter.execute(`SELECT "upper_name" FROM "virtual_columns" LIMIT 1`);
-    expect(rows[0].upper_name).toBe("RAILS");
+    expect((await take()).upper_name).toBe("RAILS");
   });
 
   itIfSupports("virtual_columns", "explicit virtual column", async () => {
-    const column = (await columnsHash())["lower_name"];
+    const column = columnFor("lower_name");
     expect(column.isVirtual()).toBe(true);
     expect(column.isVirtualStored()).toBe(false);
-    const rows = await adapter.execute(`SELECT "lower_name" FROM "virtual_columns" LIMIT 1`);
-    expect(rows[0].lower_name).toBe("rails");
+    expect((await take()).lower_name).toBe("rails");
   });
 
   itIfSupports("virtual_columns", "implicit virtual column", async () => {
-    const column = (await columnsHash())["octet_name"];
+    const column = columnFor("octet_name");
     expect(column.isVirtual()).toBe(true);
     expect(column.isVirtualStored()).toBe(false);
-    const rows = await adapter.execute(`SELECT "octet_name" FROM "virtual_columns" LIMIT 1`);
-    expect(rows[0].octet_name).toBe(5);
+    expect((await take()).octet_name).toBe(5);
   });
 
   itIfSupports("virtual_columns", "virtual column with comma in definition", async () => {
-    const column = (await columnsHash())["mutated_name"];
+    const column = columnFor("mutated_name");
     expect(column.isVirtual()).toBe(true);
     expect(column.isVirtualStored()).toBe(false);
     expect(column.defaultFunction).not.toBeNull();
-    const rows = await adapter.execute(`SELECT "mutated_name" FROM "virtual_columns" LIMIT 1`);
-    expect(rows[0].mutated_name).toBe("RaiLs");
+    expect((await take()).mutated_name).toBe("RaiLs");
   });
 
   itIfSupports("virtual_columns", "change table with stored generated column", async () => {
     await adapter.changeTable("virtual_columns", async (t) => {
       await t.virtual("decr_column1", { type: "integer", as: "column1 - 1", stored: true });
     });
-    const column = (await columnsHash())["decr_column1"];
+    await reloadColumnInformation();
+    const column = columnFor("decr_column1");
     expect(column.isVirtual()).toBe(true);
     expect(column.isVirtualStored()).toBe(true);
-    const rows = await adapter.execute(`SELECT "decr_column1" FROM "virtual_columns" LIMIT 1`);
-    expect(rows[0].decr_column1).toBe(9);
+    expect((await take()).decr_column1).toBe(9);
   });
 
   itIfSupports(
@@ -86,11 +129,11 @@ describeIfSqlite("SQLite3VirtualColumnTest", () => {
       await adapter.changeTable("virtual_columns", async (t) => {
         await t.virtual("incr_column1", { type: "integer", as: "column1 + 1", stored: false });
       });
-      const column = (await columnsHash())["incr_column1"];
+      await reloadColumnInformation();
+      const column = columnFor("incr_column1");
       expect(column.isVirtual()).toBe(true);
       expect(column.isVirtualStored()).toBe(false);
-      const rows = await adapter.execute(`SELECT "incr_column1" FROM "virtual_columns" LIMIT 1`);
-      expect(rows[0].incr_column1).toBe(11);
+      expect((await take()).incr_column1).toBe(11);
     },
   );
 
@@ -101,19 +144,26 @@ describeIfSqlite("SQLite3VirtualColumnTest", () => {
       await adapter.changeTable("virtual_columns", async (t) => {
         await t.virtual("sqr_column1", { type: "integer", as: "pow(column1, 2)" });
       });
-      const column = (await columnsHash())["sqr_column1"];
+      await reloadColumnInformation();
+      const column = columnFor("sqr_column1");
       expect(column.isVirtual()).toBe(true);
       expect(column.isVirtualStored()).toBe(false);
-      const rows = await adapter.execute(`SELECT "sqr_column1" FROM "virtual_columns" LIMIT 1`);
-      expect(rows[0].sqr_column1).toBe(100);
+      expect((await take()).sqr_column1).toBe(100);
     },
   );
 
-  // null-overridden: needs model layer / schema dump / fixture infrastructure
-  // it.skip("virtual column with full inserts", () => {});
-  // it.skip("schema dumping", () => {});
-  // it.skip("build fixture sql", () => {});
-});
+  itIfSupports("virtual_columns", "schema dumping", async () => {
+    const output = await SchemaDumper.dumpTableSchema(adapter, "virtual_columns");
+    expect(output).toMatch(
+      /t\.virtual\(\s*"upper_name",\s*\{\s*type:\s*"string",\s*as:\s*"UPPER\(name\)",\s*stored:\s*true\s*\}\s*\);/i,
+    );
+  });
 
-// -- Rails test class: virtual_table_test.rb --
-// All tests null-overridden (needs schema dump/load infrastructure)
+  itIfSupports("virtual_columns", "build fixture sql", async () => {
+    const created = await FixtureSet.createFixtures(adapter, VirtualColumn, {
+      one: { name: "hello" },
+      two: { name: "world" },
+    });
+    expect(Object.keys(created).length).toBe(2);
+  });
+});

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -78,6 +78,8 @@ export interface ColumnInfo {
   unsigned?: boolean;
   /** Generated-column flag — emitted as `t.virtual` by the dialect dumper. */
   virtual?: boolean;
+  /** SQLite `STORED` vs `VIRTUAL` generation flag — emitted as `stored:` by the dialect dumper. */
+  virtualStored?: boolean;
   /** Raw adapter `Extra` string (MySQL) — read to distinguish stored vs virtual generated columns. */
   extra?: string | null;
 }
@@ -252,6 +254,12 @@ class AdapterSchemaSource implements SchemaSource {
         typeof (col as any).isVirtual === "function"
           ? (col as any).isVirtual()
           : (col as any).virtual === true;
+      // SQLite distinguishes STORED from VIRTUAL generation; the flag lives
+      // behind `isVirtualStored()` on the real SQLite3 Column.
+      const isVirtualStored =
+        typeof (col as any).isVirtualStored === "function"
+          ? (col as any).isVirtualStored()
+          : (col as any).virtualStored === true;
       return {
         name: col.name,
         // Carry the dsl cast type in `type` and the raw SQL type in `sqlType`.
@@ -282,6 +290,7 @@ class AdapterSchemaSource implements SchemaSource {
         autoIncrement: (col as any).autoIncrement === true ? true : undefined,
         unsigned: (col as any).unsigned === true ? true : undefined,
         virtual: isVirtual ? true : undefined,
+        virtualStored: isVirtual && isVirtualStored ? true : undefined,
         extra: (col as any).extra ?? undefined,
       };
     });

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -254,8 +254,6 @@ class AdapterSchemaSource implements SchemaSource {
         typeof (col as any).isVirtual === "function"
           ? (col as any).isVirtual()
           : (col as any).virtual === true;
-      // SQLite distinguishes STORED from VIRTUAL generation; the flag lives
-      // behind `isVirtualStored()` on the real SQLite3 Column.
       const isVirtualStored =
         typeof (col as any).isVirtualStored === "function"
           ? (col as any).isVirtualStored()


### PR DESCRIPTION
Ports `adapters/sqlite3/virtual_column_test.rb` to the model layer, matching
Rails: a `VirtualColumn extends Base` over a `create_table :virtual_columns`
built with `t.virtual`, using `columnsHash()` / `take()` instead of the
adapter-level `columns()` predicates + raw SELECTs PR #5127 left in place.

The three previously null-overridden Rails tests now run:

- `test_virtual_column_with_full_inserts` — `partialInserts = false` insert
  over generated columns.
- `test_schema_dumping` — `dumpTableSchema` emits the `t.virtual` spec.
- `test_build_fixture_sql` — `FixtureSet.createFixtures` skips generated
  columns; drives the canonical `virtualColumnFixtureData` (the mirror of
  Rails' `test/fixtures/virtual_columns.yml`), 2 rows.

## Real fix

`test_schema_dumping` surfaced a genuine gap: `AdapterSchemaSource#columns`
projected `isVirtual()` through but dropped the SQLite STORED/VIRTUAL
distinction, so `sqlite3/schema-dumper.ts` read `column.virtualStored` as
`undefined` and every generated column dumped as `stored: false` — a dump
that would not round-trip. `virtualStored` is now carried alongside `virtual`.

`virtual_columns` is not a canonical-schema table by design: Rails' own test
builds it inline in `setup` via `@connection.create_table :virtual_columns`,
so this mirrors that rather than reaching for a canonical table.

## Verification

- `virtual-column.test.ts` 10/10, `virtual-column.trails.test.ts`,
  `schema-dumper.test.ts` pass.
- `pnpm test:compare`: `adapters/sqlite3/virtual_column_test.rb` → 10 matched,
  0 mismatches of any kind.

Closes-story: sqlite3-virtual-column-model-layer-port
