### PR TITLE
fix(predicate-builder): bind single-col composite IN values through the column type

### DIFF
--- a/packages/activerecord/src/relation/composite-where.test.ts
+++ b/packages/activerecord/src/relation/composite-where.test.ts
@@ -162,18 +162,13 @@ describe("Relation#where — composite-key form", () => {
 
   it("single-column composite values flow through the column type as binds, not inlined literals", () => {
     // Regression: the single-column branch used `attribute.in(rawValues)`,
-    // whose values become Arel::Nodes::Casted and are inlined untyped —
-    // so a string "2" for an integer column stayed a string, and the SQL
-    // carried literals instead of bind placeholders (breaking
-    // compileWithBinds / prepared-statement caching). Rails routes the
-    // same shape through ArrayHandler → HomogeneousIn, which casts each
-    // value through the resolved column's type and emits real binds.
+    // which inlines untyped `Casted` literals — so a string "2" for an
+    // integer column stayed a string and never became a bind (breaking
+    // compileWithBinds / prepared-statement caching).
     const rel = (Post as any).all();
     const node: any = rel.predicateBuilder.buildComposite(["comments.post_id"], [["1"], ["2"]]);
     expect(node.constructor.name).toBe("HomogeneousIn");
     expect(node.castedValues).toEqual([1, 2]);
-    // Binds render as placeholders before substitution; the substituted
-    // form carries the cast integers, not the raw quoted strings.
     const sql = (Post as any).all().where(node).toSql();
     expect(sql).toMatch(/IN \(1,\s*2\)/);
   });
@@ -194,8 +189,8 @@ describe("Relation#where — composite-key form", () => {
   it("single-column composite uses IN(...) (not OR-chain) for compactness", () => {
     const rel = (CpkBook as any).all();
     const node = rel.predicateBuilder.buildComposite(["author_id"], [[1], [2], [3]]);
-    // The HomogeneousIn node renders as `author_id IN (1, 2, 3)` (bind
-    // placeholders, substituted by `toSql`); an OR-chain would render as
+    // The HomogeneousIn node renders as `author_id IN (?, ?, ?)`, which
+    // `toSql` substitutes to `IN (1, 2, 3)`; an OR-chain would render as
     // `author_id = 1 OR author_id = 2 OR author_id = 3`.
     expect(node.constructor.name).toBe("HomogeneousIn");
     const sql = (CpkBook as any).all().where(node).toSql();

--- a/packages/activerecord/src/relation/composite-where.test.ts
+++ b/packages/activerecord/src/relation/composite-where.test.ts
@@ -160,6 +160,24 @@ describe("Relation#where — composite-key form", () => {
     expect(node.left.name).toBe("post_id");
   });
 
+  it("single-column composite values flow through the column type as binds, not inlined literals", () => {
+    // Regression: the single-column branch used `attribute.in(rawValues)`,
+    // whose values become Arel::Nodes::Casted and are inlined untyped —
+    // so a string "2" for an integer column stayed a string, and the SQL
+    // carried literals instead of bind placeholders (breaking
+    // compileWithBinds / prepared-statement caching). Rails routes the
+    // same shape through ArrayHandler → HomogeneousIn, which casts each
+    // value through the resolved column's type and emits real binds.
+    const rel = (Post as any).all();
+    const node: any = rel.predicateBuilder.buildComposite(["comments.post_id"], [["1"], ["2"]]);
+    expect(node.constructor.name).toBe("HomogeneousIn");
+    expect(node.castedValues).toEqual([1, 2]);
+    // Binds render as placeholders before substitution; the substituted
+    // form carries the cast integers, not the raw quoted strings.
+    const sql = (Post as any).all().where(node).toSql();
+    expect(sql).toMatch(/IN \(1,\s*2\)/);
+  });
+
   it("qualified composite cols match rows through a join", async () => {
     const post: any = await (Post as any).create({ title: "joined", body: "b", author_id: 1 });
     const other: any = await (Post as any).create({ title: "unjoined", body: "b", author_id: 1 });
@@ -176,8 +194,10 @@ describe("Relation#where — composite-key form", () => {
   it("single-column composite uses IN(...) (not OR-chain) for compactness", () => {
     const rel = (CpkBook as any).all();
     const node = rel.predicateBuilder.buildComposite(["author_id"], [[1], [2], [3]]);
-    // The Arel In node renders as `author_id IN (1, 2, 3)`; OR-chain
-    // would render as `author_id = 1 OR author_id = 2 OR author_id = 3`.
+    // The HomogeneousIn node renders as `author_id IN (1, 2, 3)` (bind
+    // placeholders, substituted by `toSql`); an OR-chain would render as
+    // `author_id = 1 OR author_id = 2 OR author_id = 3`.
+    expect(node.constructor.name).toBe("HomogeneousIn");
     const sql = (CpkBook as any).all().where(node).toSql();
     expect(sql).toMatch(/IN \(1,\s*2,\s*3\)/);
     expect(sql).not.toMatch(/OR/);

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -449,15 +449,11 @@ export class PredicateBuilder {
     });
     // Single-column degenerate case: a single `IN (...)` predicate is
     // more compact than `c=v1 OR c=v2 OR ...` and typically optimizes
-    // identically (or better) on indexed columns. Route the value list
-    // through `build` (→ ArrayHandler, array_handler.rb:13) rather than
-    // `attribute.in(values)`: ArrayHandler builds `HomogeneousIn` (real
-    // binds, cast through the column's type) for multiple values and a
-    // bind Equality for one, whereas a bare `in` wraps the raw values in
-    // `Nodes::Casted` and inlines them untyped — the same problem the
-    // multi-column branch below avoids. Resolve through the *column's*
-    // builder so a qualified col (`comments.post_id`) casts against the
-    // joined table's type, not the base table's.
+    // identically (or better) on indexed columns. Routing the values
+    // through the resolved column's `build` (→ ArrayHandler,
+    // array_handler.rb:13) is what makes them binds cast by that column's
+    // type; a bare `attribute.in(values)` wraps them in `Nodes::Casted`
+    // and inlines them untyped.
     if (cols.length === 1) {
       const { attribute, builder } = resolved[0];
       return builder.build(

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -449,10 +449,21 @@ export class PredicateBuilder {
     });
     // Single-column degenerate case: a single `IN (...)` predicate is
     // more compact than `c=v1 OR c=v2 OR ...` and typically optimizes
-    // identically (or better) on indexed columns.
+    // identically (or better) on indexed columns. Route the value list
+    // through `build` (→ ArrayHandler, array_handler.rb:13) rather than
+    // `attribute.in(values)`: ArrayHandler builds `HomogeneousIn` (real
+    // binds, cast through the column's type) for multiple values and a
+    // bind Equality for one, whereas a bare `in` wraps the raw values in
+    // `Nodes::Casted` and inlines them untyped — the same problem the
+    // multi-column branch below avoids. Resolve through the *column's*
+    // builder so a qualified col (`comments.post_id`) casts against the
+    // joined table's type, not the base table's.
     if (cols.length === 1) {
-      const values = validTuples.map((t) => t[0]);
-      return resolved[0].attribute.in(values);
+      const { attribute, builder } = resolved[0];
+      return builder.build(
+        attribute,
+        validTuples.map((t) => t[0]),
+      );
     }
     // Build equalities through `buildBindAttribute` so each value
     // becomes a `QueryAttribute` (= bind param) rather than an


### PR DESCRIPTION
`PredicateBuilder#buildComposite`'s single-column degenerate branch emitted
`attribute.in(rawValues)`, so the tuple values were wrapped as
`Nodes::Casted` and inlined into SQL untyped — never becoming binds and
never passing through the column's type. The multi-column branch in the
same method does the opposite (`buildBindAttribute` → `QueryAttribute` →
`BindParam`), so the arity of the column list silently decided whether
values were bound and cast. After #5186 a qualified single col
(`where(["comments.post_id"], [[1]])`) resolved its attribute on the joined
table but still inlined its values untyped.

Rails has no such split: `where(key => array)` routes through
`ArrayHandler` (`relation/predicate_builder/array_handler.rb`), which builds
the `IN` list as `Arel::Nodes::HomogeneousIn` — real binds, cast through the
attribute's type caster.

This routes the single-column branch through the *resolved column's*
`predicateBuilder.build(attribute, values)`, i.e. ArrayHandler, so it gets
the same treatment: `HomogeneousIn` for multiple values, a bind `Equality`
for one, and casting against the joined table's type for qualified cols.

Regression test asserts a single-col composite over an integer column with
string values produces `HomogeneousIn` with `castedValues === [1, 2]`; it
fails on baseline (`In`, values left as strings). The existing
"single-column composite uses IN(...) (not OR-chain) for compactness" test
is updated for the bind form without being renamed.

Closes-story: buildcomposite-single-col-in-path-inlines-untyped-values
