### PR TITLE
fix(calculations): apply the having clause on every ungrouped count manager

### DIFF
--- a/packages/activerecord/src/calculations.trails.test.ts
+++ b/packages/activerecord/src/calculations.trails.test.ts
@@ -293,16 +293,17 @@ describe("ungrouped calculation HAVING", () => {
   it("emits HAVING with no GROUP BY on the count paths", async () => {
     const { Account } = await import("./test-helpers/models/account.js");
     const total = (await Account.count()) as number;
+    const credited = (await Account.where("credit_limit IS NOT NULL").count()) as number;
     expect(total).toBeGreaterThan(1);
-    // Plain COUNT(*), COUNT(DISTINCT pk) and the limited count-subquery path all
-    // build their own managers; each has to carry the having clause.
+    expect(credited).toBeGreaterThan(1);
+
     expect(await Account.having("count(*) > 1").count()).toBe(total);
     expect(await Account.having("count(*) > 100000").count()).toBe(0);
+
+    expect(await Account.having("count(*) > 1").count("credit_limit")).toBe(credited);
+    expect(await Account.having("count(*) > 100000").count("credit_limit")).toBe(0);
+
     expect(await Account.distinct().having("count(*) > 1").count()).toBe(total);
     expect(await Account.distinct().having("count(*) > 100000").count()).toBe(0);
-    // The limited count-subquery path also carries the clause (Rails puts it in
-    // the inner query, per `build_count_subquery`), but it can't be asserted
-    // here: that inner query projects `1 AS one`, and SQLite rejects a HAVING
-    // clause on a non-aggregate query outright.
   });
 });

--- a/packages/activerecord/src/calculations.trails.test.ts
+++ b/packages/activerecord/src/calculations.trails.test.ts
@@ -289,4 +289,20 @@ describe("ungrouped calculation HAVING", () => {
     expect(await Account.having("sum(credit_limit) > 100").sum("credit_limit")).toBe(total);
     expect(await Account.having("sum(credit_limit) > 100000").sum("credit_limit")).toBe(0);
   });
