### PR TITLE
fix(parity): compile node query dumps through a real sqlite3 connection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,13 @@ jobs:
           # packages (ci.yml:604) — and both are carved out of the infra sweep
           # (INFRA_CARVEOUT_RE), so this clause is what keeps their self-tests
           # running on a subtree-only change.
-          UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport)/|scripts/(tasks|guides-typecheck)/)'
+          # scripts/parity/ rides on it too: the query-runner integration tests
+          # spawn dump.ts/ar_dump.ts against the fixtures, so a change to either
+          # the runners or the fixtures has to re-run them. (Their other input,
+          # packages/activerecord/, is deliberately NOT on this gate — pulling
+          # every AR PR into the leaf-package suites costs more than it catches;
+          # the label-gated query-parity-trails job covers that direction.)
+          UNIT_TESTS_PKGS_RE='^(packages/(arel|activemodel|activesupport)/|scripts/(tasks|guides-typecheck|parity)/)'
           # guides_affected gates the Guides Code Type Check job, which
           # compiles fenced TS blocks in packages/website/docs/guides/**.
           # Today guides only import @blazetrails/activerecord,
@@ -643,6 +649,11 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-pnpm
       - run: pnpm install --frozen-lockfile --prefer-offline
+      - uses: ./.github/actions/cache-build
+      # scripts/parity/query/node spawns the dump runners as real subprocesses;
+      # they resolve @blazetrails/* through package `main` entries, so the
+      # dist/ trees have to exist before vitest starts.
+      - run: pnpm build
       - run: >
           pnpm vitest run
           packages/arel
@@ -650,6 +661,7 @@ jobs:
           packages/activesupport
           scripts/guides-typecheck
           scripts/tasks
+          scripts/parity/query/node
 
   # Consolidated leaf-test job. The cheapest sub-minute leaf suites — rack
   # (~27 s), actionview (~26 s), tse-compiler (~22 s), and the DX type tests

--- a/scripts/parity/fixtures/ar-01/query.ts
+++ b/scripts/parity/fixtures/ar-01/query.ts
@@ -2,10 +2,8 @@ import { weeks } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Book } from "./models.js";
 
-// `1.week.ago` on the Ruby side. trails' `Time` analogue is Temporal, not JS
-// Date (the adapter's `quote` rejects a Date outright), and the Instant is read
-// through `Date.now()` so the runner's frozen clock pins it — `Temporal.Now`
-// carries sub-millisecond hrtime precision that no clock freeze reaches.
+// Ruby `1.week.ago`. Built from `Date.now()`, not `Temporal.Now.instant()`:
+// only the former is pinned by the runner's frozen clock.
 const oneWeekAgo = weeks(1).ago(Temporal.Instant.fromEpochMilliseconds(Date.now()));
 
 export default Book.joins("reviews").where("reviews.created_at > ?", oneWeekAgo);

--- a/scripts/parity/fixtures/ar-01/query.ts
+++ b/scripts/parity/fixtures/ar-01/query.ts
@@ -1,8 +1,11 @@
+import { weeks } from "@blazetrails/activesupport";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Book } from "./models.js";
 
-// `1.week.ago` on the Ruby side → `new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)`
-// here. Both runners install the same frozen clock before evaluating the
-// fixture, so `now` is identical on both sides and subtraction is deterministic.
-const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+// `1.week.ago` on the Ruby side. trails' `Time` analogue is Temporal, not JS
+// Date (the adapter's `quote` rejects a Date outright), and the Instant is read
+// through `Date.now()` so the runner's frozen clock pins it — `Temporal.Now`
+// carries sub-millisecond hrtime precision that no clock freeze reaches.
+const oneWeekAgo = weeks(1).ago(Temporal.Instant.fromEpochMilliseconds(Date.now()));
 
 export default Book.joins("reviews").where("reviews.created_at > ?", oneWeekAgo);

--- a/scripts/parity/fixtures/ar-52/query.ts
+++ b/scripts/parity/fixtures/ar-52/query.ts
@@ -3,9 +3,8 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Range } from "@blazetrails/activerecord";
 import { Order } from "./models.js";
 
-// Ruby `Time.now` — read through `Date.now()` so the parity runner's frozen
-// clock pins it deterministically (Temporal.Now.instant() carries sub-millisecond
-// hrtime precision that no clock freeze reaches).
+// Ruby `Time.now`. Built from `Date.now()`, not `Temporal.Now.instant()`:
+// only the former is pinned by the runner's frozen clock.
 const now = Temporal.Instant.fromEpochMilliseconds(Date.now());
 const weekAgo = weeks(1).ago(now);
 export default Order.where({ created_at: new Range(weekAgo, now) });

--- a/scripts/parity/fixtures/ar-52/query.ts
+++ b/scripts/parity/fixtures/ar-52/query.ts
@@ -1,7 +1,11 @@
 import { weeks } from "@blazetrails/activesupport";
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Range } from "@blazetrails/activerecord";
 import { Order } from "./models.js";
 
-const now = new Date();
+// Ruby `Time.now` — read through `Date.now()` so the parity runner's frozen
+// clock pins it deterministically (Temporal.Now.instant() carries sub-millisecond
+// hrtime precision that no clock freeze reaches).
+const now = Temporal.Instant.fromEpochMilliseconds(Date.now());
 const weekAgo = weeks(1).ago(now);
 export default Order.where({ created_at: new Range(weekAgo, now) });

