### PR TITLE
test(autosave-association): converge canonical model shadows no pass enumerates

### DIFF
--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -496,22 +496,39 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
   }
   fixtures([]);
 
+  class UnvalidatedClient extends Base {
+    declare name: string | null;
+    declare client_of: number | null;
+
+    static {
+      this._tableName = "companies";
+      this.attribute("name", "string");
+      this.attribute("client_of", "integer");
+    }
+  }
+
   function makeModels() {
-    class HmaFirm extends Base {
+    class AutosaveFirm extends Base {
       declare name: string | null;
-      declare clients: AssociationProxy<HmaClient>;
+      declare clients: AssociationProxy<AutosaveClient>;
+      declare unvalidatedClients: AssociationProxy<UnvalidatedClient>;
 
       static {
         this._tableName = "companies";
         this.attribute("name", "string");
         this.hasMany("clients", {
           autosave: true,
-          className: "HmaClient",
+          className: "AutosaveClient",
+          foreignKey: "client_of",
+        });
+        this.hasMany("unvalidatedClients", {
+          autosave: true,
+          className: "UnvalidatedClient",
           foreignKey: "client_of",
         });
       }
     }
-    class HmaClient extends Base {
+    class AutosaveClient extends Base {
       declare name: string | null;
       declare client_of: number | null;
 
@@ -522,56 +539,42 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
         this.validates("name", { presence: true });
       }
     }
-    registerModel("HmaFirm", HmaFirm);
-    registerModel("HmaClient", HmaClient);
-    return { Company: HmaFirm, Client: HmaClient };
+    registerModel("AutosaveFirm", AutosaveFirm);
+    registerModel("AutosaveClient", AutosaveClient);
+    return { AutosaveFirm, AutosaveClient };
   }
 
   it("invalid adding", async () => {
-    const { Company, Client } = makeModels();
-    const company = await Company.create({ name: "Acme" });
-    const badClient = new Client({ name: "" });
+    const { AutosaveFirm, AutosaveClient } = makeModels();
+    const company = await AutosaveFirm.create({ name: "Acme" });
+    const badClient = new AutosaveClient({ name: "" });
     cacheAssoc(company, "clients", [badClient]);
     const saved = await company.save();
     expect(saved).toBe(false);
   });
 
   it("invalid adding before save", async () => {
-    const { Company, Client } = makeModels();
-    const company = new Company({ name: "Acme" });
-    const badClient = new Client({ name: "" });
+    const { AutosaveFirm, AutosaveClient } = makeModels();
+    const company = new AutosaveFirm({ name: "Acme" });
+    const badClient = new AutosaveClient({ name: "" });
     cacheAssoc(company, "clients", [badClient]);
     const saved = await company.save();
     expect(saved).toBe(false);
   });
 
   it("adding unsavable association", async () => {
-    const { Company, Client } = makeModels();
-    const company = await Company.create({ name: "Acme" });
-    const badClient = new Client({ name: "" });
+    const { AutosaveFirm, AutosaveClient } = makeModels();
+    const company = await AutosaveFirm.create({ name: "Acme" });
+    const badClient = new AutosaveClient({ name: "" });
     cacheAssoc(company, "clients", [badClient]);
     const saved = await company.save();
     expect(saved).toBe(false);
   });
 
   it("invalid adding with validate false", async () => {
-    const { Company } = makeModels();
-    class UnvalidatedClient extends Base {
-      declare name: string | null;
-      declare client_of: number | null;
-
-      static {
-        this._tableName = "companies";
-        this.attribute("name", "string");
-        this.attribute("client_of", "integer");
-      }
-    }
+    const { AutosaveFirm } = makeModels();
     registerModel("UnvalidatedClient", UnvalidatedClient);
-    Associations.hasMany.call(Company, "unvalidatedClients", {
-      autosave: true,
-      foreignKey: "client_of",
-    });
-    const company = await Company.create({ name: "Acme" });
+    const company = await AutosaveFirm.create({ name: "Acme" });
     const client = new UnvalidatedClient({ name: "" });
     cacheAssoc(company, "unvalidatedClients", [client]);
     const saved = await company.save();
@@ -580,9 +583,9 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
   });
 
   it("valid adding with validate false", async () => {
-    const { Company, Client } = makeModels();
-    const company = await Company.create({ name: "Acme" });
-    const client = new Client({ name: "Valid" });
+    const { AutosaveFirm, AutosaveClient } = makeModels();
+    const company = await AutosaveFirm.create({ name: "Acme" });
+    const client = new AutosaveClient({ name: "Valid" });
     cacheAssoc(company, "clients", [client]);
     const saved = await company.save();
     expect(saved).toBe(true);
@@ -590,17 +593,17 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
   });
 
   it("circular autosave does not validate children", async () => {
-    const { Company, Client } = makeModels();
-    const company = await Company.create({ name: "Acme" });
+    const { AutosaveFirm, AutosaveClient } = makeModels();
+    const company = await AutosaveFirm.create({ name: "Acme" });
     // No cached associations — saving should succeed without loading children
     const saved = await company.save();
     expect(saved).toBe(true);
   });
 
   it("parent should save children record with foreign key validation set in before save callback", async () => {
-    const { Company, Client } = makeModels();
-    const company = new Company({ name: "Acme" });
-    const client = new Client({ name: "Alice" });
+    const { AutosaveFirm, AutosaveClient } = makeModels();
+    const company = new AutosaveFirm({ name: "Acme" });
+    const client = new AutosaveClient({ name: "Alice" });
     cacheAssoc(company, "clients", [client]);
     const saved = await company.save();
     expect(saved).toBe(true);
@@ -608,10 +611,10 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
   });
 
   it("parent should not get saved with duplicate children records", async () => {
-    const { Company, Client } = makeModels();
-    const company = await Company.create({ name: "Acme" });
-    const c1 = new Client({ name: "Alice" });
-    const c2 = new Client({ name: "Alice" });
+    const { AutosaveFirm, AutosaveClient } = makeModels();
+    const company = await AutosaveFirm.create({ name: "Acme" });
+    const c1 = new AutosaveClient({ name: "Alice" });
+    const c2 = new AutosaveClient({ name: "Alice" });
     cacheAssoc(company, "clients", [c1, c2]);
     const saved = await company.save();
     expect(saved).toBe(true);
@@ -620,18 +623,18 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
   });
 
   it("invalid build", async () => {
-    const { Company, Client } = makeModels();
-    const company = await Company.create({ name: "Acme" });
-    const client = new Client({ name: "" });
+    const { AutosaveFirm, AutosaveClient } = makeModels();
+    const company = await AutosaveFirm.create({ name: "Acme" });
+    const client = new AutosaveClient({ name: "" });
     cacheAssoc(company, "clients", [client]);
     const saved = await company.save();
     expect(saved).toBe(false);
   });
 
   it("adding before save", async () => {
-    const { Company, Client } = makeModels();
-    const company = new Company({ name: "Acme" });
-    const client = new Client({ name: "Bob" });
+    const { AutosaveFirm, AutosaveClient } = makeModels();
+    const company = new AutosaveFirm({ name: "Acme" });
+    const client = new AutosaveClient({ name: "Bob" });
     cacheAssoc(company, "clients", [client]);
     const saved = await company.save();
     expect(saved).toBe(true);
@@ -640,10 +643,10 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
   });
 
   it("assign ids", async () => {
-    const { Company, Client } = makeModels();
-    const company = await Company.create({ name: "Apple" });
-    const c1 = await Client.create({ name: "First" });
-    const c2 = await Client.create({ name: "Second" });
+    const { AutosaveFirm, AutosaveClient } = makeModels();
+    const company = await AutosaveFirm.create({ name: "Apple" });
+    const c1 = await AutosaveClient.create({ name: "First" });
+    const c2 = await AutosaveClient.create({ name: "Second" });
 
     const proxy = association(company, "clients");
     await proxy.setIds([c1.id as number, c2.id as number]);
@@ -900,9 +903,9 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
   });
 
   it("build before save", async () => {
-    const { Company, Client } = makeModels();
-    const company = new Company({ name: "Acme" });
-    const client = new Client({ name: "Built" });
+    const { AutosaveFirm, AutosaveClient } = makeModels();
+    const company = new AutosaveFirm({ name: "Acme" });
+    const client = new AutosaveClient({ name: "Built" });
     cacheAssoc(company, "clients", [client]);
     await company.save();
     expect(company.isNewRecord()).toBe(false);
@@ -910,10 +913,10 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
   });
 
   it("build many before save", async () => {
-    const { Company, Client } = makeModels();
-    const company = new Company({ name: "Acme" });
-    const c1 = new Client({ name: "A" });
-    const c2 = new Client({ name: "B" });
+    const { AutosaveFirm, AutosaveClient } = makeModels();
+    const company = new AutosaveFirm({ name: "Acme" });
+    const c1 = new AutosaveClient({ name: "A" });
+    const c2 = new AutosaveClient({ name: "B" });
     cacheAssoc(company, "clients", [c1, c2]);
     await company.save();
     expect(c1.isNewRecord()).toBe(false);
@@ -921,34 +924,34 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
   });
 
   it("build via block before save", async () => {
-    const { Company, Client } = makeModels();
-    const company = await Company.create({ name: "Acme" });
-    await Client.create({ name: "Summit", client_of: company.id });
-    await Client.create({ name: "Microsoft", client_of: company.id });
+    const { AutosaveFirm, AutosaveClient } = makeModels();
+    const company = await AutosaveFirm.create({ name: "Acme" });
+    await AutosaveClient.create({ name: "Summit", client_of: company.id });
+    await AutosaveClient.create({ name: "Microsoft", client_of: company.id });
     const newClient = (company as any).clients.build({}, (client: any) => {
-      client.name = "Another Client";
+      client.name = "Another AutosaveClient";
     }) as Base;
     expect((company as any).clients.loaded).toBeFalsy();
     company.name += "-changed";
     expect(await company.save()).toBeTruthy();
     expect(newClient.isPersisted()).toBeTruthy();
-    expect(Number(await Client.where({ client_of: company.id }).count())).toBe(3);
+    expect(Number(await AutosaveClient.where({ client_of: company.id }).count())).toBe(3);
   });
 
   it("build many via block before save", async () => {
-    const { Company, Client } = makeModels();
-    const company = await Company.create({ name: "Acme" });
-    await Client.create({ name: "Summit", client_of: company.id });
-    await Client.create({ name: "Microsoft", client_of: company.id });
+    const { AutosaveFirm, AutosaveClient } = makeModels();
+    const company = await AutosaveFirm.create({ name: "Acme" });
+    await AutosaveClient.create({ name: "Summit", client_of: company.id });
+    await AutosaveClient.create({ name: "Microsoft", client_of: company.id });
     (company as any).clients.build(
-      [{ name: "Another Client" }, { name: "Another Client II" }],
+      [{ name: "Another AutosaveClient" }, { name: "Another AutosaveClient II" }],
       (client: any) => {
         client.name = "changed";
       },
     );
     company.name += "-changed";
     expect(await company.save()).toBeTruthy();
-    expect(Number(await Client.where({ client_of: company.id }).count())).toBe(4);
+    expect(Number(await AutosaveClient.where({ client_of: company.id }).count())).toBe(4);
   });
 
   it("collection-proxy build without load autosaves built children (Slot B)", async () => {
@@ -959,8 +962,8 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
     // followed by `pirate.save` persists the child. `_loadedAssociation`
     // treats non-empty `proxy.target` as cached data without flipping
     // proxy `loaded` (matches Rails' @_was_loaded ephemeral semantics).
-    const { Company, Client } = makeModels();
-    const company = new Company({ name: "Acme" });
+    const { AutosaveFirm, AutosaveClient } = makeModels();
+    const company = new AutosaveFirm({ name: "Acme" });
     const built = (company as any).clients.build({ name: "ProxyBuilt" }) as Base;
     expect(built.isNewRecord()).toBe(true);
     await company.save();
@@ -969,32 +972,32 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
   });
 
   it("replace on new object", async () => {
-    const { Company, Client } = makeModels();
-    const company = new Company({ name: "Acme" });
-    const c1 = new Client({ name: "Old" });
+    const { AutosaveFirm, AutosaveClient } = makeModels();
+    const company = new AutosaveFirm({ name: "Acme" });
+    const c1 = new AutosaveClient({ name: "Old" });
     cacheAssoc(company, "clients", [c1]);
     await company.save();
     expect(c1.isNewRecord()).toBe(false);
-    const c2 = new Client({ name: "New" });
+    const c2 = new AutosaveClient({ name: "New" });
     cacheAssoc(company, "clients", [c2]);
     await company.save();
     expect(c2.isNewRecord()).toBe(false);
   });
 
   it("replace on duplicated object", async () => {
-    const { Company, Client } = makeModels();
-    const original = await Company.create({ name: "New Firm" });
+    const { AutosaveFirm, AutosaveClient } = makeModels();
+    const original = await AutosaveFirm.create({ name: "New Firm" });
     const firm = original.dup();
-    const existing = await Client.create({ name: "Summit", client_of: original.id });
-    const fresh = new Client({ name: "New Client" });
+    const existing = await AutosaveClient.create({ name: "Summit", client_of: original.id });
+    const fresh = new AutosaveClient({ name: "New AutosaveClient" });
     cacheAssoc(firm, "clients", [existing, fresh]);
     expect(await firm.save()).toBeTruthy();
-    expect(Number(await Client.where({ client_of: firm.id }).count())).toBe(2);
+    expect(Number(await AutosaveClient.where({ client_of: firm.id }).count())).toBe(2);
   });
 
   it("should not load the associated model", async () => {
-    const { Company } = makeModels();
-    const company = await Company.create({ name: "Acme" });
+    const { AutosaveFirm } = makeModels();
+    const company = await AutosaveFirm.create({ name: "Acme" });
     // No cached associations — save should not trigger loading
     const saved = await company.save();
     expect(saved).toBe(true);
@@ -2373,8 +2376,6 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
       activerecord: {
         errors: {
           models: {
-            // Rails keys this on `person/references`; the owner here is a
-            // bespoke stand-in, so the i18n key follows its underscored name.
             "index_errors_person/references": { format: "%{message}" },
           },
         },
@@ -2398,25 +2399,25 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
       }
       class IndexErrorsPerson extends Base {
         declare name: string | null;
+        declare references: AssociationProxy<IndexErrorsReference>;
 
         static {
           this._tableName = "people";
           this.attribute("name", "string");
+          this.hasMany("references", {
+            autosave: true,
+            indexErrors: true,
+            className: "IndexErrorsReference",
+            foreignKey: "person_id",
+          });
         }
       }
-      const Person = IndexErrorsPerson;
       registerModel("IndexErrorsPerson", IndexErrorsPerson);
       registerModel("IndexErrorsReference", IndexErrorsReference);
-      Associations.hasMany.call(Person, "references", {
-        autosave: true,
-        indexErrors: true,
-        className: "IndexErrorsReference",
-        foreignKey: "person_id",
-      });
 
       const refValid = new IndexErrorsReference({ favorite: true, job_id: 1 });
       const refInvalid = new IndexErrorsReference({ favorite: false });
-      const p = new Person({});
+      const p = new IndexErrorsPerson({});
       cacheAssoc(p, "references", [refValid, refInvalid]);
 
       expect(await refValid.isValid()).toBe(true);
@@ -2432,8 +2433,6 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
     I18n.storeTranslations("en", {
       activerecord: {
         attributes: {
-          // Rails keys this on `person`; the owner here is a bespoke stand-in,
-          // so the i18n key follows its underscored name.
           base_errors_person: { reference: "Super reference" },
           reference: { base: "" },
         },
@@ -2457,23 +2456,24 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
       }
       class BaseErrorsPerson extends Base {
         declare name: string | null;
+        declare reference: BaseErrorsReference | null;
+        declare loadHasOne: (name: "reference") => Promise<BaseErrorsReference | null>;
 
         static {
           this._tableName = "people";
           this.attribute("name", "string");
           this.validates("reference", { presence: true });
+          this.hasOne("reference", {
+            autosave: true,
+            className: "BaseErrorsReference",
+            foreignKey: "person_id",
+          });
         }
       }
-      const Person = BaseErrorsPerson;
       registerModel("BaseErrorsPerson", BaseErrorsPerson);
       registerModel("BaseErrorsReference", BaseErrorsReference);
-      Associations.hasOne.call(Person, "reference", {
-        autosave: true,
-        className: "BaseErrorsReference",
-        foreignKey: "person_id",
-      });
 
-      const p = new Person({});
+      const p = new BaseErrorsPerson({});
       expect(await p.isValid()).toBe(false);
       expect(p.errors.fullMessages).toEqual(["Super reference can't be blank"]);
 
@@ -2569,11 +2569,10 @@ describe("TestAutosaveAssociationsInGeneral", () => {
         });
       }
     }
-    const Person = ContextPerson;
     registerModel("ContextPerson", ContextPerson);
     registerModel("ContextReference", ContextReference);
 
-    const person = await Person.create({ first_name: "cool" });
+    const person = await ContextPerson.create({ first_name: "cool" });
     // Change to "nah" — still valid because on:create validator doesn't run in :update context
     person.first_name = "nah";
     expect(await person.isValid()).toBe(true);
@@ -2612,11 +2611,10 @@ describe("TestAutosaveAssociationsInGeneral", () => {
         this.hasMany("widgets", { autosave: true, foreignKey: "author_id" });
       }
     }
-    const Owner = WidgetOwner;
     registerModel("Widget", Widget);
     registerModel("WidgetOwner", WidgetOwner);
 
-    const owner = await Owner.create({ name: "Alice" });
+    const owner = await WidgetOwner.create({ name: "Alice" });
     // Create a persisted, unchanged widget with a blank status
     const widget = await Widget.create({ name: "", author_id: owner.id });
     cacheAssoc(owner, "widgets", [widget]);
@@ -2687,24 +2685,25 @@ describe("TestAutosaveAssociationsInGeneral", () => {
         });
       }
     }
-    class ProfileUser extends Base {
+    class AutosaveProfileUser extends Base {
       declare name: string | null;
+      declare profile: Profile | null;
+      declare loadHasOne: (name: "profile") => Promise<Profile | null>;
 
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
+        this.hasOne("profile", {
+          autosave: true,
+          foreignKey: "author_id",
+          className: "Profile",
+        });
       }
     }
-    const User = ProfileUser;
     registerModel("Profile", Profile);
-    registerModel("ProfileUser", ProfileUser);
-    Associations.hasOne.call(User, "profile", {
-      autosave: true,
-      foreignKey: "author_id",
-      className: "Profile",
-    });
+    registerModel("AutosaveProfileUser", AutosaveProfileUser);
 
-    const user = await User.create({ name: "Test" });
+    const user = await AutosaveProfileUser.create({ name: "Test" });
     const profile = new Profile({ name: "Hello" });
     cacheAssoc(user, "profile", profile);
     user.name = "trigger save";
@@ -2946,27 +2945,28 @@ describe("TestAutosaveAssociationsInGeneral", () => {
         });
       }
     }
