### PR TITLE
refactor(api-compare): unify enumerable-idiom knowledge in shared module

### DIFF
--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -89,6 +89,7 @@ import {
   displayLiteral,
 } from "./literals.js";
 import { isSourceUnported } from "./unported-files.js";
+import { JS_ENUMERABLE_ALIASES, jsEnumerableAliases } from "./enumerable-idioms.js";
 
 // Fidelity-critical Ruby calls for the advisory calls-parity check. Omitting
 // one of these from a ported body is almost always a real bug (callback /
@@ -150,48 +151,11 @@ const WIDE_SIGNIFICANT_CALLS: { has(value: string): boolean } = {
   has: (value) => value !== "super",
 };
 
-// Ruby Enumerable/Comparable calls whose faithful port is a native JS method
-// with a DIFFERENT name. `rubyMethodToTs` is a pure naming-convention mapper, so
-// it turns `any?` into ["isAny", "any"] and never into `some` — the wide gate
-// (which admits every call name) then flags
-// `_connections.some((c) => c.isConnected())` as failing to call `any?`, even
-// though it is the exact analogue. These aliases are consulted ONLY when
-// deciding whether the TS body already makes the call; they never widen which
-// Ruby calls are considered ported (see significantMissingCalls gate 2), so
-// adding one can never introduce a new mismatch.
-// Entries list ONLY the differently-named JS spelling: the convention name is
-// already a candidate, so `select → filter` needs just ["filter"]. Every alias
-// must be the whole call's analogue, not merely a plausible building block —
-// `min_by → reduce` would let any reduce anywhere silence a dropped min_by, so
-// such loose pairs are deliberately absent.
-export const JS_ENUMERABLE_ALIASES = new Map<string, string[]>([
-  ["any?", ["some"]],
-  ["all?", ["every"]],
-  ["none?", ["some", "every"]],
-  ["one?", ["filter"]],
-  ["include?", ["includes", "has"]],
-  ["member?", ["includes", "has"]],
-  ["key?", ["has"]],
-  ["has_key?", ["has"]],
-  ["select", ["filter"]],
-  ["reject", ["filter"]],
-  ["detect", ["find"]],
-  ["collect", ["map"]],
-  ["collect_concat", ["flatMap"]],
-  ["each", ["forEach"]],
-  ["inject", ["reduce"]],
-  ["index", ["indexOf", "findIndex"]],
-  ["find_index", ["indexOf"]],
-  ["sort_by", ["sort"]],
-  // Ruby Array#concat mutates the receiver; the JS port is `push(...xs)`
-  // (Array#concat returns a new array, so it is NOT the analogue).
-  ["concat", ["push"]],
-]);
-
-/** JS-native call names that count as making Ruby call `rubyCall`. */
-export function jsEnumerableAliases(rubyCall: string): string[] {
-  return JS_ENUMERABLE_ALIASES.get(rubyCall) ?? [];
-}
+// The Ruby-Enumerable-idiom knowledge (differently-named JS analogues) lives in
+// one shared module so lint-calls.ts's noise list and this wide call ratchet
+// can't drift apart (RFC 0025). Re-exported so existing importers of these
+// names from compare.ts (compare.test.ts, the redundancy guard) keep working.
+export { JS_ENUMERABLE_ALIASES, jsEnumerableAliases };
 
 /**
  * Core of the advisory calls-parity check (pure, exported for tests). For a

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -151,10 +151,8 @@ const WIDE_SIGNIFICANT_CALLS: { has(value: string): boolean } = {
   has: (value) => value !== "super",
 };
 
-// The Ruby-Enumerable-idiom knowledge (differently-named JS analogues) lives in
-// one shared module so lint-calls.ts's noise list and this wide call ratchet
-// can't drift apart (RFC 0025). Re-exported so existing importers of these
-// names from compare.ts (compare.test.ts, the redundancy guard) keep working.
+// Re-exported from the shared idiom table so existing importers (compare.test.ts,
+// the redundancy guard) keep resolving these names from compare.ts.
 export { JS_ENUMERABLE_ALIASES, jsEnumerableAliases };
 
 /**

--- a/scripts/api-compare/enumerable-idioms.ts
+++ b/scripts/api-compare/enumerable-idioms.ts
@@ -1,31 +1,19 @@
 /**
  * Single source of truth for Ruby Enumerable/Comparable idioms whose faithful
- * TypeScript port is a native JS method — usually spelled differently.
+ * port is a native JS method spelled DIFFERENTLY. Two api-compare tools consume
+ * it (RFC 0025), so it lives here rather than in a copy each keeps in sync:
+ *   - compare.ts's wide call ratchet counts the analogue (`some` for `any?`) as
+ *     making the Ruby call, so a faithful port isn't flagged as an omission;
+ *   - lint-calls.ts's call-graph lint treats the KEYS as noise — Ruby records
+ *     them as calls but the port is a native JS method, not a ported internal.
  *
- * Two api-compare tools consume this knowledge, and before RFC 0025 each kept
- * its own hand-maintained copy that drifted:
- *   - compare.ts's WIDE call ratchet (JS_ENUMERABLE_ALIASES): when the TS body
- *     calls the differently-named analogue (`some` for `any?`), that counts as
- *     making the Ruby call, so the omission isn't flagged.
- *   - lint-calls.ts's internal call-graph lint (SKIP_CALLS): these idiom names
- *     are noise — Ruby records them as calls but the port is a native JS method,
- *     not a ported internal — so they're skipped when diffing call-sets.
- *
- * The map's KEYS are the Ruby idiom names both tools care about; the VALUES are
- * the differently-named JS spellings the wide ratchet accepts. Entries list
- * ONLY the differently-named JS spelling: the naming-convention name (from
- * `rubyMethodToTs`) is already a candidate, so `select → filter` needs just
- * ["filter"]. Every alias must be the whole call's analogue, not merely a
- * plausible building block — `min_by → reduce` would let any reduce anywhere
- * silence a dropped min_by, so such loose pairs are deliberately absent.
- *
- * `rubyMethodToTs` is a pure naming-convention mapper, so it turns `any?` into
- * ["isAny", "any"] and never into `some` — without these aliases the wide gate
- * (which admits every call name) would flag `_connections.some(...)` as failing
- * to call `any?`, even though it is the exact analogue. The aliases are consulted
- * ONLY when deciding whether the TS body already makes the call; they never
- * widen which Ruby calls are considered ported, so adding one can never
- * introduce a new mismatch.
+ * A value lists ONLY the differently-named spelling: the naming-convention name
+ * (`rubyMethodToTs`) is already a candidate, so `select` needs just ["filter"].
+ * Each alias must be the WHOLE call's analogue, never a building block —
+ * `min_by → reduce` would let any reduce silence a dropped min_by, so such loose
+ * pairs are deliberately absent. Aliases are consulted only to decide whether a
+ * TS body already makes a call; they never widen which Ruby calls count as
+ * ported, so adding one can never introduce a new mismatch.
  */
 export const JS_ENUMERABLE_ALIASES = new Map<string, string[]>([
   ["any?", ["some"]],
@@ -46,8 +34,8 @@ export const JS_ENUMERABLE_ALIASES = new Map<string, string[]>([
   ["index", ["indexOf", "findIndex"]],
   ["find_index", ["indexOf"]],
   ["sort_by", ["sort"]],
-  // Ruby Array#concat mutates the receiver; the JS port is `push(...xs)`
-  // (Array#concat returns a new array, so it is NOT the analogue).
+  // Ruby Array#concat mutates the receiver → JS `push(...xs)`; Array#concat's
+  // new-array return is NOT the analogue.
   ["concat", ["push"]],
 ]);
 

--- a/scripts/api-compare/enumerable-idioms.ts
+++ b/scripts/api-compare/enumerable-idioms.ts
@@ -1,0 +1,57 @@
+/**
+ * Single source of truth for Ruby Enumerable/Comparable idioms whose faithful
+ * TypeScript port is a native JS method — usually spelled differently.
+ *
+ * Two api-compare tools consume this knowledge, and before RFC 0025 each kept
+ * its own hand-maintained copy that drifted:
+ *   - compare.ts's WIDE call ratchet (JS_ENUMERABLE_ALIASES): when the TS body
+ *     calls the differently-named analogue (`some` for `any?`), that counts as
+ *     making the Ruby call, so the omission isn't flagged.
+ *   - lint-calls.ts's internal call-graph lint (SKIP_CALLS): these idiom names
+ *     are noise — Ruby records them as calls but the port is a native JS method,
+ *     not a ported internal — so they're skipped when diffing call-sets.
+ *
+ * The map's KEYS are the Ruby idiom names both tools care about; the VALUES are
+ * the differently-named JS spellings the wide ratchet accepts. Entries list
+ * ONLY the differently-named JS spelling: the naming-convention name (from
+ * `rubyMethodToTs`) is already a candidate, so `select → filter` needs just
+ * ["filter"]. Every alias must be the whole call's analogue, not merely a
+ * plausible building block — `min_by → reduce` would let any reduce anywhere
+ * silence a dropped min_by, so such loose pairs are deliberately absent.
+ *
+ * `rubyMethodToTs` is a pure naming-convention mapper, so it turns `any?` into
+ * ["isAny", "any"] and never into `some` — without these aliases the wide gate
+ * (which admits every call name) would flag `_connections.some(...)` as failing
+ * to call `any?`, even though it is the exact analogue. The aliases are consulted
+ * ONLY when deciding whether the TS body already makes the call; they never
+ * widen which Ruby calls are considered ported, so adding one can never
+ * introduce a new mismatch.
+ */
+export const JS_ENUMERABLE_ALIASES = new Map<string, string[]>([
+  ["any?", ["some"]],
+  ["all?", ["every"]],
+  ["none?", ["some", "every"]],
+  ["one?", ["filter"]],
+  ["include?", ["includes", "has"]],
+  ["member?", ["includes", "has"]],
+  ["key?", ["has"]],
+  ["has_key?", ["has"]],
+  ["select", ["filter"]],
+  ["reject", ["filter"]],
+  ["detect", ["find"]],
+  ["collect", ["map"]],
+  ["collect_concat", ["flatMap"]],
+  ["each", ["forEach"]],
+  ["inject", ["reduce"]],
+  ["index", ["indexOf", "findIndex"]],
+  ["find_index", ["indexOf"]],
+  ["sort_by", ["sort"]],
+  // Ruby Array#concat mutates the receiver; the JS port is `push(...xs)`
+  // (Array#concat returns a new array, so it is NOT the analogue).
+  ["concat", ["push"]],
+]);
+
+/** JS-native call names that count as making Ruby call `rubyCall`. */
+export function jsEnumerableAliases(rubyCall: string): string[] {
+  return JS_ENUMERABLE_ALIASES.get(rubyCall) ?? [];
+}

--- a/scripts/api-compare/lint-calls.ts
+++ b/scripts/api-compare/lint-calls.ts
@@ -240,6 +240,11 @@ const SKIP_CALLS = new Set([
   // Collection / Enumerable. Idioms with a differently-named JS analogue come
   // from the shared JS_ENUMERABLE_ALIASES table (RFC 0025) so this noise list
   // and compare.ts's wide ratchet can't drift; same-named idioms stay literal.
+  // Deriving from the table's keys intentionally widens this set beyond what it
+  // listed before (adds one?/member?/collect_concat/index/find_index/concat):
+  // all are Enumerable idioms that port to a native JS method, i.e. the same
+  // noise the literal entries already skip. This lint is advisory (no ratchet),
+  // so the widening only affects its manual report.
   ...JS_ENUMERABLE_ALIASES.keys(),
   "map",
   "flat_map",

--- a/scripts/api-compare/lint-calls.ts
+++ b/scripts/api-compare/lint-calls.ts
@@ -276,7 +276,6 @@ const SKIP_CALLS = new Set([
   "match",
   "scan",
   "sort",
-  "sort_by",
   "min",
   "max",
   "sum",

--- a/scripts/api-compare/lint-calls.ts
+++ b/scripts/api-compare/lint-calls.ts
@@ -16,6 +16,7 @@ import * as ts from "typescript";
 import type { ApiManifest, ClassInfo, MethodInfo } from "./types.js";
 import { OUTPUT_DIR, packageSrcDir } from "./config.js";
 import { rubyFileToTs, rubyMethodToTs } from "./conventions.js";
+import { JS_ENUMERABLE_ALIASES } from "./enumerable-idioms.js";
 
 function parseArgs() {
   const args = process.argv.slice(2);
@@ -236,32 +237,24 @@ const SKIP_CALLS = new Set([
   "yield",
   "require",
   "require_relative",
-  // Collection / Enumerable
+  // Collection / Enumerable. The differently-named-JS-analogue idioms
+  // (any?/select/include?/…) come from the shared JS_ENUMERABLE_ALIASES table
+  // (RFC 0025) so this noise list and compare.ts's wide call ratchet can't
+  // drift; the same-named or analogue-less idioms below stay as literals.
+  ...JS_ENUMERABLE_ALIASES.keys(),
   "map",
-  "each",
-  "select",
-  "reject",
   "flat_map",
   "compact",
   "flatten",
   "reduce",
-  "inject",
-  "detect",
   "find",
-  "collect",
   "filter_map",
-  "any?",
-  "all?",
-  "none?",
   "empty?",
   "size",
   "length",
   "count",
   "first",
   "last",
-  "include?",
-  "key?",
-  "has_key?",
   "keys",
   "fetch",
   "merge",

--- a/scripts/api-compare/lint-calls.ts
+++ b/scripts/api-compare/lint-calls.ts
@@ -237,10 +237,9 @@ const SKIP_CALLS = new Set([
   "yield",
   "require",
   "require_relative",
-  // Collection / Enumerable. The differently-named-JS-analogue idioms
-  // (any?/select/include?/…) come from the shared JS_ENUMERABLE_ALIASES table
-  // (RFC 0025) so this noise list and compare.ts's wide call ratchet can't
-  // drift; the same-named or analogue-less idioms below stay as literals.
+  // Collection / Enumerable. Idioms with a differently-named JS analogue come
+  // from the shared JS_ENUMERABLE_ALIASES table (RFC 0025) so this noise list
+  // and compare.ts's wide ratchet can't drift; same-named idioms stay literal.
   ...JS_ENUMERABLE_ALIASES.keys(),
   "map",
   "flat_map",


### PR DESCRIPTION
## What

Two hand-maintained lists independently encoded the same Ruby-Enumerable-idiom
facts:

- `compare.ts`'s wide call ratchet — `JS_ENUMERABLE_ALIASES` (`some` for `any?`,
  `filter` for `select`, …).
- `lint-calls.ts`'s internal call-graph lint — the common-call noise list that
  names `any?` / `all?` / `include?` and friends as ignorable.

They drift: adding an idiom to one didn't touch the other, and only the wide
table had a redundancy guard test.

## Change

- Extract the table into a new shared module,
  `scripts/api-compare/enumerable-idioms.ts`, as the single definition of
  `JS_ENUMERABLE_ALIASES` / `jsEnumerableAliases`.
- `compare.ts` imports and re-exports it, so `compare.test.ts` and the
  redundancy guard keep importing the names from `compare.ts` unchanged.
- `lint-calls.ts` derives its enumerable-idiom skips from
  `JS_ENUMERABLE_ALIASES.keys()`; same-named or analogue-less idioms stay as
  literals.

The `JS_ENUMERABLE_ALIASES` map contents are moved verbatim (so both ratchets
are byte-identical — see Verification).

### Intentional widening of `lint-calls.ts`'s `SKIP_CALLS`

Deriving the noise list from `JS_ENUMERABLE_ALIASES.keys()` is the approach the
story sanctions, and it deliberately widens `SKIP_CALLS`. Before this PR the set
skipped 13 enumerable idioms (`each, select, reject, inject, detect, collect,
any?, all?, none?, include?, key?, has_key?, sort_by`). The shared table's keys
add **6 more**: `one?`, `member?`, `collect_concat`, `index`, `find_index`,
`concat`.

This is correct, not an accident: all six are Ruby Enumerable/Comparable idioms
whose faithful port is a native JS method (`one? → filter`, `member? →
includes/has`, `collect_concat → flatMap`, `index/find_index → indexOf`,
`concat → push`) — the *exact same rationale* as the 13 pre-existing entries.
`lint-calls.ts` skips such names because Ruby records them as calls but the port
is a native JS method, not a ported internal, so they are noise in the internal
call-graph diff. Leaving them out of the shared derivation is precisely the
drift this story removes.

Scope of the change is contained:

- `lint-calls.ts` is a standalone, advisory dev tool — it is wired to no `pnpm`
  script and no CI ratchet (only invoked manually via
  `npx tsx scripts/api-compare/lint-calls.ts`), so this only affects that
  manual report, never a gate. The narrow/wide ratchets are unaffected (they run
  through `compare.ts`, whose table is byte-identical).
- On `index` as a high-collision generic name: `SKIP_CALLS` already ignores many
  such generic names (`name`, `call`, `type`, `scope`, `target`, `model`,
  `find`, `map`, `count`, `first`, `last`, `delete`, `merge`, `sort`, `keys`,
  `values`, …); this lint is coarse by design, and `index` is a genuine
  Enumerable method, so it belongs with the rest.

## Verification

- The narrow (`pnpm api:calls`, 19) and wide (`pnpm api:calls:wide`, 6317)
  ratchets both derive from `jsEnumerableAliases`, which is byte-identical, so
  counts are unchanged by construction; `lint-calls.ts` feeds neither ratchet.
- `compare.test.ts` passes (81/81), including the "lists no alias that
  rubyMethodToTs already produces" redundancy guard.
- `tsc --build` / typecheck pass.

Closes-story: unify-enumerable-idiom-lists-narrow-and-wide-call-lints

