### PR TITLE
fix(test-models): resolve Eye's has_one iris on a cold cache in callbacks

### DIFF
--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -32,7 +32,6 @@ import { Parrot as CanonicalParrot } from "./test-helpers/models/parrot.js";
 import { Bird as CanonicalBird } from "./test-helpers/models/bird.js";
 import { Eye, Iris, IrisWithReadOnlyForeignKey } from "./test-helpers/models/eye.js";
 import { Invoice } from "./test-helpers/models/invoice.js";
-import { Eye, Iris, IrisWithReadOnlyForeignKey } from "./test-helpers/models/eye.js";
 import { LineItem } from "./test-helpers/models/line-item.js";
 import {
   markForDestruction,
@@ -998,12 +997,6 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
     record.association(name).setTarget(value as any);
   }
   fixtures([]);
-  beforeAll(() => {
-    registerModel(Eye);
-    registerModel(Iris);
-    registerModel(IrisWithReadOnlyForeignKey);
-  });
-
   beforeAll(() => {
     registerModel(CanonicalFirm);
     registerModel(Account);

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -32,6 +32,7 @@ import { Parrot as CanonicalParrot } from "./test-helpers/models/parrot.js";
 import { Bird as CanonicalBird } from "./test-helpers/models/bird.js";
 import { Eye, Iris, IrisWithReadOnlyForeignKey } from "./test-helpers/models/eye.js";
 import { Invoice } from "./test-helpers/models/invoice.js";
+import { Eye, Iris, IrisWithReadOnlyForeignKey } from "./test-helpers/models/eye.js";
 import { LineItem } from "./test-helpers/models/line-item.js";
 import {
   markForDestruction,
@@ -997,6 +998,11 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
     record.association(name).setTarget(value as any);
   }
   fixtures([]);
+  beforeAll(() => {
+    registerModel(Eye);
+    registerModel(Iris);
+    registerModel(IrisWithReadOnlyForeignKey);
+  });
 
   beforeAll(() => {
     registerModel(CanonicalFirm);
@@ -1141,154 +1147,24 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
   });
 
   it("callbacks firing order on create", async () => {
-    const log: string[] = [];
-    class CbFirm extends Base {
-      declare name: string | null;
-      declare cbAccount: CbAccount | null;
-      declare loadHasOne: (name: "cbAccount") => Promise<CbAccount | null>;
-
-      static {
-        this._tableName = "companies";
-        this.attribute("name", "string");
-        this.beforeSave(function () {
-          log.push("before_save");
-        });
-        this.afterCreate(function () {
-          log.push("after_create");
-        });
-        this.afterSave(function () {
-          log.push("after_save");
-        });
-        this.hasOne("cbAccount", {
-          autosave: true,
-          className: "CbAccount",
-          foreignKey: "firm_id",
-        });
-      }
-    }
-    class CbAccount extends Base {
-      declare credit_limit: number | null;
-      declare firm_id: number | null;
-
-      static {
-        this._tableName = "accounts";
-        this.attribute("credit_limit", "integer");
-        this.attribute("firm_id", "integer");
-      }
-    }
-    registerModel("CbFirm", CbFirm);
-    registerModel("CbAccount", CbAccount);
-    const firm = new CbFirm({ name: "LLC" });
-    const account = new CbAccount({ credit_limit: 100 });
-    cacheAssoc(firm, "cbAccount", account);
-    await firm.save();
-    expect(log).toContain("before_save");
-    expect(log).toContain("after_create");
-    expect(log).toContain("after_save");
-    // before_save should come before after_create
-    expect(log.indexOf("before_save")).toBeLessThan(log.indexOf("after_create"));
-    // after_create before after_save
-    expect(log.indexOf("after_create")).toBeLessThan(log.indexOf("after_save"));
-    // child should be persisted
-    expect(account.isNewRecord()).toBe(false);
+    const eye = await Eye.create({ irisAttributes: { color: "honey" } });
+    expect(eye.afterCreateCallbacksStack).toEqual([true, false]);
   });
+
   it("callbacks firing order on update", async () => {
-    const log: string[] = [];
-    class CuFirm extends Base {
-      declare name: string | null;
-      declare cuAccount: CuAccount | null;
-      declare loadHasOne: (name: "cuAccount") => Promise<CuAccount | null>;
-
-      static {
-        this._tableName = "companies";
-        this.attribute("name", "string");
-        this.beforeSave(function () {
-          log.push("before_save");
-        });
-        this.afterUpdate(function () {
-          log.push("after_update");
-        });
-        this.afterSave(function () {
-          log.push("after_save");
-        });
-        this.hasOne("cuAccount", {
-          autosave: true,
-          className: "CuAccount",
-          foreignKey: "firm_id",
-        });
-      }
-    }
-    class CuAccount extends Base {
-      declare credit_limit: number | null;
-      declare firm_id: number | null;
-
-      static {
-        this._tableName = "accounts";
-        this.attribute("credit_limit", "integer");
-        this.attribute("firm_id", "integer");
-      }
-    }
-    registerModel("CuFirm", CuFirm);
-    registerModel("CuAccount", CuAccount);
-    const firm = await CuFirm.create({ name: "LLC" });
-    log.length = 0;
-    firm.name = "Updated LLC";
-    const account = new CuAccount({ credit_limit: 200 });
-    cacheAssoc(firm, "cuAccount", account);
-    await firm.save();
-    expect(log).toContain("before_save");
-    expect(log).toContain("after_update");
-    expect(log).toContain("after_save");
-    expect(log.indexOf("before_save")).toBeLessThan(log.indexOf("after_update"));
-    expect(log.indexOf("after_update")).toBeLessThan(log.indexOf("after_save"));
-    expect(account.isNewRecord()).toBe(false);
+    const eye = await Eye.create({ irisAttributes: { color: "honey" } });
+    await eye.update({ irisAttributes: { color: "green" } });
+    expect(eye.afterUpdateCallbacksStack).toEqual([true, false]);
   });
+
   it("callbacks firing order on save", async () => {
-    const log: string[] = [];
-    class CsFirm extends Base {
-      declare name: string | null;
-      declare csAccount: CsAccount | null;
-      declare loadHasOne: (name: "csAccount") => Promise<CsAccount | null>;
+    const eye = await Eye.create({ irisAttributes: { color: "honey" } });
+    expect(eye.afterSaveCallbacksStack).toEqual([false, false]);
 
-      static {
-        this._tableName = "companies";
-        this.attribute("name", "string");
-        this.beforeSave(function () {
-          log.push("before_save");
-        });
-        this.afterSave(function () {
-          log.push("after_save");
-        });
-        this.hasOne("csAccount", {
-          autosave: true,
-          className: "CsAccount",
-          foreignKey: "firm_id",
-        });
-      }
-    }
-    class CsAccount extends Base {
-      declare credit_limit: number | null;
-      declare firm_id: number | null;
-
-      static {
-        this._tableName = "accounts";
-        this.attribute("credit_limit", "integer");
-        this.attribute("firm_id", "integer");
-      }
-    }
-    registerModel("CsFirm", CsFirm);
-    registerModel("CsAccount", CsAccount);
-    const firm = await CsFirm.create({ name: "LLC" });
-    log.length = 0;
-    const account = new CsAccount({ credit_limit: 10 });
-    cacheAssoc(firm, "csAccount", account);
-    firm.name = "Updated";
-    await firm.save();
-    expect(log).toContain("before_save");
-    expect(log).toContain("after_save");
-    expect(log.indexOf("before_save")).toBeLessThan(log.indexOf("after_save"));
-    expect(account.isNewRecord()).toBe(false);
+    await eye.update({ irisAttributes: { color: "blue" } });
+    expect(eye.afterSaveCallbacksStack).toEqual([false, false, false, false]);
   });
+
   it("callbacks on child when parent autosaves child", async () => {
     const log: string[] = [];
     class CbParent extends Base {

--- a/packages/activerecord/src/autosave-association.trails.test.ts
+++ b/packages/activerecord/src/autosave-association.trails.test.ts
@@ -1,0 +1,33 @@
+/**
+ * TypeScript-only coverage for autosave association callbacks: cases Rails has
+ * no test for because they are indistinguishable there (its association reader
+ * is synchronous, so a cold cache is invisible to callback code).
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { registerModel } from "./index.js";
+import { Eye, Iris, IrisWithReadOnlyForeignKey } from "./test-helpers/models/eye.js";
+import { fixtures } from "./test-helpers/fixtures.js";
+
+describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
+  fixtures([]);
+  beforeAll(() => {
+    registerModel(Eye);
+    registerModel(Iris);
+    registerModel(IrisWithReadOnlyForeignKey);
+  });
+
+  // Rails' `after_save :trace_after_save, if: :iris` reads the association
+  // through the plain reader, which loads the target from the DB when the
+  // cache is cold (Association#load_target — `find_target?` only skips the
+  // query while the owner is *building*). So an Eye fetched fresh and saved
+  // without anyone touching `iris` still pushes onto the stacks.
+  it("callbacks read a cold has_one cache", async () => {
+    const created = await Eye.create({ irisAttributes: { color: "honey" } });
+    const eye = await Eye.find(created.id);
+    expect(eye.association("iris").isLoaded()).toBe(false);
+
+    await eye.save();
+
+    expect(eye.afterSaveCallbacksStack).toEqual([false, false]);
+  });
+});

--- a/packages/activerecord/src/autosave-association.trails.test.ts
+++ b/packages/activerecord/src/autosave-association.trails.test.ts
@@ -1,8 +1,3 @@
-/**
- * TypeScript-only coverage for autosave association callbacks: cases Rails has
- * no test for because they are indistinguishable there (its association reader
- * is synchronous, so a cold cache is invisible to callback code).
- */
 import { describe, it, expect, beforeAll } from "vitest";
 import { registerModel } from "./index.js";
 import { Eye, Iris, IrisWithReadOnlyForeignKey } from "./test-helpers/models/eye.js";
@@ -16,11 +11,6 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
     registerModel(IrisWithReadOnlyForeignKey);
   });
 
-  // Rails' `after_save :trace_after_save, if: :iris` reads the association
-  // through the plain reader, which loads the target from the DB when the
-  // cache is cold (Association#load_target — `find_target?` only skips the
-  // query while the owner is *building*). So an Eye fetched fresh and saved
-  // without anyone touching `iris` still pushes onto the stacks.
   it("callbacks read a cold has_one cache", async () => {
     const created = await Eye.create({ irisAttributes: { color: "honey" } });
     const eye = await Eye.find(created.id);
@@ -28,6 +18,7 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
 
     await eye.save();
 
+    expect(eye.association("iris").isLoaded()).toBe(true);
     expect(eye.afterSaveCallbacksStack).toEqual([false, false]);
   });
 });

--- a/packages/activerecord/src/test-helpers/models/eye.ts
+++ b/packages/activerecord/src/test-helpers/models/eye.ts
@@ -2,15 +2,8 @@
 import { Base } from "../../base.js";
 import { acceptsNestedAttributesFor } from "../../nested-attributes.js";
 
-/**
- * Rails reads `iris` through the plain association reader, which loads the
- * target on a cold cache (`Association#load_target` — `find_target?` only
- * skips the query while the owner is *building*). The trails reader returns a
- * Promise on that path, so callbacks resolve it before touching the record;
- * `after_*` callbacks are awaited by the chain, keeping the read faithful.
- */
-function irisReader(eye: Eye): Promise<Iris | null> {
-  return Promise.resolve(eye.association("iris").reader as Iris | null | Promise<Iris | null>);
+function read<T extends Base>(eye: Eye, name: string): Promise<T | null> {
+  return Promise.resolve(eye.association(name).reader as T | null | Promise<T | null>);
 }
 
 export class Eye extends Base {
@@ -26,30 +19,30 @@ export class Eye extends Base {
 
   static {
     this.afterCreate(async function (this: Eye) {
-      const iris = await irisReader(this);
+      const iris = await read<Iris>(this, "iris");
       if (iris) this.afterCreateCallbacksStack.push(!iris.isPersisted());
     });
     this.afterUpdate(async function (this: Eye) {
-      const iris = await irisReader(this);
+      const iris = await read<Iris>(this, "iris");
       if (iris) this.afterUpdateCallbacksStack.push(iris.hasChangesToSave);
     });
     this.afterSave(async function (this: Eye) {
-      const iris = await irisReader(this);
+      const iris = await read<Iris>(this, "iris");
       if (iris) this.afterSaveCallbacksStack.push(iris.hasChangesToSave);
     });
 
     this.hasOne("iris");
 
     this.afterCreate(async function (this: Eye) {
-      const iris = await irisReader(this);
+      const iris = await read<Iris>(this, "iris");
       if (iris) this.afterCreateCallbacksStack.push(!iris.isPersisted());
     });
     this.afterUpdate(async function (this: Eye) {
-      const iris = await irisReader(this);
+      const iris = await read<Iris>(this, "iris");
       if (iris) this.afterUpdateCallbacksStack.push(iris.hasChangesToSave);
     });
     this.afterSave(async function (this: Eye) {
-      const iris = await irisReader(this);
+      const iris = await read<Iris>(this, "iris");
       if (iris) this.afterSaveCallbacksStack.push(iris.hasChangesToSave);
     });
 
@@ -59,12 +52,7 @@ export class Eye extends Base {
     });
 
     this.beforeSave(async function (this: Eye) {
-      const iris = await Promise.resolve(
-        this.association("irisWithReadOnlyForeignKey").reader as
-          | IrisWithReadOnlyForeignKey
-          | null
-          | Promise<IrisWithReadOnlyForeignKey | null>,
-      );
+      const iris = await read<IrisWithReadOnlyForeignKey>(this, "irisWithReadOnlyForeignKey");
       if (iris && this.overrideIrisWithReadOnlyForeignKeyColor) {
         iris.color = "blue";
       }

--- a/packages/activerecord/src/test-helpers/models/eye.ts
+++ b/packages/activerecord/src/test-helpers/models/eye.ts
@@ -2,6 +2,17 @@
 import { Base } from "../../base.js";
 import { acceptsNestedAttributesFor } from "../../nested-attributes.js";
 
+/**
+ * Rails reads `iris` through the plain association reader, which loads the
+ * target on a cold cache (`Association#load_target` — `find_target?` only
+ * skips the query while the owner is *building*). The trails reader returns a
+ * Promise on that path, so callbacks resolve it before touching the record;
+ * `after_*` callbacks are awaited by the chain, keeping the read faithful.
+ */
+function irisReader(eye: Eye): Promise<Iris | null> {
+  return Promise.resolve(eye.association("iris").reader as Iris | null | Promise<Iris | null>);
+}
+
 export class Eye extends Base {
   declare iris: Iris | null;
   declare irisWithReadOnlyForeignKey: IrisWithReadOnlyForeignKey | null;
@@ -13,46 +24,33 @@ export class Eye extends Base {
   afterSaveCallbacksStack: boolean[] = [];
   overrideIrisWithReadOnlyForeignKeyColor: boolean = false;
 
-  /**
-   * Rails reads `iris` directly in these callbacks (eye.rb). The trails has_one
-   * reader is async, so a sync callback firing while the association is
-   * unloaded receives a thenable rather than a record; read the loaded target
-   * instead.
-   *
-   * KNOWN DIVERGENCE: Rails' reader would `load_target` on a cold cache — a
-   * *persisted* Eye saved without anyone first touching `iris` still queries and
-   * pushes the result onto the callback stacks, where this getter pushes
-   * nothing. Every current caller pre-loads the target (association assignment
-   * or nested attributes), so no test observes the gap. Closing it needs a
-   * sync-readable has_one target, tracked by the story
-   * `eye-callbacks-cold-cache-has-one-read-diverges-from-rails`.
-   */
-  private get irisTarget(): Iris | null {
-    const assoc = this.association("iris");
-    return assoc.isLoaded() ? (assoc.target as Iris | null) : null;
-  }
-
   static {
-    this.afterCreate(function (this: Eye) {
-      if (this.irisTarget) this.afterCreateCallbacksStack.push(!this.irisTarget.isPersisted());
+    this.afterCreate(async function (this: Eye) {
+      const iris = await irisReader(this);
+      if (iris) this.afterCreateCallbacksStack.push(!iris.isPersisted());
     });
-    this.afterUpdate(function (this: Eye) {
-      if (this.irisTarget) this.afterUpdateCallbacksStack.push(this.irisTarget.hasChangesToSave);
+    this.afterUpdate(async function (this: Eye) {
+      const iris = await irisReader(this);
+      if (iris) this.afterUpdateCallbacksStack.push(iris.hasChangesToSave);
     });
-    this.afterSave(function (this: Eye) {
-      if (this.irisTarget) this.afterSaveCallbacksStack.push(this.irisTarget.hasChangesToSave);
+    this.afterSave(async function (this: Eye) {
+      const iris = await irisReader(this);
+      if (iris) this.afterSaveCallbacksStack.push(iris.hasChangesToSave);
     });
 
     this.hasOne("iris");
 
-    this.afterCreate(function (this: Eye) {
-      if (this.irisTarget) this.afterCreateCallbacksStack.push(!this.irisTarget.isPersisted());
+    this.afterCreate(async function (this: Eye) {
+      const iris = await irisReader(this);
+      if (iris) this.afterCreateCallbacksStack.push(!iris.isPersisted());
     });
-    this.afterUpdate(function (this: Eye) {
-      if (this.irisTarget) this.afterUpdateCallbacksStack.push(this.irisTarget.hasChangesToSave);
+    this.afterUpdate(async function (this: Eye) {
+      const iris = await irisReader(this);
+      if (iris) this.afterUpdateCallbacksStack.push(iris.hasChangesToSave);
     });
-    this.afterSave(function (this: Eye) {
-      if (this.irisTarget) this.afterSaveCallbacksStack.push(this.irisTarget.hasChangesToSave);
+    this.afterSave(async function (this: Eye) {
+      const iris = await irisReader(this);
+      if (iris) this.afterSaveCallbacksStack.push(iris.hasChangesToSave);
     });
 
     this.hasOne("irisWithReadOnlyForeignKey", {
@@ -60,12 +58,15 @@ export class Eye extends Base {
       foreignKey: "eye_id",
     });
 
-    this.beforeSave(function (this: Eye) {
-      if (
-        (this as any).irisWithReadOnlyForeignKey &&
-        this.overrideIrisWithReadOnlyForeignKeyColor
-      ) {
-        (this as any).irisWithReadOnlyForeignKey.color = "blue";
+    this.beforeSave(async function (this: Eye) {
+      const iris = await Promise.resolve(
+        this.association("irisWithReadOnlyForeignKey").reader as
+          | IrisWithReadOnlyForeignKey
+          | null
+          | Promise<IrisWithReadOnlyForeignKey | null>,
+      );
+      if (iris && this.overrideIrisWithReadOnlyForeignKeyColor) {
+        iris.color = "blue";
       }
     });
   }


### PR DESCRIPTION
Rails' `Eye` reads `iris` through the plain association reader inside its
`after_create` / `after_update` / `after_save` callbacks
(`vendor/rails/activerecord/test/models/eye.rb`). That reader loads the target
on a cold cache — `Association#find_target?` only skips the query while the
owner is *building*, not merely because the owner is persisted.

The trails reader returns a `Promise` on that cold path, so the callbacks were
reading a thenable: `if (this.iris)` was always truthy and
`iris.hasChangesToSave` / `iris.isPersisted()` resolved to `undefined` (pushing
`undefined` onto the stacks, and blowing up on any stricter read). Every
existing caller happened to pre-load the target, so nothing observed it.

Fix: resolve the reader inside the callbacks. `after_*` callbacks are awaited by
the callback chain, so an `async` callback is a faithful place to do the load —
no special-cased "sync has_one target" primitive is needed. The `before_save`
that reads `iris_with_read_only_foreign_key` gets the same treatment (async
before callbacks are supported under the default terminator).

Coverage:

- Ported `autosave_association_test.rb:294-311` — `test_callbacks_firing_order_on_create`
  / `_on_update` / `_on_save` — against the canonical `Eye` / `Iris` models and
  `iris_attributes`, replacing three bespoke `CbFirm` / `CuFirm` / `CsFirm`
  stand-ins that asserted only relative callback ordering.
- New `autosave-association.trails.test.ts` covers the cold-cache case Rails has
  no test for (indistinguishable there): an `Eye` fetched fresh and saved
  without anyone touching `iris` still pushes `[false, false]`. This fails on
  `main` with `[undefined, undefined]`.

Closes-story: eye-callbacks-cold-cache-has-one-read-diverges-from-rails
