### PR TITLE
refactor(postgresql): mirror Rails add_modifier-before-register source order

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
@@ -48,12 +48,9 @@ import { Uuid } from "./oid/uuid.js";
 import { Vector } from "./oid/vector.js";
 import { Xml } from "./oid/xml.js";
 
-// Mirrors: postgresql_adapter.rb:1166-1167. Rails scopes these to
-// `adapter: :postgresql`; "postgres" is trails' normalized name for that family.
 ArType.addModifier({ array: true }, OidArray, { adapter: "postgres" });
 ArType.addModifier({ range: true }, RangeType, { adapter: "postgres" });
 
-// Mirrors: postgresql_adapter.rb:1168-1185.
 ArType.register("bit", Bit, { adapter: "postgres" });
 ArType.register("bit_varying", BitVarying, { adapter: "postgres" });
 ArType.register("binary", Bytea, { adapter: "postgres" });

--- a/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
@@ -48,6 +48,11 @@ import { Uuid } from "./oid/uuid.js";
 import { Vector } from "./oid/vector.js";
 import { Xml } from "./oid/xml.js";
 
+// Mirrors: postgresql_adapter.rb:1166-1167. Rails scopes these to
+// `adapter: :postgresql`; "postgres" is trails' normalized name for that family.
+ArType.addModifier({ array: true }, OidArray, { adapter: "postgres" });
+ArType.addModifier({ range: true }, RangeType, { adapter: "postgres" });
+
 // Mirrors: postgresql_adapter.rb:1168-1185.
 ArType.register("bit", Bit, { adapter: "postgres" });
 ArType.register("bit_varying", BitVarying, { adapter: "postgres" });
@@ -67,11 +72,6 @@ ArType.register("legacy_point", LegacyPoint, { adapter: "postgres" });
 ArType.register("uuid", Uuid, { adapter: "postgres" });
 ArType.register("vector", Vector, { adapter: "postgres" });
 ArType.register("xml", Xml, { adapter: "postgres" });
-
-// Mirrors: postgresql_adapter.rb:1166-1167. Rails scopes these to
-// `adapter: :postgresql`; "postgres" is trails' normalized name for that family.
-ArType.addModifier({ array: true }, OidArray, { adapter: "postgres" });
-ArType.addModifier({ range: true }, RangeType, { adapter: "postgres" });
 
 /**
  * Mirrors: PostgreSQLAdapter.extract_limit — `$1.to_i if sql_type =~ /\((.*)\)/`.


### PR DESCRIPTION
Moves the two `ArType.addModifier` calls in PG `type-map-init.ts` above the
`ArType.register` block to match `postgresql_adapter.rb:1166-1185` source order,
and drops the two `Mirrors:` comments in that region.

Ordering confirmed cosmetic: `AdapterSpecificRegistry` keeps a single
`_registrations` list, but `DecorationRegistration.priority` ORs in `4`, so a
modifier always outranks a plain registration in `findRegistration`'s reduce.
The two kinds therefore never tie, and their relative insertion order cannot
change any lookup. Rails' registry has the same structure (`select` + `max`).

No behavior change. `type-map-init.test.ts` and
`adapter-specific-registry.test.ts` pass (44 tests); eslint and `tsc --build`
are clean.

Closes-story: pg-type-map-init-modifier-register-source-order
