### PR TITLE
fix(postgresql): scope the OID type registrations to the postgres adapter

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
@@ -19,10 +19,6 @@ import {
 import * as ArType from "../../type.js";
 
 import { Date as OidDate } from "./oid/date.js";
-import { DateTime as OidDateTime } from "./oid/date-time.js";
-import { Enum } from "./oid/enum.js";
-import { LegacyPoint } from "./oid/legacy-point.js";
-import { Vector } from "./oid/vector.js";
 import { DecimalWithoutScale } from "../../type/decimal-without-scale.js";
 import { HashLookupTypeMap } from "../../type/hash-lookup-type-map.js";
 import { Json as ArJson } from "../../type/json.js";
@@ -31,11 +27,14 @@ import { Bit } from "./oid/bit.js";
 import { BitVarying } from "./oid/bit-varying.js";
 import { Bytea } from "./oid/bytea.js";
 import { Cidr } from "./oid/cidr.js";
+import { DateTime as OidDateTime } from "./oid/date-time.js";
 import { Decimal } from "./oid/decimal.js";
+import { Enum } from "./oid/enum.js";
 import { Hstore } from "./oid/hstore.js";
 import { Inet } from "./oid/inet.js";
 import { Interval } from "./oid/interval.js";
 import { Jsonb } from "./oid/jsonb.js";
+import { LegacyPoint } from "./oid/legacy-point.js";
 import { Macaddr } from "./oid/macaddr.js";
 import { Money } from "./oid/money.js";
 import { Oid } from "./oid/oid.js";
@@ -44,10 +43,11 @@ import { SpecializedString } from "./oid/specialized-string.js";
 import { Timestamp } from "./oid/timestamp.js";
 import { TimestampWithTimeZone } from "./oid/timestamp-with-time-zone.js";
 import { Uuid } from "./oid/uuid.js";
+import { Vector } from "./oid/vector.js";
 import { Xml } from "./oid/xml.js";
 
-// Mirrors: postgresql_adapter.rb:1168-1185. The `add_modifier` lines above
-// them (array/range) have no counterpart yet — trails has no registry
+// Mirrors: postgresql_adapter.rb:1168-1185. The two `add_modifier` lines that
+// open that block (array/range) are unported: trails has no registry
 // modifiers, and `attribute(..., array: true)` does not route through them.
 ArType.register("bit", Bit, { adapter: "postgres" });
 ArType.register("bit_varying", BitVarying, { adapter: "postgres" });

--- a/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
@@ -19,6 +19,10 @@ import {
 import * as ArType from "../../type.js";
 
 import { Date as OidDate } from "./oid/date.js";
+import { DateTime as OidDateTime } from "./oid/date-time.js";
+import { Enum } from "./oid/enum.js";
+import { LegacyPoint } from "./oid/legacy-point.js";
+import { Vector } from "./oid/vector.js";
 import { DecimalWithoutScale } from "../../type/decimal-without-scale.js";
 import { HashLookupTypeMap } from "../../type/hash-lookup-type-map.js";
 import { Json as ArJson } from "../../type/json.js";
@@ -42,21 +46,27 @@ import { TimestampWithTimeZone } from "./oid/timestamp-with-time-zone.js";
 import { Uuid } from "./oid/uuid.js";
 import { Xml } from "./oid/xml.js";
 
-// Mirrors: postgresql_adapter.rb:1168-1185. Deviation: registered for all
-// adapters, not `adapter: :postgresql` — PG-only tests declare these on models
-// whose connectionDbConfig() raises, so adapterNameFrom degrades to "sqlite"
-// and a scoped registration would read as Unknown type. Tracked separately.
-ArType.register("bit", Bit, { override: false });
-ArType.register("bit_varying", BitVarying, { override: false });
-ArType.register("cidr", Cidr, { override: false });
-ArType.register("hstore", Hstore, { override: false });
-ArType.register("inet", Inet, { override: false });
-ArType.register("interval", Interval, { override: false });
-ArType.register("jsonb", Jsonb, { override: false });
-ArType.register("money", Money, { override: false });
-ArType.register("point", Point, { override: false });
-ArType.register("uuid", Uuid, { override: false });
-ArType.register("xml", Xml, { override: false });
+// Mirrors: postgresql_adapter.rb:1168-1185. The `add_modifier` lines above
+// them (array/range) have no counterpart yet — trails has no registry
+// modifiers, and `attribute(..., array: true)` does not route through them.
+ArType.register("bit", Bit, { adapter: "postgres" });
+ArType.register("bit_varying", BitVarying, { adapter: "postgres" });
+ArType.register("binary", Bytea, { adapter: "postgres" });
+ArType.register("cidr", Cidr, { adapter: "postgres" });
+ArType.register("date", OidDate, { adapter: "postgres" });
+ArType.register("datetime", OidDateTime, { adapter: "postgres" });
+ArType.register("decimal", Decimal, { adapter: "postgres" });
+ArType.register("enum", Enum, { adapter: "postgres" });
+ArType.register("hstore", Hstore, { adapter: "postgres" });
+ArType.register("inet", Inet, { adapter: "postgres" });
+ArType.register("interval", Interval, { adapter: "postgres" });
+ArType.register("jsonb", Jsonb, { adapter: "postgres" });
+ArType.register("money", Money, { adapter: "postgres" });
+ArType.register("point", Point, { adapter: "postgres" });
+ArType.register("legacy_point", LegacyPoint, { adapter: "postgres" });
+ArType.register("uuid", Uuid, { adapter: "postgres" });
+ArType.register("vector", Vector, { adapter: "postgres" });
+ArType.register("xml", Xml, { adapter: "postgres" });
 
 /**
  * Mirrors: PostgreSQLAdapter.extract_limit — `$1.to_i if sql_type =~ /\((.*)\)/`.

--- a/packages/activerecord/src/type.trails.test.ts
+++ b/packages/activerecord/src/type.trails.test.ts
@@ -13,7 +13,10 @@ import { ConnectionNotDefined } from "./errors.js";
 import { Type, StringType } from "@blazetrails/activemodel";
 import "./connection-adapters/mysql2-adapter.js";
 import "./connection-adapters/postgresql/type-map-init.js";
+import { Bytea } from "./connection-adapters/postgresql/oid/bytea.js";
 import { Date as OidDate } from "./connection-adapters/postgresql/oid/date.js";
+import { DateTime as OidDateTime } from "./connection-adapters/postgresql/oid/date-time.js";
+import { Decimal as OidDecimal } from "./connection-adapters/postgresql/oid/decimal.js";
 import { Interval } from "./connection-adapters/postgresql/oid/interval.js";
 import { Money } from "./connection-adapters/postgresql/oid/money.js";
 import { Uuid } from "./connection-adapters/postgresql/oid/uuid.js";
@@ -135,6 +138,38 @@ describe("the PostgreSQL OID registrations", () => {
   it("shadow the generic registrations of the same name under postgres", () => {
     expect(lookup("date", { adapter: "postgres" })).toBeInstanceOf(OidDate);
     expect(lookup("date", { adapter: "sqlite" })).not.toBeInstanceOf(OidDate);
+
+    expect(lookup("binary", { adapter: "postgres" })).toBeInstanceOf(Bytea);
+    expect(lookup("binary", { adapter: "sqlite" })).not.toBeInstanceOf(Bytea);
+
+    expect(lookup("datetime", { adapter: "postgres" })).toBeInstanceOf(OidDateTime);
+    expect(lookup("decimal", { adapter: "postgres" })).toBeInstanceOf(OidDecimal);
+  });
+
+  it("cover every type Rails registers for the postgresql adapter", () => {
+    // postgresql_adapter.rb:1168-1185, minus the two add_modifier lines.
+    for (const name of [
+      "bit",
+      "bit_varying",
+      "binary",
+      "cidr",
+      "date",
+      "datetime",
+      "decimal",
+      "enum",
+      "hstore",
+      "inet",
+      "interval",
+      "jsonb",
+      "money",
+      "point",
+      "legacy_point",
+      "uuid",
+      "vector",
+      "xml",
+    ]) {
+      expect(() => lookup(name, { adapter: "postgres" })).not.toThrow();
+    }
   });
 
   it("resolve for a model carrying a directly-assigned postgres adapter", () => {

--- a/packages/activerecord/src/type.trails.test.ts
+++ b/packages/activerecord/src/type.trails.test.ts
@@ -12,6 +12,11 @@ import { Base } from "./base.js";
 import { ConnectionNotDefined } from "./errors.js";
 import { Type, StringType } from "@blazetrails/activemodel";
 import "./connection-adapters/mysql2-adapter.js";
+import "./connection-adapters/postgresql/type-map-init.js";
+import { Date as OidDate } from "./connection-adapters/postgresql/oid/date.js";
+import { Interval } from "./connection-adapters/postgresql/oid/interval.js";
+import { Money } from "./connection-adapters/postgresql/oid/money.js";
+import { Uuid } from "./connection-adapters/postgresql/oid/uuid.js";
 
 class GenericType extends Type<unknown> {
   readonly name: string = "generic";
@@ -114,6 +119,33 @@ describe("Type.lookup under a non-sqlite configuration", () => {
     stubAdapter("sqlite3");
     expect(lookup("foo")).toBeInstanceOf(GenericType);
     expect(lookup("foo")).not.toBeInstanceOf(AdapterType);
+  });
+});
+
+describe("the PostgreSQL OID registrations", () => {
+  it("resolve only under a postgres adapter", () => {
+    expect(lookup("money", { adapter: "postgres" })).toBeInstanceOf(Money);
+    expect(lookup("interval", { adapter: "postgres" })).toBeInstanceOf(Interval);
+    expect(lookup("uuid", { adapter: "postgres" })).toBeInstanceOf(Uuid);
+
+    expect(() => lookup("money", { adapter: "sqlite" })).toThrow("Unknown type :money");
+    expect(() => lookup("interval", { adapter: "mysql" })).toThrow("Unknown type :interval");
+  });
+
+  it("shadow the generic registrations of the same name under postgres", () => {
+    expect(lookup("date", { adapter: "postgres" })).toBeInstanceOf(OidDate);
+    expect(lookup("date", { adapter: "sqlite" })).not.toBeInstanceOf(OidDate);
+  });
+
+  it("resolve for a model carrying a directly-assigned postgres adapter", () => {
+    const model = {
+      _adapter: { adapterName: "postgres" },
+      connectionDbConfig: () => {
+        throw new ConnectionNotDefined("No database connection defined.");
+      },
+    };
+    expect(adapterNameFrom(model)).toBe("postgres");
+    expect(lookup("interval", { adapter: adapterNameFrom(model) })).toBeInstanceOf(Interval);
   });
 });
 

--- a/packages/activerecord/src/type.ts
+++ b/packages/activerecord/src/type.ts
@@ -63,10 +63,9 @@ let _currentAdapterResolver: (() => AdapterNameSource) | undefined;
 export interface AdapterNameSource {
   connectionDbConfig: () => { adapter?: string } | undefined;
   // trails-only: a model may carry a directly-assigned adapter instead of an
-  // established connection (`Base._adapter`, base.ts). Rails has no analogue —
-  // every model resolves through a pool — so this field has no counterpart in
-  // `adapter_name_from`; it is read first because a per-model adapter overrides
-  // whatever pool the class would otherwise inherit from Base.
+  // established connection (`Base._adapter`). Rails has no analogue — every
+  // model resolves through a pool — so `adapter_name_from` has nothing to read
+  // it from.
   _adapter?: { adapterName?: string } | null;
 }
 
@@ -135,11 +134,13 @@ export function defaultValue(): Type {
  * Mirrors: ActiveRecord::Type.adapter_name_from
  */
 export function adapterNameFrom(model: AdapterNameSource): AdapterName {
-  let configAdapter: string | undefined;
-  // See AdapterNameSource: a directly-assigned adapter is the model's
-  // connection, and no pool (hence no db_config) exists for it.
+  // A directly-assigned adapter (see AdapterNameSource) IS the model's
+  // connection and has no pool, so it both outranks the pool the class would
+  // otherwise inherit from Base and is the only place its name can be read.
   const directAdapterName = model._adapter?.adapterName;
   if (directAdapterName) return adapterNameFromConfig(directAdapterName);
+
+  let configAdapter: string | undefined;
   try {
     configAdapter = model.connectionDbConfig()?.adapter;
   } catch (error) {

--- a/packages/activerecord/src/type.ts
+++ b/packages/activerecord/src/type.ts
@@ -62,6 +62,12 @@ let _currentAdapterResolver: (() => AdapterNameSource) | undefined;
 
 export interface AdapterNameSource {
   connectionDbConfig: () => { adapter?: string } | undefined;
+  // trails-only: a model may carry a directly-assigned adapter instead of an
+  // established connection (`Base._adapter`, base.ts). Rails has no analogue —
+  // every model resolves through a pool — so this field has no counterpart in
+  // `adapter_name_from`; it is read first because a per-model adapter overrides
+  // whatever pool the class would otherwise inherit from Base.
+  _adapter?: { adapterName?: string } | null;
 }
 
 _registry.register("big_integer", BigIntegerType, { override: false });
@@ -130,6 +136,10 @@ export function defaultValue(): Type {
  */
 export function adapterNameFrom(model: AdapterNameSource): AdapterName {
   let configAdapter: string | undefined;
+  // See AdapterNameSource: a directly-assigned adapter is the model's
+  // connection, and no pool (hence no db_config) exists for it.
+  const directAdapterName = model._adapter?.adapterName;
+  if (directAdapterName) return adapterNameFromConfig(directAdapterName);
   try {
     configAdapter = model.connectionDbConfig()?.adapter;
   } catch (error) {


### PR DESCRIPTION
Rails registers the PostgreSQL OID types adapter-scoped
(`postgresql_adapter.rb:1168-1185`, e.g.
`ActiveRecord::Type.register(:money, OID::Money, adapter: :postgresql)`), so
`attribute :col, :money` resolves only on a PostgreSQL model. #5196 moved these
into AR's `AdapterSpecificRegistry` but deliberately registered them **unscoped**,
because models in the PG adapter tests (e.g. `adapters/postgresql/datatype.test.ts`)
carry a directly-assigned `_adapter` rather than an established connection: there
`connectionDbConfig()` raises `ConnectionNotEstablished`, `adapterNameFrom`
degraded to `"sqlite"`, and a scoped registration would have turned
`attribute("scaled_time_interval", "interval")` into `Unknown type :interval`.

This PR closes that deviation:

- `Type.adapterNameFrom` reads a directly-assigned adapter's `adapterName`
  first. A per-model `_adapter` *is* that model's connection and has no pool
  (hence no `db_config`), so it both outranks the pool the class would otherwise
  inherit from Base and is the only place its name can be read. It is a
  trails-only field — Rails models always resolve through a pool.
- The registrations in `connection-adapters/postgresql/type-map-init.ts` now
  carry `{ adapter: "postgres" }` and the deviation comment is gone.
- Added the entries Rails registers and trails lacked: `binary` (OID::Bytea),
  `date`, `datetime`, `decimal`, `enum`, `legacy_point` and `vector` — all seven
  classes already existed under `postgresql/oid/`. The only unported lines from
  that Rails block are the two `add_modifier` calls (array/range): trails has no
  registry modifiers and `attribute(..., array: true)` does not route through
  them; noted at the call site rather than stubbed.

Coverage in `type.trails.test.ts`: `money`/`interval`/`uuid` resolve under
`adapter: "postgres"` and raise `Unknown type` under sqlite/mysql; PG's
`date`/`binary`/`datetime`/`decimal` shadow the generic registrations only under
postgres; every one of the eighteen names Rails registers resolves under
postgres; and a model carrying a directly-assigned postgres adapter resolves as
postgres. These fail on baseline.

Verified locally against PG 17: `adapters/postgresql/{datatype,uuid,hstore,money,
interval,network,range,bit-string,array,json,xml,composite-types,enum}.test.ts`,
plus `attributes.test.ts`, `types.test.ts`, `type.test.ts`, `type.trails.test.ts`
and `attribute-methods/time-zone-conversion.test.ts` under both `ARCONN=postgresql`
and the default sqlite lane. (Running several PG files in one invocation trips the
known shared-database residue flakes — `1_need_quoting already exists` — each file
is green on its own.)

Closes-story: ar-pg-oid-type-registrations-not-adapter-scoped
