### PR TITLE
fix(calculations): apply relation order in composite-key grouped calculations

### DIFF
--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -704,6 +704,11 @@ async function groupedCompositeAssoc(
   for (const n of groupNodes) manager.group(n);
   foldSelectValuesForHaving(rel, manager);
   applyHavingToManager(rel, manager);
+  // Rails `execute_grouped_calculation` does not special-case key arity — it
+  // runs `select_all` on the relation's own arel, so order_values ride along
+  // for composite FKs too. Without the ORDER BY, LIMIT/OFFSET pick arbitrary
+  // groups on PG/MySQL.
+  rel._applyOrderToManager(manager, table);
 
   if (rel._limitValue !== null) manager.take(rel._limitValue);
   if (rel._offsetValue !== null) manager.skip(rel._offsetValue);

--- a/packages/activerecord/src/relation/grouped-composite-assoc-applies-order.trails.test.ts
+++ b/packages/activerecord/src/relation/grouped-composite-assoc-applies-order.trails.test.ts
@@ -95,4 +95,24 @@ describe("CpkBook grouped calculation over a composite-key belongs_to applies or
     // Ordered groups are (2 → 3), (3 → 2), (1 → 1); offset(2) leaves order 1.
     expect(counts).toEqual([[[1, 1], 1]]);
   });
+
+  it("group by a composite-key belongs_to with a group-key column order and limit returns the ordered groups", async () => {
+    await seedOrders();
+    // A bare column order (rather than an aggregate expression) must resolve
+    // against the model's table: descending order_id makes the top-2 groups
+    // (3, 2) rather than the insertion-order (1, 2).
+    const result = (await CpkBook.group("order").order("order_id DESC").limit(2).count()) as Map<
+      unknown,
+      number
+    >;
+
+    const counts = [...result.entries()].map(([order, count]) => [
+      (order as CpkOrder | null)?.id,
+      count,
+    ]);
+    expect(counts).toEqual([
+      [[1, 3], 2],
+      [[1, 2], 3],
+    ]);
+  });
 });

