### PR TITLE
fix(tasks): serve the origin/main read index regardless of TASKS_DIR resolution

### DIFF
--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -88,6 +88,8 @@ import {
   dirtyWorktreeLines,
   syncWorktreeToOrigin,
   buildIndexFromOriginMain,
+  readIndexSource,
+  syncFromOrigin,
   readIndexedFile,
   claimAgeHours,
   isStaleClaim,
@@ -3480,6 +3482,34 @@ describe("buildIndexFromOriginMain (read path serves the origin/main tree)", () 
       },
     });
     expect(buildIndexFromOriginMain()).toBeNull();
+  });
+});
+
+describe("readIndexSource (origin/main index is not gated on the symlink)", () => {
+  const fromOrigin = { index: { ...emptyIdx, generated_at: "from-origin" }, sha: "d".repeat(40) };
+
+  it("serves the origin/main index however TASKS_DIR resolved", () => {
+    const sync = vi.fn();
+    const load = vi.fn(() => emptyIdx);
+    const got = readIndexSource({ fromOriginMain: () => fromOrigin, sync, load });
+    expect(got.sha).toBe(fromOrigin.sha);
+    expect(got.index.generated_at).toBe("from-origin");
+    // No working-tree read and, critically, no reset of an explicit $TASKS_DIR.
+    expect(sync).not.toHaveBeenCalled();
+    expect(load).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the working-tree index when the origin/main export fails", () => {
+    const sync = vi.fn();
+    const load = vi.fn(() => ({ ...emptyIdx, generated_at: "working-tree" }));
+    const got = readIndexSource({ fromOriginMain: () => null, sync, load });
+    expect(got).toEqual({ index: { ...emptyIdx, generated_at: "working-tree" }, sha: null });
+    expect(sync).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the reset fallback when TASKS_DIR is not the per-worktree symlink", () => {
+    syncFromOrigin(false);
+    expect(execFileSyncMock).not.toHaveBeenCalled();
   });
 });
 

--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -3483,31 +3483,17 @@ describe("buildIndexFromOriginMain (read path serves the origin/main tree)", () 
     });
     expect(buildIndexFromOriginMain()).toBeNull();
   });
-});
 
