### PR TITLE
chore(ci): drop PG/MySQL test retry now that shared-DB flakes are fixed

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -369,23 +369,13 @@ export default defineConfig({
               ? ["./packages/activerecord/src/test-setup-ddl-profile.ts"]
               : []),
           ],
-          // Real-DB tests share a per-worker DB; the module-level state in
-          // test-adapter.ts has known race windows (see PR #1114 for prior
-          // _createdTables drift recovery). Retry intermittents on PG/MySQL
-          // only.
-          //
-          // Tradeoff: this is broader than the known shared-DB flakes — it
-          // also covers describeIfPg/describeIfMysql backend-only tests that
-          // SQLite never exercises, so a flaky-but-real regression in
-          // backend-only code could slip through after a retry. We accept
-          // this because (a) retries only mask non-deterministic failures —
-          // a 100% regression still fails through all attempts, (b) the
-          // observed flake pattern spans 10+ files across the project,
-          // making per-file scoping brittle, and (c) the alternative —
-          // letting CI fail on every transient race — burns more reviewer
-          // time than the rare hidden flake costs. Revisit if a real
-          // regression slips through.
-          retry: process.env.ARCONN === "postgresql" || process.env.ARCONN === "mysql2" ? 2 : 0,
+          // No retries on any backend. PG/MySQL used to run with retry: 2 to
+          // mask shared-per-worker-DB intermittents; repairWorkerSchema (PR
+          // #3351) fixed the canonical-table shape drift systemically and the
+          // two remaining runtime bespoke-table hazards were fixed in PRs
+          // #5228 and #5230. A red PG/MariaDB run is now a real regression or
+          // a real flake to track — do not restore the retry to re-mask it.
+          retry: 0,
           // Large-schema beforeAll(defineSchema(...)) calls on MySQL issue
           // hundreds of CREATE TABLE statements (e.g. has-many-associations.test.ts
           // creates ~354 tables in one beforeAll). At ~30ms per CREATE on MySQL

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -369,12 +369,6 @@ export default defineConfig({
               ? ["./packages/activerecord/src/test-setup-ddl-profile.ts"]
               : []),
           ],
-          // No retries on any backend. PG/MySQL used to run with retry: 2 to
-          // mask shared-per-worker-DB intermittents; repairWorkerSchema (PR
-          // #3351) fixed the canonical-table shape drift systemically and the
-          // two remaining runtime bespoke-table hazards were fixed in PRs
-          // #5228 and #5230. A red PG/MariaDB run is now a real regression or
-          // a real flake to track — do not restore the retry to re-mask it.
           retry: 0,
           // Large-schema beforeAll(defineSchema(...)) calls on MySQL issue
           // hundreds of CREATE TABLE statements (e.g. has-many-associations.test.ts


### PR DESCRIPTION
Drops the PG/MySQL-only `retry: 2` in `vitest.config.ts` to an unconditional
`retry: 0`, so a red PG/MariaDB CI run means a real regression again instead of
being silently re-run. The stale 16-line rationale block above it goes with it.

```diff
-          // Real-DB tests share a per-worker DB; ... (16 lines of rationale)
-          retry: process.env.ARCONN === "postgresql" || process.env.ARCONN === "mysql2" ? 2 : 0,
+          retry: 0,
```

## Why this is safe now

The retry masked shared-per-worker-DB intermittents. Both causes are fixed:

- **Canonical-table shape drift** — fixed systemically by `repairWorkerSchema` (#3351).
- **The two runtime bespoke-table hazards** that forced the #4136 revert and were
  re-confirmed on #5205 (CI run 30060420840):
  - `hot_compatibilities` PG cached-plan `0A000` — fixed in #5228.
  - `TransactionIsolationTest` `id`-reflection race on PG + MariaDB — fixed in #5230.

Both are recorded as `deps` on the story and both are `done`.

## Note on the "5 green runs" criterion

The story asks for ~5 consecutive green PG/MariaDB runs on `main` **with
`retry: 0` already in effect**. That evidence cannot exist on `main` while the
retry is still present, so it is satisfied by the post-removal PG/MariaDB runs on
this PR instead.

If a further bespoke-drift failure surfaces here, the fix is a new blocker story —
not restoring the retry.

Closes-story: remove-pg-mysql-test-retry-after-flake-burndown


## No-retry CI evidence (5 consecutive green)

All runs below had `retry: 0` already in effect, so green means the flakes are
gone — not that a retry re-ran. Every run was green across **all four** AR
backend jobs (PG and MariaDB are 2 shards each), with no failures anywhere in
the run:

| # | Run | Trigger | PG (1/2) | MariaDB (1/2) |
|---|-----|---------|----------|---------------|
| 1 | 30114094082 | push `d0609b55` | ✅ ✅ | ✅ ✅ |
| 2 | 30119145492 | push `5a605d5d` (rebase) | ✅ ✅ | ✅ ✅ |
| 3 | 30119145492 attempt 2 | rerun | ✅ ✅ | ✅ ✅ |
| 4 | 30121217949 | push `9d340944` (rebase onto new `main`) | ✅ ✅ | ✅ ✅ |
| 5 | 30121217949 attempt 2 | rerun | ✅ ✅ | ✅ ✅ |

**20 consecutive clean PG/MariaDB job-samples.** Runs 2 and 4 were true rebases
onto an advancing `main`, so the streak covers integration as well as
flake-consistency; runs 3 and 5 held the code constant to isolate flakiness.

This does not prove a low-frequency flake (say 1-in-50) is absent. If one
surfaces on `main` later, the fix is a new blocker story — not restoring the
retry.
