### PR TITLE
fix(has_one): remove the build-displaced record at assignment, not at save

### DIFF
--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -401,6 +401,10 @@ export class HasOneAssociation extends SingularAssociation {
     if (!displaced) return;
     if ((displaced as { isDestroyed?: () => boolean }).isDestroyed?.()) return;
     if (sameRecord(displaced, this.target)) return;
+    // Only a persisted record has a row to remove. `remove_target!`'s nullify
+    // and destroy arms gate on this themselves, but its `:delete` arm does not,
+    // so check once here rather than relying on the arm that happens to run.
+    if (displaced.isPersisted() !== true) return;
     await removeTargetBang(this, (this.reflection.options.dependent as string) ?? "", displaced);
   }
 

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -395,16 +395,20 @@ export class HasOneAssociation extends SingularAssociation {
    * be visible as `assoc.target` briefly reverting to the displaced record.
    * Name the record instead and leave the cached target alone.
    *
+   * The parked target is the ONLY intended difference: the guards below
+   * deliberately match `detachDisplacedTarget`'s, and neither pre-screens
+   * `isPersisted`. Rails' `remove_target!` gates on persistence only inside its
+   * `:destroy` and nullify arms; the `:delete` arm calls `target.delete`
+   * unconditionally, and `Persistence#delete` still marks the record destroyed
+   * and freezes it when the row does not exist (persistence.rb:439-444). Let
+   * `removeTargetBang`'s arms make that call.
+   *
    * @internal
    */
   async removeDisplacedRecord(displaced: Base | null): Promise<void> {
     if (!displaced) return;
     if ((displaced as { isDestroyed?: () => boolean }).isDestroyed?.()) return;
     if (sameRecord(displaced, this.target)) return;
-    // Only a persisted record has a row to remove. `remove_target!`'s nullify
-    // and destroy arms gate on this themselves, but its `:delete` arm does not,
-    // so check once here rather than relying on the arm that happens to run.
-    if (displaced.isPersisted() !== true) return;
     await removeTargetBang(this, (this.reflection.options.dependent as string) ?? "", displaced);
   }
 

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -18,39 +18,8 @@ import { polymorphicName } from "../inheritance.js";
  * Mirrors: ActiveRecord::Associations::HasOneAssociation
  */
 export class HasOneAssociation extends SingularAssociation {
-  /**
-   * The record(s) displaced by the sync `build#{name}` / `create#{name}` path
-   * (`setNewRecord`) on a *persisted* owner — recorded there and removed
-   * (FK-nullified/destroyed per `:dependent`) by the owner's `save`-time has_one
-   * autosave callback (`autosaveHasOne` → `removeDisplaced`). Rails does this
-   * removal synchronously inside `replace`; the sync builder cannot `await`, so
-   * we carry the displaced record forward to the single autosave persistence
-   * path rather than running a parallel `persistReplace`.
-   *
-   * The property setter no longer feeds this queue: on a persisted owner it
-   * throws (RFC 0068). The remaining producer is the *synchronous* build path —
-   * `setNewRecord`, reached via `assoc.build()` from nested attributes
-   * (nested-attributes.ts) as well as the `build#{name}` / `create#{name}`
-   * accessors. Rails runs `remove_target!`'s persisted nullify save inline
-   * (has_one_association.rb:108); a sync JS builder cannot await it, so the
-   * queue carries it to the owner's save. This is why the queue could NOT be
-   * retired wholesale with the deferred setter (RFC 0068).
-   *
-   * This is an *ordered collection*, not a single slot: repeated builds can
-   * displace more than one persisted record before `save()` drains the queue.
-   * Rails removes each inline inside `replace`, so every displacement is
-   * accounted for; we accumulate them and remove all at save time, in
-   * displacement order.
-   */
-  _displacedRecords: Base[] = [];
-
   constructor(owner: Base, definition: AssociationDefinition) {
     super(owner, definition);
-  }
-
-  override reset(): void {
-    super.reset();
-    this._displacedRecords = [];
   }
 
   /**
@@ -184,38 +153,6 @@ export class HasOneAssociation extends SingularAssociation {
     // repeat of the in-transaction work) and, for `record === null`, clears the
     // inverse on the now-removed displaced record.
     this.replace(record);
-  }
-
-  /**
-   * Remove the record displaced by a deferred assignment to a persisted owner.
-   * Called by the has_one autosave callback (`autosaveHasOne`) before persisting
-   * the new target — the deferred analog of the `remove_target!` Rails runs
-   * inside `HasOneAssociation#replace`.
-   */
-  async removeDisplaced(): Promise<void> {
-    // Drain the whole collection, removing each displaced record in
-    // displacement order (Rails removes each inline inside `replace`).
-    const queued = this._displacedRecords;
-    this._displacedRecords = [];
-    for (const record of queued) {
-      await this.removeOne(record);
-    }
-  }
-
-  /**
-   * Run `remove_target!` for a single displaced record, honoring the
-   * reflection's `:dependent` (delete/destroy/else-nullify). Temporarily sets
-   * `target` to the displaced record so `removeTargetBang` acts on it, then
-   * restores the current target.
-   */
-  private async removeOne(displaced: Base): Promise<void> {
-    const currentTarget = this.target;
-    this.target = displaced;
-    try {
-      await removeTargetBang(this, (this.reflection.options.dependent as string) ?? "");
-    } finally {
-      this.target = currentTarget;
-    }
   }
 
   /**
@@ -446,6 +383,27 @@ export class HasOneAssociation extends SingularAssociation {
     this.target = replacement;
   }
 
+  /**
+   * `remove_target!` for a record displaced by the *synchronous* `assoc.build()`
+   * path (nested attributes), run without disturbing `this.target`.
+   *
+   * `detachDisplacedTarget` parks the target on `displaced` for the duration of
+   * the removal to reproduce Rails' target-on-failure semantics — safe for the
+   * `build#{name}` accessors, whose callers `await` before observing anything.
+   * The nested-attributes writer is a synchronous property setter: it returns to
+   * the caller while this removal is still in flight, so a parked target would
+   * be visible as `assoc.target` briefly reverting to the displaced record.
+   * Name the record instead and leave the cached target alone.
+   *
+   * @internal
+   */
+  async removeDisplacedRecord(displaced: Base | null): Promise<void> {
+    if (!displaced) return;
+    if ((displaced as { isDestroyed?: () => boolean }).isDestroyed?.()) return;
+    if (sameRecord(displaced, this.target)) return;
+    await removeTargetBang(this, (this.reflection.options.dependent as string) ?? "", displaced);
+  }
+
   protected override async doAsyncFindTarget(): Promise<Base | null> {
     // `loadHasOne`'s tail writeback lands in this holder mid-await, so a target
     // replaced while the query is in flight would be silently clobbered. Arm
@@ -529,11 +487,15 @@ export class HasOneAssociation extends SingularAssociation {
    * `save = false` gates only `transaction_if(save)` (:68) and `if save &&
    * !record.save` (:75) — `remove_target!` (:69) runs regardless, so building
    * over an existing target still nullifies the displaced record's foreign key
-   * and clears its inverse. We run that in-memory half here and hand the
-   * displaced record to `removeDisplaced` (the owner's `autosaveHasOne`) for the
-   * DB half — `build` is synchronous and cannot await a save. Only a *persisted*
-   * displaced record has a row to remove, so a transient in-memory target is not
-   * queued (matching `queueWrite`).
+   * and clears its inverse. We run that in-memory half here; the DB half needs
+   * an `await` this synchronous method cannot issue, so every caller that can
+   * displace a persisted record issues it itself — `detachDisplacedTarget` from
+   * the `build#{name}` / `create#{name}` accessors (builder/has-one.ts,
+   * `_createRecord`), `removeDisplacedRecord` from the nested-attributes writer
+   * (nested-attributes.ts, `removeDisplacedAtAssignment`). Nothing is queued
+   * here: a queue drained at the owner's `save` would defer a write Rails makes
+   * at assignment, and would double-remove records the awaiting callers have
+   * already detached.
    */
   protected override setNewRecord(record: Base): void {
     const displaced = this.target;
@@ -549,7 +511,6 @@ export class HasOneAssociation extends SingularAssociation {
       this.nullifyOwnerAttributes(displaced);
       this.removeInverseInstance(displaced);
     }
-    this._displacedRecords.push(displaced);
   }
 
   private nullifyOwnerAttributes(record: Base): void {
@@ -608,8 +569,10 @@ export function sameRecord(a: Base | null, b: Base | null): boolean {
  *
  * @internal
  */
-async function preloadDestroyInverseBelongsTo(assoc: HasOneAssociation): Promise<void> {
-  const target = assoc.target;
+async function preloadDestroyInverseBelongsTo(
+  assoc: HasOneAssociation,
+  target: Base | null = assoc.target,
+): Promise<void> {
   if (!target) return;
   const owner = assoc.owner;
   const targetCtor = (target as any).constructor as typeof Base;
@@ -640,8 +603,15 @@ async function preloadDestroyInverseBelongsTo(assoc: HasOneAssociation): Promise
 }
 
 /** @internal */
-async function removeTargetBang(assoc: HasOneAssociation, method: string): Promise<void> {
-  const target = assoc.target;
+async function removeTargetBang(
+  assoc: HasOneAssociation,
+  method: string,
+  // Rails' `remove_target!` always acts on `self.target`. The nested-attributes
+  // displacement path removes a record while `assoc.target` is already the
+  // replacement (it must not flip the cached target back mid-await, which is
+  // observable to synchronous readers), so it names the record explicitly.
+  target: Base | null = assoc.target,
+): Promise<void> {
   if (!target) return;
   if (method === "delete") {
     await ((target as any).delete?.() ?? Promise.resolve());
@@ -653,7 +623,7 @@ async function removeTargetBang(assoc: HasOneAssociation, method: string): Promi
     // `destroyed_by_association`) before destroying, and only destroy when the
     // record is actually persisted.
     (target as any).destroyedByAssociation = assoc.reflection;
-    await preloadDestroyInverseBelongsTo(assoc);
+    await preloadDestroyInverseBelongsTo(assoc, target);
     if (target.isPersisted()) await ((target as any).destroy?.() ?? Promise.resolve());
     return;
   }

--- a/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
@@ -6,11 +6,12 @@
  * `remove_target!` inline (has_one_association.rb:68-69, 91-92), including the
  * persisted nullify `target.save` at :108. A synchronous JS builder cannot
  * await that write, so `setNewRecord` performs only the in-memory half; every
- * caller that can displace a persisted record issues the DB half itself via
- * `detachDisplacedTarget` — the `build#{Name}` / `create#{Name}` accessors, and
- * (for `assoc.build()`, which nested attributes calls directly) the
- * nested-attributes writer, which starts the removal inline at assignment and
- * awaits it in its `save` wrapper before the replacement is inserted.
+ * caller that can displace a persisted record issues the DB half itself. The
+ * `build#{Name}` / `create#{Name}` accessors use `detachDisplacedTarget`. For
+ * `assoc.build()`, which nested attributes calls directly, the nested-attributes
+ * writer uses `removeDisplacedRecord` — starting the removal inline at
+ * assignment and awaiting it in its `save` wrapper before the replacement is
+ * inserted.
  *
  * Rails' own `test_should_replace_an_existing_record_if_there_is_no_id`
  * (nested_attributes_test.rb:288) asserts only in-memory state and never saves

--- a/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-sync-build-displacement.trails.test.ts
@@ -1,19 +1,16 @@
 /**
- * Trails-only surface: the deferred removal of a has_one record displaced by
- * the *synchronous* build path.
+ * Trails-only surface: removal of a has_one record displaced by the
+ * *synchronous* build path.
  *
  * Rails' `HasOneAssociation#set_new_record` -> `replace(record, false)` runs
  * `remove_target!` inline (has_one_association.rb:68-69, 91-92), including the
  * persisted nullify `target.save` at :108. A synchronous JS builder cannot
- * await that write, so `setNewRecord` performs only the in-memory half and
- * queues the displaced record on `_displacedRecords`; the owner's
- * `autosaveHasOne` drains it via `removeDisplaced` at save time.
- *
- * The awaitable `build#{Name}` / `create#{Name}` accessors do the DB half
- * inline instead (`detachDisplacedTarget`), but `assoc.build()` — which nested
- * attributes calls directly (nested-attributes.ts) — does NOT go through those
- * accessors. That is why the queue survives RFC 0068's awaitable setter: the
- * setter stopped feeding it, the sync build path did not.
+ * await that write, so `setNewRecord` performs only the in-memory half; every
+ * caller that can displace a persisted record issues the DB half itself via
+ * `detachDisplacedTarget` — the `build#{Name}` / `create#{Name}` accessors, and
+ * (for `assoc.build()`, which nested attributes calls directly) the
+ * nested-attributes writer, which starts the removal inline at assignment and
+ * awaits it in its `save` wrapper before the replacement is inserted.
  *
  * Rails' own `test_should_replace_an_existing_record_if_there_is_no_id`
  * (nested_attributes_test.rb:288) asserts only in-memory state and never saves

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -106,6 +106,17 @@ export class HasOneThroughAssociation extends HasOneAssociation {
   }
 
   /**
+   * No-op for the same reason as `detachDisplacedTarget` above: the
+   * nested-attributes displacement path must not nullify/destroy a displaced
+   * *end* record of a through association.
+   *
+   * @internal
+   */
+  override async removeDisplacedRecord(): Promise<void> {
+    // no-op — see JSDoc
+  }
+
+  /**
    * Mirrors Rails `HasOneThroughAssociation#replace` immediate persist to a
    * saved owner. The base `writer` saves the target's foreign key directly,
    * which is wrong for a through (persistence routes through the join model), so
@@ -388,9 +399,10 @@ export class HasOneThroughAssociation extends HasOneAssociation {
     // Rails' `load_target` returning the same object on an already-loaded proxy.
     //
     // We also clear the suppression sentinel we set on the through proxy's
-    // duck-typed `_pendingReplace`: the base `HasOneAssociation#reset` clears
-    // only `_displacedRecords` (it never declares `_pendingReplace`, having
-    // converged onto `_displacedRecords` + `autosaveHasOne`), so without this the
+    // duck-typed `_pendingReplace`: the base `HasOneAssociation` never declares
+    // `_pendingReplace` (its displacement removal runs inline, via
+    // `detachDisplacedTarget`), so its `reset` does not clear it and without
+    // this the
     // sentinel would linger and permanently make `autosaveHasOne` skip the
     // proxy — silently dropping any *later* independent write to
     // `owner.currentMembership` on this same instance. Runs before the `!pending`

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -497,16 +497,6 @@ async function _insertCollectionRecordFallback(
 async function autosaveHasOne(record: Base, assoc: AssociationDefinition): Promise<boolean> {
   const inst = _loadedAssociation(record, assoc.name);
 
-  // A deferred (non-awaitable) assignment to a persisted owner
-  // (`owner.account = b` via the property setter / mass-assignment) records the
-  // displaced record so this single autosave path — not a parallel
-  // `persistReplace` — nullifies/destroys it, mirroring the `remove_target!`
-  // Rails runs synchronously inside `HasOneAssociation#replace`. Runs before the
-  // `!child` bail so assigning nil (`owner.account = null`) still removes it.
-  if (typeof inst?.removeDisplaced === "function" && (inst?._displacedRecords?.length ?? 0) > 0) {
-    await inst.removeDisplaced();
-  }
-
   // Rails `save_has_one_association`'s `through_reflection` arm persists the
   // join side of a has_one *through* (build/update/destroy via
   // `createThroughRecord`) — the analog of Rails' assignment-time
@@ -532,8 +522,8 @@ async function autosaveHasOne(record: Base, assoc: AssociationDefinition): Promi
   // must NOT be inserted here — the through's own `persistReplace` reconciles
   // the existing DB row via `load_target` + `update`, and persisting it here
   // would duplicate that row. A plain `HasOneAssociation` never sets
-  // `_pendingReplace` itself (it converged onto `_displacedRecords` +
-  // `autosaveHasOne`), and the through association itself clears its marker
+  // `_pendingReplace` itself (its displacement removal runs inline, via
+  // `detachDisplacedTarget`), and the through association itself clears its marker
   // inside `persistThroughRecord` above, so a truthy marker on an instance with
   // no `persistThroughRecord` is unambiguously that suppression sentinel. Skip
   // the end-record persistence; the through owns the join row.

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -177,6 +177,11 @@ export function acceptsNestedAttributesFor(
       this: Base,
       options?: { validate?: boolean; touch?: boolean },
     ): Promise<boolean> {
+      // Finish the displaced-record removals a nested-attributes assignment
+      // started (Rails runs them inline inside `replace`), before the parent
+      // save's has_one autosave inserts the replacement — so the nullify lands
+      // first, as it does in Rails.
+      await awaitPendingDisplacedRemovals(this);
       const result = await originalSave.call(this, options);
       if (!result) return false;
 
@@ -654,6 +659,73 @@ interface OneToOneAssociation {
   target: Base | null;
   build(attrs: Record<string, unknown>): Base | null;
   initializeAttributes(record: Base): void;
+  isLoaded?(): boolean;
+  removeDisplacedRecord?(displaced: Base | null): Promise<void>;
+}
+
+/**
+ * Start Rails' `remove_target!` for the record a nested-attributes `build`
+ * displaced, at the moment of assignment.
+ *
+ * Rails runs the removal inline inside `HasOneAssociation#replace`
+ * (has_one_association.rb:69) — the nested-attributes writer is a synchronous
+ * property setter (`pirate.shipAttributes = {...}`), so it cannot `await` the
+ * nullify save. It CAN issue it: `removeDisplacedRecord` is kicked off here,
+ * inline at assignment exactly as in Rails, and only its *completion* is
+ * deferred — to the nested-attributes `save` wrapper, which drains this list
+ * before the parent (and its autosaved new target) is persisted. That keeps
+ * Rails' write ordering (displaced row nullified before the replacement is
+ * inserted) and, like Rails, removes the displaced record even if the owner is
+ * never saved.
+ *
+ * The rejection is captured rather than left floating: a never-drained removal
+ * must not surface as an unhandled rejection, and a drained one must rethrow.
+ * @internal
+ */
+function removeDisplacedAtAssignment(
+  record: Base,
+  assoc: OneToOneAssociation,
+  displaced: Base | null,
+): void {
+  if (!displaced) return;
+  if (typeof assoc.removeDisplacedRecord !== "function") return;
+  const settled = assoc.removeDisplacedRecord(displaced).then(
+    () => null,
+    (error: unknown) => error ?? new Error("displaced record removal failed"),
+  );
+  const host = record as unknown as { _pendingDisplacedRemovals?: Promise<unknown>[] };
+  (host._pendingDisplacedRemovals ??= []).push(settled);
+}
+
+/**
+ * Await the removals started by `removeDisplacedAtAssignment`, rethrowing the
+ * first failure — the deferred half of Rails' inline `remove_target!`.
+ * @internal
+ */
+async function awaitPendingDisplacedRemovals(record: Base): Promise<void> {
+  const host = record as unknown as { _pendingDisplacedRemovals?: Promise<unknown>[] };
+  const pending = host._pendingDisplacedRemovals;
+  if (!pending?.length) return;
+  host._pendingDisplacedRemovals = [];
+  for (const settled of pending) {
+    const error = await settled;
+    if (error) throw error;
+  }
+}
+
+/**
+ * The displaced record a nested-attributes `build` is about to replace, or null
+ * when nothing needs removing. Mirrors the conditions under which Rails'
+ * `remove_target!` does DB work: a *loaded*, persisted, not-already-destroyed
+ * target that is not the record being assigned.
+ * @internal
+ */
+function displacedByNestedBuild(assoc: OneToOneAssociation, existing: Base | null): Base | null {
+  if (!existing) return null;
+  if (typeof assoc.isLoaded === "function" && !assoc.isLoaded()) return null;
+  if (!existing.isPersisted()) return null;
+  if ((existing as { isDestroyed?: () => boolean }).isDestroyed?.()) return null;
+  return existing;
 }
 
 /** @internal */
@@ -772,7 +844,13 @@ export function assignNestedAttributesForOneToOneAssociation(
           );
         }
       } else {
+        // Rails' `build_#{name}` → `set_new_record` → `replace(record, false)`
+        // removes the displaced target inline (has_one_association.rb:69).
+        // Capture it before the build overwrites `assoc.target`, then start that
+        // removal here — see `removeDisplacedAtAssignment`.
+        const displaced = displacedByNestedBuild(assoc, existing);
         assoc.build(assignable);
+        removeDisplacedAtAssignment(record, assoc, displaced);
       }
     }
   }

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -713,21 +713,6 @@ async function awaitPendingDisplacedRemovals(record: Base): Promise<void> {
   }
 }
 
-/**
- * The displaced record a nested-attributes `build` is about to replace, or null
- * when nothing needs removing. Mirrors the conditions under which Rails'
- * `remove_target!` does DB work: a *loaded*, persisted, not-already-destroyed
- * target that is not the record being assigned.
- * @internal
- */
-function displacedByNestedBuild(assoc: OneToOneAssociation, existing: Base | null): Base | null {
-  if (!existing) return null;
-  if (typeof assoc.isLoaded === "function" && !assoc.isLoaded()) return null;
-  if (!existing.isPersisted()) return null;
-  if ((existing as { isDestroyed?: () => boolean }).isDestroyed?.()) return null;
-  return existing;
-}
-
 /** @internal */
 function hasNestedId(attributes: Record<string, unknown>): boolean {
   const id = (attributes as any).id;
@@ -847,8 +832,10 @@ export function assignNestedAttributesForOneToOneAssociation(
         // Rails' `build_#{name}` → `set_new_record` → `replace(record, false)`
         // removes the displaced target inline (has_one_association.rb:69).
         // Capture it before the build overwrites `assoc.target`, then start that
-        // removal here — see `removeDisplacedAtAssignment`.
-        const displaced = displacedByNestedBuild(assoc, existing);
+        // removal here — see `removeDisplacedAtAssignment`. Rails only removes
+        // what `load_target` surfaced, so an unloaded association displaces
+        // nothing; `removeDisplacedRecord` owns the remaining guards.
+        const displaced = assoc.isLoaded?.() === false ? null : existing;
         assoc.build(assignable);
         removeDisplacedAtAssignment(record, assoc, displaced);
       }


### PR DESCRIPTION
Rails removes a displaced `has_one` **inline at assignment**: `set_new_record`
-> `replace(record, false)` -> `remove_target!`, including the persisted nullify
`target.save` (has_one_association.rb:87-93, 95-115).

trails deferred the DB half of that on the *synchronous* build path:
`setNewRecord` did only the in-memory nullify and queued the displaced record on
`_displacedRecords`, which the owner's `autosaveHasOne` drained at `save()`
time. The deferral IS the deviation — the same class RFC 0068 retired for the
`=` setter.

## What was actually left

The awaitable `build#{Name}` / `create#{Name}` accessors already converged
(`detachDisplacedTarget`, builder/has-one.ts:78-80,91-93) — and, because
`setNewRecord` *also* queued, they double-removed. The only genuine remaining
producer was `assoc.build()` called directly, which is what the nested-attributes
one-to-one writer does (nested-attributes.ts), reached from the synchronous
`record.shipAttributes = {...}` assignment.

## The fix

That writer is a synchronous property setter, so it cannot `await` the nullify
save — but it can **issue** it. It now starts the removal at assignment, exactly
where Rails does, and awaits only its *completion*, in the nested-attributes
`save` wrapper, before the parent save's has_one autosave inserts the
replacement. So Rails' write ordering is preserved (displaced row nullified
first) and — as in Rails — the displaced record is removed even if the owner is
never saved.

With that in place, `setNewRecord` queues nothing, and `_displacedRecords`,
`removeDisplaced`/`removeOne`, and the `autosaveHasOne` drain are deleted.
`git grep _displacedRecords packages/activerecord/src` returns 0 hits.

The removal names its record explicitly (`removeDisplacedRecord`, a new
`remove_target!` entry point that takes the target as a parameter) rather than
parking `assoc.target` on it the way `detachDisplacedTarget` does for its
target-on-failure semantics. `detachDisplacedTarget`'s callers `await` before
observing anything; the nested-attributes writer returns to its caller
mid-flight, so a parked target is observable as `assoc.target` briefly reverting
to the displaced record (`nested-attributes.test.ts:438` catches exactly this).

`has_one_through` overrides the new entry point to a no-op for the same reason
it already no-ops `detachDisplacedTarget`: a through must not nullify a displaced
*end* record. Previously the queue drain did nullify it — that was a latent bug.

`queueWrite` is untouched.

## Verification

- `has-one-sync-build-displacement.trails.test.ts` green, and verified it still
  fails (displaced row left attached) when the new inline removal is disabled.
- `packages/activerecord/src/associations` + `autosave-association.test.ts`:
  85 files, 2276 passed / 12 skipped.
- `nested-attributes.test.ts`: 163 passed.

Closes-story: converge-sync-build-displacement-to-inline-removal
