### PR TITLE
test(schema): burn down the require-canonical-rebuild backlog to zero

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,13 +48,15 @@ const requireTableTeardownRawSqlExclude = JSON.parse(
     "utf8",
   ),
 );
-// AR test files exempt from require-canonical-rebuild, in two groups.
-// `memoryScoped` files own a private `:memory:` adapter — they never touch the
-// shared per-worker database, so a canonical table they drop cannot drift it,
-// and the exemption is permanent. `backlog` files do drop a canonical table on
-// the shared database and leave it dropped; ratchet that array to zero (story
-// burn-down-canonical-rebuild-exclude). See eslint/require-canonical-rebuild.mjs.
-/** @type {{ memoryScoped: string[], backlog: string[] }} */
+// AR test files exempt from require-canonical-rebuild, in two permanent groups.
+// `privateAdapter` files own an adapter of their own — a `:memory:` database or
+// a throwaway file under a per-test tmpdir — so a canonical table they drop
+// cannot drift the shared per-worker database. `nonExecuting` files name a
+// canonical table in a drop that never reaches a database at all: SQL captured
+// for assertion, or a hand-rolled fake adapter. Neither group is backlog; a
+// file that really does leave a canonical table dropped belongs in neither and
+// must be fixed. See eslint/require-canonical-rebuild.mjs.
+/** @type {{ privateAdapter: string[], nonExecuting: string[] }} */
 const requireCanonicalRebuildExclude = JSON.parse(
   readFileSync(new URL("./eslint/require-canonical-rebuild-exclude.json", import.meta.url), "utf8"),
 );
@@ -456,8 +458,8 @@ export default defineConfig(
     files: ["packages/activerecord/src/**/*.test.ts"],
     ignores: [
       "packages/activerecord/src/test-helpers/**",
-      ...requireCanonicalRebuildExclude.memoryScoped,
-      ...requireCanonicalRebuildExclude.backlog,
+      ...requireCanonicalRebuildExclude.privateAdapter,
+      ...requireCanonicalRebuildExclude.nonExecuting,
     ],
     rules: {
       "blazetrails/require-canonical-rebuild": ["error", { canonicalTables }],

--- a/eslint/require-canonical-rebuild-exclude.json
+++ b/eslint/require-canonical-rebuild-exclude.json
@@ -17,7 +17,6 @@
     "packages/activerecord/src/transactions.trails.test.ts"
   ],
   "nonExecuting": [
-    "packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts",
     "packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.test.ts"
   ]
 }

