### PR TITLE
fix(test-compare): resolve Ruby mixin includers by definition node

### DIFF
--- a/scripts/test-compare/extract-ruby-assertions.test.ts
+++ b/scripts/test-compare/extract-ruby-assertions.test.ts
@@ -353,11 +353,129 @@ describe("Ruby extractor assertion-count collection", () => {
         end
       `,
     });
-    // actionpack routing_assertions_test.rb includes a nested shared module by
-    // its QUALIFIED constant, so the includer is keyed
-    // "SharedTests::WithRoutingSharedTests" while the module's scope path is
-    // segmented — the includer must still be found and its override (1) win.
     expect(counts["reachable"]).toBe(1);
+  });
+
+  it("finds the includer of a module included by ::-rooted constant", () => {
+    const counts = rubyAssertionCounts({
+      "cases/rooted_mixin_test.rb": `
+        module SharedTests
+          def test_reachable
+            check_route
+          end
+
+          def check_route
+            assert_equal 1, a
+            assert_equal 2, b
+          end
+        end
+
+        class RootedTest < ActionDispatch::IntegrationTest
+          include ::SharedTests
+
+          def check_route
+            assert_equal 1, a
+          end
+        end
+      `,
+    });
+    expect(counts["reachable"]).toBe(1);
+  });
+
+  it("finds the includer of a nested module included from the enclosing scope", () => {
+    const counts = rubyAssertionCounts({
+      "cases/enclosing_mixin_test.rb": `
+        module Outer
+          module SharedTests
+            def test_reachable
+              check_route
+            end
+
+            def check_route
+              assert_equal 1, a
+              assert_equal 2, b
+            end
+          end
+
+          class EnclosingTest < ActionDispatch::IntegrationTest
+            include SharedTests
+
+            def check_route
+              assert_equal 1, a
+            end
+          end
+        end
+      `,
+    });
+    expect(counts["reachable"]).toBe(1);
+  });
+
+  it("finds the includer of a nested module included by partially-qualified constant", () => {
+    const counts = rubyAssertionCounts({
+      "cases/partial_mixin_test.rb": `
+        module Outer
+          module SharedTests
+            module Inner
+              def test_reachable
+                check_route
+              end
+
+              def check_route
+                assert_equal 1, a
+                assert_equal 2, b
+              end
+            end
+          end
+
+          class PartialTest < ActionDispatch::IntegrationTest
+            include SharedTests::Inner
+
+            def check_route
+              assert_equal 1, a
+            end
+          end
+        end
+      `,
+    });
+    expect(counts["reachable"]).toBe(1);
+  });
+
+  it("does not attribute a module to an unrelated same-basename includer", () => {
+    const counts = rubyAssertionCounts({
+      "cases/collision_mixin_test.rb": `
+        module Alpha
+          module Shared
+            def test_reachable
+              check_route
+            end
+
+            def check_route
+              assert_equal 1, a
+              assert_equal 2, b
+            end
+          end
+        end
+
+        module Beta
+          module Shared
+            def check_route
+              assert_equal 1, a
+            end
+          end
+
+          class BetaTest < ActionDispatch::IntegrationTest
+            include Shared
+
+            def check_route
+              assert_equal 1, a
+              assert_equal 2, b
+              assert_equal 3, c
+            end
+          end
+        end
+      `,
+    });
+    expect(counts["reachable"]).toBe(2);
   });
 });
 

--- a/scripts/test-compare/extract-ruby-tests.rb
+++ b/scripts/test-compare/extract-ruby-tests.rb
@@ -12,6 +12,7 @@
 require "ripper"
 require "json"
 require "pathname"
+require "set"
 require "time"
 
 SCRIPT_DIR = File.dirname(__FILE__)
@@ -143,11 +144,9 @@ class TestExtractor
     @helper_defs = {}
     collect_helper_defs(sexp, [])
 
-    # module name → scope path of the FIRST class that `include`s it. A module's
-    # tests are emitted once and attributed to the first includer (see
-    # process_include / flush_collected_modules), so that class is the one whose
-    # method overrides Ruby's lookup would actually run for those tests.
-    # Pre-collected because a module body is walked before the later `include`.
+    @module_defs = Set.new
+    collect_module_defs(sexp, [])
+
     @module_includers = {}
     collect_module_includers(sexp, [])
 
@@ -986,9 +985,18 @@ class TestExtractor
     node.each { |child| collect_helper_defs(child, scope) if child.is_a?(Array) }
   end
 
-  # Record the first class to `include` each module, keyed module name → the
-  # including class's scope path. Mirrors process_include's first-include-wins
-  # rule, which flush_collected_modules already uses for gates.
+  def collect_module_defs(node, scope)
+    return unless node.is_a?(Array)
+    if node[0] == :class || node[0] == :module
+      name = const_name(node[1])
+      inner = name ? scope + [name] : scope
+      @module_defs << inner if node[0] == :module && name
+      node.each { |child| collect_module_defs(child, inner) if child.is_a?(Array) }
+      return
+    end
+    node.each { |child| collect_module_defs(child, scope) if child.is_a?(Array) }
+  end
+
   def collect_module_includers(node, scope)
     return unless node.is_a?(Array)
     if node[0] == :class || node[0] == :module
@@ -997,10 +1005,58 @@ class TestExtractor
       node.each { |child| collect_module_includers(child, inner) if child.is_a?(Array) }
       return
     elsif node[0] == :command && ident_name(node[1]) == "include"
-      mod = const_name_from_args(node[2])
-      @module_includers[mod] ||= scope if mod && !scope.empty?
+      target = resolve_include_target(node[2], scope)
+      @module_includers[target] ||= scope if target && !scope.empty?
     end
     node.each { |child| collect_module_includers(child, scope) if child.is_a?(Array) }
+  end
+
+  def resolve_include_target(args, scope)
+    path = const_path_from_args(args)
+    return nil unless path
+    segments = path[:segments]
+    return nil if segments.empty?
+    return @module_defs.include?(segments) ? segments : nil if path[:rooted]
+
+    prefix = scope.dup
+    loop do
+      candidate = prefix + segments
+      return candidate if @module_defs.include?(candidate)
+      break if prefix.empty?
+      prefix = prefix[0...-1]
+    end
+    nil
+  end
+
+  def const_path(node)
+    return nil unless node.is_a?(Array)
+    case node[0]
+    when :@const
+      { segments: [node[1]], rooted: false }
+    when :const_ref, :var_ref
+      const_path(node[1])
+    when :top_const_ref
+      inner = const_path(node[1])
+      inner && { segments: inner[:segments], rooted: true }
+    when :const_path_ref
+      left = const_path(node[1])
+      right = const_path(node[2])
+      return nil unless left && right
+      { segments: left[:segments] + right[:segments], rooted: left[:rooted] }
+    end
+  end
+
+  def const_path_from_args(args)
+    return nil unless args.is_a?(Array)
+    if %i[var_ref const_ref const_path_ref top_const_ref].include?(args[0])
+      return const_path(args)
+    end
+    args.each do |child|
+      next unless child.is_a?(Array)
+      result = const_path_from_args(child)
+      return result if result
+    end
+    nil
   end
 
   # Scope paths to search, in Ruby method-resolution order, for a call made from
@@ -1013,12 +1069,7 @@ class TestExtractor
   def lookup_scopes(scope)
     return [scope] if scope.empty?
 
-    # A nested module is `include`d by its QUALIFIED constant
-    # (`include RoutingAssertionsSharedTests::WithRoutingSharedTests` —
-    # actionpack routing_assertions_test.rb), which is how the includer is
-    # keyed; an include from within the enclosing scope names it bare. Try the
-    # qualified path first, then the bare name.
-    includer = @module_includers[scope.join("::")] || @module_includers[scope.last]
+    includer = @module_includers[scope]
     includer && includer != scope ? [includer, scope] : [scope]
   end
 


### PR DESCRIPTION
## What

test:compare's Ruby extractor matched a mixin module to its including class by
**name** — `collect_module_includers` keyed `@module_includers` by the constant
as written at the `include` site, and `lookup_scopes` looked that up from the
module's definition scope path. #4967 papered over the divergence with a
`scope.join("::")` / `scope.last` string fallback; two review rounds each found
a bug in that same weak primitive.

This resolves the include against the module's **definition node** instead:

- `collect_module_defs` records every in-file `module` definition scope path.
- `collect_module_includers` resolves each `include`'s constant path against
  those definitions the way Ruby constant lookup does (rooted vs. lexical
  enclosing-scope walk) and keys the includer by the resolved definition path.
- `lookup_scopes` then finds the includer with a single array lookup, since the
  key is exactly the module's definition path (== the call site's scope).

Handles bare, fully-qualified, `::`-rooted, and partially-qualified (resolved
through an enclosing scope) includes uniformly, and stops mis-attributing a
module's tests to an unrelated includer that merely shares its last constant
segment.

## Tests

- Existing #4967 tests unchanged and passing.
- New extractor unit tests for the partially-qualified spelling and the
  same-basename collision — both demonstrated to fail on baseline.
- `::`-rooted and enclosing-scope tests added as regression coverage.
- `pnpm test:compare` totals unchanged (report-only; affected tests have no TS
  counterpart being compared).

Closes-story: resolve-mixin-includer-by-definition-node