--- a/scripts/parity/fixtures/ar-65/query.ts
+++ b/scripts/parity/fixtures/ar-65/query.ts
@@ -1,3 +1,9 @@
+import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Order } from "./models.js";
 
-export default Order.where({ created_at: new Date() });
+// Ruby `Time.now` — read through `Date.now()` so the parity runner's frozen
+// clock pins it deterministically (Temporal.Now.instant() carries sub-millisecond
+// hrtime precision that no clock freeze reaches).
+export default Order.where({
+  created_at: Temporal.Instant.fromEpochMilliseconds(Date.now()),
+});

--- a/scripts/parity/fixtures/ar-65/query.ts
+++ b/scripts/parity/fixtures/ar-65/query.ts
@@ -1,9 +1,8 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Order } from "./models.js";
 
-// Ruby `Time.now` — read through `Date.now()` so the parity runner's frozen
-// clock pins it deterministically (Temporal.Now.instant() carries sub-millisecond
-// hrtime precision that no clock freeze reaches).
+// Ruby `Time.now`. Built from `Date.now()`, not `Temporal.Now.instant()`:
+// only the former is pinned by the runner's frozen clock.
 export default Order.where({
   created_at: Temporal.Instant.fromEpochMilliseconds(Date.now()),
 });

--- a/scripts/parity/query/node/ar_dump.ts
+++ b/scripts/parity/query/node/ar_dump.ts
@@ -80,7 +80,7 @@ function describe(v: unknown): string {
   return name ?? typeof v;
 }
 