+
+  it("emits HAVING with no GROUP BY on the count paths", async () => {
+    const { Account } = await import("./test-helpers/models/account.js");
+    const total = (await Account.count()) as number;
+    expect(total).toBeGreaterThan(1);
+    // Plain COUNT(*), COUNT(DISTINCT pk) and the limited count-subquery path all
+    // build their own managers; each has to carry the having clause.
+    expect(await Account.having("count(*) > 1").count()).toBe(total);
+    expect(await Account.having("count(*) > 100000").count()).toBe(0);
+    expect(await Account.distinct().having("count(*) > 1").count()).toBe(total);
+    expect(await Account.distinct().having("count(*) > 100000").count()).toBe(0);
+    // The limited count-subquery path also carries the clause (Rails puts it in
+    // the inner query, per `build_count_subquery`), but it can't be asserted
+    // here: that inner query projects `1 AS one`, and SQLite rejects a HAVING
+    // clause on a non-aggregate query outright.
+  });
 });

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -472,9 +472,9 @@ async function singleAggregate(
 }
 
 /**
- * Every calculation arm (including all of `perform_count`'s managers) runs
- * `select_all` on the relation's own arel, and
- * `build_arel` emits `arel.having(having_clause.ast) unless having_clause.empty?`
+ * Every calculation arm — including each of `performCount`'s managers — runs
+ * `select_all` on the relation's own arel, and `build_arel` emits
+ * `arel.having(having_clause.ast) unless having_clause.empty?`
  * unconditionally — with or without a GROUP BY (query_methods.rb:1756). Our arms
  * project explicitly instead of reusing `build_arel`, so the having clause has to
  * be re-applied by hand.

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -472,7 +472,8 @@ async function singleAggregate(
 }
 
 /**
- * Both calculation arms run `select_all` on the relation's own arel, and
+ * Every calculation arm (including all of `perform_count`'s managers) runs
+ * `select_all` on the relation's own arel, and
  * `build_arel` emits `arel.having(having_clause.ast) unless having_clause.empty?`
  * unconditionally — with or without a GROUP BY (query_methods.rb:1756). Our arms
  * project explicitly instead of reusing `build_arel`, so the having clause has to
@@ -868,6 +869,7 @@ export async function performCount(
             Array.isArray(distinctSelect) ? distinctSelect : [distinctSelect]
           ).map((s) => new Nodes.SqlLiteral(s));
           applyFromToManager(this, idSubquery);
+          applyHavingToManager(this, idSubquery);
           if (this._limitValue !== null) idSubquery.take(this._limitValue);
           if (this._offsetValue !== null) idSubquery.skip(this._offsetValue);
           const [idSql, idBinds] = compileManagerWithBinds(this, idSubquery);
@@ -893,6 +895,7 @@ export async function performCount(
           // constraining the count, not just the id set.
           this._applyWheresToManager(countManager, table);
           applyFromToManager(this, countManager);
+          applyHavingToManager(this, countManager);
           countManager.where(table.get(pk).in(limitedIds));
           const [countSql, countBinds] = compileManagerWithBinds(this, countManager);
           const [withCtes, ctedBinds] = prependCtes(this, countSql, [...countBinds]);
@@ -913,6 +916,7 @@ export async function performCount(
         this._applyJoinsToManager(manager, makeEagerJd());
         this._applyWheresToManager(manager, table);
         applyFromToManager(this, manager);
+        applyHavingToManager(this, manager);
         const [rawSql, managerBinds] = compileManagerWithBinds(this, manager);
         const [withCtes, ctedBinds] = prependCtes(this, rawSql, managerBinds);
         const result = await this._conn().selectAll(
@@ -968,6 +972,7 @@ export async function performCount(
               Array.isArray(distinctSelect) ? distinctSelect : [distinctSelect]
             ).map((s) => new Nodes.SqlLiteral(s));
             applyFromToManager(this, idSubquery);
+            applyHavingToManager(this, idSubquery);
             if (this._limitValue !== null) idSubquery.take(this._limitValue);
             if (this._offsetValue !== null) idSubquery.skip(this._offsetValue);
             const [idSql, idBinds] = compileManagerWithBinds(this, idSubquery);
@@ -987,6 +992,7 @@ export async function performCount(
             this._applyJoinsToManager(countManager, makeEagerJd());
             this._applyWheresToManager(countManager, table);
             applyFromToManager(this, countManager);
+            applyHavingToManager(this, countManager);
             // Rails `distinct_relation_for_primary_key` restricts via
             // `where!(pk.zip(limited_ids.transpose).to_h)` — a per-column `IN`
             // (`author_id IN (...) AND id IN (...)`), not a tuple `IN`.
@@ -1008,6 +1014,7 @@ export async function performCount(
           this._applyJoinsToManager(manager, makeEagerJd());
           this._applyWheresToManager(manager, table);
           applyFromToManager(this, manager);
+          applyHavingToManager(this, manager);
           const [rawSql, managerBinds] = compileManagerWithBinds(this, manager);
           const [withCtes, ctedBinds] = prependCtes(this, rawSql, managerBinds);
           const result = await this._conn().selectAll(
@@ -1022,6 +1029,7 @@ export async function performCount(
         this._applyJoinsToManager(innerManager, makeEagerJd());
         this._applyWheresToManager(innerManager, table);
         applyFromToManager(this, innerManager);
+        applyHavingToManager(this, innerManager);
         if (this._limitValue !== null) innerManager.take(this._limitValue);
         if (this._offsetValue !== null) innerManager.skip(this._offsetValue);
         const [innerSql, allInnerBinds] = compileManagerWithBinds(this, innerManager);
@@ -1122,6 +1130,7 @@ export async function performCount(
     this._applyJoinsToManager(innerManager);
     this._applyWheresToManager(innerManager, innerTable);
     applyFromToManager(this, innerManager);
+    applyHavingToManager(this, innerManager);
     if (this._limitValue !== null) innerManager.take(this._limitValue);
     if (this._offsetValue !== null) innerManager.skip(this._offsetValue);
     // Wrap inner query as Arel AST: Grouping (parens) + TableAlias.
@@ -1172,6 +1181,7 @@ export async function performCount(
     this._applyJoinsToManager(manager);
     this._applyWheresToManager(manager, table);
     applyFromToManager(this, manager);
+    applyHavingToManager(this, manager);
     const [rawSql, managerBinds] = compileManagerWithBinds(this, manager);
     const [withCtes, ctedBinds] = prependCtes(this, rawSql, managerBinds);
     const result = await this._conn().selectAll(
@@ -1193,6 +1203,7 @@ export async function performCount(
       this._applyJoinsToManager(innerManager);
       this._applyWheresToManager(innerManager, table);
       applyFromToManager(this, innerManager);
+      applyHavingToManager(this, innerManager);
       const [innerSqlWithFrom, allInnerBinds] = compileManagerWithBinds(this, innerManager);
       const countAll = new Nodes.NamedFunction("COUNT", [new Nodes.SqlLiteral("*")]);
       const outerManager = project(countAll.as("count"));
@@ -1212,6 +1223,7 @@ export async function performCount(
     this._applyJoinsToManager(manager);
     this._applyWheresToManager(manager, table);
     applyFromToManager(this, manager);
+    applyHavingToManager(this, manager);
     const [rawSql, managerBinds] = compileManagerWithBinds(this, manager);
     const [withCtes, ctedBinds] = prependCtes(this, rawSql, managerBinds);
     const result = await this._conn().selectAll(
@@ -1228,6 +1240,7 @@ export async function performCount(
   this._applyJoinsToManager(manager);
   this._applyWheresToManager(manager, table);
   applyFromToManager(this, manager);
+  applyHavingToManager(this, manager);
   const [rawSql, managerBinds] = compileManagerWithBinds(this, manager);
   const [withCtes, ctedBinds] = prependCtes(this, rawSql, managerBinds);
   const result = await this._conn().selectAll(


### PR DESCRIPTION
Follow-up to #5184, which fixed the dropped HAVING on the grouped arms and on
the ungrouped `singleAggregate` but left `performCount` out.

`performCount` isn't one manager but ~eight — the DISTINCT-on-pk fan-out, the
eager-load id/count queries (scalar and composite PK), the `from()` variants,
the limited count-subquery and the plain `COUNT(*)` tail — and none of them
applied `_havingClause`, so `Account.having("count(*) > 1").count()` (no
`.group`) silently dropped the clause.

Rails has one path for all of these: `execute_simple_calculation` builds
`query_builder = relation.arel` (calculations.rb:475/485) and `build_arel`
emits `arel.having(having_clause.ast) unless having_clause.empty?` with no
GROUP BY guard (query_methods.rb:1756). `build_count_subquery` likewise spawns
from the relation, so the clause rides into the inner query.

This threads the existing `applyHavingToManager` helper through every
relation-derived manager in `performCount` (right after `applyFromToManager`,
so subquery paths get it on the inner query as Rails does). It is a no-op when
the having clause is empty.

## Testing

Trails-only regression guard in `calculations.trails.test.ts`, alongside the
existing "ungrouped calculation HAVING" describe — Rails has no test for this.
It covers `COUNT(*)`, `COUNT(<column>)` and the `DISTINCT` fan-out, in both the
satisfied and unsatisfied directions. Verified it fails on the pre-fix
implementation (`expected 6 to be +0`).

Closes-story: ungrouped-count-having-dropped
