### PR TITLE
test(postgresql): drive virtual-column fixture sql from canonical data

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/virtual-column.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/virtual-column.test.ts
@@ -6,6 +6,7 @@ import { describeIfPg, PostgreSQLAdapter } from "./test-helper.js";
 import { itIfSupports } from "../../test-helpers/supports.js";
 import { FixtureSet } from "../../test-helpers/fixture-set.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
+import { virtualColumnFixtureData } from "../../test-helpers/fixtures/virtual-columns.js";
 import { Base } from "../../index.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 
@@ -129,11 +130,12 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     itIfSupports("virtual_columns", "build fixture sql", async () => {
-      const fixtures = await FixtureSet.createFixtures(adapter, VirtualColumn, {
-        one: { name: "hello" },
-        two: { name: "world" },
-      });
-      expect(Object.keys(fixtures).length).toBe(2);
+      const created = await FixtureSet.createFixtures(
+        adapter,
+        VirtualColumn,
+        virtualColumnFixtureData,
+      );
+      expect(Object.keys(created).length).toBe(2);
     });
   });
 });


### PR DESCRIPTION
The PG `build fixture sql` test hardcoded the fixture rows inline; Rails reads `test/fixtures/virtual_columns.yml`, whose canonical mirror is `virtualColumnFixtureData`. #5177 switched the sqlite3 sibling over — this does the same for PG so the two copies can't drift.

Closes-story: pg-virtual-column-build-fixture-sql-canonical-data