### PR TITLE
fix(test-helpers): make rebuildCanonicalTables drop order FK-safe

### DIFF
--- a/packages/activerecord/src/test-helpers/canonical-schema.test.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, test } from "vitest";
 import "../sqlite/better-sqlite3.js";
 import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
 import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
+import type { FkSafeDropOrderHost } from "./canonical-schema.js";
 import {
   ensureCanonicalTables,
+  fkSafeDropOrder,
   loadCanonicalSchema,
   rebuildCanonicalTables,
 } from "./canonical-schema.js";
@@ -78,6 +80,65 @@ describe("rebuildCanonicalTables", () => {
     } finally {
       await (adapter as unknown as BetterSQLite3Adapter).close();
     }
+  });
+});
+
+describe("fkSafeDropOrder", () => {
+  // Stands in for the live database: `fks` maps a table to the tables it
+  // references, as `foreignKeys` would report them.
+  function host(tables: string[], fks: Record<string, string[]> = {}): FkSafeDropOrderHost {
+    return {
+      tables: async () => tables,
+      foreignKeys: async (name) => (fks[name] ?? []).map((toTable) => ({ toTable })),
+    };
+  }
+
+  test("drops a referencing table before its target", async () => {
+    // Registry order: lessons_students (referencer) is registered *before*
+    // students (target), so reversing registry order would drop students first.
+    const order = await fkSafeDropOrder(
+      host(["lessons_students", "students"], { lessons_students: ["students"] }),
+      ["lessons_students", "students"],
+    );
+    expect(order).toEqual(["lessons_students", "students"]);
+  });
+
+  test("keeps input order when no foreign keys are declared", async () => {
+    const order = await fkSafeDropOrder(host(["lessons_students", "students"]), [
+      "lessons_students",
+      "students",
+    ]);
+    expect(order).toEqual(["lessons_students", "students"]);
+  });
+
+  test("ignores foreign keys pointing outside the dropped set", async () => {
+    const order = await fkSafeDropOrder(host(["a", "b"], { a: ["elsewhere"], b: ["a"] }), [
+      "a",
+      "b",
+    ]);
+    expect(order).toEqual(["b", "a"]);
+  });
+
+  test("skips tables that do not exist yet", async () => {
+    const calls: string[] = [];
+    const base = host(["b"], { a: ["b"] });
+    const order = await fkSafeDropOrder(
+      {
+        tables: base.tables,
+        foreignKeys: async (name) => {
+          calls.push(name);
+          return base.foreignKeys(name);
+        },
+      },
+      ["a", "b"],
+    );
+    expect(calls).toEqual(["b"]);
+    expect(order).toEqual(["a", "b"]);
+  });
+
+  test("falls back to input order for a cycle", async () => {
+    const order = await fkSafeDropOrder(host(["a", "b"], { a: ["b"], b: ["a"] }), ["a", "b"]);
+    expect(order).toEqual(["a", "b"]);
   });
 });
 

--- a/packages/activerecord/src/test-helpers/canonical-schema.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.ts
@@ -2075,6 +2075,66 @@ export async function loadCanonicalSchema(adapter: DatabaseAdapter): Promise<voi
   (adapter as { clearCacheBang?: () => void }).clearCacheBang?.();
 }
 
