### PR TITLE
lint(eslint): guard a canonical table dropped without a canonical rebuild

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,12 +48,13 @@ const requireTableTeardownRawSqlExclude = JSON.parse(
     "utf8",
   ),
 );
-// AR test files exempt from require-canonical-rebuild: the ones that own a
-// private `:memory:` adapter (they never touch the shared per-worker database,
-// so a canonical table they drop can't drift it) plus a grandfathered backlog
-// of files that do drop a canonical table without restoring it. Ratchet the
-// backlog to zero — see eslint/require-canonical-rebuild.mjs.
-/** @type {string[]} */
+// AR test files exempt from require-canonical-rebuild, in two groups.
+// `memoryScoped` files own a private `:memory:` adapter — they never touch the
+// shared per-worker database, so a canonical table they drop cannot drift it,
+// and the exemption is permanent. `backlog` files do drop a canonical table on
+// the shared database and leave it dropped; ratchet that array to zero (story
+// burn-down-canonical-rebuild-exclude). See eslint/require-canonical-rebuild.mjs.
+/** @type {{ memoryScoped: string[], backlog: string[] }} */
 const requireCanonicalRebuildExclude = JSON.parse(
   readFileSync(new URL("./eslint/require-canonical-rebuild-exclude.json", import.meta.url), "utf8"),
 );
