### PR TITLE
test(tasks): dump schema cache off the ambient connection

### DIFF
--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -155,8 +155,6 @@ describe("DatabaseTasksRegisterTask", () => {
 });
 
 describe("DatabaseTasksDumpSchemaCacheTest", () => {
-  // Rails' `ActiveRecord::Base.lease_connection`: the ambient arunit
-  // connection, not a per-test one.
   fixtures([]);
 
   let originalSchema: string | undefined;

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -9,6 +9,7 @@ import { NoEnvironmentInSchemaError, ProtectedEnvironmentError } from "../migrat
 import { SchemaMigration } from "../schema-migration.js";
 import { Base } from "../base.js";
 import { adapterType, inMemoryDb } from "../test-adapter.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 
 describe("DatabaseTasksCheckProtectedEnvironmentsTest", () => {
   it("raises an error when called with protected environment", async () => {
@@ -154,6 +155,10 @@ describe("DatabaseTasksRegisterTask", () => {
 });
 
 describe("DatabaseTasksDumpSchemaCacheTest", () => {
+  // Rails' `ActiveRecord::Base.lease_connection`: the ambient arunit
+  // connection, not a per-test one.
+  fixtures([]);
+
   let originalSchema: string | undefined;
   let originalDbDir: string;
 
@@ -171,19 +176,13 @@ describe("DatabaseTasksDumpSchemaCacheTest", () => {
   it("dump schema cache", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-dump-sc-"));
     const cachePath = path.join(tmp, "schema_cache.json");
-    const dbFile = path.join(tmp, "arunit.sqlite3");
-    await Base.establishConnection({ adapter: "sqlite3", database: dbFile, pool: 1 });
     try {
       expect(fs.existsSync(cachePath)).toBe(false);
-      const adapter = await Base.connectionPool().leaseConnection();
+      const adapter = await Base.leaseConnection();
       await DatabaseTasks.dumpSchemaCache(adapter, cachePath);
       expect(fs.existsSync(cachePath)).toBe(true);
     } finally {
-      try {
-        Base.removeConnection();
-      } catch {
-        /* ignore */
-      }
+      Base.clearCacheBang();
       fs.rmSync(tmp, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
Rails' `test_dump_schema_cache` (`vendor/rails/activerecord/test/cases/tasks/database_tasks_test.rb:288`) establishes nothing — it dumps off the ambient arunit connection via `ActiveRecord::Base.lease_connection`, and its `ensure` block calls `ActiveRecord::Base.clear_cache!`.

Ours established a private file-backed SQLite connection and tore it down with `removeConnection`, so the dumped schema cache was never cleared and could leak into a later test in the same worker.

- `DatabaseTasksDumpSchemaCacheTest` declares `fixtures([])` for the ambient connection (same pattern as #5287).
- The test leases via `Base.leaseConnection()` instead of establishing its own config.
- Teardown mirrors Rails' `ensure`: `Base.clearCacheBang()`.
- The case now exercises all three lane adapters instead of SQLite only.

Test name unchanged, so the `test:compare` delta is zero by construction. Verified green locally on SQLite, PostgreSQL, and MySQL (whole file, 76-77 passed / 1-2 skipped each).

Closes-story: database-tasks-dump-schema-cache-ambient-connection
