### PR TITLE
ci(activerecord): set AR_DB_FORKS to the fork count CI actually runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1022,7 +1022,10 @@ jobs:
           PGUSER: postgres
           PGPASSWORD: postgres
           PGDATABASE: rails_js_test
-          AR_DB_FORKS: 8
+          # Must match the concurrency vitest actually runs: TEST_FORKS is
+          # clamped to numCpus - 1 (3 on the 4-vCPU runner) in vitest.config.ts,
+          # and this value also sizes the advisory slot-DB pool (forks + 2).
+          AR_DB_FORKS: "3"
       # CLI E2E is not sharded — run it once, on shard 1 only, to avoid a
       # redundant double-run across the two legs.
       # PG_TEST_URL is the activerecord-cli E2E's own input (it drives the CLI's
@@ -1089,7 +1092,10 @@ jobs:
           MYSQL_PORT: "3306"
           MYSQL_USER: root
           MYSQL_DATABASE: rails_js_test
-          AR_DB_FORKS: 8
+          # Must match the concurrency vitest actually runs: TEST_FORKS is
+          # clamped to numCpus - 1 (3 on the 4-vCPU runner) in vitest.config.ts,
+          # and this value also sizes the advisory slot-DB pool (forks + 2).
+          AR_DB_FORKS: "3"
       # No MySQL connection env: no mysql-happy-path E2E exists yet. This run
       # covers the SQLite E2E until a mysql suite lands and can be wired up.
       - run: pnpm vitest run packages/activerecord-cli
@@ -1156,7 +1162,10 @@ jobs:
           MYSQL_PORT: "3306"
           MYSQL_USER: root
           MYSQL_DATABASE: rails_js_test
-          AR_DB_FORKS: 8
+          # Must match the concurrency vitest actually runs: TEST_FORKS is
+          # clamped to numCpus - 1 (3 on the 4-vCPU runner) in vitest.config.ts,
+          # and this value also sizes the advisory slot-DB pool (forks + 2).
+          AR_DB_FORKS: "3"
       # No MySQL connection env: no mysql-happy-path E2E exists yet. This run
       # covers the SQLite E2E until a mysql suite lands and can be wired up.
       # CLI E2E is not sharded — run it once, on shard 1 only.

