### PR TITLE
test(multiple-db): restore canonical HABTM tables after second-pool suites

### DIFF
--- a/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
@@ -1,7 +1,7 @@
 /**
  * Mirrors Rails activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
  */
-import { describe, it, expect, beforeAll, vi } from "vitest";
+import { describe, it, expect, afterAll, beforeAll, vi } from "vitest";
 import { Base, registerModel, AssociationTypeMismatch, ReadOnlyRecord } from "../index.js";
 import { assertNoQueries, assertQueriesCount } from "../testing/query-assertions.js";
 import { fixtures } from "../test-helpers/fixtures.js";
@@ -37,7 +37,7 @@ import { Computer } from "../test-helpers/models/computer.js";
 import { PublisherArticle, PublisherMagazine } from "../test-helpers/models/publisher.js";
 import { Professor } from "../test-helpers/models/professor.js";
 import { Course } from "../test-helpers/models/course.js";
-import { setupSecondPool } from "../test-helpers/setup-second-pool.js";
+import { setupSecondPool, teardownSecondPool } from "../test-helpers/setup-second-pool.js";
 import { isSqliteRun } from "../test-helpers/sqlite-template.js";
 
 // Test-file-local models mirroring the Rails fixture file's inline class
@@ -1194,6 +1194,12 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     expect(await (professor as any).courses.count()).toBe(0);
     await expect((professor as any).courses.push(course)).resolves.not.toThrow();
     expect(await (professor as any).courses.count()).toBe(1);
+  });
+
+  // `setupSecondPool` drops the arunit2-only tables from the shared primary
+  // database; restore them so sibling files see the canonical schema.
+  afterAll(async () => {
+    if (isSqliteRun()) await teardownSecondPool();
   });
 
   it("habtm scope can unscope", async () => {

--- a/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
@@ -1196,8 +1196,6 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     expect(await (professor as any).courses.count()).toBe(1);
   });
 
-  // `setupSecondPool` drops the arunit2-only tables from the shared primary
-  // database; restore them so sibling files see the canonical schema.
   afterAll(async () => {
     if (isSqliteRun()) await teardownSecondPool();
   });

--- a/packages/activerecord/src/multiple-db.test.ts
+++ b/packages/activerecord/src/multiple-db.test.ts
@@ -22,8 +22,6 @@ describe.skipIf(!isSqliteRun())("MultipleDbTest", () => {
     await setupSecondPool();
   });
 
-  // `setupSecondPool` drops the arunit2-only tables from the shared primary
-  // database; restore them so sibling files see the canonical schema.
   afterAll(async () => {
     await teardownSecondPool();
   });

