### PR TITLE
fix(api-compare): honour leading :: on assert_valid_keys const expansion

### DIFF
--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -1515,7 +1515,7 @@ class ApiExtractor
   # Members of a `when *CONST` guard: `[:args_add_star, [], const_ref]`.
   def when_star_members(guard)
     return nil unless guard.is_a?(Array) && guard[0] == :args_add_star
-    resolve_const_symbol_array(guard[2])
+    resolve_const_symbol_array(const_name(guard[2]))
   end
 
   # The literal suffix after the `#{loop_var}` interpolation in a branch's first
@@ -1616,18 +1616,27 @@ class ApiExtractor
     found
   end
 
-  # Resolve a constant reference (`Relation::MULTI_VALUE_METHODS` or a bare
-  # `CONST`) to its recorded pure-symbol-array members, searching @const_symbol_arrays
-  # (which spans files) by matching the container path against stored FQNs.
-  def resolve_const_symbol_array(node)
-    name = const_name(node)
+  # Resolve a constant name (`Relation::MULTI_VALUE_METHODS` or a bare `CONST`)
+  # to its recorded pure-symbol-array members, searching @const_symbol_arrays
+  # (which spans files) by matching the container path against stored FQNs. A
+  # leading `::` forces an absolute lookup: the container is anchored to the top
+  # level (`fqn == container`, or the empty top level for `::CONST`) and the
+  # relative `end_with?` suffix match is skipped, honouring Ruby's rule that
+  # `::Foo::KEYS` binds to top-level `Foo`, never a nested `X::Foo`.
+  def resolve_const_symbol_array(name)
     return nil unless name
+    absolute = name.start_with?("::")
+    name = name[2..-1] if absolute
     parts = name.split("::")
     const = parts.last
     container = parts[0...-1].join("::")
     @const_symbol_arrays.each do |fqn, consts|
       next unless consts.key?(const)
-      next unless container.empty? || fqn == container || fqn.end_with?("::#{container}")
+      if absolute
+        next unless container.empty? ? fqn.empty? : fqn == container
+      else
+        next unless container.empty? || fqn == container || fqn.end_with?("::#{container}")
+      end
       return consts[const]
     end
     nil
@@ -1801,8 +1810,11 @@ class ApiExtractor
     if meth == "assert_valid_keys"
       traverse_for_symbols(args, keys)
       const_refs = []
-      traverse_for_consts(args, const_refs)
-      const_refs.each { |c| (consts[c] || []).each { |s| keys << s } }
+      traverse_for_consts(args, const_refs, keep_absolute: true)
+      const_refs.each do |c|
+        members = c.start_with?("::") ? resolve_const_symbol_array(c) : consts[c]
+        (members || []).each { |s| keys << s }
+      end
     elsif OPTION_READER_METHODS.include?(meth)
       syms = []
       traverse_for_symbols(args, syms)

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -810,3 +810,62 @@ describe("Ruby extractor method source lines", () => {
     expect(lines["Foo#qux"]).toEqual(["classMethods", 7]);
   });
 });
+
+describe("Ruby extractor option-key const expansion", () => {
+  const RUBY_SCRIPT = path.join(HERE, "extract-ruby-api.rb");
+
+  // Returns a map of "<fqn>#<method>" -> the method's expanded option_keys.
+  function optionKeys(fixtures: Record<string, string>): Record<string, string[] | undefined> {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "optkeys-rb-"));
+    try {
+      for (const [rel, src] of Object.entries(fixtures)) {
+        const p = path.join(dir, rel);
+        fs.mkdirSync(path.dirname(p), { recursive: true });
+        fs.writeFileSync(p, src);
+      }
+      const rels = JSON.stringify(Object.keys(fixtures));
+      const driver = `
+        require_relative ${JSON.stringify(RUBY_SCRIPT)}
+        require "json"
+        ex = ApiExtractor.new
+        JSON.parse(${JSON.stringify(rels)}).each do |rel|
+          ex.process_file(File.join(${JSON.stringify(dir)}, rel), ${JSON.stringify(dir)})
+        end
+        out = {}
+        (ex.classes.to_a + ex.modules.to_a).each do |fqn, info|
+          (info[:instanceMethods] + info[:classMethods]).each do |m|
+            out["#{fqn}##{m[:name]}"] = m[:option_keys]
+          end
+        end
+        puts JSON.generate(out)
+      `;
+      const stdout = execFileSync("ruby", ["-e", driver], { encoding: "utf-8" });
+      return JSON.parse(stdout);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("binds a leading :: option-key const to the top level, not a nested const", () => {
+    const r = optionKeys({
+      "abs_opt.rb": `
+        module Foo
+          KEYS = [:top_a, :top_b]
+        end
+
+        module Bar
+          module Foo
+            KEYS = [:nested_a, :nested_b]
+          end
+
+          class Rel
+            def build(options = {})
+              options.assert_valid_keys(::Foo::KEYS)
+            end
+          end
+        end
+      `,
+    });
+    expect(r["Bar::Rel#build"]).toEqual(["top_a", "top_b"]);
+  });
+});


### PR DESCRIPTION
## Summary

PR #4965 taught the Ruby extractor to preserve a leading `::` on mixin and
superclass references so absolute lookups honour Ruby's rule that `::` bypasses
lexical scope. The `assert_valid_keys` option-key expansion was left on the old
bare-name behaviour, so `assert_valid_keys ::Foo::KEYS` still resolved with the
absoluteness dropped — the same latent misresolution, on the option-key path.

## Changes

- `handle_option_call` now passes `keep_absolute: true` to `traverse_for_consts`
  and routes `::`-prefixed refs through `resolve_const_symbol_array`; bare refs
  keep the same-class `consts` lookup unchanged.
- `resolve_const_symbol_array` takes a name string and gains an absolute-container
  branch that anchors to the top level (`fqn == container`, or the empty top level
  for `::CONST`) and skips the relative `end_with?` suffix match. `when_star_members`
  passes `const_name(guard[2])`, preserving its existing bare behaviour.
- Unit coverage pins `assert_valid_keys ::Foo::KEYS` to top-level `Foo` when a
  nested `Bar::Foo::KEYS` also exists, mirroring the mixin test from #4965.

Inert on vendored Rails, which has no absolute constant reference on this path
(regression check, not a target).

Closes-story: extractor-absolute-const-refs-option-key-path
