### PR TITLE
feat(schema-compare): parse the four adapter-specific schema.rb companions

### DIFF
--- a/scripts/schema-compare/compare.test.ts
+++ b/scripts/schema-compare/compare.test.ts
@@ -5,11 +5,13 @@ import {
   applyBaseline,
   compareSchemas,
   isFatal,
+  loadRailsTables,
   normalizeRailsDefault,
   optionMismatches,
   optionRegressions,
   partitionFindings,
   readBaseline,
+  SCHEMA_FILES,
   unresolvedCallSites,
 } from "./compare.js";
 import { TEST_SCHEMA } from "../../packages/activerecord/src/test-helpers/test-schema.js";
@@ -211,6 +213,19 @@ describe("parseSchemaRb", () => {
     expect([...table.columns.keys()]).toEqual(["name", "tag"]);
     expect(table.columns.get("tag")!.options.default).toBe('"#hash"');
   });
+
+  it("gathers a create_table whose parenthesised args wrap across lines", () => {
+    const tables = parse(
+      `create_table(:measurements_toronto, id: false, force: true,
+                    options: "PARTITION OF measurements FOR VALUES IN (1)")
+       create_table :after, force: true do |t|
+         t.string :name
+       end`,
+    );
+    expect(tables.has("measurements_toronto")).toBe(true);
+    // The continuation must not swallow the table that follows it.
+    expect([...tables.get("after")!.columns.keys()]).toEqual(["name"]);
+  });
 });
 
 describe("compareSchemas", () => {
@@ -269,6 +284,41 @@ describe("compareSchemas", () => {
     const findings = compareSchemas({ accounts: { firm_name: "string" } }, rails);
     expect(verdicts(findings)).toEqual(["UNPORTED-COLUMN:accounts.credit_limit"]);
     expect(findings.every((f) => !isFatal(f))).toBe(true);
+  });
+
+  it("records the source file a matched table came from", () => {
+    const sources = new Map([["accounts", ["postgresql_specific_schema.rb"]]]);
+    const findings = compareSchemas(
+      { accounts: { firm_name: "string", region_id: "integer" } },
+      rails,
+      sources,
+    );
+    expect(findings.find((f) => f.verdict === "INVENTED-COLUMN")?.source).toBe(
+      "postgresql_specific_schema.rb",
+    );
+  });
+
+  it("suppresses shape and unported findings for an ambiguous multi-source table", () => {
+    // credit_limit is absent from TEST_SCHEMA and firm_name's type diverges;
+    // both are phantom for a table whose columns differ by adapter.
+    const findings = compareSchemas(
+      { accounts: { firm_name: "integer" } },
+      rails,
+      new Map([["accounts", ["mysql2_specific_schema.rb", "postgresql_specific_schema.rb"]]]),
+      new Set(["accounts"]),
+    );
+    expect(findings).toEqual([]);
+  });
+
+  it("still flags a truly-invented column on an ambiguous table", () => {
+    // A column real on no adapter variant (union) is a genuine invention.
+    const findings = compareSchemas(
+      { accounts: { firm_name: "string", made_up: "string" } },
+      rails,
+      new Map([["accounts", ["mysql2_specific_schema.rb", "postgresql_specific_schema.rb"]]]),
+      new Set(["accounts"]),
+    );
+    expect(verdicts(findings)).toEqual(["INVENTED-COLUMN:accounts.made_up"]);
   });
 });
 
