### PR TITLE
fix(model-schema): read columns() memo with != null to match sibling readers

### DIFF
--- a/packages/activerecord/src/base.trails.test.ts
+++ b/packages/activerecord/src/base.trails.test.ts
@@ -408,6 +408,27 @@ describe("ignored columns follow Rails' value-keyed attribute set (trails)", () 
     expect(Company.columnNames()).toContain("rating");
   });
 
+  it("a subclass that ignores every column memoizes and serves an empty columns list", () => {
+    class Company extends Base {
+      static override tableName = "companies";
+      static {
+        this.inheritanceColumn = "type";
+      }
+    }
+    class Firm extends Company {
+      static {
+        registerSubclass(this);
+        this.ignoredColumns = Company.columnNames();
+      }
+    }
+    const cols = Firm.columns();
+    expect(cols).toEqual([]);
+    // Pins that a legitimately empty column list is memoized and served on the
+    // next read (same instance), not recomputed — the sentinel the `!= null`
+    // memo read distinguishes from an absent (`undefined`) memo.
+    expect(Firm.columns()).toBe(cols);
+  });
+
   it("an STI subclass's own columns memo is rebuilt when the base re-reflects", async () => {
     class Company extends Base {
       static override tableName = "companies";

--- a/packages/activerecord/src/base.trails.test.ts
+++ b/packages/activerecord/src/base.trails.test.ts
@@ -417,15 +417,11 @@ describe("ignored columns follow Rails' value-keyed attribute set (trails)", () 
     }
     class Firm extends Company {
       static {
-        registerSubclass(this);
         this.ignoredColumns = Company.columnNames();
       }
     }
     const cols = Firm.columns();
     expect(cols).toEqual([]);
-    // Pins that a legitimately empty column list is memoized and served on the
-    // next read (same instance), not recomputed — the sentinel the `!= null`
-    // memo read distinguishes from an absent (`undefined`) memo.
     expect(Firm.columns()).toBe(cols);
   });
 

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -758,7 +758,7 @@ export function attributesBuilder(this: SchemaHost): AttributeSetBuilder {
  */
 export function columns(this: SchemaHost): any[] {
   const ownColumns = ownSchemaMemo(this, "_columns");
-  if (ownColumns) return ownColumns;
+  if (ownColumns != null) return ownColumns;
   this._columns = Object.values(columnsHash.call(this as unknown as typeof Base));
   return this._columns;
 }


### PR DESCRIPTION
## What

`columns()` in `model-schema.ts` read its `_columns` memo with a plain truthy
check while its two sibling readers — `columnsHash()` and `getColumnsHash` —
use `!= null` on the same `ownSchemaMemo` helper. That helper returns
`SchemaHost[K] | undefined`, so `!= null` is the contract-correct sentinel
test. This converges the third reader onto that idiom.

## Why it's safe (no behavior change)

`[]` is truthy in JS, so an empty-but-memoized column list was already served
by the truthy check — the mixed idiom happened to work by accident. Rails has
no analogue to hedge against: `columns` is `@columns ||= columns_hash.values`
(model_schema.rb:432-434), where `||=` serves an empty-but-memoized `[]` too.
This is idiom hygiene, guarding against a future nullable memo value diverging
silently between the three readers.

## Test

Adds a one-line pin: a subclass that ignores every column memoizes and serves
`[]` on re-read (same instance). Existing STI ignoredColumns tests pass
unchanged.

Closes-story: columns-memo-read-idiom-mismatch-truthy-vs-nullcheck
