### PR TITLE
test(connection-pool): port test_new_connection_no_query, pin leaseConnection's lazy connect

### DIFF
--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -277,8 +277,6 @@ describe("ConnectionHandlingTest", () => {
 
   it("is_connected?", async () => {
     const pool = Base.connectionPool();
-    // trails' checkout is lazy where Rails' `checkout_and_verify` runs
-    // `verify!`, so the raw connection is opened here as Rails' checkout would.
     await (await pool.leaseConnection()).verifyBang();
     expect(Base.isConnectedQ()).toBe(true);
     pool.releaseConnection();

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -6,7 +6,7 @@ import { ConnectionDescriptor } from "./connection-adapters/abstract/connection-
 import { PoolConfig } from "./connection-adapters/pool-config.js";
 import { SchemaCache, SchemaReflection } from "./connection-adapters/schema-cache.js";
 import { HashConfig } from "./database-configurations/hash-config.js";
-import { newRawTestAdapter, ambientPoolConfiguration } from "./test-adapter.js";
+import { newRawTestAdapter, ambientPoolConfiguration, inMemoryDb } from "./test-adapter.js";
 import { AbstractAdapter } from "./connection-adapters/abstract-adapter.js";
 import type {
   AdapterName,
@@ -14,6 +14,7 @@ import type {
 } from "./connection-adapters/abstract-adapter.js";
 import { Result } from "./result.js";
 import { Base } from "./base.js";
+import { assertNoQueries } from "./testing/query-assertions.js";
 
 interface AmbientPoolOptions {
   role?: string;
@@ -169,6 +170,18 @@ it("with connection", async () => {
     }),
   ).rejects.toThrow("boom");
   expect(pool.stat().busy).toBe(0);
+});
+
+it.skipIf(inMemoryDb())("new connection no query", async () => {
+  const pool = makePool();
+  expect(pool.stat().connections).toBe(0);
+  await pool.withConnection(() => {});
+  await pool.flush(0);
+  expect(pool.stat().connections).toBe(0);
+
+  await assertNoQueries(false, async () => {
+    await pool.withConnection(() => {});
+  });
 });
 
 it("active connection in use", async () => {

--- a/packages/activerecord/src/connection-pool.trails.test.ts
+++ b/packages/activerecord/src/connection-pool.trails.test.ts
@@ -107,6 +107,22 @@ it("verifyBang on a checked-out adapter establishes the raw connection on every 
   }
 });
 
+it("leaseConnection routes its verify through checkout and establishes on verifyBang", async () => {
+  const pool = makePool();
+  const checkoutSpy = vi.spyOn(pool, "checkout");
+  try {
+    const conn = await pool.leaseConnection();
+    expect(checkoutSpy).toHaveBeenCalledTimes(1);
+    await conn.verifyBang();
+    expect(conn.isConnected()).toBe(true);
+    expect(pool.isConnected()).toBe(true);
+  } finally {
+    checkoutSpy.mockRestore();
+    pool.releaseConnection();
+    await closePoolConnections(pool);
+  }
+});
+
 it("with connection prevent permanent checkout releases connection", async () => {
   const pool = makePool();
   await pool.leaseConnection();


### PR DESCRIPTION
## Summary

The story asked the pool to verify on lease, so that `isConnected()` is true
straight out of `leaseConnection()`. **Verified against `vendor/rails/` — the
premise is wrong**, and it is the same mis-specification already adjudicated on
PR #5159 for the sibling `checkout` story:

- `ConnectionPool#checkout_and_verify` runs `c.clean!` only
  (`connection_pool.rb:941-951`). `verify!` fires **solely** on the pinned paths
  (`connection_pool.rb:336` / `:554`) — both already ported and awaited in trails
  (`connection-pool.ts:792`).
- `db_config.new_connection` constructs the adapter without connecting, and
  `connected?` is `!@raw_connection.nil?` (`abstract_adapter.rb:649`).
- `test_new_connection_no_query` (`connection_pool_test.rb:105`) asserts that a
  `with_connection` — i.e. lease → checkout — issues **zero queries**. Verifying
  on lease would break exactly that.
- Rails' own `test_connected?`
  (`connection_handlers_multi_pool_config_test.rb:73`) therefore establishes the
  handle explicitly with `pool.checkout.connect!`, and `connect!` is just
  `verify!` (`abstract_adapter.rb:778`).

So the `verifyBang()` in `connection-handling.test.ts`'s `is_connected?` **is**
Rails' `checkout.connect!` idiom, not a trails workaround.

Rather than restate that in a comment, this PR pins it with the Rails test that
proves it — so the story cannot be filed a third time.

## What ships

- **`connection-pool.test.ts`** — ports `test_new_connection_no_query`, which
  was unported. It was the **last unmatched test in
  `connection_pool_test.rb`**: `test:compare` now reports that file at
  **31/31 matched, 0 missing (100%)**.
- **`connection-pool.trails.test.ts`** — trails guard that `leaseConnection`
  routes through `checkout` (one `checkout` call, spied) rather than carrying a
  verify path of its own, then that `verifyBang` leaves `conn.isConnected()` and
  `pool.isConnected()` true against the real lane adapter. This is AC 2's finding
  as an executable assertion.
- **`connection-handling.test.ts`** — deletes the comment that wrongly claimed
  "Rails' `checkout_and_verify` runs `verify!`". That false comment is what
  caused this story to be refiled after #5159 settled it.

No production code changes — behavior on `main` was already faithful.

## Acceptance criteria

- **AC 1** (`isConnected` true straight out of `leaseConnection`, no prior
  query) — **deliberately not implemented**: anti-Rails per the citations above,
  and it would break `test_new_connection_no_query`, now ported here. I
  reproduced the reported PG failure first (bare `leaseConnection()` →
  `isConnectedQ()` false) to confirm the code path, then rejected the fix rather
  than ship the divergence.
- **AC 2** — confirmed and now tested: `leaseConnection` delegates to `checkout`
  (`connection-pool.ts:599`); one shared chokepoint, nothing to converge.
- **AC 3** (drop the `verifyBang` workaround) — **not applicable**: it isn't a
  workaround. Dropping it makes the test assert something Rails does not do.

## Verification

All three lanes, all three files (144 tests; sqlite ambient, PG and MySQL on an
isolated compose stack on non-default ports):

| lane | result |
| --- | --- |
| sqlite | 144 passed |
| postgresql | 143 passed, 1 lane-skip |
| mysql2 | 143 passed, 1 lane-skip |

`new connection no query` confirmed **running** (not lane-skipped) on all three,
and confirmed **non-vacuous**: adding a `SELECT 1` inside the block fails it with
`1 instead of 0 queries were executed`.

Two MySQL runs on a cold container failed 5 pre-existing schema-cache tests on
5000ms timeouts; baselined against `origin/main` for those files and re-run warm
— pre-existing marginal timing flake, unrelated to this diff.

Closes-story: lease-connection-leaves-raw-connection-unestablished
