### PR TITLE
test(adapter): restore canonical fk_test tables after AdapterForeignKeyTest

### DIFF
--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -22,6 +22,7 @@ import {
 } from "./index.js";
 import { Result } from "./result.js";
 import { fixtures } from "./test-helpers/fixtures.js";
+import { rebuildCanonicalTables } from "./test-helpers/canonical-schema.js";
 import { adapterType, inMemoryDb } from "./test-adapter.js";
 import { itIfSupports } from "./test-helpers/supports.js";
 import { establishFromTestConfig } from "./test-helpers/test-database-config.js";
@@ -576,8 +577,10 @@ describe("AdapterForeignKeyTest", () => {
   });
   afterAll(async () => {
     if (adapterType === "sqlite") {
-      await Base.connection.executeMutation("DROP TABLE IF EXISTS fk_test_has_fk");
-      await Base.connection.executeMutation("DROP TABLE IF EXISTS fk_test_has_pk");
+      // Hand both names back in their canonical TEST_SCHEMA shape: the bespoke
+      // FK-carrying tables above replaced the boot-laid ones, and a later file
+      // in the same worker reading them would otherwise trip repairWorkerSchema.
+      await rebuildCanonicalTables(Base.connection, ["fk_test_has_pk", "fk_test_has_fk"]);
       return;
     }
     await Base.connection.execute(dropFkSql()).catch(() => {});

--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -577,9 +577,6 @@ describe("AdapterForeignKeyTest", () => {
   });
   afterAll(async () => {
     if (adapterType === "sqlite") {
-      // Hand both names back in their canonical TEST_SCHEMA shape: the bespoke
-      // FK-carrying tables above replaced the boot-laid ones, and a later file
-      // in the same worker reading them would otherwise trip repairWorkerSchema.
       await rebuildCanonicalTables(Base.connection, ["fk_test_has_pk", "fk_test_has_fk"]);
       return;
     }


### PR DESCRIPTION
AdapterForeignKeyTest's sqlite branch drops the canonical `fk_test_has_pk`/`fk_test_has_fk` and recreates them with an inline FK constraint (SQLite can't `ALTER TABLE … ADD CONSTRAINT`), then its `afterAll` dropped both without restoring the canonical `TEST_SCHEMA` shape. Any later file in the same worker reading either table tripped `repairWorkerSchema` — 1 of 12 firings in the RFC 0070 Phase-1 measurement (sqlite; victim `associations/has-one-associations`).

Teardown now hands both names back via `rebuildCanonicalTables`, matching the fix in #5254.

Verified locally: on `main`, running `adapter.test.ts` before `relation/select.test.ts` in the same worker logs `[schema-repair] restored drifted canonical tables: fk_test_has_pk, fk_test_has_fk`; with this change it does not, and both files pass. No test renamed.

Closes-story: restore-fk-test-canonical-tables
