### PR TITLE
fix(api-compare): sort the body-pins manifest by code unit, not ICU collation

### DIFF
--- a/scripts/api-compare/body-pins.test.ts
+++ b/scripts/api-compare/body-pins.test.ts
@@ -50,9 +50,8 @@ describe("comparePinKeys", () => {
     expect(comparePinKeys(bang, bang)).toBe(0);
   });
 
-  it("sorts a manifest the same way regardless of locale collation", () => {
-    const keys = ["permit!", "permit_all", "permitted?", "Permit"];
-    const sorted = keys
+  it("puts uppercase before lowercase, unlike ICU's case-insensitive primary strength", () => {
+    const sorted = ["permit!", "permit_all", "permitted?", "Permit"]
       .map((rubyName) => pin({ rubyName }))
       .sort(comparePinKeys)
       .map((p) => p.rubyName);
@@ -126,6 +125,19 @@ describe("pinPairs", () => {
     expect(next.find((p) => p.rubyName === "save")!.digest).toBe("new1");
     // querying.rb was not selected → its pin stays at the old digest.
     expect(next.find((p) => p.rubyName === "find")!.digest).toBe("old2");
+  });
+
+  it("emits the same manifest order for any input order (no reseed churn)", () => {
+    // The manifest is regenerated from whatever order the artifact lists
+    // records in; a permuted artifact must not reorder committed pins.
+    const names = ["permit!", "permit_all", "permitted?", "Permit", "save"];
+    const records = names.map((rubyName, i) => record({ rubyName, digest: `${i}00000000000000` }));
+    const forward = pinPairs(records, [], { all: true }).map(keyOf);
+    const reversed = pinPairs([...records].reverse(), [], { all: true }).map(keyOf);
+    expect(reversed).toEqual(forward);
+    // Array#sort with no comparator is code-unit order — the emitted order
+    // must match it exactly.
+    expect(forward).toEqual([...forward].sort());
   });
 });
 

--- a/scripts/api-compare/body-pins.test.ts
+++ b/scripts/api-compare/body-pins.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   type BodyHashRecord,
   type BodyPin,
+  comparePinKeys,
   currentDigests,
   diffPins,
   findDuplicateKeys,
@@ -35,6 +36,27 @@ function pin(over: Partial<BodyPin> = {}): BodyPin {
 describe("keyOf", () => {
   it("keys on package + rubyFile + rubyName", () => {
     expect(keyOf(record())).toBe("activerecord persistence.rb save");
+  });
+});
+
+describe("comparePinKeys", () => {
+  it("orders by code unit, not ICU collation", () => {
+    const bang = pin({ rubyName: "permit!" });
+    const under = pin({ rubyName: "permit_any_in_array" });
+    // "!" (0x21) < "_" (0x5f) by code unit; ICU demotes punctuation to a
+    // secondary difference and can order these either way.
+    expect(comparePinKeys(bang, under)).toBeLessThan(0);
+    expect(comparePinKeys(under, bang)).toBeGreaterThan(0);
+    expect(comparePinKeys(bang, bang)).toBe(0);
+  });
+
+  it("sorts a manifest the same way regardless of locale collation", () => {
+    const keys = ["permit!", "permit_all", "permitted?", "Permit"];
+    const sorted = keys
+      .map((rubyName) => pin({ rubyName }))
+      .sort(comparePinKeys)
+      .map((p) => p.rubyName);
+    expect(sorted).toEqual(["Permit", "permit!", "permit_all", "permitted?"]);
   });
 });
 

--- a/scripts/api-compare/body-pins.ts
+++ b/scripts/api-compare/body-pins.ts
@@ -151,8 +151,25 @@ export function findDuplicateKeys(pins: BodyPin[]): string[] {
   return [...dups];
 }
 
+/**
+ * Total order on the committed manifest, by UTF-16 code unit over `keyOf`
+ * (`package rubyFile rubyName`). Deliberately NOT `localeCompare`: ICU
+ * collation is locale- and ICU-version-dependent and treats punctuation as
+ * secondary, so keys differing only in `!`/`_`/`?` sort differently depending
+ * on who runs `--pin-all`, emitting symmetric +/- manifest churn with no
+ * content change. (Same fix as `compareKeys` in lint-call-mismatches.ts, which
+ * cannot be reused directly: body-pins keys on `rubyFile`, not `tsFile`/call.)
+ * `keyOf` is unique per pin (findDuplicateKeys enforces it), so no tie-break
+ * is needed.
+ */
+export function comparePinKeys(a: PinKey, b: PinKey): number {
+  const ka = keyOf(a);
+  const kb = keyOf(b);
+  return ka < kb ? -1 : ka > kb ? 1 : 0;
+}
+
 function sortPins(pins: BodyPin[]): BodyPin[] {
-  return [...pins].sort((a, b) => keyOf(a).localeCompare(keyOf(b)));
+  return [...pins].sort(comparePinKeys);
 }
 
 // Pin (or re-pin) matched pairs at their CURRENT digest. `select` limits which


### PR DESCRIPTION
## What

`sortPins` in `scripts/api-compare/body-pins.ts` sorted the committed manifest
with `keyOf(a).localeCompare(keyOf(b))` — the same locale/ICU-dependent
comparator that made the wide call-mismatch baseline reorder untouched packages
on every reseed (#5183). ICU collation demotes punctuation to a secondary
difference, so pin keys differing only in `!` / `_` / `?` order differently
depending on the runner's locale and ICU version, and any `--pin-all` / `--pin`
run could emit a symmetric +/- diff with no content change.

Replaced with `comparePinKeys`, a documented UTF-16 code-unit total order over
`keyOf` (`package rubyFile rubyName`). `compareKeys` from
`lint-call-mismatches.ts` can't be imported directly — body-pins keys on
`rubyFile`, not `tsFile`/call — so this is the equivalent local comparator, with
a doc comment carrying the shared rationale. `keyOf` is unique per pin
(`findDuplicateKeys` enforces it), so the order is total; no tie-break needed.

## No reorder commit needed

The committed `scripts/api-compare/body-pins.json` is currently `[]` (0
entries), so the one-time reordering is a verified no-op: rewriting it through
the new comparator leaves the file byte-identical (`git status` clean; entry
count and entry multiset unchanged). The determinism guarantee now holds by
construction for every pin added from here on, and is enforced by test rather
than by the current emptiness of the file.

## extra-surface: checked, out of scope

The `localeCompare` calls in `extra-surface.ts` (lines 657/681/838) order
in-memory report rows that are only ever printed to stdout (including with
`--json`); nothing there is written to a committed artifact, so locale variance
cannot produce diff churn. Left alone rather than widening scope.

## Tests

- `comparePinKeys` orders `permit!` before `permit_any_in_array` by code unit
  (the ICU-ambiguous pair from #5183) and is antisymmetric/reflexive.
- `comparePinKeys` puts `Permit` before `permit!`, which ICU's case-insensitive
  primary strength does not.
- `pinPairs` emits the same manifest order for a forward and a reversed
  artifact, and that order equals plain `Array#sort` (code-unit) order. This is
  the actual anti-churn invariant; **it fails on the pre-fix `localeCompare`
  comparator and passes after** (verified locally by reverting `sortPins`).

Gate: `pnpm vitest run scripts/api-compare/body-pins.test.ts` — 14 passed.

Closes-story: body-pins-manifest-locale-sort-churn
