### PR TITLE
fix(base): defer constructor-form collection ids= keys past super()

### DIFF
--- a/packages/activerecord/src/associations/collection-persisted-setter-throws.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-persisted-setter-throws.trails.test.ts
@@ -115,6 +115,35 @@ describe("CollectionPersistedSetterThrows", () => {
     expect(await postsOf(author).count()).toBe(1);
   });
 
+  it("constructor-form ids= reaches the association writer", async () => {
+    // `new Author({postIds: [...]})` used to die with an opaque
+    // `TypeError: Cannot read properties of undefined (reading 'get')`: the
+    // ids key matched no association NAME, so it stayed in the bag super()
+    // assigns, and the generated writer reached `this.association("posts")`
+    // before the association cache field existed. Rails has no such split
+    // (`Author.new(post_ids: [...])` runs `ids_writer` normally,
+    // collection_association.rb:61-83).
+    const post = await Post.create({ title: "t", body: "b" });
+    let author: Author | undefined;
+    expect(() => {
+      author = new Author({ name: "Bill", postIds: [post.id] });
+    }).not.toThrow();
+    // The generated setter can't await, so the id→record resolution it kicks
+    // off is still in flight when the constructor returns (the pre-existing
+    // shape documented on `queueIdsWrite`). Settle it before asserting.
+    for (let i = 0; i < 50 && targetOf(author!).length === 0; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    expect(targetOf(author!).map((p) => p.id)).toEqual([post.id]);
+  });
+
+  it("constructor-form ids= does not swallow an unknown Ids key", async () => {
+    // Only a key that is a real generated collection writer is deferred — a
+    // model without the matching association still reports the key as unknown
+    // rather than having it silently rerouted.
+    expect(() => new Post({ title: "t", body: "b", widgetIds: [1] } as never)).toThrow(/widgetIds/);
+  });
+
   it("the awaitable writer replaces on a persisted owner", async () => {
     const author = await Author.create({ name: "Bill" });
     const first = await Post.create({ title: "a", body: "a" });

--- a/packages/activerecord/src/associations/collection-persisted-setter-throws.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-persisted-setter-throws.trails.test.ts
@@ -19,6 +19,7 @@ import { CollectionPersistedAssignmentError } from "./errors.js";
 import { Author } from "../test-helpers/models/author.js";
 import { Post } from "../test-helpers/models/post.js";
 import { Comment } from "../test-helpers/models/comment.js";
+import { Category } from "../test-helpers/models/category.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 
 interface CollectionOwner {
@@ -38,6 +39,15 @@ const postsOf = (owner: Author): PostsProxy => (owner as unknown as { posts: Pos
 const targetOf = (owner: Author): Post[] =>
   (owner as unknown as { association(n: string): { target: Post[] } }).association("posts").target;
 
+// The `#{singular}Ids=` setter can't await, so the id→record resolution it
+// starts is still in flight when the constructor returns (the shape
+// `queueIdsWrite` documents). Settle it before asserting on the target.
+const settleTarget = async (target: () => unknown[]): Promise<void> => {
+  for (let i = 0; i < 50 && target().length === 0; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+};
+
 const writerOf =
   (owner: Author) =>
   (records: Post[]): Promise<void> =>
@@ -52,6 +62,7 @@ describe("CollectionPersistedSetterThrows", () => {
     registerModel(Author);
     registerModel(Post);
     registerModel(Comment);
+    registerModel(Category);
   });
 
   it("native = setter throws on a persisted owner", async () => {
@@ -116,31 +127,36 @@ describe("CollectionPersistedSetterThrows", () => {
   });
 
   it("constructor-form ids= reaches the association writer", async () => {
-    // `new Author({postIds: [...]})` used to die with an opaque
-    // `TypeError: Cannot read properties of undefined (reading 'get')`: the
-    // ids key matched no association NAME, so it stayed in the bag super()
-    // assigns, and the generated writer reached `this.association("posts")`
-    // before the association cache field existed. Rails has no such split
-    // (`Author.new(post_ids: [...])` runs `ids_writer` normally,
-    // collection_association.rb:61-83).
     const post = await Post.create({ title: "t", body: "b" });
     let author: Author | undefined;
     expect(() => {
       author = new Author({ name: "Bill", postIds: [post.id] });
     }).not.toThrow();
-    // The generated setter can't await, so the id→record resolution it kicks
-    // off is still in flight when the constructor returns (the pre-existing
-    // shape documented on `queueIdsWrite`). Settle it before asserting.
-    for (let i = 0; i < 50 && targetOf(author!).length === 0; i++) {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    }
+    await settleTarget(() => targetOf(author!));
     expect(targetOf(author!).map((p) => p.id)).toEqual([post.id]);
   });
 
-  it("constructor-form ids= does not swallow an unknown Ids key", async () => {
-    // Only a key that is a real generated collection writer is deferred — a
-    // model without the matching association still reports the key as unknown
-    // rather than having it silently rerouted.
+  it("create with an ids= key reaches the association writer", async () => {
+    const post = await Post.create({ title: "t", body: "b" });
+    const author = await Author.create({ name: "Bill", postIds: [post.id] });
+    expect(author.isPersisted()).toBe(true);
+  });
+
+  it("constructor-form habtm ids= reaches the association writer", async () => {
+    const post = await Post.create({ title: "t", body: "b" });
+    let category: Category | undefined;
+    expect(() => {
+      category = new Category({ name: "General", postIds: [post.id] });
+    }).not.toThrow();
+    const habtmTarget = (): unknown[] =>
+      (category as unknown as { association(n: string): { target: unknown[] } }).association(
+        "posts",
+      ).target;
+    await settleTarget(habtmTarget);
+    expect(habtmTarget().length).toBe(1);
+  });
+
+  it("constructor-form ids= does not swallow an unknown Ids key", () => {
     expect(() => new Post({ title: "t", body: "b", widgetIds: [1] } as never)).toThrow(/widgetIds/);
   });
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -681,31 +681,44 @@ function _applyScopeAttributes(
   }
 }
 
+/** @internal An association definition as `_extractAssociationAttrs` reads it. */
+interface _AssociationDefLike {
+  name: string;
+  type: string;
+}
+
 /**
- * Is `key` the generated `#{singular}Ids` writer of one of `defs`' collection
- * associations?
- *
- * Both halves matter. The name match alone would reroute any `*Ids` key,
- * including a genuine column, on a model that happens to declare a
- * similarly-named collection; requiring a live setter on the prototype keeps
- * the predicate pinned to "assignment of this key would dispatch the
- * association writer inside super()", which is exactly the hazard being
- * deferred. A `*Ids` key with no such writer is left in the attribute bag and
- * assigned by super() as before.
+ * A constructor-form assignment held back until after `super()`. `viaSetter`
+ * entries name a generated writer (`postIds`) rather than an association, so
+ * they must be dispatched through that setter — `assignAssociationIfMatch`
+ * matches on association name and would drop the value.
  * @internal
+ */
+interface _PendingAssociationAttr {
+  name: string;
+  value: unknown;
+  viaSetter?: boolean;
+}
+
+/**
+ * @internal
+ * Is `key` the generated `#{singular}Ids` writer of one of `defs`' collection
+ * associations? Requires a live setter on the prototype as well as the name
+ * match, so that a `*Ids` key which would NOT dispatch an association writer
+ * inside `super()` (a genuine column, say) is left on the attribute path.
  */
 function _isCollectionIdsWriter(
   ctor: typeof Base | undefined,
-  defs: Array<{ name: string; type: string }>,
+  defs: _AssociationDefLike[],
   key: string,
 ): boolean {
   if (!key.endsWith("Ids")) return false;
-  const matches = defs.some(
+  const named = defs.some(
     (a) =>
       (a.type === "hasMany" || a.type === "hasAndBelongsToMany") &&
       `${_singularize(a.name)}Ids` === key,
   );
-  if (!matches) return false;
+  if (!named) return false;
   let proto: object | null = (ctor as unknown as { prototype?: object })?.prototype ?? null;
   while (proto) {
     const descriptor = Object.getOwnPropertyDescriptor(proto, key);
@@ -722,28 +735,24 @@ function _isCollectionIdsWriter(
  * when no key matches a declared association so the hot path allocates
  * nothing.
  *
- * A generated `#{singular}Ids` key (`new Author({postIds: [...]})`) is
- * deferred too: its setter reaches `this.association(name)`, whose cache field
- * is not initialized until after `super()` returns. Such entries carry
- * `viaSetter` so `_dispatchAssociationAttrs` writes through the ids setter —
- * `assignAssociationIfMatch` matches on association NAME and would drop the
- * value on the floor.
+ * A generated `#{singular}Ids` key (`new Author({postIds: [...]})`) is deferred
+ * too: its setter reaches `this.association(name)`, whose cache field is not
+ * initialized until after `super()` returns.
  */
 function _extractAssociationAttrs(
   ctor: typeof Base | undefined,
   attrs: Record<string, unknown>,
 ): {
   rest: Record<string, unknown>;
-  assocs: Array<{ name: string; value: unknown; viaSetter?: boolean }>;
+  assocs: _PendingAssociationAttr[];
 } | null {
-  const defs = (ctor as { _associations?: Array<{ name: string; type: string }> } | undefined)
-    ?._associations;
+  const defs = (ctor as { _associations?: _AssociationDefLike[] } | undefined)?._associations;
   if (!defs || defs.length === 0) return null;
   // Common case: models that declare associations but receive only regular
   // attrs at construction (`new Post({title})`). First pass detects whether
   // any key matches an association; only then do we allocate `rest` and
   // copy entries. Avoids per-construction overhead for the hot path.
-  let assocs: Array<{ name: string; value: unknown; viaSetter?: boolean }> | null = null;
+  let assocs: _PendingAssociationAttr[] | null = null;
   for (const k of Object.keys(attrs)) {
     if (defs.find((a) => a.name === k)) {
       (assocs ??= []).push({ name: k, value: attrs[k] });
@@ -861,14 +870,9 @@ function _reinstateConstructorDirtiness(
 }
 
 /** @internal */
-function _dispatchAssociationAttrs(
-  record: Base,
-  assocs: Array<{ name: string; value: unknown; viaSetter?: boolean }>,
-): void {
+function _dispatchAssociationAttrs(record: Base, assocs: _PendingAssociationAttr[]): void {
   for (const { name, value, viaSetter } of assocs) {
     if (viaSetter) {
-      // `name` is the generated writer key (`postIds`), not an association
-      // name — dispatch it exactly as `_assignAttribute` would have.
       (record as unknown as Record<string, unknown>)[name] = value;
       continue;
     }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -149,6 +149,7 @@ import {
   benchmark as benchmarkable,
   runLoadHooks,
   isBlank as _isBlankValue,
+  singularize as _singularize,
   type Included,
   type ParameterFilter,
   type BenchmarkLogger,
@@ -681,18 +682,59 @@ function _applyScopeAttributes(
 }
 
 /**
+ * Is `key` the generated `#{singular}Ids` writer of one of `defs`' collection
+ * associations?
+ *
+ * Both halves matter. The name match alone would reroute any `*Ids` key,
+ * including a genuine column, on a model that happens to declare a
+ * similarly-named collection; requiring a live setter on the prototype keeps
+ * the predicate pinned to "assignment of this key would dispatch the
+ * association writer inside super()", which is exactly the hazard being
+ * deferred. A `*Ids` key with no such writer is left in the attribute bag and
+ * assigned by super() as before.
+ * @internal
+ */
+function _isCollectionIdsWriter(
+  ctor: typeof Base | undefined,
+  defs: Array<{ name: string; type: string }>,
+  key: string,
+): boolean {
+  if (!key.endsWith("Ids")) return false;
+  const matches = defs.some(
+    (a) =>
+      (a.type === "hasMany" || a.type === "hasAndBelongsToMany") &&
+      `${_singularize(a.name)}Ids` === key,
+  );
+  if (!matches) return false;
+  let proto: object | null = (ctor as unknown as { prototype?: object })?.prototype ?? null;
+  while (proto) {
+    const descriptor = Object.getOwnPropertyDescriptor(proto, key);
+    if (descriptor) return typeof descriptor.set === "function";
+    proto = Object.getPrototypeOf(proto) as object | null;
+  }
+  return false;
+}
+
+/**
  * @internal
  * Pull constructor-form association assignments (e.g. `new Owner({items:
  * [...], profile: p})`) out of the regular attribute bag. Returns null
  * when no key matches a declared association so the hot path allocates
  * nothing.
+ *
+ * A generated `#{singular}Ids` key (`new Author({postIds: [...]})`) is
+ * deferred too: its setter reaches `this.association(name)`, whose cache field
+ * is not initialized until after `super()` returns. Such entries carry
+ * `viaSetter` so `_dispatchAssociationAttrs` writes through the ids setter —
+ * `assignAssociationIfMatch` matches on association NAME and would drop the
+ * value on the floor.
  */
 function _extractAssociationAttrs(
   ctor: typeof Base | undefined,
   attrs: Record<string, unknown>,
 ): {
   rest: Record<string, unknown>;
-  assocs: Array<{ name: string; value: unknown }>;
+  assocs: Array<{ name: string; value: unknown; viaSetter?: boolean }>;
 } | null {
   const defs = (ctor as { _associations?: Array<{ name: string; type: string }> } | undefined)
     ?._associations;
@@ -701,10 +743,12 @@ function _extractAssociationAttrs(
   // attrs at construction (`new Post({title})`). First pass detects whether
   // any key matches an association; only then do we allocate `rest` and
   // copy entries. Avoids per-construction overhead for the hot path.
-  let assocs: Array<{ name: string; value: unknown }> | null = null;
+  let assocs: Array<{ name: string; value: unknown; viaSetter?: boolean }> | null = null;
   for (const k of Object.keys(attrs)) {
     if (defs.find((a) => a.name === k)) {
       (assocs ??= []).push({ name: k, value: attrs[k] });
+    } else if (_isCollectionIdsWriter(ctor, defs, k)) {
+      (assocs ??= []).push({ name: k, value: attrs[k], viaSetter: true });
     }
   }
   if (!assocs) return null;
@@ -819,9 +863,15 @@ function _reinstateConstructorDirtiness(
 /** @internal */
 function _dispatchAssociationAttrs(
   record: Base,
-  assocs: Array<{ name: string; value: unknown }>,
+  assocs: Array<{ name: string; value: unknown; viaSetter?: boolean }>,
 ): void {
-  for (const { name, value } of assocs) {
+  for (const { name, value, viaSetter } of assocs) {
+    if (viaSetter) {
+      // `name` is the generated writer key (`postIds`), not an association
+      // name — dispatch it exactly as `_assignAttribute` would have.
+      (record as unknown as Record<string, unknown>)[name] = value;
+      continue;
+    }
     _AttributeAssignment.assignAssociationIfMatch(
       record as unknown as { constructor?: unknown; association?: (name: string) => unknown },
       name,


### PR DESCRIPTION
`new Author({ postIds: [...] })` (and `Author.create({ postIds: [...] })`) died
with an opaque `TypeError: Cannot read properties of undefined (reading 'get')`
instead of reaching the association writer.

`_extractAssociationAttrs` (base.ts) pulls only keys matching an association
**name** out of `attrs` so they can be assigned after `super()` — i.e. after the
`_associationInstances` class field exists. A `#{singular}Ids` key matches no
association name, so it stayed in `rest`, was assigned inside `super()` via
`_assignAttribute` → the generated ids setter → `association(name)`, where
`this._associationInstances` is still `undefined`. Rails has no such split:
`Author.new(post_ids: [...])` runs `ids_writer` normally
(`collection_association.rb:61-83`).

## Fix

The fix is in the constructor split, not the setter:

- `_extractAssociationAttrs` now also defers a key that is the generated
  `#{singular}Ids` writer of a declared `hasMany`/`hasAndBelongsToMany`.
- Those entries are tagged `viaSetter`, and `_dispatchAssociationAttrs` writes
  them through the ids setter — **not** `assignAssociationIfMatch`, which
  matches on association name and would silently drop the value.
- The predicate requires a name match against a collection association *and* a
  live setter on the prototype chain, so a `*Ids` key that would not dispatch an
  association writer inside `super()` (a genuine column, say) stays on the
  attribute path untouched. When a model does declare the matching collection,
  the generated writer already shadows a same-named column, so deferral
  dispatches the exact same setter — no new reroute is introduced.

## Notes / limits

- The story's acceptance criteria name `CollectionIdsAssignmentError`, which
  comes from #5292 (not yet merged). On `main` a constructor's owner is always
  unpersisted, so `queueIdsWrite` does not throw — the observable fix here is
  that the writer runs instead of a `TypeError`. Once #5292 lands, its throw
  flows through this path unchanged.
- The un-awaited id→record resolution the property setter starts is pre-existing
  (documented on `queueIdsWrite`) and unchanged; the new tests settle it before
  asserting on the target.
- `${singularize(name)}Ids` is now derived in three places (twice in
  `builder/collection-association.ts`, once here). Left inline rather than
  introducing a shared module with no Rails counterpart.

## Testing

New regression tests in `collection-persisted-setter-throws.trails.test.ts`
covering the `new`, `create`, and habtm arms — all three fail on baseline with
the exact `TypeError`; plus a guard test that an unrecognised `*Ids` key is still
reported unknown rather than rerouted.

Green locally: `base.test.ts`, `associations.test.ts`,
`has-many-associations.test.ts`, `has-many-through-associations.test.ts`,
`nested-attributes.test.ts`, `persistence.test.ts`, `transactions.test.ts`.
No test renames.

Closes-story: collection-ids-key-in-constructor-throws-typeerror
