### PR TITLE
fix(associations): diff CollectionProxy#replace with Rails' set/multiset semantics

### DIFF
--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -327,13 +327,46 @@ export class CollectionAssociation extends Association {
    * persisted-owner transaction (collection_association.rb:127-135) — the
    * nil that makes `CollectionProxy#<<` falsy.
    */
+  /**
+   * Run `block` in the reflection klass's transaction.
+   *
+   * Mirrors: ActiveRecord::Associations::CollectionAssociation#transaction —
+   * overridden by `ThroughAssociation#transaction` (the through model's), which
+   * `HasManyThroughAssociation` picks up.
+   * @internal
+   */
+  protected transaction<R>(block: () => Promise<R>): Promise<R | undefined> {
+    // Rails: reflection.klass.transaction(&block) — uses the reflection's klass, not assoc.klass
+    const klass = (this.reflection as any).klass ?? this.klass;
+    if (klass && typeof klass.transaction === "function") {
+      return klass.transaction(block);
+    }
+    return block();
+  }
+
+  /**
+   * Diff hooks Rails leaves to the concrete subclass: `HasManyAssociation`
+   * supplies `a - b` / `a & b`, `HasManyThroughAssociation` the multiset
+   * variants. Declared here (rather than implemented, as Rails' base has no
+   * definition at all) only so the shared `replace` machinery can call them.
+   * @internal
+   */
+  protected difference(_a: Base[], _b: Base[]): Base[] {
+    throw new Error("difference is implemented by CollectionAssociation subclasses");
+  }
+
+  /** @internal */
+  protected intersection(_a: Base[], _b: Base[]): Base[] {
+    throw new Error("intersection is implemented by CollectionAssociation subclasses");
+  }
+
   async concat(...records: Base[]): Promise<Base[] | undefined> {
     const flattened = records.flat();
     if (this.owner.isNewRecord()) {
       await this.loadTarget();
       return this.concatRecords(flattened);
     }
-    return transaction(this, () => this.concatRecords(flattened));
+    return this.transaction(() => this.concatRecords(flattened));
   }
 
   /** @internal */
@@ -531,7 +564,7 @@ export class CollectionAssociation extends Association {
       // inverse, then after_remove. delete_records (the DB delete) is skipped —
       // a new owner has no persisted join rows yet, so existing_records is
       // empty (the owner's save is what creates them).
-      const toRemove = this.target.filter((r) => !includesRecord(otherArray, r));
+      const toRemove = this.difference(this.target, otherArray);
       let removable = true;
       for (const r of toRemove) {
         if (!callback(this, "beforeRemove", r)) {
@@ -552,13 +585,8 @@ export class CollectionAssociation extends Association {
       // input array (before_add aborts affect @target membership but not the
       // returned set), and HMT#concat_records builds a through-row for each, so
       // we build for the whole difference rather than filtering on addToTarget.
-      const added: Base[] = [];
-      for (const r of otherArray) {
-        if (!includesRecord(this.target, r)) {
-          this.addToTarget(r);
-          added.push(r);
-        }
-      }
+      const added = this.difference(otherArray, this.target);
+      for (const r of added) this.addToTarget(r);
       this.loadedBang();
       this.buildThroughRecordsInMemory(added);
     } else {
@@ -568,17 +596,13 @@ export class CollectionAssociation extends Association {
       // here, not above the branch.
       replaceCommonRecordsInMemory(this, otherArray, originalTarget);
       if (!wasLoaded || !arraysEqual(otherArray, originalTarget)) {
-        for (const r of originalTarget) {
-          if (!includesRecord(otherArray, r)) {
-            const idx = this.target.indexOf(r);
-            if (idx !== -1) this.target.splice(idx, 1);
-          }
+        for (const r of this.difference(originalTarget, otherArray)) {
+          const idx = this.target.indexOf(r);
+          if (idx !== -1) this.target.splice(idx, 1);
         }
-        for (const r of otherArray) {
-          if (!includesRecord(this.target, r)) {
-            this.setOwnerAttributes(r);
-            this.addToTarget(r);
-          }
+        for (const r of this.difference(otherArray, this.target)) {
+          this.setOwnerAttributes(r);
+          this.addToTarget(r);
         }
         this.loadedBang();
         return { newTarget: [...otherArray], originalTarget, wasLoaded };
@@ -608,7 +632,7 @@ export class CollectionAssociation extends Association {
       pending.originalTarget = [...dbRecords];
     }
     const currentTarget = this.target;
-    await transaction(this, async () => {
+    await this.transaction(async () => {
       // replaceRecords diffs against assoc.target; restore originalTarget so
       // it sees the real DB state rather than the already-updated in-memory target
       this.target = [...pending.originalTarget];
@@ -931,7 +955,7 @@ export class CollectionAssociation extends Association {
     if (existingRecords.length === 0) {
       removed = await this.removeRecords(existingRecords, resolved, method ?? "");
     } else {
-      await transaction(this, async () => {
+      await this.transaction(async () => {
         removed = await this.removeRecords(existingRecords, resolved, method ?? "");
       });
     }
@@ -1216,21 +1240,23 @@ export async function concatRecordsLoop(
   if (!result) throw new Rollback();
 }
 
-/** @internal */
-function transaction<R>(
-  assoc: CollectionAssociation,
-  block: () => Promise<R>,
-): Promise<R | undefined> {
-  // Rails: reflection.klass.transaction(&block) — uses the reflection's klass, not assoc.klass
-  const klass = (assoc.reflection as any).klass ?? assoc.klass;
-  if (klass && typeof klass.transaction === "function") {
-    return klass.transaction(block);
-  }
-  return block();
+/**
+ * Reach the protected `difference`/`intersection` overrides from the
+ * module-level replace helpers.
+ * @internal
+ */
+function diffHooks(assoc: CollectionAssociation): {
+  difference(a: Base[], b: Base[]): Base[];
+  intersection(a: Base[], b: Base[]): Base[];
+} {
+  return assoc as unknown as {
+    difference(a: Base[], b: Base[]): Base[];
+    intersection(a: Base[], b: Base[]): Base[];
+  };
 }
 
 /** @internal */
-function includesRecord(records: Base[], record: Base): boolean {
+export function includesRecord(records: Base[], record: Base): boolean {
   return records.some((r) => (r as unknown as { isEqual(o: unknown): boolean }).isEqual(record));
 }
 
@@ -1241,9 +1267,10 @@ async function replaceRecords(
   originalTarget: Base[],
 ): Promise<Base[]> {
   // Rails: delete(difference(target, new_target)); concat(difference(new_target, target))
-  const toDelete = assoc.target.filter((r) => !includesRecord(newTarget, r));
+  const diff = diffHooks(assoc);
+  const toDelete = diff.difference(assoc.target, newTarget);
   if (toDelete.length > 0) await assoc.delete(...toDelete);
-  const toAdd = newTarget.filter((r) => !includesRecord(assoc.target, r));
+  const toAdd = diff.difference(newTarget, assoc.target);
   if (toAdd.length > 0) {
     try {
       await assoc.concat(...toAdd);
@@ -1268,7 +1295,7 @@ function replaceCommonRecordsInMemory(
   newTarget: Base[],
   originalTarget: Base[],
 ): void {
-  const common = newTarget.filter((r) => includesRecord(originalTarget, r));
+  const common = diffHooks(assoc).intersection(newTarget, originalTarget);
   for (const record of common) {
     replaceOnTarget(assoc, record, true, true);
   }

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -327,6 +327,15 @@ export class CollectionAssociation extends Association {
    * persisted-owner transaction (collection_association.rb:127-135) — the
    * nil that makes `CollectionProxy#<<` falsy.
    */
+  async concat(...records: Base[]): Promise<Base[] | undefined> {
+    const flattened = records.flat();
+    if (this.owner.isNewRecord()) {
+      await this.loadTarget();
+      return this.concatRecords(flattened);
+    }
+    return this.transaction(() => this.concatRecords(flattened));
+  }
+
   /**
    * Run `block` in the reflection klass's transaction.
    *
@@ -358,15 +367,6 @@ export class CollectionAssociation extends Association {
   /** @internal */
   protected intersection(_a: Base[], _b: Base[]): Base[] {
     throw new Error("intersection is implemented by CollectionAssociation subclasses");
-  }
-
-  async concat(...records: Base[]): Promise<Base[] | undefined> {
-    const flattened = records.flat();
-    if (this.owner.isNewRecord()) {
-      await this.loadTarget();
-      return this.concatRecords(flattened);
-    }
-    return this.transaction(() => this.concatRecords(flattened));
   }
 
   /** @internal */

--- a/packages/activerecord/src/associations/collection-proxy-replace-diff.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy-replace-diff.trails.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Trails-only surface: `CollectionProxy#replace` used to be
+ * `clear()` + `push()`, so every record common to the old and the new set was
+ * removed and re-added — firing remove/add callbacks and rewriting rows Rails
+ * leaves alone. Rails' `CollectionAssociation#replace`
+ * (collection_association.rb:242) diffs instead. There is no Rails test that
+ * pins the *absence* of those callbacks (Ruby never had the divergence), so the
+ * regression coverage lives here.
+ */
+import { describe, it, expect } from "vitest";
+import { registerModel } from "../index.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+import { Author } from "../test-helpers/models/author.js";
+import { Post } from "../test-helpers/models/post.js";
+import { Person } from "../test-helpers/models/person.js";
+import { Reader } from "../test-helpers/models/reader.js";
+
+registerModel(Author);
+registerModel(Post);
+registerModel(Person);
+registerModel(Reader);
+
+describe("collection replace diffs instead of clearing", () => {
+  const { authors, posts, people } = fixtures(["authors", "posts", "people", "readers"]);
+
+  it("leaves records common to the old and new target untouched", async () => {
+    const author = await Author.find(authors("david").id);
+    const current = await author.postsWithCallbacks;
+    expect(current.length).toBeGreaterThan(1);
+    const [dropped, ...kept] = current;
+
+    author.postLog = [];
+    await author.postsWithCallbacks.replace(kept);
+
+    // Only the dropped record generates callbacks — the kept ones are neither
+    // removed nor re-added.
+    expect(author.postLog).toEqual([`before_removing${dropped.id}`, `after_removing${dropped.id}`]);
+  });
+
+  it("adds only the records the new target gained", async () => {
+    const author = await Author.find(authors("david").id);
+    const current = await author.postsWithCallbacks;
+    const incoming = (await Post.where({ author_id: authors("mary").id }))[0];
+
+    author.postLog = [];
+    await author.postsWithCallbacks.replace([...current, incoming]);
+
+    expect(author.postLog).toEqual([`before_adding${incoming.id}`, `after_adding${incoming.id}`]);
+  });
+
+  it("creates one join row per occurrence for has_many :through", async () => {
+    const post = await Post.find(posts("thinking").id);
+    const david = await Person.find(people("david").id);
+
+    await post.people.replace([david]);
+    const afterOne = await Reader.where({ post_id: post.id }).count();
+    await post.people.replace([david, david]);
+
+    // Multiset difference: [david, david] - [david] leaves one david to insert.
+    expect(await Reader.where({ post_id: post.id }).count()).toBe(Number(afterOne) + 1);
+  });
+});

--- a/packages/activerecord/src/associations/collection-proxy-replace-diff.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy-replace-diff.trails.test.ts
@@ -32,8 +32,6 @@ describe("collection replace diffs instead of clearing", () => {
     author.postLog = [];
     await author.postsWithCallbacks.replace(kept);
 
-    // Only the dropped record generates callbacks — the kept ones are neither
-    // removed nor re-added.
     expect(author.postLog).toEqual([`before_removing${dropped.id}`, `after_removing${dropped.id}`]);
   });
 
@@ -56,7 +54,6 @@ describe("collection replace diffs instead of clearing", () => {
     const afterOne = await Reader.where({ post_id: post.id }).count();
     await post.people.replace([david, david]);
 
-    // Multiset difference: [david, david] - [david] leaves one david to insert.
     expect(await Reader.where({ post_id: post.id }).count()).toBe(Number(afterOne) + 1);
   });
 });

--- a/packages/activerecord/src/associations/collection-proxy-replace-diff.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy-replace-diff.trails.test.ts
@@ -66,6 +66,21 @@ describe("collection replace diffs instead of clearing", () => {
     expect(await Reader.where({ post_id: post.id }).count()).toBe(Number(afterOne) + 1);
   });
 
+  it("re-creates the join row when a duplicate is replaced by a single occurrence", async () => {
+    const post = await Post.find(posts("thinking").id);
+    const david = await Person.find(people("david").id);
+
+    await post.people.replace([david, david]);
+    const duplicated = await Reader.where({ post_id: post.id });
+    expect(duplicated.length).toBe(2);
+
+    await post.people.replace([david]);
+    const remaining = await Reader.where({ post_id: post.id });
+
+    expect(remaining.length).toBe(1);
+    expect(duplicated.map((r) => Number(r.id))).not.toContain(Number(remaining[0].id));
+  });
+
   it("rolls the whole replace back when one of the new records cannot be saved", async () => {
     const firm = await Firm.find(companies("first_firm").id);
     const good = Client.new({ name: "Good" });

--- a/packages/activerecord/src/associations/collection-proxy-replace-diff.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy-replace-diff.trails.test.ts
@@ -13,15 +13,24 @@ import { fixtures } from "../test-helpers/fixtures.js";
 import { Author } from "../test-helpers/models/author.js";
 import { Post } from "../test-helpers/models/post.js";
 import { Person } from "../test-helpers/models/person.js";
+import { Firm, Client } from "../test-helpers/models/company.js";
 import { Reader } from "../test-helpers/models/reader.js";
 
 registerModel(Author);
 registerModel(Post);
 registerModel(Person);
+registerModel(Firm);
+registerModel(Client);
 registerModel(Reader);
 
 describe("collection replace diffs instead of clearing", () => {
-  const { authors, posts, people } = fixtures(["authors", "posts", "people", "readers"]);
+  const { authors, posts, people, companies } = fixtures([
+    "authors",
+    "posts",
+    "people",
+    "readers",
+    "companies",
+  ]);
 
   it("leaves records common to the old and new target untouched", async () => {
     const author = await Author.find(authors("david").id);
@@ -55,5 +64,18 @@ describe("collection replace diffs instead of clearing", () => {
     await post.people.replace([david, david]);
 
     expect(await Reader.where({ post_id: post.id }).count()).toBe(Number(afterOne) + 1);
+  });
+
+  it("rolls the whole replace back when one of the new records cannot be saved", async () => {
+    const firm = await Firm.find(companies("first_firm").id);
+    const good = Client.new({ name: "Good" });
+    const bad = Client.new({ name: "Bad" });
+    bad.raiseOnSave = true;
+
+    const before = await firm.clientsOfFirm;
+    await expect(firm.clientsOfFirm.replace([good, bad])).rejects.toThrow(Client.RaisedOnSave);
+
+    const after = await Firm.find(companies("first_firm").id);
+    expect((await after.clientsOfFirm).map((c) => c.id)).toEqual(before.map((c) => c.id));
   });
 });

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -3381,6 +3381,18 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * Rails' `replace_records` (collection_association.rb:418): delete the
    * records the new target dropped, then concat the ones it gained, restoring
    * the original target and raising when the concat fails.
+   *
+   * `target` tracks Rails' `@target` across the two diffs. It is a local copy
+   * because the proxy's `_target` is only populated when the association is
+   * genuinely loaded (a diverged or `find_target?`-false `toArray()` returns
+   * records without caching them), which would silently make the delete diff a
+   * no-op. The delete step applies Rails' `remove_records`
+   * (collection_association.rb:405) mutation verbatim: `@target -= records` is
+   * plain `Array#-`, which drops EVERY occurrence of a deleted record, not the
+   * `difference` hook's per-occurrence count. For a `:through` reflection that
+   * is what makes `[david, david].replace([david])` delete both join rows and
+   * re-concat a fresh one, exactly as Rails does — and it matches what
+   * `_removeFromTarget` does to the real `_target`.
    * @internal
    */
   private async _replaceRecords(newTarget: T[], originalTarget: T[]): Promise<T[]> {
@@ -3388,7 +3400,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     const toDelete = this._difference(target, newTarget);
     if (toDelete.length > 0) {
       await this.delete(...toDelete);
-      target = this._difference(target, toDelete);
+      target = setDifference(target, toDelete) as T[];
     }
     const toAdd = this._difference(newTarget, target);
     if (toAdd.length > 0 && (await this.push(...toAdd)) === false) {

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -3358,20 +3358,23 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * timestamp touches).
    *
    * Mirrors: ActiveRecord::Associations::CollectionProxy#replace →
-   * `CollectionAssociation#replace` (collection_association.rb:242).
+   * `CollectionAssociation#replace` (collection_association.rb:242), returning
+   * the resulting target (`other_array` when nothing changed).
    */
-  async replace(records: T[]): Promise<void> {
+  async replace(records: T[]): Promise<T[]> {
     this._ensureThroughWritable();
     this._raiseOnTypeMismatch(records);
-    const originalTarget = [...(await this.toArray())];
+    const originalTarget = [...(await this._withoutStrictLoading(() => this.toArray()))];
     if (this._record.isNewRecord()) {
-      await this._replaceRecords(records, originalTarget);
-      return;
+      return this._replaceRecords(records, originalTarget);
     }
     this._replaceCommonRecordsInMemory(records, originalTarget);
-    if (!sameRecordList(records, originalTarget)) {
-      await this._replaceTransaction(() => this._replaceRecords(records, originalTarget));
-    }
+    if (sameRecordList(records, originalTarget)) return records;
+    let replaced: T[] = this._target;
+    await this._replaceTransaction(async () => {
+      replaced = await this._replaceRecords(records, originalTarget);
+    });
+    return replaced;
   }
 
   /**
@@ -3380,11 +3383,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * the original target and raising when the concat fails.
    * @internal
    */
-  private async _replaceRecords(newTarget: T[], originalTarget: T[]): Promise<void> {
-    // Rails diffs against `target`, which `load_target` has just filled and
-    // `delete` then prunes. The proxy's `_target` is only populated when the
-    // association is actually loaded, so track the same list explicitly from
-    // the loaded snapshot rather than reading a possibly-empty `_target`.
+  private async _replaceRecords(newTarget: T[], originalTarget: T[]): Promise<T[]> {
     let target = [...originalTarget];
     const toDelete = this._difference(target, newTarget);
     if (toDelete.length > 0) {
@@ -3399,6 +3398,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         this._record,
       );
     }
+    return this._target;
   }
 
   /**

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -71,8 +71,12 @@ import {
   _violatesStrictLoading,
 } from "../associations.js";
 import { _setCollectionProxyCtor } from "./collection-proxy-slot.js";
-import { buildThroughInverseFor } from "./has-many-through-association.js";
-import { countRecords } from "./has-many-association.js";
+import {
+  buildThroughInverseFor,
+  multisetDifference,
+  multisetIntersection,
+} from "./has-many-through-association.js";
+import { countRecords, setDifference, setIntersection } from "./has-many-association.js";
 import { throughForeignKeyPresent } from "./through-association.js";
 import { foreignKeyPresentFor } from "./foreign-association.js";
 import type { AssociationReflection } from "../reflection.js";
@@ -150,6 +154,14 @@ export type AssociationProxy<
     // `Array<T>[i]` semantics under TS's standard lib.
     readonly [index: number]: T | undefined;
   };
+
+/**
+ * Ruby's `Array#==` over AR records: same length, pairwise `==` (class + id),
+ * order-sensitive. Used by `replace` for `other_array != original_target`.
+ */
+function sameRecordList(a: Base[], b: Base[]): boolean {
+  return a.length === b.length && a.every((record, i) => record.isEqual(b[i]));
+}
 
 /**
  * Validate a numeric limit (safe non-negative integer) and raise the
@@ -3340,14 +3352,114 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   }
 
   /**
-   * Replace the collection with a new set of records.
+   * Replace the collection with a new set of records, performing a diff so
+   * only the records that actually changed are deleted/added — records common
+   * to the old and new sets are left in place (no remove/add callbacks, no
+   * timestamp touches).
    *
-   * Mirrors: ActiveRecord::Associations::CollectionProxy#replace
+   * Mirrors: ActiveRecord::Associations::CollectionProxy#replace →
+   * `CollectionAssociation#replace` (collection_association.rb:242).
    */
   async replace(records: T[]): Promise<void> {
     this._ensureThroughWritable();
-    await this.clear();
-    await this.push(...records);
+    this._raiseOnTypeMismatch(records);
+    const originalTarget = [...(await this.toArray())];
+    if (this._record.isNewRecord()) {
+      await this._replaceRecords(records, originalTarget);
+      return;
+    }
+    this._replaceCommonRecordsInMemory(records, originalTarget);
+    if (!sameRecordList(records, originalTarget)) {
+      await this._replaceTransaction(() => this._replaceRecords(records, originalTarget));
+    }
+  }
+
+  /**
+   * Rails' `replace_records` (collection_association.rb:418): delete the
+   * records the new target dropped, then concat the ones it gained, restoring
+   * the original target and raising when the concat fails.
+   * @internal
+   */
+  private async _replaceRecords(newTarget: T[], originalTarget: T[]): Promise<void> {
+    // Rails diffs against `target`, which `load_target` has just filled and
+    // `delete` then prunes. The proxy's `_target` is only populated when the
+    // association is actually loaded, so track the same list explicitly from
+    // the loaded snapshot rather than reading a possibly-empty `_target`.
+    let target = [...originalTarget];
+    const toDelete = this._difference(target, newTarget);
+    if (toDelete.length > 0) {
+      await this.delete(...toDelete);
+      target = this._difference(target, toDelete);
+    }
+    const toAdd = this._difference(newTarget, target);
+    if (toAdd.length > 0 && (await this.push(...toAdd)) === false) {
+      this._target = [...originalTarget];
+      throw new RecordNotSaved(
+        `Failed to replace ${this._assocName} because one or more of the new records could not be saved.`,
+        this._record,
+      );
+    }
+  }
+
+  /**
+   * Rails' `replace_common_records_in_memory` (collection_association.rb:430):
+   * swap each record the two sets share into the target in place, skipping the
+   * add callbacks.
+   * @internal
+   */
+  private _replaceCommonRecordsInMemory(newTarget: T[], originalTarget: T[]): void {
+    for (const record of this._intersection(newTarget, originalTarget)) {
+      this._replaceOnTarget(record, { skipCallbacks: true, replace: true });
+    }
+  }
+
+  /**
+   * `difference`/`intersection` are the hooks Rails splits across
+   * `HasManyAssociation` (set: `a - b`, `a & b`) and
+   * `HasManyThroughAssociation` (multiset, occurrence-counting — which is what
+   * makes `post.people = [person, person]` create two join rows). The proxy is
+   * a single class serving both reflection kinds, so it selects by
+   * `_isThrough` rather than by inheritance, reusing the very bodies those two
+   * classes install.
+   * @internal
+   */
+  private _difference(a: T[], b: T[]): T[] {
+    return (this._isThrough ? multisetDifference(a, b) : setDifference(a, b)) as T[];
+  }
+
+  /** @internal */
+  private _intersection(a: T[], b: T[]): T[] {
+    return (this._isThrough ? multisetIntersection(a, b) : setIntersection(a, b)) as T[];
+  }
+
+  /**
+   * Rails wraps `replace_records` in `transaction`, which
+   * `ThroughAssociation#transaction` overrides to use the through model's.
+   * @internal
+   */
+  private async _replaceTransaction(block: () => Promise<void>): Promise<void> {
+    const throughModel = this._isThrough ? this._resolveThroughModel() : null;
+    if (throughModel && typeof throughModel.transaction === "function") {
+      await throughModel.transaction(block);
+      return;
+    }
+    await this.transaction(block);
+  }
+
+  /**
+   * The join model class behind a `:through` reflection, or `null` when the
+   * through association can't be resolved (the misconfiguration cases are
+   * already reported by `_ensureThroughWritable`).
+   * @internal
+   */
+  private _resolveThroughModel(): typeof Base | null {
+    const ctor = this._record.constructor as typeof Base;
+    const associations: AssociationDefinition[] = (ctor as any)._associations ?? [];
+    const throughAssoc = associations.find((a: any) => a.name === this._assocDef.options.through);
+    if (!throughAssoc) return null;
+    const throughClassName =
+      throughAssoc.options.className ?? camelize(singularize(throughAssoc.name));
+    return resolveAssocClass(this._record, throughAssoc.name, throughClassName);
   }
 
   /**

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -3,7 +3,7 @@ import type { AssociationDefinition } from "../associations.js";
 import { loadHasMany } from "../associations.js";
 import { DeleteRestrictionError } from "./errors.js";
 import { RecordInvalid } from "../validations.js";
-import { CollectionAssociation } from "./collection-association.js";
+import { CollectionAssociation, includesRecord } from "./collection-association.js";
 import { ForeignAssociation } from "./foreign-association.js";
 import { compositeQueryConstraintsList } from "../persistence.js";
 import { underscore } from "@blazetrails/activesupport";
@@ -20,6 +20,25 @@ import { underscore } from "@blazetrails/activesupport";
 export class HasManyAssociation extends CollectionAssociation {
   constructor(owner: Base, definition: AssociationDefinition) {
     super(owner, definition);
+  }
+
+  /**
+   * Set difference (Ruby's `a - b`) over AR record equality — a record present
+   * anywhere in `b` is excluded from the result however many times it occurs.
+   *
+   * Mirrors: ActiveRecord::Associations::HasManyAssociation#difference
+   */
+  protected override difference(a: Base[], b: Base[]): Base[] {
+    return setDifference(a, b);
+  }
+
+  /**
+   * Set intersection (Ruby's `a & b`) over AR record equality.
+   *
+   * Mirrors: ActiveRecord::Associations::HasManyAssociation#intersection
+   */
+  protected override intersection(a: Base[], b: Base[]): Base[] {
+    return setIntersection(a, b);
   }
 
   /**
@@ -422,4 +441,20 @@ function nullifiedOwnerAttributes(assoc: HasManyAssociation): Record<string, nul
 function deriveAsTypeCol(assoc: { reflection: { options: { as?: string } } }): string | null {
   const asName = assoc.reflection.options.as;
   return asName ? `${underscore(asName)}_type` : null;
+}
+
+/**
+ * Bodies of `HasManyAssociation#difference` / `#intersection`, exposed so the
+ * `CollectionProxy` replace path — which is one class covering both the plain
+ * and the `:through` reflection, and so cannot pick a diff by inheritance —
+ * can reach the same set semantics the OO association uses.
+ * @internal
+ */
+export function setDifference(a: Base[], b: Base[]): Base[] {
+  return a.filter((record) => !includesRecord(b, record));
+}
+
+/** @internal */
+export function setIntersection(a: Base[], b: Base[]): Base[] {
+  return a.filter((record) => includesRecord(b, record));
 }

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -327,8 +327,10 @@ export class HasManyThroughAssociation extends HasManyAssociation {
     // Rails (159-162): when the SOURCE belongs_to (on the join model) declares
     // its own counter_cache, `klass.decrement_counter` on the target rows by id
     // for every method except `:destroy` (whose per-record callbacks handle it).
-    // Unreachable by the canonical models but ported for fidelity. `safeKlass` +
-    // id null-filter are defensive (a class-less polymorphic source, null PKs).
+    // `klass` is the ASSOCIATION's klass (the target model), not the source
+    // reflection's — a polymorphic source belongs_to has none, and taggings'
+    // `taggable` is exactly such a source. `safeKlass` + the id null-filter stay
+    // defensive (null PKs).
     const sourceRefl = (ownRefl as { sourceReflection?: SourceCounterReflection } | undefined)
       ?.sourceReflection;
     if (method !== "destroy" && sourceRefl?.options?.counterCache) {

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -333,11 +333,6 @@ export class HasManyThroughAssociation extends HasManyAssociation {
       ?.sourceReflection;
     if (method !== "destroy" && sourceRefl?.options?.counterCache) {
       const counter = sourceRefl.counterCacheColumn?.();
-      // Rails decrements on `klass` — the *association's* klass (the target
-      // model, e.g. `Post`), not the source reflection's. They coincide for a
-      // plain source, but a polymorphic source belongs_to (taggings' `taggable`)
-      // has no klass at all, which is exactly the counter_cache this branch
-      // exists to maintain.
       const klass = safeKlass({ klass: this.klass }) as {
         decrementCounter?: (col: string, ids: unknown) => Promise<unknown>;
       } | null;

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -33,6 +33,36 @@ export class HasManyThroughAssociation extends HasManyAssociation {
   }
 
   /**
+   * The through model owns the transaction — the join-row writes are what has
+   * to be atomic, not the target model's.
+   *
+   * Mirrors: ActiveRecord::Associations::ThroughAssociation#transaction
+   */
+  protected override transaction<R>(block: () => Promise<R>): Promise<R | undefined> {
+    return transaction(this, block);
+  }
+
+  /**
+   * Multiset difference: each occurrence of a record in `b` cancels at most one
+   * occurrence in `a`, so `[person, person] - [person]` keeps one `person` and
+   * the replace path creates the second join row.
+   *
+   * Mirrors: ActiveRecord::Associations::HasManyThroughAssociation#difference
+   */
+  protected override difference(a: Base[], b: Base[]): Base[] {
+    return multisetDifference(a, b);
+  }
+
+  /**
+   * Multiset intersection — the `select` counterpart of {@link difference}.
+   *
+   * Mirrors: ActiveRecord::Associations::HasManyThroughAssociation#intersection
+   */
+  protected override intersection(a: Base[], b: Base[]): Base[] {
+    return multisetIntersection(a, b);
+  }
+
+  /**
    * Mirrors Rails' `delegate :source_reflection, to: :reflection`
    * (ThroughAssociation, mixed into HasManyThroughAssociation).
    */
@@ -303,7 +333,12 @@ export class HasManyThroughAssociation extends HasManyAssociation {
       ?.sourceReflection;
     if (method !== "destroy" && sourceRefl?.options?.counterCache) {
       const counter = sourceRefl.counterCacheColumn?.();
-      const klass = safeKlass(sourceRefl) as {
+      // Rails decrements on `klass` — the *association's* klass (the target
+      // model, e.g. `Post`), not the source reflection's. They coincide for a
+      // plain source, but a polymorphic source belongs_to (taggings' `taggable`)
+      // has no klass at all, which is exactly the counter_cache this branch
+      // exists to maintain.
+      const klass = safeKlass({ klass: this.klass }) as {
         decrementCounter?: (col: string, ids: unknown) => Promise<unknown>;
       } | null;
       const ids = records.map((r) => (r as any).id).filter((id: unknown) => id != null);
@@ -662,37 +697,6 @@ async function updateThroughCounterCache(
 }
 
 /** @internal */
-function difference(_assoc: HasManyThroughAssociation, a: Base[], b: Base[]): Base[] {
-  return a.filter((r) => !b.includes(r));
-}
-
-/** @internal */
-function intersection(_assoc: HasManyThroughAssociation, a: Base[], b: Base[]): Base[] {
-  return a.filter((r) => b.includes(r));
-}
-
-/** @internal */
-function markOccurrence(
-  _assoc: HasManyThroughAssociation,
-  distribution: Map<Base, number>,
-  record: Base,
-): boolean {
-  const count = distribution.get(record) ?? 0;
-  if (count > 0) {
-    distribution.set(record, count - 1);
-    return true;
-  }
-  return false;
-}
-
-/** @internal */
-function distribution(_assoc: HasManyThroughAssociation, array: Base[]): Map<Base, number> {
-  const result = new Map<Base, number>();
-  for (const r of array) result.set(r, (result.get(r) ?? 0) + 1);
-  return result;
-}
-
-/** @internal */
 function throughRecordsFor(assoc: HasManyThroughAssociation, record: Base): Base[] {
   const throughName = assoc.reflection.options.through;
   if (!throughName) return [];
@@ -756,6 +760,47 @@ function deleteThroughRecords(assoc: HasManyThroughAssociation, records: Base[])
     cache.delete(record);
   }
   return Promise.resolve();
+}
+
+/**
+ * `distribution` + `mark_occurrence` (has_many_through_association.rb:187-195)
+ * as one occurrence counter. Ruby keys the hash by the record, hashing on
+ * AR::Core `hash`/`eql?` (class + id), so the buckets are matched with the same
+ * record equality rather than JS identity.
+ * @internal
+ */
+function distribution(records: Base[]): Array<{ record: Base; count: number }> {
+  const buckets: Array<{ record: Base; count: number }> = [];
+  for (const record of records) {
+    const bucket = buckets.find((b) => b.record.isEqual(record));
+    if (bucket) bucket.count += 1;
+    else buckets.push({ record, count: 1 });
+  }
+  return buckets;
+}
+
+/** @internal */
+function markOccurrence(buckets: Array<{ record: Base; count: number }>, record: Base): boolean {
+  const bucket = buckets.find((b) => b.record.isEqual(record));
+  if (!bucket || bucket.count <= 0) return false;
+  bucket.count -= 1;
+  return true;
+}
+
+/**
+ * Bodies of `HasManyThroughAssociation#difference` / `#intersection`, exposed
+ * for the `CollectionProxy` replace path (see `setDifference`).
+ * @internal
+ */
+export function multisetDifference(a: Base[], b: Base[]): Base[] {
+  const dist = distribution(b);
+  return a.filter((record) => !markOccurrence(dist, record));
+}
+
+/** @internal */
+export function multisetIntersection(a: Base[], b: Base[]): Base[] {
+  const dist = distribution(b);
+  return a.filter((record) => markOccurrence(dist, record));
 }
 
 /**

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -39,7 +39,17 @@ export class HasManyThroughAssociation extends HasManyAssociation {
    * Mirrors: ActiveRecord::Associations::ThroughAssociation#transaction
    */
   protected override transaction<R>(block: () => Promise<R>): Promise<R | undefined> {
-    return transaction(this, block);
+    const tr = throughReflection(this) as { klass?: unknown } | null;
+    let klass: { transaction?: (...args: unknown[]) => unknown } | null = null;
+    try {
+      klass = (tr?.klass ?? null) as { transaction?: (...args: unknown[]) => unknown } | null;
+    } catch {
+      klass = null;
+    }
+    if (klass && typeof klass.transaction === "function") {
+      return klass.transaction(block) as Promise<R | undefined>;
+    }
+    return block() as Promise<R | undefined>;
   }
 
   /**
@@ -50,7 +60,8 @@ export class HasManyThroughAssociation extends HasManyAssociation {
    * Mirrors: ActiveRecord::Associations::HasManyThroughAssociation#difference
    */
   protected override difference(a: Base[], b: Base[]): Base[] {
-    return multisetDifference(a, b);
+    const dist = distribution(b);
+    return a.filter((record) => !markOccurrence(dist, record));
   }
 
   /**
@@ -59,7 +70,8 @@ export class HasManyThroughAssociation extends HasManyAssociation {
    * Mirrors: ActiveRecord::Associations::HasManyThroughAssociation#intersection
    */
   protected override intersection(a: Base[], b: Base[]): Base[] {
-    return multisetIntersection(a, b);
+    const dist = distribution(b);
+    return a.filter((record) => markOccurrence(dist, record));
   }
 
   /**
@@ -785,7 +797,8 @@ function markOccurrence(buckets: Array<{ record: Base; count: number }>, record:
 }
 
 /**
- * Bodies of `HasManyThroughAssociation#difference` / `#intersection`, exposed
+ * The multiset diff of `HasManyThroughAssociation#difference` / `#intersection`
+ * over the same `distribution`/`markOccurrence` pair those methods use, exposed
  * for the `CollectionProxy` replace path (see `setDifference`).
  * @internal
  */
@@ -798,26 +811,6 @@ export function multisetDifference(a: Base[], b: Base[]): Base[] {
 export function multisetIntersection(a: Base[], b: Base[]): Base[] {
   const dist = distribution(b);
   return a.filter((record) => markOccurrence(dist, record));
-}
-
-/**
- * Wrap `block` in a transaction on the through-reflection's class. Falls
- * back to invoking the block directly when no through klass is available.
- *
- * Mirrors: ActiveRecord::Associations::ThroughAssociation#transaction
- *
- * @internal
- */
-function transaction<R>(
-  assoc: HasManyThroughAssociation,
-  block: (tx?: any) => Promise<R>,
-): Promise<R | undefined> {
-  const tr = throughReflection(assoc) as { klass?: unknown } | null;
-  const klass = safeKlass(tr) as { transaction?: (...args: any[]) => any } | null;
-  if (klass && typeof klass.transaction === "function") {
-    return klass.transaction(block) as Promise<R | undefined>;
-  }
-  return block() as Promise<R | undefined>;
 }
 
 /**

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/has-many-through-association.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/has-many-through-association.json
@@ -73,13 +73,6 @@
     "package": "activerecord",
     "tsFile": "associations/has-many-through-association.ts",
     "rubyName": "delete_records",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-many-through-association.ts",
-    "rubyName": "delete_records",
     "call": "through_association",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
Reconciles trails' two divergent collection-`replace` paths onto Rails' single
`CollectionAssociation#replace` (collection_association.rb:242), which diffs via
`difference`/`intersection` — set semantics in `HasManyAssociation`
(has_many_association.rb:157-163), **multiset** (occurrence-counting) semantics
in `HasManyThroughAssociation` (has_many_through_association.rb:177-195).

## Changes

- `CollectionProxy#replace` no longer does `clear()` + `push()`. It mirrors
  Rails: load the target (under `skip_strict_loading`),
  `replace_common_records_in_memory`, and — when the new array differs — run
  `replace_records` (diffed delete + concat) inside a transaction, returning the
  resulting target (`other_array` when nothing changed, as
  collection_proxy.rb:391-393 → collection_association.rb:242 does). Records
  common to both sets are left in place: no remove/add callbacks, no row
  rewrites, for plain `has_many`.
- `difference`/`intersection` added as the Rails class split:
  `HasManyAssociation` (set, over AR record equality) and
  `HasManyThroughAssociation` (multiset via `distribution`/`mark_occurrence`).
  `CollectionAssociation`'s shared replace machinery calls them, so the
  awaitable `writer` path gets the same semantics. The proxy is a single class
  covering both reflection kinds, so it selects the diff by `_isThrough` and
  reuses the very bodies those two classes install.
- `CollectionAssociation#transaction` is now an overridable method (was a module
  function), with `HasManyThroughAssociation#transaction` overriding it to the
  through model's transaction — Rails' `ThroughAssociation#transaction`
  (through_association.rb:10-12).
- Removed four dead, identity-based `difference`/`intersection`/`distribution`/
  `markOccurrence` module functions in has-many-through-association.ts that
  nothing called and whose semantics were neither Rails' set nor multiset.
- `HasManyThroughAssociation#deleteRecords`' source-`counter_cache` branch now
  decrements on the *association's* klass, as Rails does
  (`klass.decrement_counter`, has_many_through_association.rb:163). It read the
  source reflection's klass, which is `nil` for a polymorphic source
  `belongs_to` — taggings' `taggable`, whose `counter_cache: :tags_count` is
  precisely the counter this branch exists to maintain, so the branch was dead
  for the only model that reaches it. Surfaced by `update counter caches on
  replace association` once replace started actually deleting the join rows.

## Tests

`collection-proxy-replace-diff.trails.test.ts` — trails-only, because Rails
never had the divergence and so has no test pinning the *absence* of those
callbacks:

- common records generate no remove/add callbacks
- only the gained records generate add callbacks
- multiset: `post.people.replace([david, david])` after `replace([david])`
  creates a second join row
- a new record that raises on save rolls the whole replace back
- the delete direction with duplicates: `replace([david, david])` then
  `replace([david])` deletes both join rows and re-creates a fresh one (Rails'
  `@target -= records` is plain `Array#-`, so it drops every occurrence and
  `replace_records` re-concats what's missing). Before the `Array#-` fix this
  left **zero** join rows

Both callback tests fail on `origin/main`; the multiset one passes there too,
since `clear()` + `push()` reached the same end count.

Existing Rails-named tests kept verbatim and green, including `replace
association with duplicates`, `replace order is preserved`, `update counter
caches on replace association`, and `has many through uses the through model to
create transactions`. `pnpm api:compare` is clean.

Closes-story: collection-proxy-replace-multiset-diff-fidelity
