### PR TITLE
fix(associations): throw from the collection ids= setter on both owner arms

### DIFF
--- a/packages/activerecord/src/associations/builder/collection-association.ts
+++ b/packages/activerecord/src/associations/builder/collection-association.ts
@@ -167,8 +167,13 @@ export class CollectionAssociation extends Association {
     if (existing && !existing.configurable) return;
     Object.defineProperty(mixin, idsName, {
       get: existing?.get,
+      // The ids setter throws on BOTH owner arms (`CollectionIdsAssignmentError`):
+      // Rails' `ids_writer` resolves the ids with a query even for a new record,
+      // so there is no arm a sync setter can serve. Returning the promise here
+      // instead made a bad id an unhandled rejection and raced an immediate
+      // `save()`. RFC 0068.
       set(this: AssociationInstanceHost, ids: unknown) {
-        return (this.association(name) as any).queueIdsWrite(ids);
+        (this.association(name) as any).queueIdsWrite(ids);
       },
       configurable: true,
     });

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -1,13 +1,13 @@
 import type { Base } from "../base.js";
 import type { AssociationDefinition } from "../associations.js";
 import { association as associationProxy } from "../associations.js";
-import { underscore, isAbortSignal } from "@blazetrails/activesupport";
+import { underscore, isAbortSignal, singularize } from "@blazetrails/activesupport";
 import { Association } from "./association.js";
 import { foreignKeyPresentFor } from "./foreign-association.js";
 import { throughForeignKeyPresent } from "./through-association.js";
 import type { AssociationReflection } from "../reflection.js";
 import { RecordNotSaved, Rollback } from "../errors.js";
-import { CollectionPersistedAssignmentError } from "./errors.js";
+import { CollectionIdsAssignmentError, CollectionPersistedAssignmentError } from "./errors.js";
 import { raiseNotFoundAll } from "../relation/finder-methods.js";
 import { normalizeAssociationKey } from "./key-normalization.js";
 import { polymorphicName } from "../inheritance.js";
@@ -109,23 +109,26 @@ export class CollectionAssociation extends Association {
   }
 
   /**
-   * The `#{singular}Ids=` analogue of {@link queueWrite}. Resolving ids to
-   * records is itself a query, so even the unpersisted-owner arm is async.
+   * The `#{singular}Ids=` analogue of {@link queueWrite} — and, unlike it,
+   * a throw on BOTH owner arms.
    *
-   * The unpersisted arm returns a promise the property setter must discard —
-   * an id that doesn't resolve (`raiseNotFoundAll`) surfaces as an unhandled
-   * rejection, not a catchable throw, and an immediate `save()` can race the
-   * in-flight resolution. This is the pre-existing shape (the setter always
-   * called `idsWriter` un-awaited) and the story's acceptance criteria keep
-   * unpersisted-owner assignment working, so it is retained rather than made
-   * a second persisted-style throw; callers who need the result awaitable use
-   * `await owner.association(name).idsWriter(ids)`.
+   * `queueWrite`'s unpersisted arm is faithful because Rails does no I/O for a
+   * new-record owner either. `ids_writer` has no such arm: it resolves the ids
+   * to records with a query before replacing
+   * (collection_association.rb:61-83), so the new-record path is DB I/O too.
+   * The sync setter used to return that promise for it to discard, which made
+   * a bad id (`raiseNotFoundAll`) an unhandled rejection instead of a
+   * catchable throw and let an immediate `save()` read the target before the
+   * in-flight replace landed. Awaitable surfaces exist for both arms —
+   * `await owner.update({ itemIds: [...] })` (persistence.ts routes collection
+   * keys through `idsWriter`) and `await owner.association(name).idsWriter()`
+   * — so this throws loudly and names them. RFC 0068.
    */
-  queueIdsWrite(ids: unknown[]): Promise<void> {
-    if ((this.owner as { isPersisted?: () => boolean }).isPersisted?.()) {
-      throw new CollectionPersistedAssignmentError(this.reflection.name);
-    }
-    return this.idsWriter(ids);
+  queueIdsWrite(_ids: unknown[]): never {
+    throw new CollectionIdsAssignmentError(
+      this.reflection.name,
+      `${singularize(this.reflection.name)}Ids`,
+    );
   }
 
   /**

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -1,7 +1,7 @@
 import type { Base } from "../base.js";
 import type { AssociationDefinition } from "../associations.js";
 import { association as associationProxy } from "../associations.js";
-import { underscore, isAbortSignal, singularize } from "@blazetrails/activesupport";
+import { underscore, isAbortSignal } from "@blazetrails/activesupport";
 import { Association } from "./association.js";
 import { foreignKeyPresentFor } from "./foreign-association.js";
 import { throughForeignKeyPresent } from "./through-association.js";
@@ -125,10 +125,7 @@ export class CollectionAssociation extends Association {
    * — so this throws loudly and names them. RFC 0068.
    */
   queueIdsWrite(_ids: unknown[]): never {
-    throw new CollectionIdsAssignmentError(
-      this.reflection.name,
-      `${singularize(this.reflection.name)}Ids`,
-    );
+    throw new CollectionIdsAssignmentError(this.reflection.name);
   }
 
   /**

--- a/packages/activerecord/src/associations/collection-persisted-setter-throws.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-persisted-setter-throws.trails.test.ts
@@ -12,10 +12,17 @@
  * (`await owner.items.replace([...])`). On an *unpersisted* owner Rails does
  * no I/O either, so the in-memory replace is faithful and kept. There is no
  * Rails test for this deviation.
+ *
+ * The `#{singular}Ids=` setter goes further and throws on BOTH owner arms
+ * (`CollectionIdsAssignmentError`): `ids_writer` resolves the ids to records
+ * with a query before replacing (collection_association.rb:61-83), so even the
+ * new-record arm is DB I/O. The awaitable surfaces are
+ * `await owner.update({ itemIds: [...] })` and
+ * `await owner.association(name).idsWriter([...])`.
  */
 import { describe, it, expect, beforeAll } from "vitest";
-import { registerModel, AssociationTypeMismatch } from "../index.js";
-import { CollectionPersistedAssignmentError } from "./errors.js";
+import { registerModel, AssociationTypeMismatch, RecordNotFound } from "../index.js";
+import { CollectionIdsAssignmentError, CollectionPersistedAssignmentError } from "./errors.js";
 import { Author } from "../test-helpers/models/author.js";
 import { Post } from "../test-helpers/models/post.js";
 import { Comment } from "../test-helpers/models/comment.js";
@@ -81,7 +88,44 @@ describe("CollectionPersistedSetterThrows", () => {
     const post = await Post.create({ title: "t", body: "b" });
     expect(() => {
       author.postIds = [post.id];
-    }).toThrow(CollectionPersistedAssignmentError);
+    }).toThrow(CollectionIdsAssignmentError);
+    // The message names the awaitable replacements.
+    expect(() => {
+      author.postIds = [post.id];
+    }).toThrow(/await owner\.update\(\{ postIds: \[\.\.\.\] \}\)/);
+  });
+
+  it("ids= setter throws on an unpersisted owner too", () => {
+    // Unlike the record writer, whose unpersisted arm is pure in-memory work,
+    // `ids_writer` queries to resolve the ids even for a new record. Returning
+    // that promise from the sync setter made a bad id an unhandled rejection
+    // and let an immediate `save()` race the in-flight replace, so this arm
+    // throws rather than floating a promise.
+    const author = new Author({ name: "Bill" });
+    expect(() => {
+      (author as unknown as CollectionOwner).postIds = [1];
+    }).toThrow(CollectionIdsAssignmentError);
+  });
+
+  it("a bad id is a catchable rejection on the awaitable ids surface", async () => {
+    // The hazard this replaces: through the setter, an id that doesn't resolve
+    // surfaced as an unhandled rejection. Through `update` it is catchable.
+    const author = await Author.create({ name: "Bill" });
+    await expect(author.update({ postIds: [0] })).rejects.toThrow(RecordNotFound);
+  });
+
+  it("update assigns collection ids on a persisted owner", async () => {
+    const author = await Author.create({ name: "Bill" });
+    const first = await Post.create({ title: "a", body: "a" });
+    const second = await Post.create({ title: "b", body: "b" });
+
+    expect(await author.update({ postIds: [first.id, second.id] })).toBeTruthy();
+    await author.reload();
+    expect(await postsOf(author).count()).toBe(2);
+
+    expect(await author.update({ postIds: [second.id] })).toBeTruthy();
+    await author.reload();
+    expect((await postsOf(author).toArray()).map((p) => p.title)).toEqual(["b"]);
   });
 
   it("mass-assignment throws on a persisted owner", async () => {

--- a/packages/activerecord/src/associations/collection-persisted-setter-throws.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-persisted-setter-throws.trails.test.ts
@@ -107,6 +107,26 @@ describe("CollectionPersistedSetterThrows", () => {
     }).toThrow(CollectionIdsAssignmentError);
   });
 
