### PR TITLE
fix(activerecord): type CollectionProxy push/concat returns as then-less

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1990,13 +1990,13 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * adoption — otherwise `return this` would call the proxy's `then` and
    * load the target, breaking Rails' "push does not load target" invariant.
    */
-  async push(...records: T[]): Promise<this> {
+  async push(...records: T[]): Promise<Omit<this, "then">> {
     this._ensureThroughWritable();
     this._raiseOnTypeMismatch(records);
     // Through association (including HABTM): create join records
     if (this._assocDef.options.through) {
       await this._pushThrough(records);
-      return stripThenable(this._proxySelf ?? this) as this;
+      return stripThenable(this._proxySelf ?? this);
     }
 
     // Mirror Rails CollectionAssociation#concat: a new-record owner loads the
@@ -2108,7 +2108,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     } else {
       await this.transaction(concatRecords);
     }
-    return stripThenable(this._proxySelf ?? this) as this;
+    return stripThenable(this._proxySelf ?? this);
   }
 
   /**
@@ -2539,7 +2539,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   /**
    * Alias for push.
    */
-  async concat(...records: T[]): Promise<this> {
+  async concat(...records: T[]): Promise<Omit<this, "then">> {
     return this.push(...records);
   }
 
@@ -4157,7 +4157,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#append
    */
-  async append(...records: T[]): Promise<this> {
+  async append(...records: T[]): Promise<Omit<this, "then">> {
     return this.push(...records);
   }
 


### PR DESCRIPTION
`CollectionProxy#push` / `#concat` / `#append` return
`stripThenable(this._proxySelf ?? this)` — a then-less `Proxy` view — but cast
the static type back to `this`, which IS thenable. That lie matters for the
`prefer-await-relation` lint rule (widened in #5233): its `receiverIsThenable`
type gate would trust the `this` type and autofix `await pushResult.toArray()`
→ `await pushResult`, resolving to the view object rather than the array.

Types the stripped returns as `Omit<this, "then">`, mirroring `reload()`
(`collection-proxy.ts:3551`), and drops the now-unneeded `as this` casts.
`append` is an alias for `push` and had to follow.

Rails' chaining ergonomics (`push`/`<<`/`concat` return `self`,
`collection_proxy.rb`) are unaffected — the runtime value is unchanged and
`pnpm typecheck` is clean across the workspace, so no call site relied on the
thenability of the result.

No behavior change — type-annotation fidelity only.

Closes-story: collection-proxy-push-return-then-less-type
