### PR TITLE
fix(calculations): emit HAVING from grouped calculations

### DIFF
--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -482,8 +482,13 @@ describe("CalculationsTest", () => {
     expect(c.get(6)).toBe(105);
     expect(c.get(2)).toBe(60);
     expect(c.get(9)).toBe(53);
+    // firm_id=1 (sum=50) and the NULL group (sum=50) fail sum > 50
+    expect(c.has(1)).toBe(false);
+    expect(c.has(null)).toBe(false);
   });
 
+  // Rails skips this on PG/Oracle: only MySQL and SQLite let HAVING reference a
+  // SELECT alias (calculations_test.rb:451).
   it.skipIf(adapterType === "postgres")(
     "should group by summed field having condition from select",
     async () => {
@@ -491,6 +496,7 @@ describe("CalculationsTest", () => {
         .group("firm_id")
         .having("min_credit_limit > 50")
         .sum("credit_limit")) as Map<unknown, number>;
+      expect(c.get(1)).toBeUndefined();
       expect(c.get(2)).toBe(60);
       expect(c.get(9)).toBe(53);
     },
@@ -544,12 +550,11 @@ describe("CalculationsTest", () => {
   it("should group by summed field with conditions and having", async () => {
     const c = (await Account.where("firm_id > 1")
       .group("firm_id")
-      .having("sum(credit_limit) > 50")
+      .having("sum(credit_limit) > 60")
       .sum("credit_limit")) as Map<unknown, number>;
-    expect(c.get(6)).toBe(105);
-    expect(c.get(2)).toBe(60);
-    expect(c.get(9)).toBe(53);
     expect(c.get(1)).toBeUndefined();
+    expect(c.get(6)).toBe(105);
+    expect(c.get(2)).toBeUndefined();
   });
 
   it("should group by fields with table alias", async () => {

--- a/packages/activerecord/src/calculations.trails.test.ts
+++ b/packages/activerecord/src/calculations.trails.test.ts
@@ -265,3 +265,28 @@ describe("grouped calculation HAVING on a composite-FK belongs_to", () => {
     expect(entries[0][1]).toBe(2);
   });
 });
+
+// ==========================================================================
+// Ungrouped calculation HAVING
+//
+// `execute_simple_calculation` runs the relation's own arel (calculations.rb:485)
+// and `build_arel` emits `arel.having(having_clause.ast) unless
+// having_clause.empty?` with no GROUP BY guard (query_methods.rb:1756), so an
+// ungrouped `having(...)` reaches the SQL. Rails has no test for it — trails
+// projects explicitly instead of reusing `build_arel`, so the clause has to be
+// re-applied by hand and needs a guard.
+// ==========================================================================
+
+describe("ungrouped calculation HAVING", () => {
+  fixtures(["companies", "accounts"]);
+
+  it("emits HAVING with no GROUP BY and filters the single aggregate row", async () => {
+    const { Account } = await import("./test-helpers/models/account.js");
+    // The whole-table sum survives the satisfied predicate; the unsatisfied one
+    // drops the only row, leaving sum-of-no-rows.
+    const total = (await Account.sum("credit_limit")) as number;
+    expect(total).toBeGreaterThan(100);
+    expect(await Account.having("sum(credit_limit) > 100").sum("credit_limit")).toBe(total);
+    expect(await Account.having("sum(credit_limit) > 100000").sum("credit_limit")).toBe(0);
+  });
+});

--- a/packages/activerecord/src/calculations.trails.test.ts
+++ b/packages/activerecord/src/calculations.trails.test.ts
@@ -230,3 +230,38 @@ describe("multi-field grouped bigint sum", () => {
     expect(keys.every((k) => k[1] === 2n ** 62n)).toBe(true);
   });
 });
+
+// ==========================================================================
+// Grouped calculation HAVING — composite-FK belongs_to arm
+//
+// Rails routes every grouped calculation through `execute_grouped_calculation`,
+// which builds from the relation's own arel so `having_clause` rides along
+// regardless of key arity (calculations.rb:553-556). trails splits the
+// composite-FK belongs_to case into its own `groupedCompositeAssoc` arm, which
+// has no Rails counterpart to port a test from — this guards that the arm keeps
+// emitting HAVING.
+// ==========================================================================
+
+describe("grouped calculation HAVING on a composite-FK belongs_to", () => {
+  fixtures([]);
+
+  it("filters groups keyed by the associated composite-PK record", async () => {
+    const { CpkBook, CpkAuthor, CpkChapter } = await import("./test-helpers/models/cpk.js");
+    await CpkAuthor.create({ id: 1, name: "Author One" });
+    await CpkBook.create({ id: [1, 1], title: "Alpha", revision: 1 });
+    await CpkBook.create({ id: [1, 2], title: "Beta", revision: 2 });
+    await CpkChapter.create({ id: [1, 10], book_id: 1, title: "ch-1" });
+    await CpkChapter.create({ id: [1, 11], book_id: 1, title: "ch-2" });
+    await CpkChapter.create({ id: [1, 12], book_id: 2, title: "ch-3" });
+
+    const result = (await CpkChapter.group("book").having("COUNT(*) > 1").count()) as Map<
+      unknown,
+      number
+    >;
+
+    const entries = [...result.entries()] as [{ id: unknown[] } | null, number][];
+    expect(entries).toHaveLength(1);
+    expect(entries[0][0]?.id).toEqual([1, 1]);
+    expect(entries[0][1]).toBe(2);
+  });
+});

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -92,6 +92,10 @@ interface CalculationRelation {
   _isDistinct: boolean;
   _groupColumns: string[];
   _whereClause: { isContradiction(): boolean };
+  /** Mirrors `Relation#having_clause`; grouped calculations ride the relation's own arel. */
+  havingClause: { isEmpty(): boolean; ast: Nodes.Node };
+  /** Mirrors `Relation#select_values`; folded into a grouped projection when HAVING is present. */
+  selectValues: (string | symbol | Nodes.Node)[];
   _ctes: Array<{ name: string; expression: Nodes.Node; recursive: boolean }>;
   _applyJoinsToManager(manager: any, eagerJd?: JoinDependency): void;
   _applyWheresToManager(manager: any, table: any): void;
@@ -463,6 +467,24 @@ async function singleAggregate(
   return castAggValue(val, fn, colType, coerceNumeric);
 }
 
+/**
+ * Rails' `execute_grouped_calculation` builds the grouped query from the
+ * relation's own arel, so `having_clause` rides along (calculations.rb:553-556),
+ * and folds the relation's own `select_values` into the projection whenever the
+ * having clause is non-empty (calculations.rb:542) — that is what makes an
+ * aliased select (`select("MIN(x) AS min_x").having("min_x > 50")`) referencable
+ * from HAVING. Our arms project explicitly rather than reusing `build_arel`, so
+ * both steps are applied here.
+ * @internal
+ */
+function applyHavingToManager(rel: CalculationRelation, manager: any): void {
+  const having = rel.havingClause;
+  if (having.isEmpty()) return;
+  const extraSelects = arelColumns.call(rel as never, rel.selectValues as never[]) as Nodes.Node[];
+  if (extraSelects.length > 0) manager.project(...extraSelects);
+  manager.having(having.ast);
+}
+
 async function groupedAggregate(
   rel: CalculationRelation,
   fn: AggFn,
@@ -521,6 +543,7 @@ async function groupedAggregate(
   rel._applyWheresToManager(manager, table);
   applyFromToManager(rel, manager);
   for (const n of groupNodes) manager.group(n);
+  applyHavingToManager(rel, manager);
   // Rails `execute_grouped_calculation` runs `select_all` on the relation's own
   // arel, which retains order_values — without the ORDER BY, LIMIT/OFFSET pick
   // arbitrary groups on PG/MySQL.
@@ -664,6 +687,7 @@ async function groupedCompositeAssoc(
   rel._applyWheresToManager(manager, table);
   applyFromToManager(rel, manager);
   for (const n of groupNodes) manager.group(n);
+  applyHavingToManager(rel, manager);
 
   if (rel._limitValue !== null) manager.take(rel._limitValue);
   if (rel._offsetValue !== null) manager.skip(rel._offsetValue);

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -451,6 +451,10 @@ async function singleAggregate(
   rel._applyJoinsToManager(manager, eagerJd);
   rel._applyWheresToManager(manager, table);
   applyFromToManager(rel, manager);
+  // `execute_simple_calculation` runs the relation's own arel too, and
+  // `build_arel` applies the having clause with no GROUP BY guard — an ungrouped
+  // `having("sum(x) > n").sum(:x)` is unusual but valid, and Rails emits it.
+  applyHavingToManager(rel, manager);
 
   const colType = resolveColType(rel, column);
   const [rawSql, managerBinds] = compileManagerWithBinds(rel, manager);
@@ -468,21 +472,31 @@ async function singleAggregate(
 }
 
 /**
- * Rails' `execute_grouped_calculation` builds the grouped query from the
- * relation's own arel, so `having_clause` rides along (calculations.rb:553-556),
- * and folds the relation's own `select_values` into the projection whenever the
- * having clause is non-empty (calculations.rb:542) — that is what makes an
- * aliased select (`select("MIN(x) AS min_x").having("min_x > 50")`) referencable
- * from HAVING. Our arms project explicitly rather than reusing `build_arel`, so
- * both steps are applied here.
+ * Both calculation arms run `select_all` on the relation's own arel, and
+ * `build_arel` emits `arel.having(having_clause.ast) unless having_clause.empty?`
+ * unconditionally — with or without a GROUP BY (query_methods.rb:1756). Our arms
+ * project explicitly instead of reusing `build_arel`, so the having clause has to
+ * be re-applied by hand.
  * @internal
  */
 function applyHavingToManager(rel: CalculationRelation, manager: any): void {
   const having = rel.havingClause;
-  if (having.isEmpty()) return;
+  if (!having.isEmpty()) manager.having(having.ast);
+}
+
+/**
+ * `execute_grouped_calculation` folds the relation's own `select_values` into the
+ * projection whenever the having clause is non-empty (calculations.rb:542) — that
+ * is what makes an aliased select (`select("MIN(x) AS min_x").having("min_x > 50")`)
+ * referencable from HAVING. Grouped only: `execute_simple_calculation` REPLACES
+ * `select_values` with the lone aggregate (calculations.rb:484), so the ungrouped
+ * arm must not fold.
+ * @internal
+ */
+function foldSelectValuesForHaving(rel: CalculationRelation, manager: any): void {
+  if (rel.havingClause.isEmpty()) return;
   const extraSelects = arelColumns.call(rel as never, rel.selectValues as never[]) as Nodes.Node[];
   if (extraSelects.length > 0) manager.project(...extraSelects);
-  manager.having(having.ast);
 }
 
 async function groupedAggregate(
@@ -543,6 +557,7 @@ async function groupedAggregate(
   rel._applyWheresToManager(manager, table);
   applyFromToManager(rel, manager);
   for (const n of groupNodes) manager.group(n);
+  foldSelectValuesForHaving(rel, manager);
   applyHavingToManager(rel, manager);
   // Rails `execute_grouped_calculation` runs `select_all` on the relation's own
   // arel, which retains order_values — without the ORDER BY, LIMIT/OFFSET pick
@@ -687,6 +702,7 @@ async function groupedCompositeAssoc(
   rel._applyWheresToManager(manager, table);
   applyFromToManager(rel, manager);
   for (const n of groupNodes) manager.group(n);
+  foldSelectValuesForHaving(rel, manager);
   applyHavingToManager(rel, manager);
 
   if (rel._limitValue !== null) manager.take(rel._limitValue);


### PR DESCRIPTION
Grouped calculations built their projection explicitly and never called
`manager.having()`, so the relation's `_havingClause` was silently dropped:
`Account.group("firm_id").having("sum(credit_limit) > 50").sum("credit_limit")`
returned every group, including the ones the HAVING should have filtered.

- Apply the having clause in `groupedAggregate`, `groupedCompositeAssoc`, and
  `singleAggregate`. `build_arel` emits
  `arel.having(having_clause.ast) unless having_clause.empty?` with no GROUP BY
  guard (`query_methods.rb:1756`), and both `execute_grouped_calculation`
  (`calculations.rb:553-556`) and `execute_simple_calculation`
  (`calculations.rb:485`) run the relation's own arel — so an ungrouped
  `having(...)` reaches the SQL in Rails too.
- Fold the relation's own `select_values` into the projection when the having
  clause is non-empty (`calculations.rb:542`), so an aliased select
  (`select("MIN(x) AS min_x").having("min_x > 50")`) is referencable from HAVING.
  Grouped arms only: `execute_simple_calculation` REPLACES `select_values` with
  the lone aggregate (`calculations.rb:484`), so the ungrouped arm must not fold.
- Converge the having assertions to Rails: they asserted only the surviving
  groups, never the absence of the filtered ones. "with conditions and having"
  now uses Rails' `> 60` threshold and asserts `c[2]` is absent
  (`calculations_test.rb:490-498`).
- Add trails tests for the composite-FK belongs_to arm and the ungrouped arm.
  Both are trails-only shapes (Rails has one `execute_grouped_calculation` and
  no ungrouped-HAVING test), so there is nothing to port; nothing else covered
  HAVING on either.

The `skipIf(postgres)` on "having condition from select" stays — Rails skips
that test on everything but MySQL/SQLite (`calculations_test.rb:451`), since
only those let HAVING reference a SELECT alias.

Every new assertion was verified to fail against the pre-fix implementation.
Hash-form `having({...})` (bind path) and grouped `count` were checked by hand
on top of the fix as well.

### Deliberately out of scope

Ungrouped `count` — `performCount` is roughly eight separate managers (the
DISTINCT-on-pk fan-out, the eager-load subquery, the `from()` variants, the
plain pk-count), none of which apply the having clause. Rails funnels all of
them through the single `relation.arel` path, so the same defect is there.
Threading it through every site would roughly double this diff and touch the
eager/DISTINCT count paths, which carry their own fidelity stories. Registered
as `0030-ar-test-compare-residual-burndown/ungrouped-count-having-dropped`.

Closes-story: grouped-calculation-having-dropped
