### PR TITLE
feat(test-compare): detect name-matched tests with hollow bodies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,6 +499,14 @@ jobs:
           fi
           echo "No new or modified docs/activerecord trackers."
 
+      # test:compare matches our tests to Rails BY NAME, so a test whose name
+      # promises a behaviour its body never exercises reports coverage it does
+      # not provide (PR #4892). The tree is clean, so this is a zero-tolerance
+      # gate rather than a ratchet.
+      - name: Hollow Test Bodies
+        if: ${{ !cancelled() }}
+        run: pnpm test:hollow
+
       # PR attribution check. Scoped to deanmarano-authored PRs: the project
       # forbids Claude attribution in *his* PR descriptions and commits (see
       # CLAUDE.md "Do NOT add ... Generated with Claude Code"). Other

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,6 +384,16 @@ jobs:
       - uses: ./.github/actions/setup-pnpm
       - run: pnpm install --frozen-lockfile --prefer-offline
       - run: pnpm lint
+      # test:compare matches our tests to Rails BY NAME, so a test whose name
+      # promises a behaviour its body never exercises reports coverage it does
+      # not provide (PR #4892). The tree is clean, so this is a zero-tolerance
+      # gate rather than a ratchet. Lives here rather than in `preflight`:
+      # that job deliberately never installs pnpm, and this needs the workspace
+      # deps (tsx, typescript, tinyglobby). `!cancelled()` so a `pnpm lint`
+      # failure can't skip it.
+      - name: Hollow test bodies
+        if: ${{ !cancelled() }}
+        run: pnpm test:hollow
   # Consolidated sub-minute PR/push preflight checks. Each of prettier,
   # docs-AR-freeze, and pr-attribution does a few seconds of independent shell
   # work; GitHub bills every job rounded UP to a whole minute, so running them
@@ -498,14 +508,6 @@ jobs:
             exit 1
           fi
           echo "No new or modified docs/activerecord trackers."
-
-      # test:compare matches our tests to Rails BY NAME, so a test whose name
-      # promises a behaviour its body never exercises reports coverage it does
-      # not provide (PR #4892). The tree is clean, so this is a zero-tolerance
-      # gate rather than a ratchet.
-      - name: Hollow Test Bodies
-        if: ${{ !cancelled() }}
-        run: pnpm test:hollow
 
       # PR attribution check. Scoped to deanmarano-authored PRs: the project
       # forbids Claude attribution in *his* PR descriptions and commits (see

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,17 +382,20 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-pnpm
-      - run: pnpm install --frozen-lockfile --prefer-offline
+      - id: install
+        run: pnpm install --frozen-lockfile --prefer-offline
       - run: pnpm lint
       # test:compare matches our tests to Rails BY NAME, so a test whose name
       # promises a behaviour its body never exercises reports coverage it does
       # not provide (PR #4892). The tree is clean, so this is a zero-tolerance
       # gate rather than a ratchet. Lives here rather than in `preflight`:
       # that job deliberately never installs pnpm, and this needs the workspace
-      # deps (tsx, typescript, tinyglobby). `!cancelled()` so a `pnpm lint`
-      # failure can't skip it.
+      # deps (tsx, typescript, tinyglobby). The guard runs this step after a
+      # `pnpm lint` failure (independent reporting) but NOT after a failed
+      # install — without deps `pnpm test:hollow` would die on a missing tsx and
+      # mask the real failure with a confusing secondary one.
       - name: Hollow test bodies
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: pnpm test:hollow
   # Consolidated sub-minute PR/push preflight checks. Each of prettier,
   # docs-AR-freeze, and pr-attribution does a few seconds of independent shell

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "api:conventions": "pnpm tsx scripts/api-compare/conventions-doc.ts",
     "lint:deps": "pnpm vendor:fetch && LIB_PATHS_JSON=$(pnpm -s vendor:fetch --print-lib-paths) LOCKFILE_PATH=$PWD/vendor/sources.lock.json ruby scripts/api-compare/extract-ruby-api.rb && pnpm tsx scripts/api-compare/lint-deps.ts",
     "test:compare": "bash scripts/test-compare/run.sh",
