### PR TITLE
feat(test-compare): arm hard-zero CI gate on activerecord gate-mismatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1292,10 +1292,13 @@ jobs:
           RAILS_STRUCTURE_REPORT: "1"
         run: pnpm exec tsx scripts/build-rails-file-structure-manifest.ts && pnpm exec eslint packages/arel/src packages/activemodel/src
       - name: Test comparison
-        # --gates prints the advisory adapter/feature gate-mismatch breakdown
+        # --gates prints the adapter/feature gate-mismatch breakdown
         # (should-gate / missing-gate / wrong-gate / over-gated) in the log.
-        # Non-failing: gate mismatches never affect the exit code.
-        run: pnpm exec tsx scripts/test-compare/extract-ts-tests.ts && pnpm exec tsx scripts/test-compare/test-compare.ts --gates
+        # --check arms the hard-zero gate: the step fails if activerecord's
+        # gate-mismatch count is non-zero (RFC 0032 ar-gate-fidelity-burndown,
+        # cluster `enforcement`). No baseline / exclude-list — the four burndown
+        # clusters are already at zero, so any regrowth turns CI red.
+        run: pnpm exec tsx scripts/test-compare/extract-ts-tests.ts && pnpm exec tsx scripts/test-compare/test-compare.ts --gates --check
       - name: Fixtures comparison
         run: pnpm exec tsx scripts/fixtures-compare/compare.ts --package activerecord --ci
       - name: Models comparison

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1292,12 +1292,9 @@ jobs:
           RAILS_STRUCTURE_REPORT: "1"
         run: pnpm exec tsx scripts/build-rails-file-structure-manifest.ts && pnpm exec eslint packages/arel/src packages/activemodel/src
       - name: Test comparison
-        # --gates prints the adapter/feature gate-mismatch breakdown
-        # (should-gate / missing-gate / wrong-gate / over-gated) in the log.
-        # --check arms the hard-zero gate: the step fails if activerecord's
-        # gate-mismatch count is non-zero (RFC 0032 ar-gate-fidelity-burndown,
-        # cluster `enforcement`). No baseline / exclude-list — the four burndown
-        # clusters are already at zero, so any regrowth turns CI red.
+        # --gates prints the adapter/feature gate-mismatch breakdown; --check
+        # fails the step if activerecord's gate-mismatch count is non-zero
+        # (hard zero, no baseline — RFC 0032 ar-gate-fidelity-burndown).
         run: pnpm exec tsx scripts/test-compare/extract-ts-tests.ts && pnpm exec tsx scripts/test-compare/test-compare.ts --gates --check
       - name: Fixtures comparison
         run: pnpm exec tsx scripts/fixtures-compare/compare.ts --package activerecord --ci

