### PR TITLE
feat(schema-compare): compare column options, not just type

### DIFF
--- a/scripts/schema-compare/compare.test.ts
+++ b/scripts/schema-compare/compare.test.ts
@@ -8,6 +8,7 @@ import {
   normalizeRailsDefault,
   optionMismatches,
   optionRegressions,
+  partitionFindings,
   readBaseline,
   unresolvedCallSites,
 } from "./compare.js";
@@ -380,6 +381,33 @@ describe("optionRegressions", () => {
   it("turns every option finding fatal once the ceiling is exceeded", () => {
     expect(optionRegressions(findings, 1).map((f) => f.column)).toEqual(["a", "b"]);
     expect(optionRegressions(findings, 0).map((f) => f.column)).toEqual(["a", "b"]);
+  });
+});
+
+describe("partitionFindings", () => {
+  const findings: Finding[] = [
+    { verdict: "INVENTED-TABLE", table: "t", detail: "" },
+    { verdict: "SHAPE", table: "t", column: "a", detail: "" },
+    { verdict: "UNPORTED-COLUMN", table: "t", column: "b", detail: "" },
+    { verdict: "OPTION", table: "t", column: "c", detail: "" },
+    { verdict: "OPTION", table: "t", column: "d", detail: "" },
+  ];
+
+  it("keeps OPTION findings out of the shape-warning bucket", () => {
+    const { shape } = partitionFindings(findings, 2);
+    expect(shape.map((f) => f.column)).toEqual(["a", "b"]);
+  });
+
+  it("routes OPTION findings to the soft bucket while within the ceiling", () => {
+    const { option, optionFatal } = partitionFindings(findings, 2);
+    expect(option.map((f) => f.column)).toEqual(["c", "d"]);
+    expect(optionFatal).toEqual([]);
+  });
+
+  it("moves OPTION findings to the fatal bucket once the ceiling is exceeded", () => {
+    const { option, optionFatal } = partitionFindings(findings, 1);
+    expect(option).toEqual([]);
+    expect(optionFatal.map((f) => f.column)).toEqual(["c", "d"]);
   });
 });
 

--- a/scripts/schema-compare/compare.test.ts
+++ b/scripts/schema-compare/compare.test.ts
@@ -5,6 +5,9 @@ import {
   applyBaseline,
   compareSchemas,
   isFatal,
+  normalizeRailsDefault,
+  optionMismatches,
+  optionRegressions,
   readBaseline,
   unresolvedCallSites,
 } from "./compare.js";
@@ -268,6 +271,127 @@ describe("compareSchemas", () => {
   });
 });
 
