### PR TITLE
refactor(predicate-builder): route array ranges through build like Rails

### DIFF
--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -377,14 +377,6 @@ export class PredicateBuilder {
     return this.table.type(columnName).cast(value);
   }
 
-  buildRangePredicate(attribute: Nodes.Attribute, range: Range): Nodes.Node {
-    // Same force-equality precedence `build` applies (predicate_builder.rb:57-69).
-    if (this.table.type(attribute.name).isForceEquality?.(range) === true) {
-      return attribute.eq(this.buildBindAttribute(attribute.name, range));
-    }
-    return this.rangeHandler.call(attribute, range);
-  }
-
   /**
    * Build a composite-key predicate. For `cols.length > 1`:
    *

--- a/packages/activerecord/src/relation/predicate-builder/array-handler.ts
+++ b/packages/activerecord/src/relation/predicate-builder/array-handler.ts
@@ -91,7 +91,7 @@ export class ArrayHandler {
       return valuesPredicate === NullPredicate ? attribute.in([]) : (valuesPredicate as Nodes.Node);
     }
 
-    const rangePreds = ranges.map((r) => this.predicateBuilder.buildRangePredicate(attribute, r));
+    const rangePreds = ranges.map((r) => this.predicateBuilder.build(attribute, r));
     let result: Nodes.Node | typeof NullPredicate = valuesPredicate;
     for (const rp of rangePreds) {
       result = result === NullPredicate ? rp : groupedOr(result as Nodes.Node, rp);


### PR DESCRIPTION
`PredicateBuilder#buildRangePredicate` was a trails-only method with no Rails
counterpart. It bypassed `build` and re-stated `build`'s force-equality
precedence inline (added in #5193), leaving two copies of one rule.

Rails' `array_handler.rb` calls `predicate_builder.build(attribute, range)` for
each extracted range. Its only caller (`ArrayHandler#call`) now does the same,
and `buildRangePredicate` is deleted. A `Range` through `build` takes exactly
the same path: no `id` deref, excluded from the scalar-normalize branch, not
nil, then the force-equality check, then `rangeHandler` — so behavior is
unchanged while the precedence lives in one place.

`predicate-builder.test.ts`, `predicate-builder.trails.test.ts` and
`connection-adapters/postgresql/oid/range.test.ts` pass unchanged;
`pnpm api:calls:wide` is clean with no new baseline entries.

Closes-story: buildrangepredicate-duplicates-build-force-equality-precedence
