### PR TITLE
test(schema-repair): THROWAWAY Phase-1 firing measurement [do not merge]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -766,7 +766,19 @@ jobs:
       # large suite's worker scheduler (they otherwise starve its reporter RPC
       # / perturb fork scheduling — see trails-models-dump tests).
       - run: pnpm vitest run packages/activerecord/
+        env:
+          # THROWAWAY (RFC drop-repair-worker-schema Phase 1): attribute every
+          # repairWorkerSchema firing to its triggering test file.
+          AR_REPAIR_COUNT_DIR: ${{ github.workspace }}/repair-counts
       - run: pnpm vitest run packages/activerecord-cli
+      - name: Upload repair counts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: repair-counts-sqlite
+          path: repair-counts/
+          if-no-files-found: ignore
+          retention-days: 7
 
   # Reporting-only AR coverage (story ar-sqlite-lane-coverage-reporting, RFC
   # 0028). Runs the sqlite AR suite (the cheapest backend) with v8 coverage and
@@ -1017,6 +1029,8 @@ jobs:
           PGDATABASE: rails_js_test
           # AR_DB_FORKS deliberately unset: vitest.config.ts derives both the
           # worker count and the slot-DB pool from the runner's vCPU count.
+          # THROWAWAY (RFC drop-repair-worker-schema Phase 1).
+          AR_REPAIR_COUNT_DIR: ${{ github.workspace }}/repair-counts
       # CLI E2E is not sharded — run it once, on shard 1 only, to avoid a
       # redundant double-run across the two legs.
       # PG_TEST_URL is the activerecord-cli E2E's own input (it drives the CLI's
@@ -1026,6 +1040,14 @@ jobs:
         run: pnpm vitest run packages/activerecord-cli
         env:
           PG_TEST_URL: postgres://postgres:postgres@localhost:5432/rails_js_test
+      - name: Upload repair counts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: repair-counts-postgres-shard${{ matrix.shard }}
+          path: repair-counts/
+          if-no-files-found: ignore
+          retention-days: 7
 
   mysql-tests:
     name: Active Record MySQL Tests
@@ -1153,11 +1175,21 @@ jobs:
           MYSQL_DATABASE: rails_js_test
           # AR_DB_FORKS deliberately unset: vitest.config.ts derives both the
           # worker count and the slot-DB pool from the runner's vCPU count.
+          # THROWAWAY (RFC drop-repair-worker-schema Phase 1).
+          AR_REPAIR_COUNT_DIR: ${{ github.workspace }}/repair-counts
       # No MySQL connection env: no mysql-happy-path E2E exists yet. This run
       # covers the SQLite E2E until a mysql suite lands and can be wired up.
       # CLI E2E is not sharded — run it once, on shard 1 only.
       - if: ${{ matrix.shard == 1 }}
         run: pnpm vitest run packages/activerecord-cli
+      - name: Upload repair counts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: repair-counts-maria-shard${{ matrix.shard }}
+          path: repair-counts/
+          if-no-files-found: ignore
+          retention-days: 7
 
   website:
     name: Website

--- a/packages/activerecord/src/test-setup-dy.ts
+++ b/packages/activerecord/src/test-setup-dy.ts
@@ -29,6 +29,7 @@ import { generateSchemaFile } from "./test-helpers/schema-file-generator.js";
 import { TEST_SCHEMA } from "./test-helpers/test-schema.js";
 import { Base } from "./base.js";
 import { DatabaseTasks } from "./tasks/database-tasks.js";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 // Registers _RelationCtor so Model.first()/.all()/.where() etc. work in
 // test files that import base.js directly rather than index.js (which
 // re-exports relation.js as a side effect).
@@ -74,6 +75,37 @@ if (process.env.AR_DISABLE_SCHEMA_REPAIR === undefined) {
   // Silence with AR_QUIET_SCHEMA_REPAIR once a table is known/tracked.
   if (repaired.length > 0 && process.env.AR_QUIET_SCHEMA_REPAIR === undefined) {
     console.warn(`[schema-repair] restored drifted canonical tables: ${repaired.join(", ")}`);
+  }
+  // THROWAWAY instrumentation (RFC drop-repair-worker-schema, Phase 1). When
+  // AR_REPAIR_COUNT_DIR is set, append one JSONL record per firing attributing
+  // the drift to the TRIGGERING test file (the file whose setup ran the repair),
+  // adapter, and repaired tables. A CI step uploads the dir; a local aggregator
+  // tallies by file/table/backend. DELETE this block with the capstone story.
+  if (repaired.length > 0 && process.env.AR_REPAIR_COUNT_DIR !== undefined) {
+    try {
+      const { getFs } = await import("@blazetrails/activesupport");
+      const fs = getFs();
+      const dir = process.env.AR_REPAIR_COUNT_DIR;
+      fs.mkdirSync(dir, { recursive: true });
+      // Attribute to the current test file: at setup-module eval vitest has
+      // already set the worker state's `filepath` to the file being started.
+      const w = (globalThis as { __vitest_worker__?: { filepath?: string } }).__vitest_worker__;
+      const rawFile = w?.filepath ?? null;
+      const file = rawFile ? rawFile.replace(/^.*\/packages\//, "packages/") : "(unknown)";
+      const workerId = process.env.VITEST_POOL_ID ?? process.env.VITEST_WORKER_ID ?? "1";
+      const record =
+        JSON.stringify({
+          file,
+          adapter,
+          tables: repaired,
+          worker: workerId,
+          pid: process.pid,
+          at: Temporal.Now.instant().toString(),
+        }) + "\n";
+      fs.appendFileSync(`${dir}/repair-${adapter}-w${workerId}-${process.pid}.jsonl`, record);
+    } catch {
+      // best-effort; never break a test run on instrumentation failure
+    }
   }
 }
 


### PR DESCRIPTION
## THROWAWAY — do NOT merge

Phase-1 measurement for the `drop-repair-worker-schema` RFC. Instruments
`repairWorkerSchema` so every firing is attributed to its **triggering test
file**, adapter, and repaired canonical table(s), then uploaded as a CI
artifact per AR lane (sqlite / postgres / maria; mysql lane is temporarily
disabled).

- `test-setup-dy.ts`: when `AR_REPAIR_COUNT_DIR` is set, append a JSONL record
  per non-empty repair (file, adapter, tables, worker, pid, timestamp). Dormant
  when the env var is unset — zero cost on normal runs.
- `ci.yml`: set `AR_REPAIR_COUNT_DIR` on the three active AR vitest steps and
  upload `repair-counts/` as an artifact each.

Harvested locally after the AR lanes finish, then this PR is **closed, not
merged**. The instrumentation block + CI steps are deleted by the RFC capstone
story.
