### PR TITLE
fix(activerecord): resolve attribute() type names through the model's adapter

### DIFF
--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -338,9 +338,9 @@ export function resolveAttributeName(this: AttributeHostInternals, name: string)
 export function resolveTypeName(
   this: AttributeHostInternals,
   name: string,
-  _options?: Record<string, unknown>,
+  options?: Record<string, unknown>,
 ): Type {
-  return typeRegistry.lookup(name);
+  return typeRegistry.lookup(name, options);
 }
 
 /**

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -101,12 +101,44 @@ export interface AttributeOptions {
   limit?: number | null;
 }
 
+/**
+ * Rails: `type = resolve_type_name(type, **options)` — `default:` is peeled off
+ * by the keyword signature, so only the remaining options reach the registry.
+ * `virtual` / `userProvidedDefault` are trails-side declaration flags with no
+ * Rails counterpart, so they are peeled off here too rather than leaking into a
+ * type constructor.
+ */
+function resolveType(
+  host: { resolveTypeName?(name: string, options?: Record<string, unknown>): Type },
+  name: string,
+  options?: AttributeOptions,
+): Type {
+  if (!host.resolveTypeName) return typeRegistry.lookup(name);
+  const {
+    default: _default,
+    virtual: _virtual,
+    userProvidedDefault: _userProvidedDefault,
+    ...typeOptions
+  } = options ?? {};
+  return host.resolveTypeName(
+    name,
+    Object.keys(typeOptions).length > 0 ? (typeOptions as Record<string, unknown>) : undefined,
+  );
+}
+
 /** @internal */
 export function attribute(
   this: {
     _attributeDefinitions: Map<string, AttributeDefinition>;
     prototype: object;
     _cachedDefaultAttributes?: AttributeSet | null;
+    // Mirrors Rails' `resolve_type_name(type, **options)` call in
+    // AttributeRegistration::ClassMethods#attribute. ActiveRecord overrides it
+    // to resolve through the adapter-specific registry, so the declaring class
+    // — not this module — decides which registry a symbolic name resolves in.
+    // Optional so bare attribute hosts that don't mix in AttributeRegistration
+    // still work; they fall back to the ActiveModel registry.
+    resolveTypeName?(name: string, options?: Record<string, unknown>): Type;
   },
   name: string,
   // Mirrors Rails' `attribute(name, type = nil, **options)`: the type is
@@ -135,7 +167,7 @@ export function attribute(
   const type = typeProvided
     ? typeName instanceof Type
       ? typeName
-      : typeRegistry.lookup(typeName as string)
+      : resolveType(this, typeName as string, options)
     : (existing?.type ?? typeRegistry.lookup("value"));
   // Preserve the existing defaultValue when no default is explicitly provided,
   // matching Rails' PendingType behavior: with_type only changes the type and

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -99,6 +99,13 @@ export interface AttributeOptions {
    */
   userProvidedDefault?: boolean;
   limit?: number | null;
+  /**
+   * PG type modifiers, forwarded to the registry as Rails' `**options` are:
+   * `attribute :tags, :string, array: true` / `:my_range, :string, range: true`
+   * (postgresql_adapter.rb:1166-1167 register them via `add_modifier`).
+   */
+  array?: boolean;
+  range?: boolean;
 }
 
 /** @internal */

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -101,44 +101,13 @@ export interface AttributeOptions {
   limit?: number | null;
 }
 
-/**
- * Rails: `type = resolve_type_name(type, **options)` — `default:` is peeled off
- * by the keyword signature, so only the remaining options reach the registry.
- * `virtual` / `userProvidedDefault` are trails-side declaration flags with no
- * Rails counterpart, so they are peeled off here too rather than leaking into a
- * type constructor.
- */
-function resolveType(
-  host: { resolveTypeName?(name: string, options?: Record<string, unknown>): Type },
-  name: string,
-  options?: AttributeOptions,
-): Type {
-  if (!host.resolveTypeName) return typeRegistry.lookup(name);
-  const {
-    default: _default,
-    virtual: _virtual,
-    userProvidedDefault: _userProvidedDefault,
-    ...typeOptions
-  } = options ?? {};
-  return host.resolveTypeName(
-    name,
-    Object.keys(typeOptions).length > 0 ? (typeOptions as Record<string, unknown>) : undefined,
-  );
-}
-
 /** @internal */
 export function attribute(
   this: {
     _attributeDefinitions: Map<string, AttributeDefinition>;
     prototype: object;
     _cachedDefaultAttributes?: AttributeSet | null;
-    // Mirrors Rails' `resolve_type_name(type, **options)` call in
-    // AttributeRegistration::ClassMethods#attribute. ActiveRecord overrides it
-    // to resolve through the adapter-specific registry, so the declaring class
-    // — not this module — decides which registry a symbolic name resolves in.
-    // Optional so bare attribute hosts that don't mix in AttributeRegistration
-    // still work; they fall back to the ActiveModel registry.
-    resolveTypeName?(name: string, options?: Record<string, unknown>): Type;
+    resolveTypeName(name: string, options?: Record<string, unknown>): Type;
   },
   name: string,
   // Mirrors Rails' `attribute(name, type = nil, **options)`: the type is
@@ -167,7 +136,7 @@ export function attribute(
   const type = typeProvided
     ? typeName instanceof Type
       ? typeName
-      : resolveType(this, typeName as string, options)
+      : this.resolveTypeName(typeName as string, typeOptions(options))
     : (existing?.type ?? typeRegistry.lookup("value"));
   // Preserve the existing defaultValue when no default is explicitly provided,
   // matching Rails' PendingType behavior: with_type only changes the type and
@@ -242,6 +211,28 @@ export function attribute(
 }
 
 /**
+ * Mirrors: ActiveModel::Attributes::ClassMethods#define_method_attribute=
+ *
+ * In Rails this generates a `canonical_name=` writer via code evaluation.
+ * Trails installs writers via Object.defineProperty in `attribute()`, so no
+ * code generation is required here. The method exists for API-compare parity
+ * and to expose the AttrNames accessor-method computation that Rails uses
+ * to derive the writer method name.
+ *
+ * @internal Rails-private helper.
+ */
+export function defineMethodAttribute(
+  canonicalName: string,
+  _options?: { owner?: unknown; as?: string },
+): void {
+  // Writers are already installed by attribute() via Object.defineProperty.
+  // Compute and expose the method name the same way Rails would, for callers
+  // that inspect the name (e.g. alias generation paths).
+  const { methodName } = AttrNames.defineAttributeAccessorMethod(canonicalName, true);
+  void methodName;
+}
+
+/**
  * Concrete mixin host for `ActiveModel::Attributes`. Rails ships
  * `Attributes` as a module included into a model; in TS this class is
  * the canonical instance-side surface. `Model` composes the same
@@ -294,26 +285,14 @@ export class Attributes {
   }
 }
 
-/**
- * Mirrors: ActiveModel::Attributes::ClassMethods#define_method_attribute=
- *
- * In Rails this generates a `canonical_name=` writer via code evaluation.
- * Trails installs writers via Object.defineProperty in `attribute()`, so no
- * code generation is required here. The method exists for API-compare parity
- * and to expose the AttrNames accessor-method computation that Rails uses
- * to derive the writer method name.
- *
- * @internal Rails-private helper.
- */
-export function defineMethodAttribute(
-  canonicalName: string,
-  _options?: { owner?: unknown; as?: string },
-): void {
-  // Writers are already installed by attribute() via Object.defineProperty.
-  // Compute and expose the method name the same way Rails would, for callers
-  // that inspect the name (e.g. alias generation paths).
-  const { methodName } = AttrNames.defineAttributeAccessorMethod(canonicalName, true);
-  void methodName;
+function typeOptions(options?: AttributeOptions): Record<string, unknown> | undefined {
+  const {
+    default: _default,
+    virtual: _virtual,
+    userProvidedDefault: _userProvidedDefault,
+    ...rest
+  } = options ?? {};
+  return Object.keys(rest).length > 0 ? (rest as Record<string, unknown>) : undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/activemodel/src/type/registry.ts
+++ b/packages/activemodel/src/type/registry.ts
@@ -12,6 +12,17 @@ import { ImmutableStringType } from "./immutable-string.js";
 import { BinaryType } from "./binary.js";
 import { TimeType } from "./time.js";
 
+/**
+ * Mirrors the block ActiveModel::Type::Registry#register builds —
+ * `proc { |_, *args| klass.new(*args) }` (registry.rb:16) — so `lookup`
+ * can forward the caller's options the way `lookup(symbol, ...)` does.
+ */
+export type TypeOptions = { precision?: number; scale?: number; limit?: number } & Record<
+  string,
+  unknown
+>;
+export type TypeFactory = (name: string, options?: TypeOptions) => Type;
+
 export class TypeRegistry {
   /**
    * Mirrors: ActiveModel::Type::Registry's `@registrations` ivar
@@ -21,31 +32,31 @@ export class TypeRegistry {
    *
    * @internal Rails-private storage.
    */
-  protected registrationsMap = new Map<string, () => Type>();
+  protected registrationsMap = new Map<string, TypeFactory>();
 
   constructor() {
-    this.register("string", () => new StringType());
-    this.register("integer", () => new IntegerType());
-    this.register("float", () => new FloatType());
-    this.register("boolean", () => new BooleanType());
-    this.register("date", () => new DateType());
-    this.register("datetime", () => new DateTimeType());
-    this.register("decimal", () => new DecimalType());
-    this.register("big_integer", () => new BigIntegerType());
-    this.register("immutable_string", () => new ImmutableStringType());
-    this.register("value", () => new ValueType());
-    this.register("binary", () => new BinaryType());
-    this.register("time", () => new TimeType());
+    this.register("string", (_name, options) => new StringType(options));
+    this.register("integer", (_name, options) => new IntegerType(options));
+    this.register("float", (_name, options) => new FloatType(options));
+    this.register("boolean", (_name, options) => new BooleanType(options));
+    this.register("date", (_name, options) => new DateType(options));
+    this.register("datetime", (_name, options) => new DateTimeType(options));
+    this.register("decimal", (_name, options) => new DecimalType(options));
+    this.register("big_integer", (_name, options) => new BigIntegerType(options));
+    this.register("immutable_string", (_name, options) => new ImmutableStringType(options));
+    this.register("value", (_name, options) => new ValueType(options));
+    this.register("binary", (_name, options) => new BinaryType(options));
+    this.register("time", (_name, options) => new TimeType(options));
   }
 
-  register(name: string, factory: () => Type): void {
+  register(name: string, factory: TypeFactory): void {
     this.registrations.set(name, factory);
   }
 
-  lookup(name: string): Type {
+  lookup(name: string, options?: TypeOptions): Type {
     const factory = this.registrations.get(name);
     if (!factory) throw new ArgumentError(`Unknown type: ${name}`);
-    return factory();
+    return factory(name, options);
   }
 
   /**
@@ -55,7 +66,7 @@ export class TypeRegistry {
    *
    * @internal Rails-private helper.
    */
-  protected get registrations(): Map<string, () => Type> {
+  protected get registrations(): Map<string, TypeFactory> {
     return this.registrationsMap;
   }
 }

--- a/packages/activerecord/src/attributes.test.ts
+++ b/packages/activerecord/src/attributes.test.ts
@@ -348,7 +348,7 @@ describe("CustomPropertiesTest", () => {
   it.skipIf(adapterType !== "postgres")("array types can be specified", () => {
     class Klass extends OverloadedType {
       static {
-        this.attribute("my_array", "string", { limit: 50, array: true } as any);
+        this.attribute("my_array", "string", { limit: 50, array: true });
         this.attribute("my_int_array", "integer", { array: true } as any);
       }
     }
@@ -361,7 +361,7 @@ describe("CustomPropertiesTest", () => {
   it.skipIf(adapterType !== "postgres")("range types can be specified", () => {
     class Klass extends OverloadedType {
       static {
-        this.attribute("my_range", "string", { limit: 50, range: true } as any);
+        this.attribute("my_range", "string", { limit: 50, range: true });
         this.attribute("my_int_range", "integer", { range: true } as any);
       }
     }

--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -334,7 +334,11 @@ function resetDefaultAttributes(this: AnyClass): void {
  * @internal
  * Mirrors: ActiveRecord::Attributes::ClassMethods#resolve_type_name
  */
-function resolveTypeName(this: AnyClass, name: string, options?: Record<string, unknown>): Type {
+export function resolveTypeName(
+  this: AnyClass,
+  name: string,
+  options?: Record<string, unknown>,
+): Type {
   return typeLookup(name, {
     ...options,
     adapter: adapterNameFrom(this as unknown as AdapterNameSource),

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -87,6 +87,7 @@ import * as ReadonlyAttributes from "./readonly-attributes.js";
 import {
   defineAttribute as _defineAttribute,
   _defaultAttributes as _arDefaultAttributes,
+  resolveTypeName as _resolveTypeName,
 } from "./attributes.js";
 import * as Timestamp from "./timestamp.js";
 import * as TouchLater from "./touch-later.js";
@@ -1591,6 +1592,7 @@ export class Base extends Model {
   declare static initializeGeneratedModules: typeof _initializeGeneratedModules;
   declare static _generatedAttributeMethods?: GeneratedAttributeMethods;
   declare static _defaultAttributes: typeof _arDefaultAttributes;
+  declare static resolveTypeName: typeof _resolveTypeName;
 
   // Mirrors: ActiveRecord::ModelSchema::ClassMethods
   declare static columnNames: typeof ModelSchema.columnNames;
@@ -4832,6 +4834,9 @@ extend(Base, {
   initializeGeneratedModules: _initializeGeneratedModules,
   generateAliasAttributes: _generateAliasAttributes,
   _defaultAttributes: _arDefaultAttributes,
+  // Overrides ActiveModel's registry-blind resolve_type_name so `attribute`
+  // declarations resolve against the declaring model's adapter.
+  resolveTypeName: _resolveTypeName,
 });
 // AttributeMethods class method — gates association/attribute names that would
 // clash with an Active Record instance method (Rails: dangerous_attribute_method?).

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1592,6 +1592,7 @@ export class Base extends Model {
   declare static initializeGeneratedModules: typeof _initializeGeneratedModules;
   declare static _generatedAttributeMethods?: GeneratedAttributeMethods;
   declare static _defaultAttributes: typeof _arDefaultAttributes;
+  /** @internal */
   declare static resolveTypeName: typeof _resolveTypeName;
 
   // Mirrors: ActiveRecord::ModelSchema::ClassMethods
@@ -4834,8 +4835,6 @@ extend(Base, {
   initializeGeneratedModules: _initializeGeneratedModules,
   generateAliasAttributes: _generateAliasAttributes,
   _defaultAttributes: _arDefaultAttributes,
-  // Overrides ActiveModel's registry-blind resolve_type_name so `attribute`
-  // declarations resolve against the declaring model's adapter.
   resolveTypeName: _resolveTypeName,
 });
 // AttributeMethods class method — gates association/attribute names that would

--- a/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
@@ -15,8 +15,8 @@ import {
   StringType,
   TimeType,
   Type,
-  typeRegistry,
 } from "@blazetrails/activemodel";
+import * as ArType from "../../type.js";
 
 import { Date as OidDate } from "./oid/date.js";
 import { DecimalWithoutScale } from "../../type/decimal-without-scale.js";
@@ -42,21 +42,28 @@ import { TimestampWithTimeZone } from "./oid/timestamp-with-time-zone.js";
 import { Uuid } from "./oid/uuid.js";
 import { Xml } from "./oid/xml.js";
 
-// Rails registers PG's :interval type into the AM type registry so that
-// `attribute :col, :interval` resolves on AR-PG models. Mirror that here
-// as a module side-effect — AR-side type.ts already does the same for
-// the built-in AR types (date/datetime/time/text/json).
-typeRegistry.register("interval", () => new Interval());
-typeRegistry.register("hstore", () => new Hstore());
-typeRegistry.register("jsonb", () => new Jsonb());
-typeRegistry.register("money", () => new Money());
-typeRegistry.register("inet", () => new Inet());
-typeRegistry.register("cidr", () => new Cidr());
-typeRegistry.register("bit", () => new Bit());
-typeRegistry.register("bit_varying", () => new BitVarying());
-typeRegistry.register("xml", () => new Xml());
-typeRegistry.register("point", () => new Point());
-typeRegistry.register("uuid", () => new Uuid());
+// Mirrors: postgresql_adapter.rb:1168-1185, which registers these under
+// `adapter: :postgresql`. These live in ActiveRecord's registry (not
+// ActiveModel's) now that AR models resolve `attribute` names through
+// ActiveRecord::Type.
+//
+// Deviation: registered for all adapters rather than `adapter: "postgres"`.
+// Several PG-only tests declare `attribute(..., "interval" | "uuid")` on models
+// carrying a per-model adapter, where `connectionDbConfig()` raises
+// ConnectionNotEstablished and `Type.adapterNameFrom` degrades to "sqlite" — an
+// adapter-scoped registration would turn those into "Unknown type". Narrowing
+// these to :postgresql is tracked separately.
+ArType.register("bit", Bit, { override: false });
+ArType.register("bit_varying", BitVarying, { override: false });
+ArType.register("cidr", Cidr, { override: false });
+ArType.register("hstore", Hstore, { override: false });
+ArType.register("inet", Inet, { override: false });
+ArType.register("interval", Interval, { override: false });
+ArType.register("jsonb", Jsonb, { override: false });
+ArType.register("money", Money, { override: false });
+ArType.register("point", Point, { override: false });
+ArType.register("uuid", Uuid, { override: false });
+ArType.register("xml", Xml, { override: false });
 
 /**
  * Mirrors: PostgreSQLAdapter.extract_limit — `$1.to_i if sql_type =~ /\((.*)\)/`.

--- a/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
@@ -42,17 +42,10 @@ import { TimestampWithTimeZone } from "./oid/timestamp-with-time-zone.js";
 import { Uuid } from "./oid/uuid.js";
 import { Xml } from "./oid/xml.js";
 
-// Mirrors: postgresql_adapter.rb:1168-1185, which registers these under
-// `adapter: :postgresql`. These live in ActiveRecord's registry (not
-// ActiveModel's) now that AR models resolve `attribute` names through
-// ActiveRecord::Type.
-//
-// Deviation: registered for all adapters rather than `adapter: "postgres"`.
-// Several PG-only tests declare `attribute(..., "interval" | "uuid")` on models
-// carrying a per-model adapter, where `connectionDbConfig()` raises
-// ConnectionNotEstablished and `Type.adapterNameFrom` degrades to "sqlite" — an
-// adapter-scoped registration would turn those into "Unknown type". Narrowing
-// these to :postgresql is tracked separately.
+// Mirrors: postgresql_adapter.rb:1168-1185. Deviation: registered for all
+// adapters, not `adapter: :postgresql` — PG-only tests declare these on models
+// whose connectionDbConfig() raises, so adapterNameFrom degrades to "sqlite"
+// and a scoped registration would read as Unknown type. Tracked separately.
 ArType.register("bit", Bit, { override: false });
 ArType.register("bit_varying", BitVarying, { override: false });
 ArType.register("cidr", Cidr, { override: false });

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -5,9 +5,9 @@ import {
   ValueType,
   IntegerType,
   Type,
-  typeRegistry,
   isDecoratorReplay,
 } from "@blazetrails/activemodel";
+import { lookup as arTypeLookup } from "./type.js";
 import { dangerousAttributeMethods } from "./attribute-methods.js";
 import { getOrCreateModuleCarrier } from "./module-carrier.js";
 import { isDangerousClassMethod, isRelationInstanceMethod } from "./scoping/named.js";
@@ -44,13 +44,13 @@ function inferSubtype(values: Iterable<EnumValue>): string {
 /**
  * Build the ValueType instance backing an enum subtype's cast/serialize.
  * Mirrors Rails passing the column's real `Type::Value` into `EnumType.new`:
- * resolve the declared subtype name through the shared type registry so
+ * resolve the declared subtype name through ActiveRecord's registry so
  * float/decimal/datetime/etc. columns delegate to their actual type. Falls
  * back to IntegerType only for names the registry doesn't know.
  */
 function subtypeInstance(subtype: string): ValueType<unknown> {
   try {
-    return typeRegistry.lookup(subtype) as ValueType<unknown>;
+    return arTypeLookup(subtype) as ValueType<unknown>;
   } catch {
     return new IntegerType();
   }

--- a/packages/activerecord/src/inheritance.test.ts
+++ b/packages/activerecord/src/inheritance.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { StringType, typeRegistry } from "@blazetrails/activemodel";
+import { StringType } from "@blazetrails/activemodel";
 import { classify, underscore } from "@blazetrails/activesupport";
 import { Base } from "./index.js";
+import * as Type from "./type.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import {
   stiName,
@@ -636,7 +637,7 @@ describe("InheritanceAttributeMappingTest", () => {
       return null;
     }
   }
-  typeRegistry.register("omg_sti", () => new OmgStiType());
+  Type.register("omg_sti", OmgStiType);
 
   class IamtCompany extends Base {
     static {

--- a/packages/activerecord/src/test-helpers/models/developer.ts
+++ b/packages/activerecord/src/test-helpers/models/developer.ts
@@ -12,8 +12,9 @@ import type { Ship } from "./ship.js";
 import type { SpecialContract } from "./contract.js";
 import type { SpecialProject } from "./project.js";
 // vendor/rails/activerecord/test/models/developer.rb
-import { StringType, typeRegistry } from "@blazetrails/activemodel";
+import { StringType } from "@blazetrails/activemodel";
 import { Base } from "../../base.js";
+import * as Type from "../../type.js";
 import type { Relation } from "../../relation.js";
 import { acceptsNestedAttributesFor } from "../../nested-attributes.js";
 
@@ -578,7 +579,7 @@ export class DeveloperName extends StringType {
   }
 }
 
-typeRegistry.register("developer_name", () => new DeveloperName());
+Type.register("developer_name", DeveloperName);
 
 export class AttributedDeveloper extends Base {
   declare name: unknown;

--- a/packages/activerecord/src/type.trails.test.ts
+++ b/packages/activerecord/src/type.trails.test.ts
@@ -117,11 +117,6 @@ describe("Type.lookup under a non-sqlite configuration", () => {
   });
 });
 
-// The wiring the #5181 review asked for: `attribute()` on an AR model must go
-// through ActiveRecord's resolve_type_name (attributes.rb:296-298), so the
-// declaring model's adapter selects the registration. Before Base.resolveTypeName
-// was wired this resolved against ActiveModel's adapter-blind typeRegistry and
-// every model got the generic string type.
 describe("attribute() resolves through the declaring model's adapter", () => {
   const originalConnectionDbConfig = (Base as unknown as { connectionDbConfig: unknown })
     .connectionDbConfig;

--- a/packages/activerecord/src/type.trails.test.ts
+++ b/packages/activerecord/src/type.trails.test.ts
@@ -116,3 +116,42 @@ describe("Type.lookup under a non-sqlite configuration", () => {
     expect(lookup("foo")).not.toBeInstanceOf(AdapterType);
   });
 });
+
+// The wiring the #5181 review asked for: `attribute()` on an AR model must go
+// through ActiveRecord's resolve_type_name (attributes.rb:296-298), so the
+// declaring model's adapter selects the registration. Before Base.resolveTypeName
+// was wired this resolved against ActiveModel's adapter-blind typeRegistry and
+// every model got the generic string type.
+describe("attribute() resolves through the declaring model's adapter", () => {
+  const originalConnectionDbConfig = (Base as unknown as { connectionDbConfig: unknown })
+    .connectionDbConfig;
+
+  afterEach(() => {
+    (Base as unknown as { connectionDbConfig: unknown }).connectionDbConfig =
+      originalConnectionDbConfig;
+  });
+
+  function modelForAdapter(adapter: string): typeof Base {
+    class AdapterScoped extends Base {}
+    (
+      AdapterScoped as unknown as { connectionDbConfig: () => { adapter: string } }
+    ).connectionDbConfig = () => ({ adapter });
+    return AdapterScoped as unknown as typeof Base;
+  }
+
+  it("picks the mysql2 string registration for a mysql2 model", () => {
+    const model = modelForAdapter("mysql2");
+    model.attribute("mystring", "string");
+
+    const type = model.resolveTypeName("string");
+    expect(type.cast(true)).toBe("1");
+    expect(model._defaultAttributes().getAttribute("mystring").type.cast(true)).toBe("1");
+  });
+
+  it("leaves a sqlite3 model on the generic string registration", () => {
+    const model = modelForAdapter("sqlite3");
+    model.attribute("mystring", "string");
+
+    expect(model._defaultAttributes().getAttribute("mystring").type.cast(true)).toBe("t");
+  });
+});

--- a/packages/activerecord/src/type.ts
+++ b/packages/activerecord/src/type.ts
@@ -77,10 +77,6 @@ _registry.register("json", Json, { override: false });
 _registry.register("string", StringType, { override: false });
 _registry.register("text", Text, { override: false });
 _registry.register("time", Time, { override: false });
-// Not in Rails' list: ActiveModel::Type::Registry registers :value and
-// ActiveRecord::Type inherits nothing from it, so without this every
-// `attribute :x, :value` declaration would raise "Unknown type :value" once AR
-// models resolve through this registry.
 _registry.register("value", ValueType, { override: false });
 
 /** Mirrors Rails' `ActiveRecord::Type.registry` (attr_accessor getter). */

--- a/packages/activerecord/src/type.ts
+++ b/packages/activerecord/src/type.ts
@@ -77,6 +77,11 @@ _registry.register("json", Json, { override: false });
 _registry.register("string", StringType, { override: false });
 _registry.register("text", Text, { override: false });
 _registry.register("time", Time, { override: false });
+// Not in Rails' list: ActiveModel::Type::Registry registers :value and
+// ActiveRecord::Type inherits nothing from it, so without this every
+// `attribute :x, :value` declaration would raise "Unknown type :value" once AR
+// models resolve through this registry.
+_registry.register("value", ValueType, { override: false });
 
 /** Mirrors Rails' `ActiveRecord::Type.registry` (attr_accessor getter). */
 export function registry(): AdapterSpecificRegistry {


### PR DESCRIPTION
## What

`ActiveRecord::Attributes::ClassMethods#resolve_type_name`
(`attributes.rb:296-298`) overrides the ActiveModel one so `attribute`
declarations on AR models resolve through
`Type.lookup(name, **options, adapter: Type.adapter_name_from(self))`.

trails had both halves but **nothing called either**: `attribute()`
(`activemodel/src/attributes.ts`) looked names up directly in ActiveModel's
adapter-blind `typeRegistry`, and the adapter-aware AR implementation added by
#5181 was an unexported, uncalled module-level function.

## How

- `activemodel/src/attributes.ts` — `attribute()` now calls the declaring
  class's `resolveTypeName(name, **options)`, mirroring
  `attribute_registration.rb:14`. `default` (peeled off by Rails' kwarg
  signature) and the trails-only `virtual` / `userProvidedDefault` flags are
  stripped before the options reach the registry, so `limit` reaches the type
  constructor as it does in Rails. `AttributeOptions` declares `array` / `range`
  so PG modifier declarations no longer need an `as any` escape hatch — but
  **this PR does not implement the modifiers themselves**: trails never calls
  `Type.add_modifier({ array: true }, OID::Array, ...)`
  (`postgresql_adapter.rb:1166-1167`), so `array: true` is forwarded into the
  registry, matches no `DecorationRegistration`, and is silently dropped by the
  `StringType` constructor. `attribute :my_array, :string, array: true` still
  yields a bare `StringType` rather than Rails' `OID::Array.new(Type::String)`.
  Pre-existing, unchanged by this diff, tracked as
  `ar-pg-array-range-type-modifiers-never-registered`.
- `activemodel/src/type/registry.ts` — `TypeRegistry#lookup(name, options)`
  forwards its options to the registered factory, mirroring
  `lookup(symbol, ...)` -> `registration.call(symbol, ...)` and the
  `proc { |_, *args| klass.new(*args) }` block `register` builds
  (`activemodel/lib/active_model/type/registry.rb:16,22-26`). ActiveModel's
  `resolveTypeName` forwards too, so plain ActiveModel hosts get the same
  `attribute("foo", "decimal", { limit: 5 })` behavior AR models do.
- `activerecord/src/base.ts` — `Base.resolveTypeName` is wired to the
  activerecord implementation via the module-mixin convention.
- Registry migration, so no name that resolved before becomes `Unknown type`:
  - `Type.register("value", ValueType)` — ActiveModel's registry has `:value`,
    AR's did not.
  - PG OID types (`interval`, `hstore`, `money`, `uuid`, …) move from
    `typeRegistry` into `ActiveRecord::Type`'s registry. They stay unscoped
    rather than `adapter: :postgresql`; the reason is documented at the call
    site and tracked as `ar-pg-oid-type-registrations-not-adapter-scoped`.
  - The `omg_sti` / `developer_name` test types now use
    `ActiveRecord::Type.register`, matching `inheritance_test.rb:615`.
- `enum.ts`'s subtype lookup follows the same path.

## Test

`type.trails.test.ts` — a model whose `connectionDbConfig` reports `mysql2`
declares `attribute("mystring", "string")` and gets the mysql2 registration
(booleans serialize as `"1"`/`"0"`), while a sqlite3 model keeps the generic
one (`"t"`). The first assertion fails on today's `main` (`"t"` received) —
verified by reverting only the `Base.resolveTypeName` wiring.

Closes-story: ar-resolve-type-name-unwired-attribute-path-adapter-blind