--- a/scripts/test-compare/gate-check.test.ts
+++ b/scripts/test-compare/gate-check.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { GATE_ENFORCED_PACKAGES, gateMismatchOffenders } from "./test-compare.js";
+
+describe("gateMismatchOffenders (hard-zero --check gate)", () => {
+  it("enforces activerecord only", () => {
+    expect(GATE_ENFORCED_PACKAGES.has("activerecord")).toBe(true);
+    expect(GATE_ENFORCED_PACKAGES.has("activemodel")).toBe(false);
+  });
+
+  it("passes (no offenders) when activerecord is at zero", () => {
+    expect(gateMismatchOffenders([{ package: "activerecord", totalGateMismatch: 0 }])).toEqual([]);
+  });
+
+  it("flags activerecord when its gate-mismatch count is non-zero", () => {
+    const offenders = gateMismatchOffenders([{ package: "activerecord", totalGateMismatch: 3 }]);
+    expect(offenders).toHaveLength(1);
+    expect(offenders[0]?.package).toBe("activerecord");
+  });
+
+  it("ignores non-enforced packages even when they have mismatches", () => {
+    expect(
+      gateMismatchOffenders([
+        { package: "activemodel", totalGateMismatch: 5 },
+        { package: "arel", totalGateMismatch: 2 },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("only reports the enforced package from a mixed result set", () => {
+    const offenders = gateMismatchOffenders([
+      { package: "activemodel", totalGateMismatch: 5 },
+      { package: "activerecord", totalGateMismatch: 1 },
+    ]);
+    expect(offenders.map((o) => o.package)).toEqual(["activerecord"]);
+  });
+});

--- a/scripts/test-compare/test-compare.ts
+++ b/scripts/test-compare/test-compare.ts
@@ -21,8 +21,14 @@
  *
  * Usage:
  *   npx tsx scripts/test-compare/test-compare.ts [--missing] [--json]
- *     [--incomplete] [--gates] [--sort-extra] [--min-extra=N]
+ *     [--incomplete] [--gates] [--check] [--sort-extra] [--min-extra=N]
  *     [--package activesupport]
+ *
+ *   --check       Hard-zero CI gate: exit non-zero if the gate-mismatch count
+ *                 for any enforced package (see GATE_ENFORCED_PACKAGES —
+ *                 activerecord only) is non-zero. No baseline, no exclude-list.
+ *                 Independent of --gates/--json; combine with --gates so the CI
+ *                 log carries the per-test breakdown alongside the exit code.
  *
  *   --incomplete  In the per-file table, hide files that are fully complete
  *                 (every Ruby test matched in the convention TS file, no
@@ -73,6 +79,42 @@ const OUTPUT_DIR = path.join(SCRIPT_DIR, "output");
 // `assertionCount` everywhere, but we only surface the mismatch metric (summary
 // tokens, `--assertions` section, JSON) here so it can't leak into other totals.
 const ASSERTION_REPORT_PACKAGES = new Set(["activerecord"]);
+
+// Packages whose gate-mismatch count is a hard-zero CI gate (`--check`). Once
+// the four burndown clusters (missing-gate / wrong-gate / over-gated /
+// should-gate) reached zero for activerecord, this locks it in so it can't
+// silently regrow. Hard zero: no exclude-list, no baseline ratchet. Scoped to
+// activerecord only (RFC 0032 `ar-gate-fidelity-burndown`); other packages
+// stay report-only.
+export const GATE_ENFORCED_PACKAGES = new Set(["activerecord"]);
+
+/**
+ * Pure selector for the hard-zero gate: the enforced packages (activerecord)
+ * whose gate-mismatch count is non-zero. Empty array = gate passes.
+ */
+export function gateMismatchOffenders<T extends { package: string; totalGateMismatch: number }>(
+  results: T[],
+): T[] {
+  return results.filter((r) => GATE_ENFORCED_PACKAGES.has(r.package) && r.totalGateMismatch > 0);
+}
+
+/**
+ * Hard-zero enforcement for `--check`: exit non-zero if any enforced package
+ * has a non-zero gate-mismatch count. Prints the offending package(s) so the CI
+ * log points straight at the regression; run `--gates` for the per-test
+ * breakdown.
+ */
+function enforceGateZero(results: { package: string; totalGateMismatch: number }[]): void {
+  const offenders = gateMismatchOffenders(results);
+  if (offenders.length === 0) return;
+  console.error("");
+  console.error("✗ gate-mismatch check failed (hard zero, no baseline):");
+  for (const r of offenders) {
+    console.error(`  ${r.package}: ${r.totalGateMismatch} gate-mismatch (must be 0)`);
+  }
+  console.error("  Run `pnpm test:compare -- --gates` for the per-test breakdown.");
+  process.exit(1);
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -360,6 +402,7 @@ function main() {
   const jsonOutput = args.includes("--json");
   const showIncomplete = args.includes("--incomplete");
   const showGates = args.includes("--gates");
+  const checkGates = args.includes("--check");
   const showAssertions = args.includes("--assertions");
   const sortExtra = args.includes("--sort-extra");
   let minExtra = 0;
@@ -857,6 +900,7 @@ function main() {
 
   if (jsonOutput) {
     console.log(`Written to ${outPath}`);
+    if (checkGates) enforceGateZero(results);
     return;
   }
 
@@ -1164,6 +1208,8 @@ function main() {
     `  Overall: ${grandImplemented}/${grandRuby} tests (${grandPct}%)${grandDetailStr}  |  ${grandMapped}/${grandFiles} files  |  ${grandMisplaced} misplaced`,
   );
   console.log(`${"=".repeat(90)}\n`);
+
+  if (checkGates) enforceGateZero(results);
 }
 
 /** Compact one-line rendering of a gate for the --gates report. */

--- a/scripts/test-compare/test-compare.ts
+++ b/scripts/test-compare/test-compare.ts
@@ -24,12 +24,6 @@
  *     [--incomplete] [--gates] [--check] [--sort-extra] [--min-extra=N]
  *     [--package activesupport]
  *
- *   --check       Hard-zero CI gate: exit non-zero if the gate-mismatch count
- *                 for any enforced package (see GATE_ENFORCED_PACKAGES —
- *                 activerecord only) is non-zero. No baseline, no exclude-list.
- *                 Independent of --gates/--json; combine with --gates so the CI
- *                 log carries the per-test breakdown alongside the exit code.
- *
  *   --incomplete  In the per-file table, hide files that are fully complete
  *                 (every Ruby test matched in the convention TS file, no
  *                 wrong-describe). Misplaced tests are not in this file's
@@ -40,6 +34,10 @@
  *                 missing-gate / wrong-gate / over-gated). Advisory: does not
  *                 affect the matched/skipped/percent counts. Always emitted to
  *                 the JSON artifact regardless of this flag.
+ *   --check       Hard-zero CI gate: exit non-zero if the gate-mismatch count
+ *                 for an enforced package (GATE_ENFORCED_PACKAGES — activerecord
+ *                 only) is non-zero. No baseline, no exclude-list. Combine with
+ *                 --gates so the CI log carries the per-test breakdown too.
  *   --assertions  Print the assertion-count-mismatch report — matched,
  *                 implemented tests whose trails port has a different assertion-
  *                 call count than its Rails counterpart. Scoped to activerecord
@@ -80,32 +78,25 @@ const OUTPUT_DIR = path.join(SCRIPT_DIR, "output");
 // tokens, `--assertions` section, JSON) here so it can't leak into other totals.
 const ASSERTION_REPORT_PACKAGES = new Set(["activerecord"]);
 
-// Packages whose gate-mismatch count is a hard-zero CI gate (`--check`). Once
-// the four burndown clusters (missing-gate / wrong-gate / over-gated /
-// should-gate) reached zero for activerecord, this locks it in so it can't
-// silently regrow. Hard zero: no exclude-list, no baseline ratchet. Scoped to
-// activerecord only (RFC 0032 `ar-gate-fidelity-burndown`); other packages
-// stay report-only.
 export const GATE_ENFORCED_PACKAGES = new Set(["activerecord"]);
 
-/**
- * Pure selector for the hard-zero gate: the enforced packages (activerecord)
- * whose gate-mismatch count is non-zero. Empty array = gate passes.
- */
 export function gateMismatchOffenders<T extends { package: string; totalGateMismatch: number }>(
   results: T[],
 ): T[] {
   return results.filter((r) => GATE_ENFORCED_PACKAGES.has(r.package) && r.totalGateMismatch > 0);
 }
 
-/**
- * Hard-zero enforcement for `--check`: exit non-zero if any enforced package
- * has a non-zero gate-mismatch count. Prints the offending package(s) so the CI
- * log points straight at the regression; run `--gates` for the per-test
- * breakdown.
- */
 function enforceGateZero(results: { package: string; totalGateMismatch: number }[]): void {
-  const offenders = gateMismatchOffenders(results);
+  const enforced = results.filter((r) => GATE_ENFORCED_PACKAGES.has(r.package));
+  if (enforced.length === 0) {
+    console.error("");
+    console.error(
+      `✗ --check found no enforced package to gate (expected one of: ${[...GATE_ENFORCED_PACKAGES].join(", ")}).`,
+    );
+    console.error("  The gate can't be scoped away — drop the --package filter or fix the wiring.");
+    process.exit(1);
+  }
+  const offenders = enforced.filter((r) => r.totalGateMismatch > 0);
   if (offenders.length === 0) return;
   console.error("");
   console.error("✗ gate-mismatch check failed (hard zero, no baseline):");


### PR DESCRIPTION
## What

Arms a **hard-zero CI gate** on the `activerecord` gate-mismatch count so it
can't silently regrow now that the four burndown clusters (`missing-gate`,
`wrong-gate`, `over-gated`, `should-gate`) all read zero.

## Mechanism (decision)

Chose the **`--check` exit-code path** over asserting a count from
`convention-comparison.json` in `gate-mismatch.test.ts`. That JSON is generated
during the CI `test:compare` run and isn't present at unit-test time, so wiring
the gate into the tool that already produces it — right where the count is
computed — is the direct fit and keeps the enforcement in the same lane.

- `test-compare.ts` gains a `--check` flag. After building results it exits
  non-zero if any package in `GATE_ENFORCED_PACKAGES` (activerecord only) has a
  non-zero gate-mismatch count. Works with or without `--json`/`--gates`.
- The existing **Test comparison** CI step now runs `... --gates --check`, so
  the advisory per-test breakdown still prints and the exit code enforces zero.
- Pure selector `gateMismatchOffenders()` is extracted and unit-tested in
  `gate-check.test.ts`.

Hard zero: **no baseline, no exclude-list**. Scoped to activerecord only (other
packages stay report-only per RFC 0032).

Verified locally: `test:compare --package activerecord --gates --check` reports
`activerecord: 0 gate-mismatch` and exits 0.

Closes-story: gate-mismatch-zero-ci-enforcement

## Safety

`--check` also fails if it finds **no** enforced package in the results — so a
future edit that accidentally scopes activerecord away (e.g. an added
`--package` filter) can't silently neuter the gate. Verified both paths locally:
`--gates --check --package activerecord` exits 0; `--check --package
activesupport` exits 1 with a clear message.
