### PR TITLE
perf(test-helpers): bulk reverse-FK lookup for the inbound scan

### DIFF
--- a/packages/activerecord/src/test-helpers/canonical-schema.test.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.test.ts
@@ -4,6 +4,7 @@ import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adap
 import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 import type { FkSafeDropPlanHost } from "./canonical-schema.js";
 import {
+  bulkInboundFkHost,
   ensureCanonicalTables,
   fkSafeDropPlan,
   loadCanonicalSchema,
@@ -259,6 +260,58 @@ describe("fkSafeDropPlan", () => {
       { scanInbound: true },
     );
     expect(plan.blockers).toEqual([{ fromTable: "outside", toTable: "a", name: "fk_outside_a" }]);
+  });
+});
+
+describe("bulkInboundFkHost", () => {
+  // Stands in for a live adapter: records the SQL it is handed and replays
+  // `rows` as the catalog result.
+  function fakeAdapter(adapterName: string, rows: Record<string, unknown>[] = []) {
+    const queries: string[] = [];
+    const adapter = {
+      adapterName,
+      quote: (value: unknown) => `'${String(value)}'`,
+      schemaQuery: async (sql: string) => {
+        queries.push(sql);
+        return rows;
+      },
+    } as unknown as AbstractAdapter;
+    return { adapter, queries };
+  }
+
+  const base: FkSafeDropPlanHost = { tables: async () => [], foreignKeys: async () => [] };
+
+  test("leaves the per-table host untouched on sqlite", () => {
+    const { adapter } = fakeAdapter("sqlite3");
+    expect(bulkInboundFkHost(adapter, base)).toBe(base);
+  });
+
+  test("asks the catalog once for every referenced table", async () => {
+    const { adapter, queries } = fakeAdapter("postgres");
+    await bulkInboundFkHost(adapter, base).foreignKeysReferencing!(["authors", "topics"]);
+    expect(queries).toHaveLength(1);
+    expect(queries[0]).toContain("'authors', 'topics'");
+    expect(queries[0]).toContain("pg_constraint");
+  });
+
+  test("collapses a composite foreign key to one blocker", async () => {
+    const row = {
+      from_table: "lessons_students",
+      to_table: "authors",
+      name: "fk_rails_13f362e4f5",
+    };
+    // MySQL's key_column_usage reports one row per constrained column.
+    const { adapter } = fakeAdapter("mysql", [row, { ...row }]);
+    const blockers = await bulkInboundFkHost(adapter, base).foreignKeysReferencing!(["authors"]);
+    expect(blockers).toEqual([
+      { fromTable: "lessons_students", toTable: "authors", name: "fk_rails_13f362e4f5" },
+    ]);
+  });
+
+  test("skips the catalog query when nothing is being dropped", async () => {
+    const { adapter, queries } = fakeAdapter("mysql");
+    expect(await bulkInboundFkHost(adapter, base).foreignKeysReferencing!([])).toEqual([]);
+    expect(queries).toEqual([]);
   });
 });
 

