### PR TITLE
fix(has-one): remove an awaited-build displaced record exactly once

### DIFF
--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -435,12 +435,6 @@ export class HasOneAssociation extends SingularAssociation {
     if (!displaced) return;
     if ((displaced as { isDestroyed?: () => boolean }).isDestroyed?.()) return;
     if (sameRecord(displaced, replacement)) return;
-    // The `build`/`create` that produced `replacement` ran `setNewRecord`, which
-    // queued this same record on `_displacedRecords` for the owner's autosave
-    // drain. We are about to run `remove_target!` on it inline, so drop it from
-    // the queue: Rails runs `remove_target!` exactly once per displacement
-    // (has_one_association.rb:68-69, 91-92), and a queued duplicate would issue
-    // a second, redundant removal at save time.
     this.dequeueDisplaced(displaced);
     // Mirror Rails' `HasOneAssociation#replace`, where `self.target = record` runs
     // only after the transaction block: if `remove_target!` raises (e.g. a failed
@@ -453,12 +447,6 @@ export class HasOneAssociation extends SingularAssociation {
     this.target = replacement;
   }
 
-  /**
-   * Drop the first queued entry matching `record` from `_displacedRecords`, so
-   * a displacement removed inline is not removed a second time by the owner's
-   * autosave drain. Only the first match is dropped: the queue is an ordered
-   * collection and repeated builds can queue the same record more than once.
-   */
   private dequeueDisplaced(record: Base): void {
     const index = this._displacedRecords.findIndex((queued) => sameRecord(queued, record));
     if (index !== -1) this._displacedRecords.splice(index, 1);

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -435,6 +435,13 @@ export class HasOneAssociation extends SingularAssociation {
     if (!displaced) return;
     if ((displaced as { isDestroyed?: () => boolean }).isDestroyed?.()) return;
     if (sameRecord(displaced, replacement)) return;
+    // The `build`/`create` that produced `replacement` ran `setNewRecord`, which
+    // queued this same record on `_displacedRecords` for the owner's autosave
+    // drain. We are about to run `remove_target!` on it inline, so drop it from
+    // the queue: Rails runs `remove_target!` exactly once per displacement
+    // (has_one_association.rb:68-69, 91-92), and a queued duplicate would issue
+    // a second, redundant removal at save time.
+    this.dequeueDisplaced(displaced);
     // Mirror Rails' `HasOneAssociation#replace`, where `self.target = record` runs
     // only after the transaction block: if `remove_target!` raises (e.g. a failed
     // nullify save, which restores the old record's owner attributes before
@@ -444,6 +451,17 @@ export class HasOneAssociation extends SingularAssociation {
     this.target = displaced;
     await removeTargetBang(this, (this.reflection.options.dependent as string) ?? "");
     this.target = replacement;
+  }
+
+  /**
+   * Drop the first queued entry matching `record` from `_displacedRecords`, so
+   * a displacement removed inline is not removed a second time by the owner's
+   * autosave drain. Only the first match is dropped: the queue is an ordered
+   * collection and repeated builds can queue the same record more than once.
+   */
+  private dequeueDisplaced(record: Base): void {
+    const index = this._displacedRecords.findIndex((queued) => sameRecord(queued, record));
+    if (index !== -1) this._displacedRecords.splice(index, 1);
   }
 
   protected override async doAsyncFindTarget(): Promise<Base | null> {

--- a/packages/activerecord/src/associations/has-one-awaited-build-displacement.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-awaited-build-displacement.trails.test.ts
@@ -1,21 +1,3 @@
-/**
- * Trails-only surface: the awaitable `build#{Name}` / `create#{Name}` accessors
- * remove the displaced has_one target inline (`detachDisplacedTarget`), while
- * the synchronous `setNewRecord` underneath them ALSO queues that record on
- * `_displacedRecords` for the owner's autosave drain (`removeDisplaced`) — so
- * `remove_target!` ran twice for one displacement.
- *
- * Rails runs it exactly once: `set_new_record` -> `replace(record, false)`
- * (has_one_association.rb:68-69, 91-92). The end state was already correct on
- * both paths (the second removal's writes are absorbed: the `:destroy` branch
- * is gated on `target.persisted?`, and the nullify branch re-saves an unchanged
- * record, which emits no UPDATE), so these assert the removal COUNT — the
- * displaced record's `save` under the nullify branch, plus the drained queue.
- *
- * The queue itself stays: the synchronous `assoc.build()` path nested
- * attributes uses never reaches these accessors (see
- * has-one-sync-build-displacement.trails.test.ts).
- */
 import { describe, it, expect, beforeAll } from "vitest";
 import { registerModel, type Base } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
@@ -36,7 +18,6 @@ interface PirateWithShip {
   save(): Promise<boolean>;
 }
 
-/** Count `save` calls on the association's loaded target. */
 function spyOnTargetSave(assoc: ShipAssociation): () => number {
   const target = assoc.target as unknown as { save: (...args: unknown[]) => unknown };
   const original = target.save.bind(target);
@@ -85,5 +66,21 @@ describe("has_one displacement via the awaitable build/create accessors", () => 
     await pirate.save();
 
     expect(saveCalls()).toBe(1);
+  });
+
+  it("removes each displaced record exactly once across repeated awaited builds", async () => {
+    const pirate = await pirateWithLoadedShip();
+    const assoc = pirate.association("ship");
+    const firstSaveCalls = spyOnTargetSave(assoc);
+
+    await pirate.createShip({ name: "Second Ship" });
+    const secondSaveCalls = spyOnTargetSave(assoc);
+    await pirate.buildShip({ name: "Third Ship" });
+
+    expect(assoc._displacedRecords).toHaveLength(0);
+    await pirate.save();
+
+    expect(firstSaveCalls()).toBe(1);
+    expect(secondSaveCalls()).toBe(1);
   });
 });

--- a/packages/activerecord/src/associations/has-one-awaited-build-displacement.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-awaited-build-displacement.trails.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Trails-only surface: the awaitable `build#{Name}` / `create#{Name}` accessors
+ * remove the displaced has_one target inline (`detachDisplacedTarget`), while
+ * the synchronous `setNewRecord` underneath them ALSO queues that record on
+ * `_displacedRecords` for the owner's autosave drain (`removeDisplaced`) — so
+ * `remove_target!` ran twice for one displacement.
+ *
+ * Rails runs it exactly once: `set_new_record` -> `replace(record, false)`
+ * (has_one_association.rb:68-69, 91-92). The end state was already correct on
+ * both paths (the second removal's writes are absorbed: the `:destroy` branch
+ * is gated on `target.persisted?`, and the nullify branch re-saves an unchanged
+ * record, which emits no UPDATE), so these assert the removal COUNT — the
+ * displaced record's `save` under the nullify branch, plus the drained queue.
+ *
+ * The queue itself stays: the synchronous `assoc.build()` path nested
+ * attributes uses never reaches these accessors (see
+ * has-one-sync-build-displacement.trails.test.ts).
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { registerModel, type Base } from "../index.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+import { Pirate } from "../test-helpers/models/pirate.js";
+import { Ship } from "../test-helpers/models/ship.js";
+
+interface ShipAssociation {
+  target: Base | null;
+  _displacedRecords: Base[];
+}
+
+interface PirateWithShip {
+  id: number;
+  ship: Promise<Base | null>;
+  association(name: string): ShipAssociation;
+  buildShip(attributes: Record<string, unknown>): Promise<Base>;
+  createShip(attributes: Record<string, unknown>): Promise<Base>;
+  save(): Promise<boolean>;
+}
+
+/** Count `save` calls on the association's loaded target. */
+function spyOnTargetSave(assoc: ShipAssociation): () => number {
+  const target = assoc.target as unknown as { save: (...args: unknown[]) => unknown };
+  const original = target.save.bind(target);
+  let calls = 0;
+  target.save = (...args: unknown[]) => {
+    calls++;
+    return original(...args);
+  };
+  return () => calls;
+}
+
+describe("has_one displacement via the awaitable build/create accessors", () => {
+  fixtures(["pirates", "ships"]);
+
+  beforeAll(() => {
+    registerModel(Pirate);
+    registerModel(Ship);
+  });
+
+  async function pirateWithLoadedShip(): Promise<PirateWithShip> {
+    const pirate = (await Pirate.create({ catchphrase: "Aye" })) as unknown as PirateWithShip;
+    await Ship.create({ name: "Old Ship", pirate_id: pirate.id });
+    await pirate.ship;
+    return pirate;
+  }
+
+  it("removes the displaced record exactly once for an awaited build", async () => {
+    const pirate = await pirateWithLoadedShip();
+    const assoc = pirate.association("ship");
+    const saveCalls = spyOnTargetSave(assoc);
+
+    await pirate.buildShip({ name: "New Ship" });
+    expect(assoc._displacedRecords).toHaveLength(0);
+    await pirate.save();
+
+    expect(saveCalls()).toBe(1);
+  });
+
+  it("removes the displaced record exactly once for an awaited create", async () => {
+    const pirate = await pirateWithLoadedShip();
+    const assoc = pirate.association("ship");
+    const saveCalls = spyOnTargetSave(assoc);
+
+    await pirate.createShip({ name: "New Ship" });
+    expect(assoc._displacedRecords).toHaveLength(0);
+    await pirate.save();
+
+    expect(saveCalls()).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

The awaitable `build#{Name}` / `create#{Name}` has_one accessors detach the
displaced target inline (`detachDisplacedTarget`), but the synchronous
`setNewRecord` beneath them also queues that same record on
`_displacedRecords`, so the owner's autosave drain (`removeDisplaced`) ran
`remove_target!` on it a second time. Rails runs it exactly once —
`set_new_record` -> `replace(record, false)`
(`has_one_association.rb:68-69, 91-92`).

Fix: `detachDisplacedTarget` dequeues the record it removed (first matching
entry only — the queue is an ordered collection and repeated builds can queue
several displacements). The queue itself stays: the synchronous
`assoc.build()` path nested attributes uses never reaches those accessors.

## Observable

Measured, the duplicate removal produced no extra SQL — every `:dependent`
branch absorbs it (`:destroy` is gated on `target.persisted?`, `:delete` no-ops
because `Persistence#delete` only emits SQL when persisted, and nullify re-saves
an unchanged record, which emits no UPDATE). What it did do was run the
displaced record's `save` — and its callbacks — twice. The regression tests
assert that count plus the drained queue; all three fail on `main` and pass
here.

## Tests

- New `has-one-awaited-build-displacement.trails.test.ts`: awaited `build`,
  awaited `create`, and repeated builds (each of two displacements removed once).
- `has-one-sync-build-displacement.trails.test.ts`, `has-one-associations`,
  `has-one-through-associations`, `autosave-association`, `nested-attributes`
  green locally (523 passed).

Closes-story: has-one-displaced-record-removed-twice-on-awaited-build

## Review reply — has_one **through** and the inherited `setNewRecord`

Confirmed real, and worse than described — but pre-existing and untouched here.
An awaited `buildClub(...)` over a **loaded**
`Member has_one :club, through: :current_membership` does not merely queue the
displaced end record: it raises before it gets that far.

    MissingAttributeError: can't write unknown attribute `club_id`
      nullifyOwnerAttributes  has-one-association.ts:568
      setNewRecord            has-one-association.ts:555
      SingularAssociation#build  singular-association.ts:37
      build#{name} accessor   builder/has-one.ts:91

Byte-identical on `origin/main` — verified by baselining
`has-one-association.ts` against `main` and re-running the same probe. This PR
does not touch `setNewRecord`, so it neither causes nor masks it. The push onto
`_displacedRecords` is never reached for this model; a through whose end model
happened to carry a column named like the owner's derived FK would instead hit
exactly the silent save-time nullify the review describes.

Rails routes has_one-through displacement entirely through
`create_through_record`
(`has_one_through_association.rb:15-40`) and never touches the end record's
attributes — the same reasoning behind the existing
`HasOneThroughAssociation#detachDisplacedTarget` no-op override
(`has-one-through-association.ts:104`).

The review is also right that `has-one-through-associations` being green does
not cover this: the suite has no awaited `build`/`create` over a loaded through
target.

Filed as a follow-up story rather than expanding this PR (per CLAUDE.md's
no-fan-out rule): `0068-awaitable-has-one-setter/has-one-through-inherits-direct-fk-set-new-record`,
with the trace, the Rails anchor, and acceptance criteria.

Everything else in the review matches my reading of the diff; no code changes
were requested and none were made.
