### PR TITLE
chore(website): cover scripts/ in a tsconfig for typed lint

### DIFF
--- a/packages/website/scripts/tsconfig.json
+++ b/packages/website/scripts/tsconfig.json
@@ -8,8 +8,7 @@
     "skipLibCheck": true,
     "allowJs": true,
     "resolveJsonModule": true,
-    "isolatedModules": true,
-    "types": ["vitest/globals"]
+    "isolatedModules": true
   },
   "include": ["**/*.ts", "**/*.mjs"]
 }

--- a/packages/website/scripts/tsconfig.json
+++ b/packages/website/scripts/tsconfig.json
@@ -1,4 +1,9 @@
 {
+  // Deliberately standalone rather than `extends: "../tsconfig.json"`: that
+  // chain resolves through the generated `.svelte-kit/tsconfig.json`, which
+  // does not exist until `svelte-kit sync` runs. Extending it makes `tsc -p`
+  // here fail with TS5083 on a fresh checkout, and these build scripts must
+  // type-check independently of the SvelteKit sync step.
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",

--- a/packages/website/scripts/tsconfig.json
+++ b/packages/website/scripts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["**/*.ts", "**/*.mjs"]
+}


### PR DESCRIPTION
Adds `packages/website/scripts/tsconfig.json` so `scripts/*.ts` is covered by a TypeScript program the eslint `projectService` can resolve.

Before (with `.svelte-kit/` synced, as in a real dev/CI checkout):

```text
Parsing error: packages/website/scripts/escape-typedoc.test.ts was not found by
the project service. Consider either including it in the tsconfig.json or
including it in allowDefaultProject.
```

`packages/website/tsconfig.json` extends the generated `.svelte-kit/tsconfig.json`, whose `include` lists only `../src/**`, `../test/**`, `../tests/**`. Rather than the `allowDefaultProject` escape hatch, this gives `scripts/` real tsconfig coverage.

Verified: with the new tsconfig, `eslint packages/website/scripts/escape-typedoc.test.ts` reports no messages, and a probe file with an unnecessary type assertion in that dir now correctly triggers `@typescript-eslint/no-unnecessary-type-assertion` (proving the program resolves rather than silently skipping). Pre-commit lint-staged passed without `--no-verify`.

Closes-story: website-scripts-tests-tsconfig-coverage


## Review follow-up: why not `extends: "../tsconfig.json"`?

Tried it — it works while `.svelte-kit/` is present, but `packages/website/tsconfig.json` extends the *generated* `./.svelte-kit/tsconfig.json`, which does not exist until `svelte-kit sync` runs. On a fresh checkout the chain hard-fails:

```text
error TS5083: Cannot read file 'packages/website/.svelte-kit/tsconfig.json'.
```

These are build scripts (`escape-typedoc.mjs` runs from `docs:typedoc`); they should type-check and lint independently of the SvelteKit sync step, so the config stays standalone. The duplicated options are now justified in a comment at the top of the file rather than left to look accidental.
