### PR TITLE
fix(lint-deps): resolve import aliases before matching referenced types

### DIFF
--- a/scripts/api-compare/lint-deps.test.ts
+++ b/scripts/api-compare/lint-deps.test.ts
@@ -5,6 +5,7 @@ import * as path from "path";
 import * as ts from "typescript";
 import {
   collectDirectImports,
+  collectImportAliases,
   collectTaintedSymbols,
   isImportFromPackage,
   methodUsesDepImport,
@@ -203,6 +204,79 @@ describe("methodUsesDepImport — collectRefs mode", () => {
   });
 });
 
+describe("methodUsesDepImport — import-alias resolution", () => {
+  const AM = "@blazetrails/activemodel";
+
+  it("records an aliased identifier under its exported name", () => {
+    const sf = makeSourceFile(`
+      import { Attribute as ModelAttribute } from "${AM}";
+      function foo() { return new ModelAttribute(); }
+    `);
+    const node = firstMethod(sf);
+    const aliasMap = collectImportAliases(sf, AM);
+    const refs = new Set<string>();
+    methodUsesDepImport(
+      node,
+      new Set(["ModelAttribute"]),
+      new Set(),
+      "activemodel",
+      sf,
+      node,
+      undefined,
+      refs,
+      aliasMap,
+    );
+    expect(refs.has("Attribute")).toBe(true);
+    expect(refs.has("ModelAttribute")).toBe(false);
+  });
+
+  it("records the aliased class name for a static access base", () => {
+    const sf = makeSourceFile(`
+      import { Attribute as AMAttribute } from "${AM}";
+      function foo() { return AMAttribute.withCastValue("a", 1, null); }
+    `);
+    const node = firstMethod(sf);
+    const aliasMap = collectImportAliases(sf, AM);
+    const refs = new Set<string>();
+    methodUsesDepImport(
+      node,
+      new Set(["AMAttribute"]),
+      new Set(),
+      "activemodel",
+      sf,
+      node,
+      undefined,
+      refs,
+      aliasMap,
+    );
+    expect(refs.has("Attribute")).toBe(true);
+    expect(refs.has("AMAttribute")).toBe(false);
+  });
+
+  it("still records the leaf for a non-aliased namespace-style member access", () => {
+    const sf = makeSourceFile(`
+      import { Nodes } from "@blazetrails/arel";
+      function foo() { return new Nodes.OuterJoin(); }
+    `);
+    const node = firstMethod(sf);
+    const aliasMap = collectImportAliases(sf, "@blazetrails/arel");
+    const refs = new Set<string>();
+    methodUsesDepImport(
+      node,
+      new Set(["Nodes"]),
+      new Set(),
+      "arel",
+      sf,
+      node,
+      undefined,
+      refs,
+      aliasMap,
+    );
+    expect(refs.has("OuterJoin")).toBe(true);
+    expect(refs.has("Nodes")).toBe(false);
+  });
+});
+
 describe("methodUsesDepImport — lint-deps-ignore annotation", () => {
   it("opt-out comment above method marks as covered", () => {
     const sf = makeSourceFile(`
@@ -318,7 +392,7 @@ describe("collectTaintedSymbols — transitive dep usage", () => {
       `,
     });
     const program = programFor(dir);
-    const tainted = collectTaintedSymbols(program, dir, pkg, [], "activesupport");
+    const { tainted } = collectTaintedSymbols(program, dir, pkg, [], "activesupport");
     const helperSf = program.getSourceFiles().find((sf) => sf.fileName.endsWith("helper.ts"))!;
     const consumerSf = program.getSourceFiles().find((sf) => sf.fileName.endsWith("consumer.ts"))!;
     const checker = program.getTypeChecker();
@@ -374,7 +448,7 @@ describe("collectTaintedSymbols — transitive dep usage", () => {
       `,
     });
     const program = programFor(dir);
-    const tainted = collectTaintedSymbols(program, dir, pkg, [], "activesupport");
+    const { tainted } = collectTaintedSymbols(program, dir, pkg, [], "activesupport");
     const checker = program.getTypeChecker();
     for (const f of ["a.ts", "b.ts", "c.ts"]) {
       const sf = program.getSourceFiles().find((s) => s.fileName.endsWith(f))!;
@@ -395,7 +469,7 @@ describe("collectTaintedSymbols — transitive dep usage", () => {
       `,
     });
     const program = programFor(dir);
-    const tainted = collectTaintedSymbols(program, dir, pkg, [], "activesupport");
+    const { tainted } = collectTaintedSymbols(program, dir, pkg, [], "activesupport");
     expect(tainted.size).toBe(0);
   });
 
@@ -408,7 +482,7 @@ describe("collectTaintedSymbols — transitive dep usage", () => {
       `,
     });
     const program = programFor(dir);
-    const tainted = collectTaintedSymbols(program, dir, pkg, [], "activemodel");
+    const { tainted } = collectTaintedSymbols(program, dir, pkg, [], "activemodel");
     const sf = program.getSourceFiles().find((s) => s.fileName.endsWith("helper.ts"))!;
     const stmt = sf.statements.find((s): s is ts.VariableStatement => ts.isVariableStatement(s))!;
     const decl = stmt.declarationList.declarations[0];
@@ -427,7 +501,7 @@ describe("collectTaintedSymbols — transitive dep usage", () => {
       `,
     });
     const program = programFor(dir);
-    const tainted = collectTaintedSymbols(program, dir, pkg, [], "arel");
+    const { tainted } = collectTaintedSymbols(program, dir, pkg, [], "arel");
     expect(tainted.size).toBe(0);
   });
 