--- a/packages/activerecord/src/multiple-db.test.ts
+++ b/packages/activerecord/src/multiple-db.test.ts
@@ -1,9 +1,9 @@
-import { beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import "./index.js";
 import { Base } from "./base.js";
 import { StatementInvalid } from "./errors.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { setupSecondPool } from "./test-helpers/setup-second-pool.js";
+import { setupSecondPool, teardownSecondPool } from "./test-helpers/setup-second-pool.js";
 import { isSqliteRun } from "./test-helpers/sqlite-template.js";
 import { ARUnit2Model } from "./test-helpers/models/arunit2-model.js";
 import { Course } from "./test-helpers/models/course.js";
@@ -20,6 +20,12 @@ describe.skipIf(!isSqliteRun())("MultipleDbTest", () => {
   fixtures({}, { useTransactionalTests: false });
   beforeAll(async () => {
     await setupSecondPool();
+  });
+
+  // `setupSecondPool` drops the arunit2-only tables from the shared primary
+  // database; restore them so sibling files see the canonical schema.
+  afterAll(async () => {
+    await teardownSecondPool();
   });
 
   // Rails: `fixtures :colleges, :courses, :entrants`.

--- a/packages/activerecord/src/prepared-statement-status.test.ts
+++ b/packages/activerecord/src/prepared-statement-status.test.ts
@@ -22,8 +22,6 @@ describe.skipIf(!isSqliteRun())("PreparedStatementStatusTest", () => {
     await setupSecondPool();
   });
 
-  // `setupSecondPool` drops the arunit2-only tables from the shared primary
-  // database; restore them so sibling files see the canonical schema.
   afterAll(async () => {
     await teardownSecondPool();
   });

--- a/packages/activerecord/src/prepared-statement-status.test.ts
+++ b/packages/activerecord/src/prepared-statement-status.test.ts
@@ -1,9 +1,9 @@
-import { beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { IsolatedExecutionState } from "@blazetrails/activesupport";
 import "./index.js";
 import { Base } from "./base.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { setupSecondPool } from "./test-helpers/setup-second-pool.js";
+import { setupSecondPool, teardownSecondPool } from "./test-helpers/setup-second-pool.js";
 import { isSqliteRun } from "./test-helpers/sqlite-template.js";
 import { Course } from "./test-helpers/models/course.js";
 import { Entrant } from "./test-helpers/models/entrant.js";
@@ -20,6 +20,12 @@ describe.skipIf(!isSqliteRun())("PreparedStatementStatusTest", () => {
   fixtures({}, { useTransactionalTests: false });
   beforeAll(async () => {
     await setupSecondPool();
+  });
+
+  // `setupSecondPool` drops the arunit2-only tables from the shared primary
+  // database; restore them so sibling files see the canonical schema.
+  afterAll(async () => {
+    await teardownSecondPool();
   });
 
   it("prepared statement status is thread and instance specific", async () => {

--- a/packages/activerecord/src/test-helpers/setup-second-pool.ts
+++ b/packages/activerecord/src/test-helpers/setup-second-pool.ts
@@ -69,12 +69,9 @@ export async function setupSecondPool(): Promise<void> {
 }
 
 /**
- * Undoes `setupSecondPool`'s primary-database surgery.
- *
- * Rails' two-database split is per-process and disappears with the process;
- * ours shares one primary database with every sibling suite in the worker, so
- * the `arunit2`-only tables dropped above must be put back or later files
- * (which never touch `courses`/`colleges`) observe a drifted schema.
+ * Undoes `setupSecondPool`'s primary-database surgery: Rails' two-database
+ * split dies with the process, but ours shares one primary database with every
+ * sibling suite in the worker, so the dropped tables must be put back.
  *
  * @internal
  */
@@ -84,5 +81,6 @@ export async function teardownSecondPool(): Promise<void> {
     "courses",
     "professors",
     "courses_professors",
+    "entrants",
   ]);
 }

--- a/packages/activerecord/src/test-helpers/setup-second-pool.ts
+++ b/packages/activerecord/src/test-helpers/setup-second-pool.ts
@@ -67,3 +67,22 @@ export async function setupSecondPool(): Promise<void> {
   ]);
   await rebuildCanonicalTables(primary, ["entrants"]);
 }
+
+/**
+ * Undoes `setupSecondPool`'s primary-database surgery.
+ *
+ * Rails' two-database split is per-process and disappears with the process;
+ * ours shares one primary database with every sibling suite in the worker, so
+ * the `arunit2`-only tables dropped above must be put back or later files
+ * (which never touch `courses`/`colleges`) observe a drifted schema.
+ *
+ * @internal
+ */
+export async function teardownSecondPool(): Promise<void> {
+  await rebuildCanonicalTables(Base.connection, [
+    "colleges",
+    "courses",
+    "professors",
+    "courses_professors",
+  ]);
+}


### PR DESCRIPTION
Fixes the second drift source in RFC 0070: `setupSecondPool` drops the arunit2-only tables (`courses`, `colleges`, `professors`, `courses_professors`) from the shared primary database to mirror Rails' arunit/arunit2 split, but never restores them. Sibling files that never touch those tables (`deprecator.test.ts`, `database-selector.test.ts`) then hit a drifted schema and trigger the repair worker.

Adds `teardownSecondPool()` which rebuilds the four canonical tables on the primary connection, and calls it from an `afterAll` in the three suites that call `setupSecondPool`: `multiple-db.test.ts`, `prepared-statement-status.test.ts`, and the sqlite-gated "alternate database" test in `has-and-belongs-to-many-associations.test.ts`.

No test renamed; no schema changes.

Closes-story: restore-habtm-courses-canonical-tables
