### PR TITLE
feat(api-compare): collapse required kwargs into one options slot for arity

### DIFF
--- a/scripts/api-compare/arity.test.ts
+++ b/scripts/api-compare/arity.test.ts
@@ -102,6 +102,39 @@ describe("arityMatches", () => {
     expect(arityMatches([req("a"), kw("rk"), kwopt("ok")], [req("a"), req("opts")]).ok).toBe(true);
   });
 
+  it("collapses multiple required kwargs into one TS options object", () => {
+    // ruby perform_query(raw_connection, sql, binds, type_casted_binds, prepare:,
+    //   notification_payload:, batch:) → [7,7]; collapsed → [5,5]
+    // ts performQuery(rawConnection, sql, binds, typeCastedBinds, options = …) → [4,5]
+    const rubyPerformQuery = [
+      req("raw_connection"),
+      req("sql"),
+      req("binds"),
+      req("type_casted_binds"),
+      kw("prepare"),
+      kw("notification_payload"),
+      kw("batch"),
+    ];
+    const tsPerformQuery = [
+      req("rawConnection"),
+      req("sql"),
+      req("binds"),
+      req("typeCastedBinds"),
+      opt("options"),
+    ];
+    expect(arityMatches(rubyPerformQuery, tsPerformQuery).ok).toBe(true);
+    // all-kwargs signature (batch_on_unloaded_relation) vs a single `opts`
+    expect(arityMatches([kw("a"), kw("b"), kw("c"), kw("d")], [req("opts")]).ok).toBe(true);
+  });
+
+  it("still flags a positional-count mismatch alongside collapsible kwargs", () => {
+    // ruby m(a, b, k1:, k2:) collapses to [3,3] — a 1-arg TS port stays flagged.
+    const m = arityMatches([req("a"), req("b"), kw("k1"), kw("k2")], [req("a")]);
+    expect(m.ok).toBe(false);
+    expect(m.rubyRange).toEqual({ min: 4, max: 4 });
+    expect(m.tsRange).toEqual({ min: 1, max: 1 });
+  });
+
   it("flags a genuinely missing positional arg", () => {
     // def foo(a, b)  vs  foo(a)  → ranges [2,2] vs [1,1] do not overlap
     const m = arityMatches([req("a"), req("b")], [req("a")]);

--- a/scripts/api-compare/arity.test.ts
+++ b/scripts/api-compare/arity.test.ts
@@ -127,6 +127,15 @@ describe("arityMatches", () => {
     expect(arityMatches([kw("a"), kw("b"), kw("c"), kw("d")], [req("opts")]).ok).toBe(true);
   });
 
+  it("counts the collapsed kwarg group as ONE slot, not one plus max-slack", () => {
+    // def m(k1:, k2:, k3:, opt: default) — the optional kwarg rides in the SAME
+    // options object, so the collapsed form is [1,1] with no extra slack: a
+    // two-positional TS port is still a mismatch.
+    const ruby = [kw("k1"), kw("k2"), kw("k3"), kwopt("opt")];
+    expect(arityMatches(ruby, [req("opts")]).ok).toBe(true);
+    expect(arityMatches(ruby, [req("a"), req("b")]).ok).toBe(false);
+  });
+
   it("still flags a positional-count mismatch alongside collapsible kwargs", () => {
     // ruby m(a, b, k1:, k2:) collapses to [3,3] — a 1-arg TS port stays flagged.
     const m = arityMatches([req("a"), req("b"), kw("k1"), kw("k2")], [req("a")]);

--- a/scripts/api-compare/arity.test.ts
+++ b/scripts/api-compare/arity.test.ts
@@ -136,6 +136,14 @@ describe("arityMatches", () => {
     expect(arityMatches(ruby, [req("a"), req("b")]).ok).toBe(false);
   });
 
+  it("matches one required kwarg plus **opts without collapsing", () => {
+    // def m(a, k:, **o) — below the ≥2 collapse threshold, but the required
+    // kwarg already maps 1:1 onto the options slot and `**o` rides along via
+    // the existing hasKeywords slack: ruby [2,2+1] vs ts [2,2] overlaps.
+    expect(arityMatches([req("a"), kw("k"), kwrest("o")], [req("a"), req("opts")]).ok).toBe(true);
+    expect(arityMatches([kw("k"), kwrest("o")], [req("opts")]).ok).toBe(true);
+  });
+
   it("still flags a positional-count mismatch alongside collapsible kwargs", () => {
     // ruby m(a, b, k1:, k2:) collapses to [3,3] — a 1-arg TS port stays flagged.
     const m = arityMatches([req("a"), req("b"), kw("k1"), kw("k2")], [req("a")]);

--- a/scripts/api-compare/arity.ts
+++ b/scripts/api-compare/arity.ts
@@ -234,27 +234,29 @@ export function positionalArity(params: ParamInfo[], side: "ruby" | "ts"): Arity
   };
 }
 
-/** Collapse a Ruby method's *required* keywords (`key:`, no default) into ONE
- *  required slot — the port's convention bundles every kwarg into a single
- *  trailing options object, so `(sql, prepare:, batch:)` ports as
- *  `(sql, options)`. Only meaningful with ≥2 required kwargs (one already maps
- *  1:1); returns the list unchanged otherwise. Used solely as an extra Ruby-side
- *  candidate form, so it can only ever *gain* a match. */
-function collapseRequiredKeywords(params: ParamInfo[]): ParamInfo[] {
-  const requiredKeywords = params.filter((p) => p.kind === "keyword" && p.default === undefined);
-  if (requiredKeywords.length < 2) return params;
-  let emitted = false;
-  const out: ParamInfo[] = [];
-  for (const p of params) {
-    if (p.kind === "keyword" && p.default === undefined) {
-      if (emitted) continue;
-      emitted = true;
-      out.push({ name: "options", kind: "required" });
-      continue;
-    }
-    out.push(p);
-  }
-  return out;
+function isRequiredKeyword(p: ParamInfo): boolean {
+  return p.kind === "keyword" && p.default === undefined;
+}
+
+function isKeywordParam(p: ParamInfo): boolean {
+  return p.kind === "keyword" || p.kind === "keyword_rest";
+}
+
+/** Collapse a Ruby method's whole keyword group into ONE required slot — the
+ *  port's convention bundles every kwarg into a single trailing options object,
+ *  so `(sql, prepare:, notification_payload:, batch:)` ports as
+ *  `(sql, options)`. Optional kwargs / `**opts` ride in that same object, so
+ *  they collapse into the slot too rather than also claiming the `hasKeywords`
+ *  max-slack (which would over-count the options object as two slots).
+ *
+ *  Only applied with ≥2 required kwargs: with 0 the existing `hasKeywords`
+ *  slack already covers the convention, and with 1 the kwarg already maps 1:1
+ *  onto the options slot — so the list is returned unchanged. Used solely as an
+ *  extra Ruby-side candidate form, so it can only ever *gain* a match. */
+function collapseKeywordsIntoOptionsObject(params: ParamInfo[]): ParamInfo[] | null {
+  if (params.filter(isRequiredKeyword).length < 2) return null;
+  const positional = params.filter((p) => !isKeywordParam(p));
+  return [...positional, { name: "options", kind: "required" }];
 }
 
 /** Do the ranges overlap, granting Ruby one extra max slot per optional-kwargs/block convention? */
@@ -280,7 +282,8 @@ export function arityMatches(ruby: ParamInfo[], ts: ParamInfo[]): ArityMatch {
   const r = positionalArity(ruby, "ruby");
   const tAsDeclared = positionalArity(ts, "ts");
 
-  const rubyForms = [r, positionalArity(collapseRequiredKeywords(ruby), "ruby")];
+  const collapsed = collapseKeywordsIntoOptionsObject(ruby);
+  const rubyForms = collapsed ? [r, positionalArity(collapsed, "ruby")] : [r];
   const base = stripThis(ts);
   const forms = [
     base,

--- a/scripts/api-compare/arity.ts
+++ b/scripts/api-compare/arity.ts
@@ -13,6 +13,9 @@
 //     conventional receiver name (see RECEIVER_PARAM_NAMES);
 //   - trailing callback: a `&block` ported as an explicit `fn`/`callback` param
 //     that the Ruby extractor didn't record (bare `yield`).
+// On the Ruby side, a method with ≥2 *required* keywords is also tried with the
+// whole kwarg group collapsed into one slot, since the port bundles them into a
+// single options object.
 // Every such strip is tried only as an *additional* candidate form alongside the
 // as-declared signature, and a match needs only ONE form to overlap — so a strip
 // can only ever gain a match, never manufacture a mismatch.
@@ -231,6 +234,29 @@ export function positionalArity(params: ParamInfo[], side: "ruby" | "ts"): Arity
   };
 }
 
+/** Collapse a Ruby method's *required* keywords (`key:`, no default) into ONE
+ *  required slot — the port's convention bundles every kwarg into a single
+ *  trailing options object, so `(sql, prepare:, batch:)` ports as
+ *  `(sql, options)`. Only meaningful with ≥2 required kwargs (one already maps
+ *  1:1); returns the list unchanged otherwise. Used solely as an extra Ruby-side
+ *  candidate form, so it can only ever *gain* a match. */
+function collapseRequiredKeywords(params: ParamInfo[]): ParamInfo[] {
+  const requiredKeywords = params.filter((p) => p.kind === "keyword" && p.default === undefined);
+  if (requiredKeywords.length < 2) return params;
+  let emitted = false;
+  const out: ParamInfo[] = [];
+  for (const p of params) {
+    if (p.kind === "keyword" && p.default === undefined) {
+      if (emitted) continue;
+      emitted = true;
+      out.push({ name: "options", kind: "required" });
+      continue;
+    }
+    out.push(p);
+  }
+  return out;
+}
+
 /** Do the ranges overlap, granting Ruby one extra max slot per optional-kwargs/block convention? */
 function rangesOverlap(r: Arity, t: Arity): boolean {
   const slack = (r.hasKeywords ? 1 : 0) + (r.hasBlock ? 1 : 0);
@@ -254,6 +280,7 @@ export function arityMatches(ruby: ParamInfo[], ts: ParamInfo[]): ArityMatch {
   const r = positionalArity(ruby, "ruby");
   const tAsDeclared = positionalArity(ts, "ts");
 
+  const rubyForms = [r, positionalArity(collapseRequiredKeywords(ruby), "ruby")];
   const base = stripThis(ts);
   const forms = [
     base,
@@ -261,7 +288,10 @@ export function arityMatches(ruby: ParamInfo[], ts: ParamInfo[]): ArityMatch {
     stripTrailingCallback(base),
     stripTrailingCallback(stripHostParam(base)),
   ];
-  const ok = forms.some((f) => rangesOverlap(r, positionalArity(f, "ts")));
+  const ok = forms.some((f) => {
+    const t = positionalArity(f, "ts");
+    return rubyForms.some((rf) => rangesOverlap(rf, t));
+  });
 
   return {
     ok,


### PR DESCRIPTION
`positionalArity` counted each Ruby *required* keyword (`key:`, no default) as
its own required positional slot, so any Rails method with ≥2 required kwargs
could never match its faithful TS port — the port's convention bundles all
kwargs into ONE trailing options object.

`arityMatches` now also tries a Ruby-side candidate form with the whole
required-kwarg group collapsed to a single required slot. Like the existing
receiver/callback strips, it's an *additional* form only, so it can only ever
gain a match, never manufacture a mismatch.

Arity mismatches: 183 → 163 (`arity: 7442/7625` → `7462/7625`). Diffing the
before/after `output/arity-mismatches.json` shows **0 new entries**; the 20
removed include all 8 targeted by the story (`perform_query` ×4,
`batch_on_loaded_relation` / `batch_on_unloaded_relation` ×2 files) plus 12
same-shape wins in actioncontroller/actiondispatch/actionview/activesupport.

Closes-story: arity-collapse-required-kwargs-into-options-object
