### PR TITLE
test(ci): drop the PG/MySQL vitest retry now that shared-DB flakes are closed

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -376,13 +376,22 @@ export default defineConfig({
               ? ["./packages/activerecord/src/test-setup-ddl-profile.ts"]
               : []),
           ],
-          // No retries on any backend. PG/MySQL used to run `retry: 2` to mask
-          // shared-per-worker-DB intermittents; both sources are now closed —
-          // canonical-table shape drift is repaired systemically by
-          // repairWorkerSchema, and leaked bespoke tables are gone by
-          // construction (the `require-table-teardown` raw-SQL exclude list is
-          // empty). A red PG/MySQL run is therefore a real regression or a real
-          // flake to track, not something to paper over.
+          // No retries, on any backend. PG/MySQL used to run `retry: 2` to mask
+          // intermittents from the shared per-worker DB. Both sources of those
+          // are now closed: canonical-table shape drift is repaired
+          // systemically by repairWorkerSchema, and bespoke tables — which
+          // repairWorkerSchema does NOT cover — are gone, the RFC 0019
+          // canonical burndown having taken require-canonical-schema-exclude
+          // from 70 files to 0 (the rule was then retired in #4540) with
+          // require-table-teardown standing guard on what remains.
+          //
+          // Removal was attempted once before, in #4136, and reverted: at that
+          // point the burndown was still mid-flight at 70 files and bespoke
+          // tables promptly drifted. Do not restore the retry without first
+          // establishing that a genuinely new flake class exists — the point of
+          // running at 0 is that describeIfPg/describeIfMysql backend-only
+          // failures, which SQLite never exercises, now surface as red instead
+          // of being silently absorbed.
           retry: 0,
           // Large-schema beforeAll(defineSchema(...)) calls on MySQL issue
           // hundreds of CREATE TABLE statements (e.g. has-many-associations.test.ts

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -376,23 +376,14 @@ export default defineConfig({
               ? ["./packages/activerecord/src/test-setup-ddl-profile.ts"]
               : []),
           ],
-          // Real-DB tests share a per-worker DB; the module-level state in
-          // test-adapter.ts has known race windows (see PR #1114 for prior
-          // _createdTables drift recovery). Retry intermittents on PG/MySQL
-          // only.
-          //
-          // Tradeoff: this is broader than the known shared-DB flakes — it
-          // also covers describeIfPg/describeIfMysql backend-only tests that
-          // SQLite never exercises, so a flaky-but-real regression in
-          // backend-only code could slip through after a retry. We accept
-          // this because (a) retries only mask non-deterministic failures —
-          // a 100% regression still fails through all attempts, (b) the
-          // observed flake pattern spans 10+ files across the project,
-          // making per-file scoping brittle, and (c) the alternative —
-          // letting CI fail on every transient race — burns more reviewer
-          // time than the rare hidden flake costs. Revisit if a real
-          // regression slips through.
-          retry: process.env.ARCONN === "postgresql" || process.env.ARCONN === "mysql2" ? 2 : 0,
+          // No retries on any backend. PG/MySQL used to run `retry: 2` to mask
+          // shared-per-worker-DB intermittents; both sources are now closed —
+          // canonical-table shape drift is repaired systemically by
+          // repairWorkerSchema, and leaked bespoke tables are gone by
+          // construction (the `require-table-teardown` raw-SQL exclude list is
+          // empty). A red PG/MySQL run is therefore a real regression or a real
+          // flake to track, not something to paper over.
+          retry: 0,
           // Large-schema beforeAll(defineSchema(...)) calls on MySQL issue
           // hundreds of CREATE TABLE statements (e.g. has-many-associations.test.ts
           // creates ~354 tables in one beforeAll). At ~30ms per CREATE on MySQL


### PR DESCRIPTION
## What

Drop the PG/MySQL-only `retry: 2` in the `activerecord` vitest project to `retry: 0`, and replace the now-stale 16-line tradeoff comment with a short note. All lanes now run without retries.

## Why the gate is met now

This was attempted once before in #4136 and **closed as premature** — removing the retry re-exposed shape drift on *bespoke* tables (`defaults` schema-dump drift on MariaDB, `hot_compatibilities` cached-plan invalidation on PG), which `repairWorkerSchema` does not cover since it repairs canonical tables only. The precondition set at that time was the RFC 0019 canonical-schema burndown reaching zero, `require-canonical-schema-exclude.json` then standing at 70.

That precondition is now satisfied:

1. **Canonical burndown complete.** `require-canonical-schema-exclude.json` went 70 → 0 through real per-file conversions over 2026-06-26 … 2026-07-02 — including `defaults.test.ts` (the exact MariaDB flake cited when #4136 was closed) in "converge defaults.test.ts onto canonical schema". The rule and its empty baseline were then retired in #4540.
2. **Bespoke-leak class closed by construction.** `eslint/require-table-teardown-raw-sql-exclude.json` is `[]`. The remaining six inline disables are each justified in place (stub-mode `execute` interception, per-test tmp SQLite DB, etc.).
3. **Shape drift covered systemically** by `repairWorkerSchema`.
4. **7 consecutive green `main` runs** across both PostgreSQL shards and both MariaDB shards (the MySQL-family stand-in lane; `mysql-tests` itself is parked behind `false &&`).

## Risk / what to watch

`hot_compatibilities` is still a bespoke table (`hot-compatibility.test.ts`), matching Rails' `HotCompatibilityTest`. It drops itself in `afterEach`, so it is not a *leak*, but the PG cached-plan-invalidation intermittent seen in #4136 originated there. This PR's own PG and MariaDB runs are the evidence for whether it still bites; if it does, that is a real flake to track and fix, which is the point of removing the mask.

## Test plan

- PG and MariaDB CI on this PR run without retries.
- Re-run those lanes a few times before undrafting to confirm stability.

Closes-story: remove-pg-mysql-test-retry-after-flake-burndown
