### PR TITLE
fix(arel): whereSql always wraps in Nodes.And and returns SqlLiteral

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -3445,7 +3445,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     const conditionsClause = (): string => {
       const scope = this.scope() as unknown as {
         _whereClause: { isEmpty(): boolean };
-        arel(): { whereSql(engine: unknown): { value: string } | null };
+        arel(): { whereSql(engine: unknown): Nodes.SqlLiteral | null };
       };
       return scope._whereClause.isEmpty()
         ? ""

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -3445,9 +3445,11 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     const conditionsClause = (): string => {
       const scope = this.scope() as unknown as {
         _whereClause: { isEmpty(): boolean };
-        arel(): { whereSql(engine: unknown): string | null };
+        arel(): { whereSql(engine: unknown): { value: string } | null };
       };
-      return scope._whereClause.isEmpty() ? "" : ` [${scope.arel().whereSql(targetModel) ?? ""}]`;
+      return scope._whereClause.isEmpty()
+        ? ""
+        : ` [${scope.arel().whereSql(targetModel)?.value ?? ""}]`;
     };
 
     // Composite + any-multi: always use the "Couldn't find all" shape

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -284,7 +284,7 @@ interface FinderRelation {
   _clone(): any;
   _whereClause: { isEmpty(): boolean };
   /** Relation#arel — the built SelectManager (relation.ts). */
-  arel(): { whereSql(engine: unknown): string | null };
+  arel(): { whereSql(engine: unknown): { value: string } | null };
   where(conditions: unknown, ...rest: unknown[]): any;
   findBy(conditions: unknown): Promise<any>;
   findByBang(conditions: unknown): Promise<any>;
@@ -323,7 +323,7 @@ export async function performFind(this: FinderRelation, ...args: unknown[]): Pro
   // default-scope predicates.
   const conditions = this._whereClause.isEmpty()
     ? ""
-    : ` [${this.arel().whereSql(this._modelClass) ?? ""}]`;
+    : ` [${this.arel().whereSql(this._modelClass)?.value ?? ""}]`;
 
   // Composite PK: OR over per-tuple WHERE conditions. The
   // `Array.isArray(pk)` guard narrows `pk` to `string[]` via
@@ -690,7 +690,7 @@ export function raiseRecordNotFoundExceptionBang(
   // wheres, which Ruby interpolates as "" — hence the `?? ""`.
   const conditions = this._whereClause.isEmpty()
     ? ""
-    : ` [${this.arel().whereSql(this._modelClass) ?? ""}]`;
+    : ` [${this.arel().whereSql(this._modelClass)?.value ?? ""}]`;
 
   const name = this._modelClass.name;
   const k = key ?? String(this._modelClass.primaryKey);

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -284,7 +284,7 @@ interface FinderRelation {
   _clone(): any;
   _whereClause: { isEmpty(): boolean };
   /** Relation#arel — the built SelectManager (relation.ts). */
-  arel(): { whereSql(engine: unknown): { value: string } | null };
+  arel(): { whereSql(engine: unknown): Nodes.SqlLiteral | null };
   where(conditions: unknown, ...rest: unknown[]): any;
   findBy(conditions: unknown): Promise<any>;
   findByBang(conditions: unknown): Promise<any>;

--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -1359,7 +1359,7 @@ describe("SelectManagerTest", () => {
     it("copies where", () => {
       const mgr = new SelectManager(users);
       mgr.project(star).where(users.get("id").eq(1)).where(users.get("name").eq("Alice"));
-      const whereSql = mgr.whereSql();
+      const whereSql = mgr.whereSql()?.value;
       expect(whereSql).toContain("WHERE");
       expect(whereSql).toContain("AND");
       expect(mgr.constraints.length).toBe(2);
@@ -1367,6 +1367,23 @@ describe("SelectManagerTest", () => {
   });
 
   describe("where_sql", () => {
+    it("gives me back the where sql", () => {
+      const mgr = new SelectManager();
+      mgr.from(users);
+      mgr.where(users.get("id").eq(10));
+      const sql = mgr.whereSql();
+      expect(sql).toBeInstanceOf(Nodes.SqlLiteral);
+      expect(sql?.value).toBe('WHERE "users"."id" = 10');
+    });
+
+    it("joins wheres with AND", () => {
+      const mgr = new SelectManager();
+      mgr.from(users);
+      mgr.where(users.get("id").eq(10));
+      mgr.where(users.get("id").eq(11));
+      expect(mgr.whereSql()?.value).toBe('WHERE "users"."id" = 10 AND "users"."id" = 11');
+    });
+
     it("returns nil when there are no wheres", () => {
       const mgr = new SelectManager(users).project(star);
       expect(mgr.whereSql()).toBeNull();

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -361,11 +361,9 @@ export class SelectManager extends TreeManager {
    *
    * Mirrors: Arel::SelectManager#where_sql
    */
-  whereSql(engine: ArelEngine | null = _engine.current): string | null {
+  whereSql(engine: ArelEngine | null = _engine.current): SqlLiteral | null {
     if (this.core.wheres.length === 0) return null;
-    const predicate =
-      this.core.wheres.length === 1 ? this.core.wheres[0] : new And(this.core.wheres);
-    return `WHERE ${predicate.toSql(engine)}`;
+    return new SqlLiteral(`WHERE ${new And(this.core.wheres).toSql(engine)}`);
   }
 
   /**


### PR DESCRIPTION
Mirrors `vendor/rails/activerecord/lib/arel/select_manager.rb:192-196`:

```ruby
def where_sql(engine = Table.engine)
  return if @ctx.wheres.empty?
  Nodes::SqlLiteral.new("WHERE #{Nodes::And.new(@ctx.wheres).to_sql(engine)}")
end
```

trails diverged twice: it special-cased a single where (`wheres.length === 1 ? wheres[0] : new And(...)`) instead of wrapping unconditionally, and returned a plain `string | null` instead of a `Nodes::SqlLiteral`.

- `whereSql` now always wraps `core.wheres` in `Nodes.And` and returns a `SqlLiteral` (`null` for the empty case, matching Ruby's bare `return`).
- The three callers (`finder-methods.ts` x2, `collection-proxy.ts`) read `.value` for the not-found-message interpolation; SQL output is unchanged since a one-element `And` renders as its sole child.
- Ports the two remaining Rails `where_sql` tests ("gives me back the where sql", "joins wheres with AND"). The `handles database-specific statements` case is skipped — it swaps the global connection visitor, which RFC 0007 is removing.

`_conditionsClause` no longer exists (already inlined at its call sites, as Rails does), and the wide call-mismatches exclude file has no `raise_record_not_found_exception!` / `where_sql` entry to drop — both were handled by earlier PRs.

Closes-story: where-sql-wraps-in-and-and-returns-sqlliteral
