### PR TITLE
test(postgresql-adapter): guard conn-param allowlist against pg driver drift

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql-adapter-conn-param-drift.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter-conn-param-drift.trails.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { readFile } from "fs/promises";
+import { createRequire } from "module";
+import { PostgreSQLAdapter } from "./postgresql-adapter.js";
+
+// Trails-only guard (no Rails counterpart). Rails derives its conn_params
+// allowlist at RUNTIME from the driver
+// (postgresql_adapter.rb:330 — `conn_params.slice!(*valid_conn_param_keys)`
+// where `valid_conn_param_keys` comes from `PG::Connection.conndefaults_hash`),
+// so it can never drift. Ours (`PostgreSQLAdapter.VALID_CONN_PARAM_KEYS`) is a
+// hand-maintained literal transcribed from node-pg's source, so it CAN drift:
+//
+//   1. pg adds a keyword  -> it lands outside the allowlist and is silently
+//      dropped before reaching the driver ("option had no effect", not error).
+//   2. pg removes a keyword (`Promise` and `connection` are already deprecated
+//      with removal announced for pg@9, see client.js) -> the allowlist keeps
+//      accepting a key that no longer does anything.
+//
+// This test re-derives the accepted-keyword set from the INSTALLED `pg` package
+// and fails when VALID_CONN_PARAM_KEYS drifts from it in EITHER direction.
+describe("PostgreSQLAdapter VALID_CONN_PARAM_KEYS drift guard (trails)", () => {
+  const require = createRequire(import.meta.url);
+
+  // The two pg source files whose config-key reads define the driver's accepted
+  // keyword set. Named explicitly so a pg upgrade points at exactly what to
+  // re-check. Verified against pg@8.20.0:
+  //   - connection-parameters.js:63-127 — ConnectionParameters reads keys via
+  //     `val('name', config)` and a handful of direct `config.name` accesses.
+  //   - client.js:60-101 — the Client constructor reads its own keys off the
+  //     raw config as `c.name`.
+  const CONNECTION_PARAMETERS_JS = "pg/lib/connection-parameters.js";
+  const CLIENT_JS = "pg/lib/client.js";
+
+  // The exact pg version the extraction regexes below were verified against.
+  // A version bump fails this assertion FIRST, forcing a human to re-read the
+  // two source files and confirm the three access patterns (`val('x', config)`,
+  // `config.x`, `c.x`) still capture every accepted keyword — and to handle any
+  // removed key (see the deprecated-key note at the bottom of this file).
+  const PINNED_PG_VERSION = "8.20.0";
+
+  async function deriveDriverKeys(): Promise<Set<string>> {
+    const connParamsSrc = await readFile(require.resolve(CONNECTION_PARAMETERS_JS), "utf-8");
+    const clientSrc = await readFile(require.resolve(CLIENT_JS), "utf-8");
+
+    const keys = new Set<string>();
+    // ConnectionParameters: `val('name', config)`.
+    for (const m of connParamsSrc.matchAll(/val\('([a-zA-Z_]+)'/g)) keys.add(m[1]);
+    // ConnectionParameters: direct `config.name` reads (connectionString, ssl,
+    // keepAlive, keepAliveInitialDelayMillis, connectionTimeoutMillis).
+    for (const m of connParamsSrc.matchAll(/config\.([a-zA-Z_]+)/g)) keys.add(m[1]);
+    // Client constructor: `c.name` reads (config is bound to `c`).
+    for (const m of clientSrc.matchAll(/\bc\.([a-zA-Z_]+)/g)) keys.add(m[1]);
+    return keys;
+  }
+
+  it("is pinned to the pg version its extraction was verified against", () => {
+    expect(require("pg/package.json").version).toBe(PINNED_PG_VERSION);
+  });
+
+  it("accepts every keyword the installed pg driver reads, and no extras", async () => {
+    const driverKeys = deriveKeysSorted(await deriveDriverKeys());
+    const allowlist = deriveKeysSorted(
+      (
+        PostgreSQLAdapter as unknown as {
+          VALID_CONN_PARAM_KEYS: ReadonlySet<string>;
+        }
+      ).VALID_CONN_PARAM_KEYS,
+    );
+
+    // Bidirectional: a symmetric-difference of {} means neither a pg addition
+    // (dropped silently) nor a pg removal (accepted but dead) has slipped in.
+    expect(allowlist).toEqual(driverKeys);
+  });
+});
+
+function deriveKeysSorted(keys: Iterable<string>): string[] {
+  return [...keys].sort();
+}
+
+// Deprecated-key policy (`Promise`, `connection`):
+//
+// Both are read by pg@8's Client constructor (client.js — `c.Promise`,
+// `c.connection`) and are therefore in the derived set today, so they belong in
+// VALID_CONN_PARAM_KEYS now. pg@9 has announced their removal
+// (client.js:60-70 deprecation notices, "will be removed in pg@9.0"). When we
+// upgrade to pg@9:
+//   1. PINNED_PG_VERSION above fails first — re-verify the extraction.
+//   2. `c.Promise` / `c.connection` will no longer appear in client.js, so
+//      `deriveDriverKeys()` will drop them and the bidirectional test will fail
+//      until they are removed from VALID_CONN_PARAM_KEYS.
+// i.e. the guard MANDATES their removal at the pg@9 bump rather than leaving a
+// dead key that silently accepts an option the driver no longer honours.

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter-conn-param-drift.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter-conn-param-drift.trails.test.ts
@@ -3,90 +3,65 @@ import { readFile } from "fs/promises";
 import { createRequire } from "module";
 import { PostgreSQLAdapter } from "./postgresql-adapter.js";
 
-// Trails-only guard (no Rails counterpart). Rails derives its conn_params
-// allowlist at RUNTIME from the driver
-// (postgresql_adapter.rb:330 — `conn_params.slice!(*valid_conn_param_keys)`
-// where `valid_conn_param_keys` comes from `PG::Connection.conndefaults_hash`),
-// so it can never drift. Ours (`PostgreSQLAdapter.VALID_CONN_PARAM_KEYS`) is a
-// hand-maintained literal transcribed from node-pg's source, so it CAN drift:
-//
-//   1. pg adds a keyword  -> it lands outside the allowlist and is silently
-//      dropped before reaching the driver ("option had no effect", not error).
-//   2. pg removes a keyword (`Promise` and `connection` are already deprecated
-//      with removal announced for pg@9, see client.js) -> the allowlist keeps
-//      accepting a key that no longer does anything.
-//
-// This test re-derives the accepted-keyword set from the INSTALLED `pg` package
-// and fails when VALID_CONN_PARAM_KEYS drifts from it in EITHER direction.
-describe("PostgreSQLAdapter VALID_CONN_PARAM_KEYS drift guard (trails)", () => {
-  const require = createRequire(import.meta.url);
+const require = createRequire(import.meta.url);
 
-  // The two pg source files whose config-key reads define the driver's accepted
-  // keyword set. Named explicitly so a pg upgrade points at exactly what to
-  // re-check. Verified against pg@8.20.0:
-  //   - connection-parameters.js:63-127 — ConnectionParameters reads keys via
-  //     `val('name', config)` and a handful of direct `config.name` accesses.
-  //   - client.js:60-101 — the Client constructor reads its own keys off the
-  //     raw config as `c.name`.
-  const CONNECTION_PARAMETERS_JS = "pg/lib/connection-parameters.js";
-  const CLIENT_JS = "pg/lib/client.js";
+const PINNED_PG_VERSION = "8.20.0";
 
-  // The exact pg version the extraction regexes below were verified against.
-  // A version bump fails this assertion FIRST, forcing a human to re-read the
-  // two source files and confirm the three access patterns (`val('x', config)`,
-  // `config.x`, `c.x`) still capture every accepted keyword — and to handle any
-  // removed key (see the deprecated-key note at the bottom of this file).
-  const PINNED_PG_VERSION = "8.20.0";
+const PG_KEYWORD_SOURCES = [
+  {
+    module: "pg/lib/connection-parameters.js",
+    lines: "63-127",
+    patterns: [/val\('([a-zA-Z_]+)'/g, /config\.([a-zA-Z_]+)/g],
+  },
+  {
+    module: "pg/lib/client.js",
+    lines: "60-101",
+    patterns: [/\bc\.([a-zA-Z_]+)/g],
+  },
+] as const;
 
-  async function deriveDriverKeys(): Promise<Set<string>> {
-    const connParamsSrc = await readFile(require.resolve(CONNECTION_PARAMETERS_JS), "utf-8");
-    const clientSrc = await readFile(require.resolve(CLIENT_JS), "utf-8");
+const PG9_DEPRECATED_KEYWORDS = ["Promise", "connection"] as const;
 
-    const keys = new Set<string>();
-    // ConnectionParameters: `val('name', config)`.
-    for (const m of connParamsSrc.matchAll(/val\('([a-zA-Z_]+)'/g)) keys.add(m[1]);
-    // ConnectionParameters: direct `config.name` reads (connectionString, ssl,
-    // keepAlive, keepAliveInitialDelayMillis, connectionTimeoutMillis).
-    for (const m of connParamsSrc.matchAll(/config\.([a-zA-Z_]+)/g)) keys.add(m[1]);
-    // Client constructor: `c.name` reads (config is bound to `c`).
-    for (const m of clientSrc.matchAll(/\bc\.([a-zA-Z_]+)/g)) keys.add(m[1]);
-    return keys;
+async function deriveDriverKeywords(): Promise<Set<string>> {
+  const keys = new Set<string>();
+  for (const { module, patterns } of PG_KEYWORD_SOURCES) {
+    const source = await readFile(require.resolve(module), "utf-8");
+    for (const pattern of patterns) {
+      for (const [, key] of source.matchAll(pattern)) keys.add(key);
+    }
   }
+  return keys;
+}
 
-  it("is pinned to the pg version its extraction was verified against", () => {
-    expect(require("pg/package.json").version).toBe(PINNED_PG_VERSION);
-  });
+function allowlistKeywords(): Set<string> {
+  return (
+    PostgreSQLAdapter as unknown as {
+      VALID_CONN_PARAM_KEYS: ReadonlySet<string>;
+    }
+  ).VALID_CONN_PARAM_KEYS as Set<string>;
+}
 
-  it("accepts every keyword the installed pg driver reads, and no extras", async () => {
-    const driverKeys = deriveKeysSorted(await deriveDriverKeys());
-    const allowlist = deriveKeysSorted(
-      (
-        PostgreSQLAdapter as unknown as {
-          VALID_CONN_PARAM_KEYS: ReadonlySet<string>;
-        }
-      ).VALID_CONN_PARAM_KEYS,
-    );
-
-    // Bidirectional: a symmetric-difference of {} means neither a pg addition
-    // (dropped silently) nor a pg removal (accepted but dead) has slipped in.
-    expect(allowlist).toEqual(driverKeys);
-  });
-});
-
-function deriveKeysSorted(keys: Iterable<string>): string[] {
+function sorted(keys: Iterable<string>): string[] {
   return [...keys].sort();
 }
 
-// Deprecated-key policy (`Promise`, `connection`):
-//
-// Both are read by pg@8's Client constructor (client.js — `c.Promise`,
-// `c.connection`) and are therefore in the derived set today, so they belong in
-// VALID_CONN_PARAM_KEYS now. pg@9 has announced their removal
-// (client.js:60-70 deprecation notices, "will be removed in pg@9.0"). When we
-// upgrade to pg@9:
-//   1. PINNED_PG_VERSION above fails first — re-verify the extraction.
-//   2. `c.Promise` / `c.connection` will no longer appear in client.js, so
-//      `deriveDriverKeys()` will drop them and the bidirectional test will fail
-//      until they are removed from VALID_CONN_PARAM_KEYS.
-// i.e. the guard MANDATES their removal at the pg@9 bump rather than leaving a
-// dead key that silently accepts an option the driver no longer honours.
+const RECHECK_HINT = `re-derive from ${PG_KEYWORD_SOURCES.map((s) => `${s.module}:${s.lines}`).join(
+  " + ",
+)} after the pg bump`;
+
+describe("PostgreSQLAdapter conn-param allowlist drift guard (trails)", () => {
+  it("is pinned to the pg version its keyword extraction was verified against", () => {
+    expect(require("pg/package.json").version, RECHECK_HINT).toBe(PINNED_PG_VERSION);
+  });
+
+  it("accepts every keyword the installed pg driver reads, and no extras", async () => {
+    expect(sorted(allowlistKeywords()), RECHECK_HINT).toEqual(sorted(await deriveDriverKeywords()));
+  });
+
+  it("still derives the pg@9-deprecated Promise and connection keywords from pg@8", async () => {
+    const driverKeys = await deriveDriverKeywords();
+    for (const key of PG9_DEPRECATED_KEYWORDS) {
+      expect(driverKeys.has(key)).toBe(true);
+    }
+  });
+});

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter-conn-param-drift.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter-conn-param-drift.trails.test.ts
@@ -10,12 +10,14 @@ const PINNED_PG_VERSION = "8.20.0";
 const PG_KEYWORD_SOURCES = [
   {
     module: "pg/lib/connection-parameters.js",
-    lines: "63-127",
+    firstLine: 59,
+    lastLine: 127,
     patterns: [/val\('([a-zA-Z_]+)'/g, /config\.([a-zA-Z_]+)/g],
   },
   {
     module: "pg/lib/client.js",
-    lines: "60-101",
+    firstLine: 62,
+    lastLine: 99,
     patterns: [/\bc\.([a-zA-Z_]+)/g],
   },
 ] as const;
@@ -24,10 +26,14 @@ const PG9_DEPRECATED_KEYWORDS = ["Promise", "connection"] as const;
 
 async function deriveDriverKeywords(): Promise<Set<string>> {
   const keys = new Set<string>();
-  for (const { module, patterns } of PG_KEYWORD_SOURCES) {
+  for (const { module, firstLine, lastLine, patterns } of PG_KEYWORD_SOURCES) {
     const source = await readFile(require.resolve(module), "utf-8");
+    const slice = source
+      .split("\n")
+      .slice(firstLine - 1, lastLine)
+      .join("\n");
     for (const pattern of patterns) {
-      for (const [, key] of source.matchAll(pattern)) keys.add(key);
+      for (const [, key] of slice.matchAll(pattern)) keys.add(key);
     }
   }
   return keys;
@@ -45,9 +51,9 @@ function sorted(keys: Iterable<string>): string[] {
   return [...keys].sort();
 }
 
-const RECHECK_HINT = `re-derive from ${PG_KEYWORD_SOURCES.map((s) => `${s.module}:${s.lines}`).join(
-  " + ",
-)} after the pg bump`;
+const RECHECK_HINT = `re-derive from ${PG_KEYWORD_SOURCES.map(
+  (s) => `${s.module}:${s.firstLine}-${s.lastLine}`,
+).join(" + ")} after the pg bump`;
 
 describe("PostgreSQLAdapter conn-param allowlist drift guard (trails)", () => {
   it("is pinned to the pg version its keyword extraction was verified against", () => {
@@ -60,8 +66,12 @@ describe("PostgreSQLAdapter conn-param allowlist drift guard (trails)", () => {
 
   it("still derives the pg@9-deprecated Promise and connection keywords from pg@8", async () => {
     const driverKeys = await deriveDriverKeywords();
+    const allowlist = allowlistKeywords();
     for (const key of PG9_DEPRECATED_KEYWORDS) {
-      expect(driverKeys.has(key)).toBe(true);
+      expect(
+        allowlist.has(key) && !driverKeys.has(key),
+        `pg no longer reads "${key}": drop it from VALID_CONN_PARAM_KEYS (removed in pg@9)`,
+      ).toBe(false);
     }
   });
 });


### PR DESCRIPTION
## What

`PostgreSQLAdapter.VALID_CONN_PARAM_KEYS` is a hand-maintained literal
transcribed from node-pg's source. Rails derives its equivalent allowlist at
runtime from the driver (`PG::Connection.conndefaults_hash`), so it can never
drift; ours can, silently, in both directions:

1. **pg adds a keyword** — it lands outside the allowlist and is dropped before
   reaching the driver ("option had no effect", not an error).
2. **pg removes a keyword** — `Promise`/`connection` are already deprecated for
   removal in pg@9; the allowlist keeps accepting a dead key.

## Approach

A trails-only guard test (`postgresql-adapter-conn-param-drift.trails.test.ts`)
re-derives the accepted-keyword set from the **installed** `pg` package by
reading `pg/lib/connection-parameters.js` and `pg/lib/client.js` (async fs,
`createRequire` resolution) and extracting the three config-access patterns
(`val('x', config)`, `config.x`, `c.x`). It asserts `VALID_CONN_PARAM_KEYS`
equals that derived set **bidirectionally**.

Full automatic derivation IS viable here (25 keys, extracted exactly, zero
false positives), so it's the primary mechanism — but it's backed by a **pinned
pg-version assertion** (`8.20.0`) that fails first on any bump, forcing a human
to re-verify the extraction regexes against pg's private layout.

The source files and line ranges are named in-test so a pg upgrade points at
exactly what to re-check. The deprecated-key policy for `Promise`/`connection`
is documented: at the pg@9 bump they vanish from the derived set and the guard
mandates their removal rather than leaving dead keys.

Mutation-verified: adding or removing any allowlist key fails the guard.

Closes-story: guard-pg-conn-param-allowlist-against-driver-drift
