### PR TITLE
fix(gate-extractor): drop positive adapter+feature compounds per Ruby mixed rule

### DIFF
--- a/scripts/test-compare/extract-ts-gates.test.ts
+++ b/scripts/test-compare/extract-ts-gates.test.ts
@@ -93,11 +93,14 @@ describe("gates.ts pure helpers", () => {
       features: ["insert_returning"],
       source: ["test"],
     });
-    // Mysql-only + feature: `adapterType !== "mysql"` skips everything but mysql.
+    // POSITIVE adapter + feature: `adapterType !== "mysql"` runs when true (a
+    // positive mysql set), and mixing a positive adapter set with a feature is
+    // unsound (`&&` vs `||` changes the run-on set), so the adapter set is
+    // dropped and only the feature survives — mirroring the Ruby extractor's
+    // `mixed` rule (positive `adapter_syms` + feature → drop the adapter set).
     expect(
       gateFromGuardExpr('adapterType !== "mysql" || !adapterSupports("expression_index")', false),
     ).toEqual({
-      adapters: ["mysql"],
       features: ["expression_index"],
       source: ["test"],
     });

--- a/scripts/test-compare/gates.ts
+++ b/scripts/test-compare/gates.ts
@@ -97,14 +97,22 @@ export function gateFromWrapper(name: string, featureArg?: string | null): TestG
  *
  * Recognizes the adapter idiom in the suite — `adapterType === "mysql"` /
  * `adapterType !== "sqlite"` — anywhere in the expression, and feature
- * predicates — `adapterSupports("x")`. A compound guard mixing the two (e.g.
- * `adapterType === "sqlite" || !adapterSupports("insert_returning")`, the
- * De-Morgan'd skip form of Rails' `if supports_insert_returning? &&
- * !current_adapter?(:SQLite3Adapter)`) yields BOTH an adapter set and a feature
- * set, mirroring how the Ruby extractor derives adapters from `current_adapter?`
- * and features from `supports_X?` as independent dimensions. Anything with
- * neither resolves to a `guards: ["unknown"]` gate so the comparison knows the
- * test is conditional without inventing an adapter set.
+ * predicates — `adapterSupports("x")`. How a compound mixing the two resolves
+ * depends on the adapter term's polarity, mirroring the Ruby extractor's
+ * `mixed` rule:
+ *   - EXCLUSION (`adapterType === "sqlite" || !adapterSupports("insert_returning")`,
+ *     the De-Morgan'd skip form of Rails' `if supports_insert_returning? &&
+ *     !current_adapter?(:SQLite3Adapter)`) → the run condition is the pure
+ *     conjunction `!sqlite && insert_returning?`, so BOTH the adapter exclusion
+ *     `[mysql,postgresql]` and the feature set are sound and emitted.
+ *   - POSITIVE (`adapterType !== "mysql" || !adapterSupports("expression_index")`)
+ *     → mixing a positive adapter set with a feature is unsound (the run-on set
+ *     differs under `&&` vs `||`), so the adapter set is DROPPED and only the
+ *     feature set survives — exactly as Ruby drops a positive `adapter_syms` set
+ *     whenever the condition also carries a feature or guard.
+ * Anything with neither adapter nor feature resolves to a `guards: ["unknown"]`
+ * gate so the comparison knows the test is conditional without inventing an
+ * adapter set.
  *
  * Source is `"test"` (per-test inline guard) — the TS analog of the Ruby
  * extractor's `"body-skip"`, distinct from a named `"wrapper"` suite.
@@ -149,15 +157,12 @@ export function gateFromGuardExpr(exprText: string, runsWhenTrue: boolean): Test
   const guards: string[] = [];
   if (/isMaria[Dd]b\b/.test(text)) guards.push("mariadb");
 
-  // A POSITIVE adapter set mixed with a guard isn't sound (the run-on set
-  // depends on whether the compound is `&&` or `||`) — drop it and keep the
-  // guard, mirroring the Ruby extractor's `mixed` rule in
-  // `gate_from_run_condition`. An adapter EXCLUSION stays: in the standard skip
-  // idiom `skipIf(adapterType === "x" || guard)` the run condition is the pure
-  // conjunction `!x && !guard`, which Ruby likewise keeps as
-  // adapters-minus-x + guard.
+  // The `mixed` rule (see the docstring): a POSITIVE adapter set is unsound and
+  // must be dropped once the compound also carries a feature or guard; an
+  // adapter EXCLUSION composes soundly and stays. Mirrors `gate_from_run_condition`.
+  const mixed = adapterIsPositive && (guards.length > 0 || featureMatches.length > 0);
   const gate: TestGate = { source: ["test"] };
-  if (adapters && !(guards.length && adapterIsPositive)) gate.adapters = adapters;
+  if (adapters && !mixed) gate.adapters = adapters;
   if (featureMatches.length) gate.features = sortedUnique(featureMatches);
   if (guards.length) gate.guards = guards;
   if (!gate.adapters && !gate.features && !gate.guards) gate.guards = ["unknown"];


### PR DESCRIPTION
## What

`gateFromGuardExpr` (`scripts/test-compare/gates.ts`) kept BOTH an adapter set
and a feature set when a POSITIVE `adapterType` term was mixed with
`adapterSupports(...)` predicates. Ruby's extractor
(`extract-ruby-tests.rb` `gate_from_run_condition`) drops a positive
`adapter_syms` set whenever the condition also carries a feature or guard — the
run-on set differs under `&&` vs `||`, so a positive adapter set mixed with a
feature is unsound. PR #5075 already applied this `mixed` rule to the guard
dimension; this extends it to features so both dimensions are treated uniformly.

An adapter EXCLUSION mixed with a feature is unchanged: the standard skip idiom
`adapterType === "x" || rest` is the pure conjunction `!x && !rest` on the run
side, which Ruby likewise keeps (`[mysql,postgresql]` + feature).

## Verification

- `extract-ts-gates.test.ts` covers both polarities of the feature-mixed case
  (exclusion → keep adapters+feature; positive → drop adapters, keep feature).
- `test:compare --gates` produces an identical report before and after — no new
  gate-mismatch rows.

Closes-story: gate-extractor-feature-mixed-positive-adapter