+/** Minimal slice of the schema-statement surface {@link fkSafeDropOrder} needs. */
+export interface FkSafeDropOrderHost {
+  tables(): Promise<string[]>;
+  foreignKeys(tableName: string): Promise<readonly { readonly toTable: string }[]>;
+}
+
+/**
+ * Order `names` so every table is dropped before any table it references,
+ * i.e. referencing tables first.
+ *
+ * Registry order cannot stand in for this: it is roughly alphabetical, not
+ * topological — `lessons_students` is registered before `students`, so merely
+ * reversing it drops the target before its referencer. The canonical registry
+ * declares no foreign keys of its own, but a test may add one (e.g.
+ * `addForeignKey("lessons_students", "students")` in the abstract-mysql-adapter
+ * schema tests), so the order is derived from the FKs the database actually
+ * holds rather than from anything declared here.
+ *
+ * FKs are read only for tables that currently exist, and only for the tables
+ * being dropped — an adapter with no FK introspection reports none and the
+ * input order is preserved. A cycle (mutually-referencing tables) has no safe
+ * order; those tables keep their input order, which is what dropping them
+ * without this helper would have done anyway.
+ *
+ * @internal
+ */
+export async function fkSafeDropOrder(
+  ss: FkSafeDropOrderHost,
+  names: readonly string[],
+): Promise<string[]> {
+  if (names.length < 2) return [...names];
+  const inSet = new Set(names);
+  const existing = new Set(await ss.tables());
+  const referencedBy = new Map<string, string[]>();
+  for (const name of names) {
+    if (!existing.has(name)) continue;
+    const targets = (await ss.foreignKeys(name))
+      .map((fk) => fk.toTable)
+      .filter((t) => t !== name && inSet.has(t));
+    if (targets.length > 0) referencedBy.set(name, targets);
+  }
+  if (referencedBy.size === 0) return [...names];
+
+  const ordered: string[] = [];
+  const emitted = new Set<string>();
+  const onPath = new Set<string>();
+  const visit = (name: string): void => {
+    if (emitted.has(name) || onPath.has(name)) return;
+    onPath.add(name);
+    for (const target of referencedBy.get(name) ?? []) visit(target);
+    onPath.delete(name);
+    emitted.add(name);
+    ordered.push(name);
+  };
+  // Referencers are emitted after their targets, so walk in input order and
+  // reverse: the result drops referencers first.
+  for (const name of names) visit(name);
+  return ordered.reverse();
+}
+
 /**
  * Drop and recreate a named subset of canonical tables, restoring each to its
  * full canonical shape — the `create_table`-based equivalent of
@@ -2100,17 +2160,11 @@ export async function rebuildCanonicalTables(
   const defs = registry.filter((d) => wanted.has(d.name));
   if (defs.length === 0) return;
   const { ss, typeMap } = await prepareSchema(adapter);
-  // Drop in reverse registry order, then recreate in forward registry order.
-  // Registry order is roughly alphabetical, NOT topological, so reversing it
-  // does not order referencers before their targets (`lessons_students` is
-  // registered before `students`, so the reverse loop drops the target first).
-  // That is safe only because the canonical registry declares no foreign keys
-  // at all — no `addForeignKey` / `t.foreignKey` anywhere in this file — so no
-  // drop order can violate a persisted constraint. If a canonical table ever
-  // gains an FK, this loop must be made genuinely FK-safe (topological drop, or
-  // dropping with FK checks suspended) before that table can be rebuilt here.
-  for (const def of [...defs].reverse()) {
-    await ss.dropTable(def.name, { ifExists: true });
+  for (const name of await fkSafeDropOrder(
+    ss,
+    defs.map((d) => d.name),
+  )) {
+    await ss.dropTable(name, { ifExists: true });
   }
   for (const def of defs) {
     await runTable(adapter, ss, typeMap, def);

--- a/packages/activerecord/src/test-helpers/canonical-schema.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.ts
@@ -2100,8 +2100,15 @@ export async function rebuildCanonicalTables(
   const defs = registry.filter((d) => wanted.has(d.name));
   if (defs.length === 0) return;
   const { ss, typeMap } = await prepareSchema(adapter);
-  // Drop in reverse registry order (FK-referencing tables before their targets),
-  // then recreate forward so targets exist first.
+  // Drop in reverse registry order, then recreate in forward registry order.
+  // Registry order is roughly alphabetical, NOT topological, so reversing it
+  // does not order referencers before their targets (`lessons_students` is
+  // registered before `students`, so the reverse loop drops the target first).
+  // That is safe only because the canonical registry declares no foreign keys
+  // at all — no `addForeignKey` / `t.foreignKey` anywhere in this file — so no
+  // drop order can violate a persisted constraint. If a canonical table ever
+  // gains an FK, this loop must be made genuinely FK-safe (topological drop, or
+  // dropping with FK checks suspended) before that table can be rebuilt here.
   for (const def of [...defs].reverse()) {
     await ss.dropTable(def.name, { ifExists: true });
   }


### PR DESCRIPTION
`rebuildCanonicalTables` documented its drop loop as "drop in reverse registry
order (FK-referencing tables before their targets)". The registry is roughly
alphabetical, not topological, so reversing it does not order referencers
before targets — `lessons_students` is registered before `students`, so the
reverse loop dropped the target first for exactly that pair.

Rather than correcting the comment to describe a weaker guarantee, this takes
the story's other acceptance branch and makes the drop order genuinely FK-safe:
`fkSafeDropOrder` derives the order from the foreign keys the database actually
holds (topological, referencers first). Deriving it from the live DB rather than
from the registry is what makes it robust to the real hazard the story names — a
*test-added* FK such as `addForeignKey("lessons_students", "students")` in the
abstract-mysql-adapter schema tests, which no declaration in `canonical-schema.ts`
can predict.

- FKs are read only for tables that currently exist and only for the tables
  being dropped, so the added cost is one `tables()` call plus at most one
  `foreignKeys()` call per rebuilt table — noise next to the DDL the same call
  already issues (a DROP + CREATE per table).
- An adapter without FK introspection reports none and the previous order is
  preserved; a cycle keeps input order (no safe order exists, and that is what
  the old loop did anyway).
- No behavior change for existing callers: the canonical registry declares no
  foreign keys, so `referencedBy` is empty and the function short-circuits to
  the input (registry) order. That is the one visible difference — the old loop
  dropped in *reversed* registry order — and it is inert, because with no FK
  anywhere in the registry no drop order can fail. Creation order is unchanged.

Covered by five unit tests against a fake schema-statement host, including the
`lessons_students` / `students` pair that motivated the story.

Closes-story: rebuild-canonical-tables-drop-order-comment
