### PR TITLE
fix(model-schema): route nested shared-table STI overlay to its schema host

### DIFF
--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -514,7 +514,13 @@ export function abstractClass(this: typeof Base, value?: boolean): boolean {
 }
 
 /**
- * Get the STI base class for a model.
+ * Get the STI base class for a model — the TOPMOST `_inheritanceColumn`
+ * ancestor. Topmost-wins is deliberate and matches Rails' `base_class`, which
+ * walks up until the superclass is `Base` or abstract (inheritance.rb
+ * `set_base_class`); a nested hierarchy with no abstract class in between still
+ * resolves to the outermost root there. Callers that need the class owning the
+ * *table* (rather than the type column) want `stiSchemaHost` in model-schema.ts,
+ * which stops at the last ancestor still sharing the receiver's table.
  */
 export function getStiBase(modelClass: object): typeof Base {
   let current = modelClass as typeof Base;

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -514,13 +514,9 @@ export function abstractClass(this: typeof Base, value?: boolean): boolean {
 }
 
 /**
- * Get the STI base class for a model — the TOPMOST `_inheritanceColumn`
- * ancestor. Topmost-wins is deliberate and matches Rails' `base_class`, which
- * walks up until the superclass is `Base` or abstract (inheritance.rb
- * `set_base_class`); a nested hierarchy with no abstract class in between still
- * resolves to the outermost root there. Callers that need the class owning the
- * *table* (rather than the type column) want `stiSchemaHost` in model-schema.ts,
- * which stops at the last ancestor still sharing the receiver's table.
+ * Get the STI base class for a model — the topmost `_inheritanceColumn`
+ * ancestor, matching Rails' `base_class`. Callers that need the class owning
+ * the table rather than the type column want `stiSchemaHost` in model-schema.ts.
  */
 export function getStiBase(modelClass: object): typeof Base {
   let current = modelClass as typeof Base;

--- a/packages/activerecord/src/model-schema-reload-recursion.trails.test.ts
+++ b/packages/activerecord/src/model-schema-reload-recursion.trails.test.ts
@@ -122,4 +122,38 @@ describe("reloadSchemaFromCache recursion — non-STI descendant under STI", () 
     expect(own<number>(Ticket, "_schemaRevision")).toBe((ticketRevisionBefore ?? 0) + 1);
     expect(own<number>(Shape, "_schemaRevision")).toBe(shapeRevisionBefore);
   });
+
+  it("does not redirect across an abstract intermediate ancestor that inherits the base table", async () => {
+    class Shape extends Base {
+      static override tableName = "tickets";
+      static {
+        this.inheritanceColumn = "type";
+      }
+    }
+    class Mediator extends Shape {
+      static {
+        this.abstractClass = true;
+      }
+    }
+    class Ticket extends Mediator {}
+    registerSubclass(Ticket);
+
+    const cols = { guid: { sqlType: "uuid", name: "guid", default: null } };
+    for (const klass of [Shape, Ticket]) {
+      (klass as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
+    }
+
+    await Ticket.loadSchema();
+    const ticketRevisionBefore = own<number>(Ticket, "_schemaRevision");
+    const shapeRevisionBefore = own<number>(Shape, "_schemaRevision");
+
+    // The abstract Mediator inherits tableName "tickets", so a bare
+    // immediate-parent table comparison would redirect the reload to
+    // stiSchemaHost(Ticket) — which stops at the abstract boundary and returns
+    // Ticket — recursing on Ticket forever. Ticket is its own host here.
+    reloadSchemaFromCache.call(Ticket as never);
+
+    expect(own<number>(Ticket, "_schemaRevision")).toBe((ticketRevisionBefore ?? 0) + 1);
+    expect(own<number>(Shape, "_schemaRevision")).toBe(shapeRevisionBefore);
+  });
 });

--- a/packages/activerecord/src/model-schema-reload-recursion.trails.test.ts
+++ b/packages/activerecord/src/model-schema-reload-recursion.trails.test.ts
@@ -84,4 +84,42 @@ describe("reloadSchemaFromCache recursion — non-STI descendant under STI", () 
     expect(own<number>(Ticket, "_schemaRevision")).toBe((ticketRevisionBefore ?? 0) + 1);
     expect(own<number>(Shape, "_schemaRevision")).toBe(shapeRevisionBefore);
   });
