### PR TITLE
feat(tasks): serve read commands from the origin/main tree

### DIFF
--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -87,6 +87,7 @@ import {
   dirtyWorktreeLines,
   syncWorktreeToOrigin,
   buildIndexFromOriginMain,
+  readIndexedFile,
   claimAgeHours,
   isStaleClaim,
   staleClaims,
@@ -3342,9 +3343,11 @@ describe("dirtyWorktreeLines", () => {
   });
 });
 
+const emptyIdx: Index = { generated_at: "2026-01-01", rfcs: [], stories: [] };
+
 describe("buildIndexFromOriginMain (read path serves the origin/main tree)", () => {
   const SHA = "a".repeat(40);
-  const emptyIndex = { generated_at: "2026-01-01", rfcs: [], stories: [] };
+  const emptyIndex = emptyIdx;
 
   function setup(opts: { onFetch?: () => void } = {}) {
     const gitDir = mkdtempSync(join(tmpdir(), "trails-read-index-"));
@@ -3387,15 +3390,21 @@ describe("buildIndexFromOriginMain (read path serves the origin/main tree)", () 
 
   it("exports the tree, builds the index there, and caches it by sha", () => {
     const { gitDir, seen } = setup();
-    const stale = join(gitDir, "trails-tasks-read-index", `${"b".repeat(40)}.json`);
-    mkdirSync(join(gitDir, "trails-tasks-read-index"), { recursive: true });
+    const cacheDir = join(gitDir, "trails-tasks-read-index");
+    mkdirSync(cacheDir, { recursive: true });
+    const stale = join(cacheDir, `${"b".repeat(40)}.json`);
+    const otherAgentInFlight = join(cacheDir, `${"c".repeat(40)}.999.staging`);
     writeFileSync(stale, "{}");
+    writeFileSync(otherAgentInFlight, "{}");
     const got = buildIndexFromOriginMain();
     expect(got?.index.generated_at).toBe("2026-01-01");
     expect(seen).toEqual(["fetch", "rev-parse", "rev-parse", "archive", "tar", "build-index"]);
     // Cached for the next reader, and the superseded sha is pruned.
     expect(existsSync(join(gitDir, "trails-tasks-read-index", `${SHA}.json`))).toBe(true);
     expect(existsSync(stale)).toBe(false);
+    // Another agent's half-written entry is not a superseded index — pruning it
+    // would break its rename.
+    expect(existsSync(otherAgentInFlight)).toBe(true);
   });
 
   it("returns null when the fetch fails so the caller can fall back", () => {
@@ -3405,6 +3414,34 @@ describe("buildIndexFromOriginMain (read path serves the origin/main tree)", () 
       },
     });
     expect(buildIndexFromOriginMain()).toBeNull();
+  });
+});
+
+describe("readIndexedFile (body comes from the index's own source)", () => {
+  it("reads the body out of the origin/main commit the index was built from", () => {
+    const sha = "c".repeat(40);
+    const seen: string[][] = [];
+    execFileSyncMock.mockImplementation(((_file: string, args: string[]) => {
+      seen.push(args);
+      return "---\ntitle: x\n---\n" as never;
+    }) as never);
+    expect(readIndexedFile({ index: emptyIdx, sha }, "rfcs/0025-x/stories/y.md")).toContain(
+      "title: x",
+    );
+    expect(seen[0].slice(2)).toEqual(["show", `${sha}:rfcs/0025-x/stories/y.md`]);
+  });
+
+  it("returns null when the path is absent from that commit", () => {
+    execFileSyncMock.mockImplementation((() => {
+      throw new Error("path does not exist");
+    }) as never);
+    expect(readIndexedFile({ index: emptyIdx, sha: "d".repeat(40) }, "gone.md")).toBeNull();
+  });
+
+  it("falls back to the working tree when the index came from there", () => {
+    const dir = mkdtempSync(join(tmpdir(), "trails-read-body-"));
+    expect(readIndexedFile({ index: emptyIdx, sha: null }, join(dir, "missing.md"))).toBeNull();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
   });
 });
 

