### PR TITLE
test(hot-compatibility): disconnect pool per-test to clear stale PG plans

### DIFF
--- a/packages/activerecord/src/hot-compatibility.test.ts
+++ b/packages/activerecord/src/hot-compatibility.test.ts
@@ -1,5 +1,5 @@
 // vendor/rails/activerecord/test/cases/hot_compatibility_test.rb
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { Base } from "./index.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import { adapterType } from "./test-adapter.js";
@@ -21,6 +21,20 @@ function preparedStatementCacheSize(adapter: DatabaseAdapter): number {
 describe("HotCompatibilityTest", () => {
   // Rails `use_transactional_tests = false`: tests build/drop tables per test.
   fixtures({}, { useTransactionalTests: false });
+
+  // The bespoke `hot_compatibilities` table is dropped and recreated (via
+  // `force: true`) across the tests in this file. Under the shared per-worker
+  // Postgres DB, a server-side prepared plan cached against a prior incarnation
+  // of the table on ANY pooled connection would raise a raw `0A000` ("cached
+  // plan must not change result type") the next time that connection is
+  // re-leased and re-runs it — a flake `repairWorkerSchema` can't cover because
+  // the table is bespoke. Rails' `with_two_connections` sidesteps this by
+  // ending each PG test with `clear_all_connections!(:all)`; mirror that for
+  // every test here by disconnecting the pool (which deallocates all
+  // server-side statements), so no stale plan survives into the next test.
+  afterEach(async () => {
+    await Base.connectionPool().disconnectBang();
+  });
   // Rails' setup builds the table + model fresh per test (use_transactional_tests
   // = false). We mirror that with a helper that creates the table and a model
   // bound to a fresh adapter, returning both so the test can drive remove_column

--- a/packages/activerecord/src/hot-compatibility.test.ts
+++ b/packages/activerecord/src/hot-compatibility.test.ts
@@ -120,104 +120,75 @@ describe("HotCompatibilityTest", () => {
     }
   });
 
+  // Both PG tests share Rails' body verbatim (create the record, warm the reload
+  // plan in a transaction, `add_column` on the second connection, then assert the
+  // stale re-run raises PreparedStatementCacheExpired and drains the cache); they
+  // differ only in the transaction nesting around the failing reload, which the
+  // caller supplies as `staleReload`.
+  async function assertPreparedStatementCleanup(
+    ddlConnection: DatabaseAdapter,
+    staleReload: (model: typeof Base, record: { reload(): Promise<unknown> }) => Promise<unknown>,
+  ): Promise<void> {
+    const adapter = Base.connection;
+    await new MigrationContext(adapter).createTable("hot_compatibilities", { force: true }, (t) => {
+      t.string("foo");
+      t.string("bar");
+    });
+    try {
+      class HotCompatibility extends Base {}
+      HotCompatibility.tableName = "hot_compatibilities";
+      (HotCompatibility as unknown as { adapter: DatabaseAdapter }).adapter = adapter;
+
+      const record = await HotCompatibility.create({ bar: "bar" });
+
+      // prepare the reload statement in a transaction
+      await HotCompatibility.transaction(async () => {
+        await record.reload();
+      });
+
+      expect(preparedStatementCacheSize(adapter)).toBeGreaterThan(0);
+
+      // add a new column on the second connection
+      await new MigrationContext(ddlConnection).addColumn("hot_compatibilities", "baz", "string");
+
+      await expect(staleReload(HotCompatibility, record)).rejects.toBeInstanceOf(
+        PreparedStatementCacheExpired,
+      );
+
+      expect(preparedStatementCacheSize(adapter)).toBe(0);
+    } finally {
+      await new MigrationContext(adapter).dropTable("hot_compatibilities", { ifExists: true });
+    }
+  }
+
   // Rails gates these on current_adapter?(:PostgreSQL) + prepared_statements.
   it.skipIf(adapterType !== "postgres")(
     "cleans up after prepared statement failure in a transaction",
     async () => {
-      await withTwoConnections(async (ddlConnection) => {
-        const adapter = Base.connection;
-        await new MigrationContext(adapter).createTable(
-          "hot_compatibilities",
-          { force: true },
-          (t) => {
-            t.string("foo");
-            t.string("bar");
-          },
-        );
-        try {
-          class HotCompatibility extends Base {}
-          HotCompatibility.tableName = "hot_compatibilities";
-          (HotCompatibility as unknown as { adapter: DatabaseAdapter }).adapter = adapter;
-
-          const record = await HotCompatibility.create({ bar: "bar" });
-
-          // prepare the reload statement in a transaction
-          await HotCompatibility.transaction(async () => {
+      await withTwoConnections((ddlConnection) =>
+        assertPreparedStatementCleanup(ddlConnection, (model, record) =>
+          model.transaction(async () => {
             await record.reload();
-          });
-
-          expect(preparedStatementCacheSize(adapter)).toBeGreaterThan(0);
-
-          // add a new column on the second connection
-          await new MigrationContext(ddlConnection).addColumn(
-            "hot_compatibilities",
-            "baz",
-            "string",
-          );
-
-          await expect(
-            HotCompatibility.transaction(async () => {
-              await record.reload();
-            }),
-          ).rejects.toBeInstanceOf(PreparedStatementCacheExpired);
-
-          expect(preparedStatementCacheSize(adapter)).toBe(0);
-        } finally {
-          await new MigrationContext(adapter).dropTable("hot_compatibilities", { ifExists: true });
-        }
-      });
+          }),
+        ),
+      );
     },
   );
 
   it.skipIf(adapterType !== "postgres")(
     "cleans up after prepared statement failure in nested transactions",
     async () => {
-      await withTwoConnections(async (ddlConnection) => {
-        const adapter = Base.connection;
-        await new MigrationContext(adapter).createTable(
-          "hot_compatibilities",
-          { force: true },
-          (t) => {
-            t.string("foo");
-            t.string("bar");
-          },
-        );
-        try {
-          class HotCompatibility extends Base {}
-          HotCompatibility.tableName = "hot_compatibilities";
-          (HotCompatibility as unknown as { adapter: DatabaseAdapter }).adapter = adapter;
-
-          const record = await HotCompatibility.create({ bar: "bar" });
-
-          // prepare the reload statement in a transaction
-          await HotCompatibility.transaction(async () => {
-            await record.reload();
-          });
-
-          expect(preparedStatementCacheSize(adapter)).toBeGreaterThan(0);
-
-          // add a new column on the second connection
-          await new MigrationContext(ddlConnection).addColumn(
-            "hot_compatibilities",
-            "baz",
-            "string",
-          );
-
-          await expect(
-            HotCompatibility.transaction(async () => {
-              await HotCompatibility.transaction(async () => {
-                await HotCompatibility.transaction(async () => {
-                  await record.reload();
-                });
+      await withTwoConnections((ddlConnection) =>
+        assertPreparedStatementCleanup(ddlConnection, (model, record) =>
+          model.transaction(async () => {
+            await model.transaction(async () => {
+              await model.transaction(async () => {
+                await record.reload();
               });
-            }),
-          ).rejects.toBeInstanceOf(PreparedStatementCacheExpired);
-
-          expect(preparedStatementCacheSize(adapter)).toBe(0);
-        } finally {
-          await new MigrationContext(adapter).dropTable("hot_compatibilities", { ifExists: true });
-        }
-      });
+            });
+          }),
+        ),
+      );
     },
   );
 });

--- a/packages/activerecord/src/hot-compatibility.test.ts
+++ b/packages/activerecord/src/hot-compatibility.test.ts
@@ -1,5 +1,5 @@
 // vendor/rails/activerecord/test/cases/hot_compatibility_test.rb
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { Base } from "./index.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import { adapterType } from "./test-adapter.js";
@@ -22,19 +22,32 @@ describe("HotCompatibilityTest", () => {
   // Rails `use_transactional_tests = false`: tests build/drop tables per test.
   fixtures({}, { useTransactionalTests: false });
 
-  // The bespoke `hot_compatibilities` table is dropped and recreated (via
-  // `force: true`) across the tests in this file. Under the shared per-worker
-  // Postgres DB, a server-side prepared plan cached against a prior incarnation
-  // of the table on ANY pooled connection would raise a raw `0A000` ("cached
-  // plan must not change result type") the next time that connection is
-  // re-leased and re-runs it — a flake `repairWorkerSchema` can't cover because
-  // the table is bespoke. Rails' `with_two_connections` sidesteps this by
-  // ending each PG test with `clear_all_connections!(:all)`; mirror that for
-  // every test here by disconnecting the pool (which deallocates all
-  // server-side statements), so no stale plan survives into the next test.
-  afterEach(async () => {
-    await Base.connectionPool().disconnectBang();
-  });
+  // Rails' `with_two_connections` (hot_compatibility_test.rb): the model reads
+  // through its leased connection while a separately checked-out `ddlConnection`
+  // runs the migration — simulating a migration on one worker invalidating cached
+  // plans on another. Rails brackets this with a *fresh* `establish_connection(…,
+  // pool_size: 2)` up front and `clear_all_connections!(:all)` in the ensure;
+  // both discard every pooled connection, so no server-side plan cached against a
+  // prior incarnation of the bespoke `hot_compatibilities` table can survive
+  // across the boundary and raise a raw `0A000` ("cached plan must not change
+  // result type") when a connection is re-leased under the shared per-worker DB.
+  // We mirror all three: disconnect the pool before and after (the earlier
+  // non-isolated `remove_column` tests share this pool and leave such plans), and
+  // check out the second connection in between.
+  async function withTwoConnections(
+    body: (ddlConnection: DatabaseAdapter) => Promise<void>,
+  ): Promise<void> {
+    const pool = Base.connectionPool();
+    await pool.disconnectBang();
+    const ddlConnection = await pool.checkout();
+    try {
+      await body(ddlConnection);
+    } finally {
+      pool.checkin(ddlConnection);
+      await pool.disconnectBang();
+    }
+  }
+
   // Rails' setup builds the table + model fresh per test (use_transactional_tests
   // = false). We mirror that with a helper that creates the table and a model
   // bound to a fresh adapter, returning both so the test can drive remove_column
@@ -108,106 +121,103 @@ describe("HotCompatibilityTest", () => {
   });
 
   // Rails gates these on current_adapter?(:PostgreSQL) + prepared_statements.
-  // Rails' `with_two_connections` re-establishes the pool at size 2: the model
-  // runs on the leased connection while a separately checked-out connection runs
-  // the DDL — simulating a migration on one worker invalidating cached plans on
-  // another. We mirror that by leasing the model's connection and checking out a
-  // second pool connection for the `add_column`.
   it.skipIf(adapterType !== "postgres")(
     "cleans up after prepared statement failure in a transaction",
     async () => {
-      const pool = Base.connectionPool();
-      const adapter = Base.connection;
-      const ddlConnection = await pool.checkout();
-      try {
-        const migration = new MigrationContext(adapter);
-        await migration.createTable("hot_compatibilities", { force: true }, (t) => {
-          t.string("foo");
-          t.string("bar");
-        });
+      await withTwoConnections(async (ddlConnection) => {
+        const adapter = Base.connection;
+        await new MigrationContext(adapter).createTable(
+          "hot_compatibilities",
+          { force: true },
+          (t) => {
+            t.string("foo");
+            t.string("bar");
+          },
+        );
+        try {
+          class HotCompatibility extends Base {}
+          HotCompatibility.tableName = "hot_compatibilities";
+          (HotCompatibility as unknown as { adapter: DatabaseAdapter }).adapter = adapter;
 
-        class HotCompatibility extends Base {}
-        HotCompatibility.tableName = "hot_compatibilities";
-        (HotCompatibility as unknown as { adapter: DatabaseAdapter }).adapter = adapter;
+          const record = await HotCompatibility.create({ bar: "bar" });
 
-        const record = await HotCompatibility.create({ bar: "bar" });
-
-        // prepare the reload statement in a transaction
-        await HotCompatibility.transaction(async () => {
-          await record.reload();
-        });
-
-        expect(preparedStatementCacheSize(adapter)).toBeGreaterThan(0);
-
-        // add a new column on the second connection
-        await new MigrationContext(ddlConnection).addColumn("hot_compatibilities", "baz", "string");
-
-        await expect(
-          HotCompatibility.transaction(async () => {
+          // prepare the reload statement in a transaction
+          await HotCompatibility.transaction(async () => {
             await record.reload();
-          }),
-        ).rejects.toBeInstanceOf(PreparedStatementCacheExpired);
+          });
 
-        expect(preparedStatementCacheSize(adapter)).toBe(0);
-      } finally {
-        await new MigrationContext(adapter).dropTable("hot_compatibilities", { ifExists: true });
-        // Mirror Rails' `with_two_connections` ensure
-        // (`clear_all_connections!(:all)`): return both the checked-out DDL
-        // connection and the leased model connection to the shared pool.
-        pool.checkin(ddlConnection);
-        pool.releaseConnection();
-      }
+          expect(preparedStatementCacheSize(adapter)).toBeGreaterThan(0);
+
+          // add a new column on the second connection
+          await new MigrationContext(ddlConnection).addColumn(
+            "hot_compatibilities",
+            "baz",
+            "string",
+          );
+
+          await expect(
+            HotCompatibility.transaction(async () => {
+              await record.reload();
+            }),
+          ).rejects.toBeInstanceOf(PreparedStatementCacheExpired);
+
+          expect(preparedStatementCacheSize(adapter)).toBe(0);
+        } finally {
+          await new MigrationContext(adapter).dropTable("hot_compatibilities", { ifExists: true });
+        }
+      });
     },
   );
 
   it.skipIf(adapterType !== "postgres")(
     "cleans up after prepared statement failure in nested transactions",
     async () => {
-      const pool = Base.connectionPool();
-      const adapter = Base.connection;
-      const ddlConnection = await pool.checkout();
-      try {
-        const migration = new MigrationContext(adapter);
-        await migration.createTable("hot_compatibilities", { force: true }, (t) => {
-          t.string("foo");
-          t.string("bar");
-        });
+      await withTwoConnections(async (ddlConnection) => {
+        const adapter = Base.connection;
+        await new MigrationContext(adapter).createTable(
+          "hot_compatibilities",
+          { force: true },
+          (t) => {
+            t.string("foo");
+            t.string("bar");
+          },
+        );
+        try {
+          class HotCompatibility extends Base {}
+          HotCompatibility.tableName = "hot_compatibilities";
+          (HotCompatibility as unknown as { adapter: DatabaseAdapter }).adapter = adapter;
 
-        class HotCompatibility extends Base {}
-        HotCompatibility.tableName = "hot_compatibilities";
-        (HotCompatibility as unknown as { adapter: DatabaseAdapter }).adapter = adapter;
+          const record = await HotCompatibility.create({ bar: "bar" });
 
-        const record = await HotCompatibility.create({ bar: "bar" });
+          // prepare the reload statement in a transaction
+          await HotCompatibility.transaction(async () => {
+            await record.reload();
+          });
 
-        // prepare the reload statement in a transaction
-        await HotCompatibility.transaction(async () => {
-          await record.reload();
-        });
+          expect(preparedStatementCacheSize(adapter)).toBeGreaterThan(0);
 
-        expect(preparedStatementCacheSize(adapter)).toBeGreaterThan(0);
+          // add a new column on the second connection
+          await new MigrationContext(ddlConnection).addColumn(
+            "hot_compatibilities",
+            "baz",
+            "string",
+          );
 
-        // add a new column on the second connection
-        await new MigrationContext(ddlConnection).addColumn("hot_compatibilities", "baz", "string");
-
-        await expect(
-          HotCompatibility.transaction(async () => {
-            await HotCompatibility.transaction(async () => {
+          await expect(
+            HotCompatibility.transaction(async () => {
               await HotCompatibility.transaction(async () => {
-                await record.reload();
+                await HotCompatibility.transaction(async () => {
+                  await record.reload();
+                });
               });
-            });
-          }),
-        ).rejects.toBeInstanceOf(PreparedStatementCacheExpired);
+            }),
+          ).rejects.toBeInstanceOf(PreparedStatementCacheExpired);
 
-        expect(preparedStatementCacheSize(adapter)).toBe(0);
-      } finally {
-        await new MigrationContext(adapter).dropTable("hot_compatibilities", { ifExists: true });
-        // Mirror Rails' `with_two_connections` ensure
-        // (`clear_all_connections!(:all)`): return both the checked-out DDL
-        // connection and the leased model connection to the shared pool.
-        pool.checkin(ddlConnection);
-        pool.releaseConnection();
-      }
+          expect(preparedStatementCacheSize(adapter)).toBe(0);
+        } finally {
+          await new MigrationContext(adapter).dropTable("hot_compatibilities", { ifExists: true });
+        }
+      });
     },
   );
 });


### PR DESCRIPTION
## Problem

`hot-compatibility.test.ts` (Rails `HotCompatibilityTest`) creates a **bespoke**
`hot_compatibilities` table with `force: true` and drops it per test. Under the
shared per-worker Postgres DB this flakes with a raw `0A000`
(`plancache.c` / `RevalidateCachedQuery`, "cached plan must not change result
type"): a server-side prepared plan cached against a prior incarnation of the
table on a pooled connection is re-executed after the table is recreated with a
different shape. This is the drift class `repairWorkerSchema` does not cover —
it repairs *canonical* tables, and `hot_compatibilities` is bespoke. Observed on
CI run 30060420840 (PR #5205), the first PG run with the shared-DB `retry: 2`
removed, and the reason the earlier retry-removal (PR #4136) was reverted.

Reproduced locally against a real Postgres in worker-DB mode with `--retry=0`:
the **first** PG-gated test failed deterministically with the exact `0A000`,
because the earlier (non-isolated) `remove_column` tests share the pool and
leave a stale plan behind.

## Fix

Rails' `with_two_connections` brackets the two-connection scenario with a *fresh*
`establish_connection(…, pool_size: 2)` up front and `clear_all_connections!(:all)`
in the ensure — both discard every pooled connection, so no stale plan survives
across the boundary. Extract a `withTwoConnections` helper that mirrors all three
halves: disconnect the pool **before** (clears plans left by the earlier
`remove_column` tests) and **after** the scenario, and check out the second
connection in between. The two PG tests now run their body through it.

No assertion weakened, no subtest skipped, test names unchanged (they match
Rails verbatim).

## Testing

- Postgres (worker-DB mode, `--retry=0`): the previously-deterministic `0A000`
  repro is gone; all 4 tests pass across repeated runs.
- SQLite: 4 tests (2 skipped) pass.
- MariaDB (mysql2): 4 tests (2 skipped) pass.

Closes-story: fix-hot-compatibilities-pg-cached-plan-flake