+  it("ids= mass-assignment throws on both owner arms", async () => {
+    // Mass-assignment shares the setter, so it raises through
+    // `_assign_attributes`' rescue — the deviation is the `cause`, as in the
+    // record-writer case below.
+    const post = await Post.create({ title: "t", body: "b" });
+    const causeOf = (owner: Author): unknown => {
+      try {
+        (owner as unknown as CollectionOwner).assignAttributes({ postIds: [post.id] });
+      } catch (e) {
+        return (e as { cause?: unknown }).cause;
+      }
+      return undefined;
+    };
+
+    expect(causeOf(new Author({ name: "Bill" }))).toBeInstanceOf(CollectionIdsAssignmentError);
+    expect(causeOf(await Author.create({ name: "Bill" }))).toBeInstanceOf(
+      CollectionIdsAssignmentError,
+    );
+  });
+
   it("a bad id is a catchable rejection on the awaitable ids surface", async () => {
     // The hazard this replaces: through the setter, an id that doesn't resolve
     // surfaced as an unhandled rejection. Through `update` it is catchable.

--- a/packages/activerecord/src/associations/errors.ts
+++ b/packages/activerecord/src/associations/errors.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::Associations error classes defined in
  * activerecord/lib/active_record/associations/errors.rb
  */
+import { singularize } from "@blazetrails/activesupport";
 import { ActiveRecordError, ConfigurationError } from "../errors.js";
 
 /**
@@ -441,7 +442,11 @@ export class CollectionPersistedAssignmentError extends ActiveRecordError {
 export class CollectionIdsAssignmentError extends ActiveRecordError {
   readonly association: string;
 
-  constructor(association: string, idsName: string) {
+  constructor(association: string) {
+    // The setter that raised, derived here rather than passed in so the
+    // message can never name a key that differs from the installed writer
+    // (builder/collection-association.ts singularizes the same way).
+    const idsName = `${singularize(association)}Ids`;
     super(
       `Cannot assign collection association \`${association}\` ids with \`=\`: ` +
         `Rails resolves the ids with a query and replaces the collection at ` +

--- a/packages/activerecord/src/associations/errors.ts
+++ b/packages/activerecord/src/associations/errors.ts
@@ -422,3 +422,34 @@ export class CollectionPersistedAssignmentError extends ActiveRecordError {
     this.association = association;
   }
 }
+
+/**
+ * Thrown when a collection association's ids are assigned with the native
+ * `#{singular}Ids=` setter — `owner.itemIds = [...]` or the matching
+ * mass-assignment key — on *either* owner arm.
+ *
+ * The ids writer is stricter than {@link CollectionPersistedAssignmentError}'s
+ * record writer, which only throws for a persisted owner: Rails' `ids_writer`
+ * (collection_association.rb:61-83) *resolves the ids to records with a query*
+ * before it replaces, so even the new-record arm — where the replace itself is
+ * pure in-memory work — needs I/O the sync setter cannot await. Returning that
+ * promise from the setter made a bad id (`raise_record_not_found_exception!`)
+ * surface as an unhandled rejection rather than a catchable throw, and let an
+ * immediate `save()` race the in-flight resolution. See RFC
+ * 0068-awaitable-has-one-setter ("Why 'loud' beats 'deferred'").
+ */
+export class CollectionIdsAssignmentError extends ActiveRecordError {
+  readonly association: string;
+
+  constructor(association: string, idsName: string) {
+    super(
+      `Cannot assign collection association \`${association}\` ids with \`=\`: ` +
+        `Rails resolves the ids with a query and replaces the collection at ` +
+        `assignment time, which requires \`await\` in JS. Use ` +
+        `\`await owner.update({ ${idsName}: [...] })\` (or ` +
+        `\`await owner.association("${association}").idsWriter([...])\`).`,
+    );
+    this.name = "CollectionIdsAssignmentError";
+    this.association = association;
+  }
+}

--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -2290,18 +2290,15 @@ describe("HasManyThroughAssociationsTest", () => {
     const author = await Author.create({ name: "Bill" });
     const general = await Category.find(categories("general").id);
 
-    // Rails assigns these ids through `update`, which persists the replacement
-    // inline. Mass-assignment cannot `await`, so the collection arm throws and
-    // callers use the awaitable `idsWriter` instead (RFC 0068).
-    const idsWriterFor = (name: string) =>
-      author.association(name) as unknown as { idsWriter(ids: unknown[]): Promise<void> };
-    await idsWriterFor("specialCategoriesWithConditions").idsWriter([general.id]);
-    await idsWriterFor("nonspecialCategoriesWithConditions").idsWriter([general.id]);
+    await author.update({
+      specialCategoriesWithConditionIds: [general.id],
+      nonspecialCategoriesWithConditionIds: [general.id],
+    });
 
     expect(await (author as any).specialCategoriesWithConditionIds).toEqual([general.id]);
     expect(await (author as any).nonspecialCategoriesWithConditionIds).toEqual([general.id]);
 
-    await idsWriterFor("nonspecialCategoriesWithConditions").idsWriter([]);
+    await author.update({ nonspecialCategoriesWithConditionIds: [] });
     await author.reload();
 
     expect(await (author as any).specialCategoriesWithConditionIds).toEqual([general.id]);

--- a/packages/activerecord/src/attribute-assignment.ts
+++ b/packages/activerecord/src/attribute-assignment.ts
@@ -169,7 +169,6 @@ export function assignAssociationIfMatch(
         replace?: (v: unknown[]) => void;
         writer?: (v: unknown) => void;
         queueWrite?: (v: unknown) => void;
-        queueIdsWrite?: (v: unknown) => unknown;
       }
     | null
     | undefined;

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -301,6 +301,7 @@ export {
   DeleteRestrictionError,
   HasOnePersistedAssignmentError,
   CollectionPersistedAssignmentError,
+  CollectionIdsAssignmentError,
 } from "./associations/errors.js";
 export {
   AbstractReflection,


### PR DESCRIPTION
Closes the two ids-specific gaps disclosed in #5042.

## What was left

1. `await owner.update({ postIds: [...] })` on a persisted owner. **Already
   fixed** by #5169: `persistence.ts#collectionWriterPromise` routes collection
   and `#{singular}Ids` keys in `#update` / `#update!` through the awaitable
   `writer` / `idsWriter`, ending in `ids_writer` → `replace`. This PR adds
   direct coverage for it and migrates the test that had to work around it.
2. `queueIdsWrite`'s unpersisted arm returned a floating promise.

## The fix

Rails' `ids_writer` (`collection_association.rb:61-83`) resolves the ids to
records **with a query** before it replaces. Unlike the record writer — whose
new-record arm is genuinely in-memory, so `queueWrite` can serve it faithfully
— `ids_writer` has no arm a synchronous JS property setter can express.
Returning that promise for the setter to discard made a bad id
(`raise_record_not_found_exception!`) an unhandled rejection rather than a
catchable throw, and let an immediate `save()` read the target before the
in-flight replace landed.

So the `#{singular}Ids=` setter now throws on **both** owner arms, with a new
`CollectionIdsAssignmentError` naming the awaitable surfaces:

- `await owner.update({ itemIds: [...] })`
- `await owner.association(name).idsWriter([...])`

The record writer's arms are unchanged: persisted still throws
`CollectionPersistedAssignmentError`, unpersisted still replaces in memory.

## Tests

- `has many through update ids with conditions` returns to Rails' verbatim
  `update({ ...Ids })` shape (no rename; the workaround comment is gone).
- `collection-persisted-setter-throws.trails.test.ts`: the ids= persisted case
  now expects the new error and asserts the message names the awaitable call;
  new cases cover the unpersisted arm, the mass-assignment arm on both owners,
  a bad id being a *catchable* rejection through `update`, and `update`
  replacing ids on a persisted owner.

## Found, not fixed here

`new Author({ postIds: [...] })` dies with an opaque
`TypeError: Cannot read properties of undefined (reading 'get')` and never
reaches the setter — pre-existing, unrelated to this change. `base.ts`'s
`_extractAssociationAttrs` defers only association-**name** keys past `super()`,
so an ids key is assigned while the `_associationInstances` class field is still
`undefined`. That is why the constructor is not in the coverage above. Filed as
`collection-ids-key-in-constructor-throws-typeerror` on RFC 0068.

RFC 0068's design note is amended in the tasks repo to record the ids=
exception to its "new-owner assignment stays in-memory" rule.

Closes-story: awaitable-ids-assignment-for-update-and-unpersisted-race
