### PR TITLE
fix(method-order): enforce order for Ruby mixin modules ported as TS classes

### DIFF
--- a/scripts/build-rails-file-structure-manifest.ts
+++ b/scripts/build-rails-file-structure-manifest.ts
@@ -28,6 +28,7 @@ import { rubyMethodToTs, rubyFileToTs } from "./api-compare/conventions.js";
 import { writeJsonManifest } from "./api-compare/write-json-manifest.js";
 import { mergeBySourceLine } from "./api-compare/source-order.js";
 import { operatorSpelling } from "./api-compare/operator-order-spelling.js";
+import { resolveMixinParent } from "./rails-file-structure-mixins.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
@@ -197,6 +198,13 @@ for (const [pkg, rubyPkg] of Object.entries<any>(railsApi.packages)) {
     fqns.add(fqn);
   };
 
+  // fqn → class host, so a `Foo::InstanceMethods` / `Foo::ClassMethods` mixin
+  // module can find the CLASS it is mixed into (see visitModules).
+  const classByFqn = new Map<string, RubyEntity>();
+  for (const host of Object.values<RubyEntity>(rubyPkg.classes ?? {})) {
+    classByFqn.set(host.fqn, host);
+  }
+
   // Ruby classes port to TS classes: instance + static members live in the
   // class container keyed by the fqn's last segment (`Arel::Nodes::Casted` →
   // `Casted`). Ruby modules port to top-level `this`-typed / mixin functions