-describe("readIndexSource (origin/main index is not gated on the symlink)", () => {
-  const fromOrigin = { index: { ...emptyIdx, generated_at: "from-origin" }, sha: "d".repeat(40) };
-
-  it("serves the origin/main index however TASKS_DIR resolved", () => {
-    const sync = vi.fn();
-    const load = vi.fn(() => emptyIdx);
-    const got = readIndexSource({ fromOriginMain: () => fromOrigin, sync, load });
-    expect(got.sha).toBe(fromOrigin.sha);
-    expect(got.index.generated_at).toBe("from-origin");
-    // No working-tree read and, critically, no reset of an explicit $TASKS_DIR.
-    expect(sync).not.toHaveBeenCalled();
-    expect(load).not.toHaveBeenCalled();
+  it("serves the read index when TASKS_DIR did not resolve to the per-worktree symlink", () => {
+    const { seen } = setup();
+    const got = readIndexSource(false);
+    expect(got.sha).toBe(SHA);
+    expect(got.index.generated_at).toBe("2026-01-01");
+    expect(seen).not.toContain("reset");
   });
 
-  it("falls back to the working-tree index when the origin/main export fails", () => {
-    const sync = vi.fn();
-    const load = vi.fn(() => ({ ...emptyIdx, generated_at: "working-tree" }));
-    const got = readIndexSource({ fromOriginMain: () => null, sync, load });
-    expect(got).toEqual({ index: { ...emptyIdx, generated_at: "working-tree" }, sha: null });
-    expect(sync).toHaveBeenCalledTimes(1);
-  });
-
-  it("skips the reset fallback when TASKS_DIR is not the per-worktree symlink", () => {
+  it("skips the reset fallback for a non-symlink TASKS_DIR when the export is unavailable", () => {
+    setup();
     syncFromOrigin(false);
     expect(execFileSyncMock).not.toHaveBeenCalled();
   });

--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -3492,7 +3492,7 @@ describe("buildIndexFromOriginMain (read path serves the origin/main tree)", () 
     expect(seen).not.toContain("reset");
   });
 
-  it("skips the reset fallback for a non-symlink TASKS_DIR when the export is unavailable", () => {
+  it("is a no-op fallback for a non-symlink TASKS_DIR", () => {
     setup();
     syncFromOrigin(false);
     expect(execFileSyncMock).not.toHaveBeenCalled();

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -245,26 +245,14 @@ export function buildIndexFromOriginMain(cwd?: string): { index: Index; sha: str
   }
 }
 
-// Seams so the two branches can be exercised without a real tasks checkout.
-export interface ReadIndexDeps {
-  fromOriginMain?: () => { index: Index; sha: string } | null;
-  sync?: () => void;
-  load?: () => Index;
-}
-
-// The origin/main-tree index is served however TASKS_DIR resolved: the export
-// mutates nothing, so there is no checkout to protect. Only the fallback —
-// syncFromOrigin's `reset --hard` — stays gated on TASKS_DIR_IS_SYMLINK.
-export function readIndexSource(deps: ReadIndexDeps = {}): ReadIndex {
-  const {
-    fromOriginMain = buildIndexFromOriginMain,
-    sync = syncFromOrigin,
-    load = loadIndex,
-  } = deps;
-  const fromOrigin = fromOriginMain();
+// The origin/main-tree export mutates no checkout, so it is served however
+// TASKS_DIR resolved. Only the fallback — syncFromOrigin's `reset --hard` —
+// stays gated on TASKS_DIR_IS_SYMLINK.
+export function readIndexSource(isSymlink: boolean = TASKS_DIR_IS_SYMLINK): ReadIndex {
+  const fromOrigin = buildIndexFromOriginMain();
   if (fromOrigin) return fromOrigin;
-  sync();
-  return { index: load(), sha: null };
+  syncFromOrigin(isSymlink);
+  return { index: loadIndex(), sha: null };
 }
 
 export function readIndexedFile(src: ReadIndex, filePath: string): string | null {
@@ -597,7 +585,7 @@ function assertCleanWorktree(cwd: string | undefined): void {
 // index straight from the origin/main tree and only lands here when that is
 // unavailable (offline, no `tar`). Only runs when using the per-worktree
 // symlink (TASKS_DIR_IS_SYMLINK); the canonical fallback and explicit
-// $TASKS_DIR overrides are left alone — a read must never reset a checkout the
+// $TASKS_DIR overrides are left alone: a read must never reset a checkout the
 // user chose.
 export function syncFromOrigin(isSymlink: boolean = TASKS_DIR_IS_SYMLINK): void {
   if (!isSymlink) return;

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -245,13 +245,26 @@ export function buildIndexFromOriginMain(cwd?: string): { index: Index; sha: str
   }
 }
 
-export function readIndexSource(): ReadIndex {
-  if (TASKS_DIR_IS_SYMLINK) {
-    const fromOrigin = buildIndexFromOriginMain();
-    if (fromOrigin) return fromOrigin;
-    syncFromOrigin();
-  }
-  return { index: loadIndex(), sha: null };
+// Seams so the two branches can be exercised without a real tasks checkout.
+export interface ReadIndexDeps {
+  fromOriginMain?: () => { index: Index; sha: string } | null;
+  sync?: () => void;
+  load?: () => Index;
+}
+
+// The origin/main-tree index is served however TASKS_DIR resolved: the export
+// mutates nothing, so there is no checkout to protect. Only the fallback —
+// syncFromOrigin's `reset --hard` — stays gated on TASKS_DIR_IS_SYMLINK.
+export function readIndexSource(deps: ReadIndexDeps = {}): ReadIndex {
+  const {
+    fromOriginMain = buildIndexFromOriginMain,
+    sync = syncFromOrigin,
+    load = loadIndex,
+  } = deps;
+  const fromOrigin = fromOriginMain();
+  if (fromOrigin) return fromOrigin;
+  sync();
+  return { index: load(), sha: null };
 }
 
 export function readIndexedFile(src: ReadIndex, filePath: string): string | null {
@@ -584,9 +597,10 @@ function assertCleanWorktree(cwd: string | undefined): void {
 // index straight from the origin/main tree and only lands here when that is
 // unavailable (offline, no `tar`). Only runs when using the per-worktree
 // symlink (TASKS_DIR_IS_SYMLINK); the canonical fallback and explicit
-// $TASKS_DIR overrides are left alone.
-function syncFromOrigin(): void {
-  if (!TASKS_DIR_IS_SYMLINK) return;
+// $TASKS_DIR overrides are left alone — a read must never reset a checkout the
+// user chose.
+export function syncFromOrigin(isSymlink: boolean = TASKS_DIR_IS_SYMLINK): void {
+  if (!isSymlink) return;
   syncWorktreeToOrigin();
 }
 


### PR DESCRIPTION
PR #5271 moved the read commands (`ready`, `list`, `next-bundle`, `show`,
`status`) onto an index built from the `origin/main` tree, but gated the whole
thing on `TASKS_DIR_IS_SYMLINK` — the gate the old destructive
`syncFromOrigin()` needed. An agent with an explicit `$TASKS_DIR` (or the
canonical `~/github/blazetrailsdev/tasks` fallback) therefore still read
whatever the working tree happened to hold, with no freshness guarantee.

Nothing about the origin/main tree export needs the symlink: it fetches,
`git archive`s into a temp dir, and caches by sha under the git common dir —
it mutates no checkout. The gate now sits only on the fallback
(`syncFromOrigin` → `reset --hard`), which is the destructive one.

- `readIndexSource()` always tries `buildIndexFromOriginMain()` first and
  forwards the symlink flag only to the fallback.
- `syncFromOrigin(isSymlink = TASKS_DIR_IS_SYMLINK)` keeps the gate and is
  exported so the non-symlink no-op is directly testable.
- Two tests in `scripts/tasks/cli.test.ts` cover the non-symlink read path:
  the origin/main index is served with no `reset`, and the fallback is a no-op
  against a checkout the user chose.

Closes-story: tasks-read-index-ungated-from-symlink-check
