### PR TITLE
docs(test-infra): audit AR test-setup layout vs Rails cases/helper.rb

### DIFF
--- a/docs/infrastructure/ar-test-setup-cases-helper-layout-audit.md
+++ b/docs/infrastructure/ar-test-setup-cases-helper-layout-audit.md
@@ -1,0 +1,132 @@
+# AR test-setup layout vs Rails `test/cases/helper.rb` (spike audit)
+
+RFC 0064 (ar-test-infra-layout-fidelity), story
+`spike-align-test-setup-with-cases-helper`. Question raised while reviewing
+PR #4791: now that `packages/activerecord/src/test-setup-ar.ts` mirrors four
+distinct `helper.rb` lines, should the AR test-setup files be reorganized under
+a Rails-style `cases/` tree (e.g. `cases/helper.ts`), or does the
+`test-setup-*` convention stay?
+
+**Recommendation: keep as-is (option b).** Rationale below; this document
+exists so the question is not re-litigated.
+
+## What `helper.rb` actually does
+
+`vendor/rails/activerecord/test/cases/helper.rb` is 107 lines and does a dozen
+unrelated things. Mapped to trails:
+
+| helper.rb responsibility                                         | trails location                                                                                                      |
+| ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `:3` `require "config"` — test DB config / connection env        | `test-helpers/test-connection-env.ts`, `test-helpers/test-database-config.ts`                                        |
+| `:7–12` requires — library load                                  | ESM imports at each call site                                                                                        |
+| `:14–16` PG `create_unlogged_tables = true`                      | `connection-adapters/postgresql-adapter.ts` (flag exists); **not** set suite-wide                                    |
+| `:20` `Thread.abort_on_exception`                                | no analogue (single-threaded JS)                                                                                     |
+| `:23` `deprecator.debug = true`                                  | no analogue                                                                                                          |
+| `:27` `permanent_connection_checkout = :disallowed`              | `ar-config.ts:126` (flag exists); **not** set suite-wide                                                             |
+| `:29` `delegate_base_methods = false`                            | `test-setup-ar.ts:39`                                                                                                |
+| `:32` `Relation.remove_method(:klass)`                           | no analogue (no Ruby alias to un-define)                                                                             |
+| `:35` `I18n.enforce_available_locales`                           | no analogue                                                                                                          |
+| `:38` `QUOTED_TYPE`                                              | resolved per-site; see `test-helpers/models/comment.ts:122`                                                          |
+| `:40` `automatically_invert_plural_associations`                 | `test-setup-ar.ts:42`                                                                                                |
+| `:42` `raise_on_assign_to_attr_readonly`                         | `test-setup-ar.ts:47`                                                                                                |
+| `:43` `belongs_to_required_validates_foreign_key = false`        | `ar-config.ts` / `trailtie.ts` defaults; **not** set suite-wide                                                      |
+| `:45–46` register `abstract` / `fake` adapters                   | `connection-adapters.ts` resolve pre-warm in `test-setup-worker-db.ts:181-186`; the `fake` adapter is built per-test |
+| `:48–95` `SQLSubscriber`, `InTimeZone`, `WaitForAsyncTestHelper` | `adapters/postgresql/test-helper.ts` (SQLSubscriber), `test-helpers/in-time-zone.ts`; no `waitForAsyncQuery`         |
+| `:99–102` `Encryption.configure`                                 | `test-setup-ar.ts:55-59`                                                                                             |
+| `:104–107` `extend_queries = true` + `install_support`           | `encryption/config.ts:22` defaults to `false`; **not** installed suite-wide                                          |
+
+Plus responsibilities trails needs that `helper.rb` has no counterpart for,
+because Rails' test runner is a single process with a single database:
+
+- per-worker DB isolation slots (advisory lock / `GET_LOCK`) —
+  `test-setup-worker-db.ts`
+- canonical-schema template build + per-worker clone — vitest `globalSetup`
+  (`test-helpers/template-global-setup.ts`), `test-helpers/canonical-schema.ts`
+- per-worker `establishConnection` + `loadSchema`/`reconstructFromSchema` —
+  `test-setup-dy.ts`
+- MySQL unhandled-rejection shield — `test-setup-mysql.ts`
+- opt-in DDL profiler — `test-setup-ddl-profile.ts`
+
+So `helper.rb`'s content is a **strict subset** of what the trails setup files
+do, spread across five files, three of which exist only because of vitest's
+fork model. `test-setup-ar.ts` covers 4 of ~16 `helper.rb` responsibilities.
+
+## Trade-offs
+
+**Vitest `setupFiles` vs Rails `require`.** The `test-setup-*` files are not
+libraries — they are _ordered side-effect entry points_ declared in
+`vitest.config.ts:363-371`, and the order is load-bearing
+(`test-setup-worker-db` claims the slot → `test-setup-ar` registers the driver
+and flips config → `test-setup-dy` opens the connection and lays the schema).
+Rails' `helper.rb` is `require`d by each test file, so it is a library and one
+file is the natural shape. A `cases/helper.ts` name would suggest importable
+setup that our files explicitly are not; `test-setup-*` names the mechanism
+that actually runs them.
+
+**Consolidation is not available.** The one-file-per-`helper.rb` shape only
+works if the five files can merge, and they cannot: `globalSetup` runs in the
+main process before forks, the other four run per-worker at three different
+points in the boot order, and two are conditionally wired
+(`test-setup-mysql.ts` on the MySQL lane, `test-setup-ddl-profile.ts` on
+`DDL_PROFILE=1`). A `cases/helper.ts` would therefore be a rename of one of
+five files, not a consolidation.
+
+**Partial-mirror over-claim.** Per the table, `test-setup-ar.ts` is 4/16.
+Naming it `cases/helper.ts` invites a future agent to assume the other twelve
+lines are handled there and to stop checking — the exact failure mode the
+per-line `// Mirror Rails activerecord/test/cases/helper.rb:NN` comments
+prevent. Those comments already deliver the discoverability the rename is
+after, at the granularity where it matters (per setting, not per file), and
+`pnpm rails:find` covers the reverse lookup.
+
+**`test:compare` / `api:compare` gain nothing.** Both map _test cases_ and
+_source_, not setup infra: `scripts/test-compare/` and `scripts/api-compare/`
+have zero references to `test-setup*` or `helper.rb` outside one fixture
+string in `extra-surface.test.ts:743`. `schema-compare` and `fixtures-compare`
+key off `test-helpers/test-schema.ts`, `test-helpers/fixtures/`, and
+`test-helpers/models/` — all unaffected by a setup-file rename. No parity
+metric moves.
+
+**Rename cost.** 47 `test-setup` references across the repo: 6 in
+`vitest.config.ts` (5 paths + prose), a glob in `eslint.config.mjs:484`
+(`packages/activerecord/src/test-setup-*.ts`, the `no-raw-sql` test-infra
+exemption), the `**/test-*.ts` allow-list pattern planned for the
+`no-direct-process-env` rule (`docs/infrastructure/browser-compat-plan.md:158`),
+and ~35 doc/comment cross-references. The `test-setup-*` glob is what makes
+those lint exemptions expressible as one pattern; a `cases/` tree would need
+either a second glob or a directory-wide exemption that is wider than intended.
+
+**Sibling consistency.** `packages/arel/src/test-setup-engine.ts`
+(`vitest.config.ts:420`) follows the same convention for the non-AR `other`
+project. Moving only AR's files under `cases/` splits a repo-wide convention
+for one package. (Aside: `test-setup-ar.ts:3-4`'s header refers to "the sibling
+`test-setup.ts`", which no longer exists — a stale comment, not a file.)
+
+**Rails' own view.** `helper.rb:18` reads
+`# TODO: Move all these random hacks into the ARTest namespace and into the support/ dir` —
+Rails considers the single-file grab-bag a wart, not a layout to copy. Our
+`test-helpers/` tree is already the `test/support/` analogue that TODO asks for.
+
+## Decision
+
+Keep the `test-setup-*` convention. Fidelity to Rails here lives in the
+_settings applied and their values_, which the per-line mirror comments already
+pin to `helper.rb:NN`, not in the filename. Do not re-open this without a new
+argument that survives the four points above (no consolidation available,
+over-claim risk, zero compare-tooling gain, lint-glob cost).
+
+## Observations out of scope for this spike
+
+Recorded here because the mapping surfaced them; they are _fidelity_ gaps, not
+layout gaps, and none is proposed as a follow-up by this spike:
+
+- `helper.rb:27` `permanent_connection_checkout = :disallowed` — the flag
+  exists (`ar-config.ts:126`) but the suite does not set it, so trails does not
+  ban `Base.connection` in tests the way Rails does. Flipping it is a
+  large behavioral change across the AR suite.
+- `helper.rb:104-107` `extend_queries = true` + the two `install_support`
+  calls — `encryption/config.ts:22` defaults `extendQueries` to `false` and
+  install is per-test, so deterministic-encryption query extension is not
+  suite-wide as in Rails.
+- `helper.rb:43` `belongs_to_required_validates_foreign_key = false` and
+  `:14-16` PG `create_unlogged_tables = true` — flags exist, not set suite-wide.

--- a/docs/infrastructure/ar-test-setup-cases-helper-layout-audit.md
+++ b/docs/infrastructure/ar-test-setup-cases-helper-layout-audit.md
@@ -7,8 +7,13 @@ distinct `helper.rb` lines, should the AR test-setup files be reorganized under
 a Rails-style `cases/` tree (e.g. `cases/helper.ts`), or does the
 `test-setup-*` convention stay?
 
-**Recommendation: keep as-is (option b).** Rationale below; this document
-exists so the question is not re-litigated.
+**Recommendation: rename to a Rails `cases/` + `support/` layout (option a).**
+Plan and follow-up stories at the bottom.
+
+> **Revision, 2026-07-26.** The first version of this audit recommended keeping
+> `test-setup-*`. That was wrong on a fact and wrong on a weighting, and is
+> corrected here — see [Why the first recommendation was
+> wrong](#why-the-first-recommendation-was-wrong).
 
 ## What `helper.rb` actually does
 
@@ -64,107 +69,125 @@ The boot order these files run in, which is what actually constrains the layout:
 | per worker, after the driver is registered | `test-setup-dy.ts`                      | `vitest.config.ts:368` |
 | per worker, `DDL_PROFILE=1` only           | `test-setup-ddl-profile.ts`             | `vitest.config.ts:371` |
 
-## Trade-offs
+## Why the first recommendation was wrong
 
-**Vitest `setupFiles` vs Rails `require`.** The `test-setup-*` files are not
-libraries — they are _ordered side-effect entry points_ declared in
-`vitest.config.ts:363-371`, and the order is load-bearing
-(`test-setup-worker-db` claims the slot → `test-setup-ar` registers the driver
-and flips config → `test-setup-dy` opens the connection and lays the schema).
-Rails' `helper.rb` is `require`d by each test file, so it is a library and one
-file is the natural shape. A `cases/helper.ts` name would suggest importable
-setup that our files explicitly are not; `test-setup-*` names the mechanism
-that actually runs them.
+**The factual error.** v1 claimed the trails setup files have "no counterpart"
+in Rails and that a `cases/` tree would be "a rename of 1 of 5 files, not a
+consolidation." That is false. `vendor/rails/activerecord/test/support/`
+contains ten files — `config.rb`, `connection.rb`, `connection_helper.rb`,
+`load_schema_helper.rb`, `adapter_helper.rb`, `async_helper.rb`, `ddl_helper.rb`,
+`schema_dumping_helper.rb`, `fake_adapter.rb`, `tools.rb` — plus
+`test/config.rb`. Most of what our test-infra files do has a _named_ Rails home.
+v1 only compared against `cases/helper.rb` and concluded from that narrow view
+that nothing else mapped.
 
-**Consolidation is not available.** The one-file-per-`helper.rb` shape only
-works if the five files can merge, and they cannot: `globalSetup` runs in the
-main process before forks, the other four run per-worker at three different
-points in the boot order, and two are conditionally wired
-(`test-setup-mysql.ts` on the MySQL lane, `test-setup-ddl-profile.ts` on
-`DDL_PROFILE=1`). A `cases/helper.ts` would therefore be a rename of one of
-five files, not a consolidation.
+**The weighting error.** Three of v1's five arguments were convenience, not
+fidelity: rename cost (93 references, lint globs, ratchet JSONs), consistency
+with the sibling `test-setup-*` convention (a trails invention, not a Rails
+one), and "the compare tooling doesn't map these files anyway." Fidelity is this
+project's primary goal; those are costs to pay and mechanisms to update, not
+reasons to keep a non-Rails name.
 
-**Partial-mirror over-claim.** Per the table, `test-setup-ar.ts` owns 4 of the
-13 `helper.rb` responsibilities that have a trails home. Naming it
-`cases/helper.ts` invites a future agent to assume the other nine are there and
-to stop checking — the exact failure mode the per-line
-`// Mirror Rails activerecord/test/cases/helper.rb:NN` comments prevent. Those
-comments already deliver the discoverability the rename is after, at the granularity where it matters (per setting, not per file), and
-`pnpm rails:find` covers the reverse lookup.
+What survives from v1: the boot-order constraint is real, so the five setup
+files cannot collapse into one. But Rails' test infra is not one file either —
+it is `cases/helper.rb` plus ten `support/*.rb`. Multiple files is the faithful
+shape; only our _names and directories_ are invented.
 
-**`test:compare` / `api:compare` gain nothing.** Both map _test cases_ and
-_source_, not setup infra: `scripts/test-compare/` and `scripts/api-compare/`
-have zero references to `test-setup*` or `helper.rb` outside one fixture
-string in `extra-surface.test.ts:743`. `schema-compare` and `fixtures-compare`
-key off `test-helpers/test-schema.ts`, `test-helpers/fixtures/`, and
-`test-helpers/models/` — all unaffected by a setup-file rename. No parity
-metric moves.
+**The precedent already exists.** `test-helpers/` already contains
+`connection-helper.ts` and `schema-dumping-helper.ts` — exact kebab-case
+renderings of `support/connection_helper.rb` and `support/schema_dumping_helper.rb`.
+Someone already started mirroring `support/` file-for-file; they just did it
+inside a directory named `test-helpers/`. This plan finishes that work rather
+than starting something new.
 
-**Rename cost.** 93 `test-setup` references outside `vendor/` — 52 in
-code/config, 41 in docs. The load-bearing ones:
+## Target layout
 
-- `vitest.config.ts` — 9 (5 setupFile paths + the arel one + prose).
-- `eslint/no-raw-sql.mjs:42` — a hardcoded filename regex,
-  `/(^|\/)test-setup-[^/]*\.ts$/`, exempting setup files from the raw-SQL ban.
-- `eslint.config.mjs:484` — the `packages/activerecord/src/test-setup-*.ts` glob
-  for the same exemption at config level.
-- `eslint/no-explicit-any-src-exclude.json:194` and
-  `eslint/rails-error-parity-exclude.json:115-116` — per-file ratchet entries
-  keyed by path.
-- `docs/infrastructure/browser-compat-plan.md:158` — the `**/test-*.ts`
-  allow-list pattern planned for the `no-direct-process-env` rule.
+```
+packages/activerecord/src/
+  cases/
+    helper.ts               <- test/cases/helper.rb
+  support/
+    config.ts               <- test/support/config.rb  (+ test/config.rb)
+    connection.ts           <- test/support/connection.rb
+    connection-helper.ts    <- test/support/connection_helper.rb    [name already matches]
+    schema-dumping-helper.ts<- test/support/schema_dumping_helper.rb [name already matches]
+    load-schema-helper.ts   <- test/support/load_schema_helper.rb
+    adapter-helper.ts       <- test/support/adapter_helper.rb
+    async-helper.ts         <- test/support/async_helper.rb
+    ddl-helper.ts           <- test/support/ddl_helper.rb
+    fake-adapter.ts         <- test/support/fake_adapter.rb
+  test-setup-worker-db.ts   (no Rails counterpart — Rails is single-process)
+  test-helpers/
+    models/ fixtures/ test-schema.ts   (already mirror Rails; unchanged)
+```
 
-The `test-setup-` **prefix** is what lets four separate lint mechanisms name
-this set with one pattern each. A `cases/` tree replaces each with either a
-second pattern or a directory-wide exemption wider than intended — and the
-ratchet JSONs would need path rewrites that conflict with any sibling PR
-touching them.
+Current `test-helpers/*.ts` with no `support/*.rb` counterpart (`ar-db-slots.ts`,
+`sqlite-template.ts`, `template-global-setup.ts`, `skip-global-reset.ts`, …) are
+vitest-fork-model infrastructure Rails has no analogue for. They keep invented
+names because there is nothing to be faithful to — but they should not sit in a
+directory that _looks_ like `support/`. Each story decides its file's home
+explicitly.
 
-**Sibling consistency.** `packages/arel/src/test-setup-engine.ts`
-(`vitest.config.ts:420`) follows the same convention for the non-AR `other`
-project. Moving only AR's files under `cases/` splits a repo-wide convention
-for one package. (Aside: `test-setup-ar.ts:3-4`'s header refers to "the sibling
-`test-setup.ts`", which no longer exists — a stale comment, not a file.)
+## What does NOT move
 
-**Rails' own view.** `helper.rb:18` reads
-`# TODO: Move all these random hacks into the ARTest namespace and into the support/ dir` —
-Rails considers the single-file grab-bag a wart, not a layout to copy. Our
-`test-helpers/` tree is already the `test/support/` analogue that TODO asks for.
+- **`test-setup-worker-db.ts` and the template `globalSetup`.** Per-worker DB
+  isolation via advisory locks exists because vitest forks; Rails' suite is one
+  process against one database. No Rails name to adopt.
+- **`test-helpers/models/`, `fixtures/`, `test-schema.ts`.** Already faithful to
+  `test/models/`, `test/fixtures/`, `test/schema/schema.rb`, and already the
+  keys `schema:compare` / `fixtures:compare` read. Moving them buys nothing and
+  risks the compare manifests.
+- **Test files themselves.** Rails puts tests in `test/cases/*_test.rb`; trails
+  puts `*.test.ts` next to source by repo convention (CLAUDE.md). That is a
+  settled, separate divergence — this plan does not reopen it, which is why
+  `cases/` here holds only `helper.ts`.
 
-## Decision
+## Follow-up stories
 
-Keep the `test-setup-*` convention. Fidelity to Rails here lives in the
-_settings applied and their values_, which the per-line mirror comments already
-pin to `helper.rb:NN`, not in the filename. Do not re-open this without a new
-argument that survives the five points above (nothing to consolidate,
-over-claim risk, zero compare-tooling gain, four lint mechanisms keyed on the
-`test-setup-` prefix, cross-package convention). What _would_ change the answer:
-if vitest gained a single ordered-setup entry point so the five files could
-genuinely merge into one, the one-file `helper.rb` shape becomes available and
-the naming question is worth re-asking.
+Filed under RFC 0064. Ordering matters, and per CLAUDE.md these ship one at a
+time from `main` — no stacking. The directory rename goes first so later stories
+edit files at their final paths.
+
+1. `move-test-helpers-to-support-dir` — mechanical `test-helpers/` → `support/`
+   rename (keeping `models/`, `fixtures/`, `test-schema.ts` in place), plus the
+   lint globs, ratchet JSON paths, and `vitest.config.ts` references. Single
+   mechanical rename — the one CLAUDE.md exception to the fan-out rule.
+2. `rename-test-setup-ar-to-cases-helper` — `test-setup-ar.ts` → `cases/helper.ts`.
+3. `support-config-and-connection` — `test-connection-env.ts`,
+   `test-database-config.ts`, `arunit2-config.ts` → `support/config.ts`;
+   the connection bootstrap in `test-setup-dy.ts` → `support/connection.ts`.
+4. `support-adapter-helper` — `currentAdapter` / `inMemoryDb` and the
+   `supports.ts` predicates → `support/adapter-helper.ts`, matching
+   `adapter_helper.rb`'s method set.
+5. `support-load-schema-helper` — `canonical-schema.ts` /
+   `schema-file-generator.ts` → `support/load-schema-helper.ts`.
+6. `port-missing-support-helpers` — `ddl_helper.rb` (`with_example_table`),
+   `async_helper.rb` (`assert_async_equal`), `fake_adapter.rb`
+   (`FakeActiveRecordAdapter`, which `helper.rb:46` registers). These have no
+   trails file at all today.
 
 ## Observations out of scope for this spike
 
-Recorded here because the mapping surfaced them; they are _fidelity_ gaps, not
-layout gaps, so they are out of RFC 0064's scope (whose non-goal is "no behavior
-change to the test harness"). They are filed under **RFC 0071
-ar-test-helper-suite-wide-config-fidelity** (`status: active`) as four ready
-stories:
+The mapping also surfaced four `helper.rb` settings that trails has a flag for
+but never applies suite-wide. Those are _fidelity_ gaps, not layout gaps, so
+they were filed separately under **RFC 0071
+ar-test-helper-suite-wide-config-fidelity**. As of 2026-07-26 they are already
+resolved or superseded:
 
-- `helper.rb:27` `permanent_connection_checkout = :disallowed` — the flag
-  exists (`ar-config.ts:126`) but the suite does not set it, so trails does not
-  ban `Base.connection` in tests the way Rails does. 114 test files reference
-  `Base.connection`, so this is scoped as an audit first, not a flip →
-  `audit-permanent-connection-checkout-disallowed`.
-- `helper.rb:104-107` `extend_queries = true` + the two `install_support`
-  calls — `encryption/config.ts:22` defaults `extendQueries` to `false` and
-  install is per-test, so deterministic-encryption query extension is not
-  suite-wide as in Rails. `trailtie.ts` has no `extendQueries` handling at all,
-  so the production-side `railtie.rb:351` arm is unported too →
-  `encryption-extend-queries-suite-wide`.
-- `helper.rb:43` `belongs_to_required_validates_foreign_key = false` —
-  `ar-config.ts:213` / `trailtie.ts:139` default `true` →
+- `helper.rb:104-107` `extend_queries = true` + the two `install_support` calls
+  (`encryption/config.ts:22` defaulted `false`; `trailtie.ts` had no
+  `extendQueries` handling, so the production `railtie.rb:351` arm was unported
+  too) — **done**, `encryption-extend-queries-suite-wide`.
+- `helper.rb:43` `belongs_to_required_validates_foreign_key = false`
+  (`ar-config.ts:213` / `trailtie.ts:139` defaulted `true`) — **done**,
   `belongs-to-required-validates-fk-false`.
-- `helper.rb:14-16` PG `create_unlogged_tables = true` —
-  `postgresql-adapter.ts:321` defaults `false`, so the PG lane pays full WAL
-  cost on every table build → `pg-create-unlogged-tables-in-suite`.
+- `helper.rb:14-16` PG `create_unlogged_tables = true`
+  (`postgresql-adapter.ts:321` defaults `false`) — closed,
+  `pg-create-unlogged-tables-in-suite`.
+- `helper.rb:27` `permanent_connection_checkout = :disallowed` — owned by
+  **RFC 0073 permanent-connection-checkout-disallowed**, which has 11 stories
+  and a completed measurement. Note that RFC's finding before touching this:
+  the `Base.connection` textual grep this audit originally cited (114 files) is
+  the wrong instrument — instrumenting the gate found 2077 hits, 1983 of them
+  (95.5%) from a single line, `use-fixtures.ts:610`, that the grep does not
+  match. The duplicate RFC 0071 story was closed as superseded.

--- a/docs/infrastructure/ar-test-setup-cases-helper-layout-audit.md
+++ b/docs/infrastructure/ar-test-setup-cases-helper-layout-audit.md
@@ -48,8 +48,21 @@ because Rails' test runner is a single process with a single database:
 - opt-in DDL profiler — `test-setup-ddl-profile.ts`
 
 So `helper.rb`'s content is a **strict subset** of what the trails setup files
-do, spread across five files, three of which exist only because of vitest's
-fork model. `test-setup-ar.ts` covers 4 of ~16 `helper.rb` responsibilities.
+do, spread across five files (plus `globalSetup`), three of which exist only
+because of vitest's fork model. Of the 17 rows above, 4 have no analogue by
+language (`Thread.abort_on_exception`, the deprecator, `remove_method`, I18n)
+and 13 have a trails home; `test-setup-ar.ts` owns 4 of those 13.
+
+The boot order these files run in, which is what actually constrains the layout:
+
+| when                                       | file                                    | wired at               |
+| ------------------------------------------ | --------------------------------------- | ---------------------- |
+| once, main process, pre-fork               | `test-helpers/template-global-setup.ts` | `globalSetup`          |
+| per worker, 1st setupFile                  | `test-setup-worker-db.ts`               | `vitest.config.ts:363` |
+| per worker, 2nd                            | `test-setup-ar.ts`                      | `vitest.config.ts:364` |
+| per worker, MySQL lane only                | `test-setup-mysql.ts`                   | `vitest.config.ts:366` |
+| per worker, after the driver is registered | `test-setup-dy.ts`                      | `vitest.config.ts:368` |
+| per worker, `DDL_PROFILE=1` only           | `test-setup-ddl-profile.ts`             | `vitest.config.ts:371` |
 
 ## Trade-offs
 
@@ -71,11 +84,11 @@ points in the boot order, and two are conditionally wired
 `DDL_PROFILE=1`). A `cases/helper.ts` would therefore be a rename of one of
 five files, not a consolidation.
 
-**Partial-mirror over-claim.** Per the table, `test-setup-ar.ts` is 4/16.
-Naming it `cases/helper.ts` invites a future agent to assume the other twelve
-lines are handled there and to stop checking — the exact failure mode the
-per-line `// Mirror Rails activerecord/test/cases/helper.rb:NN` comments
-prevent. Those comments already deliver the discoverability the rename is
+**Partial-mirror over-claim.** Per the table, `test-setup-ar.ts` owns 4 of the
+13 `helper.rb` responsibilities that have a trails home. Naming it
+`cases/helper.ts` invites a future agent to assume the other nine are there and
+to stop checking — the exact failure mode the per-line
+`// Mirror Rails activerecord/test/cases/helper.rb:NN` comments prevent. Those comments already deliver the discoverability the rename is
 after, at the granularity where it matters (per setting, not per file), and
 `pnpm rails:find` covers the reverse lookup.
 
@@ -87,14 +100,25 @@ key off `test-helpers/test-schema.ts`, `test-helpers/fixtures/`, and
 `test-helpers/models/` — all unaffected by a setup-file rename. No parity
 metric moves.
 
-**Rename cost.** 47 `test-setup` references across the repo: 6 in
-`vitest.config.ts` (5 paths + prose), a glob in `eslint.config.mjs:484`
-(`packages/activerecord/src/test-setup-*.ts`, the `no-raw-sql` test-infra
-exemption), the `**/test-*.ts` allow-list pattern planned for the
-`no-direct-process-env` rule (`docs/infrastructure/browser-compat-plan.md:158`),
-and ~35 doc/comment cross-references. The `test-setup-*` glob is what makes
-those lint exemptions expressible as one pattern; a `cases/` tree would need
-either a second glob or a directory-wide exemption that is wider than intended.
+**Rename cost.** 93 `test-setup` references outside `vendor/` — 52 in
+code/config, 41 in docs. The load-bearing ones:
+
+- `vitest.config.ts` — 9 (5 setupFile paths + the arel one + prose).
+- `eslint/no-raw-sql.mjs:42` — a hardcoded filename regex,
+  `/(^|\/)test-setup-[^/]*\.ts$/`, exempting setup files from the raw-SQL ban.
+- `eslint.config.mjs:484` — the `packages/activerecord/src/test-setup-*.ts` glob
+  for the same exemption at config level.
+- `eslint/no-explicit-any-src-exclude.json:194` and
+  `eslint/rails-error-parity-exclude.json:115-116` — per-file ratchet entries
+  keyed by path.
+- `docs/infrastructure/browser-compat-plan.md:158` — the `**/test-*.ts`
+  allow-list pattern planned for the `no-direct-process-env` rule.
+
+The `test-setup-` **prefix** is what lets four separate lint mechanisms name
+this set with one pattern each. A `cases/` tree replaces each with either a
+second pattern or a directory-wide exemption wider than intended — and the
+ratchet JSONs would need path rewrites that conflict with any sibling PR
+touching them.
 
 **Sibling consistency.** `packages/arel/src/test-setup-engine.ts`
 (`vitest.config.ts:420`) follows the same convention for the non-AR `other`
@@ -112,8 +136,12 @@ Rails considers the single-file grab-bag a wart, not a layout to copy. Our
 Keep the `test-setup-*` convention. Fidelity to Rails here lives in the
 _settings applied and their values_, which the per-line mirror comments already
 pin to `helper.rb:NN`, not in the filename. Do not re-open this without a new
-argument that survives the four points above (no consolidation available,
-over-claim risk, zero compare-tooling gain, lint-glob cost).
+argument that survives the five points above (nothing to consolidate,
+over-claim risk, zero compare-tooling gain, four lint mechanisms keyed on the
+`test-setup-` prefix, cross-package convention). What _would_ change the answer:
+if vitest gained a single ordered-setup entry point so the five files could
+genuinely merge into one, the one-file `helper.rb` shape becomes available and
+the naming question is worth re-asking.
 
 ## Observations out of scope for this spike
 

--- a/docs/infrastructure/ar-test-setup-cases-helper-layout-audit.md
+++ b/docs/infrastructure/ar-test-setup-cases-helper-layout-audit.md
@@ -146,15 +146,25 @@ the naming question is worth re-asking.
 ## Observations out of scope for this spike
 
 Recorded here because the mapping surfaced them; they are _fidelity_ gaps, not
-layout gaps, and none is proposed as a follow-up by this spike:
+layout gaps, so they are out of RFC 0064's scope (whose non-goal is "no behavior
+change to the test harness"). They are filed under **RFC 0071
+ar-test-helper-suite-wide-config-fidelity** — four stories, currently draft
+pending RFC acceptance:
 
 - `helper.rb:27` `permanent_connection_checkout = :disallowed` — the flag
   exists (`ar-config.ts:126`) but the suite does not set it, so trails does not
-  ban `Base.connection` in tests the way Rails does. Flipping it is a
-  large behavioral change across the AR suite.
+  ban `Base.connection` in tests the way Rails does. 114 test files reference
+  `Base.connection`, so this is scoped as an audit first, not a flip →
+  `audit-permanent-connection-checkout-disallowed`.
 - `helper.rb:104-107` `extend_queries = true` + the two `install_support`
   calls — `encryption/config.ts:22` defaults `extendQueries` to `false` and
   install is per-test, so deterministic-encryption query extension is not
-  suite-wide as in Rails.
-- `helper.rb:43` `belongs_to_required_validates_foreign_key = false` and
-  `:14-16` PG `create_unlogged_tables = true` — flags exist, not set suite-wide.
+  suite-wide as in Rails. `trailtie.ts` has no `extendQueries` handling at all,
+  so the production-side `railtie.rb:351` arm is unported too →
+  `encryption-extend-queries-suite-wide`.
+- `helper.rb:43` `belongs_to_required_validates_foreign_key = false` —
+  `ar-config.ts:213` / `trailtie.ts:139` default `true` →
+  `belongs-to-required-validates-fk-false`.
+- `helper.rb:14-16` PG `create_unlogged_tables = true` —
+  `postgresql-adapter.ts:321` defaults `false`, so the PG lane pays full WAL
+  cost on every table build → `pg-create-unlogged-tables-in-suite`.

--- a/docs/infrastructure/ar-test-setup-cases-helper-layout-audit.md
+++ b/docs/infrastructure/ar-test-setup-cases-helper-layout-audit.md
@@ -148,8 +148,8 @@ the naming question is worth re-asking.
 Recorded here because the mapping surfaced them; they are _fidelity_ gaps, not
 layout gaps, so they are out of RFC 0064's scope (whose non-goal is "no behavior
 change to the test harness"). They are filed under **RFC 0071
-ar-test-helper-suite-wide-config-fidelity** — four stories, currently draft
-pending RFC acceptance:
+ar-test-helper-suite-wide-config-fidelity** (`status: active`) as four ready
+stories:
 
 - `helper.rb:27` `permanent_connection_checkout = :disallowed` — the flag
   exists (`ar-config.ts:126`) but the suite does not set it, so trails does not

--- a/docs/infrastructure/ar-test-setup-cases-helper-layout-audit.md
+++ b/docs/infrastructure/ar-test-setup-cases-helper-layout-audit.md
@@ -12,8 +12,8 @@ exists so the question is not re-litigated.
 
 ## What `helper.rb` actually does
 
-`vendor/rails/activerecord/test/cases/helper.rb` is 107 lines and does a dozen
-unrelated things. Mapped to trails:
+`vendor/rails/activerecord/test/cases/helper.rb` is 107 lines and does seventeen
+loosely related things. Mapped to trails:
 
 | helper.rb responsibility                                         | trails location                                                                                                      |
 | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
@@ -88,8 +88,8 @@ five files, not a consolidation.
 13 `helper.rb` responsibilities that have a trails home. Naming it
 `cases/helper.ts` invites a future agent to assume the other nine are there and
 to stop checking — the exact failure mode the per-line
-`// Mirror Rails activerecord/test/cases/helper.rb:NN` comments prevent. Those comments already deliver the discoverability the rename is
-after, at the granularity where it matters (per setting, not per file), and
+`// Mirror Rails activerecord/test/cases/helper.rb:NN` comments prevent. Those
+comments already deliver the discoverability the rename is after, at the granularity where it matters (per setting, not per file), and
 `pnpm rails:find` covers the reverse lookup.
 
 **`test:compare` / `api:compare` gain nothing.** Both map _test cases_ and

--- a/docs/infrastructure/ar-test-setup-cases-helper-layout-audit.md
+++ b/docs/infrastructure/ar-test-setup-cases-helper-layout-audit.md
@@ -121,12 +121,53 @@ packages/activerecord/src/
     models/ fixtures/ test-schema.ts   (already mirror Rails; unchanged)
 ```
 
-Current `test-helpers/*.ts` with no `support/*.rb` counterpart (`ar-db-slots.ts`,
-`sqlite-template.ts`, `template-global-setup.ts`, `skip-global-reset.ts`, …) are
-vitest-fork-model infrastructure Rails has no analogue for. They keep invented
-names because there is nothing to be faithful to — but they should not sit in a
-directory that _looks_ like `support/`. Each story decides its file's home
-explicitly.
+### Every current `test-helpers/` entry has a destination
+
+`test-helpers/` is today a mashup of two different Rails trees: some of it
+mirrors `test/support/*.rb`, and some of it mirrors the **`test/` root**
+(`vendor/rails/activerecord/test/` contains `assets/`, `cases/`, `fixtures/`,
+`migrations/`, `models/`, `schema/`, `support/`). The directory is **not**
+deleted and **not** moved wholesale — it is partially drained. Disposition of
+all 36 files and 4 subdirectories:
+
+**A. Mirrors the Rails `test/` root — stays put, keeps its name** (already
+faithful; `schema:compare` / `fixtures:compare` key off these paths):
+`models/`, `fixtures/`, `migrations/`, `assets/`, `test-schema.ts`
+(← `test/schema/schema.rb`).
+
+**B. Moves to `support/` with a Rails name** (story 1 relocates; stories 3-5
+rename): `connection-helper.ts` and `schema-dumping-helper.ts` (names already
+correct), `test-connection-env.ts` + `test-database-config.ts` +
+`arunit2-config.ts` → `config.ts`, `supports.ts` → `adapter-helper.ts`,
+`canonical-schema.ts` + `schema-file-generator.ts` → `load-schema-helper.ts`,
+`second-connection.ts` + `setup-second-pool.ts` + `setup-handler-suite.ts`
+→ `connection.ts`.
+
+**C. Moves to `support/`, keeps its invented name** — vitest-fork-model or
+trails-harness infrastructure with no Rails counterpart, but still test support:
+`ar-db-slots.ts`, `ar-db-forks-default.ts`, `sqlite-template.ts`,
+`template-global-setup.ts`, `skip-global-reset.ts`, `ddl-profile.ts`,
+`canonical-model-index.ts`, `canonical-model-index-encryption-setup.ts`,
+`quote-regex.ts`, `with-db-warnings-action.ts`, `setup-adapter-suite.ts`,
+`drop-all-tables.ts`, `seed-association-cache.ts`, `schema-types.ts`.
+Each keeps its name because there is nothing to be faithful to — but it belongs
+in the support tree, not a differently-named one.
+
+**D. Destination unresolved — `disposition-remaining-test-helpers` decides**
+(story 7). These are suspected of being _library_ code misfiled into test
+infra, or of mapping somewhere other than `support/`, and each needs its Rails
+counterpart confirmed before it moves:
+`fixtures.ts`, `fixture-set.ts`, `define-fixtures.ts`, `fixtures-registry.ts`,
+`use-fixtures.ts`, `with-transactional-fixtures.ts`, `use-transactional-tests.ts`
+(Rails' equivalents are `lib/active_record/fixtures.rb`,
+`lib/active_record/fixture_set/`, `lib/active_record/test_fixtures.rb` — **lib**,
+not test support, and trails already has a top-level `src/test-fixtures.ts`);
+`in-time-zone.ts` (Rails' `InTimeZone` is a module _inside_ `cases/helper.rb:66-79`,
+so it may belong in `cases/helper.ts`); `protected-params.ts`;
+`repair-validations.ts`.
+
+Nothing in `test-helpers/` is left unaccounted for by A-D. Story 1 moves only
+B and C; A stays; D waits for story 7.
 
 ## What does NOT move
 
@@ -148,10 +189,12 @@ Filed under RFC 0064. Ordering matters, and per CLAUDE.md these ship one at a
 time from `main` — no stacking. The directory rename goes first so later stories
 edit files at their final paths.
 
-1. `move-test-helpers-to-support-dir` — mechanical `test-helpers/` → `support/`
-   rename (keeping `models/`, `fixtures/`, `test-schema.ts` in place), plus the
-   lint globs, ratchet JSON paths, and `vitest.config.ts` references. Single
-   mechanical rename — the one CLAUDE.md exception to the fan-out rule.
+1. `move-test-helpers-to-support-dir` — create `support/` and move **only
+   buckets B and C** into it. `test-helpers/` survives, holding bucket A
+   (`models/`, `fixtures/`, `migrations/`, `assets/`, `test-schema.ts`) and
+   bucket D until story 7. This is explicitly **not** a whole-directory
+   `git mv`. Includes the lint globs, ratchet JSON paths, and
+   `vitest.config.ts` references for the moved files.
 2. `rename-test-setup-ar-to-cases-helper` — `test-setup-ar.ts` → `cases/helper.ts`.
 3. `support-config-and-connection` — `test-connection-env.ts`,
    `test-database-config.ts`, `arunit2-config.ts` → `support/config.ts`;
@@ -165,6 +208,9 @@ edit files at their final paths.
    `async_helper.rb` (`assert_async_equal`), `fake_adapter.rb`
    (`FakeActiveRecordAdapter`, which `helper.rb:46` registers). These have no
    trails file at all today.
+7. `disposition-remaining-test-helpers` — resolve bucket D above: confirm each
+   file's Rails counterpart and move it (or establish that it is library code
+   that belongs outside the test tree entirely).
 
 ## Observations out of scope for this spike
 

--- a/docs/infrastructure/ar-test-setup-cases-helper-layout-audit.md
+++ b/docs/infrastructure/ar-test-setup-cases-helper-layout-audit.md
@@ -164,10 +164,20 @@ counterpart confirmed before it moves:
 not test support, and trails already has a top-level `src/test-fixtures.ts`);
 `in-time-zone.ts` (Rails' `InTimeZone` is a module _inside_ `cases/helper.rb:66-79`,
 so it may belong in `cases/helper.ts`); `protected-params.ts`;
-`repair-validations.ts`.
+`repair-validations.ts`; `rocket-tables.ts` (its own docstring notes that
+`ActiveRecord::Migration::ForeignKeyTest` creates and drops `rockets` /
+`astronauts` **inline**, `foreign_key_test.rb:178-194` — so the faithful home is
+the test file that uses it, not a shared support helper; confirm before moving).
 
-Nothing in `test-helpers/` is left unaccounted for by A-D. Story 1 moves only
-B and C; A stays; D waits for story 7.
+**Staleness warning.** This table was taken against this branch's base commit,
+and `main` moves. `rocket-tables.ts` landed on `main` after the branch was cut
+and is absent from the branch checkout — it appears above only via a
+`git show origin/main` read. **Whichever story executes first must re-scan
+`test-helpers/` against current `main`** and bucket anything new rather than
+trusting this list verbatim; story 1's acceptance criteria carry that
+instruction.
+
+Story 1 moves only B and C; A stays; D waits for story 7.
 
 ## What does NOT move
 


### PR DESCRIPTION
Spike (RFC 0064 ar-test-infra-layout-fidelity): should the AR test-setup files be
reorganized under a Rails-style `cases/` tree, or does the `test-setup-*`
convention stay? Question raised while reviewing #4791.

**Outcome: rename to a Rails `cases/` + `support/` layout.** Docs-only — one
audit report, no code change. Six follow-up stories filed under RFC 0064.

> This PR previously recommended the opposite ("keep `test-setup-*`"). That was
> reversed after review; the report carries the correction inline rather than
> hiding it in history.

### Why the reversal

The v1 recommendation was wrong twice over:

- **Factually.** It compared trails only against `cases/helper.rb` and concluded
  our setup files have "no Rails counterpart." But
  `vendor/rails/activerecord/test/support/` has ten named files — `config.rb`,
  `connection.rb`, `connection_helper.rb`, `load_schema_helper.rb`,
  `adapter_helper.rb`, `async_helper.rb`, `ddl_helper.rb`,
  `schema_dumping_helper.rb`, `fake_adapter.rb`, `tools.rb` — and most of what
  our test infra does has a name there. Two of ours,
  `test-helpers/connection-helper.ts` and `test-helpers/schema-dumping-helper.ts`,
  are *already* exact renderings of `support/*.rb` names; the mirroring had
  started and only the directory name was wrong.
- **By weighting.** Three of its five arguments were rename cost (93 refs, lint
  globs, ratchet JSONs), consistency with the `test-setup-*` convention (a
  trails invention), and "the compare tooling doesn't map these files." Fidelity
  is this project's primary goal; those are costs to pay, not reasons to keep an
  invented name.

What survives from v1: the boot-order constraint is real, so the five setup
files can't collapse into one. But Rails' test infra isn't one file either —
it's `cases/helper.rb` plus ten `support/*.rb`. Multiple files is the faithful
shape; only our names and directories are invented.

### Target

```
cases/helper.ts             <- test/cases/helper.rb
support/config.ts           <- test/support/config.rb (+ test/config.rb)
support/connection.ts       <- test/support/connection.rb
support/adapter-helper.ts   <- test/support/adapter_helper.rb
support/load-schema-helper.ts <- test/support/load_schema_helper.rb
support/ddl-helper.ts       <- test/support/ddl_helper.rb
support/async-helper.ts     <- test/support/async_helper.rb
support/fake-adapter.ts     <- test/support/fake_adapter.rb
support/connection-helper.ts, schema-dumping-helper.ts  [names already match]
test-setup-worker-db.ts     (no Rails counterpart - vitest forks; Rails doesn't)
```

The report also states what does **not** move: the worker-DB slot machinery and
template `globalSetup` (no Rails analogue), `models/` + `fixtures/` +
`test-schema.ts` (already faithful, and the keys `schema:compare` /
`fixtures:compare` read), and the `*.test.ts`-next-to-source convention, which
is a separate settled divergence — hence `cases/` holds only `helper.ts`.

### Follow-up stories (RFC 0064, now active)

`move-test-helpers-to-support-dir` is ready; the other five are dependency-gated
behind it so they edit files at final paths, and ship one at a time from `main`
per the no-stacking rule.

1. `move-test-helpers-to-support-dir` — partial drain of `test-helpers/` into
   `support/` (buckets B and C only) + lint globs, ratchet JSON paths, and the
   `scripts/*-compare/` path constants.
2. `rename-test-setup-ar-to-cases-helper`
3. `support-config-and-connection`
4. `support-adapter-helper`
5. `support-load-schema-helper`
6. `port-missing-support-helpers` — `ddl_helper.rb`, `async_helper.rb`,
   `fake_adapter.rb` have no trails file at all today.
7. `disposition-remaining-test-helpers` — resolves bucket D (below).

### Review #4 follow-ups

Both issues were merge-blocking for the plan's usability and are **fixed in
this PR**, not deferred:

- *Target tree vs. story 1 wording inconsistent* — the doc now states outright
  that `test-helpers/` is **partially drained, not renamed**, and story 1's body
  leads with "This is NOT a whole-directory `git mv`."
- *Unaccounted files* — every one of the 36 files and 4 subdirectories in
  `test-helpers/` is now assigned to bucket **A** (mirrors the Rails `test/`
  root — `models/`, `fixtures/`, `migrations/`, `assets/`, `test-schema.ts`;
  stays put), **B** (moves to `support/` with a Rails name), **C** (moves to
  `support/`, keeps its invented name — no Rails counterpart), or **D**
  (destination unresolved → story `disposition-remaining-test-helpers`).
  The other named files land in C (`drop-all-tables.ts`, `seed-association-cache.ts`),
  B (`second-connection.ts`, `setup-second-pool.ts`), D (`protected-params.ts`,
  `repair-validations.ts`), and A (`migrations/`, `assets/`).
- *"93 references" not reproducible* — the doc now states the methodology
  (lines containing `test-setup` outside `vendor/`, per a quoted grep) and flags
  it as a lower bound on edit sites rather than an occurrence count.

### Review #5 follow-up

`rocket-tables.ts` — **I was wrong last cycle** when I said it doesn't exist. It
exists on `main`; it is absent only from this branch, which was cut before it
landed, and I checked the branch. It is now bucketed **D**, not C: its own
docstring records that `ActiveRecord::Migration::ForeignKeyTest` creates and
drops `rockets` / `astronauts` inline (`foreign_key_test.rb:178-194`), so the
faithful home is the test file that uses it, not a shared support helper.

The general point behind that finding is the more valuable one, so it is now
written into both the doc and story 1's acceptance criteria: the A-D table is a
snapshot against this branch's base, `main` drifts, and **whichever story
executes first must re-scan `test-helpers/` against current `main`** and bucket
anything new rather than trusting the table verbatim. `rocket-tables.ts` is the
one confirmed drift as of this commit.

Bucket D turned up a finding worth flagging: the fixtures machinery
(`fixtures.ts`, `fixture-set.ts`, `use-fixtures.ts`, …) maps to
`lib/active_record/fixtures.rb` / `test_fixtures.rb` — **library** code, not
`test/support/` — and trails already has a top-level `src/test-fixtures.ts`.
That may be misfiled library code rather than test infra; story 7 verifies
before moving anything.

### Out-of-scope observations

Four `helper.rb` settings trails has a flag for but never applies suite-wide were
filed under RFC 0071; two are now done, one closed, and `helper.rb:27` is owned
by RFC 0073 (whose measurement showed the `Base.connection` grep this audit
originally cited is the wrong instrument — 95.5% of real hits come from one line
the grep misses). The duplicate story was closed as superseded.

Closes-story: spike-align-test-setup-with-cases-helper
