### PR TITLE
docs(postgresql): drop stale add_modifier unported comment

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
@@ -48,9 +48,7 @@ import { Uuid } from "./oid/uuid.js";
 import { Vector } from "./oid/vector.js";
 import { Xml } from "./oid/xml.js";
 
-// Mirrors: postgresql_adapter.rb:1168-1185. The two `add_modifier` lines that
-// open that block (array/range) are unported: trails has no registry
-// modifiers, and `attribute(..., array: true)` does not route through them.
+// Mirrors: postgresql_adapter.rb:1168-1185.
 ArType.register("bit", Bit, { adapter: "postgres" });
 ArType.register("bit_varying", BitVarying, { adapter: "postgres" });
 ArType.register("binary", Bytea, { adapter: "postgres" });


### PR DESCRIPTION
The comment above the `ArType.register` block in `type-map-init.ts` claimed the
two `add_modifier` lines opening Rails' registration block
(`postgresql_adapter.rb:1166-1167`) were unported. That stopped being true when
#5203 landed those exact calls twelve lines below, so the comment contradicted
the code and risked re-filing an already-closed story.

Deleted the stale claim; the `Mirrors:` line stays. The normalized-adapter-name
note is already covered by the comment on the `addModifier` block.

Closes-story: pg-type-map-init-stale-unported-modifier-comment
