### PR TITLE
fix(activerecord): save_through_record uses a bang save

### DIFF
--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -6,7 +6,6 @@ import {
   HasManyThroughNestedAssociationsAreReadonly,
 } from "./errors.js";
 import { compositeQueryConstraintsList } from "../persistence.js";
-import { raiseValidationError } from "../validations.js";
 import { underscore, singularize, camelize } from "@blazetrails/activesupport";
 import { resolveAssocClass, association as collectionProxyFor } from "../associations.js";
 import {
@@ -140,7 +139,7 @@ export class HasManyThroughAssociation extends HasManyAssociation {
     }
     // Rails' two-step: super.insert_record (above) saves the target; then
     // save_through_record builds + saves the join row via the through proxy.
-    return saveThroughRecord(this, record, validate, raise);
+    return saveThroughRecord(this, record);
   }
 
   /**
@@ -575,25 +574,20 @@ function throughScopeAttributes(assoc: HasManyThroughAssociation): Record<string
 }
 
 /** @internal */
-async function saveThroughRecord(
-  assoc: HasManyThroughAssociation,
-  record: Base,
-  validate = true,
-  raise = false,
-): Promise<boolean> {
-  // Mirrors Rails' has_many_through_association#save_through_record: build
-  // the join row (via the through proxy for HMT, or via habtm options for
-  // HABTM) and save it when it has pending changes. The `ensure`-clear evicts
-  // the per-record cache so the same target can be associated again later.
+async function saveThroughRecord(assoc: HasManyThroughAssociation, record: Base): Promise<boolean> {
+  // Mirrors Rails' has_many_through_association#save_through_record
+  // (has_many_through_association.rb:81-85): build the join row (via the
+  // through proxy for HMT, or via habtm options for HABTM) and `save!` it when
+  // it has pending changes. `save_through_record` takes neither `validate` nor
+  // `raise` — those only reach the *target* save via `insert_record`'s `super`
+  // — so an invalid join row is always fatal, even on the `concat`/`<<` path.
+  // The `ensure`-clear evicts the per-record cache so the same target can be
+  // associated again later.
   try {
     const joinRecord = buildThroughRecord(assoc, record);
     if (!joinRecord) return true;
     if (!joinRecord.changed) return true;
-    const saved = await (joinRecord as any).save({ validate });
-    if (!saved) {
-      if (raise) raiseValidationError(joinRecord);
-      return false;
-    }
+    await (joinRecord as any).saveBang();
     return true;
   } finally {
     throughRecordsCache(assoc).delete(record);

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -137,8 +137,6 @@ export class HasManyThroughAssociation extends HasManyAssociation {
       const saved = await super.insertRecord(record, validate, raise);
       if (!saved) return false;
     }
-    // Rails' two-step: super.insert_record (above) saves the target; then
-    // save_through_record builds + saves the join row via the through proxy.
     return saveThroughRecord(this, record);
   }
 
@@ -575,14 +573,6 @@ function throughScopeAttributes(assoc: HasManyThroughAssociation): Record<string
 
 /** @internal */
 async function saveThroughRecord(assoc: HasManyThroughAssociation, record: Base): Promise<boolean> {
-  // Mirrors Rails' has_many_through_association#save_through_record
-  // (has_many_through_association.rb:81-85): build the join row (via the
-  // through proxy for HMT, or via habtm options for HABTM) and `save!` it when
-  // it has pending changes. `save_through_record` takes neither `validate` nor
-  // `raise` — those only reach the *target* save via `insert_record`'s `super`
-  // — so an invalid join row is always fatal, even on the `concat`/`<<` path.
-  // The `ensure`-clear evicts the per-record cache so the same target can be
-  // associated again later.
   try {
     const joinRecord = buildThroughRecord(assoc, record);
     if (!joinRecord) return true;

--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -2534,10 +2534,7 @@ describe("HasManyThroughAssociationsTest", () => {
     await expect((order as any).chapters.toArray()).resolves.toBeInstanceOf(Array);
   });
 
-  // TS-only: insertRecord with validate false still raises on an invalid join record.
-  // Rails' save_through_record (has_many_through_association.rb:81-85) takes
-  // neither `validate` nor `raise`; those reach only the target save via
-  // insert_record's `super`, so the join row is always a bang save.
+  // TS-only: insertRecord with validate false still raises on invalid join record
   it("insertRecord with validate false still raises on invalid join record", async () => {
     class IrpvTagging extends Base {
       declare taggable_id: number | null;

--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -2534,8 +2534,11 @@ describe("HasManyThroughAssociationsTest", () => {
     await expect((order as any).chapters.toArray()).resolves.toBeInstanceOf(Array);
   });
 
-  // TS-only: insertRecord with validate false skips join record validation
-  it("insertRecord with validate false skips join record validation", async () => {
+  // TS-only: insertRecord with validate false still raises on an invalid join record.
+  // Rails' save_through_record (has_many_through_association.rb:81-85) takes
+  // neither `validate` nor `raise`; those reach only the target save via
+  // insert_record's `super`, so the join row is always a bang save.
+  it("insertRecord with validate false still raises on invalid join record", async () => {
     class IrpvTagging extends Base {
       declare taggable_id: number | null;
       declare taggable_type: string | null;
@@ -2548,7 +2551,7 @@ describe("HasManyThroughAssociationsTest", () => {
         this.attribute("taggable_id", "integer");
         this.attribute("taggable_type", "string");
         this.attribute("tag_id", "integer");
-        (this as any).validates((r: any) => {
+        (this as any).validate((r: any) => {
           r.errors.add("base", "Join always invalid");
         });
         this.belongsTo("tag", { className: "Tag", foreignKey: "tag_id" });
@@ -2577,9 +2580,8 @@ describe("HasManyThroughAssociationsTest", () => {
 
     const irpvPost = await IrpvPost.find(post.id);
     const assoc = (irpvPost as any).association("irpvTags");
-    const result = await assoc.insertRecord(tag, false, false);
-    expect(result).toBe(true);
-    expect(await IrpvTagging.where({ taggable_id: post.id }).count()).toBe(1);
+    await expect(assoc.insertRecord(tag, false, false)).rejects.toThrow(RecordInvalid);
+    expect(await IrpvTagging.where({ taggable_id: post.id }).count()).toBe(0);
   });
 
   // TS-only: loads through a join model


### PR DESCRIPTION
`saveThroughRecord` saved the join row with a non-bang save and only raised
when the caller passed `raise: true`, so an invalid join row was silently
dropped on the default `concat` / `<<` path.

Rails' `save_through_record`
(`has_many_through_association.rb:81-85`) takes neither `validate` nor
`raise` — those reach only the *target* save via `insert_record`'s `super` —
and calls `association.save!`. A bad join row is always fatal.

- `saveThroughRecord` drops both flags and uses `saveBang()`.
- Reconciled the TS-only test `insertRecord with validate false skips join
  record validation`, which pinned the old behavior. It also used
  `validates(fn)` — the block form is `validate(fn)`, so its "always invalid"
  join validator never actually ran and the test passed vacuously. Fixed the
  registration and renamed it to assert the Rails behavior: `validate: false`
  does not reach the join row, which raises `RecordInvalid`.

Suites run locally: has_many_through, HABTM, nested-through, has_one_through,
constructor-form-and-hmt-insert — all pass.

Closes-story: save-through-record-uses-bang-save
