### PR TITLE
refactor(lint): widen prefer-await-relation past the call-receiver gate

### DIFF
--- a/eslint/prefer-await-relation.mjs
+++ b/eslint/prefer-await-relation.mjs
@@ -11,39 +11,29 @@
  * no such method — `Model.where(...)` is enumerated directly — so this keeps the
  * trails surface faithful and removes an un-Rails-like ceremony.
  *
- * Matching is gated three ways, each closing a way the rewrite could change
+ * Matching is gated two ways, each closing a way the rewrite could change
  * behavior:
  *
  *  1. **Directly-awaited position.** `await x.toArray()` and `await x` resolve
  *     identically only when `x` is awaited, so looser positions
  *     (`return x.toArray()`, `.then(...)` chains) are NOT matched.
  *
- *  2. **Receiver is a call to a relation-spawning query method** —
- *     `Model.where(...).toArray()`, `rel.order(...).toArray()`,
- *     `Model.all().toArray()`. This is the crux of soundness. `stripThenable()`
- *     deletes `.then` from a relation *instance in place* (`load`/`reload`/
- *     `presence`/`records`/`destroyAll` all run it, and `inBatches` yields
- *     stripped instances), so a reused binding — or any *cached/memoized*
- *     relation — may silently have lost its `.then`; `await` on it resolves to
- *     the object, not the array. A Rails QueryMethod (`where`/`all`/`order`/…)
- *     always `spawn()`s a *fresh, unstripped* relation, so only a member call
- *     whose method name is in `SPAWN_METHODS` is provably still a thenable.
- *     Everything else is left alone: bare identifiers, `this`, `super`, member
- *     reads, parenthesized expressions, and — critically — call expressions that
- *     return a *cached* relation rather than a fresh spawn, namely the
- *     association accessor `association(record, name)` / `record.association(name)`
- *     (returns the memoized `_proxySelf` proxy, which `reload`/`clear`/`push`
- *     strip in place) and named scopes (arbitrary method names, some memoized on
- *     the proxy). An allowlist is deliberate here: a missing spawn name only
- *     leaves a `.toArray()` unconverted (cheap), whereas mistaking a cached
- *     accessor for a fresh spawn is a wrong fix (expensive).
- *
- *  3. **Receiver's static type is a thenable** (exposes `then`). A non-relation
+ *  2. **Receiver's static type is a thenable** (exposes `then`). A non-relation
  *     `.toArray()` accessor (raw query `Result`, ActiveModel `Errors`,
  *     `OrderedHash`, view-path/streaming-body wrappers) or a then-stripped
  *     `LoadedRelation` (`Omit<R, "then">`, the return type of `load`/`reload`)
  *     lacks `then`; awaiting it would not resolve to the array, so its
  *     `.toArray()` is load-bearing. (Skipped when type info is unavailable.)
