### PR TITLE
refactor(ci): derive AR slot pool from the clamped effective fork count

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1022,10 +1022,8 @@ jobs:
           PGUSER: postgres
           PGPASSWORD: postgres
           PGDATABASE: rails_js_test
-          # AR_DB_FORKS is deliberately unset: vitest.config.ts and
-          # ar-db-slots.ts both clamp the requested fork count to the host's
-          # numCpus - 1, so worker count and advisory slot-DB pool track the
-          # runner's vCPU count without this workflow encoding it.
+          # AR_DB_FORKS deliberately unset: vitest.config.ts derives both the
+          # worker count and the slot-DB pool from the runner's vCPU count.
       # CLI E2E is not sharded — run it once, on shard 1 only, to avoid a
       # redundant double-run across the two legs.
       # PG_TEST_URL is the activerecord-cli E2E's own input (it drives the CLI's
@@ -1092,10 +1090,8 @@ jobs:
           MYSQL_PORT: "3306"
           MYSQL_USER: root
           MYSQL_DATABASE: rails_js_test
-          # AR_DB_FORKS is deliberately unset: vitest.config.ts and
-          # ar-db-slots.ts both clamp the requested fork count to the host's
-          # numCpus - 1, so worker count and advisory slot-DB pool track the
-          # runner's vCPU count without this workflow encoding it.
+          # AR_DB_FORKS deliberately unset: vitest.config.ts derives both the
+          # worker count and the slot-DB pool from the runner's vCPU count.
       # No MySQL connection env: no mysql-happy-path E2E exists yet. This run
       # covers the SQLite E2E until a mysql suite lands and can be wired up.
       - run: pnpm vitest run packages/activerecord-cli
@@ -1162,10 +1158,8 @@ jobs:
           MYSQL_PORT: "3306"
           MYSQL_USER: root
           MYSQL_DATABASE: rails_js_test
-          # AR_DB_FORKS is deliberately unset: vitest.config.ts and
-          # ar-db-slots.ts both clamp the requested fork count to the host's
-          # numCpus - 1, so worker count and advisory slot-DB pool track the
-          # runner's vCPU count without this workflow encoding it.
+          # AR_DB_FORKS deliberately unset: vitest.config.ts derives both the
+          # worker count and the slot-DB pool from the runner's vCPU count.
       # No MySQL connection env: no mysql-happy-path E2E exists yet. This run
       # covers the SQLite E2E until a mysql suite lands and can be wired up.
       # CLI E2E is not sharded — run it once, on shard 1 only.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1022,10 +1022,10 @@ jobs:
           PGUSER: postgres
           PGPASSWORD: postgres
           PGDATABASE: rails_js_test
-          # Must match the concurrency vitest actually runs: TEST_FORKS is
-          # clamped to numCpus - 1 (3 on the 4-vCPU runner) in vitest.config.ts,
-          # and this value also sizes the advisory slot-DB pool (forks + 2).
-          AR_DB_FORKS: "3"
+          # AR_DB_FORKS is deliberately unset: vitest.config.ts and
+          # ar-db-slots.ts both clamp the requested fork count to the host's
+          # numCpus - 1, so worker count and advisory slot-DB pool track the
+          # runner's vCPU count without this workflow encoding it.
       # CLI E2E is not sharded — run it once, on shard 1 only, to avoid a
       # redundant double-run across the two legs.
       # PG_TEST_URL is the activerecord-cli E2E's own input (it drives the CLI's
@@ -1092,10 +1092,10 @@ jobs:
           MYSQL_PORT: "3306"
           MYSQL_USER: root
           MYSQL_DATABASE: rails_js_test