--- a/packages/activerecord/src/relation/grouped-composite-assoc-applies-order.trails.test.ts
+++ b/packages/activerecord/src/relation/grouped-composite-assoc-applies-order.trails.test.ts
@@ -18,6 +18,7 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { registerModel } from "../associations.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { CpkBook, CpkOrder, CpkAuthor } from "../test-helpers/models/cpk.js";
+import { sql as arelSql } from "@blazetrails/arel";
 import { captureSql } from "../testing/sql-capture.js";
 
 describe("CpkBook grouped calculation over a composite-key belongs_to applies order", () => {
@@ -29,6 +30,11 @@ describe("CpkBook grouped calculation over a composite-key belongs_to applies or
     [CpkBook, CpkOrder, CpkAuthor].forEach((m) => registerModel(m));
   });
 
+  // An aggregate order expression must go through `Arel.sql`: a bare
+  // "COUNT(*) DESC" string is a non-attribute argument, so `disallowRawSql`
+  // rejects it once `allowUnsafeRawSql` is disabled (as it is under the full
+  // suite run).
+  //
   // Three orders in shop 1. Book counts per order: 1 → 1, 2 → 3, 3 → 2.
   // Grouping by the composite belongs_to and ordering by COUNT(*) DESC makes
   // the ordered top-2 orders (2, 3) differ from the unordered/insertion-order
@@ -61,10 +67,10 @@ describe("CpkBook grouped calculation over a composite-key belongs_to applies or
     await seedOrders();
     let result: Map<unknown, number> = new Map();
     const sqls = await captureSql(async () => {
-      result = (await CpkBook.group("order").order("COUNT(*) DESC").limit(2).count()) as Map<
-        unknown,
-        number
-      >;
+      result = (await CpkBook.group("order")
+        .order(arelSql("COUNT(*) DESC"))
+        .limit(2)
+        .count()) as Map<unknown, number>;
     });
 
     const counts = [...result.entries()].map(([order, count]) => [
@@ -83,10 +89,10 @@ describe("CpkBook grouped calculation over a composite-key belongs_to applies or
 
   it("group by a composite-key belongs_to with order and offset skips the ordered groups", async () => {
     await seedOrders();
-    const result = (await CpkBook.group("order").order("COUNT(*) DESC").offset(2).count()) as Map<
-      unknown,
-      number
-    >;
+    const result = (await CpkBook.group("order")
+      .order(arelSql("COUNT(*) DESC"))
+      .offset(2)
+      .count()) as Map<unknown, number>;
 
     const counts = [...result.entries()].map(([order, count]) => [
       (order as CpkOrder | null)?.id,

--- a/packages/activerecord/src/relation/grouped-composite-assoc-applies-order.trails.test.ts
+++ b/packages/activerecord/src/relation/grouped-composite-assoc-applies-order.trails.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Grouped calculation over a composite-key `belongsTo` must apply the
+ * relation's order before LIMIT/OFFSET.
+ *
+ * `groupedCompositeAssoc` (`relation/calculations.ts`) — the composite-FK
+ * belongs_to arm of grouped calculations — applied LIMIT/OFFSET but never the
+ * relation's `order_values`, so
+ * `group(<composite belongs_to>).order(...).limit(n)` picked arbitrary groups
+ * on PG/MySQL instead of the ordered first n. The sibling scalar/expression
+ * arm `groupedAggregate` already applied it.
+ *
+ * Rails does not special-case key arity here: `execute_grouped_calculation`
+ * builds ONE query from the relation's own arel, so `order_values` ride along
+ * for composite and scalar foreign keys alike
+ * (`activerecord/lib/active_record/relation/calculations.rb:553-556`).
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { registerModel } from "../associations.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+import { CpkBook, CpkOrder, CpkAuthor } from "../test-helpers/models/cpk.js";
+import { captureSql } from "../testing/sql-capture.js";
+
+describe("CpkBook grouped calculation over a composite-key belongs_to applies order", () => {
+  // Rails creates CPK rows inline; no cpk fixtures exist. Ride the canonical,
+  // empty cpk tables and let transactional rollback clean up each insert.
+  fixtures([]);
+
+  beforeAll(() => {
+    [CpkBook, CpkOrder, CpkAuthor].forEach((m) => registerModel(m));
+  });
+
+  // Three orders in shop 1. Book counts per order: 1 → 1, 2 → 3, 3 → 2.
+  // Grouping by the composite belongs_to and ordering by COUNT(*) DESC makes
+  // the ordered top-2 orders (2, 3) differ from the unordered/insertion-order
+  // top-2 (1, 2), so a dropped ORDER BY changes the answer.
+  async function seedOrders(): Promise<void> {
+    await CpkAuthor.create({ id: 1, name: "Author One" });
+    for (const id of [1, 2, 3]) {
+      await CpkOrder.create({ id: [1, id], status: `s-${id}` });
+    }
+    const books: Array<[number, number]> = [
+      [1, 1],
+      [2, 2],
+      [3, 2],
+      [4, 2],
+      [5, 3],
+      [6, 3],
+    ];
+    for (const [bookId, orderId] of books) {
+      await CpkBook.create({
+        id: [1, bookId],
+        title: `book-${bookId}`,
+        revision: 1,
+        shop_id: 1,
+        order_id: orderId,
+      });
+    }
+  }
+
+  it("group by a composite-key belongs_to with order and limit returns the ordered groups", async () => {
+    await seedOrders();
+    let result: Map<unknown, number> = new Map();
+    const sqls = await captureSql(async () => {
+      result = (await CpkBook.group("order").order("COUNT(*) DESC").limit(2).count()) as Map<
+        unknown,
+        number
+      >;
+    });
+
+    const counts = [...result.entries()].map(([order, count]) => [
+      (order as CpkOrder | null)?.id,
+      count,
+    ]);
+    expect(counts).toEqual([
+      [[1, 2], 3],
+      [[1, 3], 2],
+    ]);
+
+    const groupedSql = sqls.find((s) => /GROUP BY/i.test(s) && /LIMIT 2/i.test(s));
+    expect(groupedSql).toBeTruthy();
+    expect(groupedSql).toMatch(/ORDER BY[\s\S]*LIMIT 2/i);
+  });
+
+  it("group by a composite-key belongs_to with order and offset skips the ordered groups", async () => {
+    await seedOrders();
+    const result = (await CpkBook.group("order").order("COUNT(*) DESC").offset(2).count()) as Map<
+      unknown,
+      number
+    >;
+
+    const counts = [...result.entries()].map(([order, count]) => [
+      (order as CpkOrder | null)?.id,
+      count,
+    ]);
+    // Ordered groups are (2 → 3), (3 → 2), (1 → 1); offset(2) leaves order 1.
+    expect(counts).toEqual([[[1, 1], 1]]);
+  });
+});


### PR DESCRIPTION
`groupedCompositeAssoc` (the composite-key `belongs_to` arm of grouped
calculations in `relation/calculations.ts`) applied LIMIT/OFFSET but never the
relation's order, so `group(<composite belongs_to>).order(...).limit(n)` picked
arbitrary groups on PG/MySQL instead of the ordered first n. The sibling
scalar/expression arm `groupedAggregate` already applied it.

Rails does not special-case key arity: `execute_grouped_calculation` builds one
query from the relation's own arel, so `order_values` ride along for composite
and scalar foreign keys alike (`calculations.rb:553-556`).

Fix: call `rel._applyOrderToManager(manager, table)` before take/skip, matching
`groupedAggregate`.

Test: `grouped-composite-assoc-applies-order.trails.test.ts` covers ordered +
limited and ordered + offset grouped counts over `CpkBook.group("order")`
(composite FK `["shop_id", "order_id"]`), asserting the ordered subset. Both
tests fail on baseline and pass with the fix.

Closes-story: grouped-composite-assoc-missing-order
