### PR TITLE
fix(test-helpers): handle inbound and cyclic FKs in the canonical drop plan

### DIFF
--- a/packages/activerecord/src/test-helpers/canonical-schema.test.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.test.ts
@@ -6,6 +6,7 @@ import type { FkSafeDropOrderHost } from "./canonical-schema.js";
 import {
   ensureCanonicalTables,
   fkSafeDropOrder,
+  fkSafeDropPlan,
   loadCanonicalSchema,
   rebuildCanonicalTables,
 } from "./canonical-schema.js";
@@ -87,6 +88,29 @@ describe("rebuildCanonicalTables", () => {
     }
   });
 
+  test("drops a foreign key reaching in from a table it is not rebuilding", async () => {
+    const adapter = new BetterSQLite3Adapter(":memory:") as unknown as AbstractAdapter;
+    const sqlite = adapter as unknown as BetterSQLite3Adapter;
+    try {
+      await loadCanonicalSchema(adapter);
+      const canonical = await dumpSchema(adapter);
+
+      // A test-added FK from a table outside the rebuild set: no drop order can
+      // work around it, so the rebuild has to drop the constraint itself.
+      await sqlite.addForeignKey("lessons_students", "fk_test_has_pk", {
+        column: "lesson_id",
+        primaryKey: "pk_id",
+      });
+      expect(await sqlite.foreignKeys("lessons_students")).toHaveLength(1);
+
+      await rebuildCanonicalTables(adapter, ["fk_test_has_pk"]);
+      expect(await sqlite.foreignKeys("lessons_students")).toEqual([]);
+      expect(await dumpSchema(adapter)).toBe(canonical);
+    } finally {
+      await sqlite.close();
+    }
+  });
+
   test("throws on an unknown canonical table name", async () => {
     const adapter = new BetterSQLite3Adapter(":memory:") as unknown as AbstractAdapter;
     try {
@@ -106,7 +130,8 @@ describe("fkSafeDropOrder", () => {
   function host(tables: string[], fks: Record<string, string[]> = {}): FkSafeDropOrderHost {
     return {
       tables: async () => tables,
-      foreignKeys: async (name) => (fks[name] ?? []).map((toTable) => ({ toTable })),
+      foreignKeys: async (name) =>
+        (fks[name] ?? []).map((toTable) => ({ toTable, name: `fk_${name}_${toTable}` })),
     };
   }
 
@@ -156,6 +181,47 @@ describe("fkSafeDropOrder", () => {
   test("falls back to input order for a cycle", async () => {
     const order = await fkSafeDropOrder(host(["a", "b"], { a: ["b"], b: ["a"] }), ["a", "b"]);
     expect(order).toEqual(["a", "b"]);
+  });
+
+  test("reports the constraint that closes a cycle", async () => {
+    const plan = await fkSafeDropPlan(host(["a", "b"], { a: ["b"], b: ["a"] }), ["a", "b"]);
+    expect(plan.order).toEqual(["a", "b"]);
+    expect(plan.blockers).toEqual([{ fromTable: "b", name: "fk_b_a" }]);
+  });
+
+  test("reports a foreign key reaching in from outside the dropped set", async () => {
+    // `outside` is not being dropped, so no order among a/b can help: PG and
+    // MySQL refuse to drop `a` while its constraint is live.
+    const plan = await fkSafeDropPlan(host(["a", "b", "outside"], { outside: ["a"], b: ["a"] }), [
+      "a",
+      "b",
+    ]);
+    expect(plan.order).toEqual(["b", "a"]);
+    expect(plan.blockers).toEqual([{ fromTable: "outside", name: "fk_outside_a" }]);
+  });
+
+  test("does not scan outside tables when the dropped set holds no foreign key", async () => {
+    const calls: string[] = [];
+    const base = host(["a", "b", "outside"], { outside: ["a"] });
+    const plan = await fkSafeDropPlan(
+      {
+        tables: base.tables,
+        foreignKeys: async (name) => {
+          calls.push(name);
+          return base.foreignKeys(name);
+        },
+      },
+      ["a", "b"],
+    );
+    expect(calls).toEqual(["a", "b"]);
+    expect(plan.blockers).toEqual([]);
+  });
+
+  test("scans outside tables anyway when scanInbound is requested", async () => {
+    const plan = await fkSafeDropPlan(host(["a", "b", "outside"], { outside: ["a"] }), ["a", "b"], {
+      scanInbound: true,
+    });
+    expect(plan.blockers).toEqual([{ fromTable: "outside", name: "fk_outside_a" }]);
   });
 });
 

--- a/packages/activerecord/src/test-helpers/canonical-schema.test.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.test.ts
@@ -2,10 +2,9 @@ import { describe, expect, test } from "vitest";
 import "../sqlite/better-sqlite3.js";
 import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
 import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
-import type { FkSafeDropOrderHost } from "./canonical-schema.js";
+import type { FkSafeDropPlanHost } from "./canonical-schema.js";
 import {
   ensureCanonicalTables,
-  fkSafeDropOrder,
   fkSafeDropPlan,
   loadCanonicalSchema,
   rebuildCanonicalTables,
@@ -124,10 +123,10 @@ describe("rebuildCanonicalTables", () => {
   });
 });
 
-describe("fkSafeDropOrder", () => {
+describe("fkSafeDropPlan", () => {
   // Stands in for the live database: `fks` maps a table to the tables it
   // references, as `foreignKeys` would report them.
-  function host(tables: string[], fks: Record<string, string[]> = {}): FkSafeDropOrderHost {
+  function host(tables: string[], fks: Record<string, string[]> = {}): FkSafeDropPlanHost {
     return {
       tables: async () => tables,
       foreignKeys: async (name) =>
@@ -138,7 +137,7 @@ describe("fkSafeDropOrder", () => {
   test("drops a referencing table before its target", async () => {
     // Registry order: lessons_students (referencer) is registered *before*
     // students (target), so reversing registry order would drop students first.
-    const order = await fkSafeDropOrder(
+    const { order } = await fkSafeDropPlan(
       host(["lessons_students", "students"], { lessons_students: ["students"] }),
       ["lessons_students", "students"],
     );
@@ -146,7 +145,7 @@ describe("fkSafeDropOrder", () => {
   });
 
   test("keeps input order when no foreign keys are declared", async () => {
-    const order = await fkSafeDropOrder(host(["lessons_students", "students"]), [
+    const { order } = await fkSafeDropPlan(host(["lessons_students", "students"]), [
       "lessons_students",
       "students",
     ]);
@@ -154,7 +153,7 @@ describe("fkSafeDropOrder", () => {
   });
 
   test("ignores foreign keys pointing outside the dropped set", async () => {
-    const order = await fkSafeDropOrder(host(["a", "b"], { a: ["elsewhere"], b: ["a"] }), [
+    const { order } = await fkSafeDropPlan(host(["a", "b"], { a: ["elsewhere"], b: ["a"] }), [
       "a",
       "b",
     ]);
@@ -164,7 +163,7 @@ describe("fkSafeDropOrder", () => {
   test("skips tables that do not exist yet", async () => {
     const calls: string[] = [];
     const base = host(["b"], { a: ["b"] });
-    const order = await fkSafeDropOrder(
+    const { order } = await fkSafeDropPlan(
       {
         tables: base.tables,
         foreignKeys: async (name) => {
@@ -178,15 +177,10 @@ describe("fkSafeDropOrder", () => {
     expect(order).toEqual(["a", "b"]);
   });
 
-  test("falls back to input order for a cycle", async () => {
-    const order = await fkSafeDropOrder(host(["a", "b"], { a: ["b"], b: ["a"] }), ["a", "b"]);
-    expect(order).toEqual(["a", "b"]);
-  });
-
-  test("reports the constraint that closes a cycle", async () => {
+  test("falls back to input order for a cycle, reporting the constraint that closes it", async () => {
     const plan = await fkSafeDropPlan(host(["a", "b"], { a: ["b"], b: ["a"] }), ["a", "b"]);
     expect(plan.order).toEqual(["a", "b"]);
-    expect(plan.blockers).toEqual([{ fromTable: "b", name: "fk_b_a" }]);
+    expect(plan.blockers).toEqual([{ fromTable: "b", toTable: "a", name: "fk_b_a" }]);
   });
 
   test("reports a foreign key reaching in from outside the dropped set", async () => {
@@ -197,7 +191,7 @@ describe("fkSafeDropOrder", () => {
       "b",
     ]);
     expect(plan.order).toEqual(["b", "a"]);
-    expect(plan.blockers).toEqual([{ fromTable: "outside", name: "fk_outside_a" }]);
+    expect(plan.blockers).toEqual([{ fromTable: "outside", toTable: "a", name: "fk_outside_a" }]);
   });
 
   test("does not scan outside tables when the dropped set holds no foreign key", async () => {
@@ -221,7 +215,7 @@ describe("fkSafeDropOrder", () => {
     const plan = await fkSafeDropPlan(host(["a", "b", "outside"], { outside: ["a"] }), ["a", "b"], {
       scanInbound: true,
     });
-    expect(plan.blockers).toEqual([{ fromTable: "outside", name: "fk_outside_a" }]);
+    expect(plan.blockers).toEqual([{ fromTable: "outside", toTable: "a", name: "fk_outside_a" }]);
   });
 });
 

--- a/packages/activerecord/src/test-helpers/canonical-schema.test.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.test.ts
@@ -96,13 +96,12 @@ describe("rebuildCanonicalTables", () => {
 
       // A test-added FK from a table outside the rebuild set: no drop order can
       // work around it, so the rebuild has to drop the constraint itself.
-      await sqlite.addForeignKey("lessons_students", "fk_test_has_pk", {
-        column: "lesson_id",
-        primaryKey: "pk_id",
-      });
+      // `authors` declares no FK of its own, so nothing about the rebuilt set
+      // hints that an inbound FK might exist — the rebuild has to go looking.
+      await sqlite.addForeignKey("lessons_students", "authors", { column: "lesson_id" });
       expect(await sqlite.foreignKeys("lessons_students")).toHaveLength(1);
 
-      await rebuildCanonicalTables(adapter, ["fk_test_has_pk"]);
+      await rebuildCanonicalTables(adapter, ["authors"]);
       expect(await sqlite.foreignKeys("lessons_students")).toEqual([]);
       expect(await dumpSchema(adapter)).toBe(canonical);
     } finally {

--- a/packages/activerecord/src/test-helpers/canonical-schema.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.ts
@@ -2088,7 +2088,7 @@ export async function loadCanonicalSchema(adapter: DatabaseAdapter): Promise<voi
 }
 
 /** Minimal slice of the schema-statement surface {@link fkSafeDropPlan} needs. */
-export interface FkSafeDropOrderHost {
+export interface FkSafeDropPlanHost {
   tables(): Promise<string[]>;
   foreignKeys(
     tableName: string,
@@ -2103,6 +2103,7 @@ export interface FkSafeDropOrderHost {
  */
 export interface FkDropBlocker {
   readonly fromTable: string;
+  readonly toTable: string;
   readonly name: string;
 }
 
@@ -2149,7 +2150,7 @@ export interface FkSafeDropPlan {
  * @internal
  */
 export async function fkSafeDropPlan(
-  ss: FkSafeDropOrderHost,
+  ss: FkSafeDropPlanHost,
   names: readonly string[],
   { scanInbound = false }: { scanInbound?: boolean } = {},
 ): Promise<FkSafeDropPlan> {
@@ -2176,7 +2177,9 @@ export async function fkSafeDropPlan(
   for (const table of existing) {
     if (inSet.has(table)) continue;
     for (const fk of await ss.foreignKeys(table)) {
-      if (inSet.has(fk.toTable)) blockers.push({ fromTable: table, name: fk.name });
+      if (inSet.has(fk.toTable)) {
+        blockers.push({ fromTable: table, toTable: fk.toTable, name: fk.name });
+      }
     }
   }
   if (edges.size === 0) return { order: [...names], blockers };
@@ -2191,7 +2194,7 @@ export async function fkSafeDropPlan(
       // A target still on the current path closes a cycle: no drop order can
       // satisfy this edge, so report the constraint and ignore the edge.
       if (onPath.has(edge.toTable)) {
-        blockers.push({ fromTable: name, name: edge.name });
+        blockers.push({ fromTable: name, toTable: edge.toTable, name: edge.name });
         continue;
       }
       visit(edge.toTable);
@@ -2204,19 +2207,6 @@ export async function fkSafeDropPlan(
   // reverse: the result drops referencers first.
   for (const name of names) visit(name);
   return { order: ordered.reverse(), blockers };
-}
-
-/**
- * {@link fkSafeDropPlan}'s order alone, for callers that have already dealt
- * with (or provably cannot have) blocking foreign keys.
- *
- * @internal
- */
-export async function fkSafeDropOrder(
-  ss: FkSafeDropOrderHost,
-  names: readonly string[],
-): Promise<string[]> {
-  return (await fkSafeDropPlan(ss, names)).order;
 }
 
 /**
@@ -2291,7 +2281,10 @@ export async function rebuildCanonicalTables(
   // referencing table keeps its shape — only the constraint is lost, and a
   // canonical table's own FKs come back with the recreate below.
   for (const blocker of plan.blockers) {
-    await ss.removeForeignKey(blocker.fromTable, { name: blocker.name, ifExists: true });
+    await ss.removeForeignKey(blocker.fromTable, {
+      name: blocker.name,
+      toTable: blocker.toTable,
+    });
   }
   for (const name of plan.order) {
     await ss.dropTable(name, { ifExists: true });

--- a/packages/activerecord/src/test-helpers/canonical-schema.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.ts
@@ -2140,12 +2140,18 @@ export interface FkSafeDropPlan {
  *
  * FKs are read only for tables that currently exist, and by default only for
  * the tables being dropped: finding inbound FKs means introspecting every
- * *other* live table (hundreds, for the canonical schema), so that scan is
- * skipped unless the drop set itself reported at least one foreign key. On an
- * FK-free database this costs exactly what it did before. The trade-off is
- * deliberate and one-sided: a drop set whose tables hold no FK of their own but
- * are pointed at from outside is not detected — pass `scanInbound` to force the
- * scan when a caller knows that shape is possible.
+ * *other* live table (hundreds, for the canonical schema), so that scan runs
+ * only when `scanInbound` is passed or the drop set reported a foreign key —
+ * *any* foreign key, counted before self-loops and out-of-set targets are
+ * filtered out, because the signal wanted there is the weak "this database uses
+ * foreign keys at all", not "these tables constrain each other". On an FK-free
+ * database this costs exactly what it did before.
+ *
+ * That default is a cheap heuristic, not a guarantee: a drop set whose tables
+ * hold no FK of their own but are pointed at from outside is precisely what it
+ * misses. Any caller that has to be *right* about inbound FKs — as
+ * {@link rebuildCanonicalTables} does — must pass `scanInbound` and pay for the
+ * scan rather than rely on it.
  *
  * @internal
  */
@@ -2272,9 +2278,15 @@ export async function rebuildCanonicalTables(
   const defs = registry.filter((d) => wanted.has(d.name));
   if (defs.length === 0) return;
   const { ss, typeMap } = await prepareSchema(adapter);
+  // `scanInbound` is not optional here: this helper exists as the shield against
+  // a sibling test that left a stray foreign key pointing at a canonical table,
+  // which is exactly the shape fkSafeDropPlan's default heuristic cannot see —
+  // the dropped table holds no FK of its own, so nothing would trigger the scan.
+  // The scan costs one FK introspection per live table not being rebuilt.
   const plan = await fkSafeDropPlan(
     ss,
     defs.map((d) => d.name),
+    { scanInbound: true },
   );
   // An FK reaching in from a table nobody asked for (or one closing a cycle)
   // has no drop order that works; drop the constraint itself first. The

--- a/packages/activerecord/src/test-helpers/canonical-schema.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.ts
@@ -2087,56 +2087,115 @@ export async function loadCanonicalSchema(adapter: DatabaseAdapter): Promise<voi
   (adapter as { clearCacheBang?: () => void }).clearCacheBang?.();
 }
 
-/** Minimal slice of the schema-statement surface {@link fkSafeDropOrder} needs. */
+/** Minimal slice of the schema-statement surface {@link fkSafeDropPlan} needs. */
 export interface FkSafeDropOrderHost {
   tables(): Promise<string[]>;
-  foreignKeys(tableName: string): Promise<readonly { readonly toTable: string }[]>;
+  foreignKeys(
+    tableName: string,
+  ): Promise<readonly { readonly toTable: string; readonly name: string }[]>;
 }
 
 /**
- * Order `names` so every table is dropped before any table it references,
- * i.e. referencing tables first.
+ * A foreign key that has to be dropped before the plan's order can run: either
+ * it points into the drop set from a table outside it (no ordering among the
+ * dropped tables can help — PG/MySQL refuse the `DROP TABLE` outright), or it
+ * closes a cycle among the dropped tables (which has no safe order at all).
+ */
+export interface FkDropBlocker {
+  readonly fromTable: string;
+  readonly name: string;
+}
+
+/** Drop order plus the constraints that must be removed first. */
+export interface FkSafeDropPlan {
+  readonly order: string[];
+  readonly blockers: readonly FkDropBlocker[];
+}
+
+/**
+ * Plan the drop of `names`: order them so every table is dropped before any
+ * table it references (referencing tables first), and list the foreign keys
+ * that no ordering can work around and so must be removed first.
  *
- * Registry order cannot stand in for this: it is roughly alphabetical, not
- * topological — `lessons_students` is registered before `students`, so merely
- * reversing it drops the target before its referencer. The canonical registry
- * declares no foreign keys of its own, but a test may add one (e.g.
+ * Registry order cannot stand in for the ordering: it is roughly alphabetical,
+ * not topological — `lessons_students` is registered before `students`, so
+ * merely reversing it drops the target before its referencer. The canonical
+ * registry declares no foreign keys of its own, but a test may add one (e.g.
  * `addForeignKey("lessons_students", "students")` in the abstract-mysql-adapter
- * schema tests), so the order is derived from the FKs the database actually
+ * schema tests), so the plan is derived from the FKs the database actually
  * holds rather than from anything declared here.
  *
- * FKs are read only for tables that currently exist, and only for the tables
- * being dropped — an adapter with no FK introspection reports none and the
- * input order is preserved. A cycle (mutually-referencing tables) has no safe
- * order; those tables keep their input order, which is what dropping them
- * without this helper would have done anyway.
+ * Two shapes have no safe order and surface as `blockers` instead:
+ *
+ * - an FK from a table *outside* `names` into one inside it — PG and MySQL
+ *   refuse to drop a referenced table however the drops are sequenced;
+ * - a cycle among the dropped tables — the back edge is reported and the
+ *   remaining (acyclic) edges still shape the order.
+ *
+ * Suspending referential integrity is not an alternative for the inbound case:
+ * `disableReferentialIntegrity` covers MySQL/SQLite, but PG's `DISABLE TRIGGER
+ * ALL` still refuses to let a referenced table be dropped, so the constraint
+ * has to go regardless.
+ *
+ * FKs are read only for tables that currently exist, and by default only for
+ * the tables being dropped: finding inbound FKs means introspecting every
+ * *other* live table (hundreds, for the canonical schema), so that scan is
+ * skipped unless the drop set itself reported at least one foreign key. On an
+ * FK-free database this costs exactly what it did before. The trade-off is
+ * deliberate and one-sided: a drop set whose tables hold no FK of their own but
+ * are pointed at from outside is not detected — pass `scanInbound` to force the
+ * scan when a caller knows that shape is possible.
  *
  * @internal
  */
-export async function fkSafeDropOrder(
+export async function fkSafeDropPlan(
   ss: FkSafeDropOrderHost,
   names: readonly string[],
-): Promise<string[]> {
-  if (names.length < 2) return [...names];
+  { scanInbound = false }: { scanInbound?: boolean } = {},
+): Promise<FkSafeDropPlan> {
+  if (names.length === 0) return { order: [], blockers: [] };
   const inSet = new Set(names);
   const existing = new Set(await ss.tables());
-  const referencedBy = new Map<string, string[]>();
+  const edges = new Map<string, { toTable: string; name: string }[]>();
+  let sawForeignKey = false;
   for (const name of names) {
     if (!existing.has(name)) continue;
-    const targets = (await ss.foreignKeys(name))
-      .map((fk) => fk.toTable)
-      .filter((t) => t !== name && inSet.has(t));
-    if (targets.length > 0) referencedBy.set(name, targets);
+    const fks = await ss.foreignKeys(name);
+    if (fks.length > 0) sawForeignKey = true;
+    const targets = fks.filter((fk) => fk.toTable !== name && inSet.has(fk.toTable));
+    if (targets.length > 0) {
+      edges.set(
+        name,
+        targets.map((fk) => ({ toTable: fk.toTable, name: fk.name })),
+      );
+    }
   }
-  if (referencedBy.size === 0) return [...names];
+  if (!sawForeignKey && !scanInbound) return { order: [...names], blockers: [] };
+
+  const blockers: FkDropBlocker[] = [];
+  for (const table of existing) {
+    if (inSet.has(table)) continue;
+    for (const fk of await ss.foreignKeys(table)) {
+      if (inSet.has(fk.toTable)) blockers.push({ fromTable: table, name: fk.name });
+    }
+  }
+  if (edges.size === 0) return { order: [...names], blockers };
 
   const ordered: string[] = [];
   const emitted = new Set<string>();
   const onPath = new Set<string>();
   const visit = (name: string): void => {
-    if (emitted.has(name) || onPath.has(name)) return;
+    if (emitted.has(name)) return;
     onPath.add(name);
-    for (const target of referencedBy.get(name) ?? []) visit(target);
+    for (const edge of edges.get(name) ?? []) {
+      // A target still on the current path closes a cycle: no drop order can
+      // satisfy this edge, so report the constraint and ignore the edge.
+      if (onPath.has(edge.toTable)) {
+        blockers.push({ fromTable: name, name: edge.name });
+        continue;
+      }
+      visit(edge.toTable);
+    }
     onPath.delete(name);
     emitted.add(name);
     ordered.push(name);
@@ -2144,7 +2203,20 @@ export async function fkSafeDropOrder(
   // Referencers are emitted after their targets, so walk in input order and
   // reverse: the result drops referencers first.
   for (const name of names) visit(name);
-  return ordered.reverse();
+  return { order: ordered.reverse(), blockers };
+}
+
+/**
+ * {@link fkSafeDropPlan}'s order alone, for callers that have already dealt
+ * with (or provably cannot have) blocking foreign keys.
+ *
+ * @internal
+ */
+export async function fkSafeDropOrder(
+  ss: FkSafeDropOrderHost,
+  names: readonly string[],
+): Promise<string[]> {
+  return (await fkSafeDropPlan(ss, names)).order;
 }
 
 /**
@@ -2210,10 +2282,18 @@ export async function rebuildCanonicalTables(
   const defs = registry.filter((d) => wanted.has(d.name));
   if (defs.length === 0) return;
   const { ss, typeMap } = await prepareSchema(adapter);
-  for (const name of await fkSafeDropOrder(
+  const plan = await fkSafeDropPlan(
     ss,
     defs.map((d) => d.name),
-  )) {
+  );
+  // An FK reaching in from a table nobody asked for (or one closing a cycle)
+  // has no drop order that works; drop the constraint itself first. The
+  // referencing table keeps its shape — only the constraint is lost, and a
+  // canonical table's own FKs come back with the recreate below.
+  for (const blocker of plan.blockers) {
+    await ss.removeForeignKey(blocker.fromTable, { name: blocker.name, ifExists: true });
+  }
+  for (const name of plan.order) {
     await ss.dropTable(name, { ifExists: true });
   }
   for (const def of defs) {


### PR DESCRIPTION
`fkSafeDropOrder` (#5267) ordered drops topologically but only over FKs *among*
the tables being dropped. Two shapes stayed unsafe:

- an FK from a table **outside** the drop set into one inside it — PG/MySQL
  refuse the `DROP TABLE` however the drops are sequenced (PG's
  `DISABLE TRIGGER ALL` does not help either, so the constraint must go);
- a **cycle**, which has no safe order at all — the old code silently emitted
  input order.

`fkSafeDropOrder` becomes `fkSafeDropPlan`, returning `{ order, blockers }`:
`blockers` are the constraints (inbound, or cycle-closing back edges) that must
be removed before the order can run, each named with its `fromTable`/`toTable`.
`rebuildCanonicalTables` drops them via `removeForeignKey` before dropping
tables; the remaining acyclic edges still shape the order.

### Cost

Finding inbound FKs means one FK introspection per live table not being rebuilt,
so `fkSafeDropPlan` runs that scan only when asked (`scanInbound`) or when the
drop set itself reported any FK — a weak "this database uses FKs at all" signal,
counted before self-loops and out-of-set targets are filtered out. That default
is a heuristic, and the shape it misses is exactly the one it would need to
catch: a table with no FKs of its own that something outside points at. So
`rebuildCanonicalTables` — whose entire job is shielding against a sibling test's
stray FK — passes `scanInbound: true` unconditionally and pays for the scan.
Callers that only need an order keep the cheap default; an FK-free database still
costs what it did before.

Tests: cycle blocker, inbound blocker, the `scanInbound` override, a
no-extra-introspection assertion pinning the default heuristic, and an
integration test on a real SQLite adapter where a test-added FK from
`lessons_students` into `authors` (a table with no FKs of its own, so nothing
about the rebuilt set hints the FK exists) is dropped by the rebuild. That test
fails if `rebuildCanonicalTables` stops passing `scanInbound`.

Closes-story: fk-safe-drop-inbound-and-cyclic-fks