--- a/packages/activerecord/src/test-helpers/canonical-schema.test.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.test.ts
@@ -282,7 +282,7 @@ describe("bulkInboundFkHost", () => {
   const base: FkSafeDropPlanHost = { tables: async () => [], foreignKeys: async () => [] };
 
   test("leaves the per-table host untouched on sqlite", () => {
-    const { adapter } = fakeAdapter("sqlite3");
+    const { adapter } = fakeAdapter("sqlite");
     expect(bulkInboundFkHost(adapter, base)).toBe(base);
   });
 
@@ -290,8 +290,10 @@ describe("bulkInboundFkHost", () => {
     const { adapter, queries } = fakeAdapter("postgres");
     await bulkInboundFkHost(adapter, base).foreignKeysReferencing!(["authors", "topics"]);
     expect(queries).toHaveLength(1);
-    expect(queries[0]).toContain("'authors', 'topics'");
     expect(queries[0]).toContain("pg_constraint");
+    // Matched by resolved OID, not by name: `relname IN (...)` would also match
+    // a same-named table in another search-path schema.
+    expect(queries[0]).toContain("c.confrelid IN (to_regclass('authors'), to_regclass('topics'))");
   });
 
   test("collapses a composite foreign key to one blocker", async () => {

--- a/packages/activerecord/src/test-helpers/canonical-schema.test.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.test.ts
@@ -216,6 +216,50 @@ describe("fkSafeDropPlan", () => {
     });
     expect(plan.blockers).toEqual([{ fromTable: "outside", toTable: "a", name: "fk_outside_a" }]);
   });
+
+  test("uses the bulk reverse lookup for the inbound scan when the host offers one", async () => {
+    const calls: string[] = [];
+    const bulk: string[][] = [];
+    const base = host(["a", "b", "outside"], { outside: ["a"] });
+    const plan = await fkSafeDropPlan(
+      {
+        tables: base.tables,
+        foreignKeys: async (name) => {
+          calls.push(name);
+          return base.foreignKeys(name);
+        },
+        foreignKeysReferencing: async (toTables) => {
+          bulk.push([...toTables]);
+          return [{ fromTable: "outside", toTable: "a", name: "fk_outside_a" }];
+        },
+      },
+      ["a", "b"],
+      { scanInbound: true },
+    );
+    // Only the dropped set is introspected per-table; `outside` is never
+    // touched individually — that is the whole point of the bulk lookup.
+    expect(calls).toEqual(["a", "b"]);
+    expect(bulk).toEqual([["a", "b"]]);
+    expect(plan.blockers).toEqual([{ fromTable: "outside", toTable: "a", name: "fk_outside_a" }]);
+  });
+
+  test("ignores bulk-reported keys from tables inside the dropped set or already gone", async () => {
+    const base = host(["a", "b", "outside"], { outside: ["a"] });
+    const plan = await fkSafeDropPlan(
+      {
+        tables: base.tables,
+        foreignKeys: base.foreignKeys,
+        foreignKeysReferencing: async () => [
+          { fromTable: "b", toTable: "a", name: "fk_b_a" },
+          { fromTable: "dropped_already", toTable: "a", name: "fk_gone_a" },
+          { fromTable: "outside", toTable: "a", name: "fk_outside_a" },
+        ],
+      },
+      ["a", "b"],
+      { scanInbound: true },
+    );
+    expect(plan.blockers).toEqual([{ fromTable: "outside", toTable: "a", name: "fk_outside_a" }]);
+  });
 });
 
 // Read the live table-name set from sqlite_master.

