### PR TITLE
test(migration): port add_foreign_key cases of ForeignKeyTest

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -83,6 +83,7 @@ import {
   newColumnFromField,
   quotedScope,
   tableAliasLength as mysqlTableAliasLength,
+  extractForeignKeyAction as mysqlExtractForeignKeyAction,
 } from "./mysql/schema-statements.js";
 import type { Column as MysqlColumn } from "./mysql/column.js";
 import { TypeMap } from "../type/type-map.js";
@@ -1060,16 +1061,10 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   protected _mysqlFkAction(
     rule: string | null | undefined,
   ): "cascade" | "nullify" | "restrict" | undefined {
-    switch ((rule ?? "").toUpperCase()) {
-      case "CASCADE":
-        return "cascade";
-      case "SET NULL":
-        return "nullify";
-      case "RESTRICT":
-        return "restrict";
-      default:
-        return undefined;
-    }
+    // MySQL::SchemaStatements#extract_foreign_key_action overrides the abstract
+    // one with `super unless specifier == "RESTRICT"` (mysql/schema_statements.rb:225)
+    // — RESTRICT is MySQL's default, so it reports as nil (foreign_key_test.rb:267).
+    return mysqlExtractForeignKeyAction((rule ?? "").toUpperCase());
   }
 
   async checkConstraints(tableName: string): Promise<CheckConstraintDefinition[]> {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -622,7 +622,9 @@ export class SchemaCreation {
       case "set_default":
         return `ON ${action} SET DEFAULT`;
       default:
-        throw new Error(
+        // Rails raises ArgumentError here (schema_creation.rb:181), which
+        // foreign_key_test.rb:302 asserts on.
+        throw new ArgumentError(
           `'${String(dependency)}' is not supported for on_update or on_delete. ` +
             `Supported values are: cascade, nullify, restrict, no_action, set_default`,
         );

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -12,32 +12,10 @@ import { AbstractSQLite3Adapter } from "../sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "../better-sqlite3-adapter.js";
 import { AbstractAdapter } from "../abstract-adapter.js";
 import { ForeignKeyDefinition } from "./schema-definitions.js";
-import { Base } from "../../index.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
+import { ambientConnection, withRocketTables } from "../../test-helpers/rocket-tables.js";
 
 let adapter: AbstractSQLite3Adapter | undefined;
-
-// Rails' `@connection = ActiveRecord::Base.lease_connection`.
-async function ambientConnection(): Promise<AbstractAdapter> {
-  return (await Base.leaseConnection()) as unknown as AbstractAdapter;
-}
-
-// ForeignKeyTest's setup/teardown, foreign_key_test.rb:178-194.
-async function withRocketTables(conn: AbstractAdapter, body: () => Promise<void>): Promise<void> {
-  await conn.createTable("rockets", { force: true }, (t) => {
-    t.string("name");
-  });
-  await conn.createTable("astronauts", { force: true }, (t) => {
-    t.string("name");
-    t.references("rocket", { type: "bigint" });
-    t.references("favorite_rocket");
-  });
-  try {
-    await body();
-  } finally {
-    await conn.dropTable("astronauts", "rockets", { ifExists: true });
-  }
-}
 
 afterEach(async () => {
   await adapter?.close();

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2397,6 +2397,15 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       (col) => Number(col.hidden ?? 0) !== 1,
     );
 
+    // Rails' alter_table -> copy_table -> primary_key(from) reaches
+    // table_structure, which raises StatementInvalid naming the table when it
+    // doesn't exist (sqlite3_adapter.rb:598, foreign_key_test.rb:322). Our
+    // rebuild reads PRAGMA directly, so raise the same error here rather than
+    // emitting a column-less CREATE TABLE that fails with a syntax error.
+    if (!tableInfo.length) {
+      throw new StatementInvalid(`Could not find table '${tableName}'`, { sql: "", binds: [] });
+    }
+
     const hasGenerated = tableInfo.some((col) => Number(col.hidden ?? 0) >= 2);
     const reflected = hasGenerated ? await this.columns(tableName) : [];
     const columns: Record<string, Record<string, unknown>> = {};
@@ -3183,7 +3192,17 @@ const REFERENTIAL_ACTION_MAP: Record<string, string> = {
 };
 
 function normalizeReferentialAction(action: string): string {
-  return REFERENTIAL_ACTION_MAP[action.toLowerCase()] ?? action.toUpperCase();
+  const sql = REFERENTIAL_ACTION_MAP[action.toLowerCase()];
+  // Rails reaches action_sql (schema_creation.rb:175) even on SQLite's
+  // table-rebuild path, so an unsupported :on_delete/:on_update raises
+  // ArgumentError rather than emitting invalid SQL (foreign_key_test.rb:302).
+  if (sql === undefined) {
+    throw new ArgumentError(
+      `'${action}' is not supported for on_update or on_delete. ` +
+        `Supported values are: cascade, nullify, restrict, no_action, set_default`,
+    );
+  }
+  return sql;
 }
 
 /** @internal */

--- a/packages/activerecord/src/migration/foreign-key.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Port of the `add_foreign_key` half of
+ * `ActiveRecord::Migration::ForeignKeyTest`
+ * (vendor/rails/activerecord/test/cases/migration/foreign_key_test.rb:209-330).
+ *
+ * Driven by the ambient connection, mirroring Rails'
+ * `@connection = ActiveRecord::Base.lease_connection`. The rockets/astronauts
+ * setup/teardown is shared with schema-statements-on-adapter.test.ts via
+ * `withRocketTables`.
+ */
+import { describe, it, expect } from "vitest";
+import { ArgumentError } from "@blazetrails/activemodel";
+import { StatementInvalid } from "../errors.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+import { ambientConnection, withRocketTables } from "../test-helpers/rocket-tables.js";
+import { adapterType } from "../test-adapter.js";
+
+// Rails' `unless current_adapter?(:SQLite3Adapter)` — SQLite's
+// PRAGMA foreign_key_list exposes no constraint name, so Rails skips the
+// `fk.name` assertions there.
+const namesForeignKeys = adapterType !== "sqlite";
+
+describe("ActiveRecord::Migration::ForeignKeyTest", () => {
+  // DDL can't run inside the transactional-fixtures wrapper (PG aborts the
+  // outer transaction on a failed statement), matching the schema-statements
+  // suite's setup.
+  fixtures([], { useTransactionalTests: false });
+
+  it("add foreign key inferes column", async () => {
+    const conn = await ambientConnection();
+    await withRocketTables(conn, async () => {
+      await conn.addForeignKey("astronauts", "rockets");
+
+      const foreignKeys = await conn.foreignKeys("astronauts");
+      expect(foreignKeys.length).toBe(1);
+
+      const fk = foreignKeys[0];
+      expect(fk.fromTable).toBe("astronauts");
+      expect(fk.toTable).toBe("rockets");
+      expect(fk.column).toBe("rocket_id");
+      expect(fk.primaryKey).toBe("id");
+      if (namesForeignKeys) expect(fk.name).toBe("fk_rails_78146ddd2e");
+    });
+  });
+
+  it("add foreign key with column", async () => {
+    const conn = await ambientConnection();
+    await withRocketTables(conn, async () => {
+      await conn.addForeignKey("astronauts", "rockets", { column: "rocket_id" });
+
+      const foreignKeys = await conn.foreignKeys("astronauts");
+      expect(foreignKeys.length).toBe(1);
+
+      const fk = foreignKeys[0];
+      expect(fk.fromTable).toBe("astronauts");
+      expect(fk.toTable).toBe("rockets");
+      expect(fk.column).toBe("rocket_id");
+      expect(fk.primaryKey).toBe("id");
+      if (namesForeignKeys) expect(fk.name).toBe("fk_rails_78146ddd2e");
+    });
+  });
+
+  it("add foreign key with if not exists to already referenced table", async () => {
+    const conn = await ambientConnection();
+    await withRocketTables(conn, async () => {
+      await conn.addForeignKey("astronauts", "rockets");
+      await conn.addForeignKey("astronauts", "rockets", {
+        column: "favorite_rocket_id",
+        ifNotExists: true,
+      });
+
+      const foreignKeys = await conn.foreignKeys("astronauts");
+      expect(foreignKeys.length).toBe(2);
+      expect(foreignKeys.every((fk) => fk.toTable === "rockets")).toBe(true);
+      expect(foreignKeys.map((fk) => fk.column).sort()).toEqual([
+        "favorite_rocket_id",
+        "rocket_id",
+      ]);
+    });
+  });
+
+  it("add foreign key with non standard primary key", async () => {
+    const conn = await ambientConnection();
+    await withRocketTables(conn, async () => {
+      await conn.createTable("space_shuttles", { id: false, force: true }, (t) => {
+        t.bigint("pk", { primaryKey: true });
+      });
+
+      try {
+        await conn.addForeignKey("astronauts", "space_shuttles", {
+          column: "rocket_id",
+          primaryKey: "pk",
+          name: "custom_pk",
+        });
+
+        const foreignKeys = await conn.foreignKeys("astronauts");
+        expect(foreignKeys.length).toBe(1);
+
+        const fk = foreignKeys[0];
+        expect(fk.fromTable).toBe("astronauts");
+        expect(fk.toTable).toBe("space_shuttles");
+        expect(fk.primaryKey).toBe("pk");
+      } finally {
+        await conn.removeForeignKey("astronauts", {
+          name: "custom_pk",
+          toTable: "space_shuttles",
+        });
+        await conn.dropTable("space_shuttles");
+      }
+    });
+  });
+
+  it("add on delete restrict foreign key", async () => {
+    const conn = await ambientConnection();
+    await withRocketTables(conn, async () => {
+      await conn.addForeignKey("astronauts", "rockets", {
+        column: "rocket_id",
+        onDelete: "restrict",
+      });
+
+      const foreignKeys = await conn.foreignKeys("astronauts");
+      expect(foreignKeys.length).toBe(1);
+
+      const fk = foreignKeys[0];
+      if (adapterType === "mysql") {
+        // ON DELETE RESTRICT is the default on MySQL
+        expect(fk.onDelete).toBeUndefined();
+      } else {
+        expect(fk.onDelete).toBe("restrict");
+      }
+    });
+  });
+
+  it("add on delete cascade foreign key", async () => {
+    const conn = await ambientConnection();
+    await withRocketTables(conn, async () => {
+      await conn.addForeignKey("astronauts", "rockets", {
+        column: "rocket_id",
+        onDelete: "cascade",
+      });
+
+      const foreignKeys = await conn.foreignKeys("astronauts");
+      expect(foreignKeys.length).toBe(1);
+      expect(foreignKeys[0].onDelete).toBe("cascade");
+    });
+  });
+
+  it("add on delete nullify foreign key", async () => {
+    const conn = await ambientConnection();
+    await withRocketTables(conn, async () => {
+      await conn.addForeignKey("astronauts", "rockets", {
+        column: "rocket_id",
+        onDelete: "nullify",
+      });
+
+      const foreignKeys = await conn.foreignKeys("astronauts");
+      expect(foreignKeys.length).toBe(1);
+      expect(foreignKeys[0].onDelete).toBe("nullify");
+    });
+  });
+
+  it("on update and on delete raises with invalid values", async () => {
+    const conn = await ambientConnection();
+    await withRocketTables(conn, async () => {
+      await expect(
+        conn.addForeignKey("astronauts", "rockets", {
+          column: "rocket_id",
+          onDelete: "invalid" as never,
+        }),
+      ).rejects.toThrow(ArgumentError);
+
+      await expect(
+        conn.addForeignKey("astronauts", "rockets", {
+          column: "rocket_id",
+          onUpdate: "invalid" as never,
+        }),
+      ).rejects.toThrow(ArgumentError);
+    });
+  });
+
+  it("add foreign key with on update", async () => {
+    const conn = await ambientConnection();
+    await withRocketTables(conn, async () => {
+      await conn.addForeignKey("astronauts", "rockets", {
+        column: "rocket_id",
+        onUpdate: "nullify",
+      });
+
+      const foreignKeys = await conn.foreignKeys("astronauts");
+      expect(foreignKeys.length).toBe(1);
+      expect(foreignKeys[0].onUpdate).toBe("nullify");
+    });
+  });
+
+  it("add foreign key with non existent from table raises", async () => {
+    const conn = await ambientConnection();
+    await withRocketTables(conn, async () => {
+      await expect(conn.addForeignKey("missions", "rockets")).rejects.toThrow(
+        expect.objectContaining({ message: expect.stringMatching(/missions/) }),
+      );
+      await expect(conn.addForeignKey("missions", "rockets")).rejects.toThrow(StatementInvalid);
+    });
+  });
+
+  it("add foreign key with non existent to table raises", async () => {
+    const conn = await ambientConnection();
+    await withRocketTables(conn, async () => {
+      await expect(conn.addForeignKey("missions", "rockets")).rejects.toThrow(
+        expect.objectContaining({ message: expect.stringMatching(/missions/) }),
+      );
+      await expect(conn.addForeignKey("missions", "rockets")).rejects.toThrow(StatementInvalid);
+    });
+  });
+});

--- a/packages/activerecord/src/migration/foreign-key.test.ts
+++ b/packages/activerecord/src/migration/foreign-key.test.ts
@@ -11,14 +11,15 @@
 import { describe, it, expect } from "vitest";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { StatementInvalid } from "../errors.js";
+import type { ReferentialAction } from "../connection-adapters/abstract/schema-definitions.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { ambientConnection, withRocketTables } from "../test-helpers/rocket-tables.js";
 import { adapterType } from "../test-adapter.js";
 
-// Rails' `unless current_adapter?(:SQLite3Adapter)` — SQLite's
-// PRAGMA foreign_key_list exposes no constraint name, so Rails skips the
-// `fk.name` assertions there.
-const namesForeignKeys = adapterType !== "sqlite";
+// Rails' `unless current_adapter?(:SQLite3Adapter)` guard on the `fk.name`
+// assertions: PRAGMA foreign_key_list exposes no constraint name, so SQLite
+// has no name to compare.
+const unlessSqlite3Adapter = adapterType !== "sqlite";
 
 describe("ActiveRecord::Migration::ForeignKeyTest", () => {
   // DDL can't run inside the transactional-fixtures wrapper (PG aborts the
@@ -39,7 +40,7 @@ describe("ActiveRecord::Migration::ForeignKeyTest", () => {
       expect(fk.toTable).toBe("rockets");
       expect(fk.column).toBe("rocket_id");
       expect(fk.primaryKey).toBe("id");
-      if (namesForeignKeys) expect(fk.name).toBe("fk_rails_78146ddd2e");
+      if (unlessSqlite3Adapter) expect(fk.name).toBe("fk_rails_78146ddd2e");
     });
   });
 
@@ -56,7 +57,7 @@ describe("ActiveRecord::Migration::ForeignKeyTest", () => {
       expect(fk.toTable).toBe("rockets");
       expect(fk.column).toBe("rocket_id");
       expect(fk.primaryKey).toBe("id");
-      if (namesForeignKeys) expect(fk.name).toBe("fk_rails_78146ddd2e");
+      if (unlessSqlite3Adapter) expect(fk.name).toBe("fk_rails_78146ddd2e");
     });
   });
 
@@ -165,14 +166,14 @@ describe("ActiveRecord::Migration::ForeignKeyTest", () => {
       await expect(
         conn.addForeignKey("astronauts", "rockets", {
           column: "rocket_id",
-          onDelete: "invalid" as never,
+          onDelete: "invalid" as unknown as ReferentialAction,
         }),
       ).rejects.toThrow(ArgumentError);
 
       await expect(
         conn.addForeignKey("astronauts", "rockets", {
           column: "rocket_id",
-          onUpdate: "invalid" as never,
+          onUpdate: "invalid" as unknown as ReferentialAction,
         }),
       ).rejects.toThrow(ArgumentError);
     });
@@ -195,20 +196,28 @@ describe("ActiveRecord::Migration::ForeignKeyTest", () => {
   it("add foreign key with non existent from table raises", async () => {
     const conn = await ambientConnection();
     await withRocketTables(conn, async () => {
-      await expect(conn.addForeignKey("missions", "rockets")).rejects.toThrow(
-        expect.objectContaining({ message: expect.stringMatching(/missions/) }),
+      // Rails asserts twice on ONE raise (`e = assert_raises ...`), so the
+      // error is captured rather than the call repeated.
+      const e = await conn.addForeignKey("missions", "rockets").then(
+        () => undefined,
+        (err: unknown) => err,
       );
-      await expect(conn.addForeignKey("missions", "rockets")).rejects.toThrow(StatementInvalid);
+      expect(e).toBeInstanceOf(StatementInvalid);
+      expect((e as Error).message).toMatch(/missions/);
     });
   });
 
   it("add foreign key with non existent to table raises", async () => {
     const conn = await ambientConnection();
     await withRocketTables(conn, async () => {
-      await expect(conn.addForeignKey("missions", "rockets")).rejects.toThrow(
-        expect.objectContaining({ message: expect.stringMatching(/missions/) }),
+      // Rails asserts twice on ONE raise (`e = assert_raises ...`), so the
+      // error is captured rather than the call repeated.
+      const e = await conn.addForeignKey("missions", "rockets").then(
+        () => undefined,
+        (err: unknown) => err,
       );
-      await expect(conn.addForeignKey("missions", "rockets")).rejects.toThrow(StatementInvalid);
+      expect(e).toBeInstanceOf(StatementInvalid);
+      expect((e as Error).message).toMatch(/missions/);
     });
   });
 });

--- a/packages/activerecord/src/test-helpers/rocket-tables.ts
+++ b/packages/activerecord/src/test-helpers/rocket-tables.ts
@@ -1,0 +1,32 @@
+import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
+import { Base } from "../index.js";
+
+/** Rails' `@connection = ActiveRecord::Base.lease_connection`. */
+export async function ambientConnection(): Promise<AbstractAdapter> {
+  return (await Base.leaseConnection()) as unknown as AbstractAdapter;
+}
+
+/**
+ * `ActiveRecord::Migration::ForeignKeyTest`'s setup/teardown,
+ * foreign_key_test.rb:178-194. rockets/astronauts are not canonical-schema
+ * tables in Rails either — the FK test creates and drops them itself — so this
+ * mirrors that rather than reaching for the canonical schema.
+ */
+export async function withRocketTables(
+  conn: AbstractAdapter,
+  body: () => Promise<void>,
+): Promise<void> {
+  await conn.createTable("rockets", { force: true }, (t) => {
+    t.string("name");
+  });
+  await conn.createTable("astronauts", { force: true }, (t) => {
+    t.string("name");
+    t.references("rocket", { type: "bigint" });
+    t.references("favorite_rocket");
+  });
+  try {
+    await body();
+  } finally {
+    await conn.dropTable("astronauts", "rockets", { ifExists: true });
+  }
+}


### PR DESCRIPTION
Ports the `add_foreign_key` half of `ActiveRecord::Migration::ForeignKeyTest`
(`vendor/rails/activerecord/test/cases/migration/foreign_key_test.rb:209-330`)
into `packages/activerecord/src/migration/foreign-key.test.ts`, driven by the
ambient connection and Rails' rockets/astronauts setup.

All 11 cases in that range are ported with Rails' names, honoring the
`unless current_adapter?(:SQLite3Adapter)` FK-name guards and the MySQL
`assert_nil fk.on_delete` branch, and keeping Rails' assertion shape (the
`e = assert_raises ...; assert_match(...)` cases capture one raise and assert
twice on it rather than invoking the call again).

`withRocketTables` (built by #5287) moves out of
`connection-adapters/abstract/schema-statements-on-adapter.test.ts` into
`test-helpers/rocket-tables.ts` alongside `ambientConnection`, so both suites
share one copy of `foreign_key_test.rb:178-194`.

### Four fidelity fixes the ported cases surfaced

1. **`actionSql` raised a plain `Error`** for an unsupported `on_delete` /
   `on_update`. Rails raises `ArgumentError` (`schema_creation.rb:181`), which
   `test_on_update_and_on_delete_raises_with_invalid_values` asserts on.
2. **SQLite bypassed that check entirely.** The table-rebuild path builds FK SQL
   by hand and `normalizeReferentialAction` fell back to `action.toUpperCase()`,
   emitting `ON DELETE INVALID` and failing with a SQLite syntax error. It now
   raises the same `ArgumentError`, matching Rails, where the rebuild still goes
   through `schema_creation`.
3. **SQLite `alterTable` on a missing table** produced a column-less
   `CREATE TABLE` and a raw `SqliteError`. Rails' `alter_table` → `copy_table` →
   `primary_key(from)` reaches `table_structure`, which raises
   `StatementInvalid: Could not find table 'missions'`
   (`foreign_key_test.rb:322`). The rebuild now raises that same error.
4. **MySQL reported `on_delete: :restrict`.** `MySQL::SchemaStatements`
   overrides `extract_foreign_key_action` with `super unless specifier ==
   "RESTRICT"` (`mysql/schema_statements.rb:225`) — RESTRICT is MySQL's default,
   so Rails reports `nil`. Our ported `extractForeignKeyAction` already had
   this, but `AbstractMysqlAdapter#_mysqlFkAction` was a divergent duplicate
   that returned `"restrict"`; it now delegates to the ported override.

### test:compare

The delta for `foreign_key_test.rb` is **0, and cannot be positive today**:
`scripts/test-compare/extract-ruby-tests.rb:52` skips the entire
`test/cases/migration/` directory as "migration test infrastructure", so none
of that directory's ~20 real test files are in the manifest. Filed as
`0005-activerecord-gaps/unskip-migration-dir-in-test-compare`; removing the
pattern will surface a large one-time drop in the reported percentage and
belongs in its own PR.

Green on sqlite, PostgreSQL 17 and MySQL 8 locally.

Closes-story: port-migration-foreign-key-add-cases