+
+  it("routes a shared-table STI child of an own-table descendant to the overlay clear, not a full reload", async () => {
+    class Shape extends Base {
+      static override tableName = "shapes";
+      static {
+        this.inheritanceColumn = "type";
+      }
+    }
+    class Ticket extends Shape {
+      static override tableName = "tickets";
+      static {
+        this.inheritanceColumn = "type";
+      }
+    }
+    registerSubclass(Ticket);
+    class Urgent extends Ticket {}
+    registerSubclass(Urgent);
+
+    const cols = { guid: { sqlType: "uuid", name: "guid", default: null } };
+    for (const klass of [Shape, Ticket, Urgent]) {
+      (klass as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
+    }
+
+    await Urgent.loadSchema();
+    const urgentRevisionBefore = own<number>(Urgent, "_schemaRevision");
+    const ticketRevisionBefore = own<number>(Ticket, "_schemaRevision");
+    const shapeRevisionBefore = own<number>(Shape, "_schemaRevision");
+
+    reloadSchemaFromCache.call(Urgent as never);
+
+    // Overlay clear: Urgent's own memos are dropped without bumping its
+    // revision, and the full reload lands on Ticket (its schema host), not
+    // Shape (the topmost STI ancestor).
+    expect(own<number>(Urgent, "_schemaRevision")).toBe(urgentRevisionBefore);
+    expect(own<boolean>(Urgent, "_schemaLoaded")).toBeUndefined();
+    expect(own<number>(Ticket, "_schemaRevision")).toBe((ticketRevisionBefore ?? 0) + 1);
+    expect(own<number>(Shape, "_schemaRevision")).toBe(shapeRevisionBefore);
+  });
 });

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -934,15 +934,16 @@ function invalidateStiDescendantColumnMemos(host: SchemaHost): void {
   }
 }
 
