### PR TITLE
test(mysql2-adapter): restore canonical subscribers instead of dropping it

### DIFF
--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.trails.test.ts
@@ -31,6 +31,7 @@ import {
   ValueTooLong,
 } from "../../errors.js";
 import { AbstractMysqlAdapter } from "../../connection-adapters/abstract-mysql-adapter.js";
+import { rebuildCanonicalTables } from "../../test-helpers/canonical-schema.js";
 import { Result } from "../../result.js";
 
 // Fabricated-error translate_exception checks. These don't touch a live
@@ -247,29 +248,16 @@ describeIfMysql("Mysql2Adapter (trails extensions)", () => {
     // Mirrors adapter_test.rb: a zero-row SELECT must still report its
     // columns from the field descriptors, not collapse to an empty Result.
     // Rails runs this against the canonical `subscribers` fixture table; the
-    // describeIfMysql suite does not bootstrap the canonical schema, so seed
-    // the real `subscribers` table with its exact schema.rb shape (id: false;
-    // nick/name/id/books_count/update_count; unique index on nick) before the
-    // probe rather than inventing a scratch table name.
-    await adapter.executeMutation("DROP TABLE IF EXISTS `subscribers`");
-    await adapter.executeMutation(
-      "CREATE TABLE `subscribers` (" +
-        "`nick` VARCHAR(255) NOT NULL, " +
-        "`name` VARCHAR(255), " +
-        "`id` INT, " +
-        "`books_count` INT NOT NULL DEFAULT 0, " +
-        "`update_count` INT NOT NULL DEFAULT 0, " +
-        "UNIQUE KEY `index_subscribers_on_nick` (`nick`)" +
-        ") ENGINE=InnoDB",
-    );
-    try {
-      const result = await adapter.execQuery("SELECT * FROM subscribers WHERE 1=0");
-      expect(result).toBeInstanceOf(Result);
-      expect(result.rows).toEqual([]);
-      expect(result.columns).toEqual(["nick", "name", "id", "books_count", "update_count"]);
-    } finally {
-      await adapter.executeMutation("DROP TABLE IF EXISTS `subscribers`");
-    }
+    // describeIfMysql suite does not bootstrap the canonical schema, so lay the
+    // canonical table through the canonical loader rather than hand-rolling its
+    // DDL. It is left in place afterwards on purpose: this suite shares the
+    // per-worker database with every other file, and dropping a canonical table
+    // here is exactly the shape drift `repairWorkerSchema` has to clean up.
+    await rebuildCanonicalTables(adapter, ["subscribers"]);
+    const result = await adapter.execQuery("SELECT * FROM subscribers WHERE 1=0");
+    expect(result).toBeInstanceOf(Result);
+    expect(result.rows).toEqual([]);
+    expect(result.columns).toEqual(["nick", "name", "id", "books_count", "update_count"]);
   });
 
   it("database timezone changes synced to connection (extended re-sync paths)", async () => {


### PR DESCRIPTION
## Problem

`repairWorkerSchema` was firing for `subscribers` (1 of 12 measured firings, mysql
lane), with `calculations.trails.test.ts` as the downstream victim.

The culprit is the trails-only empty-result-set guard in
`packages/activerecord/src/adapters/mysql2/mysql2-adapter.trails.test.ts`
(`#exec_query queries with an empty result set still return the columns`). It
hand-rolled a `subscribers` table with raw DDL and then **dropped it in a
`finally` block**, leaving the canonical table missing entirely on the shared
per-worker MySQL database. The next file scheduled in that worker tripped the
repair.

Note the story's listed candidates (`adapter.test.ts`, `finder.test.ts`,
`insert-all.test.ts`, `associations/has-many-associations.test.ts`,
`test-helpers/use-fixtures.test.ts`) were stale — all five now go through
`fixtures([...])`, and no `defineSchema` of `subscribers` survives anywhere.

## Fix

Lay the table through `rebuildCanonicalTables(adapter, ["subscribers"])` — the
canonical loader, per RFC 0059 — and leave it in place afterwards, since the
per-worker DB is shared and a canonical table is not this file's to drop. The
sibling mirror `mysql2-adapter.test.ts` already uses the same helper the same
way, so this is the established pattern in this directory, not a new one.

## Completeness sweep

Grepped every `*.test.ts` in `packages/activerecord/src` for `DROP TABLE` /
`dropTable` / `dropAllTables` against `subscribers`. After this change the only
remaining hit is `adapter-prevent-writes.test.ts`, which creates and drops its
`subscribers` on a private `new BetterSQLite3Adapter(":memory:")` — it never
touches the shared per-worker DB, so it cannot cause shape drift.

## Verification

- Ran the file against an isolated MySQL 8 (`ARCONN=mysql2`, dedicated compose
  project): 14/14 pass.
- `SHOW COLUMNS FROM subscribers` **after** the run reports the canonical
  `nick / name / id / books_count / update_count` shape (`nick` PRI via the
  unique index) instead of the table being gone — i.e. the drift that fired the
  repair is eliminated at the source.
- `pnpm test:compare` before and after are byte-identical: overall
  `14606/21663 (67.4%)`, `753/1023` files, `196 misplaced`. Delta = 0. (Expected:
  this is a `.trails.test.ts` extension file and no test name changed.)

## Not in scope

`require-table-teardown` balances raw DDL per table name, so the old
create-then-drop read as balanced even though it left a *canonical* table
dropped. A lint guard for "dropped a canonical table without rebuilding it" is
registered separately as
`0070-drop-repair-worker-schema/lint-guard-canonical-table-drop-without-rebuild`
rather than fanned out into this PR.

Closes-story: restore-subscribers-canonical-table
