### PR TITLE
test(adapter): derive disable-prepared-statements connection from ambient config

### DIFF
--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -241,8 +241,7 @@ describe("AdapterTest", () => {
       "indexes",
       "remove index when name and wrong column name specified",
       "remove index when name and wrong column name specified positional argument",
-      // Re-establishes `Base` (swapping the pool out from under the fixture
-      // pin), so it cannot ride the shared transaction.
+      // Re-establishes `Base`, swapping the pool out from under the fixture pin.
       "disable prepared statements",
     ],
   });
@@ -389,15 +388,9 @@ describe("AdapterTest", () => {
   // charset / collation / show-variable / cross-database-selects (MySQL-only)
   // live in the describeIfMysql AdapterTest block below.
 
-  // Rails gates this `unless in_memory_db? || TrilogyAdapter` — a bare
-  // `:memory:` sqlite worker cannot re-establish `Base` without losing the
-  // schema, so it is skipped there exactly as in Rails.
+  // Rails gates this `unless in_memory_db?` (adapter_test.rb:176): a
+  // re-established `:memory:` connection is a fresh, empty database.
   it.skipIf(inMemoryDb())("disable prepared statements", async () => {
-    // Rails re-establishes `Base` from `arunit`'s configuration_hash merged with
-    // `prepared_statements: true` on both sides of the global
-    // `ActiveRecord.disable_prepared_statements` toggle, then restores `:arunit`
-    // in an `ensure`. `runWithoutConnection` is our ConnectionHelper port of
-    // that capture/restore, and hands back the ambient config to merge into.
     const original = disablePreparedStatements;
     try {
       await runWithoutConnection(async (origConnection) => {

--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -4,7 +4,6 @@ import { Notifications } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import { AbstractAdapter } from "./connection-adapters/abstract-adapter.js";
-import { BetterSQLite3Adapter } from "./connection-adapters/better-sqlite3-adapter.js";
 import { SchemaCreation } from "./connection-adapters/abstract/schema-creation.js";
 import { AdapterError, ConnectionFailed } from "./errors.js";
 import {
@@ -242,6 +241,9 @@ describe("AdapterTest", () => {
       "indexes",
       "remove index when name and wrong column name specified",
       "remove index when name and wrong column name specified positional argument",
+      // Re-establishes `Base` (swapping the pool out from under the fixture
+      // pin), so it cannot ride the shared transaction.
+      "disable prepared statements",
     ],
   });
 
@@ -387,21 +389,25 @@ describe("AdapterTest", () => {
   // charset / collation / show-variable / cross-database-selects (MySQL-only)
   // live in the describeIfMysql AdapterTest block below.
 
-  it("disable prepared statements", async () => {
-    // Rails asserts `prepared_statements?` flips false once the global
-    // `ActiveRecord.disable_prepared_statements` toggle is set. Rails gates this
-    // `unless in_memory_db?`; our default DB is sqlite `:memory:`, so we hit the
-    // same setter chokepoint by constructing adapters on each side of the toggle.
+  // Rails gates this `unless in_memory_db? || TrilogyAdapter` — a bare
+  // `:memory:` sqlite worker cannot re-establish `Base` without losing the
+  // schema, so it is skipped there exactly as in Rails.
+  it.skipIf(inMemoryDb())("disable prepared statements", async () => {
+    // Rails re-establishes `Base` from `arunit`'s configuration_hash merged with
+    // `prepared_statements: true` on both sides of the global
+    // `ActiveRecord.disable_prepared_statements` toggle, then restores `:arunit`
+    // in an `ensure`. `runWithoutConnection` is our ConnectionHelper port of
+    // that capture/restore, and hands back the ambient config to merge into.
     const original = disablePreparedStatements;
     try {
-      const enabled = new BetterSQLite3Adapter(":memory:", { preparedStatements: true });
-      expect(enabled.preparedStatements).toBe(true);
-      await enabled.close();
+      await runWithoutConnection(async (origConnection) => {
+        await Base.establishConnection({ ...origConnection, preparedStatements: true });
+        expect((await Base.leaseConnection()).preparedStatements).toBe(true);
 
-      setDisablePreparedStatements(true);
-      const disabled = new BetterSQLite3Adapter(":memory:", { preparedStatements: true });
-      expect(disabled.preparedStatements).toBe(false);
-      await disabled.close();
+        setDisablePreparedStatements(true);
+        await Base.establishConnection({ ...origConnection, preparedStatements: true });
+        expect((await Base.leaseConnection()).preparedStatements).toBe(false);
+      });
     } finally {
       setDisablePreparedStatements(original);
     }


### PR DESCRIPTION
Ports the `disable prepared statements` case in `adapter.test.ts` off its hardcoded `:memory:` `BetterSQLite3Adapter` pair and onto the ambient test config, mirroring `adapter_test.rb:176-190`.

Before, the test constructed two throwaway `BetterSQLite3Adapter(":memory:")` instances — it never exercised `establish_connection`, never touched the live pool, and asserted only that the constructor honours the global toggle. Now:

- `runWithoutConnection` (our `ConnectionHelper#run_without_connection` port) captures the ambient config and restores `Base` afterwards, standing in for Rails's `ensure ... establish_connection :arunit`.
- Both halves re-establish `Base` with that config merged with `preparedStatements: true`, then assert `preparedStatements` on the leased connection across the global `disablePreparedStatements` toggle.
- Gated `skipIf(inMemoryDb())`, matching Rails' `unless in_memory_db?`.
- Listed in `usesTransaction`, since re-establishing `Base` swaps the pool out from under the fixture pin.

This was the last hardcoded connection literal in the file; the MySQL-gated block already derives its adapter from the config-built `MYSQL_TEST_URL` (and its cross-database probe from that URL with the database removed), so no other case needed changing.

Test name unchanged, so `test:compare` is unaffected.

Verified locally on all three CI lanes: sqlite (file-backed) 47 passed, postgresql 65 passed, mysql2 70 passed.

Closes-story: adapter-test-ambient-connection
