### PR TITLE
fix(pg): register the array/range type modifiers so attribute() wraps in OID::Array/Range

### DIFF
--- a/packages/activerecord/src/attributes.test.ts
+++ b/packages/activerecord/src/attributes.test.ts
@@ -9,7 +9,9 @@
  */
 import { describe, it, expect, beforeAll, vi } from "vitest";
 import { Base } from "./index.js";
-import { typeRegistry } from "@blazetrails/activemodel";
+import { typeRegistry, StringType, IntegerType } from "@blazetrails/activemodel";
+import { Array as OidArray } from "./connection-adapters/postgresql/oid/array.js";
+import { RangeType } from "./connection-adapters/postgresql/oid/range.js";
 import { BigDecimal } from "@blazetrails/activesupport";
 
 import { registerModel } from "./associations.js";
@@ -349,26 +351,36 @@ describe("CustomPropertiesTest", () => {
     class Klass extends OverloadedType {
       static {
         this.attribute("my_array", "string", { limit: 50, array: true });
-        this.attribute("my_int_array", "integer", { array: true } as any);
+        this.attribute("my_int_array", "integer", { array: true });
       }
     }
 
-    const stringArray = Klass.typeForAttribute("my_array");
-    const intArray = Klass.typeForAttribute("my_int_array");
+    const stringArray = Klass.typeForAttribute("my_array") as OidArray;
+    const intArray = Klass.typeForAttribute("my_int_array") as OidArray;
     expect(stringArray).not.toEqual(intArray);
+    expect(stringArray).toBeInstanceOf(OidArray);
+    expect(stringArray.subtype).toBeInstanceOf(StringType);
+    expect(stringArray.subtype.limit).toBe(50);
+    expect(intArray).toBeInstanceOf(OidArray);
+    expect(intArray.subtype).toBeInstanceOf(IntegerType);
   });
 
   it.skipIf(adapterType !== "postgres")("range types can be specified", () => {
     class Klass extends OverloadedType {
       static {
         this.attribute("my_range", "string", { limit: 50, range: true });
-        this.attribute("my_int_range", "integer", { range: true } as any);
+        this.attribute("my_int_range", "integer", { range: true });
       }
     }
 
-    const stringRange = Klass.typeForAttribute("my_range");
-    const intRange = Klass.typeForAttribute("my_int_range");
+    const stringRange = Klass.typeForAttribute("my_range") as RangeType;
+    const intRange = Klass.typeForAttribute("my_int_range") as RangeType;
     expect(stringRange).not.toEqual(intRange);
+    expect(stringRange).toBeInstanceOf(RangeType);
+    expect(stringRange.subtype).toBeInstanceOf(StringType);
+    expect((stringRange.subtype as StringType).limit).toBe(50);
+    expect(intRange).toBeInstanceOf(RangeType);
+    expect(intRange.subtype).toBeInstanceOf(IntegerType);
   });
 
   it("attributes added after subclasses load are inherited", () => {

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/array.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/array.ts
@@ -32,7 +32,7 @@ function stableStringify(value: unknown): string {
 }
 
 export interface ArraySubtype {
-  readonly type?: string | (() => string);
+  readonly type?: string | (() => string | undefined);
   readonly limit?: number;
   readonly precision?: number;
   readonly scale?: number;
@@ -83,7 +83,7 @@ export class Array extends ValueType<unknown> {
    */
   override type(): string {
     const subtypeType = this.subtype.type;
-    if (typeof subtypeType === "function") return subtypeType.call(this.subtype);
+    if (typeof subtypeType === "function") return subtypeType.call(this.subtype) ?? "array";
     if (typeof subtypeType === "string") return subtypeType;
     return "array";
   }

--- a/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
@@ -18,6 +18,8 @@ import {
 } from "@blazetrails/activemodel";
 import * as ArType from "../../type.js";
 
+import { Array as OidArray } from "./oid/array.js";
+import { RangeType } from "./oid/range.js";
 import { Date as OidDate } from "./oid/date.js";
 import { DecimalWithoutScale } from "../../type/decimal-without-scale.js";
 import { HashLookupTypeMap } from "../../type/hash-lookup-type-map.js";
@@ -57,6 +59,11 @@ ArType.register("money", Money, { override: false });
 ArType.register("point", Point, { override: false });
 ArType.register("uuid", Uuid, { override: false });
 ArType.register("xml", Xml, { override: false });
+
+// Mirrors: postgresql_adapter.rb:1166-1167. Rails scopes these to
+// `adapter: :postgresql`; "postgres" is trails' normalized name for that family.
+ArType.addModifier({ array: true }, OidArray, { adapter: "postgres" });
+ArType.addModifier({ range: true }, RangeType, { adapter: "postgres" });
 
 /**
  * Mirrors: PostgreSQLAdapter.extract_limit — `$1.to_i if sql_type =~ /\((.*)\)/`.

--- a/packages/activerecord/src/type.ts
+++ b/packages/activerecord/src/type.ts
@@ -110,6 +110,15 @@ export function register(
   _registry.register(typeName, klass, options, block);
 }
 
+/** Mirrors: ActiveRecord::Type.add_modifier */
+export function addModifier(
+  options: Record<string, unknown>,
+  klass: new (subtype: Type) => Type,
+  registrationOptions?: { adapter?: string },
+): void {
+  _registry.addModifier(options, klass, registrationOptions);
+}
+
 export function lookup(
   symbol: string,
   options?: { adapter?: string; [key: string]: unknown },


### PR DESCRIPTION
Rails registers two PostgreSQL type modifiers at
`postgresql_adapter.rb:1166-1167`, so `attribute :my_array, :string, limit: 50,
array: true` resolves to `OID::Array.new(Type::String.new(limit: 50))`. trails
had `AdapterSpecificRegistry#addModifier` and `OID::Array` / `OID::Range` but
never registered either modifier, so `array: true` rode into
`new StringType({ limit: 50, array: true })` and was silently dropped — the
declared type stayed a bare `StringType`.

- `Type.addModifier` (mirrors `ActiveRecord::Type.add_modifier`) added in
  `activerecord/src/type.ts`.
- `postgresql/type-map-init.ts` registers both modifiers, adapter-scoped to
  `"postgres"` (trails' normalized name for the `:postgresql` family), right
  beside the scalar `ArType.register` calls — same ordering as
  postgresql_adapter.rb.
- `ArraySubtype.type` widened to `() => string | undefined` so a plain `Type`
  satisfies it and the modifier registration needs no cast; `Array#type()`
  falls back to the `"array"` default it already used for the untyped case.

The `attribute()` → `resolveTypeName` → `Type.lookup` plumbing this depends on
landed separately in #5196, so this PR is only the registrations plus the test.

`attributes.test.ts`'s "array types can be specified" / "range types can be
specified" now assert the wrapper class and subtype/limit (matching
`attributes_test.rb:254-266`) instead of the `!==` check that passed on the
base-type difference alone. Both fail without the registrations.

Verified against PostgreSQL: `attributes.test.ts` (55 passed),
`adapters/postgresql/array.test.ts` (43), `range.test.ts`; on SQLite the whole
of `activemodel` + `actionpack` (5603 passed) and 33 AR type/attribute/OID
files (562 passed).

Closes-story: ar-pg-array-range-type-modifiers-never-registered
