### PR TITLE
test(sqlite): make the worker-DB fallback file-backed

### DIFF
--- a/packages/activerecord/src/test-helpers/test-database-config.test.ts
+++ b/packages/activerecord/src/test-helpers/test-database-config.test.ts
@@ -42,11 +42,24 @@ describe("buildTestDatabaseConfig", () => {
     vi.stubEnv("ARCONN", "sqlite3");
     vi.stubEnv("AR_TEST_WORKER_DB", "");
     const { envConfig } = await buildTestDatabaseConfig();
-    // Rails' `sqlite3` connection is file-backed (config.example.yml);
-    // `:memory:` is the opt-in `sqlite3_mem` connection only.
     expect(envConfig.database).not.toBe(":memory:");
     expect(envConfig.database).toMatch(/\.sqlite$/);
     expect(envConfig.pool).toBe(5);
+  });
+
+  it("reuses one fallback database path across calls", async () => {
+    vi.stubEnv("ARCONN", "sqlite3");
+    vi.stubEnv("AR_TEST_WORKER_DB", "");
+    const first = (await buildTestDatabaseConfig()).envConfig.database;
+    const second = (await buildTestDatabaseConfig()).envConfig.database;
+    expect(second).toBe(first);
+  });
+
+  it("prefers AR_TEST_WORKER_DB over the fallback database", async () => {
+    vi.stubEnv("ARCONN", "sqlite3");
+    vi.stubEnv("AR_TEST_WORKER_DB", "/tmp/ar-test-worker.sqlite3");
+    const { envConfig } = await buildTestDatabaseConfig();
+    expect(envConfig.database).toBe("/tmp/ar-test-worker.sqlite3");
   });
 
   it("pins pool 1 on the sqlite3_mem :memory: connection", async () => {

--- a/packages/activerecord/src/test-helpers/test-database-config.test.ts
+++ b/packages/activerecord/src/test-helpers/test-database-config.test.ts
@@ -38,6 +38,17 @@ describe("buildTestDatabaseConfig", () => {
     expect(envConfig.pool).toBe(5);
   });
 
+  it("falls back to a file-backed sqlite DB when AR_TEST_WORKER_DB is unset", async () => {
+    vi.stubEnv("ARCONN", "sqlite3");
+    vi.stubEnv("AR_TEST_WORKER_DB", "");
+    const { envConfig } = await buildTestDatabaseConfig();
+    // Rails' `sqlite3` connection is file-backed (config.example.yml);
+    // `:memory:` is the opt-in `sqlite3_mem` connection only.
+    expect(envConfig.database).not.toBe(":memory:");
+    expect(envConfig.database).toMatch(/\.sqlite$/);
+    expect(envConfig.pool).toBe(5);
+  });
+
   it("pins pool 1 on the sqlite3_mem :memory: connection", async () => {
     vi.stubEnv("ARCONN", "sqlite3_mem");
     vi.stubEnv("AR_TEST_WORKER_DB", "");

--- a/packages/activerecord/src/test-helpers/test-database-config.ts
+++ b/packages/activerecord/src/test-helpers/test-database-config.ts
@@ -158,38 +158,20 @@ async function resolve(): Promise<{ adapter: TestAdapterName; envConfig: HashCon
   return { adapter: connection.lane, envConfig };
 }
 
-/**
- * Path of this process' fallback sqlite DB, used when globalSetup did not
- * stamp `AR_TEST_WORKER_DB`. Memoized on `globalThis` so every connection
- * opened in this process — and every re-evaluation of the module graph within
- * one worker, which vitest's `isolate: true` does per file — lands on the same
- * file. The token keeps concurrent processes on distinct files, so the
- * per-worker isolation of the primary lane is preserved here too.
- */
 async function fallbackDatabasePath(): Promise<string> {
   const g = globalThis as typeof globalThis & { __arFallbackDbPath?: string };
   if (g.__arFallbackDbPath) return g.__arFallbackDbPath;
   const path = await getPathAsync();
   const os = await getOsAsync();
-  const token = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  const runToken =
+    getEnv("AR_TEST_RUN_TOKEN") ||
+    `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+  const slot = getEnv("VITEST_POOL_ID") || getEnv("VITEST_WORKER_ID") || "1";
+  const token = `${runToken}-${slot}`;
   g.__arFallbackDbPath = path.join(os.tmpdir(), `ar-test-fallback-${token}.sqlite`);
   return g.__arFallbackDbPath;
 }
 
-/**
- * Build the sqlite primary config hash. Mirrors Rails' primary test config,
- * which is file-backed (`config.example.yml`'s `sqlite3` entry points at
- * `FIXTURES_ROOT/fixture_database.sqlite3`; `:memory:` is the opt-in
- * `sqlite3_mem` connection only) and leaves `pool` unset so `HashConfig#pool`
- * defaults to 5 (`hash_config.rb:72`).
- *
- * `AR_TEST_WORKER_DB` — the per-worker clone stamped by globalSetup — wins when
- * present; without it we still hand back a file, just a per-process temp one,
- * rather than silently dropping to an in-memory DB (which additionally gives
- * separate connections separate empty DBs under better-sqlite3, Rails'
- * `in_memory_db?`). Either way the file is shared across this process'
- * connections, so both inherit Rails' pool of 5.
- */
 async function sqliteHash(): Promise<{ adapter: string; database: string }> {
   const workerDb = getEnv("AR_TEST_WORKER_DB");
   return { adapter: "sqlite3", database: workerDb || (await fallbackDatabasePath()) };

--- a/packages/activerecord/src/test-helpers/test-database-config.ts
+++ b/packages/activerecord/src/test-helpers/test-database-config.ts
@@ -23,7 +23,8 @@
  * Phase 4 of RFC 0002 — sole env-sniff source after bootstrap-test-handler deleted.
  */
 
-import { getEnv } from "@blazetrails/activesupport";
+import { getEnv, getOsAsync } from "@blazetrails/activesupport";
+import { getPathAsync } from "@blazetrails/activesupport/fs-adapter";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { Base } from "../base.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
@@ -66,7 +67,7 @@ interface NamedConnection {
   adapter: string;
   /** The public {@link TestAdapterName} lane this connection drives. */
   lane: TestAdapterName;
-  build(): HashConfig;
+  build(): Promise<HashConfig>;
 }
 
 /**
@@ -93,23 +94,24 @@ const CONNECTIONS: Record<ConnectionName, NamedConnection> = {
   sqlite3: {
     adapter: "sqlite3",
     lane: "sqlite",
-    build: () => new HashConfig("test", "primary", sqliteHash()),
+    build: async () => new HashConfig("test", "primary", await sqliteHash()),
   },
   sqlite3_mem: {
     adapter: "sqlite3",
     lane: "sqlite",
-    build: () =>
+    build: async () =>
       new HashConfig("test", "primary", { adapter: "sqlite3", database: ":memory:", pool: 1 }),
   },
   postgresql: {
     adapter: "postgresql",
     lane: "postgres",
-    build: () => new HashConfig("test", "primary", serverHash("postgresql", postgresSettings())),
+    build: async () =>
+      new HashConfig("test", "primary", serverHash("postgresql", postgresSettings())),
   },
   mysql2: {
     adapter: "mysql2",
     lane: "mysql",
-    build: () => new HashConfig("test", "primary", serverHash("mysql2", mysqlSettings())),
+    build: async () => new HashConfig("test", "primary", serverHash("mysql2", mysqlSettings())),
   },
 };
 
@@ -119,7 +121,7 @@ const CONNECTIONS: Record<ConnectionName, NamedConnection> = {
  * Mirrors `ARTest.connection_name` / `test_configuration_hashes` / the
  * adapter-name guard in `connection.rb`.
  */
-function resolve(): { adapter: TestAdapterName; envConfig: HashConfig | UrlConfig } {
+async function resolve(): Promise<{ adapter: TestAdapterName; envConfig: HashConfig | UrlConfig }> {
   const name = connectionName();
   // `name` is arbitrary user input from ARCONN, so the lookup is a partial one;
   // the miss below is Rails' "Connection not found" exit (connection.rb:14-19).
@@ -136,7 +138,7 @@ function resolve(): { adapter: TestAdapterName; envConfig: HashConfig | UrlConfi
     );
   }
 
-  const envConfig = connection.build();
+  const envConfig = await connection.build();
   // Rails: `unless connection_name.include?(arunit_adapter) raise ArgumentError`
   // (connection.rb:35-37). Previously this fired on a missing `*_TEST_URL` — an
   // env-presence proxy, since absent connection details silently resolved to
@@ -157,19 +159,40 @@ function resolve(): { adapter: TestAdapterName; envConfig: HashConfig | UrlConfi
 }
 
 /**
- * Build the sqlite primary config hash. Mirrors Rails' primary test config,
- * which leaves `pool` unset so `HashConfig#pool` defaults to 5
- * (`hash_config.rb:72`). We only pin `pool: 1` on a bare `:memory:` primary
- * (no `AR_TEST_WORKER_DB`): better-sqlite3 gives separate connections separate
- * empty `:memory:` DBs (Rails' `in_memory_db?`). The file-backed per-worker
- * clone lane shares the file across connections, so it inherits Rails' 5.
+ * Path of this process' fallback sqlite DB, used when globalSetup did not
+ * stamp `AR_TEST_WORKER_DB`. Memoized on `globalThis` so every connection
+ * opened in this process — and every re-evaluation of the module graph within
+ * one worker, which vitest's `isolate: true` does per file — lands on the same
+ * file. The token keeps concurrent processes on distinct files, so the
+ * per-worker isolation of the primary lane is preserved here too.
  */
-function sqliteHash(): { adapter: string; database: string; pool?: number } {
+async function fallbackDatabasePath(): Promise<string> {
+  const g = globalThis as typeof globalThis & { __arFallbackDbPath?: string };
+  if (g.__arFallbackDbPath) return g.__arFallbackDbPath;
+  const path = await getPathAsync();
+  const os = await getOsAsync();
+  const token = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  g.__arFallbackDbPath = path.join(os.tmpdir(), `ar-test-fallback-${token}.sqlite`);
+  return g.__arFallbackDbPath;
+}
+
+/**
+ * Build the sqlite primary config hash. Mirrors Rails' primary test config,
+ * which is file-backed (`config.example.yml`'s `sqlite3` entry points at
+ * `FIXTURES_ROOT/fixture_database.sqlite3`; `:memory:` is the opt-in
+ * `sqlite3_mem` connection only) and leaves `pool` unset so `HashConfig#pool`
+ * defaults to 5 (`hash_config.rb:72`).
+ *
+ * `AR_TEST_WORKER_DB` — the per-worker clone stamped by globalSetup — wins when
+ * present; without it we still hand back a file, just a per-process temp one,
+ * rather than silently dropping to an in-memory DB (which additionally gives
+ * separate connections separate empty DBs under better-sqlite3, Rails'
+ * `in_memory_db?`). Either way the file is shared across this process'
+ * connections, so both inherit Rails' pool of 5.
+ */
+async function sqliteHash(): Promise<{ adapter: string; database: string }> {
   const workerDb = getEnv("AR_TEST_WORKER_DB");
-  if (workerDb) {
-    return { adapter: "sqlite3", database: workerDb };
-  }
-  return { adapter: "sqlite3", database: ":memory:", pool: 1 };
+  return { adapter: "sqlite3", database: workerDb || (await fallbackDatabasePath()) };
 }
 
 /**
@@ -180,7 +203,7 @@ function sqliteHash(): { adapter: string; database: string; pool?: number } {
  * `_registeredTasks` (e.g. `database-tasks.test.ts`) can re-register.
  */
 export async function buildTestDatabaseConfig(): Promise<TestDatabaseConfig> {
-  const { adapter, envConfig } = resolve();
+  const { adapter, envConfig } = await resolve();
   const configs = new DatabaseConfigurations([envConfig]);
   DatabaseTasks.databaseConfiguration = configs;
 
@@ -218,7 +241,7 @@ export async function buildTestDatabaseConfig(): Promise<TestDatabaseConfig> {
  */
 export async function establishFromTestConfig(): Promise<void> {
   if (Base.isConnectedQ()) return;
-  const { envConfig } = resolve();
+  const { envConfig } = await resolve();
   if (envConfig instanceof UrlConfig) {
     await Base.establishConnection(envConfig.url);
     return;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -344,7 +344,9 @@ export default defineConfig({
       {
         // All activerecord tests. Each fork gets its own database (rails_js_test_N
         // for PG/MySQL, provisioned via AR_DB_FORKS) so files can run in parallel.
-        // SQLite uses :memory: which is isolated per fork by default.
+        // SQLite is file-backed too: globalSetup builds one on-disk template and
+        // each fork restores it into its own private `.sqlite` clone stamped into
+        // AR_TEST_WORKER_DB (see test-helpers/sqlite-template.ts).
         resolve: { alias },
         test: {
           name: "activerecord",


### PR DESCRIPTION
Rails' default sqlite test connection is file-backed — `config.example.yml`'s
`sqlite3` entry points at `FIXTURES_ROOT/fixture_database.sqlite3`, and
`:memory:` is the opt-in `sqlite3_mem` profile only.

In trails the live CI path is already file-backed (globalSetup builds an on-disk
template, each worker restores a private clone into `AR_TEST_WORKER_DB`), but the
unset-`AR_TEST_WORKER_DB` fallback in `test-database-config.ts` silently dropped
to `:memory:` — a latent fidelity loss on the setup-free path.

## Changes

- `sqliteHash()` now falls back to a temp `.sqlite` file resolved through the
  activesupport `os`/`path` adapters (no `node:*`). The path is keyed on
  `AR_TEST_RUN_TOKEN` + `VITEST_POOL_ID` — the same (run, worker slot) pair
  `sqlite-template.ts` uses for the clone — so per-worker isolation is identical
  to the primary lane and stale files don't accumulate per run. Outside vitest it
  falls back to a per-process token. It is memoized on `globalThis` so every
  connection in the process, across vitest's per-file module-graph reloads, lands
  on one file.
- `resolve()` / `NamedConnection.build()` become async; both call sites already
  awaited them.
- The `pool: 1` pin is gone from the `sqlite3` lane — it existed only because a
  bare `:memory:` gives each connection its own empty DB; a shared file inherits
  Rails' default of 5. `sqlite3_mem` keeps `:memory:` + `pool: 1`.
- Corrected the stale `vitest.config.ts` comment claiming SQLite workers use
  `:memory:`; it now points at the on-disk template/clone model.

The primary CI path is unchanged: a stamped `AR_TEST_WORKER_DB` still wins (new
test asserts it), and no shared file path is introduced.

Closes-story: worker-db-fallback-file-backed
