### PR TITLE
fix(associations): stop hasOne-through setNewRecord running the direct-FK tail

### DIFF
--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -106,6 +106,25 @@ export class HasOneThroughAssociation extends HasOneAssociation {
   }
 
   /**
+   * Rails' `set_new_record` is `replace(record, false)` and nothing else
+   * (has_one_association.rb:87-93). The base `HasOneAssociation` override adds a
+   * direct-FK tail — `nullifyOwnerAttributes` / `removeInverseInstance` on the
+   * displaced target plus a `_displacedRecords` push — standing in for
+   * `remove_target!`, which Rails' `HasOneThroughAssociation#replace`
+   * (has_one_through_association.rb:9-13) does NOT run: a through's end record
+   * carries no foreign key back to the owner, so nullifying it either raises
+   * `MissingAttributeError` (no such column) or silently blanks an unrelated
+   * column that merely matches the derived FK name. Displacement belongs to
+   * `createThroughRecord` / `persistReplace`, which mutate the *join* row. Same
+   * reason `detachDisplacedTarget` is a no-op above.
+   *
+   * @internal
+   */
+  protected override setNewRecord(record: Base): void {
+    this.replace(record, false);
+  }
+
+  /**
    * Mirrors Rails `HasOneThroughAssociation#replace` immediate persist to a
    * saved owner. The base `writer` saves the target's foreign key directly,
    * which is wrong for a through (persistence routes through the join model), so

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -105,21 +105,6 @@ export class HasOneThroughAssociation extends HasOneAssociation {
     // no-op — see JSDoc
   }
 
-  /**
-   * Rails' `set_new_record` is `replace(record, false)` and nothing else
-   * (has_one_association.rb:87-93). The base `HasOneAssociation` override adds a
-   * direct-FK tail — `nullifyOwnerAttributes` / `removeInverseInstance` on the
-   * displaced target plus a `_displacedRecords` push — standing in for
-   * `remove_target!`, which Rails' `HasOneThroughAssociation#replace`
-   * (has_one_through_association.rb:9-13) does NOT run: a through's end record
-   * carries no foreign key back to the owner, so nullifying it either raises
-   * `MissingAttributeError` (no such column) or silently blanks an unrelated
-   * column that merely matches the derived FK name. Displacement belongs to
-   * `createThroughRecord` / `persistReplace`, which mutate the *join* row. Same
-   * reason `detachDisplacedTarget` is a no-op above.
-   *
-   * @internal
-   */
   protected override setNewRecord(record: Base): void {
     this.replace(record, false);
   }

