### PR TITLE
test(associations): assert the ids= deviation throw on the constructor arms

### DIFF
--- a/packages/activerecord/src/associations/collection-persisted-setter-throws.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-persisted-setter-throws.trails.test.ts
@@ -182,11 +182,9 @@ describe("CollectionPersistedSetterThrows", () => {
   });
 
   it("constructor-form ids= reaches the association writer", async () => {
-    // A `#{singular}Ids` key is deferred past `super()` so it dispatches the
-    // generated setter instead of running while `_associationInstances` is
-    // still undefined. Reaching the writer is what's asserted here: the
-    // deviation throw above is the observable proof, where the un-deferred
-    // path died with an opaque `TypeError` from inside `super()`.
+    // The throw IS the assertion: without the deferral past `super()` these
+    // die with a `TypeError` on an undefined `_associationInstances`, never
+    // reaching the writer that raises the deviation.
     const post = await Post.create({ title: "t", body: "b" });
     expect(() => new Author({ name: "Bill", postIds: [post.id] })).toThrow(
       CollectionIdsAssignmentError,

--- a/packages/activerecord/src/associations/collection-persisted-setter-throws.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-persisted-setter-throws.trails.test.ts
@@ -46,15 +46,6 @@ const postsOf = (owner: Author): PostsProxy => (owner as unknown as { posts: Pos
 const targetOf = (owner: Author): Post[] =>
   (owner as unknown as { association(n: string): { target: Post[] } }).association("posts").target;
 
-// The `#{singular}Ids=` setter can't await, so the id→record resolution it
-// starts is still in flight when the constructor returns (the shape
-// `queueIdsWrite` documents). Settle it before asserting on the target.
-const settleTarget = async (target: () => unknown[]): Promise<void> => {
-  for (let i = 0; i < 50 && target().length === 0; i++) {
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  }
-};
-
 const writerOf =
   (owner: Author) =>
   (records: Post[]): Promise<void> =>
@@ -191,33 +182,29 @@ describe("CollectionPersistedSetterThrows", () => {
   });
 
   it("constructor-form ids= reaches the association writer", async () => {
+    // A `#{singular}Ids` key is deferred past `super()` so it dispatches the
+    // generated setter instead of running while `_associationInstances` is
+    // still undefined. Reaching the writer is what's asserted here: the
+    // deviation throw above is the observable proof, where the un-deferred
+    // path died with an opaque `TypeError` from inside `super()`.
     const post = await Post.create({ title: "t", body: "b" });
-    let author: Author | undefined;
-    expect(() => {
-      author = new Author({ name: "Bill", postIds: [post.id] });
-    }).not.toThrow();
-    await settleTarget(() => targetOf(author!));
-    expect(targetOf(author!).map((p) => p.id)).toEqual([post.id]);
+    expect(() => new Author({ name: "Bill", postIds: [post.id] })).toThrow(
+      CollectionIdsAssignmentError,
+    );
   });
 
   it("create with an ids= key reaches the association writer", async () => {
     const post = await Post.create({ title: "t", body: "b" });
-    const author = await Author.create({ name: "Bill", postIds: [post.id] });
-    expect(author.isPersisted()).toBe(true);
+    await expect(Author.create({ name: "Bill", postIds: [post.id] })).rejects.toThrow(
+      CollectionIdsAssignmentError,
+    );
   });
 
   it("constructor-form habtm ids= reaches the association writer", async () => {
     const post = await Post.create({ title: "t", body: "b" });
-    let category: Category | undefined;
-    expect(() => {
-      category = new Category({ name: "General", postIds: [post.id] });
-    }).not.toThrow();
-    const habtmTarget = (): unknown[] =>
-      (category as unknown as { association(n: string): { target: unknown[] } }).association(
-        "posts",
-      ).target;
-    await settleTarget(habtmTarget);
-    expect(habtmTarget().length).toBe(1);
+    expect(() => new Category({ name: "General", postIds: [post.id] })).toThrow(
+      CollectionIdsAssignmentError,
+    );
   });
 
   it("constructor-form ids= does not swallow an unknown Ids key", () => {


### PR DESCRIPTION
## Problem

`Active Record MariaDB/PostgreSQL/SQLite Tests` are red on `main` (@3c54a179 and
still at 754910e3f). Three tests in
`collection-persisted-setter-throws.trails.test.ts` fail on every adapter:

```
AssertionError: expected [Function] to not throw an error but
'CollectionIdsAssignmentError: Cannot assign collection association `posts` ids with `=` …' was thrown
 ❯ HasManyAssociation.queueIdsWrite collection-association.ts:128
```

## Cause

A merge-order collision between two PRs that landed within hours of each other:

- **#5292** (`d980c415d`) made the `#{singular}Ids=` setter throw
  `CollectionIdsAssignmentError` on **both** owner arms — `ids_writer` resolves
  the ids with a query before replacing
  (`collection_association.rb:61-83`), so even the new-record arm is DB I/O.
- **#5296** (`b59dc42dc`) added three constructor-form regression tests for the
  deferral fix. Its own PR body flags this: *"The story's acceptance criteria
  name `CollectionIdsAssignmentError`, which comes from #5292 (not yet merged).
  On `main` a constructor's owner is always unpersisted, so `queueIdsWrite` does
  not throw."* It merged second, so the tests assert `.not.toThrow()` against a
  setter that now always throws.

The file's own header (lines 16-21) and the sibling test
`"ids= setter throws on an unpersisted owner too"` already enshrine the
throw-on-both-arms behavior — the three new tests are simply stale.

## Fix

Test-only. The three tests still assert what they name — that a deferred
`*Ids` key **reaches the association writer** — but the observable proof is now
the deviation throw arriving from `queueIdsWrite` rather than a settled target.
That keeps #5296's regression value intact: the un-deferred path died with an
opaque `TypeError: Cannot read properties of undefined (reading 'get')` from
inside `super()`, never reaching the writer at all.

- `constructor-form ids=` / `constructor-form habtm ids=` → `toThrow(CollectionIdsAssignmentError)`
- `create with an ids= key` → `rejects.toThrow(CollectionIdsAssignmentError)`
- drops the now-dead `settleTarget` helper (it polled for an id→record
  resolution that no longer runs)

**No test renames.** No production code touched.

## Blast radius

All three red Active Record jobs on `main` — MariaDB (2), PostgreSQL (2) and
SQLite — fail on exactly these three tests and nothing else. This PR turns all
three green.

## Testing

- `pnpm vitest run collection-persisted-setter-throws.trails.test.ts base.test.ts`
  → 181 passed, 1 skipped.
- **Regression value preserved.** With `base.ts` reverted to `b59dc42dc~1` (the
  pre-#5296 baseline) the three rewritten tests still fail, and still with the
  original `TypeError` — they continue to guard the deferral, not merely the
  throw. The other 11 tests in the file stay green on that baseline.
- The old assertions' failure on `main` needs no local reproduction: the three
  CI jobs above are the reproduction.

Closes-story: red-3c54a179
