### PR TITLE
test(mysql): lease the ambient connection in ten MySQL adapter suites

### DIFF
--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -36,6 +36,7 @@ import { Subscriber } from "./test-helpers/models/subscriber.js";
 import { Event } from "./test-helpers/models/event.js";
 import { QueryAttribute } from "./relation/query-attribute.js";
 import {
+  leaseMysqlAdapter,
   Mysql2Adapter,
   ARUNIT_DATABASE,
   ARUNIT2_DATABASE,
@@ -1241,18 +1242,10 @@ describe("InvalidateTransactionTest", () => {
 });
 
 describe.runIf(adapterType === "mysql")("AdapterTest", () => {
-  const leaseMysql = async (): Promise<Mysql2Adapter> =>
-    (await Base.leaseConnection()) as unknown as Mysql2Adapter;
-
   let adapter: Mysql2Adapter;
 
-  beforeAll(async () => {
-    await establishFromTestConfig();
-  });
-
   beforeEach(async () => {
-    adapter = await leaseMysql();
-    await adapter.materializeTransactions();
+    adapter = await leaseMysqlAdapter();
   });
 
   it("current database", async () => {
@@ -1290,14 +1283,14 @@ describe.runIf(adapterType === "mysql")("AdapterTest", () => {
     try {
       await runWithoutConnection(async ({ database: _database, ...exceptDatabase }) => {
         await Base.establishConnection(exceptDatabase);
-        const connection = await leaseMysql();
+        const connection = await leaseMysqlAdapter();
         await connection.execute(
           `SELECT ${ARUNIT_DATABASE}.pirates.*, ${ARUNIT2_DATABASE}.courses.* ` +
             `FROM ${ARUNIT_DATABASE}.pirates, ${ARUNIT2_DATABASE}.courses`,
         );
       });
     } finally {
-      const connection = await leaseMysql();
+      const connection = await leaseMysqlAdapter();
       for (const database of [ARUNIT_DATABASE, ARUNIT2_DATABASE]) {
         await connection.execute(`DROP DATABASE IF EXISTS ${database}`);
       }

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/auto-increment.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/auto-increment.test.ts
@@ -2,17 +2,14 @@
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/auto_increment_test.rb
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+import { describeIfMysqlAdapter, leaseMysqlAdapter, Mysql2Adapter } from "./test-helper.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 import type { SchemaSource } from "../../schema-dumper.js";
 
-describeIfMysql("Mysql2Adapter", () => {
+describeIfMysqlAdapter("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   beforeEach(async () => {
-    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
-  });
-  afterEach(async () => {
-    await adapter.close();
+    adapter = await leaseMysqlAdapter();
   });
 
   describe("AutoIncrementTest", () => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/case-sensitivity.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/case-sensitivity.test.ts
@@ -2,17 +2,14 @@
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/case_sensitivity_test.rb
  */
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
-import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+import { describeIfMysqlAdapter, leaseMysqlAdapter, Mysql2Adapter } from "./test-helper.js";
 import { Base } from "../../index.js";
 import { captureSql } from "../../testing/sql-capture.js";
 
-describeIfMysql("Mysql2Adapter", () => {
+describeIfMysqlAdapter("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   beforeEach(async () => {
-    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
-  });
-  afterEach(async () => {
-    await adapter.close();
+    adapter = await leaseMysqlAdapter();
   });
 
   describe("CaseSensitivityTest", () => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/charset-collation.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/charset-collation.test.ts
@@ -2,17 +2,14 @@
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/charset_collation_test.rb
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+import { describeIfMysqlAdapter, leaseMysqlAdapter, Mysql2Adapter } from "./test-helper.js";
 import { dumpTableSchema } from "../../test-helpers/schema-dumping-helper.js";
 import type { SchemaSource } from "../../schema-dumper.js";
 
-describeIfMysql("Mysql2Adapter", () => {
+describeIfMysqlAdapter("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   beforeEach(async () => {
-    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
-  });
-  afterEach(async () => {
-    await adapter.close();
+    adapter = await leaseMysqlAdapter();
   });
 
   describe("CharsetCollationTest", () => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-enum.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-enum.test.ts
@@ -2,15 +2,15 @@
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_enum_test.rb
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+import { describeIfMysqlAdapter, leaseMysqlAdapter, Mysql2Adapter } from "./test-helper.js";
 import { Base } from "../../base.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 import type { SchemaSource } from "../../schema-dumper.js";
 
-describeIfMysql("Mysql2Adapter", () => {
+describeIfMysqlAdapter("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   beforeEach(async () => {
-    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
+    adapter = await leaseMysqlAdapter();
     await adapter.createTable("enum_tests", { id: false, force: true }, (t: any) => {
       t.column("enum_column", "enum('text','blob','tiny','medium','long','unsigned','bigint')");
       t.column("state", "TINYINT(1)");
@@ -18,7 +18,6 @@ describeIfMysql("Mysql2Adapter", () => {
   });
   afterEach(async () => {
     await adapter.dropTable("enum_tests", { ifExists: true });
-    await adapter.close();
   });
 
   describe("MysqlEnumTest", () => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/quoting.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/quoting.test.ts
@@ -1,16 +1,13 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/quoting_test.rb
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+import { describe, it, expect, beforeEach } from "vitest";
+import { describeIfMysqlAdapter, leaseMysqlAdapter, Mysql2Adapter } from "./test-helper.js";
 
-describeIfMysql("Mysql2Adapter", () => {
+describeIfMysqlAdapter("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   beforeEach(async () => {
-    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
-  });
-  afterEach(async () => {
-    await adapter.close();
+    adapter = await leaseMysqlAdapter();
   });
 
   describe("QuotingTest", () => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/schema-migrations.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/schema-migrations.test.ts
@@ -1,19 +1,16 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/schema_migrations_test.rb
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { SchemaMigration } from "../../schema-migration.js";
 import { InternalMetadata } from "../../internal-metadata.js";
-import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+import { describeIfMysqlAdapter, leaseMysqlAdapter, Mysql2Adapter } from "./test-helper.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
 
-describeIfMysql("Mysql2Adapter", () => {
+describeIfMysqlAdapter("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   beforeEach(async () => {
-    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
-  });
-  afterEach(async () => {
-    await adapter.close();
+    adapter = await leaseMysqlAdapter();
   });
 
   describe("SchemaMigrationsTest", () => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/set.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/set.test.ts
@@ -2,21 +2,20 @@
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/set_test.rb
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+import { describeIfMysqlAdapter, leaseMysqlAdapter, Mysql2Adapter } from "./test-helper.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 import type { SchemaSource } from "../../schema-dumper.js";
 
-describeIfMysql("Mysql2Adapter", () => {
+describeIfMysqlAdapter("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   beforeEach(async () => {
-    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
+    adapter = await leaseMysqlAdapter();
     await adapter.createTable("set_tests", { id: false, force: true }, (t: any) => {
       t.column("set_column", "set('text','blob','tiny','medium','long','unsigned','bigint')");
     });
   });
   afterEach(async () => {
     await adapter.dropTable("set_tests", { ifExists: true });
-    await adapter.close();
   });
 
   describe("SetTest", () => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/sql-types.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/sql-types.test.ts
@@ -1,16 +1,13 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/sql_types_test.rb
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+import { describe, it, expect, beforeEach } from "vitest";
+import { describeIfMysqlAdapter, leaseMysqlAdapter, Mysql2Adapter } from "./test-helper.js";
 
-describeIfMysql("Mysql2Adapter", () => {
+describeIfMysqlAdapter("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   beforeEach(async () => {
-    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
-  });
-  afterEach(async () => {
-    await adapter.close();
+    adapter = await leaseMysqlAdapter();
   });
 
   describe("SqlTypesTest", () => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/table-options.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/table-options.test.ts
@@ -6,11 +6,11 @@ import { Version } from "../../connection-adapters/abstract-adapter.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 import type { SchemaSource } from "../../schema-dumper.js";
 import {
-  describeIfMysql,
+  describeIfMysqlAdapter,
   isMariaDb,
   mysqlVersion,
+  leaseMysqlAdapter,
   Mysql2Adapter,
-  MYSQL_TEST_URL,
 } from "./test-helper.js";
 
 // Rails: `skip "..." if @connection.database_version >= "5.7.22"`. We add
@@ -23,13 +23,10 @@ const skipNoTableOptions =
 const dumpTable = (adapter: Mysql2Adapter, tableName: string) =>
   SchemaDumper.dumpTableSchema(adapter as unknown as SchemaSource, tableName);
 
-describeIfMysql("Mysql2Adapter", () => {
+describeIfMysqlAdapter("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   beforeEach(async () => {
-    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
-  });
-  afterEach(async () => {
-    await adapter.close();
+    adapter = await leaseMysqlAdapter();
   });
 
   describe("TableOptionsTest", () => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
@@ -4,6 +4,9 @@ import { Mysql2Adapter } from "../../connection-adapters/mysql2-adapter.js";
 import { Version } from "../../connection-adapters/abstract-adapter.js";
 import { arunitDatabaseNames } from "../../test-helpers/arunit2-config.js";
 import { mysqlSettings, mysqlUrl } from "../../test-helpers/test-connection-env.js";
+import { adapterType } from "../../test-adapter.js";
+import { Base } from "../../base.js";
+import { establishFromTestConfig } from "../../test-helpers/test-database-config.js";
 
 // `dbWarningsAction` is a single global setting on the base adapter, so the
 // shared helper toggles it for every adapter (including MySQL). Re-exported
@@ -96,3 +99,28 @@ export const supportsExpressionIndex =
   mysqlAvailable && !mariaDb && _serverVersion?.gte("8.0.13") === true;
 
 export { Mysql2Adapter };
+
+/**
+ * The port of `current_adapter?(:Mysql2Adapter)` — the gate every
+ * `ActiveRecord::AbstractMysqlTestCase` suite runs under. `describeIfMysql`
+ * above is a *server-reachability* probe (it runs these suites against a
+ * self-built adapter under every `ARCONN`); this is the adapter gate, so the
+ * suite rides the ambient `Base.connection` on the mysql2 lane and skips
+ * everywhere else, exactly as Rails does.
+ */
+export const describeIfMysqlAdapter =
+  adapterType === "mysql" ? describe : (describe.skip as typeof describe);
+
+/**
+ * Port of these suites' `setup` line
+ * `@connection = ActiveRecord::Base.lease_connection`: leases the ambient pool
+ * connection (establishing it first when the file runs without `fixtures()`),
+ * so the leased connection's config plumbing — `configureConnection`, pool
+ * settings, `preparedStatements` — is what the test exercises.
+ */
+export async function leaseMysqlAdapter(): Promise<Mysql2Adapter> {
+  await establishFromTestConfig();
+  const adapter = (await Base.leaseConnection()) as unknown as Mysql2Adapter;
+  await adapter.materializeTransactions();
+  return adapter;
+}

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
@@ -14,9 +14,12 @@ import { establishFromTestConfig } from "../../test-helpers/test-database-config
 export { withDbWarningsAction } from "../../test-helpers/with-db-warnings-action.js";
 
 // A *serialization* of the MySQL sub-settings (MYSQL_HOST/MYSQL_PORT/
-// MYSQL_USER/...), not an env var of its own: these adapter suites probe the
-// server directly via describeIfMysql regardless of ARCONN, so they need a URL
-// to hand the driver, but they no longer source one from the environment.
+// MYSQL_USER/...), not an env var of its own: the suites still on
+// describeIfMysql probe the server directly regardless of ARCONN, so they need
+// a URL to hand the driver, but they no longer source one from the
+// environment. Being burned down in favour of describeIfMysqlAdapter +
+// leaseMysqlAdapter below; the remaining legitimate callers are the tests that
+// deliberately build a second, differently configured adapter.
 export const MYSQL_TEST_URL = mysqlUrl();
 
 export { databaseName } from "../../test-helpers/arunit2-config.js";
@@ -56,6 +59,12 @@ async function checkMysql(): Promise<{ available: boolean; isMariaDb: boolean; v
 
 ({ available: mysqlAvailable, isMariaDb: mariaDb, version: mysqlVersionStr } = await checkMysql());
 
+/**
+ * Server-reachability probe, NOT the port of `current_adapter?(:Mysql2Adapter)`
+ * — use {@link describeIfMysqlAdapter} for that. A suite gated on this one runs
+ * under every `ARCONN` against a self-built adapter, bypassing the leased pool
+ * connection.
+ */
 export const describeIfMysql = mysqlAvailable ? describe : (describe.skip as typeof describe);
 /** true when the connected server is MariaDB; false on MySQL or when MySQL is unavailable. */
 export const isMariaDb = mariaDb;

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/unsigned-type.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/unsigned-type.test.ts
@@ -2,7 +2,7 @@
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/unsigned_type_test.rb
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+import { describeIfMysqlAdapter, leaseMysqlAdapter, Mysql2Adapter } from "./test-helper.js";
 import { Base } from "../../base.js";
 import { RangeError as ActiveRecordRangeError } from "../../errors.js";
 import { RangeError as ActiveModelRangeError } from "@blazetrails/activemodel";
@@ -10,10 +10,10 @@ import { SchemaDumper } from "../../schema-dumper.js";
 import type { SchemaSource } from "../../schema-dumper.js";
 import { deprecator } from "../../deprecator.js";
 
-describeIfMysql("Mysql2Adapter", () => {
+describeIfMysqlAdapter("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   beforeEach(async () => {
-    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
+    adapter = await leaseMysqlAdapter();
     await adapter.createTable("unsigned_types", { force: true }, (t: any) => {
       t.integer("unsigned_integer", { unsigned: true });
       t.bigint("unsigned_bigint", { unsigned: true });
@@ -24,7 +24,6 @@ describeIfMysql("Mysql2Adapter", () => {
   });
   afterEach(async () => {
     await adapter.dropTable("unsigned_types", { ifExists: true });
-    await adapter.close();
   });
 
   async function unsignedTypeModel(): Promise<typeof Base> {

--- a/scripts/test-compare/extract-ts-core.ts
+++ b/scripts/test-compare/extract-ts-core.ts
@@ -288,6 +288,7 @@ const ADAPTER_SUITE_WRAPPERS = new Set([
   "describe",
   "describeIfPg",
   "describeIfMysql",
+  "describeIfMysqlAdapter",
   "describeIfSqlite",
 ]);
 

--- a/scripts/test-compare/extract-ts-gates.test.ts
+++ b/scripts/test-compare/extract-ts-gates.test.ts
@@ -21,6 +21,10 @@ describe("gates.ts pure helpers", () => {
       adapters: ["mysql"],
       source: ["wrapper"],
     });
+    expect(gateFromWrapper("describeIfMysqlAdapter")).toEqual({
+      adapters: ["mysql"],
+      source: ["wrapper"],
+    });
     expect(gateFromWrapper("describeIfSqlite")).toEqual({
       adapters: ["sqlite"],
       source: ["wrapper"],

--- a/scripts/test-compare/gates.ts
+++ b/scripts/test-compare/gates.ts
@@ -77,6 +77,10 @@ export function gateFromWrapper(name: string, featureArg?: string | null): TestG
     case "describeIfPg":
       return { adapters: ["postgresql"], source: ["wrapper"] };
     case "describeIfMysql":
+    // The port of `current_adapter?(:Mysql2Adapter)` — same gate as
+    // describeIfMysql, but keyed on the active adapter rather than on a
+    // server-reachability probe.
+    case "describeIfMysqlAdapter":
       return { adapters: ["mysql"], source: ["wrapper"] };
     case "describeIfSqlite":
       return { adapters: ["sqlite"], source: ["wrapper"] };


### PR DESCRIPTION
Rails' `AbstractMysqlTestCase` suites lease the ambient connection in `setup`
(`@connection = ActiveRecord::Base.lease_connection`). trails built its own
`new Mysql2Adapter(MYSQL_TEST_URL)` in `beforeEach` instead, so the leased pool
connection and its config plumbing — `configureConnection`, pool settings,
`preparedStatements` — were never exercised. This is batch 1 of the burn-down,
following the conversion #5303 did for the MySQL-gated `AdapterTest` block.

Two helpers land in `adapters/abstract-mysql-adapter/test-helper.ts`:

- `leaseMysqlAdapter()` — the port of the `setup` lease:
  `establishFromTestConfig()` + `Base.leaseConnection()` +
  `materializeTransactions()`.
- `describeIfMysqlAdapter` — the port of `current_adapter?(:Mysql2Adapter)`
  (`adapterType === "mysql"`), replacing `describeIfMysql` in the converted
  files. `describeIfMysql` is a *server-reachability* probe, and it now carries
  a doc comment saying so.

Converted (10 suites, 10 sites — the self-built adapter and the close-only
`afterEach` both go away): `quoting`, `sql-types`, `set`, `mysql-enum`,
`auto-increment`, `case-sensitivity`, `charset-collation`, `table-options`,
`unsigned-type`, `schema-migrations`.

`adapter.test.ts`'s MySQL-gated block (added by #5303) had the same lease
inline as a local `leaseMysql` + `beforeAll(establishFromTestConfig)`; it now
calls the shared helper instead, so there is exactly one port of the `setup`
lease.

Test names unchanged.

**On the gate swap:** `vitest.config.ts:63-79` already excludes
`adapters/abstract-mysql-adapter/**` on every lane except `ARCONN=mysql2`, so
these ten files only ever ran on the MySQL lane — the swap is not what stops
them running elsewhere. What it changes is the intent and the failure mode:
the suite is now gated on *which adapter is active* rather than on a module-load
`SELECT VERSION()` probe, so an unreachable MySQL server on the MySQL lane
fails loudly instead of silently skipping the whole file. The sites in
`migration.test.ts` and `defaults.test.ts`, which are *not* covered by that
exclude, are where the gate itself matters; they are in the follow-up batches.

### Inventory (acceptance criterion 1)

All 40 `new Mysql2Adapter(MYSQL_TEST_URL)` sites were classified as (a) should
lease the ambient connection, or (b) legitimately needs its own adapter. The
`(b)` set is real: second connections where contention *is* the test
(`transaction.test.ts:35,82`, `nested-deadlock.test.ts:117,133,147`,
`statement-pool.test.ts:151`, `count-deleted-rows-with-lock.test.ts:34`),
differently configured adapters (`statement-pool.test.ts:115,138,145`
`statementLimit`; `schema.test.ts:196` `sql_mode: ANSI_QUOTES`;
`defaults.test.ts:475` `strict: false`), and deliberately bad or alternate
configs throughout `connection.test.ts` (`:31,167,249,271,282,294,421,431,443,455`).
Rails builds second adapters in-test from the primary config too, so those stay.

The remaining `(a)` sites are registered as follow-up stories, each with the
full per-site inventory and Rails citations in its body:

- `mysql-tests-self-built-adapter-burndown-batch-2` — schema/DDL suites
  (`active-schema`, `virtual-column`, `mysql-boolean`, `bind-parameter`,
  `warnings`, `schema`, `migration.test.ts:2319`).
- `mysql-tests-self-built-adapter-burndown-batch-3` — the `mysql2/` suites plus
  two second-connection audits (`savepoint-reconnect`,
  `mysql2-adapter.trails`).

`scripts/test-compare/{gates,extract-ts-core}.ts` learn the new wrapper next to
`describeIfMysql`. Without that, the ten converted suites read as *ungated*
against Rails' mysql-gated `AbstractMysqlTestCase` and the hard-zero
gate-mismatch check failed with 52 mismatches; with it, `pnpm test:compare`
reports 0 again.

### Verification

Local `ARCONN=mysql2` (isolated compose MySQL 8): all ten converted files pass
(`quoting` 8, `sql-types` 1, `set` 3, `mysql-enum` 4, `auto-increment` 4,
`case-sensitivity` 7, `charset-collation` 8, `unsigned-type` 5,
`schema-migrations` 3, `table-options` 8 + 1 skipped), and `adapter.test.ts`
still passes 70 / 3 skipped after the helper swap. `table-options`' "charset and
partitioned table options" needs a raised `--testTimeout` locally — a
128-partition `CREATE TABLE` takes ~17s on a non-tmpfs local MySQL; unchanged by
this diff. `pnpm test:compare` gate-mismatch 0, `pnpm typecheck` and `eslint`
clean.

Closes-story: mysql-tests-self-built-adapter-burndown
