### PR TITLE
test(schema): declare schema.rb foreign keys in the canonical schema

### DIFF
--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeAll, beforeEach, afterEach, afterAll } from "vitest";
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
 import { Nodes } from "@blazetrails/arel";
 import { Notifications } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
@@ -22,7 +22,6 @@ import {
 } from "./index.js";
 import { Result } from "./result.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { rebuildCanonicalTables } from "./test-helpers/canonical-schema.js";
 import { adapterType, inMemoryDb } from "./test-adapter.js";
 import { itIfSupports } from "./test-helpers/supports.js";
 import { establishFromTestConfig } from "./test-helpers/test-database-config.js";
@@ -533,55 +532,17 @@ describe("AdapterTest", () => {
 });
 
 // Rails declares `fixtures :fk_test_has_pk` and a real `foreign_key` on
-// fk_test_has_fk. defineSchema can't express FK constraints (see test-schema.ts
-// header), so we add it via raw DDL once per worker and tear it down after,
-// then drive the tables directly (Rails sets `use_transactional_tests = false`).
+// fk_test_has_fk, which the canonical schema now declares too, so the tables
+// ride the boot-laid schema and are driven directly (Rails sets
+// `use_transactional_tests = false`).
 describe("AdapterForeignKeyTest", () => {
   fixtures({}, { useTransactionalTests: false });
-
-  const addFkSql = (): string =>
-    "ALTER TABLE fk_test_has_fk ADD CONSTRAINT fk_name " +
-    "FOREIGN KEY (fk_id) REFERENCES fk_test_has_pk (pk_id)";
-  const dropFkSql = (): string =>
-    adapterType === "mysql"
-      ? "ALTER TABLE fk_test_has_fk DROP FOREIGN KEY fk_name"
-      : "ALTER TABLE fk_test_has_fk DROP CONSTRAINT IF EXISTS fk_name";
 
   const cleanup = async (): Promise<void> => {
     await Base.connection.executeMutation("DELETE FROM fk_test_has_fk");
     await Base.connection.executeMutation("DELETE FROM fk_test_has_pk");
   };
 
-  beforeAll(async () => {
-    if (adapterType === "sqlite") {
-      // SQLite can't `ALTER TABLE … ADD CONSTRAINT`, so create the FK inline
-      // (Rails' schema.rb declares the foreign_key). SQLite enforces it because
-      // the adapter sets `PRAGMA foreign_keys=ON` by default.
-      await Base.connection.executeMutation("DROP TABLE IF EXISTS fk_test_has_fk");
-      await Base.connection.executeMutation("DROP TABLE IF EXISTS fk_test_has_pk");
-      await Base.connection.executeMutation(
-        "CREATE TABLE fk_test_has_pk (pk_id INTEGER NOT NULL PRIMARY KEY)",
-      );
-      await Base.connection.executeMutation(
-        "CREATE TABLE fk_test_has_fk (id INTEGER PRIMARY KEY AUTOINCREMENT, " +
-          "fk_id INTEGER NOT NULL, FOREIGN KEY (fk_id) REFERENCES fk_test_has_pk (pk_id))",
-      );
-      return;
-    }
-    // `fk_test_has_pk`/`fk_test_has_fk` ride the boot-laid canonical schema
-    // (both integer keys, so the FK types match). schema.rb declares a real
-    // `foreign_key` on them, which our canonical loader can't express, so add
-    // the constraint here via raw DDL and drop it in afterAll.
-    await Base.connection.execute(dropFkSql()).catch(() => {});
-    await Base.connection.execute(addFkSql());
-  });
-  afterAll(async () => {
-    if (adapterType === "sqlite") {
-      await rebuildCanonicalTables(Base.connection, ["fk_test_has_pk", "fk_test_has_fk"]);
-      return;
-    }
-    await Base.connection.execute(dropFkSql()).catch(() => {});
-  });
   beforeEach(cleanup);
   afterEach(cleanup);
 
@@ -604,7 +565,8 @@ describe("AdapterForeignKeyTest", () => {
       static {
         this.tableName = "fk_test_has_fk";
         // Declare fk_id so the constructor assignment is a known name under
-        // strict writeFromUser (the raw-created FK table is not schema-warmed);
+        // strict writeFromUser — this anonymous class has never been
+        // schema-warmed, and Ruby's lazy column load has no sync analogue here;
         // otherwise the value is dropped and the INSERT hits NOT NULL before FK.
         this.attribute("fk_id", "integer");
       }

--- a/packages/activerecord/src/test-helpers/canonical-schema.test.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.test.ts
@@ -68,6 +68,23 @@ describe("rebuildCanonicalTables", () => {
     }
   });
 
+  test("rebuilds a referencing table when only its target was named", async () => {
+    const adapter = new BetterSQLite3Adapter(":memory:") as unknown as AbstractAdapter;
+    try {
+      await loadCanonicalSchema(adapter);
+      const canonical = await dumpSchema(adapter);
+
+      // Naming only the FK target must still restore the child: MySQL refuses to
+      // drop a table a live foreign key points at.
+      await rebuildCanonicalTables(adapter, ["fk_test_has_pk"]);
+      const dump = await dumpSchema(adapter);
+      expect(dump).toBe(canonical);
+      expect(dump).toContain('CONSTRAINT "fk_name" FOREIGN KEY ("fk_id")');
+    } finally {
+      await (adapter as unknown as BetterSQLite3Adapter).close();
+    }
+  });
+
   test("throws on an unknown canonical table name", async () => {
     const adapter = new BetterSQLite3Adapter(":memory:") as unknown as AbstractAdapter;
     try {

--- a/packages/activerecord/src/test-helpers/canonical-schema.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.ts
@@ -2088,6 +2088,32 @@ export async function loadCanonicalSchema(adapter: DatabaseAdapter): Promise<voi
 }
 
 /**
+ * Map of referenced table -> tables whose definition declares a foreign key into
+ * it. Built by replaying each table's block against a probe TableDefinition that
+ * records `foreignKey` calls and discards columns, so the edges come from the
+ * one declaration site rather than a hand-maintained second list.
+ */
+let _dependents: Map<string, string[]> | null = null;
+
+async function foreignKeyDependents(): Promise<Map<string, string[]>> {
+  if (_dependents) return _dependents;
+  const dependents = new Map<string, string[]>();
+  for (const def of await buildCanonicalRegistry()) {
+    const probe = {
+      column: () => {},
+      foreignKey: (toTable: string) => {
+        const children = dependents.get(toTable) ?? [];
+        children.push(def.name);
+        dependents.set(toTable, children);
+      },
+    } as unknown as TableDefinition;
+    def.fn(new TableBuilder(probe, "sqlite", COLUMN_TYPE_MAP_SQLITE, null, null));
+  }
+  _dependents = dependents;
+  return dependents;
+}
+
+/**
  * Drop and recreate a named subset of canonical tables, restoring each to its
  * full canonical shape — the `create_table`-based equivalent of
  * `defineSchema({ …subset }, { dropExisting: true })`. Test files use it as an
@@ -2108,6 +2134,18 @@ export async function rebuildCanonicalTables(
     // intentional (mirrors the sibling ensureCanonicalTables throw below).
     // eslint-disable-next-line blazetrails/rails-error-parity
     throw new Error(`rebuildCanonicalTables: unknown canonical table(s): ${unknown.join(", ")}`);
+  }
+  // A table nobody asked for still has to be rebuilt when it holds a foreign key
+  // into one that was: MySQL refuses to drop a table a live FK points at, and PG
+  // would cascade the constraint away silently.
+  const dependents = await foreignKeyDependents();
+  const queue = [...wanted];
+  for (const name of queue) {
+    for (const child of dependents.get(name) ?? []) {
+      if (wanted.has(child)) continue;
+      wanted.add(child);
+      queue.push(child);
+    }
   }
   const defs = registry.filter((d) => wanted.has(d.name));
   if (defs.length === 0) return;

--- a/packages/activerecord/src/test-helpers/canonical-schema.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.ts
@@ -17,6 +17,7 @@ import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/
 import type {
   TableDefinition,
   AddIndexOptions,
+  AddForeignKeyOptions,
 } from "../connection-adapters/abstract/schema-definitions.js";
 import type { SchemaStatements } from "../connection-adapters/abstract/schema-statements.js";
 import type { ColumnSpec } from "./schema-types.js";
@@ -143,6 +144,16 @@ class TableBuilder {
   }
   json(name: string, o?: ColOpts): void {
     this.col(name, "json", o);
+  }
+
+  /**
+   * schema.rb's `t.foreign_key :to_table, column:, primary_key:, name:`. The
+   * constraint is carried on the TableDefinition, so every adapter emits it
+   * inline in the CREATE TABLE — the only form SQLite accepts (it has no
+   * `ALTER TABLE … ADD CONSTRAINT`).
+   */
+  foreignKey(toTable: string, opts: Partial<AddForeignKeyOptions> = {}): void {
+    this.t.foreignKey(toTable, opts);
   }
 
   index(columns: string | string[], opts: IndexOpts = {}): void {
@@ -1686,6 +1697,7 @@ async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
 
   await define("fk_test_has_fk", {}, (t) => {
     t.integer("fk_id", { null: false });
+    t.foreignKey("fk_test_has_pk", { column: "fk_id", name: "fk_name", primaryKey: "pk_id" });
   });
 
   await define("fk_object_to_point_tos", {}, (t) => {});

--- a/packages/activerecord/src/test-helpers/schema-file-generator.test.ts
+++ b/packages/activerecord/src/test-helpers/schema-file-generator.test.ts
@@ -182,6 +182,52 @@ describe("generateSchemaFile (MySQL adapter)", () => {
   });
 });
 
+const FK_SCHEMA: Schema = {
+  fk_test_has_pk: { columns: { pk_id: { type: "integer", null: false } }, primaryKey: ["pk_id"] },
+  fk_test_has_fk: {
+    columns: { fk_id: { type: "integer", null: false } },
+    foreignKeys: [
+      { toTable: "fk_test_has_pk", column: "fk_id", primaryKey: "pk_id", name: "fk_name" },
+    ],
+  },
+};
+
+describe("generateSchemaFile foreign keys", () => {
+  const written: string[] = [];
+
+  const generate = async (adapterName?: string): Promise<string> => {
+    const filePath = await generateSchemaFile(FK_SCHEMA, adapterName);
+    written.push(filePath);
+    return (await getFsAsync()).readFileSync(filePath, "utf-8");
+  };
+
+  afterAll(async () => {
+    const fs = await getFsAsync();
+    for (const filePath of written) {
+      try {
+        fs.unlinkSync(filePath);
+      } catch {
+        /* already gone */
+      }
+    }
+  });
+
+  it("emits t.foreignKey inside the create-table block", async () => {
+    const content = await generate();
+    expect(content).toContain(
+      '    t.foreignKey("fk_test_has_pk", {"column":"fk_id","primaryKey":"pk_id","name":"fk_name"});',
+    );
+  });
+
+  it("drops referencing tables up front on the force-recreate adapters", async () => {
+    const content = await generate("postgres");
+    const drop = content.indexOf('ctx.dropTable("fk_test_has_fk", { ifExists: true })');
+    const createParent = content.indexOf('ctx.createTable("fk_test_has_pk"');
+    expect(drop).toBeGreaterThan(-1);
+    expect(drop).toBeLessThan(createParent);
+  });
+});
+
 describe("generateSchemaFile single-column integer PK id type per adapter", () => {
   const SCHEMA: Schema = {
     gadgets: { columns: { gadget_id: "integer", name: "string" }, primaryKey: ["gadget_id"] },

--- a/packages/activerecord/src/test-helpers/schema-file-generator.ts
+++ b/packages/activerecord/src/test-helpers/schema-file-generator.ts
@@ -11,7 +11,7 @@
 
 import { getEnv, getOsAsync } from "@blazetrails/activesupport";
 import { getFsAsync, getPathAsync } from "@blazetrails/activesupport/fs-adapter";
-import type { Schema, ColumnSpec, TableSchema, IndexSpec } from "./schema-types.js";
+import type { Schema, ColumnSpec, TableSchema, IndexSpec, ForeignKeySpec } from "./schema-types.js";
 
 const SCHEMA_TO_AR: Record<string, string> = { big_integer: "bigint" };
 
@@ -23,6 +23,7 @@ function isWrapped(t: TableSchema): t is {
   columns: Record<string, ColumnSpec>;
   primaryKey?: string[] | false;
   indexes?: IndexSpec[];
+  foreignKeys?: ForeignKeySpec[];
 } {
   if (!t || typeof t !== "object") return false;
   if (!("columns" in t)) return false;
@@ -31,6 +32,7 @@ function isWrapped(t: TableSchema): t is {
     if (pk !== false && !Array.isArray(pk)) return false;
     return true;
   }
+  if (Array.isArray((t as { foreignKeys?: unknown }).foreignKeys)) return true;
   return Array.isArray((t as { indexes?: unknown }).indexes);
 }
 
@@ -44,6 +46,10 @@ function primaryKeyOf(t: TableSchema): string[] | false | undefined {
 
 function indexesOf(t: TableSchema): IndexSpec[] {
   return isWrapped(t) ? ((t as { indexes?: IndexSpec[] }).indexes ?? []) : [];
+}
+
+function foreignKeysOf(t: TableSchema): ForeignKeySpec[] {
+  return isWrapped(t) ? ((t as { foreignKeys?: ForeignKeySpec[] }).foreignKeys ?? []) : [];
 }
 
 // `integer` and `big_integer` both map to an auto-increment serial/identity PK
@@ -125,6 +131,17 @@ function generateCode(
   // drop+recreate instead — safe for concurrent workers on a shared DB.
   const needsForce = adapterName === "postgres" || adapterName === "mysql";
 
+  // A referencing table must go before the table it points at: PG/MySQL below
+  // drop+recreate each table in declaration order, and a live child FK blocks
+  // (MySQL) or cascades away (PG) the parent's drop. Dropping every FK-carrying
+  // table up front keeps the per-table `force: "cascade"` recreate safe.
+  if (needsForce) {
+    for (const [tableName, tableSpec] of Object.entries(schema)) {
+      if (foreignKeysOf(tableSpec).length === 0) continue;
+      lines.push(`  await ctx.dropTable(${JSON.stringify(tableName)}, { ifExists: true });`);
+    }
+  }
+
   for (const [tableName, tableSpec] of Object.entries(schema)) {
     const cols = columnsOf(tableSpec);
     const pk = primaryKeyOf(tableSpec);
@@ -151,8 +168,20 @@ function generateCode(
     if (needsForce) tOptsEntries.push(`force: "cascade"`);
     const tOpts = tOptsEntries.length === 0 ? `{}` : `{ ${tOptsEntries.join(", ")} }`;
 
+    // Foreign keys ride inside the create-table block (Rails `t.foreign_key`),
+    // so a table declaring one always emits a block even with no columns.
+    const fks = foreignKeysOf(tableSpec);
+    const fkLines = fks.map(
+      (fk) =>
+        `    t.foreignKey(${JSON.stringify(fk.toTable)}, ${JSON.stringify({
+          column: fk.column,
+          ...(fk.primaryKey === undefined ? {} : { primaryKey: fk.primaryKey }),
+          ...(fk.name === undefined ? {} : { name: fk.name }),
+        })});`,
+    );
+
     const colEntries = Object.entries(cols);
-    if (colEntries.length === 0) {
+    if (colEntries.length === 0 && fkLines.length === 0) {
       lines.push(`  await ctx.createTable(${JSON.stringify(tableName)}, ${tOpts});`);
     } else {
       lines.push(`  await ctx.createTable(${JSON.stringify(tableName)}, ${tOpts}, (t) => {`);
@@ -172,6 +201,7 @@ function generateCode(
           `    t.column(${JSON.stringify(colName)}, ${JSON.stringify(toArType(primitive))}, ${colOpts(colSpec, colName, cpkCols, primitive, adapterName)});`,
         );
       }
+      lines.push(...fkLines);
       lines.push(`  });`);
     }
 

--- a/packages/activerecord/src/test-helpers/schema-types.ts
+++ b/packages/activerecord/src/test-helpers/schema-types.ts
@@ -99,6 +99,18 @@ export interface IndexSpec {
   adapters?: readonly string[];
 }
 
+/**
+ * A table-level foreign key, mirroring Rails' `t.foreign_key :to_table,
+ * column:, primary_key:, name:`. Emitted inline in the CREATE TABLE — the only
+ * form SQLite accepts (it has no `ALTER TABLE … ADD CONSTRAINT`).
+ */
+export interface ForeignKeySpec {
+  toTable: string;
+  column: string;
+  primaryKey?: string;
+  name?: string;
+}
+
 export interface WrappedTableSchema {
   columns: Record<string, ColumnSpec>;
   /**
@@ -119,12 +131,17 @@ export interface WrappedTableSchema {
    * (mirrors Rails' `t.index`). Names default to Rails' `index_<table>_on_<cols>`.
    */
   indexes?: IndexSpec[];
+  /**
+   * Table-level foreign keys, emitted inline in the CREATE TABLE (mirrors
+   * Rails' `t.foreign_key`).
+   */
+  foreignKeys?: ForeignKeySpec[];
 }
 export type TableSchema = Record<string, ColumnSpec> | WrappedTableSchema;
 export type Schema = Record<string, TableSchema>;
 
 /** @internal */
-const WRAPPER_KEYS = new Set(["columns", "primaryKey", "indexes"]);
+const WRAPPER_KEYS = new Set(["columns", "primaryKey", "indexes", "foreignKeys"]);
 
 /** @internal */
 export function isWrappedSchema(table: TableSchema): table is WrappedTableSchema {
@@ -139,16 +156,17 @@ export function isWrappedSchema(table: TableSchema): table is WrappedTableSchema
   //
   // Rule:
   //   1. `columns` is present and an object map.
-  //   2. At least one of `primaryKey` / `indexes` is present (the
-  //      disambiguator from the legacy shape).
-  //   3. Any present `primaryKey` / `indexes` is wrapper-shaped.
+  //   2. At least one of `primaryKey` / `indexes` / `foreignKeys` is present
+  //      (the disambiguator from the legacy shape).
+  //   3. Any present `primaryKey` / `indexes` / `foreignKeys` is wrapper-shaped.
   //   4. No other top-level keys.
   if (!table || typeof table !== "object") return false;
   const candidate = (table as { columns?: unknown }).columns;
   if (!candidate || typeof candidate !== "object") return false;
   const hasPk = "primaryKey" in table;
   const hasIndexes = "indexes" in table;
-  if (!hasPk && !hasIndexes) return false;
+  const hasForeignKeys = "foreignKeys" in table;
+  if (!hasPk && !hasIndexes && !hasForeignKeys) return false;
   if (hasPk) {
     const pk = (table as { primaryKey?: unknown }).primaryKey;
     // Validate primaryKey is the wrapper-shaped value; otherwise this is a
@@ -157,6 +175,9 @@ export function isWrappedSchema(table: TableSchema): table is WrappedTableSchema
     if (Array.isArray(pk) && !pk.every((v) => typeof v === "string")) return false;
   }
   if (hasIndexes && !Array.isArray((table as { indexes?: unknown }).indexes)) return false;
+  if (hasForeignKeys && !Array.isArray((table as { foreignKeys?: unknown }).foreignKeys)) {
+    return false;
+  }
   for (const key of Object.keys(table)) {
     if (!WRAPPER_KEYS.has(key)) return false;
   }

--- a/packages/activerecord/src/test-helpers/test-schema.ts
+++ b/packages/activerecord/src/test-helpers/test-schema.ts
@@ -11,7 +11,6 @@
 // express (deliberately dropped during the port — fixture-row tests
 // don't depend on them):
 //   - secondary indexes / expression indexes
-//   - foreign-key constraints (add_foreign_key)
 //   - identifier-length stress columns (t.string "a" * max_identifier_length)
 //   - polymorphic helper (modeled directly as `<name>_id` + `<name>_type`)
 
@@ -1652,9 +1651,7 @@ export const TEST_SCHEMA: Schema = {
   records: {},
 
   // Rails declares `primary_key: "pk_id"` — DB-level PK on a non-`id`
-  // column; no synthetic `id`. The foreign_key constraint Rails declares
-  // on fk_test_has_fk is dropped (defineSchema can't express FKs; see
-  // header note).
+  // column; no synthetic `id`.
   fk_test_has_pk: {
     columns: {
       pk_id: { type: "integer", null: false },
@@ -1662,7 +1659,12 @@ export const TEST_SCHEMA: Schema = {
     primaryKey: ["pk_id"],
   },
   fk_test_has_fk: {
-    fk_id: { type: "integer", null: false },
+    columns: {
+      fk_id: { type: "integer", null: false },
+    },
+    foreignKeys: [
+      { toTable: "fk_test_has_pk", column: "fk_id", primaryKey: "pk_id", name: "fk_name" },
+    ],
   },
 
   fk_object_to_point_tos: {},


### PR DESCRIPTION
## What

Both schema sources can now express schema.rb's `t.foreign_key`, and
`fk_test_has_fk` declares its real FK (`fk_id` -> `fk_test_has_pk.pk_id`,
named `fk_name`) canonically:

- `canonical-schema.ts`: `TableBuilder#foreignKey` forwards to
  `TableDefinition#foreignKey`, so the constraint is emitted inline in the
  CREATE TABLE — the only form SQLite accepts.
- `schema-types.ts` / `schema-file-generator.ts`: a `foreignKeys` entry on the
  wrapped table shape, emitted as `t.foreignKey(...)` inside the create-table
  block. Both sources are needed: the per-worker rebuild regenerates tables
  from `TEST_SCHEMA`, which otherwise strips the constraint the template
  carries.
- The generated schema file drops FK-carrying tables up front on PG/MySQL —
  those adapters recreate each table in declaration order with
  `force: "cascade"`, and a live child FK blocks the parent's drop.
- `rebuildCanonicalTables` rebuilds a table's FK-referencing children along
  with it (edges replayed from the canonical declarations, not hand-listed):
  repairing only the target would otherwise hit MySQL's refusal to drop a
  table a live foreign key points at.

`AdapterForeignKeyTest` drops its raw-DDL `ALTER TABLE … ADD/DROP CONSTRAINT`
workaround and the sqlite drop/recreate + `rebuildCanonicalTables` teardown —
the RFC 0070 drift source this story chain is eliminating. No test renamed.

## Verification

`adapter.test.ts` on all three adapters (including a second MySQL run, to
exercise the schema load against an already-populated shared DB), plus the
`schema-file-generator`, `canonical-schema`, `schema-dumper`, and `migration`
suites. `test:compare` delta 0.

Closes-story: canonical-schema-express-foreign-keys