-function assertBuilt(): void {
+function assertPackagesBuilt(): void {
   // All four packages contribute to the AR query surface; if any dist/ is
   // missing, model load will fail with a cryptic module-not-found error.
   // Check all four up-front with a clear hint.
@@ -117,7 +117,7 @@ async function main(): Promise<void> {
     }
   }
 
-  assertBuilt();
+  assertPackagesBuilt();
 
   const frozenTs = frozenAt ?? DEFAULT_FROZEN_AT;
   const frozenMs = new Date(frozenTs).getTime();
@@ -128,7 +128,7 @@ async function main(): Promise<void> {
   const tmpDir = mkdtempSync(join(tmpdir(), "parity-ar-node-"));
   const clock = FakeTimers.install({ now: frozenMs, toFake: ["Date"] });
 
-  // Imported dynamically, after assertBuilt() — static imports would resolve
+  // Imported dynamically, after assertPackagesBuilt() — static imports would resolve
   // (and fail) at module load, replacing the "missing dist/" hint with a bare
   // module-not-found. Specifiers are package names, not dist paths, so Node ESM
   // dedupes them with the fixture models' own imports to one module instance.

--- a/scripts/parity/query/node/ar_dump.ts
+++ b/scripts/parity/query/node/ar_dump.ts
@@ -29,6 +29,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import type { CanonicalQuery } from "../../canonical/query-types.js";
 import { Base, modelRegistry } from "@blazetrails/activerecord";
 import { Visitors } from "@blazetrails/arel";
+import { getFsAsync, getPathAsync } from "@blazetrails/activesupport";
 
 function usage(): never {
   process.stderr.write(
@@ -150,7 +151,22 @@ async function main(): Promise<void> {
     //    process-global registry. Without this eager access Relation#toSql()
     //    would use the default generic visitor since it never touches
     //    Base.adapter itself, producing incorrect boolean/date literals.
-    await Base.establishConnection(dbPath);
+    //
+    //    The sqlite3 adapter resolves the database path through
+    //    ActiveSupport's filesystem adapter *synchronously* (`getFs()` in
+    //    `prepareDatabasePath`), but the Node adapter's auto-registration is
+    //    async-only under pure ESM. Warm the registry first so the sync
+    //    lookup hits the cache instead of throwing "No filesystem adapter
+    //    configured".
+    await getFsAsync();
+    await getPathAsync();
+    //
+    //    The config must be an explicit adapter/database hash, mirroring the
+    //    Rails side's `establish_connection adapter: "sqlite3", database: ...`.
+    //    A bare path string is resolved as an *environment name* (Rails'
+    //    `resolve_config_for_connection`), which fails with "the `<path>`
+    //    database is not configured for the `development` environment".
+    await Base.establishConnection({ adapter: "sqlite3", database: dbPath });
     void Base.adapter; // trigger _wireArelVisitor so the correct Arel visitor is active
     // Regression coverage: fixtures ar-09/ar-11/ar-19/ar-29 each produce a
     // distinct wrong literal under the generic visitor (TRUE/FALSE, FOR UPDATE)
@@ -207,12 +223,15 @@ async function main(): Promise<void> {
         // paramSql/binds are informational-only; wrap the entire extraction so any
         // unexpected visitor or bind-processing error falls back to sql / empty binds.
         try {
-          // Use the adapter-wired dialect visitor (e.g. Visitors.SQLite for SQLite)
-          // so boolean literals, DISTINCT, etc. match the actual execution dialect.
-          const adapterVisitor = (Base.adapter as { arelVisitor?: unknown }).arelVisitor;
-          const visitorCtor =
-            adapterVisitor != null ? (adapterVisitor as object).constructor : Visitors.ToSql;
-          const visitor = new (visitorCtor as new () => InstanceType<typeof Visitors.ToSql>)();
+          // Use the connection's own visitor (e.g. Visitors.SQLite for SQLite)
+          // so boolean literals, DISTINCT, etc. match the actual execution
+          // dialect — and so quoting resolves through the real connection, the
+          // way `Node#to_sql` does. `arelVisitor()` is the *factory* method
+          // (abstract-adapter.ts:1715, mirroring Rails' `arel_visitor`);
+          // `visitor` is the instance it built at connect time.
+          const visitor = (Base.adapter as { visitor?: InstanceType<typeof Visitors.ToSql> })
+            .visitor;
+          if (visitor == null) throw new Error("connection has no Arel visitor");
           const [ps, bs] = (
             visitor as unknown as { compileWithBinds(node: unknown): [string, unknown[]] }
           ).compileWithBinds((manager as { ast: unknown }).ast);
@@ -235,11 +254,28 @@ async function main(): Promise<void> {
             return String(v);
           };
 
-          // Build a consistent paramSql where ONLY Date values become `?`; all
-          // other bind values are re-inlined using the visitor's quoting rules.
-          // This keeps `? count = binds.length` and matches adapter-specific rendering.
+          // Build a consistent paramSql where ONLY datetime values become `?`;
+          // all other bind values are re-inlined using the visitor's quoting
+          // rules. This keeps `? count = binds.length` and matches
+          // adapter-specific rendering.
+          //
+          // trails' Time analogue is Temporal, not JS Date (the adapter's
+          // `quote` rejects a Date outright), so the datetime probe is
+          // `epochMilliseconds` — carried by Temporal.Instant and
+          // Temporal.ZonedDateTime alike — with `instanceof Date` kept for any
+          // bind that never reaches a Temporal-typed attribute.
+          const epochMsOf = (v: unknown): number | null => {
+            if (v instanceof Date) return v.getTime();
+            if (v != null && typeof v === "object" && "epochMilliseconds" in v) {
+              const ms = (v as { epochMilliseconds: unknown }).epochMilliseconds;
+              if (typeof ms === "number") return ms;
+              if (typeof ms === "bigint") return Number(ms);
+            }
+            return null;
+          };
+
           let placeholderIdx = 0;
-          const dateBind: Date[] = [];
+          const dateBind: number[] = [];
           let mismatch = false;
           const processedParamSql = ps.replace(/\?/g, () => {
             if (placeholderIdx >= resolvedBinds.length) {
@@ -247,8 +283,9 @@ async function main(): Promise<void> {
               return "?";
             }
             const v = resolvedBinds[placeholderIdx++];
-            if (v instanceof Date) {
-              dateBind.push(v);
+            const epochMs = epochMsOf(v);
+            if (epochMs !== null) {
+              dateBind.push(epochMs);
               return "?";
             }
             return quoteBindValue(v);
@@ -262,7 +299,7 @@ async function main(): Promise<void> {
             binds = [];
           } else {
             paramSql = processedParamSql.trim();
-            binds = dateBind.map((b) => b.toISOString());
+            binds = dateBind.map((ms) => new Date(ms).toISOString());
           }
         } catch {
           paramSql = sqlStr;

--- a/scripts/parity/query/node/ar_dump.ts
+++ b/scripts/parity/query/node/ar_dump.ts
@@ -22,11 +22,12 @@
 
 import Database from "better-sqlite3";
 import FakeTimers from "@sinonjs/fake-timers";
-import { readFileSync, mkdtempSync, writeFileSync, rmSync, mkdirSync, existsSync } from "node:fs";
+import { readFileSync, mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve, dirname, basename } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { pathToFileURL } from "node:url";
 import type { CanonicalQuery } from "../../canonical/query-types.js";
+import { assertPackagesBuilt } from "./assert-packages-built.js";
 import type { Visitors } from "@blazetrails/arel";
 
 function usage(): never {
@@ -80,23 +81,6 @@ function describe(v: unknown): string {
   return name ?? typeof v;
 }
 
-function assertPackagesBuilt(): void {
-  // All four packages contribute to the AR query surface; if any dist/ is
-  // missing, model load will fail with a cryptic module-not-found error.
-  // Check all four up-front with a clear hint.
-  const scriptDir = dirname(fileURLToPath(import.meta.url));
-  const missing: string[] = [];
-  for (const pkg of ["activesupport", "activemodel", "arel", "activerecord"]) {
-    const dist = resolve(scriptDir, `../../../../packages/${pkg}/dist/index.js`);
-    if (!existsSync(dist)) missing.push(`@blazetrails/${pkg}`);
-  }
-  if (missing.length > 0) {
-    process.stderr.write(`parity ar_dump (trails): missing dist/ for ${missing.join(", ")}\n`);
-    process.stderr.write("Run: pnpm build\n");
-    process.exit(1);
-  }
-}
-
 async function main(): Promise<void> {
   const {
     fixtureDir: fixtureDirRaw,
@@ -117,7 +101,7 @@ async function main(): Promise<void> {
     }
   }
 
-  assertPackagesBuilt();
+  assertPackagesBuilt("parity ar_dump (trails)");
 
   const frozenTs = frozenAt ?? DEFAULT_FROZEN_AT;
   const frozenMs = new Date(frozenTs).getTime();

--- a/scripts/parity/query/node/ar_dump.ts
+++ b/scripts/parity/query/node/ar_dump.ts
@@ -27,9 +27,7 @@ import { tmpdir } from "node:os";
 import { join, resolve, dirname, basename } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import type { CanonicalQuery } from "../../canonical/query-types.js";
-import { Base, modelRegistry } from "@blazetrails/activerecord";
-import { Visitors } from "@blazetrails/arel";
-import { getFsAsync, getPathAsync } from "@blazetrails/activesupport";
+import type { Visitors } from "@blazetrails/arel";
 
 function usage(): never {
   process.stderr.write(
@@ -94,9 +92,7 @@ function assertBuilt(): void {
   }
   if (missing.length > 0) {
     process.stderr.write(`parity ar_dump (trails): missing dist/ for ${missing.join(", ")}\n`);
-    process.stderr.write(
-      `Run: pnpm --filter @blazetrails/activesupport --filter @blazetrails/activemodel --filter @blazetrails/arel --filter @blazetrails/activerecord build\n`,
-    );
+    process.stderr.write("Run: pnpm build\n");
     process.exit(1);
   }
 }
@@ -132,6 +128,13 @@ async function main(): Promise<void> {
   const tmpDir = mkdtempSync(join(tmpdir(), "parity-ar-node-"));
   const clock = FakeTimers.install({ now: frozenMs, toFake: ["Date"] });
 
+  // Imported dynamically, after assertBuilt() — static imports would resolve
+  // (and fail) at module load, replacing the "missing dist/" hint with a bare
+  // module-not-found. Specifiers are package names, not dist paths, so Node ESM
+  // dedupes them with the fixture models' own imports to one module instance.
+  const { getFsAsync, getPathAsync } = await import("@blazetrails/activesupport");
+  const { Base, modelRegistry } = await import("@blazetrails/activerecord");
+
   try {
     // 1. Apply schema.sql to a fresh temp SQLite file.
     const dbPath = join(tmpDir, "query.db");
@@ -152,20 +155,17 @@ async function main(): Promise<void> {
     //    would use the default generic visitor since it never touches
     //    Base.adapter itself, producing incorrect boolean/date literals.
     //
-    //    The sqlite3 adapter resolves the database path through
-    //    ActiveSupport's filesystem adapter *synchronously* (`getFs()` in
-    //    `prepareDatabasePath`), but the Node adapter's auto-registration is
-    //    async-only under pure ESM. Warm the registry first so the sync
-    //    lookup hits the cache instead of throwing "No filesystem adapter
-    //    configured".
+    //    The sqlite3 adapter resolves the database path through the *sync*
+    //    `getFs()`, whose node auto-registration is async-only under pure ESM —
+    //    warm the registry first or it throws "No filesystem adapter configured".
     await getFsAsync();
     await getPathAsync();
     //
     //    The config must be an explicit adapter/database hash, mirroring the
     //    Rails side's `establish_connection adapter: "sqlite3", database: ...`.
-    //    A bare path string is resolved as an *environment name* (Rails'
-    //    `resolve_config_for_connection`), which fails with "the `<path>`
-    //    database is not configured for the `development` environment".
+    //    A bare path string resolves as an *environment name*
+    //    (`resolve_config_for_connection`), failing with "the `<path>` database
+    //    is not configured for the `development` environment".
     await Base.establishConnection({ adapter: "sqlite3", database: dbPath });
     void Base.adapter; // trigger _wireArelVisitor so the correct Arel visitor is active
     // Regression coverage: fixtures ar-09/ar-11/ar-19/ar-29 each produce a
@@ -223,12 +223,10 @@ async function main(): Promise<void> {
         // paramSql/binds are informational-only; wrap the entire extraction so any
         // unexpected visitor or bind-processing error falls back to sql / empty binds.
         try {
-          // Use the connection's own visitor (e.g. Visitors.SQLite for SQLite)
-          // so boolean literals, DISTINCT, etc. match the actual execution
-          // dialect — and so quoting resolves through the real connection, the
-          // way `Node#to_sql` does. `arelVisitor()` is the *factory* method
-          // (abstract-adapter.ts:1715, mirroring Rails' `arel_visitor`);
-          // `visitor` is the instance it built at connect time.
+          // The connection's own visitor, so literals and quoting match the
+          // execution dialect. Not `arelVisitor` — that is the *factory* method
+          // (abstract-adapter.ts:1715, Rails' `arel_visitor`); `visitor` is the
+          // instance it built at connect time.
           const visitor = (Base.adapter as { visitor?: InstanceType<typeof Visitors.ToSql> })
             .visitor;
           if (visitor == null) throw new Error("connection has no Arel visitor");
@@ -262,14 +260,12 @@ async function main(): Promise<void> {
           // trails' Time analogue is Temporal, not JS Date (the adapter's
           // `quote` rejects a Date outright), so the datetime probe is
           // `epochMilliseconds` — carried by Temporal.Instant and
-          // Temporal.ZonedDateTime alike — with `instanceof Date` kept for any
-          // bind that never reaches a Temporal-typed attribute.
+          // Temporal.ZonedDateTime alike.
           const epochMsOf = (v: unknown): number | null => {
             if (v instanceof Date) return v.getTime();
             if (v != null && typeof v === "object" && "epochMilliseconds" in v) {
               const ms = (v as { epochMilliseconds: unknown }).epochMilliseconds;
               if (typeof ms === "number") return ms;
-              if (typeof ms === "bigint") return Number(ms);
             }
             return null;
           };

--- a/scripts/parity/query/node/assert-packages-built.ts
+++ b/scripts/parity/query/node/assert-packages-built.ts
@@ -1,0 +1,29 @@
+import { existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Every package the query runners compile through. Both runners resolve
+// @blazetrails/* via package "main" → packages/<pkg>/dist/index.js; tsx's
+// loader doesn't help, because the fixtures are modules on disk that Node
+// resolves through the normal package graph, not via the TS source.
+const REQUIRED_PACKAGES = ["activesupport", "activemodel", "arel", "activerecord"];
+
+/**
+ * Exit with a readable hint when any package the runner needs is unbuilt.
+ *
+ * Callers must invoke this *before* importing @blazetrails/* — a static import
+ * resolves at module load, which would replace this hint with a bare
+ * module-not-found. Both runners therefore import those packages dynamically.
+ */
+export function assertPackagesBuilt(label: string): void {
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
+  const missing = REQUIRED_PACKAGES.filter(
+    (pkg) => !existsSync(resolve(scriptDir, `../../../../packages/${pkg}/dist/index.js`)),
+  ).map((pkg) => `@blazetrails/${pkg}`);
+
+  if (missing.length > 0) {
+    process.stderr.write(`${label}: missing dist/ for ${missing.join(", ")}\n`);
+    process.stderr.write("Run: pnpm build\n");
+    process.exit(1);
+  }
+}

--- a/scripts/parity/query/node/dump.ts
+++ b/scripts/parity/query/node/dump.ts
@@ -84,7 +84,7 @@ function describe(v: unknown): string {
   return name ?? typeof v;
 }
 
-function assertArelBuilt(): void {
+function assertPackagesBuilt(): void {
   // These resolve via package "main" → packages/<pkg>/dist/index.js. tsx's own
   // loader doesn't help here: the fixture is a module on disk that Node
   // resolves through the normal package graph, not via the TS source. The
@@ -125,7 +125,7 @@ async function main(): Promise<void> {
     }
   }
 
-  assertArelBuilt();
+  assertPackagesBuilt();
 
   const frozenTs = frozenAt ?? DEFAULT_FROZEN_AT;
   const frozenMs = new Date(frozenTs).getTime();
@@ -139,7 +139,7 @@ async function main(): Promise<void> {
   // module-evaluation time (e.g. a translated `1.week.ago` analog).
   const clock = FakeTimers.install({ now: frozenMs, toFake: ["Date"] });
 
-  // Imported dynamically, after assertArelBuilt() — a static import would
+  // Imported dynamically, after assertPackagesBuilt() — a static import would
   // resolve (and fail) at module load, replacing the "run pnpm build" hint with
   // a bare module-not-found. Specifiers are the package names, not dist paths,
   // so Node ESM dedupes them with the fixture's own `@blazetrails/arel` import

--- a/scripts/parity/query/node/dump.ts
+++ b/scripts/parity/query/node/dump.ts
@@ -12,9 +12,10 @@
  * pins the timestamp to a specific ISO 8601 UTC value (trailing Z required,
  * e.g. 2026-01-01T00:00:00.000Z); omitting it uses 2000-01-01T00:00:00.000Z.
  *
- * @blazetrails/arel must be built (packages/arel/dist/index.js) before running —
- * resolution goes through the published package `main` entry. In CI mirror the
- * schema-parity-trails job: `pnpm --filter @blazetrails/arel build` first.
+ * @blazetrails/{activesupport,activemodel,arel,activerecord} must all be built
+ * before running — resolution goes through the published package `main`
+ * entries, and the runner compiles through a real sqlite3 adapter connection.
+ * In CI mirror the query-parity-trails job and build them in dep order.
  */
 
 import Database from "better-sqlite3";
@@ -84,16 +85,20 @@ function describe(v: unknown): string {
 }
 
 function assertArelBuilt(): void {
-  // @blazetrails/arel resolves via package "main" → packages/arel/dist/index.js.
-  // tsx's own loader doesn't help here: the fixture is a module on disk that
-  // Node resolves through the normal package graph, not via the TS source.
+  // These resolve via package "main" → packages/<pkg>/dist/index.js. tsx's own
+  // loader doesn't help here: the fixture is a module on disk that Node
+  // resolves through the normal package graph, not via the TS source. The
+  // runner compiles through a real sqlite3 adapter connection, so the whole
+  // activerecord chain has to be built, not just arel.
   const scriptDir = dirname(fileURLToPath(import.meta.url));
-  const arelDist = resolve(scriptDir, "../../../../packages/arel/dist/index.js");
-  if (!existsSync(arelDist)) {
-    process.stderr.write(
-      `parity dump (trails): @blazetrails/arel is not built (missing ${arelDist}).\n`,
-    );
-    process.stderr.write("Run: pnpm --filter @blazetrails/arel build\n");
+  const missing: string[] = [];
+  for (const pkg of ["activesupport", "activemodel", "arel", "activerecord"]) {
+    const dist = resolve(scriptDir, `../../../../packages/${pkg}/dist/index.js`);
+    if (!existsSync(dist)) missing.push(`@blazetrails/${pkg}`);
+  }
+  if (missing.length > 0) {
+    process.stderr.write(`parity dump (trails): missing dist/ for ${missing.join(", ")}\n`);
+    process.stderr.write("Run: pnpm build\n");
     process.exit(1);
   }
 }
@@ -146,22 +151,40 @@ async function main(): Promise<void> {
       db.close();
     }
 
-    // 2. Point `Arel::Table.engine` at an engine whose connection carries the
-    //    SQLite visitor, so both `Node#toSql()` and `TreeManager#toSql()`
-    //    compile through it (both resolve `engine.connection.visitor`).
-    //    Mirrors the Rails side's
-    //    `establish_connection adapter: "sqlite3"` — for example,
-    //    `IS DISTINCT FROM` now emits as `IS NOT` because
-    //    Visitors.SQLite#visitIsDistinctFrom overrides it.
+    // 2. Establish a real SQLite connection through trails AR. Mirrors the
+    //    Rails side's `establish_connection adapter: "sqlite3"`: importing
+    //    `@blazetrails/activerecord` sets `Arel::Table.engine` to a
+    //    Base-backed engine (base.ts, mirroring
+    //    `on_load(:active_record) { Arel::Table.engine = self }`), so both
+    //    `Node#toSql()` and `TreeManager#toSql()` resolve
+    //    `engine.connection.visitor` to the sqlite3 adapter's visitor — one
+    //    that carries real `quoteTableName`/`quoteColumnName`/`quote`.
+    //    A hand-rolled `{ connection: { visitor } }` stub cannot: RFC 0007
+    //    deleted the connection-less quoters, so a visitor built with no
+    //    connection dies on the first `quoteTableName` (to-sql.ts:1665-1667).
     //
-    //    Imported as `@blazetrails/arel` (not via dist path) because
-    //    scripts/parity is itself a workspace package — see
-    //    scripts/parity/package.json. That ensures Node ESM dedupes
-    //    this import with the fixture's `@blazetrails/arel` import to a
-    //    single module instance, so the engine assignment is visible
-    //    to the fixture's nodes.
-    const arel = await import("@blazetrails/arel");
-    arel.Table.engine = { connection: { visitor: new arel.Visitors.SQLite() } };
+    //    Imported as `@blazetrails/activerecord`/`@blazetrails/arel` (not via
+    //    dist paths) because scripts/parity is itself a workspace package —
+    //    see scripts/parity/package.json. That ensures Node ESM dedupes these
+    //    imports with the fixture's `@blazetrails/arel` import to a single
+    //    module instance, so the engine wiring is visible to the fixture's
+    //    nodes.
+    //
+    //    The sqlite3 adapter resolves the database path through
+    //    ActiveSupport's filesystem adapter *synchronously* (`getFs()` in
+    //    `prepareDatabasePath`), but the Node adapter's auto-registration is
+    //    async-only under pure ESM. Warm the registry first so the sync
+    //    lookup hits the cache instead of throwing "No filesystem adapter
+    //    configured".
+    const { getFsAsync, getPathAsync } = await import("@blazetrails/activesupport");
+    await getFsAsync();
+    await getPathAsync();
+
+    const { Base } = await import("@blazetrails/activerecord");
+    await Base.establishConnection({ adapter: "sqlite3", database: dbPath });
+    // Checking out the connection triggers the adapter's Arel-visitor wiring
+    // (e.g. `IS DISTINCT FROM` emits as `IS NOT` via Visitors.SQLite).
+    void Base.adapter;
 
     // 4. Import query.ts. Fixtures end with `export default <expr>` — see
     //    scripts/parity/translate/arel.ts (generateTs).
@@ -209,6 +232,16 @@ async function main(): Promise<void> {
     process.stdout.write(`  → ${outPathAbs}\n`);
   } finally {
     clock.uninstall();
+    // Close the adapter's SQLite handle before removing the temp dir — an open
+    // handle makes rmSync of the .db file fail on Windows.
+    try {
+      const { Base } = await import("@blazetrails/activerecord");
+      const a = Base.adapter as { close?: () => void };
+      if (typeof a.close === "function") a.close();
+      Base.removeConnection();
+    } catch {
+      /* connection never established, or already closed */
+    }
     try {
       rmSync(tmpDir, { recursive: true, force: true });
     } catch (err) {

--- a/scripts/parity/query/node/dump.ts
+++ b/scripts/parity/query/node/dump.ts
@@ -205,13 +205,19 @@ async function main(): Promise<void> {
   } finally {
     clock.uninstall();
     // Close the adapter's SQLite handle before removing the temp dir — an open
-    // handle makes rmSync of the .db file fail on Windows.
+    // handle makes rmSync of the .db file fail on Windows. Two independent
+    // try/catches, matching ar_dump.ts and scripts/parity/schema/node/dump.ts:
+    // a throwing close() must not skip removeConnection().
     try {
       const a = Base.adapter as { close?: () => void };
       if (typeof a.close === "function") a.close();
+    } catch {
+      /* adapter unavailable or already closed */
+    }
+    try {
       Base.removeConnection();
     } catch {
-      /* connection never established, or already closed */
+      /* already removed or never opened */
     }
     try {
       rmSync(tmpDir, { recursive: true, force: true });

--- a/scripts/parity/query/node/dump.ts
+++ b/scripts/parity/query/node/dump.ts
@@ -20,11 +20,12 @@
 
 import Database from "better-sqlite3";
 import FakeTimers from "@sinonjs/fake-timers";
-import { readFileSync, mkdtempSync, writeFileSync, rmSync, mkdirSync, existsSync } from "node:fs";
+import { readFileSync, mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve, dirname, basename } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { pathToFileURL } from "node:url";
 import type { CanonicalQuery } from "../../canonical/query-types.js";
+import { assertPackagesBuilt } from "./assert-packages-built.js";
 
 function usage(): never {
   process.stderr.write(
@@ -84,25 +85,6 @@ function describe(v: unknown): string {
   return name ?? typeof v;
 }
 
-function assertPackagesBuilt(): void {
-  // These resolve via package "main" → packages/<pkg>/dist/index.js. tsx's own
-  // loader doesn't help here: the fixture is a module on disk that Node
-  // resolves through the normal package graph, not via the TS source. The
-  // runner compiles through a real sqlite3 adapter connection, so the whole
-  // activerecord chain has to be built, not just arel.
-  const scriptDir = dirname(fileURLToPath(import.meta.url));
-  const missing: string[] = [];
-  for (const pkg of ["activesupport", "activemodel", "arel", "activerecord"]) {
-    const dist = resolve(scriptDir, `../../../../packages/${pkg}/dist/index.js`);
-    if (!existsSync(dist)) missing.push(`@blazetrails/${pkg}`);
-  }
-  if (missing.length > 0) {
-    process.stderr.write(`parity dump (trails): missing dist/ for ${missing.join(", ")}\n`);
-    process.stderr.write("Run: pnpm build\n");
-    process.exit(1);
-  }
-}
-
 async function main(): Promise<void> {
   const {
     fixtureDir: fixtureDirRaw,
@@ -125,7 +107,7 @@ async function main(): Promise<void> {
     }
   }
 
-  assertPackagesBuilt();
+  assertPackagesBuilt("parity dump (trails)");
 
   const frozenTs = frozenAt ?? DEFAULT_FROZEN_AT;
   const frozenMs = new Date(frozenTs).getTime();

--- a/scripts/parity/query/node/dump.ts
+++ b/scripts/parity/query/node/dump.ts
@@ -139,6 +139,15 @@ async function main(): Promise<void> {
   // module-evaluation time (e.g. a translated `1.week.ago` analog).
   const clock = FakeTimers.install({ now: frozenMs, toFake: ["Date"] });
 
+  // Imported dynamically, after assertArelBuilt() — a static import would
+  // resolve (and fail) at module load, replacing the "run pnpm build" hint with
+  // a bare module-not-found. Specifiers are the package names, not dist paths,
+  // so Node ESM dedupes them with the fixture's own `@blazetrails/arel` import
+  // to one module instance — that is what makes `Arel::Table.engine` visible to
+  // the fixture's nodes.
+  const { getFsAsync, getPathAsync } = await import("@blazetrails/activesupport");
+  const { Base } = await import("@blazetrails/activerecord");
+
   try {
     // 1. Apply schema.sql to a fresh temp SQLite file. We don't currently hand
     //    the DB to the fixture, but applying the schema keeps the pipeline
@@ -151,40 +160,21 @@ async function main(): Promise<void> {
       db.close();
     }
 
-    // 2. Establish a real SQLite connection through trails AR. Mirrors the
-    //    Rails side's `establish_connection adapter: "sqlite3"`: importing
-    //    `@blazetrails/activerecord` sets `Arel::Table.engine` to a
-    //    Base-backed engine (base.ts, mirroring
-    //    `on_load(:active_record) { Arel::Table.engine = self }`), so both
-    //    `Node#toSql()` and `TreeManager#toSql()` resolve
-    //    `engine.connection.visitor` to the sqlite3 adapter's visitor — one
-    //    that carries real `quoteTableName`/`quoteColumnName`/`quote`.
-    //    A hand-rolled `{ connection: { visitor } }` stub cannot: RFC 0007
-    //    deleted the connection-less quoters, so a visitor built with no
-    //    connection dies on the first `quoteTableName` (to-sql.ts:1665-1667).
+    // 2. Establish a real SQLite connection, mirroring the Rails side's
+    //    `establish_connection adapter: "sqlite3"`. Importing activerecord is
+    //    what points `Arel::Table.engine` at Base, so `Node#toSql()` and
+    //    `TreeManager#toSql()` resolve `engine.connection.visitor` to the
+    //    sqlite3 visitor. A `{ connection: { visitor } }` stub cannot stand in:
+    //    RFC 0007 deleted the connection-less quoters, so a visitor built with
+    //    no connection dies on `quoteTableName` (to-sql.ts:1665-1667).
     //
-    //    Imported as `@blazetrails/activerecord`/`@blazetrails/arel` (not via
-    //    dist paths) because scripts/parity is itself a workspace package —
-    //    see scripts/parity/package.json. That ensures Node ESM dedupes these
-    //    imports with the fixture's `@blazetrails/arel` import to a single
-    //    module instance, so the engine wiring is visible to the fixture's
-    //    nodes.
-    //
-    //    The sqlite3 adapter resolves the database path through
-    //    ActiveSupport's filesystem adapter *synchronously* (`getFs()` in
-    //    `prepareDatabasePath`), but the Node adapter's auto-registration is
-    //    async-only under pure ESM. Warm the registry first so the sync
-    //    lookup hits the cache instead of throwing "No filesystem adapter
-    //    configured".
-    const { getFsAsync, getPathAsync } = await import("@blazetrails/activesupport");
+    //    The sqlite3 adapter resolves the database path through the *sync*
+    //    `getFs()`, whose node auto-registration is async-only under pure ESM —
+    //    warm the registry first or it throws "No filesystem adapter configured".
     await getFsAsync();
     await getPathAsync();
-
-    const { Base } = await import("@blazetrails/activerecord");
     await Base.establishConnection({ adapter: "sqlite3", database: dbPath });
-    // Checking out the connection triggers the adapter's Arel-visitor wiring
-    // (e.g. `IS DISTINCT FROM` emits as `IS NOT` via Visitors.SQLite).
-    void Base.adapter;
+    void Base.adapter; // checkout wires the dialect visitor (IS DISTINCT FROM → IS NOT)
 
     // 4. Import query.ts. Fixtures end with `export default <expr>` — see
     //    scripts/parity/translate/arel.ts (generateTs).
@@ -235,7 +225,6 @@ async function main(): Promise<void> {
     // Close the adapter's SQLite handle before removing the temp dir — an open
     // handle makes rmSync of the .db file fail on Windows.
     try {
-      const { Base } = await import("@blazetrails/activerecord");
       const a = Base.adapter as { close?: () => void };
       if (typeof a.close === "function") a.close();
       Base.removeConnection();


### PR DESCRIPTION
Both node-side parity query runners had bit-rotted: 8 of the 13 integration
tests in `scripts/parity/query/node` failed even with `pnpm build` run first,
and the label-gated `query-parity-trails` job was failing a fixture for the
same reason.

## Root causes

- **`dump.ts`** pointed `Arel::Table.engine` at a hand-rolled
  `{ connection: { visitor: new Visitors.SQLite() } }`. RFC 0007 deleted the
  connection-less quoters, so `ToSql` resolves `this.connection.quoteTableName`
  (`packages/arel/src/visitors/to-sql.ts:1665-1667`) and a visitor built with no
  connection died on the first table name. It now establishes a **real sqlite3
  connection** — importing `@blazetrails/activerecord` is what points
  `Table.engine` at `Base` (`base.ts`, mirroring
  `on_load(:active_record) { Arel::Table.engine = self }`), so the visitor
  carries real quoting. That is the Rails side's
  `establish_connection adapter: "sqlite3"`, not another stub.
- **`ar_dump.ts`** passed a bare path to `establishConnection`, which
  `resolve_config_for_connection` treats as an *environment name* — hence "the
  `/tmp/.../query.db` database is not configured for the `development`
  environment". Now `{ adapter: "sqlite3", database: dbPath }`.
- **Both** warm ActiveSupport's fs adapter before connecting: the sqlite3
  adapter's `prepareDatabasePath` calls the **sync** `getFs()`, whose node
  auto-registration is async-only under pure ESM.
- **`ar_dump.ts`**'s bind extraction read `adapter.arelVisitor` as a visitor
  instance, but it is the *factory method* (`abstract-adapter.ts:1715`), so
  `new (…).constructor()` produced a bare `Function` and every
  `compileWithBinds` call silently fell into the catch-all. It now uses the
  connection's own `visitor`, which is also what makes quoting resolve through
  the real connection.

## Fixtures

`ar-01`, `ar-52`, and `ar-65` translated Ruby `Time` to a JS `Date`, which the
adapter's `quote` rejects outright — trails' `Time` analogue is Temporal. They
now build a `Temporal.Instant` from `Date.now()`, so the runner's frozen clock
still pins them (`Temporal.Now.instant()` carries sub-millisecond hrtime
precision that no clock freeze reaches). The bind probe in `ar_dump.ts` follows:
`epochMilliseconds`, with `instanceof Date` kept as a fallback.

## Adjacent fixes found on the way

- `assertBuilt()` in `ar_dump.ts` was **dead code**: its static `@blazetrails/*`
  imports resolved (and failed) at module load, so a missing `dist/` produced a
  bare module-not-found instead of the intended hint. Both runners now import
  those packages dynamically, after the guard. Verified by moving
  `packages/activerecord/dist/index.js` aside — both exit 1 with
  `missing dist/ for @blazetrails/activerecord / Run: pnpm build`.
- That guard was duplicated verbatim in both runners, and this PR had to widen
  both copies identically; it is now one `assertPackagesBuilt(label)` module.

## CI

`scripts/parity/query/node` joins the `unit-tests` job's vitest invocation, and
that job gains `cache-build` + `pnpm build` (the tests spawn the runners as real
subprocesses, which resolve `@blazetrails/*` through package `main` entries).
`scripts/parity/` joins the job's change gate.

`packages/activerecord/` is deliberately **not** added to that gate — pulling
every AR PR into the leaf-package suites costs more than it catches, and the
label-gated `query-parity-trails` job already covers that direction.

## Verification

- `pnpm build && pnpm vitest run scripts/parity/query/node` — **13/13 pass**
  (was 5/13).
- The **Unit Tests** job ran and passed on this branch with the new path and
  build step, so the CI wiring is confirmed, not just asserted.
- A full `pnpm tsx scripts/parity/run.ts --type=query --side=trails` drops
  `ar-01` from the failure list (3 → 2). The remaining `ar-37` / `ar-153`
  failures are pre-existing and unrelated (a missing association and a missing
  `joinSources`).

Closes-story: fix-parity-node-dump-runners