-    class ProfileUser extends Base {
+    class DuplicateCallbackProfileUser extends Base {
       declare name: string | null;
+      declare profile: Profile | null;
+      declare loadHasOne: (name: "profile") => Promise<Profile | null>;
 
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
+        this.hasOne("profile", {
+          autosave: true,
+          foreignKey: "author_id",
+          className: "Profile",
+        });
       }
     }
-    const User = ProfileUser;
     registerModel("Profile", Profile);
-    registerModel("ProfileUser", ProfileUser);
-    Associations.hasOne.call(User, "profile", {
-      autosave: true,
-      foreignKey: "author_id",
-      className: "Profile",
-    });
+    registerModel("DuplicateCallbackProfileUser", DuplicateCallbackProfileUser);
     // Calling addAutosaveAssociationCallbacks a second time must not duplicate callbacks
-    const reflection = (User as any)._reflectOnAssociation("profile");
-    addAutosaveAssociationCallbacks(User, reflection);
+    const reflection = (DuplicateCallbackProfileUser as any)._reflectOnAssociation("profile");
+    addAutosaveAssociationCallbacks(DuplicateCallbackProfileUser, reflection);
 
-    const user = await User.create({ name: "Test" });
+    const user = await DuplicateCallbackProfileUser.create({ name: "Test" });
     const profile = new Profile({ name: "Hello" });
     profile.name = "Changed";
     cacheAssoc(user, "profile", profile);
