### PR TITLE
test(canonical-shadows): converge bespoke registerModel shadows in finder/base/habtm siblings

### DIFF
--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -47,6 +47,7 @@ import { DeleteRestrictionError } from "./errors.js";
 import { assertQueriesCount, assertNoQueries } from "../testing/query-assertions.js";
 
 import { fixtures } from "../test-helpers/fixtures.js";
+import "../test-helpers/canonical-model-index.js";
 // Imported under HM-prefixed local aliases so the top-level bindings don't
 // collide with the bespoke `class Author` / `class Post` declarations in the
 // still-unconverted describes below. Without the alias, esbuild renames those
@@ -1016,21 +1017,21 @@ describe("HasManyAssociationsTest", () => {
   it.skip("depends and nullify with composite foreign key nulls every FK column", async () => {
     // Regression guard: the pre-ForeignAssociation.nullifiedOwnerAttributes
     // path only nulled the first FK column when `foreignKey` was an array.
-    class CpkAuthor extends Base {
+    class NullifyCompositeAuthor extends Base {
       declare name: string | null;
-      declare cpk_posts: AssociationProxy<CpkPost>;
+      declare cpk_posts: AssociationProxy<NullifyCompositePost>;
 
       static {
         this.attribute("name", "string");
         this.hasMany("cpk_posts", {
-          className: "CpkPost",
+          className: "NullifyCompositePost",
           foreignKey: ["tenant_id", "author_id"],
           primaryKey: ["id", "id"],
           dependent: "nullify",
         });
       }
     }
-    class CpkPost extends Base {
+    class NullifyCompositePost extends Base {
       declare tenant_id: number | null;
       declare author_id: number | null;
       declare title: string | null;
@@ -1041,17 +1042,17 @@ describe("HasManyAssociationsTest", () => {
         this.attribute("title", "string");
       }
     }
-    registerModel(CpkAuthor);
-    registerModel(CpkPost);
-    const author = await CpkAuthor.create({ name: "Alice" });
-    const post = await CpkPost.create({
+    registerModel(NullifyCompositeAuthor);
+    registerModel(NullifyCompositePost);
+    const author = await NullifyCompositeAuthor.create({ name: "Alice" });
+    const post = await NullifyCompositePost.create({
       tenant_id: author.id,
       author_id: author.id,
       title: "A",
       body: "body",
     });
     await author.destroy();
-    const reloaded = await CpkPost.find(post.id!);
+    const reloaded = await NullifyCompositePost.find(post.id!);
     expect((reloaded as any).tenant_id).toBeNull();
     expect((reloaded as any).author_id).toBeNull();
   });
@@ -2798,17 +2799,16 @@ describe("HasManyAssociationsTest", () => {
     expect((post as any).author_id).toBeNull();
   });
   it("create with bang on habtm when parent is new raises", async () => {
-    class Author extends Base {
-      declare name: string | null;
-
-      static {
-        this.attribute("name", "string");
-      }
+    const developer = Developer.new({ name: "Aredridel" });
+    let error: any;
+    try {
+      await association(developer, "projects").createBang({});
+    } catch (e) {
+      error = e;
     }
-    registerModel(Author);
-    const author = Author.new({ name: "Unsaved" });
-    expect(author.isNewRecord()).toBe(true);
-    expect(author.id).toBeNull();
+    expect(error).toBeInstanceOf(RecordNotSaved);
+    expect(error.message).toBe("You cannot call create unless the parent is saved");
+    expect(error.record).toBe(developer);
   });
   it("adding a mismatch class", async () => {
     const author = await HmAuthor.create({ name: "Alice" });

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -1013,7 +1013,8 @@ describe("BasicsTest", () => {
 
   it("equality of relation and collection proxy", async () => {
     const car = await Car.create({});
-    await association(car, "bulbs").create({});
+    association(car, "bulbs").build({});
+    await car.save();
 
     const bulbsOfCar = Bulb.where({ car_id: car.id });
     const proxyResults = await association(car, "bulbs");
@@ -1026,7 +1027,8 @@ describe("BasicsTest", () => {
 
   it("equality of relation and association relation", async () => {
     const car = await Car.create({});
-    await association(car, "bulbs").create({});
+    association(car, "bulbs").build({});
+    await car.save();
 
     const bulbsOfCar = Bulb.where({ car_id: car.id });
     // Rails: assert_equal bulbs_of_car, car.bulbs.includes(:car)
@@ -1042,7 +1044,8 @@ describe("BasicsTest", () => {
 
   it("equality of collection proxy and association relation", async () => {
     const car = await Car.create({});
-    await association(car, "bulbs").create({});
+    association(car, "bulbs").build({});
+    await car.save();
 
     // Rails: assert_equal car.bulbs, car.bulbs.includes(:car)
     // CollectionProxy and includes-chain produce the same underlying rows

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -14,7 +14,7 @@ import { TableNotSpecified, ActiveRecordError } from "./errors.js";
 
 import { adapterType } from "./test-adapter.js";
 import { quoteColumnName } from "./test-helpers/quote-regex.js";
-import { registerModel } from "./associations.js";
+import { association } from "./associations.js";
 import { connectedToStack } from "./core.js";
 import { Range as ArRange } from "./connection-adapters/postgresql/oid/range.js";
 import { Notifications, Logger, TimeWithZone } from "@blazetrails/activesupport";
@@ -33,6 +33,9 @@ import {
   AttributedDeveloper,
 } from "./test-helpers/models/developer.js";
 import { Topic as CanonicalTopic } from "./test-helpers/models/topic.js";
+import { Car } from "./test-helpers/models/car.js";
+import { Bulb } from "./test-helpers/models/bulb.js";
+import "./test-helpers/canonical-model-index.js";
 import { MultiparameterAssignmentErrors, type AttributeAssignmentError } from "./errors.js";
 
 vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
@@ -676,15 +679,9 @@ describe("BasicsTest", () => {
   });
 
   it("incomplete schema loading", async () => {
-    class Topic extends Base {
-      static {
-        this.tableName = "topics";
-        this.attribute("content", "json");
-      }
-    }
-    registerModel(Topic);
+    const Topic = CanonicalTopic;
     const payload = { foo: 42 };
-    const topic = await Topic.create({ content: payload });
+    const topic = await Topic.create({ content: payload as any });
     expect((topic as any).content).toEqual(payload);
 
     Topic.resetColumnInformation();
@@ -1015,23 +1012,12 @@ describe("BasicsTest", () => {
   });
 
   it("equality of relation and collection proxy", async () => {
-    class Bulb extends Base {
-      static {
-        this.attribute("car_id", "integer");
-      }
-    }
-    class Car extends Base {
-      static {
-        this.hasMany("bulbs", { className: "Bulb", foreignKey: "car_id" });
-      }
-    }
-    registerModel("Bulb", Bulb);
-    registerModel("Car", Car);
     const car = await Car.create({});
-    await Bulb.create({ car_id: car.id });
+    await association(car, "bulbs").create({});
 
-    const proxyResults = await (car as any).bulbs.toArray();
-    const relationResults = await Bulb.where({ car_id: car.id });
+    const bulbsOfCar = Bulb.where({ car_id: car.id });
+    const proxyResults = await association(car, "bulbs");
+    const relationResults = await bulbsOfCar;
     expect(proxyResults).toHaveLength(1);
     expect(proxyResults.map((r: any) => r.id).sort()).toEqual(
       relationResults.map((r: any) => r.id).sort(),
@@ -1039,28 +1025,15 @@ describe("BasicsTest", () => {
   });
 
   it("equality of relation and association relation", async () => {
-    class Bulb extends Base {
-      static {
-        this.attribute("car_id", "integer");
-        this.belongsTo("car", { className: "Car", foreignKey: "car_id" });
-      }
-    }
-    class Car extends Base {
-      static {
-        this.hasMany("bulbs", { className: "Bulb", foreignKey: "car_id" });
-      }
-    }
-    registerModel("Bulb", Bulb);
-    registerModel("Car", Car);
     const car = await Car.create({});
-    await Bulb.create({ car_id: car.id });
+    await association(car, "bulbs").create({});
 
     const bulbsOfCar = Bulb.where({ car_id: car.id });
     // Rails: assert_equal bulbs_of_car, car.bulbs.includes(:car)
     // AssociationRelation (includes chain off proxy) returns same rows as plain Relation
-    const assocRelation = (car as any).bulbs.includes("car");
+    const assocRelation = association(car, "bulbs").includes("car");
     const relationResults = await bulbsOfCar;
-    const assocResults = await assocRelation.toArray();
+    const assocResults = await assocRelation;
     expect(relationResults).toHaveLength(1);
     expect(assocResults.map((r: any) => r.id).sort()).toEqual(
       relationResults.map((r: any) => r.id).sort(),
@@ -1068,26 +1041,13 @@ describe("BasicsTest", () => {
   });
 
   it("equality of collection proxy and association relation", async () => {
-    class Bulb extends Base {
-      static {
-        this.attribute("car_id", "integer");
-        this.belongsTo("car", { className: "Car", foreignKey: "car_id" });
-      }
-    }
-    class Car extends Base {
-      static {
-        this.hasMany("bulbs", { className: "Bulb", foreignKey: "car_id" });
-      }
-    }
-    registerModel("Bulb", Bulb);
-    registerModel("Car", Car);
     const car = await Car.create({});
-    await Bulb.create({ car_id: car.id });
+    await association(car, "bulbs").create({});
 
     // Rails: assert_equal car.bulbs, car.bulbs.includes(:car)
     // CollectionProxy and includes-chain produce the same underlying rows
-    const proxyResults = await (car as any).bulbs.toArray();
-    const assocRelResults = await (car as any).bulbs.includes("car").toArray();
+    const proxyResults = await association(car, "bulbs");
+    const assocRelResults = await association(car, "bulbs").includes("car");
     expect(proxyResults).toHaveLength(1);
     expect(proxyResults.map((r: any) => r.id).sort()).toEqual(
       assocRelResults.map((r: any) => r.id).sort(),

--- a/packages/activerecord/src/finder.test.ts
+++ b/packages/activerecord/src/finder.test.ts
@@ -14,6 +14,7 @@ import {
 import { sql as arelSql } from "@blazetrails/arel";
 
 import { fixtures } from "./test-helpers/fixtures.js";
+import "./test-helpers/canonical-model-index.js";
 import { CpkBook } from "./test-helpers/models/cpk.js";
 import { adapterType } from "./test-adapter.js";
 import { Topic as CanonicalTopic } from "./test-helpers/models/topic.js";

--- a/packages/activerecord/src/habtm-destroy-order.test.ts
+++ b/packages/activerecord/src/habtm-destroy-order.test.ts
@@ -30,8 +30,6 @@ describe("HabtmDestroyOrderTest", () => {
 
   it("not destroying a student with lessons leaves student<=>lesson association intact", async () => {
     // test a normal before_destroy doesn't destroy the habtm joins
-    // `resetCallbacks` restores Student's destroy callbacks afterwards, matching
-    // the `ensure Student.reset_callbacks(:destroy)` in the Rails test.
     await resetCallbacks(Student, "destroy", async () => {
       // add a before destroy to student
       Student.beforeDestroy(async (r: any) => {

--- a/packages/activerecord/src/habtm-destroy-order.test.ts
+++ b/packages/activerecord/src/habtm-destroy-order.test.ts
@@ -1,53 +1,16 @@
-import type { AssociationProxy } from "./associations/collection-proxy.js";
 import { describe, it, expect } from "vitest";
-import { Base, association, registerModel, Rollback } from "./index.js";
+import { association, registerModel, resetCallbacks, Rollback } from "./index.js";
+import "./test-helpers/canonical-model-index.js";
+import { Lesson, LessonError } from "./test-helpers/models/lesson.js";
+import { Student } from "./test-helpers/models/student.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-
-// Mirrors vendor/rails/activerecord/test/models/lesson.rb — `class LessonError`.
-class LessonError extends Error {}
 
 fixtures([]);
 
 describe("HabtmDestroyOrderTest", () => {
-  function makeModels() {
-    class Student extends Base {
-      declare name: string;
-      declare lessons: AssociationProxy<Lesson>;
-
-      static {
-        this.attribute("name", "string");
-        this.hasAndBelongsToMany("lessons", {
-          className: "Lesson",
-          joinTable: "lessons_students",
-        });
-      }
-    }
-    class Lesson extends Base {
-      declare name: string;
-      declare students: AssociationProxy<Student>;
-
-      static {
-        this.attribute("name", "string");
-        // Mirrors models/lesson.rb: before_destroy :ensure_no_students,
-        // which raises `unless students.empty?`. Because destroyAssociations
-        // (HABTM join cleanup) runs AFTER before_destroy, this callback still
-        // sees the students at destroy time.
-        this.beforeDestroy(async (r: any) => {
-          if (!(await association(r, "students").isEmpty())) throw new LessonError();
-        });
-        this.hasAndBelongsToMany("students", {
-          className: "Student",
-          joinTable: "lessons_students",
-        });
-      }
-    }
-    registerModel("Student", Student);
-    registerModel("Lesson", Lesson);
-    return { Student, Lesson };
-  }
+  registerModel([Lesson, Student]);
 
   it("may not delete a lesson with students", async () => {
-    const { Student, Lesson } = makeModels();
     const sicp = await Lesson.create({ name: "SICP" });
     const ben = await Student.create({ name: "Ben Bitdiddle" });
     await association(sicp, "students").push(ben);
@@ -59,7 +22,6 @@ describe("HabtmDestroyOrderTest", () => {
   });
 
   it("should not raise error if have foreign key in the join table", async () => {
-    const { Student, Lesson } = makeModels();
     const student = await Student.create({ name: "Ben Bitdiddle" });
     const lesson = await Lesson.create({ name: "SICP" });
     await association(lesson, "students").push(student);
@@ -68,23 +30,25 @@ describe("HabtmDestroyOrderTest", () => {
 
   it("not destroying a student with lessons leaves student<=>lesson association intact", async () => {
     // test a normal before_destroy doesn't destroy the habtm joins
-    const { Student, Lesson } = makeModels();
-    // add a before destroy to student
-    Student.beforeDestroy(async (r: any) => {
-      if (!(await association(r, "lessons").isEmpty())) throw new Rollback();
-    });
-    const sicp = await Lesson.create({ name: "SICP" });
-    const ben = await Student.create({ name: "Ben Bitdiddle" });
-    await association(ben, "lessons").push(sicp);
+    // `resetCallbacks` restores Student's destroy callbacks afterwards, matching
+    // the `ensure Student.reset_callbacks(:destroy)` in the Rails test.
+    await resetCallbacks(Student, "destroy", async () => {
+      // add a before destroy to student
+      Student.beforeDestroy(async (r: any) => {
+        if (!(await association(r, "lessons").isEmpty())) throw new Rollback();
+      });
+      const sicp = await Lesson.create({ name: "SICP" });
+      const ben = await Student.create({ name: "Ben Bitdiddle" });
+      await association(ben, "lessons").push(sicp);
 
-    await ben.destroy();
-    await ben.reload();
-    expect(await association(ben, "lessons").isEmpty()).toBe(false);
+      await ben.destroy();
+      await ben.reload();
+      expect(await association(ben, "lessons").isEmpty()).toBe(false);
+    });
   });
 
   it("not destroying a lesson with students leaves student<=>lesson association intact", async () => {
     // test a more aggressive before_destroy doesn't destroy the habtm joins and still throws the exception
-    const { Student, Lesson } = makeModels();
     const sicp = await Lesson.create({ name: "SICP" });
     const ben = await Student.create({ name: "Ben Bitdiddle" });
     await association(sicp, "students").push(ben);


### PR DESCRIPTION
Arms the `registerModel` canonical-shadow guard
(`guardCanonicalNameShadow`, added in #5216) in four sibling suites that
carried the same bespoke-shadow anti-pattern but never imported
`test-helpers/canonical-model-index.js`, so the guard was dormant there.

Each file now imports the index; the registrations that would have tripped it
are converged onto the canonical models:

- **`habtm-destroy-order.test.ts`** — bespoke `Student`/`Lesson` replaced with
  the canonical models (`test-helpers/models/{lesson,student}.ts`). The
  callback-mutating test now wraps in `resetCallbacks(Student, "destroy", …)`,
  mirroring the `ensure Student.reset_callbacks(:destroy)` in
  `vendor/rails/activerecord/test/cases/habtm_destroy_order_test.rb`.
- **`base.test.ts`** — `incomplete schema loading` rides the canonical `Topic`
  (as in `base_test.rb:124`), and the three `equality of …` tests ride the
  canonical `Car`/`Bulb` pair (`base_test.rb:617-653`).
- **`associations/has-many-associations.test.ts`** —
  `create with bang on habtm when parent is new raises` now actually ports
  `has_many_associations_test.rb:1068` (`Developer#projects.create!` raising
  `RecordNotSaved`) instead of registering a bespoke `Author`. The skipped
  composite-FK nullify regression guard uses invented tables with no canonical
  counterpart, so its classes are de-collided to
  `NullifyCompositeAuthor`/`NullifyCompositePost`.
- **`finder.test.ts`** — every `registerModel` there already passed canonical
  classes; the index import just arms the guard.

`autosave-association.test.ts` (~5,500 lines, ~204 `registerModel` sites) is
far past the 500 LOC ceiling for this pass and is registered as a follow-up
story: `converge-autosave-association-bespoke-registermodel-canonical-shadows`.

Not in scope here: `finder.test.ts` still declares a few unregistered bespoke
`Post`/`Topic` classes in the ad-hoc `FinderTest2` block. They never reach
`registerModel`, so the guard does not fire on them; faithfully porting that
block onto the real finder_test.rb models is already tracked under RFC 0048.

Tests: the four touched files pass locally on SQLite (171 + 269 + 320 tests).

Closes-story: converge-sibling-test-bespoke-registermodel-canonical-shadows
