### PR TITLE
fix(connection-adapters): route ported Ruby truthiness guards through isRubyTruthy

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -15,6 +15,7 @@ import {
   returningColumnValues as mysqlReturningColumnValues,
 } from "./mysql/database-statements.js";
 import { Result } from "../result.js";
+import { isRubyTruthy } from "../ruby-truthy.js";
 import type { InsertBuilder } from "../insert-all.js";
 import type { AdapterName } from "./abstract-adapter.js";
 import { AbstractAdapter, Version } from "./abstract-adapter.js";
@@ -1322,17 +1323,17 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     options: Record<string, unknown> = {},
   ): string[] {
     const args: string[] = ["mysql"];
-    if (config.host) args.push(`--host=${config.host}`);
-    if (config.port) args.push(`--port=${config.port}`);
-    if (config.socket) args.push(`--socket=${config.socket}`);
-    if (config.username) args.push(`--user=${config.username}`);
-    if (config.sslCa) args.push(`--ssl-ca=${config.sslCa}`);
-    if (config.sslCert) args.push(`--ssl-cert=${config.sslCert}`);
-    if (config.sslKey) args.push(`--ssl-key=${config.sslKey}`);
+    if (isRubyTruthy(config.host)) args.push(`--host=${config.host}`);
+    if (isRubyTruthy(config.port)) args.push(`--port=${config.port}`);
+    if (isRubyTruthy(config.socket)) args.push(`--socket=${config.socket}`);
+    if (isRubyTruthy(config.username)) args.push(`--user=${config.username}`);
+    if (isRubyTruthy(config.sslCa)) args.push(`--ssl-ca=${config.sslCa}`);
+    if (isRubyTruthy(config.sslCert)) args.push(`--ssl-cert=${config.sslCert}`);
+    if (isRubyTruthy(config.sslKey)) args.push(`--ssl-key=${config.sslKey}`);
     // Rails: --password=… only with include_password; otherwise -p prompts.
-    if (config.password && options.includePassword) {
+    if (isRubyTruthy(config.password) && options.includePassword) {
       args.push(`--password=${config.password}`);
-    } else if (config.password && String(config.password) !== "") {
+    } else if (isRubyTruthy(config.password) && String(config.password) !== "") {
       args.push("-p");
     }
     if (config.database) args.push(config.database as string);

--- a/packages/activerecord/src/connection-adapters/dbconsole-option-keys.test.ts
+++ b/packages/activerecord/src/connection-adapters/dbconsole-option-keys.test.ts
@@ -20,6 +20,14 @@ describe("AbstractMysqlAdapter.dbconsole option keys", () => {
     expect(args).toContain("--password=secret");
     expect(args).not.toContain("-p");
   });
+
+  it("keeps Ruby-truthy empty-string and zero config values", () => {
+    const args = AbstractMysqlAdapter.dbconsole({ host: "", username: "", port: 0, socket: "" });
+    expect(args).toContain("--host=");
+    expect(args).toContain("--user=");
+    expect(args).toContain("--port=0");
+    expect(args).toContain("--socket=");
+  });
 });
 
 describe("AbstractSQLite3Adapter.dbconsole option keys", () => {
@@ -32,6 +40,13 @@ describe("AbstractSQLite3Adapter.dbconsole option keys", () => {
   it("omits the flags when mode/header are absent", () => {
     expect(AbstractSQLite3Adapter.dbconsole({ database: "db.sqlite3" })).toEqual(["db.sqlite3"]);
   });
+
+  it("keeps a Ruby-truthy empty-string mode", () => {
+    expect(AbstractSQLite3Adapter.dbconsole({ database: "db.sqlite3" }, { mode: "" })).toEqual([
+      "-",
+      "db.sqlite3",
+    ]);
+  });
 });
 
 describe("PostgreSQLAdapter.dbconsole option keys", () => {
@@ -42,6 +57,18 @@ describe("PostgreSQLAdapter.dbconsole option keys", () => {
     expect(PostgreSQLAdapter.dbconsole(config, { includePassword: true }).PGPASSWORD).toBe(
       "secret",
     );
+  });
+
+  it("exports Ruby-truthy empty-string and zero config values", () => {
+    const env = PostgreSQLAdapter.dbconsole({ username: "", host: "", port: 0 });
+    expect(env.PGUSER).toBe("");
+    expect(env.PGHOST).toBe("");
+    expect(env.PGPORT).toBe("0");
+  });
+
+  it("skips a false password even when includePassword is set", () => {
+    const env = PostgreSQLAdapter.dbconsole({ password: false }, { includePassword: true });
+    expect(env.PGPASSWORD).toBeUndefined();
   });
 
   it("builds PGOPTIONS from variables, dropping only :default (not the bare string default)", () => {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -194,16 +194,16 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     options: { includePassword?: boolean } = {},
   ): Record<string, string> {
     const env: Record<string, string> = {};
-    if (config.username) env.PGUSER = String(config.username);
-    if (config.host) env.PGHOST = String(config.host);
-    if (config.port) env.PGPORT = String(config.port);
-    if (config.password != null && options.includePassword) {
+    if (isRubyTruthy(config.username)) env.PGUSER = String(config.username);
+    if (isRubyTruthy(config.host)) env.PGHOST = String(config.host);
+    if (isRubyTruthy(config.port)) env.PGPORT = String(config.port);
+    if (isRubyTruthy(config.password) && options.includePassword) {
       env.PGPASSWORD = String(config.password);
     }
-    if (config.sslmode) env.PGSSLMODE = String(config.sslmode);
-    if (config.sslcert) env.PGSSLCERT = String(config.sslcert);
-    if (config.sslkey) env.PGSSLKEY = String(config.sslkey);
-    if (config.sslrootcert) env.PGSSLROOTCERT = String(config.sslrootcert);
+    if (isRubyTruthy(config.sslmode)) env.PGSSLMODE = String(config.sslmode);
+    if (isRubyTruthy(config.sslcert)) env.PGSSLCERT = String(config.sslcert);
+    if (isRubyTruthy(config.sslkey)) env.PGSSLKEY = String(config.sslkey);
+    if (isRubyTruthy(config.sslrootcert)) env.PGSSLROOTCERT = String(config.sslrootcert);
     const variables = config.variables as Record<string, unknown> | undefined;
     if (variables) {
       // Rails: PGOPTIONS = variables.filter_map { "-c name=value" unless :default }

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -12,6 +12,7 @@ import type { AdapterName } from "./abstract-adapter.js";
 import type { ExplainOption } from "./abstract/database-statements.js";
 import type { SQLite3AdapterOptions, SQLite3Config } from "./pool-config.js";
 import { AbstractAdapter, Version } from "./abstract-adapter.js";
+import { isRubyTruthy } from "../ruby-truthy.js";
 import { SchemaCreation as SQLite3SchemaCreation } from "./sqlite3/schema-creation.js";
 import { TableDefinition as SQLite3TableDefinition } from "./sqlite3/schema-definitions.js";
 import {
@@ -1512,7 +1513,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     options: { mode?: string; header?: boolean } = {},
   ): string[] {
     const args: string[] = [];
-    if (options.mode) args.push(`-${options.mode}`);
+    if (isRubyTruthy(options.mode)) args.push(`-${options.mode}`);
     if (options.header) args.push("-header");
     args.push(config?.database ?? ":memory:");
     return args;


### PR DESCRIPTION
## What

Audit of ported Ruby truthiness guards for the bare-JS-truthiness hazard from
#4964, plus adoption of `isRubyTruthy` (`packages/activerecord/src/ruby-truthy.ts`)
at the real divergences found.

Ruby treats `""`, `0`, `0.0`, `NaN`, `[]` as truthy and only `nil`/`false` as
falsey. A ported `if some_value` rendered as a bare JS `if (value)` therefore
silently drops empty strings and zeroes; a naive `!= null` "fix" over-accepts
`false`. The sweep prioritized config/option-reading paths, where `""`/`0` are
realistic values, with `vendor/rails` as the oracle.

## Divergences fixed (each routed through `isRubyTruthy`)

| Site | Rails oracle | Value that diverged |
|------|--------------|---------------------|
| `abstract-mysql-adapter.ts` `dbconsole` host/port/socket/username/ssl* | `abstract_mysql_adapter.rb:60-72` `filter_map { … if cfg[opt] }` | `host: ""`, `port: 0` dropped |
| `abstract-mysql-adapter.ts` `dbconsole` password `-p` / `--password` | `abstract_mysql_adapter.rb:74-77` | `password: 0` dropped by `password &&`; `false` path preserved |
| `postgresql-adapter.ts` `dbconsole` PGUSER/PGHOST/PGPORT/PGSSL* | `postgresql_adapter.rb:76-83` `ENV[…] = … if pg_config[:k]` | `""`/`0` dropped; `password != null` over-accepted `false` |
| `sqlite3-adapter.ts` `dbconsole` `-#{mode}` | `sqlite3_adapter.rb:47` `if options[:mode]` | `mode: ""` dropped |

Regression tests covering the `""`/`0`/`false` cases live in
`dbconsole-option-keys.test.ts` and are verified to fail on the pre-fix code.

## Second known site — already converged on main

The other hand-rolled site named in the story, `adapter-args.ts`' mysql
`socket` normalization, was independently converged on `main`: the
`socket`→`socketPath` mapping now lives in `Mysql2Adapter#constructor` and
already routes through `isRubyTruthy` (so `socket: ""` maps, matching Ruby
truthiness). Nothing is left to fix there, and the residual bare
`!adapterConfig.socket` in `adapter-args`' host-default is intentional trails
driver-normalization (a blank socket must fall back to host), not a Ruby
`if socket` port — so this PR no longer touches that file.

## Sweep notes (audited, no change)

- Association/reflection option reads (`options.className ?? …`,
  `if (options.through)`, `if (options.polymorphic)`, …) use `??` (matches Ruby
  `||` for the string/symbol values in play) or guard booleans/symbols where
  `""`/`0` are not realizable — no divergence.
- Value-parsing `=== ""` sites (OID types, ranges, geometric, hstore, etc.)
  are genuine empty-value checks, not truthiness ports.
- `abstract-mysql-adapter.ts` `dbconsole` pushes `config.database` under a JS
  guard where Rails pushes unconditionally; that is a separate (non-truthiness)
  gap and `dbconsole`'s PTY exec is itself flagged Ruby-only, so it is left as-is.

## Lint feasibility — conclusion

A **general** lint is not feasible: nothing in the TypeScript marks a value as
Ruby-derived, so a rule flagging every bare `if (x)` would be almost entirely
false positives. A **scoped** rule (flag bare truthiness on a value read from a
`config`/`options`/configuration hash) is theoretically possible but still
noisy — most such reads are legitimately boolean/presence checks — and would
need a manifest of Ruby-derived hashes to be precise, which does not exist.
Recommendation: **do not add a lint.** The durable guardrail is the shared
`isRubyTruthy` helper plus its doc comment; adopt it at each ported guard by
convention. (Contrast `rails-callback-invocation-lint-rule`, which is tractable
because it keys off a concrete manifest of callback method names.)

Closes-story: rails-ruby-truthiness-audit-and-isrubytruthy-adoption