@@ -227,9 +235,33 @@ for (const [pkg, rubyPkg] of Object.entries<any>(railsApi.packages)) {
   const visitModules = (entities: Record<string, RubyEntity>) => {
     for (const host of Object.values(entities)) {
       if (!host.file) continue;
-      // Modules port to top-level functions, which have no staticness — every
-      // entry stays bare regardless of whether Ruby declared it on the module
-      // or its singleton.
+      // A `Foo::InstanceMethods` / `Foo::ClassMethods` module whose PARENT is a
+      // CLASS is a mixin flattened onto that class's TS port (Rails
+      // `include`/`extend`), NOT a standalone module ported to top-level
+      // functions. Its order lands on the class container so it is enforced
+      // rather than dropped into `functions` (which no class body reads) — see
+      // resolveMixinParent. The methods append AFTER the class's own members
+      // (the class defines its body, then includes the mixin), and
+      // `ClassMethods` entries become `static` since `extend` promotes them to
+      // singleton methods.
+      const mixin = resolveMixinParent(host.fqn, (fqn) => classByFqn.has(fqn));
+      if (mixin) {
+        for (const m of mergeBySourceLine(
+          tagStatic(host.instanceMethods, false),
+          tagStatic(host.classMethods, true),
+        )) {
+          const file = m.file ?? host.file;
+          noteClass(file, mixin.className, mixin.parentFqn);
+          const b = bucketFor(file, mixin.className);
+          const isStatic = mixin.extendsSingleton || m.isStatic;
+          const opCandidates = isStatic ? undefined : operatorSpelling(mixin.parentFqn, m.name);
+          pushMethod(b.names, b.seen, m.name, isStatic, opCandidates);
+        }
+        continue;
+      }
+      // Standalone modules port to top-level functions, which have no
+      // staticness — every entry stays bare regardless of whether Ruby declared
+      // it on the module or its singleton.
       for (const m of mergeBySourceLine(
         tagStatic(host.instanceMethods, false),
         tagStatic(host.classMethods, true),

--- a/scripts/rails-file-structure-mixins.test.ts
+++ b/scripts/rails-file-structure-mixins.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { resolveMixinParent } from "./rails-file-structure-mixins.js";
+
+describe("resolveMixinParent", () => {
+  // The live case: a nested InstanceMethods module of a ported class flattens
+  // onto that class rather than the manifest's `functions` bucket.
+  const classes = new Set([
+    "ActiveModel::Type::Helpers::AcceptsMultiparameterTime",
+    "ActiveRecord::QueryCache",
+  ]);
+  const isClassFqn = (fqn: string) => classes.has(fqn);
+
+  it("maps InstanceMethods of a class to that class, instance-scoped", () => {
+    expect(
+      resolveMixinParent(
+        "ActiveModel::Type::Helpers::AcceptsMultiparameterTime::InstanceMethods",
+        isClassFqn,
+      ),
+    ).toEqual({
+      className: "AcceptsMultiparameterTime",
+      parentFqn: "ActiveModel::Type::Helpers::AcceptsMultiparameterTime",
+      extendsSingleton: false,
+    });
+  });
+
+  it("maps ClassMethods of a class to that class, singleton-scoped (extend)", () => {
+    expect(resolveMixinParent("ActiveRecord::QueryCache::ClassMethods", isClassFqn)).toEqual({
+      className: "QueryCache",
+      parentFqn: "ActiveRecord::QueryCache",
+      extendsSingleton: true,
+    });
+  });
+
+  it("does not sweep InstanceMethods/ClassMethods of a MODULE parent", () => {
+    // The overwhelmingly common shape: a concern (module) with a ClassMethods
+    // sub-module. These port as standalone functions, not onto a class.
+    expect(resolveMixinParent("ActiveRecord::Persistence::ClassMethods", isClassFqn)).toBeNull();
+  });
+
+  it("ignores arbitrarily-named nested modules of a class", () => {
+    expect(resolveMixinParent("ActiveRecord::QueryCache::Runtime", isClassFqn)).toBeNull();
+  });
+
+  it("returns null for a top-level module with no parent", () => {
+    expect(resolveMixinParent("InstanceMethods", isClassFqn)).toBeNull();
+  });
+});

--- a/scripts/rails-file-structure-mixins.ts
+++ b/scripts/rails-file-structure-mixins.ts
@@ -1,0 +1,55 @@
+/**
+ * Mixin-module resolution for the rails-file-structure method-order manifest.
+ *
+ * Rails frequently defines a concern's per-instance / per-class API in nested
+ * `InstanceMethods` / `ClassMethods` modules that are `include`d / `extend`ed
+ * into a surrounding container. When that container is a CLASS ported 1:1 to a
+ * TS class, the mixin's methods flatten onto that class rather than living as
+ * standalone top-level functions — so their source order belongs on the class
+ * container, not the manifest's `functions` bucket (which no class body reads).
+ *
+ * `ActiveModel::Type::Helpers::AcceptsMultiparameterTime::InstanceMethods` is
+ * the live case: `class AcceptsMultiparameterTime < Module` mixes in its
+ * `InstanceMethods` sub-module, and trails ports the whole thing as
+ * `export class AcceptsMultiparameterTime`.
+ *
+ * Restricting to the two canonical mixin-module names keeps the mapping 1:1 and
+ * unambiguous — an arbitrarily-named module nested under a class is NOT swept
+ * onto it.
+ *
+ * Constraints: no `node:` specifiers, no `process` references.
+ */
+
+export interface MixinParent {
+  /** Last segment of the parent class's fqn — the TS class bucket key. */
+  className: string;
+  /** Parent class fqn, for operator-spelling / collision bookkeeping. */
+  parentFqn: string;
+  /**
+   * `ClassMethods` is mixed via `extend`, promoting its instance methods to the
+   * target's singleton — the manifest records those as `static`.
+   */
+  extendsSingleton: boolean;
+}
+
+/**
+ * If `moduleFqn` names a `<Class>::InstanceMethods` / `<Class>::ClassMethods`
+ * mixin whose parent is a known class, return where its methods flatten;
+ * otherwise null (a standalone module ported to top-level functions).
+ */
+export function resolveMixinParent(
+  moduleFqn: string,
+  isClassFqn: (fqn: string) => boolean,
+): MixinParent | null {
+  const segments = moduleFqn.split("::");
+  const last = segments[segments.length - 1];
+  if (last !== "InstanceMethods" && last !== "ClassMethods") return null;
+  const parentFqn = segments.slice(0, -1).join("::");
+  if (!parentFqn || !isClassFqn(parentFqn)) return null;
+  const parentSegments = parentFqn.split("::");
+  return {
+    className: parentSegments[parentSegments.length - 1] ?? parentFqn,
+    parentFqn,
+    extendsSingleton: last === "ClassMethods",
+  };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -428,6 +428,7 @@ export default defineConfig({
             "scripts/schema-compare/*.test.ts",
             "scripts/parity/**/*.test.ts",
             "scripts/strip-asany.test.ts",
+            "scripts/rails-file-structure-mixins.test.ts",
             "scripts/test-deps/*.test.ts",
             "scripts/tasks/*.test.ts",
             "scripts/test-compare/*.test.ts",


### PR DESCRIPTION
## Problem

The method-order manifest keyed class-member order per TS class and routed
Ruby MODULE methods to the `functions` bucket (`visitModules` in
`scripts/build-rails-file-structure-manifest.ts`). But a Rails concern's
`Foo::InstanceMethods` / `Foo::ClassMethods` sub-module whose **parent is a
class** is not a standalone module — it's a mixin (`include`/`extend`)
flattened onto that class's TS port. Its order landed in `functions`, which no
class body reads, and was silently dropped.

Live case: `ActiveModel::Type::Helpers::AcceptsMultiparameterTime::InstanceMethods`
(`serialize`, `serializeCastValue`, `cast`, `assertValidValue`,
`isValueConstructedByMassAssignment`) is ported as instance methods of
`export class AcceptsMultiparameterTime`
(`packages/activemodel/src/type/helpers/accepts-multiparameter-time.ts`) — its
order was not enforced.

## Fix

`resolveMixinParent` (new `scripts/rails-file-structure-mixins.ts`) recognizes
a `<Class>::InstanceMethods` / `<Class>::ClassMethods` module whose parent fqn
is a known class and returns the target class + staticness. `visitModules`
routes those methods onto the class container instead of `functions`:

- Appended **after** the class's own members (the class defines its body, then
  includes the mixin).
- `ClassMethods` entries become `static` (`extend` promotes to singleton).

Restricting to the two canonical mixin-module names keeps the mapping 1:1 and
unambiguous — repo-wide only two modules match this shape
(`AcceptsMultiparameterTime::InstanceMethods`, `QueryCache::ClassMethods`); an
arbitrarily-named nested module of a class is not swept in.

## Result

- `AcceptsMultiparameterTime`'s class bucket now carries the mixin order and
  the file lints clean (already in the correct order).
- `type/helpers/accepts-multiparameter-time.ts` no longer appears in the
  `RAILS_STRUCTURE_REPORT` unmatched-bucket output.
- Remaining `classes:` report entries are the genuinely-ambiguous rename cases
  (`value.ts` Value, `dot.ts` Node, `to-sql.ts`, `user-provided-default.ts`).

## Tests

- New `scripts/rails-file-structure-mixins.test.ts` covers the 1:1 mapping,
  the `extend`→static case, and the non-matches (module parent, arbitrary
  nested module, parentless top-level module).

Closes-story: method-order-recover-module-ported-as-class
