### PR TITLE
test(autosave-association): port callbacks on child when parent autosaves child onto canonical Eye/Iris

### DIFF
--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -1171,9 +1171,7 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
   });
 
   it("callbacks on child when parent autosaves child", async () => {
-    const eye = new Eye();
-    cacheAssoc(eye, "iris", new Iris());
-    await eye.saveBang();
+    const eye = await Eye.createBang({ iris: new Iris() });
     const iris = eye.iris;
     expect(iris?.beforeValidationCallbacksCounter).toBe(1);
     expect(iris?.beforeCreateCallbacksCounter).toBe(1);

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -1171,43 +1171,16 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
   });
 
   it("callbacks on child when parent autosaves child", async () => {
-    const log: string[] = [];
-    class CbParent extends Base {
-      declare name: string | null;
-      declare cbChild: CbChild | null;
-      declare loadHasOne: (name: "cbChild") => Promise<CbChild | null>;
-
-      static {
-        this._tableName = "authors";
-        this.attribute("name", "string");
-        this.hasOne("cbChild", {
-          autosave: true,
-          className: "CbChild",
-          foreignKey: "author_id",
-        });
-      }
-    }
-    class CbChild extends Base {
-      declare name: string | null;
-      declare author_id: number | null;
-
-      static {
-        this._tableName = "books";
-        this.attribute("name", "string");
-        this.attribute("author_id", "integer");
-        this.afterSave(function () {
-          log.push("child_after_save");
-        });
-      }
-    }
-    registerModel("CbParent", CbParent);
-    registerModel("CbChild", CbChild);
-    const parent = await CbParent.create({ name: "P" });
-    const child = new CbChild({ name: "V" });
-    cacheAssoc(parent, "cbChild", child);
-    await parent.save();
-    expect(log).toContain("child_after_save");
-    expect(child.isNewRecord()).toBe(false);
+    const eye = new Eye();
+    cacheAssoc(eye, "iris", new Iris());
+    await eye.saveBang();
+    const iris = eye.iris;
+    expect(iris?.beforeValidationCallbacksCounter).toBe(1);
+    expect(iris?.beforeCreateCallbacksCounter).toBe(1);
+    expect(iris?.beforeSaveCallbacksCounter).toBe(1);
+    expect(iris?.afterValidationCallbacksCounter).toBe(1);
+    expect(iris?.afterCreateCallbacksCounter).toBe(1);
+    expect(iris?.afterSaveCallbacksCounter).toBe(1);
   });
   it("callbacks on child when parent autosaves child twice", async () => {
     const eye = new Eye();


### PR DESCRIPTION
Ports `test_callbacks_on_child_when_parent_autosaves_child`
(`vendor/rails/activerecord/test/cases/autosave_association_test.rb:313-322`)
onto the canonical `Eye` / `Iris` models.

The trails test was a bespoke stand-in: `CbParent` (on `authors`) / `CbChild`
(on `books`) asserting only that a `child_after_save` string landed in a log
array. It now asserts the six Rails counters verbatim on `eye.iris`, which
`Iris` already carries.

This path reads the association through the warm reader branch (in-memory
target), a different arm than #5251's cold-cache work.

Closes-story: port-callbacks-on-child-when-parent-autosaves-child
