### PR TITLE
test(connection-pool): derive PoolConfig from the ambient db_config

### DIFF
--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -15,13 +15,12 @@ import type {
 import { Result } from "./result.js";
 import { Base } from "./base.js";
 
-/**
- * Mirrors connection_pool_test.rb:20-29 — the duplicate pool's HashConfig is
- * built from the ambient `Base.connection_pool.db_config`'s configuration hash
- * with per-test options merged on (`:265-269`, `:293-296`), never a literal
- * database name. `reapingFrequency: null` keeps the idle reaper quiet unless a
- * test opts in.
- */
+interface AmbientPoolOptions {
+  role?: string;
+  shard?: string;
+  adapterFactory?: () => DatabaseAdapter;
+}
+
 function makeAmbientDbConfig(overrides: Record<string, unknown> = {}): HashConfig {
   return new HashConfig("test", "primary", {
     ...ambientPoolConfiguration(),
@@ -31,15 +30,26 @@ function makeAmbientDbConfig(overrides: Record<string, unknown> = {}): HashConfi
   });
 }
 
-function makePool(size: number = 5): ConnectionPool {
+function makeAmbientPool(
+  overrides: Record<string, unknown> = {},
+  {
+    role = "writing",
+    shard = "default",
+    adapterFactory = newRawTestAdapter,
+  }: AmbientPoolOptions = {},
+): ConnectionPool {
   const pc = new PoolConfig(
     new ConnectionDescriptor("primary"),
-    makeAmbientDbConfig({ pool: size }),
-    "writing",
-    "default",
-    { adapterFactory: newRawTestAdapter },
+    makeAmbientDbConfig(overrides),
+    role,
+    shard,
+    { adapterFactory },
   );
   return new ConnectionPool(pc);
+}
+
+function makePool(size: number = 5): ConnectionPool {
+  return makeAmbientPool({ pool: size });
 }
 
 class TransactionAwareTestAdapter extends AbstractAdapter implements DatabaseAdapter {
@@ -115,14 +125,10 @@ class TransactionAwareTestAdapter extends AbstractAdapter implements DatabaseAda
 }
 
 function makeTransactionAwarePool(size: number = 5): ConnectionPool {
-  const pc = new PoolConfig(
-    new ConnectionDescriptor("primary"),
-    makeAmbientDbConfig({ pool: size }),
-    "writing",
-    "default",
+  return makeAmbientPool(
+    { pool: size },
     { adapterFactory: () => new TransactionAwareTestAdapter() },
   );
-  return new ConnectionPool(pc);
 }
 
 it("checkout after close", async () => {
@@ -217,14 +223,7 @@ it("reap and active", async () => {
 
 it("idle timeout configuration", async () => {
   // High idleTimeout: flush() with no args keeps connections
-  const keepPc = new PoolConfig(
-    new ConnectionDescriptor("primary"),
-    makeAmbientDbConfig({ idleTimeout: 9999 }),
-    "writing",
-    "default",
-    { adapterFactory: newRawTestAdapter },
-  );
-  const keepPool = new ConnectionPool(keepPc);
+  const keepPool = makeAmbientPool({ idleTimeout: 9999 });
   const keepConn = await keepPool.checkout();
   keepPool.checkin(keepConn);
   expect(keepPool.stat().connections).toBe(1);
@@ -232,14 +231,7 @@ it("idle timeout configuration", async () => {
   expect(keepPool.stat().connections).toBe(1);
 
   // Small idleTimeout: flush() with no args removes expired idle connections
-  const flushPc = new PoolConfig(
-    new ConnectionDescriptor("primary"),
-    makeAmbientDbConfig({ idleTimeout: 1 }),
-    "writing",
-    "default",
-    { adapterFactory: newRawTestAdapter },
-  );
-  const flushPool = new ConnectionPool(flushPc);
+  const flushPool = makeAmbientPool({ idleTimeout: 1 });
   vi.useFakeTimers();
   try {
     const flushConn = await flushPool.checkout();
@@ -258,14 +250,7 @@ it("idle timeout configuration", async () => {
 });
 
 it("disable flush", async () => {
-  const pc = new PoolConfig(
-    new ConnectionDescriptor("primary"),
-    makeAmbientDbConfig({ idleTimeout: null }),
-    "writing",
-    "default",
-    { adapterFactory: newRawTestAdapter },
-  );
-  const pool = new ConnectionPool(pc);
+  const pool = makeAmbientPool({ idleTimeout: null });
   const conn = await pool.checkout();
   pool.checkin(conn);
   // flush is a no-op when idleTimeout is null
@@ -451,14 +436,7 @@ it("connection pool stat", async () => {
 });
 
 it("role and shard is returned", async () => {
-  const pc = new PoolConfig(
-    new ConnectionDescriptor("primary"),
-    makeAmbientDbConfig(),
-    "reading",
-    "shard_one",
-    { adapterFactory: newRawTestAdapter },
-  );
-  const pool = new ConnectionPool(pc);
+  const pool = makeAmbientPool({}, { role: "reading", shard: "shard_one" });
   expect(pool.role).toBe("reading");
   expect(pool.shard).toBe("shard_one");
 });
@@ -587,17 +565,10 @@ it("inspect does not show secrets", async () => {
   expect(str).toMatch(/env_name="test"/);
   expect(str).toMatch(/role="writing"/);
   expect(str).not.toMatch(/password/);
-  expect(str).not.toMatch(/sqlite3/);
+  expect(str).not.toContain(String(ambientPoolConfiguration().adapter));
 
   // With non-default shard
-  const pc = new PoolConfig(
-    new ConnectionDescriptor("primary"),
-    makeAmbientDbConfig(),
-    "reading",
-    "shard_one",
-    { adapterFactory: newRawTestAdapter },
-  );
-  const pool2 = new ConnectionPool(pc);
+  const pool2 = makeAmbientPool({}, { role: "reading", shard: "shard_one" });
   expect(pool2.inspect()).toMatch(/shard="shard_one"/);
   expect(pool2.inspect()).toMatch(/role="reading"/);
 });

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -6,7 +6,7 @@ import { ConnectionDescriptor } from "./connection-adapters/abstract/connection-
 import { PoolConfig } from "./connection-adapters/pool-config.js";
 import { SchemaCache, SchemaReflection } from "./connection-adapters/schema-cache.js";
 import { HashConfig } from "./database-configurations/hash-config.js";
-import { newRawTestAdapter } from "./test-adapter.js";
+import { newRawTestAdapter, ambientPoolConfiguration } from "./test-adapter.js";
 import { AbstractAdapter } from "./connection-adapters/abstract-adapter.js";
 import type {
   AdapterName,
@@ -15,16 +15,30 @@ import type {
 import { Result } from "./result.js";
 import { Base } from "./base.js";
 
-function makePool(size: number = 5): ConnectionPool {
-  const dbConfig = new HashConfig("test", "primary", {
-    adapter: "sqlite3",
-    database: "test.db",
-    pool: size,
+/**
+ * Mirrors connection_pool_test.rb:20-29 — the duplicate pool's HashConfig is
+ * built from the ambient `Base.connection_pool.db_config`'s configuration hash
+ * with per-test options merged on (`:265-269`, `:293-296`), never a literal
+ * database name. `reapingFrequency: null` keeps the idle reaper quiet unless a
+ * test opts in.
+ */
+function makeAmbientDbConfig(overrides: Record<string, unknown> = {}): HashConfig {
+  return new HashConfig("test", "primary", {
+    ...ambientPoolConfiguration(),
+    checkoutTimeout: 0.2,
     reapingFrequency: null,
+    ...overrides,
   });
-  const pc = new PoolConfig(new ConnectionDescriptor("primary"), dbConfig, "writing", "default", {
-    adapterFactory: newRawTestAdapter,
-  });
+}
+
+function makePool(size: number = 5): ConnectionPool {
+  const pc = new PoolConfig(
+    new ConnectionDescriptor("primary"),
+    makeAmbientDbConfig({ pool: size }),
+    "writing",
+    "default",
+    { adapterFactory: newRawTestAdapter },
+  );
   return new ConnectionPool(pc);
 }
 
@@ -101,15 +115,13 @@ class TransactionAwareTestAdapter extends AbstractAdapter implements DatabaseAda
 }
 
 function makeTransactionAwarePool(size: number = 5): ConnectionPool {
-  const dbConfig = new HashConfig("test", "primary", {
-    adapter: "sqlite3",
-    database: "test.db",
-    pool: size,
-    reapingFrequency: null,
-  });
-  const pc = new PoolConfig(new ConnectionDescriptor("primary"), dbConfig, "writing", "default", {
-    adapterFactory: () => new TransactionAwareTestAdapter(),
-  });
+  const pc = new PoolConfig(
+    new ConnectionDescriptor("primary"),
+    makeAmbientDbConfig({ pool: size }),
+    "writing",
+    "default",
+    { adapterFactory: () => new TransactionAwareTestAdapter() },
+  );
   return new ConnectionPool(pc);
 }
 
@@ -205,15 +217,9 @@ it("reap and active", async () => {
 
 it("idle timeout configuration", async () => {
   // High idleTimeout: flush() with no args keeps connections
-  const keepConfig = new HashConfig("test", "primary", {
-    adapter: "sqlite3",
-    database: "test.db",
-    idleTimeout: 9999,
-    reapingFrequency: null,
-  });
   const keepPc = new PoolConfig(
     new ConnectionDescriptor("primary"),
-    keepConfig,
+    makeAmbientDbConfig({ idleTimeout: 9999 }),
     "writing",
     "default",
     { adapterFactory: newRawTestAdapter },
@@ -226,15 +232,9 @@ it("idle timeout configuration", async () => {
   expect(keepPool.stat().connections).toBe(1);
 
   // Small idleTimeout: flush() with no args removes expired idle connections
-  const flushConfig = new HashConfig("test", "primary", {
-    adapter: "sqlite3",
-    database: "test.db",
-    idleTimeout: 1,
-    reapingFrequency: null,
-  });
   const flushPc = new PoolConfig(
     new ConnectionDescriptor("primary"),
-    flushConfig,
+    makeAmbientDbConfig({ idleTimeout: 1 }),
     "writing",
     "default",
     { adapterFactory: newRawTestAdapter },
@@ -258,15 +258,13 @@ it("idle timeout configuration", async () => {
 });
 
 it("disable flush", async () => {
-  const dbConfig = new HashConfig("test", "primary", {
-    adapter: "sqlite3",
-    database: "test.db",
-    idleTimeout: null,
-    reapingFrequency: null,
-  });
-  const pc = new PoolConfig(new ConnectionDescriptor("primary"), dbConfig, "writing", "default", {
-    adapterFactory: newRawTestAdapter,
-  });
+  const pc = new PoolConfig(
+    new ConnectionDescriptor("primary"),
+    makeAmbientDbConfig({ idleTimeout: null }),
+    "writing",
+    "default",
+    { adapterFactory: newRawTestAdapter },
+  );
   const pool = new ConnectionPool(pc);
   const conn = await pool.checkout();
   pool.checkin(conn);
@@ -382,10 +380,7 @@ it("connection notification is called", async () => {
     payloads.push(event.payload as Record<string, unknown>);
   });
   try {
-    const dbConfig = new HashConfig("test", "primary", {
-      adapter: "sqlite3",
-      database: ":memory:",
-    });
+    const dbConfig = new HashConfig("test", "primary", ambientPoolConfiguration());
     Base.connectionHandler.establishConnection(dbConfig, { owner: ConnectionTestModel });
     expect(payloads).toHaveLength(1);
     expect(Object.keys(payloads[0]).sort()).toEqual(["config", "connection_name", "role", "shard"]);
@@ -405,7 +400,7 @@ it("connection notification is called for shard", async () => {
   });
   try {
     ConnectionTestModel.connectsTo({
-      shards: { default: { writing: { adapter: "sqlite3", database: ":memory:" } } },
+      shards: { default: { writing: ambientPoolConfiguration() } },
     });
     expect(payloads).toHaveLength(1);
     expect(Object.keys(payloads[0]).sort()).toEqual(["config", "connection_name", "role", "shard"]);
@@ -456,14 +451,13 @@ it("connection pool stat", async () => {
 });
 
 it("role and shard is returned", async () => {
-  const dbConfig = new HashConfig("test", "primary", {
-    adapter: "sqlite3",
-    database: "test.db",
-    reapingFrequency: null,
-  });
-  const pc = new PoolConfig(new ConnectionDescriptor("primary"), dbConfig, "reading", "shard_one", {
-    adapterFactory: newRawTestAdapter,
-  });
+  const pc = new PoolConfig(
+    new ConnectionDescriptor("primary"),
+    makeAmbientDbConfig(),
+    "reading",
+    "shard_one",
+    { adapterFactory: newRawTestAdapter },
+  );
   const pool = new ConnectionPool(pc);
   expect(pool.role).toBe("reading");
   expect(pool.shard).toBe("shard_one");
@@ -596,14 +590,13 @@ it("inspect does not show secrets", async () => {
   expect(str).not.toMatch(/sqlite3/);
 
   // With non-default shard
-  const dbConfig = new HashConfig("test", "primary", {
-    adapter: "sqlite3",
-    reapingFrequency: null,
-    database: "test.db",
-  });
-  const pc = new PoolConfig(new ConnectionDescriptor("primary"), dbConfig, "reading", "shard_one", {
-    adapterFactory: newRawTestAdapter,
-  });
+  const pc = new PoolConfig(
+    new ConnectionDescriptor("primary"),
+    makeAmbientDbConfig(),
+    "reading",
+    "shard_one",
+    { adapterFactory: newRawTestAdapter },
+  );
   const pool2 = new ConnectionPool(pc);
   expect(pool2.inspect()).toMatch(/shard="shard_one"/);
   expect(pool2.inspect()).toMatch(/role="reading"/);


### PR DESCRIPTION
Mirrors `connection_pool_test.rb:20-29`: the pool-under-test's
`HashConfig`/`PoolConfig` is built from the ambient worker-DB config
(`ambientPoolConfiguration()` — the trails analogue of
`Base.connection_pool.db_config.configuration_hash`) with `checkoutTimeout: 0.2`
merged on, and per-test options merged for the idle-timeout / disable-flush /
role-shard / inspect cases (`:265-269`, `:293-296`) — instead of a hardcoded
`adapter: sqlite3, database: "test.db"` / `:memory:`.

- One `makeAmbientPool(overrides, { role, shard, adapterFactory })` helper now
  builds every pool-under-test, replacing six copies of the same five-argument
  `PoolConfig` construction.
- The two `!connection.active_record` notification tests establish from the
  ambient config rather than a literal `:memory:` hash.
- `inspect does not show secrets` asserts the *ambient* adapter name is absent
  instead of the literal `sqlite3` (which was vacuous on the PG/MySQL lanes).

Test names unchanged; behavior unchanged. Net -8 LOC. Local: 36/36 pass on both
`sqlite3` and `sqlite3_mem`.

Closes-story: connection-pool-derive-from-ambient
