### PR TITLE
test(transaction-isolation): warm schema to fix id-reflection race on PG/MariaDB

### DIFF
--- a/packages/activerecord/src/transaction-isolation.test.ts
+++ b/packages/activerecord/src/transaction-isolation.test.ts
@@ -13,7 +13,7 @@ describe("TransactionIsolationUnsupportedTest", () => {
   it.skipIf(adapterType !== "sqlite")("setting the isolation level raises an error", async () => {
     class Tag extends Base {
       static {
-        this.attribute("name", "string");
+        this._tableName = "tags";
       }
     }
     await expect(
@@ -43,14 +43,12 @@ describe("TransactionIsolationTest", () => {
   class Tag extends Base {
     static {
       this._tableName = "tags";
-      this.attribute("name", "string");
     }
   }
 
   class Tag2 extends Base {
     static {
       this._tableName = "tags";
-      this.attribute("name", "string");
     }
   }
 


### PR DESCRIPTION
## Summary

`TransactionIsolationTest`'s `Tag`/`Tag2` (both bound to the canonical `tags`
table, each with its own connection) carried a **trails-only**
`this.attribute("name", "string")`. That declaration makes a model own its
schema, which suppresses DB column reflection (`ensureSchemaLoaded` bails), so
the `id` PK is only known if reflection happened to run first.

Under the shared per-worker DB the two separately-connected models race the
`tags` schema-cache warmth, so `id` is intermittently absent when the insert
path writes it back — surfacing as
`MissingAttributeError: can't write unknown attribute 'id'` from `Tag2.create({})`
/ `Tag.create({ name: "jon" })` on `read uncommitted` and `repeatable read`.
`retry: 2` masked it; at `retry: 0` (shared-DB retry removed) it flakes on
PG/MariaDB.

## Fix

Remove the declaration. Rails' `Tag`/`Tag2` have **empty bodies** (just
`self.table_name`) and reflect the full `tags` schema from the DB — this
restores that fidelity. With no declared attributes, both models reflect the
complete canonical schema (`id` + `name`) via the awaited `ensureSchemaLoaded`
on the persistence path, so `id` is always present before any insert. This
fixes the **root cause** (a reflection-suppressing deviation) rather than
warming around it. The same trails-only declaration on
`TransactionIsolationUnsupportedTest`'s `Tag` is dropped for the same fidelity.

No assertions weakened, no subtest skipped, test names unchanged, `tags` stays
canonical.

## Validation

Isolated PG + MySQL compose stacks, `--retry 0`:
- PG: 3× runs, 6 passed / 1 skipped each — no `MissingAttributeError`.
- MySQL: 6 passed / 1 skipped.
- SQLite lane: 1 passed / 6 skipped (subtests skip by design; the reflected
  unsupported-test `Tag` passes).

Closes-story: fix-transaction-isolation-id-reflection-race