@@ -529,5 +579,50 @@ describe("against the vendored schema.rb", () => {
     // Ratchet: this number may fall as debt is paid off, never rise.
     const baseline = await readBaseline();
     expect(baseline.tables.length + baseline.columns.length).toBeLessThanOrEqual(91);
+  });
+});
+
+// The adapter-specific companions (postgresql_specific_schema.rb et al.) declare
+// further canonical tables; a TEST_SCHEMA table mirroring one must not be
+// flagged invented, and their create_table forms must resolve too.
+describe("against the adapter-specific companion schemas", () => {
+  it("resolves every create_table call site across all five sources", async () => {
+    const { unresolved } = await loadRailsTables();
+    expect(unresolved).toEqual([]);
+  });
+
+  it("treats a PG-only companion table as canonical and records its source", async () => {
+    const { tables, sources } = await loadRailsTables();
+    expect(tables.has("uuid_children")).toBe(true);
+    expect(sources.get("uuid_children")).toEqual(["postgresql_specific_schema.rb"]);
+  });
+
+  it("keeps a create_table whose parenthesised args wrap across physical lines", async () => {
+    const { tables } = await loadRailsTables();
+    expect(tables.has("measurements_toronto")).toBe(true);
+    expect(tables.has("measurements_concepcion")).toBe(true);
+  });
+
+  it("keeps a schema.rb table authoritative over a same-named companion", async () => {
+    // schema.rb leads, so a table it declares keeps that source, is never
+    // mislabelled adapter-scoped, and is not treated as ambiguous.
+    const { sources, ambiguous } = await loadRailsTables();
+    expect(SCHEMA_FILES[0]).toBe("schema.rb");
+    expect(sources.get("accounts")).toEqual(["schema.rb"]);
+    expect(ambiguous.has("accounts")).toBe(false);
+  });
+
+  it("marks a table declared by several companions ambiguous and unions its columns", async () => {
+    // `defaults` is declared in every companion with different columns; Rails
+    // loads exactly one variant per adapter, so we cannot pick one — the table
+    // is canonical (a superset) but ambiguous.
+    const { tables, sources, ambiguous } = await loadRailsTables();
+    expect(sources.get("defaults")!.length).toBeGreaterThan(1);
+    expect(sources.get("defaults")).not.toContain("schema.rb");
+    expect(ambiguous.has("defaults")).toBe(true);
+    const columns = tables.get("defaults")!.columns;
+    // Union: a column absent from MySQL and one absent from PG both survive.
+    expect(columns.has("char3")).toBe(true); // t.text :char3 — not in MySQL
+    expect(columns.has("char2_concatenated")).toBe(true); // MySQL only, not in PG
   });
 });

--- a/scripts/schema-compare/compare.ts
+++ b/scripts/schema-compare/compare.ts
@@ -20,13 +20,36 @@ import type {
 } from "../../packages/activerecord/src/test-helpers/schema-types.js";
 import { columnsOf } from "../../packages/activerecord/src/test-helpers/schema-types.js";
 import type { RailsColumnOptions, RailsTable } from "./parse-schema-rb.js";
-import { parseSchemaRb, parseSchemaRbWithCoverage } from "./parse-schema-rb.js";
+import { parseSchemaRbWithCoverage } from "./parse-schema-rb.js";
 import { writeJsonManifest } from "../api-compare/write-json-manifest.js";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(HERE, "..", "..");
-const SCHEMA_RB = path.join(ROOT, "vendor/rails/activerecord/test/schema/schema.rb");
+const SCHEMA_DIR = path.join(ROOT, "vendor/rails/activerecord/test/schema");
 const BASELINE = path.join(HERE, "invented-baseline.json");