@@ -444,7 +518,7 @@ describe("collectTaintedSymbols — transitive dep usage", () => {
       `,
     });
     const program = programFor(dir);
-    const tainted = collectTaintedSymbols(program, dir, pkg, [], "activesupport");
+    const { tainted } = collectTaintedSymbols(program, dir, pkg, [], "activesupport");
     const checker = program.getTypeChecker();
     const consumerSf = program.getSourceFiles().find((sf) => sf.fileName.endsWith("consumer.ts"))!;
     const importedNames = collectDirectImports(consumerSf, pkg);
@@ -463,5 +537,41 @@ describe("collectTaintedSymbols — transitive dep usage", () => {
       refs,
     );
     expect(refs.has("executionContextId")).toBe(true);
+  });
+
+  it("inherits a wrapper's alias-resolved refs through taint", () => {
+    const pkg = "@blazetrails/activemodel";
+    const dir = writePkg({
+      "helper.ts": `
+        import { Attribute as ModelAttribute } from "${pkg}";
+        export function isActiveModelAttribute(v: unknown) { return v instanceof ModelAttribute; }
+      `,
+      "consumer.ts": `
+        import { isActiveModelAttribute } from "./helper.js";
+        export function visit(v: unknown) { return isActiveModelAttribute(v); }
+      `,
+    });
+    const program = programFor(dir);
+    const { tainted, taintedRefs } = collectTaintedSymbols(program, dir, pkg, [], "activemodel");
+    const checker = program.getTypeChecker();
+    const consumerSf = program.getSourceFiles().find((sf) => sf.fileName.endsWith("consumer.ts"))!;
+    const fn = consumerSf.statements.find((s): s is ts.FunctionDeclaration =>
+      ts.isFunctionDeclaration(s),
+    )!;
+    const refs = new Set<string>();
+    methodUsesDepImport(
+      fn,
+      collectDirectImports(consumerSf, pkg),
+      new Set(),
+      "activemodel",
+      consumerSf,
+      fn,
+      { checker, taintedSymbols: tainted, taintedRefs },
+      refs,
+    );
+    // The consumer reaches ActiveModel::Attribute only through the wrapper, so
+    // it inherits `Attribute` (not the wrapper identifier).
+    expect(refs.has("Attribute")).toBe(true);
+    expect(refs.has("isActiveModelAttribute")).toBe(false);
   });
 });

--- a/scripts/api-compare/lint-deps.test.ts
+++ b/scripts/api-compare/lint-deps.test.ts
@@ -569,9 +569,37 @@ describe("collectTaintedSymbols — transitive dep usage", () => {
       { checker, taintedSymbols: tainted, taintedRefs },
       refs,
     );
-    // The consumer reaches ActiveModel::Attribute only through the wrapper, so
-    // it inherits `Attribute` (not the wrapper identifier).
     expect(refs.has("Attribute")).toBe(true);
     expect(refs.has("isActiveModelAttribute")).toBe(false);
+  });
+
+  it("propagates alias-resolved refs through a wrapper chain to a fixed point", () => {
+    const pkg = "@blazetrails/activemodel";
+    const dir = writePkg({
+      "a.ts": `
+        import { Attribute as ModelAttribute } from "${pkg}";
+        export function isAttr(v: unknown) { return v instanceof ModelAttribute; }
+      `,
+      "b.ts": `
+        import { isAttr } from "./a.js";
+        export function checkAttr(v: unknown) { return isAttr(v); }
+      `,
+      "c.ts": `
+        import { checkAttr } from "./b.js";
+        export function visit(v: unknown) { return checkAttr(v); }
+      `,
+    });
+    const program = programFor(dir);
+    const { tainted, taintedRefs } = collectTaintedSymbols(program, dir, pkg, [], "activemodel");
+    const checker = program.getTypeChecker();
+    for (const f of ["a.ts", "b.ts", "c.ts"]) {
+      const sf = program.getSourceFiles().find((s) => s.fileName.endsWith(f))!;
+      const fn = sf.statements.find((s): s is ts.FunctionDeclaration =>
+        ts.isFunctionDeclaration(s),
+      )!;
+      const sym = checker.getSymbolAtLocation(fn.name!)!;
+      expect(tainted.has(sym)).toBe(true);
+      expect(taintedRefs.get(sym)?.has("Attribute")).toBe(true);
+    }
   });
 });

--- a/scripts/api-compare/lint-deps.ts
+++ b/scripts/api-compare/lint-deps.ts
@@ -161,6 +161,32 @@ export function collectDirectImports(sf: ts.SourceFile, tsImport: string): Set<s
   return names;
 }
 
+/**
+ * Map each locally-bound name to the original exported name it aliases, for
+ * named imports from tsImport. `import { Attribute as ModelAttribute }` yields
+ * `ModelAttribute -> Attribute`. Only aliased bindings (local !== original) are
+ * recorded; default/namespace imports have no distinct original type name to
+ * resolve. Used so ref matching compares against the exported name Rails
+ * references, not the local disambiguation alias.
+ */
+export function collectImportAliases(sf: ts.SourceFile, tsImport: string): Map<string, string> {
+  const aliases = new Map<string, string>();
+  for (const stmt of sf.statements) {
+    if (!ts.isImportDeclaration(stmt)) continue;
+    const specifier = (stmt.moduleSpecifier as ts.StringLiteral).text;
+    if (!isImportFromPackage(specifier, tsImport)) continue;
+    const bindings = stmt.importClause?.namedBindings;
+    if (bindings && ts.isNamedImports(bindings)) {
+      for (const el of bindings.elements) {
+        if (el.propertyName && el.propertyName.text !== el.name.text) {
+          aliases.set(el.name.text, el.propertyName.text);
+        }
+      }
+    }
+  }
+  return aliases;
+}
+
 // Visits every top-level "taint candidate" — a binding whose body or
 // initializer could (transitively) use the dep, making the binding
 // itself a wrapper that callers should inherit credit from.
@@ -200,16 +226,26 @@ export function collectTaintedSymbols(
   tsImport: string,
   tsIdentifiers: string[],
   dep: string,
-): Set<ts.Symbol> {
+): { tainted: Set<ts.Symbol>; taintedRefs: Map<ts.Symbol, Set<string>> } {
   const checker = program.getTypeChecker();
   const knownIds = new Set(tsIdentifiers);
   const tainted = new Set<ts.Symbol>();
+  const taintedRefs = new Map<ts.Symbol, Set<string>>();
   const directCache = new Map<ts.SourceFile, Set<string>>();
+  const aliasCache = new Map<ts.SourceFile, Map<string, string>>();
   const getDirect = (sf: ts.SourceFile): Set<string> => {
     let s = directCache.get(sf);
     if (!s) {
       s = collectDirectImports(sf, tsImport);
       directCache.set(sf, s);
+    }
+    return s;
+  };
+  const getAlias = (sf: ts.SourceFile): Map<string, string> => {
+    let s = aliasCache.get(sf);
+    if (!s) {
+      s = collectImportAliases(sf, tsImport);
+      aliasCache.set(sf, s);
     }
     return s;
   };
@@ -229,22 +265,37 @@ export function collectTaintedSymbols(
     for (const { sf, name, body, anchor } of candidates) {
       const sym = checker.getSymbolAtLocation(name);
       if (!sym || tainted.has(sym)) continue;
+      const refs = new Set<string>();
       if (
-        methodUsesDepImport(body, getDirect(sf), knownIds, dep, sf, anchor, {
-          checker,
-          taintedSymbols: tainted,
-          // A lint-deps-ignore opt-out should not taint the wrapper —
-          // otherwise an "uses raw SQL; no Arel needed" helper would
-          // grant credit to every caller and hide real violations.
-          skipIgnoreAnnotation: true,
-        })
+        methodUsesDepImport(
+          body,
+          getDirect(sf),
+          knownIds,
+          dep,
+          sf,
+          anchor,
+          {
+            checker,
+            taintedSymbols: tainted,
+            taintedRefs,
+            // A lint-deps-ignore opt-out should not taint the wrapper —
+            // otherwise an "uses raw SQL; no Arel needed" helper would
+            // grant credit to every caller and hide real violations.
+            skipIgnoreAnnotation: true,
+          },
+          refs,
+          getAlias(sf),
+        )
       ) {
         tainted.add(sym);
+        // Record the dep type-names this wrapper resolves to, so callers
+        // that reach the dep only through it inherit the right refs.
+        taintedRefs.set(sym, refs);
         changed = true;
       }
     }
   }
-  return tainted;
+  return { tainted, taintedRefs };
 }
 
 function analyzeTsDepUsage(
@@ -269,7 +320,13 @@ function analyzeTsDepUsage(
 
   const checker = program.getTypeChecker();
   const knownIds = new Set(tsIdentifiers);
-  const taintedSymbols = collectTaintedSymbols(program, pkgSrcDir, tsImport, tsIdentifiers, dep);
+  const { tainted: taintedSymbols, taintedRefs } = collectTaintedSymbols(
+    program,
+    pkgSrcDir,
+    tsImport,
+    tsIdentifiers,
+    dep,
+  );
 
   for (const sourceFile of program.getSourceFiles()) {
     if (!isPkgSourceFile(sourceFile, pkgSrcDir)) continue;
@@ -280,6 +337,7 @@ function analyzeTsDepUsage(
     // tsDepMap.get(rubyFileToTs(...)) lookup misses.
     const relPath = path.relative(pkgSrcDir, sourceFile.fileName).split(path.sep).join("/");
     const importedNames = collectDirectImports(sourceFile, tsImport);
+    const aliasMap = collectImportAliases(sourceFile, tsImport);
 
     const methodMap = new Map<string, TsMethodDepInfo>();
     visitMethodDeclarations(sourceFile, (name, methodNode, anchor) => {
@@ -291,8 +349,9 @@ function analyzeTsDepUsage(
         dep,
         sourceFile,
         anchor,
-        { checker, taintedSymbols },
+        { checker, taintedSymbols, taintedRefs },
         refs,
+        aliasMap,
       );
       const existing = methodMap.get(name);
       if (existing === undefined) {
@@ -396,6 +455,12 @@ export function hasLintDepsIgnore(node: ts.Node, dep: string, sourceFile: ts.Sou
 export interface TransitiveContext {
   checker: ts.TypeChecker;
   taintedSymbols: Set<ts.Symbol>;
+  // Dep type-names each tainted wrapper references directly. When a method
+  // reaches the dep only through a wrapper (e.g. `isActiveModelAttribute`,
+  // which does `v instanceof ModelAttribute`), the method inherits the
+  // wrapper's refs (`Attribute`) rather than the wrapper's own name — so ref
+  // matching sees the type Rails references, not the helper identifier.
+  taintedRefs?: Map<ts.Symbol, Set<string>>;
   // Suppresses lint-deps-ignore detection. Used during taint
   // computation so an opt-out helper doesn't spuriously taint callers.
   skipIgnoreAnnotation?: boolean;
@@ -410,8 +475,12 @@ export function methodUsesDepImport(
   anchor: ts.Node = node,
   transitive?: TransitiveContext,
   collectRefs?: Set<string>,
+  aliasMap?: Map<string, string>,
 ): boolean {
   if (!transitive?.skipIgnoreAnnotation && hasLintDepsIgnore(anchor, dep, sourceFile)) return true;
+  // Resolve a locally-bound alias back to the exported name Rails references,
+  // so `Attribute as ModelAttribute` is recorded as a ref to `Attribute`.
+  const recordRef = (name: string) => collectRefs?.add(aliasMap?.get(name) ?? name);
   let found = false;
   // Walk top-down so we can distinguish:
   //   - signature type positions (param/return/typeParam of the function
@@ -427,7 +496,13 @@ export function methodUsesDepImport(
     if (ts.isPropertyAccessExpression(n) && ts.isIdentifier(n.expression)) {
       if (importedNames.has(n.expression.text)) {
         found = true;
-        collectRefs?.add(n.name.text);
+        // Leaf: for a namespace-style import (`Nodes.OuterJoin`) the member
+        // names the type.
+        recordRef(n.name.text);
+        // Base: a class imported under a disambiguating alias and used as a
+        // static access (`AMAttribute.withCastValue`) names its type via the
+        // base identifier, so record its resolved export name too.
+        if (aliasMap?.has(n.expression.text)) recordRef(n.expression.text);
         if (!collectRefs) return;
       }
     }
@@ -443,7 +518,7 @@ export function methodUsesDepImport(
           if (!inType || inSignatureType) {
             if (importedNames.has(n.text) || knownIdentifiers.has(n.text)) {
               found = true;
-              collectRefs?.add(n.text);
+              recordRef(n.text);
               if (!collectRefs) return;
             }
             if (transitive && transitive.taintedSymbols.size > 0) {
@@ -453,7 +528,12 @@ export function methodUsesDepImport(
                   sym.flags & ts.SymbolFlags.Alias ? transitive.checker.getAliasedSymbol(sym) : sym;
                 if (transitive.taintedSymbols.has(resolved)) {
                   found = true;
-                  collectRefs?.add(n.text);
+                  const wrapperRefs = transitive.taintedRefs?.get(resolved);
+                  if (collectRefs && wrapperRefs && wrapperRefs.size > 0) {
+                    for (const r of wrapperRefs) collectRefs.add(r);
+                  } else {
+                    recordRef(n.text);
+                  }
                   if (!collectRefs) return;
                 }
               }

--- a/scripts/api-compare/lint-deps.ts
+++ b/scripts/api-compare/lint-deps.ts
@@ -282,11 +282,14 @@ export function collectTaintedSymbols(
         tainted.add(sym);
         changed = true;
       }
-      const prev = taintedRefs.get(sym);
-      if (!prev || refs.size > prev.size) {
-        taintedRefs.set(sym, refs);
-        changed = true;
+      let acc = taintedRefs.get(sym);
+      if (!acc) {
+        acc = new Set();
+        taintedRefs.set(sym, acc);
       }
+      const before = acc.size;
+      for (const r of refs) acc.add(r);
+      if (acc.size > before) changed = true;
     }
   }
   return { tainted, taintedRefs };

--- a/scripts/api-compare/lint-deps.ts
+++ b/scripts/api-compare/lint-deps.ts
@@ -161,14 +161,6 @@ export function collectDirectImports(sf: ts.SourceFile, tsImport: string): Set<s
   return names;
 }
 
-/**
- * Map each locally-bound name to the original exported name it aliases, for
- * named imports from tsImport. `import { Attribute as ModelAttribute }` yields
- * `ModelAttribute -> Attribute`. Only aliased bindings (local !== original) are
- * recorded; default/namespace imports have no distinct original type name to
- * resolve. Used so ref matching compares against the exported name Rails
- * references, not the local disambiguation alias.
- */
 export function collectImportAliases(sf: ts.SourceFile, tsImport: string): Map<string, string> {
   const aliases = new Map<string, string>();
   for (const stmt of sf.statements) {
@@ -264,32 +256,34 @@ export function collectTaintedSymbols(
     changed = false;
     for (const { sf, name, body, anchor } of candidates) {
       const sym = checker.getSymbolAtLocation(name);
-      if (!sym || tainted.has(sym)) continue;
+      if (!sym) continue;
       const refs = new Set<string>();
-      if (
-        methodUsesDepImport(
-          body,
-          getDirect(sf),
-          knownIds,
-          dep,
-          sf,
-          anchor,
-          {
-            checker,
-            taintedSymbols: tainted,
-            taintedRefs,
-            // A lint-deps-ignore opt-out should not taint the wrapper —
-            // otherwise an "uses raw SQL; no Arel needed" helper would
-            // grant credit to every caller and hide real violations.
-            skipIgnoreAnnotation: true,
-          },
-          refs,
-          getAlias(sf),
-        )
-      ) {
+      const uses = methodUsesDepImport(
+        body,
+        getDirect(sf),
+        knownIds,
+        dep,
+        sf,
+        anchor,
+        {
+          checker,
+          taintedSymbols: tainted,
+          taintedRefs,
+          // A lint-deps-ignore opt-out should not taint the wrapper —
+          // otherwise an "uses raw SQL; no Arel needed" helper would
+          // grant credit to every caller and hide real violations.
+          skipIgnoreAnnotation: true,
+        },
+        refs,
+        getAlias(sf),
+      );
+      if (!uses) continue;
+      if (!tainted.has(sym)) {
         tainted.add(sym);
-        // Record the dep type-names this wrapper resolves to, so callers
-        // that reach the dep only through it inherit the right refs.
+        changed = true;
+      }
+      const prev = taintedRefs.get(sym);
+      if (!prev || refs.size > prev.size) {
         taintedRefs.set(sym, refs);
         changed = true;
       }
@@ -455,11 +449,6 @@ export function hasLintDepsIgnore(node: ts.Node, dep: string, sourceFile: ts.Sou
 export interface TransitiveContext {
   checker: ts.TypeChecker;
   taintedSymbols: Set<ts.Symbol>;
-  // Dep type-names each tainted wrapper references directly. When a method
-  // reaches the dep only through a wrapper (e.g. `isActiveModelAttribute`,
-  // which does `v instanceof ModelAttribute`), the method inherits the
-  // wrapper's refs (`Attribute`) rather than the wrapper's own name — so ref
-  // matching sees the type Rails references, not the helper identifier.
   taintedRefs?: Map<ts.Symbol, Set<string>>;
   // Suppresses lint-deps-ignore detection. Used during taint
   // computation so an opt-out helper doesn't spuriously taint callers.
@@ -478,8 +467,6 @@ export function methodUsesDepImport(
   aliasMap?: Map<string, string>,
 ): boolean {
   if (!transitive?.skipIgnoreAnnotation && hasLintDepsIgnore(anchor, dep, sourceFile)) return true;
-  // Resolve a locally-bound alias back to the exported name Rails references,
-  // so `Attribute as ModelAttribute` is recorded as a ref to `Attribute`.
   const recordRef = (name: string) => collectRefs?.add(aliasMap?.get(name) ?? name);
   let found = false;
   // Walk top-down so we can distinguish:
@@ -496,12 +483,7 @@ export function methodUsesDepImport(
     if (ts.isPropertyAccessExpression(n) && ts.isIdentifier(n.expression)) {
       if (importedNames.has(n.expression.text)) {
         found = true;
-        // Leaf: for a namespace-style import (`Nodes.OuterJoin`) the member
-        // names the type.
         recordRef(n.name.text);
-        // Base: a class imported under a disambiguating alias and used as a
-        // static access (`AMAttribute.withCastValue`) names its type via the
-        // base identifier, so record its resolved export name too.
         if (aliasMap?.has(n.expression.text)) recordRef(n.expression.text);
         if (!collectRefs) return;
       }


### PR DESCRIPTION
## Summary

`scripts/api-compare/lint-deps.ts` matched referenced types by **local
identifier name**, so an aliased import hid the Rails type name. Aliasing is the
`packages/arel` convention for activemodel's `Attribute` (arel has its own
`Attribute`): `import { Attribute as ModelAttribute }`. As a result the
`arel -> activemodel` section reported **4/4 methods as ref mismatches** even
though every one references `Attribute` correctly.

## Changes

- `collectImportAliases` maps each locally-bound alias back to its exported name
  for named imports; refs are recorded under the exported name.
- A static access on an aliased class (`AMAttribute.withCastValue`) records the
  resolved class name (`Attribute`), not just the member leaf. Non-aliased
  namespace-style accesses (`Nodes.OuterJoin`) still record the leaf.
- Methods that reach the dep only through a tainted wrapper
  (`isActiveModelAttribute` -> `instanceof ModelAttribute`) inherit the
  wrapper's alias-resolved refs (`taintedRefs`) instead of the wrapper
  identifier. Wrapper refs are accumulated to a fixed point so a method reaching
  the dep through several wrappers gets all their refs.
- No import was changed to satisfy the linter.

## Result

All four `arel -> activemodel` entries stop reporting `missing Attribute`:

```
Dependency Lint -- arel -> activemodel
  4/4 methods use activemodel (100%)
  1 ref mismatches (uses activemodel but different types):
    != procForBinds -- missing Type  (nodes/homogeneous-in.ts)
```

The one remaining mismatch — `procForBinds -- missing Type` — is a genuine
`ValueType` vs `ActiveModel::Type` naming divergence (not an alias), and
correctly still reports: no false negative introduced.

The change is **strictly an improvement** across every section. Diffing the full
ref-mismatch output against `origin/main`: **zero new mismatches introduced**,
and several pre-existing alias-noise entries resolved —
`activerecord -> arel` (`Table`, `InnerJoin`, `OuterJoin`, plus `Node`/`Attribute`
on `preprocessOrderArgs`), `activerecord -> activemodel` (`_enum`/`Type`,
`typeCastedBinds`/`Attribute`), and `activerecord -> activesupport`
(`deriveKeyFrom`/`KeyGenerator`).

## Gate decision (advisory vs blocking)

**Stays advisory.** The exit code is driven solely by `blocking` *rule
violations*, never by ref mismatches — and `arel -> activemodel` has 0
violations regardless. Ref-mismatch reporting is advisory by construction across
every rule. Flipping ref mismatches to gate would red the pre-existing,
out-of-scope `procForBinds`/`Type` naming divergence, plus the remaining benign
naming divergences the `activerecord` rules carry (JSON, Chars, Digest, ...).
What changes here is trust, not the exit code: a `missing X` line now means a
genuinely absent reference rather than alias noise, so a reviewer no longer has
to hand-verify each aliased line.

## Tests

New tests cover: aliased identifier recorded under exported name; aliased-class
static-access base recorded; non-aliased namespace member still records the
leaf; wrapper alias-resolved refs inherited through taint; and refs propagated
through a wrapper chain to a fixed point. Existing `collectTaintedSymbols` tests
updated for the new `{ tainted, taintedRefs }` return. 36/36 pass.

Closes-story: lint-deps-resolve-import-aliases
