### PR TITLE
fix(model-schema): memoize columns per class for STI subclasses with own ignoredColumns

### DIFF
--- a/packages/activerecord/src/base.trails.test.ts
+++ b/packages/activerecord/src/base.trails.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect } from "vitest";
 import { Base, UnknownPrimaryKey } from "./index.js";
 import { quoteSqlValue } from "./base.js";
+import { registerSubclass } from "./inheritance.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Type } from "@blazetrails/activemodel";
 import { fixtures } from "./test-helpers/fixtures.js";
@@ -378,6 +379,33 @@ describe("ignored columns follow Rails' value-keyed attribute set (trails)", () 
     expect(Firm.columns().map((c: { name: string }) => c.name)).not.toContain("rating");
     expect(Firm.columnNames()).not.toContain("rating");
     expect(Company.columns().map((c: { name: string }) => c.name)).toContain("rating");
+  });
+
+  it("an STI subclass's own ignoredColumns memoizes per class and reloads with the base", async () => {
+    class Company extends Base {
+      static override tableName = "companies";
+      static {
+        this.inheritanceColumn = "type";
+      }
+    }
+    class Firm extends Company {
+      static {
+        registerSubclass(this);
+        this.ignoredColumns = ["rating"];
+      }
+    }
+    const first = Firm.columnsHash();
+    expect(Firm.columnsHash()).toBe(first);
+    expect(Firm.columns()).toBe(Firm.columns());
+    expect(Company.columnsHash()).not.toBe(first);
+
+    Company.resetColumnInformation();
+    await Company.loadSchema();
+    const afterReset = Firm.columnsHash();
+    expect(afterReset).not.toBe(first);
+    expect(Object.keys(afterReset)).not.toContain("rating");
+    expect(Firm.columns().map((c: { name: string }) => c.name)).not.toContain("rating");
+    expect(Company.columnNames()).toContain("rating");
   });
 
   it("an ignored column still declared via attribute() casts and responds on SELECT *", async () => {

--- a/packages/activerecord/src/base.trails.test.ts
+++ b/packages/activerecord/src/base.trails.test.ts
@@ -424,19 +424,22 @@ describe("ignored columns follow Rails' value-keyed attribute set (trails)", () 
     const first = Firm.columnsHash();
     expect(Firm.columnsHash()).toBe(first);
 
-    // The virtual-attribute reconciliation path clears only the base's
-    // `_columnsHash`/`_schemaLoaded`; the next load re-applies the reflected
-    // columns and must not leave the subclass on its pre-reflection memo.
-    const internals = Company as unknown as {
+    // The end state `reflectColumnNames` leaves behind when it warms a cold
+    // shared cache (model-schema.ts): only the BASE's `_columnsHash`/`_columns`/
+    // `_schemaLoaded` are dropped, subclasses are untouched. Simulated rather
+    // than driven through `reconcileVirtualAttributes(true)` because that
+    // function short-circuits on `cachedColumnNames` — in this suite the shared
+    // cache is always warm, so the clearing branch is unreachable from a test.
+    const base = Company as unknown as {
       _columnsHash?: unknown;
       _columns?: unknown;
       _schemaLoaded?: boolean;
-      _schemaLoadPromise?: Promise<void>;
     };
-    internals._columnsHash = undefined;
-    internals._columns = undefined;
-    internals._schemaLoaded = false;
-    internals._schemaLoadPromise = undefined;
+    base._columnsHash = undefined;
+    base._columns = undefined;
+    base._schemaLoaded = false;
+    // The next load re-applies the reflected columns; it must not leave the
+    // subclass on its pre-reflection memo.
     expect(Company.columnNames()).toContain("rating");
 
     const rebuilt = Firm.columnsHash();

--- a/packages/activerecord/src/base.trails.test.ts
+++ b/packages/activerecord/src/base.trails.test.ts
@@ -408,6 +408,43 @@ describe("ignored columns follow Rails' value-keyed attribute set (trails)", () 
     expect(Company.columnNames()).toContain("rating");
   });
 
+  it("an STI subclass's own columns memo is rebuilt when the base re-reflects", async () => {
+    class Company extends Base {
+      static override tableName = "companies";
+      static {
+        this.inheritanceColumn = "type";
+      }
+    }
+    class Firm extends Company {
+      static {
+        registerSubclass(this);
+        this.ignoredColumns = ["rating"];
+      }
+    }
+    const first = Firm.columnsHash();
+    expect(Firm.columnsHash()).toBe(first);
+
+    // The virtual-attribute reconciliation path clears only the base's
+    // `_columnsHash`/`_schemaLoaded`; the next load re-applies the reflected
+    // columns and must not leave the subclass on its pre-reflection memo.
+    const internals = Company as unknown as {
+      _columnsHash?: unknown;
+      _columns?: unknown;
+      _schemaLoaded?: boolean;
+      _schemaLoadPromise?: Promise<void>;
+    };
+    internals._columnsHash = undefined;
+    internals._columns = undefined;
+    internals._schemaLoaded = false;
+    internals._schemaLoadPromise = undefined;
+    expect(Company.columnNames()).toContain("rating");
+
+    const rebuilt = Firm.columnsHash();
+    expect(rebuilt).not.toBe(first);
+    expect(Object.keys(rebuilt)).not.toContain("rating");
+    expect(Object.keys(Company.columnsHash())).toContain("rating");
+  });
+
   it("an ignored column still declared via attribute() casts and responds on SELECT *", async () => {
     const { AttributedDeveloper } = await import("./test-helpers/models/developer.js");
     const dev = await AttributedDeveloper.create();

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -247,6 +247,18 @@ export interface ColumnLike {
   [key: string]: unknown;
 }
 
+/**
+ * DEVIATION (trails): Rails gives EVERY class its own `@columns_hash`/`@columns`
+ * — `inherited` nils the child's ivars (model_schema.rb:574-580) and each
+ * `load_schema!` re-filters `schema_cache.columns_hash(table_name)` by that
+ * class's own `ignored_columns` (:587-594). Ruby classes inherit no ivars, so
+ * there is no base-owns/subclass-inherits split to port. trails memoizes on the
+ * STI base (the schema-host redirect) and carves out only subclasses that
+ * declared their own `ignoredColumns`, because they filter a different column
+ * set than the base does. Converging the rest is story-sized: flipping this to
+ * plain `isStiSubclass(host)` passes everything except
+ * model-schema-sync-load.test.ts:261-280, which asserts the shared memo.
+ */
 function ownsColumnMemo(host: SchemaHost): boolean {
   return isStiSubclass(host) && Object.prototype.hasOwnProperty.call(host, "_ignoredColumns");
 }

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -248,6 +248,15 @@ export interface ColumnLike {
 }
 
 /**
+ * True when `host` must keep its own `_columnsHash`/`_columns` rather than
+ * share the STI base's: an STI subclass that declared its own
+ * `ignoredColumns` filters a different column set than the base does.
+ */
+function ownsColumnMemo(host: SchemaHost): boolean {
+  return isStiSubclass(host) && Object.prototype.hasOwnProperty.call(host, "_ignoredColumns");
+}
+
+/**
  * Return a hash of column definitions keyed by name.
  *
  * Mirrors: ActiveRecord::ModelSchema::ClassMethods#columns_hash
@@ -257,11 +266,19 @@ export function columnsHash(this: typeof Base): Record<string, ColumnLike> {
   loadSchema.call(this as SchemaHost);
 
   const memoHost = this as unknown as SchemaHost;
-  const hasOwnIgnored =
-    isStiSubclass(this) && Object.prototype.hasOwnProperty.call(this, "_ignoredColumns");
-  if (!hasOwnIgnored && memoHost._columnsHash != null) {
-    return memoHost._columnsHash as Record<string, ColumnLike>;
-  }
+  // Rails keeps `@columns_hash` as a per-class ivar, each class's `load_schema!`
+  // filtering with that class's own `ignored_columns` (model_schema.rb:427-433).
+  // trails reflects onto the STI base, so a subclass with its own
+  // `ignoredColumns` must not read (or write) the base's memo — it keeps its
+  // own, invalidated with the base's by `applyColumnsHash` /
+  // `reloadSchemaFromCache`.
+  const ownsMemo = ownsColumnMemo(memoHost);
+  const memo = ownsMemo
+    ? Object.prototype.hasOwnProperty.call(memoHost, "_columnsHash")
+      ? memoHost._columnsHash
+      : undefined
+    : memoHost._columnsHash;
+  if (memo != null) return memo as Record<string, ColumnLike>;
 
   // STI-aware adapter + table resolution: adapter may live on the base
   // OR the concrete subclass. Use the same candidate-list logic the
@@ -299,6 +316,7 @@ export function columnsHash(this: typeof Base): Record<string, ColumnLike> {
         if (ignored.has(k)) continue;
         filtered[k] = v;
       }
+      if (ownsMemo && memoHost._schemaLoaded) memoHost._columnsHash = filtered;
       return filtered;
     }
   }
@@ -728,8 +746,17 @@ export function attributesBuilder(this: SchemaHost): AttributeSetBuilder {
  * Rails: @columns ||= columns_hash.values.freeze
  */
 export function columns(this: SchemaHost): any[] {
-  if (isStiSubclass(this) && Object.prototype.hasOwnProperty.call(this, "_ignoredColumns")) {
-    return Object.values((this as unknown as typeof Base).columnsHash());
+  // Per-class memo (Rails' `@columns`) when this class filters with its own
+  // `ignoredColumns`; otherwise the STI base owns the memo so subclasses
+  // inherit it — and a base reset propagates — via the prototype chain.
+  const ownsMemo = ownsColumnMemo(this);
+  if (ownsMemo) {
+    if (Object.prototype.hasOwnProperty.call(this, "_columns") && this._columns) {
+      return this._columns;
+    }
+    const own = Object.values((this as unknown as typeof Base).columnsHash());
+    if (this._schemaLoaded) this._columns = own;
+    return own;
   }
   if (this._columns) return this._columns;
   loadSchema.call(this);
@@ -874,6 +901,21 @@ function clearStiSubclassLocalCaches(sub: SchemaHost): void {
     } else {
       reloadSchemaFromCache.call(deeper);
     }
+  }
+}
+
+/**
+ * Delete own `_columnsHash`/`_columns` memos on every same-table STI
+ * descendant of `host`, so a class that keeps its own memo (see
+ * `ownsColumnMemo`) rebuilds it from the freshly reflected columns.
+ */
+function invalidateStiDescendantColumnMemos(host: SchemaHost): void {
+  for (const sub of (host as { subclasses?: SchemaHost[] }).subclasses ?? []) {
+    if (!sharesStiBaseTable(sub)) continue;
+    for (const key of ["_columnsHash", "_columns"]) {
+      if (Object.prototype.hasOwnProperty.call(sub, key)) Reflect.deleteProperty(sub, key);
+    }
+    invalidateStiDescendantColumnMemos(sub);
   }
 }
 
@@ -1332,6 +1374,11 @@ function applyColumnsHash(
   };
   invalidate(host, { deleteOwn: false });
   if (originatingHost && originatingHost !== host) invalidate(originatingHost, { deleteOwn: true });
+  // Descendants that keep their own `_columnsHash`/`_columns` (subclasses with
+  // their own `ignoredColumns`) would otherwise hold a memo built from the
+  // pre-reflection columns. Mirrors reload_schema_from_cache's recursion into
+  // `descendants`.
+  invalidateStiDescendantColumnMemos(host);
   host._columnsHash = filteredHash;
 
   // Encryption still needs a post-reflection pass — not for type wrapping (the

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -329,6 +329,7 @@ export function columnsHash(this: typeof Base): Record<string, ColumnLike> {
       ...(fn != null ? { defaultFunction: fn } : {}),
     };
   }
+  if (ownsMemo && memoHost._schemaLoaded) memoHost._columnsHash = result;
   return result;
 }
 

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -247,13 +247,16 @@ export interface ColumnLike {
   [key: string]: unknown;
 }
 
-/**
- * True when `host` must keep its own `_columnsHash`/`_columns` rather than
- * share the STI base's: an STI subclass that declared its own
- * `ignoredColumns` filters a different column set than the base does.
- */
 function ownsColumnMemo(host: SchemaHost): boolean {
   return isStiSubclass(host) && Object.prototype.hasOwnProperty.call(host, "_ignoredColumns");
+}
+
+function columnMemo<K extends "_columnsHash" | "_columns">(
+  host: SchemaHost,
+  key: K,
+): SchemaHost[K] | undefined {
+  if (ownsColumnMemo(host) && !Object.prototype.hasOwnProperty.call(host, key)) return undefined;
+  return host[key];
 }
 
 /**
@@ -266,18 +269,8 @@ export function columnsHash(this: typeof Base): Record<string, ColumnLike> {
   loadSchema.call(this as SchemaHost);
 
   const memoHost = this as unknown as SchemaHost;
-  // Rails keeps `@columns_hash` as a per-class ivar, each class's `load_schema!`
-  // filtering with that class's own `ignored_columns` (model_schema.rb:427-433).
-  // trails reflects onto the STI base, so a subclass with its own
-  // `ignoredColumns` must not read (or write) the base's memo — it keeps its
-  // own, invalidated with the base's by `applyColumnsHash` /
-  // `reloadSchemaFromCache`.
   const ownsMemo = ownsColumnMemo(memoHost);
-  const memo = ownsMemo
-    ? Object.prototype.hasOwnProperty.call(memoHost, "_columnsHash")
-      ? memoHost._columnsHash
-      : undefined
-    : memoHost._columnsHash;
+  const memo = columnMemo(memoHost, "_columnsHash");
   if (memo != null) return memo as Record<string, ColumnLike>;
 
   // STI-aware adapter + table resolution: adapter may live on the base
@@ -746,19 +739,13 @@ export function attributesBuilder(this: SchemaHost): AttributeSetBuilder {
  * Rails: @columns ||= columns_hash.values.freeze
  */
 export function columns(this: SchemaHost): any[] {
-  // Per-class memo (Rails' `@columns`) when this class filters with its own
-  // `ignoredColumns`; otherwise the STI base owns the memo so subclasses
-  // inherit it — and a base reset propagates — via the prototype chain.
-  const ownsMemo = ownsColumnMemo(this);
-  if (ownsMemo) {
-    if (Object.prototype.hasOwnProperty.call(this, "_columns") && this._columns) {
-      return this._columns;
-    }
+  const memo = columnMemo(this, "_columns");
+  if (memo) return memo;
+  if (ownsColumnMemo(this)) {
     const own = Object.values((this as unknown as typeof Base).columnsHash());
     if (this._schemaLoaded) this._columns = own;
     return own;
   }
-  if (this._columns) return this._columns;
   loadSchema.call(this);
   const hash = getColumnsHash(this);
   const cacheHost = isStiSubclass(this) ? (getStiBase(this) as SchemaHost) : this;
@@ -904,11 +891,6 @@ function clearStiSubclassLocalCaches(sub: SchemaHost): void {
   }
 }
 
-/**
- * Delete own `_columnsHash`/`_columns` memos on every same-table STI
- * descendant of `host`, so a class that keeps its own memo (see
- * `ownsColumnMemo`) rebuilds it from the freshly reflected columns.
- */
 function invalidateStiDescendantColumnMemos(host: SchemaHost): void {
   for (const sub of (host as { subclasses?: SchemaHost[] }).subclasses ?? []) {
     if (!sharesStiBaseTable(sub)) continue;
@@ -1159,7 +1141,8 @@ export function loadSchema(this: SchemaHost): void {
 }
 
 function getColumnsHash(host: SchemaHost): Record<string, unknown> {
-  if (host._columnsHash != null) return host._columnsHash;
+  const memo = columnMemo(host, "_columnsHash");
+  if (memo != null) return memo;
   const ch = (host as any).columnsHash;
   if (typeof ch === "function") return ch.call(host) ?? {};
   return {};
@@ -1374,10 +1357,6 @@ function applyColumnsHash(
   };
   invalidate(host, { deleteOwn: false });
   if (originatingHost && originatingHost !== host) invalidate(originatingHost, { deleteOwn: true });
-  // Descendants that keep their own `_columnsHash`/`_columns` (subclasses with
-  // their own `ignoredColumns`) would otherwise hold a memo built from the
-  // pre-reflection columns. Mirrors reload_schema_from_cache's recursion into
-  // `descendants`.
   invalidateStiDescendantColumnMemos(host);
   host._columnsHash = filteredHash;
 


### PR DESCRIPTION
Rails keeps `@columns_hash` / `@columns` as per-class ivars, each class's
`load_schema!` filtering with that class's own `ignored_columns`
(`model_schema.rb:427-433,587-594`). trails memoized both on the STI base, so an
STI subclass with its own `ignoredColumns` was special-cased: `columnsHash()`
and `columns()` skipped the memo entirely and recomputed the filtered view on
every call.

- Such a subclass now keeps its own `_columnsHash`/`_columns` (own property,
  written only once the schema is loaded) on **both** `columnsHash()` return
  paths — the warm schema-cache branch and the synthesized attribute-defs
  fallback. The read-time recompute guards are gone. `columnMemo()` centralises
  the "own memo or inherited base memo" read, and `getColumnsHash` routes
  through it so `columnForAttribute` / `symbolColumnToString` see the
  subclass-filtered set too.
- `applyColumnsHash` deletes same-table STI descendants' own memos when the base
  re-reflects, mirroring `reload_schema_from_cache`'s recursion into
  descendants. This covers the base-only invalidation done by
  `reflectColumnNames`, which drops the base's `_columnsHash`/`_columns`/
  `_schemaLoaded` without touching subclasses.
- Two trails regression tests: the memo is stable across calls, distinct from
  the base's, and rebuilt both after a base reset+reload and after a base-only
  re-reflection. Both fail on `main` / with the descendant invalidation removed.
  The second one simulates `reflectColumnNames`' end state rather than calling
  `reconcileVirtualAttributes(true)`, because that function short-circuits on
  `cachedColumnNames` — the shared cache is always warm in this suite, so the
  clearing branch is unreachable from a test.

Closes-story: sti-subclass-own-ignoredcolumns-unmemoized-read-time


## Convergence status

This narrows the deviation but does not remove it. Rails gives EVERY class its
own `@columns_hash`/`@columns` — `inherited` nils the child's ivars
(`model_schema.rb:574-580`) and each `load_schema!` re-filters
`schema_cache.columns_hash(table_name)` by that class's own `ignored_columns`
(`:587-594`) — so the base-owns/subclass-inherits split is a trails invention
with no Rails counterpart. `ownsColumnMemo` names that split's boundary and
carries a call-site JSDoc saying so.

Measured cost of finishing the job: flipping `ownsColumnMemo` to plain
`isStiSubclass(host)` passes 354 tests and breaks exactly one assertion pair —
`model-schema-sync-load.test.ts:261-280`, which asserts the shared memo — so the
deviation is enshrined in a trails-side test. Retiring it is filed as
`0056-adapter-type-column-reflection-fidelity/sti-subclass-per-class-columns-memo-full-convergence`.
