### PR TITLE
refactor(associations): share one find_from_target? body between association and proxy

### DIFF
--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -24,47 +24,6 @@ export interface ReplacePlan {
 }
 
 /**
- * Host shape for {@link findFromTarget}: the `CollectionAssociation` and the
- * `CollectionProxy` (which is its own association — `CollectionProxy#_association`
- * returns `this`).
- *
- * @internal
- */
-export interface FindFromTargetHost {
-  owner: Base;
-  reflection: Pick<AssociationDefinition, "options">;
-  target: readonly Base[];
-}
-
-/**
- * The single body behind `CollectionAssociation#isFindFromTarget` and
- * `CollectionProxy#isFindFromTarget`. Mirrors
- * ActiveRecord::Associations::CollectionAssociation#find_from_target?
- * (collection_association.rb:308).
- *
- * The final clause is Rails' `record.changed?`, NOT `has_changes_to_save?` —
- * different mutation sources (`mutations_from_user` vs
- * `mutations_from_database`), even though both currently resolve to
- * `_dirty.changed` here.
- *
- * `loaded` is a parameter rather than a host member because the two hosts spell
- * it differently, and the proxy additionally inherits an unrelated
- * `Relation#isLoaded` over `_loaded` — so any single name read off the host
- * would pick the wrong flag on one of them.
- *
- * @internal
- */
-export function findFromTarget(this: FindFromTargetHost, loaded: boolean): boolean {
-  return (
-    loaded ||
-    (this.owner.isStrictLoading() && this.owner.isStrictLoadingAll()) ||
-    !!this.reflection.options.strictLoading ||
-    this.owner.isNewRecord() ||
-    this.target.some((r) => r.isNewRecord() || r.changed)
-  );
-}
-
-/**
  * Base class for has_many and has_and_belongs_to_many associations.
  *
  * CollectionAssociation provides common CRUD methods for collections.
@@ -783,11 +742,28 @@ export class CollectionAssociation extends Association {
    * Returns true if find should search the loaded target rather than
    * going to the database. Mirrors
    * ActiveRecord::Associations::CollectionAssociation#find_from_target?
-   * (collection_association.rb:308). The clause list lives in
-   * {@link findFromTarget}, shared with `CollectionProxy#isFindFromTarget`.
+   * (collection_association.rb:308): loaded, owner strict-loading-all,
+   * reflection strict-loading, owner new record, or any target record
+   * new/changed.
+   *
+   * The final clause is Rails' `record.changed?`, NOT `has_changes_to_save?` —
+   * different mutation sources (`mutations_from_user` vs
+   * `mutations_from_database`), even though both currently resolve to
+   * `_dirty.changed` here.
+   *
+   * `loaded` falls back to this association's own `isLoaded()` and is only
+   * passed explicitly by `CollectionProxy#isFindFromTarget`, which borrows this body
+   * (Rails' proxy delegates to `@association.find_from_target?`) but tracks
+   * loadedness in its own `_targetLoaded`. Rails' method takes no argument.
    */