+
+/**
+ * The canonical schema sources. Rails declares most tables in `schema.rb` but
+ * puts adapter-scoped ones (PG's `uuid_*`, MySQL's `binary_fields`, ...) in
+ * per-adapter companions. All are canonical: a TEST_SCHEMA table mirroring any
+ * of them is NOT invented.
+ *
+ * This is NOT a Ruby load order. Rails loads `schema.rb` plus exactly ONE
+ * companion, chosen at runtime by the live connection's adapter name
+ * (`load_schema_helper.rb`) — the four companions never coexist in one process.
+ * We merge all four into a single canonical superset instead, which is why a
+ * table declared by more than one companion is treated as ambiguous rather than
+ * resolved to whichever file sorts first (see `loadRailsTables`). `schema.rb`
+ * leads only so a table it declares stays authoritative over a same-named
+ * companion table; the order among the companions carries no meaning.
+ */
+export const SCHEMA_FILES: readonly string[] = [
+  "schema.rb",
+  "postgresql_specific_schema.rb",
+  "mysql2_specific_schema.rb",
+  "sqlite_specific_schema.rb",
+  "trilogy_specific_schema.rb",
+];
 
 /**
  * Pre-existing invented entries, recorded so the gate ratchets: anything in
@@ -106,6 +129,13 @@ export interface Finding {
   table: string;
   column?: string;
   detail: string;
+  /**
+   * The canonical schema file the table was matched against (one of
+   * SCHEMA_FILES). Populated for findings on tables that DO exist in a Rails
+   * source, so an adapter-scoped table laid unconditionally by TEST_SCHEMA is
+   * distinguishable in the report. Absent for INVENTED-TABLE (no match).
+   */
+  source?: string;
 }
 
 export function isFatal(finding: Finding): boolean {
@@ -223,11 +253,14 @@ export function optionMismatches(rails: RailsColumnOptions, spec: ColumnSpec): s
 export function compareSchemas(
   testSchema: Schema,
   railsTables: ReadonlyMap<string, RailsTable>,
+  sources?: ReadonlyMap<string, string[]>,
+  ambiguous?: ReadonlySet<string>,
 ): Finding[] {
   const findings: Finding[] = [];
 
   for (const [tableName, tableSchema] of Object.entries(testSchema)) {
     const rails = railsTables.get(tableName);
+    const source = sources?.get(tableName)?.[0];
     if (!rails) {
       if (TABLE_ALLOW_LIST.has(tableName)) continue;
       findings.push({
@@ -237,6 +270,13 @@ export function compareSchemas(
       });
       continue;
     }
+
+    // A table with several colliding companion variants has no single column
+    // set: its type/options/presence differ by adapter and we cannot tell which
+    // one TEST_SCHEMA targets. INVENTED-COLUMN still fires — against the union,
+    // so a column real on any adapter is spared — but SHAPE, OPTION, and
+    // UNPORTED-COLUMN would be phantom, so they are suppressed for these tables.
+    const merged = ambiguous?.has(tableName) ?? false;
 
     const tsColumns = columnsOf(tableSchema);
     for (const [columnName, spec] of Object.entries(tsColumns)) {
@@ -254,16 +294,19 @@ export function compareSchemas(
           table: tableName,
           column: columnName,
           detail: "not declared in the schema.rb create_table block",
+          source,
         });
         continue;
       }
+      if (merged) continue;
       const tsType = specType(spec);
       if (!typesAgree(railsColumn.type, tsType)) {
         findings.push({
           verdict: "SHAPE",
           table: tableName,
           column: columnName,
-          detail: `schema.rb says ${railsColumn.type}, TEST_SCHEMA says ${tsType}`,
+          detail: `${source ?? "schema.rb"} says ${railsColumn.type}, TEST_SCHEMA says ${tsType}`,
+          source,
         });
         // A type divergence makes the options incomparable (a limit on a
         // string means nothing against an integer), so stop at the type.
@@ -276,10 +319,12 @@ export function compareSchemas(
           table: tableName,
           column: columnName,
           detail: mismatches.join("; "),
+          source,
         });
       }
     }
 
+    if (merged) continue;
     for (const columnName of rails.columns.keys()) {
       if (columnName in tsColumns) continue;
       if (rails.primaryKeyColumns.has(columnName)) continue;
@@ -287,7 +332,8 @@ export function compareSchemas(
         verdict: "UNPORTED-COLUMN",
         table: tableName,
         column: columnName,
-        detail: "declared in schema.rb, absent from TEST_SCHEMA",
+        detail: `declared in ${source ?? "schema.rb"}, absent from TEST_SCHEMA`,
+        source,
       });
     }
   }