@@ -63,7 +64,8 @@ const requireCanonicalRebuildExclude = JSON.parse(
  * test-helpers/test-schema.ts, which the lint rule needs but cannot import
  * (it is TypeScript). Read from the source so the list can never drift: the
  * object's table keys are the only ones at two-space indent, column keys
- * nesting one level deeper.
+ * nesting one level deeper. A parse that comes back near-empty would silently
+ * disable the rule, so it fails loudly instead.
  */
 function canonicalTableNames() {
   const source = readFileSync(
@@ -72,7 +74,13 @@ function canonicalTableNames() {
   );
   const declaration = source.slice(source.indexOf("export const TEST_SCHEMA"));
   const body = declaration.slice(0, declaration.indexOf("\n};"));
-  return [...body.matchAll(/^ {2}"?([\w.]+)"?: [{[]/gm)].map((m) => m[1]);
+  const names = [...body.matchAll(/^ {2}"?([\w.]+)"?: [{[]/gm)].map((m) => m[1]);
+  if (names.length < 100) {
+    throw new Error(
+      `canonicalTableNames(): parsed only ${names.length} tables from test-schema.ts — the TEST_SCHEMA layout changed and require-canonical-rebuild would silently stop guarding.`,
+    );
+  }
+  return names;
 }
 /** @type {string[]} */
 const canonicalTables = canonicalTableNames();
@@ -446,7 +454,11 @@ export default defineConfig(
   //    test. See eslint/require-canonical-rebuild.mjs. ──
   {
     files: ["packages/activerecord/src/**/*.test.ts"],
-    ignores: ["packages/activerecord/src/test-helpers/**", ...requireCanonicalRebuildExclude],
+    ignores: [
+      "packages/activerecord/src/test-helpers/**",
+      ...requireCanonicalRebuildExclude.memoryScoped,
+      ...requireCanonicalRebuildExclude.backlog,
+    ],
     rules: {
       "blazetrails/require-canonical-rebuild": ["error", { canonicalTables }],
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,7 @@ import expectedFixtures from "./eslint/expected-fixtures.mjs";
 import manifestComplete from "./eslint/manifest-complete.mjs";
 import testFixtureParity from "./eslint/test-fixture-parity.mjs";
 import requireTableTeardown from "./eslint/require-table-teardown.mjs";
+import requireCanonicalRebuild from "./eslint/require-canonical-rebuild.mjs";
 import noRawSql from "./eslint/no-raw-sql.mjs";
 import noStandaloneAssociations from "./eslint/no-standalone-associations.mjs";
 import noInternalCanonicalLoaders from "./eslint/no-internal-canonical-loaders.mjs";
@@ -47,6 +48,34 @@ const requireTableTeardownRawSqlExclude = JSON.parse(
     "utf8",
   ),
 );
+// AR test files exempt from require-canonical-rebuild: the ones that own a
+// private `:memory:` adapter (they never touch the shared per-worker database,
+// so a canonical table they drop can't drift it) plus a grandfathered backlog
+// of files that do drop a canonical table without restoring it. Ratchet the
+// backlog to zero — see eslint/require-canonical-rebuild.mjs.
+/** @type {string[]} */
+const requireCanonicalRebuildExclude = JSON.parse(
+  readFileSync(new URL("./eslint/require-canonical-rebuild-exclude.json", import.meta.url), "utf8"),
+);
+
+/**
+ * The canonical table names — the top-level keys of `TEST_SCHEMA` in
+ * test-helpers/test-schema.ts, which the lint rule needs but cannot import
+ * (it is TypeScript). Read from the source so the list can never drift: the
+ * object's table keys are the only ones at two-space indent, column keys
+ * nesting one level deeper.
+ */
+function canonicalTableNames() {
+  const source = readFileSync(
+    new URL("./packages/activerecord/src/test-helpers/test-schema.ts", import.meta.url),
+    "utf8",
+  );
+  const declaration = source.slice(source.indexOf("export const TEST_SCHEMA"));
+  const body = declaration.slice(0, declaration.indexOf("\n};"));
+  return [...body.matchAll(/^ {2}"?([\w.]+)"?: [{[]/gm)].map((m) => m[1]);
+}
+/** @type {string[]} */
+const canonicalTables = canonicalTableNames();
 
 export default defineConfig(
   {
@@ -159,6 +188,7 @@ export default defineConfig(
           "expected-fixtures": expectedFixtures,
           "test-fixture-parity": testFixtureParity,
           "require-table-teardown": requireTableTeardown,
+          "require-canonical-rebuild": requireCanonicalRebuild,
           "no-raw-sql": noRawSql,
           "no-standalone-associations": noStandaloneAssociations,
           "no-internal-canonical-loaders": noInternalCanonicalLoaders,
@@ -407,6 +437,20 @@ export default defineConfig(
         },
       ]
     : []),
+
+  // ── require-canonical-rebuild: a test file that drops a canonical table
+  //    (a TEST_SCHEMA key) must restore it in the same file, via
+  //    rebuildCanonicalTables()/loadCanonicalSchema(). A canonical table left
+  //    dropped drifts the shared per-worker database for the next file.
+  //    test-helpers/** is exempt — the canonical loaders are its subject under
+  //    test. See eslint/require-canonical-rebuild.mjs. ──
+  {
+    files: ["packages/activerecord/src/**/*.test.ts"],
+    ignores: ["packages/activerecord/src/test-helpers/**", ...requireCanonicalRebuildExclude],
+    rules: {
+      "blazetrails/require-canonical-rebuild": ["error", { canonicalTables }],
+    },
+  },
 
   // ── no-raw-sql: ban raw SQL strings passed to execution sinks (and the
   //    RFC-0022 `sql.replace`/`sql.concat` string-surgery pattern) outside the

--- a/eslint/require-canonical-rebuild-exclude.json
+++ b/eslint/require-canonical-rebuild-exclude.json
@@ -1,22 +1,26 @@
-[
-  "packages/activerecord/src/adapter-prevent-writes.test.ts",
-  "packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts",
-  "packages/activerecord/src/adapters/postgresql/schema.test.ts",
-  "packages/activerecord/src/adapters/sqlite3-adapter.test.ts",
-  "packages/activerecord/src/adapters/sqlite3/bind-parameter.test.ts",
-  "packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts",
-  "packages/activerecord/src/adapters/sqlite3/transaction.test.ts",
-  "packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts",
-  "packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts",
-  "packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.test.ts",
-  "packages/activerecord/src/connection-adapters/schema-cache.test.ts",
-  "packages/activerecord/src/connection-adapters/sqlite3-adapter.transactions.test.ts",
-  "packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts",
-  "packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts",
-  "packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts",
-  "packages/activerecord/src/database-statements.test.ts",
-  "packages/activerecord/src/migration.test.ts",
-  "packages/activerecord/src/schema-dumper.test.ts",
-  "packages/activerecord/src/sqlite/libsql.test.ts",
-  "packages/activerecord/src/transactions.trails.test.ts"
-]
+{
+  "memoryScoped": [
+    "packages/activerecord/src/adapter-prevent-writes.test.ts",
+    "packages/activerecord/src/adapters/sqlite3-adapter.test.ts",
+    "packages/activerecord/src/adapters/sqlite3/bind-parameter.test.ts",
+    "packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts",
+    "packages/activerecord/src/adapters/sqlite3/transaction.test.ts",
+    "packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts",
+    "packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts",
+    "packages/activerecord/src/connection-adapters/schema-cache.test.ts",
+    "packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts",
+    "packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts",
+    "packages/activerecord/src/database-statements.test.ts",
+    "packages/activerecord/src/sqlite/libsql.test.ts",
+    "packages/activerecord/src/transactions.trails.test.ts"
+  ],
+  "backlog": [
+    "packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts",
+    "packages/activerecord/src/adapters/postgresql/schema.test.ts",
+    "packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.test.ts",
+    "packages/activerecord/src/connection-adapters/sqlite3-adapter.transactions.test.ts",
+    "packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts",
+    "packages/activerecord/src/migration.test.ts",
+    "packages/activerecord/src/schema-dumper.test.ts"
+  ]
+}

--- a/eslint/require-canonical-rebuild-exclude.json
+++ b/eslint/require-canonical-rebuild-exclude.json
@@ -1,0 +1,22 @@
+[
+  "packages/activerecord/src/adapter-prevent-writes.test.ts",
+  "packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts",
+  "packages/activerecord/src/adapters/postgresql/schema.test.ts",
+  "packages/activerecord/src/adapters/sqlite3-adapter.test.ts",
+  "packages/activerecord/src/adapters/sqlite3/bind-parameter.test.ts",
+  "packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts",
+  "packages/activerecord/src/adapters/sqlite3/transaction.test.ts",
+  "packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts",
+  "packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts",
+  "packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.test.ts",
+  "packages/activerecord/src/connection-adapters/schema-cache.test.ts",
+  "packages/activerecord/src/connection-adapters/sqlite3-adapter.transactions.test.ts",
+  "packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts",
+  "packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts",
+  "packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts",
+  "packages/activerecord/src/database-statements.test.ts",
+  "packages/activerecord/src/migration.test.ts",
+  "packages/activerecord/src/schema-dumper.test.ts",
+  "packages/activerecord/src/sqlite/libsql.test.ts",
+  "packages/activerecord/src/transactions.trails.test.ts"
+]

--- a/eslint/require-canonical-rebuild.mjs
+++ b/eslint/require-canonical-rebuild.mjs
@@ -40,10 +40,11 @@
  *     the set can't be read statically, so the file is treated as restoring
  *     everything rather than guessed at (no false positives).
  *
- * Files that operate on a private `:memory:` adapter never touch the shared
- * per-worker database and so cannot drift it; they are excluded in
- * eslint.config.mjs via `eslint/require-canonical-rebuild-exclude.json`, the
- * same pattern `require-table-teardown-raw-sql-exclude.json` uses.
+ * Exemptions live in `eslint/require-canonical-rebuild-exclude.json`, on the
+ * same pattern `require-table-teardown-raw-sql-exclude.json` uses, split into
+ * two groups: `memoryScoped` files own a private `:memory:` adapter, never
+ * touch the shared per-worker database, and are permanently exempt; `backlog`
+ * files really do leave a canonical table dropped and are ratcheted to zero.
  */
 
 import { calledName, staticString, rawDropNames, SQL_SINKS } from "./require-table-teardown.mjs";
@@ -92,7 +93,7 @@ const rule = {
     ],
     messages: {
       missingRebuild:
-        'Canonical table `{{table}}` is dropped but never restored in this file. Add `await rebuildCanonicalTables(adapter, ["{{table}}"])` after the drop. A canonical table left dropped drifts the shared per-worker database for every file that runs next. If this file owns a private `:memory:` adapter, add it to eslint/require-canonical-rebuild-exclude.json.',
+        'Canonical table `{{table}}` is dropped but never restored in this file. Add `await rebuildCanonicalTables(adapter, ["{{table}}"])` after the drop. A canonical table left dropped drifts the shared per-worker database for every file that runs next. If this file owns a private `:memory:` adapter it cannot drift the shared database — add it to the `memoryScoped` group in eslint/require-canonical-rebuild-exclude.json.',
     },
   },
 
@@ -116,10 +117,14 @@ const rule = {
             for (const table of rawDropNames(arg.value)) recordDrop(table, arg);
           }
         } else if (arg.type === "TemplateLiteral") {
-          for (const quasi of arg.quasis) {
-            if (!quasi.value.cooked) continue;
-            for (const table of rawDropNames(quasi.value.cooked)) recordDrop(table, arg);
-          }
+          // A quasi followed by an interpolation has a dynamic end: a name that
+          // runs to it is a prefix of a dynamic name, not a table (see
+          // rawDropNames).
+          const last = arg.quasis.length - 1;
+          arg.quasis.forEach((quasi, i) => {
+            if (!quasi.value.cooked) return;
+            for (const table of rawDropNames(quasi.value.cooked, i < last)) recordDrop(table, arg);
+          });
         }
       }
     }

--- a/eslint/require-canonical-rebuild.mjs
+++ b/eslint/require-canonical-rebuild.mjs
@@ -1,0 +1,160 @@
+/**
+ * ESLint rule: require-canonical-rebuild
+ *
+ * The inverse of `require-table-teardown`. That rule balances DDL **per table
+ * name** — a bespoke `CREATE TABLE foo` must be matched by a `DROP TABLE foo`
+ * — which catches a table that outlives its test. It cannot catch the opposite
+ * drift: a test file that **drops a canonical table and leaves it dropped**.
+ *
+ * That is what happened to `subscribers` (PR #5256): the mysql2 adapter test
+ * hand-rolled `CREATE TABLE subscribers` and dropped it again in a `finally`,
+ * perfectly balanced by the teardown rule's accounting, and still left the
+ * shared per-worker database missing the canonical `subscribers` for whichever
+ * file ran next — shape drift `repairWorkerSchema` then had to repair.
+ *
+ * The invariant: a **canonical** table (a key of `TEST_SCHEMA` in
+ * `test-helpers/test-schema.ts`, supplied to the rule via the
+ * `canonicalTables` option) may be dropped by a test file only if that same
+ * file restores it, via `rebuildCanonicalTables(adapter, ["…"])` or
+ * `loadCanonicalSchema(adapter)`.
+ *
+ *   ✗  await adapter.executeMutation("DROP TABLE IF EXISTS `subscribers`");
+ *      // …no rebuild anywhere in the file
+ *
+ *   ✓  await adapter.executeMutation("DROP TABLE IF EXISTS `subscribers`");
+ *      await rebuildCanonicalTables(adapter, ["subscribers"]);
+ *
+ * Drops are seen in both forms `require-table-teardown` understands: the
+ * `dropTable("foo")` helper (receiver-agnostic, multiple names per call) and a
+ * raw `DROP TABLE foo` inside an execution sink's string/template argument
+ * (`SQL_SINKS`). Only statically-known names participate in either direction;
+ * a name behind an interpolation (`` `DROP TABLE ${t}` ``) is invisible, so it
+ * is never flagged.
+ *
+ * Restores are recognised as:
+ *   - `rebuildCanonicalTables(adapter, ["a", "b"])` — each static element of
+ *     the array literal is restored;
+ *   - `loadCanonicalSchema(adapter)` — restores everything, so the file is
+ *     clean by construction;
+ *   - `rebuildCanonicalTables(adapter, NAMES)` with a non-literal name list —
+ *     the set can't be read statically, so the file is treated as restoring
+ *     everything rather than guessed at (no false positives).
+ *
+ * Files that operate on a private `:memory:` adapter never touch the shared
+ * per-worker database and so cannot drift it; they are excluded in
+ * eslint.config.mjs via `eslint/require-canonical-rebuild-exclude.json`, the
+ * same pattern `require-table-teardown-raw-sql-exclude.json` uses.
+ */
+
+import { calledName, staticString, rawDropNames, SQL_SINKS } from "./require-table-teardown.mjs";
+
+/** Call names that restore the canonical schema for every table at once. */
+const FULL_RESTORE_CALLS = new Set(["loadCanonicalSchema"]);
+/** Call name that restores a named subset of the canonical schema. */
+const REBUILD_CALL = "rebuildCanonicalTables";
+
+/**
+ * The statically-known table names a `rebuildCanonicalTables(adapter, names)`
+ * call restores, or null when the name list isn't a literal array of static
+ * strings — a spread, a variable, or a computed element makes the set unknown,
+ * which the caller treats as a full restore.
+ */
+function rebuiltTableNames(call) {
+  const names = call.arguments[1];
+  if (!names || names.type !== "ArrayExpression") return null;
+  const out = [];
+  for (const element of names.elements) {
+    if (!element) continue;
+    const name = staticString(element);
+    if (name === null) return null;
+    out.push(name);
+  }
+  return out;
+}
+
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Require a test file that drops a canonical table to restore it in the same file, via rebuildCanonicalTables() or loadCanonicalSchema().",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          // The canonical table names (keys of TEST_SCHEMA), supplied by
+          // eslint.config.mjs so the rule stays free of filesystem access.
+          canonicalTables: { type: "array", items: { type: "string" } },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      missingRebuild:
+        'Canonical table `{{table}}` is dropped but never restored in this file. Add `await rebuildCanonicalTables(adapter, ["{{table}}"])` after the drop. A canonical table left dropped drifts the shared per-worker database for every file that runs next. If this file owns a private `:memory:` adapter, add it to eslint/require-canonical-rebuild-exclude.json.',
+    },
+  },
+
+  create(context) {
+    const canonical = new Set(context.options[0]?.canonicalTables ?? []);
+    if (canonical.size === 0) return {};
+
+    // canonical table name → first drop node seen (for the report location).
+    const dropped = new Map();
+    const rebuilt = new Set();
+    let restoresEverything = false;
+
+    function recordDrop(table, node) {
+      if (canonical.has(table) && !dropped.has(table)) dropped.set(table, node);
+    }
+
+    function recordSinkSql(call) {
+      for (const arg of call.arguments) {
+        if (arg.type === "Literal") {
+          if (typeof arg.value === "string") {
+            for (const table of rawDropNames(arg.value)) recordDrop(table, arg);
+          }
+        } else if (arg.type === "TemplateLiteral") {
+          for (const quasi of arg.quasis) {
+            if (!quasi.value.cooked) continue;
+            for (const table of rawDropNames(quasi.value.cooked)) recordDrop(table, arg);
+          }
+        }
+      }
+    }
+
+    return {
+      CallExpression(node) {
+        const name = calledName(node.callee);
+        if (name === null) return;
+        if (name === "dropTable") {
+          for (const arg of node.arguments) {
+            const table = staticString(arg);
+            if (table !== null) recordDrop(table, node);
+          }
+        } else if (name === REBUILD_CALL) {
+          const names = rebuiltTableNames(node);
+          if (names === null) restoresEverything = true;
+          else for (const table of names) rebuilt.add(table);
+        } else if (FULL_RESTORE_CALLS.has(name)) {
+          restoresEverything = true;
+        } else if (SQL_SINKS.has(name)) {
+          recordSinkSql(node);
+        }
+      },
+
+      // Deferred so a rebuild anywhere in the file — including a hook declared
+      // after the test that drops — counts as the restore.
+      "Program:exit"() {
+        if (restoresEverything) return;
+        for (const [table, node] of dropped) {
+          if (rebuilt.has(table)) continue;
+          context.report({ node, messageId: "missingRebuild", data: { table } });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/eslint/require-canonical-rebuild.test.mjs
+++ b/eslint/require-canonical-rebuild.test.mjs
@@ -61,6 +61,12 @@ tester.run("require-canonical-rebuild", rule, {
         'await rebuildCanonicalTables(adapter, ["people", "subscribers"]);',
       options,
     },
+    // A canonical name that only *prefixes* an interpolated one is not a drop
+    // of that table (`DROP TABLE posts_${suffix}` is a bespoke scratch table).
+    {
+      code: "await adapter.execute(`DROP TABLE posts${suffix}`);",
+      options,
+    },
     // A bespoke (non-canonical) table may be dropped freely — that balance is
     // require-table-teardown's job, not this rule's.
     {

--- a/eslint/require-canonical-rebuild.test.mjs
+++ b/eslint/require-canonical-rebuild.test.mjs
@@ -1,0 +1,135 @@
+import { RuleTester } from "eslint";
+import rule from "./require-canonical-rebuild.mjs";
+
+const tester = new RuleTester({
+  languageOptions: {
+    parser: (await import("typescript-eslint")).parser,
+    ecmaVersion: 2022,
+    sourceType: "module",
+  },
+});
+
+// A stand-in for the TEST_SCHEMA keys eslint.config.mjs feeds the rule.
+const options = [{ canonicalTables: ["subscribers", "people", "posts", "widgets"] }];
+
+tester.run("require-canonical-rebuild", rule, {
+  valid: [
+    // Raw drop of a canonical table, restored by name.
+    {
+      code:
+        'await adapter.executeMutation("DROP TABLE IF EXISTS `subscribers`");\n' +
+        'await rebuildCanonicalTables(adapter, ["subscribers"]);',
+      options,
+    },
+    // dropTable helper on a canonical table, restored by name.
+    {
+      code: 'await ctx.dropTable("posts");\nawait rebuildCanonicalTables(ctx, ["posts"]);',
+      options,
+    },
+    // The rebuild may sit in a later hook — matching is file-wide, not ordered.
+    {
+      code:
+        'it("…", async () => { await ctx.dropTable("posts"); });\n' +
+        'beforeEach(async () => { await rebuildCanonicalTables(ctx, ["posts"]); });',
+      options,
+    },
+    // One rebuild call restores several dropped tables.
+    {
+      code:
+        'await ctx.dropTable("posts", "people");\n' +
+        'await rebuildCanonicalTables(ctx, ["people", "posts"]);',
+      options,
+    },
+    // loadCanonicalSchema restores everything, so no per-name rebuild is needed.
+    {
+      code: 'await ctx.dropTable("posts");\nawait loadCanonicalSchema(ctx);',
+      options,
+    },
+    // A non-literal name list is an unknowable set — treated as a full restore
+    // rather than guessed at (the reserved-word/abstract-mysql-adapter shape).
+    {
+      code: "await ctx.dropTable(`people`);\nawait rebuildCanonicalTables(ctx, CANONICAL_TABLES);",
+      options,
+    },
+    // The mysql2-adapter.test.ts pattern: interpolated drop names are not
+    // statically knowable, so nothing is recorded (and it rebuilds anyway).
+    {
+      code:
+        'for (const t of ["people", "subscribers"]) {\n' +
+        "  await adapter.executeMutation(`DROP TABLE IF EXISTS \\`${t}\\``);\n" +
+        "}\n" +
+        'await rebuildCanonicalTables(adapter, ["people", "subscribers"]);',
+      options,
+    },
+    // A bespoke (non-canonical) table may be dropped freely — that balance is
+    // require-table-teardown's job, not this rule's.
+    {
+      code: 'await ctx.dropTable("ex_long");\nawait ctx.dropTable("foos");',
+      options,
+    },
+    // A DDL string that is an assertion target, not a sink argument, is ignored.
+    {
+      code: 'expect(sql).toContain("DROP TABLE subscribers");',
+      options,
+    },
+    // No canonical table list configured — the rule is inert.
+    { code: 'await ctx.dropTable("posts");', options: [{}] },
+  ],
+
+  invalid: [
+    // The pre-#5256 mysql2-adapter.trails.test.ts shape: a canonical table
+    // hand-rolled and dropped again in a `finally`, leaving it missing.
+    {
+      code:
+        'await adapter.executeMutation("DROP TABLE IF EXISTS `subscribers`");\n' +
+        'await adapter.executeMutation("CREATE TABLE `subscribers` (`nick` VARCHAR(255))");\n' +
+        "try {\n" +
+        '  await adapter.execQuery("SELECT * FROM subscribers WHERE 1=0");\n' +
+        "} finally {\n" +
+        '  await adapter.executeMutation("DROP TABLE IF EXISTS `subscribers`");\n' +
+        "}",
+      options,
+      errors: [{ messageId: "missingRebuild", data: { table: "subscribers" } }],
+    },
+    // The dropTable helper leaves the same drift as raw SQL.
+    {
+      code: 'await ctx.dropTable("posts");',
+      options,
+      errors: [{ messageId: "missingRebuild", data: { table: "posts" } }],
+    },
+    // Each unrestored canonical table is reported once; the restored one isn't.
+    {
+      code:
+        'await ctx.dropTable("posts", "people", "widgets");\n' +
+        'await rebuildCanonicalTables(ctx, ["people"]);',
+      options,
+      errors: [
+        { messageId: "missingRebuild", data: { table: "posts" } },
+        { messageId: "missingRebuild", data: { table: "widgets" } },
+      ],
+    },
+    // A rebuild of a *different* table does not cover this one.
+    {
+      code:
+        'await adapter.execute("DROP TABLE subscribers");\n' +
+        'await rebuildCanonicalTables(adapter, ["people"]);',
+      options,
+      errors: [{ messageId: "missingRebuild", data: { table: "subscribers" } }],
+    },
+    // A multi-name raw drop reports each canonical name it lists.
+    {
+      code: 'await adapter.execute("DROP TABLE posts, people CASCADE");',
+      options,
+      errors: [
+        { messageId: "missingRebuild", data: { table: "posts" } },
+        { messageId: "missingRebuild", data: { table: "people" } },
+      ],
+    },
+    // Repeated drops of the same table report once, at the first drop.
+    {
+      code: 'await ctx.dropTable("posts");\nawait ctx.dropTable("posts");',
+      options,
+      errors: [{ messageId: "missingRebuild", data: { table: "posts" }, line: 1 }],
+    },
+  ],
+});

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -109,7 +109,7 @@
  * rule cares about the operation, not what it's invoked on. Returns null for
  * dynamic/computed callees (`recv[fn](...)`).
  */
-function calledName(callee) {
+export function calledName(callee) {
   if (callee.type === "Identifier") return callee.name;
   if (callee.type !== "MemberExpression") return null;
   if (callee.computed || callee.property.type !== "Identifier") return null;
@@ -122,7 +122,7 @@ function calledName(callee) {
  * (`` `foo` ``) both qualify; a template with an interpolation (`` `${s}.foo` ``)
  * does not — its table name can't be matched statically, so it's skipped.
  */
-function staticString(node) {
+export function staticString(node) {
   if (!node) return null;
   if (node.type === "Literal" && typeof node.value === "string") return node.value;
   if (node.type === "TemplateLiteral" && node.expressions.length === 0) {
@@ -165,7 +165,7 @@ const NAME_RE = /^\s*(`|"|')?([\w.]+)\1?/;
  * `expect(...).toContain` does not. Receiver-agnostic, like every other name
  * the rule matches. Extend this set if a new execution sink appears.
  */
-const SQL_SINKS = new Set([
+export const SQL_SINKS = new Set([
   "exec",
   "execute",
   "executeMutation",
@@ -198,7 +198,7 @@ function rawCreateNames(text, endIsDynamic) {
  * at a trailing `CASCADE`/`RESTRICT`, statement terminator, or a non-static
  * (interpolated) name.
  */
-function rawDropNames(text) {
+export function rawDropNames(text) {
   const names = [];
   DROP_TABLE_RE.lastIndex = 0;
   let m;

--- a/eslint/require-table-teardown.mjs
+++ b/eslint/require-table-teardown.mjs
@@ -196,9 +196,12 @@ function rawCreateNames(text, endIsDynamic) {
  * Statically-knowable `DROP TABLE` names in `text`. A single statement may drop
  * several tables (`DROP TABLE a, b`); each comma-separated name counts, stopping
  * at a trailing `CASCADE`/`RESTRICT`, statement terminator, or a non-static
- * (interpolated) name.
+ * (interpolated) name. `endIsDynamic` works exactly as it does for
+ * `rawCreateNames`: a name that runs to the very end of a quasi followed by an
+ * interpolation (`DROP TABLE posts_${suffix}`) is a static *prefix* of a
+ * dynamic name, not a table, and is dropped rather than recorded.
  */
-export function rawDropNames(text) {
+export function rawDropNames(text, endIsDynamic = false) {
   const names = [];
   DROP_TABLE_RE.lastIndex = 0;
   let m;
@@ -207,8 +210,9 @@ export function rawDropNames(text) {
     let nm;
     while ((nm = NAME_RE.exec(rest)) !== null) {
       if (/^(?:cascade|restrict)$/i.test(nm[2])) break;
-      names.push(nm[2]);
-      rest = rest.slice(nm[0].length).replace(/^\s+/, "");
+      rest = rest.slice(nm[0].length);
+      if (!(endIsDynamic && rest.length === 0)) names.push(nm[2]);
+      rest = rest.replace(/^\s+/, "");
       if (rest[0] !== ",") break;
       rest = rest.slice(1);
     }
@@ -351,7 +355,7 @@ const rule = {
       for (const table of rawCreateNames(text, endIsDynamic)) {
         if (!created.has(table)) created.set(table, node);
       }
-      for (const table of rawDropNames(text)) dropped.add(table);
+      for (const table of rawDropNames(text, endIsDynamic)) dropped.add(table);
     }
 
     function recordSinkSql(call) {

--- a/eslint/require-table-teardown.test.mjs
+++ b/eslint/require-table-teardown.test.mjs
@@ -80,6 +80,15 @@ tester.run("require-table-teardown", rule, {
     'await ctx.dropTable(name);\nawait ctx.dropTable("b");',
   ],
   invalid: [
+    // Symmetrically, a DROP name flush against an interpolation is a prefix,
+    // not a table: the phantom `tmp_` must not be credited as the teardown of
+    // the real `tmp_a`.
+    {
+      code:
+        'await c.exec("CREATE TABLE tmp_a (id int)");\n' +
+        "await c.exec(`DROP TABLE tmp_${suffix}`);",
+      errors: [{ messageId: "missingTeardown", data: { table: "tmp_a" } }],
+    },
     // Created, never dropped.
     {
       code: 'beforeAll(async () => { await ctx.createTable("widgets", () => {}); });',


### PR DESCRIPTION
## What

Adds `blazetrails/require-canonical-rebuild`, the inverse of
`require-table-teardown`: a test file that **drops a canonical table** (a
`TEST_SCHEMA` key) must **restore it in the same file**, via
`rebuildCanonicalTables(adapter, ["…"])` or `loadCanonicalSchema(adapter)`.

`require-table-teardown` balances DDL per table name, so the pre-#5256
`subscribers` drift passed clean: the mysql2 trails test hand-rolled
`CREATE TABLE subscribers` and dropped it again in a `finally` — perfectly
balanced — and still left the shared per-worker DB missing the canonical
`subscribers` for the next file, which `repairWorkerSchema` had to repair.

## How

- `eslint/require-canonical-rebuild.mjs` — new rule. Sees drops in both shapes
  the teardown rule understands (the `dropTable` helper and raw `DROP TABLE` in
  an execution-sink argument), reports only names in the configured canonical
  set, and treats `rebuildCanonicalTables(adapter, ["a"])` /
  `loadCanonicalSchema(adapter)` as the restore. A non-literal name list
  (`rebuildCanonicalTables(adapter, NAMES)`) is an unknowable set and suppresses
  the file rather than being guessed at.
- `eslint/require-table-teardown.mjs` — exports `calledName`, `staticString`,
  `rawDropNames`, `SQL_SINKS` so the sibling rule shares the same parsing, and
  `rawDropNames` gains the `endIsDynamic` flag `rawCreateNames` already had: a
  DROP name flush against an interpolation (`DROP TABLE tmp_${suffix}`) is a
  prefix of a dynamic name, not a table. Both rules thread it, so neither
  invents a phantom table — and a phantom drop can no longer be credited as a
  real create's teardown (new invalid case in the teardown suite).
- `eslint.config.mjs` — feeds the rule the canonical table names, read out of
  `test-helpers/test-schema.ts` at config load so the list can't drift; wires
  the rule at `error` over `packages/activerecord/src/**/*.test.ts`
  (`test-helpers/**` exempt, as for the teardown rule).
- `eslint/require-canonical-rebuild-exclude.json` — 20 grandfathered files, on
  the same pattern as `require-table-teardown-raw-sql-exclude.json` but split
  into two named groups so they are not confusable: `memoryScoped` (13 files
  that own a private `:memory:` adapter — permanently exempt, they cannot drift
  the shared DB) and `backlog` (7 files that really do leave a canonical table
  dropped). Burn-down of `backlog` is registered as story
  `burn-down-canonical-rebuild-exclude` on the same RFC.

## Verification

- Regression: linting the **pre-#5256** body of
  `mysql2-adapter.trails.test.ts` reports `subscribers` at `254:35`; the current
  tree is clean.
- `npx eslint "packages/activerecord/src/**/*.test.ts"` — 0
  `require-canonical-rebuild` errors with the exclude list in place; no false
  positive on `adapters/mysql2/mysql2-adapter.test.ts` (its interpolated
  `DROP TABLE \`${t}\`` names aren't static, and it rebuilds anyway).
- `vitest run eslint/require-canonical-rebuild.test.mjs` — 16 tests pass;
  `require-table-teardown.test.mjs` still 52 pass.

Closes-story: lint-guard-canonical-table-drop-without-rebuild