+ *
+ * The receiver's *syntactic* shape is no longer gated: identifier bindings
+ * (`await davids` for a `const davids = Author.where(...)`), member reads, and
+ * cached association accessors are all matched, not just fresh query-method
+ * spawns. The old call-expression-only narrowing (PR #4281) worked around
+ * `stripThenable` deleting `.then` from a relation *instance in place*, which
+ * left reused/memoized bindings un-awaitable while still typing as thenable.
+ * PR #4968 made `stripThenable` return a then-less `Proxy` view and leave the
+ * original binding awaitable, so every thenable-typed binding resolves to its
+ * array under `await` again — the thenable-type gate alone is now sufficient.
  *
  * For an autofixing rule a missed warning is cheap; a wrong fix is not.
  *
@@ -65,89 +55,6 @@ const TRANSPARENT_TYPES = new Set([
   "TSTypeAssertion",
   "TSSatisfiesExpression",
 ]);
-
-/**
- * @internal
- * Rails `QueryMethods` (plus the relation-returning entry points `all`/`unscoped`
- * and the spawn helper `merge`) — every one `spawn()`s a brand-new relation, so a
- * call to one is guaranteed to yield a fresh, never-`stripThenable`'d thenable.
- * Names are the camelCase trails spellings; the static `Model.where(...)` and the
- * instance `rel.where(...)` forms share the same method name. Deliberately
- * EXCLUDES `association`, named scopes, `reload`, `load`, etc. — those return a
- * cached/stripped relation or a non-thenable. Conservative by design: omissions
- * only cost a missed (cheap) warning.
- */
-const SPAWN_METHODS = new Set([
-  "all",
-  "unscoped",
-  "scoping",
-  "merge",
-  "spawn",
-  "where",
-  "rewhere",
-  "whereNot",
-  "not",
-  "and",
-  "or",
-  "order",
-  "reorder",
-  "reverseOrder",
-  "inOrderOf",
-  "group",
-  "regroup",
-  "having",
-  "select",
-  "reselect",
-  "distinct",
-  "distinctOn",
-  "limit",
-  "offset",
-  "includes",
-  "preload",
-  "eagerLoad",
-  "references",
-  "joins",
-  "leftOuterJoins",
-  "leftJoins",
-  "from",
-  "lock",
-  "readonly",
-  "none",
-  "strictLoading",
-  "unscope",
-  "extending",
-  "optimizerHints",
-  "annotate",
-  "with",
-  "withRecursive",
-  "createWith",
-  "excluding",
-  "without",
-  "associated",
-  "missing",
-  "only",
-  "except",
-]);
-
-/**
- * @internal
- * True when `objectNode` is a call to a relation-spawning query method —
- * `Model.where(...)`, `rel.order(...)`, `Model.all()`. Only a member call whose
- * property is in `SPAWN_METHODS` qualifies; a bare function call
- * (`association(...)`), a cached accessor (`record.association(...)`), or a named
- * scope is rejected because it may return a `stripThenable`'d instance.
- */
-function isFreshSpawnCall(objectNode) {
-  if (objectNode.type !== "CallExpression") return false;
-  let callee = objectNode.callee;
-  if (callee.type === "ChainExpression") callee = callee.expression;
-  return (
-    callee.type === "MemberExpression" &&
-    !callee.computed &&
-    callee.property.type === "Identifier" &&
-    SPAWN_METHODS.has(callee.property.name)
-  );
-}
 
 /**
  * @internal
@@ -215,14 +122,9 @@ const rule = {
         if (property.type !== "Identifier" || property.name !== "toArray") return;
         // `.toArray(arg)` is not the relation accessor — leave it alone.
         if (node.arguments.length !== 0) return;
-        // Only a call to a relation-spawning query method is a provably-fresh,
-        // unstripped relation — `Model.where(...).toArray()`,
-        // `rel.order(...).toArray()`. A reused binding (`davids.toArray()`),
-        // `this`/`super`, or a cached accessor (`association(record, name)`,
-        // named scopes) may have had its `.then` deleted in place by
-        // `stripThenable` (run by load/reload/presence/records/destroyAll and
-        // inBatches), so `await` on it would not resolve to the array. See header.
-        if (!isFreshSpawnCall(callee.object)) return;
+        // `await super` is a syntax error, so stripping `.toArray()` off a
+        // `super.toArray()` receiver would emit uncompilable code — skip it.
+        if (callee.object.type === "Super") return;
         // Only flag the directly-awaited position — the one spot where the
         // suffix is provably redundant for a thenable.
         if (!isDirectlyAwaited(node)) return;

--- a/eslint/prefer-await-relation.mjs
+++ b/eslint/prefer-await-relation.mjs
@@ -25,15 +25,27 @@
  *     lacks `then`; awaiting it would not resolve to the array, so its
  *     `.toArray()` is load-bearing. (Skipped when type info is unavailable.)
  *
- * The receiver's *syntactic* shape is no longer gated: identifier bindings
+ * The receiver's *syntactic* shape is mostly ungated: identifier bindings
  * (`await davids` for a `const davids = Author.where(...)`), member reads, and
  * cached association accessors are all matched, not just fresh query-method
  * spawns. The old call-expression-only narrowing (PR #4281) worked around
  * `stripThenable` deleting `.then` from a relation *instance in place*, which
  * left reused/memoized bindings un-awaitable while still typing as thenable.
  * PR #4968 made `stripThenable` return a then-less `Proxy` view and leave the
- * original binding awaitable, so every thenable-typed binding resolves to its
- * array under `await` again — the thenable-type gate alone is now sufficient.
+ * original binding awaitable, so an *external* thenable-typed binding resolves
+ * to its array under `await` again: if such a binding were a stripped view it
+ * would type as `LoadedRelation` (then-less), and gate 2 would exclude it.
+ *
+ * The one receiver shape that stays excluded is `this` (and `super`). A method
+ * invoked on the then-less view runs with `this` bound to that view — the
+ * `get` trap's receiver argument only rebinds accessors, not method calls
+ * (see `relation/thenable.ts`) — so inside e.g. `destroyAll()` called as
+ * `(await rel.load()).destroyAll()`, `await this` would resolve to the view,
+ * not the array. Unlike an external binding, `this`'s static type inside the
+ * class is always the live (thenable) relation and can never narrow to the
+ * stripped view, so gate 2 cannot catch it. `this.toArray()` runs correctly on
+ * the view (only the thenable protocol is defeated, not ordinary method calls),
+ * so it is left as-is.
  *
  * For an autofixing rule a missed warning is cheap; a wrong fix is not.
  *
@@ -122,9 +134,15 @@ const rule = {
         if (property.type !== "Identifier" || property.name !== "toArray") return;
         // `.toArray(arg)` is not the relation accessor — leave it alone.
         if (node.arguments.length !== 0) return;
-        // `await super` is a syntax error, so stripping `.toArray()` off a
-        // `super.toArray()` receiver would emit uncompilable code — skip it.
-        if (callee.object.type === "Super") return;
+        // Skip `this`/`super` receivers. `await super` is a syntax error, so
+        // stripping the suffix off `super.toArray()` emits uncompilable code.
+        // `this.toArray()` is unsound to convert: a method invoked on the
+        // then-less view that `stripThenable` returns from `load`/`reload`/
+        // `presence` runs with `this` bound to that view (its `then` is
+        // `undefined`), so `await this` resolves to the view object, not the
+        // array — and `this`'s static type can never reflect that it might be
+        // the stripped view, so `receiverIsThenable` cannot catch it. See header.
+        if (callee.object.type === "Super" || callee.object.type === "ThisExpression") return;
         // Only flag the directly-awaited position — the one spot where the
         // suffix is provably redundant for a thenable.
         if (!isDirectlyAwaited(node)) return;

--- a/eslint/prefer-await-relation.test.mjs
+++ b/eslint/prefer-await-relation.test.mjs
@@ -44,6 +44,11 @@ tester.run("prefer-await-relation", rule, {
     // `super` — `await super` is a syntax error, so a `super.toArray()` receiver
     // is left alone rather than rewritten to uncompilable code.
     { code: "class R extends B { async f() { return await super.toArray(); } }" },
+    // `this` inside a relation method — a method invoked on the then-less view
+    // returned by load/reload/presence binds `this` to that view, whose `then`
+    // is undefined, so `await this` would resolve to the view, not the array;
+    // `this`'s type can never narrow to the stripped view. Left alone. See header.
+    { code: "class R { async f() { return await this.toArray(); } }" },
     // No `reload().toArray()` case here: reload() returns a then-stripped
     // LoadedRelation whose `.toArray()` is load-bearing, but that exclusion is
     // the thenable-type gate's job — untestable without type info, so it is
@@ -56,12 +61,6 @@ tester.run("prefer-await-relation", rule, {
       code: "async function f(rel: any) { await rel.toArray(); }",
       errors: [{ messageId: "preferAwait" }],
       output: "async function f(rel: any) { await rel; }",
-    },
-    // `this` inside a relation method
-    {
-      code: "class R { async f() { return await this.toArray(); } }",
-      errors: [{ messageId: "preferAwait" }],
-      output: "class R { async f() { return await this; } }",
     },
     // member read — a cached association proxy is awaitable again
     {

--- a/eslint/prefer-await-relation.test.mjs
+++ b/eslint/prefer-await-relation.test.mjs
@@ -44,9 +44,10 @@ tester.run("prefer-await-relation", rule, {
     // `super` — `await super` is a syntax error, so a `super.toArray()` receiver
     // is left alone rather than rewritten to uncompilable code.
     { code: "class R extends B { async f() { return await super.toArray(); } }" },
-    // reload() returns a then-stripped LoadedRelation whose `.toArray()` is
-    // load-bearing — proven left alone by the thenable-type gate under `pnpm
-    // lint` (no type info here, so it degrades to permissive; see header).
+    // No `reload().toArray()` case here: reload() returns a then-stripped
+    // LoadedRelation whose `.toArray()` is load-bearing, but that exclusion is
+    // the thenable-type gate's job — untestable without type info, so it is
+    // exercised by `pnpm lint` over the real codebase (see header), not here.
   ],
   invalid: [
     // Awaited identifier binding — the widened receiver gate now reports these
@@ -98,7 +99,7 @@ tester.run("prefer-await-relation", rule, {
       errors: [{ messageId: "preferAwait" }],
       output: "async function f(Post: any) { return await Post.all(); }",
     },
-    // longer chain, still a call-expression receiver
+    // longer chain off a query-method call
     {
       code: "async function f(rel: any) { await rel.order('id').limit(1).toArray(); }",
       errors: [{ messageId: "preferAwait" }],

--- a/eslint/prefer-await-relation.test.mjs
+++ b/eslint/prefer-await-relation.test.mjs
@@ -5,11 +5,11 @@ import rule from "./prefer-await-relation.mjs";
 // code and tests), and TS-only wrapper forms must parse to be exercised.
 //
 // RuleTester runs without type information (no `program`), so the rule's
-// thenable-type gate degrades to permissive here; these cases exercise the two
-// syntactic gates — directly-awaited position and call-expression receiver. The
-// type gate itself is exercised by `pnpm lint` over the real codebase (where
-// `projectService` supplies types), which is where the LoadedRelation / raw
-// `Result` receivers are proven to be left alone.
+// thenable-type gate degrades to permissive here; these cases exercise the
+// syntactic gate — directly-awaited position — and the `.toArray()`/`super`
+// shape checks. The type gate itself is exercised by `pnpm lint` over the real
+// codebase (where `projectService` supplies types), which is where the
+// LoadedRelation / raw `Result` receivers are proven to be left alone.
 const tester = new RuleTester({
   languageOptions: {
     ecmaVersion: 2022,
@@ -41,29 +41,51 @@ tester.run("prefer-await-relation", rule, {
     { code: "const f = (result: any) => result.toArray();" },
     // .then chain, not awaited
     { code: "ship.parts.toArray().then((p: any) => p);" },
-    // Awaited, but the receiver is NOT a call expression — these are left alone
-    // because the binding may be a `stripThenable`'d instance whose `.then` was
-    // deleted in place (await would then resolve to the relation, not the array):
-    // bare identifier
-    { code: "async function f(rel: any) { await rel.toArray(); }" },
-    // `this` inside a relation method (may be stripped: load/reload/presence)
-    { code: "class R { async f() { return await this.toArray(); } }" },
-    // `super` — `await super` is a syntax error anyway
+    // `super` — `await super` is a syntax error, so a `super.toArray()` receiver
+    // is left alone rather than rewritten to uncompilable code.
     { code: "class R extends B { async f() { return await super.toArray(); } }" },
-    // member read — a cached association proxy may have been stripped
-    { code: "async function f(author: any) { await author.posts.toArray(); }" },
-    // call expression, but NOT a relation-spawning query method — these return a
-    // cached/memoized relation that load/reload/clear/push may have stripped:
-    // the `association()` helper (bare function call)
-    { code: "async function f(rec: any) { await association(rec, 'tags').toArray(); }" },
-    // the `record.association(name)` accessor (property not in SPAWN_METHODS)
-    { code: "async function f(rec: any) { await rec.association('tags').toArray(); }" },
-    // a named scope (arbitrary method name, may be memoized on the proxy)
-    { code: "async function f(Post: any) { await Post.mostCommented(3).toArray(); }" },
-    // reload() returns a then-stripped LoadedRelation
-    { code: "async function f(rel: any) { await rel.reload().toArray(); }" },
+    // reload() returns a then-stripped LoadedRelation whose `.toArray()` is
+    // load-bearing — proven left alone by the thenable-type gate under `pnpm
+    // lint` (no type info here, so it degrades to permissive; see header).
   ],
   invalid: [
+    // Awaited identifier binding — the widened receiver gate now reports these
+    // (PR #4968 made every thenable-typed binding awaitable again).
+    {
+      code: "async function f(rel: any) { await rel.toArray(); }",
+      errors: [{ messageId: "preferAwait" }],
+      output: "async function f(rel: any) { await rel; }",
+    },
+    // `this` inside a relation method
+    {
+      code: "class R { async f() { return await this.toArray(); } }",
+      errors: [{ messageId: "preferAwait" }],
+      output: "class R { async f() { return await this; } }",
+    },
+    // member read — a cached association proxy is awaitable again
+    {
+      code: "async function f(author: any) { await author.posts.toArray(); }",
+      errors: [{ messageId: "preferAwait" }],
+      output: "async function f(author: any) { await author.posts; }",
+    },
+    // the `association()` helper (bare function call)
+    {
+      code: "async function f(rec: any) { await association(rec, 'tags').toArray(); }",
+      errors: [{ messageId: "preferAwait" }],
+      output: "async function f(rec: any) { await association(rec, 'tags'); }",
+    },
+    // the `record.association(name)` accessor
+    {
+      code: "async function f(rec: any) { await rec.association('tags').toArray(); }",
+      errors: [{ messageId: "preferAwait" }],
+      output: "async function f(rec: any) { await rec.association('tags'); }",
+    },
+    // a named scope (arbitrary method name)
+    {
+      code: "async function f(Post: any) { await Post.mostCommented(3).toArray(); }",
+      errors: [{ messageId: "preferAwait" }],
+      output: "async function f(Post: any) { await Post.mostCommented(3); }",
+    },
     // awaited, chained off a query method call
     {
       code: "async function f(rel: any) { const a = await rel.where({ x: 1 }).toArray(); }",

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
@@ -109,7 +109,7 @@ describeIfMysql("Mysql2Adapter", () => {
     // the absence of double quotes), proves the capture path was used.
     it("Relation#explain on MySQL re-executes an already-loaded relation", async () => {
       const relation = Author.where({ id: authors("david").id });
-      await relation.toArray(); // prime the load cache
+      await relation; // prime the load cache
       const plan = await relation.explain();
       expect(plan).toContain("`authors`");
       expect(plan).not.toMatch(/"authors"/);

--- a/packages/activerecord/src/adapters/postgresql/bind-parameter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/bind-parameter.test.ts
@@ -24,7 +24,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       const relation = Post.where("title = ?", value);
       expect(relation.toSql()).toBe(`SELECT "posts".* FROM "posts" WHERE (title = ${expected})`);
       if (match === 0) {
-        expect(await relation.toArray()).toHaveLength(0);
+        expect(await relation).toHaveLength(0);
       } else {
         expect(await relation.count()).toBe(match);
       }

--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -245,7 +245,7 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
    * explicit `equals` method.
    */
   async equals(other: Relation<T> | T[]): Promise<boolean> {
-    const ours = await this;
+    const ours = await this.toArray();
     const theirs = Array.isArray(other) ? other : await other;
     if (ours.length !== theirs.length) return false;
     for (let i = 0; i < ours.length; i++) {

--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -245,8 +245,8 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
    * explicit `equals` method.
    */
   async equals(other: Relation<T> | T[]): Promise<boolean> {
-    const ours = await this.toArray();
-    const theirs = Array.isArray(other) ? other : await other.toArray();
+    const ours = await this;
+    const theirs = Array.isArray(other) ? other : await other;
     if (ours.length !== theirs.length) return false;
     for (let i = 0; i < ours.length; i++) {
       if (!ours[i].isEqual(theirs[i])) return false;

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -1932,7 +1932,7 @@ describe("AssociationsTest", () => {
 
   it("should construct new finder sql after create", async () => {
     const person = Person.new({ first_name: "clark" });
-    expect(await association(person, "readers").toArray()).toEqual([]);
+    expect(await association(person, "readers")).toEqual([]);
     await person.save();
     const reader = await Reader.create({
       person,
@@ -1943,7 +1943,7 @@ describe("AssociationsTest", () => {
 
   it("subselect", async () => {
     const author = authors("david");
-    const favs = await association(author, "authorFavorites").toArray();
+    const favs = await association(author, "authorFavorites");
     const fav2 = await association(author, "authorFavorites").where({
       author: Author.where({ id: author.id }),
     });
@@ -2025,7 +2025,7 @@ describe("AssociationsTest", () => {
     const firm = new Firm({ name: "A New Firm, Inc" });
     await firm.save();
     // forcing to load all clients
-    for (const _ of await firm.clients.toArray()) {
+    for (const _ of await firm.clients) {
       void _;
     }
     expect(await firm.clients.isEmpty()).toBe(true);
@@ -2050,7 +2050,7 @@ describe("AssociationsTest", () => {
     await comment.save();
     await association(blogPost, "comments").push(comment);
 
-    const comments = await association(blogPost, "comments").toArray();
+    const comments = await association(blogPost, "comments");
     expect(comments.map((c: any) => c.id)).toContain((comment as any).id);
     expect(Number((comment as any).blog_post_id)).toBe(Number((blogPost as any).id));
     expect((comment as any).blog_id).toBe((blogPost as any).blog_id);
@@ -2205,7 +2205,7 @@ describe("AssociationsTest", () => {
     await association(blogPost, "comments").push(comment);
 
     expect(comment.isPersisted()).toBe(true);
-    const comments = await association(blogPost, "comments").toArray();
+    const comments = await association(blogPost, "comments");
     expect(comments.map((c: any) => c.id)).toContain((comment as any).id);
     expect(Number((comment as any).blog_post_id)).toBe(Number((blogPost as any).id));
     expect((comment as any).blog_id).toBe((blogPost as any).blog_id);
@@ -2235,7 +2235,7 @@ describe("AssociationsTest", () => {
     await association(blogPost, "tags").push(tag);
 
     await blogPost.reload();
-    const reloadedTags = await association(blogPost, "tags").toArray();
+    const reloadedTags = await association(blogPost, "tags");
     expect(reloadedTags.map((t: any) => t.id)).toContain((tag as any).id);
     expect(reloadedTags.map((t: any) => t.id)).not.toContain((noiseTag as any).id);
     const join = await ShardedBlogPostTag.where({
@@ -2262,7 +2262,7 @@ describe("AssociationsTest", () => {
 
     expect(tag.isPersisted()).toBe(true);
     await blogPost.reload();
-    const reloadedTags = await association(blogPost, "tags").toArray();
+    const reloadedTags = await association(blogPost, "tags");
     expect(reloadedTags.map((t: any) => t.id)).toContain((tag as any).id);
     const join = await ShardedBlogPostTag.where({
       blog_post_id: (blogPost as any).id,
@@ -2276,16 +2276,16 @@ describe("AssociationsTest", () => {
     const blogPost = shardedBlogPosts("great_post_blog_one");
     let comment = shardedComments("great_comment_blog_post_one");
 
-    expect(await association(blogPost, "comments").toArray()).not.toHaveLength(0);
+    expect(await association(blogPost, "comments")).not.toHaveLength(0);
     await association(blogPost, "comments").replace([]);
 
     comment = (await ShardedComment.find((comment as any).id)) as never;
     expect((comment as any).blog_post_id).toBeNull();
     expect((comment as any).blog_id).toBeNull();
 
-    expect(await association(blogPost, "comments").toArray()).toHaveLength(0);
+    expect(await association(blogPost, "comments")).toHaveLength(0);
     await blogPost.reload();
-    expect(await association(blogPost, "comments").toArray()).toHaveLength(0);
+    expect(await association(blogPost, "comments")).toHaveLength(0);
   });
 
   it("assign persisted composite foreign key belongs to association", async () => {
@@ -2450,7 +2450,7 @@ describe("AssociationsTest", () => {
       const blogPost = shardedBlogPosts("great_post_blog_one");
       let error: unknown;
       try {
-        await association(blogPost, "commentsWithoutSingleColumnQueryConstraints").toArray();
+        await association(blogPost, "commentsWithoutSingleColumnQueryConstraints");
       } catch (e) {
         error = e;
       }
@@ -2475,7 +2475,7 @@ describe("AssociationsTest", () => {
       const blogPost = shardedBlogPosts("great_post_blog_one");
       let error: unknown;
       try {
-        await association(blogPost, "commentsWithoutMultipleColumnQueryConstraints").toArray();
+        await association(blogPost, "commentsWithoutMultipleColumnQueryConstraints");
       } catch (e) {
         error = e;
       }
@@ -2505,7 +2505,7 @@ describe("AssociationsTest", () => {
       const blogPost = shardedBlogPosts("great_post_blog_one");
       let error: unknown;
       try {
-        await association(blogPost, "commentsWithCompositePkOwner").toArray();
+        await association(blogPost, "commentsWithCompositePkOwner");
       } catch (e) {
         error = e;
       }
@@ -2520,13 +2520,13 @@ describe("AssociationsTest", () => {
 
   it("nullify composite has many through association", async () => {
     const blogPost = shardedBlogPosts("great_post_blog_one");
-    expect((await association(blogPost, "tags").toArray()).length).toBeGreaterThan(0);
+    expect((await association(blogPost, "tags")).length).toBeGreaterThan(0);
 
     await association(blogPost, "tags").replace([]);
 
-    expect(await association(blogPost, "tags").toArray()).toEqual([]);
+    expect(await association(blogPost, "tags")).toEqual([]);
     await association(blogPost, "tags").reload();
-    expect(await association(blogPost, "tags").toArray()).toEqual([]);
+    expect(await association(blogPost, "tags")).toEqual([]);
     expect(
       await ShardedBlogPostTag.where({
         blog_post_id: (blogPost as any).id,

--- a/packages/activerecord/src/associations/association-relation.test.ts
+++ b/packages/activerecord/src/associations/association-relation.test.ts
@@ -94,7 +94,7 @@ describe("AssociationRelation", () => {
     const scope = proxy
       .where({ name: "A" })
       .order("id") as unknown as AssociationRelation<ShipPart>;
-    const records = await scope.toArray();
+    const records = await scope;
     expect(records.length).toBe(2);
     expect(await scope.equals(records)).toBe(true);
     expect(await scope.equals([])).toBe(false);
@@ -113,7 +113,7 @@ describe("AssociationRelation", () => {
     await proxy.create({ name: "P1" });
 
     const scope = proxy.where({}) as unknown as AssociationRelation<ShipPart>;
-    const [part] = await scope.toArray();
+    const [part] = await scope;
     expect((part as any)._associationCache("ship")?.target).toBe(ship);
   });
 });

--- a/packages/activerecord/src/associations/belongs-to-associations.test.ts
+++ b/packages/activerecord/src/associations/belongs-to-associations.test.ts
@@ -1290,7 +1290,7 @@ describe("BelongsToAssociationsTest", () => {
 
     expect((await topic.reload()).readAttribute("replies_count")).toBe(5);
 
-    const reply = (await topic.replies.toArray())[0];
+    const reply = (await topic.replies)[0];
     await reply.destroy();
     expect((await topic.reload()).readAttribute("replies_count")).toBe(4);
 
@@ -1308,7 +1308,7 @@ describe("BelongsToAssociationsTest", () => {
 
     expect((await topic.reload()).readAttribute("replies_count")).toBe(5);
 
-    const reply = (await topic.replies.toArray())[0];
+    const reply = (await topic.replies)[0];
     const replyClone = await Reply.find(reply.id!);
 
     await reply.destroy();

--- a/packages/activerecord/src/associations/callbacks.test.ts
+++ b/packages/activerecord/src/associations/callbacks.test.ts
@@ -286,7 +286,7 @@ describe("AssociationCallbacksTest", () => {
     const proxy = association(author, "posts");
     const p = new (Post as any)({ title: "Blocked", body: "Body", author_id: author.id });
     await proxy.push(p);
-    const posts = await proxy.toArray();
+    const posts = await proxy;
     expect(posts.length).toBe(0);
   });
 
@@ -414,7 +414,7 @@ describe("AssociationCallbacksTest", () => {
     const proxy = association(author, "posts");
     const p = new (Post as any)({ title: "abc", body: "Body", author_id: author.id });
     await proxy.push(p);
-    expect((await proxy.toArray()).length).toBe(0);
+    expect((await proxy).length).toBe(0);
   });
 
   it("has many callbacks halt execution when abort is trown when removing from association", async () => {
@@ -422,12 +422,12 @@ describe("AssociationCallbacksTest", () => {
     const author = await Author.create({ name: "David" });
     const p = await (Post as any).create({ title: "abc", body: "Body", author_id: author.id });
     const proxy = association(author, "posts");
-    expect((await proxy.toArray()).length).toBe(1);
+    expect((await proxy).length).toBe(1);
     // Rails passes the bare id to `destroy` (not `delete`): the abortable
     // before_remove loop shares remove_records with delete, so an abort leaves
     // the record (and its DB row) in place.
     await proxy.destroy(p.id);
-    expect((await proxy.toArray()).length).toBe(1);
+    expect((await proxy).length).toBe(1);
     expect(await (Post as any).exists(p.id)).toBe(true);
   });
 
@@ -447,10 +447,10 @@ describe("AssociationCallbacksTest", () => {
     });
     const p2 = await (Post as any).create({ title: "keep", body: "Body", author_id: author.id });
     const proxy = association(author, "posts");
-    expect((await proxy.toArray()).length).toBe(2);
+    expect((await proxy).length).toBe(2);
     await proxy.delete(p1, p2);
     // p1 must NOT have been removed even though its own before_remove passed.
-    expect((await proxy.toArray()).length).toBe(2);
+    expect((await proxy).length).toBe(2);
   });
 
   it("has many callbacks with create!", async () => {
@@ -506,7 +506,7 @@ describe("AssociationCallbacksTest", () => {
     } catch {
       // swallowed, like Rails' `rescue Exception`
     }
-    expect((await proxy.toArray()).length).toBe(0);
+    expect((await proxy).length).toBe(0);
   });
 
   it("after_add callback throwing abort propagates (not swallowed)", async () => {
@@ -652,7 +652,7 @@ describe("AssociationCallbacksTest", () => {
     // david + jamis (+ poor_jamis) are joined to active_record via the
     // developers_projects fixtures, so clear() actually removes rows — and
     // must do so without firing the before/after remove callbacks.
-    expect((await proxy.toArray()).length).toBeGreaterThan(0);
+    expect((await proxy).length).toBeGreaterThan(0);
     await proxy.clear();
     expect(activerecord.developersLog).toEqual([]);
   });
@@ -665,7 +665,7 @@ describe("AssociationCallbacksTest", () => {
     const callbackLog = ["before_adding<new>", "after_adding<new>"];
     expect(project.developersLog).toEqual(callbackLog);
     expect(await project.save()).toBe(true);
-    expect((await proxy.toArray()).length).toBe(1);
+    expect((await proxy).length).toBe(1);
     expect(project.developersLog).toEqual(callbackLog);
   });
 });

--- a/packages/activerecord/src/associations/cascaded-eager-loading.test.ts
+++ b/packages/activerecord/src/associations/cascaded-eager-loading.test.ts
@@ -182,7 +182,7 @@ describe("CascadedEagerLoadingTest", () => {
     // `posts_authors`/`posts_authors_join` re-emitted for the eager spec.
     const sql = rel.toSql();
     expect(sql).not.toMatch(/posts_authors/);
-    const loaded = await rel.toArray();
+    const loaded = await rel;
     // INNER JOIN semantics (manual join wins): only authors reachable through a
     // post that has a comment. The single deduped `posts`/`comments` joins drive
     // the eager hydration with no fan-out duplication from an extra alias.
@@ -207,9 +207,9 @@ describe("CascadedEagerLoadingTest", () => {
       .joins("categorizations")
       .includes({ posts: "comments" }, "authors");
     expect(await categories.count()).toBe(4);
-    expect((await categories.toArray()).length).toBe(4);
+    expect((await categories).length).toBe(4);
     expect(await categories.distinct().count()).toBe(3);
-    const uniqIds = new Set((await categories.toArray()).map((c) => c.id));
+    const uniqIds = new Set((await categories).map((c) => c.id));
     expect(uniqIds.size).toBe(3);
   });
 
@@ -220,7 +220,7 @@ describe("CascadedEagerLoadingTest", () => {
       .where("categorizations.id is not null")
       .references("categorizations");
     expect(await categories.count()).toBe(3);
-    expect((await categories.toArray()).length).toBe(3);
+    expect((await categories).length).toBe(3);
   });
 
   it("cascaded eager association loading with twice includes edge cases", async () => {
@@ -230,14 +230,14 @@ describe("CascadedEagerLoadingTest", () => {
       .where("posts.id is not null")
       .references("posts");
     expect(await categories.count()).toBe(3);
-    expect((await categories.toArray()).length).toBe(3);
+    expect((await categories).length).toBe(3);
   });
 
   it("eager association loading with join for count", async () => {
     const authorsRel = Author.all().joins("specialPosts").includes("posts", "categorizations");
     await authorsRel.count();
     await assertQueriesCount(3, false, async () => {
-      await authorsRel.toArray();
+      await authorsRel;
     });
   });
 

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -399,7 +399,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     thisArg?: unknown,
   ): Promise<boolean> {
     if (!fn) return !(await this.isEmpty());
-    const records = await this.toArray();
+    const records = await this;
     return records.some(fn as (v: T, i: number, a: T[]) => unknown, thisArg);
   }
 
@@ -2976,7 +2976,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       // nullified FK makes a reload return nothing. Only the non-through path
       // needs this; the through branch returns early after a full reset, so its
       // `toArray()` load is avoided entirely.
-      const records = await this.toArray();
+      const records = await this;
       // Honor the association's `:dependent` like Rails `delete_all` (nil arg):
       // `dependent == :destroy` collapses to `:delete_all`, so
       // destroy/delete/delete_all bulk-DELETE the child rows while
@@ -3346,7 +3346,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * Mirrors: ActiveRecord::Associations::CollectionProxy#destroy_all
    */
   async destroyAll(): Promise<T[]> {
-    const records = await this.toArray();
+    const records = await this;
     await this.destroy(...records);
     this._invalidateAssociationIds();
     return records;
@@ -3509,9 +3509,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     const allStrings = columns.every((c) => typeof c === "string");
     if (allStrings && (this._isThrough || this._targetLoaded)) {
       const stringCols = columns;
-      const records = (this._isThrough ? await this.toArray() : this._target).filter(
-        (r) => !r.isNewRecord(),
-      );
+      const records = (this._isThrough ? await this : this._target).filter((r) => !r.isNewRecord());
       if (stringCols.length === 1) {
         return records.map((r) => r._readAttribute(stringCols[0]));
       }
@@ -3533,9 +3531,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     const allStrings = columns.every((c) => typeof c === "string");
     if (allStrings && (this._isThrough || this._targetLoaded)) {
       const stringCols = columns;
-      const records = (this._isThrough ? await this.toArray() : this._target).filter(
-        (r) => !r.isNewRecord(),
-      );
+      const records = (this._isThrough ? await this : this._target).filter((r) => !r.isNewRecord());
       if (records.length === 0) return null;
       if (stringCols.length === 1) return records[0]._readAttribute(stringCols[0]);
       return stringCols.map((c) => records[0]._readAttribute(c));

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -399,7 +399,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     thisArg?: unknown,
   ): Promise<boolean> {
     if (!fn) return !(await this.isEmpty());
-    const records = await this;
+    const records = await this.toArray();
     return records.some(fn as (v: T, i: number, a: T[]) => unknown, thisArg);
   }
 
@@ -2976,7 +2976,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       // nullified FK makes a reload return nothing. Only the non-through path
       // needs this; the through branch returns early after a full reset, so its
       // `toArray()` load is avoided entirely.
-      const records = await this;
+      const records = await this.toArray();
       // Honor the association's `:dependent` like Rails `delete_all` (nil arg):
       // `dependent == :destroy` collapses to `:delete_all`, so
       // destroy/delete/delete_all bulk-DELETE the child rows while
@@ -3346,7 +3346,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * Mirrors: ActiveRecord::Associations::CollectionProxy#destroy_all
    */
   async destroyAll(): Promise<T[]> {
-    const records = await this;
+    const records = await this.toArray();
     await this.destroy(...records);
     this._invalidateAssociationIds();
     return records;
@@ -3509,7 +3509,9 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     const allStrings = columns.every((c) => typeof c === "string");
     if (allStrings && (this._isThrough || this._targetLoaded)) {
       const stringCols = columns;
-      const records = (this._isThrough ? await this : this._target).filter((r) => !r.isNewRecord());
+      const records = (this._isThrough ? await this.toArray() : this._target).filter(
+        (r) => !r.isNewRecord(),
+      );
       if (stringCols.length === 1) {
         return records.map((r) => r._readAttribute(stringCols[0]));
       }
@@ -3531,7 +3533,9 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     const allStrings = columns.every((c) => typeof c === "string");
     if (allStrings && (this._isThrough || this._targetLoaded)) {
       const stringCols = columns;
-      const records = (this._isThrough ? await this : this._target).filter((r) => !r.isNewRecord());
+      const records = (this._isThrough ? await this.toArray() : this._target).filter(
+        (r) => !r.isNewRecord(),
+      );
       if (records.length === 0) return null;
       if (stringCols.length === 1) return records[0]._readAttribute(stringCols[0]);
       return stringCols.map((c) => records[0]._readAttribute(c));

--- a/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
@@ -107,7 +107,7 @@ describe("DisableJoinsAssociationScope", () => {
     }) as DisableJoinsAssociationRelation<Base>;
     expect(built).toBeInstanceOf(DisableJoinsAssociationRelation);
 
-    const records = await built.toArray();
+    const records = await built;
     expect(records.map((r: any) => r.body).sort()).toEqual(["c1", "c2"]);
   });
 
@@ -130,7 +130,7 @@ describe("DisableJoinsAssociationScope", () => {
       if (typeof sql === "string") observed.push(sql);
     });
     try {
-      const records = await built.toArray();
+      const records = await built;
       expect(records.length).toBe(1);
       expect((records[0] as any).body).toBe("c1");
     } finally {
@@ -181,7 +181,7 @@ describe("DisableJoinsAssociationScope", () => {
       klass: reflection.klass,
     }) as DisableJoinsAssociationRelation<Base>;
 
-    const records = await built.toArray();
+    const records = await built;
     expect(records.map((r: any) => r.body)).toEqual(["from-a", "from-b"]);
   });
 
@@ -213,7 +213,7 @@ describe("DisableJoinsAssociationScope", () => {
     (djar as any)._whereClause.predicates.push(
       ...(DjsPost as any).where({ id: [post1.id, post2.id] })._whereClause.predicates,
     );
-    const loaded = await djar.toArray();
+    const loaded = await djar;
     expect(loaded.map((p: any) => p.title)).toEqual(["p2", "p1"]);
   });
 });

--- a/packages/activerecord/src/associations/eager.test.ts
+++ b/packages/activerecord/src/associations/eager.test.ts
@@ -330,7 +330,7 @@ describe("EagerAssociationTest", () => {
   });
   it("eager loaded has many association without primary key", async () => {
     const pirate = pirates("blackbeard");
-    const mateysList: Matey[] = await pirate.mateys.toArray();
+    const mateysList: Matey[] = await pirate.mateys;
     const eagerLoaded = await Pirate.eagerLoad("mateys").where({ id: pirate.id }).first();
     expect(mateysList.length).toBeGreaterThan(0);
     const mateyAttrs = (m: any) => ({
@@ -628,13 +628,13 @@ describe("EagerAssociationTest", () => {
     await Tagging.create({ taggable_type: "Post", taggable_id: post2.id, tag_id: tag.id });
 
     const tagWithIncludes = await OrderedTag.includes("taggedPosts").find(tag.id);
-    const taggings = await tagWithIncludes.orderedTaggings.toArray();
+    const taggings = await tagWithIncludes.orderedTaggings;
     const taggableTitles: string[] = [];
     for (const tagging of taggings) {
       const taggable = (await tagging.loadBelongsTo("taggable")) as Post;
       taggableTitles.push(taggable.title);
     }
-    const taggedPostTitles = (await tagWithIncludes.taggedPosts.toArray()).map((p: any) => p.title);
+    const taggedPostTitles = (await tagWithIncludes.taggedPosts).map((p: any) => p.title);
     expect(taggedPostTitles).toEqual(taggableTitles);
   });
   it("eager has many through multiple with order", async () => {
@@ -655,11 +655,11 @@ describe("EagerAssociationTest", () => {
     const tag1WithIncludes = tagsWithIncludes[0];
     const tag2WithIncludes = tagsWithIncludes[tagsWithIncludes.length - 1];
 
-    expect((await tag1WithIncludes.taggedPosts.toArray()).map((p: any) => p.title)).toEqual([
+    expect((await tag1WithIncludes.taggedPosts).map((p: any) => p.title)).toEqual([
       post2.title,
       post1.title,
     ]);
-    expect((await tag2WithIncludes.taggedPosts.toArray()).map((p: any) => p.title)).toEqual([
+    expect((await tag2WithIncludes.taggedPosts).map((p: any) => p.title)).toEqual([
       post1.title,
       post2.title,
     ]);
@@ -811,12 +811,12 @@ describe("EagerAssociationTest", () => {
     });
   });
   it("preload has many using primary key", async () => {
-    const expected = (await (await Firm.first())!.clientsUsingPrimaryKey.toArray()).sort(
+    const expected = (await (await Firm.first())!.clientsUsingPrimaryKey).sort(
       (a: any, b: any) => Number(a.id) - Number(b.id),
     );
     const firm = await Firm.includes("clientsUsingPrimaryKey").first();
     await assertNoQueries(false, async () => {
-      const actual = (await firm!.clientsUsingPrimaryKey.toArray()).sort(
+      const actual = (await firm!.clientsUsingPrimaryKey).sort(
         (a: any, b: any) => Number(a.id) - Number(b.id),
       );
       expect(actual.map((c: any) => c.id)).toEqual(expected.map((c: any) => c.id));
@@ -824,15 +824,15 @@ describe("EagerAssociationTest", () => {
   });
 
   it("include has many using primary key", async () => {
-    const expected = (await (await Firm.find(1)).clientsUsingPrimaryKey.toArray()).sort(
-      (a: any, b: any) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0),
+    const expected = (await (await Firm.find(1)).clientsUsingPrimaryKey).sort((a: any, b: any) =>
+      a.name < b.name ? -1 : a.name > b.name ? 1 : 0,
     );
     const firm = await Firm.all()
       .includes("clientsUsingPrimaryKey")
       .order("clients_using_primary_keys_companies.name")
       .find(1);
     await assertNoQueries(false, async () => {
-      const actual = await firm.clientsUsingPrimaryKey.toArray();
+      const actual = await firm.clientsUsingPrimaryKey;
       expect(actual.map((c: any) => c.id)).toEqual(expected.map((c: any) => c.id));
     });
   });
@@ -845,7 +845,7 @@ describe("EagerAssociationTest", () => {
       client = await Client.preload("accounts").find(c.id);
     });
     await assertNoQueries(false, async () => {
-      expect(await client.accounts.toArray()).toHaveLength(0);
+      expect(await client.accounts).toHaveLength(0);
     });
   });
   it("preloading empty belongs to polymorphic", async () => {
@@ -2114,7 +2114,7 @@ describe("EagerAssociationTest", () => {
     expect(sql).toMatch(/LEFT OUTER JOIN.*categories_posts/);
     expect(sql).toMatch(/LEFT OUTER JOIN.*categories[^_]/);
 
-    const loaded = await rel.toArray();
+    const loaded = await rel;
     const welcome = loaded.find((p) => p.id === posts("welcome").id)!;
     const thinking = loaded.find((p) => p.id === posts("thinking").id)!;
     expect(await (welcome as any).categories.length()).toBe(2);
@@ -2784,7 +2784,7 @@ describe("EagerAssociationTest", () => {
     const posts = ShardedBlogPost.where({ blog_id: blogIds }).includes("comments");
 
     const sqls = await captureSql(async () => {
-      const loaded = (await posts.toArray()) as Base[];
+      const loaded = (await posts) as Base[];
       // Exercise the public reader (Rails: `posts.map(&:comments)`); the size
       // is the post count (3), populated from the preload, not a fresh query.
       const commentsCollection = await Promise.all(

--- a/packages/activerecord/src/associations/getmodelcolumns-virtual-projection.test.ts
+++ b/packages/activerecord/src/associations/getmodelcolumns-virtual-projection.test.ts
@@ -39,9 +39,7 @@ describe("getModelColumns virtual-attribute eager projection", () => {
     for (const sql of eagerSqls) expect(sql).not.toContain("metadata");
 
     expect(firm.id).toBe(companies("first_firm").id);
-    const clients = await (
-      firm as Firm & { clients: { toArray(): Promise<unknown[]> } }
-    ).clients.toArray();
+    const clients = await (firm as Firm & { clients: { toArray(): Promise<unknown[]> } }).clients;
     expect((clients as { id: number }[]).map((c) => c.id)).toEqual([companies("first_client").id]);
   });
 });

--- a/packages/activerecord/src/associations/habtm.test.ts
+++ b/packages/activerecord/src/associations/habtm.test.ts
@@ -23,7 +23,7 @@ describe("has_and_belongs_to_many", () => {
   it("loads associated records through a join table", async () => {
     // `david` joins both projects via the `developers_projects` join table.
     const david = developers("david");
-    const projectList = await association<CanonicalProject>(david, "projects").toArray();
+    const projectList = await association<CanonicalProject>(david, "projects");
     expect(projectList).toHaveLength(2);
     const names = projectList.map((p) => p.name).sort();
     expect(names).toEqual(["Active Controller", "Active Record"]);
@@ -34,7 +34,7 @@ describe("has_and_belongs_to_many", () => {
     // join table, so it resolves to the alphabetical default
     // ("developers" + "projects" -> "developers_projects").
     const activeRecord = projects("active_record");
-    const devs = await association<CanonicalDeveloper>(activeRecord, "developers").toArray();
+    const devs = await association<CanonicalDeveloper>(activeRecord, "developers");
     expect(devs.length).toBeGreaterThan(0);
     expect(devs.map((d) => d.name)).toContain("David");
   });

--- a/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
@@ -268,11 +268,11 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
 
   it("has and belongs to many", async () => {
     const david = await Developer.find(1);
-    expect((await david.projects.toArray()).length).toBeGreaterThan(0);
+    expect((await david.projects).length).toBeGreaterThan(0);
     expect(await david.projects.size()).toBe(2);
 
     const activeRecord = await Project.find(1);
-    const devs = await activeRecord.developers.toArray();
+    const devs = await activeRecord.developers;
     expect(devs.length).toBe(3);
     expect(devs.map((d) => d.id)).toContain(david.id);
   });
@@ -371,15 +371,15 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
 
     await newProject.reload();
     expect(await newProject.developers.size()).toBe(amountOfDevelopers);
-    expect((await newProject.developers.toArray()).map((d) => d.id)).toEqual(devs.map((d) => d.id));
+    expect((await newProject.developers).map((d) => d.id)).toEqual(devs.map((d) => d.id));
   });
 
   it("habtm distinct order preserved", async () => {
     const activeRecord = projects("active_record");
     const expected = [developers("poor_jamis").id, developers("jamis").id, developers("david").id];
-    const nonUnique = (await activeRecord.nonUniqueDevelopers.toArray()).map((d) => d.id);
+    const nonUnique = (await activeRecord.nonUniqueDevelopers).map((d) => d.id);
     expect(nonUnique).toEqual(expected);
-    const unique = (await activeRecord.developers.toArray()).map((d) => d.id);
+    const unique = (await activeRecord.developers).map((d) => d.id);
     expect(unique).toEqual(expected);
   });
 
@@ -423,7 +423,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     expect(devel.isNewRecord()).toBe(false);
     expect(proj2.isNewRecord()).toBe(false);
     const found = (await Developer.findBy({ name: "Marcel" })) as Developer;
-    const projs = await found.projects.toArray();
+    const projs = await found.projects;
     expect(projs.map((p) => p.id)).toContain(proj2.id);
   });
 
@@ -432,7 +432,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     const proj = await devel.projects.create({ name: "Projekt" });
     expect(proj.isPersisted()).toBe(true);
     const fresh = await Developer.find(1);
-    const projs = await fresh.projects.toArray();
+    const projs = await fresh.projects;
     expect(projs.map((p) => p.id)).toContain(proj.id);
   });
 
@@ -516,9 +516,9 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
 
   it("removing associations on destroy", async () => {
     const david = await DeveloperWithBeforeDestroyRaise.find(1);
-    expect((await david.projects.toArray()).length).toBeGreaterThan(0);
+    expect((await david.projects).length).toBeGreaterThan(0);
     await david.destroy();
-    expect((await david.projects.toArray()).length).toBe(0);
+    expect((await david.projects).length).toBe(0);
     const joins = await Base.connection.execute(
       "SELECT * FROM developers_projects WHERE developer_id = 1",
     );
@@ -566,7 +566,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
   it("destroy all", async () => {
     const david = await Developer.find(1);
     await david.projects.reload();
-    expect((await david.projects.toArray()).length).toBeGreaterThan(0);
+    expect((await david.projects).length).toBeGreaterThan(0);
 
     const projectCountBefore = Number(await Project.count());
     await david.projects.destroyAll();
@@ -576,14 +576,14 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
       `SELECT * FROM developers_projects WHERE developer_id = ${david.id}`,
     );
     expect(joins.length).toBe(0);
-    expect((await david.projects.toArray()).length).toBe(0);
+    expect((await david.projects).length).toBe(0);
     expect(await (await david.projects.reload()).size()).toBe(0);
   });
 
   it("destroy associations destroys multiple associations", async () => {
     const george = (await Parrot.findBy({ name: "Curious George" })) as Parrot;
-    expect((await george.pirates.toArray()).length).toBeGreaterThan(0);
-    expect((await george.treasures.toArray()).length).toBeGreaterThan(0);
+    expect((await george.pirates).length).toBeGreaterThan(0);
+    expect((await george.treasures).length).toBeGreaterThan(0);
 
     const pirateBefore = (await Pirate.all()).length;
     const treasureBefore = (await Treasure.all()).length;
@@ -669,7 +669,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
   it("find with merged options", async () => {
     const activeRecord = projects("active_record");
     expect(await activeRecord.limitedDevelopers.size()).toBe(1);
-    expect((await activeRecord.limitedDevelopers.toArray()).length).toBe(1);
+    expect((await activeRecord.limitedDevelopers).length).toBe(1);
     expect((await (activeRecord.limitedDevelopers as any).limit(null).toArray()).length).toBe(3);
   });
 
@@ -699,12 +699,12 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
 
   it("dynamic find all should respect readonly access", async () => {
     const activeRecord = projects("active_record");
-    for (const d of await activeRecord.readonlyDevelopers.toArray()) {
+    for (const d of await activeRecord.readonlyDevelopers) {
       if (await d.isValid()) {
         await expect((d as any).saveBang()).rejects.toThrow(ReadOnlyRecord);
       }
     }
-    for (const d of await activeRecord.readonlyDevelopers.toArray()) {
+    for (const d of await activeRecord.readonlyDevelopers) {
       (d as any).isReadonly();
     }
   });
@@ -728,7 +728,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
 
   it("find in association with options", async () => {
     const activeRecord = projects("active_record");
-    const devs = await activeRecord.developers.toArray();
+    const devs = await activeRecord.developers;
     expect(devs.length).toBe(3);
     const poorJamis = developers("poor_jamis");
     const first = (await activeRecord.developers.where("salary < 10000").first()) as Developer;
@@ -745,7 +745,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     const actionController = projects("action_controller");
     await david.projects.clear();
     await david.projects.push(actionController);
-    expect((await david.projects.toArray()).length).toBe(1);
+    expect((await david.projects).length).toBe(1);
   });
 
   it("replace with new", async () => {
@@ -754,7 +754,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     const actionController = projects("action_controller");
     const newProj = await Project.create({ name: "ActionWebSearch" });
     await david.projects.push(actionController, newProj);
-    const projs = await david.projects.toArray();
+    const projs = await david.projects;
     expect(projs.length).toBe(2);
     expect(projs.map((p) => p.id)).not.toContain((await Project.find(1)).id);
   });
@@ -765,20 +765,20 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     const newProj = new Project({ name: "ActionWebSearch" });
     await newDeveloper.projects.concat(actionController, newProj);
     await newDeveloper.save();
-    expect((await newDeveloper.projects.toArray()).length).toBe(2);
+    expect((await newDeveloper.projects).length).toBe(2);
   });
 
   it("consider type", async () => {
     const developer = (await Developer.all())[0];
     const specialProject = await SpecialProject.create({ name: "Special Project" });
 
-    const otherProject = (await developer.projects.toArray())[0];
+    const otherProject = (await developer.projects)[0];
     await developer.specialProjects.push(specialProject);
     const fresh = await Developer.find(developer.id);
 
-    const projs = await fresh.projects.toArray();
+    const projs = await fresh.projects;
     expect(projs.map((p) => p.id)).toContain(specialProject.id);
-    const specials = await fresh.specialProjects.toArray();
+    const specials = await fresh.specialProjects;
     expect(specials.map((p) => p.id)).toContain(specialProject.id);
     expect(specials.map((p) => p.id)).not.toContain(otherProject.id);
   });
@@ -789,7 +789,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
       name: "omg",
     });
     const fresh = await Developer.find(developer.id);
-    const specials = await fresh.symSpecialProjects.toArray();
+    const specials = await fresh.symSpecialProjects;
     expect(specials.map((p) => p.id)).toContain(sp.id);
   });
 
@@ -807,7 +807,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
 
   it("updating attributes on non rich associations", async () => {
     const technology = await Category.find(2);
-    const welcome = (await technology.posts.toArray())[0];
+    const welcome = (await technology.posts)[0];
     welcome.title = "Something else";
     expect(await (welcome as any).saveBang()).toBeTruthy();
   });
@@ -817,13 +817,13 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     for (const o of await technology.selectTestingPosts.reload()) {
       expect((o as any).attributes).toHaveProperty("correctness_marker");
     }
-    const first = (await technology.selectTestingPosts.toArray())[0] as any;
+    const first = (await technology.selectTestingPosts)[0] as any;
     expect(first.attributes).toHaveProperty("correctness_marker");
   });
 
   it("habtm selects all columns by default", async () => {
     const david = developers("david");
-    const first = (await david.projects.toArray())[0];
+    const first = (await david.projects)[0];
     expect(Object.keys((first as any).attributes).sort()).toEqual(
       Project.columnNames().slice().sort(),
     );
@@ -880,14 +880,14 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
 
   it("find scoped grouped", async () => {
     const general = await Category.find(1);
-    expect((await general.postsGroupedByTitle.toArray()).length).toBe(5);
+    expect((await general.postsGroupedByTitle).length).toBe(5);
     const technology = await Category.find(2);
-    expect((await technology.postsGroupedByTitle.toArray()).length).toBe(1);
+    expect((await technology.postsGroupedByTitle).length).toBe(1);
   });
 
   it("find scoped grouped having", async () => {
     const activeRecord = projects("active_record");
-    const groups = await activeRecord.wellPaidSalaryGroups.toArray();
+    const groups = await activeRecord.wellPaidSalaryGroups;
     expect(groups.length).toBe(2);
     expect(groups.every((g: any) => Number(g.salary) > 10000)).toBe(true);
   });
@@ -937,7 +937,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     await developer.projects.setIds([activeRecord.id, actionController.id] as any);
     await (developer as any).save();
     await developer.reload();
-    expect((await developer.projects.toArray()).length).toBe(2);
+    expect((await developer.projects).length).toBe(2);
     const ids = [...((await (developer as any).projectIds) as number[])]
       .map(Number)
       .sort((a, b) => a - b);
@@ -951,7 +951,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     await developer.projects.setIds([activeRecord.id, null, actionController.id, ""] as any);
     await (developer as any).save();
     await developer.reload();
-    expect((await developer.projects.toArray()).length).toBe(2);
+    expect((await developer.projects).length).toBe(2);
     const ids = [...((await (developer as any).projectIds) as number[])]
       .map(Number)
       .sort((a, b) => a - b);
@@ -975,7 +975,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
 
   it("has many through polymorphic has manys works", async () => {
     const redbeard = (await Pirate.findBy({ catchphrase: "Avast!" })) as Pirate;
-    const prices = (await redbeard.treasureEstimates.toArray()).map((e: any) => e.price);
+    const prices = (await redbeard.treasureEstimates).map((e: any) => e.price);
     expect(new Set(prices)).toEqual(new Set(["$10.00", "$20.00"]));
   });
 
@@ -1097,7 +1097,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     const dev = new Developer({});
     const proxy = dev.projects;
     await assertNoQueries(false, async () => {
-      expect(await proxy.toArray()).toEqual([]);
+      expect(await proxy).toEqual([]);
       expect(await (proxy as any).where({ title: "omg" }).toArray()).toEqual([]);
       expect(await proxy.count()).toBe(0);
     });
@@ -1167,7 +1167,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     // `sharedComputers: ["laptop"]` association label on `david` into a
     // computers_developers join row — exercised by the data assertion below.
     const david = developers("david");
-    const sharedComputers = await david.sharedComputers.toArray();
+    const sharedComputers = await david.sharedComputers;
     expect((sharedComputers[0] as any).id).toBe((computers("laptop") as any).id);
   });
 
@@ -1230,7 +1230,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     const preloadedDeveloper = await Developer.preload({
       projects: "salariedDevelopers",
     }).first();
-    const preloadedProjects = await preloadedDeveloper!.projects.toArray();
+    const preloadedProjects = await preloadedDeveloper!.projects;
     const preloadedFirstProject = preloadedProjects.find(
       (p: Project) => (p as any).id === (firstProject as any).id,
     );

--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -2256,7 +2256,7 @@ describe("HasManyThroughAssociationsTest", () => {
 
   it("through scope is affected by unscoping", async () => {
     const author = authors("david");
-    const expected = ids(await association(author, "comments").toArray());
+    const expected = ids(await association(author, "comments"));
 
     const inside = await FirstPost.unscoped(async () => {
       return association(author, "commentsOnFirstPosts").toArray();
@@ -2268,7 +2268,7 @@ describe("HasManyThroughAssociationsTest", () => {
 
   it("through scope isnt affected by scoping", async () => {
     const author = authors("david");
-    const expected = ids(await association(author, "commentsOnFirstPosts").toArray());
+    const expected = ids(await association(author, "commentsOnFirstPosts"));
 
     const inside = await FirstPost.where({ id: 2 }).scoping(async () => {
       association(author, "commentsOnFirstPosts").reset();

--- a/packages/activerecord/src/associations/has-many-through-disable-joins-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-disable-joins-associations.test.ts
@@ -114,8 +114,8 @@ describe("HasManyThroughDisableJoinsAssociationsTest", () => {
   });
 
   it("to a on disable joins through", async () => {
-    const normalComments = await association(author, "comments").toArray();
-    const noJoinsComments = await association(author, "noJoinsComments").toArray();
+    const normalComments = await association(author, "comments");
+    const noJoinsComments = await association(author, "noJoinsComments");
     const normalIds = normalComments.map((c: any) => c.id).sort(sortIds);
     const noJoinsIds = noJoinsComments.map((c: any) => c.id).sort(sortIds);
     expect(noJoinsIds).toEqual(normalIds);
@@ -137,16 +137,16 @@ describe("HasManyThroughDisableJoinsAssociationsTest", () => {
 
   it("empty on disable joins through", async () => {
     const emptyAuthor = await Author.find(authors("bob").id);
-    const normal = await association(emptyAuthor, "comments").toArray();
-    const noJoins = await association(emptyAuthor, "noJoinsComments").toArray();
+    const normal = await association(emptyAuthor, "comments");
+    const noJoins = await association(emptyAuthor, "noJoinsComments");
     expect(normal).toEqual([]);
     expect(noJoins).toEqual([]);
   });
 
   it("empty on disable joins through using custom foreign key", async () => {
     const emptyAuthor = await Author.find(authors("bob").id);
-    const normal = await association(emptyAuthor, "commentsWithForeignKey").toArray();
-    const noJoins = await association(emptyAuthor, "noJoinsCommentsWithForeignKey").toArray();
+    const normal = await association(emptyAuthor, "commentsWithForeignKey");
+    const noJoins = await association(emptyAuthor, "noJoinsCommentsWithForeignKey");
     expect(normal).toEqual([]);
     expect(noJoins).toEqual([]);
   });
@@ -176,8 +176,8 @@ describe("HasManyThroughDisableJoinsAssociationsTest", () => {
 
   it("to a on disable joins with multiple scopes", async () => {
     const expectedIds = [rating1.id, rating2.id].sort(sortIds);
-    const normalRatings = await association(author, "goodRatings").toArray();
-    const noJoinsRatings = await association(author, "noJoinsGoodRatings").toArray();
+    const normalRatings = await association(author, "goodRatings");
+    const noJoinsRatings = await association(author, "noJoinsGoodRatings");
     expect(normalRatings.map((r: any) => r.id)).toEqual(expectedIds);
     expect(noJoinsRatings.map((r: any) => r.id)).toEqual(expectedIds);
   });
@@ -206,8 +206,8 @@ describe("HasManyThroughDisableJoinsAssociationsTest", () => {
   });
 
   it("polymophic disable joins through ordering", async () => {
-    const normalMembers = await association(author, "orderedMembers").toArray();
-    const noJoinsMembers = await association(author, "noJoinsOrderedMembers").toArray();
+    const normalMembers = await association(author, "orderedMembers");
+    const noJoinsMembers = await association(author, "noJoinsOrderedMembers");
     expect(normalMembers.map((m: any) => m.id)).toEqual([member2.id, member.id]);
     expect(noJoinsMembers.map((m: any) => m.id)).toEqual([member2.id, member.id]);
   });
@@ -265,7 +265,7 @@ describe("HasManyThroughDisableJoinsAssociationsTest", () => {
   });
 
   it("order applied in double join", async () => {
-    const noJoinsMembers = await association(author, "noJoinsMembers").toArray();
+    const noJoinsMembers = await association(author, "noJoinsMembers");
     expect(noJoinsMembers.map((m: any) => m.id)).toEqual([member2.id, member.id]);
   });
 

--- a/packages/activerecord/src/associations/nested-through-advanced.test.ts
+++ b/packages/activerecord/src/associations/nested-through-advanced.test.ts
@@ -43,7 +43,7 @@ describe("HMT Slot E — nested-through advanced", () => {
     // distinctTags deduplicates by tag PK, so we get exactly one row.
     const david = authors("david");
     const general = tags("general");
-    const result = await david.distinctTags.toArray();
+    const result = await david.distinctTags;
     expect(result.length).toBe(1);
     expect(result[0].id).toBe(general.id);
   });
@@ -121,7 +121,7 @@ describe("HMT Slot E — nested-through advanced", () => {
     const david = authors("david");
     const before = await Tagging.where({ taggable_type: "Post" }).count();
     await david.save();
-    const tags = await david.tags.toArray();
+    const tags = await david.tags;
     expect(tags.length).toBeGreaterThan(0);
     const after = await Tagging.where({ taggable_type: "Post" }).count();
     expect(after).toBe(before);

--- a/packages/activerecord/src/associations/nested-through-associations.test.ts
+++ b/packages/activerecord/src/associations/nested-through-associations.test.ts
@@ -120,7 +120,7 @@ describe("NestedThroughAssociationsTest", () => {
   it("has many through has many with has many through source reflection", async () => {
     const general = tags("general");
     const david = authors("david");
-    const davidTags = await david.tags.toArray();
+    const davidTags = await david.tags;
     expect(davidTags.map((t) => t.id)).toEqual([general.id, general.id]);
   });
 
@@ -179,7 +179,7 @@ describe("NestedThroughAssociationsTest", () => {
   it("has many through has one with has one through source reflection", async () => {
     const founding = memberTypes("founding");
     const groucho = members("groucho");
-    const result = await groucho.nestedMemberTypes.toArray();
+    const result = await groucho.nestedMemberTypes;
     expect(result.map((t) => t.id)).toEqual([founding.id]);
   });
 
@@ -205,7 +205,7 @@ describe("NestedThroughAssociationsTest", () => {
   it("has many through has one through with has one source reflection", async () => {
     const mustache = sponsors("moustache_club_sponsor_for_groucho");
     const groucho = members("groucho");
-    const result = await groucho.nestedSponsors.toArray();
+    const result = await groucho.nestedSponsors;
     expect(result.map((s) => s.id)).toEqual([mustache.id]);
   });
 
@@ -230,7 +230,7 @@ describe("NestedThroughAssociationsTest", () => {
     const grouchoDetails = memberDetails("groucho");
     const otherDetails = memberDetails("some_other_guy");
     const groucho = members("groucho");
-    const result = await groucho.organizationMemberDetails.toArray();
+    const result = await groucho.organizationMemberDetails;
     const sortedIds = result.map((d) => d.id).sort((a: any, b: any) => Number(a) - Number(b));
     expect(sortedIds).toEqual(
       [grouchoDetails.id, otherDetails.id].sort((a: any, b: any) => Number(a) - Number(b)),
@@ -272,7 +272,7 @@ describe("NestedThroughAssociationsTest", () => {
     const grouchoDetails = memberDetails("groucho");
     const otherDetails = memberDetails("some_other_guy");
     const groucho = members("groucho");
-    const result = await groucho.organizationMemberDetails_2.toArray();
+    const result = await groucho.organizationMemberDetails_2;
     const sortedIds = result.map((d) => d.id).sort((a: any, b: any) => Number(a) - Number(b));
     expect(sortedIds).toEqual(
       [grouchoDetails.id, otherDetails.id].sort((a: any, b: any) => Number(a) - Number(b)),
@@ -316,7 +316,7 @@ describe("NestedThroughAssociationsTest", () => {
     const general = categories("general");
     const cooking = categories("cooking");
     const bob = authors("bob");
-    const result = await bob.postCategories.toArray();
+    const result = await bob.postCategories;
     const sortedIds = result.map((c) => c.id).sort((a: any, b: any) => Number(a) - Number(b));
     expect(sortedIds).toEqual(
       [general.id, cooking.id].sort((a: any, b: any) => Number(a) - Number(b)),
@@ -415,7 +415,7 @@ describe("NestedThroughAssociationsTest", () => {
   it("has many through has many through with belongs to source reflection", async () => {
     const general = tags("general");
     const david = authors("david");
-    const result = await david.taggingTags.toArray();
+    const result = await david.taggingTags;
     expect(result.map((t: any) => t.id)).toEqual([general.id, general.id]);
   });
 
@@ -440,7 +440,7 @@ describe("NestedThroughAssociationsTest", () => {
     const welcomeGeneral = taggings("welcome_general");
     const thinkingGeneral = taggings("thinking_general");
     const davidWelcomeGeneral = categorizations("david_welcome_general");
-    const result = await davidWelcomeGeneral.postTaggings.toArray();
+    const result = await davidWelcomeGeneral.postTaggings;
     const sortedIds = result.map((t) => t.id).sort((a: any, b: any) => Number(a) - Number(b));
     expect(sortedIds).toEqual(
       [welcomeGeneral.id, thinkingGeneral.id].sort((a: any, b: any) => Number(a) - Number(b)),
@@ -537,7 +537,7 @@ describe("NestedThroughAssociationsTest", () => {
   it("distinct has many through a has many through association on source reflection", async () => {
     const david = authors("david");
     const general = tags("general");
-    const result = await david.distinctTags.toArray();
+    const result = await david.distinctTags;
     expect(result.map((t) => t.id)).toEqual([general.id]);
   });
 
@@ -545,7 +545,7 @@ describe("NestedThroughAssociationsTest", () => {
     const david = authors("david");
     const luke = subscribers("first");
     const davidSub = subscribers("second");
-    const result = await david.distinctSubscribers.toArray();
+    const result = await david.distinctSubscribers;
     const nicksSorted = result.map((s: any) => s.nick).sort();
     expect(nicksSorted).toEqual([luke, davidSub].map((s: any) => s.nick).sort());
   });
@@ -557,7 +557,7 @@ describe("NestedThroughAssociationsTest", () => {
     const otherByBob = posts("other_by_bob");
     const otherByMary = posts("other_by_mary");
 
-    const similarPosts = await bob.similarPosts.toArray();
+    const similarPosts = await bob.similarPosts;
     const sortedIds = similarPosts.map((p) => p.id).sort((a: any, b: any) => Number(a) - Number(b));
     expect(sortedIds).toEqual(
       [miscByBob.id, miscByMary.id, otherByBob.id, otherByMary.id].sort(
@@ -602,13 +602,13 @@ describe("NestedThroughAssociationsTest", () => {
     const davidUnicyclist = references("david_unicyclist");
     const davidAuthor = authors("david");
 
-    const agentsPosts = await david.agentsPosts.toArray();
+    const agentsPosts = await david.agentsPosts;
     const sortedIds = agentsPosts.map((p) => p.id).sort((a: any, b: any) => Number(a) - Number(b));
     expect(sortedIds).toEqual(
       [welcome.id, authorless.id].sort((a: any, b: any) => Number(a) - Number(b)),
     );
 
-    const agentsPostsAuthors = await davidUnicyclist.agentsPostsAuthors.toArray();
+    const agentsPostsAuthors = await davidUnicyclist.agentsPostsAuthors;
     expect(agentsPostsAuthors.map((a) => a.id)).toEqual([davidAuthor.id]);
 
     const refsResult = await Reference.joins("agentsPostsAuthors").where({
@@ -622,7 +622,7 @@ describe("NestedThroughAssociationsTest", () => {
     const michael = people("michael");
     const susan = people("susan");
 
-    const agents = await unicyclist.agents.toArray();
+    const agents = await unicyclist.agents;
     const sortedIds = agents.map((p) => p.id).sort((a: any, b: any) => Number(a) - Number(b));
     expect(sortedIds).toEqual(
       [michael.id, susan.id].sort((a: any, b: any) => Number(a) - Number(b)),
@@ -637,7 +637,7 @@ describe("NestedThroughAssociationsTest", () => {
     const specialRating = ratings("special_comment_rating");
     const subSpecialRating = ratings("sub_special_comment_rating");
 
-    const ratingsResult = await stiComments.specialCommentsRatings.toArray();
+    const ratingsResult = await stiComments.specialCommentsRatings;
     const sortedIds = ratingsResult
       .map((r) => r.id)
       .sort((a: any, b: any) => Number(a) - Number(b));
@@ -658,7 +658,7 @@ describe("NestedThroughAssociationsTest", () => {
     const stiComments = posts("sti_comments");
     const specialRatingTagging = taggings("special_comment_rating");
 
-    const taggingsResult = await stiComments.specialCommentsRatingsTaggings.toArray();
+    const taggingsResult = await stiComments.specialCommentsRatingsTaggings;
     expect(taggingsResult.map((t) => t.id)).toEqual([specialRatingTagging.id]);
 
     const scope = Post.joins("specialCommentsRatingsTaggings").where({ id: stiComments.id });
@@ -686,7 +686,7 @@ describe("NestedThroughAssociationsTest", () => {
   it("nested has many through with conditions on through associations", async () => {
     const bob = authors("bob");
     const blue = tags("blue");
-    const result = await bob.miscPostFirstBlueTags.toArray();
+    const result = await bob.miscPostFirstBlueTags;
     expect(result.map((t) => t.id)).toEqual([blue.id]);
   });
 
@@ -711,7 +711,7 @@ describe("NestedThroughAssociationsTest", () => {
   it("nested has many through with conditions on source associations", async () => {
     const bob = authors("bob");
     const blue = tags("blue");
-    const result = await bob.miscPostFirstBlueTags_2.toArray();
+    const result = await bob.miscPostFirstBlueTags_2;
     expect(result.map((t) => t.id)).toEqual([blue.id]);
   });
 
@@ -727,7 +727,7 @@ describe("NestedThroughAssociationsTest", () => {
       [, , author] = await Author.includes("miscPostFirstBlueTags_2").order("authors.id");
     });
     await assertNoQueries(false, async () => {
-      const preloaded = await author.miscPostFirstBlueTags_2.toArray();
+      const preloaded = await author.miscPostFirstBlueTags_2;
       expect(preloaded.map((t) => t.id)).toEqual([blue.id]);
     });
   });
@@ -739,8 +739,8 @@ describe("NestedThroughAssociationsTest", () => {
       miscPostFirstBlueTags_2: {},
     }).order("authors.id");
     await assertNoQueries(false, async () => {
-      const firstPost = (await author.posts.toArray())[0];
-      const preloaded = await firstPost.firstBlueTags_2.toArray();
+      const firstPost = (await author.posts)[0];
+      const preloaded = await firstPost.firstBlueTags_2;
       expect(preloaded.map((t) => t.id)).toEqual([blue.id]);
     });
   });
@@ -757,7 +757,7 @@ describe("NestedThroughAssociationsTest", () => {
     const nsa = organizations("nsa");
     const general = categories("general");
 
-    const essayCategories = await nsa.authorEssayCategories.toArray();
+    const essayCategories = await nsa.authorEssayCategories;
     expect(essayCategories.map((c) => c.id)).toEqual([general.id]);
 
     const orgsResult = await Organization.joins("authorEssayCategories").where({
@@ -848,7 +848,7 @@ describe("NestedThroughAssociationsTest", () => {
     const preloadedIds = ((preloaded.association("orderedPostComments").target ?? []) as any[]).map(
       (c: any) => c.id,
     );
-    const originalIds = (await original.orderedPostComments.toArray()).map((c: any) => c.id);
+    const originalIds = (await original.orderedPostComments).map((c: any) => c.id);
     expect(originalIds).toEqual(preloadedIds);
   });
 });

--- a/packages/activerecord/src/associations/nested-through-preloader.test.ts
+++ b/packages/activerecord/src/associations/nested-through-preloader.test.ts
@@ -56,7 +56,7 @@ describe("HMT Slot D — nested-through preloader / STI / joins+includes", () =>
     const r1 = ratings("normal_comment_rating");
     const r2 = ratings("special_comment_rating");
     const r3 = ratings("sub_special_comment_rating");
-    const result = await david.ratings.toArray();
+    const result = await david.ratings;
     expect(result.map((r) => r.id).sort((a: any, b: any) => Number(a) - Number(b))).toEqual(
       [r1.id, r2.id, r3.id].sort((a: any, b: any) => Number(a) - Number(b)),
     );
@@ -130,7 +130,7 @@ describe("HMT Slot D — nested-through preloader / STI / joins+includes", () =>
     expect(subSpecialRow!.constructor).toBe(SubSpecialComment);
 
     // Same check via proxy (direct load)
-    const directComments = await david.comments.toArray();
+    const directComments = await david.comments;
     const directById = new Map(directComments.map((c) => [c.id, c]));
     const directSpecial = directById.get(
       fixtureComments("eager_sti_on_associations_s_comment1").id,

--- a/packages/activerecord/src/associations/preloader.ts
+++ b/packages/activerecord/src/associations/preloader.ts
@@ -85,7 +85,7 @@ export class Preloader {
    */
   async materialize(): Promise<void> {
     if (this._materialized) return;
-    this._tree.preloadedRecords = await (this.records as Relation<Base>).toArray();
+    this._tree.preloadedRecords = await (this.records as Relation<Base>);
     this._materialized = true;
   }
 

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -345,7 +345,7 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     await proxy.create({ name: "parrots_0" });
     await proxy.create({ name: "parrots_1" });
 
-    const parrots = await proxy.toArray();
+    const parrots = await proxy;
     expect(parrots.some((p) => isMarkedForDestruction(p))).toBe(false);
     for (const p of parrots) markForDestruction(p);
 
@@ -356,7 +356,7 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     expect(Number(await Parrot.count())).toBe(before);
 
     const reloaded = await Pirate.find(pirate.id!);
-    expect((await association(reloaded, "parrots").toArray()).length).toBe(0);
+    expect((await association(reloaded, "parrots")).length).toBe(0);
   });
 
   it("should skip validation on habtm if marked for destruction", async () => {
@@ -366,7 +366,7 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     await proxy.create({ name: "parrots_0" });
     await proxy.create({ name: "parrots_1" });
 
-    const parrots = await proxy.toArray();
+    const parrots = await proxy;
     for (const p of parrots) p.name = "";
     expect(await pirate.isValid()).toBe(false);
 
@@ -388,7 +388,7 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     expect(validatedIds).toEqual([]);
 
     const reloaded = await Pirate.find(pirate.id!);
-    expect((await association(reloaded, "parrots").toArray()).length).toBe(0);
+    expect((await association(reloaded, "parrots")).length).toBe(0);
   });
 
   it("should skip validation on habtm if destroyed", async () => {
@@ -449,7 +449,7 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     const proxy = association(pirate, "parrots");
     await proxy.create({ name: "parrots_1" });
 
-    for (const p of await proxy.toArray()) markForDestruction(p);
+    for (const p of await proxy) markForDestruction(p);
     expect(await pirate.save()).toBe(true);
 
     // The join record is already gone — saving again issues no queries.
@@ -464,8 +464,8 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     await proxy.create({ name: "parrots_0" });
     await proxy.create({ name: "parrots_1" });
 
-    const before = (await proxy.toArray()).map((p) => p.id).sort();
-    for (const p of await proxy.toArray()) markForDestruction(p);
+    const before = (await proxy).map((p) => p.id).sort();
+    for (const p of await proxy) markForDestruction(p);
 
     // Mirror Rails: override the parrots association's `destroy` to raise after
     // running the real destroy, so the whole save transaction rolls back.
@@ -478,7 +478,7 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     await expect(pirate.save()).rejects.toThrow("Oh noes!");
 
     const reloaded = await Pirate.find(pirate.id!);
-    const after = (await association(reloaded, "parrots").toArray()).map((p) => p.id).sort();
+    const after = (await association(reloaded, "parrots")).map((p) => p.id).sort();
     expect(after).toEqual(before);
   });
 });
@@ -637,7 +637,7 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
     const proxy = association(company, "clients");
     await proxy.setIds([c1.id as number, c2.id as number]);
 
-    const clients = await proxy.toArray();
+    const clients = await proxy;
     expect(clients).toHaveLength(2);
     const ids = clients.map((c) => c.id).sort();
     expect(ids).toEqual([c1.id, c2.id].sort());
@@ -689,14 +689,14 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
     const orderAgreements = [a1.id, a2.id];
 
     const proxy = association(order, "orderAgreements");
-    expect(await proxy.toArray()).toHaveLength(0);
+    expect(await proxy).toHaveLength(0);
 
     await proxy.setIds(orderAgreements as number[]);
     await order.save();
     await order.reload();
 
     expect(await order.orderAgreementIds).toEqual(orderAgreements);
-    const loadedAgreements = await association(order, "orderAgreements").toArray();
+    const loadedAgreements = await association(order, "orderAgreements");
     expect(loadedAgreements).toHaveLength(2);
     expect(loadedAgreements.map((a) => a.id)).toContain(a2.id);
   });
@@ -763,14 +763,14 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
     const bookIds = [b1.id, b2.id];
 
     const proxy = association(order, "books");
-    expect(await proxy.toArray()).toHaveLength(0);
+    expect(await proxy).toHaveLength(0);
 
     await proxy.setIds(bookIds as number[][]);
     await order.save();
     await order.reload();
 
     expect(await order.bookIds).toEqual(bookIds);
-    const loadedBooks = await association(order, "books").toArray();
+    const loadedBooks = await association(order, "books");
     expect(loadedBooks).toHaveLength(2);
     const loadedTitles = loadedBooks.map((b) => b.title);
     expect(loadedTitles).toContain("First");

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -1059,7 +1059,7 @@ describe("BasicsTest", () => {
     // Rails: assert_equal bulbs_of_car, car.bulbs.includes(:car)
     // AssociationRelation (includes chain off proxy) returns same rows as plain Relation
     const assocRelation = (car as any).bulbs.includes("car");
-    const relationResults = await bulbsOfCar.toArray();
+    const relationResults = await bulbsOfCar;
     const assocResults = await assocRelation.toArray();
     expect(relationResults).toHaveLength(1);
     expect(assocResults.map((r: any) => r.id).sort()).toEqual(

--- a/packages/activerecord/src/batches.test.ts
+++ b/packages/activerecord/src/batches.test.ts
@@ -531,7 +531,7 @@ describe("EachTest", () => {
 
   it("in batches when loaded runs no queries", async () => {
     const posts = Post.all();
-    await posts.toArray(); // load
+    await posts; // load
     const total = Number(await Post.count());
     let batchCount = 0;
     await assertQueriesCount(0, false, async () => {
@@ -545,7 +545,7 @@ describe("EachTest", () => {
 
   it("in batches when loaded runs no queries with order argument", async () => {
     const allPosts = Post.all().order("id asc");
-    await allPosts.toArray(); // load
+    await allPosts; // load
     const total = Number(await Post.count());
     let batchCount = 0;
     await assertQueriesCount(0, false, async () => {
@@ -559,7 +559,7 @@ describe("EachTest", () => {
 
   it("in batches when loaded runs no queries with start and end arguments", async () => {
     const allPosts = Post.all().order("id asc");
-    const loadedPosts = await allPosts.toArray();
+    const loadedPosts = await allPosts;
     const startId = loadedPosts[1].id as number;
     const finishId = loadedPosts[loadedPosts.length - 2].id as number;
     let batchCount = 0;
@@ -578,7 +578,7 @@ describe("EachTest", () => {
 
   it("in batches when loaded runs no queries with start and end arguments and reverse order", async () => {
     const allPosts = Post.all().order("id asc");
-    const loadedPosts = await allPosts.toArray();
+    const loadedPosts = await allPosts;
     const startId = loadedPosts[loadedPosts.length - 2].id as number;
     const finishId = loadedPosts[1].id as number;
     let batchCount = 0;
@@ -598,7 +598,7 @@ describe("EachTest", () => {
 
   it("in batches when loaded can return an enum", async () => {
     const allPosts = Post.all();
-    await allPosts.toArray(); // load
+    await allPosts; // load
     const total = Number(await Post.count());
     let batchCount = 0;
     await assertQueriesCount(0, false, async () => {
@@ -612,7 +612,7 @@ describe("EachTest", () => {
 
   it("in batches when loaded runs no queries when batching over cpk model", async () => {
     const incorrectlySorted = CpkOrder.order({ shop_id: "asc", id: "desc" });
-    await incorrectlySorted.toArray(); // load
+    await incorrectlySorted; // load
     const correctlySorted = await CpkOrder.order({ shop_id: "desc", id: "asc" });
     const expected = correctlySorted.slice(1, correctlySorted.length - 1);
     const startId = (expected[0] as any).id;
@@ -640,7 +640,7 @@ describe("EachTest", () => {
     });
     try {
       const orderedPosts = Post.order("id desc");
-      await orderedPosts.toArray(); // load
+      await orderedPosts; // load
       const expected = await Post.order("id desc");
       const collected: any[] = [];
       for await (const post of orderedPosts

--- a/packages/activerecord/src/bind-parameter.test.ts
+++ b/packages/activerecord/src/bind-parameter.test.ts
@@ -146,7 +146,7 @@ describe("BindParameterTest", () => {
 
     const cap = captureSelectSql();
     const topics = Topic.where({ id: 1 });
-    expect((await topics.toArray()).map((t: any) => Number(t.id))).toEqual([1]);
+    expect((await topics).map((t: any) => Number(t.id))).toEqual([1]);
     cap.stop();
 
     const key = conn.sqlKey(cap.sqls.at(-1));
@@ -166,7 +166,7 @@ describe("BindParameterTest", () => {
     try {
       const cap = captureSelectSql();
       const topics = Topic.where({ id: 1 });
-      expect((await topics.toArray()).map((t: any) => Number(t.id))).toEqual([1]);
+      expect((await topics).map((t: any) => Number(t.id))).toEqual([1]);
       cap.stop();
 
       expect(statementCacheKeys(conn)).toContain(conn.sqlKey(cap.sqls.at(-1)));
@@ -231,7 +231,7 @@ describe("BindParameterTest", () => {
     const cap = captureSelectSql();
     const topics = Topic.where({ id: [1, 3] });
     expect(
-      (await topics.toArray()).map((t: any) => Number(t.id)).sort((a: number, b: number) => a - b),
+      (await topics).map((t: any) => Number(t.id)).sort((a: number, b: number) => a - b),
     ).toEqual([1, 3]);
     cap.stop();
 
@@ -252,7 +252,7 @@ describe("BindParameterTest", () => {
     // BoundSqlLiteral (preparable), so the statement IS pooled (assert_includes,
     // bind_parameter_test.rb:100-107).
     const topics = Topic.where("topics.id = ?", 1);
-    expect((await topics.toArray()).map((t: any) => Number(t.id))).toEqual([1]);
+    expect((await topics).map((t: any) => Number(t.id))).toEqual([1]);
     cap.stop();
 
     expect(statementCacheKeys(conn)).toContain(conn.sqlKey(cap.sqls.at(-1)));
@@ -427,7 +427,7 @@ describe("BindParameterTest", () => {
     let sql = `SELECT ${table}.* FROM ${table} WHERE (${pk} IN (${bindParams(conn, [1, 2, 3])}) OR ${pk} IS NULL)`;
     const authors = Author.where({ id: [1, 2, 3, null] });
     expect(conn.toSql(authors.arel())).toBe(sql);
-    expect((await authors.toArray()).length).toBe(3);
+    expect((await authors).length).toBe(3);
 
     // Rails' middle assertion (`where(id: [1, 2, 3, 2**63])` → `IN (1, 2, 3)`)
     // tests that an over-range integer is excluded from the array condition.

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -65,7 +65,7 @@ describe("CalculationsTest", () => {
     expect(accounts.isLoaded).toBe(false);
     expect(await accounts.sum("accounts.credit_limit")).toBe(318);
 
-    await accounts.toArray();
+    await accounts;
     expect(accounts.isLoaded).toBe(true);
     expect(await accounts.sum("accounts.credit_limit")).toBe(318);
   });
@@ -82,7 +82,7 @@ describe("CalculationsTest", () => {
     ]);
     expect(await accounts.count()).toEqual(expected);
 
-    await accounts.toArray();
+    await accounts;
     expect(await accounts.count()).toEqual(expected);
   });
 
@@ -998,7 +998,7 @@ describe("CalculationsTest", () => {
 
   it("async pluck on loaded relation", async () => {
     const relation = Topic.order("id");
-    await relation.toArray();
+    await relation;
     const ids = (await relation.pluck("id")).map(Number);
     expect(ids).toEqual([1, 2, 3, 4, 5]);
   });
@@ -1197,7 +1197,7 @@ describe("CalculationsTest", () => {
   it("ids for a composite primary key on loaded relation", async () => {
     const book = cpkBooks("cpk_great_author_first_book");
     const relation = CpkBook.where({ title: book.title });
-    const records = await relation.toArray();
+    const records = await relation;
     expect(relation.isLoaded).toBe(true);
     expect(records[0].title).toBe(book.title);
   });
@@ -1522,7 +1522,7 @@ describe("CalculationsTest", () => {
     expect(t.isLoaded).toBe(false);
     const before = (await t.pluck("topics.id")).map(Number);
     expect(before).toEqual([1, 3]);
-    await t.toArray();
+    await t;
     expect(t.isLoaded).toBe(true);
     const after = (await t.pluck("topics.id")).map(Number);
     expect(after).toEqual(before);
@@ -1653,7 +1653,7 @@ describe("CalculationsTest", () => {
   it("pick loaded relation", async () => {
     const companies = await Company.order("id").limit(3);
     const rel = Company.order("id").limit(3);
-    await rel.toArray();
+    await rel;
     const name = await rel.pick("name");
     expect(name).toBe("37signals");
     void companies;
@@ -1661,14 +1661,14 @@ describe("CalculationsTest", () => {
 
   it("pick loaded relation multiple columns", async () => {
     const rel = Company.order("id").limit(3);
-    await rel.toArray();
+    await rel;
     const result = (await rel.pick("id", "name")) as [unknown, string];
     expect([Number(result[0]), result[1]]).toEqual([1, "37signals"]);
   });
 
   it("pick loaded relation sql fragment", async () => {
     const rel = Company.order("name").limit(3);
-    await rel.toArray();
+    await rel;
     const name = await rel.pick(arelSql("DISTINCT name"));
     expect(name).toBe("37signals");
   });
@@ -1676,7 +1676,7 @@ describe("CalculationsTest", () => {
   it("pick loaded relation aliased attribute", async () => {
     // Rails: pick(:new_name) uses aliasAttribute new_name→name.
     const rel = Company.order("id").limit(3);
-    await rel.toArray();
+    await rel;
     const name = await rel.pick("name");
     expect(name).toBe("37signals");
   });

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -568,7 +568,7 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
   override limit(value: number | null): Relation<T> | Promise<T[]> {
     if (this._chainWalker) return Relation.prototype.limit.call(this, value) as Relation<T>;
     return (async () => {
-      const records = await this;
+      const records = await this.toArray();
       // null = "clear the limit" (matches Relation#limit). Without
       // this guard, `records.slice(0, null)` returns an empty array.
       return value === null ? records : records.slice(0, value);
@@ -600,7 +600,7 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
       ).findNthWithLimit(0, limit ?? 1);
       return limit === undefined ? (rows[0] ?? null) : rows;
     }
-    const records = await this;
+    const records = await this.toArray();
     return limit === undefined ? (records[0] ?? null) : records.slice(0, limit);
   }
 }

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -568,7 +568,7 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
   override limit(value: number | null): Relation<T> | Promise<T[]> {
     if (this._chainWalker) return Relation.prototype.limit.call(this, value) as Relation<T>;
     return (async () => {
-      const records = await this.toArray();
+      const records = await this;
       // null = "clear the limit" (matches Relation#limit). Without
       // this guard, `records.slice(0, null)` returns an empty array.
       return value === null ? records : records.slice(0, value);
@@ -600,7 +600,7 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
       ).findNthWithLimit(0, limit ?? 1);
       return limit === undefined ? (rows[0] ?? null) : rows;
     }
-    const records = await this.toArray();
+    const records = await this;
     return limit === undefined ? (records[0] ?? null) : records.slice(0, limit);
   }
 }

--- a/packages/activerecord/src/excluding.test.ts
+++ b/packages/activerecord/src/excluding.test.ts
@@ -93,7 +93,7 @@ describe("ExcludingTest", () => {
     const relation = post.comments;
 
     const records = await Comment.excluding(relation);
-    const postComments = await post.comments.toArray();
+    const postComments = await post.comments;
 
     expect(records.length).toBeGreaterThan(0);
     expect(postComments.length).toBeGreaterThan(0);
@@ -106,7 +106,7 @@ describe("ExcludingTest", () => {
     const relation = await post.comments.load();
 
     const records = await Comment.excluding(relation);
-    const postComments = await post.comments.toArray();
+    const postComments = await post.comments;
 
     expect(records.length).toBeGreaterThan(0);
     expect(postComments.length).toBeGreaterThan(0);
@@ -118,7 +118,7 @@ describe("ExcludingTest", () => {
     const post = posts("welcome");
 
     const assertNoExcludes = async (relation: Relation<Post>) => {
-      expect(ids(await relation.toArray())).toContain(post.id);
+      expect(ids(await relation)).toContain(post.id);
       expect(await relation.count()).toBe(await Post.count());
     };
 

--- a/packages/activerecord/src/finder.test.ts
+++ b/packages/activerecord/src/finder.test.ts
@@ -1549,8 +1549,8 @@ describe("FinderTest", () => {
   it("find on a scope does not perform statement caching", async () => {
     await Post.create({ title: "scope-test" });
     const scope = Post.where({ title: "scope-test" });
-    const r1 = await scope.toArray();
-    const r2 = await scope.toArray();
+    const r1 = await scope;
+    const r2 = await scope;
     expect(r1.length).toBe(r2.length);
   });
 

--- a/packages/activerecord/src/modules.test.ts
+++ b/packages/activerecord/src/modules.test.ts
@@ -163,7 +163,7 @@ describe("ModulesTest", () => {
     Base.storeFullStiClass = true;
     try {
       const collection = await ShopCollection.first();
-      expect(await collection!.products.toArray()).not.toEqual([]);
+      expect(await collection!.products).not.toEqual([]);
       let error: unknown;
       try {
         await collection!.destroy();
@@ -181,7 +181,7 @@ describe("ModulesTest", () => {
     Base.storeFullStiClass = true;
     try {
       const product = await ShopProduct.first();
-      expect(await product!.variants.toArray()).not.toEqual([]);
+      expect(await product!.variants).not.toEqual([]);
       let error: unknown;
       try {
         await product!.destroy();

--- a/packages/activerecord/src/querying-methods-delegation.test.ts
+++ b/packages/activerecord/src/querying-methods-delegation.test.ts
@@ -40,7 +40,7 @@ describe("Base static query delegations", () => {
     await Topic.create({ title: "Alice" });
 
     const rel = Topic.select("title");
-    const results = await rel.toArray();
+    const results = await rel;
     expect(results.length).toBe(1);
   });
 

--- a/packages/activerecord/src/relation-exec-main-query.test.ts
+++ b/packages/activerecord/src/relation-exec-main-query.test.ts
@@ -20,7 +20,7 @@ describe("RelationTest", () => {
 
   it("find in empty array", async () => {
     const authors = Author.all().where({ id: [] });
-    expect(await authors.toArray()).toEqual([]);
+    expect(await authors).toEqual([]);
   });
 
   it("contradiction where-clause issues no query", async () => {

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -85,7 +85,7 @@ describe("RelationTest", () => {
   it("reload", async () => {
     await CanonPost.create({ title: "reltest-reload", body: "b" });
     const rel = CanonPost.all();
-    await rel.toArray();
+    await rel;
     expect(rel.isLoaded).toBe(true);
     await rel.reload();
     expect(rel.isLoaded).toBe(true);
@@ -597,7 +597,7 @@ describe("RelationTest", () => {
     expect(await mergedAuthorsWithCommentedPostsRelation.count()).toBe(
       manualCommentsOnPostThatHaveAuthor.length,
     );
-    expect((await mergedAuthorsWithCommentedPostsRelation.toArray()).length).toBe(
+    expect((await mergedAuthorsWithCommentedPostsRelation).length).toBe(
       manualCommentsOnPostThatHaveAuthor.length,
     );
   });
@@ -644,8 +644,6 @@ describe("RelationTest", () => {
       .pluck("id");
 
     expect(await postsWithJoinsAndMerges.count()).toBe(postsWithAuthorAndCategorizations.length);
-    expect((await postsWithJoinsAndMerges.toArray()).length).toBe(
-      postsWithAuthorAndCategorizations.length,
-    );
+    expect((await postsWithJoinsAndMerges).length).toBe(postsWithAuthorAndCategorizations.length);
   });
 });

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2264,7 +2264,7 @@ export class Relation<T extends Base> {
    */
   async isAny(pattern?: EnumerablePattern<T>): Promise<boolean> {
     if (this._isEmptyRelation()) return false;
-    if (pattern !== undefined) return (await this.toArray()).some(this._patternMatcher(pattern));
+    if (pattern !== undefined) return (await this).some(this._patternMatcher(pattern));
     if (this._loaded) return this._records.length > 0;
     return this.exists();
   }
@@ -2306,7 +2306,7 @@ export class Relation<T extends Base> {
   async _countMatching(pattern: EnumerablePattern<T>, limit: number): Promise<number> {
     const matches = this._patternMatcher(pattern);
     let count = 0;
-    for (const record of await this.toArray()) {
+    for (const record of await this) {
       if (matches(record) && ++count === limit) break;
     }
     return count;
@@ -2355,7 +2355,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#length
    */
   async length(): Promise<number> {
-    const records = await this.toArray();
+    const records = await this;
     return records.length;
   }
 
@@ -2365,7 +2365,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#reject (Ruby Enumerable)
    */
   async reject(fn: (record: T) => boolean): Promise<T[]> {
-    const records = await this.toArray();
+    const records = await this;
     return records.filter((r) => !fn(r));
   }
 
@@ -2377,7 +2377,7 @@ export class Relation<T extends Base> {
    * Mirrors: Enumerable#detect / #find (via Relation#include Enumerable)
    */
   async detect(fn: (record: T, index: number, all: T[]) => unknown): Promise<T | undefined> {
-    const records = await this.toArray();
+    const records = await this;
     return records.find(fn);
   }
 
@@ -2391,7 +2391,7 @@ export class Relation<T extends Base> {
    * Mirrors: Enumerable#sort_by (via Relation#include Enumerable)
    */
   async sortBy(key: (record: T) => any): Promise<T[]> {
-    const records = await this.toArray();
+    const records = await this;
     return records
       .map((record, index) => ({ record, index, sortKey: key(record) }))
       .sort((a, b) => {
@@ -2424,7 +2424,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#load
    */
   async load(): Promise<LoadedRelation<this>> {
-    await this.toArray();
+    await this;
     return stripThenable(this);
   }
 
@@ -2897,7 +2897,7 @@ export class Relation<T extends Base> {
    * Async iterator support — allows `for await (const record of relation)`.
    */
   async *[Symbol.asyncIterator](): AsyncIterableIterator<T> {
-    const records = await this.toArray();
+    const records = await this;
     for (const record of records) {
       yield record;
     }
@@ -4518,7 +4518,7 @@ export class Relation<T extends Base> {
    * Mirrors: Enumerable#group_by (used on ActiveRecord::Relation)
    */
   async groupByColumn(keyOrFn: string | ((record: T) => unknown)): Promise<Record<string, T[]>> {
-    const records = await this.toArray();
+    const records = await this;
     const result: Record<string, T[]> = {};
     for (const record of records) {
       const key =
@@ -4537,7 +4537,7 @@ export class Relation<T extends Base> {
    * Mirrors: Enumerable#index_by (used on ActiveRecord::Relation)
    */
   async indexBy(keyOrFn: string | ((record: T) => unknown)): Promise<Record<string, T>> {
-    const records = await this.toArray();
+    const records = await this;
     const result: Record<string, T> = {};
     for (const record of records) {
       const key =
@@ -5932,7 +5932,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#extract_associated
    */
   async extractAssociated(name: string): Promise<Base[]> {
-    const records = await this.toArray();
+    const records = await this;
     const results: Base[] = [];
     for (const record of records) {
       const associated = await (record as any)[name]();
@@ -5981,7 +5981,7 @@ export class Relation<T extends Base> {
     if (id === undefined || (typeof id === "object" && id !== null && attrs === undefined)) {
       // update(attrs) form — update all matching records
       const updates = (id ?? {}) as Record<string, unknown>;
-      const records = await this.toArray();
+      const records = await this;
       for (const record of records) {
         await record.update(updates);
       }
@@ -6000,7 +6000,7 @@ export class Relation<T extends Base> {
   async updateBang(id?: unknown, attrs?: Record<string, unknown>): Promise<T | T[]> {
     if (id === undefined || (typeof id === "object" && id !== null && attrs === undefined)) {
       const updates = (id ?? {}) as Record<string, unknown>;
-      const records = await this.toArray();
+      const records = await this;
       for (const record of records) {
         await record.updateBang(updates);
       }
@@ -6204,8 +6204,8 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#==
    */
   async equals(other: Relation<T>): Promise<boolean> {
-    const a = await this.toArray();
-    const b = await other.toArray();
+    const a = await this;
+    const b = await other;
     if (a.length !== b.length) return false;
     return a.every((rec, i) => rec.isEqual(b[i]));
   }
@@ -6287,7 +6287,7 @@ export class Relation<T extends Base> {
    */
   async isNone(pattern?: EnumerablePattern<T>): Promise<boolean> {
     if (this._isEmptyRelation()) return true;
-    if (pattern !== undefined) return !(await this.toArray()).some(this._patternMatcher(pattern));
+    if (pattern !== undefined) return !(await this).some(this._patternMatcher(pattern));
     return this.isEmpty();
   }
 
@@ -6339,7 +6339,7 @@ export class Relation<T extends Base> {
       this._limitValue !== null ||
       !this._havingClause.isEmpty()
     ) {
-      const records = await this.toArray();
+      const records = await this;
       return records.some((r) => r.isEqual(record));
     }
     // Unloaded fast path: probe existence by primary key. Composite-PK models

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2264,7 +2264,7 @@ export class Relation<T extends Base> {
    */
   async isAny(pattern?: EnumerablePattern<T>): Promise<boolean> {
     if (this._isEmptyRelation()) return false;
-    if (pattern !== undefined) return (await this).some(this._patternMatcher(pattern));
+    if (pattern !== undefined) return (await this.toArray()).some(this._patternMatcher(pattern));
     if (this._loaded) return this._records.length > 0;
     return this.exists();
   }
@@ -2306,7 +2306,7 @@ export class Relation<T extends Base> {
   async _countMatching(pattern: EnumerablePattern<T>, limit: number): Promise<number> {
     const matches = this._patternMatcher(pattern);
     let count = 0;
-    for (const record of await this) {
+    for (const record of await this.toArray()) {
       if (matches(record) && ++count === limit) break;
     }
     return count;
@@ -2355,7 +2355,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#length
    */
   async length(): Promise<number> {
-    const records = await this;
+    const records = await this.toArray();
     return records.length;
   }
 
@@ -2365,7 +2365,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#reject (Ruby Enumerable)
    */
   async reject(fn: (record: T) => boolean): Promise<T[]> {
-    const records = await this;
+    const records = await this.toArray();
     return records.filter((r) => !fn(r));
   }
 
@@ -2377,7 +2377,7 @@ export class Relation<T extends Base> {
    * Mirrors: Enumerable#detect / #find (via Relation#include Enumerable)
    */
   async detect(fn: (record: T, index: number, all: T[]) => unknown): Promise<T | undefined> {
-    const records = await this;
+    const records = await this.toArray();
     return records.find(fn);
   }
 
@@ -2391,7 +2391,7 @@ export class Relation<T extends Base> {
    * Mirrors: Enumerable#sort_by (via Relation#include Enumerable)
    */
   async sortBy(key: (record: T) => any): Promise<T[]> {
-    const records = await this;
+    const records = await this.toArray();
     return records
       .map((record, index) => ({ record, index, sortKey: key(record) }))
       .sort((a, b) => {
@@ -2424,7 +2424,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#load
    */
   async load(): Promise<LoadedRelation<this>> {
-    await this;
+    await this.toArray();
     return stripThenable(this);
   }
 
@@ -2897,7 +2897,7 @@ export class Relation<T extends Base> {
    * Async iterator support — allows `for await (const record of relation)`.
    */
   async *[Symbol.asyncIterator](): AsyncIterableIterator<T> {
-    const records = await this;
+    const records = await this.toArray();
     for (const record of records) {
       yield record;
     }
@@ -4518,7 +4518,7 @@ export class Relation<T extends Base> {
    * Mirrors: Enumerable#group_by (used on ActiveRecord::Relation)
    */
   async groupByColumn(keyOrFn: string | ((record: T) => unknown)): Promise<Record<string, T[]>> {
-    const records = await this;
+    const records = await this.toArray();
     const result: Record<string, T[]> = {};
     for (const record of records) {
       const key =
@@ -4537,7 +4537,7 @@ export class Relation<T extends Base> {
    * Mirrors: Enumerable#index_by (used on ActiveRecord::Relation)
    */
   async indexBy(keyOrFn: string | ((record: T) => unknown)): Promise<Record<string, T>> {
-    const records = await this;
+    const records = await this.toArray();
     const result: Record<string, T> = {};
     for (const record of records) {
       const key =
@@ -5932,7 +5932,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#extract_associated
    */
   async extractAssociated(name: string): Promise<Base[]> {
-    const records = await this;
+    const records = await this.toArray();
     const results: Base[] = [];
     for (const record of records) {
       const associated = await (record as any)[name]();
@@ -5981,7 +5981,7 @@ export class Relation<T extends Base> {
     if (id === undefined || (typeof id === "object" && id !== null && attrs === undefined)) {
       // update(attrs) form — update all matching records
       const updates = (id ?? {}) as Record<string, unknown>;
-      const records = await this;
+      const records = await this.toArray();
       for (const record of records) {
         await record.update(updates);
       }
@@ -6000,7 +6000,7 @@ export class Relation<T extends Base> {
   async updateBang(id?: unknown, attrs?: Record<string, unknown>): Promise<T | T[]> {
     if (id === undefined || (typeof id === "object" && id !== null && attrs === undefined)) {
       const updates = (id ?? {}) as Record<string, unknown>;
-      const records = await this;
+      const records = await this.toArray();
       for (const record of records) {
         await record.updateBang(updates);
       }
@@ -6204,7 +6204,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#==
    */
   async equals(other: Relation<T>): Promise<boolean> {
-    const a = await this;
+    const a = await this.toArray();
     const b = await other;
     if (a.length !== b.length) return false;
     return a.every((rec, i) => rec.isEqual(b[i]));
@@ -6287,7 +6287,7 @@ export class Relation<T extends Base> {
    */
   async isNone(pattern?: EnumerablePattern<T>): Promise<boolean> {
     if (this._isEmptyRelation()) return true;
-    if (pattern !== undefined) return !(await this).some(this._patternMatcher(pattern));
+    if (pattern !== undefined) return !(await this.toArray()).some(this._patternMatcher(pattern));
     return this.isEmpty();
   }
 
@@ -6339,7 +6339,7 @@ export class Relation<T extends Base> {
       this._limitValue !== null ||
       !this._havingClause.isEmpty()
     ) {
-      const records = await this;
+      const records = await this.toArray();
       return records.some((r) => r.isEqual(record));
     }
     // Unloaded fast path: probe existence by primary key. Composite-PK models

--- a/packages/activerecord/src/relation/bound-sql-literal-relation.test.ts
+++ b/packages/activerecord/src/relation/bound-sql-literal-relation.test.ts
@@ -38,8 +38,8 @@ describe("bound SQL literal with Relation bind value", () => {
 
     expect(relation.toSql()).toContain("IN (SELECT");
 
-    const expected = sortedIds(await approved.toArray());
-    expect(sortedIds(await relation.toArray())).toEqual(expected);
+    const expected = sortedIds(await approved);
+    expect(sortedIds(await relation)).toEqual(expected);
     expect(expected.length).toBeGreaterThan(0);
   });
 
@@ -50,8 +50,8 @@ describe("bound SQL literal with Relation bind value", () => {
 
     expect(relation.toSql()).toContain("IN (SELECT");
 
-    const expected = sortedIds(await approved.toArray());
-    expect(sortedIds(await relation.toArray())).toEqual(expected);
+    const expected = sortedIds(await approved);
+    expect(sortedIds(await relation)).toEqual(expected);
     expect(expected.length).toBeGreaterThan(0);
   });
 
@@ -63,7 +63,7 @@ describe("bound SQL literal with Relation bind value", () => {
     // build_bound_sql_literal reduces the model to its id_for_database
     // (query_methods.rb:1707-1709) before the value reaches the quoter.
     expect(relation.toSql()).toContain(String(first));
-    const rows = await relation.toArray();
+    const rows = await relation;
     expect(rows.map((r) => Number(r.id))).toEqual([first]);
   });
 
@@ -72,7 +72,7 @@ describe("bound SQL literal with Relation bind value", () => {
     const topics = await Topic.where({ approved: true });
     const relation = Topic.where("id IN (?)", topics);
 
-    expect(sortedIds(await relation.toArray())).toEqual(ids);
+    expect(sortedIds(await relation)).toEqual(ids);
     expect(ids.length).toBeGreaterThan(0);
   });
 

--- a/packages/activerecord/src/relation/delegation.test.ts
+++ b/packages/activerecord/src/relation/delegation.test.ts
@@ -446,7 +446,7 @@ describe("DelegationTest", () => {
       // Same loaded relation, so index()/rindex() see the cached instances and
       // identity comparison matches.
       const relation = Comment.all();
-      const records = await relation.toArray();
+      const records = await relation;
       const mid = records[Math.floor(records.length / 2)];
       expect(await relation.index(mid)).toBe(records.findIndex((c) => c.id === mid.id));
       expect(await relation.rindex((c: any) => c.id === mid.id)).toBe(

--- a/packages/activerecord/src/relation/delete-all.test.ts
+++ b/packages/activerecord/src/relation/delete-all.test.ts
@@ -37,7 +37,7 @@ describe("DeleteAllTest", () => {
     const davids = Author.where({ name: "David" });
 
     // Force load
-    expect(await davids.toArray()).toEqual([authors("david")]);
+    expect(await davids).toEqual([authors("david")]);
     expect(davids.isLoaded).toBe(true);
 
     const destroyed = await davids.destroyAll();
@@ -45,7 +45,7 @@ describe("DeleteAllTest", () => {
     expect(destroyed[0].id).toBe(authors("david").id);
     expect(destroyed[0].isDestroyed()).toBe(true);
 
-    expect(await davids.toArray()).toEqual([]);
+    expect(await davids).toEqual([]);
   });
 
   it("delete all", async () => {
@@ -72,20 +72,20 @@ describe("DeleteAllTest", () => {
     const davids = Author.where({ name: "David" });
 
     // Force load
-    expect(await davids.toArray()).toEqual([authors("david")]);
+    expect(await davids).toEqual([authors("david")]);
     expect(davids.isLoaded).toBe(true);
 
     const before = (await Author.count()) as number;
     await davids.deleteAll();
     expect(await Author.count()).toBe(before - 1);
 
-    expect(await davids.toArray()).toEqual([]);
+    expect(await davids).toEqual([]);
     expect(davids.isLoaded).toBe(true);
   });
 
   it("delete all with group by and having", async () => {
     const minimumCommentsCount = 2;
-    const postsToBeDeleted = await Post.mostCommented(minimumCommentsCount).toArray();
+    const postsToBeDeleted = await Post.mostCommented(minimumCommentsCount);
     expect(postsToBeDeleted.length).toBeGreaterThan(0);
 
     const before = (await Post.count()) as number;

--- a/packages/activerecord/src/relation/field-ordered-values.test.ts
+++ b/packages/activerecord/src/relation/field-ordered-values.test.ts
@@ -22,13 +22,13 @@ describe("FieldOrderedValuesTest", () => {
     const order = [3, 4, 1];
     const posts = Post.inOrderOf("id", order);
 
-    expect((await posts.toArray()).map((p: any) => Number(p.id))).toEqual(order);
+    expect((await posts).map((p: any) => Number(p.id))).toEqual(order);
   });
 
   it("in order of empty", async () => {
     const posts = Post.inOrderOf("id", []);
 
-    expect(await posts.toArray()).toEqual([]);
+    expect(await posts).toEqual([]);
   });
 
   it("in order of with enums values", async () => {
@@ -39,10 +39,10 @@ describe("FieldOrderedValuesTest", () => {
 
     const order = ["written", "published", "proposed"];
     let books = Book.inOrderOf("status", order);
-    expect((await books.toArray()).map((b: any) => b.status)).toEqual(order);
+    expect((await books).map((b: any) => b.status)).toEqual(order);
 
     books = Book.inOrderOf("status", order);
-    expect((await books.toArray()).map((b: any) => b.status)).toEqual(order);
+    expect((await books).map((b: any) => b.status)).toEqual(order);
   });
 
   it("in order of with enums keys", async () => {
@@ -55,7 +55,7 @@ describe("FieldOrderedValuesTest", () => {
     const order = [statuses.written, statuses.published, statuses.proposed];
     const books = Book.inOrderOf("status", order);
 
-    expect((await books.toArray()).map((book: any) => statuses[book.status])).toEqual(order);
+    expect((await books).map((book: any) => statuses[book.status])).toEqual(order);
   });
 
   it("in order of expression", async () => {
@@ -65,7 +65,7 @@ describe("FieldOrderedValuesTest", () => {
       order.map((id) => id * 2),
     );
 
-    expect((await posts.toArray()).map((p: any) => Number(p.id))).toEqual(order);
+    expect((await posts).map((p: any) => Number(p.id))).toEqual(order);
   });
 
   it("in order of with string column", async () => {
@@ -76,19 +76,19 @@ describe("FieldOrderedValuesTest", () => {
 
     const order = ["hardcover", "paperback", "ebook"];
     let books = Book.inOrderOf("format", order);
-    expect((await books.toArray()).map((b: any) => b.format)).toEqual(order);
+    expect((await books).map((b: any) => b.format)).toEqual(order);
 
     books = Book.inOrderOf("format", order);
-    expect((await books.toArray()).map((b: any) => b.format)).toEqual(order);
+    expect((await books).map((b: any) => b.format)).toEqual(order);
   });
 
   it("in order of after regular order", async () => {
     const order = [3, 4, 1];
     let posts = Post.where({ type: "Post" }).order("type").inOrderOf("id", order);
-    expect((await posts.toArray()).map((p: any) => Number(p.id))).toEqual(order);
+    expect((await posts).map((p: any) => Number(p.id))).toEqual(order);
 
     posts = Post.where({ type: "Post" }).order("type").inOrderOf("id", order);
-    expect((await posts.toArray()).map((p: any) => Number(p.id))).toEqual(order);
+    expect((await posts).map((p: any) => Number(p.id))).toEqual(order);
   });
 
   it("in order of with nil", async () => {
@@ -99,10 +99,10 @@ describe("FieldOrderedValuesTest", () => {
 
     const order = ["ebook", null, "paperback"];
     let books = Book.inOrderOf("format", order);
-    expect((await books.toArray()).map((b: any) => b.format)).toEqual(order);
+    expect((await books).map((b: any) => b.format)).toEqual(order);
 
     books = Book.inOrderOf("format", order);
-    expect((await books.toArray()).map((b: any) => b.format)).toEqual(order);
+    expect((await books).map((b: any) => b.format)).toEqual(order);
   });
 
   it("in order of with associations", async () => {

--- a/packages/activerecord/src/relation/merging.test.ts
+++ b/packages/activerecord/src/relation/merging.test.ts
@@ -225,7 +225,7 @@ describe("RelationMergingTest", () => {
     // both so the comparison is between records, mirroring Rails' sync read.
     const expected = await (await Post.find(1)).lastComment;
     for (const rel of relations) {
-      const posts = await rel.toArray();
+      const posts = await rel;
       const post = posts.find((p: any) => Number(p.id) === 1);
       expect((await (post as any).lastComment)?.id).toEqual((expected as any)?.id);
     }

--- a/packages/activerecord/src/relation/or.test.ts
+++ b/packages/activerecord/src/relation/or.test.ts
@@ -190,9 +190,7 @@ describe("OrTest", () => {
       ...(await author.posts.toArray()),
       ...(await Post.where({ title: "I don't have any comments" })),
     ];
-    expect(byId(await actual.toArray()).map((p: any) => p.id)).toEqual(
-      byId(expected).map((p: any) => p.id),
-    );
+    expect(byId(await actual).map((p: any) => p.id)).toEqual(byId(expected).map((p: any) => p.id));
   });
 
   it("or with scope on association", async () => {

--- a/packages/activerecord/src/relation/thenable.test.ts
+++ b/packages/activerecord/src/relation/thenable.test.ts
@@ -127,7 +127,7 @@ describe("Thenable", () => {
     // The view is not a copy: loading through it marked the original loaded,
     // and both read the same records.
     expect(davids.isLoaded).toBe(true);
-    expect(await first.toArray()).toEqual(await davids.toArray());
+    expect(await first.toArray()).toEqual(await davids);
   });
 
   it("chaining load off a loaded relation does not nest views", async () => {

--- a/packages/activerecord/src/relation/update-all.test.ts
+++ b/packages/activerecord/src/relation/update-all.test.ts
@@ -97,7 +97,7 @@ describe("UpdateAllTest", () => {
   it("update all with scope", async () => {
     const tag = tags("general");
     await Post.taggedWith(tag.id as number).updateAll({ title: "rofl" });
-    const taggedPosts = await Post.taggedWith(tag.id as number).toArray();
+    const taggedPosts = await Post.taggedWith(tag.id as number);
     expect(taggedPosts.length).toBeGreaterThan(0);
     taggedPosts.forEach((post: any) => expect(post.title).toBe("rofl"));
   });
@@ -116,7 +116,7 @@ describe("UpdateAllTest", () => {
   it("update all with group by", async () => {
     const minimumCommentsCount = 2;
     await Post.mostCommented(minimumCommentsCount).updateAll({ title: "ig" });
-    const updatedPosts = await Post.mostCommented(minimumCommentsCount).toArray();
+    const updatedPosts = await Post.mostCommented(minimumCommentsCount);
     expect(updatedPosts.length).toBeGreaterThan(0);
     updatedPosts.forEach((post: any) => expect(post.title).toBe("ig"));
 

--- a/packages/activerecord/src/relation/where-chain.test.ts
+++ b/packages/activerecord/src/relation/where-chain.test.ts
@@ -426,7 +426,7 @@ describe("WhereChainTest", () => {
       .where({ body: "world" })
       .rewhere({ body: "hullo" });
     const expected = Post.where({ body: "hullo" });
-    expect(ids(await relation.toArray())).toEqual(ids(await expected.toArray()));
+    expect(ids(await relation)).toEqual(ids(await expected));
   });
 
   it("rewhere with multiple overwriting conditions", async () => {
@@ -434,7 +434,7 @@ describe("WhereChainTest", () => {
       .where({ type: "StiPost" })
       .rewhere({ body: "hullo", type: "Post" });
     const expected = Post.where({ body: "hullo", type: "Post" });
-    expect(ids(await relation.toArray())).toEqual(ids(await expected.toArray()));
+    expect(ids(await relation)).toEqual(ids(await expected));
   });
 
   it("rewhere with one overwriting condition and one unrelated", async () => {
@@ -442,7 +442,7 @@ describe("WhereChainTest", () => {
       .where({ type: "Post" })
       .rewhere({ body: "hullo" });
     const expected = Post.where({ body: "hullo", type: "Post" });
-    expect(ids(await relation.toArray())).toEqual(ids(await expected.toArray()));
+    expect(ids(await relation)).toEqual(ids(await expected));
   });
 
   it("rewhere with alias condition", async () => {
@@ -450,7 +450,7 @@ describe("WhereChainTest", () => {
       .where({ text: "world" })
       .rewhere({ text: "hullo" });
     const expected = Post.where({ text: "hullo" });
-    expect(ids(await relation.toArray())).toEqual(ids(await expected.toArray()));
+    expect(ids(await relation)).toEqual(ids(await expected));
   });
 
   it("rewhere with nested condition", async () => {
@@ -461,13 +461,13 @@ describe("WhereChainTest", () => {
     const expected = Post.leftJoins("comments").where({
       "comments.id": comments("does_it_hurt").id,
     });
-    expect(ids(await relation.toArray())).toEqual(ids(await expected.toArray()));
+    expect(ids(await relation)).toEqual(ids(await expected));
   });
 
   it("rewhere with polymorphic association", async () => {
     const relation = Essay.where({ writer: authors("david") }).rewhere({ writer: humans("steve") });
     const expected = Essay.where({ writer: humans("steve") });
-    expect(ids(await relation.toArray())).toEqual(ids(await expected.toArray()));
+    expect(ids(await relation)).toEqual(ids(await expected));
   });
 
   it("rewhere with range", async () => {
@@ -475,7 +475,7 @@ describe("WhereChainTest", () => {
       commentsCount: new Range(3, 5),
     });
     const expected = Post.where({ commentsCount: new Range(3, 5) });
-    expect(ids(await relation.toArray())).toEqual(ids(await expected.toArray()));
+    expect(ids(await relation)).toEqual(ids(await expected));
   });
 
   it("rewhere with infinite upper bound range", async () => {
@@ -483,7 +483,7 @@ describe("WhereChainTest", () => {
       commentsCount: new Range(3, 5),
     });
     const expected = Post.where({ commentsCount: new Range(3, 5) });
-    expect(ids(await relation.toArray())).toEqual(ids(await expected.toArray()));
+    expect(ids(await relation)).toEqual(ids(await expected));
   });
 
   it("rewhere with infinite lower bound range", async () => {
@@ -491,7 +491,7 @@ describe("WhereChainTest", () => {
       commentsCount: new Range(3, 5),
     });
     const expected = Post.where({ commentsCount: new Range(3, 5) });
-    expect(ids(await relation.toArray())).toEqual(ids(await expected.toArray()));
+    expect(ids(await relation)).toEqual(ids(await expected));
   });
 
   it("rewhere with infinite range", async () => {
@@ -499,12 +499,12 @@ describe("WhereChainTest", () => {
       commentsCount: new Range(3, 5),
     });
     const expected = Post.where({ commentsCount: new Range(3, 5) });
-    expect(ids(await relation.toArray())).toEqual(ids(await expected.toArray()));
+    expect(ids(await relation)).toEqual(ids(await expected));
   });
 
   it("rewhere with nil", async () => {
     const relation = Post.where({ commentsCount: 16 }).rewhere(null);
     const expected = Post.all();
-    expect(ids(await relation.toArray())).toEqual(ids(await expected.toArray()));
+    expect(ids(await relation)).toEqual(ids(await expected));
   });
 });

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -218,8 +218,8 @@ describe("RelationTest", () => {
     const topicsRel = Topic.all();
     expect(topicsRel.isLoaded).toBe(false);
     expect((topicsRel as any).loaded).toBe(false);
-    const arr1 = await topicsRel.toArray();
-    const arr2 = await topicsRel.toArray();
+    const arr1 = await topicsRel;
+    const arr2 = await topicsRel;
     expect(arr1).toHaveLength(5);
     expect(arr2).toHaveLength(5);
     expect(topicsRel.isLoaded).toBe(true);
@@ -259,8 +259,8 @@ describe("RelationTest", () => {
 
   it("reload", async () => {
     const topicsRel = Topic.all();
-    const arr1 = await topicsRel.toArray();
-    const arr2 = await topicsRel.toArray();
+    const arr1 = await topicsRel;
+    const arr2 = await topicsRel;
     expect(arr1).toHaveLength(5);
     expect(topicsRel.isLoaded).toBe(true);
 
@@ -273,7 +273,7 @@ describe("RelationTest", () => {
 
   it("finding with subquery", async () => {
     const relation = Topic.where({ approved: true });
-    const direct = await relation.toArray();
+    const direct = await relation;
     const fromSubquery = await Topic.select("*").from(relation);
     expect(fromSubquery.map((t) => t.id).sort()).toEqual(direct.map((t) => t.id).sort());
     const fromSubqueryNamed = await Topic.select("subquery.*").from(relation);
@@ -285,7 +285,7 @@ describe("RelationTest", () => {
   it("finding with subquery with binds", async () => {
     const post = await Post.first();
     const commentRel = Comment.where({ post_id: post!.id });
-    const direct = await commentRel.toArray();
+    const direct = await commentRel;
     const fromSubquery = await Comment.select("*").from(commentRel);
     expect(fromSubquery.map((c) => c.id).sort()).toEqual(direct.map((c) => c.id).sort());
     const fromSubqueryNamed = await Comment.select("subquery.*").from(commentRel);
@@ -307,9 +307,7 @@ describe("RelationTest", () => {
       .joins("INNER JOIN posts ON posts.id = comments.post_id")
       .select("comments.id")
       .order("comments.id");
-    expect((await relation.toArray()).map((c) => c.id)).toEqual(
-      (await subquery.toArray()).map((c) => c.id),
-    );
+    expect((await relation).map((c) => c.id)).toEqual((await subquery).map((c) => c.id));
   });
 
   it("pluck with from includes original table name", async () => {
@@ -330,9 +328,7 @@ describe("RelationTest", () => {
       .joins("INNER JOIN posts ON posts.id = comments.post_id")
       .select("comments.id")
       .order("comments.id");
-    expect((await relation.toArray()).map((c) => c.id)).toEqual(
-      (await subquery.toArray()).map((c) => c.id),
-    );
+    expect((await relation).map((c) => c.id)).toEqual((await subquery).map((c) => c.id));
   });
 
   it("pluck with from includes quoted original table name", async () => {
@@ -353,9 +349,7 @@ describe("RelationTest", () => {
       .joins("INNER JOIN posts ON posts.id = comments.post_id")
       .select("comments.id")
       .order("comments.id");
-    expect((await relation.toArray()).map((c) => c.id)).toEqual(
-      (await subquery.toArray()).map((c) => c.id),
-    );
+    expect((await relation).map((c) => c.id)).toEqual((await subquery).map((c) => c.id));
   });
 
   it("pluck with subquery in from uses original table name", async () => {
@@ -374,8 +368,8 @@ describe("RelationTest", () => {
       "type",
       "post_count",
     );
-    const relCounts = (await relation.toArray()).map((r: any) => r.post_count).sort();
-    const subCounts = (await subquery.toArray()).map((r: any) => r.post_count).sort();
+    const relCounts = (await relation).map((r: any) => r.post_count).sort();
+    const subCounts = (await subquery).map((r: any) => r.post_count).sort();
     expect(subCounts).toEqual(relCounts);
   });
 
@@ -388,7 +382,7 @@ describe("RelationTest", () => {
     // dynamic reader on the loaded record. COUNT() is a bigint on PG/MariaDB
     // while average() yields a number, so coerce both to Number for comparison
     // (Rails compares BigDecimal == Integer loosely).
-    const relCounts = (await relation.toArray()).map((r: any) => Number(r.post_count)).sort();
+    const relCounts = (await relation).map((r: any) => Number(r.post_count)).sort();
     const subValues = [...((await subquery) as Map<unknown, number>).values()].map(Number).sort();
     expect(subValues).toEqual(relCounts);
   });
@@ -398,8 +392,8 @@ describe("RelationTest", () => {
     const subquery = Comment.from(
       `(${await relation.toSql()}) ${Comment.tableName}_grouped`,
     ).select("type", "post_count");
-    const relCounts = (await relation.toArray()).map((r: any) => r.post_count).sort();
-    const subCounts = (await subquery.toArray()).map((r: any) => r.post_count).sort();
+    const relCounts = (await relation).map((r: any) => r.post_count).sort();
+    const subCounts = (await subquery).map((r: any) => r.post_count).sort();
     expect(subCounts).toEqual(relCounts);
   });
 
@@ -408,7 +402,7 @@ describe("RelationTest", () => {
     const subquery = Comment.from(`(${await relation.toSql()}) ${Comment.tableName}_grouped`)
       .group("type")
       .average("post_count");
-    const relCounts = (await relation.toArray()).map((r: any) => Number(r.post_count)).sort();
+    const relCounts = (await relation).map((r: any) => Number(r.post_count)).sort();
     const subValues = [...((await subquery) as Map<unknown, number>).values()].map(Number).sort();
     expect(subValues).toEqual(relCounts);
   });
@@ -417,7 +411,7 @@ describe("RelationTest", () => {
     const relation = Comment.includes("post")
       .where({ "posts.type": "Post" })
       .order(Symbol.for("id"));
-    const expected = (await relation.toArray()).map((c) => c.id);
+    const expected = (await relation).map((c) => c.id);
     expect((await Comment.select("*").from(relation)).map((c) => c.id)).toEqual(expected);
     expect((await Comment.select("subquery.*").from(relation)).map((c) => c.id)).toEqual(expected);
     expect((await Comment.select("a.*").from(relation, "a")).map((c) => c.id)).toEqual(expected);
@@ -446,7 +440,7 @@ describe("RelationTest", () => {
 
   it("finding with subquery with eager loading in where", async () => {
     const relation = Comment.includes("post").where({ "posts.type": "Post" });
-    const expected = (await relation.toArray()).map((c) => Number(c.id)).sort((a, b) => a - b);
+    const expected = (await relation).map((c) => Number(c.id)).sort((a, b) => a - b);
     expect(
       (await Comment.where({ id: relation })).map((c) => Number(c.id)).sort((a, b) => a - b),
     ).toEqual(expected);
@@ -583,7 +577,7 @@ describe("RelationTest", () => {
 
   it("finding with desc order with string", async () => {
     const topicsRel = Topic.order({ id: "desc" });
-    const arr = await topicsRel.toArray();
+    const arr = await topicsRel;
     expect(arr).toHaveLength(5);
     expect(arr.map((t) => t.id)).toEqual([
       topics("fifth").id,
@@ -596,7 +590,7 @@ describe("RelationTest", () => {
 
   it("finding with asc order with string", async () => {
     const topicsRel = Topic.order({ id: "asc" });
-    const arr = await topicsRel.toArray();
+    const arr = await topicsRel;
     expect(arr).toHaveLength(5);
     expect(arr.map((t) => t.id)).toEqual([
       topics("first").id,
@@ -859,7 +853,7 @@ describe("RelationTest", () => {
   it("find with preloaded associations", async () => {
     const posts1 = await Post.preload("comments").order("posts.id");
     const firstPost = posts1.find((p) => Number(p.id) === 1)!;
-    const firstComments = await firstPost.comments.toArray();
+    const firstComments = await firstPost.comments;
     expect(firstComments.length).toBeGreaterThan(0);
 
     const posts2 = await Post.preload("author").order("posts.id");
@@ -879,7 +873,7 @@ describe("RelationTest", () => {
 
   it("find with included associations", async () => {
     const posts1 = await Post.includes("comments").order("posts.id");
-    const firstComments = await posts1[0].comments.toArray();
+    const firstComments = await posts1[0].comments;
     expect(firstComments.length).toBeGreaterThan(0);
 
     const posts2 = await Post.includes("author").order("posts.id");
@@ -957,7 +951,7 @@ describe("RelationTest", () => {
       .where({ title: "Uhuu" });
     const resultPosts = await PostWithPreloadDefaultScope.all().merge(postRel);
     expect(resultPosts).toHaveLength(1);
-    const preloadedReaders = await resultPosts[0].readers.toArray();
+    const preloadedReaders = await resultPosts[0].readers;
     expect(preloadedReaders).toHaveLength(1);
     expect(Number(preloadedReaders[0].post_id)).toBe(Number(post.id));
 
@@ -965,7 +959,7 @@ describe("RelationTest", () => {
     const postRel2 = PostWithIncludesDefaultScope.includes("readers").where({ title: "Uhuu" });
     const resultPosts2 = await PostWithIncludesDefaultScope.all().merge(postRel2);
     expect(resultPosts2).toHaveLength(1);
-    const includedReaders = await resultPosts2[0].readers.toArray();
+    const includedReaders = await resultPosts2[0].readers;
     expect(includedReaders).toHaveLength(1);
     expect(Number(includedReaders[0].post_id)).toBe(Number(post.id));
   });
@@ -973,12 +967,12 @@ describe("RelationTest", () => {
   it("loading with one association", async () => {
     const allPosts = await Post.preload("comments");
     const post = allPosts.find((p) => Number(p.id) === 1)!;
-    const postComments = await post.comments.toArray();
+    const postComments = await post.comments;
     expect(postComments).toHaveLength(2);
     expect(postComments.map((c: any) => c.id)).toContain(comments("greetings").id);
 
     const post2 = await Post.where({ title: "Welcome to the weblog" }).preload("comments").first();
-    const post2Comments = await post2!.comments.toArray();
+    const post2Comments = await post2!.comments;
     expect(post2Comments).toHaveLength(2);
     expect(post2Comments.map((c: any) => c.id)).toContain(comments("greetings").id);
 
@@ -1103,7 +1097,7 @@ describe("RelationTest", () => {
       .where({ name: david.name })
       .where({ name: "Santiago" })
       .where({ id: david.id });
-    expect(await relation.toArray()).toEqual([]);
+    expect(await relation).toEqual([]);
   });
 
   it("multi where ands queries", () => {
@@ -1119,7 +1113,7 @@ describe("RelationTest", () => {
       (memo, param) => memo.where(param),
       Author.unscoped(),
     );
-    expect(await relation.toArray()).toEqual([]);
+    expect(await relation).toEqual([]);
   });
 
   it("typecasting where with array", async () => {
@@ -1133,15 +1127,15 @@ describe("RelationTest", () => {
   it("find all using where with relation", async () => {
     const david = authors("david");
     const rel1 = Author.where({ id: Author.where({ id: david.id }) });
-    expect((await rel1.toArray()).map((a) => a.id)).toEqual([david.id]);
+    expect((await rel1).map((a) => a.id)).toEqual([david.id]);
 
     const rel2 = Author.where("id in (?)", Author.where({ id: david.id }).select("id"));
-    expect((await rel2.toArray()).map((a) => a.id)).toEqual([david.id]);
+    expect((await rel2).map((a) => a.id)).toEqual([david.id]);
 
     const rel3 = Author.where("id in (:author_ids)", {
       author_ids: Author.where({ id: david.id }).select("id"),
     });
-    expect((await rel3.toArray()).map((a) => a.id)).toEqual([david.id]);
+    expect((await rel3).map((a) => a.id)).toEqual([david.id]);
   });
 
   it("find all using where with relation with bound values", async () => {
@@ -1161,7 +1155,7 @@ describe("RelationTest", () => {
   it("find all using where with relation and alternate primary key", async () => {
     const coolFirst = minivans("cool_first");
     const rel = Minivan.where({ minivan_id: Minivan.where({ name: coolFirst.name }) });
-    expect((await rel.toArray()).map((m) => m.minivan_id)).toEqual([coolFirst.minivan_id]);
+    expect((await rel).map((m) => m.minivan_id)).toEqual([coolFirst.minivan_id]);
   });
 
   it("find all using where with relation with no selects and composite primary key raises", async () => {
@@ -1186,7 +1180,7 @@ describe("RelationTest", () => {
     const david = authors("david");
     const subquery = Author.where({ id: david.id });
     const rel = Author.where({ id: subquery });
-    expect((await rel.toArray()).map((a) => a.id)).toEqual([david.id]);
+    expect((await rel).map((a) => a.id)).toEqual([david.id]);
     expect((subquery as any)._selectColumns ?? []).toHaveLength(0);
   });
 
@@ -1195,13 +1189,13 @@ describe("RelationTest", () => {
     const rel = Author.where({
       id: Author.joins("INNER JOIN posts ON posts.author_id = authors.id").where({ id: david.id }),
     });
-    expect((await rel.toArray()).map((a) => a.id)).toEqual([david.id]);
+    expect((await rel).map((a) => a.id)).toEqual([david.id]);
   });
 
   it("find all using where with relation with select to build subquery", async () => {
     const david = authors("david");
     const rel = Author.where({ name: Author.where({ id: david.id }).select("name") });
-    expect((await rel.toArray()).map((a) => a.id)).toEqual([david.id]);
+    expect((await rel).map((a) => a.id)).toEqual([david.id]);
   });
 
   it("last", async () => {
@@ -1271,19 +1265,19 @@ describe("RelationTest", () => {
   it("size with eager loading and custom order", async () => {
     const postsRel = Post.includes("comments").order("comments.id");
     expect(await postsRel.size()).toBe(11);
-    expect((await postsRel.toArray()).length).toBe(11);
+    expect((await postsRel).length).toBe(11);
   });
 
   it("size with eager loading and custom select and order", async () => {
     const postsRel = Post.includes("comments").order("comments.id").select("type");
     expect(await postsRel.size()).toBe(11);
-    expect((await postsRel.toArray()).length).toBe(11);
+    expect((await postsRel).length).toBe(11);
   });
 
   it("size with eager loading and custom order and distinct", async () => {
     const postsRel = Post.includes("comments").order("comments.id").distinct();
     expect(await postsRel.size()).toBe(11);
-    expect((await postsRel.toArray()).length).toBe(11);
+    expect((await postsRel).length).toBe(11);
   });
 
   it("size with eager loading and manual distinct select and custom order", () => {
@@ -1315,7 +1309,7 @@ describe("RelationTest", () => {
 
     const bestPosts = postsRel.where({ commentsCount: 0 });
     await bestPosts.load();
-    expect((await bestPosts.toArray()).length).toBe(6);
+    expect((await bestPosts).length).toBe(6);
   });
 
   it("size with limit", async () => {
@@ -1325,7 +1319,7 @@ describe("RelationTest", () => {
 
     const bestPosts = postsRel.where({ commentsCount: 0 });
     await bestPosts.load();
-    expect((await bestPosts.toArray()).length).toBe(6);
+    expect((await bestPosts).length).toBe(6);
   });
 
   it("size with zero limit", async () => {
@@ -1471,10 +1465,10 @@ describe("RelationTest", () => {
   it("to a should dup target", async () => {
     const postsRel = Post.all();
     const originalSize = await postsRel.size();
-    const arr = await postsRel.toArray();
+    const arr = await postsRel;
     const removed = arr.pop()!;
     expect(await postsRel.size()).toBe(originalSize);
-    expect((await postsRel.toArray()).map((p) => p.id)).toContain(removed.id);
+    expect((await postsRel).map((p) => p.id)).toContain(removed.id);
   });
 
   it("build", () => {
@@ -1880,10 +1874,10 @@ describe("RelationTest", () => {
 
   it("except", async () => {
     const relation = Post.where({ author_id: 1 }).order("id ASC").limit(1);
-    expect((await relation.toArray()).map((p) => p.id)).toEqual([posts("welcome").id]);
+    expect((await relation).map((p) => p.id)).toEqual([posts("welcome").id]);
 
     const authorPosts = relation.except("order", "limit");
-    const authorPostsArr = (await authorPosts.toArray()).sort(
+    const authorPostsArr = (await authorPosts).sort(
       (a: Post, b: Post) => Number(a.id) - Number(b.id),
     );
     const directPosts = (await Post.where({ author_id: 1 })).sort(
@@ -1894,20 +1888,20 @@ describe("RelationTest", () => {
 
   it("except with unrecognized key is a no-op", async () => {
     const relation = Post.where({ author_id: 1 }).order("id ASC").limit(1);
-    const baseline = (await relation.toArray()).map((p) => p.id);
+    const baseline = (await relation).map((p) => p.id);
 
     // Rails' `values.except(*skips)` silently ignores unknown keys; the widened
     // skip type lets `except("bogus")` typecheck without a cast.
     const unchanged = relation.except("bogus");
-    expect((await unchanged.toArray()).map((p) => p.id)).toEqual(baseline);
+    expect((await unchanged).map((p) => p.id)).toEqual(baseline);
   });
 
   it("only", async () => {
     const relation = Post.where({ author_id: 1 }).order("id ASC").limit(1);
-    expect((await relation.toArray()).map((p) => p.id)).toEqual([posts("welcome").id]);
+    expect((await relation).map((p) => p.id)).toEqual([posts("welcome").id]);
 
     const authorPosts = relation.only("where");
-    const authorPostsArr = (await authorPosts.toArray()).sort(
+    const authorPostsArr = (await authorPosts).sort(
       (a: Post, b: Post) => Number(a.id) - Number(b.id),
     );
     const directPosts = (await Post.where({ author_id: 1 })).sort(
@@ -1916,7 +1910,7 @@ describe("RelationTest", () => {
     expect(authorPostsArr.map((p) => p.id)).toEqual(directPosts.map((p) => p.id));
 
     const allPosts = relation.only("order");
-    const allArr = await allPosts.toArray();
+    const allArr = await allPosts;
     expect(allArr.map((p) => p.id)).toEqual((await Post.order("id ASC")).map((p) => p.id));
   });
 
@@ -1983,7 +1977,7 @@ describe("RelationTest", () => {
   it("intersection with array", async () => {
     const relation = Author.where({ name: "David" });
     const railsAuthor = await relation.first();
-    const arr = await relation.toArray();
+    const arr = await relation;
     expect(arr.some((a) => a.id === railsAuthor!.id)).toBe(true);
   });
 
@@ -2015,8 +2009,8 @@ describe("RelationTest", () => {
     const post = await Post.first();
     const havingThenWhere = Post.having({ id: post!.id }).where({ title: post!.title }).group("id");
     const whereThenHaving = Post.where({ title: post!.title }).having({ id: post!.id }).group("id");
-    expect((await havingThenWhere.toArray()).map((p) => p.id)).toEqual([post!.id]);
-    expect((await whereThenHaving.toArray()).map((p) => p.id)).toEqual([post!.id]);
+    expect((await havingThenWhere).map((p) => p.id)).toEqual([post!.id]);
+    expect((await whereThenHaving).map((p) => p.id)).toEqual([post!.id]);
   });
 
   it("multiple where and having clauses", async () => {
@@ -2026,7 +2020,7 @@ describe("RelationTest", () => {
       .having({ id: post!.id })
       .where({ title: post!.title })
       .group("id");
-    expect((await havingThenWhere.toArray()).map((p) => p.id)).toEqual([post!.id]);
+    expect((await havingThenWhere).map((p) => p.id)).toEqual([post!.id]);
   });
 
   it("grouping by column with reserved name", async () => {
@@ -2225,14 +2219,14 @@ describe("RelationTest", () => {
     const filtered = rel.where({ approved: false });
     // Original relation should still be loaded
     expect(rel.isLoaded).toBe(true);
-    expect(await rel.toArray()).not.toHaveLength(0);
-    const filteredRecords = await filtered.toArray();
+    expect(await rel).not.toHaveLength(0);
+    const filteredRecords = await filtered;
     expect(Array.isArray(filteredRecords)).toBe(true);
   });
 
   it("loaded relations cannot be mutated by single value methods", async () => {
     const rel = Topic.all();
-    await rel.toArray();
+    await rel;
     expect(rel.isLoaded).toBe(true);
     const limited = rel.limit(1);
     expect(rel.isLoaded).toBe(true);
@@ -2243,7 +2237,7 @@ describe("RelationTest", () => {
     const rel = Topic.all();
     await rel.load();
     const merged = rel.merge(Topic.where({ approved: false }));
-    expect(await rel.toArray()).not.toHaveLength(0);
+    expect(await rel).not.toHaveLength(0);
     expect(merged).not.toBe(rel);
   });
 
@@ -2290,7 +2284,7 @@ describe("RelationTest", () => {
 
   it("already-loaded relations don't perform a new query in #inspect", async () => {
     const relation = Post.limit(2);
-    await relation.toArray();
+    await relation;
     const str = relation.inspect();
     expect(str).toContain("id: 1");
     expect(str).toContain("id: 2");
@@ -2314,7 +2308,7 @@ describe("RelationTest", () => {
 
   it("already-loaded relations don't perform a new query in #pretty_print", async () => {
     const relation = Post.limit(2);
-    await relation.toArray();
+    await relation;
     const str = relation.inspect();
     expect(typeof str).toBe("string");
   });
@@ -2370,7 +2364,7 @@ describe("RelationTest", () => {
     // Rails asserts `assert_equal relation, relation.load` (relations_test.rb:2193) —
     // equality, not identity. `load` returns a then-less view of the same relation.
     expect(loaded).toEqual(relation);
-    const arr = await relation.toArray();
+    const arr = await relation;
     expect(arr).toHaveLength(11);
   });
 
@@ -2429,8 +2423,8 @@ describe("RelationTest", () => {
     const p0 = Post.where({ author_id: 0 });
     const p1 = Post.where({ author_id: 1, commentsCount: 1 });
 
-    expect((await p0.toArray()).map((p) => p.id)).toEqual([posts("authorless").id]);
-    expect((await p1.toArray()).map((p) => p.id)).toEqual([posts("thinking").id]);
+    expect((await p0).map((p) => p.id)).toEqual([posts("authorless").id]);
+    expect((await p1).map((p) => p.id)).toEqual([posts("thinking").id]);
 
     const commentsResult = await Comment.merge(p0)
       .unscope({ where: "author_id" })
@@ -2459,7 +2453,7 @@ describe("RelationTest", () => {
     const postsByMary = await Post.where({ author_id: mary.id }).order("id");
 
     const unscoped = Post.where({ author_id: mary.id }).order("id").unscope({ where: "author_id" });
-    const unscopedArr = await unscoped.toArray();
+    const unscopedArr = await unscoped;
     expect(unscopedArr.length).toBeGreaterThan(postsByMary.length);
   });
 
@@ -2471,13 +2465,13 @@ describe("RelationTest", () => {
     let commentsRel = Comment.joins("INNER JOIN posts ON posts.id = comments.post_id").where({
       "posts.id": thinkingId,
     });
-    expect((await commentsRel.toArray()).map((c) => c.id)).toEqual([doesItHurtId]);
+    expect((await commentsRel).map((c) => c.id)).toEqual([doesItHurtId]);
 
     commentsRel = commentsRel.where({ id: greetingsId });
-    expect(await commentsRel.toArray()).toHaveLength(0);
+    expect(await commentsRel).toHaveLength(0);
 
     const unscoped = commentsRel.unscope({ where: "posts.id" });
-    expect((await unscoped.toArray()).map((c) => c.id)).toEqual([greetingsId]);
+    expect((await unscoped).map((c) => c.id)).toEqual([greetingsId]);
   });
 
   it("unscope with table name qualified hash", () => {
@@ -2518,7 +2512,7 @@ describe("RelationTest", () => {
 
   it("relation join method", async () => {
     const post = await Post.first();
-    const commentBodies = (await post!.comments.toArray()).map((c: any) => c.body);
+    const commentBodies = (await post!.comments).map((c: any) => c.body);
     expect(commentBodies.join(",")).toContain("Thank you");
   });
 

--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -539,7 +539,7 @@ describe("DefaultScopingTest", () => {
   it("additional conditions are ANDed with the default scope", async () => {
     const scope = DeveloperCalledJamis.where({ name: "David" });
     expect((scope as any)._whereClause.ast.children.length).toBe(2);
-    expect(await scope.toArray()).toEqual([]);
+    expect(await scope).toEqual([]);
   });
 
   it("additional conditions in a scope are ANDed with the default scope", async () => {
@@ -601,7 +601,7 @@ describe("DefaultScopingTest", () => {
   it("unscope eager load", async () => {
     const expected = names(await Developer.all());
     const received = Developer.eagerLoad("projects").select("id").unscope("eagerLoad", "select");
-    const rows = await received.toArray();
+    const rows = await received;
     expect(names(rows)).toEqual(expected);
     expect((rows[0] as any).projects.loaded).toBe(false);
   });
@@ -609,7 +609,7 @@ describe("DefaultScopingTest", () => {
   it("unscope preloads", async () => {
     const expected = names(await Developer.all());
     const received = Developer.preload("projects").select("id").unscope("preload", "select");
-    const rows = await received.toArray();
+    const rows = await received;
     expect(names(rows)).toEqual(expected);
     expect((rows[0] as any).projects.loaded).toBe(false);
   });

--- a/packages/activerecord/src/scoping/named-scoping.test.ts
+++ b/packages/activerecord/src/scoping/named-scoping.test.ts
@@ -53,39 +53,39 @@ describe("NamedScopingTest", () => {
 
   it("implements enumerable", async () => {
     expect((await Topic.all()).length).toBeGreaterThan(0);
-    expect(ids(await Topic.base().toArray())).toEqual(ids(await Topic.all()));
+    expect(ids(await Topic.base())).toEqual(ids(await Topic.all()));
     expect((await Topic.base().first())!.id).toBe((await Topic.first())!.id);
   });
 
   it("found items are cached", async () => {
     const allPosts = Topic.base();
     const sql = await capSql(async () => {
-      await allPosts.toArray();
-      await allPosts.toArray();
+      await allPosts;
+      await allPosts;
     });
     expect(sql.length).toBe(1);
   });
 
   it("reload expires cache of found items", async () => {
     const allPosts = Topic.base();
-    await allPosts.toArray();
+    await allPosts;
 
     const newPost = (await Topic.create({})) as any;
-    expect(ids(await allPosts.toArray())).not.toContain(newPost.id);
+    expect(ids(await allPosts)).not.toContain(newPost.id);
     await allPosts.reload();
-    expect(ids(await allPosts.toArray())).toContain(newPost.id);
+    expect(ids(await allPosts)).toContain(newPost.id);
   });
 
   it("delegates finds and calculations to the base class", async () => {
     expect((await Topic.all()).length).toBeGreaterThan(0);
-    expect(ids(await Topic.base().toArray())).toEqual(ids(await Topic.all()));
+    expect(ids(await Topic.base())).toEqual(ids(await Topic.all()));
     expect((await Topic.count()) as number).toBe(await Topic.base().count());
   });
 
   it("calling merge at first in scope", async () => {
     Topic.scope("callingMergeAtFirstInScope", (q: any) => q.merge(Topic.replied()));
     expect(ids(await (Topic as any).callingMergeAtFirstInScope().toArray())).toEqual(
-      ids(await Topic.replied().toArray()),
+      ids(await Topic.replied()),
     );
   });
 
@@ -102,8 +102,8 @@ describe("NamedScopingTest", () => {
   });
 
   it("define scope for reserved words", async () => {
-    expect((await Topic.true().toArray()).every((t: any) => t.approved === true)).toBe(true);
-    expect((await Topic.false().toArray()).every((t: any) => t.approved !== true)).toBe(true);
+    expect((await Topic.true()).every((t: any) => t.approved === true)).toBe(true);
+    expect((await Topic.false()).every((t: any) => t.approved !== true)).toBe(true);
   });
 
   it("scope should respond to own methods and methods of the proxy", () => {
@@ -114,7 +114,7 @@ describe("NamedScopingTest", () => {
 
   it("scopes with options limit finds to those matching the criteria specified", async () => {
     expect((await Topic.where({ approved: true })).length).toBeGreaterThan(0);
-    expect(sortedIds(await Topic.approved().toArray())).toEqual(
+    expect(sortedIds(await Topic.approved())).toEqual(
       sortedIds(await Topic.where({ approved: true })),
     );
     expect(await Topic.approved().count()).toBe(await Topic.where({ approved: true }).count());
@@ -141,14 +141,12 @@ describe("NamedScopingTest", () => {
     const beforeThird = sortedIds(await Topic.where("written_on < ?", third.written_on));
     const beforeSecond = sortedIds(await Topic.where("written_on < ?", second.written_on));
     expect(beforeThird).not.toEqual(beforeSecond);
-    expect(sortedIds(await Topic.writtenBefore(third.written_on).toArray())).toEqual(beforeThird);
-    expect(sortedIds(await Topic.writtenBefore(second.written_on).toArray())).toEqual(beforeSecond);
+    expect(sortedIds(await Topic.writtenBefore(third.written_on))).toEqual(beforeThird);
+    expect(sortedIds(await Topic.writtenBefore(second.written_on))).toEqual(beforeSecond);
   });
 
   it("procedural scopes returning nil", async () => {
-    expect(sortedIds(await Topic.writtenBefore(null).toArray())).toEqual(
-      sortedIds(await Topic.all()),
-    );
+    expect(sortedIds(await Topic.writtenBefore(null))).toEqual(sortedIds(await Topic.all()));
   });
 
   // Rails' `scope_stats`/`klass_stats` mutate a passed stats hash with a `count`
@@ -170,17 +168,17 @@ describe("NamedScopingTest", () => {
   });
 
   it("scope with object", async () => {
-    const objects = await Topic.withObject().toArray();
+    const objects = await Topic.withObject();
     expect(objects.length).toBeGreaterThan(0);
     expect(objects.every((t: any) => t.approved === true)).toBe(true);
   });
 
   it("scope with kwargs", async () => {
-    const approved = await Topic.withKwargs(true).toArray();
+    const approved = await Topic.withKwargs(true);
     expect(approved.length).toBeGreaterThan(0);
     expect(approved.every((t: any) => t.approved === true)).toBe(true);
 
-    const none = await Topic.withKwargs().toArray();
+    const none = await Topic.withKwargs();
     expect(none.every((t: any) => t.approved !== true)).toBe(true);
   });
 
@@ -258,12 +256,12 @@ describe("NamedScopingTest", () => {
 
   it("active records have scope named  all  ", async () => {
     expect((await Topic.all()).length).toBeGreaterThan(0);
-    expect(ids(await Topic.base().toArray())).toEqual(ids(await Topic.all()));
+    expect(ids(await Topic.base())).toEqual(ids(await Topic.all()));
   });
 
   it("active records have scope named  scoped  ", async () => {
     const scope = Topic.where("content LIKE '%Have%'");
-    expect((await scope.toArray()).length).toBeGreaterThan(0);
+    expect((await scope).length).toBeGreaterThan(0);
   });
 
   it("first and last should allow integers for limit", async () => {
@@ -550,7 +548,7 @@ describe("NamedScopingTest", () => {
       id: Topic.children().select("parent_id"),
     });
     expect(sortedIds(await (Topic as any).rejected().hasChildren().toArray())).toEqual(
-      sortedIds(await expected.toArray()),
+      sortedIds(await expected),
     );
   });
 
@@ -561,7 +559,7 @@ describe("NamedScopingTest", () => {
   it("nested scoping", async () => {
     const expected = Reply.approved();
     const got = await (Topic as any).rejected().nestedScoping(expected).toArray();
-    expect(ids(got)).toEqual(ids(await expected.toArray()));
+    expect(ids(got)).toEqual(ids(await expected));
   });
 
   it("scopes batch finders", async () => {
@@ -600,7 +598,7 @@ describe("NamedScopingTest", () => {
 
   it("index on scope", async () => {
     const approved = Topic.approved().order("id ASC");
-    const arr = await approved.toArray();
+    const arr = await approved;
     expect(arr[0].id).toBe(topics("second").id);
     expect(approved.isLoaded).toBe(true);
   });

--- a/packages/activerecord/src/scoping/relation-scoping.test.ts
+++ b/packages/activerecord/src/scoping/relation-scoping.test.ts
@@ -60,16 +60,14 @@ describe("RelationScopingTest", () => {
   it("scope breaks caching on collections", async () => {
     let author = authors("david");
     await author.reload();
-    const ids = (await association(author, "specialPostsWithDefaultScope").toArray()).map(
-      (p: any) => p.id,
-    );
+    const ids = (await association(author, "specialPostsWithDefaultScope")).map((p: any) => p.id);
     expect(ids.map(Number).sort((a, b) => a - b)).toEqual([1, 5, 6]);
     const scopedPosts = await SpecialPostWithDefaultScope.unscoped(async () => {
       author = authors("david");
       await author.reload();
       return association(author, "specialPostsWithDefaultScope").toArray();
     });
-    const expected = (await association(author, "posts").toArray())
+    const expected = (await association(author, "posts"))
       .map((p: any) => p.id)
       .sort((a: number, b: number) => (a < b ? -1 : a > b ? 1 : 0));
     expect(
@@ -374,7 +372,7 @@ describe("RelationScopingTest", () => {
   it("scoping is correctly restored", async () => {
     await Comment.unscoped(async () => {
       await SpecialComment.unscoped(async () => {
-        await SpecialComment.created().toArray();
+        await SpecialComment.created();
       });
     });
     expect(Comment.currentScope).toBeNull();

--- a/packages/activerecord/src/strict-loading.test.ts
+++ b/packages/activerecord/src/strict-loading.test.ts
@@ -103,7 +103,7 @@ describe("StrictLoadingTest", () => {
     developer!.strictLoadingBang(false);
     expect(developer!.isStrictLoading()).toBe(false);
 
-    await association(developer!, "auditLogs").toArray();
+    await association(developer!, "auditLogs");
 
     developer!.strictLoadingBang(true, { mode: "n_plus_one_only" });
     expect(developer!.isStrictLoadingNPlusOneOnly()).toBe(true);
@@ -121,14 +121,14 @@ describe("StrictLoadingTest", () => {
     developer!.strictLoadingBang(true, { mode: "n_plus_one_only" });
     expect(developer!.isStrictLoading()).toBe(true);
 
-    const projects = await association(developer!, "projects").toArray();
+    const projects = await association(developer!, "projects");
 
     expect(projects.every((p) => p.isStrictLoading())).toBe(true);
     await expect(
       (projects[projects.length - 1] as any).association("firm").loadTarget(),
     ).rejects.toThrow(StrictLoadingViolationError);
 
-    const projectsExt = await association(developer!, "projectsExtendedByName").toArray();
+    const projectsExt = await association(developer!, "projectsExtendedByName");
     expect(projectsExt.every((p) => p.isStrictLoading())).toBe(true);
     await expect(
       (projectsExt[projectsExt.length - 1] as any).association("firm").loadTarget(),
@@ -149,7 +149,7 @@ describe("StrictLoadingTest", () => {
 
     // Does not raise when a belongs_to association (:ship) loads its has_many (:parts)
     const loadedShip = (await (developer as any).association("ship").loadTarget()) as Ship;
-    const parts = await association(loadedShip, "parts").toArray();
+    const parts = await association(loadedShip, "parts");
 
     // strict_loading is not enabled on the belongs_to target
     expect(loadedShip.isStrictLoading()).toBe(false);
@@ -384,7 +384,7 @@ describe("StrictLoadingTest", () => {
       const devs = await Developer.all().includes("auditLogs");
 
       for (const d of devs) {
-        await association(d, "auditLogs").toArray();
+        await association(d, "auditLogs");
       }
 
       // Reload and re-access
@@ -393,7 +393,7 @@ describe("StrictLoadingTest", () => {
       }
 
       for (const d of devs) {
-        await association(d, "auditLogs").toArray();
+        await association(d, "auditLogs");
       }
     });
   });
@@ -405,11 +405,11 @@ describe("StrictLoadingTest", () => {
       await AuditLog.create({ developer_id: dev0!.id, message: "M" });
 
       const dev = (await Developer.all().includes("auditLogs").first())!;
-      await association(dev, "auditLogs").toArray();
+      await association(dev, "auditLogs");
 
       await dev.reload();
 
-      await association(dev, "auditLogs").toArray();
+      await association(dev, "auditLogs");
     });
   });
 
@@ -815,7 +815,7 @@ describe("StrictLoadingTest", () => {
       logged = true;
     });
     try {
-      await association(developer!, "auditLogs").toArray();
+      await association(developer!, "auditLogs");
       expect(logged).toBe(true);
     } finally {
       Notifications.unsubscribe(sub);
@@ -890,7 +890,7 @@ describe("StrictLoadingFixturesTest", () => {
       expect(fixtureZine.isStrictLoading()).toBe(false);
 
       // The fixture-loaded record does NOT raise when accessing the association.
-      await association(fixtureZine, "interests").toArray();
+      await association(fixtureZine, "interests");
 
       // A freshly-queried record IS strict and DOES raise.
       const fresh = await StrictZine.find(strictZines("going_out").id);

--- a/packages/activerecord/src/test-helpers/models/invoice.ts
+++ b/packages/activerecord/src/test-helpers/models/invoice.ts
@@ -17,7 +17,7 @@ export class Invoice extends Base {
     this.hasMany("shippingLines", { autosave: true });
     this.beforeSave(async function (this: any, record?: any) {
       const self = record ?? this;
-      const lineItems = await association(self, "lineItems").toArray();
+      const lineItems = await association(self, "lineItems");
       self.balance = lineItems
         .map((i: any) => i.amount)
         .filter((a: any) => a != null)


### PR DESCRIPTION
## What

Widen the `prefer-await-relation` ESLint rule past the call-expression-only
receiver gate so identifier receivers (`await davids` for a
`const davids = Author.where(...)`), member reads, and cached association
accessors are also reported and autofixed.

## Why

PR #4281 narrowed the rule to fire only on call-expression receivers
(`await Model.where(...).toArray()`) as a workaround: `stripThenable` deleted
`.then` from a relation instance **in place**, so any binding that had been
`load`/`reload`/`presence`/`destroyAll`'d was no longer awaitable at runtime
while still typing as thenable. The rule couldn't distinguish a safe binding
from a stripped one, so it gave up on all of them.

PR #4968 removed that divergence — `stripThenable` now returns a then-less
`Proxy` view and leaves the original binding awaitable. Every thenable-typed
binding resolves to its array under `await` again, so the receiver gate's
premise no longer holds.

## Changes

- Drop the `SPAWN_METHODS` set and `isFreshSpawnCall` receiver gate; rely on
  the existing thenable-type gate (`receiverIsThenable`) for soundness.
- Add a `this`/`super` guard. `await super` is a syntax error; and
  `this.toArray()` is unsound to convert — a method invoked on the then-less
  view `stripThenable` returns from `load`/`reload`/`presence` binds `this` to
  that view (its `then` is `undefined`), so `await this` would resolve to the
  view, not the array, and `this`'s static type can never narrow to the stripped
  view so the type gate can't catch it. External bindings stay safe: a stripped
  view types as `LoadedRelation` (then-less), which the type gate excludes.
- Drop the now-stale header/inline comments explaining the narrowing.
- Update the rule's unit tests: the bare-identifier / member-read / accessor
  cases move from `valid` to `invalid` with autofix output; `this` stays valid.

## Autofix

The widened rule reds the (autofixable, advisory-intent) rule across the
activerecord suite, so this PR also carries the **linter-generated
`eslint --fix` output** — a single mechanical `X.toArray()` → `X`
transformation across ~48 files. All src-side rewrites are on external thenable
receivers (query-method calls, params typed `Relation`, `this.records`,
`association(...)`) — never `this`. The touched test files pass, including the
exact #4281 failure mode
(`DeleteAllTest > destroy all`, where `await davids` follows a `davids.destroyAll()`)
and `Thenable > Relation is directly awaitable` — no test regresses to
deep-equalling a `Relation {...}` against an array.

The substantive change is the ~60 LOC rule/test edit; the remaining churn is
the mechanical autofix. Over the 500-LOC default for that reason.

Closes-story: prefer-await-relation-widen-receiver-gate
