### PR TITLE
test(postgresql): read canonical CamelCase table instead of recreating it

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -121,7 +121,6 @@ describeIfPg("PostgreSQLAdapter", () => {
     vi.restoreAllMocks();
     try {
       await adapter.exec(`DROP TABLE IF EXISTS ex, ex2 CASCADE`);
-      await adapter.exec(`DROP TABLE IF EXISTS "CamelCase" CASCADE`);
     } catch {
       // ignore cleanup errors
     }
@@ -233,12 +232,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("primary key works tables containing capital letters", async () => {
-      await adapter.exec(`CREATE TABLE "CamelCase" (id serial primary key)`);
-      try {
-        expect(await adapter.primaryKey("CamelCase")).toBe("id");
-      } finally {
-        await adapter.exec(`DROP TABLE IF EXISTS "CamelCase" CASCADE`);
-      }
+      expect(await adapter.primaryKey("CamelCase")).toBe("id");
     });
 
     it("non standard primary key", async () => {


### PR DESCRIPTION
## What

Rails' `test_primary_key_works_tables_containing_capital_letters`
(`test/cases/adapters/postgresql/postgresql_adapter_test.rb:136`) reads the
schema-loaded `"CamelCase"` table straight from `schema.rb:187`:

```ruby
def test_primary_key_works_tables_containing_capital_letters
  assert_equal "id", @connection.primary_key("CamelCase")
end
```

Our port instead created an id-only `"CamelCase"`, dropped it in a `finally`,
and dropped it again in the suite `afterEach`. On the shared PG worker DB that
left the canonical `CamelCase` (which carries a `name` column) gone entirely —
1 of 12 repair-worker firings, victim `adapters/postgresql/uuid.test.ts`.

The canonical schema already lays `CamelCase` per worker DB and the describe
runs under `fixtures([...], { useTransactionalTests: false })` (global reset
shielded), so the test now just reads it. The body is byte-for-byte the Rails
assertion; the diff is pure deletion.

Note: the story named `schema-dumper.test.ts` as the culprit. That file was
already converged (it asserts on the canonical dump and declares no
`CamelCase` table); the surviving writer was the PG adapter suite.

## Verification

Against an isolated PG 17 worker set:

- `postgresql-adapter.test.ts`, `uuid.test.ts` (the victim), and
  `schema-dumper.test.ts` — 181 passed, 11 skipped.
- `\d "CamelCase"` on all four worker DBs afterwards shows the canonical
  `id` + `name` shape intact (previously the table was dropped).

No test renamed; no test removed; `test:compare` delta 0.

Closes-story: restore-camelcase-canonical-table
