### PR TITLE
test(autosave-association): drop canonical Author/Post/Book/Comment/Category shadows

### DIFF
--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -2044,9 +2044,12 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
         this.attribute("author_id", "integer");
       }
     }
-    registerModel("Author", Author);
-    registerModel("Post", Post);
-    Associations.belongsTo.call(Post, "author", { autosave: true });
+    registerModel("BelongsToAutosaveAuthor", Author);
+    registerModel("BelongsToAutosavePost", Post);
+    Associations.belongsTo.call(Post, "author", {
+      autosave: true,
+      className: "BelongsToAutosaveAuthor",
+    });
     return { Author, Post };
   }
 
@@ -2984,12 +2987,12 @@ describe("TestAutosaveAssociationsInGeneral", () => {
         this.attribute("name", "string");
       }
     }
-    registerModel("Book", Book);
-    registerModel("Author", Author);
+    registerModel("CallbacksOnceBook", Book);
+    registerModel("CallbacksOnceAuthor", Author);
     Associations.hasMany.call(Author, "books", {
       autosave: true,
       foreignKey: "author_id",
-      className: "Book",
+      className: "CallbacksOnceBook",
     });
 
     const author = await Author.create({ name: "Test" });
@@ -3066,12 +3069,12 @@ describe("TestAutosaveAssociationsInGeneral", () => {
         this.attribute("author_id", "integer");
       }
     }
-    registerModel("Author", Author);
-    registerModel("Post", Post);
+    registerModel("BelongsToCallbacksOnceAuthor", Author);
+    registerModel("BelongsToCallbacksOncePost", Post);
     Associations.belongsTo.call(Post, "author", {
       autosave: true,
       foreignKey: "author_id",
-      className: "Author",
+      className: "BelongsToCallbacksOnceAuthor",
     });
 
     const author = new Author({ name: "New Author" });
@@ -3107,12 +3110,12 @@ describe("TestAutosaveAssociationsInGeneral", () => {
         this.attribute("author_id", "integer");
       }
     }
-    registerModel("Author", Author);
-    registerModel("Post", Post);
+    registerModel("DefaultBelongsToAuthor", Author);
+    registerModel("DefaultBelongsToPost", Post);
     // No `autosave:` option — exercises the default-on registration path.
     Associations.belongsTo.call(Post, "author", {
       foreignKey: "author_id",
-      className: "Author",
+      className: "DefaultBelongsToAuthor",
     });
 
     const author = new Author({ name: "New Author" });
@@ -3326,12 +3329,12 @@ describe("TestAutosaveAssociationsInGeneral", () => {
         this.attribute("author_id", "integer");
       }
     }
-    registerModel("Author", Author);
-    registerModel("Post", Post);
+    registerModel("DuplicateCallbacksBelongsToAuthor", Author);
+    registerModel("DuplicateCallbacksBelongsToPost", Post);
     Associations.belongsTo.call(Post, "author", {
       autosave: true,
       foreignKey: "author_id",
-      className: "Author",
+      className: "DuplicateCallbacksBelongsToAuthor",
     });
     const reflection = (Post as any)._reflectOnAssociation("author");
     addAutosaveAssociationCallbacks(Post, reflection);
@@ -3367,12 +3370,12 @@ describe("TestAutosaveAssociationsInGeneral", () => {
         this.attribute("name", "string");
       }
     }
-    registerModel("Book", Book);
-    registerModel("Author", Author);
+    registerModel("DuplicateCallbacksHasManyBook", Book);
+    registerModel("DuplicateCallbacksHasManyAuthor", Author);
     Associations.hasMany.call(Author, "books", {
       autosave: true,
       foreignKey: "author_id",
-      className: "Book",
+      className: "DuplicateCallbacksHasManyBook",
     });
     const reflection = (Author as any)._reflectOnAssociation("books");
     addAutosaveAssociationCallbacks(Author, reflection);
@@ -3921,12 +3924,12 @@ describe("TestDefaultAutosaveAssociationOnNewRecord", () => {
         this.attribute("author_id", "integer");
       }
     }
-    registerModel("Author", Author);
-    registerModel("Post", Post);
+    registerModel("NewRecordBelongsToAuthor", Author);
+    registerModel("NewRecordBelongsToPost", Post);
     Associations.belongsTo.call(Post, "author", {
       autosave: false,
       foreignKey: "author_id",
-      className: "Author",
+      className: "NewRecordBelongsToAuthor",
     });
 
     const author = new Author({ name: "Unsaved" });
@@ -3993,12 +3996,12 @@ describe("TestDefaultAutosaveAssociationOnNewRecord", () => {
         this.attribute("name", "string");
       }
     }
