### PR TITLE
test(finder): converge FinderTest2 bespoke Post/Topic onto canonical models

### DIFF
--- a/packages/activerecord/src/finder.test.ts
+++ b/packages/activerecord/src/finder.test.ts
@@ -15,6 +15,7 @@ import { sql as arelSql } from "@blazetrails/arel";
 
 import { fixtures } from "./test-helpers/fixtures.js";
 import { postFixtureData } from "./test-helpers/fixtures/posts.js";
+import { Account } from "./test-helpers/models/account.js";
 import "./test-helpers/canonical-model-index.js";
 import { CpkBook } from "./test-helpers/models/cpk.js";
 import { adapterType } from "./test-adapter.js";
@@ -1502,8 +1503,11 @@ describe("FinderTest", () => {
 // FinderTest2 — additional coverage for finder_test.rb
 // ==========================================================================
 describe("FinderTest", () => {
-  const { posts } = fixtures(["posts"]);
+  const { posts, topics, accounts } = fixtures(["posts", "topics", "accounts", "companies"]);
   registerModel(CanonicalPost);
+  registerModel("Topic", CanonicalTopic);
+  registerModel(Account);
+  registerModel(CanonicalCompany);
   const Post = CanonicalPost;
   const rid = (r: unknown) => (r as { id: number }).id;
 
@@ -1513,8 +1517,20 @@ describe("FinderTest", () => {
   });
 
   it("find with nil inside set passed for one attribute", async () => {
-    const results = await Post.where({ title: [posts("welcome").title, null] });
-    expect(results.map(rid)).toEqual([rid(posts("welcome"))]);
+    const clientOf = (
+      await CanonicalCompany.where({
+        client_of: [2, 1, null],
+        name: ["37signals", "Summit", "Microsoft"],
+      }).order("client_of DESC")
+    ).map((r) => (r as { client_of: bigint | number | null }).client_of);
+
+    expect(clientOf).toContain(null);
+    expect(
+      clientOf
+        .filter((c) => c != null)
+        .map(Number)
+        .sort(),
+    ).toEqual([1, 2]);
   });
 
   it("find_by with associations", async () => {
@@ -1553,11 +1569,12 @@ describe("FinderTest", () => {
   });
 
   it("find by on relation with large number", async () => {
-    expect(await Post.where("1=1").findBy({ id: 999999999 })).toBeNull();
-    const found = await Post.where({ id: [rid(posts("welcome")), 999999999] }).findBy({
-      id: rid(posts("welcome")),
+    const huge = 9999999999999999999999999999999n;
+    expect(await CanonicalTopic.where("1=1").findBy({ id: huge })).toBeNull();
+    const found = await CanonicalTopic.where({ id: [rid(topics("first")), huge] }).findBy({
+      id: rid(topics("first")),
     });
-    expect(rid(found)).toBe(rid(posts("welcome")));
+    expect(rid(found)).toBe(rid(topics("first")));
   });
 
   // Rails: test "find_by! raises RecordNotFound if the record is missing"
@@ -1575,14 +1592,20 @@ describe("FinderTest", () => {
   });
 
   it("implicit order set to primary key", async () => {
-    await assertQueriesMatch(
-      new RegExp(`ORDER BY ${escapeRegExp(quoteTableName("posts.id"))} DESC LIMIT`, "i"),
-      undefined,
-      false,
-      async () => {
-        await Post.last();
-      },
-    );
+    const oldImplicitOrderColumn = CanonicalTopic.implicitOrderColumn;
+    CanonicalTopic.implicitOrderColumn = "id";
+    try {
+      await assertQueriesMatch(
+        new RegExp(`ORDER BY ${escapeRegExp(quoteTableName("topics.id"))} DESC LIMIT`, "i"),
+        undefined,
+        false,
+        async () => {
+          await CanonicalTopic.last();
+        },
+      );
+    } finally {
+      CanonicalTopic.implicitOrderColumn = oldImplicitOrderColumn;
+    }
   });
 
   it("joins dont clobber id", async () => {
@@ -1612,10 +1635,10 @@ describe("FinderTest", () => {
   });
 
   it("find by one attribute with several options", async () => {
-    const found = await Post.order("id DESC")
-      .where(`id != ${rid(posts("welcome"))}`)
-      .findBy({ title: posts("thinking").title });
-    expect(rid(found)).toBe(rid(posts("thinking")));
+    const found = await Account.order("id DESC")
+      .where("id != ?", rid(accounts("rails_core_account")))
+      .findBy({ credit_limit: 50 });
+    expect(rid(found)).toBe(rid(accounts("unknown")));
   });
 });
 

--- a/packages/activerecord/src/finder.test.ts
+++ b/packages/activerecord/src/finder.test.ts
@@ -16,6 +16,7 @@ import { sql as arelSql } from "@blazetrails/arel";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { postFixtureData } from "./test-helpers/fixtures/posts.js";
 import { Account } from "./test-helpers/models/account.js";
+import { Client } from "./test-helpers/models/company.js";
 import "./test-helpers/canonical-model-index.js";
 import { CpkBook } from "./test-helpers/models/cpk.js";
 import { adapterType } from "./test-adapter.js";
@@ -1503,11 +1504,17 @@ describe("FinderTest", () => {
 // FinderTest2 — additional coverage for finder_test.rb
 // ==========================================================================
 describe("FinderTest", () => {
-  const { posts, topics, accounts } = fixtures(["posts", "topics", "accounts", "companies"]);
+  const { posts, topics, accounts, companies } = fixtures([
+    "posts",
+    "topics",
+    "accounts",
+    "companies",
+  ]);
   registerModel(CanonicalPost);
   registerModel("Topic", CanonicalTopic);
   registerModel(Account);
   registerModel(CanonicalCompany);
+  registerModel(Client);
   const Post = CanonicalPost;
   const rid = (r: unknown) => (r as { id: number }).id;
 
@@ -1540,8 +1547,12 @@ describe("FinderTest", () => {
   });
 
   it("first have determined order by default", async () => {
-    const first = await Post.first();
-    expect(rid(first)).toBe(rid(posts("welcome")));
+    const expected = [companies("second_client"), companies("another_client")];
+    const clients = Client.where({ name: expected.map((c) => (c as { name: string }).name) });
+
+    expect((await clients.first(2)).map(rid)).toEqual(expected.map(rid));
+    expect((await clients.limit(5).first(2)).map(rid)).toEqual(expected.map(rid));
+    expect((await clients.order(null).first(2)).map(rid)).toEqual(expected.map(rid));
   });
 
   it("find without primary key", async () => {

--- a/packages/activerecord/src/finder.test.ts
+++ b/packages/activerecord/src/finder.test.ts
@@ -1501,38 +1501,29 @@ describe("FinderTest", () => {
 // FinderTest2 — additional coverage for finder_test.rb
 // ==========================================================================
 describe("FinderTest", () => {
-  fixtures([]);
-
-  class Post extends Base {
-    static {
-      this.tableName = "posts";
-      this.attribute("title", "string", { default: "" });
-      this.attribute("body", "string", { default: "" });
-    }
-  }
+  const { posts } = fixtures(["posts"]);
+  registerModel(CanonicalPost);
+  const Post = CanonicalPost;
 
   it("find by empty in condition", async () => {
-    await Post.create({ title: "a" });
     const results = await Post.where({ title: [] });
     expect(results.length).toBe(0);
   });
 
   it("find with nil inside set passed for one attribute", async () => {
-    await Post.create({ title: "a" });
-    const results = await Post.where({ title: ["a", null] });
-    expect(Array.isArray(results)).toBe(true);
+    const results = await Post.where({ title: [posts("welcome").title, null] });
+    expect(results.map((r: any) => r.id)).toEqual([posts("welcome").id]);
   });
 
   it("find_by with associations", async () => {
-    await Post.create({ title: "unique-title" });
-    const found = await Post.findBy({ title: "unique-title" });
+    const found = await Post.findBy({ title: posts("welcome").title });
     expect(found).not.toBeNull();
+    expect((found as any).id).toBe(posts("welcome").id);
   });
 
   it("first have determined order by default", async () => {
-    await Post.create({ title: "a" });
     const first = await Post.first();
-    expect(first).not.toBeNull();
+    expect((first as any).id).toBe(posts("welcome").id);
   });
 
   it("find without primary key", async () => {
@@ -1541,30 +1532,29 @@ describe("FinderTest", () => {
   });
 
   it("finder with offset string", async () => {
-    await Post.create({ title: "a" });
-    await Post.create({ title: "b" });
     const sql = Post.all().offset(1).toSql();
     expect(sql).toContain("OFFSET");
   });
 
   it("find on a scope does not perform statement caching", async () => {
-    await Post.create({ title: "scope-test" });
-    const scope = Post.where({ title: "scope-test" });
+    const scope = Post.where({ title: posts("welcome").title });
     const r1 = await scope;
     const r2 = await scope;
     expect(r1.length).toBe(r2.length);
   });
 
   it("find_by on a scope does not perform statement caching", async () => {
-    await Post.create({ title: "findby-scope" });
-    const r1 = await Post.findBy({ title: "findby-scope" });
-    const r2 = await Post.findBy({ title: "findby-scope" });
+    const r1 = await Post.findBy({ title: posts("welcome").title });
+    const r2 = await Post.findBy({ title: posts("welcome").title });
     expect(r1?.id).toBe(r2?.id);
   });
 
   it("find by on relation with large number", async () => {
-    const result = await Post.findBy({ id: 999999999 });
-    expect(result).toBeNull();
+    expect(await Post.where("1=1").findBy({ id: 999999999 })).toBeNull();
+    const found = await Post.where({ id: [posts("welcome").id, 999999999] }).findBy({
+      id: posts("welcome").id,
+    });
+    expect((found as any).id).toBe(posts("welcome").id);
   });
 
   // Rails: test "find_by! raises RecordNotFound if the record is missing"
@@ -1582,20 +1572,18 @@ describe("FinderTest", () => {
   });
 
   it("implicit order set to primary key", async () => {
-    await Post.create({ title: "pk-order" });
     const sql = Post.all().toSql();
     expect(sql).toContain("SELECT");
   });
 
   it("joins dont clobber id", async () => {
-    const p = await Post.create({ title: "join-test" });
-    expect(p.id).toBeTruthy();
+    const first = await Post.where(`posts.id = ${posts("welcome").id}`).first();
+    expect((first as any).id).toBe(posts("welcome").id);
   });
 
   it("named bind variables with quotes", async () => {
-    await Post.create({ title: "it's quoted" });
-    const results = await Post.where({ title: "it's quoted" });
-    expect(results.length).toBe(1);
+    const results = await Post.where({ title: posts("authorless").title });
+    expect(results.map((r: any) => r.id)).toEqual([posts("authorless").id]);
   });
 
   it("find by one attribute bang with blank defined", async () => {
@@ -1603,40 +1591,35 @@ describe("FinderTest", () => {
   });
 
   it("select rows", async () => {
-    await Post.create({ title: "row1" });
     const results = await Post.all();
-    expect(results.length).toBe(1);
+    expect(results.length).toBe(11);
   });
 
+  // Rails creates a row here on purpose: the point is that `where(id: nil)`
+  // still finds nothing afterwards.
   it("find ignores previously inserted record", async () => {
-    const p = await Post.create({ title: "first" });
-    await Post.create({ title: "second" });
-    const found = await Post.find(p.id);
-    expect(found.id).toBe(p.id);
+    await Post.create({ title: "test", body: "it out", author_id: 0 });
+    expect(await Post.where({ id: null })).toEqual([]);
   });
 
   it("find by one attribute with several options", async () => {
-    await Post.create({ title: "opt1" });
-    const found = await Post.findBy({ title: "opt1" });
-    expect(found).not.toBeNull();
+    const found = await Post.order("id DESC")
+      .where(`id != ${posts("welcome").id}`)
+      .findBy({ title: posts("thinking").title });
+    expect((found as any).id).toBe(posts("thinking").id);
   });
 });
 
 describe("FinderTest", () => {
-  fixtures([]);
+  fixtures(["topics"]);
+  registerModel("Topic", CanonicalTopic);
 
   // Rails: test_find_with_array_of_ids
   // Rails: test_find_raises_record_not_found
   // Rails: test_find_by_with_conditions
   // Rails: test_find_by_returns_nil
   it("find_by returns nil if the record is missing", async () => {
-    class Topic extends Base {
-      static {
-        this.attribute("title", "string");
-      }
-    }
-    await Topic.create({ title: "Alice" });
-    const found = await Topic.findBy({ title: "Nobody" });
+    const found = await CanonicalTopic.findBy({ title: "Nobody" });
     expect(found).toBeNull();
   });
 

--- a/packages/activerecord/src/finder.test.ts
+++ b/packages/activerecord/src/finder.test.ts
@@ -14,6 +14,7 @@ import {
 import { sql as arelSql } from "@blazetrails/arel";
 
 import { fixtures } from "./test-helpers/fixtures.js";
+import { postFixtureData } from "./test-helpers/fixtures/posts.js";
 import "./test-helpers/canonical-model-index.js";
 import { CpkBook } from "./test-helpers/models/cpk.js";
 import { adapterType } from "./test-adapter.js";
@@ -1504,6 +1505,7 @@ describe("FinderTest", () => {
   const { posts } = fixtures(["posts"]);
   registerModel(CanonicalPost);
   const Post = CanonicalPost;
+  const rid = (r: unknown) => (r as { id: number }).id;
 
   it("find by empty in condition", async () => {
     const results = await Post.where({ title: [] });
@@ -1512,18 +1514,18 @@ describe("FinderTest", () => {
 
   it("find with nil inside set passed for one attribute", async () => {
     const results = await Post.where({ title: [posts("welcome").title, null] });
-    expect(results.map((r: any) => r.id)).toEqual([posts("welcome").id]);
+    expect(results.map(rid)).toEqual([rid(posts("welcome"))]);
   });
 
   it("find_by with associations", async () => {
     const found = await Post.findBy({ title: posts("welcome").title });
     expect(found).not.toBeNull();
-    expect((found as any).id).toBe(posts("welcome").id);
+    expect(rid(found)).toBe(rid(posts("welcome")));
   });
 
   it("first have determined order by default", async () => {
     const first = await Post.first();
-    expect((first as any).id).toBe(posts("welcome").id);
+    expect(rid(first)).toBe(rid(posts("welcome")));
   });
 
   it("find without primary key", async () => {
@@ -1551,10 +1553,10 @@ describe("FinderTest", () => {
 
   it("find by on relation with large number", async () => {
     expect(await Post.where("1=1").findBy({ id: 999999999 })).toBeNull();
-    const found = await Post.where({ id: [posts("welcome").id, 999999999] }).findBy({
-      id: posts("welcome").id,
+    const found = await Post.where({ id: [rid(posts("welcome")), 999999999] }).findBy({
+      id: rid(posts("welcome")),
     });
-    expect((found as any).id).toBe(posts("welcome").id);
+    expect(rid(found)).toBe(rid(posts("welcome")));
   });
 
   // Rails: test "find_by! raises RecordNotFound if the record is missing"
@@ -1577,13 +1579,15 @@ describe("FinderTest", () => {
   });
 
   it("joins dont clobber id", async () => {
-    const first = await Post.where(`posts.id = ${posts("welcome").id}`).first();
-    expect((first as any).id).toBe(posts("welcome").id);
+    const first = await Post.where(`posts.id = ${rid(posts("welcome"))}`).first();
+    expect(rid(first)).toBe(rid(posts("welcome")));
   });
 
   it("named bind variables with quotes", async () => {
-    const results = await Post.where({ title: posts("authorless").title });
-    expect(results.map((r: any) => r.id)).toEqual([posts("authorless").id]);
+    const quoted = posts("authorless").title;
+    expect(quoted).toContain("'");
+    const results = await Post.where({ title: quoted });
+    expect(results.map(rid)).toEqual([rid(posts("authorless"))]);
   });
 
   it("find by one attribute bang with blank defined", async () => {
@@ -1592,11 +1596,9 @@ describe("FinderTest", () => {
 
   it("select rows", async () => {
     const results = await Post.all();
-    expect(results.length).toBe(11);
+    expect(results.length).toBe(Object.keys(postFixtureData).length);
   });
 
-  // Rails creates a row here on purpose: the point is that `where(id: nil)`
-  // still finds nothing afterwards.
   it("find ignores previously inserted record", async () => {
     await Post.create({ title: "test", body: "it out", author_id: 0 });
     expect(await Post.where({ id: null })).toEqual([]);
@@ -1604,9 +1606,9 @@ describe("FinderTest", () => {
 
   it("find by one attribute with several options", async () => {
     const found = await Post.order("id DESC")
-      .where(`id != ${posts("welcome").id}`)
+      .where(`id != ${rid(posts("welcome"))}`)
       .findBy({ title: posts("thinking").title });
-    expect((found as any).id).toBe(posts("thinking").id);
+    expect(rid(found)).toBe(rid(posts("thinking")));
   });
 });
 

--- a/packages/activerecord/src/finder.test.ts
+++ b/packages/activerecord/src/finder.test.ts
@@ -1534,8 +1534,9 @@ describe("FinderTest", () => {
   });
 
   it("finder with offset string", async () => {
-    const sql = Post.all().offset(1).toSql();
-    expect(sql).toContain("OFFSET");
+    // Rails passes the offset as a string here; trails types `offset()` as
+    // number, so the cast is what keeps the string path under test.
+    await expect(Post.offset("3" as unknown as number)).resolves.toBeDefined();
   });
 
   it("find on a scope does not perform statement caching", async () => {
@@ -1574,8 +1575,14 @@ describe("FinderTest", () => {
   });
 
   it("implicit order set to primary key", async () => {
-    const sql = Post.all().toSql();
-    expect(sql).toContain("SELECT");
+    await assertQueriesMatch(
+      new RegExp(`ORDER BY ${escapeRegExp(quoteTableName("posts.id"))} DESC LIMIT`, "i"),
+      undefined,
+      false,
+      async () => {
+        await Post.last();
+      },
+    );
   });
 
   it("joins dont clobber id", async () => {

--- a/packages/activerecord/src/finder.test.ts
+++ b/packages/activerecord/src/finder.test.ts
@@ -1552,7 +1552,7 @@ describe("FinderTest", () => {
   it("finder with offset string", async () => {
     // Rails passes the offset as a string here; trails types `offset()` as
     // number, so the cast is what keeps the string path under test.
-    await expect(Post.offset("3" as unknown as number)).resolves.toBeDefined();
+    await expect(CanonicalTopic.offset("3" as unknown as number)).resolves.toBeDefined();
   });
 
   it("find on a scope does not perform statement caching", async () => {
@@ -1609,15 +1609,12 @@ describe("FinderTest", () => {
   });
 
   it("joins dont clobber id", async () => {
-    const first = await Post.where(`posts.id = ${rid(posts("welcome"))}`).first();
-    expect(rid(first)).toBe(rid(posts("welcome")));
-  });
-
-  it("named bind variables with quotes", async () => {
-    const quoted = posts("authorless").title;
-    expect(quoted).toContain("'");
-    const results = await Post.where({ title: quoted });
-    expect(results.map(rid)).toEqual([rid(posts("authorless"))]);
+    const first = await CanonicalFirm.joins(
+      "INNER JOIN companies clients ON clients.firm_id = companies.id",
+    )
+      .where("companies.id = 1")
+      .first();
+    expect(rid(first)).toBe(1);
   });
 
   it("find by one attribute bang with blank defined", async () => {


### PR DESCRIPTION
The ad-hoc `FinderTest2` block in `packages/activerecord/src/finder.test.ts`
still declared bespoke `class Post extends Base` / `class Topic extends Base`
locals with hand-declared `attribute()` calls over the canonical
`posts`/`topics` tables. They never reached `registerModel`, so the
canonical-shadow guard armed by #5246 could not see them — but they were the
same latent shadow: the moment one of those tests resolved an association
target by name it would get the wrong class.

This converges them onto the canonical models and their real fixtures
(`posts`, `topics`, `accounts`, `companies`):

- `FinderTest2` rides `fixtures([...])` + `registerModel` and asserts against
  fixture rows instead of `create`-ing throwaway ones.
- `find ignores previously inserted record` keeps its `create` (Rails creates
  there too) and now asserts the Rails behaviour: `Post.where(id: nil)` is `[]`.

Tests moved onto the model their Rails counterpart actually uses:

- `find with nil inside set passed for one attribute` (finder_test.rb:1670) now
  rides `Company` / `client_of: [2, 1, nil]` and asserts the `nil` arm of the
  IN-list is really returned — on `posts` it could not be, since
  `legacy_comments_count` defaults to `0` and no post fixture has a null title.
- `find by on relation with large number` (finder_test.rb:683) rides `Topic`
  with the out-of-range bignum literal `9999999999999999999999999999999n`, so
  the overflow/predicate-coercion path is exercised rather than a plain int.
- `find by one attribute with several options` (finder_test.rb:1553) rides
  `Account.order("id DESC").where("id != ?", 3).findBy({ credit_limit: 50 })`
  → `accounts(:unknown)`. (trails has no dynamic `findByCreditLimit`; `findBy`
  with the attribute hash is the equivalent surface.)
- `implicit order set to primary key` (finder_test.rb:1114) now sets and
  restores `Topic.implicitOrderColumn = "id"` around the
  `ORDER BY topics.id DESC LIMIT` assertion, matching Rails' ensure block.
- `first have determined order by default` (finder_test.rb:1091) rides
  `Client.where(name: [...])` over `companies(:second_client)` /
  `companies(:another_client)` and asserts the same ordered pair for
  `first(2)`, `limit(5).first(2)` and `order(nil).first(2)` — so the
  determinism-under-ties behaviour is actually exercised.
- `finder with offset string` (finder_test.rb:1754) executes `Topic.offset("3")`.
- `joins dont clobber id` (finder_test.rb:1592) now performs the actual
  ambiguous-`id` self-join:
  `Firm.joins("INNER JOIN companies clients ON clients.firm_id = companies.id").where("companies.id = 1").first`.
- The thin `named bind variables with quotes` in this block is removed rather
  than re-ported: a faithful port of finder_test.rb:1459 (`Company` +
  `where(["name = :name", { name: "37signals' go'es against" }])`) already
  exists further down the same file, and the ad-hoc copy was an attribute-hash
  lookup that never touched the named-placeholder path.
- The bespoke `Topic` local in `find_by returns nil if the record is missing`
  is replaced by the canonical `Topic` + `topics` fixtures.

Still thin, deliberately out of scope: `find without primary key` asserts on
`toSql()` because the Rails test rides `Matey` (a model without a primary key)
which we do not have yet; porting it is separate work.

No test was renamed; the `canonical-model-index` import stays.
`finder.test.ts` is green (269 tests).

Closes-story: converge-findertest2-bespoke-post-topic-onto-canonical-models