@@ -3636,24 +3636,25 @@ describe("TestDefaultAutosaveAssociationOnNewRecord", () => {
         this.attribute("author_id", "integer");
       }
     }
-    class ProfileUser extends Base {
+    class DisabledProfileUser extends Base {
       declare name: string | null;
+      declare profile: Profile | null;
+      declare loadHasOne: (name: "profile") => Promise<Profile | null>;
 
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
+        this.hasOne("profile", {
+          autosave: false,
+          foreignKey: "author_id",
+          className: "Profile",
+        });
       }
     }
-    const User = ProfileUser;
     registerModel("Profile", Profile);
-    registerModel("ProfileUser", ProfileUser);
-    Associations.hasOne.call(User, "profile", {
-      autosave: false,
-      foreignKey: "author_id",
-      className: "Profile",
-    });
+    registerModel("DisabledProfileUser", DisabledProfileUser);
 
-    const user = await User.create({ name: "test" });
+    const user = await DisabledProfileUser.create({ name: "test" });
     const profile = new Profile({ name: "Unsaved" });
     cacheAssoc(user, "profile", profile);
     user.name = "trigger save";
@@ -3727,7 +3728,6 @@ describe("TestDefaultAutosaveAssociationOnNewRecord", () => {
 
   it("autosave new record with after create callback and habtm association", async () => {
     registerModel(PostWithAfterCreateCallback);
-    // Comment belongsTo post (counter cache) resolves "Post" at save time.
     registerModel(CanonicalPost);
     registerModel(CanonicalComment);
     registerModel(CanonicalCategory);

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -31,6 +31,11 @@ import { ShipPart } from "./test-helpers/models/ship-part.js";
 import { Parrot as CanonicalParrot } from "./test-helpers/models/parrot.js";
 import { Bird as CanonicalBird } from "./test-helpers/models/bird.js";
 import { Eye, Iris, IrisWithReadOnlyForeignKey } from "./test-helpers/models/eye.js";
+import { Comment as CanonicalComment } from "./test-helpers/models/comment.js";
+import { Category as CanonicalCategory } from "./test-helpers/models/category.js";
+import { Post as CanonicalPost, PostWithAfterCreateCallback } from "./test-helpers/models/post.js";
+import { Customer as CanonicalCustomer } from "./test-helpers/models/customer.js";
+import { Order as CanonicalOrder } from "./test-helpers/models/order.js";
 import { Invoice } from "./test-helpers/models/invoice.js";
 import { LineItem } from "./test-helpers/models/line-item.js";
 import {
@@ -492,17 +497,21 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
   fixtures([]);
 
   function makeModels() {
-    class Company extends Base {
+    class HmaFirm extends Base {
       declare name: string | null;
-      declare clients: AssociationProxy<Client>;
+      declare clients: AssociationProxy<HmaClient>;
 
       static {
         this._tableName = "companies";
         this.attribute("name", "string");
-        this.hasMany("clients", { autosave: true, foreignKey: "client_of" });
+        this.hasMany("clients", {
+          autosave: true,
+          className: "HmaClient",
+          foreignKey: "client_of",
+        });
       }
     }
-    class Client extends Base {
+    class HmaClient extends Base {
       declare name: string | null;
       declare client_of: number | null;
 
@@ -513,9 +522,9 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
         this.validates("name", { presence: true });
       }
     }
-    registerModel("Company", Company);
-    registerModel("Client", Client);
-    return { Company, Client };
+    registerModel("HmaFirm", HmaFirm);
+    registerModel("HmaClient", HmaClient);
+    return { Company: HmaFirm, Client: HmaClient };
   }
 
   it("invalid adding", async () => {
@@ -1786,43 +1795,9 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
   }
 
   function makeOrderModels() {
-    class Customer extends Base {
-      declare name: string | null;
-
-      static {
-        this._tableName = "customers";
-        this.attribute("name", "string");
-      }
-    }
-    class Order extends Base {
-      declare name: string | null;
-      declare tree_id: number | null;
-      declare parent_id: number | null;
-      declare billing: Customer | null;
-      declare shipping: Customer | null;
-      declare loadBelongsTo: ((name: "billing") => Promise<Customer | null>) &
-        ((name: "shipping") => Promise<Customer | null>);
-
-      static {
-        this._tableName = "nodes";
-        this.attribute("name", "string");
-        this.attribute("tree_id", "integer");
-        this.attribute("parent_id", "integer");
-        this.belongsTo("billing", {
-          autosave: true,
-          className: "Customer",
-          foreignKey: "tree_id",
-        });
-        this.belongsTo("shipping", {
-          autosave: true,
-          className: "Customer",
-          foreignKey: "parent_id",
-        });
-      }
-    }
-    registerModel("Customer", Customer);
-    registerModel("Order", Order);
-    return { Customer, Order };
+    registerModel(CanonicalCustomer);
+    registerModel(CanonicalOrder);
+    return { Customer: CanonicalCustomer, Order: CanonicalOrder };
   }
 
   function setBilling(order: Base, customer: Base) {
@@ -2398,13 +2373,15 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
       activerecord: {
         errors: {
           models: {
-            "person/references": { format: "%{message}" },
+            // Rails keys this on `person/references`; the owner here is a
+            // bespoke stand-in, so the i18n key follows its underscored name.
+            "index_errors_person/references": { format: "%{message}" },
           },
         },
       },
     });
     try {
-      class Reference extends Base {
+      class IndexErrorsReference extends Base {
         declare favorite: boolean | null;
         declare job_id: number | null;
         declare person_id: number | null;
@@ -2419,24 +2396,26 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
           this.validates("job_id", { presence: true });
         }
       }
-      class Person extends Base {
+      class IndexErrorsPerson extends Base {
         declare name: string | null;
 
         static {
+          this._tableName = "people";
           this.attribute("name", "string");
         }
       }
-      registerModel("Person", Person);
-      registerModel("Reference", Reference);
+      const Person = IndexErrorsPerson;
+      registerModel("IndexErrorsPerson", IndexErrorsPerson);
+      registerModel("IndexErrorsReference", IndexErrorsReference);
       Associations.hasMany.call(Person, "references", {
         autosave: true,
         indexErrors: true,
-        className: "Reference",
+        className: "IndexErrorsReference",
         foreignKey: "person_id",
       });
 
-      const refValid = new Reference({ favorite: true, job_id: 1 });
-      const refInvalid = new Reference({ favorite: false });
+      const refValid = new IndexErrorsReference({ favorite: true, job_id: 1 });
+      const refInvalid = new IndexErrorsReference({ favorite: false });
       const p = new Person({});
       cacheAssoc(p, "references", [refValid, refInvalid]);
 
@@ -2453,13 +2432,15 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
     I18n.storeTranslations("en", {
       activerecord: {
         attributes: {
-          person: { reference: "Super reference" },
+          // Rails keys this on `person`; the owner here is a bespoke stand-in,
+          // so the i18n key follows its underscored name.
+          base_errors_person: { reference: "Super reference" },
           reference: { base: "" },
         },
       },
     });
     try {
-      class Reference extends Base {
+      class BaseErrorsReference extends Base {
         declare favorite: boolean | null;
         declare job_id: number | null;
         declare person_id: number | null;
@@ -2474,19 +2455,21 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
           this.validates("job_id", { presence: true });
         }
       }
-      class Person extends Base {
+      class BaseErrorsPerson extends Base {
         declare name: string | null;
 
         static {
+          this._tableName = "people";
           this.attribute("name", "string");
           this.validates("reference", { presence: true });
         }
       }
-      registerModel("Person", Person);
-      registerModel("Reference", Reference);
+      const Person = BaseErrorsPerson;
+      registerModel("BaseErrorsPerson", BaseErrorsPerson);
+      registerModel("BaseErrorsReference", BaseErrorsReference);
       Associations.hasOne.call(Person, "reference", {
         autosave: true,
-        className: "Reference",
+        className: "BaseErrorsReference",
         foreignKey: "person_id",
       });
 
@@ -2494,7 +2477,7 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
       expect(await p.isValid()).toBe(false);
       expect(p.errors.fullMessages).toEqual(["Super reference can't be blank"]);
 
-      const refInvalid = new Reference({ favorite: false });
+      const refInvalid = new BaseErrorsReference({ favorite: false });
       cacheAssoc(p, "reference", refInvalid);
       expect(await refInvalid.isValid()).toBe(false);
       expect(await p.isValid()).toBe(false);
@@ -2554,7 +2537,7 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     // Rails: test "autosave does not pass through non custom validation contexts"
     // When autosave validates an associated record, it should NOT pass the owner's
     // standard (:create/:update) validation context — only custom contexts propagate.
-    class Person extends Base {
+    class ContextPerson extends Base {
       declare first_name: string | null;
 
       static {
@@ -2571,21 +2554,24 @@ describe("TestAutosaveAssociationsInGeneral", () => {
         );
       }
     }
-    class Reference extends Base {
+    class ContextReference extends Base {
       declare person_id: number | null;
+      declare person: ContextPerson | null;
+      declare loadBelongsTo: (name: "person") => Promise<ContextPerson | null>;
 
       static {
         this._tableName = "references";
         this.attribute("person_id", "integer");
+        this.belongsTo("person", {
+          autosave: true,
+          className: "ContextPerson",
+          foreignKey: "person_id",
+        });
       }
     }
-    registerModel("Person", Person);
-    registerModel("Reference", Reference);
-    Associations.belongsTo.call(Reference, "person", {
-      autosave: true,
-      className: "Person",
-      foreignKey: "person_id",
-    });
+    const Person = ContextPerson;
+    registerModel("ContextPerson", ContextPerson);
+    registerModel("ContextReference", ContextReference);
 
     const person = await Person.create({ first_name: "cool" });
     // Change to "nah" — still valid because on:create validator doesn't run in :update context
@@ -2595,7 +2581,7 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     // autosave through reference should also be valid —
     // autosave uses the owner's _validationContext (nil → not custom) so person is validated
     // in its default :update context, where the :create-only validator is skipped.
-    const ref = new Reference({ person });
+    const ref = new ContextReference({ person });
     cacheAssoc(ref, "person", person);
     const valid = await ref.isValid();
     expect(valid).toBe(true);
@@ -2616,7 +2602,7 @@ describe("TestAutosaveAssociationsInGeneral", () => {
         this.validates("name", { presence: true, on: "publish" } as any);
       }
     }
-    class Owner extends Base {
+    class WidgetOwner extends Base {
       declare name: string | null;
       declare widgets: AssociationProxy<Widget>;
 
@@ -2626,8 +2612,9 @@ describe("TestAutosaveAssociationsInGeneral", () => {
         this.hasMany("widgets", { autosave: true, foreignKey: "author_id" });
       }
     }
+    const Owner = WidgetOwner;
     registerModel("Widget", Widget);
-    registerModel("Owner", Owner);
+    registerModel("WidgetOwner", WidgetOwner);
 
     const owner = await Owner.create({ name: "Alice" });
     // Create a persisted, unchanged widget with a blank status
@@ -2700,7 +2687,7 @@ describe("TestAutosaveAssociationsInGeneral", () => {
         });
       }
     }
-    class User extends Base {
+    class ProfileUser extends Base {
       declare name: string | null;
 
       static {
@@ -2708,8 +2695,9 @@ describe("TestAutosaveAssociationsInGeneral", () => {
         this.attribute("name", "string");
       }
     }
+    const User = ProfileUser;
     registerModel("Profile", Profile);
-    registerModel("User", User);
+    registerModel("ProfileUser", ProfileUser);
     Associations.hasOne.call(User, "profile", {
       autosave: true,
       foreignKey: "author_id",
@@ -2958,7 +2946,7 @@ describe("TestAutosaveAssociationsInGeneral", () => {
         });
       }
     }
-    class User extends Base {
+    class ProfileUser extends Base {
       declare name: string | null;
 
       static {
@@ -2966,8 +2954,9 @@ describe("TestAutosaveAssociationsInGeneral", () => {
         this.attribute("name", "string");
       }
     }
+    const User = ProfileUser;
     registerModel("Profile", Profile);
-    registerModel("User", User);
+    registerModel("ProfileUser", ProfileUser);
     Associations.hasOne.call(User, "profile", {
       autosave: true,
       foreignKey: "author_id",
@@ -3647,7 +3636,7 @@ describe("TestDefaultAutosaveAssociationOnNewRecord", () => {
         this.attribute("author_id", "integer");
       }
     }
-    class User extends Base {
+    class ProfileUser extends Base {
       declare name: string | null;
 
       static {
@@ -3655,8 +3644,9 @@ describe("TestDefaultAutosaveAssociationOnNewRecord", () => {
         this.attribute("name", "string");
       }
     }
+    const User = ProfileUser;
     registerModel("Profile", Profile);
-    registerModel("User", User);
+    registerModel("ProfileUser", ProfileUser);
     Associations.hasOne.call(User, "profile", {
       autosave: false,
       foreignKey: "author_id",
@@ -3736,59 +3726,11 @@ describe("TestDefaultAutosaveAssociationOnNewRecord", () => {
   });
 
   it("autosave new record with after create callback and habtm association", async () => {
-    class Comment extends Base {
-      declare post_id: number | null;
-      declare body: string | null;
-
-      static {
-        this._tableName = "comments";
-        this.attribute("post_id", "integer");
-        this.attribute("body", "string");
-      }
-    }
-    class Category extends Base {
-      declare name: string | null;
-
-      static {
-        this._tableName = "categories";
-        this.attribute("name", "string");
-      }
-    }
-    class PostWithAfterCreateCallback extends Base {
-      declare title: string | null;
-      declare body: string | null;
-      declare author_id: number | null;
-      declare comments: AssociationProxy<Comment>;
-      declare categories: AssociationProxy<Category>;
-
-      static {
-        this._tableName = "posts";
-        this.attribute("title", "string");
-        this.attribute("body", "string");
-        this.attribute("author_id", "integer");
-        this.hasMany("comments", {
-          className: "HabtmAutosaveComment",
-          foreignKey: "post_id",
-        });
-        this.hasAndBelongsToMany("categories", {
-          className: "HabtmAutosaveCategory",
-          joinTable: "categories_posts",
-          foreignKey: "post_id",
-          associationForeignKey: "category_id",
-          autosave: true,
-        });
-      }
-    }
-    registerModel("HabtmAutosaveComment", Comment);
-    registerModel("HabtmAutosaveCategory", Category);
-    registerModel("PostWithAfterCreateCallback", PostWithAfterCreateCallback);
-    // Registered after the association so the habtm autosave after_create
-    // callback fires first — matching Rails, where `has_and_belongs_to_many`
-    // is declared before the model's own `after_create` block.
-    PostWithAfterCreateCallback.afterCreate(async (post: any) => {
-      const firstComment = post.association("comments").target[0];
-      await post.updateAttribute("author_id", firstComment.id);
-    });
+    registerModel(PostWithAfterCreateCallback);
+    // Comment belongsTo post (counter cache) resolves "Post" at save time.
+    registerModel(CanonicalPost);
+    registerModel(CanonicalComment);
+    registerModel(CanonicalCategory);
 
     const post = new PostWithAfterCreateCallback({
       title: "Captain Murphy",

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -540,6 +540,7 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
       }
     }
     registerModel("AutosaveFirm", AutosaveFirm);
+    registerModel("UnvalidatedClient", UnvalidatedClient);
     registerModel("AutosaveClient", AutosaveClient);
     return { AutosaveFirm, AutosaveClient };
   }
@@ -573,7 +574,6 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
 
   it("invalid adding with validate false", async () => {
     const { AutosaveFirm } = makeModels();
-    registerModel("UnvalidatedClient", UnvalidatedClient);
     const company = await AutosaveFirm.create({ name: "Acme" });
     const client = new UnvalidatedClient({ name: "" });
     cacheAssoc(company, "unvalidatedClients", [client]);


### PR DESCRIPTION
Converges the `autosave-association.test.ts` `registerModel` sites that shadow a
canonical model name but are enumerated by no pass of the burndown — so the
final pass (`converge-autosave-association-remaining-canonical-shadows-arm-guard`)
can actually import the canonical model index and stay green.

## Live collision list

Re-derived by temporarily adding `import "./test-helpers/canonical-model-index.js"`
to the file (arming `guardCanonicalNameShadow`) rather than trusting the story's
line numbers. Names still rejected on top of `main`:

`Company`, `Customer`, `Person` (x3), `Reference` (x3), `Owner`, `User` (x3),
`PostWithAfterCreateCallback`.

`Reference` only surfaced after the `Person` sites were fixed — the guard throws
on the first offender in each suite, so the list had to be re-derived twice.
`Eye`, `Firm`, `Parrot`, `Pirate` and `Ship` from the story context are already
clean on current `main`.

## Changes

**Canonical model adopted** (it matches the Rails test exactly):

- `Customer` / `Order` — Rails `autosave_association_test.rb:449+` drives the
  canonical `Order` (`billing`/`shipping` → `Customer`). The bespoke pair sat on
  the `nodes` table with `tree_id`/`parent_id` as stand-in FKs; the canonical
  `Order` has real `billing_customer_id`/`shipping_customer_id` columns, and
  belongsTo autosaves new records without an explicit `autosave: true`.
- `PostWithAfterCreateCallback` (+ canonical `Comment`, `Category`, `Post`) —
  `test/models/post.rb:319`. The canonical model already declares the habtm and
  the `after_create` callback in Rails' order, so the local re-declaration went
  away entirely. `Post` is registered because canonical `Comment` resolves it
  through its counter-cache `belongsTo`.

**Distinct non-canonical names** (bespoke stand-ins with no canonical
counterpart — a canonical table plus a couple of attributes):

| was | now |
| --- | --- |
| `Company` / `Client` | `AutosaveFirm` / `AutosaveClient` |
| `Person` (x3) | `IndexErrorsPerson`, `BaseErrorsPerson`, `ContextPerson` |
| `Reference` (x3) | `IndexErrorsReference`, `BaseErrorsReference`, `ContextReference` |
| `Owner` | `WidgetOwner` |
| `User` (x3) | `AutosaveProfileUser`, `DuplicateCallbackProfileUser`, `DisabledProfileUser` |

`AutosaveFirm.hasMany("clients")` gets an explicit `className: "AutosaveClient"` —
the derived-name fallout the story warns about.

Two i18n **model** keys follow their renamed owner
(`person/references` → `index_errors_person/references`,
`attributes.person` → `attributes.base_errors_person`). The nested-path key
`attributes.reference.base` is unchanged — it keys on the association path, not
on the model, which the suite confirms.

**Fallout:** the renames made `no-standalone-associations` fire on six
`Associations.<macro>.call(...)` sites that a local `const Person = …` alias had
previously hidden from the rule. Each is now declared in its owner's `static {}`
block, and the three identically-named `ProfileUser` classes had to take
per-test names for the rule to resolve them at all.

## Verification

`pnpm vitest run packages/activerecord/src/autosave-association.test.ts` —
209/209 pass, both with and without the guard armed. The arming import is not
committed: importing the index sets the global autoload index for every test
file sharing the worker, which is the final pass's job, not this one's.
`eslint` clean on the file.

## Follow-up

`TestDefaultAutosaveAssociationOnAHasManyAssociation` is really Rails'
`Firm`/`Client` + `clients_of_firm` suite; converging its ~12 test bodies to the
canonical STI models changes association names, fixture sets and per-test
autosave semantics, so it is registered separately as
`0025-fidelity-verification-tooling/converge-autosave-association-hasmany-describe-to-canonical-firm-client`.

Closes-story: converge-autosave-association-unenumerated-canonical-shadows
