### PR TITLE
test(transactions): stop re-laying canonical items in SchemaAdapter TM tests

### DIFF
--- a/packages/activerecord/src/transactions.trails.test.ts
+++ b/packages/activerecord/src/transactions.trails.test.ts
@@ -426,8 +426,7 @@ describe("SchemaAdapter TM delegation", () => {
     // The model runs on `Base.connection`; spy on that same adapter — it's what
     // TM dispatches `withinNewTransaction` against.
     const testAdapter = Base.connection;
-    const realAdapter = Base.connection;
-    const spy = vi.spyOn(realAdapter, "withinNewTransaction");
+    const spy = vi.spyOn(testAdapter, "withinNewTransaction");
     class Item extends Base {
       static {
         this.attribute("id", "integer");
@@ -492,7 +491,7 @@ describe("SchemaAdapter TM delegation", () => {
         this.adapter = testAdapter;
       }
     }
-    // Force a defineSchema-like priming so concurrent creates don't race on DDL.
+    // Prime schema reflection up front so concurrent creates don't race on it.
     await Item.create({ name: "prime" });
 
     const observed: Array<{ inside: unknown }> = [];

--- a/packages/activerecord/src/transactions.trails.test.ts
+++ b/packages/activerecord/src/transactions.trails.test.ts
@@ -426,14 +426,6 @@ describe("SchemaAdapter TM delegation", () => {
     // The model runs on `Base.connection`; spy on that same adapter — it's what
     // TM dispatches `withinNewTransaction` against.
     const testAdapter = Base.connection;
-    // Re-lay canonical `items` (drop-and-recreate, mirroring schema.rb's
-    // `create_table :items`) to prime the signature cache. `items` is a
-    // boot-owned canonical table, so it is not torn down here (the describe's
-    // afterAll clears rows; the boot schema owns/restores the shape).
-    // eslint-disable-next-line blazetrails/require-table-teardown
-    await testAdapter.createTable("items", { force: true }, (t) => {
-      t.column("name", "string");
-    });
     const realAdapter = Base.connection;
     const spy = vi.spyOn(realAdapter, "withinNewTransaction");
     class Item extends Base {
@@ -454,14 +446,6 @@ describe("SchemaAdapter TM delegation", () => {
     const { SavepointTransaction, RealTransaction } =
       await import("./connection-adapters/abstract/transaction.js");
     const testAdapter = Base.connection;
-    // Re-lay canonical `items` (drop-and-recreate, mirroring
-    // schema.rb's `create_table :items`) to prime the signature cache.
-    // `items` is a boot-owned canonical table, so it is not torn down here (the
-    // describe's afterAll clears rows; the boot schema owns/restores the shape).
-
-    await testAdapter.createTable("items", { force: true }, (t) => {
-      t.column("name", "string");
-    });
     class Item extends Base {
       static {
         this.attribute("id", "integer");
@@ -501,14 +485,6 @@ describe("SchemaAdapter TM delegation", () => {
     // in favour of pool-per-connection isolation (tested by the E1 safety-net
     // in with-transactional-fixtures.test.ts). Wrapper deleted entirely in E4.
     const testAdapter = Base.connection;
-    // Re-lay canonical `items` (drop-and-recreate, mirroring
-    // schema.rb's `create_table :items`) to prime the signature cache.
-    // `items` is a boot-owned canonical table, so it is not torn down here (the
-    // describe's afterAll clears rows; the boot schema owns/restores the shape).
-
-    await testAdapter.createTable("items", { force: true }, (t) => {
-      t.column("name", "string");
-    });
     class Item extends Base {
       static {
         this.attribute("id", "integer");
@@ -565,14 +541,6 @@ describe("SchemaAdapter TM delegation", () => {
 
   it("manual beginTransaction/commit pair delegates inner state unconditionally", async () => {
     const testAdapter = Base.connection;
-    // Re-lay canonical `items` (drop-and-recreate, mirroring
-    // schema.rb's `create_table :items`) to prime the signature cache.
-    // `items` is a boot-owned canonical table, so it is not torn down here (the
-    // describe's afterAll clears rows; the boot schema owns/restores the shape).
-
-    await testAdapter.createTable("items", { force: true }, (t) => {
-      t.column("name", "string");
-    });
     class Item extends Base {
       static {
         this.attribute("id", "integer");


### PR DESCRIPTION
## Summary

The `SchemaAdapter TM delegation` tests in `transactions.trails.test.ts` each
drop-and-recreated the canonical `items` table with
`createTable("items", { force: true })`, purely to prime the create-table
signature cache. Against the shared per-worker postgres database that DDL left
`items` churned for later files, and the per-file schema-repair worker then had
to rebuild it for the victim (`associations/inverse-associations.test.ts`) —
1 of the 12 recorded repair firings.

The describe already calls `fixtures({}, { useTransactionalTests: false })`,
which preloads the canonical schema, so `items` (`test-schema.ts:860`) is
present in its canonical shape before any test body runs and the re-lays were
redundant. Removing all four leaves zero `items` DDL on the shared-DB path, in
line with RFC 0059.

Row cleanup is unchanged: the describe's `afterAll` still `DELETE FROM items`.

Also drops a now-pointless `realAdapter` alias (it was a second
`Base.connection` read that only existed alongside the removed re-lay) and
rewords a comment that referenced the retired `defineSchema`.

## Audit: is this every `items` firing source?

Every other test that touches an `items` table does so on its own throwaway
adapter, not the shared worker DB, so none of them can drift the canonical
table:

- `connection-adapters/sqlite3-adapter.transactions.test.ts` — per-test
  `mkdtemp` sqlite file.
- `sqlite/libsql.test.ts` — its own libsql file, removed in `afterAll`.
- `adapters/sqlite3-adapter.test.ts`, `adapters/sqlite3/sqlite3-adapter.test.ts`
  — `:memory:` adapters.

The four `createTable` calls removed here were the only shared-database `items`
DDL in the suite.

## Testing

- `pnpm vitest run packages/activerecord/src/transactions.trails.test.ts`
  (sqlite) — 16 passed, 1 skipped.
- Isolated postgres stack: `transactions.trails.test.ts` +
  `associations/inverse-associations.test.ts` + `batches.test.ts` —
  217 passed, 1 skipped.

No test renamed; the change is deletions only, so the `test:compare` delta is 0.

Closes-story: restore-items-canonical-table
