### PR TITLE
test(arel): exercise real superclass fallback in threadsafe dispatch test

### DIFF
--- a/packages/arel/src/visitors/dispatch-contamination.test.ts
+++ b/packages/arel/src/visitors/dispatch-contamination.test.ts
@@ -1,9 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { testConnection } from "../test-helpers/connection.js";
-import { Table, Nodes, Visitors } from "../index.js";
+import { Nodes, Visitors } from "../index.js";
 
 describe("DispatchContaminationTest", () => {
-  const users = new Table("users");
   it("dispatches properly after failing upwards", () => {
     const node = new Nodes.Union(new Nodes.True(), new Nodes.False());
     expect(node.toSql()).toBe("( TRUE UNION FALSE )");
@@ -32,11 +30,32 @@ describe("DispatchContaminationTest", () => {
   });
 
   it("is threadsafe when implementing superclass fallback", () => {
-    const v1 = new Visitors.ToSql(testConnection);
-    const v2 = new Visitors.ToSql(testConnection);
-    const n1 = users.get("id").eq(1);
-    const n2 = users.get("id").eq(2);
-    expect(v1.compile(n1)).toBe('"users"."id" = 1');
-    expect(v2.compile(n2)).toBe('"users"."id" = 2');
+    // Rails races two threads through one DummyVisitor, using a CyclicBarrier
+    // inside an overridden `send` to force both to fail dispatch on
+    // DummySubNode at the same instant, then asserts both still resolve to the
+    // DummySuperNode handler (42). JS is single-threaded and has no
+    // interruptible dispatch, so the barrier/thread machinery has no analogue
+    // here. What is portable — and what the race guards — is that the
+    // corrective write lands on the shared per-class cache, so a second
+    // visitor observing the corrected entry resolves to the same handler as
+    // the first that resolved it by ancestor fallthrough.
+    class DummySuperNode {}
+    class DummySubNode extends DummySuperNode {}
+
+    class DummyVisitor extends Visitors.Visitor {
+      protected visitArelVisitorsDummySuperNode(_node: unknown): number {
+        return 42;
+      }
+    }
+    const cache = DummyVisitor.dispatchCache();
+    cache.set(DummySuperNode, "visitArelVisitorsDummySuperNode");
+    expect(cache.has(DummySubNode)).toBe(false);
+
+    const visitor = new DummyVisitor();
+    const racingVisitor = new DummyVisitor();
+
+    expect(visitor.accept(new DummySubNode())).toBe(42);
+    expect(cache.get(DummySubNode)).toBe("visitArelVisitorsDummySuperNode");
+    expect(racingVisitor.accept(new DummySubNode())).toBe(42);
   });
 });

--- a/packages/arel/src/visitors/dispatch-contamination.test.ts
+++ b/packages/arel/src/visitors/dispatch-contamination.test.ts
@@ -30,15 +30,11 @@ describe("DispatchContaminationTest", () => {
   });
 
   it("is threadsafe when implementing superclass fallback", () => {
-    // Rails races two threads through one DummyVisitor, using a CyclicBarrier
-    // inside an overridden `send` to force both to fail dispatch on
-    // DummySubNode at the same instant, then asserts both still resolve to the
-    // DummySuperNode handler (42). JS is single-threaded and has no
-    // interruptible dispatch, so the barrier/thread machinery has no analogue
-    // here. What is portable — and what the race guards — is that the
-    // corrective write lands on the shared per-class cache, so a second
-    // visitor observing the corrected entry resolves to the same handler as
-    // the first that resolved it by ancestor fallthrough.
+    // Rails' thread/CyclicBarrier machinery has no analogue: JS is
+    // single-threaded and dispatch is not interruptible. The portable core of
+    // the race is that the corrective write lands on the shared per-class
+    // cache, so a second visitor resolves the same handler the first resolved
+    // by ancestor fallthrough.
     class DummySuperNode {}
     class DummySubNode extends DummySuperNode {}
 


### PR DESCRIPTION
Converges Arel `DispatchContaminationTest` "is threadsafe when implementing superclass fallback" onto the real `Visitor` machinery.

Previously the test compiled two unrelated `ToSql` visitors over `users.id.eq(...)` and asserted the SQL — no subclass, no ancestor fallback, no dispatch-cache write. It now mirrors Rails `DummyVisitor`/`DummySuperNode`/`DummySubNode`: the handler is registered on the ancestor, both visitors accept a `DummySubNode`, both resolve 42, and the memoized correction is asserted to land on the shared per-class cache. The thread/barrier machinery has no JS analogue and is justified at the call site.

Test name unchanged.

Closes-story: threadsafe-fallback-test-does-not-exercise-fallback
