### PR TITLE
fix(calculations): alias composite-key grouped aggregates via columnAliasFor

### DIFF
--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -535,13 +535,7 @@ async function groupedAggregate(
   const groupKeyAliases = groupNodes.map(
     (n, i) => new Nodes.As(n, new Nodes.SqlLiteral(aliases[i])),
   );
-  // Rails aliases the aggregate as `column_alias_for("#{operation} #{column_name}")`
-  // — e.g. `sum_credit_limit`, `count_all` — so order("sum_credit_limit desc")
-  // can reference it (calculations.rb:537). A raw Arel node keeps "val".
-  const aggAlias =
-    typeof column === "string"
-      ? columnAliasFor(`${fn} ${column.toLowerCase()}`.replace(/\*/g, "all"))
-      : "val";
+  const aggAlias = aggregateAliasFor(fn, column);
   const manager = table.project(...groupKeyAliases, aggNode.as(aggAlias));
   // Rails `calculate` (calculations.rb:217-238) folds the eager JoinDependency
   // into `joins_values` via `apply_join_dependency` before dispatching to the
@@ -686,14 +680,7 @@ async function groupedCompositeAssoc(
   const groupNodes = fkCols.map((c) => groupColumnToArel(c, table));
   const aggNode = buildAggNode(rel, fn, column, rel._isDistinct);
   const projections = groupNodes.map((n, i) => new Nodes.As(n, new Nodes.SqlLiteral(aliases[i])));
-  // Rails' `execute_grouped_calculation` aliases the aggregate through the
-  // column-alias tracker regardless of foreign-key arity (calculations.rb:536),
-  // so `order("count_all desc")` resolves on the composite arm too. A raw Arel
-  // node keeps "val", as in `groupedAggregate`.
-  const aggAlias =
-    typeof column === "string"
-      ? columnAliasFor(`${fn} ${column.toLowerCase()}`.replace(/\*/g, "all"))
-      : "val";
+  const aggAlias = aggregateAliasFor(fn, column);
   const manager = table.project(...projections, aggNode.as(aggAlias));
   // Rails `calculate` (calculations.rb:217-238) folds the eager JoinDependency
   // into `joins_values` via `apply_join_dependency` before dispatching to the
@@ -1377,6 +1364,20 @@ export class ColumnAliasTracker {
 // ---------------------------------------------------------------------------
 // Private helpers (mirrors Rails' ActiveRecord::Calculations private methods)
 // ---------------------------------------------------------------------------
+
+/**
+ * The alias Rails' `execute_grouped_calculation` gives the aggregate column:
+ * `column_alias_tracker.alias_for("#{operation} #{column_name.to_s.downcase}")`
+ * (calculations.rb:536) — `count_all`, `sum_credit_limit`, … — which is what
+ * makes `order("count_all desc")` resolvable. Rails does not special-case
+ * foreign-key arity, so both grouped arms alias through here. A raw Arel node
+ * has no name to build an alias from and keeps the internal "val".
+ * @internal
+ */
+function aggregateAliasFor(fn: AggFn, column: string | Nodes.Node): string {
+  if (typeof column !== "string") return "val";
+  return columnAliasFor(`${fn} ${column.toLowerCase()}`.replace(/\*/g, "all"));
+}
 
 /** @internal */
 function columnAliasFor(field: string): string {

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -686,7 +686,15 @@ async function groupedCompositeAssoc(
   const groupNodes = fkCols.map((c) => groupColumnToArel(c, table));
   const aggNode = buildAggNode(rel, fn, column, rel._isDistinct);
   const projections = groupNodes.map((n, i) => new Nodes.As(n, new Nodes.SqlLiteral(aliases[i])));
-  const manager = table.project(...projections, aggNode.as("val"));
+  // Rails' `execute_grouped_calculation` aliases the aggregate through the
+  // column-alias tracker regardless of foreign-key arity (calculations.rb:536),
+  // so `order("count_all desc")` resolves on the composite arm too. A raw Arel
+  // node keeps "val", as in `groupedAggregate`.
+  const aggAlias =
+    typeof column === "string"
+      ? columnAliasFor(`${fn} ${column.toLowerCase()}`.replace(/\*/g, "all"))
+      : "val";
+  const manager = table.project(...projections, aggNode.as(aggAlias));
   // Rails `calculate` (calculations.rb:217-238) folds the eager JoinDependency
   // into `joins_values` via `apply_join_dependency` before dispatching to the
   // grouped calculation, regardless of key arity. Fold it into the shared
@@ -718,7 +726,7 @@ async function groupedCompositeAssoc(
   const [withCtes, ctedBinds] = prependCtes(rel, rawSql, managerBinds);
   const sql =
     isBigintColumn(rel, fn, column) && needsBigintCast(rel)
-      ? `SELECT ${aliases.map((a) => `"${a}"`).join(", ")}, CAST("val" AS TEXT) AS "val" FROM (${withCtes}) AS "_bigint_agg"`
+      ? wrapBigintAgg(withCtes, aliases, aggAlias)
       : withCtes;
   const opName = fn.charAt(0).toUpperCase() + fn.slice(1);
   const queryResult = await rel
@@ -750,7 +758,7 @@ async function groupedCompositeAssoc(
   for (const row of rows) {
     const vals = aliases.map((a) => row[a]);
     const record = vals.every((v) => v != null) ? (byKey.get(keyOf(vals)) ?? null) : null;
-    result.set(record, aggOf(row.val));
+    result.set(record, aggOf(row[aggAlias]));
   }
   return result;
 }

--- a/packages/activerecord/src/relation/grouped-composite-assoc-aggregate-alias.trails.test.ts
+++ b/packages/activerecord/src/relation/grouped-composite-assoc-aggregate-alias.trails.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Grouped calculation over a composite-key `belongsTo` must alias the aggregate
+ * through the column-alias tracker, not a hard-coded "val".
+ *
+ * Rails' `execute_grouped_calculation` does not special-case foreign-key arity:
+ * it always aliases the aggregate as
+ * `column_alias_tracker.alias_for("#{operation} #{column_name}")` — `count_all`,
+ * `sum_status`, … — so `order("count_all desc")` can reference the aggregate
+ * (`activerecord/lib/active_record/relation/calculations.rb:536-539`). The
+ * composite-FK arm `groupedCompositeAssoc` (`relation/calculations.ts`) instead
+ * projected `AS "val"`, which both diverged from Rails' SQL and made an order by
+ * the Rails alias unresolvable — reachable only since #5190 taught that arm to
+ * apply `order_values` at all.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { registerModel } from "../associations.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+import { CpkBook, CpkOrder, CpkAuthor } from "../test-helpers/models/cpk.js";
+import { sql as arelSql } from "@blazetrails/arel";
+import { captureSql } from "../testing/sql-capture.js";
+
+describe("CpkBook grouped calculation over a composite-key belongs_to aliases the aggregate", () => {
+  // Rails creates CPK rows inline; no cpk fixtures exist. Ride the canonical,
+  // empty cpk tables and let transactional rollback clean up each insert.
+  fixtures([]);
+
+  beforeAll(() => {
+    [CpkBook, CpkOrder, CpkAuthor].forEach((m) => registerModel(m));
+  });
+
+  // Three orders in shop 1. Book counts per order: 1 → 1, 2 → 3, 3 → 2.
+  async function seedOrders(): Promise<void> {
+    await CpkAuthor.create({ id: 1, name: "Author One" });
+    for (const id of [1, 2, 3]) {
+      await CpkOrder.create({ id: [1, id], status: `s-${id}` });
+    }
+    const books: Array<[number, number]> = [
+      [1, 1],
+      [2, 2],
+      [3, 2],
+      [4, 2],
+      [5, 3],
+      [6, 3],
+    ];
+    for (const [bookId, orderId] of books) {
+      await CpkBook.create({
+        id: [1, bookId],
+        title: `book-${bookId}`,
+        revision: 1,
+        shop_id: 1,
+        order_id: orderId,
+      });
+    }
+  }
+
+  it("group by a composite-key belongs_to projects the aggregate as count_all", async () => {
+    await seedOrders();
+    let result: Map<unknown, number> = new Map();
+    const sqls = await captureSql(async () => {
+      result = (await CpkBook.group("order").count()) as Map<unknown, number>;
+    });
+
+    const groupedSql = sqls.find((s) => /GROUP BY/i.test(s));
+    expect(groupedSql).toMatch(/AS ["`]?count_all["`]?/i);
+    expect(groupedSql).not.toMatch(/AS ["`]?val["`]?/i);
+
+    const counts = [...result.entries()].map(([order, count]) => [
+      (order as CpkOrder | null)?.id,
+      count,
+    ]);
+    expect(counts.sort()).toEqual(
+      [
+        [[1, 1], 1],
+        [[1, 2], 3],
+        [[1, 3], 2],
+      ].sort(),
+    );
+  });
+
+  it("group by a composite-key belongs_to can order by the aggregate alias", async () => {
+    await seedOrders();
+    const result = (await CpkBook.group("order")
+      .order(arelSql("count_all DESC"))
+      .limit(2)
+      .count()) as Map<unknown, number>;
+
+    const counts = [...result.entries()].map(([order, count]) => [
+      (order as CpkOrder | null)?.id,
+      count,
+    ]);
+    expect(counts).toEqual([
+      [[1, 2], 3],
+      [[1, 3], 2],
+    ]);
+  });
+
+  it("group by a composite-key belongs_to aliases a sum as sum_order_id", async () => {
+    await seedOrders();
+    let result: Map<unknown, unknown> = new Map();
+    const sqls = await captureSql(async () => {
+      result = (await CpkBook.group("order").sum("order_id")) as Map<unknown, unknown>;
+    });
+
+    const groupedSql = sqls.find((s) => /GROUP BY/i.test(s));
+    expect(groupedSql).toMatch(/AS ["`]?sum_order_id["`]?/i);
+
+    const sums = [...result.entries()].map(([order, s]) => [(order as CpkOrder | null)?.id, s]);
+    expect(sums.sort()).toEqual(
+      [
+        [[1, 1], 1],
+        [[1, 2], 6],
+        [[1, 3], 6],
+      ].sort(),
+    );
+  });
+});


### PR DESCRIPTION
`groupedCompositeAssoc` (the composite-FK belongs_to arm of grouped
calculations in `relation/calculations.ts`) hard-coded the aggregate alias as
`val`, while the sibling scalar arm `groupedAggregate` derives it from
`columnAliasFor`.

Rails' `execute_grouped_calculation` does not special-case key arity: the
aggregate is always aliased via the column-alias tracker
(`calculations.rb:536-539`), so a grouped count emits `AS count_all` and
`order("count_all desc")` resolves. Ours diverged in the emitted SQL and made
that order unresolvable on the composite arm — reachable only since #5190
taught that arm to apply order_values at all.

Fix: compute `aggAlias` exactly as `groupedAggregate` does, project through it,
thread it into the bigint-cast wrapper (now `wrapBigintAgg` rather than a
literal `"val"` interpolation), and read the rows by it.

Closes-story: grouped-composite-assoc-aggregate-alias