--- a/eslint/require-canonical-rebuild-exclude.json
+++ b/eslint/require-canonical-rebuild-exclude.json
@@ -1,5 +1,5 @@
 {
-  "memoryScoped": [
+  "privateAdapter": [
     "packages/activerecord/src/adapter-prevent-writes.test.ts",
     "packages/activerecord/src/adapters/sqlite3-adapter.test.ts",
     "packages/activerecord/src/adapters/sqlite3/bind-parameter.test.ts",
@@ -8,19 +8,16 @@
     "packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts",
     "packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts",
     "packages/activerecord/src/connection-adapters/schema-cache.test.ts",
+    "packages/activerecord/src/connection-adapters/sqlite3-adapter.transactions.test.ts",
     "packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts",
+    "packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts",
     "packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts",
     "packages/activerecord/src/database-statements.test.ts",
     "packages/activerecord/src/sqlite/libsql.test.ts",
     "packages/activerecord/src/transactions.trails.test.ts"
   ],
-  "backlog": [
+  "nonExecuting": [
     "packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts",
-    "packages/activerecord/src/adapters/postgresql/schema.test.ts",
-    "packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.test.ts",
-    "packages/activerecord/src/connection-adapters/sqlite3-adapter.transactions.test.ts",
-    "packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts",
-    "packages/activerecord/src/migration.test.ts",
-    "packages/activerecord/src/schema-dumper.test.ts"
+    "packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.test.ts"
   ]
 }

--- a/eslint/require-canonical-rebuild.mjs
+++ b/eslint/require-canonical-rebuild.mjs
@@ -42,9 +42,13 @@
  *
  * Exemptions live in `eslint/require-canonical-rebuild-exclude.json`, on the
  * same pattern `require-table-teardown-raw-sql-exclude.json` uses, split into
- * two groups: `memoryScoped` files own a private `:memory:` adapter, never
- * touch the shared per-worker database, and are permanently exempt; `backlog`
- * files really do leave a canonical table dropped and are ratcheted to zero.
+ * two permanently-exempt groups: `privateAdapter` files own their own adapter
+ * (a `:memory:` database, or a throwaway file under a per-test tmpdir), so a
+ * canonical table they drop cannot drift the shared per-worker database;
+ * `nonExecuting` files name a canonical table in a drop that never reaches a
+ * database — SQL captured for assertion, or a hand-rolled fake adapter.
+ * Neither is backlog: a file that really leaves a canonical table dropped is
+ * fixed, not listed.
  */
 
 import { calledName, staticString, rawDropNames, SQL_SINKS } from "./require-table-teardown.mjs";
@@ -93,7 +97,7 @@ const rule = {
     ],
     messages: {
       missingRebuild:
-        'Canonical table `{{table}}` is dropped but never restored in this file. Add `await rebuildCanonicalTables(adapter, ["{{table}}"])` after the drop. A canonical table left dropped drifts the shared per-worker database for every file that runs next. If this file owns a private `:memory:` adapter it cannot drift the shared database — add it to the `memoryScoped` group in eslint/require-canonical-rebuild-exclude.json.',
+        'Canonical table `{{table}}` is dropped but never restored in this file. Add `await rebuildCanonicalTables(adapter, ["{{table}}"])` after the drop. A canonical table left dropped drifts the shared per-worker database for every file that runs next. If this file owns a private adapter (`:memory:` or a tmpdir file) it cannot drift the shared database — add it to the `privateAdapter` group in eslint/require-canonical-rebuild-exclude.json.',
     },
   },
 

--- a/eslint/require-canonical-rebuild.mjs
+++ b/eslint/require-canonical-rebuild.mjs
@@ -45,10 +45,11 @@
  * two permanently-exempt groups: `privateAdapter` files own their own adapter
  * (a `:memory:` database, or a throwaway file under a per-test tmpdir), so a
  * canonical table they drop cannot drift the shared per-worker database;
- * `nonExecuting` files name a canonical table in a drop that never reaches a
- * database — SQL captured for assertion, or a hand-rolled fake adapter.
- * Neither is backlog: a file that really leaves a canonical table dropped is
- * fixed, not listed.
+ * `nonExecuting` files have no database at all — a hand-rolled fake adapter
+ * records the DDL instead of running it. Neither is backlog: a file that
+ * really leaves a canonical table dropped is fixed, not listed, and a file
+ * that only sometimes skips execution (captureSql's stub mode) takes a
+ * line-scoped disable at the drop rather than a whole-file exemption.
  */
 
 import { calledName, staticString, rawDropNames, SQL_SINKS } from "./require-table-teardown.mjs";

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts
@@ -189,6 +189,10 @@ describeIfMysql("Mysql2Adapter", () => {
     });
 
     it("drop table", async () => {
+      // Stub mode: the DROP is instrumented and returned, never executed, so
+      // the canonical `people` survives and needs no rebuild. The disable also
+      // covers the "drop tables" case below — the rule reports a table once.
+      // eslint-disable-next-line blazetrails/require-canonical-rebuild
       const sqls = await captureSql(() => adapter.dropTable("people"), { stub: adapter });
       expect(sqls[0]).toBe("DROP TABLE `people`");
     });

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -934,6 +934,10 @@ describeIfPg("PostgreSQLAdapter", () => {
       await (Article as any).create({ title: "zOMG, welcome to my blorgh!" });
       const welcome = await (Article as any).last();
       expect(welcome.title).toBe("zOMG, welcome to my blorgh!");
+      // Not the canonical `articles`: the search path set at the top of this
+      // test puts both the createTable above and this drop in "my.schema", so
+      // public.articles is never touched and needs no canonical rebuild.
+      // eslint-disable-next-line blazetrails/require-canonical-rebuild
       await adapter.dropTable("articles", { ifExists: true });
     });
   });

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -16,6 +16,7 @@ import { quoteDefaultExpression } from "./connection-adapters/abstract/quoting.j
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import { Migration } from "./migration.js";
 import { fixtures } from "./test-helpers/fixtures.js";
+import { rebuildCanonicalTables } from "./test-helpers/canonical-schema.js";
 import { repairWorkerSchema } from "./test-helpers/schema-repair.js";
 import { TEST_SCHEMA } from "./test-helpers/test-schema.js";
 import { TableDefinition } from "./connection-adapters/abstract/schema-definitions.js";
@@ -1494,6 +1495,10 @@ describe("MigrationTest", () => {
         expect(await connection.indexExists("values", "value")).toBe(false);
       } finally {
         await connection.dropTable("values", { ifExists: true });
+        // `values` is canonical: the bespoke shape above replaced it, so put
+        // the canonical one back rather than leaving the shared worker DB
+        // short a table for whichever file runs next.
+        await rebuildCanonicalTables(connection, ["values"]);
       }
     });
   });
