### PR TITLE
test(connection-handling): bind to the ambient test connection, not :memory:

### DIFF
--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -605,6 +605,11 @@ describe("withRoleAndShard loads Relation return values within scope (Story K ga
   });
 });
 
+// The pools below inject their adapter via `adapterFactory`, so the pool never
+// opens the declared `database` — `new BetterSQLite3Adapter()` defaults to
+// `:memory:` (sqlite3-adapter.ts:357). The config therefore states what is
+// actually opened; naming a file here would claim a file-backed pool that does
+// not exist.
 describe("AbstractAdapter#isPreventingWrites stack matching", () => {
   afterEach(async () => {
     connectedToStack().length = 0;
@@ -619,10 +624,7 @@ describe("AbstractAdapter#isPreventingWrites stack matching", () => {
       }
     }
     Base.connectionHandler.establishConnection(
-      new HashConfig("test", "UnrelatedAbstract", {
-        adapter: "sqlite3",
-        database: "db/secondary.sqlite3",
-      }),
+      new HashConfig("test", "UnrelatedAbstract", { adapter: "sqlite3", database: ":memory:" }),
       {
         owner: "UnrelatedAbstract",
         role: "writing",
@@ -651,14 +653,11 @@ describe("AbstractAdapter#isPreventingWrites stack matching", () => {
       }
     }
     Base.connectionHandler.establishConnection(
-      new HashConfig("test", "AnimalsRecord", {
-        adapter: "sqlite3",
-        database: "db/animals.sqlite3",
-      }),
+      new HashConfig("test", "AnimalsRecord", { adapter: "sqlite3", database: ":memory:" }),
       { owner: "AnimalsRecord", role: "writing", adapterFactory: () => new BetterSQLite3Adapter() },
     );
     Base.connectionHandler.establishConnection(
-      new HashConfig("test", "MealsRecord", { adapter: "sqlite3", database: "db/meals.sqlite3" }),
+      new HashConfig("test", "MealsRecord", { adapter: "sqlite3", database: ":memory:" }),
       { owner: "MealsRecord", role: "writing", adapterFactory: () => new BetterSQLite3Adapter() },
     );
     const animals = await AnimalsRecord.leaseConnection();
@@ -691,10 +690,7 @@ describe("AbstractAdapter#isPreventingWrites stack matching", () => {
       }
     }
     Base.connectionHandler.establishConnection(
-      new HashConfig("test", "ApplicationRecord", {
-        adapter: "sqlite3",
-        database: "db/primary.sqlite3",
-      }),
+      new HashConfig("test", "ApplicationRecord", { adapter: "sqlite3", database: ":memory:" }),
       {
         owner: ApplicationRecord,
         role: "writing",
@@ -702,10 +698,7 @@ describe("AbstractAdapter#isPreventingWrites stack matching", () => {
       },
     );
     Base.connectionHandler.establishConnection(
-      new HashConfig("test", "OtherAbstract", {
-        adapter: "sqlite3",
-        database: "db/secondary.sqlite3",
-      }),
+      new HashConfig("test", "OtherAbstract", { adapter: "sqlite3", database: ":memory:" }),
       { owner: "OtherAbstract", role: "writing", adapterFactory: () => new BetterSQLite3Adapter() },
     );
     const appConn = await ApplicationRecord.leaseConnection();

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from "vitest";
 import { Base } from "./base.js";
 import { withQueryConnection, threadedConnectionFor } from "./connection-handling.js";
 import { setPermanentConnectionCheckout } from "./ar-config.js";
@@ -16,23 +16,31 @@ import {
   withIsolatedConnectionState,
 } from "./core.js";
 import { setTrailsRoot } from "@blazetrails/activesupport";
+import type { DatabaseConfig } from "./database-configurations/database-config.js";
+import { establishFromTestConfig } from "./test-helpers/test-database-config.js";
+import { adapterType } from "./test-adapter.js";
 import * as nodeFs from "node:fs";
 import * as nodeOs from "node:os";
 import * as nodePath from "node:path";
 
-function setupConnection() {
-  const config = new HashConfig("test", "primary", {
-    adapter: "sqlite3",
-    database: "test.db",
-    pool: 5,
-    reapingFrequency: null,
-  });
-  Base.connectionHandler.establishConnection(config, { owner: "Base" });
+// Rails' `ConnectionHandlingTest` declares no configuration of its own — it
+// drives `ActiveRecord::Base` against the ambient, file-backed test connection
+// established by the suite helper. Capture that db_config once and re-establish
+// from it between cases (the block removes/clears the pool as it goes).
+let ambientDbConfig: DatabaseConfig;
+
+async function setupConnection() {
+  await Base.establishConnection(ambientDbConfig);
 }
 
 describe("ConnectionHandlingTest", () => {
+  beforeAll(async () => {
+    await establishFromTestConfig();
+    ambientDbConfig = Base.connectionDbConfig();
+  });
+
   beforeEach(async () => {
-    setupConnection();
+    await setupConnection();
   });
 
   afterEach(async () => {
@@ -257,7 +265,7 @@ describe("ConnectionHandlingTest", () => {
 
   it("connection_db_config", async () => {
     const config = Base.connectionDbConfig();
-    expect(config.adapter).toBe("sqlite3");
+    expect(config.adapter).toBe(ambientDbConfig.adapter);
   });
 
   // Rails' build_db_config_from_hash deletes :url before constructing the
@@ -327,18 +335,18 @@ describe("ConnectionHandlingTest", () => {
     expect(Base.connectionPool()).toBeTruthy();
     // Mirrors Rails `remove_connection`: returns the removed pool's db_config.
     const removed = Base.removeConnection();
-    expect(removed?.adapter).toBe("sqlite3");
-    expect(removed?.configurationHash.database).toBe("test.db");
+    expect(removed?.adapter).toBe(ambientDbConfig.adapter);
+    expect(removed?.configurationHash.database).toBe(ambientDbConfig.configurationHash.database);
     expect(() => Base.connectionPool()).toThrow(/No database connection/);
     // Re-establish for other tests
-    setupConnection();
+    await setupConnection();
   });
 
   it("remove_connection returns undefined when no pool exists", async () => {
     Base.removeConnection();
     expect(Base.removeConnection()).toBeUndefined();
     // Re-establish for other tests
-    setupConnection();
+    await setupConnection();
   });
 
   it("connected_to stack is isolated per async context", async () => {
@@ -459,12 +467,17 @@ describe("ConnectionHandlingTest", () => {
     expect(Post.isPrimaryClass()).toBe(false);
   });
 
-  it("#adapterClass resolves to the SQLite3Adapter constructor", async () => {
-    const Klass = await Base.adapterClass();
-    const { BetterSQLite3Adapter } =
-      await import("./connection-adapters/better-sqlite3-adapter.js");
-    expect(Klass).toBe(BetterSQLite3Adapter);
-  });
+  // Now that the block binds to the ambient test connection, the resolved
+  // adapter class follows the lane — this case pins the SQLite one.
+  it.skipIf(adapterType !== "sqlite")(
+    "#adapterClass resolves to the SQLite3Adapter constructor",
+    async () => {
+      const Klass = await Base.adapterClass();
+      const { BetterSQLite3Adapter } =
+        await import("./connection-adapters/better-sqlite3-adapter.js");
+      expect(Klass).toBe(BetterSQLite3Adapter);
+    },
+  );
 
   // Mirrors Rails: `ActiveRecord::Base.establish_connection` with no args
   // reads from `Base.configurations` (the in-memory registry), not from
@@ -482,18 +495,18 @@ describe("ConnectionHandlingTest", () => {
     // Snapshot it so test ordering can't pin the wrong registry.
     const priorCurrent = (DatabaseConfigurations as any).current;
     try {
+      // The registry is in-memory (a hand-built `DatabaseConfigurations`), but
+      // the config it carries is the ambient, file-backed test config — Rails'
+      // `TestDatabases.create_and_load_schema` mutates exactly that entry.
       const inMemory = new DatabaseConfigurations([
-        new HashConfig(env, "primary", { adapter: "sqlite3", database: ":memory:" }),
+        new HashConfig(env, "primary", { ...ambientDbConfig.configurationHash }),
       ]);
 
       class InMemoryModel extends Base {}
       (InMemoryModel as any).configurations = inMemory;
 
       await InMemoryModel.establishConnection();
-      const Klass = await InMemoryModel.adapterClass();
-      const { BetterSQLite3Adapter } =
-        await import("./connection-adapters/better-sqlite3-adapter.js");
-      expect(Klass).toBe(BetterSQLite3Adapter);
+      expect(await InMemoryModel.adapterClass()).toBe(await Base.adapterClass());
     } finally {
       (DatabaseConfigurations as any).current = priorCurrent;
     }
@@ -614,7 +627,10 @@ describe("AbstractAdapter#isPreventingWrites stack matching", () => {
       }
     }
     Base.connectionHandler.establishConnection(
-      new HashConfig("test", "UnrelatedAbstract", { adapter: "sqlite3", database: ":memory:" }),
+      new HashConfig("test", "UnrelatedAbstract", {
+        adapter: "sqlite3",
+        database: "db/secondary.sqlite3",
+      }),
       {
         owner: "UnrelatedAbstract",
         role: "writing",
@@ -643,11 +659,14 @@ describe("AbstractAdapter#isPreventingWrites stack matching", () => {
       }
     }
     Base.connectionHandler.establishConnection(
-      new HashConfig("test", "AnimalsRecord", { adapter: "sqlite3", database: ":memory:" }),
+      new HashConfig("test", "AnimalsRecord", {
+        adapter: "sqlite3",
+        database: "db/animals.sqlite3",
+      }),
       { owner: "AnimalsRecord", role: "writing", adapterFactory: () => new BetterSQLite3Adapter() },
     );
     Base.connectionHandler.establishConnection(
-      new HashConfig("test", "MealsRecord", { adapter: "sqlite3", database: ":memory:" }),
+      new HashConfig("test", "MealsRecord", { adapter: "sqlite3", database: "db/meals.sqlite3" }),
       { owner: "MealsRecord", role: "writing", adapterFactory: () => new BetterSQLite3Adapter() },
     );
     const animals = await AnimalsRecord.leaseConnection();
@@ -680,7 +699,10 @@ describe("AbstractAdapter#isPreventingWrites stack matching", () => {
       }
     }
     Base.connectionHandler.establishConnection(
-      new HashConfig("test", "ApplicationRecord", { adapter: "sqlite3", database: ":memory:" }),
+      new HashConfig("test", "ApplicationRecord", {
+        adapter: "sqlite3",
+        database: "db/primary.sqlite3",
+      }),
       {
         owner: ApplicationRecord,
         role: "writing",
@@ -688,7 +710,10 @@ describe("AbstractAdapter#isPreventingWrites stack matching", () => {
       },
     );
     Base.connectionHandler.establishConnection(
-      new HashConfig("test", "OtherAbstract", { adapter: "sqlite3", database: ":memory:" }),
+      new HashConfig("test", "OtherAbstract", {
+        adapter: "sqlite3",
+        database: "db/secondary.sqlite3",
+      }),
       { owner: "OtherAbstract", role: "writing", adapterFactory: () => new BetterSQLite3Adapter() },
     );
     const appConn = await ApplicationRecord.leaseConnection();
@@ -759,7 +784,7 @@ describe("resolveConfigForConnection / connectsTo with unset configurations", ()
       primaryAbstractClass(AppRecord);
       const env = DatabaseConfigurations.currentEnv();
       (AppRecord as any).configurations = {
-        [env]: { primary: { adapter: "sqlite3", database: ":memory:" } },
+        [env]: { primary: { adapter: "sqlite3", database: "db/primary.sqlite3" } },
       };
       (SecondaryAbstract as any).configurations = (AppRecord as any).configurations;
 
@@ -871,7 +896,7 @@ describe("establish_connection accepts a DatabaseConfig", () => {
   it("re-establishes the connection from the captured DatabaseConfig object", async () => {
     const config = new HashConfig("test", "primary", {
       adapter: "sqlite3",
-      database: ":memory:",
+      database: "db/primary.sqlite3",
       pool: 5,
       reapingFrequency: null,
     });
@@ -885,7 +910,7 @@ describe("establish_connection accepts a DatabaseConfig", () => {
     const restored = Base.connectionDbConfig();
     expect(restored).toBe(captured);
     expect(restored.adapter).toBe("sqlite3");
-    expect(restored.configurationHash.database).toBe(":memory:");
+    expect(restored.configurationHash.database).toBe("db/primary.sqlite3");
   });
 });
 
@@ -906,7 +931,7 @@ describe("loadConfigFile resolves config/database.* against Trails.root", () => 
     nodeFs.mkdirSync(nodePath.join(tmpRoot, "config"));
     nodeFs.writeFileSync(
       nodePath.join(tmpRoot, "config", "database.json"),
-      JSON.stringify({ test: { adapter: "sqlite3", database: ":memory:" } }),
+      JSON.stringify({ test: { adapter: "sqlite3", database: "db/primary.sqlite3" } }),
     );
     setTrailsRoot(tmpRoot);
 
@@ -917,6 +942,6 @@ describe("loadConfigFile resolves config/database.* against Trails.root", () => 
 
     const dbConfig = RootConfigModel.connectionDbConfig();
     expect(dbConfig.adapter).toBe("sqlite3");
-    expect(dbConfig.configurationHash.database).toBe(":memory:");
+    expect(dbConfig.configurationHash.database).toBe("db/primary.sqlite3");
   });
 });

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -23,17 +23,13 @@ import * as nodeFs from "node:fs";
 import * as nodeOs from "node:os";
 import * as nodePath from "node:path";
 
-// Rails' `ConnectionHandlingTest` declares no configuration of its own — it
-// drives `ActiveRecord::Base` against the ambient, file-backed test connection
-// established by the suite helper. Capture that db_config once and re-establish
-// from it between cases (the block removes/clears the pool as it goes).
-let ambientDbConfig: DatabaseConfig;
-
-async function setupConnection() {
-  await Base.establishConnection(ambientDbConfig);
-}
-
 describe("ConnectionHandlingTest", () => {
+  let ambientDbConfig: DatabaseConfig;
+
+  async function setupConnection() {
+    await Base.establishConnection(ambientDbConfig);
+  }
+
   beforeAll(async () => {
     await establishFromTestConfig();
     ambientDbConfig = Base.connectionDbConfig();
@@ -264,8 +260,7 @@ describe("ConnectionHandlingTest", () => {
   });
 
   it("connection_db_config", async () => {
-    const config = Base.connectionDbConfig();
-    expect(config.adapter).toBe(ambientDbConfig.adapter);
+    expect(Base.connectionDbConfig()).toBe(ambientDbConfig);
   });
 
   // Rails' build_db_config_from_hash deletes :url before constructing the
@@ -282,7 +277,9 @@ describe("ConnectionHandlingTest", () => {
 
   it("is_connected?", async () => {
     const pool = Base.connectionPool();
-    await pool.leaseConnection();
+    // trails' checkout is lazy where Rails' `checkout_and_verify` runs
+    // `verify!`, so the raw connection is opened here as Rails' checkout would.
+    await (await pool.leaseConnection()).verifyBang();
     expect(Base.isConnectedQ()).toBe(true);
     pool.releaseConnection();
   });
@@ -335,8 +332,7 @@ describe("ConnectionHandlingTest", () => {
     expect(Base.connectionPool()).toBeTruthy();
     // Mirrors Rails `remove_connection`: returns the removed pool's db_config.
     const removed = Base.removeConnection();
-    expect(removed?.adapter).toBe(ambientDbConfig.adapter);
-    expect(removed?.configurationHash.database).toBe(ambientDbConfig.configurationHash.database);
+    expect(removed).toBe(ambientDbConfig);
     expect(() => Base.connectionPool()).toThrow(/No database connection/);
     // Re-establish for other tests
     await setupConnection();
@@ -467,15 +463,10 @@ describe("ConnectionHandlingTest", () => {
     expect(Post.isPrimaryClass()).toBe(false);
   });
 
-  // Now that the block binds to the ambient test connection, the resolved
-  // adapter class follows the lane — this case pins the SQLite one.
   it.skipIf(adapterType !== "sqlite")(
     "#adapterClass resolves to the SQLite3Adapter constructor",
     async () => {
-      const Klass = await Base.adapterClass();
-      const { BetterSQLite3Adapter } =
-        await import("./connection-adapters/better-sqlite3-adapter.js");
-      expect(Klass).toBe(BetterSQLite3Adapter);
+      expect(await Base.adapterClass()).toBe(BetterSQLite3Adapter);
     },
   );
 
@@ -495,17 +486,18 @@ describe("ConnectionHandlingTest", () => {
     // Snapshot it so test ordering can't pin the wrong registry.
     const priorCurrent = (DatabaseConfigurations as any).current;
     try {
-      // The registry is in-memory (a hand-built `DatabaseConfigurations`), but
-      // the config it carries is the ambient, file-backed test config — Rails'
-      // `TestDatabases.create_and_load_schema` mutates exactly that entry.
       const inMemory = new DatabaseConfigurations([
-        new HashConfig(env, "primary", { ...ambientDbConfig.configurationHash }),
+        new HashConfig(env, "primary", {
+          ...ambientDbConfig.configurationHash,
+          database: "db/common.sqlite3",
+        }),
       ]);
 
       class InMemoryModel extends Base {}
       (InMemoryModel as any).configurations = inMemory;
 
       await InMemoryModel.establishConnection();
+      expect(InMemoryModel.connectionPool().dbConfig.database).toBe("db/common.sqlite3");
       expect(await InMemoryModel.adapterClass()).toBe(await Base.adapterClass());
     } finally {
       (DatabaseConfigurations as any).current = priorCurrent;


### PR DESCRIPTION
## Summary

`connection_handling_test.rb` declares no configuration of its own — it drives
`ActiveRecord::Base` against the ambient, file-backed test connection. The
trails port hand-established a bespoke `test.db` `HashConfig` and used literal
`:memory:` databases in the config-resolution cases.

- `ConnectionHandlingTest` now captures the ambient `db_config` once
  (`establishFromTestConfig` → `Base.connectionDbConfig()`) and re-establishes
  from it between cases, which remove/clear the pool as they go.
- Config-shape assertions (`connection_db_config`, `remove_connection`) assert
  `db_config` identity against that ambient config instead of pinning
  `sqlite3` / `test.db`.
- The `autoConnect` registry case carries the ambient config under a distinct
  database name, so it proves the in-memory registry was honored rather than
  passing on an identical fallback.
- `#adapterClass resolves to the SQLite3Adapter constructor` is lane-gated
  (`it.skipIf(adapterType !== "sqlite")`), since the resolved class now follows
  the ambient adapter.
- Config-resolution-only cases name file-backed sqlite paths mirroring Rails'
  `db/primary.sqlite3` / `db/common.sqlite3`.
- `is_connected?` now verifies the leased connection. trails' checkout is lazy
  where Rails' `checkout_and_verify` runs `verify!`, so against a real PG/MySQL
  pool the raw connection was still unopened — this only surfaced once the test
  stopped running on a hardcoded SQLite config.

Test names unchanged.

## Review response: `db/` paths under a non-existent directory

Half right, and the fix landed — but not for the predicted reason.

**The `isPreventingWrites` pools never open the declared database at all.** They
pass `adapterFactory: () => new BetterSQLite3Adapter()`, and that constructor
takes `filenameOrConfig = ":memory:"` as its default
(`connection-adapters/sqlite3-adapter.ts:357`) — it never reads the
`HashConfig`'s `database`. So `.leaseConnection()` opens `:memory:` regardless
of what the config says, which is why the runs were clean. Naming a file there
was still wrong, just in the other direction: it *claimed* a file-backed pool
that does not exist. Those five are back to `:memory:` — the value that matches
what is actually opened — with the reasoning noted at the call site.

**The remaining `db/*.sqlite3` paths are config-resolution-only and never
connect.** `establish_connection` is lazy, and these cases only read
`connectionDbConfig()` / `pool.dbConfig` afterwards. The pre-existing
`sqlite3:db/discrete.sqlite3` and `sqlite3:db/foo.sqlite3` cases in this same
file have relied on that for as long as they've existed. Empirical
confirmation: all three lanes pass and no `db/` directory exists in the
worktree before or after the run — if any of these opened, `better-sqlite3`
would have raised exactly the error quoted in the review.

So no `mkdirSync` is needed: nothing in this file opens a relative sqlite path.

## Verification

Ran locally on all three lanes against an isolated compose stack (own ports,
torn down after), after the final commit:

- SQLite — 55/55 pass
- PostgreSQL — 54 pass, 1 skipped (the lane-gated `#adapterClass` case)
- MySQL — 54 pass, 1 skipped

Closes-story: connection-handling-ambient-connection
