### PR TITLE
perf(manifest-emitter): batch prettier invocations into one spawn

### DIFF
--- a/scripts/api-compare/write-json-manifest.test.ts
+++ b/scripts/api-compare/write-json-manifest.test.ts
@@ -90,18 +90,36 @@ describe("writeJsonManifest", () => {
     expect(JSON.parse(fs.readFileSync(out, "utf8"))).toEqual(SAMPLE);
   });
 
-  it("defers formatting until flush inside a batch, then formats every path", () => {
+  it("buffers writes in memory until flush, then formats every path", () => {
     const a = tmpManifest();
     const b = tmpManifest();
     beginManifestBatch();
     writeJsonManifest(a, SAMPLE);
     writeJsonManifest(b, SAMPLE);
-    // Bytes are on disk immediately, but unformatted until the batch flushes.
-    expect(prettierCheck(a)).toBe(false);
-    expect(prettierCheck(b)).toBe(false);
+    // Nothing touches disk until the batch flushes.
+    expect(fs.existsSync(a)).toBe(false);
+    expect(fs.existsSync(b)).toBe(false);
     flushManifestBatch();
     expect(prettierCheck(a)).toBe(true);
     expect(prettierCheck(b)).toBe(true);
+  });
+
+  it("leaves the tracked file untouched when a batch is abandoned before flush", () => {
+    const out = tmpManifest();
+    fs.writeFileSync(out, "sentinel\n");
+    beginManifestBatch();
+    writeJsonManifest(out, SAMPLE);
+    // A throw between begin and flush must not churn the committed bytes.
+    expect(fs.readFileSync(out, "utf8")).toBe("sentinel\n");
+    flushManifestBatch();
+    expect(prettierCheck(out)).toBe(true);
+  });
+
+  it("leaves no temp files beside a committed manifest", () => {
+    const out = tmpManifest();
+    writeJsonManifest(out, SAMPLE);
+    const strays = fs.readdirSync(path.dirname(out)).filter((f) => f.includes(".tmp."));
+    expect(strays).toEqual([]);
   });
 
   it("batches to output byte-identical to the immediate path", () => {

--- a/scripts/api-compare/write-json-manifest.test.ts
+++ b/scripts/api-compare/write-json-manifest.test.ts
@@ -4,7 +4,11 @@ import * as os from "os";
 import * as path from "path";
 import { execFileSync } from "child_process";
 import { fileURLToPath } from "url";
-import { writeJsonManifest } from "./write-json-manifest.js";
+import {
+  writeJsonManifest,
+  beginManifestBatch,
+  flushManifestBatch,
+} from "./write-json-manifest.js";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const PRETTIER_BIN = path.join(REPO_ROOT, "node_modules/.bin/prettier");
@@ -84,6 +88,30 @@ describe("writeJsonManifest", () => {
     const out = tmpManifest();
     writeJsonManifest(out, SAMPLE);
     expect(JSON.parse(fs.readFileSync(out, "utf8"))).toEqual(SAMPLE);
+  });
+
+  it("defers formatting until flush inside a batch, then formats every path", () => {
+    const a = tmpManifest();
+    const b = tmpManifest();
+    beginManifestBatch();
+    writeJsonManifest(a, SAMPLE);
+    writeJsonManifest(b, SAMPLE);
+    // Bytes are on disk immediately, but unformatted until the batch flushes.
+    expect(prettierCheck(a)).toBe(false);
+    expect(prettierCheck(b)).toBe(false);
+    flushManifestBatch();
+    expect(prettierCheck(a)).toBe(true);
+    expect(prettierCheck(b)).toBe(true);
+  });
+
+  it("batches to output byte-identical to the immediate path", () => {
+    const immediate = tmpManifest();
+    writeJsonManifest(immediate, SAMPLE);
+    const batched = tmpManifest();
+    beginManifestBatch();
+    writeJsonManifest(batched, SAMPLE);
+    flushManifestBatch();
+    expect(fs.readFileSync(batched, "utf8")).toBe(fs.readFileSync(immediate, "utf8"));
   });
 });
 

--- a/scripts/api-compare/write-json-manifest.ts
+++ b/scripts/api-compare/write-json-manifest.ts
@@ -9,11 +9,18 @@
  *
  * Prettier 3 exposes no synchronous format API, and the emitters that call
  * this are transpiled to CJS by tsx (top-level `await` is a hard esbuild
- * error there), so we shell out to the repo-local prettier CLI with
- * `--stdin-filepath` — that resolves .prettierrc.json for the target path the
- * same way `prettier --write` would. Async emitters call this same sync
- * helper on purpose: one formatting code path means the manifests cannot
+ * error there), so we shell out to the repo-local prettier CLI. The raw
+ * stringify is written to disk first, then prettier is invoked with `--write`
+ * over the on-disk path(s); `--write` resolves .prettierrc.json for each target
+ * path exactly as it would for a hand-run format. Async emitters share this
+ * same helper on purpose: one formatting code path means the manifests cannot
  * drift apart from each other.
+ *
+ * Batching: prettier startup is ~330ms, dwarfing the format work, so an emitter
+ * that produces several manifests can wrap its writes in
+ * `beginManifestBatch()` / `flushManifestBatch()` to collect the paths and
+ * format them all in a single `prettier --write path…` spawn. Outside a batch,
+ * each write formats immediately.
  *
  * Every call reformats unconditionally rather than short-circuiting on
  * unchanged data: a manifest already churned by an older generator must be
@@ -27,33 +34,56 @@ import { fileURLToPath } from "url";
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const PRETTIER_BIN = path.join(REPO_ROOT, "node_modules/.bin/prettier");
 
-// `--stdin-filepath` consults --ignore-path (default: .gitignore AND
-// .prettierignore) and, for a matched path, echoes stdin back UNFORMATTED and
+// `prettier --write` consults --ignore-path (default: .gitignore AND
+// .prettierignore) and, for a matched path, leaves the file UNFORMATTED and
 // exits 0 — a silent no-op, not an error. Several manifests are gitignored and
 // one was .prettierignore'd, so without this bypass the helper would quietly
 // do nothing for them and the churn trap would stay armed. Emitted manifests
 // are always formatted, regardless of what ignores them elsewhere.
 const IGNORE_BYPASS = ["--ignore-path", "/dev/null"];
 
-export function writeJsonManifest(outPath: string, data: unknown): void {
-  const raw = JSON.stringify(data, null, 2) + "\n";
-  let formatted: string;
+// When non-null, an open batch collects paths instead of formatting each write.
+let openBatch: string[] | null = null;
+
+function runPrettier(paths: string[]): void {
+  if (paths.length === 0) return;
   try {
-    formatted = execFileSync(PRETTIER_BIN, IGNORE_BYPASS.concat("--stdin-filepath", outPath), {
-      input: raw,
+    execFileSync(PRETTIER_BIN, IGNORE_BYPASS.concat("--write", ...paths), {
       encoding: "utf8",
       maxBuffer: 64 * 1024 * 1024,
     });
   } catch (err) {
     throw new Error(
-      `[write-json-manifest] prettier failed formatting ${outPath}. ` +
+      `[write-json-manifest] prettier failed formatting ${paths.join(", ")}. ` +
         `Manifests must be emitted prettier-formatted or the tree goes dirty on every ` +
-        `regeneration; refusing to write unformatted output. Is ${PRETTIER_BIN} present ` +
+        `regeneration; refusing to leave unformatted output. Is ${PRETTIER_BIN} present ` +
         `(\`pnpm install\`)?`,
       { cause: err },
     );
   }
+}
 
+export function writeJsonManifest(outPath: string, data: unknown): void {
+  const raw = JSON.stringify(data, null, 2) + "\n";
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
-  fs.writeFileSync(outPath, formatted);
+  fs.writeFileSync(outPath, raw);
+  if (openBatch) openBatch.push(outPath);
+  else runPrettier([outPath]);
+}
+
+/**
+ * Opens a batch: subsequent `writeJsonManifest` calls write their raw bytes but
+ * defer formatting until `flushManifestBatch()`, which formats every collected
+ * path in one prettier spawn. Idempotent — a second call while a batch is open
+ * is a no-op, so nested callers can't clobber the outer batch.
+ */
+export function beginManifestBatch(): void {
+  if (!openBatch) openBatch = [];
+}
+
+/** Formats every path collected since `beginManifestBatch()` in one spawn. */
+export function flushManifestBatch(): void {
+  const paths = openBatch;
+  openBatch = null;
+  if (paths) runPrettier(paths);
 }

--- a/scripts/api-compare/write-json-manifest.ts
+++ b/scripts/api-compare/write-json-manifest.ts
@@ -9,18 +9,23 @@
  *
  * Prettier 3 exposes no synchronous format API, and the emitters that call
  * this are transpiled to CJS by tsx (top-level `await` is a hard esbuild
- * error there), so we shell out to the repo-local prettier CLI. The raw
- * stringify is written to disk first, then prettier is invoked with `--write`
- * over the on-disk path(s); `--write` resolves .prettierrc.json for each target
- * path exactly as it would for a hand-run format. Async emitters share this
- * same helper on purpose: one formatting code path means the manifests cannot
- * drift apart from each other.
+ * error there), so we shell out to the repo-local prettier CLI. Because
+ * `--write` operates on files, each manifest is staged to a sibling temp file
+ * (same directory, `.json` extension, so prettier resolves the identical
+ * .prettierrc.json and JSON parser as it would for the real path), formatted
+ * there, and only then renamed over the tracked path. The tracked manifest is
+ * therefore never touched until prettier has succeeded: a failed spawn unlinks
+ * the temp and leaves the committed bytes intact, rather than churning them.
+ * Async emitters share this same helper on purpose: one formatting code path
+ * means the manifests cannot drift apart from each other.
  *
  * Batching: prettier startup is ~330ms, dwarfing the format work, so an emitter
  * that produces several manifests can wrap its writes in
- * `beginManifestBatch()` / `flushManifestBatch()` to collect the paths and
- * format them all in a single `prettier --write path…` spawn. Outside a batch,
- * each write formats immediately.
+ * `beginManifestBatch()` / `flushManifestBatch()`. Inside a batch the raw bytes
+ * are buffered in memory — nothing hits disk — until the flush stages every
+ * temp, formats them in a single `prettier --write path…` spawn, and renames
+ * them all into place. A batch abandoned by an exception before its flush thus
+ * leaves the tracked manifests entirely untouched, not half-churned.
  *
  * Every call reformats unconditionally rather than short-circuiting on
  * unchanged data: a manifest already churned by an older generator must be
@@ -42,48 +47,71 @@ const PRETTIER_BIN = path.join(REPO_ROOT, "node_modules/.bin/prettier");
 // are always formatted, regardless of what ignores them elsewhere.
 const IGNORE_BYPASS = ["--ignore-path", "/dev/null"];
 
-// When non-null, an open batch collects paths instead of formatting each write.
-let openBatch: string[] | null = null;
+interface PendingWrite {
+  outPath: string;
+  raw: string;
+}
 
-function runPrettier(paths: string[]): void {
-  if (paths.length === 0) return;
+// When non-null, an open batch buffers writes in memory instead of committing
+// each one; flushManifestBatch() commits them all in a single prettier spawn.
+let openBatch: PendingWrite[] | null = null;
+
+// Disambiguates concurrent temp files (tests emit several manifests from one
+// process); the .json extension keeps prettier's parser + config resolution
+// identical to the real target.
+let tempSeq = 0;
+function tempPathFor(outPath: string): string {
+  return `${outPath}.${(tempSeq += 1)}.tmp.json`;
+}
+
+// Stage each write to a sibling temp, format every temp in one spawn, then
+// rename them over their targets. On failure no target is touched — the temps
+// are unlinked and the error is surfaced.
+function commit(writes: PendingWrite[]): void {
+  if (writes.length === 0) return;
+  const staged = writes.map((w) => {
+    fs.mkdirSync(path.dirname(w.outPath), { recursive: true });
+    const tmp = tempPathFor(w.outPath);
+    fs.writeFileSync(tmp, w.raw);
+    return { tmp, outPath: w.outPath };
+  });
   try {
-    execFileSync(PRETTIER_BIN, IGNORE_BYPASS.concat("--write", ...paths), {
+    execFileSync(PRETTIER_BIN, IGNORE_BYPASS.concat("--write", ...staged.map((s) => s.tmp)), {
       encoding: "utf8",
       maxBuffer: 64 * 1024 * 1024,
     });
   } catch (err) {
+    for (const s of staged) fs.rmSync(s.tmp, { force: true });
     throw new Error(
-      `[write-json-manifest] prettier failed formatting ${paths.join(", ")}. ` +
+      `[write-json-manifest] prettier failed formatting ${writes.map((w) => w.outPath).join(", ")}. ` +
         `Manifests must be emitted prettier-formatted or the tree goes dirty on every ` +
-        `regeneration; refusing to leave unformatted output. Is ${PRETTIER_BIN} present ` +
+        `regeneration; refusing to write unformatted output. Is ${PRETTIER_BIN} present ` +
         `(\`pnpm install\`)?`,
       { cause: err },
     );
   }
+  for (const s of staged) fs.renameSync(s.tmp, s.outPath);
 }
 
 export function writeJsonManifest(outPath: string, data: unknown): void {
-  const raw = JSON.stringify(data, null, 2) + "\n";
-  fs.mkdirSync(path.dirname(outPath), { recursive: true });
-  fs.writeFileSync(outPath, raw);
-  if (openBatch) openBatch.push(outPath);
-  else runPrettier([outPath]);
+  const write: PendingWrite = { outPath, raw: JSON.stringify(data, null, 2) + "\n" };
+  if (openBatch) openBatch.push(write);
+  else commit([write]);
 }
 
 /**
- * Opens a batch: subsequent `writeJsonManifest` calls write their raw bytes but
- * defer formatting until `flushManifestBatch()`, which formats every collected
- * path in one prettier spawn. Idempotent — a second call while a batch is open
- * is a no-op, so nested callers can't clobber the outer batch.
+ * Opens a batch: subsequent `writeJsonManifest` calls buffer their bytes in
+ * memory until `flushManifestBatch()` formats and commits them in one prettier
+ * spawn. Idempotent — a second call while a batch is open is a no-op, so nested
+ * callers can't clobber the outer batch.
  */
 export function beginManifestBatch(): void {
   if (!openBatch) openBatch = [];
 }
 
-/** Formats every path collected since `beginManifestBatch()` in one spawn. */
+/** Commits every write buffered since `beginManifestBatch()` in one spawn. */
 export function flushManifestBatch(): void {
-  const paths = openBatch;
+  const writes = openBatch;
   openBatch = null;
-  if (paths) runPrettier(paths);
+  if (writes) commit(writes);
 }

--- a/scripts/build-rails-privates-manifest.ts
+++ b/scripts/build-rails-privates-manifest.ts
@@ -31,7 +31,11 @@ import * as path from "path";
 import { fileURLToPath } from "url";
 import { rubyMethodToTs, rubyFileToTs } from "./api-compare/conventions.js";
 import { libPathsManifest } from "../vendor/sources.js";
-import { writeJsonManifest } from "./api-compare/write-json-manifest.js";
+import {
+  writeJsonManifest,
+  beginManifestBatch,
+  flushManifestBatch,
+} from "./api-compare/write-json-manifest.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
@@ -53,6 +57,10 @@ const PACKAGE_DIRS: Record<string, string> = {
 const RAILS_API_PATH = path.join(ROOT, "scripts/api-compare/output/rails-api.json");
 const OUT = path.join(ROOT, "eslint/rails-private-methods.json");
 
+// This script emits three manifests per run. Collect their writes and format
+// them all in one prettier spawn (~330ms of startup, once instead of thrice).
+beginManifestBatch();
+
 // The deprecation-parity manifest scans the vendored Ruby source directly and
 // does NOT depend on rails-api.json, so emit it up front — before the early
 // exit below that fires when rails-api.json is missing.
@@ -65,6 +73,7 @@ emitCallbackInvocationsManifest();
 
 if (!fs.existsSync(RAILS_API_PATH)) {
   writeJsonManifest(OUT, { files: {} });
+  flushManifestBatch();
   console.warn(
     `[build-rails-privates-manifest] ${RAILS_API_PATH} missing; wrote empty manifest. ` +
       `Run \`pnpm api:compare\` to regenerate with real data.`,
@@ -224,6 +233,7 @@ for (const k of Object.keys(manifest.files).sort()) sortedFiles[k] = manifest.fi
 const final: Manifest = { files: sortedFiles };
 
 writeJsonManifest(OUT, final);
+flushManifestBatch();
 const fileCount = Object.keys(final.files).length;
 const fileNames = Object.values(final.files).reduce((n, a) => n + a.length, 0);
 console.log(`Wrote ${OUT} — ${fileCount} files (${fileNames} names)`);


### PR DESCRIPTION
## What

`writeJsonManifest()` shelled out to the prettier CLI once per manifest (~330ms of prettier startup each). This batches those spawns.

- Add an opt-in batch (`beginManifestBatch()` / `flushManifestBatch()`): writes inside a batch buffer their bytes **in memory** and are formatted in a single `prettier --write path…` spawn at flush.
- Wire the three-manifest `build-rails-privates-manifest.ts` emitter to the batch, so it spawns prettier once per run instead of three times (both the normal path and the rails-api-missing early-exit flush exactly once).

## Crash-safety (review findings 1 & 2)

Every write — batched or immediate — is staged to a sibling `.json` temp file (same directory, so prettier resolves the identical `.prettierrc.json` + JSON parser), formatted there, then **renamed** over the tracked path. Consequences:

- A failed prettier spawn unlinks the temp and leaves the committed manifest bytes **intact** — no churn, and the "refusing to write unformatted output" error is accurate again.
- Batched writes buffer in memory, so an exception between `beginManifestBatch()` and its flush touches **no** target file — the batch can't be abandoned half-churned.

## Guarantees preserved

- **Single formatting code path** — both modes go through the same stage → `prettier --write` → rename `commit()`, so tracked manifests reproduce byte-identically. Verified by re-emitting every emitter (zero git churn) and by a unit test asserting batch output equals immediate output.
- **No skip-on-unchanged fast path** — every call still reformats unconditionally (the reverted PR #4987 decision stands).
- `--ignore-path /dev/null` bypass retained, so gitignored/`.prettierignore`d manifests are still formatted.

## Tests

`scripts/api-compare/write-json-manifest.test.ts` — 12 green, including: ignored-path, self-repair, memory-buffering-until-flush, tracked-file-untouched-when-batch-abandoned, batch-byte-identical-to-immediate, and no-stray-temp-files.

## Non-blocking notes from review

- *Failure-path coverage:* added the abandoned-batch test (asserts committed bytes untouched); the temp+rename design makes the immediate-path failure equally non-destructive.
- *Duplicate paths in one batch:* each write gets a unique temp via a monotonic sequence, so even a future caller that writes the same target twice stages distinct temps; the second rename wins, harmless.

Closes-story: manifest-emitter-prettier-spawn-batching