@@ -1515,6 +1520,10 @@ describe("MigrationTest", () => {
         expect(await connection.indexExists("values", "value")).toBe(false);
       } finally {
         await connection.dropTable("values", { ifExists: true });
+        // `values` is canonical: the bespoke shape above replaced it, so put
+        // the canonical one back rather than leaving the shared worker DB
+        // short a table for whichever file runs next.
+        await rebuildCanonicalTables(connection, ["values"]);
       }
     });
   });

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -7,6 +7,7 @@ import { adapterType } from "./test-adapter.js";
 import type { TestDatabaseAdapter } from "./test-adapter.js";
 import { itIfSupports, adapterSupports } from "./test-helpers/supports.js";
 import { fixtures } from "./test-helpers/fixtures.js";
+import { rebuildCanonicalTables } from "./test-helpers/canonical-schema.js";
 import {
   dumpAllTableSchema,
   dumpTableSchema,
@@ -1039,7 +1040,8 @@ describe("SchemaDumperDefaultsTest", () => {
 // *rides* (accounts/authors/binaries/movies/…) are shielded by `fixtures({})`
 // and are NOT dropped here. `companies`/`booleans`/`numeric_data`/`posts`/
 // `products` appear only because deferred cases still `force`-recreate them on
-// some adapters; the per-file schema repair restores the canonical shape after.
+// some adapters; the rebuildCanonicalTables call below restores their canonical
+// shape.
 afterAll(async () => {
   const ctx = new MigrationContext(Base.connection);
   const o = { ifExists: true } as const;
@@ -1069,4 +1071,16 @@ afterAll(async () => {
   await ctx.dropTable("test_uc_no_idx", o);
   await ctx.dropTable("timestamps", o);
   await ctx.dropTable("users", o);
+  // The drops above include canonical tables the deferred cases `force`-recreate
+  // in a bespoke shape; restore the canonical ones here instead of leaving the
+  // shared worker DB drifted for the next file.
+  await rebuildCanonicalTables(Base.connection, [
+    "booleans",
+    "companies",
+    "numeric_data",
+    "posts",
+    "products",
+    "string_key_objects",
+    "users",
+  ]);
 });


### PR DESCRIPTION
Burns `eslint/require-canonical-rebuild-exclude.json`'s `backlog` group to zero.
Reading the seven entries split them four ways:

**Real drift — fixed**

- `migration.test.ts` — the `ReservedWords` / `ExplicitlyNamedIndex` tests
  `force`-create a bespoke `values(value)` table over the canonical `values`
  and drop it in `finally`, leaving the shared per-worker DB short a canonical
  table. Both `finally` blocks now
  `rebuildCanonicalTables(connection, ["values"])`.
- `schema-dumper.test.ts` — the `afterAll` drops seven canonical tables
  (`booleans`, `companies`, `numeric_data`, `posts`, `products`,
  `string_key_objects`, `users`) that deferred cases `force`-recreate, and its
  comment openly deferred the restore to `repairWorkerSchema`. It now rebuilds
  them itself.

**Permanent structural exemption — regrouped, not backlog**

- `sqlite3-adapter.transactions.test.ts` and `sqlite3-introspection.test.ts`
  own a `BetterSQLite3Adapter` over a per-test `mkdtemp` file. That is the same
  "cannot drift the shared database" property `:memory:` files have, so
  `memoryScoped` is renamed `privateAdapter` and covers both.
- `postgresql/schema-statements-class.test.ts` drives a hand-rolled fake
  adapter that records DDL strings and has no database at all — a new
  `nonExecuting` group.

**Non-executing at one call site — line-scoped disable**

- `abstract-mysql-adapter/active-schema.test.ts` drops `people` inside
  `captureSql(..., { stub: adapter })`, which instruments the SQL and returns
  without touching the database. The file is *not* wholly non-executing (other
  `captureSql` calls there run real DDL), so it takes an
  `eslint-disable-next-line` at that drop rather than a whole-file exemption,
  and leaves the exclude list.

**False positive under a search path — line-scoped disable**

- `postgresql/schema.test.ts` drops `articles` with the search path set to
  `"my.schema"`, so `public.articles` is untouched. Disable plus the reason at
  the call site; the file leaves the exclude list.

The `backlog` key is gone. Both remaining groups are permanent and structural,
and the rule's docs/message now say a file that really leaves a canonical table
dropped gets fixed, not listed.

Verified: `npx eslint` clean on all seven files and `pnpm lint` clean
repo-wide; `node --test eslint/require-canonical-rebuild.test.mjs` passes;
sqlite runs of `migration.test.ts` (69 passed) and `schema-dumper.test.ts`
(40 passed). PG/MySQL paths ride CI.

Closes-story: burn-down-canonical-rebuild-exclude