+    "test:hollow": "tsx scripts/test-compare/hollow-bodies-report.ts",
     "rails:find": "bash scripts/rails-find/run.sh",
     "test:deps": "pnpm vendor:fetch >/dev/null && pnpm tsx scripts/test-deps/rails-test-deps.ts",
     "fixture-baseline:refresh": "pnpm test:deps >/dev/null && pnpm tsx scripts/test-deps/build-fixture-baseline.ts",

--- a/scripts/test-compare/extract-ts-core.ts
+++ b/scripts/test-compare/extract-ts-core.ts
@@ -149,10 +149,10 @@ function countAssertions(
 
 /**
  * Test-double callees whose callback argument is MEANT to be a no-op — a
- * silenced logger, a stubbed method. Counting those as hollow-body evidence
- * flags healthy tests.
+ * silenced logger (`mockImplementation(() => {})`), a stub. Counting those as
+ * hollow-body evidence flags healthy tests.
  */
-const NOOP_CALLBACK_SINKS = /^(mockImplementation(Once)?|fn|spyOn)$/;
+const NOOP_CALLBACK_SINKS = /^(?:mockImplementation(?:Once)?|fn)$/;
 
 /**
  * Function callbacks passed as arguments to calls inside a test's subtree,
@@ -408,6 +408,7 @@ export function extractTestsFromSource(content: string, relativePath: string): T
     if (inlineGate) gate = mergeGate(gate, inlineGate);
     const finalGate = gate ? finalizeGate(gate) : undefined;
     const { kinds: assertionKinds, values: assertionValues } = collectAssertionKinds(node, helpers);
+    const callbacks = countCallbacks(node);
     fileInfo.testCases.push({
       path: [...currentAncestors, title].join(" > "),
       description: title,
@@ -419,14 +420,9 @@ export function extractTestsFromSource(content: string, relativePath: string): T
       assertionCount: countAssertions(node, helpers),
       assertionKinds,
       assertionValues,
-      ...(() => {
-        const cb = countCallbacks(node);
-        return {
-          emptyCallbacks: cb.empty,
-          callbackCount: cb.total,
-          bodyMutations: cb.mutations,
-        };
-      })(),
+      emptyCallbacks: callbacks.empty,
+      callbackCount: callbacks.total,
+      bodyMutations: callbacks.mutations,
       pending,
       ...(finalGate ? { gate: finalGate } : {}),
     });

--- a/scripts/test-compare/extract-ts-core.ts
+++ b/scripts/test-compare/extract-ts-core.ts
@@ -148,6 +148,85 @@ function countAssertions(
 }
 
 /**
+ * Test-double callees whose callback argument is MEANT to be a no-op — a
+ * silenced logger, a stubbed method. Counting those as hollow-body evidence
+ * flags healthy tests.
+ */
+const NOOP_CALLBACK_SINKS = /^(mockImplementation(Once)?|fn|spyOn)$/;
+
+/**
+ * Function callbacks passed as arguments to calls inside a test's subtree,
+ * split into empty (`() => {}`, statement-less body) and total. This is the
+ * hollow-body signal: where Rails' original yields a block that mutates, a
+ * no-op block makes the test unable to fail (see
+ * scripts/test-compare/hollow-bodies.ts). The test's OWN callback is excluded —
+ * the walk starts from the test call's arguments' subtrees.
+ */
+function countCallbacks(node: ts.CallExpression): {
+  empty: number;
+  total: number;
+  mutations: number;
+} {
+  let empty = 0;
+  let total = 0;
+  let mutations = 0;
+  const walk = (n: ts.Node) => {
+    if (ts.isCallExpression(n)) {
+      const callee = ts.isPropertyAccessExpression(n.expression)
+        ? n.expression.name.text
+        : ts.isIdentifier(n.expression)
+          ? n.expression.text
+          : "";
+      if (!NOOP_CALLBACK_SINKS.test(callee)) {
+        for (const arg of n.arguments) {
+          if (!ts.isArrowFunction(arg) && !ts.isFunctionExpression(arg)) continue;
+          total++;
+          if (ts.isBlock(arg.body) && arg.body.statements.length === 0) empty++;
+        }
+      }
+    }
+    ts.forEachChild(n, walk);
+  };
+  for (const arg of node.arguments) {
+    walk(arg);
+    mutations += countMutations(arg);
+  }
+  return { empty, total, mutations };
+}
+
+/**
+ * Assignments / deletes / increments anywhere in a test's body — the shape any
+ * test that MUTATES something has, and the shape the hollow
+ * `Notifications.instrument` tests (#4892) lacked entirely: they pushed the
+ * event into an array and asserted it came back unchanged, never writing to the
+ * yielded payload. Deliberately body-wide rather than callback-only: plenty of
+ * faithful `modifies`-named tests mutate at the top level of the body, and
+ * flagging those buries the real signal.
+ */
+function countMutations(node: ts.Node): number {
+  let count = 0;
+  const walk = (n: ts.Node) => {
+    if (ts.isBinaryExpression(n) && isAssignmentOperator(n.operatorToken.kind)) count++;
+    else if (ts.isDeleteExpression(n)) count++;
+    else if (ts.isPostfixUnaryExpression(n) || ts.isPrefixUnaryExpression(n)) {
+      if (
+        n.operator === ts.SyntaxKind.PlusPlusToken ||
+        n.operator === ts.SyntaxKind.MinusMinusToken
+      ) {
+        count++;
+      }
+    }
+    ts.forEachChild(n, walk);
+  };
+  walk(node);
+  return count;
+}
+
+function isAssignmentOperator(kind: ts.SyntaxKind): boolean {
+  return kind >= ts.SyntaxKind.FirstAssignment && kind <= ts.SyntaxKind.LastAssignment;
+}
+
+/**
  * The terminal matcher of an `expect(...).matcher(...)` chain, or `null` when
  * the call isn't such a chain. `expect(x).not.toBeNull()` yields `not:toBeNull`
  * — the negation is folded into the token so downstream normalization can line
@@ -340,6 +419,14 @@ export function extractTestsFromSource(content: string, relativePath: string): T
       assertionCount: countAssertions(node, helpers),
       assertionKinds,
       assertionValues,
+      ...(() => {
+        const cb = countCallbacks(node);
+        return {
+          emptyCallbacks: cb.empty,
+          callbackCount: cb.total,
+          bodyMutations: cb.mutations,
+        };
+      })(),
       pending,
       ...(finalGate ? { gate: finalGate } : {}),
     });

--- a/scripts/test-compare/hollow-bodies-report.ts
+++ b/scripts/test-compare/hollow-bodies-report.ts
@@ -1,0 +1,38 @@
+/**
+ * Sweep every trails test file for hollow bodies, print the report, and FAIL if
+ * anything is found. The tree is clean as of this script landing, so this is a
+ * zero-tolerance gate, not a ratchet with a baseline: a new hollow body is a new
+ * false-negative in the parity signal, and the fix is always to write the body.
+ * See scripts/test-compare/hollow-bodies.ts for the classification rules.
+ *
+ *   pnpm test:hollow
+ */
+import * as path from "path";
+import * as fs from "fs/promises";
+import { globSync } from "tinyglobby";
+import { extractTestsFromSource } from "./extract-ts-core.js";
+import type { TestCaseInfo } from "./types.js";
+import { findHollowTests, formatReport } from "./hollow-bodies.js";
+
+const ROOT_DIR = path.resolve(__dirname, "../..");
+
+async function main(): Promise<void> {
+  const files = globSync("packages/*/src/**/*.test.ts", { cwd: ROOT_DIR }).sort();
+  const testCases: TestCaseInfo[] = [];
+  for (const file of files) {
+    const content = await fs.readFile(path.join(ROOT_DIR, file), "utf-8");
+    testCases.push(...extractTestsFromSource(content, file).testCases);
+  }
+  const findings = findHollowTests(testCases);
+  console.log(formatReport(findings, testCases.length));
+  if (findings.length > 0) {
+    console.error(
+      "\n::error::Hollow test bodies found — the test name promises a behaviour the body " +
+        "never exercises, so it passes against a broken implementation. Write the body " +
+        "against the vendored Rails original; NEVER rename the test to match the body.",
+    );
+    throw new Error(`${findings.length} hollow test bodies`);
+  }
+}
+
+void main();

--- a/scripts/test-compare/hollow-bodies-report.ts
+++ b/scripts/test-compare/hollow-bodies-report.ts
@@ -31,7 +31,9 @@ async function main(): Promise<void> {
         "never exercises, so it passes against a broken implementation. Write the body " +
         "against the vendored Rails original; NEVER rename the test to match the body.",
     );
-    throw new Error(`${findings.length} hollow test bodies`);
+    // `process.exitCode` rather than `exit(1)` so stdout flushes first — the
+    // report IS the failure message. Matches test-compare.ts's CLI convention.
+    process.exitCode = 1;
   }
 }
 