@@ -297,7 +343,65 @@ export function compareSchemas(
 
 function formatFinding(finding: Finding): string {
   const target = finding.column ? `${finding.table}.${finding.column}` : finding.table;
-  return `${isFatal(finding) ? "FAIL" : "warn"}  ${finding.verdict.padEnd(15)} ${target} — ${finding.detail}`;
+  const scope = finding.source && finding.source !== "schema.rb" ? ` [${finding.source}]` : "";
+  return `${isFatal(finding) ? "FAIL" : "warn"}  ${finding.verdict.padEnd(15)} ${target}${scope} — ${finding.detail}`;
+}
+
+export interface LoadedSchema {
+  tables: Map<string, RailsTable>;
+  /** Every file that declared each table, in scan order (schema.rb first). */
+  sources: Map<string, string[]>;
+  /**
+   * Tables declared by two or more companions with no schema.rb definition.
+   * Rails would load exactly one of those variants (per adapter), so their
+   * column sets legitimately differ and we cannot know which one TEST_SCHEMA
+   * targets. Membership is still canonical, but per-column type/option/presence
+   * diffs against an arbitrary merge would be phantom, so the comparator
+   * suppresses them (see `compareSchemas`).
+   */
+  ambiguous: Set<string>;
+  unresolved: string[];
+}
+
+/**
+ * Parses every canonical schema source into one table map — a superset across
+ * all adapters — recording which files declared each table. `schema.rb` is
+ * authoritative: when it declares a table, a same-named companion table neither
+ * overrides its columns nor makes it ambiguous. Companions that collide with
+ * each other union their columns (so a column real on any adapter is canonical)
+ * and mark the table ambiguous. Unresolved call sites are collected for the
+ * caller to abort on.
+ */
+export async function loadRailsTables(): Promise<LoadedSchema> {
+  const tables = new Map<string, RailsTable>();
+  const sources = new Map<string, string[]>();
+  const unresolved: string[] = [];
+  for (const file of SCHEMA_FILES) {
+    const source = await readFile(path.join(SCHEMA_DIR, file), "utf8");
+    const parsed = parseSchemaRbWithCoverage(source);
+    for (const site of parsed.unresolved) unresolved.push(`${file}: ${site}`);
+    for (const [name, table] of parsed.tables) {
+      const existing = tables.get(name);
+      if (!existing) {
+        tables.set(name, table);
+        sources.set(name, [file]);
+        continue;
+      }
+      sources.get(name)!.push(file);
+      // schema.rb (always first when present) stays authoritative; only
+      // cross-companion collisions union their columns into the superset.
+      if (sources.get(name)![0] === "schema.rb") continue;
+      for (const [column, def] of table.columns) {
+        if (!existing.columns.has(column)) existing.columns.set(column, def);
+      }
+    }
+  }
+  const ambiguous = new Set(
+    [...sources]
+      .filter(([, files]) => files.length > 1 && files[0] !== "schema.rb")
+      .map(([n]) => n),
+  );
+  return { tables, sources, ambiguous, unresolved };
 }
 
 /**
@@ -374,22 +478,20 @@ export function partitionFindings(
 }
 
 export async function main(): Promise<void> {
-  const source = await readFile(SCHEMA_RB, "utf8");
-  const railsTables = parseSchemaRb(source);
+  const { tables: railsTables, sources, ambiguous, unresolved } = await loadRailsTables();
 
   // Trust the parser before trusting its verdicts.
-  const unresolved = unresolvedCallSites(source);
   if (unresolved.length > 0) {
     console.error(
-      `schema.rb has ${unresolved.length} create_table call site(s) the parser could not ` +
-        `resolve to a table name:\n${unresolved.map((l) => `  ${l}`).join("\n")}\n\n` +
+      `the canonical schema files have ${unresolved.length} create_table call site(s) the ` +
+        `parser could not resolve to a table name:\n${unresolved.map((l) => `  ${l}`).join("\n")}\n\n` +
         `Every verdict would be unreliable, so nothing is reported. Teach ` +
         `scripts/schema-compare/parse-schema-rb.ts the new create_table form.`,
     );
     process.exit(1);
   }
 
-  const findings = compareSchemas(TEST_SCHEMA, railsTables);
+  const findings = compareSchemas(TEST_SCHEMA, railsTables, sources, ambiguous);
 
   if (process.argv.includes("--write")) {
     const invented = findings.filter(isFatal);
@@ -433,6 +535,28 @@ export async function main(): Promise<void> {
   if (process.argv.includes("--verbose")) {
     for (const finding of [...shape, ...option]) console.log(formatFinding(finding));
   }
+  // A TEST_SCHEMA table whose only canonical home is a per-adapter companion is
+  // being laid on every adapter, not just the one Rails scopes it to — surface
+  // that so a reviewer can weigh it, even though it is not INVENTED. Tables
+  // declared by several colliding companions get a sharper note: their
+  // per-column diffs were suppressed because no single variant is authoritative.
+  const adapterScoped = Object.keys(TEST_SCHEMA)
+    .filter((name) => {
+      const files = sources.get(name);
+      return files !== undefined && files[0] !== "schema.rb";
+    })
+    .sort();
+  for (const name of adapterScoped) {
+    const files = sources.get(name)!;
+    if (ambiguous.has(name)) {
+      console.log(
+        `note  MULTIPLE-SOURCES ${name} [${files.join(", ")}] — canonical; ` +
+          `per-column diffs suppressed (variants differ by adapter)`,
+      );
+    } else {
+      console.log(`note  ADAPTER-SCOPED  ${name} [${files[0]}] — canonical, laid unconditionally`);
+    }
+  }
   for (const key of stale) {
     console.log(
       `note  BASELINE-STALE  ${key} — no longer invented; drop it with pnpm schema:compare:reseed`,
@@ -440,7 +564,7 @@ export async function main(): Promise<void> {
   }
 
   console.log(
-    `\n${Object.keys(TEST_SCHEMA).length} TEST_SCHEMA tables vs ${railsTables.size} schema.rb tables — ` +
+    `\n${Object.keys(TEST_SCHEMA).length} TEST_SCHEMA tables vs ${railsTables.size} canonical-schema tables — ` +
       `new-inventions=${regressions.length} baselined=${known.length} ` +
       `option-divergences=${optionCount} (ceiling ${OPTION_DEBT_CEILING}) shape-warnings=${shape.length}` +
       (process.argv.includes("--verbose") ? "" : " (--verbose to list shape warnings)"),

--- a/scripts/schema-compare/parse-schema-rb.ts
+++ b/scripts/schema-compare/parse-schema-rb.ts
@@ -334,8 +334,8 @@ export function parseSchemaRbWithCoverage(source: string): ParseResult {
   let depth = 0;
   let pendingEach: { variable: string; names: string[] } | null = null;
 
-  for (const rawLine of lines) {
-    const line = stripComment(rawLine).trim();
+  for (let li = 0; li < lines.length; li++) {
+    const line = stripComment(lines[li]!).trim();
     if (line === "") continue;
 
     if (table === null) {
@@ -366,7 +366,15 @@ export function parseSchemaRbWithCoverage(source: string): ParseResult {
       const parenthesised = rest.startsWith("(");
       let braceBlock = false;
       if (parenthesised) {
-        const close = matchingParen(rest);
+        // `create_table(:measurements_concepcion, id: false, force: true,\n
+        //   options: "...")` wraps its argument list across physical lines;
+        // gather continuation lines until the `(` closes rather than dropping
+        // the table (the PG companion schema declares two tables this way).
+        let close = matchingParen(rest);
+        while (close === -1 && li + 1 < lines.length) {
+          rest += " " + stripComment(lines[++li]!).trim();
+          close = matchingParen(rest);
+        }
         if (close === -1) {
           unresolved.push(line);
           continue;


### PR DESCRIPTION
## What

`pnpm schema:compare` read only
`vendor/rails/activerecord/test/schema/schema.rb`. Rails declares further
canonical tables in four adapter-specific companions in the same directory
(`postgresql_/mysql2_/sqlite_/trilogy_specific_schema.rb`). Any TEST_SCHEMA
table mirroring one of those would be reported as an **invented table** — the
one false verdict this tool is built to never emit. Latent today (the 91
baselined inventions were manually verified absent from all five files), but it
fires the moment a PG-specific canonical table (`citext` / `uuid` / `oid` …) is
ported.

## Changes

- **`compare.ts`** — `loadRailsTables()` parses all five sources into one
  canonical superset, recording every file that declared each table. `Finding`
  carries the primary `source`, so an adapter-scoped table is distinguishable in
  the report, and TEST_SCHEMA tables whose only canonical home is a companion
  surface as an `ADAPTER-SCOPED` / `MULTIPLE-SOURCES` note.
- The unresolved-call-site abort spans every file (filename-prefixed), so a
  `create_table` form unique to a companion fails loudly.
- **`parse-schema-rb.ts`** — gathers a `create_table` whose parenthesised
  argument list wraps across physical lines (the PG companion declares
  `measurements_toronto` / `measurements_concepcion` this way).

## Adapter-collision handling (Rails `load_schema_helper.rb`)

Rails loads `schema.rb` **plus exactly one companion**, chosen at runtime by the
live connection's adapter name — the four companions never coexist in one
process, so there is no load order among them. Several table names
(`defaults`, `binary_fields`, `collation_tests`, …) are declared by multiple
companions with **different columns per adapter**. A table declared by two or
more companions (with no `schema.rb` definition) is therefore treated as
**ambiguous**: its columns are unioned into a canonical superset (so
`INVENTED-COLUMN` still fires against any column real on no adapter) while the
adapter-dependent `SHAPE` / `UNPORTED-COLUMN` diffs are suppressed and a
`MULTIPLE-SOURCES` note is emitted. `schema.rb` stays authoritative when present.

No baseline entry turned out to be declared in a companion, so
`invented-baseline.json` is unchanged.

### Review response
- **Finding 1 (first-wins conflates per-adapter variants):** fixed — colliding
  companion tables are now unioned and marked ambiguous with per-column diffs
  suppressed, rather than silently resolved to whichever file sorts first.
- **Finding 2 (misleading "Ruby load order" comments):** fixed — the
  `SCHEMA_FILES` and `loadRailsTables` docs now state plainly that this is a
  trails-tool superset convention, cite `load_schema_helper.rb`, and note the
  companion order carries no meaning.

Closes-story: schema-compare-adapter-specific-schemas