--- a/packages/activerecord/src/test-helpers/canonical-schema.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.ts
@@ -2259,15 +2259,11 @@ export function bulkInboundFkHost(
 ): FkSafeDropPlanHost {
   const name = adapter.adapterName;
   if (name !== "postgres" && name !== "mysql") return ss;
-  const conn = adapter as unknown as {
-    schemaQuery(sql: string): Promise<Record<string, unknown>[]>;
-    quote(value: unknown): string;
-  };
   const foreignKeysReferencing = async (
     toTables: readonly string[],
   ): Promise<readonly FkDropBlocker[]> => {
     if (toTables.length === 0) return [];
-    const list = toTables.map((t) => conn.quote(t)).join(", ");
+    const list = toTables.map((t) => adapter.quote(t)).join(", ");
     const sql =
       name === "postgres"
         ? `SELECT t1.relname AS from_table, t2.relname AS to_table, c.conname AS name
@@ -2279,17 +2275,17 @@ export function bulkInboundFkHost(
                AND n.nspname = ANY (current_schemas(false))
                AND t2.relname IN (${list})
              ORDER BY c.conname`
-        : `SELECT DISTINCT kcu.table_name AS from_table,
-                    kcu.referenced_table_name AS to_table,
-                    kcu.constraint_name AS name
+        : `SELECT kcu.table_name AS from_table,
+                  kcu.referenced_table_name AS to_table,
+                  kcu.constraint_name AS name
              FROM information_schema.key_column_usage kcu
              WHERE kcu.table_schema = DATABASE()
                AND kcu.referenced_table_name IN (${list})
              ORDER BY kcu.constraint_name`;
-    const rows = await conn.schemaQuery(sql);
-    // A composite foreign key yields one catalog row per column on PostgreSQL
-    // (and, MySQL's DISTINCT notwithstanding, is worth collapsing once here):
-    // the plan wants one blocker per constraint.
+    const rows = await adapter.schemaQuery(sql);
+    // `key_column_usage` reports a composite foreign key as one row per column
+    // (the PG query joins no attribute rows, so it is already per-constraint);
+    // the plan wants one blocker per constraint either way.
     const seen = new Set<string>();
     const blockers: FkDropBlocker[] = [];
     for (const row of rows) {

--- a/packages/activerecord/src/test-helpers/canonical-schema.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.ts
@@ -2093,6 +2093,18 @@ export interface FkSafeDropPlanHost {
   foreignKeys(
     tableName: string,
   ): Promise<readonly { readonly toTable: string; readonly name: string }[]>;
+  /**
+   * Optional bulk reverse lookup: every foreign key in the database that points
+   * at one of `toTables`, in one round trip. Adapters that don't provide it fall
+   * back to the per-table `foreignKeys` loop, which is what this stands in for.
+   *
+   * No Rails counterpart — `SchemaStatements#foreign_keys` is per-table there
+   * too and Rails has no reverse form. It is supplied by
+   * {@link bulkInboundFkHost} rather than by an adapter, so the invention stays
+   * inside the test helper that needs it and no production adapter grows a
+   * surface Rails lacks.
+   */
+  foreignKeysReferencing?(toTables: readonly string[]): Promise<readonly FkDropBlocker[]>;
 }
 
 /**
@@ -2180,11 +2192,18 @@ export async function fkSafeDropPlan(
   if (!sawForeignKey && !scanInbound) return { order: [...names], blockers: [] };
 
   const blockers: FkDropBlocker[] = [];
-  for (const table of existing) {
-    if (inSet.has(table)) continue;
-    for (const fk of await ss.foreignKeys(table)) {
-      if (inSet.has(fk.toTable)) {
-        blockers.push({ fromTable: table, toTable: fk.toTable, name: fk.name });
+  if (ss.foreignKeysReferencing) {
+    for (const fk of await ss.foreignKeysReferencing(names)) {
+      if (inSet.has(fk.fromTable) || !existing.has(fk.fromTable)) continue;
+      blockers.push(fk);
+    }
+  } else {
+    for (const table of existing) {
+      if (inSet.has(table)) continue;
+      for (const fk of await ss.foreignKeys(table)) {
+        if (inSet.has(fk.toTable)) {
+          blockers.push({ fromTable: table, toTable: fk.toTable, name: fk.name });
+        }
       }
     }
   }
@@ -2213,6 +2232,84 @@ export async function fkSafeDropPlan(
   // reverse: the result drops referencers first.
   for (const name of names) visit(name);
   return { order: ordered.reverse(), blockers };
+}
+
+/**
+ * Wrap `ss` so {@link fkSafeDropPlan}'s inbound scan reads every referencing
+ * foreign key in one catalog query instead of one introspection per live table
+ * not being dropped.
+ *
+ * This is an invention with no Rails counterpart: Rails' `foreign_keys` is
+ * per-table and it has no reverse form, so nothing upstream can be ported here.
+ * It is justified by cost, not taste — on a loaded canonical database (322
+ * tables) the per-table loop measured ~790ms per `rebuildCanonicalTables` call
+ * on PostgreSQL and ~530ms on MySQL, and the helper is called 21 times across
+ * the suite. Keeping it here rather than on the adapters confines the invented
+ * surface to the test helper that needs it; `fkSafeDropPlan` still takes the
+ * plain per-table host and its unit tests exercise that path unchanged.
+ *
+ * SQLite is left on the loop: `PRAGMA foreign_key_list` has no reverse form and
+ * the loop is already in the noise there (measured within run-to-run variance).
+ *
+ * @internal
+ */
+export function bulkInboundFkHost(
+  adapter: DatabaseAdapter,
+  ss: FkSafeDropPlanHost,
+): FkSafeDropPlanHost {
+  const name = adapter.adapterName;
+  if (name !== "postgres" && name !== "mysql") return ss;
+  const conn = adapter as unknown as {
+    schemaQuery(sql: string): Promise<Record<string, unknown>[]>;
+    quote(value: unknown): string;
+  };
+  const foreignKeysReferencing = async (
+    toTables: readonly string[],
+  ): Promise<readonly FkDropBlocker[]> => {
+    if (toTables.length === 0) return [];
+    const list = toTables.map((t) => conn.quote(t)).join(", ");
+    const sql =
+      name === "postgres"
+        ? `SELECT t1.relname AS from_table, t2.relname AS to_table, c.conname AS name
+             FROM pg_constraint c
+             JOIN pg_class t1 ON c.conrelid = t1.oid
+             JOIN pg_class t2 ON c.confrelid = t2.oid
+             JOIN pg_namespace n ON c.connamespace = n.oid
+             WHERE c.contype = 'f'
+               AND n.nspname = ANY (current_schemas(false))
+               AND t2.relname IN (${list})
+             ORDER BY c.conname`
+        : `SELECT DISTINCT kcu.table_name AS from_table,
+                    kcu.referenced_table_name AS to_table,
+                    kcu.constraint_name AS name
+             FROM information_schema.key_column_usage kcu
+             WHERE kcu.table_schema = DATABASE()
+               AND kcu.referenced_table_name IN (${list})
+             ORDER BY kcu.constraint_name`;
+    const rows = await conn.schemaQuery(sql);
+    // A composite foreign key yields one catalog row per column on PostgreSQL
+    // (and, MySQL's DISTINCT notwithstanding, is worth collapsing once here):
+    // the plan wants one blocker per constraint.
+    const seen = new Set<string>();
+    const blockers: FkDropBlocker[] = [];
+    for (const row of rows) {
+      const blocker = {
+        fromTable: String(row.from_table),
+        toTable: String(row.to_table),
+        name: String(row.name),
+      };
+      const key = `${blocker.fromTable} ${blocker.name}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      blockers.push(blocker);
+    }
+    return blockers;
+  };
+  return {
+    tables: () => ss.tables(),
+    foreignKeys: (table) => ss.foreignKeys(table),
+    foreignKeysReferencing,
+  };
 }
 
 /**
@@ -2282,9 +2379,11 @@ export async function rebuildCanonicalTables(
   // a sibling test that left a stray foreign key pointing at a canonical table,
   // which is exactly the shape fkSafeDropPlan's default heuristic cannot see —
   // the dropped table holds no FK of its own, so nothing would trigger the scan.
-  // The scan costs one FK introspection per live table not being rebuilt.
+  // The scan costs one FK introspection per live table not being rebuilt, which
+  // is why the host is wrapped: on PG/MySQL bulkInboundFkHost collapses that
+  // into a single catalog query (see its note on the deviation).
   const plan = await fkSafeDropPlan(
-    ss,
+    bulkInboundFkHost(adapter, ss),
     defs.map((d) => d.name),
     { scanInbound: true },
   );

--- a/packages/activerecord/src/test-helpers/canonical-schema.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.ts
@@ -2266,20 +2266,35 @@ export function bulkInboundFkHost(
     const list = toTables.map((t) => adapter.quote(t)).join(", ");
     const sql =
       name === "postgres"
-        ? `SELECT t1.relname AS from_table, t2.relname AS to_table, c.conname AS name
+        ? // The referenced table is matched by OID via `to_regclass`, not by
+          // name: `relname IN (...)` scoped to the search path would match a
+          // same-named table in *any* schema on it and report a false-positive
+          // blocker (a real `decoy.authors` did, when this filtered on
+          // `nspname = ANY (current_schemas(false))`). `to_regclass` applies
+          // exactly PostgreSQL's own name resolution — first match on the search
+          // path, NULL when nothing resolves, which simply matches no row — so a
+          // drop-set name resolves to the one relation the DDL will drop, the
+          // same relation the per-table `foreignKeys` would have introspected.
+          `SELECT t1.relname AS from_table, t2.relname AS to_table, c.conname AS name
              FROM pg_constraint c
              JOIN pg_class t1 ON c.conrelid = t1.oid
              JOIN pg_class t2 ON c.confrelid = t2.oid
-             JOIN pg_namespace n ON c.connamespace = n.oid
              WHERE c.contype = 'f'
-               AND n.nspname = ANY (current_schemas(false))
-               AND t2.relname IN (${list})
+               AND c.confrelid IN (${toTables.map((t) => `to_regclass(${adapter.quote(t)})`).join(", ")})
              ORDER BY c.conname`
-        : `SELECT kcu.table_name AS from_table,
+        : // `referenced_column_name IS NOT NULL` and the schema scoping mirror
+          // the per-table `foreignKeys` (mysql/schema-statements.ts): the null
+          // check keeps non-FK key usage out, and scoping *both* ends to
+          // DATABASE() keeps a same-named table in another database from
+          // reporting a false-positive blocker (MySQL has no search path, so
+          // there is no resolution step beyond this).
+          `SELECT kcu.table_name AS from_table,
                   kcu.referenced_table_name AS to_table,
                   kcu.constraint_name AS name
              FROM information_schema.key_column_usage kcu
-             WHERE kcu.table_schema = DATABASE()
+             WHERE kcu.referenced_column_name IS NOT NULL
+               AND kcu.table_schema = DATABASE()
+               AND kcu.referenced_table_schema = DATABASE()
                AND kcu.referenced_table_name IN (${list})
              ORDER BY kcu.constraint_name`;
     const rows = await adapter.schemaQuery(sql);


### PR DESCRIPTION
## What

`rebuildCanonicalTables` calls `fkSafeDropPlan(..., { scanInbound: true })` (#5277), which
introspects foreign keys **once per live table not being rebuilt** to find a stray FK
reaching into the drop set. This story asked to measure that and batch it if material.

### Measurement (loaded canonical DB, 322 live tables, isolated compose stack)

| adapter | `rebuildCanonicalTables` before | after |
| --- | --- | --- |
| PostgreSQL | 806 / 836 / 856 ms | 91 / 53 / 53 ms |
| MySQL | 738 / 731 / 855 ms | 271 / 220 / 227 ms |

The scan itself was ~790 ms (PG) / ~530 ms (MySQL) per call, 21 call sites — material,
so the batching arm of the story applies rather than the no-work arm.

## How

`bulkInboundFkHost(adapter, ss)` wraps the host with an optional
`foreignKeysReferencing(toTables)` — one `pg_constraint` / `information_schema` query for
every FK pointing at the drop set. `fkSafeDropPlan` keeps its signature and its per-table
loop as the fallback for hosts without the method, so all existing unit tests exercise the
unchanged path. SQLite stays on the loop: `PRAGMA foreign_key_list` has no reverse form and
the scan is already within run-to-run variance there.

The invention (Rails' `foreign_keys` is per-table with no reverse form) is justified at its
definition and referenced from the `rebuildCanonicalTables` call site. It lives in the test
helper, not on the adapters, so no production adapter grows a surface Rails lacks.

`scanInbound: true` is untouched.

### Schema scoping

The referenced table is matched by **resolved identity**, not by name. Matching
`relname IN (...)` scoped to `current_schemas(false)` produced a real false positive: a
`decoy.authors` on the search path made its child a blocker for a rebuild of
`public.authors`. PG now matches `c.confrelid IN (to_regclass(...))` — PostgreSQL's own
resolution, so a drop-set name resolves to the one relation the DDL will drop, which is the
same relation the per-table `foreignKeys` would have introspected. MySQL has no search path,
so it scopes `referenced_table_schema` to `DATABASE()` (and requires
`referenced_column_name IS NOT NULL`), mirroring `mysql/schema-statements.ts`.

## Testing

- `canonical-schema.test.ts` (22 passed). Two cases pin the `fkSafeDropPlan` seam — the bulk
  lookup replaces the per-table outside scan, and in-set / already-gone referencers are
  filtered out of its result. Four more pin `bulkInboundFkHost` itself: SQLite gets the
  unwrapped host back, the catalog is asked exactly once for all referenced tables, a
  composite key (one `key_column_usage` row per column) collapses to one blocker, and an
  empty drop set issues no query.
- Verified on real PG that a same-named `decoy.authors` on the search path is **not**
  reported, and on real MySQL that a same-named `decoy_db.authors` is not either — both
  cases failed before the scoping fix (PG) / were checked against it (MySQL).
- Verified against real PG and MySQL that the bulk query finds an actual stray FK
  (`addForeignKey("lessons_students", "authors")` → blocker reported, rebuild drops it,
  `foreignKeys("lessons_students")` empty afterwards).

Closes-story: bulk-reverse-fk-lookup-for-inbound-scan