--- a/scripts/test-compare/hollow-bodies.test.ts
+++ b/scripts/test-compare/hollow-bodies.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import { extractTestsFromSource } from "./extract-ts-core.js";
+import { findHollowTests, worstOffenders } from "./hollow-bodies.js";
+import type { HollowFinding } from "./hollow-bodies.js";
+
+function sweep(source: string): HollowFinding[] {
+  return findHollowTests(extractTestsFromSource(source, "x.test.ts").testCases);
+}
+
+describe("hollow-body detector", () => {
+  // The regression the detector exists for: the pre-#4892 body of
+  // `instrument yields the payload for further modification` passed no block at
+  // all and asserted the payload came back unchanged, so it passed against an
+  // `instrument` that never yielded.
+  it("flags the pre-#4892 notifications body", () => {
+    const findings = sweep(`
+      it("instrument yields the payload for further modification", () => {
+        const events = [];
+        Notifications.subscribe("modify", (e) => events.push(e));
+        Notifications.instrument("modify", { original: true });
+        expect(events[0].payload.original).toBe(true);
+      });
+    `);
+    expect(findings.map((f) => f.reason)).toEqual(["no-mutation"]);
+  });
+
+  it("clears the fixed body that writes to the yielded payload", () => {
+    const findings = sweep(`
+      it("instrument yields the payload for further modification", () => {
+        const events = [];
+        Notifications.subscribe("modify", (e) => events.push(e));
+        Notifications.instrument("modify", { original: true }, (payload) => {
+          payload.added = "later";
+        });
+        expect(events[0].payload.added).toBe("later");
+      });
+    `);
+    expect(findings).toEqual([]);
+  });
+
+  it("flags a no-op block where the name promises the block yields", () => {
+    const findings = sweep(`
+      it("instrumenter yields the payload for further modification", () => {
+        instrumenter.instrument("name", payload, () => {});
+        expect(payload.title).toBe("t");
+      });
+    `);
+    expect(findings.map((f) => f.reason)).toEqual(["empty-callback"]);
+  });
+
+  it("flags a behaviour-promising test that asserts nothing", () => {
+    const findings = sweep(`
+      it("raises when the record is dirty", async () => {
+        await person.lockBang();
+      });
+    `);
+    expect(findings.map((f) => f.reason)).toEqual(["no-assertions"]);
+  });
+
+  it("ignores a name that promises nothing", () => {
+    expect(sweep(`it("has a name", () => { setUp(); });`)).toEqual([]);
+  });
+
+  it("ignores pending tests", () => {
+    expect(sweep(`it.skip("raises when the record is dirty");`)).toEqual([]);
+  });
+
+  // Rails' own body for a negated promise is an `assert_nothing_raised` or a
+  // no-op block, so an assertion-free body is the faithful port.
+  it("ignores negated promises", () => {
+    const source = `
+      it("does not raise when the object is not dirty", async () => {
+        await person.lockBang();
+      });
+      it("after commit does not mutate the if options array", () => {
+        Model.afterCommit(() => {}, opts);
+        expect(opts.if).toEqual(original);
+      });
+    `;
+    expect(sweep(source)).toEqual([]);
+  });
+
+  // "instrument" ends in "nt" — an apostrophe-less `\\w+n't` negation pattern
+  // would swallow the very tests this detector exists to catch.
+  it("does not read instrument as a negation", () => {
+    const findings = sweep(`
+      it("instrument yields the payload for further modification", () => {
+        Notifications.subscribe("m", (e) => events.push(e));
+        Notifications.instrument("m", {});
+        expect(events).toHaveLength(1);
+      });
+    `);
+    expect(findings).toHaveLength(1);
+  });
+
+  it("ignores bang methods that mutate by the call", () => {
+    const findings = sweep(`
+      it("deep transform keys with bang mutates", () => {
+        deepTransformKeysBang(h, (k) => k.toUpperCase());
+        expect(h).toEqual({ A: 1 });
+      });
+    `);
+    expect(findings).toEqual([]);
+  });
+
+  it("ignores no-op callbacks handed to test doubles", () => {
+    const findings = sweep(`
+      it("yields completion sentinel", async () => {
+        vi.spyOn(console, "error").mockImplementation(() => {});
+        const chunks = await collect(renderer.renderStream(ctx, (c) => c.write("x")));
+        expect(chunks).toEqual([""]);
+      });
+    `);
+    expect(findings).toEqual([]);
+  });
+
+  it("ranks offenders by finding count", () => {
+    const findings: HollowFinding[] = [
+      { path: "a", file: "one.ts", line: 1, reason: "no-assertions" },
+      { path: "b", file: "two.ts", line: 2, reason: "no-assertions" },
+      { path: "c", file: "two.ts", line: 3, reason: "empty-callback" },
+    ];
+    expect(worstOffenders(findings)).toEqual([
+      { file: "two.ts", count: 2 },
+      { file: "one.ts", count: 1 },
+    ]);
+  });
+});

