### PR TITLE
fix(test-helpers): unlink the fallback sqlite DB on process exit

### DIFF
--- a/packages/activerecord/src/test-helpers/sqlite-template.test.ts
+++ b/packages/activerecord/src/test-helpers/sqlite-template.test.ts
@@ -6,7 +6,32 @@
  */
 import { describe, it, expect } from "vitest";
 import { getFsAsync } from "@blazetrails/activesupport/fs-adapter";
-import { TEMPLATE_PATH_ENV, RUN_TOKEN_ENV, WORKER_DB_ENV, isSqliteRun } from "./sqlite-template.js";
+import {
+  TEMPLATE_PATH_ENV,
+  RUN_TOKEN_ENV,
+  WORKER_DB_ENV,
+  isSqliteRun,
+  registerDbFileCleanupOnExit,
+  unlinkDbFiles,
+} from "./sqlite-template.js";
+
+describe("registerDbFileCleanupOnExit", () => {
+  it("registers one exit listener per path", async () => {
+    const base = `/tmp/ar-test-cleanup-probe-${Math.random().toString(36).slice(2)}.sqlite`;
+    const before = process.listenerCount("exit");
+    await registerDbFileCleanupOnExit(base);
+    await registerDbFileCleanupOnExit(base);
+    expect(process.listenerCount("exit")).toBe(before + 1);
+  });
+
+  it("unlinks the DB file and its WAL sidecars", async () => {
+    const fs = await getFsAsync();
+    const base = `/tmp/ar-test-cleanup-unlink-${Math.random().toString(36).slice(2)}.sqlite`;
+    for (const suffix of ["", "-wal", "-shm"]) fs.writeFileSync(base + suffix, "");
+    unlinkDbFiles(fs, base);
+    for (const suffix of ["", "-wal", "-shm"]) expect(await fs.exists(base + suffix)).toBe(false);
+  });
+});
 
 describe.skipIf(!isSqliteRun())("sqlite template-clone (Phase 0 probe)", () => {
   it("globalSetup built a template file for this run", async () => {

--- a/packages/activerecord/src/test-helpers/sqlite-template.test.ts
+++ b/packages/activerecord/src/test-helpers/sqlite-template.test.ts
@@ -1,11 +1,14 @@
 /**
  * Phase 0 probe: confirms the sqlite template-clone mechanism is active
  * and that canonical DDL was issued exactly once for this vitest invocation.
- *
  * Skipped automatically on PG/MySQL runs (env vars not set).
+ *
+ * The `registerDbFileCleanupOnExit` suite is adapter-agnostic and always runs;
+ * it takes its own listeners back off so they don't accumulate across files.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { getFsAsync } from "@blazetrails/activesupport/fs-adapter";
+import { getOsAsync } from "@blazetrails/activesupport";
 import {
   TEMPLATE_PATH_ENV,
   RUN_TOKEN_ENV,
@@ -15,21 +18,50 @@ import {
   unlinkDbFiles,
 } from "./sqlite-template.js";
 
+const SIDECARS = ["", "-wal", "-shm"];
+
+async function tmpPath(): Promise<string> {
+  const os = await getOsAsync();
+  return `${os.tmpdir()}/ar-test-cleanup-${Math.random().toString(36).slice(2)}.sqlite`;
+}
+
 describe("registerDbFileCleanupOnExit", () => {
-  it("registers one exit listener per path", async () => {
-    const base = `/tmp/ar-test-cleanup-probe-${Math.random().toString(36).slice(2)}.sqlite`;
-    const before = process.listenerCount("exit");
+  const added: Array<() => void> = [];
+
+  async function register(base: string): Promise<Array<() => void>> {
+    const before = new Set(process.listeners("exit"));
     await registerDbFileCleanupOnExit(base);
-    await registerDbFileCleanupOnExit(base);
-    expect(process.listenerCount("exit")).toBe(before + 1);
+    const fresh = process.listeners("exit").filter((fn) => !before.has(fn)) as Array<() => void>;
+    added.push(...fresh);
+    return fresh;
+  }
+
+  afterEach(() => {
+    for (const fn of added.splice(0)) process.off("exit", fn);
   });
 
-  it("unlinks the DB file and its WAL sidecars", async () => {
+  it("runs its exit listener to unlink the DB file and its WAL sidecars", async () => {
     const fs = await getFsAsync();
-    const base = `/tmp/ar-test-cleanup-unlink-${Math.random().toString(36).slice(2)}.sqlite`;
-    for (const suffix of ["", "-wal", "-shm"]) fs.writeFileSync(base + suffix, "");
-    unlinkDbFiles(fs, base);
-    for (const suffix of ["", "-wal", "-shm"]) expect(await fs.exists(base + suffix)).toBe(false);
+    const base = await tmpPath();
+    for (const suffix of SIDECARS) fs.writeFileSync(base + suffix, "");
+
+    const [listener] = await register(base);
+    expect(listener, "registration must add exactly one exit listener").toBeDefined();
+    listener();
+
+    for (const suffix of SIDECARS) expect(await fs.exists(base + suffix)).toBe(false);
+  });
+
+  it("registers a path only once per process", async () => {
+    const base = await tmpPath();
+    expect(await register(base)).toHaveLength(1);
+    expect(await register(base)).toHaveLength(0);
+  });
+
+  it("tolerates a DB file that was never created", async () => {
+    const fs = await getFsAsync();
+    const base = await tmpPath();
+    expect(() => unlinkDbFiles(fs, base)).not.toThrow();
   });
 });
 

--- a/packages/activerecord/src/test-helpers/sqlite-template.ts
+++ b/packages/activerecord/src/test-helpers/sqlite-template.ts
@@ -32,7 +32,9 @@
  * Hard rule: no `node:*` fs APIs — all filesystem access goes through the
  * activesupport fs-adapter. `process` is used only for runtime plumbing, not
  * fs: `process.env` reads carry the globalSetup → forked-worker handoff, and
- * `process.on("exit")` registers best-effort cleanup of the worker clone.
+ * `process.on("exit")` registers best-effort cleanup of the worker clone and,
+ * via `registerDbFileCleanupOnExit`, of file DBs owned by `process`-free
+ * modules.
  */
 import type { FsAdapter } from "@blazetrails/activesupport/fs-adapter";
 import { getFsAsync, getPathAsync } from "@blazetrails/activesupport/fs-adapter";
@@ -57,19 +59,20 @@ export function unlinkDbFiles(fs: FsAdapter, base: string): void {
   }
 }
 
-// Registration is per *process*, not per module evaluation: vitest's
-// `isolate: true` reloads the module graph for every test file, so a
-// module-level Set would re-register a listener per file and leak them.
 const cleanupG = globalThis as typeof globalThis & { __arDbCleanupPaths?: Set<string> };
 
 /**
  * Register a best-effort `process.on("exit")` unlink of a sqlite file DB and
  * its WAL sidecars, at most once per path per process.
  *
- * Callers that must stay `process`-free (e.g. `test-database-config.ts`, whose
+ * Callers that must stay `process`-free (`test-database-config.ts`, whose
  * fallback DB otherwise lingers in tmpdir after every setup-free run) route
- * their cleanup through here — this module already carries the `process` and
- * fs-adapter exception documented at the top of the file.
+ * their cleanup through here — this module already carries the `process`
+ * exception documented at the top of the file.
+ *
+ * The de-dupe set hangs off `globalThis`, not module scope: vitest's
+ * `isolate: true` reloads the module graph per test file, so a module-level
+ * set would re-register — and leak — one exit listener per file.
  */
 export async function registerDbFileCleanupOnExit(base: string): Promise<void> {
   const registered = (cleanupG.__arDbCleanupPaths ??= new Set<string>());

--- a/packages/activerecord/src/test-helpers/sqlite-template.ts
+++ b/packages/activerecord/src/test-helpers/sqlite-template.ts
@@ -57,6 +57,28 @@ export function unlinkDbFiles(fs: FsAdapter, base: string): void {
   }
 }
 
+// Registration is per *process*, not per module evaluation: vitest's
+// `isolate: true` reloads the module graph for every test file, so a
+// module-level Set would re-register a listener per file and leak them.
+const cleanupG = globalThis as typeof globalThis & { __arDbCleanupPaths?: Set<string> };
+
+/**
+ * Register a best-effort `process.on("exit")` unlink of a sqlite file DB and
+ * its WAL sidecars, at most once per path per process.
+ *
+ * Callers that must stay `process`-free (e.g. `test-database-config.ts`, whose
+ * fallback DB otherwise lingers in tmpdir after every setup-free run) route
+ * their cleanup through here — this module already carries the `process` and
+ * fs-adapter exception documented at the top of the file.
+ */
+export async function registerDbFileCleanupOnExit(base: string): Promise<void> {
+  const registered = (cleanupG.__arDbCleanupPaths ??= new Set<string>());
+  if (registered.has(base)) return;
+  registered.add(base);
+  const fs = await getFsAsync();
+  process.on("exit", () => unlinkDbFiles(fs, base));
+}
+
 /** Env var: absolute path of the canonical template DB built by globalSetup. */
 export const TEMPLATE_PATH_ENV = "AR_TEST_TEMPLATE_PATH";
 /** Env var: per-run token (stamped by globalSetup) so concurrent worktrees don't collide. */

--- a/packages/activerecord/src/test-helpers/sqlite-template.ts
+++ b/packages/activerecord/src/test-helpers/sqlite-template.ts
@@ -77,9 +77,18 @@ const cleanupG = globalThis as typeof globalThis & { __arDbCleanupPaths?: Set<st
 export async function registerDbFileCleanupOnExit(base: string): Promise<void> {
   const registered = (cleanupG.__arDbCleanupPaths ??= new Set<string>());
   if (registered.has(base)) return;
+  // Claimed before the await so concurrent callers can't both get past the
+  // check, but released again if attaching fails — otherwise a rejected
+  // `getFsAsync()` would mark the path registered with no listener behind it,
+  // silently forfeiting cleanup for the rest of the process.
   registered.add(base);
-  const fs = await getFsAsync();
-  process.on("exit", () => unlinkDbFiles(fs, base));
+  try {
+    const fs = await getFsAsync();
+    process.on("exit", () => unlinkDbFiles(fs, base));
+  } catch (error) {
+    registered.delete(base);
+    throw error;
+  }
 }
 
 /** Env var: absolute path of the canonical template DB built by globalSetup. */
@@ -138,10 +147,7 @@ export async function ensureWorkerClone(): Promise<string | null> {
       fs.copyFileSync(template, dest);
     }
   }
-  // Best-effort cleanup on process exit. Registered once per worker.
-  // WAL mode (the sqlite adapter's default for file DBs) leaves `-wal`/`-shm`
-  // sidecars next to the main file; unlink those too so nothing lingers.
-  process.on("exit", () => unlinkDbFiles(fs, dest));
+  await registerDbFileCleanupOnExit(dest);
 
   g.__arWorkerDbPath = dest;
   return dest;

--- a/packages/activerecord/src/test-helpers/test-database-config.test.ts
+++ b/packages/activerecord/src/test-helpers/test-database-config.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { DatabaseTasks } from "../tasks/database-tasks.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
+import { registerDbFileCleanupOnExit } from "./sqlite-template.js";
 import { buildTestDatabaseConfig } from "./test-database-config.js";
 
 describe("buildTestDatabaseConfig", () => {
@@ -53,6 +54,16 @@ describe("buildTestDatabaseConfig", () => {
     const first = (await buildTestDatabaseConfig()).envConfig.database;
     const second = (await buildTestDatabaseConfig()).envConfig.database;
     expect(second).toBe(first);
+  });
+
+  it("registers the fallback database for cleanup on exit", async () => {
+    vi.stubEnv("ARCONN", "sqlite3");
+    vi.stubEnv("AR_TEST_WORKER_DB", "");
+    const database = String((await buildTestDatabaseConfig()).envConfig.database);
+
+    const before = new Set(process.listeners("exit"));
+    await registerDbFileCleanupOnExit(database);
+    expect(process.listeners("exit").filter((fn) => !before.has(fn))).toHaveLength(0);
   });
 
   it("prefers AR_TEST_WORKER_DB over the fallback database", async () => {

--- a/packages/activerecord/src/test-helpers/test-database-config.ts
+++ b/packages/activerecord/src/test-helpers/test-database-config.ts
@@ -30,6 +30,7 @@ import { Base } from "../base.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { DatabaseTasks } from "../tasks/database-tasks.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
+import { registerDbFileCleanupOnExit } from "./sqlite-template.js";
 import { UrlConfig } from "../database-configurations/url-config.js";
 import {
   connectionName,
@@ -168,8 +169,13 @@ async function fallbackDatabasePath(): Promise<string> {
     `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
   const slot = getEnv("VITEST_POOL_ID") || getEnv("VITEST_WORKER_ID") || "1";
   const token = `${runToken}-${slot}`;
-  g.__arFallbackDbPath = path.join(os.tmpdir(), `ar-test-fallback-${token}.sqlite`);
-  return g.__arFallbackDbPath;
+  const dbPath = path.join(os.tmpdir(), `ar-test-fallback-${token}.sqlite`);
+  // Keyed on run token + slot, the file is bounded per run but survives it;
+  // unlink it (and its WAL sidecars) on exit. The hook lives in
+  // `sqlite-template.ts` because this module must stay `process`-free.
+  await registerDbFileCleanupOnExit(dbPath);
+  g.__arFallbackDbPath = dbPath;
+  return dbPath;
 }
 
 async function sqliteHash(): Promise<{ adapter: string; database: string }> {

--- a/packages/activerecord/src/test-helpers/test-database-config.ts
+++ b/packages/activerecord/src/test-helpers/test-database-config.ts
@@ -30,8 +30,8 @@ import { Base } from "../base.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { DatabaseTasks } from "../tasks/database-tasks.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
-import { registerDbFileCleanupOnExit } from "./sqlite-template.js";
 import { UrlConfig } from "../database-configurations/url-config.js";
+import { registerDbFileCleanupOnExit } from "./sqlite-template.js";
 import {
   connectionName,
   driverConfig,
@@ -170,9 +170,6 @@ async function fallbackDatabasePath(): Promise<string> {
   const slot = getEnv("VITEST_POOL_ID") || getEnv("VITEST_WORKER_ID") || "1";
   const token = `${runToken}-${slot}`;
   const dbPath = path.join(os.tmpdir(), `ar-test-fallback-${token}.sqlite`);
-  // Keyed on run token + slot, the file is bounded per run but survives it;
-  // unlink it (and its WAL sidecars) on exit. The hook lives in
-  // `sqlite-template.ts` because this module must stay `process`-free.
   await registerDbFileCleanupOnExit(dbPath);
   g.__arFallbackDbPath = dbPath;
   return dbPath;


### PR DESCRIPTION
PR #5282 made the unset-`AR_TEST_WORKER_DB` sqlite fallback file-backed, but
unlike the primary clone lane in `sqlite-template.ts` the fallback file and its
`-wal`/`-shm` sidecars were never unlinked — every setup-free process left an
`ar-test-fallback-<runToken>-<slot>.sqlite` behind in tmpdir. Keying on run
token + slot bounds the count per run but doesn't clean up across runs.

`test-database-config.ts` must stay `process.*`-free, so the exit hook lives in
`sqlite-template.ts` (which already carries that exception and the
`unlinkDbFiles` helper) as a new `registerDbFileCleanupOnExit(base)`. It
de-dupes on a `globalThis` Set — vitest's `isolate: true` reloads the module
graph per file, so a module-level Set would leak a listener per file — mirroring
the `ensureWorkerClone` idiom. The stamped-`AR_TEST_WORKER_DB` path is
untouched.

Async fs only (`getFsAsync`), no `node:*` imports, no new deps.

Closes-story: fallback-db-file-cleanup