-  isFindFromTarget(): boolean {
-    return findFromTarget.call(this, this.isLoaded());
+  isFindFromTarget(loaded?: boolean): boolean {
+    return (
+      (loaded ?? this.isLoaded()) ||
+      (this.owner.isStrictLoading() && this.owner.isStrictLoadingAll()) ||
+      !!this.reflection.options.strictLoading ||
+      this.owner.isNewRecord() ||
+      this.target.some((r) => r.isNewRecord() || r.changed)
+    );
   }
 
   override isCollection(): boolean {

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -32,7 +32,7 @@ export interface ReplacePlan {
  */
 export interface FindFromTargetHost {
   owner: Base;
-  reflection: { options: { strictLoading?: unknown } };
+  reflection: Pick<AssociationDefinition, "options">;
   target: readonly Base[];
 }
 

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -24,15 +24,9 @@ export interface ReplacePlan {
 }
 
 /**
- * Host shape for {@link findFromTarget} — the two objects that carry a
- * collection's target: the `CollectionAssociation` and the `CollectionProxy`
- * (which is its own association, see `CollectionProxy#_association`).
- *
- * Loadedness is passed in rather than read off the host: the association
- * exposes it as `isLoaded()`, the proxy as its `loaded` getter over
- * `_targetLoaded` — and the proxy also inherits an unrelated `Relation#isLoaded`
- * over `_loaded`, so reading either name off the host would pick the wrong flag
- * on one of them.
+ * Host shape for {@link findFromTarget}: the `CollectionAssociation` and the
+ * `CollectionProxy` (which is its own association — `CollectionProxy#_association`
+ * returns `this`).
  *
  * @internal
  */
@@ -46,14 +40,17 @@ export interface FindFromTargetHost {
  * The single body behind `CollectionAssociation#isFindFromTarget` and
  * `CollectionProxy#isFindFromTarget`. Mirrors
  * ActiveRecord::Associations::CollectionAssociation#find_from_target?
- * (collection_association.rb:308): loaded, owner strict-loading-all,
- * reflection strict-loading, owner new record, or any target record
- * new/changed.
+ * (collection_association.rb:308).
  *
- * Note the final clause is Rails' `record.changed?`, NOT `has_changes_to_save?`
- * — different mutation sources (`mutations_from_user` vs
+ * The final clause is Rails' `record.changed?`, NOT `has_changes_to_save?` —
+ * different mutation sources (`mutations_from_user` vs
  * `mutations_from_database`), even though both currently resolve to
  * `_dirty.changed` here.
+ *
+ * `loaded` is a parameter rather than a host member because the two hosts spell
+ * it differently, and the proxy additionally inherits an unrelated
+ * `Relation#isLoaded` over `_loaded` — so any single name read off the host
+ * would pick the wrong flag on one of them.
  *
  * @internal
  */
@@ -787,9 +784,7 @@ export class CollectionAssociation extends Association {
    * going to the database. Mirrors
    * ActiveRecord::Associations::CollectionAssociation#find_from_target?
    * (collection_association.rb:308). The clause list lives in
-   * {@link findFromTarget} so `CollectionProxy#isFindFromTarget` — Rails'
-   * one-line delegation at collection_proxy.rb:1154 — shares this exact body
-   * instead of hand-maintaining a copy.
+   * {@link findFromTarget}, shared with `CollectionProxy#isFindFromTarget`.
    */
   isFindFromTarget(): boolean {
     return findFromTarget.call(this, this.isLoaded());

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -24,6 +24,50 @@ export interface ReplacePlan {
 }
 
 /**
+ * Host shape for {@link findFromTarget} — the two objects that carry a
+ * collection's target: the `CollectionAssociation` and the `CollectionProxy`
+ * (which is its own association, see `CollectionProxy#_association`).
+ *
+ * Loadedness is passed in rather than read off the host: the association
+ * exposes it as `isLoaded()`, the proxy as its `loaded` getter over
+ * `_targetLoaded` — and the proxy also inherits an unrelated `Relation#isLoaded`
+ * over `_loaded`, so reading either name off the host would pick the wrong flag
+ * on one of them.
+ *
+ * @internal
+ */
+export interface FindFromTargetHost {
+  owner: Base;
+  reflection: { options: { strictLoading?: unknown } };
+  target: readonly Base[];
+}
+
+/**
+ * The single body behind `CollectionAssociation#isFindFromTarget` and
+ * `CollectionProxy#isFindFromTarget`. Mirrors
+ * ActiveRecord::Associations::CollectionAssociation#find_from_target?
+ * (collection_association.rb:308): loaded, owner strict-loading-all,
+ * reflection strict-loading, owner new record, or any target record
+ * new/changed.
+ *
+ * Note the final clause is Rails' `record.changed?`, NOT `has_changes_to_save?`
+ * — different mutation sources (`mutations_from_user` vs
+ * `mutations_from_database`), even though both currently resolve to
+ * `_dirty.changed` here.
+ *
+ * @internal
+ */
+export function findFromTarget(this: FindFromTargetHost, loaded: boolean): boolean {
+  return (
+    loaded ||
+    (this.owner.isStrictLoading() && this.owner.isStrictLoadingAll()) ||
+    !!this.reflection.options.strictLoading ||
+    this.owner.isNewRecord() ||
+    this.target.some((r) => r.isNewRecord() || r.changed)
+  );
+}
+
+/**
  * Base class for has_many and has_and_belongs_to_many associations.
  *
  * CollectionAssociation provides common CRUD methods for collections.
@@ -742,31 +786,13 @@ export class CollectionAssociation extends Association {
    * Returns true if find should search the loaded target rather than
    * going to the database. Mirrors
    * ActiveRecord::Associations::CollectionAssociation#find_from_target?
-   * (collection_association.rb:308): loaded, owner strict-loading-all,
-   * reflection strict-loading, owner new record, or any target record
-   * new/changed. Kept in clause-parity with `CollectionProxy#isFindFromTarget`.
-   *
-   * Note the final clause is Rails' `record.changed?`, NOT `has_changes_to_save?`
-   * — different mutation sources (`mutations_from_user` vs
-   * `mutations_from_database`), even though both currently resolve to
-   * `_dirty.changed` here.
-   *
-   * This method has no live callers: its only route in is the module-level
-   * `isFindFromTarget(proxy)` helper in collection-proxy.ts, which is reached
-   * solely from the module-level `findNthWithLimit` — itself referenced nowhere.
-   * The live implementation is `CollectionProxy#isFindFromTarget`, which reads
-   * the proxy's own `_target`/`_targetLoaded`. Kept here because api:compare
-   * maps `find_from_target?` to the Rails-layout file. Verified dead by making
-   * this body throw: 382 collection-proxy/has-many tests still pass.
+   * (collection_association.rb:308). The clause list lives in
+   * {@link findFromTarget} so `CollectionProxy#isFindFromTarget` — Rails'
+   * one-line delegation at collection_proxy.rb:1154 — shares this exact body
+   * instead of hand-maintaining a copy.
    */
   isFindFromTarget(): boolean {
-    return (
-      this.isLoaded() ||
-      (this.owner.isStrictLoading() && this.owner.isStrictLoadingAll()) ||
-      !!this.reflection.options.strictLoading ||
-      this.owner.isNewRecord() ||
-      this.target.some((r) => r.isNewRecord() || r.changed)
-    );
+    return findFromTarget.call(this, this.isLoaded());
   }
 
   override isCollection(): boolean {

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1,6 +1,6 @@
 import type { Base } from "../base.js";
 import { Relation } from "../relation.js";
-import { concatRecordsLoop } from "./collection-association.js";
+import { concatRecordsLoop, findFromTarget } from "./collection-association.js";
 import type { PrettyPrinter } from "../pretty-print.js";
 import type { AssociationRelation as AssociationRelationType } from "../association-relation.js";
 import {
@@ -3839,23 +3839,23 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
 
   /**
    * Whether find should read the in-memory target rather than querying the
-   * database. Canonical for the proxy path (the proxy owns `_target` and its
-   * loaded flag); the module-level `isFindFromTarget(proxy)` helper resolves
-   * here via `_association`. Mirrors
-   * ActiveRecord::Associations::CollectionAssociation#find_from_target?
-   * (collection_association.rb:308) — kept in clause-order parity with
-   * `CollectionAssociation#isFindFromTarget`.
+   * database. Mirrors `CollectionProxy#find_from_target?`
+   * (collection_proxy.rb:1154), a one-line delegation to
+   * `@association.find_from_target?`: this proxy *is* its own association
+   * (`_association` returns `this`), so the delegation is the shared
+   * {@link findFromTarget} body bound to this proxy, which supplies `owner`,
+   * `reflection`, `target` and the `loaded` getter over `_targetLoaded`.
+   *
+   * Deliberately NOT routed through `owner.association(name)`: that wrapper is
+   * a secondary copy whose loaded flag is synthesized from
+   * `Base#_associationCache`, so a merely-seeded (concat'd but unloaded) proxy
+   * surfaces there as `loaded?` — which would make `find_from_target?` true
+   * where Rails says false. The proxy owns `_target`/`_targetLoaded`.
    *
    * @internal
    */
   isFindFromTarget(): boolean {
-    return (
-      this._targetLoaded ||
-      (this._record.isStrictLoading() && this._record.isStrictLoadingAll()) ||
-      !!this._assocDef.options.strictLoading ||
-      this._record.isNewRecord() ||
-      this._target.some((r) => r.isNewRecord() || !!(r as any).changed)
-    );
+    return findFromTarget.call(this, this._targetLoaded);
   }
 
   /**
@@ -4309,22 +4309,6 @@ function primaryKeyToken(record: Base): string | null {
 }
 
 /** @internal */
-function findNthWithLimit(
-  proxy: CollectionProxy<any>,
-  index: number,
-  limit: number,
-): Promise<any[]> {
-  if (isFindFromTarget(proxy)) {
-    // await target hydration before slicing — loadTarget() is async
-    return Promise.resolve((proxy as any).loadTarget?.()).then(() => {
-      const records = (proxy as any)._association?.target;
-      return Array.isArray(records) ? records.slice(index, index + limit) : [];
-    });
-  }
-  return (proxy as any).limit(limit).offset(index).toArray();
-}
-
-/** @internal */
 function findNthFromLast(proxy: CollectionProxy<any>, index: number): Promise<any> {
   const records = (proxy as any)._association?.target;
   if (Array.isArray(records)) {
@@ -4345,11 +4329,6 @@ function findNthFromLast(proxy: CollectionProxy<any>, index: number): Promise<an
 /** @internal */
 function isNullScope(proxy: CollectionProxy<any>): boolean {
   return !!(proxy as any)._association?.isNullScope?.();
-}
-
-/** @internal */
-function isFindFromTarget(proxy: CollectionProxy<any>): boolean {
-  return !!(proxy as any)._association?.isFindFromTarget?.();
 }
 
 /** @internal */

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -3841,16 +3841,14 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * Whether find should read the in-memory target rather than querying the
    * database. Mirrors `CollectionProxy#find_from_target?`
    * (collection_proxy.rb:1154), a one-line delegation to
-   * `@association.find_from_target?`: this proxy *is* its own association
-   * (`_association` returns `this`), so the delegation is the shared
-   * {@link findFromTarget} body bound to this proxy, which supplies `owner`,
-   * `reflection`, `target` and the `loaded` getter over `_targetLoaded`.
+   * `@association.find_from_target?` — this proxy *is* its own association, so
+   * the shared {@link findFromTarget} body binds to it directly.
    *
    * Deliberately NOT routed through `owner.association(name)`: that wrapper is
    * a secondary copy whose loaded flag is synthesized from
    * `Base#_associationCache`, so a merely-seeded (concat'd but unloaded) proxy
-   * surfaces there as `loaded?` — which would make `find_from_target?` true
-   * where Rails says false. The proxy owns `_target`/`_targetLoaded`.
+   * surfaces there as loaded — making `find_from_target?` true where Rails says
+   * false. `_targetLoaded` is the proxy's own flag and the faithful one.
    *
    * @internal
    */
@@ -4306,32 +4304,4 @@ function primaryKeyToken(record: Base): string | null {
   }
   if (id == null) return null;
   return String(id);
-}
-
-/** @internal */
-function findNthFromLast(proxy: CollectionProxy<any>, index: number): Promise<any> {
-  const records = (proxy as any)._association?.target;
-  if (Array.isArray(records)) {
-    // index=1 → last (records[-1]), index=2 → second-to-last (records[-2]), etc.
-    // Matches Rails: records[-index] == records[length - index]
-    return Promise.resolve(records[records.length - index] ?? null);
-  }
-  // Mirror finder-methods.ts: reverse order then take a positive offset
-  // (negative offset is not valid SQL on most adapters)
-  return (proxy as any)
-    .reverseOrder?.()
-    .offset(index - 1)
-    .limit(1)
-    .toArray()
-    .then((r: any[]) => r[0] ?? null);
-}
-
-/** @internal */
-function isNullScope(proxy: CollectionProxy<any>): boolean {
-  return !!(proxy as any)._association?.isNullScope?.();
-}
-
-/** @internal */
-function execQueries(proxy: CollectionProxy<any>): Promise<any[]> {
-  return proxy.loadTarget();
 }

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1,6 +1,6 @@
 import type { Base } from "../base.js";
 import { Relation } from "../relation.js";
-import { concatRecordsLoop, findFromTarget } from "./collection-association.js";
+import { CollectionAssociation, concatRecordsLoop } from "./collection-association.js";
 import type { PrettyPrinter } from "../pretty-print.js";
 import type { AssociationRelation as AssociationRelationType } from "../association-relation.js";
 import {
@@ -3842,7 +3842,9 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * database. Mirrors `CollectionProxy#find_from_target?`
    * (collection_proxy.rb:1154), a one-line delegation to
    * `@association.find_from_target?` — this proxy *is* its own association, so
-   * the shared {@link findFromTarget} body binds to it directly.
+   * the delegation borrows `CollectionAssociation`'s body directly instead of
+   * re-implementing the clause list, passing `_targetLoaded` as the loaded
+   * flag (the proxy's inherited `Relation#isLoaded` tracks something else).
    *
    * Deliberately NOT routed through `owner.association(name)`: that wrapper is
    * a secondary copy whose loaded flag is synthesized from
@@ -3853,7 +3855,10 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * @internal
    */
   isFindFromTarget(): boolean {
-    return findFromTarget.call(this, this._targetLoaded);
+    return CollectionAssociation.prototype.isFindFromTarget.call(
+      this as unknown as CollectionAssociation,
+      this._targetLoaded,
+    );
   }
 
   /**

--- a/packages/activerecord/src/associations/find-from-target.trails.test.ts
+++ b/packages/activerecord/src/associations/find-from-target.trails.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Trails-only: `find_from_target?` has one body in Rails
+ * (vendor/rails/activerecord/lib/active_record/associations/collection_association.rb:308);
+ * `CollectionProxy#find_from_target?` (collection_proxy.rb:1154) is a one-line
+ * delegation to it. Trails carried two hand-maintained copies — one on
+ * `CollectionAssociation`, one on `CollectionProxy` — which drifted once (the
+ * association copy gated on `hasChangesToSave` where Rails uses `changed?`).
+ * These tests pin the now-shared body from both hosts, including the
+ * `record.changed?` clause that the association copy's drift had disabled.
+ * There is no Rails test for this predicate directly.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { registerModel } from "../index.js";
+import { Author } from "../test-helpers/models/author.js";
+import { Post } from "../test-helpers/models/post.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+
+interface FindFromTarget {
+  isFindFromTarget(): boolean;
+  isLoaded?(): boolean;
+  loaded?: boolean;
+  target: Post[];
+  concat(records: Post[] | Post): Promise<unknown>;
+  load?(): Promise<unknown>;
+}
+
+const associationOf = (owner: Author): FindFromTarget =>
+  (owner as unknown as { association(n: string): FindFromTarget }).association("posts");
+
+const proxyOf = (owner: Author): FindFromTarget =>
+  (owner as unknown as { posts: FindFromTarget }).posts;
+
+describe("FindFromTarget", () => {
+  fixtures(["authors", "posts"]);
+
+  beforeAll(() => {
+    registerModel(Author);
+    registerModel(Post);
+  });
+
+  it("is false for an unloaded association with an untouched target", async () => {
+    const author = (await Author.first())!;
+    const assoc = associationOf(author);
+    const post = (await Post.last())!;
+    await assoc.concat([post]);
+
+    expect(assoc.isLoaded!()).toBe(false);
+    expect(assoc.target).toHaveLength(1);
+    expect(assoc.isFindFromTarget()).toBe(false);
+  });
+
+  it("is true once a target record is changed", async () => {
+    const author = (await Author.first())!;
+    const assoc = associationOf(author);
+    const post = (await Post.last())!;
+    await assoc.concat([post]);
+
+    assoc.target[0].title = "a different title";
+
+    expect(assoc.isLoaded!()).toBe(false);
+    expect(assoc.isFindFromTarget()).toBe(true);
+  });
+
+  it("is true for a new target record", async () => {
+    const author = (await Author.first())!;
+    const assoc = associationOf(author);
+    assoc.target.push(Post.new({ title: "t", body: "b" }));
+
+    expect(assoc.isFindFromTarget()).toBe(true);
+  });
+
+  it("is true for a new owner", async () => {
+    const author = Author.new({ name: "Bill" });
+
+    expect(proxyOf(author).isFindFromTarget()).toBe(true);
+  });
+
+  it("the proxy shares the association's body", async () => {
+    const author = (await Author.first())!;
+    const proxy = proxyOf(author);
+    const post = (await Post.last())!;
+    await proxy.concat(post);
+
+    expect(proxy.loaded).toBe(false);
+    expect(proxy.isFindFromTarget()).toBe(false);
+
+    proxy.target[0].title = "a different title";
+    expect(proxy.isFindFromTarget()).toBe(true);
+
+    await proxy.load!();
+    expect(proxy.loaded).toBe(true);
+    expect(proxy.isFindFromTarget()).toBe(true);
+  });
+});

--- a/packages/activerecord/src/associations/find-from-target.trails.test.ts
+++ b/packages/activerecord/src/associations/find-from-target.trails.test.ts
@@ -1,50 +1,55 @@
 /**
  * Trails-only: `find_from_target?` has one body in Rails
- * (vendor/rails/activerecord/lib/active_record/associations/collection_association.rb:308);
- * `CollectionProxy#find_from_target?` (collection_proxy.rb:1154) is a one-line
- * delegation to it. Trails carried two hand-maintained copies — one on
- * `CollectionAssociation`, one on `CollectionProxy` — which drifted once (the
- * association copy gated on `hasChangesToSave` where Rails uses `changed?`).
- * These tests pin the now-shared body from both hosts, including the
- * `record.changed?` clause that the association copy's drift had disabled.
- * There is no Rails test for this predicate directly.
+ * (collection_association.rb:308); `CollectionProxy#find_from_target?`
+ * (collection_proxy.rb:1154) is a one-line delegation to it. Trails carried two
+ * hand-maintained copies — one on `CollectionAssociation`, one on
+ * `CollectionProxy` — which drifted once (the association copy gated on
+ * `hasChangesToSave` where Rails uses `changed?`). These tests pin the
+ * now-shared body from both hosts. Rails has no test for the predicate itself.
  */
 import { describe, it, expect, beforeAll } from "vitest";
 import { registerModel } from "../index.js";
 import { Author } from "../test-helpers/models/author.js";
 import { Post } from "../test-helpers/models/post.js";
+import { Developer, AuditLog } from "../test-helpers/models/developer.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 
-interface FindFromTarget {
+interface AssociationLike {
   isFindFromTarget(): boolean;
-  isLoaded?(): boolean;
-  loaded?: boolean;
+  isLoaded(): boolean;
   target: Post[];
-  concat(records: Post[] | Post): Promise<unknown>;
-  load?(): Promise<unknown>;
+  concat(records: Post[]): Promise<unknown>;
 }
 
-const associationOf = (owner: Author): FindFromTarget =>
-  (owner as unknown as { association(n: string): FindFromTarget }).association("posts");
+interface ProxyLike {
+  isFindFromTarget(): boolean;
+  loaded: boolean;
+  target: Post[];
+  concat(record: Post): Promise<unknown>;
+  load(): Promise<unknown>;
+}
 
-const proxyOf = (owner: Author): FindFromTarget =>
-  (owner as unknown as { posts: FindFromTarget }).posts;
+const associationOf = (owner: Author): AssociationLike =>
+  (owner as unknown as { association(n: string): AssociationLike }).association("posts");
+
+const proxyOf = (owner: Author): ProxyLike => (owner as unknown as { posts: ProxyLike }).posts;
 
 describe("FindFromTarget", () => {
-  fixtures(["authors", "posts"]);
+  fixtures(["authors", "posts", "developers"]);
 
   beforeAll(() => {
     registerModel(Author);
     registerModel(Post);
+    registerModel(Developer);
+    registerModel(AuditLog);
   });
 
   it("is false for an unloaded association with an untouched target", async () => {
     const author = (await Author.first())!;
     const assoc = associationOf(author);
-    const post = (await Post.last())!;
-    await assoc.concat([post]);
+    await assoc.concat([(await Post.last())!]);
 
-    expect(assoc.isLoaded!()).toBe(false);
+    expect(assoc.isLoaded()).toBe(false);
     expect(assoc.target).toHaveLength(1);
     expect(assoc.isFindFromTarget()).toBe(false);
   });
@@ -52,12 +57,11 @@ describe("FindFromTarget", () => {
   it("is true once a target record is changed", async () => {
     const author = (await Author.first())!;
     const assoc = associationOf(author);
-    const post = (await Post.last())!;
-    await assoc.concat([post]);
+    await assoc.concat([(await Post.last())!]);
 
     assoc.target[0].title = "a different title";
 
-    expect(assoc.isLoaded!()).toBe(false);
+    expect(assoc.isLoaded()).toBe(false);
     expect(assoc.isFindFromTarget()).toBe(true);
   });
 
@@ -69,17 +73,23 @@ describe("FindFromTarget", () => {
     expect(assoc.isFindFromTarget()).toBe(true);
   });
 
-  it("is true for a new owner", async () => {
-    const author = Author.new({ name: "Bill" });
+  it("is true for a new owner", () => {
+    expect(proxyOf(Author.new({ name: "Bill" })).isFindFromTarget()).toBe(true);
+  });
 
-    expect(proxyOf(author).isFindFromTarget()).toBe(true);
+  it("is true for a strict_loading reflection", async () => {
+    const developer = (await Developer.first())!;
+    const proxy = (developer as unknown as { strictLoadingAuditLogs: ProxyLike })
+      .strictLoadingAuditLogs;
+
+    expect(proxy.loaded).toBe(false);
+    expect(proxy.isFindFromTarget()).toBe(true);
   });
 
   it("the proxy shares the association's body", async () => {
     const author = (await Author.first())!;
     const proxy = proxyOf(author);
-    const post = (await Post.last())!;
-    await proxy.concat(post);
+    await proxy.concat((await Post.last())!);
 
     expect(proxy.loaded).toBe(false);
     expect(proxy.isFindFromTarget()).toBe(false);
@@ -87,7 +97,7 @@ describe("FindFromTarget", () => {
     proxy.target[0].title = "a different title";
     expect(proxy.isFindFromTarget()).toBe(true);
 
-    await proxy.load!();
+    await proxy.load();
     expect(proxy.loaded).toBe(true);
     expect(proxy.isFindFromTarget()).toBe(true);
   });

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/collection-proxy.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/collection-proxy.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/collection-proxy.ts",
-    "rubyName": "calculate",
-    "call": "null_scope?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-proxy.ts",
     "rubyName": "initialize",
     "call": "any?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -18,13 +11,6 @@
     "tsFile": "associations/collection-proxy.ts",
     "rubyName": "initialize",
     "call": "extensions",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-proxy.ts",
-    "rubyName": "pluck",
-    "call": "null_scope?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
@@ -2397,13 +2397,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "load",
-    "call": "exec_queries",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "load",
     "call": "loaded?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
Rails has one `find_from_target?` (`collection_association.rb:308`);
`CollectionProxy#find_from_target?` (`collection_proxy.rb:1154`) is a one-line
delegation to it. trails carried two hand-maintained copies, which had already
drifted once (#4900).

- `CollectionProxy#isFindFromTarget` now borrows `CollectionAssociation`'s body
  via the prototype instead of re-implementing the clause list. The clause list
  stays inside the Rails-named method (the wide call-set ratchet reads method
  bodies, so a module-level helper would read as six omitted calls); it takes an
  optional `loaded` override, since the proxy tracks loadedness in its own
  `_targetLoaded` and its inherited `Relation#isLoaded` means something else.
  Rails' `find_from_target?` takes no argument — that one param is the seam.
- Remove the unreferenced module-level `findNthWithLimit` / `isFindFromTarget`
  pair in `collection-proxy.ts` — the only route into the association copy —
  plus their equally unreferenced siblings `findNthFromLast` / `isNullScope` /
  `execQueries`, same dead-island class, same file.
- Add `find-from-target.trails.test.ts`: six cases pinning the shared body from
  both hosts — unloaded/untouched, the `record.changed?` clause the drift had
  disabled, a new target record, a new owner, the reflection `strict_loading`
  clause, and proxy/association agreement across concat → dirty → load.

**On the acceptance criteria:** delegating the proxy through
`owner.association(name)` was checked and rejected. That wrapper is a secondary
copy whose loaded flag is synthesized from `Base#_associationCache`, so a
merely-seeded (concat'd but unloaded) proxy surfaces there as loaded —
`find_from_target?` would then be `true` where Rails says `false`. Since
`CollectionProxy#_association` returns `this`, binding the shared body to the
proxy *is* Rails' delegation, without that divergence. The justification is at
the call site.

Also drops three wide call-mismatch baseline entries (`null_scope?` ×2,
`exec_queries`) that stopped flagging once the dead helpers went: those names
are no longer ported, so the pairs leave the wide population. Verified locally
with the full `extract-ruby-api` → `extract-ts-api` → `compare --wide-calls` →
ratchet chain, plus the narrow ratchet, body-pins, deps, privates and
conventions-doc gates — all green.

Suites run locally: collection-proxy, collection-proxy-count,
has-many-associations, has-many-through-associations, strict-loading (×3),
finder-methods — all green.

Closes-story: converge-find-from-target-onto-association
