### PR TITLE
test(mysql-schema): restore canonical posts/topics/students/lessons_students

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
@@ -1,9 +1,27 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/schema_test.rb
  */
-import { describe, it, beforeEach, afterEach, expect } from "vitest";
+import { describe, it, beforeEach, afterEach, afterAll, expect } from "vitest";
 import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
 import { Base } from "../../base.js";
+import { rebuildCanonicalTables } from "../../test-helpers/canonical-schema.js";
+
+/**
+ * Rails runs these tests against its own schema-loaded connection and never
+ * drops a canonical table. Here each test lays the canonical table it needs on
+ * the shared per-worker DB and drops it again, which would leave the table
+ * missing for every sibling file on that DB (the `comment.test.ts` repair
+ * firings). Restore the canonical shape once the suite is done. Uses a plain
+ * adapter so the rebuild never runs under ANSI_QUOTES.
+ */
+async function restoreCanonical(names: readonly string[]): Promise<void> {
+  const restorer = new Mysql2Adapter(MYSQL_TEST_URL);
+  try {
+    await rebuildCanonicalTables(restorer, names);
+  } finally {
+    await restorer.close();
+  }
+}
 
 describeIfMysql("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
@@ -12,6 +30,9 @@ describeIfMysql("Mysql2Adapter", () => {
   });
   afterEach(async () => {
     await adapter.close();
+  });
+  afterAll(async () => {
+    await restoreCanonical(["posts"]);
   });
 
   describe("SchemaTest", () => {
@@ -190,6 +211,9 @@ describeIfMysql("MySQLAnsiQuotesTest", () => {
     // with a secondary TypeError here.
     await ansi?.close();
     ansi = undefined;
+  });
+  afterAll(async () => {
+    await restoreCanonical(["students", "lessons_students", "topics"]);
   });
 
   it("primary key method with ansi quotes", async () => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
@@ -6,15 +6,7 @@ import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js
 import { Base } from "../../base.js";
 import { rebuildCanonicalTables } from "../../test-helpers/canonical-schema.js";
 
-/**
- * Rails runs these tests against its own schema-loaded connection and never
- * drops a canonical table. Here each test lays the canonical table it needs on
- * the shared per-worker DB and drops it again, which would leave the table
- * missing for every sibling file on that DB (the `comment.test.ts` repair
- * firings). Restore the canonical shape once the suite is done. Uses a plain
- * adapter so the rebuild never runs under ANSI_QUOTES.
- */
-async function restoreCanonical(names: readonly string[]): Promise<void> {
+async function restoreCanonicalOnPlainAdapter(names: readonly string[]): Promise<void> {
   const restorer = new Mysql2Adapter(MYSQL_TEST_URL);
   try {
     await rebuildCanonicalTables(restorer, names);
@@ -32,7 +24,7 @@ describeIfMysql("Mysql2Adapter", () => {
     await adapter.close();
   });
   afterAll(async () => {
-    await restoreCanonical(["posts"]);
+    await restoreCanonicalOnPlainAdapter(["posts"]);
   });
 
   describe("SchemaTest", () => {
@@ -213,7 +205,7 @@ describeIfMysql("MySQLAnsiQuotesTest", () => {
     ansi = undefined;
   });
   afterAll(async () => {
-    await restoreCanonical(["students", "lessons_students", "topics"]);
+    await restoreCanonicalOnPlainAdapter(["students", "lessons_students", "topics"]);
   });
 
   it("primary key method with ansi quotes", async () => {


### PR DESCRIPTION
## What

`packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts` lays
canonical `posts`, `topics`, `students` and `lessons_students` itself (Rails
gets them from its schema-loaded connection) and drops each in a `finally`.
On the shared per-worker MySQL DB that leaves all four missing for every
sibling file on that DB — the repair-worker firings whose victim was
`comment.test.ts`.

Each suite now restores the canonical shape in `afterAll` via
`rebuildCanonicalTables`. The restore runs on a plain adapter, not the
`MySQLAnsiQuotesTest` one, so the rebuild DDL never executes under
`sql_mode='ANSI_QUOTES'`.

## Verification (MySQL 8, worker slot DB `rails_js_test`)

Baseline (`origin/main` version of the file), after the suite runs — all four
tables gone from the DB that ran it, still present on the other slots:

```
rails_js_test_2/3/4  posts, topics, students, lessons_students
rails_js_test        (none)
```

With this change — all four back, in canonical shape (`posts` at its 12
canonical columns; `lessons_students` back to the `id: false`
`lesson_id`/`student_id` pair with no leftover FK from the ANSI test):

```
rails_js_test        posts, topics, students, lessons_students
```

`pnpm vitest run .../abstract-mysql-adapter/schema.test.ts` — 9 passed on both
baseline and this branch (the leak was silent for this file; it only hurt
siblings).

No test renamed, no Rails-facing behavior changed, so `test:compare` delta is 0.

Closes-story: restore-comment-habtm-canonical-tables

## Review response — `rebuildCanonicalTables` drop order

Confirmed and not changed here. The registry does register `lessons_students`
(`canonical-schema.ts:989`) before `students` (`:994`), so the reverse-order
drop loop takes `students` first for that pair — the opposite of what its
comment claims. It cannot fire today for a stronger reason than the per-test
`finally`: `buildCanonicalRegistry` emits no foreign keys at all
(`grep -c foreignKey canonical-schema.ts` = 0), so no canonical shape carries a
persisted FK constraint for any drop order to violate. The hazard needs a
caller that rebuilds while a *test-added* FK is still live.

That is a defect in the helper's own doc/contract rather than in this call
site, so per the no-fan-out rule it is registered as its own story:
`0070-drop-repair-worker-schema/stories/rebuild-canonical-tables-drop-order-comment`.
