### PR TITLE
test(tasks): converge database-tasks.test :memory: sites to Rails config fidelity

### DIFF
--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -169,9 +169,15 @@ describe("DatabaseTasksDumpSchemaCacheTest", () => {
   });
 
   it("dump schema cache", async () => {
+    // Rails dumps the cache off the ambient `arunit` connection — a file-backed
+    // sqlite3 database, not `:memory:`. A temp file DB stands in for it.
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-dump-sc-"));
     const cachePath = path.join(tmp, "schema_cache.json");
-    await Base.establishConnection({ adapter: "sqlite3", database: ":memory:", pool: 1 });
+    await Base.establishConnection({
+      adapter: "sqlite3",
+      database: path.join(tmp, "arunit.sqlite3"),
+      pool: 1,
+    });
     try {
       expect(fs.existsSync(cachePath)).toBe(false);
       const adapter = await Base.connectionPool().leaseConnection();
@@ -228,14 +234,18 @@ describe("DatabaseTasksDumpSchemaTest", () => {
     // Mirrors Rails: schemaDump is a bare filename; schemaDumpPath prepends dbDir.
     // The dir is removed before dumpSchema runs; dumpSchema must recreate it.
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-ensure-dbdir-"));
+    // Rails' db_config here is `arunit`/`primary` — a file-backed sqlite3
+    // database. It lives outside `tmp` because `tmp` is removed mid-test.
+    const dbTmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-ensure-dbdir-db-"));
+    const dbFile = path.join(dbTmp, "arunit.sqlite3");
     const prevDbDir = DatabaseTasks.dbDir;
-    await Base.establishConnection({ adapter: "sqlite3", database: ":memory:", pool: 1 });
+    await Base.establishConnection({ adapter: "sqlite3", database: dbFile, pool: 1 });
     try {
       DatabaseTasks.dbDir = tmp;
       const schemaPath = path.join(tmp, "fake_db_config_schema.ts");
       const config = new HashConfig("arunit", "primary", {
         adapter: "sqlite3",
-        database: ":memory:",
+        database: dbFile,
         schemaDump: "fake_db_config_schema.ts",
       });
       fs.rmSync(tmp, { recursive: true, force: true });
@@ -249,21 +259,26 @@ describe("DatabaseTasksDumpSchemaTest", () => {
       } catch {
         /* ignore */
       }
+      // Removes the DB file along with any -wal/-shm siblings.
       fs.rmSync(tmp, { recursive: true, force: true });
+      fs.rmSync(dbTmp, { recursive: true, force: true });
     }
   });
   it("db dir ignored if included in schema dump", async () => {
     // Mirrors Rails: schemaDump is an absolute path whose dirname == dbDir.
     // schemaDumpPath returns it verbatim (no double-prefix).
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-dbdir-ignored-"));
+    // As above: `arunit`/`primary` is file-backed, and `tmp` is removed mid-test.
+    const dbTmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-dbdir-ignored-db-"));
+    const dbFile = path.join(dbTmp, "arunit.sqlite3");
     const prevDbDir = DatabaseTasks.dbDir;
-    await Base.establishConnection({ adapter: "sqlite3", database: ":memory:", pool: 1 });
+    await Base.establishConnection({ adapter: "sqlite3", database: dbFile, pool: 1 });
     try {
       DatabaseTasks.dbDir = tmp;
       const schemaPath = path.join(tmp, "fake_db_config_schema.ts");
       const config = new HashConfig("arunit", "primary", {
         adapter: "sqlite3",
-        database: ":memory:",
+        database: dbFile,
         schemaDump: schemaPath, // absolute path — dirname == dbDir
       });
       fs.rmSync(tmp, { recursive: true, force: true });
@@ -277,7 +292,9 @@ describe("DatabaseTasksDumpSchemaTest", () => {
       } catch {
         /* ignore */
       }
+      // Removes the DB file along with any -wal/-shm siblings.
       fs.rmSync(tmp, { recursive: true, force: true });
+      fs.rmSync(dbTmp, { recursive: true, force: true });
     }
   });
 });
@@ -692,6 +709,9 @@ describe("DatabaseTasksMigrateTest", () => {
   let originalVersion: string | undefined;
   beforeEach(async () => {
     originalVersion = process.env.VERSION;
+    // `:memory:` is Rails-faithful here: DatabaseTasksMigrateTest inherits
+    // DatabaseTasksMigrationTestCase, whose setup establishes a `:memory:`
+    // connection (database_tasks_test.rb:1038) to avoid rolling back at the end.
     await Base.establishConnection({ adapter: "sqlite3", database: ":memory:", pool: 1 });
   });
   afterEach(() => {
@@ -855,6 +875,9 @@ describe("DatabaseTasksMigrateStatusTest", () => {
       stdoutChunks.push(typeof chunk === "string" ? chunk : chunk.toString());
       return true;
     });
+    // `:memory:` is Rails-faithful here too — DatabaseTasksMigrateStatusTest is
+    // another DatabaseTasksMigrationTestCase subclass, and the status output
+    // assertion below matches on `database: :memory:` (database_tasks_test.rb:1172).
     await Base.establishConnection({ adapter: "sqlite3", database: ":memory:", pool: 1 });
     // Mirror Rails test setup: @schema_migration.create_table (database_tasks_test.rb:1169)
     const pool = Base.connectionPool();
@@ -918,10 +941,15 @@ describe("DatabaseTasksMigrateErrorTest", () => {
     const { SchemaCache } = await import("../connection-adapters/schema-cache.js");
     const originalVersion = process.env.VERSION;
     delete process.env.VERSION;
-    await Base.establishConnection({ adapter: "sqlite3", database: ":memory:", pool: 1 });
+    // Rails runs this on the ambient `arunit` connection (a file-backed sqlite3
+    // database) — DatabaseTasksMigrateErrorTest is not one of the `:memory:`
+    // DatabaseTasksMigrationTestCase subclasses.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-migrate-cache-"));
+    const dbFile = path.join(tmp, "arunit.sqlite3");
+    await Base.establishConnection({ adapter: "sqlite3", database: dbFile, pool: 1 });
     DatabaseTasks.registerTask("sqlite", { create: async () => {} });
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
-      [DatabaseTasks.env]: { adapter: "sqlite3", database: ":memory:" },
+      [DatabaseTasks.env]: { adapter: "sqlite3", database: dbFile },
     });
     DatabaseTasks.registerMigrations([]);
     const clearSpy = vi.spyOn(SchemaCache.prototype, "clear");
@@ -940,6 +968,8 @@ describe("DatabaseTasksMigrateErrorTest", () => {
       DatabaseTasks.databaseConfiguration = null;
       DatabaseTasks.registerMigrations([]);
       DatabaseTasks.clearRegisteredTasks();
+      // Removes the DB file along with any -wal/-shm siblings.
+      fs.rmSync(tmp, { recursive: true, force: true });
     }
   });
 });

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -169,15 +169,10 @@ describe("DatabaseTasksDumpSchemaCacheTest", () => {
   });
 
   it("dump schema cache", async () => {
-    // Rails dumps the cache off the ambient `arunit` connection — a file-backed
-    // sqlite3 database, not `:memory:`. A temp file DB stands in for it.
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-dump-sc-"));
     const cachePath = path.join(tmp, "schema_cache.json");
-    await Base.establishConnection({
-      adapter: "sqlite3",
-      database: path.join(tmp, "arunit.sqlite3"),
-      pool: 1,
-    });
+    const dbFile = path.join(tmp, "arunit.sqlite3");
+    await Base.establishConnection({ adapter: "sqlite3", database: dbFile, pool: 1 });
     try {
       expect(fs.existsSync(cachePath)).toBe(false);
       const adapter = await Base.connectionPool().leaseConnection();
@@ -234,8 +229,6 @@ describe("DatabaseTasksDumpSchemaTest", () => {
     // Mirrors Rails: schemaDump is a bare filename; schemaDumpPath prepends dbDir.
     // The dir is removed before dumpSchema runs; dumpSchema must recreate it.
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-ensure-dbdir-"));
-    // Rails' db_config here is `arunit`/`primary` — a file-backed sqlite3
-    // database. It lives outside `tmp` because `tmp` is removed mid-test.
     const dbTmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-ensure-dbdir-db-"));
     const dbFile = path.join(dbTmp, "arunit.sqlite3");
     const prevDbDir = DatabaseTasks.dbDir;
@@ -259,7 +252,6 @@ describe("DatabaseTasksDumpSchemaTest", () => {
       } catch {
         /* ignore */
       }
-      // Removes the DB file along with any -wal/-shm siblings.
       fs.rmSync(tmp, { recursive: true, force: true });
       fs.rmSync(dbTmp, { recursive: true, force: true });
     }
@@ -268,7 +260,6 @@ describe("DatabaseTasksDumpSchemaTest", () => {
     // Mirrors Rails: schemaDump is an absolute path whose dirname == dbDir.
     // schemaDumpPath returns it verbatim (no double-prefix).
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-dbdir-ignored-"));
-    // As above: `arunit`/`primary` is file-backed, and `tmp` is removed mid-test.
     const dbTmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-dbdir-ignored-db-"));
     const dbFile = path.join(dbTmp, "arunit.sqlite3");
     const prevDbDir = DatabaseTasks.dbDir;
@@ -292,7 +283,6 @@ describe("DatabaseTasksDumpSchemaTest", () => {
       } catch {
         /* ignore */
       }
-      // Removes the DB file along with any -wal/-shm siblings.
       fs.rmSync(tmp, { recursive: true, force: true });
       fs.rmSync(dbTmp, { recursive: true, force: true });
     }
@@ -709,9 +699,6 @@ describe("DatabaseTasksMigrateTest", () => {
   let originalVersion: string | undefined;
   beforeEach(async () => {
     originalVersion = process.env.VERSION;
-    // `:memory:` is Rails-faithful here: DatabaseTasksMigrateTest inherits
-    // DatabaseTasksMigrationTestCase, whose setup establishes a `:memory:`
-    // connection (database_tasks_test.rb:1038) to avoid rolling back at the end.
     await Base.establishConnection({ adapter: "sqlite3", database: ":memory:", pool: 1 });
   });
   afterEach(() => {
@@ -875,9 +862,6 @@ describe("DatabaseTasksMigrateStatusTest", () => {
       stdoutChunks.push(typeof chunk === "string" ? chunk : chunk.toString());
       return true;
     });
-    // `:memory:` is Rails-faithful here too — DatabaseTasksMigrateStatusTest is
-    // another DatabaseTasksMigrationTestCase subclass, and the status output
-    // assertion below matches on `database: :memory:` (database_tasks_test.rb:1172).
     await Base.establishConnection({ adapter: "sqlite3", database: ":memory:", pool: 1 });
     // Mirror Rails test setup: @schema_migration.create_table (database_tasks_test.rb:1169)
     const pool = Base.connectionPool();
@@ -941,9 +925,6 @@ describe("DatabaseTasksMigrateErrorTest", () => {
     const { SchemaCache } = await import("../connection-adapters/schema-cache.js");
     const originalVersion = process.env.VERSION;
     delete process.env.VERSION;
-    // Rails runs this on the ambient `arunit` connection (a file-backed sqlite3
-    // database) — DatabaseTasksMigrateErrorTest is not one of the `:memory:`
-    // DatabaseTasksMigrationTestCase subclasses.
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-migrate-cache-"));
     const dbFile = path.join(tmp, "arunit.sqlite3");
     await Base.establishConnection({ adapter: "sqlite3", database: dbFile, pool: 1 });
@@ -968,7 +949,6 @@ describe("DatabaseTasksMigrateErrorTest", () => {
       DatabaseTasks.databaseConfiguration = null;
       DatabaseTasks.registerMigrations([]);
       DatabaseTasks.clearRegisteredTasks();
-      // Removes the DB file along with any -wal/-shm siblings.
       fs.rmSync(tmp, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
Converges the excess `:memory:` connection sites in
`packages/activerecord/src/tasks/database-tasks.test.ts` to the config shape
Rails' `tasks/database_tasks_test.rb` actually uses. Per RFC 0029, Rails uses
`:memory:` on exactly 2 lines of that file; trails had 11 occurrences.

Per-site mapping against Rails:

| trails site | Rails counterpart | outcome |
| --- | --- | --- |
| `DatabaseTasksDumpSchemaCacheTest#dump schema cache` | `test_dump_schema_cache` (`:288`) — dumps off the ambient `arunit` (file-backed) connection, no `establish_connection` | file-backed temp DB |
| `DatabaseTasksDumpSchemaTest#ensure db dir` | `test_ensure_db_dir` (`:363`) — `db_config` is `arunit`/`primary` | file-backed temp DB (connection **and** `HashConfig`) |
| `DatabaseTasksDumpSchemaTest#db dir ignored if included in schema dump` | `test_db_dir_ignored_if_included_in_schema_dump` (`:382`) — same `arunit`/`primary` `db_config` | file-backed temp DB (connection **and** `HashConfig`) |
| `DatabaseTasksMigrateErrorTest#migrate clears schema cache afterward` | `test_migrate_clears_schema_cache_afterward` (`:1236`) — a plain `ActiveRecord::TestCase` on the ambient `arunit` connection | file-backed temp DB (connection **and** config) |
| `DatabaseTasksMigrateTest` setup | inherits `DatabaseTasksMigrationTestCase`, whose setup establishes `:memory:` (`:1038`) to avoid rolling back at the end | **kept** `:memory:` |
| `DatabaseTasksMigrateStatusTest` setup + `assert_match(/database: :memory:/)` | same base class (`:1038`) / `:1172` | **kept** `:memory:` |

7 of the 11 sites converge to file-backed temp databases; the 4 that remain are
the ones Rails itself expresses as `:memory:`. Both `dumpSchema` and
`dumpSchemaCache` resolve their adapter from the established connection, so
these cases now do real disk I/O.

The two `DumpSchemaTest` cases `rm -rf` the schema-dump dir mid-test (mirroring
Rails' `FileUtils.rm_rf(dir)`), so their DB file gets its own temp dir. Every
temp dir is removed in a `finally` after the connection is closed, which takes
the `-wal`/`-shm` siblings with it, and `mkdtemp` prefixes keep concurrent
tests from colliding.

Test names are unchanged; `test:compare` still reports 77/77 matched against
`tasks/database_tasks_test.rb` with 0 missing.
`pnpm vitest run packages/activerecord/src/tasks/database-tasks.test.ts`:
77 passed, 1 skipped.

Note: the new code follows the file's established sync-`node:fs` idiom rather
than introducing a second, async style alongside it.

Closes-story: database-tasks-test-config-fidelity
