### PR TITLE
refactor(test-harness): clamp fork count in ar-db-slots via the OS adapter

### DIFF
--- a/packages/activerecord/src/test-helpers/ar-db-forks-default.ts
+++ b/packages/activerecord/src/test-helpers/ar-db-forks-default.ts
@@ -1,0 +1,8 @@
+/**
+ * Default vitest worker count for the AR DB suite.
+ *
+ * Its own module because vitest.config.ts imports it while loading the config,
+ * before any workspace package is built — so it must not pull in
+ * `@blazetrails/activesupport` (which ar-db-slots.ts does, for the OS adapter).
+ */
+export const DEFAULT_FORKS = 6;

--- a/packages/activerecord/src/test-helpers/ar-db-slots.test.ts
+++ b/packages/activerecord/src/test-helpers/ar-db-slots.test.ts
@@ -9,7 +9,7 @@ import { DEFAULT_FORKS, slotPoolSize, workerForkCount } from "./ar-db-slots.js";
 let cores = 64;
 const HOST_CORES = 64;
 
-const ENV_KEYS = ["AR_DB_FORKS", "AR_DB_SLOTS"] as const;
+const ENV_KEYS = ["TRAILS_TEST_FORKS", "AR_DB_FORKS", "AR_DB_SLOTS"] as const;
 
 describe("ar-db-slots", () => {
   beforeAll(() => {
@@ -38,7 +38,10 @@ describe("ar-db-slots", () => {
     }
   });
 
+  // TRAILS_TEST_FORKS outranks AR_DB_FORKS, so it has to be cleared for every
+  // case that exercises the latter — a dev box may well have it exported.
   function setEnv(forks?: string, slots?: string): void {
+    delete process.env.TRAILS_TEST_FORKS;
     if (forks === undefined) delete process.env.AR_DB_FORKS;
     else process.env.AR_DB_FORKS = forks;
     if (slots === undefined) delete process.env.AR_DB_SLOTS;
@@ -65,6 +68,24 @@ describe("ar-db-slots", () => {
     it("treats a non-numeric value as the default fork count", () => {
       setEnv("auto");
       expect(workerForkCount()).toBe(DEFAULT_FORKS);
+    });
+
+    it("prefers TRAILS_TEST_FORKS over AR_DB_FORKS", () => {
+      setEnv("8");
+      process.env.TRAILS_TEST_FORKS = "3";
+      expect(workerForkCount()).toBe(3);
+    });
+
+    it("reads TRAILS_TEST_FORKS when AR_DB_FORKS is unset", () => {
+      setEnv(undefined);
+      process.env.TRAILS_TEST_FORKS = "2";
+      expect(workerForkCount()).toBe(2);
+    });
+
+    it("takes the single-worker path for TRAILS_TEST_FORKS=1", () => {
+      setEnv("8");
+      process.env.TRAILS_TEST_FORKS = "1";
+      expect(workerForkCount()).toBe(1);
     });
 
     it("clamps the request to the host's core count minus one", () => {

--- a/packages/activerecord/src/test-helpers/ar-db-slots.test.ts
+++ b/packages/activerecord/src/test-helpers/ar-db-slots.test.ts
@@ -1,20 +1,36 @@
-import { getOs } from "@blazetrails/activesupport";
-import { afterEach, describe, expect, it } from "vitest";
+import { osAdapterConfig, registerOsAdapter } from "@blazetrails/activesupport";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { DEFAULT_FORKS, slotPoolSize, workerForkCount } from "./ar-db-slots.js";
 
-// The clamp workerForkCount() applies, recomputed here from the same adapter
-// so expectations hold on any host (CI runners have far fewer cores than a
-// dev box, and the requests below deliberately exceed small hosts).
-const HOST_CAP = Math.max(getOs().availableParallelism() - 1, 1);
-const capped = (n: number): number => Math.min(n, HOST_CAP);
+// workerForkCount() clamps to the host's cores - 1, so every expectation below
+// would otherwise depend on the machine running it (a 4-vCPU CI runner clamps
+// where a dev box does not). Pin the core count through the OS adapter instead
+// and vary it explicitly in the clamp tests.
+let cores = 64;
+const HOST_CORES = 64;
 
 const ENV_KEYS = ["AR_DB_FORKS", "AR_DB_SLOTS"] as const;
 
 describe("ar-db-slots", () => {
+  beforeAll(() => {
+    registerOsAdapter("ar-db-slots-test", {
+      tmpdir: () => "/tmp",
+      platform: () => "linux",
+      cwd: () => "/",
+      availableParallelism: () => cores,
+    });
+    osAdapterConfig.adapter = "ar-db-slots-test";
+  });
+
+  afterAll(() => {
+    osAdapterConfig.adapter = null;
+  });
+
   const saved = new Map<string, string | undefined>();
   for (const k of ENV_KEYS) saved.set(k, process.env[k]);
 
   afterEach(() => {
+    cores = HOST_CORES;
     for (const k of ENV_KEYS) {
       const v = saved.get(k);
       if (v === undefined) delete process.env[k];
@@ -32,43 +48,53 @@ describe("ar-db-slots", () => {
   describe("workerForkCount", () => {
     it("defaults to the shared default fork count when AR_DB_FORKS is unset", () => {
       setEnv(undefined);
-      expect(workerForkCount()).toBe(capped(DEFAULT_FORKS));
+      expect(workerForkCount()).toBe(DEFAULT_FORKS);
     });
 
     it("reads AR_DB_FORKS", () => {
       setEnv("8");
-      expect(workerForkCount()).toBe(capped(8));
+      expect(workerForkCount()).toBe(8);
     });
 
     it("clamps to at least 1", () => {
       setEnv("0");
-      expect(workerForkCount()).toBe(capped(DEFAULT_FORKS));
+      expect(workerForkCount()).toBe(DEFAULT_FORKS);
       expect(workerForkCount()).toBeGreaterThanOrEqual(1);
     });
 
     it("treats a non-numeric value as the default fork count", () => {
       setEnv("auto");
-      expect(workerForkCount()).toBe(capped(DEFAULT_FORKS));
+      expect(workerForkCount()).toBe(DEFAULT_FORKS);
     });
 
-    it("sees the host-clamped count vitest.config.ts republishes", () => {
-      // No republish any more: the clamp is applied here, against the OS
-      // adapter, so an oversized request never escapes as a worker count.
-      setEnv("1024");
-      expect(workerForkCount()).toBe(HOST_CAP);
-      expect(workerForkCount()).toBeGreaterThan(0);
+    it("clamps the request to the host's core count minus one", () => {
+      cores = 4;
+      setEnv("8");
+      expect(workerForkCount()).toBe(3);
+    });
+
+    it("clamps the default fork count on a small host", () => {
+      cores = 2;
+      setEnv(undefined);
+      expect(workerForkCount()).toBe(1);
+    });
+
+    it("never clamps below 1, even on a single-core host", () => {
+      cores = 1;
+      setEnv("8");
+      expect(workerForkCount()).toBe(1);
     });
   });
 
   describe("slotPoolSize", () => {
     it("adds headroom over the worker count", () => {
       setEnv("2");
-      expect(slotPoolSize()).toBe(capped(2) + 2);
+      expect(slotPoolSize()).toBe(4);
     });
 
     it("keeps headroom at the CI fork count of 8", () => {
       setEnv("8");
-      expect(slotPoolSize()).toBe(capped(8) + 2);
+      expect(slotPoolSize()).toBe(10);
     });
 
     it("has headroom even for a single worker", () => {
@@ -83,12 +109,18 @@ describe("ar-db-slots", () => {
 
     it("ignores a non-positive AR_DB_SLOTS override", () => {
       setEnv("4", "0");
-      expect(slotPoolSize()).toBe(capped(4) + 2);
+      expect(slotPoolSize()).toBe(6);
     });
 
     it("clamps an undersized override up to workers + 1", () => {
       setEnv("8", "4");
-      expect(slotPoolSize()).toBe(Math.max(4, capped(8) + 1));
+      expect(slotPoolSize()).toBe(9);
+    });
+
+    it("tracks the clamped worker count, not the request", () => {
+      cores = 4;
+      setEnv("8");
+      expect(slotPoolSize()).toBe(5);
     });
 
     it("is always strictly greater than the worker count", () => {

--- a/packages/activerecord/src/test-helpers/ar-db-slots.test.ts
+++ b/packages/activerecord/src/test-helpers/ar-db-slots.test.ts
@@ -1,6 +1,12 @@
-import os from "node:os";
+import { getOs } from "@blazetrails/activesupport";
 import { afterEach, describe, expect, it } from "vitest";
 import { DEFAULT_FORKS, slotPoolSize, workerForkCount } from "./ar-db-slots.js";
+
+// The clamp workerForkCount() applies, recomputed here from the same adapter
+// so expectations hold on any host (CI runners have far fewer cores than a
+// dev box, and the requests below deliberately exceed small hosts).
+const HOST_CAP = Math.max(getOs().availableParallelism() - 1, 1);
+const capped = (n: number): number => Math.min(n, HOST_CAP);
 
 const ENV_KEYS = ["AR_DB_FORKS", "AR_DB_SLOTS"] as const;
 
@@ -26,44 +32,43 @@ describe("ar-db-slots", () => {
   describe("workerForkCount", () => {
     it("defaults to the shared default fork count when AR_DB_FORKS is unset", () => {
       setEnv(undefined);
-      expect(workerForkCount()).toBe(DEFAULT_FORKS);
+      expect(workerForkCount()).toBe(capped(DEFAULT_FORKS));
     });
 
     it("reads AR_DB_FORKS", () => {
       setEnv("8");
-      expect(workerForkCount()).toBe(8);
+      expect(workerForkCount()).toBe(capped(8));
     });
 
     it("clamps to at least 1", () => {
       setEnv("0");
-      expect(workerForkCount()).toBe(DEFAULT_FORKS);
+      expect(workerForkCount()).toBe(capped(DEFAULT_FORKS));
       expect(workerForkCount()).toBeGreaterThanOrEqual(1);
     });
 
     it("treats a non-numeric value as the default fork count", () => {
       setEnv("auto");
-      expect(workerForkCount()).toBe(DEFAULT_FORKS);
+      expect(workerForkCount()).toBe(capped(DEFAULT_FORKS));
     });
 
-    // The value this process was started with, before any setEnv() below.
-    const inherited = saved.get("AR_DB_FORKS");
-
     it("sees the host-clamped count vitest.config.ts republishes", () => {
-      expect(inherited).toBeDefined();
-      expect(Number(inherited)).toBeLessThanOrEqual(Math.max(os.availableParallelism() - 1, 1));
-      expect(Number(inherited)).toBeGreaterThan(0);
+      // No republish any more: the clamp is applied here, against the OS
+      // adapter, so an oversized request never escapes as a worker count.
+      setEnv("1024");
+      expect(workerForkCount()).toBe(HOST_CAP);
+      expect(workerForkCount()).toBeGreaterThan(0);
     });
   });
 
   describe("slotPoolSize", () => {
     it("adds headroom over the worker count", () => {
       setEnv("2");
-      expect(slotPoolSize()).toBe(4);
+      expect(slotPoolSize()).toBe(capped(2) + 2);
     });
 
     it("keeps headroom at the CI fork count of 8", () => {
       setEnv("8");
-      expect(slotPoolSize()).toBe(10);
+      expect(slotPoolSize()).toBe(capped(8) + 2);
     });
 
     it("has headroom even for a single worker", () => {
@@ -78,12 +83,12 @@ describe("ar-db-slots", () => {
 
     it("ignores a non-positive AR_DB_SLOTS override", () => {
       setEnv("4", "0");
-      expect(slotPoolSize()).toBe(6);
+      expect(slotPoolSize()).toBe(capped(4) + 2);
     });
 
     it("clamps an undersized override up to workers + 1", () => {
       setEnv("8", "4");
-      expect(slotPoolSize()).toBe(9);
+      expect(slotPoolSize()).toBe(Math.max(4, capped(8) + 1));
     });
 
     it("is always strictly greater than the worker count", () => {

--- a/packages/activerecord/src/test-helpers/ar-db-slots.ts
+++ b/packages/activerecord/src/test-helpers/ar-db-slots.ts
@@ -1,10 +1,9 @@
 /**
  * Advisory-slot pool sizing for the parallel AR DB test harness.
  *
- * `AR_DB_FORKS` is the vitest worker count. vitest.config.ts clamps the
- * requested value to the host's `numCpus - 1` and rewrites the variable to
- * that effective result, so the pool sized here tracks the workers that
- * actually start. The advisory-lock
+ * `AR_DB_FORKS` is the vitest worker count. The requested value is clamped
+ * here to the host's `numCpus - 1` (the same ceiling vitest derives), so the
+ * pool sized here tracks the workers that actually start. The advisory-lock
  * **slot pool** — the set of per-worker
  * slot DBs provisioned by globalSetup and claimed by each worker in
  * test-setup-worker-db.ts — is sized SEPARATELY, with headroom over the worker
@@ -27,23 +26,41 @@
  * pool costs only a few extra CREATE DATABASEs in globalSetup.
  */
 
+import { getOs } from "@blazetrails/activesupport";
+import { DEFAULT_FORKS } from "./ar-db-forks-default.js";
+
 // Spare slots beyond the worker count. One is enough to cover a single
 // recycle overlap; two leaves margin for back-to-back recycles.
 const SLOT_HEADROOM = 2;
 
-/** Fork count when no env var requests one. Shared with vitest.config.ts. */
-export const DEFAULT_FORKS = 6;
+export { DEFAULT_FORKS };
 
 /**
- * Effective vitest worker count — `AR_DB_FORKS` as rewritten by
- * vitest.config.ts, which owns the host clamp (package sources may not import
- * `node:os`). Outside a vitest run the value is an unclamped request, which
- * can only over-provision the pool. Non-numeric or non-positive (unset,
- * "auto", "0") falls back to {@link DEFAULT_FORKS}.
+ * Host ceiling on concurrent workers: `numCpus - 1`, matching the cap vitest
+ * derives for its own fork pool. Read through the OS adapter because package
+ * sources may not import `node:os`. If no adapter can be resolved (a runtime
+ * with no notion of CPU count), the request goes unclamped — that can only
+ * over-provision the pool, never undercut it.
+ */
+function hostForkCap(): number | null {
+  try {
+    return Math.max(getOs().availableParallelism() - 1, 1);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Effective vitest worker count — the `AR_DB_FORKS` request clamped to
+ * {@link hostForkCap}, so it is correct regardless of who calls it. The env
+ * var can only lower the count, never raise it past the host. Non-numeric or
+ * non-positive (unset, "auto", "0") falls back to {@link DEFAULT_FORKS}.
  */
 export function workerForkCount(): number {
   const n = parseInt(process.env.AR_DB_FORKS ?? "", 10);
-  return Number.isFinite(n) && n > 0 ? n : DEFAULT_FORKS;
+  const requested = Number.isFinite(n) && n > 0 ? n : DEFAULT_FORKS;
+  const cap = hostForkCap();
+  return cap === null ? requested : Math.min(requested, cap);
 }
 
 /**

--- a/packages/activerecord/src/test-helpers/ar-db-slots.ts
+++ b/packages/activerecord/src/test-helpers/ar-db-slots.ts
@@ -1,7 +1,9 @@
 /**
  * Advisory-slot pool sizing for the parallel AR DB test harness.
  *
- * `AR_DB_FORKS` is the vitest worker count. The requested value is clamped
+ * `TRAILS_TEST_FORKS` / `AR_DB_FORKS` request the vitest worker count, in that
+ * precedence order — the same order vitest.config.ts uses to size the real
+ * fork pool. The requested value is clamped
  * here to the host's `numCpus - 1` (the same ceiling vitest derives), so the
  * pool sized here tracks the workers that actually start. The advisory-lock
  * **slot pool** — the set of per-worker
@@ -51,13 +53,20 @@ function hostForkCap(): number | null {
 }
 
 /**
- * Effective vitest worker count — the `AR_DB_FORKS` request clamped to
+ * Effective vitest worker count — the request clamped to
  * {@link hostForkCap}, so it is correct regardless of who calls it. The env
- * var can only lower the count, never raise it past the host. Non-numeric or
+ * vars can only lower the count, never raise it past the host. Non-numeric or
  * non-positive (unset, "auto", "0") falls back to {@link DEFAULT_FORKS}.
+ *
+ * Precedence must stay identical to vitest.config.ts's `TEST_FORKS`
+ * (TRAILS_TEST_FORKS > AR_DB_FORKS > DEFAULT_FORKS, then the host clamp):
+ * that value becomes `poolOptions.forks.maxForks`, so any divergence means
+ * the pool is sized against a worker count that never starts — and the
+ * single-worker bypass in test-setup-worker-db.ts would miss a
+ * `TRAILS_TEST_FORKS=1` solo run.
  */
 export function workerForkCount(): number {
-  const n = parseInt(process.env.AR_DB_FORKS ?? "", 10);
+  const n = parseInt(process.env.TRAILS_TEST_FORKS ?? process.env.AR_DB_FORKS ?? "", 10);
   const requested = Number.isFinite(n) && n > 0 ? n : DEFAULT_FORKS;
   const cap = hostForkCap();
   return cap === null ? requested : Math.min(requested, cap);

--- a/packages/activerecord/src/test-setup-worker-db.ts
+++ b/packages/activerecord/src/test-setup-worker-db.ts
@@ -21,10 +21,10 @@
  * (e.g. hot-module reloading in vitest watch mode) returns the same slot
  * without opening a second connection or consuming an additional lock.
  *
- * AR_DB_FORKS: vitest worker count, clamped to the host's numCpus - 1 by
- * vitest.config.ts. The advisory-slot pool is sized separately, with headroom
- * over that count — see test-helpers/ar-db-slots.ts (override with
- * AR_DB_SLOTS).
+ * TRAILS_TEST_FORKS / AR_DB_FORKS: the requested vitest worker count, clamped
+ * to the host's numCpus - 1 by workerForkCount() itself (via the OS adapter).
+ * The advisory-slot pool is sized separately, with headroom over that count —
+ * see test-helpers/ar-db-slots.ts (override with AR_DB_SLOTS).
  */
 
 import pg from "pg";

--- a/packages/activesupport/src/os-adapter.ts
+++ b/packages/activesupport/src/os-adapter.ts
@@ -2,8 +2,8 @@
  * OS adapter — mirrors the Rails adapter pattern.
  *
  * Exposes the few runtime surfaces higher-level packages need (`tmpdir`,
- * `platform`, `cwd`, `availableParallelism`) so they can avoid importing `node:os` / `process`
- * directly.
+ * `platform`, `cwd`, `availableParallelism`) so they can avoid importing
+ * `node:os` / `process` directly.
  */
 
 export interface OsAdapter {

--- a/packages/activesupport/src/os-adapter.ts
+++ b/packages/activesupport/src/os-adapter.ts
@@ -2,7 +2,7 @@
  * OS adapter — mirrors the Rails adapter pattern.
  *
  * Exposes the few runtime surfaces higher-level packages need (`tmpdir`,
- * `platform`, `cwd`) so they can avoid importing `node:os` / `process`
+ * `platform`, `cwd`, `availableParallelism`) so they can avoid importing `node:os` / `process`
  * directly.
  */
 
@@ -16,6 +16,12 @@ export interface OsAdapter {
    * relative paths resolved against.
    */
   cwd(): string;
+  /**
+   * Number of logical CPUs available to this process. On Node this is
+   * `os.availableParallelism()`. Runtimes without the notion should return
+   * their best estimate of usable concurrency (never less than 1).
+   */
+  availableParallelism(): number;
 }
 
 const registry = new Map<string, OsAdapter>();
@@ -30,7 +36,11 @@ export function registerOsAdapter(name: string, adapter: OsAdapter): void {
 let nodeAttempted = false;
 let nodeAsyncPromise: Promise<boolean> | null = null;
 
-type NodeOs = { tmpdir: () => string; platform: () => string };
+type NodeOs = {
+  tmpdir: () => string;
+  platform: () => string;
+  availableParallelism: () => number;
+};
 
 function wrap(os: NodeOs): OsAdapter {
   return {
@@ -41,6 +51,7 @@ function wrap(os: NodeOs): OsAdapter {
       if (proc && typeof proc.cwd === "function") return proc.cwd();
       throw new Error("process.cwd() is unavailable in this runtime");
     },
+    availableParallelism: () => os.availableParallelism(),
   };
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,12 +1,13 @@
 import { defineConfig } from "vitest/config";
 import path from "path";
 import os from "os";
-import { DEFAULT_FORKS } from "./packages/activerecord/src/test-helpers/ar-db-slots.js";
+import { DEFAULT_FORKS } from "./packages/activerecord/src/test-helpers/ar-db-forks-default.js";
 
 // AR_DB_FORKS (read in test-setup-worker-db.ts) requests a vitest worker
 // count; TEST_FORKS below is the effective one — the request clamped to the
-// host ceiling — and is republished as AR_DB_FORKS. The advisory-lock slot
-// pool is sized SEPARATELY, with headroom over that effective count — see
+// host ceiling, the same clamp ar-db-slots.ts applies via the OS adapter. The
+// advisory-lock slot pool is sized SEPARATELY, with headroom over that
+// effective count — see
 // test-helpers/ar-db-slots.ts (slots =
 // workers + headroom, or an explicit AR_DB_SLOTS override). TRAILS_TEST_FORKS
 // caps the vitest worker count so that concurrent local worktrees don't
@@ -100,12 +101,6 @@ const TEST_FORKS = Math.min(
   Number.isFinite(_parsedForks) && _parsedForks > 0 ? _parsedForks : DEFAULT_FORKS,
   _hostForkCap,
 );
-// Republish the effective count so ar-db-slots.ts sizes the slot pool from the
-// workers that actually start. The clamp lives only here because package
-// sources may not import `node:os` (browser compat) and the os-adapter exposes
-// no `availableParallelism`. Runs in the vitest parent before globalSetup and
-// before any worker forks; workers inherit the parent env.
-process.env.AR_DB_FORKS = String(TEST_FORKS);
 
 const alias = {
   "@blazetrails/activesupport/message-verifier": path.resolve(

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,9 +7,8 @@ import { DEFAULT_FORKS } from "./packages/activerecord/src/test-helpers/ar-db-fo
 // count; TEST_FORKS below is the effective one — the request clamped to the
 // host ceiling, the same clamp ar-db-slots.ts applies via the OS adapter. The
 // advisory-lock slot pool is sized SEPARATELY, with headroom over that
-// effective count — see
-// test-helpers/ar-db-slots.ts (slots =
-// workers + headroom, or an explicit AR_DB_SLOTS override). TRAILS_TEST_FORKS
+// effective count — see test-helpers/ar-db-slots.ts (slots = workers +
+// headroom, or an explicit AR_DB_SLOTS override). TRAILS_TEST_FORKS
 // caps the vitest worker count so that concurrent local worktrees don't
 // saturate the machine. Precedence: TRAILS_TEST_FORKS > AR_DB_FORKS >
 // DEFAULT_FORKS, all capped by the host ceiling. Raise with TRAILS_TEST_FORKS=N
@@ -95,7 +94,8 @@ const _parsedForks = parseInt(process.env.TRAILS_TEST_FORKS ?? process.env.AR_DB
 // runner, honoring a fork count above it (AR_DB_FORKS=8, as CI used to set)
 // oversubscribes PG enough to push the full-DB schema-dump tests past their
 // 5s timeout. The env vars can only lower the cap, never raise it past the
-// host.
+// host. Duplicated (not imported) from ar-db-slots.ts because the config is
+// loaded before any workspace package is built — see ar-db-forks-default.ts.
 const _hostForkCap = Math.max(os.availableParallelism() - 1, 1);
 const TEST_FORKS = Math.min(
   Number.isFinite(_parsedForks) && _parsedForks > 0 ? _parsedForks : DEFAULT_FORKS,


### PR DESCRIPTION
Moves the AR fork-count clamp out of `vitest.config.ts` and into the code that
consumes it.

- `OsAdapter` gains `availableParallelism()`; the node adapter wires
  `os.availableParallelism` alongside `tmpdir`/`platform` (both the sync and
  async registration paths share the same `wrap()`).
- `ar-db-slots.ts` applies `min(request, numCpus - 1)` itself via `getOs()`, so
  `workerForkCount()` / `slotPoolSize()` are correct regardless of caller. If no
  OS adapter can be resolved the request goes unclamped — that can only
  over-provision the pool, never undercut it.
- `vitest.config.ts` no longer rewrites `process.env.AR_DB_FORKS`; the republish
  and its rationale comment are gone.
- `DEFAULT_FORKS` moves to a dependency-free leaf module
  (`ar-db-forks-default.ts`) and is re-exported from `ar-db-slots.ts`:
  `vitest.config.ts` imports it while loading the config, before any workspace
  package is built, so it must not pull in `@blazetrails/activesupport`.
- `ar-db-slots.test.ts` pins the core count through a fake OS adapter, so the
  literal pool-size expectations stay host-independent and the clamp itself is
  covered deterministically at 4, 2 and 1 cores (including the 1-worker floor).
  The republish-contract test is replaced by those direct clamp assertions.

- `workerForkCount()` also reads `TRAILS_TEST_FORKS`, with the same
  `TRAILS_TEST_FORKS > AR_DB_FORKS > DEFAULT_FORKS` precedence
  `vitest.config.ts` uses for `maxForks`. The republish was previously the only
  path by which that variable reached the slot sizing, so dropping it alone
  would have desynced the pool from the workers that actually spawn and made
  `TRAILS_TEST_FORKS=1` solo runs miss the single-worker advisory-lock bypass.
  The stale clamp comment in `test-setup-worker-db.ts` is updated too.

Closes-story: clamp-fork-count-via-os-adapter
