### PR TITLE
fix(tasks): surface markdownlint failures instead of a git commit stack trace

### DIFF
--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -42,6 +42,7 @@ import {
   prLocDelta,
   uncheckedCheckboxes,
   commitAndPush,
+  extractMarkdownlintViolations,
   depCyclePath,
   editFrontmatter,
   finalize,
@@ -1427,6 +1428,73 @@ describe("commitAndPush (git mutation flow)", () => {
     expect(seen).not.toContain("push");
     expect(seen.filter((l) => l === "reset").length).toBe(1);
     expect(seen.filter((l) => l === "clean").length).toBe(1);
+  });
+
+  // Verbatim markdownlint-cli2 output for a `--body-file` body that wraps a PR
+  // reference to column 0 (`#4869 ...` → MD018) and pastes an unlabelled fence
+  // (MD040) — the two rules a `tasks new` body actually tripped. The chatter
+  // interleaved around it is what used to bury the real cause.
+  const MARKDOWNLINT_STDERR = [
+    "markdownlint-cli2 v0.18.1 (markdownlint v0.38.0)",
+    "Finding: rfcs/0025-x/stories/s.md !node_modules/**",
+    "Linting: 1 file(s)",
+    'rfcs/0025-x/stories/s.md:31:1 MD018/no-missing-space-atx No space after hash on atx style heading [Context: "#4869 (which fixed"]',
+    'rfcs/0025-x/stories/s.md:44 MD040/fenced-code-language Fenced code blocks should have a language specified [Context: "```"]',
+    "Summary: 2 error(s)",
+  ].join("\n");
+
+  it("extracts only the rule violations from markdownlint's chatter", () => {
+    expect(extractMarkdownlintViolations(MARKDOWNLINT_STDERR)).toEqual([
+      'rfcs/0025-x/stories/s.md:31:1 MD018/no-missing-space-atx No space after hash on atx style heading [Context: "#4869 (which fixed"]',
+      'rfcs/0025-x/stories/s.md:44 MD040/fenced-code-language Fenced code blocks should have a language specified [Context: "```"]',
+    ]);
+  });
+
+  it("exits with the markdownlint violations, not a git commit stack trace", () => {
+    const { seen, exit, lockDir } = setup();
+    const errors: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((...a: unknown[]) => {
+      errors.push(a.map(String).join(" "));
+    });
+    const NEW_FILE = "/some/new-story.md";
+    const worktree = new Set<string>();
+    execFileSyncMock.mockImplementation((_file, args) => {
+      const label = args && args.length >= 3 ? args[2] : "";
+      if (label === "symbolic-ref") return "main" as never;
+      seen.push(label);
+      if (label === "diff-tree") return "story.md" as never;
+      if (label === "clean") worktree.delete(args[args.length - 1]);
+      // The pre-commit hook's markdownlint gate rejects the body; git surfaces
+      // the hook's output on stderr and exits non-zero.
+      if (label === "commit") throw pushError(MARKDOWNLINT_STDERR);
+      return "" as never;
+    });
+    expect(
+      () =>
+        commitAndPush({
+          message: "new: 0025-x/s",
+          fileToStage: NEW_FILE,
+          createdPath: NEW_FILE,
+          mutator: () => worktree.add(NEW_FILE),
+          raceMessage: "lost the race, retry",
+          raceExitCode: 99,
+        }),
+      // Non-zero, and NOT the race exit code — a retry can never succeed here.
+    ).toThrow("exit 1");
+    expect(exit).toHaveBeenCalledWith(1);
+    // The last thing printed is the actionable `file:line rule` diagnostic,
+    // and it explicitly disclaims the transient push race.
+    const last = errors[errors.length - 1];
+    expect(last).toContain("MD018/no-missing-space-atx");
+    expect(last).toContain("rfcs/0025-x/stories/s.md:31:1");
+    expect(last).toContain("MD040/fenced-code-language");
+    expect(last).toMatch(/NOT the transient push race/);
+    expect(last).not.toContain("lost the race, retry");
+    // Nothing pushed, nothing left behind: the created file is rolled back and
+    // the lock released.
+    expect(seen).not.toContain("push");
+    expect(worktree.size).toBe(0);
+    expect(existsSync(join(lockDir, "tasks-cli.lock"))).toBe(false);
   });
 
   it("surfaces the underlying error (with stack) when a mutator throws, never a bare exit", () => {

--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -1430,10 +1430,6 @@ describe("commitAndPush (git mutation flow)", () => {
     expect(seen.filter((l) => l === "clean").length).toBe(1);
   });
 
-  // Verbatim markdownlint-cli2 output for a `--body-file` body that wraps a PR
-  // reference to column 0 (`#4869 ...` → MD018) and pastes an unlabelled fence
-  // (MD040) — the two rules a `tasks new` body actually tripped. The chatter
-  // interleaved around it is what used to bury the real cause.
   const MARKDOWNLINT_STDERR = [
     "markdownlint-cli2 v0.18.1 (markdownlint v0.38.0)",
     "Finding: rfcs/0025-x/stories/s.md !node_modules/**",
@@ -1464,37 +1460,55 @@ describe("commitAndPush (git mutation flow)", () => {
       seen.push(label);
       if (label === "diff-tree") return "story.md" as never;
       if (label === "clean") worktree.delete(args[args.length - 1]);
-      // The pre-commit hook's markdownlint gate rejects the body; git surfaces
-      // the hook's output on stderr and exits non-zero.
       if (label === "commit") throw pushError(MARKDOWNLINT_STDERR);
       return "" as never;
     });
-    expect(
-      () =>
-        commitAndPush({
-          message: "new: 0025-x/s",
-          fileToStage: NEW_FILE,
-          createdPath: NEW_FILE,
-          mutator: () => worktree.add(NEW_FILE),
-          raceMessage: "lost the race, retry",
-          raceExitCode: 99,
-        }),
-      // Non-zero, and NOT the race exit code — a retry can never succeed here.
+    expect(() =>
+      commitAndPush({
+        message: "new: 0025-x/s",
+        fileToStage: NEW_FILE,
+        createdPath: NEW_FILE,
+        mutator: () => worktree.add(NEW_FILE),
+        raceMessage: "lost the race, retry",
+        raceExitCode: 99,
+      }),
     ).toThrow("exit 1");
     expect(exit).toHaveBeenCalledWith(1);
-    // The last thing printed is the actionable `file:line rule` diagnostic,
-    // and it explicitly disclaims the transient push race.
     const last = errors[errors.length - 1];
     expect(last).toContain("MD018/no-missing-space-atx");
     expect(last).toContain("rfcs/0025-x/stories/s.md:31:1");
     expect(last).toContain("MD040/fenced-code-language");
     expect(last).toMatch(/NOT the transient push race/);
     expect(last).not.toContain("lost the race, retry");
-    // Nothing pushed, nothing left behind: the created file is rolled back and
-    // the lock released.
     expect(seen).not.toContain("push");
     expect(worktree.size).toBe(0);
     expect(existsSync(join(lockDir, "tasks-cli.lock"))).toBe(false);
+  });
+
+  it("re-raises a commit failure that carries no markdownlint violations", () => {
+    const { seen } = setup();
+    execFileSyncMock.mockImplementation((_file, args) => {
+      const label = args && args.length >= 3 ? args[2] : "";
+      if (label === "symbolic-ref") return "main" as never;
+      seen.push(label);
+      if (label === "diff-tree") return "story.md" as never;
+      if (label === "commit") throw pushError("validate: story frontmatter is invalid");
+      return "" as never;
+    });
+    let thrown: unknown;
+    try {
+      commitAndPush({
+        message: "test",
+        fileToStage: "/some/file.md",
+        mutator: () => {},
+        raceMessage: "no",
+        raceExitCode: 99,
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect((thrown as { stderr?: string })?.stderr).toContain("story frontmatter is invalid");
+    expect(seen).not.toContain("push");
   });
 
   it("surfaces the underlying error (with stack) when a mutator throws, never a bare exit", () => {

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -366,11 +366,22 @@ function inGitTasks(): void {
 // the same repo but on a feature branch.
 function git(
   args: string[],
-  opts: { silent?: boolean; cwd?: string; env?: NodeJS.ProcessEnv } = {},
+  opts: {
+    silent?: boolean;
+    cwd?: string;
+    env?: NodeJS.ProcessEnv;
+    // Pipe stderr while leaving stdin inherited. `silent` also pipes stderr but
+    // detaches stdin, which breaks commands that may prompt (credentials).
+    // Used for `commit`, whose pre-commit hook writes the markdownlint
+    // diagnostics we need to capture and re-surface on failure.
+    captureStderr?: boolean;
+  } = {},
 ): string {
   return execFileSync("git", ["-C", opts.cwd ?? TASKS_DIR, ...args], {
     encoding: "utf8",
-    stdio: opts.silent ? ["ignore", "pipe", "pipe"] : ["inherit", "pipe", "inherit"],
+    stdio: opts.silent
+      ? ["ignore", "pipe", "pipe"]
+      : ["inherit", "pipe", opts.captureStderr ? "pipe" : "inherit"],
     ...(opts.env ? { env: { ...process.env, ...opts.env } } : {}),
   }).trim();
 }
@@ -892,6 +903,20 @@ export class MutatorEarlyExit extends Error {
   }
 }
 
+// markdownlint-cli2 (run by the tasks repo's pre-commit hook) prints one line
+// per violation on stderr:
+//   <path>:<line>[:<col>] MD###/<rule-name> <description> [Context: "..."]
+// Its progress chatter ("Finding:", "Linting:", "Summary:") goes to stdout, so
+// matching this shape on stderr picks out exactly the actionable diagnostics.
+const MARKDOWNLINT_VIOLATION = /^\S+:\d+(?::\d+)?\s+MD\d{3}\/\S+\s+\S/;
+
+export function extractMarkdownlintViolations(stderr: string): string[] {
+  return stderr
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => MARKDOWNLINT_VIOLATION.test(l));
+}
+
 // Pull-rebase → run mutator → commit → push, retrying once on
 // non-fast-forward. `mutator` is run inside each attempt so a rebased
 // index file is re-read between tries. Throws (and asks caller to
@@ -1047,7 +1072,11 @@ export function commitAndPush(opts: {
         // below (and, before the pre-read sync took the lock, occasionally
         // pushing a clobbered EMPTY commit before we could reset it away). The
         // CLI owns its own push; silence the hook's.
-        git(["commit", "-q", "-m", opts.message], { cwd, env: { RFCS_NO_AUTOPUSH: "1" } });
+        git(["commit", "-q", "-m", opts.message], {
+          cwd,
+          captureStderr: true,
+          env: { RFCS_NO_AUTOPUSH: "1" },
+        });
       } catch (e) {
         // Atomic rollback: a throw between the file write and the commit (a
         // prettier crash in formatFiles, a failed `git add`/`commit`, etc.)
@@ -1066,6 +1095,31 @@ export function commitAndPush(opts: {
           earlyExit = e;
           break;
         }
+        // A pre-commit markdownlint rejection is DETERMINISTIC — the body text
+        // is invalid, and retrying (the natural response to the `git commit`
+        // stack trace this used to surface, which reads exactly like the
+        // transient push-contention race) can never succeed. Print the offending
+        // `file:line rule` lines as the last thing on the way out, and exit via
+        // the early-exit sentinel so the lock's `finally` still runs and the
+        // top-level handler doesn't append a git stack trace after them. The
+        // rollback above already removed the staged/written file, so no partial
+        // commit is left behind.
+        const violations = extractMarkdownlintViolations(
+          String((e as { stderr?: unknown }).stderr ?? ""),
+        );
+        if (violations.length > 0) {
+          console.error(
+            `error: markdownlint rejected the commit — the markdown body is invalid.\n` +
+              `  This is NOT the transient push race: retrying will fail identically.\n` +
+              `  Nothing was committed or pushed; fix the body below and re-run.\n` +
+              violations.map((v) => `  ${v}`).join("\n"),
+          );
+          earlyExit = new MutatorEarlyExit(1);
+          break;
+        }
+        // Any other commit failure (a validate.mjs rejection, a prettier crash,
+        // a genuine git error) still carries the piped hook output on `.stderr`,
+        // which the top-level handler prints before the stack.
         throw e;
       }
       // Never push an empty commit. A concurrent `reset --hard` in this shared

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -370,10 +370,6 @@ function git(
     silent?: boolean;
     cwd?: string;
     env?: NodeJS.ProcessEnv;
-    // Pipe stderr while leaving stdin inherited. `silent` also pipes stderr but
-    // detaches stdin, which breaks commands that may prompt (credentials).
-    // Used for `commit`, whose pre-commit hook writes the markdownlint
-    // diagnostics we need to capture and re-surface on failure.
     captureStderr?: boolean;
   } = {},
 ): string {
@@ -903,12 +899,7 @@ export class MutatorEarlyExit extends Error {
   }
 }
 
-// markdownlint-cli2 (run by the tasks repo's pre-commit hook) prints one line
-// per violation on stderr:
-//   <path>:<line>[:<col>] MD###/<rule-name> <description> [Context: "..."]
-// Its progress chatter ("Finding:", "Linting:", "Summary:") goes to stdout, so
-// matching this shape on stderr picks out exactly the actionable diagnostics.
-const MARKDOWNLINT_VIOLATION = /^\S+:\d+(?::\d+)?\s+MD\d{3}\/\S+\s+\S/;
+const MARKDOWNLINT_VIOLATION = /^.+?:\d+(?::\d+)?\s+MD\d{3}\/\S+\s+\S/;
 
 export function extractMarkdownlintViolations(stderr: string): string[] {
   return stderr
@@ -1095,15 +1086,6 @@ export function commitAndPush(opts: {
           earlyExit = e;
           break;
         }
-        // A pre-commit markdownlint rejection is DETERMINISTIC — the body text
-        // is invalid, and retrying (the natural response to the `git commit`
-        // stack trace this used to surface, which reads exactly like the
-        // transient push-contention race) can never succeed. Print the offending
-        // `file:line rule` lines as the last thing on the way out, and exit via
-        // the early-exit sentinel so the lock's `finally` still runs and the
-        // top-level handler doesn't append a git stack trace after them. The
-        // rollback above already removed the staged/written file, so no partial
-        // commit is left behind.
         const violations = extractMarkdownlintViolations(
           String((e as { stderr?: unknown }).stderr ?? ""),
         );
@@ -1117,9 +1099,6 @@ export function commitAndPush(opts: {
           earlyExit = new MutatorEarlyExit(1);
           break;
         }
-        // Any other commit failure (a validate.mjs rejection, a prettier crash,
-        // a genuine git error) still carries the piped hook output on `.stderr`,
-        // which the top-level handler prints before the stack.
         throw e;
       }
       // Never push an empty commit. A concurrent `reset --hard` in this shared


### PR DESCRIPTION
`pnpm tasks new/edit --body-file` runs the story body through the tasks repo's
markdownlint pre-commit gate. When a rule fires, the CLI died with a Node stack
trace whose visible tail was `Error: Command failed: git -C .../tasks commit -q
-m ...` — which reads exactly like the transient push-contention race, so the
natural response (retry with backoff) never succeeds. The real diagnostic was
buried above under `built index` / `validated` / `Finding:` / `Linting:` noise.

## Change

- `git()` gains `captureStderr`, which pipes stderr while leaving stdin
  inherited (`silent` also detaches stdin). `commit` uses it, so the pre-commit
  hook's output is captured instead of streaming into the noise.
- `extractMarkdownlintViolations()` picks the `file:line[:col] MD###/rule …`
  lines out of markdownlint-cli2's chatter.
- On a commit failure carrying violations, `commitAndPush` prints them as the
  last thing on the way out, explicitly disclaiming the push race, and exits 1
  via `MutatorEarlyExit` — so the lock's `finally` still releases and the
  top-level handler doesn't append a git stack trace after the message. The
  existing rollback already ran, so no partial commit is left behind.
- Any other commit failure re-raises unchanged, with the hook output still on
  `.stderr` for the top-level handler to print.

Note: because `commit`'s stderr is now piped, the hook's per-commit chatter
(`validated N RFCs`, `Finding:`, `Linting:`, `Summary: 0 error(s)`) no longer
prints on a *successful* mutation. That chatter is the noise this story is
about; failures are unaffected — their output is surfaced deliberately.

Before (visible tail):

```text
error: tasks CLI command failed
Error: Command failed: git -C .../tasks commit -q -m new: <rfc>/<slug>
    at genericNodeError (node:internal/errors:985:15)
```

After (verified end-to-end against a scratch clone of the tasks repo, with a
body that wraps a PR ref to column 0 and pastes an unlabelled fence):

```text
error: markdownlint rejected the commit — the markdown body is invalid.
  This is NOT the transient push race: retrying will fail identically.
  Nothing was committed or pushed; fix the body below and re-run.
  rfcs/0025-…/stories/smoke-bad-body-xyz.md:19:1 MD018/no-missing-space-atx No space after hash on atx style heading [Context: "#4869 (which fixed it)."]
  rfcs/0025-…/stories/smoke-bad-body-xyz.md:21 MD040/fenced-code-language Fenced code blocks should have a language specified [Context: "```"]
```

Exit 1 (not the race exit code), working tree left clean, nothing pushed.

## Tests

Three new cases in `scripts/tasks/cli.test.ts`, driven by verbatim
markdownlint-cli2 output for the two rules a real `--body-file` body tripped
(MD018 wrap-to-column-0 PR ref, MD040 unlabelled fence):

- the extractor keeps only the violations, dropping the surrounding chatter;
- through `commitAndPush`: exit 1 rather than the race code, the violations as
  the last output, the race message absent, no `push`, the created file rolled
  back, the lock released;
- a commit failure with no violations still re-raises with its `.stderr`
  intact and never pushes — the guard on the new stderr piping.

252 tests pass.

Closes-story: tasks-new-surfaces-markdownlint-failure