-          # Must match the concurrency vitest actually runs: TEST_FORKS is
-          # clamped to numCpus - 1 (3 on the 4-vCPU runner) in vitest.config.ts,
-          # and this value also sizes the advisory slot-DB pool (forks + 2).
-          AR_DB_FORKS: "3"
+          # AR_DB_FORKS is deliberately unset: vitest.config.ts and
+          # ar-db-slots.ts both clamp the requested fork count to the host's
+          # numCpus - 1, so worker count and advisory slot-DB pool track the
+          # runner's vCPU count without this workflow encoding it.
       # No MySQL connection env: no mysql-happy-path E2E exists yet. This run
       # covers the SQLite E2E until a mysql suite lands and can be wired up.
       - run: pnpm vitest run packages/activerecord-cli
@@ -1162,10 +1162,10 @@ jobs:
           MYSQL_PORT: "3306"
           MYSQL_USER: root
           MYSQL_DATABASE: rails_js_test
-          # Must match the concurrency vitest actually runs: TEST_FORKS is
-          # clamped to numCpus - 1 (3 on the 4-vCPU runner) in vitest.config.ts,
-          # and this value also sizes the advisory slot-DB pool (forks + 2).
-          AR_DB_FORKS: "3"
+          # AR_DB_FORKS is deliberately unset: vitest.config.ts and
+          # ar-db-slots.ts both clamp the requested fork count to the host's
+          # numCpus - 1, so worker count and advisory slot-DB pool track the
+          # runner's vCPU count without this workflow encoding it.
       # No MySQL connection env: no mysql-happy-path E2E exists yet. This run
       # covers the SQLite E2E until a mysql suite lands and can be wired up.
       # CLI E2E is not sharded — run it once, on shard 1 only.

--- a/packages/activerecord/src/test-helpers/ar-db-slots.test.ts
+++ b/packages/activerecord/src/test-helpers/ar-db-slots.test.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
 import { DEFAULT_FORKS, slotPoolSize, workerForkCount } from "./ar-db-slots.js";
 
@@ -44,11 +45,13 @@ describe("ar-db-slots", () => {
       expect(workerForkCount()).toBe(DEFAULT_FORKS);
     });
 
-    it("reads the effective count vitest.config.ts republishes", () => {
-      // vitest.config.ts overwrites AR_DB_FORKS with the host-clamped count,
-      // so a request of 8 on a 4-vCPU runner arrives here as 3.
-      setEnv("3");
-      expect(workerForkCount()).toBe(3);
+    // The value this process was started with, before any setEnv() below.
+    const inherited = saved.get("AR_DB_FORKS");
+
+    it("sees the host-clamped count vitest.config.ts republishes", () => {
+      expect(inherited).toBeDefined();
+      expect(Number(inherited)).toBeLessThanOrEqual(Math.max(os.availableParallelism() - 1, 1));
+      expect(Number(inherited)).toBeGreaterThan(0);
     });
   });
 

--- a/packages/activerecord/src/test-helpers/ar-db-slots.test.ts
+++ b/packages/activerecord/src/test-helpers/ar-db-slots.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { slotPoolSize, workerForkCount } from "./ar-db-slots.js";
+import { DEFAULT_FORKS, slotPoolSize, workerForkCount } from "./ar-db-slots.js";
 
 const ENV_KEYS = ["AR_DB_FORKS", "AR_DB_SLOTS"] as const;
 
