### PR TITLE
fix(api-compare): sort wide call-mismatch baseline by code units, not locale collation

### DIFF
--- a/scripts/api-compare/call-mismatches-wide-exclude/actioncontroller/base.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actioncontroller/base.json
@@ -30,13 +30,6 @@
   {
     "package": "actioncontroller",
     "tsFile": "base.ts",
-    "rubyName": "content_security_policy_nonce",
-    "call": "request",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "base.ts",
     "rubyName": "content_security_policy?",
     "call": "content_security_policy",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -45,6 +38,13 @@
     "package": "actioncontroller",
     "tsFile": "base.ts",
     "rubyName": "content_security_policy?",
+    "call": "request",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "base.ts",
+    "rubyName": "content_security_policy_nonce",
     "call": "request",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/http/content-security-policy.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/http/content-security-policy.json
@@ -30,6 +30,13 @@
   {
     "package": "actiondispatch",
     "tsFile": "http/content-security-policy.ts",
+    "rubyName": "content_security_policy=",
+    "call": "set_header",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/content-security-policy.ts",
     "rubyName": "content_security_policy_nonce_directives=",
     "call": "set_header",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -45,13 +52,6 @@
     "package": "actiondispatch",
     "tsFile": "http/content-security-policy.ts",
     "rubyName": "content_security_policy_report_only=",
-    "call": "set_header",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/content-security-policy.ts",
-    "rubyName": "content_security_policy=",
     "call": "set_header",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/http/mime-negotiation.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/http/mime-negotiation.json
@@ -37,13 +37,6 @@
   {
     "package": "actiondispatch",
     "tsFile": "http/mime-negotiation.ts",
-    "rubyName": "format_from_path_extension",
-    "call": "first",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/mime-negotiation.ts",
     "rubyName": "format=",
     "call": "lookup_by_extension",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -67,6 +60,13 @@
     "tsFile": "http/mime-negotiation.ts",
     "rubyName": "format=",
     "call": "to_s",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/mime-negotiation.ts",
+    "rubyName": "format_from_path_extension",
+    "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/http/request.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/http/request.json
@@ -2,6 +2,104 @@
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
+    "rubyName": "GET",
+    "call": "action_encoding_template",
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:395-404 parses query params through CustomParamEncoder.action_encoding_template + ParamBuilder.from_query_string under fetch_header memoization; trails request.ts:944-946 returns `this.queryParameters` — trails parses query strings in that accessor without the encoding-template/ParamBuilder machinery (unported by design; plain UTF-8 params only)."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "GET",
+    "call": "fetch_header",
+    "reason": "Rack header accessor (`get_header`/`set_header`/`fetch_header`/`has_header?`). trails' request/response objects expose headers as direct property/map access instead of the Rack accessor pair, so the accessor call name is absent by design. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "GET",
+    "call": "from_query_string",
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:395-404 parses query params through CustomParamEncoder.action_encoding_template + ParamBuilder.from_query_string under fetch_header memoization; trails request.ts:944-946 returns `this.queryParameters` — trails parses query strings in that accessor without the encoding-template/ParamBuilder machinery (unported by design; plain UTF-8 params only)."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "GET",
+    "call": "new",
+    "reason": "Constructor idiom: Ruby `X.new` ports to TS `new X()`, which extractCalls records as a construction/type reference rather than a named call. The construction is present in the port. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "GET",
+    "call": "path_parameters",
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:395-404 parses query params through CustomParamEncoder.action_encoding_template + ParamBuilder.from_query_string under fetch_header memoization; trails request.ts:944-946 returns `this.queryParameters` — trails parses query strings in that accessor without the encoding-template/ParamBuilder machinery (unported by design; plain UTF-8 params only)."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "GET",
+    "call": "set_header",
+    "reason": "Rack header accessor (`get_header`/`set_header`/`fetch_header`/`has_header?`). trails' request/response objects expose headers as direct property/map access instead of the Rack accessor pair, so the accessor call name is absent by design. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "POST",
+    "call": "action_encoding_template",
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:408-434 runs the body through parse_formatted_parameters/params_parsers and ParamBuilder.from_pairs/from_hash with encoding templates; trails request.ts:949-951 returns `this.requestParameters` — body parsing happens in that accessor without the encoding-template/ParamBuilder machinery (unported by design)."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "POST",
+    "call": "fetch_header",
+    "reason": "Rack header accessor (`get_header`/`set_header`/`fetch_header`/`has_header?`). trails' request/response objects expose headers as direct property/map access instead of the Rack accessor pair, so the accessor call name is absent by design. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "POST",
+    "call": "from_hash",
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:408-434 runs the body through parse_formatted_parameters/params_parsers and ParamBuilder.from_pairs/from_hash with encoding templates; trails request.ts:949-951 returns `this.requestParameters` — body parsing happens in that accessor without the encoding-template/ParamBuilder machinery (unported by design)."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "POST",
+    "call": "from_pairs",
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:408-434 runs the body through parse_formatted_parameters/params_parsers and ParamBuilder.from_pairs/from_hash with encoding templates; trails request.ts:949-951 returns `this.requestParameters` — body parsing happens in that accessor without the encoding-template/ParamBuilder machinery (unported by design)."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "POST",
+    "call": "new",
+    "reason": "Constructor idiom: Ruby `X.new` ports to TS `new X()`, which extractCalls records as a construction/type reference rather than a named call. The construction is present in the port. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "POST",
+    "call": "params_parsers",
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:408-434 runs the body through parse_formatted_parameters/params_parsers and ParamBuilder.from_pairs/from_hash with encoding templates; trails request.ts:949-951 returns `this.requestParameters` — body parsing happens in that accessor without the encoding-template/ParamBuilder machinery (unported by design)."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "POST",
+    "call": "parse_formatted_parameters",
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:408-434 runs the body through parse_formatted_parameters/params_parsers and ParamBuilder.from_pairs/from_hash with encoding templates; trails request.ts:949-951 returns `this.requestParameters` — body parsing happens in that accessor without the encoding-template/ParamBuilder machinery (unported by design)."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "POST",
+    "call": "path_parameters",
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:408-434 runs the body through parse_formatted_parameters/params_parsers and ParamBuilder.from_pairs/from_hash with encoding templates; trails request.ts:949-951 returns `this.requestParameters` — body parsing happens in that accessor without the encoding-template/ParamBuilder machinery (unported by design)."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
     "rubyName": "check_method",
     "call": "to_sentence",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -47,48 +145,6 @@
     "rubyName": "generate_content_security_policy_nonce",
     "call": "content_security_policy_nonce_generator",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
-    "rubyName": "GET",
-    "call": "action_encoding_template",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:395-404 parses query params through CustomParamEncoder.action_encoding_template + ParamBuilder.from_query_string under fetch_header memoization; trails request.ts:944-946 returns `this.queryParameters` — trails parses query strings in that accessor without the encoding-template/ParamBuilder machinery (unported by design; plain UTF-8 params only)."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
-    "rubyName": "GET",
-    "call": "fetch_header",
-    "reason": "Rack header accessor (`get_header`/`set_header`/`fetch_header`/`has_header?`). trails' request/response objects expose headers as direct property/map access instead of the Rack accessor pair, so the accessor call name is absent by design. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
-    "rubyName": "GET",
-    "call": "from_query_string",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:395-404 parses query params through CustomParamEncoder.action_encoding_template + ParamBuilder.from_query_string under fetch_header memoization; trails request.ts:944-946 returns `this.queryParameters` — trails parses query strings in that accessor without the encoding-template/ParamBuilder machinery (unported by design; plain UTF-8 params only)."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
-    "rubyName": "GET",
-    "call": "new",
-    "reason": "Constructor idiom: Ruby `X.new` ports to TS `new X()`, which extractCalls records as a construction/type reference rather than a named call. The construction is present in the port. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
-    "rubyName": "GET",
-    "call": "path_parameters",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:395-404 parses query params through CustomParamEncoder.action_encoding_template + ParamBuilder.from_query_string under fetch_header memoization; trails request.ts:944-946 returns `this.queryParameters` — trails parses query strings in that accessor without the encoding-template/ParamBuilder machinery (unported by design; plain UTF-8 params only)."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
-    "rubyName": "GET",
-    "call": "set_header",
-    "reason": "Rack header accessor (`get_header`/`set_header`/`fetch_header`/`has_header?`). trails' request/response objects expose headers as direct property/map access instead of the Rack accessor pair, so the accessor call name is absent by design. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
   },
   {
     "package": "actiondispatch",
@@ -159,62 +215,6 @@
     "rubyName": "parse_formatted_parameters",
     "call": "symbol",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
-    "rubyName": "POST",
-    "call": "action_encoding_template",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:408-434 runs the body through parse_formatted_parameters/params_parsers and ParamBuilder.from_pairs/from_hash with encoding templates; trails request.ts:949-951 returns `this.requestParameters` — body parsing happens in that accessor without the encoding-template/ParamBuilder machinery (unported by design)."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
-    "rubyName": "POST",
-    "call": "fetch_header",
-    "reason": "Rack header accessor (`get_header`/`set_header`/`fetch_header`/`has_header?`). trails' request/response objects expose headers as direct property/map access instead of the Rack accessor pair, so the accessor call name is absent by design. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
-    "rubyName": "POST",
-    "call": "from_hash",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:408-434 runs the body through parse_formatted_parameters/params_parsers and ParamBuilder.from_pairs/from_hash with encoding templates; trails request.ts:949-951 returns `this.requestParameters` — body parsing happens in that accessor without the encoding-template/ParamBuilder machinery (unported by design)."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
-    "rubyName": "POST",
-    "call": "from_pairs",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:408-434 runs the body through parse_formatted_parameters/params_parsers and ParamBuilder.from_pairs/from_hash with encoding templates; trails request.ts:949-951 returns `this.requestParameters` — body parsing happens in that accessor without the encoding-template/ParamBuilder machinery (unported by design)."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
-    "rubyName": "POST",
-    "call": "new",
-    "reason": "Constructor idiom: Ruby `X.new` ports to TS `new X()`, which extractCalls records as a construction/type reference rather than a named call. The construction is present in the port. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
-    "rubyName": "POST",
-    "call": "params_parsers",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:408-434 runs the body through parse_formatted_parameters/params_parsers and ParamBuilder.from_pairs/from_hash with encoding templates; trails request.ts:949-951 returns `this.requestParameters` — body parsing happens in that accessor without the encoding-template/ParamBuilder machinery (unported by design)."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
-    "rubyName": "POST",
-    "call": "parse_formatted_parameters",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:408-434 runs the body through parse_formatted_parameters/params_parsers and ParamBuilder.from_pairs/from_hash with encoding templates; trails request.ts:949-951 returns `this.requestParameters` — body parsing happens in that accessor without the encoding-template/ParamBuilder machinery (unported by design)."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
-    "rubyName": "POST",
-    "call": "path_parameters",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:408-434 runs the body through parse_formatted_parameters/params_parsers and ParamBuilder.from_pairs/from_hash with encoding templates; trails request.ts:949-951 returns `this.requestParameters` — body parsing happens in that accessor without the encoding-template/ParamBuilder machinery (unported by design)."
   },
   {
     "package": "actiondispatch",

--- a/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/middleware/flash.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/middleware/flash.json
@@ -16,15 +16,15 @@
   {
     "package": "actiondispatch",
     "tsFile": "middleware/flash.ts",
-    "rubyName": "flash_hash",
-    "call": "get_header",
-    "reason": "Rack header accessor (`get_header`/`set_header`/`fetch_header`/`has_header?`). trails' request/response objects expose headers as direct property/map access instead of the Rack accessor pair, so the accessor call name is absent by design. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "rubyName": "flash=",
+    "call": "set_header",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "middleware/flash.ts",
-    "rubyName": "flash=",
-    "call": "set_header",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "flash_hash",
+    "call": "get_header",
+    "reason": "Rack header accessor (`get_header`/`set_header`/`fetch_header`/`has_header?`). trails' request/response objects expose headers as direct property/map access instead of the Rack accessor pair, so the accessor call name is absent by design. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/routing/mapper.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/routing/mapper.json
@@ -493,14 +493,14 @@
     "package": "actiondispatch",
     "tsFile": "routing/mapper.ts",
     "rubyName": "member",
-    "call": "shallow_scope",
+    "call": "shallow?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "routing/mapper.ts",
     "rubyName": "member",
-    "call": "shallow?",
+    "call": "shallow_scope",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activemodel/attribute-methods.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activemodel/attribute-methods.json
@@ -79,20 +79,6 @@
   {
     "package": "activemodel",
     "tsFile": "attribute-methods.ts",
-    "rubyName": "attribute_method_patterns_matching",
-    "call": "attribute_method_patterns",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "attribute_method_patterns_matching",
-    "call": "filter_map",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-methods.ts",
     "rubyName": "attribute_method?",
     "call": "attributes",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -109,6 +95,20 @@
     "tsFile": "attribute-methods.ts",
     "rubyName": "attribute_method?",
     "call": "respond_to_without_attributes?",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "attribute-methods.ts",
+    "rubyName": "attribute_method_patterns_matching",
+    "call": "attribute_method_patterns",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "attribute-methods.ts",
+    "rubyName": "attribute_method_patterns_matching",
+    "call": "filter_map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/association-scope.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/association-scope.json
@@ -108,14 +108,14 @@
     "package": "activerecord",
     "tsFile": "associations/association-scope.ts",
     "rubyName": "add_constraints",
-    "call": "unscope_values",
+    "call": "unscope!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "associations/association-scope.ts",
     "rubyName": "add_constraints",
-    "call": "unscope!",
+    "call": "unscope_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/association.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/association.json
@@ -318,14 +318,14 @@
     "package": "activerecord",
     "tsFile": "associations/association.ts",
     "rubyName": "violates_strict_loading?",
-    "call": "strict_loading_n_plus_one_only?",
+    "call": "strict_loading?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "associations/association.ts",
     "rubyName": "violates_strict_loading?",
-    "call": "strict_loading?",
+    "call": "strict_loading_n_plus_one_only?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/attribute-methods/composite-primary-key.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/attribute-methods/composite-primary-key.json
@@ -2,15 +2,15 @@
   {
     "package": "activerecord",
     "tsFile": "attribute-methods/composite-primary-key.ts",
-    "rubyName": "id_before_type_cast",
-    "call": "attribute_before_type_cast",
+    "rubyName": "id?",
+    "call": "all?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "attribute-methods/composite-primary-key.ts",
-    "rubyName": "id?",
-    "call": "all?",
+    "rubyName": "id_before_type_cast",
+    "call": "attribute_before_type_cast",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-adapter.json
@@ -275,15 +275,15 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "reconnect_can_restore_state?",
-    "call": "transaction_manager",
+    "rubyName": "reconnect!",
+    "call": "synchronize",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "reconnect!",
-    "call": "synchronize",
+    "rubyName": "reconnect_can_restore_state?",
+    "call": "transaction_manager",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/transaction.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/transaction.json
@@ -128,6 +128,13 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/transaction.ts",
+    "rubyName": "rollback!",
+    "call": "each",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/transaction.ts",
     "rubyName": "rollback_records",
     "call": "each",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -151,13 +158,6 @@
     "tsFile": "connection-adapters/abstract/transaction.ts",
     "rubyName": "rollback_transaction",
     "call": "rollback",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/transaction.ts",
-    "rubyName": "rollback!",
-    "call": "each",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/pool-config.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/pool-config.json
@@ -16,15 +16,15 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/pool-config.ts",
-    "rubyName": "disconnect_all!",
-    "call": "each_key",
+    "rubyName": "disconnect!",
+    "call": "synchronize",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/pool-config.ts",
-    "rubyName": "disconnect!",
-    "call": "synchronize",
+    "rubyName": "disconnect_all!",
+    "call": "each_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql/quoting.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql/quoting.json
@@ -18,7 +18,7 @@
     "tsFile": "connection-adapters/postgresql/quoting.ts",
     "rubyName": "quote_default_expression",
     "call": "include?",
-    "reason": "Vetted: ported as `value.includes(\"()\")` (quoting.rb:159). Ruby `include?` maps to the TS candidates `include`/`isInclude`, which JS strings do not have \u2014 `String#includes` is the exact equivalent."
+    "reason": "Vetted: ported as `value.includes(\"()\")` (quoting.rb:159). Ruby `include?` maps to the TS candidates `include`/`isInclude`, which JS strings do not have — `String#includes` is the exact equivalent."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-handling.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-handling.json
@@ -23,20 +23,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-handling.ts",
-    "rubyName": "connected_to_all_shards",
-    "call": "map",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-handling.ts",
-    "rubyName": "connected_to_many",
-    "call": "include?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-handling.ts",
     "rubyName": "connected_to?",
     "call": "current_role",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -46,6 +32,20 @@
     "tsFile": "connection-handling.ts",
     "rubyName": "connected_to?",
     "call": "current_shard",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-handling.ts",
+    "rubyName": "connected_to_all_shards",
+    "call": "map",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-handling.ts",
+    "rubyName": "connected_to_many",
+    "call": "include?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/core.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/core.json
@@ -37,16 +37,16 @@
   {
     "package": "activerecord",
     "tsFile": "core.ts",
-    "rubyName": "connection_class_for_self",
-    "call": "connection_class?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "connection_class?",
+    "call": "connection_class",
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails core.rb:234-236 delegates to the connection_class reader (core.rb:230-232); trails core.ts:535-539 is a combined accessor reading the `_connectionClass` field directly."
   },
   {
     "package": "activerecord",
     "tsFile": "core.ts",
-    "rubyName": "connection_class?",
-    "call": "connection_class",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails core.rb:234-236 delegates to the connection_class reader (core.rb:230-232); trails core.ts:535-539 is a combined accessor reading the `_connectionClass` field directly."
+    "rubyName": "connection_class_for_self",
+    "call": "connection_class?",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption/key-provider.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption/key-provider.json
@@ -4,7 +4,7 @@
     "tsFile": "encryption/key-provider.ts",
     "rubyName": "encryption_key",
     "call": "last",
-    "reason": "Equivalent (bucket b): Rails key_provider.rb:21 reads `@keys.last`; trails key-provider.ts expresses the same read as `_keys[_keys.length - 1]` \u2014 JS arrays have no `.last`, so the call can never appear. The store_key_references tap itself is ported (PR #5143)."
+    "reason": "Equivalent (bucket b): Rails key_provider.rb:21 reads `@keys.last`; trails key-provider.ts expresses the same read as `_keys[_keys.length - 1]` — JS arrays have no `.last`, so the call can never appear. The store_key_references tap itself is ported (PR #5143)."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/model-schema.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/model-schema.json
@@ -142,6 +142,13 @@
   {
     "package": "activerecord",
     "tsFile": "model-schema.ts",
+    "rubyName": "reload_schema_from_cache",
+    "call": "each",
+    "reason": "Rails iterates `subclasses.each`; trails recurses with a for-of over the same `subclasses` list."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "model-schema.ts",
     "rubyName": "reset_column_information",
     "call": "clear_cache!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -180,13 +187,6 @@
     "rubyName": "reset_column_information",
     "call": "initialize_find_by_cache",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
-    "rubyName": "reload_schema_from_cache",
-    "call": "each",
-    "reason": "Rails iterates `subclasses.each`; trails recurses with a for-of over the same `subclasses` list."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/persistence.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/persistence.json
@@ -268,6 +268,13 @@
   {
     "package": "activerecord",
     "tsFile": "persistence.ts",
+    "rubyName": "update!",
+    "call": "assign_attributes",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "persistence.ts",
     "rubyName": "update_attribute",
     "call": "to_s",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -340,13 +347,6 @@
     "tsFile": "persistence.ts",
     "rubyName": "update_columns",
     "call": "write_cast_value",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
-    "rubyName": "update!",
-    "call": "assign_attributes",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
@@ -80,8 +80,22 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "_substitute_values",
+    "call": "build_bind_attribute",
+    "reason": "Satisfied by QueryAttribute.withCastValue: Rails build_bind_attribute (predicate_builder.rb:67-69) is a PRESERVING constructor because QueryAttribute#type_cast is identity (query_attribute.rb:22-24); trails QueryAttribute#typeCast casts its input, so calling buildBindAttribute here would cast twice."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "_substitute_values",
     "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "_substitute_values",
+    "call": "predicate_builder",
+    "reason": "Satisfied by QueryAttribute.withCastValue: Rails build_bind_attribute (predicate_builder.rb:67-69) is a PRESERVING constructor because QueryAttribute#type_cast is identity (query_attribute.rb:22-24); trails QueryAttribute#typeCast casts its input, so calling buildBindAttribute here would cast twice."
   },
   {
     "package": "activerecord",
@@ -234,14 +248,14 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "apply_join_dependency",
-    "call": "joins_values",
+    "call": "joins!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "apply_join_dependency",
-    "call": "joins!",
+    "call": "joins_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -885,14 +899,14 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "calculate",
-    "call": "distinct_select?",
+    "call": "distinct!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "calculate",
-    "call": "distinct!",
+    "call": "distinct_select?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -1143,13 +1157,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "create_or_find_by",
-    "call": "with_connection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "create!",
     "call": "collect",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -1166,6 +1173,13 @@
     "tsFile": "relation.ts",
     "rubyName": "create!",
     "call": "scoping",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "create_or_find_by",
+    "call": "with_connection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -1543,14 +1557,14 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "exec_queries",
-    "call": "strict_loading_value",
+    "call": "strict_loading!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "exec_queries",
-    "call": "strict_loading!",
+    "call": "strict_loading_value",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -3152,6 +3166,20 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
+    "rubyName": "update!",
+    "call": "each",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "update!",
+    "call": "model",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
     "rubyName": "update_all",
     "call": "apply_join_dependency",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -3327,20 +3355,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "update!",
-    "call": "each",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "update!",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "using_limitable_reflections?",
     "call": "none?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -3372,19 +3386,5 @@
     "rubyName": "where",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "_substitute_values",
-    "call": "build_bind_attribute",
-    "reason": "Satisfied by QueryAttribute.withCastValue: Rails build_bind_attribute (predicate_builder.rb:67-69) is a PRESERVING constructor because QueryAttribute#type_cast is identity (query_attribute.rb:22-24); trails QueryAttribute#typeCast casts its input, so calling buildBindAttribute here would cast twice."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "_substitute_values",
-    "call": "predicate_builder",
-    "reason": "Satisfied by QueryAttribute.withCastValue: Rails build_bind_attribute (predicate_builder.rb:67-69) is a PRESERVING constructor because QueryAttribute#type_cast is identity (query_attribute.rb:22-24); trails QueryAttribute#typeCast casts its input, so calling buildBindAttribute here would cast twice."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/merger.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/merger.json
@@ -38,15 +38,15 @@
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_joins",
-    "call": "joins_values",
-    "reason": "Wide call-set flag: Merger#mergeJoins/#mergeOuterJoins are thin wrappers delegating to the shared foldMergeJoins/foldMergeOuterJoins helper (merge-joins.ts); the Rails call is satisfied inside the helper. PR #4676."
+    "call": "joins!",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_joins",
-    "call": "joins!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "call": "joins_values",
+    "reason": "Wide call-set flag: Merger#mergeJoins/#mergeOuterJoins are thin wrappers delegating to the shared foldMergeJoins/foldMergeOuterJoins helper (merge-joins.ts); the Rails call is satisfied inside the helper. PR #4676."
   },
   {
     "package": "activerecord",
@@ -136,15 +136,15 @@
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_outer_joins",
-    "call": "left_outer_joins_values",
-    "reason": "Wide call-set flag: Merger#mergeJoins/#mergeOuterJoins are thin wrappers delegating to the shared foldMergeJoins/foldMergeOuterJoins helper (merge-joins.ts); the Rails call is satisfied inside the helper. PR #4676."
+    "call": "left_outer_joins!",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_outer_joins",
-    "call": "left_outer_joins!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "call": "left_outer_joins_values",
+    "reason": "Wide call-set flag: Merger#mergeJoins/#mergeOuterJoins are thin wrappers delegating to the shared foldMergeJoins/foldMergeOuterJoins helper (merge-joins.ts); the Rails call is satisfied inside the helper. PR #4676."
   },
   {
     "package": "activerecord",
@@ -185,14 +185,14 @@
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
-    "call": "includes_values",
+    "call": "includes!",
     "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails merger.rb:96-115; trails merger.ts:92-94 delegates to foldMergePreloads (relation/merge-preloads.ts), which performs the same body: length===0 empty? guards, same-model union via unionAppend, else reflectOnAllAssociations().find on className with preload/includes nesting — the reads happen on `_preloadAssociations`/`_includesAssociations` fields inside the helper."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
-    "call": "includes!",
+    "call": "includes_values",
     "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails merger.rb:96-115; trails merger.ts:92-94 delegates to foldMergePreloads (relation/merge-preloads.ts), which performs the same body: length===0 empty? guards, same-model union via unionAppend, else reflectOnAllAssociations().find on className with preload/includes nesting — the reads happen on `_preloadAssociations`/`_includesAssociations` fields inside the helper."
   },
   {
@@ -206,14 +206,14 @@
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
-    "call": "preload_values",
+    "call": "preload!",
     "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails merger.rb:96-115; trails merger.ts:92-94 delegates to foldMergePreloads (relation/merge-preloads.ts), which performs the same body: length===0 empty? guards, same-model union via unionAppend, else reflectOnAllAssociations().find on className with preload/includes nesting — the reads happen on `_preloadAssociations`/`_includesAssociations` fields inside the helper."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
-    "call": "preload!",
+    "call": "preload_values",
     "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails merger.rb:96-115; trails merger.ts:92-94 delegates to foldMergePreloads (relation/merge-preloads.ts), which performs the same body: length===0 empty? guards, same-model union via unionAppend, else reflectOnAllAssociations().find on className with preload/includes nesting — the reads happen on `_preloadAssociations`/`_includesAssociations` fields inside the helper."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/query-methods.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/query-methods.json
@@ -550,7 +550,7 @@
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_where_clause",
     "call": "map",
-    "reason": "Rails' `build_where_clause` `map` is `key.map { |k| attribute_aliases[k] }` inside `transform_keys` for composite ARRAY keys; JS object keys can't be arrays, so trails resolves single-key aliases via `aliases[key] ?? key` and composite keys via `PredicateBuilder#buildComposite` \u2014 no `map` over keys applies."
+    "reason": "Rails' `build_where_clause` `map` is `key.map { |k| attribute_aliases[k] }` inside `transform_keys` for composite ARRAY keys; JS object keys can't be arrays, so trails resolves single-key aliases via `aliases[key] ?? key` and composite keys via `PredicateBuilder#buildComposite` — no `map` over keys applies."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activesupport/callbacks.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activesupport/callbacks.json
@@ -261,6 +261,13 @@
   {
     "package": "activesupport",
     "tsFile": "callbacks.ts",
+    "rubyName": "skip?",
+    "call": "call",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "callbacks.ts",
     "rubyName": "skip_callback",
     "call": "delete",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -326,13 +333,6 @@
     "tsFile": "callbacks.ts",
     "rubyName": "skip_callback",
     "call": "to_s",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "callbacks.ts",
-    "rubyName": "skip?",
-    "call": "call",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/lint-call-mismatches-wide.test.ts
+++ b/scripts/api-compare/lint-call-mismatches-wide.test.ts
@@ -88,9 +88,7 @@ describe("split baseline round-trip", () => {
     const relation = JSON.parse(
       await fs.readFile(path.join(dir, "activerecord", "relation.json"), "utf-8"),
     ) as ExcludeEntry[];
-    expect(relation.map(keyOf)).toEqual(
-      [...relation].map(keyOf).sort((a, b) => a.localeCompare(b)),
-    );
+    expect(relation.map(keyOf)).toEqual([...relation].map(keyOf).sort());
   });
 
   it("deletes a converged source file (never leaves []) and prunes its empty dirs", async () => {

--- a/scripts/api-compare/lint-call-mismatches-wide.test.ts
+++ b/scripts/api-compare/lint-call-mismatches-wide.test.ts
@@ -137,3 +137,45 @@ describe("loadSplitBaseline on a missing directory", () => {
     expect(await loadSplitBaseline(missing)).toEqual([]);
   });
 });
+
+describe("emission order", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "wide-baseline-order-"));
+  });
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  const read = async (rel: string) => JSON.parse(await fs.readFile(path.join(dir, rel), "utf-8"));
+
+  // Punctuation-differing keys are where ICU collation and code-unit order part
+  // ways; `permit!` must precede `permit_any_in_array` because "!" < "_".
+  it("sorts by code units, not locale collation", async () => {
+    await writeSplitBaseline(
+      [
+        entry("actioncontroller", "metal/strong-parameters.ts", "permit_any_in_array", "each"),
+        entry("actioncontroller", "metal/strong-parameters.ts", "permit!", "wrap"),
+      ],
+      dir,
+    );
+    const written = await read(path.join("actioncontroller", "metal/strong-parameters.json"));
+    expect(written.map((e: ExcludeEntry) => e.rubyName)).toEqual([
+      "permit!",
+      "permit_any_in_array",
+    ]);
+  });
+
+  it("emits byte-identical files whatever order the entries arrive in", async () => {
+    const entries = [
+      entry("activerecord", "relation.ts", "where", "first"),
+      entry("activerecord", "relation.ts", "_substitute_values", "build_bind_attribute"),
+      entry("activerecord", "relation.ts", "empty?", "loaded?"),
+    ];
+    await writeSplitBaseline(entries, dir);
+    const first = await fs.readFile(path.join(dir, "activerecord", "relation.json"), "utf-8");
+    await writeSplitBaseline([...entries].reverse(), dir);
+    const second = await fs.readFile(path.join(dir, "activerecord", "relation.json"), "utf-8");
+    expect(second).toBe(first);
+  });
+});

--- a/scripts/api-compare/lint-call-mismatches-wide.ts
+++ b/scripts/api-compare/lint-call-mismatches-wide.ts
@@ -25,8 +25,10 @@
  * ── Split baseline layout ───────────────────────────────────────────────────
  * The baseline is NOT one file: it is a directory (call-mismatches-wide-exclude/)
  * that mirrors the source tree, one JSON file per `tsFile`, at
- * `<dir>/<package>/<tsFile with .ts→.json>`. Each file is a sorted (keyOf) JSON
- * array of exactly that source file's entries. This makes the merge-conflict
+ * `<dir>/<package>/<tsFile with .ts→.json>`. Each file is a JSON array of
+ * exactly that source file's entries, sorted by the code-unit `compareKeys`
+ * order (see lint-call-mismatches.ts) so a reseed rewrites only the files whose
+ * entries actually changed. This makes the merge-conflict
  * boundary match the unit of work: an agent converging relation.ts only touches
  * activerecord/relation.json, not a shared 47k-line monolith. The loader globs
  * and concatenates every file; `--write` partitions the reseed back out by
@@ -55,10 +57,10 @@ import {
   type Artifact,
   type CallMismatchKey,
   type ExcludeEntry,
+  compareKeys,
   diffAgainstBaseline,
   findDuplicateKeys,
   flattenArtifact,
-  keyOf,
   missingScope,
   reseed,
 } from "./lint-call-mismatches.js";
@@ -194,8 +196,10 @@ async function loadArtifact(): Promise<Artifact> {
   return readJson<Artifact>(ARTIFACT_PATH);
 }
 
+// Emission order for every baseline file (and every console listing): the
+// shared code-unit `compareKeys` order documented in lint-call-mismatches.ts.
 function sortKeys<T extends CallMismatchKey>(entries: T[]): T[] {
-  return [...entries].sort((a, b) => keyOf(a).localeCompare(keyOf(b)));
+  return [...entries].sort(compareKeys);
 }
 
 async function main(write: boolean): Promise<number> {

--- a/scripts/api-compare/lint-call-mismatches.test.ts
+++ b/scripts/api-compare/lint-call-mismatches.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   callOf,
+  compareKeys,
   diffAgainstBaseline,
   findDuplicateKeys,
   flattenArtifact,
@@ -190,5 +191,27 @@ describe("missingScope", () => {
 
   it("ignores extra packages the artifact compared beyond the expected set", () => {
     expect(missingScope({ packages: [...expected, "arel"], mismatches: [] }, expected)).toEqual([]);
+  });
+});
+
+describe("compareKeys", () => {
+  const k = (rubyName: string, call = "c") => ({
+    package: "actioncontroller",
+    tsFile: "metal/strong-parameters.ts",
+    rubyName,
+    call,
+  });
+
+  // ICU collation demotes punctuation to a secondary difference and would put
+  // `permit_any_in_array` first; code units put "!" (0x21) before "_" (0x5f).
+  it("orders punctuation by code unit, not locale collation", () => {
+    expect(compareKeys(k("permit!"), k("permit_any_in_array"))).toBeLessThan(0);
+    expect(compareKeys(k("permit_any_in_array"), k("permit!"))).toBeGreaterThan(0);
+  });
+
+  it("is zero only for identical keys", () => {
+    expect(compareKeys(k("permit!"), k("permit!"))).toBe(0);
+    expect(compareKeys(k("permit!"), k("permit?"))).not.toBe(0);
+    expect(compareKeys(k("permit!", "a"), k("permit!", "b"))).not.toBe(0);
   });
 });

--- a/scripts/api-compare/lint-call-mismatches.ts
+++ b/scripts/api-compare/lint-call-mismatches.ts
@@ -170,8 +170,25 @@ export function diffAgainstBaseline(
   };
 }
 
+/**
+ * Total order on baseline entries: ascending UTF-16 code-unit order of
+ * `keyOf` (`package tsFile rubyName call`). Deliberately NOT `localeCompare`:
+ * ICU collation is locale- and ICU-version-dependent and treats punctuation as
+ * secondary, so `permit!` vs `permit_any_in_array` (and any other key pair
+ * differing only in `!`/`_`/`?`) sorts differently depending on who runs
+ * `--write`. That made a reseed driven by one package rewrite the entry order
+ * of untouched packages' baseline files. Code-unit order has none of that
+ * environment dependence, and `keyOf` is unique per entry (findDuplicateKeys
+ * enforces it), so the order is total — no tie-break needed.
+ */
+export function compareKeys(a: CallMismatchKey, b: CallMismatchKey): number {
+  const ka = keyOf(a);
+  const kb = keyOf(b);
+  return ka < kb ? -1 : ka > kb ? 1 : 0;
+}
+
 function sortEntries<T extends CallMismatchKey>(entries: T[]): T[] {
-  return [...entries].sort((a, b) => keyOf(a).localeCompare(keyOf(b)));
+  return [...entries].sort(compareKeys);
 }
 
 // Rebuild the baseline from the live artifact: keep each still-flagging call,


### PR DESCRIPTION
## Why

`pnpm api:calls:wide --write` reseeds the whole
`scripts/api-compare/call-mismatches-wide-exclude/` tree, and reseeds driven by
one package were rewriting untouched packages' files with symmetric +/- counts
(#5023 reverted four such paths by hand).

Root cause is the sort key, not the walk order or the write site: both emitters
sorted entries with `keyOf(a).localeCompare(keyOf(b))`. ICU collation is locale-
and ICU-version-dependent and treats punctuation as a secondary difference, so
any two keys differing only in `!` / `_` / `?` order differently depending on
who runs `--write`:

```
actioncontroller metal/strong-parameters.ts permit!             wrap
actioncontroller metal/strong-parameters.ts permit_any_in_array each
```

Code-unit order puts `permit!` first (`!` < `_`); collation does not. That is
exactly the churn set — 23 committed files held keys in one order while the
emitter produced the other.

## What

1. `compareKeys` in `lint-call-mismatches.ts`: a documented total order on
   ascending UTF-16 code units of `keyOf` (`package tsFile rubyName call`).
   `keyOf` is unique per entry (`findDuplicateKeys` enforces it), so no
   tie-break is needed. Both the narrow and wide emitters use it.
2. A separate mechanical commit reordering the 23 affected baseline files.
3. An existing round-trip test asserted the emitted order equalled a
   `localeCompare` sort — it passed only because its fixture had no
   punctuation-differing keys. Repointed at the code-unit order.

The narrow baseline (`call-mismatches-exclude.json`) was already in code-unit
order, so it is untouched.

## Verification

- `pnpm api:calls:wide:reseed` output is byte-identical to the committed tree
  (`git status` clean after a full reseed); re-sorting the committed bytes a
  second time changes nothing.
- Reorder commit is content-preserving: 6595 entries before and after, identical
  multiset of `(package, tsFile, rubyName, call, reason)`, 229 insertions /
  229 deletions.
- `pnpm api:calls:wide` → `ratchet: OK (6595 baselined)`.
- New tests in `lint-call-mismatches-wide.test.ts` cover the punctuation
  ordering and byte-identical emission regardless of input order.

Out of scope, filed as its own story
(`body-pins-manifest-locale-sort-churn`): `body-pins.ts:155` sorts the committed
body-pins manifest with the same locale-dependent comparator.

Closes-story: wide-calls-exclude-reseed-reorders-untouched-packages
