### PR TITLE
test(model-schema): cover reflectColumnNames' cold-cache base-invalidation branch

### DIFF
--- a/packages/activerecord/src/base.trails.test.ts
+++ b/packages/activerecord/src/base.trails.test.ts
@@ -14,6 +14,7 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Type } from "@blazetrails/activemodel";
 import { fixtures } from "./test-helpers/fixtures.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
+import { reconcileVirtualAttributes, loadSchema } from "./model-schema.js";
 
 describe("quoteSqlValue", () => {
   it("emits bare decimal for bigint (not quoted string)", () => {
@@ -438,25 +439,33 @@ describe("ignored columns follow Rails' value-keyed attribute set (trails)", () 
         this.ignoredColumns = ["rating"];
       }
     }
+    (loadSchema as (this: unknown) => void).call(Company);
     const first = Firm.columnsHash();
     expect(Firm.columnsHash()).toBe(first);
 
-    // The end state `reflectColumnNames` leaves behind when it warms a cold
-    // shared cache (model-schema.ts): only the BASE's `_columnsHash`/`_columns`/
-    // `_schemaLoaded` are dropped, subclasses are untouched. Simulated rather
-    // than driven through `reconcileVirtualAttributes(true)` because that
-    // function short-circuits on `cachedColumnNames` — in this suite the shared
-    // cache is always warm, so the clearing branch is unreachable from a test.
+    const cache = Company.connection.schemaCache as unknown as {
+      clearDataSourceCacheBang(conn: unknown, name: string): void;
+      getCachedColumnsHash(name: string): unknown;
+    };
+    cache.clearDataSourceCacheBang(null, "companies");
+    expect(cache.getCachedColumnsHash("companies")).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(Company, "_schemaLoaded")).toBe(true);
+
+    await (reconcileVirtualAttributes as (this: unknown, reflect: boolean) => Promise<void>).call(
+      Company,
+      true,
+    );
+
     const base = Company as unknown as {
       _columnsHash?: unknown;
       _columns?: unknown;
       _schemaLoaded?: boolean;
     };
-    base._columnsHash = undefined;
-    base._columns = undefined;
-    base._schemaLoaded = false;
-    // The next load re-applies the reflected columns; it must not leave the
-    // subclass on its pre-reflection memo.
+    expect(base._schemaLoaded).toBe(false);
+    expect(base._columnsHash).toBeUndefined();
+    expect(base._columns).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(Company, "_columnNamesMemo")).toBe(false);
+
     expect(Company.columnNames()).toContain("rating");
 
     const rebuilt = Firm.columnsHash();


### PR DESCRIPTION
## Summary

`reflectColumnNames` (packages/activerecord/src/model-schema.ts) has a
base-invalidation branch that, once the shared schema cache warms, drops the
base's `_schemaLoaded`/`_columnsHash`/`_columns` and clears its name memos so the
next `loadSchema` re-reflects instead of serving the minimal synthesized view
built while the cache was cold. It is the one live path that invalidates the base
WITHOUT touching STI descendants' own memos — the reason PR #5178 added
`invalidateStiDescendantColumnMemos` to `applyColumnsHash`.

That branch was untestable from the AR suite: `reflectColumnNames` opens with
`const cached = cachedColumnNames(host); if (cached) return cached;`, and under
`fixtures({})` the canonical schema cache is always warm, so the function
returned before reaching the clearing branch. The `base.trails.test.ts` STI memo
regression therefore *simulated* the end state by assigning the base's internals
directly — leaving the wiring that produces the guarded state uncovered.

## Change

Rewrite the regression to drive the real path:

- sync-`loadSchema` the base so it owns `_schemaLoaded`/`_columnsHash`
  (the async `loadSchemaFromAdapter` only fills `_columnsHash`),
- clear the shared cache for the one table via `clearDataSourceCacheBang`
  (the DDL `clear_data_source_cache!` seam) so `cachedColumnNames` misses,
- run `reconcileVirtualAttributes(true)` so `reflectColumnNames` re-warms the
  cache and executes its base-invalidation branch,
- assert the base's memos and name memos are dropped and the descendant rebuilds.

Verified the test fails when the branch is disabled.

Closes-story: reflect-column-names-cold-cache-branch-untestable
