### PR TITLE
fix(associations): save persisted-dirty targets when pushing onto a through collection

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -2332,6 +2332,16 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
             } else {
               await record.saveBang(); // << always raises on new-record failure
             }
+          } else if (record.hasChangesToSave) {
+            // Second arm of Rails' `record.new_record? || record.has_changes_to_save?`
+            // gate (has_many_through_association.rb:27): a persisted-but-dirty target
+            // is saved before the join row is written, and `return unless super`
+            // leaves it out of the target when that save fails.
+            if (bang) {
+              await record.saveBang();
+            } else if (!(await record.save())) {
+              return false;
+            }
           }
           // Create the join record. A composite source FK arises when the join's
           // source belongs_to resolves a multi-column key — e.g. `belongs_to :tag`

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1635,7 +1635,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     if (block) block(record);
     const saved = await record.save();
     if (!saved) return record;
-    await this._pushThrough([record], false, false, throughScope);
+    await this._pushThrough([record], false, throughScope);
     return record;
   }
 
@@ -2255,7 +2255,6 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   private async _pushThrough(
     records: T[],
     skipCallbacks = false,
-    bang = false,
     throughScope?: unknown,
   ): Promise<void> {
     const ctor = this._record.constructor as typeof Base;
@@ -2327,15 +2326,13 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
           // Mirrors HasManyThroughAssociation#insert_record's
           // `if record.new_record? || record.has_changes_to_save?; return unless super`
           // (has_many_through_association.rb:26-29): a new *or* persisted-but-dirty
-          // target is saved before the join row is written, and a save that merely
-          // returns false leaves the record out of the target. A new record always
-          // raises instead, as concat (<<) does (raise_on_validation_error? == true).
+          // target is saved before the join row is written. The save always raises:
+          // HMT's concat_records hard-codes `super(records, true)`
+          // (has_many_through_association.rb:40) for every alias of `<<`, so `raise`
+          // reaches CollectionAssociation#insert_record as true and the non-raising
+          // `record.save` branch is unreachable for a through reflection.
           if (record.isNewRecord() || record.hasChangesToSave) {
-            if (bang || record.isNewRecord()) {
-              await record.saveBang();
-            } else if (!(await record.save())) {
-              return false;
-            }
+            await record.saveBang();
           }
           // Create the join record. A composite source FK arises when the join's
           // source belongs_to resolves a multi-column key — e.g. `belongs_to :tag`
@@ -4169,7 +4166,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     this._ensureThroughWritable();
     this._raiseOnTypeMismatch(records);
     if (this._assocDef.options.through) {
-      await this._pushThrough(records, false, true);
+      await this._pushThrough(records);
       return;
     }
     // Non-through: push() assigns the FK and calls save() for each record.

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -2324,20 +2324,14 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
           // write a null owner FK (the owner has no id yet) and double-insert
           // once the autosave runs.
           if (this._record.isNewRecord()) return true;
-          // Save the target record if it's new. Mirrors Rails' concat (<<) which
-          // always raises on validation failure (raise_on_validation_error? == true).
-          if (record.isNewRecord()) {
-            if (bang) {
-              await record.saveBang(); // raises RecordInvalid if invalid
-            } else {
-              await record.saveBang(); // << always raises on new-record failure
-            }
-          } else if (record.hasChangesToSave) {
-            // Second arm of Rails' `record.new_record? || record.has_changes_to_save?`
-            // gate (has_many_through_association.rb:27): a persisted-but-dirty target
-            // is saved before the join row is written, and `return unless super`
-            // leaves it out of the target when that save fails.
-            if (bang) {
+          // Mirrors HasManyThroughAssociation#insert_record's
+          // `if record.new_record? || record.has_changes_to_save?; return unless super`
+          // (has_many_through_association.rb:26-29): a new *or* persisted-but-dirty
+          // target is saved before the join row is written, and a save that merely
+          // returns false leaves the record out of the target. A new record always
+          // raises instead, as concat (<<) does (raise_on_validation_error? == true).
+          if (record.isNewRecord() || record.hasChangesToSave) {
+            if (bang || record.isNewRecord()) {
               await record.saveBang();
             } else if (!(await record.save())) {
               return false;

--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -635,8 +635,6 @@ describe("HasManyThroughAssociationsTest", () => {
   });
 
   it("pushing a persisted record with unsaved changes saves those changes", async () => {
-    // Same gate as the `concat` case above — Rails runs both entry points
-    // through `insert_record`, so `push` must save a dirty persisted target too.
     const post = await Post.find(posts("thinking").id);
     const person = await Person.find(people("michael").id);
     person.writeAttribute("first_name", "Bongo");

--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -634,6 +634,19 @@ describe("HasManyThroughAssociationsTest", () => {
     expect(person.readAttribute("first_name")).toBe("Bongo");
   });
 
+  it("pushing a persisted record with unsaved changes saves those changes", async () => {
+    // Same gate as the `concat` case above — Rails runs both entry points
+    // through `insert_record`, so `push` must save a dirty persisted target too.
+    const post = await Post.find(posts("thinking").id);
+    const person = await Person.find(people("michael").id);
+    person.writeAttribute("first_name", "Bongo");
+
+    await (post as any).people.push(person);
+
+    await person.reload();
+    expect(person.readAttribute("first_name")).toBe("Bongo");
+  });
+
   it("associate existing record twice should add to target twice", async () => {
     const post = await Post.find(posts("thinking").id);
     const person = await Person.find(people("david").id);


### PR DESCRIPTION
`CollectionProxy#push` / `<<` / `append` route through-association writes into
the trails-invented `_pushThrough`, which saved a *new* target but carried no
equivalent of the second arm of Rails' gate in
`HasManyThroughAssociation#insert_record`
(`has_many_through_association.rb:27`):

```ruby
if record.new_record? || record.has_changes_to_save?
  return unless super
end
```

So `post.people.push(persistedDirtyPerson)` silently discarded the target's
unsaved changes, while `post.association("people").concat([person])` — which
reaches the ported `insertRecord` — saved them.

This adds the missing arm: a persisted-but-dirty target is saved before the
join row is written, and a non-bang `save` returning false leaves the record
out of the target (Rails' `return unless super`).

### Structural half deferred

Acceptance criterion 1 asked for `push` to *route* through
`concatRecords` → `insertRecord`. That is not a local edit: the user-facing
`CollectionProxy` and the `HasManyThroughAssociation` object are separate
objects with separate targets (`associations.ts:3215` vs
`associations/instance-methods.ts:35`), and `_pushThrough` also backs
`create`/`createBang`/`appendBang`. Collapsing them requires shared target
state — well past the 500-LOC ceiling. Registered as
`0005-activerecord-gaps/route-through-collection-writes-onto-association-insert-record`
with the full findings.

`_createThrough` audit (also in that story): it builds and saves the target
itself before calling `_pushThrough`, so the record is persisted and clean by
then — no `has_changes_to_save?` divergence, only the same structural one.

### Testing

- New test fails on baseline (`expected 'Michael' to be 'Bongo'`), passes here.
- `has-many-through-associations`, `has-and-belongs-to-many-associations`,
  `nested-through-associations`, `autosave-association`: all green.

Closes-story: converge-push-through-onto-insert-record
