### PR TITLE
test(ci): guard fork-count precedence parity between vitest.config and ar-db-slots

### DIFF
--- a/packages/activerecord/src/test-helpers/ar-db-forks-default.ts
+++ b/packages/activerecord/src/test-helpers/ar-db-forks-default.ts
@@ -7,25 +7,11 @@
  */
 export const DEFAULT_FORKS = 6;
 
-/** The env vars that request a worker count, in precedence order. */
 export interface ForkCountEnv {
   TRAILS_TEST_FORKS?: string | undefined;
   AR_DB_FORKS?: string | undefined;
 }
 
-/**
- * Effective vitest worker count: `TRAILS_TEST_FORKS` > `AR_DB_FORKS` >
- * {@link DEFAULT_FORKS}, clamped to `hostCap`. Non-numeric or non-positive
- * (unset, "auto", "0") falls back to the default. A null `hostCap` means the
- * host core count is unknown, so the request goes unclamped.
- *
- * Both sides of the fork-count duplication call this: vitest.config.ts (for
- * `poolOptions.forks.maxForks`) and ar-db-slots.ts's `workerForkCount()` (for
- * the advisory-slot pool). They cannot share a module that imports
- * `@blazetrails/activesupport` — the config is loaded before any workspace
- * package is built — so the shared piece lives here, dependency-free, with
- * each side supplying its own host-core reading.
- */
 export function resolveForkCount(env: ForkCountEnv, hostCap: number | null): number {
   const n = parseInt(env.TRAILS_TEST_FORKS ?? env.AR_DB_FORKS ?? "", 10);
   const requested = Number.isFinite(n) && n > 0 ? n : DEFAULT_FORKS;

--- a/packages/activerecord/src/test-helpers/ar-db-forks-default.ts
+++ b/packages/activerecord/src/test-helpers/ar-db-forks-default.ts
@@ -6,3 +6,28 @@
  * `@blazetrails/activesupport` (which ar-db-slots.ts does, for the OS adapter).
  */
 export const DEFAULT_FORKS = 6;
+
+/** The env vars that request a worker count, in precedence order. */
+export interface ForkCountEnv {
+  TRAILS_TEST_FORKS?: string | undefined;
+  AR_DB_FORKS?: string | undefined;
+}
+
+/**
+ * Effective vitest worker count: `TRAILS_TEST_FORKS` > `AR_DB_FORKS` >
+ * {@link DEFAULT_FORKS}, clamped to `hostCap`. Non-numeric or non-positive
+ * (unset, "auto", "0") falls back to the default. A null `hostCap` means the
+ * host core count is unknown, so the request goes unclamped.
+ *
+ * Both sides of the fork-count duplication call this: vitest.config.ts (for
+ * `poolOptions.forks.maxForks`) and ar-db-slots.ts's `workerForkCount()` (for
+ * the advisory-slot pool). They cannot share a module that imports
+ * `@blazetrails/activesupport` — the config is loaded before any workspace
+ * package is built — so the shared piece lives here, dependency-free, with
+ * each side supplying its own host-core reading.
+ */
+export function resolveForkCount(env: ForkCountEnv, hostCap: number | null): number {
+  const n = parseInt(env.TRAILS_TEST_FORKS ?? env.AR_DB_FORKS ?? "", 10);
+  const requested = Number.isFinite(n) && n > 0 ? n : DEFAULT_FORKS;
+  return hostCap === null ? requested : Math.min(requested, hostCap);
+}

--- a/packages/activerecord/src/test-helpers/ar-db-forks-parity.test.ts
+++ b/packages/activerecord/src/test-helpers/ar-db-forks-parity.test.ts
@@ -4,23 +4,26 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { DEFAULT_FORKS, resolveForkCount } from "./ar-db-forks-default.js";
 import { workerForkCount } from "./ar-db-slots.js";
 
-// vitest.config.ts sizes the real fork pool (`poolOptions.forks.maxForks`) and
-// ar-db-slots.ts sizes the advisory-slot pool; both need the same effective
-// worker count, but the config is loaded before any workspace package is built
-// and so cannot import the activesupport-backed module. They share
-// resolveForkCount() from the dependency-free ar-db-forks-default.ts — this
-// file is the guard that keeps them there: the matrix pins workerForkCount()
-// to the shared helper across the precedence combinations, and the source
-// check fails if the config re-inlines its own parse/clamp instead of calling
-// the helper (the drift that PR #5243's first review round caught by hand).
-//
-// The config is checked as source rather than imported: it sits outside this
-// package's tsconfig rootDir and is CommonJS importing ESM-only
-// `vitest/config`, so `tsc --build` cannot take it into the program.
+const sourcePath = (relative: string): string =>
+  decodeURIComponent(new URL(relative, import.meta.url).pathname);
 
-const CONFIG_PATH = decodeURIComponent(
-  new URL("../../../../vitest.config.ts", import.meta.url).pathname,
-);
+const CONFIG_PATH = sourcePath("../../../../vitest.config.ts");
+const HELPER_PATH = sourcePath("./ar-db-forks-default.ts");
+
+async function readSource(path: string): Promise<string> {
+  const fs = await getFsAsync();
+  if (!fs.readFile) throw new Error("fs adapter has no async readFile");
+  return fs.readFile(path, "utf8");
+}
+
+function stripComments(source: string): string {
+  // Line-based on purpose: a `/* ... */` sweep would swallow the config's
+  // glob strings ("packages/*/dx-tests/**") along with the code between them.
+  return source
+    .split("\n")
+    .filter((line) => !/^\s*(\/\/|\/\*|\*)/.test(line))
+    .join("\n");
+}
 
 let cores = 64;
 const HOST_CORES = 64;
@@ -78,8 +81,6 @@ describe("ar-db fork count parity", () => {
   for (const { name, env, expected } of matrix) {
     it(`workerForkCount() matches the config's fork count: ${name}`, () => {
       setEnv(env);
-      // What vitest.config.ts computes: the shared helper against its own
-      // host reading (node os), pinned here to the same core count.
       const configForks = resolveForkCount(process.env, Math.max(cores - 1, 1));
       expect(configForks).toBe(expected);
       expect(workerForkCount()).toBe(configForks);
@@ -103,19 +104,22 @@ describe("ar-db fork count parity", () => {
   });
 
   it("vitest.config.ts derives maxForks from the shared helper, not its own parse", async () => {
-    const fs = await getFsAsync();
-    const source = await fs.readFile!(CONFIG_PATH, "utf8");
-    const code = source
-      .split("\n")
-      .filter((line) => !line.trim().startsWith("//"))
-      .join("\n");
+    const code = stripComments(await readSource(CONFIG_PATH));
 
-    expect(code).toContain("const TEST_FORKS = resolveForkCount(process.env, _hostForkCap);");
-    expect(code).toContain("const _hostForkCap = Math.max(os.availableParallelism() - 1, 1);");
-    expect(code).toContain("poolOptions: { forks: { maxForks: TEST_FORKS } }");
-    // The env vars may only be named inside the shared helper; a re-inlined
-    // parse here is exactly the drift this test exists to catch.
-    expect(code).not.toContain("process.env.TRAILS_TEST_FORKS");
-    expect(code).not.toContain("process.env.AR_DB_FORKS");
+    expect(code).toMatch(
+      /import\s*\{[^}]*\bresolveForkCount\b[^}]*\}\s*from\s*"[^"]*ar-db-forks-default\.js"/,
+    );
+    expect(code).toMatch(/const\s+TEST_FORKS\s*=\s*resolveForkCount\(\s*process\.env\s*,/);
+    expect(code).toMatch(/maxForks:\s*TEST_FORKS\b/);
+    expect(code).toMatch(/Math\.max\(\s*os\.availableParallelism\(\)\s*-\s*1\s*,\s*1\s*\)/);
+    expect(code).not.toMatch(/\bTRAILS_TEST_FORKS\b/);
+    expect(code).not.toMatch(/\bAR_DB_FORKS\b/);
+  });
+
+  it("the shared helper module imports nothing, so the config can load it unbuilt", async () => {
+    const code = stripComments(await readSource(HELPER_PATH));
+
+    expect(code).not.toMatch(/^\s*import\b/m);
+    expect(code).not.toMatch(/\brequire\(/);
   });
 });

--- a/packages/activerecord/src/test-helpers/ar-db-forks-parity.test.ts
+++ b/packages/activerecord/src/test-helpers/ar-db-forks-parity.test.ts
@@ -1,0 +1,121 @@
+import { osAdapterConfig, registerOsAdapter } from "@blazetrails/activesupport";
+import { getFsAsync } from "@blazetrails/activesupport/fs-adapter";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { DEFAULT_FORKS, resolveForkCount } from "./ar-db-forks-default.js";
+import { workerForkCount } from "./ar-db-slots.js";
+
+// vitest.config.ts sizes the real fork pool (`poolOptions.forks.maxForks`) and
+// ar-db-slots.ts sizes the advisory-slot pool; both need the same effective
+// worker count, but the config is loaded before any workspace package is built
+// and so cannot import the activesupport-backed module. They share
+// resolveForkCount() from the dependency-free ar-db-forks-default.ts — this
+// file is the guard that keeps them there: the matrix pins workerForkCount()
+// to the shared helper across the precedence combinations, and the source
+// check fails if the config re-inlines its own parse/clamp instead of calling
+// the helper (the drift that PR #5243's first review round caught by hand).
+//
+// The config is checked as source rather than imported: it sits outside this
+// package's tsconfig rootDir and is CommonJS importing ESM-only
+// `vitest/config`, so `tsc --build` cannot take it into the program.
+
+const CONFIG_PATH = decodeURIComponent(
+  new URL("../../../../vitest.config.ts", import.meta.url).pathname,
+);
+
+let cores = 64;
+const HOST_CORES = 64;
+
+const ENV_KEYS = ["TRAILS_TEST_FORKS", "AR_DB_FORKS"] as const;
+
+describe("ar-db fork count parity", () => {
+  beforeAll(() => {
+    registerOsAdapter("ar-db-forks-parity-test", {
+      tmpdir: () => "/tmp",
+      platform: () => "linux",
+      cwd: () => "/",
+      availableParallelism: () => cores,
+    });
+    osAdapterConfig.adapter = "ar-db-forks-parity-test";
+  });
+
+  afterAll(() => {
+    osAdapterConfig.adapter = null;
+  });
+
+  const saved = new Map<string, string | undefined>();
+  for (const k of ENV_KEYS) saved.set(k, process.env[k]);
+
+  afterEach(() => {
+    cores = HOST_CORES;
+    for (const k of ENV_KEYS) {
+      const v = saved.get(k);
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  function setEnv(env: Record<string, string>): void {
+    for (const k of ENV_KEYS) delete process.env[k];
+    Object.assign(process.env, env);
+  }
+
+  const matrix: Array<{ name: string; env: Record<string, string>; expected: number }> = [
+    { name: "neither var set", env: {}, expected: DEFAULT_FORKS },
+    { name: "AR_DB_FORKS only", env: { AR_DB_FORKS: "3" }, expected: 3 },
+    { name: "TRAILS_TEST_FORKS only", env: { TRAILS_TEST_FORKS: "2" }, expected: 2 },
+    {
+      name: "both set — TRAILS_TEST_FORKS wins",
+      env: { TRAILS_TEST_FORKS: "2", AR_DB_FORKS: "8" },
+      expected: 2,
+    },
+    {
+      name: "non-numeric falls back to the default",
+      env: { AR_DB_FORKS: "auto" },
+      expected: DEFAULT_FORKS,
+    },
+  ];
+
+  for (const { name, env, expected } of matrix) {
+    it(`workerForkCount() matches the config's fork count: ${name}`, () => {
+      setEnv(env);
+      // What vitest.config.ts computes: the shared helper against its own
+      // host reading (node os), pinned here to the same core count.
+      const configForks = resolveForkCount(process.env, Math.max(cores - 1, 1));
+      expect(configForks).toBe(expected);
+      expect(workerForkCount()).toBe(configForks);
+    });
+  }
+
+  it("clamps both sides to the host ceiling of cores - 1", () => {
+    cores = 4;
+    setEnv({ AR_DB_FORKS: "8" });
+    const configForks = resolveForkCount(process.env, Math.max(cores - 1, 1));
+    expect(configForks).toBe(3);
+    expect(workerForkCount()).toBe(configForks);
+  });
+
+  it("clamps both sides to at least one worker on a single-core host", () => {
+    cores = 1;
+    setEnv({});
+    const configForks = resolveForkCount(process.env, Math.max(cores - 1, 1));
+    expect(configForks).toBe(1);
+    expect(workerForkCount()).toBe(configForks);
+  });
+
+  it("vitest.config.ts derives maxForks from the shared helper, not its own parse", async () => {
+    const fs = await getFsAsync();
+    const source = await fs.readFile!(CONFIG_PATH, "utf8");
+    const code = source
+      .split("\n")
+      .filter((line) => !line.trim().startsWith("//"))
+      .join("\n");
+
+    expect(code).toContain("const TEST_FORKS = resolveForkCount(process.env, _hostForkCap);");
+    expect(code).toContain("const _hostForkCap = Math.max(os.availableParallelism() - 1, 1);");
+    expect(code).toContain("poolOptions: { forks: { maxForks: TEST_FORKS } }");
+    // The env vars may only be named inside the shared helper; a re-inlined
+    // parse here is exactly the drift this test exists to catch.
+    expect(code).not.toContain("process.env.TRAILS_TEST_FORKS");
+    expect(code).not.toContain("process.env.AR_DB_FORKS");
+  });
+});

--- a/packages/activerecord/src/test-helpers/ar-db-forks-parity.test.ts
+++ b/packages/activerecord/src/test-helpers/ar-db-forks-parity.test.ts
@@ -46,7 +46,10 @@ describe("ar-db fork count parity", () => {
   });
 
   const saved = new Map<string, string | undefined>();
-  for (const k of ENV_KEYS) saved.set(k, process.env[k]);
+
+  beforeAll(() => {
+    for (const k of ENV_KEYS) saved.set(k, process.env[k]);
+  });
 
   afterEach(() => {
     cores = HOST_CORES;

--- a/packages/activerecord/src/test-helpers/ar-db-slots.ts
+++ b/packages/activerecord/src/test-helpers/ar-db-slots.ts
@@ -29,7 +29,7 @@
  */
 
 import { getOs } from "@blazetrails/activesupport";
-import { DEFAULT_FORKS } from "./ar-db-forks-default.js";
+import { DEFAULT_FORKS, resolveForkCount } from "./ar-db-forks-default.js";
 
 // Spare slots beyond the worker count. One is enough to cover a single
 // recycle overlap; two leaves margin for back-to-back recycles.
@@ -63,13 +63,11 @@ function hostForkCap(): number | null {
  * that value becomes `poolOptions.forks.maxForks`, so any divergence means
  * the pool is sized against a worker count that never starts — and the
  * single-worker bypass in test-setup-worker-db.ts would miss a
- * `TRAILS_TEST_FORKS=1` solo run.
+ * `TRAILS_TEST_FORKS=1` solo run. Both sides run the same
+ * {@link resolveForkCount}, and ar-db-forks-parity.test.ts holds them together.
  */
 export function workerForkCount(): number {
-  const n = parseInt(process.env.TRAILS_TEST_FORKS ?? process.env.AR_DB_FORKS ?? "", 10);
-  const requested = Number.isFinite(n) && n > 0 ? n : DEFAULT_FORKS;
-  const cap = hostForkCap();
-  return cap === null ? requested : Math.min(requested, cap);
+  return resolveForkCount(process.env, hostForkCap());
 }
 
 /**

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "vitest/config";
 import path from "path";
 import os from "os";
-import { DEFAULT_FORKS } from "./packages/activerecord/src/test-helpers/ar-db-forks-default.js";
+import { resolveForkCount } from "./packages/activerecord/src/test-helpers/ar-db-forks-default.js";
 
 // AR_DB_FORKS (read in test-setup-worker-db.ts) requests a vitest worker
 // count; TEST_FORKS below is the effective one — the request clamped to the
@@ -87,20 +87,18 @@ const SQLITE_DRIVER_TESTS = [
   "packages/activerecord/src/sqlite-adapter.test.ts",
 ];
 
-const _parsedForks = parseInt(process.env.TRAILS_TEST_FORKS ?? process.env.AR_DB_FORKS ?? "", 10);
 // Clamp to vitest's own host-derived ceiling (numCpus - 1): while the root
 // maxForks cap was a per-project no-op, that ceiling is what every run
 // actually used, and the suite's timeouts are tuned to it — on the 4-vCPU CI
 // runner, honoring a fork count above it (AR_DB_FORKS=8, as CI used to set)
 // oversubscribes PG enough to push the full-DB schema-dump tests past their
 // 5s timeout. The env vars can only lower the cap, never raise it past the
-// host. Duplicated (not imported) from ar-db-slots.ts because the config is
-// loaded before any workspace package is built — see ar-db-forks-default.ts.
+// host. The precedence + clamp itself is shared with ar-db-slots.ts's
+// workerForkCount() via the dependency-free ar-db-forks-default.ts (the config
+// is loaded before any workspace package is built, so it cannot import the
+// activesupport-backed module directly); only the host-core reading differs.
 const _hostForkCap = Math.max(os.availableParallelism() - 1, 1);
-const TEST_FORKS = Math.min(
-  Number.isFinite(_parsedForks) && _parsedForks > 0 ? _parsedForks : DEFAULT_FORKS,
-  _hostForkCap,
-);
+const TEST_FORKS = resolveForkCount(process.env, _hostForkCap);
 
 const alias = {
   "@blazetrails/activesupport/message-verifier": path.resolve(


### PR DESCRIPTION
`vitest.config.ts` (`poolOptions.forks.maxForks`) and `ar-db-slots.ts`'s `workerForkCount()` each computed the effective worker count — `TRAILS_TEST_FORKS` > `AR_DB_FORKS` > `DEFAULT_FORKS`, clamped to `cores - 1` — independently, with nothing enforcing they stay identical. The duplication is forced (the config loads before any workspace package is built, so it cannot import the activesupport-backed module), but #5243's first review round caught exactly this drift by hand.

- Move the precedence + clamp into `resolveForkCount(env, hostCap)` in the dependency-free `ar-db-forks-default.ts`. Both sides call it, each supplying its own host-core reading (node `os` in the config, the OS adapter in ar-db-slots).
- Add `ar-db-forks-parity.test.ts`: the precedence matrix (neither / `AR_DB_FORKS` / `TRAILS_TEST_FORKS` / both / non-numeric) plus host-clamp cases, asserting `workerForkCount()` equals the config's computation under a pinned core count; a source check that the config still derives `maxForks` from the helper and never names the env vars itself; and a check that the helper module imports nothing, so the config can keep loading it unbuilt.

The config is checked as source rather than imported: it sits outside the package's tsconfig `rootDir` and is CommonJS importing ESM-only `vitest/config`, so `tsc --build` cannot take it into the program (verified — it errors on both counts).

Verified the guard fails, and only in the intended test, for each drift direction: config re-inlining its own parse, `workerForkCount()` reversing the precedence, `workerForkCount()` dropping the host clamp, and the helper gaining an import.

Closes-story: guard-fork-count-precedence-parity


## Review round 1

- Env snapshot moved into `beforeAll` (it was at module-eval scope, mirroring the neighbouring `ar-db-slots.test.ts`; `beforeAll` matches the rest of the suite).
- `stripComments` staying line-based is deliberate and unchanged: a general `/* … */` sweep swallows the config's glob strings (`"packages/*/dx-tests/**"`) and everything between them, which silently broke the `maxForks` assertion while it was in. An inline trailing comment naming a fork env var would false-fail the negative assertion, but that fails loudly and points straight at the line — the failure mode the sweep produced (assertions passing over deleted code) is the dangerous one.