--- a/packages/activerecord/src/associations/has-one-through-build.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-through-build.trails.test.ts
@@ -92,6 +92,7 @@ describe("HasOneThroughBuildTrails", () => {
     const displaced = (await (member as unknown as { club: Promise<Club | null> }).club) as Club;
     expect(displaced).toBeInstanceOf(Club);
     expect(member.association("club").isLoaded()).toBe(true);
+    const joinsBefore = (await CurrentMembership.where({ member_id: member.id }).count()) as number;
 
     const built = await (
       member as unknown as { buildClub(attrs: Record<string, unknown>): Promise<Club> }
@@ -99,20 +100,24 @@ describe("HasOneThroughBuildTrails", () => {
 
     expect(built.isNewRecord()).toBe(true);
     expect(member.association("club").target).toBe(built);
-
-    // The displaced end record has no FK back to the member; the through's join
-    // row owns the link, so the club itself must be untouched — in memory and
-    // after the owner's save drains its queues.
     expect(displaced.hasChangesToSave).toBe(false);
+
     await member.save();
+
     const reloadedDisplaced = await Club.find(displaced.id);
     expect(reloadedDisplaced.name).toBe(displaced.name);
+    expect((await CurrentMembership.where({ member_id: member.id }).count()) as number).toBe(
+      joinsBefore,
+    );
+    await member.association("club").reload();
+    expect((member.association("club").target as Club | null)?.id).toBe(built.id);
   });
 
   it("createClub over a loaded through target does not touch the displaced club", async () => {
     const member = members("groucho");
     const displaced = (await (member as unknown as { club: Promise<Club | null> }).club) as Club;
     expect(displaced).toBeInstanceOf(Club);
+    const joinsBefore = (await CurrentMembership.where({ member_id: member.id }).count()) as number;
 
     const created = await (
       member as unknown as { createClub(attrs: Record<string, unknown>): Promise<Club> }
@@ -120,9 +125,16 @@ describe("HasOneThroughBuildTrails", () => {
 
     expect(created.isPersisted()).toBe(true);
     expect(member.association("club").target).toBe(created);
+    expect(displaced.hasChangesToSave).toBe(false);
 
     await member.save();
+
     const reloadedDisplaced = await Club.find(displaced.id);
     expect(reloadedDisplaced.name).toBe(displaced.name);
+    expect((await CurrentMembership.where({ member_id: member.id }).count()) as number).toBe(
+      joinsBefore,
+    );
+    await member.association("club").reload();
+    expect((member.association("club").target as Club | null)?.id).toBe(created.id);
   });
 });

--- a/packages/activerecord/src/associations/has-one-through-build.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-through-build.trails.test.ts
@@ -86,4 +86,43 @@ describe("HasOneThroughBuildTrails", () => {
     await member.association("club").reload();
     expect((member.association("club").target as Club | null)?.id).toBe(newClub.id);
   });
+
+  it("buildClub over a loaded through target does not touch the displaced club", async () => {
+    const member = members("groucho");
+    const displaced = (await (member as unknown as { club: Promise<Club | null> }).club) as Club;
+    expect(displaced).toBeInstanceOf(Club);
+    expect(member.association("club").isLoaded()).toBe(true);
+
+    const built = await (
+      member as unknown as { buildClub(attrs: Record<string, unknown>): Promise<Club> }
+    ).buildClub({ name: "Displacing Club" });
+
+    expect(built.isNewRecord()).toBe(true);
+    expect(member.association("club").target).toBe(built);
+
+    // The displaced end record has no FK back to the member; the through's join
+    // row owns the link, so the club itself must be untouched — in memory and
+    // after the owner's save drains its queues.
+    expect(displaced.hasChangesToSave).toBe(false);
+    await member.save();
+    const reloadedDisplaced = await Club.find(displaced.id);
+    expect(reloadedDisplaced.name).toBe(displaced.name);
+  });
+
+  it("createClub over a loaded through target does not touch the displaced club", async () => {
+    const member = members("groucho");
+    const displaced = (await (member as unknown as { club: Promise<Club | null> }).club) as Club;
+    expect(displaced).toBeInstanceOf(Club);
+
+    const created = await (
+      member as unknown as { createClub(attrs: Record<string, unknown>): Promise<Club> }
+    ).createClub({ name: "Created Displacing Club" });
+
+    expect(created.isPersisted()).toBe(true);
+    expect(member.association("club").target).toBe(created);
+
+    await member.save();
+    const reloadedDisplaced = await Club.find(displaced.id);
+    expect(reloadedDisplaced.name).toBe(displaced.name);
+  });
 });


### PR DESCRIPTION
`HasOneThroughAssociation` inherited `HasOneAssociation#setNewRecord`
(`has-one-association.ts:538-553`), whose tail runs `nullifyOwnerAttributes` /
`removeInverseInstance` on the displaced target and pushes it onto
`_displacedRecords`. Those are direct-FK operations a through target does not
support — the end record has no foreign key back to the owner.

Measured on `main`: an awaited `member.buildClub(...)` / `member.createClub(...)`
over a **loaded** `Member hasOne :club, through: :current_membership` raises
`MissingAttributeError: can't write unknown attribute 'club_id'`. A through
whose end model happened to carry a column matching the derived FK name would
instead have it silently nullified at the owner's `save()` drain.

Rails' `HasOneThroughAssociation#replace`
(`has_one_through_association.rb:9-13`) has no `remove_target!` — displacement
is entirely `create_through_record` mutating the join row, which is why
`detachDisplacedTarget` is already a no-op override here. So `set_new_record`
is just `replace(record, false)` (`has_one_association.rb:87-93`); this
overrides it to exactly that. The override carries no JSDoc by request — this
description is its rationale.

## Tests

Two regressions in `has-one-through-build.trails.test.ts` covering awaited
`buildClub` and `createClub` over a loaded through target. Each asserts the
displaced club is unchanged in memory and in the DB after the owner's save, the
member's join-row count is unchanged (no duplicate), and the through resolves to
the newly built/created club on reload. Both fail on `origin/main` with
`MissingAttributeError` and pass here.

`has_one`, hasOne-through (+ disable-joins, setter/build trails), autosave and
nested-attributes suites green locally (532 passed / 5 skipped); eslint and
`tsc --build` clean.

Closes-story: has-one-through-inherits-direct-fk-set-new-record
