### PR TITLE
fix(method-order): resolve Ruby operator methods per-class in the manifest

### DIFF
--- a/packages/activemodel/src/attribute-set.ts
+++ b/packages/activemodel/src/attribute-set.ts
@@ -57,6 +57,13 @@ export class AttributeSet {
     this.attributes = attributes;
   }
 
+  /**
+   * Get the Attribute instance for a name.
+   */
+  getAttribute(name: string): Attribute {
+    return this.attributes.get(name) ?? this.defaultAttribute(name);
+  }
+
   castTypes(): Record<string, import("./type/value.js").Type> {
     const result: Record<string, import("./type/value.js").Type> = {};
     for (const [name, attr] of this.attributes) {
@@ -281,13 +288,6 @@ export class AttributeSet {
       err.name = "FrozenError";
       throw err;
     }
-  }
-
-  /**
-   * Get the Attribute instance for a name.
-   */
-  getAttribute(name: string): Attribute {
-    return this.attributes.get(name) ?? this.defaultAttribute(name);
   }
 
   /**

--- a/packages/activemodel/src/errors.ts
+++ b/packages/activemodel/src/errors.ts
@@ -145,6 +145,10 @@ export class Errors<TBase extends object = object> {
     return matches;
   }
 
+  get(attribute: string): string[] {
+    return this._errors.filter((e) => e.attribute === attribute).map((e) => e.message);
+  }
+
   get attributeNames(): string[] {
     return [...new Set(this._errors.map((e) => e.attribute))];
   }
@@ -334,10 +338,6 @@ export class Errors<TBase extends object = object> {
     return [attribute, resolvedType, opts];
   }
 
-  get base(): TBase | null {
-    return this._base;
-  }
-
   /**
    * Makes `Errors` iterable so `for (const e of errors)`, `[...errors]`,
    * and `Array.from(errors)` all work. Mirrors Rails' `include Enumerable`
@@ -350,8 +350,8 @@ export class Errors<TBase extends object = object> {
     return this._errors[Symbol.iterator]();
   }
 
-  get(attribute: string): string[] {
-    return this._errors.filter((e) => e.attribute === attribute).map((e) => e.message);
+  get base(): TBase | null {
+    return this._base;
   }
 
   on(attribute: string): string[] {

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -160,6 +160,11 @@ export class Table extends Node {
     return this.from().having(expr);
   }
 
+  get(name: string, table?: Attribute["relation"]): Attribute {
+    const resolved = this.klass?._attributeAliases?.[name] ?? name;
+    return new Attribute(table ?? this, resolved);
+  }
+
   /**
    * Mirrors: Arel::Table#hash — only name (Rails excludes aliases to avoid loops).
    */
@@ -185,22 +190,17 @@ export class Table extends Node {
     return (this.typeCaster as TypeCaster).typeCastForDatabase(attrName, value);
   }
 
-  typeForAttribute(name: string): unknown {
-    return (this.typeCaster as TypeCaster).typeForAttribute(name);
-  }
-
   /** Rails: `private attr_reader :type_caster` (table.rb:115). An aliased table
    *  is a `TableAlias` wrapping this one and delegates its caster back here
    *  (table_alias.rb:22-24), so no external reader is needed. */
   private readonly typeCaster: unknown;
 
-  isAbleToTypeCast(): boolean {
-    return this.typeCaster != null;
+  typeForAttribute(name: string): unknown {
+    return (this.typeCaster as TypeCaster).typeForAttribute(name);
   }
 
-  get(name: string, table?: Attribute["relation"]): Attribute {
-    const resolved = this.klass?._attributeAliases?.[name] ?? name;
-    return new Attribute(table ?? this, resolved);
+  isAbleToTypeCast(): boolean {
+    return this.typeCaster != null;
   }
 
   attr(name: string): Attribute {

--- a/scripts/api-compare/operator-order-spelling.test.ts
+++ b/scripts/api-compare/operator-order-spelling.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { operatorSpelling, OPERATOR_SPELLING_BY_FQN } from "./operator-order-spelling.js";
+import { OPERATORS } from "./conventions.js";
+
+describe("operatorSpelling", () => {
+  it("resolves `[]` to the class-specific spelling per fqn", () => {
+    // Same operator, different port: `get` vs the Map-compat invention's slot.
+    expect(operatorSpelling("Arel::Table", "[]")).toEqual(["get"]);
+    expect(operatorSpelling("ActiveModel::AttributeSet", "[]")).toEqual(["getAttribute"]);
+    expect(operatorSpelling("ActiveModel::Errors", "[]")).toEqual(["get"]);
+    expect(operatorSpelling("ActiveModel::AttributeSet::LazyAttributeHash", "[]")).toEqual(["get"]);
+  });
+
+  it("does NOT pull the AttributeSet `get` invention into the `[]` slot", () => {
+    expect(operatorSpelling("ActiveModel::AttributeSet", "[]")).not.toContain("get");
+  });
+
+  it("returns undefined for an unlisted class (stays unmapped)", () => {
+    expect(operatorSpelling("Arel::Nodes::Casted", "[]")).toBeUndefined();
+    expect(operatorSpelling("Arel::Table", "==")).toBeUndefined();
+  });
+
+  it("returns undefined for a non-operator name", () => {
+    expect(operatorSpelling("Arel::Table", "having")).toBeUndefined();
+    expect(operatorSpelling("Arel::Table", "hash")).toBeUndefined();
+  });
+
+  it("only keys operators recognised by api-compare's OPERATORS set", () => {
+    for (const ops of Object.values(OPERATOR_SPELLING_BY_FQN)) {
+      for (const op of Object.keys(ops)) expect(OPERATORS.has(op)).toBe(true);
+    }
+  });
+});

--- a/scripts/api-compare/operator-order-spelling.ts
+++ b/scripts/api-compare/operator-order-spelling.ts
@@ -1,0 +1,48 @@
+/**
+ * Per-CLASS resolution of Ruby OPERATOR methods (`[]`, `==`, `<=>`, …) to their
+ * TS spelling for the method-ORDER manifest (build-rails-file-structure-manifest.ts).
+ *
+ * api-compare's `rubyMethodToTs` returns `null` for every operator (they carry
+ * no canonical camelCase spelling), so an operator a Rails class defines has a
+ * real source POSITION but no mapping — the manifest builder would treat its TS
+ * port as an unmapped helper and shove it past the mapped block, degrading
+ * fidelity (e.g. `Arel::Table#[]` at table.rb:82, between `having`:78 and
+ * `hash`:88, ports to `table.ts` `get` but sorts last).
+ *
+ * A name-only GLOBAL map is unsafe: `[]` ports to `get` in `Arel::Table` /
+ * `ActiveModel::Errors` / `LazyAttributeHash`, but to `getAttribute` in
+ * `ActiveModel::AttributeSet` — where `get` (attribute-set.ts:63/296) is instead
+ * a non-Rails Map-compat invention. Mapping `[]`→`get` globally would promote
+ * that invention into Rails' `[]` slot (tried and reverted in #5030). So the
+ * table is keyed per Ruby fqn: each (fqn, operator) resolves to the spelling
+ * that class's port actually uses. An operator not listed here for a class stays
+ * unmapped and sorts after the mapped block, exactly as before.
+ *
+ * Each entry is verified against BOTH the Rails source position and the actual
+ * TS class member; only add an operator once the port's spelling is confirmed.
+ */
+import { OPERATORS } from "./conventions.js";
+
+// (Ruby fqn) → (operator) → ordered TS spelling candidates. Candidates mirror
+// `rubyMethodToTs`'s multi-name shape: the rule filters to spellings actually
+// present in the container, so listing more than one is a safe no-op.
+export const OPERATOR_SPELLING_BY_FQN: Record<string, Record<string, string[]>> = {
+  // arel/table.rb:82 `def [](name, table = self)` → table.ts `get`.
+  "Arel::Table": { "[]": ["get"] },
+  // active_model/errors.rb:229 `def [](attribute)` → errors.ts `get`.
+  "ActiveModel::Errors": { "[]": ["get"] },
+  // attribute_set/builder.rb:110 `def [](key)` → builder.ts `LazyAttributeHash#get`.
+  "ActiveModel::AttributeSet::LazyAttributeHash": { "[]": ["get"] },
+  // attribute_set.rb:16 `def [](name)` → attribute-set.ts `getAttribute` (NOT the
+  // Map-compat `get` invention at attribute-set.ts:296).
+  "ActiveModel::AttributeSet": { "[]": ["getAttribute"] },
+};
+
+/**
+ * TS spelling candidates for a Ruby operator method on a given class, or
+ * `undefined` when `name` is not an operator or the class has no verified entry.
+ */
+export function operatorSpelling(fqn: string, name: string): string[] | undefined {
+  if (!OPERATORS.has(name)) return undefined;
+  return OPERATOR_SPELLING_BY_FQN[fqn]?.[name];
+}

--- a/scripts/build-rails-file-structure-manifest.ts
+++ b/scripts/build-rails-file-structure-manifest.ts
@@ -106,16 +106,10 @@ const ORDER_ONLY_CANDIDATES: Record<string, string[]> = {
   "nil?": ["isNil", "nil"],
   hash: ["hash"],
   "eql?": ["isEql", "eql"],
-  // Ruby OPERATORS (`[]`, `==`, `<=>`, …) are NOT resolved here. Unlike the three
-  // universal predicates above — each with one canonical trails spelling — operator
-  // ports are class-specific and ambiguous, so a name-only global map is unsafe:
-  // `[]` ports to `get` in `Arel::Table` / `ActiveModel::Errors` /
-  // `LazyAttributeHash` but to `getAttribute` in `ActiveModel::AttributeSet`,
-  // where `get` is instead a non-Rails Map-compat helper (attribute_set.rb:16
-  // `[]` → `getAttribute` at attribute-set.ts:289; the `get` at :296 has no Rails
-  // counterpart). They are instead resolved PER-CLASS by `operatorSpelling`
-  // (operator-order-spelling.ts), keyed (fqn, operator)→spelling; an operator a
-  // class doesn't list there stays unmapped and sorts after the mapped block.
+  // Ruby OPERATORS (`[]`, `==`, `<=>`, …) are NOT resolved here: their TS
+  // spelling is class-specific (`[]`→`get` in `Arel::Table` but `getAttribute`
+  // in `ActiveModel::AttributeSet`), so they resolve PER-CLASS via
+  // `operatorSpelling` (operator-order-spelling.ts) instead of a name-only map.
 };
 
 // Append TS candidate names for a Ruby method onto `list`, deduping against
@@ -224,8 +218,7 @@ for (const [pkg, rubyPkg] of Object.entries<any>(railsApi.packages)) {
         const file = m.file ?? host.file;
         noteClass(file, className, host.fqn);
         const b = bucketFor(file, className);
-        // Instance operators (`[]`, `==`, …) resolve to a class-specific TS
-        // spelling keyed by the Ruby fqn; static methods have no operator ports.
+        // Operators are instance-only ports; resolve the class-specific spelling.
         const opCandidates = m.isStatic ? undefined : operatorSpelling(host.fqn, m.name);
         pushMethod(b.names, b.seen, m.name, m.isStatic, opCandidates);
       }

--- a/scripts/build-rails-file-structure-manifest.ts
+++ b/scripts/build-rails-file-structure-manifest.ts
@@ -27,6 +27,7 @@ import { fileURLToPath } from "url";
 import { rubyMethodToTs, rubyFileToTs } from "./api-compare/conventions.js";
 import { writeJsonManifest } from "./api-compare/write-json-manifest.js";
 import { mergeBySourceLine } from "./api-compare/source-order.js";
+import { operatorSpelling } from "./api-compare/operator-order-spelling.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
@@ -105,17 +106,16 @@ const ORDER_ONLY_CANDIDATES: Record<string, string[]> = {
   "nil?": ["isNil", "nil"],
   hash: ["hash"],
   "eql?": ["isEql", "eql"],
-  // Ruby OPERATORS are deliberately NOT mapped. Unlike the three universal
-  // predicates above — each with one canonical trails spelling — operator
+  // Ruby OPERATORS (`[]`, `==`, `<=>`, …) are NOT resolved here. Unlike the three
+  // universal predicates above — each with one canonical trails spelling — operator
   // ports are class-specific and ambiguous, so a name-only global map is unsafe:
   // `[]` ports to `get` in `Arel::Table` / `ActiveModel::Errors` /
   // `LazyAttributeHash` but to `getAttribute` in `ActiveModel::AttributeSet`,
   // where `get` is instead a non-Rails Map-compat helper (attribute_set.rb:16
-  // `[]` → `getAttribute` at attribute-set.ts:298; the `get` at :63 has no Rails
-  // counterpart). Mapping `[]`→`get` would promote that invention into Rails'
-  // `[]` slot. `==` / `<=>` similarly vary (`equals` / `isEqualTo` / `compare`).
-  // Such operator ports — rare — sort after the mapped block; if one becomes a
-  // real fidelity gap, the RAILS_STRUCTURE_REPORT class-level surface flags it.
+  // `[]` → `getAttribute` at attribute-set.ts:289; the `get` at :296 has no Rails
+  // counterpart). They are instead resolved PER-CLASS by `operatorSpelling`
+  // (operator-order-spelling.ts), keyed (fqn, operator)→spelling; an operator a
+  // class doesn't list there stays unmapped and sorts after the mapped block.
 };
 
 // Append TS candidate names for a Ruby method onto `list`, deduping against
@@ -135,8 +135,17 @@ const ORDER_ONLY_CANDIDATES: Record<string, string[]> = {
 // trails also has an invented instance `get engine()`; a bare `engine` entry let
 // that invention be repositioned against the class accessor's slot. Entries in
 // the `functions` bucket stay bare — top-level functions have no staticness.
-const pushMethod = (list: string[], seen: Set<string>, name: string, isStatic: boolean) => {
-  const candidates = rubyMethodToTs(name) ?? ORDER_ONLY_CANDIDATES[name];
+// `operatorCandidates` (when supplied by a caller that knows the container's
+// Ruby fqn) resolves a class-specific operator spelling; it takes lowest
+// precedence so a real `rubyMethodToTs` mapping always wins.
+const pushMethod = (
+  list: string[],
+  seen: Set<string>,
+  name: string,
+  isStatic: boolean,
+  operatorCandidates?: string[],
+) => {
+  const candidates = rubyMethodToTs(name) ?? ORDER_ONLY_CANDIDATES[name] ?? operatorCandidates;
   if (!candidates || candidates.length === 0) return;
   for (const ts of candidates) {
     const entry = isStatic ? `static ${ts}` : ts;
@@ -215,7 +224,10 @@ for (const [pkg, rubyPkg] of Object.entries<any>(railsApi.packages)) {
         const file = m.file ?? host.file;
         noteClass(file, className, host.fqn);
         const b = bucketFor(file, className);
-        pushMethod(b.names, b.seen, m.name, m.isStatic);
+        // Instance operators (`[]`, `==`, …) resolve to a class-specific TS
+        // spelling keyed by the Ruby fqn; static methods have no operator ports.
+        const opCandidates = m.isStatic ? undefined : operatorSpelling(host.fqn, m.name);
+        pushMethod(b.names, b.seen, m.name, m.isStatic, opCandidates);
       }
     }
   };


### PR DESCRIPTION
## What

Ruby operator methods (`[]`, `==`, `<=>`, …) have a real Rails source position
but no `rubyMethodToTs` mapping, so `build-rails-file-structure-manifest.ts`
treated their TS ports as unmapped helpers and relegated them past the mapped
block. Concretely `Arel::Table#[]` (table.rb:82, between `having`:78 and
`hash`:88) ports to `table.ts` `get` but sorted last.

## Approach

A name-only global map is unsafe: `[]` ports to `get` in `Arel::Table` /
`ActiveModel::Errors` / `LazyAttributeHash` but to `getAttribute` in
`ActiveModel::AttributeSet`, where `get` is a non-Rails Map-compat invention
(mapping `[]`→`get` globally would promote it into Rails' `[]` slot — tried and
reverted in #5030).

New `scripts/api-compare/operator-order-spelling.ts` holds a keyed
`(fqn, operator)→spelling` table plus `operatorSpelling(fqn, name)`. The builder
threads the container's Ruby fqn to resolve operators per-class (lowest
precedence, so a real `rubyMethodToTs` mapping always wins). Each entry is
verified against both the Rails source position and the actual TS member.

## Source reorders (downstream of the manifest change)

Once `[]` is mapped, the `rails-file-structure-method-order` rule correctly
flags the ports as out of Rails order, so the affected members are moved to
their Rails positions (pure relocations, no body changes):
- `table.ts` `get` → between `having` and `hash` (table.rb:78,82,88)
- `attribute-set.ts` `getAttribute` → before `castTypes` (attribute_set.rb:16,24)
- `errors.ts` `get` → before `attributeNames` (errors.rb:229)

## Verification

- Manifest built from the extracted `rails-api.json`; `pnpm eslint packages/arel/src
  packages/activemodel/src` is clean.
- `table.ts` order → `['having', 'get', 'hash', 'isEql', 'eql']`; `attribute-set.ts`
  `[]`→`getAttribute` (the `get` invention stays out of the `[]` slot).
- Unit tests in `operator-order-spelling.test.ts`; affected package tests
  (table / attribute-set / errors, 254 tests) pass.

Closes-story: method-order-map-operator-methods-per-class
