### PR TITLE
test(required-associations): restore canonical children table after teardown

### DIFF
--- a/packages/activerecord/src/associations/required.test.ts
+++ b/packages/activerecord/src/associations/required.test.ts
@@ -7,6 +7,7 @@ import { Base, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
 import { MigrationContext } from "../migration.js";
 import { fixtures } from "../test-helpers/fixtures.js";
+import { rebuildCanonicalTables } from "../test-helpers/canonical-schema.js";
 
 describe("RequiredAssociationsTest", () => {
   fixtures([]);
@@ -20,6 +21,7 @@ describe("RequiredAssociationsTest", () => {
   });
   afterAll(async () => {
     await ctx.dropTable("children", "parents", { ifExists: true });
+    await rebuildCanonicalTables(Base.connection, ["children"]);
   });
 
   it("belongs_to associations can be optional by default", async () => {


### PR DESCRIPTION
## Summary

`RequiredAssociationsTest` mirrors Rails' teardown by dropping `children`. Rails
can do that because it reloads the schema per run; here `children` is a canonical
table on the shared per-worker DB, so the drop leaves it missing for every later
file in that worker and `repairWorkerSchema` fires (the drift measured in RFC
0070: 2 firings, postgres + sqlite, victims `postgresql-adapter.get-client` and
`sqlite-database-tasks`).

The teardown now rebuilds the canonical `children` shape after the drop.
`parents` is not a canonical table — this suite owns it outright — so it stays
dropped.

## Verification

Baseline (fix removed), sqlite template lane, `children`-dropping file scheduled
before a passive file:

```
$ pnpm vitest run --no-file-parallelism associations/required.test.ts coders/json.test.ts
[schema-repair] restored drifted canonical tables: children
 Test Files  2 passed (2)
```

With the fix, same invocation: no `[schema-repair]` line, 2 passed.

No test renamed, no test body changed; `test:compare` unaffected.

Closes-story: restore-children-canonical-table
