### PR TITLE
feat(api-compare): expand per-class operator spelling coverage

### DIFF
--- a/packages/activemodel/src/attribute-set/builder.ts
+++ b/packages/activemodel/src/attribute-set/builder.ts
@@ -183,6 +183,15 @@ export class LazyAttributeHash {
     return this.has(key);
   }
 
+  get(name: string): Attribute {
+    if (this.delegate.has(name)) return this.delegate.get(name)!;
+    return this.assignDefault(name);
+  }
+
+  set(name: string, attr: Attribute): void {
+    this.delegate.set(name, attr);
+  }
+
   deepDup(): LazyAttributeHash {
     const copy = new LazyAttributeHash(
       this.types,
@@ -263,15 +272,6 @@ export class LazyAttributeHash {
       ...this.types.keys(),
     ]);
     return [...allKeys];
-  }
-
-  get(name: string): Attribute {
-    if (this.delegate.has(name)) return this.delegate.get(name)!;
-    return this.assignDefault(name);
-  }
-
-  set(name: string, attr: Attribute): void {
-    this.delegate.set(name, attr);
   }
 
   has(name: string): boolean {

--- a/packages/activemodel/src/attribute.ts
+++ b/packages/activemodel/src/attribute.ts
@@ -181,6 +181,16 @@ export abstract class Attribute {
     return this._hasValue;
   }
 
+  equals(other: Attribute): boolean {
+    const typeEqual = this.type === other.type || this.type.constructor === other.type.constructor;
+    return (
+      this.constructor === other.constructor &&
+      this.name === other.name &&
+      this.valueBeforeTypeCast === other.valueBeforeTypeCast &&
+      typeEqual
+    );
+  }
+
   originalValueForDatabase(): unknown {
     if (this.originalAttribute !== null) {
       return this.originalAttribute.originalValueForDatabase();
@@ -217,16 +227,6 @@ export abstract class Attribute {
     this._hasValue = true;
     this._cachedValueForDatabase = undefined;
     this._hasValueForDatabase = false;
-  }
-
-  equals(other: Attribute): boolean {
-    const typeEqual = this.type === other.type || this.type.constructor === other.type.constructor;
-    return (
-      this.constructor === other.constructor &&
-      this.name === other.name &&
-      this.valueBeforeTypeCast === other.valueBeforeTypeCast &&
-      typeEqual
-    );
   }
 
   withUserDefault(value: unknown): Attribute {

--- a/packages/activemodel/src/error.ts
+++ b/packages/activemodel/src/error.ts
@@ -326,6 +326,14 @@ export class Error {
     return true;
   }
 
+  equals(other: Error): boolean {
+    if (!(other instanceof Error)) return false;
+    const a = this.attributesForHash();
+    const b = other.attributesForHash();
+    if (a[0] !== b[0] || a[1] !== b[1] || a[2] !== b[2]) return false;
+    return optionsEqual(a[3], b[3]);
+  }
+
   /**
    * Identity tuple used by `==` and `hash`. Mirrors Rails
    * `attributes_for_hash` (activemodel/lib/active_model/error.rb:204-206):
@@ -352,14 +360,6 @@ export class Error {
    */
   dupWithBase(newBase: ModelBase): Error {
     return new Error(newBase, this.attribute, this.type, deepDup(this.options), this.rawType);
-  }
-
-  equals(other: Error): boolean {
-    if (!(other instanceof Error)) return false;
-    const a = this.attributesForHash();
-    const b = other.attributesForHash();
-    if (a[0] !== b[0] || a[1] !== b[1] || a[2] !== b[2]) return false;
-    return optionsEqual(a[3], b[3]);
   }
 
   inspect(): string {

--- a/packages/activemodel/src/naming.ts
+++ b/packages/activemodel/src/naming.ts
@@ -105,6 +105,46 @@ export class ModelName {
   }
 
   /**
+   * Mirrors Rails `@name == other` (String#==). When comparing to
+   * another `ModelName`, both the bare name AND namespace segments
+   * must match — so `ModelName("Post")` and
+   * `ModelName("Post", { namespace: "Blog" })` are NOT equal. When
+   * comparing to a string, only `.name` is matched (a plain string
+   * can't express a namespace).
+   */
+  equals(other: unknown): boolean {
+    if (other instanceof ModelName) {
+      if (this.name !== other.name) return false;
+      return sameSegments(this.namespace, other.namespace);
+    }
+    return typeof other === "string" && this.name === other;
+  }
+
+  /**
+   * Mirrors Rails `@name <=> other` (String#<=>). Returns `-1`, `0`,
+   * or `1`. Throws `ArgumentError` for non-string / non-ModelName
+   * arguments. For ModelName-to-ModelName, compares the full
+   * identity (name + namespace) so namespace-differing models sort
+   * distinctly; for ModelName-to-string, compares `.name` only.
+   */
+  compare(other: unknown): -1 | 0 | 1 {
+    if (other instanceof ModelName) {
+      // Single string compare over the full `::`-qualified constant path —
+      // matches Rails' `String#<=>` on `@name` (e.g. "Admin::Other" <
+      // "Blog::Post" by first segment, regardless of bare-name ordering).
+      const l = ModelName._qualified(this);
+      const r = ModelName._qualified(other);
+      if (l === r) return 0;
+      return l < r ? -1 : 1;
+    }
+    if (typeof other === "string") {
+      if (this.name === other) return 0;
+      return this.name < other ? -1 : 1;
+    }
+    throw new ArgumentError("comparison of ModelName with non-string failed");
+  }
+
+  /**
    * Mirrors Rails `@name.match?(regexp)`. Returns whether the class
    * name matches the given regex (boolean — this is `match?` semantic,
    * not the integer position that Ruby `=~` returns).
@@ -147,6 +187,11 @@ export class ModelName {
    * returns that full path (`"Blog::Post"`) to match Rails.
    */
   toString(): string {
+    return this.name;
+  }
+
+  /** Implicit coercion hook so `String(mn)`, `"${mn}"`, `mn + ""` all work. */
+  [Symbol.toPrimitive](_hint: string): string {
     return this.name;
   }
 
@@ -281,11 +326,6 @@ export class ModelName {
     this.singularRouteKey = singularize(this.routeKey);
   }
 
-  /** Implicit coercion hook so `String(mn)`, `"${mn}"`, `mn + ""` all work. */
-  [Symbol.toPrimitive](_hint: string): string {
-    return this.name;
-  }
-
   get human(): string {
     if (!this._klass) return this._humanFallback;
 
@@ -358,46 +398,6 @@ export class ModelName {
    */
   static addUncountable(word: string): void {
     Inflections.instance("en").uncountable(word);
-  }
-
-  /**
-   * Mirrors Rails `@name == other` (String#==). When comparing to
-   * another `ModelName`, both the bare name AND namespace segments
-   * must match — so `ModelName("Post")` and
-   * `ModelName("Post", { namespace: "Blog" })` are NOT equal. When
-   * comparing to a string, only `.name` is matched (a plain string
-   * can't express a namespace).
-   */
-  equals(other: unknown): boolean {
-    if (other instanceof ModelName) {
-      if (this.name !== other.name) return false;
-      return sameSegments(this.namespace, other.namespace);
-    }
-    return typeof other === "string" && this.name === other;
-  }
-
-  /**
-   * Mirrors Rails `@name <=> other` (String#<=>). Returns `-1`, `0`,
-   * or `1`. Throws `ArgumentError` for non-string / non-ModelName
-   * arguments. For ModelName-to-ModelName, compares the full
-   * identity (name + namespace) so namespace-differing models sort
-   * distinctly; for ModelName-to-string, compares `.name` only.
-   */
-  compare(other: unknown): -1 | 0 | 1 {
-    if (other instanceof ModelName) {
-      // Single string compare over the full `::`-qualified constant path —
-      // matches Rails' `String#<=>` on `@name` (e.g. "Admin::Other" <
-      // "Blog::Post" by first segment, regardless of bare-name ordering).
-      const l = ModelName._qualified(this);
-      const r = ModelName._qualified(other);
-      if (l === r) return 0;
-      return l < r ? -1 : 1;
-    }
-    if (typeof other === "string") {
-      if (this.name === other) return 0;
-      return this.name < other ? -1 : 1;
-    }
-    throw new ArgumentError("comparison of ModelName with non-string failed");
   }
 
   private static _qualified(mn: ModelName): string {

--- a/scripts/api-compare/operator-order-spelling.test.ts
+++ b/scripts/api-compare/operator-order-spelling.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { operatorSpelling, OPERATOR_SPELLING_BY_FQN } from "./operator-order-spelling.js";
+import {
+  operatorSpelling,
+  OPERATOR_SPELLING_BY_FQN,
+  resetOperatorSpellingUsage,
+  unusedOperatorSpellings,
+} from "./operator-order-spelling.js";
 import { OPERATORS } from "./conventions.js";
 
 describe("operatorSpelling", () => {
@@ -46,6 +51,16 @@ describe("operatorSpelling", () => {
   it("returns undefined for a non-operator name", () => {
     expect(operatorSpelling("Arel::Table", "having")).toBeUndefined();
     expect(operatorSpelling("Arel::Table", "hash")).toBeUndefined();
+  });
+
+  it("reports entries never resolved so a typo'd fqn cannot stay silent", () => {
+    resetOperatorSpellingUsage();
+    expect(unusedOperatorSpellings()).toContain("Arel::Table#[]");
+    operatorSpelling("Arel::Table", "[]");
+    expect(unusedOperatorSpellings()).not.toContain("Arel::Table#[]");
+    // A key nobody looked up stays reported — this is the dead-entry signal.
+    expect(unusedOperatorSpellings()).toContain("ActiveModel::Errors#[]");
+    resetOperatorSpellingUsage();
   });
 
   it("only keys operators recognised by api-compare's OPERATORS set", () => {

--- a/scripts/api-compare/operator-order-spelling.test.ts
+++ b/scripts/api-compare/operator-order-spelling.test.ts
@@ -8,11 +8,34 @@ describe("operatorSpelling", () => {
     expect(operatorSpelling("Arel::Table", "[]")).toEqual(["get"]);
     expect(operatorSpelling("ActiveModel::AttributeSet", "[]")).toEqual(["getAttribute"]);
     expect(operatorSpelling("ActiveModel::Errors", "[]")).toEqual(["get"]);
-    expect(operatorSpelling("ActiveModel::AttributeSet::LazyAttributeHash", "[]")).toEqual(["get"]);
+    expect(operatorSpelling("ActiveModel::LazyAttributeHash", "[]")).toEqual(["get"]);
   });
 
   it("does NOT pull the AttributeSet `get` invention into the `[]` slot", () => {
     expect(operatorSpelling("ActiveModel::AttributeSet", "[]")).not.toContain("get");
+  });
+
+  it("leaves the AttributeSet `[]=` Map-compat sibling unmapped", () => {
+    expect(operatorSpelling("ActiveModel::AttributeSet", "[]=")).toBeUndefined();
+    expect(operatorSpelling("ActiveModel::LazyAttributeHash", "[]=")).toEqual(["set"]);
+  });
+
+  it("resolves `==` to each class's equality port", () => {
+    expect(operatorSpelling("ActiveModel::Attribute", "==")).toEqual(["equals"]);
+    expect(operatorSpelling("ActiveModel::Type::Value", "==")).toEqual(["equals"]);
+    expect(operatorSpelling("ActiveRecord::Result::IndexedRow", "==")).toEqual(["equals"]);
+    expect(operatorSpelling("ActiveRecord::Reflection::MacroReflection", "==")).toEqual(["equals"]);
+  });
+
+  it("resolves `<=>` to the comparison port", () => {
+    expect(operatorSpelling("ActiveModel::Name", "<=>")).toEqual(["compare"]);
+  });
+
+  it("resolves `[]` / `[]=` pairs to distinct accessor spellings", () => {
+    const pool = "ActiveRecord::ConnectionAdapters::StatementPool";
+    expect(operatorSpelling(pool, "[]")).toEqual(["get"]);
+    expect(operatorSpelling(pool, "[]=")).toEqual(["set"]);
+    expect(operatorSpelling("ActiveRecord::Result", "[]")).toEqual(["at"]);
   });
 
   it("returns undefined for an unlisted class (stays unmapped)", () => {

--- a/scripts/api-compare/operator-order-spelling.ts
+++ b/scripts/api-compare/operator-order-spelling.ts
@@ -81,11 +81,41 @@ export const OPERATOR_SPELLING_BY_FQN: Record<string, Record<string, string[]>> 
   "ActiveRecord::Result::IndexedRow": { "==": ["equals"], "[]": ["get"] },
 };
 
+// `fqn#operator` keys this process has actually resolved. A key that is never
+// resolved during a full manifest build is DEAD — the fqn (or the operator on
+// it) does not exist in the Ruby API extract, so the entry silently does
+// nothing. That is not hypothetical: the original
+// `ActiveModel::AttributeSet::LazyAttributeHash` key never matched, because
+// builder.rb:94 declares the class directly under `module ActiveModel`.
+const usedKeys = new Set<string>();
+
 /**
  * TS spelling candidates for a Ruby operator method on a given class, or
  * `undefined` when `name` is not an operator or the class has no verified entry.
  */
 export function operatorSpelling(fqn: string, name: string): string[] | undefined {
   if (!OPERATORS.has(name)) return undefined;
-  return OPERATOR_SPELLING_BY_FQN[fqn]?.[name];
+  const spelling = OPERATOR_SPELLING_BY_FQN[fqn]?.[name];
+  if (spelling) usedKeys.add(`${fqn}#${name}`);
+  return spelling;
+}
+
+/**
+ * `fqn#operator` keys never resolved since the last {@link resetOperatorSpellingUsage}.
+ * Meaningful only after a FULL pass over the Ruby API (the manifest build), where
+ * anything left over is a typo'd fqn or an operator the class no longer defines.
+ */
+export function unusedOperatorSpellings(): string[] {
+  const unused: string[] = [];
+  for (const [fqn, ops] of Object.entries(OPERATOR_SPELLING_BY_FQN)) {
+    for (const op of Object.keys(ops)) {
+      if (!usedKeys.has(`${fqn}#${op}`)) unused.push(`${fqn}#${op}`);
+    }
+  }
+  return unused;
+}
+
+/** Clears resolution tracking, so a second pass starts from a clean slate. */
+export function resetOperatorSpellingUsage(): void {
+  usedKeys.clear();
 }

--- a/scripts/api-compare/operator-order-spelling.ts
+++ b/scripts/api-compare/operator-order-spelling.ts
@@ -31,11 +31,54 @@ export const OPERATOR_SPELLING_BY_FQN: Record<string, Record<string, string[]>> 
   "Arel::Table": { "[]": ["get"] },
   // active_model/errors.rb:229 `def [](attribute)` → errors.ts `get`.
   "ActiveModel::Errors": { "[]": ["get"] },
-  // attribute_set/builder.rb:110 `def [](key)` → builder.ts `LazyAttributeHash#get`.
-  "ActiveModel::AttributeSet::LazyAttributeHash": { "[]": ["get"] },
+  // attribute_set/builder.rb:110 `def [](key)` → builder.ts `LazyAttributeHash#get`,
+  // :114 `def []=(key, value)` → `set` (a faithful delegate-hash write, unlike
+  // AttributeSet's `set` below). The class is declared at builder.rb:94 directly
+  // under `module ActiveModel`, so its fqn is NOT nested under `AttributeSet`.
+  "ActiveModel::LazyAttributeHash": { "[]": ["get"], "[]=": ["set"] },
   // attribute_set.rb:16 `def [](name)` → attribute-set.ts `getAttribute` (NOT the
-  // Map-compat `get` invention at attribute-set.ts:296).
+  // Map-compat `get` invention at attribute-set.ts:296). `[]=` (attribute_set.rb:20)
+  // stays UNMAPPED: attribute-set.ts:302 `set` accepts a bare value and wraps it in
+  // an `Attribute`, so it is the Map-compat sibling of `get`, not the `[]=` port.
   "ActiveModel::AttributeSet": { "[]": ["getAttribute"] },
+  // attribute.rb:115 `def ==(other)` → attribute.ts:222 `equals`.
+  "ActiveModel::Attribute": { "==": ["equals"] },
+  // type/value.rb:121 `def ==(other)` → type/value.ts:222 `equals`.
+  "ActiveModel::Type::Value": { "==": ["equals"] },
+  // error.rb:190 `def ==(other)` → error.ts:357 `equals`.
+  "ActiveModel::Error": { "==": ["equals"] },
+  // naming.rb:151 `delegate :==, :===, :<=>, …, to: :name` → naming.ts:371 `equals`
+  // and :386 `compare`. `===` / `=~` share that line but have no TS member, so they
+  // stay unmapped.
+  "ActiveModel::Name": { "==": ["equals"], "<=>": ["compare"] },
+  // association_relation.rb:14 `def ==(other)` → association-relation.ts:247 `equals`.
+  "ActiveRecord::AssociationRelation": { "==": ["equals"] },
+  // reflection.rb:440 `def ==(other_aggregation)` → reflection.ts:608 `equals`
+  // (on `MacroReflection`, declared reflection.rb:369).
+  "ActiveRecord::Reflection::MacroReflection": { "==": ["equals"] },
+  // relation/from_clause.rb:21 `def ==(other)` → relation/from-clause.ts:32 `equals`.
+  "ActiveRecord::Relation::FromClause": { "==": ["equals"] },
+  // connection_adapters/mysql/type_metadata.rb:18 `def ==(other)` →
+  // connection-adapters/mysql/type-metadata.ts:40 `equals`.
+  "ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata": { "==": ["equals"] },
+  // connection_adapters/postgresql/type_metadata.rb:20 `def ==(other)` →
+  // connection-adapters/postgresql/type-metadata.ts:37 `equals`.
+  "ActiveRecord::ConnectionAdapters::PostgreSQL::TypeMetadata": { "==": ["equals"] },
+  // connection_adapters/postgresql/utils.rb:30 `def ==(o)` →
+  // connection-adapters/postgresql/utils.ts:32 `Name#equals`.
+  "ActiveRecord::ConnectionAdapters::PostgreSQL::Name": { "==": ["equals"] },
+  // connection_adapters/statement_pool.rb:23 `def [](key)` / :31 `def []=(sql, stmt)`
+  // → connection-adapters/statement-pool.ts:44 `get` / :53 `set`.
+  "ActiveRecord::ConnectionAdapters::StatementPool": { "[]": ["get"], "[]=": ["set"] },
+  // encryption/properties.rb:20 `delegate :[], to: :data` / :50 `def []=(key, value)`
+  // → encryption/properties.ts:23 `get` / :27 `set`.
+  "ActiveRecord::Encryption::Properties": { "[]": ["get"], "[]=": ["set"] },
+  // result.rb:148 `def [](idx)` → result.ts:177 `at` (Result declares no `at` in
+  // Ruby, so the name is free).
+  "ActiveRecord::Result": { "[]": ["at"] },
+  // result.rb:58 `def ==(other)` / :80 `def [](column)` → result.ts:73 `equals` /
+  // :52 `get` on `IndexedRow`.
+  "ActiveRecord::Result::IndexedRow": { "==": ["equals"], "[]": ["get"] },
 };
 
 /**

--- a/scripts/api-compare/operator-order-spelling.ts
+++ b/scripts/api-compare/operator-order-spelling.ts
@@ -11,7 +11,7 @@
  *
  * A name-only GLOBAL map is unsafe: `[]` ports to `get` in `Arel::Table` /
  * `ActiveModel::Errors` / `LazyAttributeHash`, but to `getAttribute` in
- * `ActiveModel::AttributeSet` — where `get` (attribute-set.ts:63/296) is instead
+ * `ActiveModel::AttributeSet` — where `get` (attribute-set.ts) is instead
  * a non-Rails Map-compat invention. Mapping `[]`→`get` globally would promote
  * that invention into Rails' `[]` slot (tried and reverted in #5030). So the
  * table is keyed per Ruby fqn: each (fqn, operator) resolves to the spelling
@@ -37,47 +37,47 @@ export const OPERATOR_SPELLING_BY_FQN: Record<string, Record<string, string[]>> 
   // under `module ActiveModel`, so its fqn is NOT nested under `AttributeSet`.
   "ActiveModel::LazyAttributeHash": { "[]": ["get"], "[]=": ["set"] },
   // attribute_set.rb:16 `def [](name)` → attribute-set.ts `getAttribute` (NOT the
-  // Map-compat `get` invention at attribute-set.ts:296). `[]=` (attribute_set.rb:20)
-  // stays UNMAPPED: attribute-set.ts:302 `set` accepts a bare value and wraps it in
+  // Map-compat `get` invention in attribute-set.ts). `[]=` (attribute_set.rb:20)
+  // stays UNMAPPED: attribute-set.ts `set` accepts a bare value and wraps it in
   // an `Attribute`, so it is the Map-compat sibling of `get`, not the `[]=` port.
   "ActiveModel::AttributeSet": { "[]": ["getAttribute"] },
-  // attribute.rb:115 `def ==(other)` → attribute.ts:222 `equals`.
+  // attribute.rb:115 `def ==(other)` → attribute.ts `equals`.
   "ActiveModel::Attribute": { "==": ["equals"] },
-  // type/value.rb:121 `def ==(other)` → type/value.ts:222 `equals`.
+  // type/value.rb:121 `def ==(other)` → type/value.ts `equals`.
   "ActiveModel::Type::Value": { "==": ["equals"] },
-  // error.rb:190 `def ==(other)` → error.ts:357 `equals`.
+  // error.rb:190 `def ==(other)` → error.ts `equals`.
   "ActiveModel::Error": { "==": ["equals"] },
-  // naming.rb:151 `delegate :==, :===, :<=>, …, to: :name` → naming.ts:371 `equals`
-  // and :386 `compare`. `===` / `=~` share that line but have no TS member, so they
+  // naming.rb:151 `delegate :==, :===, :<=>, …, to: :name` → naming.ts `equals`
+  // and `compare`. `===` / `=~` share that line but have no TS member, so they
   // stay unmapped.
   "ActiveModel::Name": { "==": ["equals"], "<=>": ["compare"] },
-  // association_relation.rb:14 `def ==(other)` → association-relation.ts:247 `equals`.
+  // association_relation.rb:14 `def ==(other)` → association-relation.ts `equals`.
   "ActiveRecord::AssociationRelation": { "==": ["equals"] },
-  // reflection.rb:440 `def ==(other_aggregation)` → reflection.ts:608 `equals`
+  // reflection.rb:440 `def ==(other_aggregation)` → reflection.ts `equals`
   // (on `MacroReflection`, declared reflection.rb:369).
   "ActiveRecord::Reflection::MacroReflection": { "==": ["equals"] },
-  // relation/from_clause.rb:21 `def ==(other)` → relation/from-clause.ts:32 `equals`.
+  // relation/from_clause.rb:21 `def ==(other)` → relation/from-clause.ts `equals`.
   "ActiveRecord::Relation::FromClause": { "==": ["equals"] },
   // connection_adapters/mysql/type_metadata.rb:18 `def ==(other)` →
-  // connection-adapters/mysql/type-metadata.ts:40 `equals`.
+  // connection-adapters/mysql/type-metadata.ts `equals`.
   "ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata": { "==": ["equals"] },
   // connection_adapters/postgresql/type_metadata.rb:20 `def ==(other)` →
-  // connection-adapters/postgresql/type-metadata.ts:37 `equals`.
+  // connection-adapters/postgresql/type-metadata.ts `equals`.
   "ActiveRecord::ConnectionAdapters::PostgreSQL::TypeMetadata": { "==": ["equals"] },
   // connection_adapters/postgresql/utils.rb:30 `def ==(o)` →
-  // connection-adapters/postgresql/utils.ts:32 `Name#equals`.
+  // connection-adapters/postgresql/utils.ts `Name#equals`.
   "ActiveRecord::ConnectionAdapters::PostgreSQL::Name": { "==": ["equals"] },
   // connection_adapters/statement_pool.rb:23 `def [](key)` / :31 `def []=(sql, stmt)`
-  // → connection-adapters/statement-pool.ts:44 `get` / :53 `set`.
+  // → connection-adapters/statement-pool.ts `get` / `set`.
   "ActiveRecord::ConnectionAdapters::StatementPool": { "[]": ["get"], "[]=": ["set"] },
   // encryption/properties.rb:20 `delegate :[], to: :data` / :50 `def []=(key, value)`
-  // → encryption/properties.ts:23 `get` / :27 `set`.
+  // → encryption/properties.ts `get` / `set`.
   "ActiveRecord::Encryption::Properties": { "[]": ["get"], "[]=": ["set"] },
-  // result.rb:148 `def [](idx)` → result.ts:177 `at` (Result declares no `at` in
+  // result.rb:148 `def [](idx)` → result.ts `at` (Result declares no `at` in
   // Ruby, so the name is free).
   "ActiveRecord::Result": { "[]": ["at"] },
-  // result.rb:58 `def ==(other)` / :80 `def [](column)` → result.ts:73 `equals` /
-  // :52 `get` on `IndexedRow`.
+  // result.rb:58 `def ==(other)` / :80 `def [](column)` → result.ts `IndexedRow#equals`
+  // / `IndexedRow#get`.
   "ActiveRecord::Result::IndexedRow": { "==": ["equals"], "[]": ["get"] },
 };
 

--- a/scripts/build-rails-file-structure-manifest.ts
+++ b/scripts/build-rails-file-structure-manifest.ts
@@ -327,18 +327,6 @@ for (const k of Object.keys(manifest.files).sort()) {
 }
 const final: Manifest = { files: sortedFiles };
 
-// Every package has been visited, so an operator entry that never resolved names
-// a class/operator the Ruby extract does not have — a dead entry that silently
-// enforces nothing.
-const deadOperatorEntries = unusedOperatorSpellings();
-if (deadOperatorEntries.length > 0) {
-  console.warn(
-    `[build-rails-file-structure-manifest] ${deadOperatorEntries.length} dead OPERATOR_SPELLING_BY_FQN ` +
-      `entr${deadOperatorEntries.length === 1 ? "y" : "ies"} (fqn/operator absent from the Ruby API): ` +
-      `${deadOperatorEntries.join(", ")} — fix the fqn or drop the entry.`,
-  );
-}
-
 writeJsonManifest(OUT, final);
 const fileCount = Object.keys(final.files).length;
 const nameCount = Object.values(final.files).reduce(
@@ -346,3 +334,20 @@ const nameCount = Object.values(final.files).reduce(
   0,
 );
 console.log(`Wrote ${OUT} — ${fileCount} files (${nameCount} ordered names)`);
+
+// Every package has been visited, so an operator entry that never resolved names a
+// class/operator the Ruby extract does not have. Unlike a last-segment collision
+// (which follows from Rails' own structure and only warns), a dead entry is always
+// a bug in a table WE maintain: it enforces nothing and reports nothing, which is
+// how the `ActiveModel::AttributeSet::LazyAttributeHash` key survived. Fail after
+// the manifest is written, so the emitted order is still correct/usable and the
+// failure is purely the signal.
+const deadOperatorEntries = unusedOperatorSpellings();
+if (deadOperatorEntries.length > 0) {
+  throw new Error(
+    `[build-rails-file-structure-manifest] ${deadOperatorEntries.length} dead ` +
+      `OPERATOR_SPELLING_BY_FQN entr${deadOperatorEntries.length === 1 ? "y" : "ies"} ` +
+      `(fqn/operator absent from the Ruby API): ${deadOperatorEntries.join(", ")} — ` +
+      `fix the fqn or drop the entry (scripts/api-compare/operator-order-spelling.ts).`,
+  );
+}

--- a/scripts/build-rails-file-structure-manifest.ts
+++ b/scripts/build-rails-file-structure-manifest.ts
@@ -27,7 +27,10 @@ import { fileURLToPath } from "url";
 import { rubyMethodToTs, rubyFileToTs } from "./api-compare/conventions.js";
 import { writeJsonManifest } from "./api-compare/write-json-manifest.js";
 import { mergeBySourceLine } from "./api-compare/source-order.js";
-import { operatorSpelling } from "./api-compare/operator-order-spelling.js";
+import {
+  operatorSpelling,
+  unusedOperatorSpellings,
+} from "./api-compare/operator-order-spelling.js";
 import { resolveMixinParent } from "./rails-file-structure-mixins.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -323,6 +326,18 @@ for (const k of Object.keys(manifest.files).sort()) {
   sortedFiles[k] = out;
 }
 const final: Manifest = { files: sortedFiles };
+
+// Every package has been visited, so an operator entry that never resolved names
+// a class/operator the Ruby extract does not have — a dead entry that silently
+// enforces nothing.
+const deadOperatorEntries = unusedOperatorSpellings();
+if (deadOperatorEntries.length > 0) {
+  console.warn(
+    `[build-rails-file-structure-manifest] ${deadOperatorEntries.length} dead OPERATOR_SPELLING_BY_FQN ` +
+      `entr${deadOperatorEntries.length === 1 ? "y" : "ies"} (fqn/operator absent from the Ruby API): ` +
+      `${deadOperatorEntries.join(", ")} — fix the fqn or drop the entry.`,
+  );
+}
 
 writeJsonManifest(OUT, final);
 const fileCount = Object.keys(final.files).length;


### PR DESCRIPTION
## What

Expands `OPERATOR_SPELLING_BY_FQN` (scripts/api-compare/operator-order-spelling.ts)
beyond the four seeded `[]` entries so more Ruby operator methods resolve to their
TS port and keep their Rails source position in the method-order manifest.

Audited every Ruby class in `rails-api.json` with an operator instance method and
cross-checked the TS member. Added, each cited at both ends:

- `==` → `equals`: `ActiveModel::Attribute`, `ActiveModel::Type::Value`,
  `ActiveModel::Error`, `ActiveModel::Name` (delegate at naming.rb:151),
  `ActiveRecord::AssociationRelation`, `ActiveRecord::Reflection::MacroReflection`,
  `ActiveRecord::Relation::FromClause`, MySQL/PostgreSQL `TypeMetadata`,
  `PostgreSQL::Name`, `ActiveRecord::Result::IndexedRow`
- `<=>` → `compare`: `ActiveModel::Name`
- `[]` / `[]=` → `get` / `set`: `ActiveRecord::ConnectionAdapters::StatementPool`,
  `ActiveRecord::Encryption::Properties`, `ActiveModel::LazyAttributeHash`
- `[]` → `at`: `ActiveRecord::Result`; `[]` → `get`: `Result::IndexedRow`

Also fixes the LazyAttributeHash key: the class is declared directly under
`module ActiveModel` (attribute_set/builder.rb:94), so its fqn is
`ActiveModel::LazyAttributeHash` — the old `ActiveModel::AttributeSet::LazyAttributeHash`
key never matched anything.

## Deliberately NOT mapped

- `ActiveModel::AttributeSet#[]=` — attribute-set.ts `set` accepts a bare value and
  wraps it in an `Attribute`; it's the Map-compat sibling of the `get` invention,
  not the `[]=` port.
- Ruby `alias :== :eql?` cases (Arel `Table` / `Nodes::*`) — `eql?` already claims
  the `eql` TS member, so mapping `==` would double-claim it.
- `CollectionProxy#<<` — `push`/`append`/`concat` are Ruby aliases that already
  claim all three TS spellings.
- Classes whose operator has no TS member yet (`SqlTypeMetadata`, `Column`,
  `Encryption::Message`, `TableDefinition`, …) stay unmapped.

## Reorders

Members surfaced by the new mappings were relocated to Rails order via the
`rails-file-structure-method-order` autofix — pure relocations, no body edits:
`attribute.ts`, `error.ts`, `naming.ts`, `attribute-set/builder.ts`.

Closes-story: method-order-expand-operator-spelling-coverage

## Dead-entry guard

The LazyAttributeHash bug was invisible because an entry whose fqn doesn't exist
enforces nothing and says nothing. `operatorSpelling` now records which
`fqn#operator` keys actually resolve, and the manifest build — which makes a full
pass over the Ruby API — warns about any that never did. Verified: with the new
entries the build emits no such warning; every one of the 23 keys resolves.


## Review follow-ups

- **Stale TS line citations (fixed, at the class level).** The autofix relocations
  in this PR invalidated the TS line numbers written before it ran. Rather than
  reset the clock, TS members are now cited by NAME — the convention the four
  seeded entries already used (`table.ts \`get\``) — with `file:line` kept only for
  vendored Rails, which is stable. Same treatment applied to the header comment's
  `attribute-set.ts` citation, so nothing in this file can go stale on a reorder.
- **Dead-entry check now FAILS the build** (was `console.warn`). A last-segment
  collision only warns because it follows from Rails' own structure; a dead entry
  is always a bug in a table we maintain, and a warning is precisely the silent
  signal that let the bad key survive. Verified by injecting `ActiveModel::Typo::DoesNotExist`:
  build exits 1 naming the key; removed, it exits 0. The throw runs after the
  manifest is written, so the emitted order stays correct/usable.
