### PR TITLE
fix(associations): return false from CollectionProxy#push/#concat on a failed insert

### DIFF
--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -321,21 +321,19 @@ export class CollectionAssociation extends Association {
   /**
    * Add records to this association. Flattens arguments and inserts
    * each record, persisting if the owner is persisted.
+   *
+   * Yields the added records, or `undefined` when a failed `insert_record`
+   * made `concat_records` raise `ActiveRecord::Rollback` inside the
+   * persisted-owner transaction (collection_association.rb:127-135) — the
+   * nil that makes `CollectionProxy#<<` falsy.
    */
-  async concat(...records: Base[]): Promise<Base[]> {
+  async concat(...records: Base[]): Promise<Base[] | undefined> {
     const flattened = records.flat();
     if (this.owner.isNewRecord()) {
       await this.loadTarget();
-      await this.concatRecords(flattened);
-    } else {
-      // Rails wraps the persisted-owner concat in a transaction so a mid-batch
-      // save failure rolls back the records already inserted
-      // (collection_association.rb:133 — `transaction { concat_records(records) }`).
-      await transaction(this, async () => {
-        await this.concatRecords(flattened);
-      });
+      return this.concatRecords(flattened);
     }
-    return flattened;
+    return transaction(this, () => this.concatRecords(flattened));
   }
 
   /** @internal */
@@ -1219,7 +1217,10 @@ export async function concatRecordsLoop(
 }
 
 /** @internal */
-function transaction(assoc: CollectionAssociation, block: () => Promise<void>): Promise<void> {
+function transaction<R>(
+  assoc: CollectionAssociation,
+  block: () => Promise<R>,
+): Promise<R | undefined> {
   // Rails: reflection.klass.transaction(&block) — uses the reflection's klass, not assoc.klass
   const klass = (assoc.reflection as any).klass ?? assoc.klass;
   if (klass && typeof klass.transaction === "function") {

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1985,13 +1985,19 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * Add one or more records to the collection by setting the FK and saving.
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#push / #<< — which
-   * return `proxy_association.concat(records) && self`: the collection proxy
-   * for chaining, or a falsy value when a record failed to insert on a
-   * persisted owner (`concat_records` rolls the transaction back, so
-   * `concat` returns nil). `self` is returned via `stripThenable` so the
-   * (thenable) proxy isn't unwrapped by promise adoption — otherwise
-   * `return this` would call the proxy's `then` and load the target,
-   * breaking Rails' "push does not load target" invariant.
+   * return `proxy_association.concat(records) && self`, so the call is falsy
+   * as soon as one child fails to insert: `concat_records` raises
+   * `ActiveRecord::Rollback` on a false `insert_record`, and the enclosing
+   * `transaction { }` swallows it and yields nil out of `concat`. That is the
+   * `concatResult` check below — the failure is reported by return value, not
+   * by raising, because `concat` passes `raise = false`. Through associations
+   * are the exception: `HasManyThroughAssociation#concat_records` calls
+   * `super(records, true)`, so they raise instead and always return the proxy.
+   *
+   * `self` is returned via `stripThenable` so the (thenable) proxy isn't
+   * unwrapped by promise adoption — otherwise `return this` would call the
+   * proxy's `then` and load the target, breaking Rails' "push does not load
+   * target" invariant.
    */
   async push(...records: T[]): Promise<Omit<this, "then"> | false> {
     this._ensureThroughWritable();
@@ -2071,13 +2077,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // `CollectionAssociation#concatRecords` parity surface stay in lock-step.
     // A record whose `save` merely *returns false* (a validation/callback abort
     // that doesn't raise) still rolls back the records already inserted.
-    // `concat_records`' accumulated `result`: false once any insert fails.
-    // Rails reports it by returning nil out of the rolled-back transaction;
-    // here the loop's Rollback is swallowed by `transaction`, so the flag is
-    // what survives to the return statement.
-    let result = true;
-    const concatRecords = (): Promise<void> =>
-      concatRecordsLoop(records, async (record, resultStillTrue) => {
+    const concatRecords = async (): Promise<T[]> => {
+      await concatRecordsLoop(records, async (record, resultStillTrue) => {
         // Route through replace_on_target (via _addToTarget) so set_inverse_instance
         // and @replaced_or_added_targets dedup tracking run on push/<<, mirroring
         // Rails' concat_records → add_to_target(record) { insert_record }. A record
@@ -2101,23 +2102,22 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
           // but still buffers this record into the target above.
           if (this._record.isNewRecord() || !resultStillTrue) return true;
           saved = (await insertRecord(record as T)) ?? false;
-          if (!saved) result = false;
           return saved;
         });
         return saved;
       });
+      return records;
+    };
     // Rails' `CollectionAssociation#concat` wraps the inserts in a transaction
     // for a persisted owner (`transaction { concat_records(records) }`,
     // collection_association.rb:133) so a mid-batch save failure rolls back the
     // records already inserted. A new-record owner skips the transaction — the
     // inserts are deferred to autosave, so no DB write happens here (and a
     // BEGIN would violate the "push does not query" invariant).
-    if (this._record.isNewRecord()) {
-      await concatRecords();
-    } else {
-      await this.transaction(concatRecords);
-    }
-    if (!result) return false;
+    const concatResult = this._record.isNewRecord()
+      ? await concatRecords()
+      : await this.transaction(concatRecords);
+    if (!concatResult) return false;
     return stripThenable(this._proxySelf ?? this);
   }
 

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1985,12 +1985,15 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * Add one or more records to the collection by setting the FK and saving.
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#push / #<< — which
-   * return `self` (the collection proxy) for chaining. Returned via
-   * `stripThenable` so the (thenable) proxy isn't unwrapped by promise
-   * adoption — otherwise `return this` would call the proxy's `then` and
-   * load the target, breaking Rails' "push does not load target" invariant.
+   * return `proxy_association.concat(records) && self`: the collection proxy
+   * for chaining, or a falsy value when a record failed to insert on a
+   * persisted owner (`concat_records` rolls the transaction back, so
+   * `concat` returns nil). `self` is returned via `stripThenable` so the
+   * (thenable) proxy isn't unwrapped by promise adoption — otherwise
+   * `return this` would call the proxy's `then` and load the target,
+   * breaking Rails' "push does not load target" invariant.
    */
-  async push(...records: T[]): Promise<Omit<this, "then">> {
+  async push(...records: T[]): Promise<Omit<this, "then"> | false> {
     this._ensureThroughWritable();
     this._raiseOnTypeMismatch(records);
     // Through association (including HABTM): create join records
@@ -2068,6 +2071,11 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // `CollectionAssociation#concatRecords` parity surface stay in lock-step.
     // A record whose `save` merely *returns false* (a validation/callback abort
     // that doesn't raise) still rolls back the records already inserted.
+    // `concat_records`' accumulated `result`: false once any insert fails.
+    // Rails reports it by returning nil out of the rolled-back transaction;
+    // here the loop's Rollback is swallowed by `transaction`, so the flag is
+    // what survives to the return statement.
+    let result = true;
     const concatRecords = (): Promise<void> =>
       concatRecordsLoop(records, async (record, resultStillTrue) => {
         // Route through replace_on_target (via _addToTarget) so set_inverse_instance
@@ -2093,6 +2101,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
           // but still buffers this record into the target above.
           if (this._record.isNewRecord() || !resultStillTrue) return true;
           saved = (await insertRecord(record as T)) ?? false;
+          if (!saved) result = false;
           return saved;
         });
         return saved;
@@ -2108,6 +2117,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     } else {
       await this.transaction(concatRecords);
     }
+    if (!result) return false;
     return stripThenable(this._proxySelf ?? this);
   }
 
@@ -2539,7 +2549,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   /**
    * Alias for push.
    */
-  async concat(...records: T[]): Promise<Omit<this, "then">> {
+  async concat(...records: T[]): Promise<Omit<this, "then"> | false> {
     return this.push(...records);
   }
 
@@ -4157,7 +4167,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#append
    */
-  async append(...records: T[]): Promise<Omit<this, "then">> {
+  async append(...records: T[]): Promise<Omit<this, "then"> | false> {
     return this.push(...records);
   }
 

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -516,7 +516,7 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
   it("invalid adding", async () => {
     const firm = await Firm.find(companies("first_firm").id);
     const c = new Client();
-    await firm.clientsOfFirm.concat(c);
+    expect(await firm.clientsOfFirm.push(c)).toBeFalsy();
     expect(c.isPersisted()).toBe(false);
     expect(await firm.isValid()).toBe(false);
     expect(await firm.save()).toBe(false);


### PR DESCRIPTION
Rails' `CollectionProxy#<<` (aliased to `push` / `append` / `concat`) returns
`proxy_association.concat(records) && self` (collection_proxy.rb:1049), so the call is
falsy as soon as one child fails to insert. The mechanism is
`CollectionAssociation#concat_records` (collection_association.rb:438-455): it folds
`result &&= insert_record(record, true, raise)` and then `raise ActiveRecord::Rollback
unless result`. For a persisted owner the fold runs inside `transaction { }`
(`:133`), which swallows the Rollback and yields nil out of `concat`. `concat` passes
`raise = false`, so the failure is reported by return value, not by raising.

trails already had the fold and the Rollback throw (`concatRecordsLoop`), but both
`CollectionProxy#push` and `CollectionAssociation#concat` returned unconditionally and
discarded the result, so `push` always resolved to the (truthy) proxy.

## Changes

- `CollectionAssociation#concat` now returns what its transaction returns —
  `Base[] | undefined` — instead of the flattened records regardless of outcome. The
  local `transaction` helper is generalized to pass the block's value through.
- `CollectionProxy#push` returns `false` when that concat result is falsy, and the
  proxy otherwise; `concat` / `append` inherit it via delegation. Return type is now
  `Promise<Omit<this, "then"> | false>`.
- No new accumulator: the falsy signal is the swallowed Rollback surfacing as an
  `undefined` transaction result, which is exactly Rails' path.
- Through associations are deliberately untouched:
  `HasManyThroughAssociation#concat_records` calls `super(records, true)`
  (has_many_through_association.rb:40), so they raise `RecordInvalid` rather than
  returning falsy. Noted in the `push` docblock.

## Tests

Rebased onto #5278, which converged this describe block onto canonical `Firm`/`Client`.
That left exactly one line for this PR to contribute: `test_invalid_adding`
(autosave_association_test.rb:819) opens with
`assert_not (firm.clients_of_firm << c = Client.new)`, which #5278 could only port as a
bare `await firm.clientsOfFirm.concat(c)` because there was no falsy value to assert on.
It now reads `expect(await firm.clientsOfFirm.push(c)).toBeFalsy()` — `push` rather than
`concat` to match Rails' `<<` on that line.

`test_invalid_adding_before_save` (`:829`) is untouched: a new-record owner defers the
inserts to autosave, so `concat` stays truthy in Rails too, and Rails asserts nothing on
its return.

## Verification

- Baseline check: with the `return false` neutralized, `invalid adding` fails —
  the assertion bites.
- `pnpm typecheck` clean. Caller audit: no `src` or test caller consumed the `push` /
  `concat` / `append` return except `expect(...).resolves`/`.rejects` assertions, none
  of which relied on the always-truthy proxy.
- Ran `packages/activerecord/src/associations/` + `associations.test.ts` +
  `autosave-association.test.ts` locally: 85/85 files, 2276 passed, 0 failed.
- Post-rebase: `autosave-association.test.ts` 209/209 green, and the baseline check
  re-confirmed against the canonical models.

Closes-story: collection-proxy-concat-returns-false-on-failed-insert
