### PR TITLE
test(database-tasks): share the DatabaseTasksMigrationTestCase setup

### DIFF
--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -749,6 +749,21 @@ async function backupIntoConnection(sourceFile: string): Promise<void> {
           `SELECT ${columnList.join(", ")} FROM backupSource.${table}`,
       );
     }
+    // `sqlite_master` hides internal tables behind the `sqlite_%` filter above,
+    // but Rails' page-level backup carries `sqlite_sequence` across, and the
+    // canonical schema's primary keys are `INTEGER PRIMARY KEY AUTOINCREMENT`
+    // (schema-creation.ts:502) — so dropping it would reset every AUTOINCREMENT
+    // counter relative to Rails. It materializes in the destination as soon as
+    // the first AUTOINCREMENT table is created above.
+    const [[sequences]] = await adapter.selectRows(
+      "SELECT count(*) FROM backupSource.sqlite_master WHERE name = 'sqlite_sequence'",
+    );
+    if (Number(sequences) > 0) {
+      await adapter.executeMutation("DELETE FROM main.sqlite_sequence");
+      await adapter.executeMutation(
+        "INSERT INTO main.sqlite_sequence (name, seq) SELECT name, seq FROM backupSource.sqlite_sequence",
+      );
+    }
   } finally {
     await adapter.execute("DETACH DATABASE backupSource");
   }

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -8,7 +8,8 @@ import { DatabaseConfigurations } from "../database-configurations.js";
 import { NoEnvironmentInSchemaError, ProtectedEnvironmentError } from "../migration.js";
 import { SchemaMigration } from "../schema-migration.js";
 import { Base } from "../base.js";
-import { adapterType, inMemoryDb } from "../test-adapter.js";
+import { adapterType, ambientPoolConfiguration, inMemoryDb } from "../test-adapter.js";
+import { establishFromTestConfig } from "../test-helpers/test-database-config.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 
 describe("DatabaseTasksCheckProtectedEnvironmentsTest", () => {
@@ -692,78 +693,167 @@ describe("DatabaseTasksDropCurrentThreeTierTest", () => {
   });
 });
 
