### PR TITLE
test(transactions): drop the hand-copied canonical topics re-lay

### DIFF
--- a/packages/activerecord/src/transactions.trails.test.ts
+++ b/packages/activerecord/src/transactions.trails.test.ts
@@ -8,7 +8,7 @@
  * machinery. They were relocated verbatim out of transactions.test.ts (which
  * mirrors transactions_test.rb) so the convention file tracks Rails 1:1.
  */
-import { describe, it, expect, beforeAll, afterEach, afterAll, vi } from "vitest";
+import { describe, it, expect, afterEach, afterAll, vi } from "vitest";
 import { throwAbort } from "@blazetrails/activesupport";
 import { Base, transaction } from "./index.js";
 import { NullTransaction } from "./connection-adapters/abstract/transaction.js";
@@ -75,35 +75,6 @@ afterEach(async () => {
 
 describe("TransactionTest", () => {
   fixtures({}, { useTransactionalTests: false });
-
-  beforeAll(async () => {
-    // Re-lay the canonical `topics` on the handler connection (drop-and-recreate,
-    // mirroring schema.rb's `create_table :topics`) so this file's signature
-    // cache is primed and a bespoke `topics` left behind by a sibling file can't
-    // shadow the CanonicalTopic model's shape. `topics` is boot-owned canonical,
-    // so it is not torn down (the boot schema owns/restores its shape).
-
-    await Base.connection.createTable("topics", { force: true }, (t) => {
-      t.string("title", { limit: 250 });
-      t.string("author_name");
-      t.string("author_email_address");
-      t.datetime("written_on");
-      t.time("bonus_time");
-      t.date("last_read");
-      t.text("content");
-      t.text("important");
-      t.binary("binary_content");
-      t.boolean("approved", { default: true });
-      t.integer("replies_count", { default: 0 });
-      t.integer("unique_replies_count", { default: 0 });
-      t.integer("parent_id");
-      t.string("parent_title");
-      t.string("type");
-      t.string("group");
-      t.timestamps({ null: true });
-      t.index(["author_name", "title"]);
-    });
-  });
 
   // trails-extra: a block-arg `tx.afterCommit(...)` registered on the explicit
   // `transaction(Model, (tx) => ...)` handle fires once the transaction commits.


### PR DESCRIPTION
Drops the hand-copied canonical `topics` re-lay from `TransactionTest`'s
`beforeAll` in `transactions.trails.test.ts` (~30 LOC, ~20 duplicated column
declarations).

Same class of removal as the four `items` re-lays in #5257: the describe already
calls `fixtures({}, { useTransactionalTests: false })`, which preloads the
canonical schema, so the re-lay was redundant for shape — and the duplicated
column list was a second source of truth for `topics` that could silently drift
from `test-helpers/test-schema.ts`.

Confirmed no sibling file lays a *bespoke* `topics` into the shared worker DB:
- `transactions.trails.test.ts:52` creates `topics` on a private
  `:memory:` adapter (not the shared handler connection).
- `adapters/abstract-mysql-adapter/schema.test.ts:214` lays the *canonical*
  shape on a dedicated MySQL adapter and restores it in `afterAll` via
  `restoreCanonicalOnPlainAdapter([... "topics"])`.

Verified: `TransactionTest` passes on sqlite and on postgres (16 passed,
1 skipped on both). No test renamed.

Closes-story: drop-topics-relay-in-transactions-trails
