### PR TITLE
fix(predicate-builder): thread join-dependency fallback into buildComposite

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -610,7 +610,13 @@ export class Relation<T extends Base> {
       // PredicateBuilder currency); spread them into the clause exactly as
       // buildWhereClause spreads buildFromHash's result, so a single tuple stays
       // flat (`WHERE c1 = ? AND c2 = ?`, no wrapping Grouping) like Rails.
-      const nodes = this.predicateBuilder.buildComposite(cols, tuples);
+      //
+      // Thread the join-dependency fallback (Rails' block to `build_where_clause`
+      // / `predicate_builder.rb:71-73`) so a qualified col naming a manual-join
+      // table binds through the joined model's column type.
+      const block = (name: string) =>
+        this.lookupTableKlassFromJoinDependencies(name) as typeof Base | null;
+      const nodes = this.predicateBuilder.buildComposite(cols, tuples, block);
       if (nodes.length === 0) return this._clone().noneBang();
       const rel = this._clone();
       rel._whereClause.predicates.push(...nodes);
@@ -827,7 +833,12 @@ export class Relation<T extends Base> {
           "Relation#whereNot(cols, tuples): composite-key form requires a tuples argument as an array of arrays",
         );
       }
-      const nodes = this.predicateBuilder.buildComposite(conditions as string[], tuples);
+      // Thread the join-dependency fallback (see `where`'s composite branch)
+      // so a qualified col naming a manual-join table binds through the joined
+      // model's type rather than the generic `TypeCasterConnection`.
+      const block = (name: string) =>
+        this.lookupTableKlassFromJoinDependencies(name) as typeof Base | null;
+      const nodes = this.predicateBuilder.buildComposite(conditions as string[], tuples, block);
       // Empty/all-filtered → NOT (no rows) = ALL rows = no predicate added
       // (matches Rails' `where.not(...)` no-op for empty hashes).
       if (nodes.length > 0) {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -614,9 +614,11 @@ export class Relation<T extends Base> {
       // Thread the join-dependency fallback (Rails' block to `build_where_clause`
       // / `predicate_builder.rb:71-73`) so a qualified col naming a manual-join
       // table binds through the joined model's column type.
-      const block = (name: string) =>
-        this.lookupTableKlassFromJoinDependencies(name) as typeof Base | null;
-      const nodes = this.predicateBuilder.buildComposite(cols, tuples, block);
+      const nodes = this.predicateBuilder.buildComposite(
+        cols,
+        tuples,
+        this.joinDependencyFallback(),
+      );
       if (nodes.length === 0) return this._clone().noneBang();
       const rel = this._clone();
       rel._whereClause.predicates.push(...nodes);
@@ -836,9 +838,11 @@ export class Relation<T extends Base> {
       // Thread the join-dependency fallback (see `where`'s composite branch)
       // so a qualified col naming a manual-join table binds through the joined
       // model's type rather than the generic `TypeCasterConnection`.
-      const block = (name: string) =>
-        this.lookupTableKlassFromJoinDependencies(name) as typeof Base | null;
-      const nodes = this.predicateBuilder.buildComposite(conditions as string[], tuples, block);
+      const nodes = this.predicateBuilder.buildComposite(
+        conditions as string[],
+        tuples,
+        this.joinDependencyFallback(),
+      );
       // Empty/all-filtered → NOT (no rows) = ALL rows = no predicate added
       // (matches Rails' `where.not(...)` no-op for empty hashes).
       if (nodes.length > 0) {
@@ -7264,6 +7268,15 @@ export class Relation<T extends Base> {
   /** @internal */
   private lookupTableKlassFromJoinDependencies(tableName: string): unknown {
     return _qm.lookupTableKlassFromJoinDependencies.call(this as any, tableName);
+  }
+
+  // The `associated_table` block Rails threads from `build_where_clause`
+  // (`predicate_builder.rb:71-73`): resolves a table name that exists only as a
+  // join-dependency (a manual join, an alias) — not a direct reflection — to its
+  // model, so a qualified col binds through that model's column type. Shared by
+  // `where` / `whereNot`'s composite branches.
+  private joinDependencyFallback(): (name: string) => typeof Base | null {
+    return (name) => this.lookupTableKlassFromJoinDependencies(name) as typeof Base | null;
   }
 
   /** @internal */

--- a/packages/activerecord/src/relation/composite-where.test.ts
+++ b/packages/activerecord/src/relation/composite-where.test.ts
@@ -187,17 +187,17 @@ describe("Relation#where — composite-key form", () => {
     //
     // `contracts.metadata` is `t.string` in the DB but Contract overrides it to
     // `attribute("metadata", "json")`. Resolved through the join-dependency
-    // fallback, the bind uses that model type and JSON-serializes the object;
-    // without the fallback it falls to a bare Table with a generic
-    // `TypeCasterConnection` (klass === null), which reads the raw string column
-    // type and stringifies the object as `[object Object]`.
+    // fallback, the bind uses that model type and JSON-serializes the value
+    // (`"x"` → `'"x"'`); without the fallback it falls to a bare Table with a
+    // generic `TypeCasterConnection` (klass === null), which reads the raw
+    // string column type and leaves it unquoted (`x`).
     const rel: any = (Comment as any)
       .joins({ company: "contracts" })
-      .where(["comments.id", "contracts.metadata"], [[1, { foo: "bar" }]]);
-    let bind: unknown;
+      .where(["comments.id", "contracts.metadata"], [[1, "x"]]);
+    let eq: any;
     const walk = (n: any) => {
       if (!n || typeof n !== "object") return;
-      if (n.value?.name === "metadata") bind = n.value.valueForDatabase;
+      if (n.right?.value?.name === "metadata") eq = n;
       for (const k of ["expr", "left", "right", "children"]) {
         const c = n[k];
         if (Array.isArray(c)) c.forEach(walk);
@@ -205,7 +205,12 @@ describe("Relation#where — composite-key form", () => {
       }
     };
     rel._whereClause.predicates.forEach(walk);
-    expect(bind).toBe('{"foo":"bar"}');
+    // Attribute re-rooted onto the join-only `contracts` table…
+    expect(eq.left.relation.name).toBe("contracts");
+    // …and the bind is typed by Contract's `attribute("metadata", "json")`
+    // override (JSON-serialized, quoted), not the raw DB `t.string` column the
+    // generic `TypeCasterConnection` would have used (unquoted `x`).
+    expect(eq.right.value.valueForDatabase).toBe('"x"');
   });
 
   it("qualified single-column composite resolves its IN(...) attribute on the joined table", () => {

--- a/packages/activerecord/src/relation/composite-where.test.ts
+++ b/packages/activerecord/src/relation/composite-where.test.ts
@@ -18,6 +18,8 @@ import { CpkBook, CpkOrder, CpkAuthor, CpkChapter } from "../test-helpers/models
 import { Post } from "../test-helpers/models/post.js";
 import { Comment } from "../test-helpers/models/comment.js";
 import { Customer, Address } from "../test-helpers/models/customer.js";
+import { Company } from "../test-helpers/models/company.js";
+import { Contract } from "../test-helpers/models/contract.js";
 
 describe("Relation#where — composite-key form", () => {
   // Rails creates the CPK rows inline with `Cpk::Book.create!` — no cpk
@@ -26,8 +28,8 @@ describe("Relation#where — composite-key form", () => {
   fixtures([]);
 
   beforeAll(() => {
-    [CpkBook, CpkOrder, CpkAuthor, CpkChapter, Post, Comment, Customer].forEach((m) =>
-      registerModel(m),
+    [CpkBook, CpkOrder, CpkAuthor, CpkChapter, Post, Comment, Customer, Company, Contract].forEach(
+      (m) => registerModel(m),
     );
   });
 
@@ -173,6 +175,37 @@ describe("Relation#where — composite-key form", () => {
     expect(bind.name).toBe("post_id");
     expect(bind.valueForDatabase).toBe(2);
     expect(left.left.relation.name).toBe("posts");
+  });
+
+  it("qualified composite col naming a join-only table binds through that table's model type", () => {
+    // A qualified col naming a table that exists only as a join-dependency
+    // (`contracts` reached via `Comment.joins({ company: "contracts" })`) — NOT
+    // a direct reflection on the base model — must still re-root on the joined
+    // model so the bind is typed by that model's column type. Rails threads
+    // `lookup_table_klass_from_join_dependencies` as the `associated_table`
+    // block (predicate_builder.rb:71-73); `buildComposite` mirrors that.
+    //
+    // `contracts.metadata` is `t.string` in the DB but Contract overrides it to
+    // `attribute("metadata", "json")`. Resolved through the join-dependency
+    // fallback, the bind uses that model type and JSON-serializes the object;
+    // without the fallback it falls to a bare Table with a generic
+    // `TypeCasterConnection` (klass === null), which reads the raw string column
+    // type and stringifies the object as `[object Object]`.
+    const rel: any = (Comment as any)
+      .joins({ company: "contracts" })
+      .where(["comments.id", "contracts.metadata"], [[1, { foo: "bar" }]]);
+    let bind: unknown;
+    const walk = (n: any) => {
+      if (!n || typeof n !== "object") return;
+      if (n.value?.name === "metadata") bind = n.value.valueForDatabase;
+      for (const k of ["expr", "left", "right", "children"]) {
+        const c = n[k];
+        if (Array.isArray(c)) c.forEach(walk);
+        else if (c) walk(c);
+      }
+    };
+    rel._whereClause.predicates.forEach(walk);
+    expect(bind).toBe('{"foo":"bar"}');
   });
 
   it("qualified single-column composite resolves its IN(...) attribute on the joined table", () => {

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -461,11 +461,25 @@ export class PredicateBuilder {
     // Thread the join-dependency fallback through the per-tuple `buildFromHash`
     // so a qualified col (`"contracts.metadata"`) naming a table that only
     // exists as a join (`.joins(...)`, an alias) — not a direct reflection —
-    // resolves against the joined model, matching Rails' block to
-    // `build_where_clause` (`predicate_builder.rb:71-73`,
-    // `lookup_table_klass_from_join_dependencies`). Without it the dotted key
-    // falls to a bare `Table` + generic `TypeCasterConnection`, so the bind is
-    // typed by the raw column type instead of the joined model's.
+    // resolves against the joined model (`lookup_table_klass_from_join_dependencies`,
+    // predicate_builder.rb:71-73). Without it the dotted key falls to a bare
+    // `Table` + generic `TypeCasterConnection`, so the bind is typed by the raw
+    // column type instead of the joined model's.
+    //
+    // Threading it UNIFORMLY across the single- and multi-column branches is a
+    // deliberate extension, not Rails-mirroring: qualified composite columns
+    // have no faithful Rails behavior to match (see this method's docstring —
+    // Rails' Array-key branch at predicate_builder.rb:93-96 recurses via
+    // `expand_from_hash(key.zip(ids_set).to_h)`, which neither re-applies
+    // `convert_dot_notation_to_hash` NOR forwards `&block`, so Rails emits a
+    // broken bare `"contracts.metadata"` attribute on the base table for either
+    // arity). The trails extension (#5186) already resolves REFLECTIONS in the
+    // multi-column branch by routing each tuple through `buildFromHash` (the
+    // "qualified composite cols bind through the joined table's type" test), so
+    // threading `fallback` there too keeps join-only tables consistent with both
+    // reflections and the single-column path — matching Rails' block-loss on
+    // recursion would instead resolve reflections but silently drop join-only
+    // tables to the generic caster, an arbitrary split.
     if (cols.length === 1) {
       return this.buildFromHash({ [cols[0]]: validTuples.map((t) => t[0]) }, fallback);
     }

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -10,6 +10,7 @@ import { Substitute } from "../statement-cache.js";
 import { PolymorphicArrayValue } from "./predicate-builder/polymorphic-array-value.js";
 import { argumentError } from "./query-methods.js";
 import type { TableMetadata } from "../table-metadata.js";
+import type { Base } from "../base.js";
 
 /**
  * The shape `table.type` answers with. Rails' single source
@@ -123,6 +124,11 @@ export class PredicateBuilder {
         ).predicateBuilder;
         nodes.push(...assocPb.expandFromHash(value));
       } else if (this.table.isAssociatedWith(key)) {
+        // No fallback here on purpose: this branch is gated by
+        // `isAssociatedWith(key)` (a direct reflection), matching Rails'
+        // `elsif table.associated_with?(key)` which calls `associated_table(key)`
+        // with NO block (predicate_builder.rb:107) — the join-dependency
+        // resolver only matters when a key is NOT a direct reflection.
         const assocNodes = this.buildFromHashAssociation(
           this.table.associatedTable(key),
           key,
@@ -425,7 +431,11 @@ export class PredicateBuilder {
    * Mirrors: ActiveRecord::PredicateBuilder#expand_from_hash, Array-key
    * branch (predicate_builder.rb:87-98).
    */
-  buildComposite(cols: string[], tuples: unknown[][]): Nodes.Node[] {
+  buildComposite(
+    cols: string[],
+    tuples: unknown[][],
+    fallback?: (name: string) => typeof Base | null,
+  ): Nodes.Node[] {
     if (cols.length === 0) {
       throw argumentError("PredicateBuilder.buildComposite: empty column list");
     }
@@ -448,11 +458,19 @@ export class PredicateBuilder {
     }
     const validTuples = tuples.filter((t) => t.every((v) => v !== null && v !== undefined));
     if (validTuples.length === 0) return [];
+    // Thread the join-dependency fallback through the per-tuple `buildFromHash`
+    // so a qualified col (`"contracts.metadata"`) naming a table that only
+    // exists as a join (`.joins(...)`, an alias) — not a direct reflection —
+    // resolves against the joined model, matching Rails' block to
+    // `build_where_clause` (`predicate_builder.rb:71-73`,
+    // `lookup_table_klass_from_join_dependencies`). Without it the dotted key
+    // falls to a bare `Table` + generic `TypeCasterConnection`, so the bind is
+    // typed by the raw column type instead of the joined model's.
     if (cols.length === 1) {
-      return this.buildFromHash({ [cols[0]]: validTuples.map((t) => t[0]) });
+      return this.buildFromHash({ [cols[0]]: validTuples.map((t) => t[0]) }, fallback);
     }
     const queryGroups = validTuples.map((tuple) =>
-      this.buildFromHash(Object.fromEntries(cols.map((col, i) => [col, tuple[i]]))),
+      this.buildFromHash(Object.fromEntries(cols.map((col, i) => [col, tuple[i]])), fallback),
     );
     return this.groupingQueries(queryGroups);
   }


### PR DESCRIPTION
## Summary

A qualified composite col naming a table that exists only as a
join-dependency (a nested join, an alias) — not a direct reflection on the base
model — fell through `TableMetadata#associatedTable` to the bare `Table` +
generic `TypeCasterConnection` branch (`klass === null`). Its bind was then
typed by the raw column type rather than the joined model's column type.

`PredicateBuilder#buildComposite` now accepts an optional join-dependency
fallback and passes it to `associatedTable`, matching `resolveArelAttribute`
and Rails' `predicate_builder.rb:71-73`
(`lookup_table_klass_from_join_dependencies`). `Relation#where` / `#whereNot`'s
composite branches thread `lookupTableKlassFromJoinDependencies` in — the same
way `buildWhereClause` threads it into `buildFromHash`.

## Call-site audit

The remaining fallback-less `associatedTable` call in `expandFromHash` is gated
on `isAssociatedWith(key)` (a direct reflection), matching Rails'
`elsif table.associated_with?(key)` branch which calls `associated_table(key)`
with **no** block (`predicate_builder.rb:107`) — justified at the call site.

## Test

`qualified composite col naming a join-only table binds through that table's
model type`: `Comment.joins({ company: "contracts" })` reaches `contracts` only
as a join-dependency. `contracts.metadata` is `t.string` in the DB but Contract
overrides it to `attribute("metadata", "json")`. Through the fallback the bind
JSON-serializes the object (`{"foo":"bar"}`); without it the generic caster
stringifies it (`[object Object]`). Verified failing on baseline.

Closes-story: composite-qualified-col-associated-table-needs-join-dependency-fallback


## Review response — uniform fallback threading (multi-column branch)

Raised: does threading `fallback` into the `cols.length > 1` branch over-mirror
Rails, whose Array-key branch (`predicate_builder.rb:93-96`) recurses via
`expand_from_hash(key.zip(ids_set).to_h)` **without** forwarding `&block`?

The Rails facts are correct, but they don't yield a behavior to match. That
recursion calls `expand_from_hash` (not `build_from_hash`), so it **also**
skips `convert_dot_notation_to_hash` — a dotted key like `"contracts.metadata"`
stays flat and falls to `self[key, value]`, emitting a **broken bare attribute**
`"contracts.metadata"` on the base table for *either* arity. Qualified composite
columns therefore have no faithful Rails semantics; they are the deliberate
`#5186` trails extension (called out in `buildComposite`'s docstring), which
routes each tuple through `buildFromHash` to resolve them.

That extension **already** resolves reflections in the multi-column branch —
the pre-existing `qualified composite cols bind through the joined table's type`
test uses `["posts.id", "comments.post_id"]` and binds `comments.post_id`
through Comment. Mirroring Rails' block-loss would resolve reflections there but
silently drop **join-only** tables to the generic caster — an arbitrary split
against both the single-column path and the reflection case. So the fallback is
threaded uniformly; rationale is captured at the call site.