-describe("DatabaseTasksMigrateTest", () => {
-  let originalVersion: string | undefined;
+/**
+ * Rails: `DatabaseTasksMigrationTestCase`
+ * (vendor/rails/activerecord/test/cases/tasks/database_tasks_test.rb:1029-1060)
+ * — the shared base of the Migrate / MigrateScope / MigrateStatus tests. Its
+ * setup connects to a memory DB "to avoid having to rollback at the end", then
+ * copies the ambient file DB into it with `SQLite3::Backup`; its teardown
+ * re-establishes `:arunit`.
+ *
+ * `self.use_transactional_tests = false` needs no analogue: trails tests are
+ * non-transactional unless they opt in via `useTransactionalTests()`. The
+ * `folder_name` class attribute likewise has none — trails migrations are
+ * registered programmatically with `DatabaseTasks.registerMigrations` rather
+ * than read from `MIGRATIONS_ROOT/<folder_name>`.
+ */
+const skipMigrationTestCase = adapterType !== "sqlite" || inMemoryDb();
+
+interface MigrationTestCase {
+  /** Rails: `capture_migration_output` (database_tasks_test.rb:1056-1060). */
+  captureMigrationOutput(): Promise<string>;
+  /** Everything the case has written to stdout since the last capture. */
+  output(): string;
+}
+
+/**
+ * Port of the `SQLite3::Backup` step (database_tasks_test.rb:1041-1046). The
+ * sqlite3 driver exposes no backup API here, so the copy runs at the SQL
+ * level: attach the ambient file DB, replay its schema into the memory DB, and
+ * copy every table's rows. Same observable result — the memory DB starts as a
+ * copy of the fixture database rather than empty.
+ */
+async function backupIntoConnection(sourceFile: string): Promise<void> {
+  const adapter = await Base.connectionPool().leaseConnection();
+  await adapter.execute(`ATTACH DATABASE ${adapter.quote(sourceFile)} AS backupSource`);
+  try {
+    const objects = await adapter.selectRows(
+      "SELECT type, name, sql FROM backupSource.sqlite_master " +
+        "WHERE sql IS NOT NULL AND name NOT LIKE 'sqlite_%'",
+    );
+    for (const [, , sql] of objects) {
+      await adapter.execute(String(sql));
+    }
+    for (const [type, name] of objects) {
+      if (type !== "table") continue;
+      await adapter.executeMutation(
+        `INSERT INTO main.${adapter.quoteTableName(String(name))} ` +
+          `SELECT * FROM backupSource.${adapter.quoteTableName(String(name))}`,
+      );
+    }
+  } finally {
+    await adapter.execute("DETACH DATABASE backupSource");
+  }
+}
+
+function databaseTasksMigrationTestCase(): MigrationTestCase {
+  let stdoutChunks: string[] = [];
+  let stdoutSpy: MockInstance | undefined;
+
   beforeEach(async () => {
-    originalVersion = process.env.VERSION;
-    await Base.establishConnection({ adapter: "sqlite3", database: ":memory:", pool: 1 });
+    if (skipMigrationTestCase) return;
+    stdoutChunks = [];
+    // `Migration.logger` writes straight to `process.stdout` (activesupport
+    // logger.ts:64), so the capture has to sit there rather than on the
+    // activesupport `stdout` shim — both funnel through this write.
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdoutChunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return true;
+    });
+    const ambient = ambientPoolConfiguration();
+    const sourceFile = String(ambient.database);
+    await Base.establishConnection({ ...ambient, database: ":memory:", pool: 1 });
+    // Rails leaves the ambient `arunit` configurations in place while the
+    // connection is `:memory:`; trails' `migrate` picks its pool by comparing
+    // the config's database to the pool's, so the ambient shape is carried
+    // over with the connected database substituted in.
+    DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
+      [DatabaseTasks.env]: { ...ambient, database: ":memory:" },
+    });
+    await backupIntoConnection(sourceFile);
   });