+// A shared-table STI overlay is one whose schema host is a proper ancestor,
+// i.e. `stiSchemaHost` climbs off the receiver. Defining it in terms of the
+// same resolver `reloadSchemaFromCache` redirects to keeps the gate and the
+// redirect target from ever disagreeing — a bare immediate-parent table
+// comparison would part ways with `stiSchemaHost` across an abstract ancestor
+// (which `stiSchemaHost` treats as a host boundary), redirecting to `this` and
+// recursing forever.
 function sharesStiBaseTable(klass: SchemaHost): boolean {
   if (!isStiSubclass(klass)) return true;
-  const parent = Object.getPrototypeOf(klass) as SchemaHost | null;
-  if (!parent || parent === (Function.prototype as unknown)) return true;
-  try {
-    return parent.tableName === klass.tableName;
-  } catch {
-    return false;
-  }
+  return stiSchemaHost(klass) !== klass;
 }
 
 /**

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -934,14 +934,6 @@ function invalidateStiDescendantColumnMemos(host: SchemaHost): void {
   }
 }
 
-// Whether `klass` is a shared-table STI overlay of its *nearest* STI ancestor.
-// Deliberately not `getStiBase(klass).tableName === klass.tableName`: getStiBase
-// keeps the TOPMOST `_inheritanceColumn` ancestor, so in a nested hierarchy
-// (Shape → Ticket, own table "tickets", STI re-enabled → Urgent, shares
-// "tickets") it reports Shape for Urgent and the table comparison then says
-// "own table" for a class that is a genuine overlay of Ticket. Comparing
-// against the immediate ancestor answers the question these callers actually
-// ask — does this class share its parent's schema host?
 function sharesStiBaseTable(klass: SchemaHost): boolean {
   if (!isStiSubclass(klass)) return true;
   const parent = Object.getPrototypeOf(klass) as SchemaHost | null;
@@ -971,13 +963,9 @@ function scrubSchemaSourcedDefinitions(host: SchemaHost): void {
 
 /** @internal */
 export function reloadSchemaFromCache(this: SchemaHost): void {
-  const host = isStiSubclass(this) && sharesStiBaseTable(this) ? stiSchemaHost(this) : this;
-  if (host !== this) {
+  if (isStiSubclass(this) && sharesStiBaseTable(this)) {
     clearStiSubclassLocalCaches(this);
-    // The full reload belongs on the schema host that actually owns the table —
-    // the topmost ancestor still sharing it — not on getStiBase's topmost STI
-    // ancestor, which may sit on a different table in a nested hierarchy.
-    reloadSchemaFromCache.call(host);
+    reloadSchemaFromCache.call(stiSchemaHost(this));
     return;
   }
   this._columnsHash = undefined;

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -13,7 +13,6 @@ import {
 } from "@blazetrails/activemodel";
 import {
   isStiSubclass,
-  getStiBase,
   isBaseClass,
   baseClass,
   getAbstractClass,
@@ -935,9 +934,23 @@ function invalidateStiDescendantColumnMemos(host: SchemaHost): void {
   }
 }
 
+// Whether `klass` is a shared-table STI overlay of its *nearest* STI ancestor.
+// Deliberately not `getStiBase(klass).tableName === klass.tableName`: getStiBase
+// keeps the TOPMOST `_inheritanceColumn` ancestor, so in a nested hierarchy
+// (Shape → Ticket, own table "tickets", STI re-enabled → Urgent, shares
+// "tickets") it reports Shape for Urgent and the table comparison then says
+// "own table" for a class that is a genuine overlay of Ticket. Comparing
+// against the immediate ancestor answers the question these callers actually
+// ask — does this class share its parent's schema host?
 function sharesStiBaseTable(klass: SchemaHost): boolean {
-  const base = getStiBase(klass) as unknown as SchemaHost;
-  return base === klass || base.tableName === klass.tableName;
+  if (!isStiSubclass(klass)) return true;
+  const parent = Object.getPrototypeOf(klass) as SchemaHost | null;
+  if (!parent || parent === (Function.prototype as unknown)) return true;
+  try {
+    return parent.tableName === klass.tableName;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -958,9 +971,13 @@ function scrubSchemaSourcedDefinitions(host: SchemaHost): void {
 
 /** @internal */
 export function reloadSchemaFromCache(this: SchemaHost): void {
-  if (isStiSubclass(this) && sharesStiBaseTable(this)) {
+  const host = isStiSubclass(this) && sharesStiBaseTable(this) ? stiSchemaHost(this) : this;
+  if (host !== this) {
     clearStiSubclassLocalCaches(this);
-    reloadSchemaFromCache.call(getStiBase(this) as SchemaHost);
+    // The full reload belongs on the schema host that actually owns the table —
+    // the topmost ancestor still sharing it — not on getStiBase's topmost STI
+    // ancestor, which may sit on a different table in a nested hierarchy.
+    reloadSchemaFromCache.call(host);
     return;
   }
   this._columnsHash = undefined;


### PR DESCRIPTION
## What

`sharesStiBaseTable` was defined as `getStiBase(klass).tableName === klass.tableName`. `getStiBase` climbs to the **topmost** `_inheritanceColumn` ancestor, so in a nested STI hierarchy — `Shape` (STI) → `Ticket` (own table `"tickets"`, STI re-enabled) → `Urgent` (shares `"tickets"`) — it returns `Shape` for `Urgent`. The table comparison then reads `"shapes" === "tickets"` → `false`, misclassifying a genuine shared-table overlay as own-table and routing `Urgent` down `reloadSchemaFromCache`'s full-reload arm instead of the overlay-clear arm.

## Fix

- `sharesStiBaseTable` now compares against the **immediate** ancestor's table — the question these callers actually ask ("does this class share its parent's schema host?").
- `reloadSchemaFromCache` lands the full reload on `stiSchemaHost(this)` (topmost ancestor still sharing the table) rather than `getStiBase(this)`.
- `getStiBase` keeps its topmost-wins semantics — that matches Rails' `base_class` (`set_base_class` walks up until the superclass is `Base` or abstract). Documented the distinction at both sites so callers reach for `stiSchemaHost` when they want the table owner.

## Test

New regression in `model-schema-reload-recursion.trails.test.ts` covering `Shape → Ticket → Urgent`: `Urgent` takes the overlay-clear arm (own memos dropped, no revision bump), the full reload lands on `Ticket`, and `Shape` is untouched. Fails on baseline, passes with the fix. Existing STI/schema suites stay green.

Closes-story: get-sti-base-returns-topmost-not-nearest-sti-ancestor