### PR TITLE
ci: fix stale rails-comparison skip comment after INFRA_RE carve-out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1729,7 +1729,8 @@ jobs:
                 rails-comparison)
                   # Legitimate skip when no comparison-relevant path changed
                   # (no packages/**, scripts/{api,test,fixtures,schema}-compare/**,
-                  # vendor/**, or cross-cutting infra).
+                  # comparison-consumed manifest builders, vendor/**, or
+                  # cross-cutting infra — see COMPARISON_RE).
                   [ "$COMPARISON_AFFECTED" = "false" ] && continue
                   ;;
                 website)


### PR DESCRIPTION
## What

Comment-only accuracy fix: the `rails-comparison` skip-allowlist comment in
the aggregate `ci` job still enumerated `scripts/{api,test,fixtures}-compare/`
after PR #5263 expanded `COMPARISON_RE` to include `schema-compare` and the
comparison-consumed manifest builders. Update the enumeration and point at
`COMPARISON_RE` as the source of truth.

## History

This PR originally carved the compare tooling and `scripts/parity/` out of
the `INFRA_RE` sweep. PR #5263 (working the `infra-re-carveout-audit` story
this investigation filed) landed a superset of that change on main first, so
this branch was reset onto main and reduced to the one remaining delta.