--- a/scripts/test-compare/hollow-bodies.test.ts
+++ b/scripts/test-compare/hollow-bodies.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { extractTestsFromSource } from "./extract-ts-core.js";
-import { findHollowTests, worstOffenders } from "./hollow-bodies.js";
+import { findHollowTests, formatReport, worstOffenders } from "./hollow-bodies.js";
 import type { HollowFinding } from "./hollow-bodies.js";
 
 function sweep(source: string): HollowFinding[] {
@@ -112,6 +112,10 @@ describe("hollow-body detector", () => {
       });
     `);
     expect(findings).toEqual([]);
+  });
+
+  it("reports a clean sweep on one line", () => {
+    expect(formatReport([], 27828)).toBe("Hollow-body sweep: 0 findings across 27828 tests");
   });
 
   it("ranks offenders by finding count", () => {

--- a/scripts/test-compare/hollow-bodies.test.ts
+++ b/scripts/test-compare/hollow-bodies.test.ts
@@ -114,6 +114,30 @@ describe("hollow-body detector", () => {
     expect(findings).toEqual([]);
   });
 
+  it("ignores a snake_case bang method", () => {
+    const findings = sweep(`
+      it("deep_merge! mutates the instance", () => {
+        h.deepMergeBang(other, (key, a, b) => a);
+        expect(h).toEqual(expected);
+      });
+    `);
+    expect(findings).toEqual([]);
+  });
+
+  // A bare "!" is prose, not a bang method — exempting on it would silently
+  // blind the no-mutation rule to any test title that ends in an exclamation.
+  it("does not treat a prose exclamation as a bang method", () => {
+    const findings = sweep(`
+      it("modifies the payload, success!", () => {
+        instrument("m", {}, (payload) => {
+          read(payload);
+        });
+        expect(events).toHaveLength(1);
+      });
+    `);
+    expect(findings.map((f) => f.reason)).toEqual(["no-mutation"]);
+  });
+
   it("reports a clean sweep on one line", () => {
     expect(formatReport([], 27828)).toBe("Hollow-body sweep: 0 findings across 27828 tests");
   });

--- a/scripts/test-compare/hollow-bodies.ts
+++ b/scripts/test-compare/hollow-bodies.ts
@@ -131,6 +131,7 @@ export function formatReport(findings: HollowFinding[], totalTests: number): str
   for (const f of findings) byReason.set(f.reason, (byReason.get(f.reason) ?? 0) + 1);
 
   lines.push(`Hollow-body sweep: ${findings.length} findings across ${totalTests} tests`);
+  if (findings.length === 0) return lines[0];
   for (const [reason, count] of [...byReason].sort((a, b) => b[1] - a[1])) {
     lines.push(`  ${reason}: ${count}`);
   }

--- a/scripts/test-compare/hollow-bodies.ts
+++ b/scripts/test-compare/hollow-bodies.ts
@@ -1,0 +1,148 @@
+/**
+ * Hollow-body detector — the false-negative class test:compare cannot see.
+ *
+ * test:compare matches our tests to Rails' BY NAME, so a test whose name
+ * promises a behaviour but whose body never exercises it reports coverage it
+ * does not provide: it passes against a broken implementation. PR #4892 (the
+ * `Notifications.instrument` payload-yield deviation) survived exactly this way
+ * behind six name-matched tests with hollow bodies.
+ *
+ * This module classifies a test as hollow from its extracted shape alone (name
+ * + assertion counts + no-op callbacks) — see {@link classifyTest}. It is a
+ * heuristic, deliberately narrow: it only fires on names that PROMISE a
+ * behaviour, so a plain setup-only test is never flagged.
+ */
+import type { TestCaseInfo } from "./types.js";
+
+/**
+ * Names that promise the test observes a behaviour. Split by what the body must
+ * then contain, so each hollow reason can name the promise it broke.
+ */
+const YIELD_PROMISE =
+  /\b(yields?|yielding|is changed during|modif(?:y|ies|ied)|mutat(?:e|es|ed)|passes? the .* to|during instrumentation)\b/i;
+/**
+ * The narrower subset that promises something is WRITTEN TO — the exact shape
+ * of the six hollow tests #4892 exposed. Rails' originals mutate the yielded
+ * payload; a body that writes to nothing at all cannot be testing this name.
+ */
+/** Ruby bang methods mutate their receiver by the CALL, not by an assignment. */
+const BANG_METHOD = /(!|\bwith bang\b)/i;
+const MUTATION_PROMISE = /\b(for further modification|is changed during|modifies|mutates)\b/i;
+/**
+ * Names that promise a raise. Used only to widen the zero-assertion rule — NOT
+ * to demand a `toThrow` matcher: a raise is legitimately observed by a
+ * try/catch helper plus `toBeInstanceOf`, so matcher-shape alone produces
+ * overwhelming false positives (221 of 233 findings in the first sweep, nearly
+ * all real assertions behind a `runAndCatch`-style helper). Proving a
+ * raise-named body actually observes the raise needs a body-vs-Rails diff,
+ * which is out of this detector's scope.
+ */
+const RAISE_PROMISE = /\b(raises?|throws?|errors? (?:if|when|on))\b/i;
+/**
+ * A NEGATED promise ("does not mutate the options", "should not raise") is the
+ * inverse shape: Rails' own body is an `assert_nothing_raised` / a no-op block,
+ * so an assertion-free body or a `() => {}` is the faithful port, not a hollow
+ * one. Excluded outright.
+ */
+// Explicit auxiliary list rather than a `\w+n't` pattern: the apostrophe-less
+// spellings we actually use ("doesnt", "shouldnt") collide with ordinary words
+// ending in "nt" — "instrument" among them, the very name this detector exists
+// to catch.
+const NEGATED_PROMISE =
+  /\b(not|never|without|does ?n'?t|did ?n'?t|do ?n'?t|should ?n'?t|would ?n'?t|wo ?n'?t|is ?n'?t|are ?n'?t|ca ?n'?t|could ?n'?t)\b/i;
+const BEHAVIOUR_PROMISE = new RegExp(`${YIELD_PROMISE.source}|${RAISE_PROMISE.source}`, "i");
+
+export type HollowReason =
+  /** The name promises a behaviour and the body asserts nothing at all. */
+  | "no-assertions"
+  /**
+   * The name promises the block yields/mutates something, and the body passes a
+   * no-op `() => {}` where that mutation would go.
+   */
+  | "empty-callback"
+  /**
+   * The name promises something is mutated, and the body writes to nothing.
+   */
+  | "no-mutation";
+
+export interface HollowFinding {
+  path: string;
+  file: string;
+  line: number;
+  reason: HollowReason;
+}
+
+/**
+ * Classify one extracted test. Returns `null` for tests that are fine, pending
+ * (a skip is an honest TODO, not a false signal), or whose name makes no
+ * behavioural promise for the body to break.
+ */
+export function classifyTest(tc: TestCaseInfo): HollowReason | null {
+  if (tc.pending) return null;
+  if (!BEHAVIOUR_PROMISE.test(tc.description)) return null;
+  if (NEGATED_PROMISE.test(tc.description)) return null;
+
+  const assertionCount = tc.assertionCount ?? tc.assertions.length;
+  if (assertionCount === 0) return "no-assertions";
+
+  const empty = tc.emptyCallbacks ?? 0;
+  if (YIELD_PROMISE.test(tc.description) && empty > 0 && empty === (tc.callbackCount ?? 0)) {
+    return "empty-callback";
+  }
+
+  // Gated on the body actually handing out a block: "mutates" on a bang method
+  // (`symbolizeKeysBang`) is mutation performed BY the call, invisible as an
+  // assignment, so those names are excluded outright.
+  if (
+    MUTATION_PROMISE.test(tc.description) &&
+    !BANG_METHOD.test(tc.description) &&
+    (tc.callbackCount ?? 0) > 0 &&
+    (tc.bodyMutations ?? 0) === 0
+  ) {
+    return "no-mutation";
+  }
+
+  return null;
+}
+
+/** Classify every test in a set of extracted files, ordered as given. */
+export function findHollowTests(testCases: TestCaseInfo[]): HollowFinding[] {
+  const findings: HollowFinding[] = [];
+  for (const tc of testCases) {
+    const reason = classifyTest(tc);
+    if (reason) findings.push({ path: tc.path, file: tc.file, line: tc.line, reason });
+  }
+  return findings;
+}
+
+/** Group findings by file, worst (most findings) first, for the report. */
+export function worstOffenders(findings: HollowFinding[]): { file: string; count: number }[] {
+  const byFile = new Map<string, number>();
+  for (const f of findings) byFile.set(f.file, (byFile.get(f.file) ?? 0) + 1);
+  return [...byFile]
+    .map(([file, count]) => ({ file, count }))
+    .sort((a, b) => b.count - a.count || a.file.localeCompare(b.file));
+}
+
+/** Render the sweep as a plain-text report. */
+export function formatReport(findings: HollowFinding[], totalTests: number): string {
+  const lines: string[] = [];
+  const byReason = new Map<HollowReason, number>();
+  for (const f of findings) byReason.set(f.reason, (byReason.get(f.reason) ?? 0) + 1);
+
+  lines.push(`Hollow-body sweep: ${findings.length} findings across ${totalTests} tests`);
+  for (const [reason, count] of [...byReason].sort((a, b) => b[1] - a[1])) {
+    lines.push(`  ${reason}: ${count}`);
+  }
+  lines.push("");
+  lines.push("Worst offenders:");
+  for (const { file, count } of worstOffenders(findings).slice(0, 20)) {
+    lines.push(`  ${count.toString().padStart(4)}  ${file}`);
+  }
+  lines.push("");
+  lines.push("Findings:");
+  for (const f of findings) {
+    lines.push(`  ${f.file}:${f.line}  [${f.reason}]  ${f.path}`);
+  }
+  return lines.join("\n");
+}

--- a/scripts/test-compare/hollow-bodies.ts
+++ b/scripts/test-compare/hollow-bodies.ts
@@ -25,8 +25,13 @@ const YIELD_PROMISE =
  * of the six hollow tests #4892 exposed. Rails' originals mutate the yielded
  * payload; a body that writes to nothing at all cannot be testing this name.
  */
-/** Ruby bang methods mutate their receiver by the CALL, not by an assignment. */
-const BANG_METHOD = /(!|\bwith bang\b)/i;
+/**
+ * Ruby bang methods mutate their receiver by the CALL, not by an assignment.
+ * Anchored to the naming convention rather than a bare `!`: an exclamation mark
+ * anywhere in a title ("raises an error!") is prose, not a method name. A bang
+ * method reads as `deep_merge!` (snake_case token) or, ported, `…Bang`.
+ */
+const BANG_METHOD = /\w+_\w*!|\bbang\b/i;
 const MUTATION_PROMISE = /\b(for further modification|is changed during|modifies|mutates)\b/i;
 /**
  * Names that promise a raise. Used only to widen the zero-assertion rule — NOT

--- a/scripts/test-compare/types.ts
+++ b/scripts/test-compare/types.ts
@@ -82,6 +82,25 @@ export interface TestCaseInfo {
    * test:compare's literal expected-value comparison (assertion-values.ts).
    */
   assertionValues?: (string | null)[];
+  /**
+   * Number of no-op callbacks (`() => {}`) the body passes to some call. A
+   * non-zero count on a test whose NAME promises the block does something
+   * (`yields the payload for further modification`) is the hollow-body signal
+   * test:compare's name matching is blind to. TS extractor only.
+   */
+  emptyCallbacks?: number;
+  /**
+   * Total function callbacks the body passes to some call, excluding
+   * test-double sinks. `emptyCallbacks === callbackCount` means EVERY block the
+   * test hands out is a no-op. TS extractor only.
+   */
+  callbackCount?: number;
+  /**
+   * Assignments / deletes / increments anywhere in the body. Zero on a test
+   * whose name promises something is MUTATED means the body never performs the
+   * mutation the name claims to test. TS extractor only.
+   */
+  bodyMutations?: number;
   /** Whether the test is pending/skipped */
   pending?: boolean;
   /**


### PR DESCRIPTION
## Problem

`test:compare` matches our tests to Rails **by name**. A test whose name promises a
behaviour but whose body never exercises it therefore reports coverage it does not
provide — it passes against a broken implementation, and the parity signal shows green.

That is exactly how the `Notifications.instrument` payload-yield deviation survived
until #4892: six name-matched tests, all hollow. Two prior clusters
(`serialization-nested-include-test-hollow-body`, `validations-test-body-rails-fidelity`)
were closed as one-off body rewrites. Nothing detected the pattern.

## What this adds

`pnpm test:hollow` (`scripts/test-compare/hollow-bodies.ts`) — a shape-based detector
run as a step of the Lint job (the Preflight job deliberately never installs pnpm). Three rules, all gated on the test NAME making a behavioural
promise, so a plain setup-only test is never flagged:

| reason | fires when |
| --- | --- |
| `no-assertions` | name promises a behaviour, body asserts nothing |
| `empty-callback` | name promises a yield, and *every* block the body hands out is `() => {}` |
| `no-mutation` | name promises something is mutated, body hands out a block, body writes to nothing |

The TS extractor gains the supporting counts (`emptyCallbacks`, `callbackCount`,
`bodyMutations`).

## Quantifying the class

**0 findings across 27,828 tests.** The gate is therefore zero-tolerance, not a
ratchet with a baseline — a new hollow body is a new false negative, and the fix is
always to write the body (never to rename the test).

Getting to a trustworthy 0 was the work. Two rules were built and then removed
because their precision was unacceptable, and the reasoning is recorded at the call
sites:

- **`raise-unobserved`** (name says "raises", no `toThrow` matcher) — 221 of 233
  findings were false positives: a raise is legitimately observed by a `runAndCatch`
  helper plus `toBeInstanceOf`. Proving a raise-named body observes the raise needs a
  body-vs-Rails diff, out of scope here.
- **Callback-scoped mutation counting** — buried the signal under faithful tests that
  mutate at the top level of the body, and under Ruby bang methods that mutate by the
  call rather than by an assignment.

Negated promises ("does not raise", "does not mutate the options") are excluded
outright: Rails' own body there is an `assert_nothing_raised` or a no-op block, so an
assertion-free body is the faithful port. The negation list is spelled out explicitly
rather than matched as `\w+n't`, because the apostrophe-less spellings we use collide
with ordinary words ending in "nt" — `instrument` among them.

## Verification

The gate is proven end-to-end against the pre-#4892 tree, not just asserted:

- Restore `packages/activesupport/src/notifications.test.ts` to `9184a7014^` and
  `pnpm test:hollow` exits **1**, naming both hollow bodies.
- On the current tree it exits **0** with `Hollow-body sweep: 0 findings across 27828 tests`.

At the unit level:

`hollow-bodies.test.ts` (12 tests) pins both polarities of the #4892 bodies — the hollow
one flagged `no-mutation`, its rewritten replacement clean — plus the
`instrument`-is-not-a-negation guard and the false-positive shapes each removed rule
produced (bang methods, no-op blocks handed to test doubles, negated promises).

No hollow bodies remained to fix — the sweep is clean, so the "fix the worst offenders"
criterion has nothing to burn down.

Closes-story: audit-hollow-name-matched-test-bodies
