### PR TITLE
test(reserved-word): restore canonical reserved-word tables on teardown

### DIFF
--- a/packages/activerecord/src/reserved-word.test.ts
+++ b/packages/activerecord/src/reserved-word.test.ts
@@ -15,6 +15,7 @@ import { Base, RecordNotFound, registerModel } from "./index.js";
 import "./relation.js";
 import { Associations } from "./associations.js";
 import { fixtures } from "./test-helpers/fixtures.js";
+import { rebuildCanonicalTables } from "./test-helpers/canonical-schema.js";
 import { SchemaStatements } from "./connection-adapters/abstract/schema-statements.js";
 import { assertNoQueries } from "./testing/query-assertions.js";
 import { defineFixtures, defineJoinTableFixtures } from "./test-helpers/define-fixtures.js";
@@ -63,6 +64,8 @@ function schema(): SchemaStatements {
 }
 
 const RESERVED_TABLES = ["values", "group", "distinct_select", "distinct", "select", "order"];
+// The subset of the above that TEST_SCHEMA declares, restored on teardown.
+const CANONICAL_RESERVED_TABLES = ["group", "select", "distinct", "distinct_select", "values"];
 
 // Mirrors Rails `setup`: rebuild the five reserved-word tables before each
 // test via `create_table`. `references` adds the `*_id` column and the
@@ -91,13 +94,19 @@ beforeEach(async () => {
   ]);
 });
 
-// Mirrors Rails teardown: drop the tables so they don't leak into sibling
-// files sharing the worker DB.
+// Mirrors Rails teardown: drop the tables so the bespoke per-test shapes built
+// above don't leak into sibling files sharing the worker DB. Rails can stop
+// there (its teardown runs against a per-process DB rebuilt from schema.rb);
+// we additionally restore the canonical shapes, because `group`/`select`/
+// `distinct`/`distinct_select`/`values` are canonical TEST_SCHEMA tables and a
+// later file in the same worker that reads one would otherwise trip
+// `repairWorkerSchema`. `order` is not canonical — dropping it is the end of it.
 afterAll(async () => {
   const conn = schema();
   await conn.dropTable("values", "group", "distinct_select", "distinct", "select", "order", {
     ifExists: true,
   });
+  await rebuildCanonicalTables(Base.connection, CANONICAL_RESERVED_TABLES);
 });
 
 // Mirrors the Rails private `create_test_fixtures` loader: seed only the named

--- a/packages/activerecord/src/reserved-word.test.ts
+++ b/packages/activerecord/src/reserved-word.test.ts
@@ -64,8 +64,9 @@ function schema(): SchemaStatements {
 }
 
 const RESERVED_TABLES = ["values", "group", "distinct_select", "distinct", "select", "order"];
-// The subset of the above that TEST_SCHEMA declares, restored on teardown.
-const CANONICAL_RESERVED_TABLES = ["group", "select", "distinct", "distinct_select", "values"];
+// `order` is the one name here TEST_SCHEMA does not declare; the rest are
+// canonical, so teardown must hand them back in their canonical shape.
+const CANONICAL_RESERVED_TABLES = RESERVED_TABLES.filter((t) => t !== "order");
 
 // Mirrors Rails `setup`: rebuild the five reserved-word tables before each
 // test via `create_table`. `references` adds the `*_id` column and the
@@ -94,13 +95,10 @@ beforeEach(async () => {
   ]);
 });
 
-// Mirrors Rails teardown: drop the tables so the bespoke per-test shapes built
-// above don't leak into sibling files sharing the worker DB. Rails can stop
-// there (its teardown runs against a per-process DB rebuilt from schema.rb);
-// we additionally restore the canonical shapes, because `group`/`select`/
-// `distinct`/`distinct_select`/`values` are canonical TEST_SCHEMA tables and a
-// later file in the same worker that reads one would otherwise trip
-// `repairWorkerSchema`. `order` is not canonical — dropping it is the end of it.
+// Mirrors Rails teardown: drop the tables so the bespoke per-test shapes don't
+// leak into sibling files sharing the worker DB. Rails can stop there; we then
+// hand the canonical names back in their TEST_SCHEMA shape, since a later file
+// in the same worker reading one would otherwise trip `repairWorkerSchema`.
 afterAll(async () => {
   const conn = schema();
   await conn.dropTable("values", "group", "distinct_select", "distinct", "select", "order", {


### PR DESCRIPTION
reserved-word.test.ts mirrors Rails' `create_table`-per-test setup, but its `afterAll` dropped the canonical `group`/`select`/`distinct`/`distinct_select`/`values` tables without restoring their canonical `TEST_SCHEMA` shape. Any later file in the same worker reading one of them tripped `repairWorkerSchema` — the top drift source in the RFC 0070 Phase-1 measurement (3 of 12 firings; sqlite, postgres, mysql; victims `left-outer-join-association`, `disable-joins-association-scope`, `establish-connection`).

Teardown now drops as Rails does, then calls `rebuildCanonicalTables` for the five canonical names. `order` is not in TEST_SCHEMA, so it stays dropped.

Verified locally: `reserved-word.test.ts` passes (12/12), and running it in the same fork as `left-outer-join-association.test.ts` emits no `[schema-repair]` warning. No test renamed.

Closes-story: restore-reserved-word-canonical-tables