### PR TITLE
fix(predicate-builder): bind qualified composite cols through the joined table's type

### DIFF
--- a/packages/activerecord/src/relation/composite-where.test.ts
+++ b/packages/activerecord/src/relation/composite-where.test.ts
@@ -140,11 +140,6 @@ describe("Relation#where — composite-key form", () => {
   });
 
   it("qualified composite cols bind through the joined table's type, not the base table's", () => {
-    // Rails' Array-key branch re-roots per key via
-    // `associated_table(key).predicate_builder` (predicate_builder.rb:88-98),
-    // so a qualified col's bind type comes from the joined table. Typing
-    // `comments.post_id` against `posts` (which has no `post_id`) would fall
-    // back to the default ValueType and leave "2" an uncast string.
     const rel = (Post as any).all();
     const node: any = rel.predicateBuilder.buildComposite(
       ["posts.id", "comments.post_id"],
@@ -155,8 +150,27 @@ describe("Relation#where — composite-key form", () => {
     const bind = right.right.value;
     expect(bind.name).toBe("post_id");
     expect(bind.valueForDatabase).toBe(2);
-    // The unqualified col still types against the base table.
     expect(left.left.relation.name).toBe("posts");
+  });
+
+  it("qualified single-column composite resolves its IN(...) attribute on the joined table", () => {
+    const rel = (Post as any).all();
+    const node: any = rel.predicateBuilder.buildComposite(["comments.post_id"], [[1], [2]]);
+    expect(node.left.relation.name).toBe("comments");
+    expect(node.left.name).toBe("post_id");
+  });
+
+  it("qualified composite cols match rows through a join", async () => {
+    const post: any = await (Post as any).create({ title: "joined", body: "b", author_id: 1 });
+    const other: any = await (Post as any).create({ title: "unjoined", body: "b", author_id: 1 });
+    await (Comment as any).create({ post_id: post.id, body: "c" });
+    await (Comment as any).create({ post_id: other.id, body: "c2" });
+
+    const rows = await (Post as any)
+      .joins("comments")
+      .where(["posts.id", "comments.post_id"], [[post.id, post.id]])
+      .toArray();
+    expect(rows.map((r: any) => r.title)).toEqual(["joined"]);
   });
 
   it("single-column composite uses IN(...) (not OR-chain) for compactness", () => {

--- a/packages/activerecord/src/relation/composite-where.test.ts
+++ b/packages/activerecord/src/relation/composite-where.test.ts
@@ -15,6 +15,8 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { registerModel } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { CpkBook, CpkOrder, CpkAuthor, CpkChapter } from "../test-helpers/models/cpk.js";
+import { Post } from "../test-helpers/models/post.js";
+import { Comment } from "../test-helpers/models/comment.js";
 
 describe("Relation#where — composite-key form", () => {
   // Rails creates the CPK rows inline with `Cpk::Book.create!` — no cpk
@@ -23,7 +25,7 @@ describe("Relation#where — composite-key form", () => {
   fixtures([]);
 
   beforeAll(() => {
-    [CpkBook, CpkOrder, CpkAuthor, CpkChapter].forEach((m) => registerModel(m));
+    [CpkBook, CpkOrder, CpkAuthor, CpkChapter, Post, Comment].forEach((m) => registerModel(m));
   });
 
   it("compiles `where(['c1','c2'], [[v1a,v1b], [v2a,v2b]])` to OR-of-AND of column equalities", async () => {
@@ -135,6 +137,26 @@ describe("Relation#where — composite-key form", () => {
     expect(rhs?.constructor?.name).toBe("BindParam");
     expect(rhs?.value?.name).toBe("author_id");
     expect(rhs?.value?.constructor?.name).toBe("QueryAttribute");
+  });
+
+  it("qualified composite cols bind through the joined table's type, not the base table's", () => {
+    // Rails' Array-key branch re-roots per key via
+    // `associated_table(key).predicate_builder` (predicate_builder.rb:88-98),
+    // so a qualified col's bind type comes from the joined table. Typing
+    // `comments.post_id` against `posts` (which has no `post_id`) would fall
+    // back to the default ValueType and leave "2" an uncast string.
+    const rel = (Post as any).all();
+    const node: any = rel.predicateBuilder.buildComposite(
+      ["posts.id", "comments.post_id"],
+      [[1, "2"]],
+    );
+    const [left, right] = node.expr.children;
+    expect(right.left.relation.name).toBe("comments");
+    const bind = right.right.value;
+    expect(bind.name).toBe("post_id");
+    expect(bind.valueForDatabase).toBe(2);
+    // The unqualified col still types against the base table.
+    expect(left.left.relation.name).toBe("posts");
   });
 
   it("single-column composite uses IN(...) (not OR-chain) for compactness", () => {

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -455,12 +455,29 @@ export class PredicateBuilder {
     // semantics — see method docstring).
     const validTuples = tuples.filter((t) => t.every((v) => v !== null && v !== undefined));
     if (validTuples.length === 0) return null;
+    // Re-root qualified cols (`"comments.post_id"`) on the referenced
+    // table the way Rails' Array-key branch does — it recurses through
+    // `associated_table(key).predicate_builder`, so both the attribute
+    // AND the bind's type come from the joined table's metadata
+    // (predicate_builder.rb:88-98). Reading the bind type off the base
+    // builder instead would type an absent column through the default
+    // `ValueType` (silent no-op cast), or a same-named base column
+    // through the wrong type.
+    const resolved = cols.map((col) => {
+      const idx = col.lastIndexOf(".");
+      if (idx === -1) return { attribute: this.table.arelTable.get(col), builder: this };
+      const associated = this.table.associatedTable(col.slice(0, idx));
+      return {
+        attribute: associated.arelTable.get(col.slice(idx + 1)),
+        builder: associated.predicateBuilder,
+      };
+    });
     // Single-column degenerate case: a single `IN (...)` predicate is
     // more compact than `c=v1 OR c=v2 OR ...` and typically optimizes
     // identically (or better) on indexed columns.
     if (cols.length === 1) {
       const values = validTuples.map((t) => t[0]);
-      return this.table.arelTable.get(cols[0]).in(values);
+      return resolved[0].attribute.in(values);
     }
     // Build equalities through `buildBindAttribute` so each value
     // becomes a `QueryAttribute` (= bind param) rather than an
@@ -472,10 +489,9 @@ export class PredicateBuilder {
     // each `arelTable.get` allocates a fresh `Arel::Attribute`.
     // Reusing the resolved attrs keeps large tuple lists
     // allocation-light. Column names are read straight off the
-    // builder's arel table, the way Rails' array-key branch of
-    // expand_from_hash does via `self[key, value]` — dotted keys are
-    // not split here (Rails doesn't either).
-    const attrs = cols.map((c) => this.table.arelTable.get(c));
+    // builder's arel table (or, for a qualified col, the re-rooted
+    // associated table's), the way Rails' array-key branch of
+    // expand_from_hash does via `self[key, value]`.
     // Per-tuple AND uses the pairwise `reduce(&:and)` shape (nested
     // binary `And` chain), matching Rails' `grouping_queries`
     // (predicate_builder.rb:157) — not a flat n-ary `And`. SQL output
@@ -489,7 +505,9 @@ export class PredicateBuilder {
     // Grouping — semantically a no-op (AND binds tighter than OR) that
     // keeps the emitted `(c1 = ? AND c2 = ?) OR (...)` form stable.
     const groupings: Nodes.Node[] = validTuples.map((tuple) => {
-      const eqs = attrs.map((attr, i) => attr.eq(this.buildBindAttribute(attr.name, tuple[i])));
+      const eqs = resolved.map(({ attribute, builder }, i) =>
+        attribute.eq(builder.buildBindAttribute(attribute.name, tuple[i])),
+      );
       return new Nodes.Grouping(eqs.reduce((left, right) => left.and(right)));
     });
     if (groupings.length === 1) return groupings[0];

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -455,14 +455,6 @@ export class PredicateBuilder {
     // semantics — see method docstring).
     const validTuples = tuples.filter((t) => t.every((v) => v !== null && v !== undefined));
     if (validTuples.length === 0) return null;
-    // Re-root qualified cols (`"comments.post_id"`) on the referenced
-    // table the way Rails' Array-key branch does — it recurses through
-    // `associated_table(key).predicate_builder`, so both the attribute
-    // AND the bind's type come from the joined table's metadata
-    // (predicate_builder.rb:88-98). Reading the bind type off the base
-    // builder instead would type an absent column through the default
-    // `ValueType` (silent no-op cast), or a same-named base column
-    // through the wrong type.
     const resolved = cols.map((col) => {
       const idx = col.lastIndexOf(".");
       if (idx === -1) return { attribute: this.table.arelTable.get(col), builder: this };
@@ -488,10 +480,8 @@ export class PredicateBuilder {
     // Pre-resolve `Attribute[]` once outside the per-tuple loop —
     // each `arelTable.get` allocates a fresh `Arel::Attribute`.
     // Reusing the resolved attrs keeps large tuple lists
-    // allocation-light. Column names are read straight off the
-    // builder's arel table (or, for a qualified col, the re-rooted
-    // associated table's), the way Rails' array-key branch of
-    // expand_from_hash does via `self[key, value]`.
+    // allocation-light.
+    //
     // Per-tuple AND uses the pairwise `reduce(&:and)` shape (nested
     // binary `And` chain), matching Rails' `grouping_queries`
     // (predicate_builder.rb:157) — not a flat n-ary `And`. SQL output


### PR DESCRIPTION
`PredicateBuilder#buildComposite` resolved every col off the builder's own arel table. `Table#get` treats its argument as a literal column name, so a qualified col like `comments.post_id` produced an attribute literally named `"comments.post_id"` on the base table, and `buildBindAttribute` typed the bind through the base table's caster (default `ValueType` when the column is absent there, or the wrong type when the name collides).

Qualified cols are now split at their last dot and resolved on `associatedTable(...)`, with the bind built through that table's `predicateBuilder` — so both the attribute and the bind type come from the joined table. Both the `cols.length === 1` (`IN`) and multi-col (AND/OR) paths go through the same resolution.

## Rails source

Rails re-roots a dotted key in `convert_dot_notation_to_hash` (`predicate_builder.rb:162-179`), which splits on `key.rindex(".")` and nests `{"comments" => {"post_id" => value}}`; `expand_from_hash`'s `value.is_a?(Hash) && !table.has_column?(key)` branch (`predicate_builder.rb:105-106`) then routes it to `table.associated_table(key).predicate_builder.expand_from_hash(...)`. This PR enters that same `associated_table(...).predicate_builder` re-rooting directly, without the hash-nesting detour — `lastIndexOf(".")` mirrors Ruby's `rindex(".")`. (An earlier revision of this description cited the Array-key branch at `predicate_builder.rb:87-98`; that branch only re-invokes `expand_from_hash` per zipped hash and is not where the re-rooting happens.)

## Known limitation

Tracked as story `composite-qualified-col-associated-table-needs-join-dependency-fallback` (RFC 0067) — not left as PR-body prose.

`associatedTable` is called without the join-dependency fallback that `resolveArelAttribute` passes. A qualified col naming a raw joined table with no reflection therefore resolves to a klass-less `TableMetadata` with a generic `TypeCasterConnection` — still better than typing against the base table, but no model-backed column types. This matches the other fallback-less `associatedTable` call sites in this file, and is unreachable from the current in-tree callers (`base.ts` and `disable-joins-association-scope.ts` only ever pass unqualified `keyCols`); threading a resolver in would need a join-dependency context `buildComposite` does not receive.

## Tests

Three tests in `composite-where.test.ts`: bind type resolution through the joined table (`"2"` → `2` via `comments.post_id`'s integer type), the qualified single-col `IN` path, and an end-to-end `joins("comments")` row assertion. The first fails on baseline.

Closes-story: composite-qualified-cols-bind-through-base-table-type