@@ -23,9 +23,9 @@ describe("ar-db-slots", () => {
   }
 
   describe("workerForkCount", () => {
-    it("defaults to 1 when AR_DB_FORKS is unset", () => {
+    it("defaults to the shared default fork count when AR_DB_FORKS is unset", () => {
       setEnv(undefined);
-      expect(workerForkCount()).toBe(1);
+      expect(workerForkCount()).toBe(DEFAULT_FORKS);
     });
 
     it("reads AR_DB_FORKS", () => {
@@ -35,12 +35,20 @@ describe("ar-db-slots", () => {
 
     it("clamps to at least 1", () => {
       setEnv("0");
-      expect(workerForkCount()).toBe(1);
+      expect(workerForkCount()).toBe(DEFAULT_FORKS);
+      expect(workerForkCount()).toBeGreaterThanOrEqual(1);
     });
 
-    it("treats a non-numeric value as single-worker", () => {
+    it("treats a non-numeric value as the default fork count", () => {
       setEnv("auto");
-      expect(workerForkCount()).toBe(1);
+      expect(workerForkCount()).toBe(DEFAULT_FORKS);
+    });
+
+    it("reads the effective count vitest.config.ts republishes", () => {
+      // vitest.config.ts overwrites AR_DB_FORKS with the host-clamped count,
+      // so a request of 8 on a 4-vCPU runner arrives here as 3.
+      setEnv("3");
+      expect(workerForkCount()).toBe(3);
     });
   });
 

--- a/packages/activerecord/src/test-helpers/ar-db-slots.ts
+++ b/packages/activerecord/src/test-helpers/ar-db-slots.ts
@@ -1,12 +1,10 @@
 /**
  * Advisory-slot pool sizing for the parallel AR DB test harness.
  *
- * `AR_DB_FORKS` is the *requested* vitest worker count; the *effective* count
- * is that request clamped down to the host's `numCpus - 1` ceiling.
- * vitest.config.ts applies that clamp once and rewrites `AR_DB_FORKS` to the
- * result, so the pool sized here tracks the workers that actually start rather
- * than the number someone asked for — a runner with a different vCPU count
- * needs no workflow edit. The advisory-lock
+ * `AR_DB_FORKS` is the vitest worker count. vitest.config.ts clamps the
+ * requested value to the host's `numCpus - 1` and rewrites the variable to
+ * that effective result, so the pool sized here tracks the workers that
+ * actually start. The advisory-lock
  * **slot pool** — the set of per-worker
  * slot DBs provisioned by globalSetup and claimed by each worker in
  * test-setup-worker-db.ts — is sized SEPARATELY, with headroom over the worker
@@ -33,30 +31,19 @@
 // recycle overlap; two leaves margin for back-to-back recycles.
 const SLOT_HEADROOM = 2;
 
-/**
- * Fork count used when neither `TRAILS_TEST_FORKS` nor `AR_DB_FORKS` is set.
- * Shared with vitest.config.ts so the pool and the worker pool agree on the
- * default just as they agree on the clamp.
- */
+/** Fork count when no env var requests one. Shared with vitest.config.ts. */
 export const DEFAULT_FORKS = 6;
 
 /**
- * Effective vitest worker count.
- *
- * The clamp itself (`min(requested, numCpus - 1)`) lives in vitest.config.ts,
- * which rewrites `AR_DB_FORKS` to the clamped result before any worker or
- * globalSetup runs — so this module reads the *effective* count without
- * duplicating the expression and without importing `node:os` (banned in
- * package sources for browser compatibility; the os-adapter exposes no
- * `availableParallelism`). A value read here that vitest did not compute
- * (a bare `tsx` invocation) is a plain request and only over-provisions.
- *
- * A non-numeric or non-positive value (unset, "auto", "0") falls back to
- * {@link DEFAULT_FORKS}, the same default vitest.config.ts uses.
+ * Effective vitest worker count — `AR_DB_FORKS` as rewritten by
+ * vitest.config.ts, which owns the host clamp (package sources may not import
+ * `node:os`). Outside a vitest run the value is an unclamped request, which
+ * can only over-provision the pool. Non-numeric or non-positive (unset,
+ * "auto", "0") falls back to {@link DEFAULT_FORKS}.
  */
 export function workerForkCount(): number {
   const n = parseInt(process.env.AR_DB_FORKS ?? "", 10);
-  return Math.max(Number.isFinite(n) && n > 0 ? n : DEFAULT_FORKS, 1);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_FORKS;
 }
 
 /**

--- a/packages/activerecord/src/test-helpers/ar-db-slots.ts
+++ b/packages/activerecord/src/test-helpers/ar-db-slots.ts
@@ -1,9 +1,12 @@
 /**
  * Advisory-slot pool sizing for the parallel AR DB test harness.
  *
- * `AR_DB_FORKS` is the requested vitest worker count (vitest.config.ts feeds it
- * into `maxForks`, clamped down to the host's `numCpus - 1` ceiling — so a
- * value above that ceiling only over-provisions this pool). The advisory-lock
+ * `AR_DB_FORKS` is the *requested* vitest worker count; the *effective* count
+ * is that request clamped down to the host's `numCpus - 1` ceiling.
+ * vitest.config.ts applies that clamp once and rewrites `AR_DB_FORKS` to the
+ * result, so the pool sized here tracks the workers that actually start rather
+ * than the number someone asked for — a runner with a different vCPU count
+ * needs no workflow edit. The advisory-lock
  * **slot pool** — the set of per-worker
  * slot DBs provisioned by globalSetup and claimed by each worker in
  * test-setup-worker-db.ts — is sized SEPARATELY, with headroom over the worker
@@ -31,18 +34,34 @@
 const SLOT_HEADROOM = 2;
 
 /**
- * vitest worker count (`AR_DB_FORKS`), clamped to >= 1. A non-numeric or
- * non-positive value (e.g. unset, "auto", "0") is treated as single-worker —
- * matching the pre-decoupling `!Number.isFinite(forks) || forks <= 1` guard.
+ * Fork count used when neither `TRAILS_TEST_FORKS` nor `AR_DB_FORKS` is set.
+ * Shared with vitest.config.ts so the pool and the worker pool agree on the
+ * default just as they agree on the clamp.
+ */
+export const DEFAULT_FORKS = 6;
+
+/**
+ * Effective vitest worker count.
+ *
+ * The clamp itself (`min(requested, numCpus - 1)`) lives in vitest.config.ts,
+ * which rewrites `AR_DB_FORKS` to the clamped result before any worker or
+ * globalSetup runs — so this module reads the *effective* count without
+ * duplicating the expression and without importing `node:os` (banned in
+ * package sources for browser compatibility; the os-adapter exposes no
+ * `availableParallelism`). A value read here that vitest did not compute
+ * (a bare `tsx` invocation) is a plain request and only over-provisions.
+ *
+ * A non-numeric or non-positive value (unset, "auto", "0") falls back to
+ * {@link DEFAULT_FORKS}, the same default vitest.config.ts uses.
  */
 export function workerForkCount(): number {
-  const n = parseInt(process.env.AR_DB_FORKS ?? "1", 10);
-  return Number.isFinite(n) && n > 0 ? n : 1;
+  const n = parseInt(process.env.AR_DB_FORKS ?? "", 10);
+  return Math.max(Number.isFinite(n) && n > 0 ? n : DEFAULT_FORKS, 1);
 }
 
 /**
  * Number of advisory-lock slot DBs to provision and to scan when claiming.
- * Decoupled from the worker count: `AR_DB_SLOTS` override, else
+ * Decoupled from the *effective* worker count: `AR_DB_SLOTS` override, else
  * `workers + SLOT_HEADROOM`. An explicit override is clamped to at least
  * `workers + 1` so it can never undercut the worker count and reintroduce the
  * pool-exhaustion this decoupling exists to prevent.

--- a/packages/activerecord/src/test-setup-worker-db.ts
+++ b/packages/activerecord/src/test-setup-worker-db.ts
@@ -21,9 +21,10 @@
  * (e.g. hot-module reloading in vitest watch mode) returns the same slot
  * without opening a second connection or consuming an additional lock.
  *
- * AR_DB_FORKS: vitest worker count (default: 1). The advisory-slot pool is
- * sized separately with headroom — see test-helpers/ar-db-slots.ts (override
- * with AR_DB_SLOTS).
+ * AR_DB_FORKS: requested vitest worker count; the effective count is that
+ * request clamped to the host's numCpus - 1. The advisory-slot pool is sized
+ * separately, with headroom over the effective count — see
+ * test-helpers/ar-db-slots.ts (override with AR_DB_SLOTS).
  */
 
 import pg from "pg";
@@ -58,14 +59,15 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-// The pool is sized at AR_DB_FORKS + headroom (ar-db-slots.ts), so exhaustion
-// means more workers ran concurrently than AR_DB_FORKS promises — name both
-// numbers so that reads as a worker-cap bug, not a schema-setup regression.
+// The pool is sized at the effective fork count + headroom (ar-db-slots.ts),
+// so exhaustion means more workers ran concurrently than that count promises —
+// name both numbers so that reads as a worker-cap bug, not a schema-setup
+// regression.
 function slotExhaustionMessage(fn: string, lockKind: string, slots: number): string {
   return (
     `${fn}: all ${slots} ${lockKind} slots are held after ` +
     `${SLOT_RETRY_ATTEMPTS} attempts (${(SLOT_RETRY_ATTEMPTS * SLOT_RETRY_DELAY_MS) / 1000}s) ` +
-    `with AR_DB_FORKS=${workerForkCount()} (slot pool = forks + headroom, see ` +
+    `with ${workerForkCount()} effective forks (slot pool = forks + headroom, see ` +
     `test-helpers/ar-db-slots.ts). More than ${workerForkCount()} workers are competing: ` +
     `check that the vitest worker cap is honored (root-level poolOptions in ` +
     `vitest.config.ts), increase AR_DB_SLOTS, or check for stuck workers.`

--- a/packages/activerecord/src/test-setup-worker-db.ts
+++ b/packages/activerecord/src/test-setup-worker-db.ts
@@ -21,10 +21,10 @@
  * (e.g. hot-module reloading in vitest watch mode) returns the same slot
  * without opening a second connection or consuming an additional lock.
  *
- * AR_DB_FORKS: requested vitest worker count; the effective count is that
- * request clamped to the host's numCpus - 1. The advisory-slot pool is sized
- * separately, with headroom over the effective count — see
- * test-helpers/ar-db-slots.ts (override with AR_DB_SLOTS).
+ * AR_DB_FORKS: vitest worker count, clamped to the host's numCpus - 1 by
+ * vitest.config.ts. The advisory-slot pool is sized separately, with headroom
+ * over that count — see test-helpers/ar-db-slots.ts (override with
+ * AR_DB_SLOTS).
  */
 
 import pg from "pg";
@@ -59,8 +59,8 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-// The pool is sized at the effective fork count + headroom (ar-db-slots.ts),
-// so exhaustion means more workers ran concurrently than that count promises —
+// The pool is sized at the effective fork count + headroom (ar-db-slots.ts), so
+// exhaustion means more workers ran concurrently than that count promises —
 // name both numbers so that reads as a worker-cap bug, not a schema-setup
 // regression.
 function slotExhaustionMessage(fn: string, lockKind: string, slots: number): string {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,16 +1,19 @@
 import { defineConfig } from "vitest/config";
 import path from "path";
 import os from "os";
+import { DEFAULT_FORKS } from "./packages/activerecord/src/test-helpers/ar-db-slots.js";
 
-// AR_DB_FORKS (read in test-setup-worker-db.ts) sets the vitest worker count
-// via TEST_FORKS below. The advisory-lock slot pool is sized SEPARATELY, with
-// headroom over the worker count — see test-helpers/ar-db-slots.ts (slots =
+// AR_DB_FORKS (read in test-setup-worker-db.ts) *requests* a vitest worker
+// count; TEST_FORKS below is the effective one — the request clamped to the
+// host ceiling. The advisory-lock slot pool is sized SEPARATELY, with headroom
+// over that same effective count — see test-helpers/ar-db-slots.ts (slots =
 // workers + headroom, or an explicit AR_DB_SLOTS override). TRAILS_TEST_FORKS
 // caps the vitest worker count so that concurrent local worktrees don't
-// saturate the machine. Precedence: TRAILS_TEST_FORKS > AR_DB_FORKS > 6,
-// all capped by the host ceiling below. Raise with TRAILS_TEST_FORKS=N for a
-// solo full run; the live AR DB jobs (postgres-tests, mysql-tests,
-// maria-tests) set AR_DB_FORKS=3, which is that ceiling on the 4-vCPU runner.
+// saturate the machine. Precedence: TRAILS_TEST_FORKS > AR_DB_FORKS >
+// DEFAULT_FORKS, all capped by the host ceiling. Raise with TRAILS_TEST_FORKS=N
+// for a solo full run; the live AR DB jobs (postgres-tests, mysql-tests,
+// maria-tests) set neither, so both the worker count and the slot pool follow
+// the runner's vCPU count with no workflow edit when that shape changes.
 //
 // Historical note: those jobs used to set AR_DB_FORKS=8, but the per-project
 // `maxForks` was a vitest-3 no-op, so every CI run actually ran at vitest's
@@ -89,14 +92,21 @@ const _parsedForks = parseInt(process.env.TRAILS_TEST_FORKS ?? process.env.AR_DB
 // actually used, and the suite's timeouts are tuned to it — on the 4-vCPU CI
 // runner, honoring a fork count above it (AR_DB_FORKS=8, as CI used to set)
 // oversubscribes PG enough to push the full-DB schema-dump tests past their
-// 5s timeout. The env vars can only
-// lower the cap, never raise it past the host. The advisory-slot pool still
-// sizes from AR_DB_FORKS (ar-db-slots.ts), so it can only over-provision.
+// 5s timeout. The env vars can only lower the cap, never raise it past the
+// host.
 const _hostForkCap = Math.max(os.availableParallelism() - 1, 1);
 const TEST_FORKS = Math.min(
-  Number.isFinite(_parsedForks) && _parsedForks > 0 ? _parsedForks : 6,
+  Number.isFinite(_parsedForks) && _parsedForks > 0 ? _parsedForks : DEFAULT_FORKS,
   _hostForkCap,
 );
+// Republish the EFFECTIVE count so ar-db-slots.ts sizes the advisory-slot pool
+// from the workers that actually start, not from the raw request. The clamp
+// exists only here: package sources may not import `node:os` (browser compat)
+// and the os-adapter exposes no `availableParallelism`, so a shared clamp
+// helper would have to live in a package and break that rule. This runs in the
+// vitest parent before globalSetup and before any worker forks, and workers
+// inherit the parent env.
+process.env.AR_DB_FORKS = String(TEST_FORKS);
 
 const alias = {
   "@blazetrails/activesupport/message-verifier": path.resolve(

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,10 +3,11 @@ import path from "path";
 import os from "os";
 import { DEFAULT_FORKS } from "./packages/activerecord/src/test-helpers/ar-db-slots.js";
 
-// AR_DB_FORKS (read in test-setup-worker-db.ts) *requests* a vitest worker
+// AR_DB_FORKS (read in test-setup-worker-db.ts) requests a vitest worker
 // count; TEST_FORKS below is the effective one — the request clamped to the
-// host ceiling. The advisory-lock slot pool is sized SEPARATELY, with headroom
-// over that same effective count — see test-helpers/ar-db-slots.ts (slots =
+// host ceiling — and is republished as AR_DB_FORKS. The advisory-lock slot
+// pool is sized SEPARATELY, with headroom over that effective count — see
+// test-helpers/ar-db-slots.ts (slots =
 // workers + headroom, or an explicit AR_DB_SLOTS override). TRAILS_TEST_FORKS
 // caps the vitest worker count so that concurrent local worktrees don't
 // saturate the machine. Precedence: TRAILS_TEST_FORKS > AR_DB_FORKS >
@@ -99,13 +100,11 @@ const TEST_FORKS = Math.min(
   Number.isFinite(_parsedForks) && _parsedForks > 0 ? _parsedForks : DEFAULT_FORKS,
   _hostForkCap,
 );
-// Republish the EFFECTIVE count so ar-db-slots.ts sizes the advisory-slot pool
-// from the workers that actually start, not from the raw request. The clamp
-// exists only here: package sources may not import `node:os` (browser compat)
-// and the os-adapter exposes no `availableParallelism`, so a shared clamp
-// helper would have to live in a package and break that rule. This runs in the
-// vitest parent before globalSetup and before any worker forks, and workers
-// inherit the parent env.
+// Republish the effective count so ar-db-slots.ts sizes the slot pool from the
+// workers that actually start. The clamp lives only here because package
+// sources may not import `node:os` (browser compat) and the os-adapter exposes
+// no `availableParallelism`. Runs in the vitest parent before globalSetup and
+// before any worker forks; workers inherit the parent env.
 process.env.AR_DB_FORKS = String(TEST_FORKS);
 
 const alias = {


### PR DESCRIPTION
`slotPoolSize()` sized the advisory-slot pool from the **raw** `AR_DB_FORKS`
request, while vitest actually runs `min(request, numCpus - 1)` workers. PR
#5185 made the two agree only by hardcoding `"3"` (the 4-vCPU runner's ceiling)
in three workflow jobs — so the next runner-shape change silently mis-sizes the
pool again.

## Change

- `vitest.config.ts` republishes the **effective** (host-clamped) count into
  `AR_DB_FORKS`, in the vitest parent, before globalSetup and before any worker
  forks (workers inherit the parent env). Re-evaluating the config is
  idempotent: `min(effective, cap) == effective`.
- `ar-db-slots.ts` therefore reads the effective count with no duplicated
  clamp. Deliberately *not* a shared clamp helper: package sources may not
  import `node:os` (eslint `blazetrails/no-node-builtins`, browser compat) and
  the os-adapter exposes no `availableParallelism`, so a shared helper would
  have to live in a package and break that rule. Rationale is at the call site.
- The default fork count is shared as `DEFAULT_FORKS` (6). The two files
  previously disagreed — config defaulted to 6, the slot pool to 1 —
  under-provisioning any run that set neither var.
- The three live AR DB jobs (postgres-tests, mysql-tests, maria-tests) no
  longer set `AR_DB_FORKS`; worker count and slot pool both follow the runner's
  vCPU count with no workflow edit.
- `AR_DB_SLOTS` override precedence and the `workers + 1` floor are unchanged.

### Behavior change worth calling out

`workerForkCount()` called **outside** a vitest run (no `AR_DB_FORKS` in the
env) now returns `DEFAULT_FORKS` (6) where it previously returned 1 — and
`slotPoolSize()` correspondingly returns 8 instead of 3. Inside vitest the
value is always the republished clamped count, and the only current caller
(`test-setup-worker-db.ts`) only ever runs under vitest, so nothing in-tree
changes. This is the intended unification of the two disagreeing defaults, not
a side effect: 1 was wrong for any run that set neither var, since vitest
started 6 (clamped) workers against a 3-slot pool.

### Config-load resolution

`vitest.config.ts` imports `./packages/activerecord/src/test-helpers/ar-db-slots.js`
— a `.js` specifier resolving to a sibling `.ts`. Vite loads the config through
`loadConfigFromFile`'s esbuild bundling path, not `vite-node`, so this was
worth confirming rather than assuming: verified with `node_modules/.vite` and
`node_modules/.vitest` removed, `vitest list` collects normally, so the remap
does apply on the config path and the result is not a cached artifact.

## Tests

New `sees the host-clamped count vitest.config.ts republishes` asserts the
inherited `AR_DB_FORKS` is present and `<= numCpus - 1`. Verified it fails on
`origin/main` (along with the three default-fork assertions) and passes here.

Two `workerForkCount` test names changed to match the new default (they
asserted "defaults to 1"); trails-only infra tests with no Rails counterpart.

Closes-story: derive-ar-slot-pool-from-clamped-fork-count
