### PR TITLE
ci: disable the reporting-only coverage lanes to save CI runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -703,7 +703,7 @@ jobs:
   coverage:
     name: Coverage (reporting-only)
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true'
+    if: false
     continue-on-error: true
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -782,9 +782,7 @@ jobs:
   ar-sqlite-coverage:
     name: Active Record SQLite Coverage (reporting-only)
     needs: changes
-    if: >-
-      needs.changes.outputs.docs_only != 'true' &&
-      needs.changes.outputs.activerecord_affected == 'true'
+    if: false
     continue-on-error: true
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -829,9 +827,7 @@ jobs:
   ar-cli-coverage:
     name: Active Record CLI Coverage (reporting-only)
     needs: changes
-    if: >-
-      needs.changes.outputs.docs_only != 'true' &&
-      needs.changes.outputs.activerecord_affected == 'true'
+    if: false
     continue-on-error: true
     runs-on: ubuntu-latest
     # TRAILS_TEST_FORKS=1 serializes the cli suite onto one worker (see below),
@@ -905,10 +901,7 @@ jobs:
     # (the covered source) or tse-compiler (which its tests exercise) changed,
     # so this dedicated job doesn't add cost to unrelated PRs. Not in `ci`'s
     # `needs`, so a skip here never trips the all-jobs gate.
-    if: >-
-      needs.changes.outputs.docs_only != 'true' &&
-      (needs.changes.outputs.trails_tsc_affected == 'true' ||
-       needs.changes.outputs.tse_compiler_affected == 'true')
+    if: false
     continue-on-error: true
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
Pauses all four reporting-only coverage jobs in `.github/workflows/ci.yml` so they stop burning CI runtime for a signal we aren't acting on right now.

## The change

Each job's `if:` becomes `if: false`:

| Job key | Name | Original `if:` |
|---|---|---|
| `coverage` | Coverage (reporting-only) | `docs_only != 'true'` |
| `ar-sqlite-coverage` | Active Record SQLite Coverage (reporting-only) | `docs_only != 'true' && activerecord_affected == 'true'` |
| `ar-cli-coverage` | Active Record CLI Coverage (reporting-only) | `docs_only != 'true' && activerecord_affected == 'true'` |
| `trails-tsc-coverage` | trails-tsc Coverage (reporting-only) | `docs_only != 'true' && (trails_tsc_affected == 'true' \|\| tse_compiler_affected == 'true')` |

(All conditions above are on `needs.changes.outputs.*`.)

Nothing else in any job is touched — `needs`, `continue-on-error: true`, `runs-on`, `timeout-minutes`, and every step are unchanged. The jobs are **paused, not removed**.

## Re-enabling

Replace each `if: false` with the original condition from the table above; the full expressions are in this PR's diff. Note that `trails-tsc-coverage` still carries its pre-existing explanatory comment describing its gating — that comment documents the condition to restore, and is dormant rather than wrong while the job is paused.

## Safety

All four jobs are `continue-on-error: true` and reporting-only, and none of them appear in the `ci` aggregator job's `needs:` list, so skipping them cannot trip the required `CI` check. Verified: the workflow still parses (`yaml.safe_load`), all four `if:` values evaluate to `false`, all four retain `continue-on-error: true`, and the aggregator's 24-entry `needs:` block is unmodified.