--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -86,6 +86,7 @@ import {
   TASKS_DIR,
   dirtyWorktreeLines,
   syncWorktreeToOrigin,
+  buildIndexFromOriginMain,
   claimAgeHours,
   isStaleClaim,
   staleClaims,
@@ -3338,6 +3339,72 @@ describe("dirtyWorktreeLines", () => {
 
   it("treats an empty porcelain as clean", () => {
     expect(dirtyWorktreeLines("")).toEqual([]);
+  });
+});
+
+describe("buildIndexFromOriginMain (read path serves the origin/main tree)", () => {
+  const SHA = "a".repeat(40);
+  const emptyIndex = { generated_at: "2026-01-01", rfcs: [], stories: [] };
+
+  function setup(opts: { onFetch?: () => void } = {}) {
+    const gitDir = mkdtempSync(join(tmpdir(), "trails-read-index-"));
+    const seen: string[] = [];
+    execFileSyncMock.mockImplementation(((file: string, args: string[], o: { cwd?: string }) => {
+      if (file === "git") {
+        const label = args[2];
+        seen.push(label);
+        if (label === "fetch") opts.onFetch?.();
+        if (label === "rev-parse") return (args[3] === "origin/main" ? SHA : gitDir) as never;
+        return "" as never;
+      }
+      seen.push(file === "tar" ? "tar" : "build-index");
+      // Stand in for build-index.mjs: it writes index.json into the exported tree.
+      if (file !== "tar" && o?.cwd)
+        writeFileSync(join(o.cwd, "index.json"), JSON.stringify(emptyIndex));
+      return "" as never;
+    }) as never);
+    return { gitDir, seen };
+  }
+
+  it("never resets the working tree", () => {
+    const { seen } = setup();
+    buildIndexFromOriginMain();
+    expect(seen).not.toContain("reset");
+    expect(seen).not.toContain("status");
+  });
+
+  it("serves a cached index for the current origin/main sha without re-exporting", () => {
+    const { gitDir, seen } = setup();
+    const cacheDir = join(gitDir, "trails-tasks-read-index");
+    mkdirSync(cacheDir, { recursive: true });
+    const cached = { ...emptyIndex, generated_at: "cached" };
+    writeFileSync(join(cacheDir, `${SHA}.json`), JSON.stringify(cached));
+    const got = buildIndexFromOriginMain();
+    expect(got?.sha).toBe(SHA);
+    expect(got?.index.generated_at).toBe("cached");
+    expect(seen).toEqual(["fetch", "rev-parse", "rev-parse"]);
+  });
+
+  it("exports the tree, builds the index there, and caches it by sha", () => {
+    const { gitDir, seen } = setup();
+    const stale = join(gitDir, "trails-tasks-read-index", `${"b".repeat(40)}.json`);
+    mkdirSync(join(gitDir, "trails-tasks-read-index"), { recursive: true });
+    writeFileSync(stale, "{}");
+    const got = buildIndexFromOriginMain();
+    expect(got?.index.generated_at).toBe("2026-01-01");
+    expect(seen).toEqual(["fetch", "rev-parse", "rev-parse", "archive", "tar", "build-index"]);
+    // Cached for the next reader, and the superseded sha is pruned.
+    expect(existsSync(join(gitDir, "trails-tasks-read-index", `${SHA}.json`))).toBe(true);
+    expect(existsSync(stale)).toBe(false);
+  });
+
+  it("returns null when the fetch fails so the caller can fall back", () => {
+    setup({
+      onFetch: () => {
+        throw new Error("offline");
+      },
+    });
+    expect(buildIndexFromOriginMain()).toBeNull();
   });
 });
 

--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -3349,15 +3349,18 @@ describe("buildIndexFromOriginMain (read path serves the origin/main tree)", () 
   const SHA = "a".repeat(40);
   const emptyIndex = emptyIdx;
 
+  // The cache lives in the shared git common dir — the same seam the lock uses.
+  afterEach(() => __setLockDirForTest(null));
   function setup(opts: { onFetch?: () => void } = {}) {
     const gitDir = mkdtempSync(join(tmpdir(), "trails-read-index-"));
+    __setLockDirForTest(gitDir);
     const seen: string[] = [];
     execFileSyncMock.mockImplementation(((file: string, args: string[], o: { cwd?: string }) => {
       if (file === "git") {
         const label = args[2];
         seen.push(label);
         if (label === "fetch") opts.onFetch?.();
-        if (label === "rev-parse") return (args[3] === "origin/main" ? SHA : gitDir) as never;
+        if (label === "rev-parse") return SHA as never;
         return "" as never;
       }
       seen.push(file === "tar" ? "tar" : "build-index");
@@ -3385,7 +3388,7 @@ describe("buildIndexFromOriginMain (read path serves the origin/main tree)", () 
     const got = buildIndexFromOriginMain();
     expect(got?.sha).toBe(SHA);
     expect(got?.index.generated_at).toBe("cached");
-    expect(seen).toEqual(["fetch", "rev-parse", "rev-parse"]);
+    expect(seen).toEqual(["fetch", "rev-parse"]);
   });
 
   it("exports the tree, builds the index there, and caches it by sha", () => {
@@ -3398,7 +3401,7 @@ describe("buildIndexFromOriginMain (read path serves the origin/main tree)", () 
     writeFileSync(otherAgentInFlight, "{}");
     const got = buildIndexFromOriginMain();
     expect(got?.index.generated_at).toBe("2026-01-01");
-    expect(seen).toEqual(["fetch", "rev-parse", "rev-parse", "archive", "tar", "build-index"]);
+    expect(seen).toEqual(["fetch", "rev-parse", "archive", "tar", "build-index"]);
     // Cached for the next reader, and the superseded sha is pruned.
     expect(existsSync(join(gitDir, "trails-tasks-read-index", `${SHA}.json`))).toBe(true);
     expect(existsSync(stale)).toBe(false);

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -217,7 +217,7 @@ export function buildIndexFromOriginMain(cwd?: string): { index: Index; sha: str
   } catch {
     return null;
   }
-  if (!/^[0-9a-f]{40}$/.test(sha) || !gitDir) return null;
+  if (!/^[0-9a-f]{40}(?:[0-9a-f]{24})?$/.test(sha) || !gitDir) return null;
   const cacheDir = join(gitDir, READ_INDEX_CACHE_DIRNAME);
   const entryName = `${sha}.json`;
   const cached = join(cacheDir, entryName);

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -7,10 +7,12 @@
 // retry pulls, re-applies the edit, and pushes again; if it fails a
 // second time the caller is told to pick another story.
 //
-// Read paths consume $TASKS_DIR/index.json, a gitignored cache rebuilt on
-// demand: if the file is missing or any story `.md` is newer than
-// index.json, this script invokes the tasks-side build-index.mjs to
-// regenerate it.
+// Read paths serve an index built from the **origin/main tree** (fetch +
+// `git archive` into a temp dir + build-index there, cached by commit sha under
+// the git common dir). They never touch the working tree and take no lock. The
+// working-tree index — $TASKS_DIR/index.json, a gitignored cache rebuilt on
+// demand when missing or older than any story `.md` — still backs mutations and
+// the offline read fallback.
 //
 // Implementation note: RFC 0001 originally specified SQLite for the
 // index. JSON was sufficient for the current scale and avoids a binary
@@ -23,8 +25,10 @@ import {
   mkdtempSync,
   readFileSync,
   readdirSync,
+  renameSync,
   rmSync,
   statSync,
+  symlinkSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -147,6 +151,144 @@ export function loadIndex(): Index {
     });
   }
   return JSON.parse(readFileSync(indexPath, "utf8")) as Index;
+}
+
+// ──────────────────── read path (origin/main tree) ────────────────────
+
+// Reads used to hard-reset the shared canonical checkout to origin/main under
+// the tasks-CLI lock, so every `ready`/`list` contended with live mutations
+// (20s wait, then a stale index and a "lock is busy" warning) and every read
+// mutated a working tree other agents were writing in. Nothing about serving a
+// fresh index requires the working tree: the index is derived purely from the
+// tree of the origin/main commit. Export that tree to a temp dir, build the
+// index there, and cache the result by commit sha under the git *common dir*
+// (never the working tree, so it can't dirty `git status` and no lock is
+// needed). The shared cache means the export runs once per new origin/main
+// commit across all agents; every other read is a fetch + a JSON parse.
+const READ_INDEX_CACHE_DIRNAME = "trails-tasks-read-index";
+
+// Sha the currently-served read index came from, or null when it came from the
+// working tree. `show` renders a story body, which must be read from the same
+// source as the index that pointed at it.
+let readIndexOriginSha: string | null = null;
+
+// Keep only the entry we just wrote: older shas are superseded the moment
+// origin/main moves, and this dir lives inside the shared .git.
+function pruneReadIndexCache(cacheDir: string, keep: string): void {
+  let names: string[];
+  try {
+    names = readdirSync(cacheDir);
+  } catch {
+    return;
+  }
+  for (const name of names) {
+    if (name === keep) continue;
+    try {
+      unlinkSync(join(cacheDir, name));
+    } catch {
+      /* concurrent prune by another agent — nothing to do */
+    }
+  }
+}
+
+// Build (or serve from cache) the index for origin/main without touching the
+// working tree. Returns null when anything in the pipeline is unavailable —
+// offline, no origin/main, no `tar` — so the caller can fall back.
+export function buildIndexFromOriginMain(cwd?: string): { index: Index; sha: string } | null {
+  let sha: string;
+  let gitDir: string;
+  try {
+    git(["fetch", "--quiet", "origin", "main"], { silent: true, cwd });
+    sha = git(["rev-parse", "origin/main"], { silent: true, cwd });
+    // The COMMON dir, not `--absolute-git-dir`: per-worktree tasks checkouts
+    // each have their own git dir but share the common one, so the sha-keyed
+    // cache is built once for all of them.
+    gitDir = git(["rev-parse", "--path-format=absolute", "--git-common-dir"], {
+      silent: true,
+      cwd,
+    });
+  } catch {
+    return null;
+  }
+  if (!/^[0-9a-f]{40}$/.test(sha) || !gitDir) return null;
+  const cacheDir = join(gitDir, READ_INDEX_CACHE_DIRNAME);
+  const cached = join(cacheDir, `${sha}.json`);
+  if (existsSync(cached)) {
+    try {
+      return { index: JSON.parse(readFileSync(cached, "utf8")) as Index, sha };
+    } catch {
+      /* truncated by a crashed writer — rebuild below */
+    }
+  }
+  const scratch = mkdtempSync(join(tmpdir(), "trails-tasks-tree-"));
+  try {
+    const tarPath = join(scratch, "tree.tar");
+    const treeDir = join(scratch, "tree");
+    mkdirSync(treeDir, { recursive: true });
+    git(["archive", "--format=tar", "-o", tarPath, sha], { silent: true, cwd });
+    execFileSync("tar", ["-xf", tarPath, "-C", treeDir], { stdio: "ignore" });
+    // build-index.mjs imports js-yaml. The exported tree has no node_modules
+    // (they're not tracked), and ESM resolution walks up from the *script's*
+    // directory, so borrow the checkout's installed deps.
+    try {
+      symlinkSync(join(cwd ?? TASKS_DIR, "node_modules"), join(treeDir, "node_modules"));
+    } catch {
+      /* no install to borrow — build-index below fails and we fall back */
+    }
+    // Same `process.execPath` reasoning as loadIndex(). stdio "ignore": this is
+    // a read command, and build-index's progress chatter isn't its output.
+    execFileSync(process.execPath, ["scripts/build-index.mjs"], {
+      cwd: treeDir,
+      stdio: "ignore",
+    });
+    const built = readFileSync(join(treeDir, "index.json"), "utf8");
+    const index = JSON.parse(built) as Index;
+    try {
+      mkdirSync(cacheDir, { recursive: true });
+      // Write-then-rename: concurrent agents must never observe a half-written
+      // cache entry for a sha they'd then parse.
+      const staging = join(cacheDir, `${sha}.${Date.now()}.staging`);
+      writeFileSync(staging, built);
+      renameSync(staging, cached);
+      pruneReadIndexCache(cacheDir, `${sha}.json`);
+    } catch {
+      /* cache is an optimization — serving the built index still works */
+    }
+    return { index, sha };
+  } catch {
+    return null;
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+}
+
+// The read commands' index source. Prefers the origin/main tree (no lock, no
+// `reset --hard`); falls back to the old locked working-tree sync only when the
+// tree export is unavailable, so an offline agent still gets its index.
+export function loadIndexForRead(): Index {
+  readIndexOriginSha = null;
+  if (!TASKS_DIR_IS_SYMLINK) return loadIndex();
+  const fromOrigin = buildIndexFromOriginMain();
+  if (fromOrigin) {
+    readIndexOriginSha = fromOrigin.sha;
+    return fromOrigin.index;
+  }
+  syncFromOrigin();
+  return loadIndex();
+}
+
+// Read a story/RFC body from whichever source served the current read index.
+// Returns null when the path doesn't exist there.
+function readIndexedFile(filePath: string): string | null {
+  if (readIndexOriginSha) {
+    try {
+      return git(["show", `${readIndexOriginSha}:${filePath}`], { silent: true });
+    } catch {
+      return null;
+    }
+  }
+  const file = join(TASKS_DIR, filePath);
+  return existsSync(file) ? readFileSync(file, "utf8") : null;
 }
 
 export function isIndexStale(indexPath: string, tasksDir: string = TASKS_DIR): boolean {
@@ -455,11 +597,12 @@ function assertCleanWorktree(cwd: string | undefined): void {
   process.exit(1);
 }
 
-// Fetch + hard-reset the per-worktree tasks checkout to origin/main before
-// read commands. Keeps `ready`/`next-bundle`/`list`/`status` from serving
-// a stale index when the checkout hasn't been updated since spawn. Only
-// runs when using the per-worktree symlink (TASKS_DIR_IS_SYMLINK); the
-// canonical fallback and explicit $TASKS_DIR overrides are left alone.
+// Fetch + hard-reset the per-worktree tasks checkout to origin/main. This is
+// now only the FALLBACK freshness path for reads: loadIndexForRead() builds the
+// index straight from the origin/main tree and only lands here when that is
+// unavailable (offline, no `tar`). Only runs when using the per-worktree
+// symlink (TASKS_DIR_IS_SYMLINK); the canonical fallback and explicit
+// $TASKS_DIR overrides are left alone.
 function syncFromOrigin(): void {
   if (!TASKS_DIR_IS_SYMLINK) return;
   syncWorktreeToOrigin();
@@ -949,8 +1092,12 @@ export function commitAndPush(opts: {
     // we're about to make. Both callers of this path expect HEAD to be even
     // with origin/main *before* the mutation commit:
     //   - story flips on the shared canonical checkout (resolved via a
-    //     per-worktree `<cwd>/tasks` symlink): syncFromOrigin hard-resets it to
-    //     origin/main, so it sits exactly at origin/main.
+    //     per-worktree `<cwd>/tasks` symlink): the mutation loop's leading
+    //     `git pull --rebase` brings it up to origin/main before the mutation
+    //     commit, so HEAD sits at origin/main. (Reads no longer reset it there
+    //     — they build their index from the origin/main tree instead — but a
+    //     checkout that is merely BEHIND is 0 commits ahead, so this guard is
+    //     unaffected.)
     //   - `refine` in an agent's tasks worktree: the agent leaves *working-tree*
     //     edits (re-applied by the mutator), never commits, so its branch HEAD
     //     is still at origin/main.
@@ -2757,14 +2904,14 @@ function showStory(index: Index, id: string): void {
     console.error(`error: story "${id}" not found in index`);
     process.exit(1);
   }
-  const file = join(TASKS_DIR, entry.file_path);
-  if (!existsSync(file)) {
-    // Index is ahead of disk (e.g. a deleted story still in a stale index).
-    // Surface it cleanly rather than letting readFileSync throw a raw ENOENT.
+  const body = readIndexedFile(entry.file_path);
+  if (body === null) {
+    // Index is ahead of its source (e.g. a deleted story still in a stale
+    // index). Surface it cleanly rather than throwing a raw ENOENT.
     console.error(`error: story "${id}" is indexed at ${entry.file_path} but the file is missing`);
     process.exit(1);
   }
-  console.log(renderStoryView(entry.file_path, readFileSync(file, "utf8")));
+  console.log(renderStoryView(entry.file_path, body));
 }
 
 function statusCounts(index: Index, thresholdHours: number): void {
@@ -2875,17 +3022,15 @@ function main(): void {
 
   switch (cmd) {
     case "ready": {
-      syncFromOrigin();
-      const rows = ready(loadIndex(), { rfc: stringFlag(flags, "rfc") });
+      const rows = ready(loadIndexForRead(), { rfc: stringFlag(flags, "rfc") });
       flags.json ? console.log(JSON.stringify(rows, null, 2)) : fmt(rows);
       break;
     }
     case "next-bundle": {
-      syncFromOrigin();
       const maxLocRaw = stringFlag(flags, "max-loc") ?? "250";
       if (!/^\d+$/.test(maxLocRaw) || Number(maxLocRaw) <= 0) usage();
       const maxLoc = Number(maxLocRaw);
-      const rows = nextBundle(loadIndex(), {
+      const rows = nextBundle(loadIndexForRead(), {
         maxLoc,
         cluster: stringFlag(flags, "cluster"),
         rfc: stringFlag(flags, "rfc"),
@@ -2904,8 +3049,7 @@ function main(): void {
       break;
     }
     case "list": {
-      syncFromOrigin();
-      const idx = loadIndex();
+      const idx = loadIndexForRead();
       const rows = listFiltered(idx, {
         rfc: stringFlag(flags, "rfc"),
         status: stringFlag(flags, "status"),
@@ -2922,13 +3066,11 @@ function main(): void {
     case "show": {
       const id = pos[0];
       if (!id) usage();
-      syncFromOrigin();
-      showStory(loadIndex(), id);
+      showStory(loadIndexForRead(), id);
       break;
     }
     case "status":
-      syncFromOrigin();
-      statusCounts(loadIndex(), numberFlag(flags, "stale-hours") ?? DEFAULT_STALE_HOURS);
+      statusCounts(loadIndexForRead(), numberFlag(flags, "stale-hours") ?? DEFAULT_STALE_HOURS);
       break;
     case "claim": {
       const id = pos[0];

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -155,26 +155,42 @@ export function loadIndex(): Index {
 
 // ──────────────────── read path (origin/main tree) ────────────────────
 
-// Reads used to hard-reset the shared canonical checkout to origin/main under
-// the tasks-CLI lock, so every `ready`/`list` contended with live mutations
-// (20s wait, then a stale index and a "lock is busy" warning) and every read
-// mutated a working tree other agents were writing in. Nothing about serving a
-// fresh index requires the working tree: the index is derived purely from the
-// tree of the origin/main commit. Export that tree to a temp dir, build the
-// index there, and cache the result by commit sha under the git *common dir*
-// (never the working tree, so it can't dirty `git status` and no lock is
-// needed). The shared cache means the export runs once per new origin/main
-// commit across all agents; every other read is a fetch + a JSON parse.
 const READ_INDEX_CACHE_DIRNAME = "trails-tasks-read-index";
 
-// Sha the currently-served read index came from, or null when it came from the
-// working tree. `show` renders a story body, which must be read from the same
-// source as the index that pointed at it.
-let readIndexOriginSha: string | null = null;
+export interface ReadIndex {
+  index: Index;
+  sha: string | null;
+}
 
-// Keep only the entry we just wrote: older shas are superseded the moment
-// origin/main moves, and this dir lives inside the shared .git.
-function pruneReadIndexCache(cacheDir: string, keep: string): void {
+// Shared by every per-worktree tasks checkout, so one sha-keyed cache entry
+// serves them all (`--absolute-git-dir` would give each its own).
+function sharedGitDir(cwd?: string): string {
+  return git(["rev-parse", "--path-format=absolute", "--git-common-dir"], { silent: true, cwd });
+}
+
+// build-index.mjs imports js-yaml, and ESM resolution walks up from the
+// script's own directory; the exported tree has no node_modules of its own.
+function linkNodeModules(treeDir: string, from: string): void {
+  try {
+    symlinkSync(join(from, "node_modules"), join(treeDir, "node_modules"));
+  } catch {
+    /* no install to borrow — build-index fails below and we fall back */
+  }
+}
+
+function writeCacheEntryAtomically(cacheDir: string, name: string, contents: string): void {
+  try {
+    mkdirSync(cacheDir, { recursive: true });
+    const staging = join(cacheDir, `${name}.${process.pid}.staging`);
+    writeFileSync(staging, contents);
+    renameSync(staging, join(cacheDir, name));
+    pruneCacheEntriesExcept(cacheDir, name);
+  } catch {
+    /* the cache is an optimization — the built index is still good */
+  }
+}
+
+function pruneCacheEntriesExcept(cacheDir: string, keep: string): void {
   let names: string[];
   try {
     names = readdirSync(cacheDir);
@@ -182,37 +198,29 @@ function pruneReadIndexCache(cacheDir: string, keep: string): void {
     return;
   }
   for (const name of names) {
-    if (name === keep) continue;
+    if (name === keep || name.endsWith(".staging")) continue;
     try {
       unlinkSync(join(cacheDir, name));
     } catch {
-      /* concurrent prune by another agent — nothing to do */
+      /* pruned concurrently by another agent */
     }
   }
 }
 
-// Build (or serve from cache) the index for origin/main without touching the
-// working tree. Returns null when anything in the pipeline is unavailable —
-// offline, no origin/main, no `tar` — so the caller can fall back.
 export function buildIndexFromOriginMain(cwd?: string): { index: Index; sha: string } | null {
   let sha: string;
   let gitDir: string;
   try {
     git(["fetch", "--quiet", "origin", "main"], { silent: true, cwd });
     sha = git(["rev-parse", "origin/main"], { silent: true, cwd });
-    // The COMMON dir, not `--absolute-git-dir`: per-worktree tasks checkouts
-    // each have their own git dir but share the common one, so the sha-keyed
-    // cache is built once for all of them.
-    gitDir = git(["rev-parse", "--path-format=absolute", "--git-common-dir"], {
-      silent: true,
-      cwd,
-    });
+    gitDir = sharedGitDir(cwd);
   } catch {
     return null;
   }
   if (!/^[0-9a-f]{40}$/.test(sha) || !gitDir) return null;
   const cacheDir = join(gitDir, READ_INDEX_CACHE_DIRNAME);
-  const cached = join(cacheDir, `${sha}.json`);
+  const entryName = `${sha}.json`;
+  const cached = join(cacheDir, entryName);
   if (existsSync(cached)) {
     try {
       return { index: JSON.parse(readFileSync(cached, "utf8")) as Index, sha };
@@ -227,33 +235,11 @@ export function buildIndexFromOriginMain(cwd?: string): { index: Index; sha: str
     mkdirSync(treeDir, { recursive: true });
     git(["archive", "--format=tar", "-o", tarPath, sha], { silent: true, cwd });
     execFileSync("tar", ["-xf", tarPath, "-C", treeDir], { stdio: "ignore" });
-    // build-index.mjs imports js-yaml. The exported tree has no node_modules
-    // (they're not tracked), and ESM resolution walks up from the *script's*
-    // directory, so borrow the checkout's installed deps.
-    try {
-      symlinkSync(join(cwd ?? TASKS_DIR, "node_modules"), join(treeDir, "node_modules"));
-    } catch {
-      /* no install to borrow — build-index below fails and we fall back */
-    }
-    // Same `process.execPath` reasoning as loadIndex(). stdio "ignore": this is
-    // a read command, and build-index's progress chatter isn't its output.
-    execFileSync(process.execPath, ["scripts/build-index.mjs"], {
-      cwd: treeDir,
-      stdio: "ignore",
-    });
+    linkNodeModules(treeDir, cwd ?? TASKS_DIR);
+    execFileSync(process.execPath, ["scripts/build-index.mjs"], { cwd: treeDir, stdio: "ignore" });
     const built = readFileSync(join(treeDir, "index.json"), "utf8");
     const index = JSON.parse(built) as Index;
-    try {
-      mkdirSync(cacheDir, { recursive: true });
-      // Write-then-rename: concurrent agents must never observe a half-written
-      // cache entry for a sha they'd then parse.
-      const staging = join(cacheDir, `${sha}.${Date.now()}.staging`);
-      writeFileSync(staging, built);
-      renameSync(staging, cached);
-      pruneReadIndexCache(cacheDir, `${sha}.json`);
-    } catch {
-      /* cache is an optimization — serving the built index still works */
-    }
+    writeCacheEntryAtomically(cacheDir, entryName, built);
     return { index, sha };
   } catch {
     return null;
@@ -262,27 +248,19 @@ export function buildIndexFromOriginMain(cwd?: string): { index: Index; sha: str
   }
 }
 
-// The read commands' index source. Prefers the origin/main tree (no lock, no
-// `reset --hard`); falls back to the old locked working-tree sync only when the
-// tree export is unavailable, so an offline agent still gets its index.
-export function loadIndexForRead(): Index {
-  readIndexOriginSha = null;
-  if (!TASKS_DIR_IS_SYMLINK) return loadIndex();
-  const fromOrigin = buildIndexFromOriginMain();
-  if (fromOrigin) {
-    readIndexOriginSha = fromOrigin.sha;
-    return fromOrigin.index;
+export function readIndexSource(): ReadIndex {
+  if (TASKS_DIR_IS_SYMLINK) {
+    const fromOrigin = buildIndexFromOriginMain();
+    if (fromOrigin) return fromOrigin;
+    syncFromOrigin();
   }
-  syncFromOrigin();
-  return loadIndex();
+  return { index: loadIndex(), sha: null };
 }
 
-// Read a story/RFC body from whichever source served the current read index.
-// Returns null when the path doesn't exist there.
-function readIndexedFile(filePath: string): string | null {
-  if (readIndexOriginSha) {
+export function readIndexedFile(src: ReadIndex, filePath: string): string | null {
+  if (src.sha) {
     try {
-      return git(["show", `${readIndexOriginSha}:${filePath}`], { silent: true });
+      return git(["show", `${src.sha}:${filePath}`], { silent: true });
     } catch {
       return null;
     }
@@ -598,7 +576,7 @@ function assertCleanWorktree(cwd: string | undefined): void {
 }
 
 // Fetch + hard-reset the per-worktree tasks checkout to origin/main. This is
-// now only the FALLBACK freshness path for reads: loadIndexForRead() builds the
+// now only the FALLBACK freshness path for reads: readIndexSource() builds the
 // index straight from the origin/main tree and only lands here when that is
 // unavailable (offline, no `tar`). Only runs when using the per-worktree
 // symlink (TASKS_DIR_IS_SYMLINK); the canonical fallback and explicit
@@ -2898,13 +2876,13 @@ export function renderStoryView(filePath: string, text: string): string {
   return `${filePath}\n\n${text.trimEnd()}`;
 }
 
-function showStory(index: Index, id: string): void {
-  const entry = index.stories.find((s) => s.id === id);
+function showStory(src: ReadIndex, id: string): void {
+  const entry = src.index.stories.find((s) => s.id === id);
   if (!entry) {
     console.error(`error: story "${id}" not found in index`);
     process.exit(1);
   }
-  const body = readIndexedFile(entry.file_path);
+  const body = readIndexedFile(src, entry.file_path);
   if (body === null) {
     // Index is ahead of its source (e.g. a deleted story still in a stale
     // index). Surface it cleanly rather than throwing a raw ENOENT.
@@ -3022,7 +3000,7 @@ function main(): void {
 
   switch (cmd) {
     case "ready": {
-      const rows = ready(loadIndexForRead(), { rfc: stringFlag(flags, "rfc") });
+      const rows = ready(readIndexSource().index, { rfc: stringFlag(flags, "rfc") });
       flags.json ? console.log(JSON.stringify(rows, null, 2)) : fmt(rows);
       break;
     }
@@ -3030,7 +3008,7 @@ function main(): void {
       const maxLocRaw = stringFlag(flags, "max-loc") ?? "250";
       if (!/^\d+$/.test(maxLocRaw) || Number(maxLocRaw) <= 0) usage();
       const maxLoc = Number(maxLocRaw);
-      const rows = nextBundle(loadIndexForRead(), {
+      const rows = nextBundle(readIndexSource().index, {
         maxLoc,
         cluster: stringFlag(flags, "cluster"),
         rfc: stringFlag(flags, "rfc"),
@@ -3049,7 +3027,7 @@ function main(): void {
       break;
     }
     case "list": {
-      const idx = loadIndexForRead();
+      const idx = readIndexSource().index;
       const rows = listFiltered(idx, {
         rfc: stringFlag(flags, "rfc"),
         status: stringFlag(flags, "status"),
@@ -3066,11 +3044,14 @@ function main(): void {
     case "show": {
       const id = pos[0];
       if (!id) usage();
-      showStory(loadIndexForRead(), id);
+      showStory(readIndexSource(), id);
       break;
     }
     case "status":
-      statusCounts(loadIndexForRead(), numberFlag(flags, "stale-hours") ?? DEFAULT_STALE_HOURS);
+      statusCounts(
+        readIndexSource().index,
+        numberFlag(flags, "stale-hours") ?? DEFAULT_STALE_HOURS,
+      );
       break;
     case "claim": {
       const id = pos[0];

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -162,12 +162,6 @@ export interface ReadIndex {
   sha: string | null;
 }
 
-// Shared by every per-worktree tasks checkout, so one sha-keyed cache entry
-// serves them all (`--absolute-git-dir` would give each its own).
-function sharedGitDir(cwd?: string): string {
-  return git(["rev-parse", "--path-format=absolute", "--git-common-dir"], { silent: true, cwd });
-}
-
 // build-index.mjs imports js-yaml, and ESM resolution walks up from the
 // script's own directory; the exported tree has no node_modules of its own.
 function linkNodeModules(treeDir: string, from: string): void {
@@ -213,7 +207,10 @@ export function buildIndexFromOriginMain(cwd?: string): { index: Index; sha: str
   try {
     git(["fetch", "--quiet", "origin", "main"], { silent: true, cwd });
     sha = git(["rev-parse", "origin/main"], { silent: true, cwd });
-    gitDir = sharedGitDir(cwd);
+    // The same shared common dir the lock resolves to (one cache entry serves
+    // every per-worktree tasks checkout), via the same helper so the two can't
+    // drift onto different dirs.
+    gitDir = lockDirForTest ?? gitCommonDir(cwd ?? TASKS_DIR);
   } catch {
     return null;
   }


### PR DESCRIPTION
## What

Read commands (`ready`, `list`, `next-bundle`, `show`, `status`) no longer
hard-reset the shared canonical tasks checkout under the tasks-CLI lock.

`buildIndexFromOriginMain()` fetches, exports the `origin/main` tree with
`git archive` into a temp dir, runs that tree's own `build-index.mjs` there,
and caches the result by commit sha under the git **common** dir
(`.git/trails-tasks-read-index/<sha>.json` — shared by every per-worktree
tasks checkout, written rename-atomically, pruned to the current sha). Reads
therefore:

- take **no lock** — no contention with mutations, so no 20s wait and no
  "lock is busy → serving a stale index" warning;
- never touch a working tree another agent is writing in, so a read can no
  longer clobber a mid-flight mutation or dirty `git status`;
- stay fresh: the index reflects `origin/main` as of the fetch, and one
  export serves every agent until `origin/main` moves.

`show` renders the story body from the same commit (`git show <sha>:<path>`)
via the threaded `ReadIndex` source, so a body can't disagree with the index
that pointed at it.

The old locked `fetch` + `reset --hard` (`syncWorktreeToOrigin`) remains as
the fallback for when the export is unavailable (offline, no `tar`). The
mutation path is unchanged.

## Notes

- The exported tree gets a `node_modules` symlink to the checkout's install:
  `build-index.mjs` imports `js-yaml` and the tracked tree has no deps.
- Verified locally: `pnpm tasks show` / `ready` / `status` serve from the
  origin/main tree, the tasks checkout stays clean (`git status` empty), and
  a warm read is a fetch + a JSON parse.

Closes-story: tasks-read-path-serves-index-without-reset-hard
