### PR TITLE
test(calculations): converge grouped HAVING through association test body

### DIFF
--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -681,9 +681,11 @@ describe("CalculationsTest", () => {
   it("should group by summed field through association and having", async () => {
     const rc = companies("rails_core");
     const firm = (await Company.where({ id: rc.id }).first())! as any;
-    const c = (await firm.companies.group("name").sum("id")) as Map<unknown, number>;
-    // Companies under rails_core: Leetsoft (id=7) and Jadedpixel (id=8)
-    expect(Number(c.get("Leetsoft"))).toBe(7);
+    const c = (await firm.companies.group("name").having("sum(id) > 7").sum("id")) as Map<
+      unknown,
+      number
+    >;
+    expect(c.get("Leetsoft")).toBeUndefined();
     expect(Number(c.get("Jadedpixel"))).toBe(8);
   });
 


### PR DESCRIPTION
The `"should group by summed field through association and having"` test in
`calculations.test.ts` was a verbatim duplicate of the `"should group by scoped
field"` test above it — it had **no `.having(...)` call**, so despite its name
it never exercised the HAVING path.

Restore Rails' body
(`calculations_test.rb:600` `test_should_group_by_summed_field_through_association_and_having`):

- `.having("sum(id) > 7")`
- `c["Leetsoft"]` absent (filtered out)
- `c["Jadedpixel"]` == 8

Passes on current `main` — the grouped HAVING emitter landed in #5184. This
confirms the association-scope spawn path (`firm.companies`) reaches
`groupedAggregate` with the having clause intact, which the #5184 tests
(`Account.group(...)`) did not cover.

Closes-story: grouped-having-through-association-test-body-missing
