### PR TITLE
test(autosave): stop shadowing canonical Pirate/Ship/Bird/Parrot in 7 sites

### DIFF
--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -2546,30 +2546,9 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
   fixtures([]);
 
   function makeModels() {
-    class Pirate extends Base {
-      declare catchphrase: string | null;
-
-      static {
-        this._tableName = "pirates";
-        this.attribute("catchphrase", "string");
-      }
-    }
-    class Bird extends Base {
-      declare name: string | null;
-      declare pirate_id: number | null;
-
-      static {
-        this._tableName = "birds";
-        this.attribute("name", "string");
-        this.attribute("pirate_id", "integer");
-        this.validates("name", { presence: true });
-      }
-    }
-    registerModel("Pirate", Pirate);
-    registerModel("Bird", Bird);
-    Associations.hasMany.call(Pirate, "birds", { autosave: true });
-    acceptsNestedAttributesFor(Pirate, "birds", { allowDestroy: true });
-    return { Pirate, Bird };
+    registerModel(CanonicalPirate);
+    registerModel(CanonicalBird);
+    return { Pirate: CanonicalPirate, Bird: CanonicalBird };
   }
 
   it("valid adding with nested attributes", async () => {
@@ -2828,18 +2807,9 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
 describe("TestAutosaveAssociationsInGeneral", () => {
   fixtures([]);
   it("autosave works even when other callbacks update the parent model", async () => {
-    class Ship extends Base {
-      declare name: string | null;
-      declare pirate_id: number | null;
-
-      static {
-        this._tableName = "ships";
-        this.attribute("name", "string");
-        this.attribute("pirate_id", "integer");
-      }
-    }
-    class Pirate extends Base {
+    class CallbackPirate extends Base {
       declare catchphrase: string | null;
+      declare ship: CanonicalShip | null;
 
       static {
         this._tableName = "pirates";
@@ -2847,18 +2817,13 @@ describe("TestAutosaveAssociationsInGeneral", () => {
         this.beforeSave(function (record: any) {
           record.catchphrase = "Ahoy!";
         });
+        this.hasOne("ship", { autosave: true, foreignKey: "pirate_id", className: "Ship" });
       }
     }
-    registerModel("Ship", Ship);
-    registerModel("Pirate", Pirate);
-    Associations.hasOne.call(Pirate, "ship", {
-      autosave: true,
-      foreignKey: "pirate_id",
-      className: "Ship",
-    });
+    registerModel("CallbackPirate", CallbackPirate);
 
-    const pirate = await Pirate.create({ catchphrase: "Yarr" });
-    const ship = new Ship({ name: "Pearl" });
+    const pirate = await CallbackPirate.create({ catchphrase: "Yarr" });
+    const ship = new CanonicalShip({ name: "Pearl" });
     cacheAssoc(pirate, "ship", ship);
     pirate.catchphrase = "trigger save";
     await pirate.save();
@@ -3387,7 +3352,7 @@ describe("TestAutosaveAssociationsInGeneral", () => {
 
   it("should not add the same callbacks multiple times for has and belongs to many", async () => {
     let saveCount = 0;
-    class Parrot extends Base {
+    class DupCbParrot extends Base {
       declare name: string | null;
 
       static {
@@ -3398,28 +3363,31 @@ describe("TestAutosaveAssociationsInGeneral", () => {
         });
       }
     }
-    class Pirate extends Base {
+    class DupCbPirate extends Base {
       declare catchphrase: string | null;
+      declare parrots: AssociationProxy<DupCbParrot>;
 
       static {
         this._tableName = "pirates";
         this.attribute("catchphrase", "string");
+        this.hasAndBelongsToMany("parrots", {
+          autosave: true,
+          className: "DupCbParrot",
+          joinTable: "parrots_pirates",
+          foreignKey: "pirate_id",
+          associationForeignKey: "parrot_id",
+        });
       }
     }
-    registerModel("Parrot", Parrot);
-    registerModel("Pirate", Pirate);
-    Associations.hasAndBelongsToMany.call(Pirate, "parrots", {
-      autosave: true,
-      className: "Parrot",
-      joinTable: "parrots_pirates",
-    });
+    registerModel("DupCbParrot", DupCbParrot);
+    registerModel("DupCbPirate", DupCbPirate);
     // Calling addAutosaveAssociationCallbacks a second time must not duplicate callbacks
-    const reflection = (Pirate as any)._reflectOnAssociation("parrots");
+    const reflection = (DupCbPirate as any)._reflectOnAssociation("parrots");
     expect(reflection).toBeDefined();
-    addAutosaveAssociationCallbacks(Pirate, reflection);
+    addAutosaveAssociationCallbacks(DupCbPirate, reflection);
 
-    const pirate = await Pirate.create({ catchphrase: "Arrr" });
-    const parrot = await Parrot.create({ name: "Polly" });
+    const pirate = await DupCbPirate.create({ catchphrase: "Arrr" });
+    const parrot = await DupCbParrot.create({ name: "Polly" });
     saveCount = 0; // reset after create (create triggers beforeSave)
     const proxy = association(pirate, "parrots");
     await proxy.push(parrot);
@@ -3486,25 +3454,39 @@ describe("TestHasManyAutosaveAssociationWhichItselfHasAutosaveAssociations", () 
   fixtures([]);
 
   function makeModels() {
-    class Pirate extends Base {
+    class GcPirate extends Base {
       declare catchphrase: string | null;
+      declare ships: AssociationProxy<GcShip>;
 
       static {
         this._tableName = "pirates";
         this.attribute("catchphrase", "string");
+        this.hasMany("ships", {
+          autosave: true,
+          className: "GcShip",
+          foreignKey: "pirate_id",
+        });
       }
     }
-    class Ship extends Base {
+    class GcShip extends Base {
       declare name: string | null;
       declare pirate_id: number | null;
+      declare pirate: GcPirate | null;
+      declare parts: AssociationProxy<GcPart>;
 
       static {
         this._tableName = "ships";
         this.attribute("name", "string");
         this.attribute("pirate_id", "integer");
+        this.belongsTo("pirate", { className: "GcPirate", foreignKey: "pirate_id" });
+        this.hasMany("parts", {
+          autosave: true,
+          className: "GcPart",
+          foreignKey: "ship_id",
+        });
       }
     }
-    class Part extends Base {
+    class GcPart extends Base {
       declare name: string | null;
       declare ship_id: number | null;
 
@@ -3515,14 +3497,10 @@ describe("TestHasManyAutosaveAssociationWhichItselfHasAutosaveAssociations", () 
         this.validates("name", { presence: true });
       }
     }
-    registerModel("Pirate", Pirate);
-    registerModel("Ship", Ship);
-    registerModel("Part", Part);
-    Associations.hasMany.call(Pirate, "ships", { autosave: true });
-    Associations.belongsTo.call(Ship, "pirate");
-
-    Associations.hasMany.call(Ship, "parts", { autosave: true });
-    return { Pirate, Ship, Part };
+    registerModel("GcPirate", GcPirate);
+    registerModel("GcShip", GcShip);
+    registerModel("GcPart", GcPart);
+    return { Pirate: GcPirate, Ship: GcShip, Part: GcPart };
   }
 
   it("when grandchild marked_for_destruction, saving parent should destroy grandchild", async () => {
@@ -3819,25 +3797,29 @@ describe("TestHasOneAutosaveAssociationWhichItselfHasAutosaveAssociations", () =
   fixtures([]);
 
   function makeModels() {
-    class Pirate extends Base {
+    class GgPirate extends Base {
       declare catchphrase: string | null;
+      declare ship: GgShip | null;
 
       static {
         this._tableName = "pirates";
         this.attribute("catchphrase", "string");
+        this.hasOne("ship", { autosave: true, className: "GgShip", foreignKey: "pirate_id" });
       }
     }
-    class Ship extends Base {
+    class GgShip extends Base {
       declare name: string | null;
       declare pirate_id: number | null;
+      declare part: GgPart | null;
 
       static {
         this._tableName = "ships";
         this.attribute("name", "string");
         this.attribute("pirate_id", "integer");
+        this.hasOne("part", { autosave: true, className: "GgPart", foreignKey: "ship_id" });
       }
     }
-    class Part extends Base {
+    class GgPart extends Base {
       declare name: string | null;
       declare ship_id: number | null;
 
@@ -3848,12 +3830,10 @@ describe("TestHasOneAutosaveAssociationWhichItselfHasAutosaveAssociations", () =
         this.validates("name", { presence: true });
       }
     }
-    registerModel("Pirate", Pirate);
-    registerModel("Ship", Ship);
-    registerModel("Part", Part);
-    Associations.hasOne.call(Pirate, "ship", { autosave: true });
-    Associations.hasOne.call(Ship, "part", { autosave: true });
-    return { Pirate, Ship, Part };
+    registerModel("GgPirate", GgPirate);
+    registerModel("GgShip", GgShip);
+    registerModel("GgPart", GgPart);
+    return { Pirate: GgPirate, Ship: GgShip, Part: GgPart };
   }
 
   it("when great-grandchild marked_for_destruction, saving parent should destroy great-grandchild", async () => {
@@ -4012,18 +3992,9 @@ describe("TestDefaultAutosaveAssociationOnNewRecord", () => {
 
   it("autosave new record with after create callback", async () => {
     const log: string[] = [];
-    class Ship extends Base {
-      declare name: string | null;
-      declare pirate_id: number | null;
-
-      static {
-        this._tableName = "ships";
-        this.attribute("name", "string");
-        this.attribute("pirate_id", "integer");
-      }
-    }
-    class Pirate extends Base {
+    class AcPirate extends Base {
       declare catchphrase: string | null;
+      declare ship: CanonicalShip | null;
 
       static {
         this._tableName = "pirates";
@@ -4031,18 +4002,13 @@ describe("TestDefaultAutosaveAssociationOnNewRecord", () => {
         this.afterCreate(() => {
           log.push("pirate_created");
         });
+        this.hasOne("ship", { autosave: true, foreignKey: "pirate_id", className: "Ship" });
       }
     }
-    registerModel("Ship", Ship);
-    registerModel("Pirate", Pirate);
-    Associations.hasOne.call(Pirate, "ship", {
-      autosave: true,
-      foreignKey: "pirate_id",
-      className: "Ship",
-    });
+    registerModel("AcPirate", AcPirate);
 
-    const pirate = new Pirate({ catchphrase: "Yarr" });
-    const ship = new Ship({ name: "Pearl" });
+    const pirate = new AcPirate({ catchphrase: "Yarr" });
+    const ship = new CanonicalShip({ name: "Pearl" });
     cacheAssoc(pirate, "ship", ship);
     await pirate.save();
     expect(log).toContain("pirate_created");
@@ -4574,30 +4540,9 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
   fixtures([]);
 
   function makeModels() {
-    class Pirate extends Base {
-      declare catchphrase: string | null;
-
-      static {
-        this._tableName = "pirates";
-        this.attribute("catchphrase", "string");
-      }
-    }
-    class Bird extends Base {
-      declare name: string | null;
-      declare pirate_id: number | null;
-
-      static {
-        this._tableName = "birds";
-        this.attribute("name", "string");
-        this.attribute("pirate_id", "integer");
-        this.validates("name", { presence: true });
-      }
-    }
-    registerModel("Pirate", Pirate);
-    registerModel("Bird", Bird);
-    Associations.hasMany.call(Pirate, "birds", { autosave: true });
-    acceptsNestedAttributesFor(Pirate, "birds", { allowDestroy: true });
-    return { Pirate, Bird };
+    registerModel(CanonicalPirate);
+    registerModel(CanonicalBird);
+    return { Pirate: CanonicalPirate, Bird: CanonicalBird };
   }
 
   it("errors details should be set for invalid nested", async () => {


### PR DESCRIPTION
Follow-up pass 2 of `converge-autosave-association-bespoke-registermodel-canonical-shadows`.

`autosave-association.test.ts` registered bespoke classes under the canonical
**Pirate / Ship / Bird / Parrot** names, which `guardCanonicalNameShadow`
(`associations.ts`) rejects once the file imports the canonical model index.
This clears the seven sites listed in the story.

**Now canonical** — both `TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAttributes`
blocks use the canonical `Pirate`/`Bird`: Rails' `Pirate` already has
`has_many :birds` plus `accepts_nested_attributes_for :birds, allow_destroy: true`
(models/pirate.rb:33,53), which is exactly what the bespoke pair re-declared.
`autosave works even when other callbacks update the parent model` and
`autosave new record with after create callback` take the canonical `Ship` as
the child.

**Still bespoke, under distinct names** — where no canonical model fits:

| site | why | new name |
| --- | --- | --- |
| other-callbacks / after-create owners | canonical `Pirate` has no catchphrase-rewriting `before_save` / `after_create` logger | `CallbackPirate`, `AcPirate` |
| habtm duplicate-callback test | child counts its own `before_save` calls | `DupCbPirate`, `DupCbParrot` |
| grandchild chain | canonical `Pirate` has `has_one :ship`, not `has_many :ships` | `Gc*` |
| great-grandchild chain | canonical `Ship` has `has_many :parts`, not `has_one :part` | `Gg*` |

The bespoke associations moved from standalone `Associations.x.call(...)` into
the classes' `static {}` blocks (per `no-standalone-associations`), and the
`DupCb*` habtm now passes explicit `foreignKey`/`associationForeignKey` since
the join-table keys are otherwise derived from the class name.

No test names changed. Net −55 LOC.
`pnpm vitest run packages/activerecord/src/autosave-association.test.ts` → 209 passed.

The four remaining `Pirate`/`Ship` shadows in this file are out of this story's
scope and are covered by the already-queued
`converge-autosave-association-remaining-canonical-shadows-arm-guard`, which
also arms the guard by importing the index.

Closes-story: converge-autosave-association-pirate-ship-bird-parrot-shadows
