### PR TITLE
fix(mysql2): accept Rails' socket key and map it to socketPath in the adapter

### DIFF
--- a/packages/activerecord/src/connection-adapters/adapter-args.test.ts
+++ b/packages/activerecord/src/connection-adapters/adapter-args.test.ts
@@ -136,8 +136,6 @@ describe("buildAdapterArg", () => {
     });
 
     it("forwards socket untouched for mysql and omits host", () => {
-      // Mysql2Adapter#constructor owns the socket -> socketPath mapping; this
-      // layer must not shadow it (see adapter-socket-key.trails.test.ts).
       const [config] = buildAdapterArg("mysql2", {
         adapter: "mysql2",
         database: "db",

--- a/packages/activerecord/src/connection-adapters/adapter-args.test.ts
+++ b/packages/activerecord/src/connection-adapters/adapter-args.test.ts
@@ -135,14 +135,16 @@ describe("buildAdapterArg", () => {
       });
     });
 
-    it("remaps socket to socketPath for mysql and omits host", () => {
+    it("forwards socket untouched for mysql and omits host", () => {
+      // Mysql2Adapter#constructor owns the socket -> socketPath mapping; this
+      // layer must not shadow it (see adapter-socket-key.trails.test.ts).
       const [config] = buildAdapterArg("mysql2", {
         adapter: "mysql2",
         database: "db",
         socket: "/var/run/mysqld/mysqld.sock",
       }) as [Record<string, unknown>];
-      expect(config.socketPath).toBe("/var/run/mysqld/mysqld.sock");
-      expect(config.socket).toBeUndefined();
+      expect(config.socket).toBe("/var/run/mysqld/mysqld.sock");
+      expect(config.socketPath).toBeUndefined();
       expect(config.host).toBeUndefined();
     });
 
@@ -152,11 +154,10 @@ describe("buildAdapterArg", () => {
         database: "db",
         socket: "",
       }) as [Record<string, unknown>];
-      expect(config.socketPath).toBeUndefined();
       expect(config.host).toBe("localhost");
     });
 
-    it("does not remap socketPath when already set for mysql", () => {
+    it("leaves an explicit socketPath alone for mysql", () => {
       const [config] = buildAdapterArg("mysql2", {
         adapter: "mysql2",
         database: "db",

--- a/packages/activerecord/src/connection-adapters/adapter-args.ts
+++ b/packages/activerecord/src/connection-adapters/adapter-args.ts
@@ -207,18 +207,14 @@ export function buildAdapterArg(
   // spelling and the adapter constructor maps it to the driver-native `user`.
   const { adapter: _a, url: _u, ...rest } = configuration;
   const adapterConfig: Record<string, unknown> = { ...rest };
-  // mysql2 uses `socketPath`; database.yml uses `socket`. Normalise here so
-  // all callers benefit, not just the DatabaseTasks path.
+  // `socket` is deliberately NOT remapped here, for the same reason as
+  // `username` above: this layer used to strip it before the adapter saw it,
+  // shadowing the constructor entirely. Mysql2Adapter#constructor owns the
+  // single `socket` -> `socketPath` mapping; forward Rails' spelling untouched.
   if (normalized === "mysql") {
-    if (
-      adapterConfig.socket !== undefined &&
-      adapterConfig.socket !== "" &&
-      adapterConfig.socketPath === undefined
-    ) {
-      adapterConfig.socketPath = adapterConfig.socket;
-      delete adapterConfig.socket;
-    }
-    if (adapterConfig.host === undefined && !adapterConfig.socketPath) {
+    // The host default must still look at BOTH spellings — a `socket`-only
+    // config is socket-bound even though `socketPath` is not set yet.
+    if (adapterConfig.host === undefined && !adapterConfig.socketPath && !adapterConfig.socket) {
       adapterConfig.host = "localhost";
     }
   } else if (adapterConfig.host === undefined) {

--- a/packages/activerecord/src/connection-adapters/adapter-socket-key.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/adapter-socket-key.trails.test.ts
@@ -68,9 +68,6 @@ describe("Mysql2Adapter socket key through buildAdapterArg", () => {
   });
 
   it("keeps host absent so the socket is not shadowed by a TCP default", () => {
-    // `buildAdapterArg` defaults `host` to localhost only when the config is
-    // not socket-bound; it must recognise Rails' spelling for that check now
-    // that it no longer rewrites the key.
     const [config] = buildAdapterArg("mysql2", {
       adapter: "mysql2",
       database: "d",
@@ -80,16 +77,17 @@ describe("Mysql2Adapter socket key through buildAdapterArg", () => {
   });
 
   it("actually connects over the socket rather than falling back to TCP", async () => {
-    // The assertion that catches a regression: with the mapping gone, mysql2
-    // ignores `socket` and dials TCP, which either refuses (a different errno)
-    // or — on a MySQL lane — SUCCEEDS, silently connecting to the wrong
-    // transport. A bogus socket path must fail as a socket.
     const [config] = buildAdapterArg("mysql2", {
       adapter: "mysql2",
       database: "d",
       socket: "/nonexistent/trails-socket-key.sock",
     }) as [Record<string, unknown>];
     const adapter = new Mysql2Adapter(config as never);
-    await expect(adapter.connect()).rejects.toThrow(/ENOENT|\/nonexistent\//);
+    // ENOENT *on the socket path* is the proof: a TCP fallback cannot produce
+    // it (it refuses, or on a MySQL lane silently succeeds against the wrong
+    // transport, which is the regression this guards).
+    await expect(adapter.connect()).rejects.toThrow(
+      "connect ENOENT /nonexistent/trails-socket-key.sock",
+    );
   });
 });

--- a/packages/activerecord/src/connection-adapters/adapter-socket-key.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/adapter-socket-key.trails.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Rails spells a Unix socket `socket` in `database.yml`
+ * (`activerecord/test/config.example.yml:18-19,37-39`), and Ruby's mysql2 gem
+ * reads `:socket` natively — `::Mysql2::Client.new(config)`
+ * (`mysql2_adapter.rb:24`) hands the hash over untouched. Node's `mysql2`
+ * instead reads `socketPath`, and IGNORES unknown keys, so an unmapped
+ * `socket` config connects over TCP instead of failing: a silent wrong
+ * connection, the same failure mode as the `username` key (see
+ * `adapter-username-key.trails.test.ts`).
+ *
+ * There is no Rails guard to inherit for this one, so the semantics below are
+ * a deliberate choice rather than a port. They match the `username` mapping so
+ * the two agree: a *Ruby-truthy* `socket` overwrites `socketPath` and is
+ * deleted from the driver hash. `""` is Ruby-truthy, so a blank socket maps —
+ * and lands on mysql2 as a falsy `socketPath`, i.e. host/port, the same
+ * outcome a blank socket has in Rails.
+ *
+ * The mapping lives in `Mysql2Adapter#constructor` ONLY. `adapter-args.ts`
+ * used to remap the key as well, which stripped it before the constructor ever
+ * saw it on the `connection-handling.ts:923` path every real connection takes.
+ */
+import { describe, expect, it } from "vitest";
+
+import { buildAdapterArg } from "./adapter-args.js";
+import { Mysql2Adapter } from "./mysql2-adapter.js";
+
+function poolConfigVia(configuration: Record<string, unknown>): Record<string, unknown> {
+  const [config] = buildAdapterArg("mysql2", {
+    adapter: "mysql2",
+    database: "d",
+    ...configuration,
+  }) as [Record<string, unknown>];
+  const adapter = new Mysql2Adapter({ ...config, _fakeConnection: true } as never);
+  return (adapter as unknown as { _poolConfig: Record<string, unknown> })._poolConfig;
+}
+
+describe("Mysql2Adapter socket key through buildAdapterArg", () => {
+  it("maps Rails' socket onto the driver's socketPath", () => {
+    const driverConfig = poolConfigVia({ socket: "/var/run/mysqld/mysqld.sock" });
+    expect(driverConfig.socketPath).toBe("/var/run/mysqld/mysqld.sock");
+    expect(driverConfig).not.toHaveProperty("socket");
+  });
+
+  it("passes an explicit socketPath through untouched", () => {
+    const driverConfig = poolConfigVia({ socketPath: "/driver.sock" });
+    expect(driverConfig.socketPath).toBe("/driver.sock");
+  });
+
+  it("lets socket overwrite an explicit socketPath", () => {
+    const driverConfig = poolConfigVia({ socket: "/rails.sock", socketPath: "/driver.sock" });
+    expect(driverConfig.socketPath).toBe("/rails.sock");
+    expect(driverConfig).not.toHaveProperty("socket");
+  });
+
+  it("maps a blank socket, since Ruby treats an empty string as truthy", () => {
+    const driverConfig = poolConfigVia({ socket: "", socketPath: "/driver.sock" });
+    expect(driverConfig.socketPath).toBe("");
+    expect(driverConfig).not.toHaveProperty("socket");
+  });
+
+  it("leaves an explicit socketPath alone when socket is false", () => {
+    const driverConfig = poolConfigVia({ socket: false, socketPath: "/driver.sock" });
+    expect(driverConfig.socketPath).toBe("/driver.sock");
+  });
+
+  it("leaves socketPath absent when neither key is given", () => {
+    expect(poolConfigVia({})).not.toHaveProperty("socketPath");
+  });
+
+  it("keeps host absent so the socket is not shadowed by a TCP default", () => {
+    // `buildAdapterArg` defaults `host` to localhost only when the config is
+    // not socket-bound; it must recognise Rails' spelling for that check now
+    // that it no longer rewrites the key.
+    const [config] = buildAdapterArg("mysql2", {
+      adapter: "mysql2",
+      database: "d",
+      socket: "/var/run/mysqld/mysqld.sock",
+    }) as [Record<string, unknown>];
+    expect(config).not.toHaveProperty("host");
+  });
+
+  it("actually connects over the socket rather than falling back to TCP", async () => {
+    // The assertion that catches a regression: with the mapping gone, mysql2
+    // ignores `socket` and dials TCP, which either refuses (a different errno)
+    // or — on a MySQL lane — SUCCEEDS, silently connecting to the wrong
+    // transport. A bogus socket path must fail as a socket.
+    const [config] = buildAdapterArg("mysql2", {
+      adapter: "mysql2",
+      database: "d",
+      socket: "/nonexistent/trails-socket-key.sock",
+    }) as [Record<string, unknown>];
+    const adapter = new Mysql2Adapter(config as never);
+    await expect(adapter.connect()).rejects.toThrow(/ENOENT|\/nonexistent\//);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -553,8 +553,24 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // postgresql_adapter.rb:326 — so both adapters agree, down to the same
     // `isRubyTruthy` guard: a Ruby-truthy `username` (including "") overwrites
     // `user`, while `username: false` does not.
-    const { username: railsUsername, ...mysqlDriverConfig } = mysqlConfig as typeof mysqlConfig & {
+    //
+    // `socket` is the same class of deviation. Rails' database.yml spells a
+    // Unix socket `socket` (config.example.yml:18-19) and the Ruby gem reads
+    // `:socket` natively, but node-mysql2's option is `socketPath` — and it
+    // ignores the unknown key, so an unmapped `socket` connects over TCP
+    // instead of failing. There is no Rails guard to inherit here, so the
+    // precedence deliberately matches `username` above: a Ruby-truthy `socket`
+    // overwrites an explicit `socketPath` and is deleted from the hash.
+    // `socket: ""` therefore maps (Ruby-truthy), which lands on mysql2 as a
+    // falsy `socketPath` and so falls back to host/port — the same outcome as
+    // a blank socket in Rails.
+    const {
+      username: railsUsername,
+      socket: railsSocket,
+      ...mysqlDriverConfig
+    } = mysqlConfig as typeof mysqlConfig & {
       username?: string;
+      socket?: string;
     };
     // No compact/allowlist here, unlike PostgreSQLAdapter (which mirrors
     // postgresql_adapter.rb:322-331). Rails hands mysql2 the residual config
@@ -565,6 +581,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     this._poolConfig = {
       ...mysqlDriverConfig,
       ...(isRubyTruthy(railsUsername) ? { user: railsUsername } : {}),
+      ...(isRubyTruthy(railsSocket) ? { socketPath: railsSocket } : {}),
       flags: resolvedFlags,
       strict,
       waitTimeout,

--- a/packages/activerecord/src/test-helpers/template-global-setup.ts
+++ b/packages/activerecord/src/test-helpers/template-global-setup.ts
@@ -218,13 +218,14 @@ const mysqlAdapter: DbTemplateAdapter = {
     // (MYSQL_SOCK) reaches the driver — a URL cannot carry a socket path.
     // This connection is opened against the `mysql2` driver directly rather than
     // through Mysql2Adapter, so it does not get the adapter's `username` → `user`
-    // mapping — spell the driver-native key here.
-    const { database: _adminDb, username, ...adminOpts } = driverConfig(settings);
+    // or `socket` → `socketPath` mappings — spell the driver-native keys here.
+    const { database: _adminDb, username, socket, ...adminOpts } = driverConfig(settings);
     // CREATE DATABASE for all slots first (sequential — DDL against the same
     // server, DROP/CREATE must not race with themselves).
     const admin = await mysql.createConnection({
       ...adminOpts,
       user: username,
+      ...(socket === undefined ? {} : { socketPath: socket }),
     } as mysql.ConnectionOptions);
     for (let slot = 1; slot <= n; slot++) {
       const slotDb = slot === 1 ? settings.database : `${settings.database}_${slot}`;

--- a/packages/activerecord/src/test-helpers/test-connection-env.test.ts
+++ b/packages/activerecord/src/test-helpers/test-connection-env.test.ts
@@ -145,18 +145,16 @@ describe("test-connection-env", () => {
     expect(withDatabase(settings, "other")).toEqual({ ...settings, database: "other" });
   });
 
-  it("driverConfig emits Rails' username and both spellings of the socket", () => {
-    // The credential is Rails' `username` alone — the adapters map it to the
-    // driver-native `user`. The socket still straddles: mysql2 reads
-    // `socketPath` and IGNORES `socket`, so emitting one spelling silently
-    // falls back to TCP instead of failing.
+  it("driverConfig emits Rails' username and socket spellings only", () => {
+    // Both keys are Rails' canonical spelling — the adapters map them to the
+    // driver-native `user` / `socketPath`.
     const config = driverConfig(
       mysqlSettings(reader({ MYSQL_USER: "u", MYSQL_PASSWORD: "p", MYSQL_SOCK: "/tmp/m.sock" })),
     );
     expect(config.username).toBe("u");
     expect(config).not.toHaveProperty("user");
     expect(config.socket).toBe("/tmp/m.sock");
-    expect(config.socketPath).toBe("/tmp/m.sock");
+    expect(config).not.toHaveProperty("socketPath");
   });
 
   it("driverConfig omits password and socket entirely when unset", () => {

--- a/packages/activerecord/src/test-helpers/test-connection-env.ts
+++ b/packages/activerecord/src/test-helpers/test-connection-env.ts
@@ -192,12 +192,10 @@ export function mysqlSettings(read: EnvReader = getEnv): ServerSettings {
  * it directly, and `Mysql2Adapter` / `PostgreSQLAdapter` map it to the
  * driver-native `user` when building their driver config.
  *
- * The socket still straddles: Rails' config key is `socket`, while mysql2's
- * driver option is `socketPath`. Emitting only one spelling fails *silently* —
- * mysql2 ignores unknown keys, so a `socket`-only config falls back to TCP
- * rather than raising.
+ * The socket is likewise Rails' canonical `socket` alone: `Mysql2Adapter` maps
+ * it to mysql2's `socketPath` when building its driver config.
  *
- * `password` and the socket keys are omitted when unset so the drivers apply
+ * `password` and `socket` are omitted when unset so the drivers apply
  * their own defaults — a literal `undefined` is not the same as absent.
  */
 export function driverConfig(settings: ServerSettings): Record<string, unknown> {
@@ -208,7 +206,7 @@ export function driverConfig(settings: ServerSettings): Record<string, unknown> 
     username: user,
     database,
     ...(password === undefined ? {} : { password }),
-    ...(socket === undefined ? {} : { socket, socketPath: socket }),
+    ...(socket === undefined ? {} : { socket }),
   };
 }
 


### PR DESCRIPTION
Sibling of #4964 (the `username` half), same root cause with a different key.

Rails spells a Unix socket `socket` in `database.yml`
(`config.example.yml:18-19,37-39`) and Ruby's mysql2 reads `:socket` natively,
so Rails hands the hash to `::Mysql2::Client.new(config)` untouched
(`mysql2_adapter.rb:24`). Node's `mysql2` reads `socketPath` and **ignores**
unknown keys, so an unmapped Rails-spelled config silently connects over TCP.

## Changes

- `Mysql2Adapter#constructor` maps `socket` -> `socketPath` when building
  `_poolConfig`, alongside the `username` -> `user` mapping from #4964.
- **Removed** the duplicate `socket` normalization from `adapter-args.ts`.
  As with `username`, that layer stripped the key before the constructor saw
  it, so a constructor-only mapping would have been dead on the
  `connection-handling.ts:923` path every real connection takes. One mapping
  site now. The mysql `host` default at the same site was updated to check
  Rails' spelling too, so a `socket`-only config is still not given a TCP host.
- `driverConfig()` collapses to Rails' `socket` alone; the straddle comment is
  gone. `template-global-setup.ts` opens mysql2 directly (bypassing the
  adapter) so it spells `socketPath` at that call site.

## Deliberate choices (no Rails guard to inherit)

This is a Node-driver-forced deviation, so precedence was chosen, not ported.
It matches the `username` mapping so the two agree: a **Ruby-truthy** `socket`
overwrites an explicit `socketPath` and is deleted from the hash. `""` is
Ruby-truthy so a blank socket maps, landing on mysql2 as a falsy `socketPath`
(host/port) — the same outcome a blank socket has in Rails. This drops
`adapter-args.ts`'s old `socket: ""` skip and its opposite precedence, both
deliberately. Documented at the call site and in the test file header.

## Tests

`adapter-socket-key.trails.test.ts` routes every case through
`buildAdapterArg` -> constructor (direct construction is exactly what let
#4964's original bug hide), and asserts a bogus `socket`-only path fails
`ENOENT` rather than silently succeeding over TCP.

Closes-story: converge-adapters-onto-rails-socket-key
