### PR TITLE
refactor(test-deps): route fixture baseline through writeJsonManifest

### DIFF
--- a/scripts/api-compare/write-json-manifest.test.ts
+++ b/scripts/api-compare/write-json-manifest.test.ts
@@ -166,10 +166,6 @@ describe("manifest emitters", () => {
     }
   });
 
-  // The committed baseline passes `prettier --check` today only by luck — it
-  // is a flat array of long paths prettier won't collapse. Round-tripping the
-  // real data through the helper proves the emitter now reproduces the tracked
-  // bytes exactly, which --check alone cannot show.
   it("reproduces the committed expected-fixtures-exclude.json byte-identically", () => {
     const tracked = path.join(REPO_ROOT, "eslint/expected-fixtures-exclude.json");
     const committed = fs.readFileSync(tracked, "utf8");

--- a/scripts/api-compare/write-json-manifest.test.ts
+++ b/scripts/api-compare/write-json-manifest.test.ts
@@ -157,11 +157,24 @@ describe("manifest emitters", () => {
       "generate-no-explicit-any-allowlist.ts",
       "generate-fixture-parity-exclude.ts",
       "generate-standalone-associations-exclude.ts",
+      "test-deps/build-fixture-baseline.ts",
     ];
     for (const name of generators) {
       const src = fs.readFileSync(path.join(REPO_ROOT, "scripts", name), "utf8");
       expect(src, `${name} must emit via writeJsonManifest`).toMatch(/\bwriteJsonManifest\b/);
       expect(src, `${name} must not hand-format JSON`).not.toMatch(/JSON\.stringify/);
     }
+  });
+
+  // The committed baseline passes `prettier --check` today only by luck — it
+  // is a flat array of long paths prettier won't collapse. Round-tripping the
+  // real data through the helper proves the emitter now reproduces the tracked
+  // bytes exactly, which --check alone cannot show.
+  it("reproduces the committed expected-fixtures-exclude.json byte-identically", () => {
+    const tracked = path.join(REPO_ROOT, "eslint/expected-fixtures-exclude.json");
+    const committed = fs.readFileSync(tracked, "utf8");
+    const out = tmpManifest();
+    writeJsonManifest(out, JSON.parse(committed));
+    expect(fs.readFileSync(out, "utf8")).toBe(committed);
   });
 });

--- a/scripts/test-deps/build-fixture-baseline.ts
+++ b/scripts/test-deps/build-fixture-baseline.ts
@@ -16,6 +16,8 @@ import * as path from "node:path";
 
 import { parser } from "typescript-eslint";
 
+import { writeJsonManifest } from "../api-compare/write-json-manifest.js";
+
 import type { FileDeps } from "./rails-test-deps.js";
 
 const ROOT = path.resolve(__dirname, "../..");
@@ -70,7 +72,7 @@ async function main(): Promise<void> {
     if (!hasAllKeys) excluded.push(path.posix.join("packages/activerecord/src", trailsRel));
   }
   excluded.sort();
-  fs.writeFileSync(OUT_PATH, JSON.stringify(excluded, null, 2) + "\n");
+  writeJsonManifest(OUT_PATH, excluded);
 
   console.log(`Rails test files declaring fixtures: ${candidates}`);
   console.log(`  scaffolding-only (no record refs, rule no-ops): ${scaffoldingOnly}`);


### PR DESCRIPTION
Routes `scripts/test-deps/build-fixture-baseline.ts` through `writeJsonManifest()` instead of `fs.writeFileSync` with a hand-formatted `JSON.stringify(..., null, 2)` payload, closing the last armed prettier-churn trap among the tracked ratchet baselines (PR #5240 converted the other three generators).

The committed `eslint/expected-fixtures-exclude.json` passes `prettier --check` today only by coincidence — it is a flat array of long path strings prettier will not collapse. The first short-enough entry would churn the tree on every regeneration.

- Extends the ratchet-generator source guard in `write-json-manifest.test.ts` to cover the script.
- Adds a round-trip test that re-emits the committed baseline data through the helper and asserts byte-identical output (stronger than `--check`).

`pnpm fixture-baseline:refresh` reproduces the tracked file with no diff.

Closes-story: fixture-baseline-emitter-prettier-churn