-  afterEach(() => {
-    if (originalVersion === undefined) delete process.env.VERSION;
-    else process.env.VERSION = originalVersion;
+
+  afterEach(async () => {
+    stdoutSpy?.mockRestore();
+    stdoutSpy = undefined;
     DatabaseTasks.registerMigrations([]);
+    DatabaseTasks.databaseConfiguration = null;
+    DatabaseTasks.clearRegisteredTasks();
     try {
       Base.removeConnection();
     } catch {
       /* no pool */
     }
-    DatabaseTasks.databaseConfiguration = null;
-    DatabaseTasks.clearRegisteredTasks();
+    if (!skipMigrationTestCase) await establishFromTestConfig();
   });
 
-  it("migrate set and unset empty values for verbose and version env vars", async () => {
-    DatabaseTasks.registerTask("sqlite", { create: async () => {} });
-    DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
-      development: { adapter: "sqlite3", database: ":memory:" },
-    });
-    let migrated = false;
-    DatabaseTasks.registerMigrations([
-      {
-        version: "1",
-        name: "M1",
-        migration: () => ({
-          up: async () => {
-            migrated = true;
-          },
-          down: async () => {},
-        }),
-      },
-    ]);
-    process.env.VERSION = "";
-    await DatabaseTasks.migrate();
-    expect(migrated).toBe(true);
+  return {
+    async captureMigrationOutput() {
+      stdoutChunks = [];
+      await DatabaseTasks.migrate();
+      return stdoutChunks.join("");
+    },
+    output() {
+      return stdoutChunks.join("");
+    },
+  };
+}
+
+describe("DatabaseTasksMigrateTest", () => {
+  let originalVersion: string | undefined;
+  databaseTasksMigrationTestCase();
+
+  beforeEach(() => {
+    originalVersion = process.env.VERSION;
+  });
+  afterEach(() => {
+    if (originalVersion === undefined) delete process.env.VERSION;
+    else process.env.VERSION = originalVersion;
   });
 
-  it("migrate set and unset nonsense values for verbose and version env vars", async () => {
-    process.env.VERSION = "nonsense";
-    await expect(DatabaseTasks.migrate()).rejects.toThrow(/Invalid format/);
-  });
+  it.skipIf(skipMigrationTestCase)(
+    "migrate set and unset empty values for verbose and version env vars",
+    async () => {
+      DatabaseTasks.registerTask("sqlite", { create: async () => {} });
+      let migrated = false;
+      DatabaseTasks.registerMigrations([
+        {
+          version: "1",
+          name: "M1",
+          migration: () => ({
+            up: async () => {
+              migrated = true;
+            },
+            down: async () => {},
+          }),
+        },
+      ]);
+      process.env.VERSION = "";
+      await DatabaseTasks.migrate();
+      expect(migrated).toBe(true);
+    },
+  );
+
+  it.skipIf(skipMigrationTestCase)(
+    "migrate set and unset nonsense values for verbose and version env vars",
+    async () => {
+      process.env.VERSION = "nonsense";
+      await expect(DatabaseTasks.migrate()).rejects.toThrow(/Invalid format/);
+    },
+  );
 });
 
 describe("DatabaseTasksMigrateScopeTest", () => {
   let originalVerbose: string | undefined;
   let originalVersion: string | undefined;
   let originalScope: string | undefined;
-  let stdoutChunks: string[];
-  let stdoutSpy: { mockRestore: () => void };
-  let tmpDir: string;
-  let dbFile: string;
+  const testCase = databaseTasksMigrationTestCase();
 
-  beforeEach(async () => {
+  beforeEach(() => {
+    if (skipMigrationTestCase) return;
     originalVerbose = process.env.VERBOSE;
     originalVersion = process.env.VERSION;
     originalScope = process.env.SCOPE;
-    stdoutChunks = [];
-    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
-      stdoutChunks.push(typeof chunk === "string" ? chunk : chunk.toString());
-      return true;
-    });
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-scope-"));
-    dbFile = path.join(tmpDir, "scope.sqlite3");
-    await Base.establishConnection({ adapter: "sqlite3", database: dbFile, pool: 1 });
-    DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
-      development: { adapter: "sqlite3", database: dbFile },
-    });
     DatabaseTasks.registerMigrations([
       {
         version: "1",
@@ -780,86 +870,57 @@ describe("DatabaseTasksMigrateScopeTest", () => {
   });
 
   afterEach(() => {
-    stdoutSpy.mockRestore();
     if (originalVerbose === undefined) delete process.env.VERBOSE;
     else process.env.VERBOSE = originalVerbose;
     if (originalVersion === undefined) delete process.env.VERSION;
     else process.env.VERSION = originalVersion;
     if (originalScope === undefined) delete process.env.SCOPE;
     else process.env.SCOPE = originalScope;
-    DatabaseTasks.registerMigrations([]);
-    try {
-      Base.removeConnection();
-    } catch {
-      /* no pool */
-    }
-    DatabaseTasks.databaseConfiguration = null;
-    try {
-      fs.rmSync(tmpDir, { recursive: true });
-    } catch {
-      /* ignore */
-    }
   });
 
-  it("migrate using scope and verbose mode", async () => {
+  it.skipIf(skipMigrationTestCase)("migrate using scope and verbose mode", async () => {
     process.env.VERSION = "2";
     process.env.VERBOSE = "true";
     process.env.SCOPE = "mysql";
 
-    await DatabaseTasks.migrate();
-    const output1 = stdoutChunks.join("");
+    const output1 = await testCase.captureMigrationOutput();
     expect(output1).toContain("migrating");
     expect(output1).not.toContain("No migrations ran. (using mysql scope)");
 
-    stdoutChunks = [];
-    await DatabaseTasks.migrate();
-    const output2 = stdoutChunks.join("");
+    const output2 = await testCase.captureMigrationOutput();
     expect(output2).toContain("No migrations ran. (using mysql scope)");
     expect(output2).not.toContain("migrating");
   });
 
-  it("migrate using scope and non verbose mode", async () => {
+  it.skipIf(skipMigrationTestCase)("migrate using scope and non verbose mode", async () => {
     process.env.VERSION = "2";
     process.env.VERBOSE = "false";
     process.env.SCOPE = "mysql";
 
-    await DatabaseTasks.migrate();
-    expect(stdoutChunks.join("")).toBe("");
-
-    stdoutChunks = [];
-    await DatabaseTasks.migrate();
-    expect(stdoutChunks.join("")).toBe("");
+    expect(await testCase.captureMigrationOutput()).toBe("");
+    expect(await testCase.captureMigrationOutput()).toBe("");
   });
 
-  it("migrate using empty scope and verbose mode", async () => {
+  it.skipIf(skipMigrationTestCase)("migrate using empty scope and verbose mode", async () => {
     process.env.VERSION = "2";
     process.env.VERBOSE = "true";
     process.env.SCOPE = "";
 
-    await DatabaseTasks.migrate();
-    const output1 = stdoutChunks.join("");
+    const output1 = await testCase.captureMigrationOutput();
     expect(output1).toContain("migrating");
     expect(output1).not.toContain("No migrations ran. (using mysql scope)");
 
-    stdoutChunks = [];
-    await DatabaseTasks.migrate();
-    const output2 = stdoutChunks.join("");
+    const output2 = await testCase.captureMigrationOutput();
     expect(output2).toBe("");
     expect(output2).not.toContain("No migrations ran. (using mysql scope)");
   });
 });
 
 describe("DatabaseTasksMigrateStatusTest", () => {
-  let stdoutChunks: string[];
-  let stdoutSpy: MockInstance;
+  const testCase = databaseTasksMigrationTestCase();
 
   beforeEach(async () => {
-    stdoutChunks = [];
-    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
-      stdoutChunks.push(typeof chunk === "string" ? chunk : chunk.toString());
-      return true;
-    });
-    await Base.establishConnection({ adapter: "sqlite3", database: ":memory:", pool: 1 });
+    if (skipMigrationTestCase) return;
     // Mirror Rails test setup: @schema_migration.create_table (database_tasks_test.rb:1169)
     const pool = Base.connectionPool();
     await new SchemaMigration(await pool.leaseConnection()).createTable();
@@ -882,19 +943,9 @@ describe("DatabaseTasksMigrateStatusTest", () => {
     ]);
   });
 
-  afterEach(() => {
-    stdoutSpy.mockRestore();
-    DatabaseTasks.registerMigrations([]);
-    try {
-      Base.removeConnection();
-    } catch {
-      /* no pool */
-    }
-  });
-
-  it("migrate status table", async () => {
+  it.skipIf(skipMigrationTestCase)("migrate status table", async () => {
     await DatabaseTasks.migrateStatus();
-    const output = stdoutChunks.join("");
+    const output = testCase.output();
     expect(output).toMatch(/database: :memory:/);
     expect(output).toMatch(/down\s+001\s+Valid people have last names/);
     expect(output).toMatch(/down\s+002\s+We need reminders/);

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -712,8 +712,8 @@ const skipMigrationTestCase = adapterType !== "sqlite" || inMemoryDb();
 interface MigrationTestCase {
   /** Rails: `capture_migration_output` (database_tasks_test.rb:1056-1060). */
   captureMigrationOutput(): Promise<string>;
-  /** Everything the case has written to stdout since the last capture. */
-  output(): string;
+  /** Rails: `capture(:stdout) { ... }` (activesupport test helper). */
+  captureStdout(fn: () => Promise<void>): Promise<string>;
 }
 
 /**
@@ -736,9 +736,17 @@ async function backupIntoConnection(sourceFile: string): Promise<void> {
     }
     for (const [type, name] of objects) {
       if (type !== "table") continue;
+      const table = adapter.quoteTableName(String(name));
+      // Column list rather than `SELECT *`: `pragma_table_info` omits generated
+      // columns, which cannot be inserted into.
+      const columns = await adapter.selectRows(
+        `SELECT name FROM pragma_table_info(${adapter.quote(String(name))}, 'backupSource')`,
+      );
+      const columnList = columns.map(([column]) => adapter.quoteColumnName(String(column)));
+      if (columnList.length === 0) continue;
       await adapter.executeMutation(
-        `INSERT INTO main.${adapter.quoteTableName(String(name))} ` +
-          `SELECT * FROM backupSource.${adapter.quoteTableName(String(name))}`,
+        `INSERT INTO main.${table} (${columnList.join(", ")}) ` +
+          `SELECT ${columnList.join(", ")} FROM backupSource.${table}`,
       );
     }
   } finally {
@@ -787,15 +795,15 @@ function databaseTasksMigrationTestCase(): MigrationTestCase {
     if (!skipMigrationTestCase) await establishFromTestConfig();
   });
 
+  const captureStdout = async (fn: () => Promise<void>): Promise<string> => {
+    stdoutChunks = [];
+    await fn();
+    return stdoutChunks.join("");
+  };
+
   return {
-    async captureMigrationOutput() {
-      stdoutChunks = [];
-      await DatabaseTasks.migrate();
-      return stdoutChunks.join("");
-    },
-    output() {
-      return stdoutChunks.join("");
-    },
+    captureStdout,
+    captureMigrationOutput: () => captureStdout(() => DatabaseTasks.migrate()),
   };
 }
 
@@ -944,8 +952,7 @@ describe("DatabaseTasksMigrateStatusTest", () => {
   });
 
   it.skipIf(skipMigrationTestCase)("migrate status table", async () => {
-    await DatabaseTasks.migrateStatus();
-    const output = testCase.output();
+    const output = await testCase.captureStdout(() => DatabaseTasks.migrateStatus());
     expect(output).toMatch(/database: :memory:/);
     expect(output).toMatch(/down\s+001\s+Valid people have last names/);
     expect(output).toMatch(/down\s+002\s+We need reminders/);

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -329,12 +329,12 @@ export class DatabaseTasks {
       pool &&
       (!pool.dbConfig.database || !config.database || config.database === pool.dbConfig.database)
     ) {
-      const adapter = await pool.leaseConnection();
-      // Probe through the established connection rather than a temporary one:
-      // a second pool on a `:memory:` database discards the data the first one
-      // holds, so the initialize step would wipe every previous migration.
-      if (!skipInitialize) await initializeDatabaseOn(adapter, config);
-      await runMigration(adapter);
+      // Rails: `initialize_database(migration_connection_pool.db_config)`
+      // (tasks/database_tasks.rb:268) — the pool's OWN config object, so the
+      // temporary pool it opens resolves to the established pool rather than a
+      // second one.
+      if (!skipInitialize) await initializeDatabase(pool.dbConfig);
+      await runMigration(await pool.leaseConnection());
     } else {
       // Multi-db or no pool: withTemporaryConnection scopes the adapter lifecycle.
       if (!skipInitialize) await initializeDatabase(config);
@@ -1098,14 +1098,28 @@ export class DatabaseTasks {
     }
     const rawConfiguration = config.configuration as Record<string, unknown>;
     const configuration = _normalizeSQLitePath(rawConfiguration, this.root);
+    // Rails passes the `DatabaseConfig` object itself
+    // (tasks/database_tasks.rb:652), which is what lets
+    // `ConnectionHandler#establish_connection` recognise an already-established
+    // pool for the same config and reuse it instead of opening a second one
+    // (connection_adapters/abstract/connection_handler.rb:139). Handing over a
+    // plain hash would mint a fresh `HashConfig` that can never match, and a
+    // second pool on a `:memory:` database discards the first one's data.
+    // The normalized hash is only used when path resolution actually rewrote
+    // something, since that rewrite has no config-object form.
+    const target = configuration === rawConfiguration ? config : configuration;
     // Mirrors Rails' `ensure` which restores even if establish_connection raises.
     try {
-      await Base.establishConnection(configuration);
+      await Base.establishConnection(target);
       const pool = Base.connectionPool();
       return await fn(pool);
     } finally {
       if (priorConfig !== null) {
-        await Base.establishConnection(priorConfig.configuration as Record<string, unknown>);
+        // Same reason as above: restoring through the config OBJECT lets the
+        // handler recognise the pool it already has. Restoring from a plain
+        // hash would replace (and disconnect) it, which on a `:memory:`
+        // database throws the data away.
+        await Base.establishConnection(priorConfig);
       } else {
         try {
           Base.removeConnection();
@@ -1483,50 +1497,36 @@ export async function checkCurrentProtectedEnvironmentBang(
 
 /** @internal */
 export async function initializeDatabase(dbConfig: DatabaseConfig): Promise<boolean> {
-  return DatabaseTasks.withTemporaryConnection(dbConfig, (adapter) =>
-    initializeDatabaseOn(adapter, dbConfig),
-  );
-}
-
-/**
- * The body of {@link initializeDatabase}, run on a caller-supplied connection.
- * `migrate` uses this to probe through the already-established pool when that
- * pool serves the same database: opening a second pool on a `:memory:` database
- * destroys the first one's data, so the probe must not own its own connection
- * when a matching one exists.
- */
-async function initializeDatabaseOn(
-  adapter: import("../connection-adapters/abstract-adapter.js").AbstractAdapter,
-  dbConfig: DatabaseConfig,
-): Promise<boolean> {
-  const { NoDatabaseError } = await import("../errors.js");
-  const { SchemaMigration } = await import("../schema-migration.js");
-  let alreadyInitialized = false;
-  try {
-    // Probe DB connectivity first — throws NoDatabaseError if the DB doesn't exist.
-    // tableExists() swallows all errors internally so can't detect a missing DB.
-    await adapter.execute("SELECT 1");
-    const sm = new SchemaMigration(adapter);
-    alreadyInitialized = await sm.tableExists();
-  } catch (error) {
-    if (error instanceof NoDatabaseError || _isMissingDatabaseError(error, adapter)) {
-      await DatabaseTasks.create(dbConfig);
-    } else {
-      throw error;
-    }
-  }
-  if (!alreadyInitialized) {
-    const rawPath = DatabaseTasks.schemaDumpPath(dbConfig);
-    if (rawPath) {
-      const p = getPath();
-      const resolved =
-        p.isAbsolute && !p.isAbsolute(rawPath) ? p.resolve(DatabaseTasks.root, rawPath) : rawPath;
-      if (getFs().existsSync(resolved)) {
-        await DatabaseTasks.loadSchema(dbConfig, DatabaseTasks.schemaFormat, resolved);
+  return DatabaseTasks.withTemporaryConnection(dbConfig, async (adapter) => {
+    const { NoDatabaseError } = await import("../errors.js");
+    const { SchemaMigration } = await import("../schema-migration.js");
+    let alreadyInitialized = false;
+    try {
+      // Probe DB connectivity first — throws NoDatabaseError if the DB doesn't exist.
+      // tableExists() swallows all errors internally so can't detect a missing DB.
+      await adapter.execute("SELECT 1");
+      const sm = new SchemaMigration(adapter);
+      alreadyInitialized = await sm.tableExists();
+    } catch (error) {
+      if (error instanceof NoDatabaseError || _isMissingDatabaseError(error, adapter)) {
+        await DatabaseTasks.create(dbConfig);
+      } else {
+        throw error;
       }
     }
-  }
-  return !alreadyInitialized;
+    if (!alreadyInitialized) {
+      const rawPath = DatabaseTasks.schemaDumpPath(dbConfig);
+      if (rawPath) {
+        const p = getPath();
+        const resolved =
+          p.isAbsolute && !p.isAbsolute(rawPath) ? p.resolve(DatabaseTasks.root, rawPath) : rawPath;
+        if (getFs().existsSync(resolved)) {
+          await DatabaseTasks.loadSchema(dbConfig, DatabaseTasks.schemaFormat, resolved);
+        }
+      }
+    }
+    return !alreadyInitialized;
+  });
 }
 
 // Mirrors SQLite3Adapter._isMemoryFilename: `:memory:`, `file::memory:`, and

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -1494,10 +1494,8 @@ export async function initializeDatabase(dbConfig: DatabaseConfig): Promise<bool
  * pool serves the same database: opening a second pool on a `:memory:` database
  * destroys the first one's data, so the probe must not own its own connection
  * when a matching one exists.
- *
- * @internal
  */
-export async function initializeDatabaseOn(
+async function initializeDatabaseOn(
   adapter: import("../connection-adapters/abstract-adapter.js").AbstractAdapter,
   dbConfig: DatabaseConfig,
 ): Promise<boolean> {

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -275,10 +275,6 @@ export class DatabaseTasks {
 
     const config = configs.find((c) => c.name === "primary") ?? configs[0];
 
-    if (!skipInitialize) {
-      await initializeDatabase(config);
-    }
-
     const { Migrator, Migration } = await import("../migration.js");
     const scope = getEnv("SCOPE");
     const verbose = isVerbose();
@@ -333,9 +329,15 @@ export class DatabaseTasks {
       pool &&
       (!pool.dbConfig.database || !config.database || config.database === pool.dbConfig.database)
     ) {
-      await runMigration(await pool.leaseConnection());
+      const adapter = await pool.leaseConnection();
+      // Probe through the established connection rather than a temporary one:
+      // a second pool on a `:memory:` database discards the data the first one
+      // holds, so the initialize step would wipe every previous migration.
+      if (!skipInitialize) await initializeDatabaseOn(adapter, config);
+      await runMigration(adapter);
     } else {
       // Multi-db or no pool: withTemporaryConnection scopes the adapter lifecycle.
+      if (!skipInitialize) await initializeDatabase(config);
       await this.withTemporaryConnection(config, runMigration);
     }
   }
@@ -1481,36 +1483,52 @@ export async function checkCurrentProtectedEnvironmentBang(
 
 /** @internal */
 export async function initializeDatabase(dbConfig: DatabaseConfig): Promise<boolean> {
-  return DatabaseTasks.withTemporaryConnection(dbConfig, async (adapter) => {
-    const { NoDatabaseError } = await import("../errors.js");
-    const { SchemaMigration } = await import("../schema-migration.js");
-    let alreadyInitialized = false;
-    try {
-      // Probe DB connectivity first — throws NoDatabaseError if the DB doesn't exist.
-      // tableExists() swallows all errors internally so can't detect a missing DB.
-      await adapter.execute("SELECT 1");
-      const sm = new SchemaMigration(adapter);
-      alreadyInitialized = await sm.tableExists();
-    } catch (error) {
-      if (error instanceof NoDatabaseError || _isMissingDatabaseError(error, adapter)) {
-        await DatabaseTasks.create(dbConfig);
-      } else {
-        throw error;
+  return DatabaseTasks.withTemporaryConnection(dbConfig, (adapter) =>
+    initializeDatabaseOn(adapter, dbConfig),
+  );
+}
+
+/**
+ * The body of {@link initializeDatabase}, run on a caller-supplied connection.
+ * `migrate` uses this to probe through the already-established pool when that
+ * pool serves the same database: opening a second pool on a `:memory:` database
+ * destroys the first one's data, so the probe must not own its own connection
+ * when a matching one exists.
+ *
+ * @internal
+ */
+export async function initializeDatabaseOn(
+  adapter: import("../connection-adapters/abstract-adapter.js").AbstractAdapter,
+  dbConfig: DatabaseConfig,
+): Promise<boolean> {
+  const { NoDatabaseError } = await import("../errors.js");
+  const { SchemaMigration } = await import("../schema-migration.js");
+  let alreadyInitialized = false;
+  try {
+    // Probe DB connectivity first — throws NoDatabaseError if the DB doesn't exist.
+    // tableExists() swallows all errors internally so can't detect a missing DB.
+    await adapter.execute("SELECT 1");
+    const sm = new SchemaMigration(adapter);
+    alreadyInitialized = await sm.tableExists();
+  } catch (error) {
+    if (error instanceof NoDatabaseError || _isMissingDatabaseError(error, adapter)) {
+      await DatabaseTasks.create(dbConfig);
+    } else {
+      throw error;
+    }
+  }
+  if (!alreadyInitialized) {
+    const rawPath = DatabaseTasks.schemaDumpPath(dbConfig);
+    if (rawPath) {
+      const p = getPath();
+      const resolved =
+        p.isAbsolute && !p.isAbsolute(rawPath) ? p.resolve(DatabaseTasks.root, rawPath) : rawPath;
+      if (getFs().existsSync(resolved)) {
+        await DatabaseTasks.loadSchema(dbConfig, DatabaseTasks.schemaFormat, resolved);
       }
     }
-    if (!alreadyInitialized) {
-      const rawPath = DatabaseTasks.schemaDumpPath(dbConfig);
-      if (rawPath) {
-        const p = getPath();
-        const resolved =
-          p.isAbsolute && !p.isAbsolute(rawPath) ? p.resolve(DatabaseTasks.root, rawPath) : rawPath;
-        if (getFs().existsSync(resolved)) {
-          await DatabaseTasks.loadSchema(dbConfig, DatabaseTasks.schemaFormat, resolved);
-        }
-      }
-    }
-    return !alreadyInitialized;
-  });
+  }
+  return !alreadyInitialized;
 }
 
 // Mirrors SQLite3Adapter._isMemoryFilename: `:memory:`, `file::memory:`, and


### PR DESCRIPTION
Ports Rails' `DatabaseTasksMigrationTestCase`
(`vendor/rails/activerecord/test/cases/tasks/database_tasks_test.rb:1029-1060`)
as a shared helper backing the Migrate / MigrateScope / MigrateStatus describes,
replacing three divergent per-describe setups.

- One `:memory:` connection per test ("to avoid having to rollback at the end"),
  with the ambient config shape carried over — the invented
  `development: { database: ":memory:" }` config and the bespoke temp-file DB in
  the scope test are gone.
- The `SQLite3::Backup` step is ported: the sqlite driver exposes no backup API,
  so the copy runs at the SQL level (`ATTACH` the ambient file DB, replay its
  schema, copy every table's rows plus `sqlite_sequence`). The memory DB now
  starts as a copy of the fixture database rather than empty.
- `capture_migration_output` and the `establish_connection :arunit` teardown are
  ported; the Rails guard `current_adapter?(:SQLite3Adapter) && !in_memory_db?`
  is applied per test.

Reusing one memory DB across two `migrate()` calls surfaced a real bug, and it
is fixed at its root rather than at the call site. Rails' `with_temporary_pool`
passes the `DatabaseConfig` **object** to `establish_connection`
(`tasks/database_tasks.rb:652`), which is what lets
`ConnectionHandler#establish_connection` recognise an already-established pool
for the same config and reuse it (`connection_handler.rb:139`). trails handed
over a plain hash on both the entry and the restore path, so `resolvePoolConfig`
always minted a fresh `HashConfig`, the identity check in
`connection-handler.ts:137` could never match, and every temporary pool replaced
— and disconnected — the ambient one. On a `:memory:` database that throws the
data away, so each `migrate()` wiped every previously recorded migration.

`withTemporaryPool` now passes the config object through on both paths, so the
reuse applies to *every* temporary-pool caller, and `migrate()` initializes from
`migration_connection_pool.db_config` exactly as Rails does
(`tasks/database_tasks.rb:268`) instead of a bespoke per-call-site branch.

Test names unchanged; `test:compare` for `database_tasks_test.rb` is 77/77 with
0 missing, and the wide call-mismatch ratchet is clean.

Closes-story: database-tasks-migration-test-case-shared-setup
