### PR TITLE
chore(tasks-cli): drop the vestigial landed-race confirm-check

### DIFF
--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -1265,9 +1265,9 @@ describe("commitAndPush (git mutation flow)", () => {
     expect(seen).not.toContain("reset");
   });
 
-  // The tasks repo's .husky/post-commit hook background-pushes main after
-  // every commit, racing commitAndPush's own explicit push (and capable of
-  // shipping an empty clobbered commit before the guard above can reset it).
+  // The tasks repo's .husky/post-commit hook pushes main after every commit,
+  // racing commitAndPush's own explicit push (and capable of shipping an empty
+  // clobbered commit before the guard above can reset it).
   // The CLI must commit with RFCS_NO_AUTOPUSH=1 so the hook stands down.
   it("commits with RFCS_NO_AUTOPUSH=1 so the post-commit hook does not race the push", () => {
     setup();
@@ -1566,9 +1566,7 @@ describe("commitAndPush (git mutation flow)", () => {
     expect(mutatorCalls).toBe(2);
     // Pre-loop: HEAD:main guard (fetch, rev-list) then one checkout per
     // generated file restores them.
-    // First attempt: pull, add, commit, push(throws). The race branch then
-    // confirms the commit did NOT land (rev-parse HEAD, fetch, rev-parse
-    // origin/main all return "" here, so HEAD !== origin/main) and resets.
+    // First attempt: pull, add, commit, push(throws), reset.
     // Second attempt: pull, add, commit, push(ok).
     expect(seen).toEqual([
       "fetch",
@@ -1580,9 +1578,6 @@ describe("commitAndPush (git mutation flow)", () => {
       "commit",
       "diff-tree",
       "push",
-      "rev-parse",
-      "fetch",
-      "rev-parse",
       "reset",
       "pull",
       "add",
@@ -1617,49 +1612,35 @@ describe("commitAndPush (git mutation flow)", () => {
     expect(seen.filter((l) => l === "reset").length).toBe(2);
   });
 
-  // Regression: the tasks repo's `.husky/post-commit` hook auto-pushes `main`
-  // in the background after every commit. That background push races this
-  // explicit push; when the hook's push lands first, origin/main advances to
-  // OUR commit and git then rejects THIS push with "[rejected] ... (fetch
-  // first)" — even though the mutation is already on origin/main. That is a
-  // success, not a lost race: commitAndPush must confirm origin/main == HEAD
-  // and return 0, NOT reset + retry (which the reflog evidence showed wrongly
-  // reporting failure on a landed `priority` flip).
-  it("treats a rejected push as success when our commit already landed on origin/main", () => {
-    const { seen, exit } = setup();
-    const HEAD_SHA = "061e7d5ad3452f6950fbe974e72326ff28b1baed";
+  // "fetch first" used to be ambiguous — the post-commit hook could land our
+  // own commit — so the catch confirmed with rev-parse/fetch/rev-parse before
+  // deciding. With the hook silenced for CLI commits every rejection is a lost
+  // race, so the confirm round-trip must stay gone.
+  it("resets and retries a fetch-first rejection without a confirm round-trip", () => {
+    const { seen } = setup();
+    let push = 0;
     execFileSyncMock.mockImplementation((_file, args) => {
       const label = args && args.length >= 3 ? args[2] : "";
       if (label === "symbolic-ref") return "main" as never;
       seen.push(label);
       if (label === "diff-tree") return "story.md" as never;
-      if (label === "push") {
-        // The background post-commit push already won the race and put our
-        // commit on origin/main; git rejects this one with stale-info info.
+      if (label === "push" && push++ === 0) {
         throw pushError("! [rejected]        main -> main (fetch first)");
       }
-      // Both HEAD and origin/main resolve to the same commit — ours landed.
-      if (label === "rev-parse") return HEAD_SHA as never;
       return "" as never;
     });
     let mutatorCalls = 0;
-    // No throw: commitAndPush returns normally (the top-level handler exits 0).
     commitAndPush({
       message: "test",
       fileToStage: "/some/file.md",
       mutator: () => mutatorCalls++,
-      raceMessage: "should not be reached",
-      raceExitCode: 3,
+      raceMessage: "no",
+      raceExitCode: 99,
     });
-    expect(mutatorCalls).toBe(1);
-    // process.exit is never called: no raceExitCode, no exit 1.
-    expect(exit).not.toHaveBeenCalled();
-    // The mutation is confirmed landed via rev-parse HEAD + fetch + rev-parse
-    // origin/main; it must NOT reset the tree or retry the mutation.
-    expect(seen.filter((l) => l === "push").length).toBe(1);
-    expect(seen.filter((l) => l === "reset").length).toBe(0);
-    expect(seen.filter((l) => l === "commit").length).toBe(1);
-    expect(seen.filter((l) => l === "rev-parse").length).toBe(2);
+    expect(mutatorCalls).toBe(2);
+    // The rejected push is followed immediately by the reset — no rev-parse or
+    // fetch in between.
+    expect(seen.slice(seen.indexOf("push"), seen.indexOf("push") + 2)).toEqual(["push", "reset"]);
   });
 
   it("surfaces non-race push failures verbatim and exits 1 (no reset, no retry)", () => {

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -1181,10 +1181,12 @@ export function commitAndPush(opts: {
         const reconciled = reconcileDuplicateRfcDirs(cwd);
         git(["add", reconciled ? "-A" : opts.fileToStage], { cwd });
         // RFCS_NO_AUTOPUSH: the tasks repo's .husky/post-commit hook otherwise
-        // background-pushes `main` after this commit, racing the explicit push
-        // below (and, before the pre-read sync took the lock, occasionally
-        // pushing a clobbered EMPTY commit before we could reset it away). The
-        // CLI owns its own push; silence the hook's.
+        // pushes `main` after this commit, racing the explicit push below (and,
+        // before the pre-read sync took the lock, occasionally pushing a
+        // clobbered EMPTY commit before we could reset it away). The CLI owns
+        // its own push; silence the hook's. The rejected-push handling below
+        // depends on this — with the hook silenced nothing else pushes our SHA,
+        // so a rejection can only be a lost race.
         git(["commit", "-q", "-m", opts.message], {
           cwd,
           captureStderr: true,
@@ -1268,31 +1270,10 @@ export function commitAndPush(opts: {
           releaseTasksLock(lock);
           process.exit(1);
         }
-        // A "[rejected]"/"fetch first" is not always a *lost* race. The tasks
-        // repo's own `.husky/post-commit` hook auto-pushes `main` to origin in
-        // the background after every commit — including the commit we just made
-        // above. That background push and this explicit push race: when the
-        // hook's push lands first, origin/main advances to OUR commit, and git
-        // then rejects THIS push with "[rejected] main -> main (stale info /
-        // fetch first)" even though the mutation is already on origin/main. That
-        // is a success, not a lost race — resetting + retrying (or exiting with
-        // raceExitCode) would wrongly report failure for a landed mutation, the
-        // exact false-negative that produced a scary error on a clean priority
-        // flip. Distinguish the two by fetching origin/main and comparing it to
-        // our HEAD: if they match, our commit is on the remote — return success.
-        // A genuine lost race leaves origin/main at someone ELSE's commit, so
-        // this check fails and the real reset/retry path below runs unchanged.
-        try {
-          const localHead = git(["rev-parse", "HEAD"], { silent: true, cwd });
-          git(["fetch", "--quiet", "origin", "main"], { silent: true, cwd });
-          const remoteHead = git(["rev-parse", "origin/main"], { silent: true, cwd });
-          if (localHead && remoteHead && localHead === remoteHead) {
-            return;
-          }
-        } catch {
-          /* offline / no origin — can't confirm the commit landed; fall through
-             to the genuine-race reset+retry path, which is the safe default. */
-        }
+        // A rejection is always a *lost* race: no other writer can push OUR
+        // SHA. The commit above sets RFCS_NO_AUTOPUSH=1, so the tasks repo's
+        // post-commit hook never pushes a CLI commit; for hand commits it
+        // pushes someone else's.
         git(["reset", "--hard", "origin/main"], { silent: true, cwd });
         if (attempt === 1) {
           console.error(opts.raceMessage);


### PR DESCRIPTION
Retires the tasks repo's background post-commit auto-push and drops the
CLI-side confirm-check that existed only to work around it.

**Decision: foreground, not delete.** The auto-push still has a real
beneficiary — a human committing by hand. Every other reader of the tasks
repo (other clones, per-worktree CLI checkouts) syncs by
`reset --hard origin/main`, so an unpushed hand commit is invisible there and
trips the CLI's "HEAD is N commit(s) ahead of origin/main" guard. What was
wrong was the *backgrounding*: a detached `git push … &` raced whatever else
was touching the checkout and reported failures after the commit command had
already returned — the "rfcs auto-push failed: … cannot lock ref" noise. It
now runs synchronously (landed in the tasks repo as
`9ceca9670 chore(hooks): foreground the post-commit auto-push`).

**This PR** simplifies `commitAndPush` in `scripts/tasks/cli.ts`. A
"[rejected] … (fetch first)" used to be ambiguous: the hook's background push
could land OUR commit and make the CLI's own push fail on an
already-succeeded mutation, so the catch did a rev-parse HEAD / fetch /
rev-parse origin/main round-trip to tell that apart from a lost race. No
other writer can land our exact SHA now — CLI commits set
`RFCS_NO_AUTOPUSH=1` so the hook stands down for them entirely, and for hand
commits the (now foreground) hook pushes someone else's SHA, never ours. So
every rejection is a genuinely lost race: reset + retry directly.

Tests updated: the obsolete "treats a rejected push as success" case is
replaced by one asserting a fetch-first rejection goes straight to reset with
no confirm round-trip, and the retry test's expected git-call sequence drops
the three confirm calls. `scripts/tasks/cli.test.ts` — 259 passed.

Closes-story: tasks-retire-post-commit-autopush-hook
