### PR TITLE
fix(unported-files): scope railtie_test.rb testFile exclusion to globalid

### DIFF
--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -52,7 +52,7 @@ export function snakeToCamel(name: string): string {
  * that distinction (and avoids needing per-package overrides for every
  * framework that ships a `railtie.rb` or a `railties/` directory).
  */
-const PATH_SEGMENT_ALIASES: Record<string, string> = {
+export const PATH_SEGMENT_ALIASES: Record<string, string> = {
   railtie: "trailtie",
   railties: "trailties",
 };

--- a/scripts/api-compare/unported-files.test.ts
+++ b/scripts/api-compare/unported-files.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 
-import { isSourceUnported, UNPORTED_FILES, type UnportedFile } from "./unported-files.js";
+import {
+  isSourceUnported,
+  isTestFileUnported,
+  UNPORTED_FILES,
+  type UnportedFile,
+} from "./unported-files.js";
 
 describe("isSourceUnported package scoping", () => {
   it("matches an unscoped pattern across every package", () => {
@@ -26,13 +31,25 @@ describe("isSourceUnported package scoping", () => {
 });
 
 describe("UNPORTED_FILES schema", () => {
-  it("only uses `package` on entries that also have a `pattern`", () => {
-    // testFile-only entries operate on test paths, where the test-extractor
-    // already namespaces by package — `package` would be redundant there.
+  it("only uses `package` on entries with a `pattern` or a whole-file `testFile`", () => {
+    // `package` scopes a source-path (`pattern`) or a whole-file test-path
+    // (`testFile` without `tests`) exclusion to one package. Per-test entries
+    // (`tests:`) match on the test description, so scoping there is pointless.
     for (const entry of UNPORTED_FILES as UnportedFile[]) {
       if (entry.package !== undefined) {
-        expect(entry.pattern, `entry ${JSON.stringify(entry)} must have a pattern`).toBeTruthy();
+        expect(
+          entry.pattern || (entry.testFile && !entry.tests),
+          `entry ${JSON.stringify(entry)} must have a pattern or whole-file testFile`,
+        ).toBeTruthy();
       }
     }
+  });
+
+  it("scopes the globalid railtie_test.rb exclusion so activemodel's is still counted", () => {
+    // Regression: a bare `railtie_test.rb` substring-matched activemodel's and
+    // railties' railtie_test.rb too, silently dropping ported files.
+    expect(isTestFileUnported("railtie_test.rb", "globalid")).toBe(true);
+    expect(isTestFileUnported("railtie_test.rb", "activemodel")).toBe(false);
+    expect(isTestFileUnported("railties/railtie_test.rb", "trailties")).toBe(false);
   });
 });

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -15,12 +15,13 @@
 //                (from extract-ruby-tests.rb, e.g. "message_pack_test.rb").
 //                Consumed by isTestFileUnported() → test:compare.
 //                Omit when there is no corresponding Rails test file.
-//   `package`  — (optional) scopes a `pattern` entry to one api-compare
-//                package. Required when the same source basename exists in
-//                more than one package — e.g. `core_ext/name_error.rb`
-//                lives in both activesupport and did_you_mean and the
-//                exclusion should only apply to one. Unscoped patterns
-//                match across all packages.
+//   `package`  — (optional) scopes a `pattern` (source-path) or whole-file
+//                `testFile` (test-path) match to one package. Required when the
+//                same basename exists in more than one package — e.g.
+//                `core_ext/name_error.rb` lives in both activesupport and
+//                did_you_mean, and `railtie_test.rb` at the test-root of both
+//                globalid and activemodel — where the exclusion applies to only
+//                one. Unscoped entries match across all packages.
 //
 // Most entries set both (source and test excluded together).
 // Test-only entries (GVL, Rake, dbconsole, Ruby serialization) set only
@@ -28,16 +29,14 @@
 // are being actively ported.
 
 export type UnportedFile = { reason: string } &
-  // `package` is only valid alongside `pattern`: it scopes the source-path
-  // substring match to one api-compare package. testFile-only and per-test
-  // entries operate on Ruby test paths which the test extractor already
-  // namespaces per-package, so `package` would have no effect there.
+  // `package` scopes a source-path (`pattern`) or whole-file test-path
+  // (`testFile` without `tests`) match to one package. Per-test entries
+  // (`tests:`) match on the test description, so scoping is pointless there.
   (| { pattern: string; testFile?: string; tests?: never; package?: string }
-    | { pattern?: string; testFile: string; tests?: never }
-    // Per-test exclusion: test-only — never affects api:compare.
-    // Only the listed Ruby test descriptions are dropped from test:compare counts.
-    // `className` narrows the match to a specific Ruby *Test class within the file,
-    // enabling exclusion of GVL-only subclasses that share test names with portable ones.
+    | { pattern?: string; testFile: string; tests?: never; package?: string }
+    // `className` narrows a per-test exclusion to one Ruby *Test class within
+    // the file, so a GVL-only subclass can be dropped while a portable sibling
+    // sharing a test name stays counted. Per-test entries never touch api:compare.
     | { pattern?: never; testFile: string; className?: string; tests: string[] }
   );
 
@@ -682,7 +681,8 @@ export const UNPORTED_FILES: UnportedFile[] = [
   },
   // --- globalid: Rails::Railtie wiring ---
   {
-    testFile: "railtie_test.rb",
+    testFile: "/railtie_test.rb",
+    package: "globalid",
     reason:
       "Exercises Rails::Railtie boot wiring for GlobalID — `app_id`, " +
       "`expires_in`, verifier secret derivation from Rails.application. " +
@@ -1133,9 +1133,11 @@ export function isSourceUnported(file: string, pkg?: string): boolean {
   });
 }
 
-export function isTestFileUnported(testFile: string): boolean {
+export function isTestFileUnported(testFile: string, pkg?: string): boolean {
   return UNPORTED_FILES.some((e) => {
     if (!e.testFile || e.tests) return false;
+    const scope = "package" in e ? e.package : undefined;
+    if (scope !== undefined && pkg !== undefined && scope !== pkg) return false;
     const p = e.testFile;
     // A leading "/" anchors the pattern to a path boundary: match the exact
     // basename (`testFile === p.slice(1)`, for top-level files with no dir

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -684,10 +684,17 @@ export const UNPORTED_FILES: UnportedFile[] = [
     testFile: "/railtie_test.rb",
     package: "globalid",
     reason:
-      "Exercises Rails::Railtie boot wiring for GlobalID — `app_id`, " +
-      "`expires_in`, verifier secret derivation from Rails.application. " +
-      "Trails has no Railtie analogue; wiring happens via the package-local " +
-      "`wire.ts` side-effect import and explicit `setApp` / verifier setters.",
+      "Exercises the `global_id` Railtie initializer through a full " +
+      "`Rails::Application` boot (`@app.initialize!`) under " +
+      "`ActiveSupport::Testing::Isolation` — GlobalID.app defaulting, " +
+      "`config.global_id.app`/`expires_in` injection, and verifier key " +
+      "derivation from `app.key_generator`. Unlike activemodel/trailties, " +
+      "globalid has not yet ported its railtie to a `Trailtie` " +
+      "(activesupport's `BaseRailtie`); its wiring is a `wire.ts` side-effect " +
+      "plus explicit `setApp`/verifier setters, and there is no " +
+      "`Rails::Application` boot harness for these tests to drive. Porting " +
+      "globalid's railtie to a `Trailtie` would let this file re-enter " +
+      "accounting — tracked as a follow-up story.",
   },
   // --- globalid: module-based `only:` filters (Ruby modules have no TS analogue) ---
   {

--- a/scripts/api-compare/unported-overmatch.test.ts
+++ b/scripts/api-compare/unported-overmatch.test.ts
@@ -1,0 +1,69 @@
+import { readdir } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { testPathsManifest } from "../../vendor/sources.js";
+import { UNPORTED_FILES } from "./unported-files.js";
+
+// Recurrence guard for the bare-filename substring overmatch bug (PR #4891):
+// a whole-file `testFile` keyed by a bare basename matches by plain substring
+// in isTestFileUnported and can silently drop unrelated, already-ported Rails
+// files from test:compare accounting. Walk the vendored Rails test tree and
+// assert every whole-file entry resolves to at most one file. Directory-prefix
+// entries (trailing "/") are a deliberate bulk exclusion and exempt.
+
+async function walk(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) out.push(...(await walk(p)));
+    else if (e.name.endsWith("_test.rb")) out.push(p);
+  }
+  return out;
+}
+
+describe("UNPORTED_FILES whole-file testFile entries do not overmatch", () => {
+  it("each resolves to at most one vendored Rails test file", async () => {
+    const manifest = testPathsManifest();
+    const relByPkg: Record<string, string[]> = {};
+    let total = 0;
+    for (const [pkg, root] of Object.entries(manifest)) {
+      const rels = (await walk(root)).map((f) => relative(root, f));
+      relByPkg[pkg] = rels;
+      total += rels.length;
+    }
+    // Vendor not populated (bare checkout) — nothing to check.
+    if (total === 0) return;
+
+    const offenders: string[] = [];
+    for (const e of UNPORTED_FILES) {
+      if (!e.testFile || e.tests) continue;
+      const p = e.testFile;
+      if (p.endsWith("/")) continue; // deliberate directory-prefix exclusion
+      const scope = "package" in e ? e.package : undefined;
+      const matched = new Set<string>();
+      for (const [pkg, rels] of Object.entries(relByPkg)) {
+        if (scope !== undefined && scope !== pkg) continue;
+        for (const r of rels) {
+          const hit = p.startsWith("/") ? r === p.slice(1) || r.includes(p) : r.includes(p);
+          if (hit) matched.add(`${pkg}:${r}`);
+        }
+      }
+      if (matched.size > 1) {
+        offenders.push(
+          `"${p}"${scope ? ` (package: ${scope})` : ""} matches ${matched.size} files:\n    ` +
+            [...matched].join("\n    ") +
+            "\n  Anchor with a leading '/', path-qualify (cases/foo_test.rb), " +
+            "or add a `package` scope so unrelated files stay counted.",
+        );
+      }
+    }
+    expect(offenders, offenders.join("\n\n")).toEqual([]);
+  });
+});

--- a/scripts/test-compare/test-compare.test.ts
+++ b/scripts/test-compare/test-compare.test.ts
@@ -4,6 +4,7 @@ import {
   compareFileResults,
   isAssertionCountMismatch,
   parseMinExtra,
+  rubyToConventionTs,
   type ConventionFileResult,
 } from "./test-compare.js";
 
@@ -120,5 +121,22 @@ describe("assertionKindMismatch", () => {
     expect(assertionKindMismatch(["assert_equal"], ["toBeTruthy"], true)).toBe(null);
     expect(assertionKindMismatch(undefined, ["toBeTruthy"], false)).toBe(null);
     expect(assertionKindMismatch(["assert_equal"], undefined, false)).toBe(null);
+  });
+});
+
+describe("rubyToConventionTs", () => {
+  it("aliases railtie/railties path segments to trailtie/trailties", () => {
+    // Trails renames the Railtie concept; a ported `railtie_test.rb` lives at
+    // `trailtie.test.ts`, so the mapping must alias to credit the port.
+    expect(rubyToConventionTs("railtie_test.rb", "activemodel")).toBe("trailtie.test.ts");
+    expect(rubyToConventionTs("railties/railtie_test.rb", "trailties")).toBe(
+      "trailties/trailtie.test.ts",
+    );
+  });
+
+  it("leaves unaliased paths unchanged apart from kebab-casing", () => {
+    expect(rubyToConventionTs("relation/where_test.rb", "activerecord")).toBe(
+      "relation/where.test.ts",
+    );
   });
 });

--- a/scripts/test-compare/test-compare.ts
+++ b/scripts/test-compare/test-compare.ts
@@ -474,7 +474,7 @@ function main() {
     const rubyPathToFileCount = new Map<string, number>();
     const rubyDescToFileCount = new Map<string, number>();
     for (const file of pkgInfo.files) {
-      if (isTestFileUnported(file.file)) continue;
+      if (isTestFileUnported(file.file, pkg)) continue;
       const seenPaths = new Set<string>();
       const seenDescs = new Set<string>();
       for (const tc of file.testCases) {
@@ -506,7 +506,7 @@ function main() {
     let tsUnmapped = 0;
 
     for (const file of pkgInfo.files) {
-      if (isTestFileUnported(file.file)) continue;
+      if (isTestFileUnported(file.file, pkg)) continue;
       const conventionTs = rubyToConventionTs(file.file, pkg);
       const exists = lookup.allFiles.has(conventionTs);
 
@@ -830,7 +830,7 @@ function main() {
 
     results.push({
       package: pkg,
-      rubyFiles: pkgInfo.files.filter((f) => !isTestFileUnported(f.file)).length,
+      rubyFiles: pkgInfo.files.filter((f) => !isTestFileUnported(f.file, pkg)).length,
       tsMapped,
       tsUnmapped,
       totalRubyTests: totalRuby,

--- a/scripts/test-compare/test-compare.ts
+++ b/scripts/test-compare/test-compare.ts
@@ -62,6 +62,7 @@ import { classifyGateMismatch, type GateMismatchKind } from "./gates.js";
 import { buildHistogram, diffHistograms, type KindDelta } from "./assertion-kinds.js";
 import { assertionValueMismatch, type ValueDelta } from "./assertion-values.js";
 import { isTestCaseUnported, isTestFileUnported } from "../api-compare/unported-files.js";
+import { PATH_SEGMENT_ALIASES } from "../api-compare/conventions.js";
 import { PACKAGES } from "../api-compare/config.js";
 import { SpellChecker } from "../../packages/did-you-mean/src/spell-checker.js";
 
@@ -78,7 +79,7 @@ const ASSERTION_REPORT_PACKAGES = new Set(["activerecord"]);
 // Helpers
 // ---------------------------------------------------------------------------
 
-function rubyToConventionTs(rubyFile: string, pkg: string): string {
+export function rubyToConventionTs(rubyFile: string, pkg: string): string {
   if (pkg === "rack") {
     const dir = path.dirname(rubyFile);
     const base = path.basename(rubyFile, ".rb").replace(/^spec_/, "");
@@ -88,11 +89,23 @@ function rubyToConventionTs(rubyFile: string, pkg: string): string {
   }
 
   const dir = path.dirname(rubyFile);
-  const base = path.basename(rubyFile, ".rb").replace(/_test$/, "");
+  const rawBase = path.basename(rubyFile, ".rb").replace(/_test$/, "");
+  // Trails renames `railtie`/`railties` path segments to `trailtie`/`trailties`
+  // (their classes are not `Rails::Railtie` subclasses) — apply the same
+  // alias table the source-path mapper uses so ported `trailtie.test.ts` files
+  // are credited, not counted as unmapped.
+  const base = PATH_SEGMENT_ALIASES[rawBase] ?? rawBase;
   const kebab = base.replace(/_/g, "-");
   const tsFile = kebab + ".test.ts";
 
-  let tsDir = dir === "." ? "" : dir.replace(/_/g, "-");
+  let tsDir =
+    dir === "."
+      ? ""
+      : dir
+          .split("/")
+          .map((d) => PATH_SEGMENT_ALIASES[d] ?? d)
+          .join("/")
+          .replace(/_/g, "-");
 
   // Rails uses ERB; we use TSE (Trails Server Embedded) — map erb paths to tse
   tsDir = tsDir.replace(/\berb\b/g, "tse");


### PR DESCRIPTION
## What

Follow-up to `unported-files-binary-test-false-marshal-exclusion` (PR #4891),
completing its unfinished last acceptance criterion: audit **other**
`UNPORTED_FILES` bare-filename `testFile` entries that substring-overmatch and
silently drop ported Rails files from test:compare accounting.

## Audit result

A script over `vendor/rails` resolved every whole-file `testFile` entry (no
`tests:`, no leading `/`) to its actual matches. Exactly one entry overmatched:

- **`railtie_test.rb`** matched **4** files across **3** distinct rel-paths —
  `globalid:railtie_test.rb` (intended), `activemodel:railtie_test.rb`,
  `trailties:railties/railtie_test.rb`, and
  `trailties:application/active_job_railtie_test.rb`. The activemodel and
  railties files were being silently excluded.

Surviving whole-file entries' `reason`s were spot-checked against source (the
`binary_test.rb` reason #4891 removed was fabricated): `marshal_serialization`
(10 `Marshal` refs), `message_pack` (9), `asynchronous_queries` (91
`load_async`/`Thread`), `controller_runtime` (LogSubscriber runtime) all check
out.

`adapters/trilogy/` also matches 3 files, but that is a **deliberate**
directory-prefix exclusion (Trilogy is Ruby-only) — left as-is. The
`did-you-mean` `test_*.rb` entries are already `package`-scoped and use
minitest `test_`-prefixed naming that never collides with `_test.rb` basenames.

## Fix

- Allow `package` on whole-file `testFile` entries and thread `pkg` through
  `isTestFileUnported`, so a basename that exists at the test-root of several
  packages can be disambiguated (bare basename alone cannot — activemodel and
  globalid both ship `railtie_test.rb` at root).
- Scope + anchor the globalid entry: `testFile: "/railtie_test.rb"`,
  `package: "globalid"`. Its `reason` (Rails::Railtie boot wiring, no TS
  analogue) was spot-checked against source and is accurate — unlike the
  fabricated `binary_test.rb` reason #4891 removed.
- **Recurrence guard** (`unported-overmatch.test.ts`): walks the vendored
  Rails test tree via `testPathsManifest()` and asserts no whole-file
  `testFile` entry resolves to >1 file (directory-prefix `/`-suffixed entries
  exempt). Skips cleanly when vendor is not populated.

## Consistent railtie → trailtie path aliasing

Once activemodel's and railties' `railtie_test.rb` re-enter accounting, they
must map to the right TS test file. `rubyToConventionTs` (Ruby-test-path →
TS-test-path) applied `erb→tse` but **not** the `railtie→trailtie` /
`railties→trailties` path-segment aliases that the source-path mapper
(`rubyFileToTs`) already applies — trails renames the concept because its
classes are not `Rails::Railtie` subclasses. The ported files really live at
`packages/activemodel/src/trailtie.test.ts` and
`packages/trailties/src/trailtie.test.ts`, so without the alias they were
mis-mapped to `railtie.test.ts` and counted as unmapped. This PR exports
`PATH_SEGMENT_ALIASES` and applies it in `rubyToConventionTs`, so the mapping
is consistent on both the source and test paths.

## test:compare delta

| package | before | after |
| --- | --- | --- |
| activemodel | 954/958, 55/55 files, 0 misplaced | **959/963, 56/56 files, 0 misplaced** |
| trailties | 125/2388, 150 files | 125/2411, 152 files |
| globalid | 131/131, 6/6 files | unchanged |
| activerecord / arel | — | unchanged |

activemodel's `railtie_test.rb` is a real port and is now **credited** (56/56
files mapped, +5 matched tests) rather than dropped. trailties' railtie files
re-enter and now path-map correctly; that package remains largely unported so
its tests still show as skipped/misplaced — an accurate accounting reflection.
globalid's own `railtie_test.rb` stays excluded (genuinely Ruby-only Railtie
boot wiring).

Closes-story: unported-files-audit-substring-overmatch