-    registerModel("Book", Book);
-    registerModel("Author", Author);
+    registerModel("NewRecordHasManyBook", Book);
+    registerModel("NewRecordHasManyAuthor", Author);
     Associations.hasMany.call(Author, "books", {
       autosave: false,
       foreignKey: "author_id",
-      className: "Book",
+      className: "NewRecordHasManyBook",
     });
 
     const author = await Author.create({ name: "test" });
@@ -4083,19 +4086,22 @@ describe("TestDefaultAutosaveAssociationOnNewRecord", () => {
         this.attribute("body", "string");
         this.attribute("author_id", "integer");
         this.hasMany("comments", {
-          className: "Comment",
+          className: "HabtmAutosaveComment",
           foreignKey: "post_id",
         });
         this.hasAndBelongsToMany("categories", {
-          className: "Category",
+          className: "HabtmAutosaveCategory",
           joinTable: "categories_posts",
           foreignKey: "post_id",
+          // The join-table column is derived from `className`, which no longer
+          // matches the canonical "Category" name the table was built for.
+          associationForeignKey: "category_id",
           autosave: true,
         });
       }
     }
-    registerModel("Comment", Comment);
-    registerModel("Category", Category);
+    registerModel("HabtmAutosaveComment", Comment);
+    registerModel("HabtmAutosaveCategory", Category);
     registerModel("PostWithAfterCreateCallback", PostWithAfterCreateCallback);
     // Registered after the association so the habtm autosave after_create
     // callback fires first — matching Rails, where `has_and_belongs_to_many`

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -4093,8 +4093,6 @@ describe("TestDefaultAutosaveAssociationOnNewRecord", () => {
           className: "HabtmAutosaveCategory",
           joinTable: "categories_posts",
           foreignKey: "post_id",
-          // The join-table column is derived from `className`, which no longer
-          // matches the canonical "Category" name the table was built for.
           associationForeignKey: "category_id",
           autosave: true,
         });


### PR DESCRIPTION
Follow-up pass 3 of the `registerModel` canonical-shadow burndown for
`packages/activerecord/src/autosave-association.test.ts`.

The bespoke test classes in this file registered themselves under the canonical
**Author / Post / Book / Comment / Category** names, which
`guardCanonicalNameShadow` (`packages/activerecord/src/associations.ts:284`)
rejects once the file imports the canonical model index.

## Why not the canonical models

Read against `vendor/rails/activerecord/test/cases/autosave_association_test.rb`
and `test/models/{author,post,book,comment,category}.rb`: none of these sites can
adopt the canonical model. Each bespoke class carries semantics the canonical one
does not — a `name` presence validation on `Author`, per-site `autosave: true` /
`autosave: false` / no-option belongs_to and has_many wiring (that is precisely
what the tests assert on), `beforeSave` counters, and a `Post` mapped onto the
`books` table. So each is registered under a distinct non-canonical name,
threaded through the matching `className` option.

This follows the convention an earlier pass already set in this file — see
`registerModel("DefaultAutosaveAuthor", Author)` — registering under a distinct
name while leaving the local class identifier alone.

## Sites converged

The `TestDefaultAutosaveAssociationOnABelongsToAssociation` `makeModels()` pair,
the three "callbacks get called once" tests, the default belongs_to test, the two
"should not add the same callbacks multiple times" tests, the two
`TestDefaultAutosaveAssociationOnNewRecord` tests, and the habtm after_create
test. The remaining `registerModel("Author", …)` / `("Book", …)` pair registers
the *canonical* classes, so it already passes the guard.

One non-mechanical detail: `ReflectionOptions#associationForeignKey`
(`reflection.ts:1106`) derives the join-table column from `className`, so
renaming `Category` would have produced `habtm_autosave_category_id` against the
canonical `categories_posts` join table. `associationForeignKey: "category_id"`
is now explicit.

## Verification

Temporarily adding `import "./test-helpers/canonical-model-index.js"` to the file
and running it arms the guard. The names it still rejects are Company, Customer,
Eye, Firm, Owner, Parrot, Person, Pirate, PostWithAfterCreateCallback, Ship and
User — every Author/Post/Book/Comment/Category shadow is gone. Those remaining
names (including the `PostWithAfterCreateCallback` registration one line below the
habtm site fixed here) belong to the other passes of this burndown and are left
for their own stories rather than fanned out from this PR.

`pnpm vitest run packages/activerecord/src/autosave-association.test.ts` — 209
passed.

Closes-story: converge-autosave-association-author-post-book-comment-shadows
