### PR TITLE
refactor(predicate-builder): delegate buildComposite to expandFromHash

### DIFF
--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -7125,10 +7125,16 @@ describe("HasManyAssociationsTest", () => {
 
     // Mirror Rails' OR-of-AND tuple-form assertion (adapter-agnostic on the
     // identifier quoting): each deleted row is scoped by its full composite key
-    // `(blog_id = .. AND id = ..)`, the two rows joined by OR.
+    // `blog_id = .. AND id = ..`, the two joined by OR inside ONE pair of
+    // parens. That single outer Grouping is `grouping_queries`' shape
+    // (predicate_builder.rb:154-161) — Rails' own `query_constraints` regex has
+    // no per-tuple parens.
     const col = (name: string) => `["\`]?sharded_comments["\`]?\\.["\`]?${name}["\`]?`;
-    const tuple = `\\(${col("blog_id")} = .*? AND ${col("id")} = .*?\\)`;
-    const expectation = new RegExp(`DELETE.*WHERE.*${tuple} OR ${tuple}`, "i");
+    const queryConstraints = `${col("blog_id")} = .* AND ${col("id")} = .*`;
+    const expectation = new RegExp(
+      `DELETE.*WHERE.* \\(${queryConstraints} OR ${queryConstraints}\\)`,
+      "i",
+    );
     const deleteSql = sqls.find((s) => /DELETE/i.test(s));
     expect(deleteSql).toBeDefined();
     expect(deleteSql).toMatch(expectation);

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -606,9 +606,15 @@ export class Relation<T extends Base> {
       }
       const cols = conditionsOrSql as string[];
       const tuples = rest[0] as unknown[][];
-      const node = this.predicateBuilder.buildComposite(cols, tuples);
-      if (node === null) return this._clone().noneBang();
-      return this._clone().whereBang(node);
+      // buildComposite returns the WhereClause predicates directly (the native
+      // PredicateBuilder currency); spread them into the clause exactly as
+      // buildWhereClause spreads buildFromHash's result, so a single tuple stays
+      // flat (`WHERE c1 = ? AND c2 = ?`, no wrapping Grouping) like Rails.
+      const nodes = this.predicateBuilder.buildComposite(cols, tuples);
+      if (nodes.length === 0) return this._clone().noneBang();
+      const rel = this._clone();
+      rel._whereClause.predicates.push(...nodes);
+      return rel;
     }
     return this._clone().whereBang(
       conditionsOrSql as Record<string, unknown> | string | Nodes.Node | null,
@@ -821,14 +827,16 @@ export class Relation<T extends Base> {
           "Relation#whereNot(cols, tuples): composite-key form requires a tuples argument as an array of arrays",
         );
       }
-      const node = this.predicateBuilder.buildComposite(conditions as string[], tuples);
-      // null = empty/all-filtered → NOT (no rows) = ALL rows = no
-      // predicate added (matches Rails' `where.not(...)` no-op for
-      // empty hashes).
-      if (node !== null) {
-        // Rails builds the positive predicate and inverts it (WhereClause#invert
-        // → node.invert): `IN` → `NOT IN`, a grouped tuple-OR → `NOT (...)`.
-        rel._whereClause.predicates.push(node.invert());
+      const nodes = this.predicateBuilder.buildComposite(conditions as string[], tuples);
+      // Empty/all-filtered → NOT (no rows) = ALL rows = no predicate added
+      // (matches Rails' `where.not(...)` no-op for empty hashes).
+      if (nodes.length > 0) {
+        // Rails builds the positive predicates as a WhereClause and inverts the
+        // whole clause (`build_where_clause(...).invert`): one predicate flips
+        // in place (`IN` → `NOT IN`, `Grouping(Or)` → `NOT (...)`), while a flat
+        // multi-predicate single tuple ANDs then negates → `NOT (c1 = ? AND
+        // c2 = ?)` — the same shape as inverting the hash-key `where.not`.
+        rel._whereClause.predicates.push(...new WhereClause(nodes).invert().predicates);
       }
       return rel;
     }
@@ -4766,8 +4774,9 @@ export class Relation<T extends Base> {
               ...self.predicateBuilder.buildFromHash({ [cursorArr[0]]: ids }),
             );
           } else {
-            const node = self.predicateBuilder.buildComposite(cursorArr, tuples);
-            if (node) batchRel._whereClause.predicates.push(node);
+            batchRel._whereClause.predicates.push(
+              ...self.predicateBuilder.buildComposite(cursorArr, tuples),
+            );
           }
           if (load) {
             (batchRel as any)._records = batchRows;

--- a/packages/activerecord/src/relation/composite-where.test.ts
+++ b/packages/activerecord/src/relation/composite-where.test.ts
@@ -198,6 +198,34 @@ describe("Relation#where — composite-key form", () => {
     expect(sql).not.toMatch(/OR/);
   });
 
+  it("multi-tuple composite builds Rails' grouping_queries tree: one Grouping wrapping an n-ary Or of And chains", () => {
+    // buildComposite delegates to grouping_queries
+    // (predicate_builder.rb:154-162), so the tree is Rails' verbatim:
+    // Grouping(Or([And([eq, eq]), And([eq, eq])])) — the per-tuple Grouping
+    // an earlier hand-rolled version added is not part of that shape.
+    const rel = (CpkBook as any).all();
+    const node: any = rel.predicateBuilder.buildComposite(
+      ["author_id", "id"],
+      [
+        [1, 100],
+        [2, 200],
+      ],
+    );
+    expect(node.constructor.name).toBe("Grouping");
+    expect(node.expr.constructor.name).toBe("Or");
+    expect(node.expr.children.map((c: any) => c.constructor.name)).toEqual(["And", "And"]);
+  });
+
+  it("composite tuple values dereference a record to its id (predicate_builder.rb:58)", async () => {
+    // Delegating through `build` inherits Rails' `value = value.id if
+    // value.respond_to?(:id)`, which the hand-rolled buildBindAttribute path
+    // skipped — a record used to be bound whole.
+    const author: any = await (CpkAuthor as any).create({ name: "deref" });
+    await CpkBook.create({ id: [author.id, 100], title: "by-record" });
+    const matched = await (CpkBook as any).where(["author_id", "id"], [[author, 100]]).toArray();
+    expect(matched.map((r: any) => r.title)).toEqual(["by-record"]);
+  });
+
   it("Relation#where(single array arg) routes to the sanitized-conditions form, not composite", () => {
     // A single all-strings array is Rails' `where(["sql fragment"])` form, not
     // the two-argument composite `where(cols, tuples)`, so it must sanitize

--- a/packages/activerecord/src/relation/composite-where.test.ts
+++ b/packages/activerecord/src/relation/composite-where.test.ts
@@ -17,6 +17,7 @@ import { fixtures } from "../test-helpers/fixtures.js";
 import { CpkBook, CpkOrder, CpkAuthor, CpkChapter } from "../test-helpers/models/cpk.js";
 import { Post } from "../test-helpers/models/post.js";
 import { Comment } from "../test-helpers/models/comment.js";
+import { Customer, Address } from "../test-helpers/models/customer.js";
 
 describe("Relation#where — composite-key form", () => {
   // Rails creates the CPK rows inline with `Cpk::Book.create!` — no cpk
@@ -25,7 +26,9 @@ describe("Relation#where — composite-key form", () => {
   fixtures([]);
 
   beforeAll(() => {
-    [CpkBook, CpkOrder, CpkAuthor, CpkChapter, Post, Comment].forEach((m) => registerModel(m));
+    [CpkBook, CpkOrder, CpkAuthor, CpkChapter, Post, Comment, Customer].forEach((m) =>
+      registerModel(m),
+    );
   });
 
   it("compiles `where(['c1','c2'], [[v1a,v1b], [v2a,v2b]])` to OR-of-AND of column equalities", async () => {
@@ -224,6 +227,23 @@ describe("Relation#where — composite-key form", () => {
     await CpkBook.create({ id: [author.id, 100], title: "by-record" });
     const matched = await (CpkBook as any).where(["author_id", "id"], [[author, 100]]).toArray();
     expect(matched.map((r: any) => r.title)).toEqual(["by-record"]);
+  });
+
+  it("single-column composite over a composed_of key keeps every mapped column's predicate", () => {
+    // An aggregate key expands to one predicate per mapped column
+    // (expand_from_hash's aggregated_with? branch, predicate_builder.rb:124-141),
+    // so the delegation returns a multi-node array for a single key. Folding
+    // with `and` — rather than taking [0] — is what keeps city/country from
+    // being silently dropped alongside street.
+    const rel = (Customer as any).all();
+    const node: any = rel.predicateBuilder.buildComposite(
+      ["address"],
+      [[new Address("Funny Street", "Scary Town", "Loony Land")]],
+    );
+    const sql = (Customer as any).all().where(node).toSql();
+    expect(sql).toMatch(/address_street/);
+    expect(sql).toMatch(/address_city/);
+    expect(sql).toMatch(/address_country/);
   });
 
   it("Relation#where(single array arg) routes to the sanitized-conditions form, not composite", () => {

--- a/packages/activerecord/src/relation/composite-where.test.ts
+++ b/packages/activerecord/src/relation/composite-where.test.ts
@@ -85,10 +85,10 @@ describe("Relation#where — composite-key form", () => {
     expect(matched.map((r: any) => r.title).sort()).toEqual(["a", "b"]);
   });
 
-  it("PredicateBuilder.buildComposite returns null on empty input (caller short-circuits with none())", async () => {
+  it("PredicateBuilder.buildComposite returns [] on empty input (caller short-circuits with none())", async () => {
     const rel = (CpkBook as any).all();
-    const node = rel.predicateBuilder.buildComposite(["author_id", "id"], []);
-    expect(node).toBeNull();
+    const nodes = rel.predicateBuilder.buildComposite(["author_id", "id"], []);
+    expect(nodes).toEqual([]);
   });
 
   it("PredicateBuilder.buildComposite throws on empty column list", () => {
@@ -130,25 +130,41 @@ describe("Relation#where — composite-key form", () => {
     // instances (carrying `name` / `type`), not raw literals or
     // Casted nodes.
     const rel = (CpkBook as any).all();
-    const node: any = rel.predicateBuilder.buildComposite(["author_id", "id"], [[1, 100]]);
-    // Single-tuple path returns Grouping(And([eq, eq])). Arel wraps
-    // QueryAttribute in BindParam at `attribute.eq()`, so the Eq's
-    // right-hand side is BindParam(QueryAttribute(name, value, type)).
-    const and = node.expr;
-    const firstEq = and.children[0];
-    const rhs = firstEq.right;
+    const nodes: any = rel.predicateBuilder.buildComposite(["author_id", "id"], [[1, 100]]);
+    // Single-tuple path returns the predicates flat ([eq, eq]), like Rails'
+    // grouping_queries. Arel wraps QueryAttribute in BindParam at
+    // `attribute.eq()`, so the first Eq's right-hand side is
+    // BindParam(QueryAttribute(name, value, type)).
+    const rhs = nodes[0].right;
     expect(rhs?.constructor?.name).toBe("BindParam");
     expect(rhs?.value?.name).toBe("author_id");
     expect(rhs?.value?.constructor?.name).toBe("QueryAttribute");
   });
 
+  it("single-tuple composite returns flat predicates (no wrapping Grouping/parens) — Rails grouping_queries one? path", () => {
+    // grouping_queries returns a single group's predicates flat
+    // (`queries.one? → queries.first`, predicate_builder.rb:155-156), so one
+    // surviving tuple is [c1 = ?, c2 = ?] — two addressable predicates, NOT a
+    // Grouping. The emitted SQL therefore has no wrapping parens, byte-for-byte
+    // Rails' `where({[c1,c2] => [[v1,v2]]})`.
+    const rel = (CpkBook as any).all();
+    const nodes: any = rel.predicateBuilder.buildComposite(["author_id", "id"], [[1, 100]]);
+    expect(nodes.map((n: any) => n.constructor.name)).toEqual(["Equality", "Equality"]);
+    const sql = (CpkBook as any)
+      .all()
+      .where(["author_id", "id"], [[1, 100]])
+      .toSql();
+    expect(sql).toMatch(/WHERE "cpk_books"\."author_id" = 1 AND "cpk_books"\."id" = 100/);
+    expect(sql).not.toMatch(/\(/);
+  });
+
   it("qualified composite cols bind through the joined table's type, not the base table's", () => {
     const rel = (Post as any).all();
-    const node: any = rel.predicateBuilder.buildComposite(
+    const nodes: any = rel.predicateBuilder.buildComposite(
       ["posts.id", "comments.post_id"],
       [[1, "2"]],
     );
-    const [left, right] = node.expr.children;
+    const [left, right] = nodes;
     expect(right.left.relation.name).toBe("comments");
     const bind = right.right.value;
     expect(bind.name).toBe("post_id");
@@ -158,7 +174,7 @@ describe("Relation#where — composite-key form", () => {
 
   it("qualified single-column composite resolves its IN(...) attribute on the joined table", () => {
     const rel = (Post as any).all();
-    const node: any = rel.predicateBuilder.buildComposite(["comments.post_id"], [[1], [2]]);
+    const node: any = rel.predicateBuilder.buildComposite(["comments.post_id"], [[1], [2]])[0];
     expect(node.left.relation.name).toBe("comments");
     expect(node.left.name).toBe("post_id");
   });
@@ -169,7 +185,7 @@ describe("Relation#where — composite-key form", () => {
     // integer column stayed a string and never became a bind (breaking
     // compileWithBinds / prepared-statement caching).
     const rel = (Post as any).all();
-    const node: any = rel.predicateBuilder.buildComposite(["comments.post_id"], [["1"], ["2"]]);
+    const node: any = rel.predicateBuilder.buildComposite(["comments.post_id"], [["1"], ["2"]])[0];
     expect(node.constructor.name).toBe("HomogeneousIn");
     expect(node.castedValues).toEqual([1, 2]);
     const sql = (Post as any).all().where(node).toSql();
@@ -191,7 +207,7 @@ describe("Relation#where — composite-key form", () => {
 
   it("single-column composite uses IN(...) (not OR-chain) for compactness", () => {
     const rel = (CpkBook as any).all();
-    const node = rel.predicateBuilder.buildComposite(["author_id"], [[1], [2], [3]]);
+    const node = rel.predicateBuilder.buildComposite(["author_id"], [[1], [2], [3]])[0];
     // The HomogeneousIn node renders as `author_id IN (?, ?, ?)`, which
     // `toSql` substitutes to `IN (1, 2, 3)`; an OR-chain would render as
     // `author_id = 1 OR author_id = 2 OR author_id = 3`.
@@ -207,13 +223,17 @@ describe("Relation#where — composite-key form", () => {
     // Grouping(Or([And([eq, eq]), And([eq, eq])])) — the per-tuple Grouping
     // an earlier hand-rolled version added is not part of that shape.
     const rel = (CpkBook as any).all();
-    const node: any = rel.predicateBuilder.buildComposite(
+    // Multiple tuples collapse to grouping_queries' single node: one
+    // Grouping(Or([And, And])), returned as a length-1 array.
+    const nodes: any = rel.predicateBuilder.buildComposite(
       ["author_id", "id"],
       [
         [1, 100],
         [2, 200],
       ],
     );
+    expect(nodes).toHaveLength(1);
+    const node = nodes[0];
     expect(node.constructor.name).toBe("Grouping");
     expect(node.expr.constructor.name).toBe("Or");
     expect(node.expr.children.map((c: any) => c.constructor.name)).toEqual(["And", "And"]);
@@ -232,15 +252,20 @@ describe("Relation#where — composite-key form", () => {
   it("single-column composite over a composed_of key keeps every mapped column's predicate", () => {
     // An aggregate key expands to one predicate per mapped column
     // (expand_from_hash's aggregated_with? branch, predicate_builder.rb:124-141),
-    // so the delegation returns a multi-node array for a single key. Folding
-    // with `and` — rather than taking [0] — is what keeps city/country from
-    // being silently dropped alongside street.
+    // so the delegation returns a multi-node array for a single key. Returning
+    // them all (Node[]) — rather than collapsing to [0] — is what keeps
+    // city/country from being silently dropped alongside street, and the caller
+    // spreads every predicate into the WhereClause.
     const rel = (Customer as any).all();
-    const node: any = rel.predicateBuilder.buildComposite(
+    const nodes: any = rel.predicateBuilder.buildComposite(
       ["address"],
       [[new Address("Funny Street", "Scary Town", "Loony Land")]],
     );
-    const sql = (Customer as any).all().where(node).toSql();
+    expect(nodes).toHaveLength(3);
+    const sql = (Customer as any)
+      .all()
+      .where(["address"], [[new Address("Funny Street", "Scary Town", "Loony Land")]])
+      .toSql();
     expect(sql).toMatch(/address_street/);
     expect(sql).toMatch(/address_city/);
     expect(sql).toMatch(/address_country/);

--- a/packages/activerecord/src/relation/composite-where.test.ts
+++ b/packages/activerecord/src/relation/composite-where.test.ts
@@ -154,7 +154,10 @@ describe("Relation#where — composite-key form", () => {
       .all()
       .where(["author_id", "id"], [[1, 100]])
       .toSql();
-    expect(sql).toMatch(/WHERE "cpk_books"\."author_id" = 1 AND "cpk_books"\."id" = 100/);
+    // Quote-agnostic (backtick on MySQL/MariaDB, double-quote elsewhere): the
+    // point is the two equalities are ANDed flat, with NO wrapping parens.
+    const col = (name: string) => `["\`]?cpk_books["\`]?\\.["\`]?${name}["\`]?`;
+    expect(sql).toMatch(new RegExp(`WHERE ${col("author_id")} = 1 AND ${col("id")} = 100`));
     expect(sql).not.toMatch(/\(/);
   });
 

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -378,7 +378,7 @@ export class PredicateBuilder {
   }
 
   /**
-   * Build a composite-key predicate:
+   * Build the composite-key predicates for `where(cols, tuples)`:
    *
    *   (c1 = v11 AND c2 = v12) OR (c1 = v21 AND c2 = v22) OR ...
    *
@@ -392,6 +392,16 @@ export class PredicateBuilder {
    * re-implemented. `cols.length === 1` takes the same route and lands on a
    * single `IN (...)`, matching Rails' one-element-key collapse
    * (predicate_builder.rb:87-90).
+   *
+   * Returns a `Node[]`, the native `PredicateBuilder` currency — the caller
+   * pushes them straight into the WhereClause, exactly as `build_where_clause`
+   * spreads `build_from_hash`'s result (query-methods.ts:1059). That is what
+   * makes the output byte-for-byte Rails: `grouping_queries` returns a single
+   * group's predicates *flat* (`queries.one? → queries.first`), so one
+   * surviving tuple yields `[c1 = ?, c2 = ?]` → `WHERE c1 = ? AND c2 = ?` with
+   * no wrapping `Grouping`/parens, while multiple tuples collapse to the single
+   * `[Grouping(Or([And, ...]))]` node. An all-filtered/empty result is `[]`,
+   * which the caller turns into `Relation#none()`.
    *
    * Deviation: it delegates via `buildFromHash`, not `expand_from_hash`, so
    * `convert_dot_notation_to_hash` is re-applied per tuple and a qualified
@@ -407,21 +417,15 @@ export class PredicateBuilder {
    *
    * Tuples containing `null` / `undefined` are filtered out: SQL
    * tuple-equality treats any null component as a non-match, whereas
-   * `Attribute#eq(null)` would emit `IS NULL`. Filtering everything returns
-   * `null`, which the caller short-circuits via `Relation#none()`. Caller
-   * bugs — empty `cols`, non-array `tuples`, non-array tuple, arity
-   * mismatch — raise ArgumentError instead, since silently dropping them
-   * would collapse into that same `null` → `none()` and hide the bug.
-   *
-   * Deviation: `buildComposite` must return ONE node, so a single surviving
-   * tuple — which `grouping_queries` returns as flat, separately addressable
-   * predicates — is wrapped in a `Grouping`. Multi-tuple output is Rails'
-   * tree verbatim.
+   * `Attribute#eq(null)` would emit `IS NULL`. Caller bugs — empty `cols`,
+   * non-array `tuples`, non-array tuple, arity mismatch — raise ArgumentError
+   * instead, since silently dropping them would collapse into that same empty
+   * → `none()` and hide the bug.
    *
    * Mirrors: ActiveRecord::PredicateBuilder#expand_from_hash, Array-key
    * branch (predicate_builder.rb:87-98).
    */
-  buildComposite(cols: string[], tuples: unknown[][]): Nodes.Node | null {
+  buildComposite(cols: string[], tuples: unknown[][]): Nodes.Node[] {
     if (cols.length === 0) {
       throw argumentError("PredicateBuilder.buildComposite: empty column list");
     }
@@ -443,14 +447,14 @@ export class PredicateBuilder {
       }
     }
     const validTuples = tuples.filter((t) => t.every((v) => v !== null && v !== undefined));
-    if (validTuples.length === 0) return null;
+    if (validTuples.length === 0) return [];
     if (cols.length === 1) {
-      return andReduceToOneNode(this.buildFromHash({ [cols[0]]: validTuples.map((t) => t[0]) }));
+      return this.buildFromHash({ [cols[0]]: validTuples.map((t) => t[0]) });
     }
     const queryGroups = validTuples.map((tuple) =>
       this.buildFromHash(Object.fromEntries(cols.map((col, i) => [col, tuple[i]]))),
     );
-    return andReduceToOneNode(this.groupingQueries(queryGroups));
+    return this.groupingQueries(queryGroups);
   }
 
   registerHandler(
@@ -599,20 +603,6 @@ function extractAggregateAttr(object: unknown, attr: string, tryBang: boolean): 
     );
   }
   return object;
-}
-
-/**
- * Collapse an expansion's predicates into the single node `buildComposite`
- * has to return. `buildFromHash` / `groupingQueries` both yield a `Node[]`
- * whose entries are ANDed by the where clause, and either can exceed one
- * entry for a single key — a `composed_of` key with a multi-column mapping
- * expands to one predicate per mapped column (buildFromHashAggregate). So
- * fold with `and` rather than indexing, which would silently drop the rest.
- */
-function andReduceToOneNode(nodes: Nodes.Node[]): Nodes.Node {
-  return nodes.length === 1
-    ? nodes[0]
-    : new Nodes.Grouping(nodes.reduce((left, right) => left.and(right)));
 }
 
 function describeAggregateValue(object: unknown): string {

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -387,11 +387,23 @@ export class PredicateBuilder {
    * JS object keys can't be arrays, so the composite shape is a separate
    * method (with a matching `Relation#where(cols, tuples)` overload) — but
    * only as an adapter: it zips `cols` with each tuple into the plain-hash
-   * shape and delegates, so dot-notation splitting, associated-table
-   * re-rooting, bind construction and the grouping tree are all inherited
-   * from that branch rather than re-implemented. `cols.length === 1` takes
-   * the same route and lands on a single `IN (...)`, matching Rails'
-   * one-element-key collapse (predicate_builder.rb:87-90).
+   * shape and delegates, so associated-table re-rooting, bind construction
+   * and the grouping tree are inherited from that branch rather than
+   * re-implemented. `cols.length === 1` takes the same route and lands on a
+   * single `IN (...)`, matching Rails' one-element-key collapse
+   * (predicate_builder.rb:87-90).
+   *
+   * Deviation: it delegates via `buildFromHash`, not `expand_from_hash`, so
+   * `convert_dot_notation_to_hash` is re-applied per tuple and a qualified
+   * column (`"comments.post_id"`) resolves against the associated table.
+   * Rails runs that conversion once at the top of `build_from_hash`
+   * (predicate_builder.rb:24-25) and its Array-key branch recurses straight
+   * into `expand_from_hash` (predicate_builder.rb:96), so a dotted string
+   * inside an Array key falls through to `self[key, value]` and yields a
+   * literal, broken attribute name. Qualified composite columns are a
+   * deliberate trails extension (#5186) that the `where(cols, tuples)`
+   * surface is expected to support; routing them here keeps that behavior
+   * on one code path instead of a second dot-splitting implementation.
    *
    * Tuples containing `null` / `undefined` are filtered out: SQL
    * tuple-equality treats any null component as a non-match, whereas
@@ -433,13 +445,12 @@ export class PredicateBuilder {
     const validTuples = tuples.filter((t) => t.every((v) => v !== null && v !== undefined));
     if (validTuples.length === 0) return null;
     if (cols.length === 1) {
-      return this.buildFromHash({ [cols[0]]: validTuples.map((t) => t[0]) })[0];
+      return andReduceToOneNode(this.buildFromHash({ [cols[0]]: validTuples.map((t) => t[0]) }));
     }
     const queryGroups = validTuples.map((tuple) =>
       this.buildFromHash(Object.fromEntries(cols.map((col, i) => [col, tuple[i]]))),
     );
-    const nodes = this.groupingQueries(queryGroups);
-    return nodes.length === 1 ? nodes[0] : new Nodes.Grouping(nodes.reduce((l, r) => l.and(r)));
+    return andReduceToOneNode(this.groupingQueries(queryGroups));
   }
 
   registerHandler(
@@ -588,6 +599,20 @@ function extractAggregateAttr(object: unknown, attr: string, tryBang: boolean): 
     );
   }
   return object;
+}
+
+/**
+ * Collapse an expansion's predicates into the single node `buildComposite`
+ * has to return. `buildFromHash` / `groupingQueries` both yield a `Node[]`
+ * whose entries are ANDed by the where clause, and either can exceed one
+ * entry for a single key — a `composed_of` key with a multi-column mapping
+ * expands to one predicate per mapped column (buildFromHashAggregate). So
+ * fold with `and` rather than indexing, which would silently drop the rest.
+ */
+function andReduceToOneNode(nodes: Nodes.Node[]): Nodes.Node {
+  return nodes.length === 1
+    ? nodes[0]
+    : new Nodes.Grouping(nodes.reduce((left, right) => left.and(right)));
 }
 
 function describeAggregateValue(object: unknown): string {

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -383,14 +383,18 @@ export class PredicateBuilder {
    *   (c1 = v11 AND c2 = v12) OR (c1 = v21 AND c2 = v22) OR ...
    *
    * For `cols.length === 1` (degenerate composite): a single
-   * `c IN (v1, v2, ...)` predicate via `Attribute#in` — more compact
-   * and often planner-friendlier than an OR chain.
+   * `c IN (v1, v2, ...)` predicate — matching Rails' one-element-key
+   * collapse (predicate_builder.rb:87-90).
    *
    * The Rails analog is `where({[col1, col2] => [[v1, v2], ...]})`,
-   * which Rails routes through `Arel::Nodes::HomogeneousIn` and the
-   * predicate builder. JS object keys can't be arrays, so we expose
-   * the composite shape as a separate method (and a matching
-   * `Relation#where(cols, tuples)` overload).
+   * handled by the Array-key branch of `expand_from_hash`
+   * (predicate_builder.rb:87-98). JS object keys can't be arrays, so we
+   * expose the composite shape as a separate method (and a matching
+   * `Relation#where(cols, tuples)` overload) — but the body is only an
+   * adapter: it zips `cols` with each tuple into the plain-hash shape and
+   * delegates to `buildFromHash` / `groupingQueries`, so dot-notation
+   * splitting, associated-table re-rooting, bind construction and the
+   * grouping tree all come from the shared Rails code path.
    *
    * Tuples containing `null` / `undefined` are filtered out: SQL
    * tuple-equality semantics treat any null component as a non-match
@@ -402,9 +406,13 @@ export class PredicateBuilder {
    * arity mismatch (silent filtering would mask real issues by
    * collapsing them into `null` → `none()`).
    *
-   * Mirrors: ActiveRecord predicate-builder composite-key handling
-   * (relation/predicate_builder/array_handler.rb's homogeneous-in
-   * path for tuple values).
+   * Remaining shape deviation: `buildComposite` must return ONE node,
+   * so a single surviving tuple — which Rails' `grouping_queries` returns
+   * as flat, separately addressable predicates — is wrapped in a
+   * `Grouping`. Multi-tuple output is Rails' tree verbatim.
+   *
+   * Mirrors: ActiveRecord::PredicateBuilder#expand_from_hash, Array-key
+   * branch (predicate_builder.rb:87-98).
    */
   buildComposite(cols: string[], tuples: unknown[][]): Nodes.Node | null {
     if (cols.length === 0) {
@@ -438,63 +446,36 @@ export class PredicateBuilder {
     // semantics — see method docstring).
     const validTuples = tuples.filter((t) => t.every((v) => v !== null && v !== undefined));
     if (validTuples.length === 0) return null;
-    const resolved = cols.map((col) => {
-      const idx = col.lastIndexOf(".");
-      if (idx === -1) return { attribute: this.table.arelTable.get(col), builder: this };
-      const associated = this.table.associatedTable(col.slice(0, idx));
-      return {
-        attribute: associated.arelTable.get(col.slice(idx + 1)),
-        builder: associated.predicateBuilder,
-      };
-    });
-    // Single-column degenerate case: a single `IN (...)` predicate is
-    // more compact than `c=v1 OR c=v2 OR ...` and typically optimizes
-    // identically (or better) on indexed columns. Routing the values
-    // through the resolved column's `build` (→ ArrayHandler,
-    // array_handler.rb:13) is what makes them binds cast by that column's
-    // type; a bare `attribute.in(values)` wraps them in `Nodes::Casted`
-    // and inlines them untyped.
+    // Single-column degenerate case. Rails' array-key branch collapses a
+    // one-element key itself (`key.is_a?(Array) && key.size == 1` →
+    // `key = key.first; value = value.flatten`, predicate_builder.rb:87-90),
+    // which lands on `self[key, values]` → ArrayHandler → a single
+    // `IN (...)`. Delegating through buildFromHash reproduces that exactly,
+    // including the dot-notation split and the typed binds ArrayHandler
+    // builds (a bare `attribute.in(values)` would inline untyped `Casted`
+    // literals instead).
     if (cols.length === 1) {
-      const { attribute, builder } = resolved[0];
-      return builder.build(
-        attribute,
-        validTuples.map((t) => t[0]),
-      );
+      return this.buildFromHash({ [cols[0]]: validTuples.map((t) => t[0]) })[0];
     }
-    // Build equalities through `buildBindAttribute` so each value
-    // becomes a `QueryAttribute` (= bind param) rather than an
-    // `Arel::Nodes::Casted` (= inlined SQL literal). Inlined values
-    // bypass `compileWithBinds` / prepared-statement caching and
-    // mishandle `StatementCache::Substitute` placeholders.
-    //
-    // Pre-resolve `Attribute[]` once outside the per-tuple loop —
-    // each `arelTable.get` allocates a fresh `Arel::Attribute`.
-    // Reusing the resolved attrs keeps large tuple lists
-    // allocation-light.
-    //
-    // Per-tuple AND uses the pairwise `reduce(&:and)` shape (nested
-    // binary `And` chain), matching Rails' `grouping_queries`
-    // (predicate_builder.rb:157) — not a flat n-ary `And`. SQL output
-    // is identical; only the AST shape differs.
-    //
-    // Deviation from the Rails array-key branch's exact tree: Rails'
-    // `grouping_queries` wraps only the outer Or in a single Grouping
-    // (and for a single tuple returns the predicates flat, as separate
-    // where-clause entries). `buildComposite` must return one node, so
-    // each tuple (and the single-tuple case) is wrapped in its own
-    // Grouping — semantically a no-op (AND binds tighter than OR) that
-    // keeps the emitted `(c1 = ? AND c2 = ?) OR (...)` form stable.
-    const groupings: Nodes.Node[] = validTuples.map((tuple) => {
-      const eqs = resolved.map(({ attribute, builder }, i) =>
-        attribute.eq(builder.buildBindAttribute(attribute.name, tuple[i])),
-      );
-      return new Nodes.Grouping(eqs.reduce((left, right) => left.and(right)));
-    });
-    if (groupings.length === 1) return groupings[0];
-    // n-ary `Or(children[])` matches Rails: `grouping_queries` builds
-    // `Arel::Nodes::Or.new(queries)` over the whole array (Arel's `Or`
-    // extends `Nary` in Rails 8.0.2 too).
-    return new Nodes.Grouping(new Nodes.Or(groupings));
+    // Multi-column: zip each tuple against `cols` and delegate, exactly as
+    // Rails' Array-key branch does (`expand_from_hash(key.zip(ids_set).to_h)`
+    // per tuple, then `grouping_queries`, predicate_builder.rb:92-98). Going
+    // through buildFromHash means dot-notation splitting
+    // (convert_dot_notation_to_hash) and the `Hash && !has_column?`
+    // re-rooting into the associated table's builder are inherited rather
+    // than re-implemented here, so fixes to expand_from_hash apply to the
+    // composite form automatically. Bind construction is likewise inherited:
+    // `build` routes scalars to BasicObjectHandler, which wraps them in a
+    // QueryAttribute (= bind param) rather than an inlined `Casted` literal.
+    const queryGroups = validTuples.map((tuple) =>
+      this.buildFromHash(Object.fromEntries(cols.map((col, i) => [col, tuple[i]]))),
+    );
+    const nodes = this.groupingQueries(queryGroups);
+    // `buildComposite` must return ONE node, but grouping_queries returns
+    // the lone group's predicates flat (multiple where-clause entries). Only
+    // that single-group case needs re-wrapping; the multi-group case is
+    // already Rails' single `Grouping(Or(...))`.
+    return nodes.length === 1 ? nodes[0] : new Nodes.Grouping(nodes.reduce((l, r) => l.and(r)));
   }
 
   registerHandler(

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -378,38 +378,33 @@ export class PredicateBuilder {
   }
 
   /**
-   * Build a composite-key predicate. For `cols.length > 1`:
+   * Build a composite-key predicate:
    *
    *   (c1 = v11 AND c2 = v12) OR (c1 = v21 AND c2 = v22) OR ...
    *
-   * For `cols.length === 1` (degenerate composite): a single
-   * `c IN (v1, v2, ...)` predicate — matching Rails' one-element-key
-   * collapse (predicate_builder.rb:87-90).
-   *
-   * The Rails analog is `where({[col1, col2] => [[v1, v2], ...]})`,
-   * handled by the Array-key branch of `expand_from_hash`
-   * (predicate_builder.rb:87-98). JS object keys can't be arrays, so we
-   * expose the composite shape as a separate method (and a matching
-   * `Relation#where(cols, tuples)` overload) — but the body is only an
-   * adapter: it zips `cols` with each tuple into the plain-hash shape and
-   * delegates to `buildFromHash` / `groupingQueries`, so dot-notation
-   * splitting, associated-table re-rooting, bind construction and the
-   * grouping tree all come from the shared Rails code path.
+   * The Rails analog is `where({[c1, c2] => [[v1, v2], ...]})`, handled by
+   * the Array-key branch of `expand_from_hash` (predicate_builder.rb:87-98).
+   * JS object keys can't be arrays, so the composite shape is a separate
+   * method (with a matching `Relation#where(cols, tuples)` overload) — but
+   * only as an adapter: it zips `cols` with each tuple into the plain-hash
+   * shape and delegates, so dot-notation splitting, associated-table
+   * re-rooting, bind construction and the grouping tree are all inherited
+   * from that branch rather than re-implemented. `cols.length === 1` takes
+   * the same route and lands on a single `IN (...)`, matching Rails'
+   * one-element-key collapse (predicate_builder.rb:87-90).
    *
    * Tuples containing `null` / `undefined` are filtered out: SQL
-   * tuple-equality semantics treat any null component as a non-match
-   * (Arel's `Attribute#eq(null)` would emit `IS NULL`, which is
-   * different). After filtering, an empty tuple list returns `null`
-   * — caller short-circuits via `Relation#none()`.
+   * tuple-equality treats any null component as a non-match, whereas
+   * `Attribute#eq(null)` would emit `IS NULL`. Filtering everything returns
+   * `null`, which the caller short-circuits via `Relation#none()`. Caller
+   * bugs — empty `cols`, non-array `tuples`, non-array tuple, arity
+   * mismatch — raise ArgumentError instead, since silently dropping them
+   * would collapse into that same `null` → `none()` and hide the bug.
    *
-   * Throws on caller bugs: empty `cols`, non-array tuple, or tuple
-   * arity mismatch (silent filtering would mask real issues by
-   * collapsing them into `null` → `none()`).
-   *
-   * Remaining shape deviation: `buildComposite` must return ONE node,
-   * so a single surviving tuple — which Rails' `grouping_queries` returns
-   * as flat, separately addressable predicates — is wrapped in a
-   * `Grouping`. Multi-tuple output is Rails' tree verbatim.
+   * Deviation: `buildComposite` must return ONE node, so a single surviving
+   * tuple — which `grouping_queries` returns as flat, separately addressable
+   * predicates — is wrapped in a `Grouping`. Multi-tuple output is Rails'
+   * tree verbatim.
    *
    * Mirrors: ActiveRecord::PredicateBuilder#expand_from_hash, Array-key
    * branch (predicate_builder.rb:87-98).
@@ -419,62 +414,31 @@ export class PredicateBuilder {
       throw argumentError("PredicateBuilder.buildComposite: empty column list");
     }
     if (!Array.isArray(tuples)) {
-      // Surface as ArgumentError instead of letting the for-of /
-      // .filter() below throw a bare TypeError on null / object /
-      // non-iterable inputs.
       throw argumentError(
         `PredicateBuilder.buildComposite: tuples must be an array, got ${tuples === null ? "null" : typeof tuples}`,
       );
     }
-    // Validate shape/arity loudly — silently dropping malformed
-    // tuples would turn caller bugs into `null` (→ `none()`), which
-    // is hard to debug. Tagged as ArgumentError so callers can catch
-    // consistently with other query-method validation throws.
-    for (const t of tuples) {
-      if (!Array.isArray(t)) {
+    for (const tuple of tuples) {
+      if (!Array.isArray(tuple)) {
         throw argumentError(
-          `PredicateBuilder.buildComposite: tuple must be an array, got ${typeof t}`,
+          `PredicateBuilder.buildComposite: tuple must be an array, got ${typeof tuple}`,
         );
       }
-      if (t.length !== cols.length) {
+      if (tuple.length !== cols.length) {
         throw argumentError(
-          `PredicateBuilder.buildComposite: tuple arity ${t.length} does not match column count ${cols.length} (cols=[${cols.join(", ")}])`,
+          `PredicateBuilder.buildComposite: tuple arity ${tuple.length} does not match column count ${cols.length} (cols=[${cols.join(", ")}])`,
         );
       }
     }
-    // Filter null/undefined-bearing tuples (SQL tuple-equality
-    // semantics — see method docstring).
     const validTuples = tuples.filter((t) => t.every((v) => v !== null && v !== undefined));
     if (validTuples.length === 0) return null;
-    // Single-column degenerate case. Rails' array-key branch collapses a
-    // one-element key itself (`key.is_a?(Array) && key.size == 1` →
-    // `key = key.first; value = value.flatten`, predicate_builder.rb:87-90),
-    // which lands on `self[key, values]` → ArrayHandler → a single
-    // `IN (...)`. Delegating through buildFromHash reproduces that exactly,
-    // including the dot-notation split and the typed binds ArrayHandler
-    // builds (a bare `attribute.in(values)` would inline untyped `Casted`
-    // literals instead).
     if (cols.length === 1) {
       return this.buildFromHash({ [cols[0]]: validTuples.map((t) => t[0]) })[0];
     }
-    // Multi-column: zip each tuple against `cols` and delegate, exactly as
-    // Rails' Array-key branch does (`expand_from_hash(key.zip(ids_set).to_h)`
-    // per tuple, then `grouping_queries`, predicate_builder.rb:92-98). Going
-    // through buildFromHash means dot-notation splitting
-    // (convert_dot_notation_to_hash) and the `Hash && !has_column?`
-    // re-rooting into the associated table's builder are inherited rather
-    // than re-implemented here, so fixes to expand_from_hash apply to the
-    // composite form automatically. Bind construction is likewise inherited:
-    // `build` routes scalars to BasicObjectHandler, which wraps them in a
-    // QueryAttribute (= bind param) rather than an inlined `Casted` literal.
     const queryGroups = validTuples.map((tuple) =>
       this.buildFromHash(Object.fromEntries(cols.map((col, i) => [col, tuple[i]]))),
     );
     const nodes = this.groupingQueries(queryGroups);
-    // `buildComposite` must return ONE node, but grouping_queries returns
-    // the lone group's predicates flat (multiple where-clause entries). Only
-    // that single-group case needs re-wrapping; the multi-group case is
-    // already Rails' single `Grouping(Or(...))`.
     return nodes.length === 1 ? nodes[0] : new Nodes.Grouping(nodes.reduce((l, r) => l.and(r)));
   }
 


### PR DESCRIPTION
`PredicateBuilder#buildComposite` re-implemented routing that Rails' `expand_from_hash` already does, and its single-node return contract forced one last SQL-shape divergence. This PR converges both.

### Routing

`buildComposite`'s body duplicated:

- qualified-column splitting (`convert_dot_notation_to_hash`, `predicate_builder.rb:162-179`) plus the `value.is_a?(Hash) && !table.has_column?(key)` re-rooting branch;
- tuple → predicate grouping (the Array-key branch, `predicate_builder.rb:87-98`, and `grouping_queries`, `predicate_builder.rb:154-162`);
- bind construction, hand-rolled via `buildBindAttribute` instead of `build` → `BasicObjectHandler`.

It is now a thin adapter: it keeps the trails-only argument validation (empty `cols`, non-array `tuples`/tuple, arity mismatch) and null-component filtering, then zips `cols` with each tuple into the plain-hash shape and delegates to `buildFromHash` / `groupingQueries`.

### Byte-exact single-tuple SQL

`buildComposite` now returns `Node[]` — the native `PredicateBuilder` currency — instead of a single `Node`, and every consumer (`where`, `whereNot`, the `in_batches` composite cursor) spreads the result into the WhereClause exactly as `build_where_clause` spreads `build_from_hash`'s result. This removes the last divergence:

```
before:  WHERE ("author_id" = 1 AND "id" = 100)     ← invented wrapping Grouping
after :  WHERE "author_id" = 1 AND "id" = 100        ← Rails-exact (grouping_queries one? → flat)
```

Rails' `grouping_queries` returns a lone group's predicates *flat* (`queries.one? → queries.first`), so a single surviving tuple is two addressable predicates, no parens. Multiple tuples still collapse to the single `Grouping(Or([And, …]))` node; empty/all-filtered returns `[]` → `Relation#none()`. `whereNot` inverts the whole WhereClause (`build_where_clause(...).invert`) rather than a lone node.

### Behavior

All pre-existing `composite-where.test.ts` / `where.test.ts` tuple tests pass (row assertions unchanged; no renames of Rails-matched names). New/updated coverage, each verified against the pre-refactor baseline:

- single-tuple returns flat `[Equality, Equality]` and emits parens-free SQL;
- multi-tuple stays `[Grouping(Or([And, And]))]`;
- record → `id` deref inherited from `build` (`predicate_builder.rb:58`);
- `composed_of` multi-column key keeps every mapped predicate (returned flat, not dropped);
- the `sharded deleting models` regex (`has_many_associations_test.rb:1306`) transcribed verbatim — multi-tuple, still `(qc OR qc)`.

### Remaining deviations (documented at the call site, forced by JS)

- `where(cols, tuples)` is a positional overload because JS object keys can't be arrays.
- null-component filtering → `none()` is a deliberate trails semantic (Rails would emit `IS NULL`).
- per-tuple dot-notation re-resolution (#5186) goes beyond Rails' Array-key branch, which never re-runs `convert_dot_notation_to_hash`.

Closes-story: buildcomposite-reimplements-expand-from-hash-routing