--- a/packages/activerecord/src/test-helpers/ar-db-slots.ts
+++ b/packages/activerecord/src/test-helpers/ar-db-slots.ts
@@ -1,8 +1,10 @@
 /**
  * Advisory-slot pool sizing for the parallel AR DB test harness.
  *
- * `AR_DB_FORKS` is the vitest worker count (it drives `maxForks` in
- * vitest.config.ts). The advisory-lock **slot pool** — the set of per-worker
+ * `AR_DB_FORKS` is the requested vitest worker count (vitest.config.ts feeds it
+ * into `maxForks`, clamped down to the host's `numCpus - 1` ceiling — so a
+ * value above that ceiling only over-provisions this pool). The advisory-lock
+ * **slot pool** — the set of per-worker
  * slot DBs provisioned by globalSetup and claimed by each worker in
  * test-setup-worker-db.ts — is sized SEPARATELY, with headroom over the worker
  * count, so a worker that vitest recycles in between files always finds a free

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,15 +7,18 @@ import os from "os";
 // headroom over the worker count — see test-helpers/ar-db-slots.ts (slots =
 // workers + headroom, or an explicit AR_DB_SLOTS override). TRAILS_TEST_FORKS
 // caps the vitest worker count so that concurrent local worktrees don't
-// saturate the machine. Precedence: TRAILS_TEST_FORKS > AR_DB_FORKS > 6.
-// Raise with TRAILS_TEST_FORKS=N for a solo full run; the live AR DB jobs
-// (postgres-tests, mysql-tests, maria-tests) all set AR_DB_FORKS=8.
+// saturate the machine. Precedence: TRAILS_TEST_FORKS > AR_DB_FORKS > 6,
+// all capped by the host ceiling below. Raise with TRAILS_TEST_FORKS=N for a
+// solo full run; the live AR DB jobs (postgres-tests, mysql-tests,
+// maria-tests) set AR_DB_FORKS=3, which is that ceiling on the 4-vCPU runner.
 //
-// On the 2-vCPU hosted runner, 8 forks is empirically not over-subscribed for
-// this suite: a measured sweep (story tune-ar-db-forks-to-runner-cores, RFC
-// 0028) found forks=8 and forks=4 wall-clock-indistinguishable (~571s vs ~574s
-// median over 5 runs) because the DDL-heavy suite is IO-bound on the tmpfs DB,
-// so extra forks overlap IO waits rather than contend for the 2 cores.
+// Historical note: those jobs used to set AR_DB_FORKS=8, but the per-project
+// `maxForks` was a vitest-3 no-op, so every CI run actually ran at vitest's
+// own `numCpus - 1` fallback. The 8 only inflated the advisory-slot pool
+// (ar-db-slots.ts sizes it from AR_DB_FORKS + 2) with slot DBs no worker could
+// ever claim. The tune-ar-db-forks-to-runner-cores sweep (RFC 0028) that found
+// forks=8 and forks=4 wall-clock-indistinguishable was comparing the clamped
+// fallback against itself, so it says nothing about 8 forks either way.
 //
 // forks=2 used to fail deterministically in that sweep (acquireAdvisorySlotPg
 // threw "all 2 advisory lock slots are held" after its bounded 5s retry) — not
@@ -84,8 +87,9 @@ const _parsedForks = parseInt(process.env.TRAILS_TEST_FORKS ?? process.env.AR_DB
 // Clamp to vitest's own host-derived ceiling (numCpus - 1): while the root
 // maxForks cap was a per-project no-op, that ceiling is what every run
 // actually used, and the suite's timeouts are tuned to it — on the 4-vCPU CI
-// runner, honoring AR_DB_FORKS=8 outright oversubscribes PG enough to push
-// the full-DB schema-dump tests past their 5s timeout. The env vars can only
+// runner, honoring a fork count above it (AR_DB_FORKS=8, as CI used to set)
+// oversubscribes PG enough to push the full-DB schema-dump tests past their
+// 5s timeout. The env vars can only
 // lower the cap, never raise it past the host. The advisory-slot pool still
 // sizes from AR_DB_FORKS (ar-db-slots.ts), so it can only over-provision.
 const _hostForkCap = Math.max(os.availableParallelism() - 1, 1);


### PR DESCRIPTION
`AR_DB_FORKS=8` on the three AR DB jobs (postgres-tests, mysql-tests,
maria-tests) has never been the concurrency CI actually ran: the per-project
`maxForks` was a vitest-3 no-op, so every run used vitest's `numCpus - 1`
fallback, and #5104 made that explicit by clamping `TEST_FORKS` in
`vitest.config.ts`. The only live effect of the `8` was inflating the advisory
slot pool (`ar-db-slots.ts` sizes it as forks + 2) to 10 slot DBs, 6-7 of which
were provisioned but never claimable.

- Set `AR_DB_FORKS: "3"` in all three jobs — `numCpus - 1` on the current
  4-vCPU runner — so the value matches what vitest runs. Slot provisioning
  drops from 10 to 5 slot DBs per job.
- Refreshed the stale `vitest.config.ts` header paragraphs that described 8
  forks as the live CI worker count and cited the
  tune-ar-db-forks-to-runner-cores sweep, whose forks=8-vs-4 comparison was
  measuring the clamped fallback both times.
- Clarified in `ar-db-slots.ts` that `AR_DB_FORKS` is the *requested* worker
  count and a value above the host ceiling only over-provisions the pool.

No behavior change to the test run itself — only to how many slot DBs
globalSetup creates.

Closes-story: align-ci-ar-db-forks-with-clamped-reality