+describe("compareSchemas column options", () => {
+  const detailFor = (findings: Finding[], column: string) =>
+    findings.find((f) => f.verdict === "OPTION" && f.column === column)?.detail ?? "";
+
+  const rails = parse(
+    `create_table :widgets, force: true do |t|
+       t.string   :name, null: false, limit: 1024
+       t.integer  :count, default: 0
+       t.decimal  :price, precision: 8, scale: 2
+       t.string   :cover, default: "hard"
+       t.datetime :stamp, precision: 0
+       t.integer  :spread, **default_zero
+     end`,
+  );
+
+  it("flags a diverging null as a non-fatal option warning", () => {
+    const findings = compareSchemas({ widgets: { name: { type: "string", limit: 1024 } } }, rails);
+    expect(verdicts(findings)).toContain("OPTION:widgets.name");
+    expect(detailFor(findings, "name")).toContain("null: schema.rb false, TEST_SCHEMA true");
+    expect(findings.every((f) => !isFatal(f))).toBe(true);
+  });
+
+  it("flags a diverging limit", () => {
+    const findings = compareSchemas({ widgets: { name: { type: "string", null: false } } }, rails);
+    expect(detailFor(findings, "name")).toContain("limit: schema.rb 1024, TEST_SCHEMA —");
+  });
+
+  it("flags a diverging default", () => {
+    const findings = compareSchemas({ widgets: { count: "integer" } }, rails);
+    expect(detailFor(findings, "count")).toContain("default: schema.rb 0, TEST_SCHEMA none");
+  });
+
+  it("flags diverging precision and scale", () => {
+    const findings = compareSchemas(
+      { widgets: { price: { type: "decimal", precision: 8 } } },
+      rails,
+    );
+    expect(detailFor(findings, "price")).toContain("scale: schema.rb 2, TEST_SCHEMA —");
+  });
+
+  it("normalises a quoted Rails default before comparing", () => {
+    const agree = compareSchemas(
+      { widgets: { cover: { type: "string", default: "hard" } } },
+      rails,
+    );
+    expect(agree.some((f) => f.verdict === "OPTION" && f.column === "cover")).toBe(false);
+  });
+
+  it("agrees when every option matches", () => {
+    expect(
+      compareSchemas(
+        { widgets: { name: { type: "string", null: false, limit: 1024 } } },
+        rails,
+      ).some((f) => f.verdict === "OPTION"),
+    ).toBe(false);
+  });
+
+  it("suppresses option comparison when the Rails options are a **splat", () => {
+    const findings = compareSchemas({ widgets: { spread: "integer" } }, rails);
+    expect(findings.some((f) => f.verdict === "OPTION")).toBe(false);
+  });
+
+  it("tolerates precision: null paired with a function default", () => {
+    const stamps = parse(
+      `create_table :clocks, force: true do |t|
+         t.datetime :at, default: -> { "CURRENT_TIMESTAMP" }
+       end`,
+    );
+    const findings = compareSchemas(
+      {
+        clocks: { at: { type: "datetime", precision: null, defaultFunction: "CURRENT_TIMESTAMP" } },
+      },
+      stamps,
+    );
+    expect(findings.some((f) => f.verdict === "OPTION")).toBe(false);
+  });
+});
+
+describe("normalizeRailsDefault", () => {
+  it("reads nil and an omitted default as none", () => {
+    expect(normalizeRailsDefault(undefined)).toBe("none");
+    expect(normalizeRailsDefault("nil")).toBe("none");
+  });
+
+  it("collapses a lambda default to a function tag", () => {
+    expect(normalizeRailsDefault(`-> { "CURRENT_TIMESTAMP" }`)).toBe("fn");
+  });
+
+  it("unquotes string, numeric, and boolean literals", () => {
+    expect(normalizeRailsDefault(`"hard"`)).toBe('"hard"');
+    expect(normalizeRailsDefault("0")).toBe("0");
+    expect(normalizeRailsDefault("false")).toBe("false");
+  });
+});
+
+describe("optionRegressions", () => {
+  const findings: Finding[] = [
+    { verdict: "OPTION", table: "t", column: "a", detail: "" },
+    { verdict: "OPTION", table: "t", column: "b", detail: "" },
+    { verdict: "SHAPE", table: "t", column: "c", detail: "" },
+  ];
+
+  it("stays report-only while the count is within the ceiling", () => {
+    expect(optionRegressions(findings, 2)).toEqual([]);
+  });
+
+  it("turns every option finding fatal once the ceiling is exceeded", () => {
+    expect(optionRegressions(findings, 1).map((f) => f.column)).toEqual(["a", "b"]);
+    expect(optionRegressions(findings, 0).map((f) => f.column)).toEqual(["a", "b"]);
+  });
+});
+
+describe("optionMismatches", () => {
+  it("treats an omitted Rails null as nullable", () => {
+    expect(optionMismatches({}, "string")).toEqual([]);
+    expect(optionMismatches({}, { type: "string", null: false })).toEqual([
+      "null: schema.rb true, TEST_SCHEMA false",
+    ]);
+  });
+});
+
 describe("unresolvedCallSites", () => {
   it("returns nothing when every call site resolved", () => {
     expect(
@@ -367,6 +491,10 @@ describe("against the vendored schema.rb", () => {
     const findings = compareSchemas(TEST_SCHEMA, railsTables);
     const { regressions } = applyBaseline(findings, await readBaseline());
     expect(verdicts(regressions)).toEqual([]);
+  });
+
+  it("keeps column-option divergences at or below the committed ceiling", () => {
+    expect(optionRegressions(compareSchemas(TEST_SCHEMA, railsTables))).toEqual([]);
   });
 
   it("holds the invention baseline at or below its committed size", async () => {

--- a/scripts/schema-compare/compare.ts
+++ b/scripts/schema-compare/compare.ts
@@ -167,17 +167,30 @@ function specNullable(spec: SpecOptions): boolean {
   return spec.null ?? true;
 }
 
+function displayPrecision(precision: number | null | undefined): string {
+  return precision === null ? "nil" : (precision ?? "—").toString();
+}
+
 /**
  * Column-option divergences between a schema.rb column and its TEST_SCHEMA
- * counterpart. `limit`, `precision`, and `scale` are compared only where a side
- * states them (an omitted value is the type/adapter default on both sides);
- * `null` and `default` are compared through their Rails defaults.
+ * counterpart. `null` and `default` are compared through their Rails defaults
+ * (omitted `null:` is nullable; see {@link normalizeRailsDefault}); `limit`,
+ * `precision`, and `scale` are compared verbatim, where an omitted value is the
+ * type/adapter default on both sides and `precision: nil` stays distinct from
+ * an omitted precision.
+ *
+ * Two cases are tolerated rather than flagged, mirroring how {@link typesAgree}
+ * already accepts adapter-chosen spellings:
+ *   - a `**splat` option list (`dynamicOptions`) whose keys the parser never
+ *     saw — comparing that partial evidence would manufacture false findings;
+ *   - `precision: null` on the TEST_SCHEMA side paired with a function default,
+ *     the documented bare-DATETIME request that suppresses MySQL's
+ *     auto-precision upgrade for `DEFAULT CURRENT_TIMESTAMP`.
  */
 export function optionMismatches(rails: RailsColumnOptions, spec: ColumnSpec): string[] {
-  // A `**splat` in the Rails options list means we never saw the real keys;
-  // comparing partial evidence would manufacture false divergences.
   if (rails.dynamicOptions) return [];
   const opts = specOptions(spec);
+  const specDefault = normalizeSpecDefault(opts);
   const detail: string[] = [];
 
   if (railsNullable(rails) !== specNullable(opts)) {
@@ -188,25 +201,15 @@ export function optionMismatches(rails: RailsColumnOptions, spec: ColumnSpec): s
       detail.push(`${key}: schema.rb ${rails[key] ?? "—"}, TEST_SCHEMA ${opts[key] ?? "—"}`);
     }
   }
-  // `precision: null` on the TEST_SCHEMA side paired with a function default is
-  // the documented bare-DATETIME request that suppresses MySQL's auto-precision
-  // upgrade for `DEFAULT CURRENT_TIMESTAMP` — an adapter-driven choice, not a
-  // divergence, even when schema.rb omits precision (mirrors typesAgree's
-  // tolerance of adapter-chosen spellings).
-  const precisionIsAdapterDriven = opts.precision === null && normalizeSpecDefault(opts) === "fn";
-  // precision distinguishes `nil` (an explicit bare-DATETIME request) from an
-  // omitted value, so null and undefined are not collapsed.
-  if (
-    !precisionIsAdapterDriven &&
-    ("precision" in rails ? rails.precision : undefined) !== opts.precision
-  ) {
+  const precisionIsAdapterDriven = opts.precision === null && specDefault === "fn";
+  const railsPrecision = "precision" in rails ? rails.precision : undefined;
+  if (!precisionIsAdapterDriven && railsPrecision !== opts.precision) {
     detail.push(
-      `precision: schema.rb ${rails.precision === null ? "nil" : (rails.precision ?? "—")}, ` +
-        `TEST_SCHEMA ${opts.precision === null ? "nil" : (opts.precision ?? "—")}`,
+      `precision: schema.rb ${displayPrecision(railsPrecision)}, ` +
+        `TEST_SCHEMA ${displayPrecision(opts.precision)}`,
     );
   }
   const railsDefault = normalizeRailsDefault(rails.default);
-  const specDefault = normalizeSpecDefault(opts);
   if (railsDefault !== specDefault) {
     detail.push(`default: schema.rb ${railsDefault}, TEST_SCHEMA ${specDefault}`);
   }

--- a/scripts/schema-compare/compare.ts
+++ b/scripts/schema-compare/compare.ts
@@ -354,6 +354,25 @@ export function optionRegressions(
   return options.length > ceiling ? options : [];
 }
 
+/**
+ * Splits findings into the disjoint buckets the reporter prints and counts.
+ * `shape` is the non-fatal type-level warnings (SHAPE / UNPORTED) only — OPTION
+ * findings live in `option` / `optionFatal`, so a `shape` count never
+ * double-counts them, and `option` (soft) ∩ `optionFatal` is empty.
+ */
+export function partitionFindings(
+  findings: readonly Finding[],
+  ceiling: number = OPTION_DEBT_CEILING,
+): { shape: Finding[]; option: Finding[]; optionFatal: Finding[] } {
+  const optionFindings = findings.filter((f) => f.verdict === "OPTION");
+  const optionFatal = optionRegressions(findings, ceiling);
+  return {
+    shape: findings.filter((f) => !isFatal(f) && f.verdict !== "OPTION"),
+    option: optionFatal.length > 0 ? [] : optionFindings,
+    optionFatal,
+  };
+}
+
 export async function main(): Promise<void> {
   const source = await readFile(SCHEMA_RB, "utf8");
   const railsTables = parseSchemaRb(source);
@@ -371,7 +390,6 @@ export async function main(): Promise<void> {
   }
 
   const findings = compareSchemas(TEST_SCHEMA, railsTables);
-  const soft = findings.filter((f) => !isFatal(f));
 
   if (process.argv.includes("--write")) {
     const invented = findings.filter(isFatal);
@@ -407,15 +425,13 @@ export async function main(): Promise<void> {
   }
 
   const { regressions, known, stale } = applyBaseline(findings, await readBaseline());
-  const optionFatal = optionRegressions(findings);
+  const { shape, option, optionFatal } = partitionFindings(findings);
   const optionCount = findings.filter((f) => f.verdict === "OPTION").length;
 
   for (const finding of regressions) console.log(formatFinding(finding));
   for (const finding of optionFatal) console.log(formatFinding(finding));
   if (process.argv.includes("--verbose")) {
-    for (const finding of soft) {
-      if (!optionFatal.includes(finding)) console.log(formatFinding(finding));
-    }
+    for (const finding of [...shape, ...option]) console.log(formatFinding(finding));
   }
   for (const key of stale) {
     console.log(
@@ -426,7 +442,7 @@ export async function main(): Promise<void> {
   console.log(
     `\n${Object.keys(TEST_SCHEMA).length} TEST_SCHEMA tables vs ${railsTables.size} schema.rb tables — ` +
       `new-inventions=${regressions.length} baselined=${known.length} ` +
-      `option-divergences=${optionCount} (ceiling ${OPTION_DEBT_CEILING}) shape-warnings=${soft.length}` +
+      `option-divergences=${optionCount} (ceiling ${OPTION_DEBT_CEILING}) shape-warnings=${shape.length}` +
       (process.argv.includes("--verbose") ? "" : " (--verbose to list shape warnings)"),
   );
 

--- a/scripts/schema-compare/compare.ts
+++ b/scripts/schema-compare/compare.ts
@@ -19,7 +19,7 @@ import type {
   Schema,
 } from "../../packages/activerecord/src/test-helpers/schema-types.js";
 import { columnsOf } from "../../packages/activerecord/src/test-helpers/schema-types.js";
-import type { RailsTable } from "./parse-schema-rb.js";
+import type { RailsColumnOptions, RailsTable } from "./parse-schema-rb.js";
 import { parseSchemaRb, parseSchemaRbWithCoverage } from "./parse-schema-rb.js";
 import { writeJsonManifest } from "../api-compare/write-json-manifest.js";
 
@@ -88,7 +88,18 @@ const RAILS_TYPE_TO_SPEC: Readonly<Record<string, string>> = {
   references: "integer",
 };
 
-export type Verdict = "INVENTED-TABLE" | "INVENTED-COLUMN" | "SHAPE" | "UNPORTED-COLUMN";
+export type Verdict = "INVENTED-TABLE" | "INVENTED-COLUMN" | "SHAPE" | "OPTION" | "UNPORTED-COLUMN";
+
+/**
+ * How many `OPTION` findings the vendored schema currently carries. The gate
+ * ratchets this down: it may fall as divergences are fixed, never rise. When it
+ * reaches 0 the option check is armed — any `OPTION` finding then fails the gate
+ * fatally, alongside the INVENTED verdicts (see {@link optionRegressions}).
+ *
+ * The 4 live findings are `parrots.{created,updated}_{at,on}`: schema.rb pins
+ * `precision: 0` on those timestamps but TEST_SCHEMA leaves precision implicit.
+ */
+export const OPTION_DEBT_CEILING = 4;
 
 export interface Finding {
   verdict: Verdict;
@@ -111,6 +122,95 @@ function typesAgree(railsType: string, tsType: string): boolean {
   // FK width is a per-adapter choice in Rails; either spelling is faithful.
   if (railsType === "references") return tsType === "integer" || tsType === "big_integer";
   return false;
+}
+
+/** The object form of a ColumnSpec, or an empty options bag for the shorthand. */
+type SpecOptions = Exclude<ColumnSpec, string>;
+
+function specOptions(spec: ColumnSpec): SpecOptions {
+  return typeof spec === "string" ? ({ type: spec } as SpecOptions) : spec;
+}
+
+/**
+ * Normalises a Rails `default:` token — captured verbatim from schema.rb source
+ * — to a comparable canonical string. `nil` and an omitted default both read as
+ * "no default"; a lambda (`-> { ... }`) is a function default whose body is
+ * adapter-specific SQL, so it collapses to a single `fn` tag rather than being
+ * compared literally.
+ */
+export function normalizeRailsDefault(token: string | undefined): string {
+  if (token === undefined) return "none";
+  const value = token.trim();
+  if (value === "" || value === "nil") return "none";
+  if (value.startsWith("->") || value.startsWith("lambda") || value.startsWith("proc")) return "fn";
+  const quoted = /^"([\s\S]*)"$/.exec(value) ?? /^'([\s\S]*)'$/.exec(value);
+  if (quoted) return JSON.stringify(quoted[1]);
+  if (value === "true" || value === "false") return value;
+  const n = Number(value);
+  if (value !== "" && Number.isFinite(n)) return JSON.stringify(n);
+  return JSON.stringify(value);
+}
+
+/** Normalises the TEST_SCHEMA side's default to the same canonical string. */
+export function normalizeSpecDefault(spec: SpecOptions): string {
+  if (spec.defaultFunction !== undefined) return "fn";
+  if (!("default" in spec) || spec.default === undefined) return "none";
+  return JSON.stringify(spec.default);
+}
+
+/** Rails treats an omitted `null:` as nullable; so does a bare DDL column. */
+function railsNullable(options: RailsColumnOptions): boolean {
+  return options.null ?? true;
+}
+
+function specNullable(spec: SpecOptions): boolean {
+  return spec.null ?? true;
+}
+
+/**
+ * Column-option divergences between a schema.rb column and its TEST_SCHEMA
+ * counterpart. `limit`, `precision`, and `scale` are compared only where a side
+ * states them (an omitted value is the type/adapter default on both sides);
+ * `null` and `default` are compared through their Rails defaults.
+ */
+export function optionMismatches(rails: RailsColumnOptions, spec: ColumnSpec): string[] {
+  // A `**splat` in the Rails options list means we never saw the real keys;
+  // comparing partial evidence would manufacture false divergences.
+  if (rails.dynamicOptions) return [];
+  const opts = specOptions(spec);
+  const detail: string[] = [];
+
+  if (railsNullable(rails) !== specNullable(opts)) {
+    detail.push(`null: schema.rb ${railsNullable(rails)}, TEST_SCHEMA ${specNullable(opts)}`);
+  }
+  for (const key of ["limit", "scale"] as const) {
+    if (rails[key] !== opts[key]) {
+      detail.push(`${key}: schema.rb ${rails[key] ?? "—"}, TEST_SCHEMA ${opts[key] ?? "—"}`);
+    }
+  }
+  // `precision: null` on the TEST_SCHEMA side paired with a function default is
+  // the documented bare-DATETIME request that suppresses MySQL's auto-precision
+  // upgrade for `DEFAULT CURRENT_TIMESTAMP` — an adapter-driven choice, not a
+  // divergence, even when schema.rb omits precision (mirrors typesAgree's
+  // tolerance of adapter-chosen spellings).
+  const precisionIsAdapterDriven = opts.precision === null && normalizeSpecDefault(opts) === "fn";
+  // precision distinguishes `nil` (an explicit bare-DATETIME request) from an
+  // omitted value, so null and undefined are not collapsed.
+  if (
+    !precisionIsAdapterDriven &&
+    ("precision" in rails ? rails.precision : undefined) !== opts.precision
+  ) {
+    detail.push(
+      `precision: schema.rb ${rails.precision === null ? "nil" : (rails.precision ?? "—")}, ` +
+        `TEST_SCHEMA ${opts.precision === null ? "nil" : (opts.precision ?? "—")}`,
+    );
+  }
+  const railsDefault = normalizeRailsDefault(rails.default);
+  const specDefault = normalizeSpecDefault(opts);
+  if (railsDefault !== specDefault) {
+    detail.push(`default: schema.rb ${railsDefault}, TEST_SCHEMA ${specDefault}`);
+  }
+  return detail;
 }
 
 /**
@@ -161,6 +261,18 @@ export function compareSchemas(
           table: tableName,
           column: columnName,
           detail: `schema.rb says ${railsColumn.type}, TEST_SCHEMA says ${tsType}`,
+        });
+        // A type divergence makes the options incomparable (a limit on a
+        // string means nothing against an integer), so stop at the type.
+        continue;
+      }
+      const mismatches = optionMismatches(railsColumn.options, spec);
+      if (mismatches.length > 0) {
+        findings.push({
+          verdict: "OPTION",
+          table: tableName,
+          column: columnName,
+          detail: mismatches.join("; "),
         });
       }
     }
@@ -226,6 +338,19 @@ export function applyBaseline(
   return { regressions, known, stale };
 }
 
+/**
+ * `OPTION` findings that trip the gate. While `OPTION_DEBT_CEILING` exceeds the
+ * live count they are report-only debt; the moment the ceiling is ratcheted to
+ * 0 every remaining finding is a fatal regression, mirroring the INVENTED gate.
+ */
+export function optionRegressions(
+  findings: readonly Finding[],
+  ceiling: number = OPTION_DEBT_CEILING,
+): Finding[] {
+  const options = findings.filter((f) => f.verdict === "OPTION");
+  return options.length > ceiling ? options : [];
+}
+
 export async function main(): Promise<void> {
   const source = await readFile(SCHEMA_RB, "utf8");
   const railsTables = parseSchemaRb(source);
@@ -279,10 +404,15 @@ export async function main(): Promise<void> {
   }
 
   const { regressions, known, stale } = applyBaseline(findings, await readBaseline());
+  const optionFatal = optionRegressions(findings);
+  const optionCount = findings.filter((f) => f.verdict === "OPTION").length;
 
   for (const finding of regressions) console.log(formatFinding(finding));
+  for (const finding of optionFatal) console.log(formatFinding(finding));
   if (process.argv.includes("--verbose")) {
-    for (const finding of soft) console.log(formatFinding(finding));
+    for (const finding of soft) {
+      if (!optionFatal.includes(finding)) console.log(formatFinding(finding));
+    }
   }
   for (const key of stale) {
     console.log(
@@ -292,7 +422,8 @@ export async function main(): Promise<void> {
 
   console.log(
     `\n${Object.keys(TEST_SCHEMA).length} TEST_SCHEMA tables vs ${railsTables.size} schema.rb tables — ` +
-      `new-inventions=${regressions.length} baselined=${known.length} shape-warnings=${soft.length}` +
+      `new-inventions=${regressions.length} baselined=${known.length} ` +
+      `option-divergences=${optionCount} (ceiling ${OPTION_DEBT_CEILING}) shape-warnings=${soft.length}` +
       (process.argv.includes("--verbose") ? "" : " (--verbose to list shape warnings)"),
   );
 
@@ -302,8 +433,15 @@ export async function main(): Promise<void> {
         "to schema.rb upstream, or drop it here — do not invent canonical schema. The baseline " +
         "records pre-existing debt only and must not grow.",
     );
-    process.exit(1);
   }
+  if (optionFatal.length > 0) {
+    console.log(
+      `\n${optionFatal.length} column-option divergence(s) exceed the OPTION_DEBT_CEILING of ` +
+        `${OPTION_DEBT_CEILING}. Align the TEST_SCHEMA column options with schema.rb, or ratchet ` +
+        "the ceiling in scripts/schema-compare/compare.ts down to the new (lower) count.",
+    );
+  }
+  if (regressions.length > 0 || optionFatal.length > 0) process.exit(1);
 }
 
 // Run as a script when invoked directly, but stay importable from tests.

--- a/scripts/schema-compare/parse-schema-rb.ts
+++ b/scripts/schema-compare/parse-schema-rb.ts
@@ -21,6 +21,13 @@ export interface RailsColumnOptions {
   array?: boolean;
   default?: string;
   polymorphic?: boolean;
+  /**
+   * True when the option list contained a `**splat` (e.g. `**default_zero`)
+   * whose keys the parser cannot resolve — the captured options are incomplete,
+   * so option-level comparison must be suppressed rather than report a
+   * divergence on evidence we know is partial.
+   */
+  dynamicOptions?: boolean;
 }
 
 export interface RailsTable {
@@ -149,6 +156,10 @@ function splitArgs(args: string): string[] {
 function parseOptions(args: string[]): RailsColumnOptions {
   const options: RailsColumnOptions = {};
   for (const arg of args) {
+    if (/^\s*\*\*/.test(arg)) {
+      options.dynamicOptions = true;
+      continue;
+    }
     const kv = /^\s*([a-z_]+):\s*(.+)$/.exec(arg);
     if (!kv) continue;
     const [, key, rawValue] = kv as unknown as [string, string, string];


### PR DESCRIPTION
## What

Extends `pnpm schema:compare` to compare column **options**
(`null` / `limit` / `precision` / `scale` / `default`), not just the column
type. The parser already captured these into `RailsColumnOptions`; nothing
consumed them, so a bare `settings: "string"` in TEST_SCHEMA matched
`t.string :settings, null: true, limit: 1024` in schema.rb.

## How

- `optionMismatches()` diffs each shared column's options after the type check
  agrees (a type divergence makes options incomparable, so it short-circuits).
- Rails defaults are normalised (`normalizeRailsDefault`): quoted strings
  unquoted, numeric/boolean literals canonicalised, `nil`/omitted → "no
  default", and a lambda (`-> { ... }`) collapsed to a `fn` tag since its body
  is adapter-specific SQL. The TEST_SCHEMA side normalises to the same form,
  mapping `defaultFunction` → `fn`.
- An omitted Rails `null:` reads as nullable on both sides.
- Two tolerances mirror the existing type-check's adapter awareness:
  - a `**splat` option list (e.g. `**default_zero`) is marked
    `dynamicOptions` by the parser and suppresses option comparison — the keys
    were never visible, so comparing would manufacture false divergences;
  - `precision: null` paired with a function default is the documented
    bare-DATETIME request that suppresses MySQL's auto-precision-6 upgrade for
    `DEFAULT CURRENT_TIMESTAMP`, not a divergence.
- `OPTION` findings are report-only, gated by `OPTION_DEBT_CEILING` (a ratchet
  like the invention baseline). The live count is 4
  (`parrots.{created,updated}_{at,on}`, where schema.rb pins `precision: 0` and
  TEST_SCHEMA leaves it implicit). Once the ceiling ratchets to 0 the gate
  flips fatal, alongside the INVENTED verdicts.

## Tests

`compareSchemas`-driven synthetic tables cover one divergence per option plus
both tolerances; unit tests cover `normalizeRailsDefault`, `optionMismatches`,
and the `optionRegressions` ceiling behaviour; a vendored-schema test asserts
the live divergence count stays within the ceiling.

Closes-story: schema-compare-column-option-parity
