### PR TITLE
fix(api-compare): resolve TS alias bindings to target params; report closest arity candidate

### DIFF
--- a/scripts/api-compare/arity.test.ts
+++ b/scripts/api-compare/arity.test.ts
@@ -188,9 +188,24 @@ describe("matchArityAgainst", () => {
     expect(matchArityAgainst([req("a")], [])).toEqual({ matched: true });
   });
 
-  it("reports a mismatch (first candidate's ranges) when none overlap", () => {
+  it("reports a mismatch (closest candidate's ranges) when none overlap", () => {
     const v = matchArityAgainst([req("a"), req("b")], [[req("a")]]);
     expect(v).toMatchObject({ matched: false, rubyRange: { min: 2 }, tsRange: { min: 1 } });
+  });
+
+  it("reports the closest candidate, not a 0-arg alias binding recorded first", () => {
+    // `isReadonlyAttribute: readonlyAttributeQ` style alias: the empty record
+    // comes first, but the 3-arg real signature is what the report must show.
+    const real: ParamInfo[] = [req("a"), req("b"), req("c")];
+    const v = matchArityAgainst([req("a"), req("b"), req("c"), req("d"), req("e")], [[], real]);
+    expect(v).toMatchObject({ matched: false, tsParams: real, tsRange: { min: 3, max: 3 } });
+  });
+
+  it("breaks a distance tie toward the longer parameter list", () => {
+    // Ruby takes 2; both candidates sit 2 slots away, so length decides.
+    const long: ParamInfo[] = [req("a"), req("b"), req("c"), req("d")];
+    const v = matchArityAgainst([req("a"), req("b")], [[], long]);
+    expect(v).toMatchObject({ matched: false, tsParams: long });
   });
 });
 

--- a/scripts/api-compare/arity.test.ts
+++ b/scripts/api-compare/arity.test.ts
@@ -201,6 +201,18 @@ describe("matchArityAgainst", () => {
     expect(v).toMatchObject({ matched: false, tsParams: real, tsRange: { min: 3, max: 3 } });
   });
 
+  it("breaks a distance tie on positional length, ignoring a `this:` receiver", () => {
+    // Equidistant candidates: the 3-positional one must beat the 2-positional
+    // one even though the latter is 3 params long counting `this`.
+    const withThis: ParamInfo[] = [req("this"), req("a"), req("b")];
+    const positional: ParamInfo[] = [req("a"), req("b"), req("c")];
+    const v = matchArityAgainst(
+      [req("a"), req("b"), req("c"), req("d"), req("e")],
+      [withThis, positional],
+    );
+    expect(v).toMatchObject({ matched: false, tsParams: positional });
+  });
+
   it("breaks a distance tie toward the longer parameter list", () => {
     // Ruby takes 2; both candidates sit 2 slots away, so length decides.
     const long: ParamInfo[] = [req("a"), req("b"), req("c"), req("d")];

--- a/scripts/api-compare/arity.ts
+++ b/scripts/api-compare/arity.ts
@@ -292,7 +292,10 @@ export function matchArityAgainst(ruby: ParamInfo[], candidates: ParamInfo[][]):
     if (
       best === null ||
       distance < best.distance ||
-      (distance === best.distance && c.length > best.params.length)
+      // Tie-break on POSITIONAL length: `distance` already comes from a
+      // `this`-stripped range, so comparing raw lengths would let a candidate
+      // win a tie on the strength of a receiver param nobody counts.
+      (distance === best.distance && stripThis(c).length > stripThis(best.params).length)
     ) {
       best = { m, params: c, distance };
     }

--- a/scripts/api-compare/arity.ts
+++ b/scripts/api-compare/arity.ts
@@ -126,7 +126,7 @@ function leafTypeName(type: string | undefined): string | null {
 }
 
 /** Drop a leading `this:`-typed mixin receiver param (literally named `this`). */
-function stripThis(params: ParamInfo[]): ParamInfo[] {
+export function stripThis(params: ParamInfo[]): ParamInfo[] {
   return params.length > 0 && params[0].name === "this" ? params.slice(1) : params;
 }
 

--- a/scripts/api-compare/arity.ts
+++ b/scripts/api-compare/arity.ts
@@ -278,22 +278,39 @@ export type ArityVerdict =
  * Verdict for a Ruby method against EVERY TS signature recorded for its name
  * (see compare.ts `tsParamsByName`). Matches if ANY candidate overlaps — that's
  * what lets the real implementation win over a 0-arg re-export binding exposed
- * under the same name; otherwise reports the first candidate's ranges.
+ * under the same name; otherwise reports the CLOSEST candidate — the one whose
+ * range sits nearest Ruby's, tie-broken by the longest parameter list — so a
+ * flagged mismatch shows the real signature rather than a 0-arg alias binding
+ * that happened to be recorded first.
  */
 export function matchArityAgainst(ruby: ParamInfo[], candidates: ParamInfo[][]): ArityVerdict {
-  let first: { m: ArityMatch; params: ParamInfo[] } | null = null;
+  let best: { m: ArityMatch; params: ParamInfo[]; distance: number } | null = null;
   for (const c of candidates) {
     const m = arityMatches(ruby, c);
     if (m.ok) return { matched: true };
-    first ??= { m, params: c };
+    const distance = rangeDistance(m.rubyRange, m.tsRange);
+    if (
+      best === null ||
+      distance < best.distance ||
+      (distance === best.distance && c.length > best.params.length)
+    ) {
+      best = { m, params: c, distance };
+    }
   }
-  if (!first) return { matched: true }; // no candidates — nothing to flag
+  if (!best) return { matched: true }; // no candidates — nothing to flag
   return {
     matched: false,
-    tsParams: first.params,
-    rubyRange: first.m.rubyRange,
-    tsRange: first.m.tsRange,
+    tsParams: best.params,
+    rubyRange: best.m.rubyRange,
+    tsRange: best.m.tsRange,
   };
+}
+
+/** Gap between two non-overlapping arity ranges (0 when they touch/overlap). */
+function rangeDistance(r: ArityRange, t: ArityRange): number {
+  if (t.min > r.max) return t.min - r.max;
+  if (r.min > t.max) return r.min - t.max;
+  return 0;
 }
 
 /** Render a parameter list as a readable signature, e.g. `(a, b = …, *rest, **opts)`. */

--- a/scripts/api-compare/call-mismatches-wide-exclude/abstractcontroller/caching.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/abstractcontroller/caching.json
@@ -38,13 +38,6 @@
     "package": "abstractcontroller",
     "tsFile": "caching.ts",
     "rubyName": "expire_fragment",
-    "call": "cache_store",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "abstractcontroller",
-    "tsFile": "caching.ts",
-    "rubyName": "expire_fragment",
     "call": "combined_fragment_cache_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -74,13 +67,6 @@
     "tsFile": "caching.ts",
     "rubyName": "fragment_exist?",
     "call": "cache_configured?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "abstractcontroller",
-    "tsFile": "caching.ts",
-    "rubyName": "fragment_exist?",
-    "call": "cache_store",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -129,13 +115,6 @@
     "package": "abstractcontroller",
     "tsFile": "caching.ts",
     "rubyName": "read_fragment",
-    "call": "cache_store",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "abstractcontroller",
-    "tsFile": "caching.ts",
-    "rubyName": "read_fragment",
     "call": "combined_fragment_cache_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -172,13 +151,6 @@
     "tsFile": "caching.ts",
     "rubyName": "write_fragment",
     "call": "cache_configured?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "abstractcontroller",
-    "tsFile": "caching.ts",
-    "rubyName": "write_fragment",
-    "call": "cache_store",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/http/request.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/http/request.json
@@ -80,13 +80,6 @@
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "POST",
-    "call": "params_parsers",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:408-434 runs the body through parse_formatted_parameters/params_parsers and ParamBuilder.from_pairs/from_hash with encoding templates; trails request.ts:949-951 returns `this.requestParameters` — body parsing happens in that accessor without the encoding-template/ParamBuilder machinery (unported by design)."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
-    "rubyName": "POST",
     "call": "parse_formatted_parameters",
     "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails request.rb:408-434 runs the body through parse_formatted_parameters/params_parsers and ParamBuilder.from_pairs/from_hash with encoding templates; trails request.ts:949-951 returns `this.requestParameters` — body parsing happens in that accessor without the encoding-template/ParamBuilder machinery (unported by design)."
   },
@@ -192,21 +185,7 @@
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "parse_formatted_parameters",
-    "call": "content_mime_type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
-    "rubyName": "parse_formatted_parameters",
     "call": "fetch",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
-    "rubyName": "parse_formatted_parameters",
-    "call": "log_parse_error_once",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -228,13 +207,6 @@
     "tsFile": "http/request.ts",
     "rubyName": "request_parameters_list",
     "call": "get_header",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
-    "rubyName": "reset_session",
-    "call": "session",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/http/response.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/http/response.json
@@ -16,20 +16,6 @@
   {
     "package": "actiondispatch",
     "tsFile": "http/response.ts",
-    "rubyName": "filtered_location",
-    "call": "location_filter_match?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/response.ts",
-    "rubyName": "filtered_location",
-    "call": "parameter_filtered_location",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/response.ts",
     "rubyName": "generate_strong_etag",
     "call": "expand_cache_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -74,13 +60,6 @@
     "tsFile": "http/response.ts",
     "rubyName": "parse_content_type",
     "call": "new",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/response.ts",
-    "rubyName": "prepare_cache_control!",
-    "call": "cache_control_headers",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/middleware/cookies.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/middleware/cookies.json
@@ -10,13 +10,6 @@
     "package": "actiondispatch",
     "tsFile": "middleware/cookies.ts",
     "rubyName": "call",
-    "call": "have_cookie_jar?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "middleware/cookies.ts",
-    "rubyName": "call",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -61,19 +54,5 @@
     "rubyName": "parse",
     "call": "reserialize?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "middleware/cookies.ts",
-    "rubyName": "parse",
-    "call": "serializer",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "middleware/cookies.ts",
-    "rubyName": "serializer",
-    "call": "cookies_serializer",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails cookies.rb:574-586 switches on `request.cookies_serializer`; trails cookies.ts:746-765 reads the same env slot directly (`request.env[\"action_dispatch.cookies_serializer\"]`) so object serializers stay visible — the narrowing cookiesSerializer accessor is bypassed, hence no same-named call."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/middleware/show-exceptions.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/middleware/show-exceptions.json
@@ -24,13 +24,6 @@
     "package": "actiondispatch",
     "tsFile": "middleware/show-exceptions.ts",
     "rubyName": "fallback_to_html_format_if_invalid_mime_type",
-    "call": "content_mime_type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "middleware/show-exceptions.ts",
-    "rubyName": "fallback_to_html_format_if_invalid_mime_type",
     "call": "formats",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/routing/route-set.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/routing/route-set.json
@@ -191,13 +191,6 @@
   {
     "package": "actiondispatch",
     "tsFile": "routing/route-set.ts",
-    "rubyName": "full_url_for",
-    "call": "url_options",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/route-set.ts",
     "rubyName": "generate_extras",
     "call": "delete",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -256,13 +249,6 @@
     "tsFile": "routing/route-set.ts",
     "rubyName": "generate_url_helpers",
     "call": "include",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/route-set.ts",
-    "rubyName": "generate_url_helpers",
-    "call": "optimize_routes_generation?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/system-testing/test-helpers/screenshot-helper.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/actiondispatch/system-testing/test-helpers/screenshot-helper.json
@@ -3,13 +3,6 @@
     "package": "actiondispatch",
     "tsFile": "system-testing/test-helpers/screenshot-helper.ts",
     "rubyName": "display_image",
-    "call": "absolute_image_path",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "system-testing/test-helpers/screenshot-helper.ts",
-    "rubyName": "display_image",
     "call": "read",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/activemodel/attribute-methods.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activemodel/attribute-methods.json
@@ -3,13 +3,6 @@
     "package": "activemodel",
     "tsFile": "attribute-methods.ts",
     "rubyName": "alias_attribute",
-    "call": "attribute_aliases",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "alias_attribute",
     "call": "merge",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -25,20 +18,6 @@
     "tsFile": "attribute-methods.ts",
     "rubyName": "alias_attribute_method_definition",
     "call": "define_call",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "attribute_alias",
-    "call": "attribute_aliases",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails attribute_methods.rb:245-247 reads `attribute_aliases[name.to_s]`; trails attribute-methods.ts:367-369 reads `host._attributeAliases[name]` directly — JS string keys need no to_s coercion."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "attribute_alias?",
-    "call": "attribute_aliases",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -66,13 +45,6 @@
     "package": "activemodel",
     "tsFile": "attribute-methods.ts",
     "rubyName": "attribute_method_patterns_matching",
-    "call": "attribute_method_patterns",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "attribute_method_patterns_matching",
     "call": "filter_map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -81,20 +53,6 @@
     "tsFile": "attribute-methods.ts",
     "rubyName": "build_mangled_name",
     "call": "match?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "define_attribute_method",
-    "call": "attribute_method_patterns",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "define_attribute_method",
-    "call": "attribute_method_patterns_cache",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -116,13 +74,6 @@
     "tsFile": "attribute-methods.ts",
     "rubyName": "define_attribute_method_pattern",
     "call": "instance_method_already_implemented?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "define_attribute_methods",
-    "call": "generated_attribute_methods",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -156,27 +107,6 @@
   {
     "package": "activemodel",
     "tsFile": "attribute-methods.ts",
-    "rubyName": "eagerly_generate_alias_attribute_methods",
-    "call": "generated_attribute_methods",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "generate_alias_attribute_methods",
-    "call": "attribute_method_patterns",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "generate_alias_attribute_methods",
-    "call": "attribute_method_patterns_cache",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-methods.ts",
     "rubyName": "generate_alias_attribute_methods",
     "call": "clear",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -198,13 +128,6 @@
   {
     "package": "activemodel",
     "tsFile": "attribute-methods.ts",
-    "rubyName": "instance_method_already_implemented?",
-    "call": "generated_attribute_methods",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-methods.ts",
     "rubyName": "match",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -213,28 +136,7 @@
     "package": "activemodel",
     "tsFile": "attribute-methods.ts",
     "rubyName": "resolve_attribute_name",
-    "call": "attribute_aliases",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails attribute_methods.rb:396-398 uses `attribute_aliases.fetch(super, &:itself)`; trails attribute-methods.ts:461-463 reads `this._attributeAliases?.[name] ?? name`."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "resolve_attribute_name",
     "call": "fetch",
     "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails attribute_methods.rb:396-398 uses `attribute_aliases.fetch(super, &:itself)`; trails attribute-methods.ts:461-463 reads `this._attributeAliases?.[name] ?? name`."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "undefine_attribute_methods",
-    "call": "attribute_method_patterns_cache",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "undefine_attribute_methods",
-    "call": "generated_attribute_methods",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activemodel/attribute-registration.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activemodel/attribute-registration.json
@@ -2,13 +2,6 @@
   {
     "package": "activemodel",
     "tsFile": "attribute-registration.ts",
-    "rubyName": "apply_pending_attribute_modifications",
-    "call": "pending_attribute_modifications",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-registration.ts",
     "rubyName": "attribute_types",
     "call": "default_value",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -18,13 +11,6 @@
     "tsFile": "attribute-registration.ts",
     "rubyName": "decorate_attributes",
     "call": "map",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-registration.ts",
-    "rubyName": "decorate_attributes",
-    "call": "pending_attribute_modifications",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activemodel/model.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activemodel/model.json
@@ -51,13 +51,6 @@
   {
     "package": "activemodel",
     "tsFile": "model.ts",
-    "rubyName": "valid?",
-    "call": "context_for_validation",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "model.ts",
     "rubyName": "validates_each",
     "call": "validates_with",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/alias-tracker.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/alias-tracker.json
@@ -3,13 +3,6 @@
     "package": "activerecord",
     "tsFile": "associations/alias-tracker.ts",
     "rubyName": "create",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/alias-tracker.ts",
-    "rubyName": "create",
     "call": "initial_count_for",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/association-scope.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/association-scope.json
@@ -31,13 +31,6 @@
     "package": "activerecord",
     "tsFile": "associations/association-scope.ts",
     "rubyName": "add_constraints",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association-scope.ts",
-    "rubyName": "add_constraints",
     "call": "eval_scope",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/association.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/association.json
@@ -136,13 +136,6 @@
     "package": "activerecord",
     "tsFile": "associations/association.ts",
     "rubyName": "initialize",
-    "call": "check_validity!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "initialize",
     "call": "reset",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -275,13 +268,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/association.ts",
-    "rubyName": "skip_statement_cache?",
-    "call": "scope_attributes?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
     "rubyName": "target_scope",
     "call": "create",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -305,13 +291,6 @@
     "tsFile": "associations/association.ts",
     "rubyName": "violates_strict_loading?",
     "call": "strict_loading?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "violates_strict_loading?",
-    "call": "strict_loading_n_plus_one_only?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/builder/association.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/builder/association.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/builder/association.ts",
-    "rubyName": "define_accessors",
-    "call": "generated_association_methods",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/builder/association.ts",
     "rubyName": "validate_options",
     "call": "assert_valid_keys",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/builder/belongs-to.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/builder/belongs-to.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/builder/belongs-to.ts",
-    "rubyName": "define_change_tracking_methods",
-    "call": "generated_association_methods",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/builder/belongs-to.ts",
     "rubyName": "define_validations",
     "call": "delete",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/builder/collection-association.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/builder/collection-association.json
@@ -9,13 +9,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/builder/collection-association.ts",
-    "rubyName": "define_callback",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/builder/collection-association.ts",
     "rubyName": "define_extensions",
     "call": "camelize",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/builder/singular-association.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/builder/singular-association.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "associations/builder/singular-association.ts",
-    "rubyName": "define_accessors",
-    "call": "generated_association_methods",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  }
-]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/collection-association.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/collection-association.json
@@ -38,13 +38,6 @@
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
     "rubyName": "delete_or_destroy",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
-    "rubyName": "delete_or_destroy",
     "call": "find",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -129,13 +122,6 @@
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
     "rubyName": "ids_reader",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
-    "rubyName": "ids_reader",
     "call": "reflection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -158,13 +144,6 @@
     "tsFile": "associations/collection-association.ts",
     "rubyName": "ids_writer",
     "call": "compact_blank",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
-    "rubyName": "ids_writer",
-    "call": "composite_primary_key?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -213,13 +192,6 @@
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
     "rubyName": "include?",
-    "call": "composite_primary_key?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
-    "rubyName": "include?",
     "call": "id",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -262,21 +234,7 @@
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
     "rubyName": "merge_target_lists",
-    "call": "attribute_names",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
-    "rubyName": "merge_target_lists",
     "call": "changed_attribute_names_to_save",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
-    "rubyName": "merge_target_lists",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -326,13 +284,6 @@
     "tsFile": "associations/collection-association.ts",
     "rubyName": "reset",
     "call": "new",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
-    "rubyName": "scope",
-    "call": "none!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/has-many-association.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/has-many-association.json
@@ -38,13 +38,6 @@
     "package": "activerecord",
     "tsFile": "associations/has-many-association.ts",
     "rubyName": "handle_dependency",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-many-association.ts",
-    "rubyName": "handle_dependency",
     "call": "enqueue_destroy_association",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -88,13 +81,6 @@
     "tsFile": "associations/has-many-association.ts",
     "rubyName": "handle_dependency",
     "call": "primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-many-association.ts",
-    "rubyName": "handle_dependency",
-    "call": "query_constraints_list",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/has-one-association.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/has-one-association.json
@@ -59,13 +59,6 @@
     "package": "activerecord",
     "tsFile": "associations/has-one-association.ts",
     "rubyName": "delete",
-    "call": "query_constraints_list",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-one-association.ts",
-    "rubyName": "delete",
     "call": "update_columns",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -122,13 +115,6 @@
     "package": "activerecord",
     "tsFile": "associations/has-one-association.ts",
     "rubyName": "replace",
-    "call": "destroyed?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-one-association.ts",
-    "rubyName": "replace",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -145,13 +131,6 @@
     "rubyName": "replace",
     "call": "owner",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-one-association.ts",
-    "rubyName": "replace",
-    "call": "persisted?",
-    "reason": "Rails `replace` gates persistence with `save &&= owner.persisted?` (has_one_association.rb:62); trails converged has_one onto the autosave path so `replace` is purely in-memory and the `owner.persisted?` gate moved to `syncWrite`/`writer`/`persistImmediate`."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/join-dependency.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/join-dependency.json
@@ -2,22 +2,8 @@
   {
     "package": "activerecord",
     "tsFile": "associations/join-dependency.ts",
-    "rubyName": "aliases",
-    "call": "column_names",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/join-dependency.ts",
     "rubyName": "apply_column_aliases",
     "call": "columns",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/join-dependency.ts",
-    "rubyName": "apply_column_aliases",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -80,13 +66,6 @@
     "package": "activerecord",
     "tsFile": "associations/join-dependency.ts",
     "rubyName": "instantiate",
-    "call": "attribute_types",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/join-dependency.ts",
-    "rubyName": "instantiate",
     "call": "column_alias",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -109,13 +88,6 @@
     "tsFile": "associations/join-dependency.ts",
     "rubyName": "instantiate",
     "call": "delete_if",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/join-dependency.ts",
-    "rubyName": "instantiate",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -171,13 +143,6 @@
     "package": "activerecord",
     "tsFile": "associations/join-dependency.ts",
     "rubyName": "join_constraints",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/join-dependency.ts",
-    "rubyName": "join_constraints",
     "call": "flat_map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -193,13 +158,6 @@
     "tsFile": "associations/join-dependency.ts",
     "rubyName": "make_constraints",
     "call": "aliased_table_for",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/join-dependency.ts",
-    "rubyName": "make_constraints",
-    "call": "arel_table",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/join-dependency/join-association.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/join-dependency/join-association.json
@@ -58,13 +58,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/join-dependency/join-association.ts",
-    "rubyName": "join_constraints",
-    "call": "relation",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/join-dependency/join-association.ts",
     "rubyName": "readonly?",
     "call": "readonly_value",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/preloader/association.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/preloader/association.json
@@ -10,13 +10,6 @@
     "package": "activerecord",
     "tsFile": "associations/preloader/association.ts",
     "rubyName": "associate_records_from_unscoped",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/association.ts",
-    "rubyName": "associate_records_from_unscoped",
     "call": "preload_scope",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -46,13 +39,6 @@
     "tsFile": "associations/preloader/association.ts",
     "rubyName": "load_records",
     "call": "derive_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/association.ts",
-    "rubyName": "load_records",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/attribute-assignment.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/attribute-assignment.json
@@ -17,13 +17,6 @@
     "package": "activerecord",
     "tsFile": "attribute-assignment.ts",
     "rubyName": "execute_callstack_for_multiparameter_attributes",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-assignment.ts",
-    "rubyName": "execute_callstack_for_multiparameter_attributes",
     "call": "join",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -53,13 +46,6 @@
     "tsFile": "attribute-assignment.ts",
     "rubyName": "execute_callstack_for_multiparameter_attributes",
     "call": "values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-assignment.ts",
-    "rubyName": "extract_callstack_for_multiparameter_attributes",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/attribute-methods.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/attribute-methods.json
@@ -72,13 +72,6 @@
   {
     "package": "activerecord",
     "tsFile": "attribute-methods.ts",
-    "rubyName": "alias_attribute",
-    "call": "generated_attribute_methods",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods.ts",
     "rubyName": "alias_attribute_method_definition",
     "call": "abstract_class?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -115,13 +108,6 @@
     "package": "activerecord",
     "tsFile": "attribute-methods.ts",
     "rubyName": "attribute_for_inspect",
-    "call": "attribute_aliases",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "attribute_for_inspect",
     "call": "format_for_inspect",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -137,13 +123,6 @@
     "tsFile": "attribute-methods.ts",
     "rubyName": "attribute_names_for_partial_inserts",
     "call": "attribute_changed?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "attribute_names_for_partial_inserts",
-    "call": "attribute_names",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -171,28 +150,7 @@
     "package": "activerecord",
     "tsFile": "attribute-methods.ts",
     "rubyName": "attribute_names_for_partial_updates",
-    "call": "attribute_names",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "attribute_names_for_partial_updates",
     "call": "changed_attribute_names_to_save",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "attribute_present?",
-    "call": "attribute_aliases",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "attribute_present?",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -226,6 +184,13 @@
   {
     "package": "activerecord",
     "tsFile": "attribute-methods.ts",
+    "rubyName": "attributes_for_update",
+    "call": "readonly_attribute?",
+    "reason": "Unmasked by alias-arity resolution (story arity-resolve-ts-alias-bindings-to-target-params): the TS body reads `_readonlyAttributes` directly instead of delegating to `readonlyAttributeQ`. Real gap, tracked as story converge-readonly-attribute-predicate-callers."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "attribute-methods.ts",
     "rubyName": "dangerous_attribute_methods",
     "call": "map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -242,13 +207,6 @@
     "tsFile": "attribute-methods.ts",
     "rubyName": "define_attribute_methods",
     "call": "alias_attribute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "define_attribute_methods",
-    "call": "attribute_names",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -276,28 +234,7 @@
     "package": "activerecord",
     "tsFile": "attribute-methods.ts",
     "rubyName": "format_for_inspect",
-    "call": "inspection_filter",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "format_for_inspect",
     "call": "to_fs",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "generate_alias_attribute_methods",
-    "call": "attribute_method_patterns",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "generate_alias_attribute_methods",
-    "call": "attribute_method_patterns_cache",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -319,20 +256,6 @@
     "tsFile": "attribute-methods.ts",
     "rubyName": "generate_alias_attributes",
     "call": "generate_alias_attribute_methods",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "generate_alias_attributes",
-    "call": "generated_attribute_methods",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "has_attribute?",
-    "call": "attribute_aliases",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -361,7 +284,7 @@
     "tsFile": "attribute-methods.ts",
     "rubyName": "initialize_generated_modules",
     "call": "include",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails attribute_methods.rb:42-50 does `include @generated_attribute_methods`; trails attribute-methods.ts:257-259 assigns a GeneratedAttributeMethods holder instance — no Module#include in TS, the holder is consulted directly."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails attribute_methods.rb:42-50 does `include @generated_attribute_methods`; trails attribute-methods.ts:257-259 assigns a GeneratedAttributeMethods holder instance \u2014 no Module#include in TS, the holder is consulted directly."
   },
   {
     "package": "activerecord",
@@ -389,7 +312,7 @@
     "tsFile": "attribute-methods.ts",
     "rubyName": "method_defined_within?",
     "call": "owner",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails attribute_methods.rb:187-197 compares `instance_method(name).owner` across class and superclass; trails attribute-methods.ts:508-517 uses `name in klass.prototype` vs `name in superklass.prototype` — the prototype chain check replaces Method#owner introspection."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails attribute_methods.rb:187-197 compares `instance_method(name).owner` across class and superclass; trails attribute-methods.ts:508-517 uses `name in klass.prototype` vs `name in superklass.prototype` \u2014 the prototype chain check replaces Method#owner introspection."
   },
   {
     "package": "activerecord",
@@ -423,13 +346,6 @@
     "package": "activerecord",
     "tsFile": "attribute-methods.ts",
     "rubyName": "read_attribute",
-    "call": "attribute_aliases",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "read_attribute",
     "call": "fetch_value",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -437,21 +353,7 @@
     "package": "activerecord",
     "tsFile": "attribute-methods.ts",
     "rubyName": "read_attribute_before_type_cast",
-    "call": "attribute_aliases",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "read_attribute_before_type_cast",
     "call": "attribute_before_type_cast",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "read_attribute_for_database",
-    "call": "attribute_aliases",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -487,13 +389,6 @@
     "tsFile": "attribute-methods.ts",
     "rubyName": "will_save_change_to_attribute?",
     "call": "changed?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "write_attribute",
-    "call": "attribute_aliases",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/attribute-methods/before-type-cast.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/attribute-methods/before-type-cast.json
@@ -3,21 +3,7 @@
     "package": "activerecord",
     "tsFile": "attribute-methods/before-type-cast.ts",
     "rubyName": "read_attribute_before_type_cast",
-    "call": "attribute_aliases",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/before-type-cast.ts",
-    "rubyName": "read_attribute_before_type_cast",
     "call": "attribute_before_type_cast",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/before-type-cast.ts",
-    "rubyName": "read_attribute_for_database",
-    "call": "attribute_aliases",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/attribute-methods/primary-key.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/attribute-methods/primary-key.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "attribute-methods/primary-key.ts",
-    "rubyName": "composite_primary_key?",
-    "call": "reset_primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/primary-key.ts",
     "rubyName": "get_primary_key",
     "call": "foreign_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -79,13 +72,6 @@
   {
     "package": "activerecord",
     "tsFile": "attribute-methods/primary-key.ts",
-    "rubyName": "primary_key",
-    "call": "reset_primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/primary-key.ts",
     "rubyName": "primary_key=",
     "call": "include",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -95,20 +81,6 @@
     "tsFile": "attribute-methods/primary-key.ts",
     "rubyName": "primary_key=",
     "call": "map",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/primary-key.ts",
-    "rubyName": "quoted_primary_key",
-    "call": "adapter_class",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/primary-key.ts",
-    "rubyName": "reset_primary_key",
-    "call": "base_class",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/attributes.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/attributes.json
@@ -24,13 +24,6 @@
     "package": "activerecord",
     "tsFile": "attributes.ts",
     "rubyName": "define_attribute",
-    "call": "attribute_types",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attributes.ts",
-    "rubyName": "define_attribute",
     "call": "define_default_attribute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/autosave-association.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/autosave-association.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "autosave-association.ts",
-    "rubyName": "associated_records_to_validate_or_save",
-    "call": "custom_validation_context?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "autosave-association.ts",
     "rubyName": "association_valid?",
     "call": "any?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -39,27 +32,6 @@
     "tsFile": "autosave-association.ts",
     "rubyName": "changed_for_autosave?",
     "call": "marked_for_destruction?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "autosave-association.ts",
-    "rubyName": "changed_for_autosave?",
-    "call": "nested_records_changed_for_autosave?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "autosave-association.ts",
-    "rubyName": "changed_for_autosave?",
-    "call": "new_record?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "autosave-association.ts",
-    "rubyName": "compute_primary_key",
-    "call": "composite_primary_key?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -108,13 +80,6 @@
     "package": "activerecord",
     "tsFile": "autosave-association.ts",
     "rubyName": "save_belongs_to_association",
-    "call": "changed_for_autosave?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "autosave-association.ts",
-    "rubyName": "save_belongs_to_association",
     "call": "compute_primary_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -123,13 +88,6 @@
     "tsFile": "autosave-association.ts",
     "rubyName": "save_belongs_to_association",
     "call": "destroy",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "autosave-association.ts",
-    "rubyName": "save_belongs_to_association",
-    "call": "destroyed?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -164,13 +122,6 @@
     "package": "activerecord",
     "tsFile": "autosave-association.ts",
     "rubyName": "save_belongs_to_association",
-    "call": "new_record?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "autosave-association.ts",
-    "rubyName": "save_belongs_to_association",
     "call": "save",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -199,13 +150,6 @@
     "package": "activerecord",
     "tsFile": "autosave-association.ts",
     "rubyName": "save_collection_association",
-    "call": "destroyed?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "autosave-association.ts",
-    "rubyName": "save_collection_association",
     "call": "insert_record",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -215,13 +159,6 @@
     "rubyName": "save_collection_association",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "autosave-association.ts",
-    "rubyName": "save_collection_association",
-    "call": "new_record?",
-    "reason": "Equivalent via delegation: `saveCollectionAssociation` performs only the marked-for-destruction collection destroy inline, then delegates the per-record save to `autosaveHasMany`, where the `record.new_record?` insert-vs-update dispatch (autosave_association.rb:442-457) lives. The call-set extractor scopes to the named body and does not follow the delegation."
   },
   {
     "package": "activerecord",
@@ -283,13 +220,6 @@
     "package": "activerecord",
     "tsFile": "autosave-association.ts",
     "rubyName": "save_has_one_association",
-    "call": "changed_for_autosave?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "autosave-association.ts",
-    "rubyName": "save_has_one_association",
     "call": "compute_primary_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -298,13 +228,6 @@
     "tsFile": "autosave-association.ts",
     "rubyName": "save_has_one_association",
     "call": "destroy",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "autosave-association.ts",
-    "rubyName": "save_has_one_association",
-    "call": "destroyed?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/base.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/base.json
@@ -23,13 +23,6 @@
   {
     "package": "activerecord",
     "tsFile": "base.ts",
-    "rubyName": "all",
-    "call": "relation",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
     "rubyName": "changed_for_autosave?",
     "call": "has_changes_to_save?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -39,20 +32,6 @@
     "tsFile": "base.ts",
     "rubyName": "changed_for_autosave?",
     "call": "marked_for_destruction?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
-    "rubyName": "changed_for_autosave?",
-    "call": "nested_records_changed_for_autosave?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
-    "rubyName": "changed_for_autosave?",
-    "call": "new_record?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -149,29 +128,8 @@
   {
     "package": "activerecord",
     "tsFile": "base.ts",
-    "rubyName": "delete",
-    "call": "persisted?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
-    "rubyName": "destroy",
-    "call": "destroy_associations",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
     "rubyName": "destroy",
     "call": "destroy_row",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
-    "rubyName": "destroy",
-    "call": "persisted?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -193,13 +151,6 @@
     "tsFile": "base.ts",
     "rubyName": "exec_explain",
     "call": "build_explain_clause",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
-    "rubyName": "exec_explain",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -235,13 +186,6 @@
     "tsFile": "base.ts",
     "rubyName": "exec_explain",
     "call": "with_connection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
-    "rubyName": "has_attribute?",
-    "call": "attribute_aliases",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -291,13 +235,6 @@
     "tsFile": "base.ts",
     "rubyName": "signed_id",
     "call": "id",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
-    "rubyName": "signed_id",
-    "call": "new_record?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -361,13 +298,6 @@
     "tsFile": "base.ts",
     "rubyName": "update!",
     "call": "with_transaction_returning_status",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
-    "rubyName": "valid?",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/callbacks.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/callbacks.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "callbacks.ts",
-    "rubyName": "_update_record",
-    "call": "record_update_timestamps",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  }
-]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-adapter.json
@@ -191,13 +191,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "preventing_writes?",
-    "call": "current_preventing_writes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
     "rubyName": "quote",
     "call": "quote_string",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -242,13 +235,6 @@
     "tsFile": "connection-adapters/abstract-adapter.ts",
     "rubyName": "reconnect!",
     "call": "synchronize",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "reconnect_can_restore_state?",
-    "call": "transaction_manager",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
@@ -87,13 +87,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "build_insert_sql",
-    "call": "quoted_table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "build_insert_sql",
     "call": "table_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -179,13 +172,6 @@
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "current_database",
     "call": "query_value",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "dbconsole",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -459,13 +445,6 @@
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "table_options",
     "call": "collation",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "table_options",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/connection-handler.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/connection-handler.json
@@ -37,13 +37,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-handler.ts",
-    "rubyName": "establish_connection",
-    "call": "primary_class?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/connection-handler.ts",
     "rubyName": "resolve_pool_config",
     "call": "configurations",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -67,13 +60,6 @@
     "tsFile": "connection-adapters/abstract/connection-handler.ts",
     "rubyName": "retrieve_connection_pool",
     "call": "compact",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/connection-handler.ts",
-    "rubyName": "retrieve_connection_pool",
-    "call": "default_shard",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/connection-pool.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/connection-pool.json
@@ -317,13 +317,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-pool.ts",
-    "rubyName": "unpin_connection!",
-    "call": "transaction_open?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/connection-pool.ts",
     "rubyName": "with_connection",
     "call": "connection_lease",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/database-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/database-statements.json
@@ -94,13 +94,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/database-statements.ts",
     "rubyName": "build_fixture_statements",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/database-statements.ts",
-    "rubyName": "build_fixture_statements",
     "call": "filter_map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -269,20 +262,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/database-statements.ts",
     "rubyName": "to_sql_and_binds",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/database-statements.ts",
-    "rubyName": "to_sql_and_binds",
-    "call": "frozen?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/database-statements.ts",
-    "rubyName": "to_sql_and_binds",
     "call": "prepared_statements",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -298,13 +277,6 @@
     "tsFile": "connection-adapters/abstract/database-statements.ts",
     "rubyName": "to_sql_and_binds",
     "call": "unprepared_statement",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/database-statements.ts",
-    "rubyName": "truncate_tables",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
@@ -17,13 +17,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "add",
-    "call": "column_names",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "add",
     "call": "columns",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
@@ -136,13 +136,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "bulk_change_table",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "bulk_change_table",
     "call": "partition",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -151,13 +144,6 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "bulk_change_table",
     "call": "quote_table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "can_remove_index_by_name?",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -347,13 +333,6 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "distinct_relation_for_primary_key",
     "call": "compile",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "distinct_relation_for_primary_key",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -569,13 +548,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "insert_versions_sql",
-    "call": "reverse",
-    "reason": "Name-collision false positive (story relation-delegation-rails-named-methods): exposing the `delegate ... to: :records` set under Rails names made `split`/`reverse`/`rindex` recognized ported method names, so this unrelated call to String#split / Array#reverse / String#rindex on a non-Relation receiver is flagged by the name-based wide call-set check."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "join_table_name",
     "call": "derive_join_table_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -648,13 +620,6 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "remove_column_for_alter",
     "call": "quote_column_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "remove_columns",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/transaction.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/transaction.json
@@ -10,13 +10,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/transaction.ts",
     "rubyName": "begin_transaction",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/transaction.ts",
-    "rubyName": "begin_transaction",
     "call": "lock",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/mysql/database-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/mysql/database-statements.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql/database-statements.ts",
-    "rubyName": "build_explain_clause",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/database-statements.ts",
     "rubyName": "combine_multi_statements",
     "call": "last",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -18,13 +11,6 @@
     "tsFile": "connection-adapters/mysql/database-statements.ts",
     "rubyName": "explain",
     "call": "new",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/database-statements.ts",
-    "rubyName": "max_allowed_packet_reached?",
-    "call": "max_allowed_packet",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/mysql2/database-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/mysql2/database-statements.json
@@ -10,20 +10,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql2/database-statements.ts",
     "rubyName": "perform_query",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql2/database-statements.ts",
-    "rubyName": "perform_query",
-    "call": "multi_statements_enabled?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql2/database-statements.ts",
-    "rubyName": "perform_query",
     "call": "prepare",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql/database-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql/database-statements.json
@@ -4,7 +4,7 @@
     "tsFile": "connection-adapters/postgresql/database-statements.ts",
     "rubyName": "affected_rows",
     "call": "clear",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails postgresql/database_statements.rb:189-193 reads cmd_tuples then `result.clear`s the libpq buffer; trails database-statements.ts:231-233 returns `result.rowCount ?? 0` \u2014 node-postgres results are GC'd, there is no clear to call."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails postgresql/database_statements.rb:189-193 reads cmd_tuples then `result.clear`s the libpq buffer; trails database-statements.ts:231-233 returns `result.rowCount ?? 0` — node-postgres results are GC'd, there is no clear to call."
   },
   {
     "package": "activerecord",
@@ -60,13 +60,6 @@
     "tsFile": "connection-adapters/postgresql/database-statements.ts",
     "rubyName": "perform_query",
     "call": "delete",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/database-statements.ts",
-    "rubyName": "perform_query",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3-adapter.json
@@ -254,13 +254,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "copy_table_indexes",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "create_virtual_table",
     "call": "exec_query",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -578,13 +571,6 @@
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "table_info",
     "call": "quote_table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "table_structure",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3/database-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/sqlite3/database-statements.json
@@ -73,13 +73,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3/database-statements.ts",
     "rubyName": "perform_query",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3/database-statements.ts",
-    "rubyName": "perform_query",
     "call": "new",
     "reason": "Deliberate deviation (documented in performQuery): reads return raw row hashes and writes source the affected-rows / insert-rowid atomically from the RunResult, so no `ActiveRecord::Result.new(columns, to_a)` is constructed here."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-handling.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-handling.json
@@ -2,29 +2,8 @@
   {
     "package": "activerecord",
     "tsFile": "connection-handling.ts",
-    "rubyName": "clear_cache!",
-    "call": "connection_pool",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-handling.ts",
     "rubyName": "connected_to",
     "call": "connection_class?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-handling.ts",
-    "rubyName": "connected_to?",
-    "call": "current_role",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-handling.ts",
-    "rubyName": "connected_to?",
-    "call": "current_shard",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -44,20 +23,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-handling.ts",
-    "rubyName": "connection",
-    "call": "lease_connection",
-    "reason": "The deprecated sync `.connection` getter routes through the sync `leaseConnectionSync` escape hatch; Rails-named `leaseConnection` is async in trails (converge-connection-pool-checkout-lease-async) and cannot be awaited from a sync getter."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-handling.ts",
-    "rubyName": "connects_to",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-handling.ts",
     "rubyName": "connects_to",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -67,20 +32,6 @@
     "tsFile": "connection-handling.ts",
     "rubyName": "establish_connection",
     "call": "connection_handler",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-handling.ts",
-    "rubyName": "establish_connection",
-    "call": "current_role",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-handling.ts",
-    "rubyName": "establish_connection",
-    "call": "current_shard",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/core.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/core.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "core.ts",
-    "rubyName": "all_attributes_for_inspect",
-    "call": "attribute_names",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "core.ts",
     "rubyName": "cached_find_by_statement",
     "call": "compute_if_absent",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -66,13 +59,6 @@
     "package": "activerecord",
     "tsFile": "core.ts",
     "rubyName": "current_shard",
-    "call": "default_shard",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "core.ts",
-    "rubyName": "current_shard",
     "call": "include?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -88,13 +74,6 @@
     "tsFile": "core.ts",
     "rubyName": "find_by",
     "call": "all?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "core.ts",
-    "rubyName": "find_by",
-    "call": "attribute_aliases",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -157,13 +136,6 @@
     "package": "activerecord",
     "tsFile": "core.ts",
     "rubyName": "find_by",
-    "call": "scope_attributes?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "core.ts",
-    "rubyName": "find_by",
     "call": "unsupported_value?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -200,13 +172,6 @@
     "tsFile": "core.ts",
     "rubyName": "generated_association_methods",
     "call": "include",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "core.ts",
-    "rubyName": "init_attributes",
-    "call": "composite_primary_key?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/counter-cache.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/counter-cache.json
@@ -80,13 +80,6 @@
     "package": "activerecord",
     "tsFile": "counter-cache.ts",
     "rubyName": "update_counters",
-    "call": "composite_primary_key?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "counter-cache.ts",
-    "rubyName": "update_counters",
     "call": "primary_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/database-configurations/database-config.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/database-configurations/database-config.json
@@ -5,12 +5,5 @@
     "rubyName": "adapter_class",
     "call": "resolve",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "database-configurations/database-config.ts",
-    "rubyName": "new_connection",
-    "call": "adapter_class",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption/cipher/aes256-gcm.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption/cipher/aes256-gcm.json
@@ -2,20 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "encryption/cipher/aes256-gcm.ts",
-    "rubyName": "decrypt",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/cipher/aes256-gcm.ts",
-    "rubyName": "encrypt",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/cipher/aes256-gcm.ts",
     "rubyName": "generate_deterministic_iv",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption/encryptable-record.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption/encryptable-record.json
@@ -94,13 +94,6 @@
     "package": "activerecord",
     "tsFile": "encryption/encryptable-record.ts",
     "rubyName": "encrypted_attribute?",
-    "call": "attribute_aliases",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/encryptable-record.ts",
-    "rubyName": "encrypted_attribute?",
     "call": "encrypted_attributes",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption/extended-deterministic-queries.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption/extended-deterministic-queries.json
@@ -17,13 +17,6 @@
     "package": "activerecord",
     "tsFile": "encryption/extended-deterministic-queries.ts",
     "rubyName": "process_arguments",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/extended-deterministic-queries.ts",
-    "rubyName": "process_arguments",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/enum.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/enum.json
@@ -37,20 +37,6 @@
   {
     "package": "activerecord",
     "tsFile": "enum.ts",
-    "rubyName": "assert_valid_enum_definition_values",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "enum.ts",
-    "rubyName": "assert_valid_enum_options",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "enum.ts",
     "rubyName": "assert_valid_value",
     "call": "has_value?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/explain.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/explain.json
@@ -17,13 +17,6 @@
     "package": "activerecord",
     "tsFile": "explain.ts",
     "rubyName": "exec_explain",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "explain.ts",
-    "rubyName": "exec_explain",
     "call": "explain",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/inheritance.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/inheritance.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "inheritance.ts",
-    "rubyName": "base_class?",
-    "call": "base_class",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
     "rubyName": "compute_type",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -73,13 +66,6 @@
     "package": "activerecord",
     "tsFile": "inheritance.ts",
     "rubyName": "find_sti_class",
-    "call": "base_class",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
-    "rubyName": "find_sti_class",
     "call": "cast",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -123,13 +109,6 @@
     "tsFile": "inheritance.ts",
     "rubyName": "set_base_class",
     "call": "abstract_class?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
-    "rubyName": "set_base_class",
-    "call": "base_class",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/insert-all.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/insert-all.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "insert-all.ts",
-    "rubyName": "configure_on_duplicate_update_logic",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "insert-all.ts",
     "rubyName": "execute",
     "call": "many?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -31,13 +24,6 @@
     "package": "activerecord",
     "tsFile": "insert-all.ts",
     "rubyName": "initialize",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "insert-all.ts",
-    "rubyName": "initialize",
     "call": "except",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -53,13 +39,6 @@
     "tsFile": "insert-all.ts",
     "rubyName": "initialize",
     "call": "first",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "insert-all.ts",
-    "rubyName": "keys_including_timestamps",
-    "call": "all_timestamp_attributes_in_model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -144,13 +123,6 @@
     "tsFile": "insert-all.ts",
     "rubyName": "resolve_sti",
     "call": "reverse_merge",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "insert-all.ts",
-    "rubyName": "timestamps_for_create",
-    "call": "all_timestamp_attributes_in_model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/locking/optimistic.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/locking/optimistic.json
@@ -9,13 +9,6 @@
   {
     "package": "activerecord",
     "tsFile": "locking/optimistic.ts",
-    "rubyName": "_update_row",
-    "call": "frozen?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "locking/optimistic.ts",
     "rubyName": "hook_attribute_type",
     "call": "locking_column",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -40,13 +33,6 @@
     "rubyName": "increment!",
     "call": "locking_enabled?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "locking/optimistic.ts",
-    "rubyName": "locking_column=",
-    "call": "reload_schema_from_cache",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails optimistic.rb:165-168 calls `reload_schema_from_cache` before assigning `value.to_s`; trails setLockingColumn (optimistic.ts:28-30) assigns the field only — the schema-cache reload (exists at attributes.ts:296) is skipped, and the TS signature already takes a string. Omission tracked in story locking-column-setter-skips-schema-reload."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration.json
@@ -73,13 +73,6 @@
     "package": "activerecord",
     "tsFile": "migration.ts",
     "rubyName": "copy",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
-    "rubyName": "copy",
     "call": "exist?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -248,13 +241,6 @@
     "package": "activerecord",
     "tsFile": "migration.ts",
     "rubyName": "format_arguments",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
-    "rubyName": "format_arguments",
     "call": "last",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -284,13 +270,6 @@
     "tsFile": "migration.ts",
     "rubyName": "get_all_versions",
     "call": "table_exists?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
-    "rubyName": "last_stored_environment",
-    "call": "connection_pool",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -495,20 +474,6 @@
     "rubyName": "revert",
     "call": "delegate",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
-    "rubyName": "revert",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
-    "rubyName": "revert",
-    "call": "reverse",
-    "reason": "trails Migration#revert takes a single migration or block, not a splat of migration classes, so Rails' `migration_classes.reverse` has no array to reverse; the single-migration path (_run) covers it."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration/command-recorder.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration/command-recorder.json
@@ -115,13 +115,6 @@
     "package": "activerecord",
     "tsFile": "migration/command-recorder.ts",
     "rubyName": "invert_drop_table",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration/command-recorder.ts",
-    "rubyName": "invert_drop_table",
     "call": "size",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -184,22 +177,8 @@
   {
     "package": "activerecord",
     "tsFile": "migration/command-recorder.ts",
-    "rubyName": "invert_remove_foreign_key",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration/command-recorder.ts",
     "rubyName": "invert_remove_index",
     "call": "delete",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration/command-recorder.ts",
-    "rubyName": "invert_remove_index",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/model-schema.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/model-schema.json
@@ -3,28 +3,7 @@
     "package": "activerecord",
     "tsFile": "model-schema.ts",
     "rubyName": "_returning_columns_for_insert",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
-    "rubyName": "_returning_columns_for_insert",
     "call": "filter_map",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
-    "rubyName": "attributes_builder",
-    "call": "attribute_types",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
-    "rubyName": "attributes_builder",
-    "call": "column_names",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -94,35 +73,7 @@
     "package": "activerecord",
     "tsFile": "model-schema.ts",
     "rubyName": "load_schema",
-    "call": "reload_schema_from_cache",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
-    "rubyName": "load_schema",
-    "call": "schema_loaded?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
-    "rubyName": "load_schema",
     "call": "synchronize",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
-    "rubyName": "quoted_table_name",
-    "call": "adapter_class",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
-    "rubyName": "reset_column_information",
-    "call": "clear_cache!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -136,21 +87,7 @@
     "package": "activerecord",
     "tsFile": "model-schema.ts",
     "rubyName": "reset_column_information",
-    "call": "connection_pool",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
-    "rubyName": "reset_column_information",
     "call": "descendants",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
-    "rubyName": "reset_column_information",
-    "call": "initialize_find_by_cache",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -177,36 +114,8 @@
   {
     "package": "activerecord",
     "tsFile": "model-schema.ts",
-    "rubyName": "reset_table_name",
-    "call": "compute_table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
-    "rubyName": "sequence_name",
-    "call": "base_class",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
     "rubyName": "sequence_name",
     "call": "base_class?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
-    "rubyName": "sequence_name",
-    "call": "reset_sequence_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
-    "rubyName": "symbol_column_to_string",
-    "call": "column_names",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -219,22 +128,8 @@
   {
     "package": "activerecord",
     "tsFile": "model-schema.ts",
-    "rubyName": "table_name",
-    "call": "reset_table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
     "rubyName": "table_name=",
     "call": "connected?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
-    "rubyName": "table_name=",
-    "call": "reset_column_information",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/nested-attributes.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/nested-attributes.json
@@ -10,21 +10,7 @@
     "package": "activerecord",
     "tsFile": "nested-attributes.ts",
     "rubyName": "accepts_nested_attributes_for",
-    "call": "nested_attributes_options",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "nested-attributes.ts",
-    "rubyName": "accepts_nested_attributes_for",
     "call": "update",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "nested-attributes.ts",
-    "rubyName": "allow_destroy?",
-    "call": "nested_attributes_options",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -46,13 +32,6 @@
     "tsFile": "nested-attributes.ts",
     "rubyName": "assign_nested_attributes_for_collection_association",
     "call": "call_reject_if",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "nested-attributes.ts",
-    "rubyName": "assign_nested_attributes_for_collection_association",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -81,13 +60,6 @@
     "tsFile": "nested-attributes.ts",
     "rubyName": "assign_nested_attributes_for_collection_association",
     "call": "loaded?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "nested-attributes.ts",
-    "rubyName": "assign_nested_attributes_for_collection_association",
-    "call": "nested_attributes_options",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -136,13 +108,6 @@
     "package": "activerecord",
     "tsFile": "nested-attributes.ts",
     "rubyName": "assign_nested_attributes_for_one_to_one_association",
-    "call": "nested_attributes_options",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "nested-attributes.ts",
-    "rubyName": "assign_nested_attributes_for_one_to_one_association",
     "call": "raise_nested_attributes_record_not_found!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -163,13 +128,6 @@
   {
     "package": "activerecord",
     "tsFile": "nested-attributes.ts",
-    "rubyName": "call_reject_if",
-    "call": "nested_attributes_options",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "nested-attributes.ts",
     "rubyName": "check_record_limit!",
     "call": "call",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -179,13 +137,6 @@
     "tsFile": "nested-attributes.ts",
     "rubyName": "check_record_limit!",
     "call": "size",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "nested-attributes.ts",
-    "rubyName": "find_record_by_id",
-    "call": "composite_primary_key?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/persistence.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/persistence.json
@@ -3,13 +3,6 @@
     "package": "activerecord",
     "tsFile": "persistence.ts",
     "rubyName": "_delete_record",
-    "call": "build_default_constraint",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
-    "rubyName": "_delete_record",
     "call": "global_current_scope",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -24,13 +17,6 @@
     "package": "activerecord",
     "tsFile": "persistence.ts",
     "rubyName": "_delete_record",
-    "call": "predicate_builder",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
-    "rubyName": "_delete_record",
     "call": "with_connection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -39,13 +25,6 @@
     "tsFile": "persistence.ts",
     "rubyName": "_in_memory_query_constraints_hash",
     "call": "attribute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
-    "rubyName": "_insert_record",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -79,13 +58,6 @@
   {
     "package": "activerecord",
     "tsFile": "persistence.ts",
-    "rubyName": "_update_record",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
     "rubyName": "_update_row",
     "call": "attributes_with_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -95,20 +67,6 @@
     "tsFile": "persistence.ts",
     "rubyName": "becomes",
     "call": "copy!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
-    "rubyName": "becomes",
-    "call": "destroyed?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
-    "rubyName": "becomes",
-    "call": "new_record?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -136,21 +94,7 @@
     "package": "activerecord",
     "tsFile": "persistence.ts",
     "rubyName": "destroy",
-    "call": "destroy_associations",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
-    "rubyName": "destroy",
     "call": "destroy_row",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
-    "rubyName": "destroy",
-    "call": "persisted?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -170,36 +114,8 @@
   {
     "package": "activerecord",
     "tsFile": "persistence.ts",
-    "rubyName": "query_constraints",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
-    "rubyName": "query_constraints_list",
-    "call": "base_class",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
     "rubyName": "query_constraints_list",
     "call": "base_class?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
-    "rubyName": "reload",
-    "call": "clear_query_cache",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
-    "rubyName": "reload",
-    "call": "connection_pool",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -276,27 +192,6 @@
     "package": "activerecord",
     "tsFile": "persistence.ts",
     "rubyName": "update_columns",
-    "call": "attribute_aliases",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
-    "rubyName": "update_columns",
-    "call": "destroyed?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
-    "rubyName": "update_columns",
-    "call": "new_record?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
-    "rubyName": "update_columns",
     "call": "readonly?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -313,5 +208,12 @@
     "rubyName": "update_columns",
     "call": "write_cast_value",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "persistence.ts",
+    "rubyName": "verify_readonly_attribute",
+    "call": "readonly_attribute?",
+    "reason": "Unmasked by alias-arity resolution (story arity-resolve-ts-alias-bindings-to-target-params): the TS body reads `_readonlyAttributes` directly instead of delegating to `readonlyAttributeQ`. Real gap, tracked as story converge-readonly-attribute-predicate-callers."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/query-cache.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/query-cache.json
@@ -3,13 +3,6 @@
     "package": "activerecord",
     "tsFile": "query-cache.ts",
     "rubyName": "cache",
-    "call": "clear_query_cache",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "query-cache.ts",
-    "rubyName": "cache",
     "call": "configurations",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -24,21 +17,7 @@
     "package": "activerecord",
     "tsFile": "query-cache.ts",
     "rubyName": "cache",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "query-cache.ts",
-    "rubyName": "cache",
     "call": "enable_query_cache",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "query-cache.ts",
-    "rubyName": "cache",
-    "call": "query_cache_enabled",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -74,13 +53,6 @@
     "tsFile": "query-cache.ts",
     "rubyName": "uncached",
     "call": "connected?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "query-cache.ts",
-    "rubyName": "uncached",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/querying.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/querying.json
@@ -3,20 +3,6 @@
     "package": "activerecord",
     "tsFile": "querying.ts",
     "rubyName": "_load_from_sql",
-    "call": "attribute_types",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "querying.ts",
-    "rubyName": "_load_from_sql",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "querying.ts",
-    "rubyName": "_load_from_sql",
     "call": "includes_column?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/readonly-attributes.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/readonly-attributes.json
@@ -3,8 +3,8 @@
     "package": "activerecord",
     "tsFile": "readonly-attributes.ts",
     "rubyName": "_write_attribute",
-    "call": "new_record?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "call": "readonly_attribute?",
+    "reason": "Unmasked by alias-arity resolution (story arity-resolve-ts-alias-bindings-to-target-params): the TS body reads `_readonlyAttributes` directly instead of delegating to `readonlyAttributeQ`. Real gap, tracked as story converge-readonly-attribute-predicate-callers."
   },
   {
     "package": "activerecord",
@@ -24,7 +24,7 @@
     "package": "activerecord",
     "tsFile": "readonly-attributes.ts",
     "rubyName": "write_attribute",
-    "call": "new_record?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "call": "readonly_attribute?",
+    "reason": "Unmasked by alias-arity resolution (story arity-resolve-ts-alias-bindings-to-target-params): the TS body reads `_readonlyAttributes` directly instead of delegating to `readonlyAttributeQ`. Real gap, tracked as story converge-readonly-attribute-predicate-callers."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/reflection.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/reflection.json
@@ -10,13 +10,6 @@
     "package": "activerecord",
     "tsFile": "reflection.ts",
     "rubyName": "add_aggregate_reflection",
-    "call": "aggregate_reflections",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "add_aggregate_reflection",
     "call": "merge",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -53,13 +46,6 @@
     "tsFile": "reflection.ts",
     "rubyName": "check_eager_loadable!",
     "call": "squish",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "clear_association_scope_cache",
-    "call": "initialize_find_by_cache",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -115,13 +101,6 @@
     "package": "activerecord",
     "tsFile": "reflection.ts",
     "rubyName": "join_scope",
-    "call": "predicate_builder",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "join_scope",
     "call": "where!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -151,20 +130,6 @@
     "tsFile": "reflection.ts",
     "rubyName": "normalize_options",
     "call": "fetch",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "reflect_on_aggregation",
-    "call": "aggregate_reflections",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "reflect_on_all_aggregations",
-    "call": "aggregate_reflections",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
@@ -38,13 +38,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "_increment_attribute",
-    "call": "predicate_builder",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "_increment_attribute",
     "call": "table",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -94,13 +87,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "_substitute_values",
-    "call": "predicate_builder",
-    "reason": "Satisfied by QueryAttribute.withCastValue: Rails build_bind_attribute (predicate_builder.rb:67-69) is a PRESERVING constructor because QueryAttribute#type_cast is identity (query_attribute.rb:22-24); trails QueryAttribute#typeCast casts its input, so calling buildBindAttribute here would cast twice."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "_substitute_values",
     "call": "table",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -143,27 +129,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "all_attributes?",
-    "call": "attribute_aliases",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "all_attributes?",
-    "call": "attribute_names",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "all_attributes?",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "all_attributes?",
     "call": "map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -172,13 +137,6 @@
     "tsFile": "relation.ts",
     "rubyName": "all_attributes?",
     "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "any?",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -346,21 +304,7 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "arel_column",
-    "call": "adapter_class",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "arel_column",
     "call": "arel_column_with_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "arel_column",
-    "call": "attribute_aliases",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -430,13 +374,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "arel_column_with_table",
-    "call": "adapter_class",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "arel_column_with_table",
     "call": "lookup_table_klass_from_join_dependencies",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -452,13 +389,6 @@
     "tsFile": "relation.ts",
     "rubyName": "arel_column_with_table",
     "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "arel_column_with_table",
-    "call": "predicate_builder",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -527,62 +457,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "async_average",
-    "call": "async",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "async_count",
-    "call": "async",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "async_ids",
-    "call": "async",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "async_maximum",
-    "call": "async",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "async_minimum",
-    "call": "async",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "async_pick",
-    "call": "async",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "async_pluck",
-    "call": "async",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "async_sum",
-    "call": "async",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "batch_condition",
     "call": "and",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -592,13 +466,6 @@
     "tsFile": "relation.ts",
     "rubyName": "batch_condition",
     "call": "or",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "batch_condition",
-    "call": "predicate_builder",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -697,13 +564,6 @@
     "tsFile": "relation.ts",
     "rubyName": "batch_on_unloaded_relation",
     "call": "build_batch_orders",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "batch_on_unloaded_relation",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -899,13 +759,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "calculate",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "calculate",
     "call": "has_include?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -969,13 +822,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "compute_cache_version",
-    "call": "adapter_class",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "compute_cache_version",
     "call": "arel",
     "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
   },
@@ -998,13 +844,6 @@
     "tsFile": "relation.ts",
     "rubyName": "compute_cache_version",
     "call": "deserialize",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "compute_cache_version",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -1151,13 +990,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "delete",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "delete",
     "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -1180,13 +1012,6 @@
     "tsFile": "relation.ts",
     "rubyName": "delete_all",
     "call": "build_arel",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "delete_all",
-    "call": "composite_primary_key?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -1235,13 +1060,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "destroy",
-    "call": "composite_primary_key?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "destroy",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -1278,13 +1096,6 @@
     "tsFile": "relation.ts",
     "rubyName": "ensure_valid_options_for_batching!",
     "call": "columns",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "ensure_valid_options_for_batching!",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -1382,13 +1193,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "exec_explain",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "exec_explain",
     "call": "map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -1432,13 +1236,6 @@
     "tsFile": "relation.ts",
     "rubyName": "exec_main_query",
     "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "exec_main_query",
-    "call": "null_relation?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -1501,13 +1298,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "execute_grouped_calculation",
-    "call": "adapter_class",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "execute_grouped_calculation",
     "call": "aggregate_column",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -1537,13 +1327,6 @@
     "tsFile": "relation.ts",
     "rubyName": "execute_grouped_calculation",
     "call": "as",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "execute_grouped_calculation",
-    "call": "base_class",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -1600,13 +1383,6 @@
     "tsFile": "relation.ts",
     "rubyName": "execute_grouped_calculation",
     "call": "distinct!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "execute_grouped_calculation",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -2145,13 +1921,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "in_order_of",
-    "call": "adapter_class",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "in_order_of",
     "call": "build_case_for_value_position",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -2173,21 +1942,7 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "in_order_of",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "in_order_of",
     "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "in_order_of",
-    "call": "none!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -2202,13 +1957,6 @@
     "tsFile": "relation.ts",
     "rubyName": "in_order_of",
     "call": "order!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "in_order_of",
-    "call": "type_caster",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -2230,13 +1978,6 @@
     "tsFile": "relation.ts",
     "rubyName": "include?",
     "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "instantiate_records",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -2300,13 +2041,6 @@
     "tsFile": "relation.ts",
     "rubyName": "load_async",
     "call": "with_connection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "lookup_cast_type_from_join_dependencies",
-    "call": "attribute_types",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -2565,13 +2299,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "references_eager_loaded_tables?",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "references_eager_loaded_tables?",
     "call": "references_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -2621,13 +2348,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "scope_for_create",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "scope_for_create",
     "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -2664,13 +2384,6 @@
     "tsFile": "relation.ts",
     "rubyName": "select_for_count",
     "call": "compile",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "select_for_count",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -2733,21 +2446,7 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "structurally_compatible?",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "structurally_compatible?",
     "call": "structurally_incompatible_values_for",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "table_name_matches?",
-    "call": "adapter_class",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -2839,20 +2538,6 @@
     "tsFile": "relation.ts",
     "rubyName": "type_cast_calculated_value",
     "call": "type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "type_cast_pluck_values",
-    "call": "attribute_types",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "type_cast_pluck_values",
-    "call": "build_join_dependencies",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -2999,20 +2684,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "update_all",
-    "call": "composite_primary_key?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "update_all",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "update_all",
     "call": "having_clause",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -3090,13 +2761,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "update_counters",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "update_counters",
     "call": "merge!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -3126,13 +2790,6 @@
     "tsFile": "relation.ts",
     "rubyName": "values_for_queries",
     "call": "except",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "where",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/batches.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/batches.json
@@ -23,13 +23,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation/batches.ts",
-    "rubyName": "batch_condition",
-    "call": "predicate_builder",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/batches.ts",
     "rubyName": "batch_on_loaded_relation",
     "call": "each_slice",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -60,13 +53,6 @@
     "tsFile": "relation/batches.ts",
     "rubyName": "batch_on_unloaded_relation",
     "call": "apply_finish_limit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/batches.ts",
-    "rubyName": "batch_on_unloaded_relation",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -151,13 +137,6 @@
     "tsFile": "relation/batches.ts",
     "rubyName": "ensure_valid_options_for_batching!",
     "call": "columns",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/batches.ts",
-    "rubyName": "ensure_valid_options_for_batching!",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/calculations.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/calculations.json
@@ -17,20 +17,6 @@
     "package": "activerecord",
     "tsFile": "relation/calculations.ts",
     "rubyName": "all_attributes?",
-    "call": "attribute_aliases",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/calculations.ts",
-    "rubyName": "all_attributes?",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/calculations.ts",
-    "rubyName": "all_attributes?",
     "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -39,13 +25,6 @@
     "tsFile": "relation/calculations.ts",
     "rubyName": "distinct_select?",
     "call": "match?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/calculations.ts",
-    "rubyName": "execute_grouped_calculation",
-    "call": "adapter_class",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -81,13 +60,6 @@
     "tsFile": "relation/calculations.ts",
     "rubyName": "execute_grouped_calculation",
     "call": "as",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/calculations.ts",
-    "rubyName": "execute_grouped_calculation",
-    "call": "base_class",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -144,13 +116,6 @@
     "tsFile": "relation/calculations.ts",
     "rubyName": "execute_grouped_calculation",
     "call": "distinct!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/calculations.ts",
-    "rubyName": "execute_grouped_calculation",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -444,13 +409,6 @@
     "package": "activerecord",
     "tsFile": "relation/calculations.ts",
     "rubyName": "lookup_cast_type_from_join_dependencies",
-    "call": "attribute_types",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/calculations.ts",
-    "rubyName": "lookup_cast_type_from_join_dependencies",
     "call": "each_join_dependencies",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -473,13 +431,6 @@
     "tsFile": "relation/calculations.ts",
     "rubyName": "perform_calculation",
     "call": "distinct_select?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/calculations.ts",
-    "rubyName": "perform_calculation",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -514,13 +465,6 @@
     "package": "activerecord",
     "tsFile": "relation/calculations.ts",
     "rubyName": "select_for_count",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/calculations.ts",
-    "rubyName": "select_for_count",
     "call": "select_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -543,20 +487,6 @@
     "tsFile": "relation/calculations.ts",
     "rubyName": "type_cast_calculated_value",
     "call": "type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/calculations.ts",
-    "rubyName": "type_cast_pluck_values",
-    "call": "attribute_types",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/calculations.ts",
-    "rubyName": "type_cast_pluck_values",
-    "call": "build_join_dependencies",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/finder-methods.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/finder-methods.json
@@ -17,13 +17,6 @@
     "package": "activerecord",
     "tsFile": "relation/finder-methods.ts",
     "rubyName": "construct_relation_for_exists",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "construct_relation_for_exists",
     "call": "except",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -59,13 +52,6 @@
     "package": "activerecord",
     "tsFile": "relation/finder-methods.ts",
     "rubyName": "find_nth_from_last",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "find_nth_from_last",
     "call": "loaded?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -74,13 +60,6 @@
     "tsFile": "relation/finder-methods.ts",
     "rubyName": "find_nth_with_limit",
     "call": "loaded?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "find_one",
-    "call": "composite_primary_key?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -115,13 +94,6 @@
     "package": "activerecord",
     "tsFile": "relation/finder-methods.ts",
     "rubyName": "find_some",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "find_some",
     "call": "size",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -130,13 +102,6 @@
     "tsFile": "relation/finder-methods.ts",
     "rubyName": "find_some",
     "call": "table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "find_some_ordered",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -213,20 +178,6 @@
     "package": "activerecord",
     "tsFile": "relation/finder-methods.ts",
     "rubyName": "find_with_ids",
-    "call": "composite_primary_key?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "find_with_ids",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "find_with_ids",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -249,20 +200,6 @@
     "tsFile": "relation/finder-methods.ts",
     "rubyName": "find_with_ids",
     "call": "size",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "ordered_relation",
-    "call": "asc",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "ordered_relation",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/merger.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/merger.json
@@ -16,23 +16,9 @@
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
-    "rubyName": "merge_clauses",
-    "call": "relation",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/merger.ts",
     "rubyName": "merge_joins",
     "call": "construct_join_dependency",
     "reason": "Wide call-set flag: Merger#mergeJoins/#mergeOuterJoins are thin wrappers delegating to the shared foldMergeJoins/foldMergeOuterJoins helper (merge-joins.ts); the Rails call is satisfied inside the helper. PR #4676."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/merger.ts",
-    "rubyName": "merge_joins",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -60,13 +46,6 @@
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_joins",
     "call": "partition",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/merger.ts",
-    "rubyName": "merge_joins",
-    "call": "relation",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -101,13 +80,6 @@
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_multi_values",
-    "call": "relation",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/merger.ts",
-    "rubyName": "merge_multi_values",
     "call": "reorder!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -124,13 +96,6 @@
     "rubyName": "merge_outer_joins",
     "call": "construct_join_dependency",
     "reason": "Wide call-set flag: Merger#mergeJoins/#mergeOuterJoins are thin wrappers delegating to the shared foldMergeJoins/foldMergeOuterJoins helper (merge-joins.ts); the Rails call is satisfied inside the helper. PR #4676."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/merger.ts",
-    "rubyName": "merge_outer_joins",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -158,20 +123,6 @@
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_outer_joins",
     "call": "partition",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/merger.ts",
-    "rubyName": "merge_outer_joins",
-    "call": "relation",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/merger.ts",
-    "rubyName": "merge_preloads",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -226,29 +177,8 @@
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
-    "rubyName": "merge_preloads",
-    "call": "relation",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails merger.rb:96-115; trails merger.ts:92-94 delegates to foldMergePreloads (relation/merge-preloads.ts), which performs the same body: length===0 empty? guards, same-model union via unionAppend, else reflectOnAllAssociations().find on className with preload/includes nesting — the reads happen on `_preloadAssociations`/`_includesAssociations` fields inside the helper."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/merger.ts",
-    "rubyName": "merge_select_values",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/merger.ts",
     "rubyName": "merge_select_values",
     "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/merger.ts",
-    "rubyName": "merge_select_values",
-    "call": "relation",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -270,13 +200,6 @@
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_single_values",
     "call": "merge",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/merger.ts",
-    "rubyName": "merge_single_values",
-    "call": "relation",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder.json
@@ -17,13 +17,6 @@
     "package": "activerecord",
     "tsFile": "relation/predicate-builder.ts",
     "rubyName": "expand_from_hash",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder.ts",
-    "rubyName": "expand_from_hash",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder/array-handler.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder/array-handler.json
@@ -3,13 +3,6 @@
     "package": "activerecord",
     "tsFile": "relation/predicate-builder/array-handler.ts",
     "rubyName": "call",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder/array-handler.ts",
-    "rubyName": "call",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder/association-query-value.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder/association-query-value.json
@@ -12,12 +12,5 @@
     "rubyName": "queries",
     "call": "pluck",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder/association-query-value.ts",
-    "rubyName": "select_clause?",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder/basic-object-handler.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder/basic-object-handler.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder/basic-object-handler.ts",
-    "rubyName": "call",
-    "call": "predicate_builder",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  }
-]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder/polymorphic-array-value.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder/polymorphic-array-value.json
@@ -5,12 +5,5 @@
     "rubyName": "klass",
     "call": "model",
     "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails polymorphic_array_value.rb:36-42 reads `value.model` for Relation inputs; trails polymorphic-array-value.ts:77-81 reads the `_modelClass` field after duck-checking for a relation."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder/polymorphic-array-value.ts",
-    "rubyName": "queries",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder/range-handler.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder/range-handler.json
@@ -12,12 +12,5 @@
     "rubyName": "call",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder/range-handler.ts",
-    "rubyName": "call",
-    "call": "predicate_builder",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder/relation-handler.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/predicate-builder/relation-handler.json
@@ -10,20 +10,6 @@
     "package": "activerecord",
     "tsFile": "relation/predicate-builder/relation-handler.ts",
     "rubyName": "call",
-    "call": "composite_primary_key?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder/relation-handler.ts",
-    "rubyName": "call",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder/relation-handler.ts",
-    "rubyName": "call",
     "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/query-attribute.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/query-attribute.json
@@ -5,12 +5,5 @@
     "rubyName": "initialize",
     "call": "deep_dup",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-attribute.ts",
-    "rubyName": "initialize",
-    "call": "mutable?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/query-methods.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/query-methods.json
@@ -3,20 +3,6 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "arel_column",
-    "call": "adapter_class",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "arel_column",
-    "call": "attribute_aliases",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "arel_column",
     "call": "column",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -66,13 +52,6 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "arel_column_aliases_from_hash",
-    "call": "adapter_class",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "arel_column_aliases_from_hash",
     "call": "as",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -88,13 +67,6 @@
     "tsFile": "relation/query-methods.ts",
     "rubyName": "arel_column_aliases_from_hash",
     "call": "quote_column_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "arel_column_with_table",
-    "call": "adapter_class",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -199,20 +171,6 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_bound_sql_literal",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_bound_sql_literal",
-    "call": "id_for_database",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_bound_sql_literal",
     "call": "sql",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -242,13 +200,6 @@
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_from",
     "call": "from_clause",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_join_buckets",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -290,13 +241,6 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_join_dependencies",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_join_dependencies",
     "call": "includes_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -318,13 +262,6 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_joins",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_joins",
     "call": "join_constraints",
     "reason": "Bucket (b) equivalent: unify-join-emission-build-joins extracted the single Rails build_joins emission into the shared `emitJoinPlan` helper (delegated to by both `buildJoins` and `_applyJoinsToManager`). The `join_constraints` call still happens, one frame deeper in `emitJoinPlan` (which has no Rails counterpart), so the static call-set analyzer no longer sees it directly under build_joins. Behavior is identical."
   },
@@ -333,20 +270,6 @@
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_joins",
     "call": "references_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_named_bound_sql_literal",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_named_bound_sql_literal",
-    "call": "id_for_database",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -387,13 +310,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_order",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
     "rubyName": "build_select",
     "call": "any?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -403,13 +319,6 @@
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_select",
     "call": "arel_columns",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_select",
-    "call": "column_names",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -451,13 +360,6 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_subquery",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_subquery",
     "call": "except",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -472,20 +374,6 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_where_clause",
-    "call": "attribute_aliases",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_where_clause",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_where_clause",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -494,7 +382,7 @@
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_where_clause",
     "call": "map",
-    "reason": "Rails' `build_where_clause` `map` is `key.map { |k| attribute_aliases[k] }` inside `transform_keys` for composite ARRAY keys; JS object keys can't be arrays, so trails resolves single-key aliases via `aliases[key] ?? key` and composite keys via `PredicateBuilder#buildComposite` \u2014 no `map` over keys applies."
+    "reason": "Rails' `build_where_clause` `map` is `key.map { |k| attribute_aliases[k] }` inside `transform_keys` for composite ARRAY keys; JS object keys can't be arrays, so trails resolves single-key aliases via `aliases[key] ?? key` and composite keys via `PredicateBuilder#buildComposite` — no `map` over keys applies."
   },
   {
     "package": "activerecord",
@@ -543,13 +431,6 @@
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_with",
     "call": "build_with_value_from_hash",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_with",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -696,20 +577,6 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "order_column",
-    "call": "adapter_class",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "order_column",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "order_column",
     "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -738,27 +605,6 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "preprocess_order_args",
-    "call": "adapter_class",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "preprocess_order_args",
-    "call": "asc",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "preprocess_order_args",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "preprocess_order_args",
     "call": "flattened_args",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -781,13 +627,6 @@
     "tsFile": "relation/query-methods.ts",
     "rubyName": "preprocess_order_args",
     "call": "order_column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "reverse_sql_order",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -844,13 +683,6 @@
     "tsFile": "relation/query-methods.ts",
     "rubyName": "structurally_incompatible_values_for",
     "call": "values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "table_name_matches?",
-    "call": "adapter_class",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/where-clause.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/where-clause.json
@@ -9,13 +9,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation/where-clause.ts",
-    "rubyName": "contradiction?",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/where-clause.ts",
     "rubyName": "extract_attributes",
     "call": "each_attributes",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -32,13 +25,6 @@
     "tsFile": "relation/where-clause.ts",
     "rubyName": "invert",
     "call": "size",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/where-clause.ts",
-    "rubyName": "or",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/sanitization.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/sanitization.json
@@ -80,13 +80,6 @@
     "package": "activerecord",
     "tsFile": "sanitization.ts",
     "rubyName": "sanitize_sql_for_order",
-    "call": "adapter_class",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "sanitization.ts",
-    "rubyName": "sanitize_sql_for_order",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/schema-dumper.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/schema-dumper.json
@@ -10,13 +10,6 @@
     "package": "activerecord",
     "tsFile": "schema-dumper.ts",
     "rubyName": "check_constraints_in_create",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "schema-dumper.ts",
-    "rubyName": "check_constraints_in_create",
     "call": "map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -200,13 +193,6 @@
     "tsFile": "schema-dumper.ts",
     "rubyName": "table",
     "call": "detect",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "schema-dumper.ts",
-    "rubyName": "table",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/schema.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/schema.json
@@ -3,13 +3,6 @@
     "package": "activerecord",
     "tsFile": "schema.ts",
     "rubyName": "define",
-    "call": "connection_pool",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "schema.ts",
-    "rubyName": "define",
     "call": "with_connection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/scoping.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/scoping.json
@@ -17,13 +17,6 @@
     "package": "activerecord",
     "tsFile": "scoping.ts",
     "rubyName": "ignore_default_scope=",
-    "call": "base_class",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "scoping.ts",
-    "rubyName": "ignore_default_scope=",
     "call": "set_ignore_default_scope",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/scoping/default.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/scoping/default.json
@@ -33,12 +33,5 @@
     "rubyName": "scope_attributes?",
     "call": "any?",
     "reason": "Ruby Array#any? has no ported counterpart: `default_scopes.any?` (scoping/default.rb:56) ports to the `defaultScopes.length` check in isScopeAttributes."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "scoping/default.ts",
-    "rubyName": "unscoped",
-    "call": "relation",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/secure-password.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/secure-password.json
@@ -17,13 +17,6 @@
     "package": "activerecord",
     "tsFile": "secure-password.ts",
     "rubyName": "authenticate_by",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "secure-password.ts",
-    "rubyName": "authenticate_by",
     "call": "map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/signed-id.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/signed-id.json
@@ -30,13 +30,6 @@
   {
     "package": "activerecord",
     "tsFile": "signed-id.ts",
-    "rubyName": "signed_id",
-    "call": "new_record?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "signed-id.ts",
     "rubyName": "signed_id_verifier",
     "call": "call",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/table-metadata.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/table-metadata.json
@@ -40,12 +40,5 @@
     "rubyName": "through_association?",
     "call": "reflection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "table-metadata.ts",
-    "rubyName": "type",
-    "call": "arel_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/tasks/database-tasks.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/tasks/database-tasks.json
@@ -255,13 +255,6 @@
     "package": "activerecord",
     "tsFile": "tasks/database-tasks.ts",
     "rubyName": "migrate",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "migrate",
     "call": "write",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -299,13 +292,6 @@
     "rubyName": "migrate_status",
     "call": "table_exists?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "migration_connection",
-    "call": "lease_connection",
-    "reason": "migrationConnection (sync) routes through `leaseConnectionSync`; Rails-named `leaseConnection` is async in trails (converge-connection-pool-checkout-lease-async) and cannot be awaited from this sync accessor."
   },
   {
     "package": "activerecord",
@@ -452,13 +438,6 @@
     "tsFile": "tasks/database-tasks.ts",
     "rubyName": "structure_load",
     "call": "structure_load_flags_for",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "target_version",
-    "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/testing/query-assertions.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/testing/query-assertions.json
@@ -3,35 +3,7 @@
     "package": "activerecord",
     "tsFile": "testing/query-assertions.ts",
     "rubyName": "assert_queries_count",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "testing/query-assertions.ts",
-    "rubyName": "assert_queries_count",
-    "call": "lease_connection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "testing/query-assertions.ts",
-    "rubyName": "assert_queries_count",
     "call": "size",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "testing/query-assertions.ts",
-    "rubyName": "assert_queries_match",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "testing/query-assertions.ts",
-    "rubyName": "assert_queries_match",
-    "call": "lease_connection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/timestamp.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/timestamp.json
@@ -12,26 +12,5 @@
     "rubyName": "max_updated_column_timestamp",
     "call": "to_time",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "timestamp.ts",
-    "rubyName": "timestamp_attributes_for_create",
-    "call": "attribute_aliases",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "timestamp.ts",
-    "rubyName": "timestamp_attributes_for_update",
-    "call": "attribute_aliases",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "timestamp.ts",
-    "rubyName": "touch_attributes_with_time",
-    "call": "attribute_aliases",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/touch-later.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/touch-later.json
@@ -19,19 +19,5 @@
     "rubyName": "touch_later",
     "call": "add_to_transaction",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "touch-later.ts",
-    "rubyName": "touch_later",
-    "call": "attribute_aliases",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "touch-later.ts",
-    "rubyName": "touch_later",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/transactions.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/transactions.json
@@ -10,13 +10,6 @@
     "package": "activerecord",
     "tsFile": "transactions.ts",
     "rubyName": "after_commit",
-    "call": "prepend_option",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "transactions.ts",
-    "rubyName": "after_commit",
     "call": "set_callback",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -31,13 +24,6 @@
     "package": "activerecord",
     "tsFile": "transactions.ts",
     "rubyName": "after_create_commit",
-    "call": "prepend_option",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "transactions.ts",
-    "rubyName": "after_create_commit",
     "call": "set_callback",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -52,13 +38,6 @@
     "package": "activerecord",
     "tsFile": "transactions.ts",
     "rubyName": "after_destroy_commit",
-    "call": "prepend_option",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "transactions.ts",
-    "rubyName": "after_destroy_commit",
     "call": "set_callback",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -73,13 +52,6 @@
     "package": "activerecord",
     "tsFile": "transactions.ts",
     "rubyName": "after_rollback",
-    "call": "prepend_option",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "transactions.ts",
-    "rubyName": "after_rollback",
     "call": "set_callback",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -94,13 +66,6 @@
     "package": "activerecord",
     "tsFile": "transactions.ts",
     "rubyName": "after_save_commit",
-    "call": "prepend_option",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "transactions.ts",
-    "rubyName": "after_save_commit",
     "call": "set_callback",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -109,13 +74,6 @@
     "tsFile": "transactions.ts",
     "rubyName": "after_save_commit",
     "call": "set_options_for_callbacks!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "transactions.ts",
-    "rubyName": "after_update_commit",
-    "call": "prepend_option",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -144,27 +102,6 @@
     "tsFile": "transactions.ts",
     "rubyName": "before_commit",
     "call": "set_options_for_callbacks!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "transactions.ts",
-    "rubyName": "current_transaction",
-    "call": "connection_pool",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "transactions.ts",
-    "rubyName": "has_transactional_callbacks?",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "transactions.ts",
-    "rubyName": "restore_transaction_record_state",
-    "call": "composite_primary_key?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -214,13 +151,6 @@
     "tsFile": "transactions.ts",
     "rubyName": "set_callback",
     "call": "transaction_include_any_action?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "transactions.ts",
-    "rubyName": "with_transaction_returning_status",
-    "call": "transaction_open?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/validations.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/validations.json
@@ -5,12 +5,5 @@
     "rubyName": "custom_validation_context?",
     "call": "exclude?",
     "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails validations.rb:77-79 uses `[:create, :update].exclude?(validation_context)`; trails validations.ts:168-171 inlines the two !== comparisons."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "validations.ts",
-    "rubyName": "valid?",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/validations/uniqueness.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/validations/uniqueness.json
@@ -17,13 +17,6 @@
     "package": "activerecord",
     "tsFile": "validations/uniqueness.ts",
     "rubyName": "validate_each",
-    "call": "id_in_database",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "validations/uniqueness.ts",
-    "rubyName": "validate_each",
     "call": "not",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }

--- a/scripts/api-compare/call-mismatches-wide-exclude/activesupport/html-safe-translation.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activesupport/html-safe-translation.json
@@ -5,5 +5,12 @@
     "rubyName": "translate",
     "call": "call",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "html-safe-translation.ts",
+    "rubyName": "translate",
+    "call": "html_safe_translation",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/trailties/application/default-middleware-stack.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/trailties/application/default-middleware-stack.json
@@ -3,13 +3,6 @@
     "package": "trailties",
     "tsFile": "application/default-middleware-stack.ts",
     "rubyName": "build_stack",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "trailties",
-    "tsFile": "application/default-middleware-stack.ts",
-    "rubyName": "build_stack",
     "call": "fetch",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/trailties/generators/named-base.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/trailties/generators/named-base.json
@@ -1,9 +1,0 @@
-[
-  {
-    "package": "trailties",
-    "tsFile": "generators/named-base.ts",
-    "rubyName": "initialize",
-    "call": "frozen?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  }
-]

--- a/scripts/api-compare/call-mismatches-wide-exclude/trailties/generators/rails/controller/controller-generator.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/trailties/generators/rails/controller/controller-generator.json
@@ -10,13 +10,6 @@
     "package": "trailties",
     "tsFile": "generators/rails/controller/controller-generator.ts",
     "rubyName": "add_routes",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "trailties",
-    "tsFile": "generators/rails/controller/controller-generator.ts",
-    "rubyName": "add_routes",
     "call": "options",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/trailties/initializable.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/trailties/initializable.json
@@ -3,13 +3,6 @@
     "package": "trailties",
     "tsFile": "initializable.ts",
     "rubyName": "initializer",
-    "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "trailties",
-    "tsFile": "initializable.ts",
-    "rubyName": "initializer",
     "call": "find",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/call-mismatches-wide-exclude/trailties/rack/logger.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/trailties/rack/logger.json
@@ -17,13 +17,6 @@
     "package": "trailties",
     "tsFile": "rack/logger.ts",
     "rubyName": "started_request_message",
-    "call": "filtered_path",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "trailties",
-    "tsFile": "rack/logger.ts",
-    "rubyName": "started_request_message",
     "call": "now",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -80,7 +80,13 @@ import {
 } from "./config.js";
 import { SpellChecker } from "../../packages/did-you-mean/src/spell-checker.js";
 import { isArityOverridden, isScopedSkip, rubyFileToTs, rubyMethodToTs } from "./conventions.js";
-import { matchArityAgainst, renderSig, shouldSkipArity, type ArityRange } from "./arity.js";
+import {
+  matchArityAgainst,
+  renderSig,
+  shouldSkipArity,
+  stripThis,
+  type ArityRange,
+} from "./arity.js";
 import { matchOptionKeysAgainst } from "./options-keys.js";
 import {
   compareDefaults,
@@ -1436,7 +1442,10 @@ export function main() {
           rubyName,
           rubyCalls,
           tsCalls,
-          (c) => (tsParamsByName.get(c) ?? []).some((sig) => sig.length > 0),
+          // A `this:` receiver is not an argument — counting it would
+          // promote zero-arg readers (`spawn`, `readonlyAttributeQ`) past the
+          // gate the moment alias bindings started carrying real params.
+          (c) => (tsParamsByName.get(c) ?? []).some((sig) => stripThis(sig).length > 0),
           rubyMethodToTs,
           callsSignificant,
         );

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -92,6 +92,19 @@ describe("harvestObjectLiteralMethods", () => {
     expect(byName["noop"]).toEqual([]);
   });
 
+  it("resolves an overloaded alias target to its widest signature", () => {
+    const methods = objectLiteralMethods(
+      `function find(id: number): void;
+      function find(id: number, options: object): void;
+      function find(id: number, options?: object): void {}
+      export const ClassMethods = { find };`,
+    );
+    expect(methods.find((m) => m.name === "find")!.params).toEqual([
+      { name: "id", kind: "required", type: "number" },
+      { name: "options", kind: "required", type: "object" },
+    ]);
+  });
+
   it("resolves alias bindings to the target function's params", () => {
     const methods = objectLiteralMethods(
       `function readonlyAttributeQ(this: unknown, attribute: string): boolean { return true; }

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1000,7 +1000,7 @@ describe("extractFromProgram — Object.defineProperty wiring", () => {
           enumerable: false,
         });
       `,
-      "callbacks.ts": `export function createRecord() {}`,
+      "callbacks.ts": `export function createRecord(attribute: string) {}`,
     });
     const methods = info.classes["base.ts:Base"].instanceMethods.map((m) => m.name);
     expect(methods).toContain("createOrUpdate");
@@ -1009,6 +1009,9 @@ describe("extractFromProgram — Object.defineProperty wiring", () => {
     )!;
     expect(m.visibility).toBe("private");
     expect(m.internal).toBe(true);
+    // The descriptor's `value` alias carries the target's arity — recording it
+    // as 0-arg put a bogus [0-0] candidate in the arity pool.
+    expect(m.params).toEqual([{ name: "attribute", kind: "required", type: "string" }]);
   });
 
   it("credits for-of loop over [name, fn][] array to host class (Pattern B)", () => {
@@ -1016,8 +1019,8 @@ describe("extractFromProgram — Object.defineProperty wiring", () => {
       "base.ts": `export class Base {}`,
       "callbacks.ts": `
         export function createOrUpdate() {}
-        export function _createRecord() {}
-        export function _updateRecord() {}
+        export function _createRecord(attributeNames: string[]) {}
+        export function _updateRecord(attributeNames: string[]) {}
       `,
       "wire.ts": `
         import { Base } from "./base.js";
@@ -1045,6 +1048,14 @@ describe("extractFromProgram — Object.defineProperty wiring", () => {
       expect(m.visibility).toBe("private");
       expect(m.internal).toBe(true);
     }
+    // Each tuple's own fn supplies the params — not one shared empty list.
+    const byName = Object.fromEntries(
+      info.classes["base.ts:Base"].instanceMethods.map((m) => [m.name, m.params]),
+    );
+    expect(byName["createOrUpdate"]).toEqual([]);
+    expect(byName["_createRecord"]).toEqual([
+      { name: "attributeNames", kind: "required", type: "string[]" },
+    ]);
   });
 
   it("skips for-of loop when descriptor has no `value` key (getter/setter descriptors)", () => {

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -88,8 +88,27 @@ describe("harvestObjectLiteralMethods", () => {
       { name: "a", kind: "required", type: "number" },
       { name: "b", kind: "optional", default: "...", literal: { kind: "int", value: "1" } },
     ]);
-    // Shorthand reference: name captured, params unknown (signature lives elsewhere).
+    // Shorthand reference to an undeclared name: params stay unknown.
     expect(byName["noop"]).toEqual([]);
+  });
+
+  it("resolves alias bindings to the target function's params", () => {
+    const methods = objectLiteralMethods(
+      `function readonlyAttributeQ(this: unknown, attribute: string): boolean { return true; }
+      export const ClassMethods = {
+        readonlyAttributeQ,
+        isReadonlyAttribute: readonlyAttributeQ,
+      };`,
+    );
+    const byName = Object.fromEntries(methods.map((m) => [m.name, m.params]));
+    const expected = [
+      { name: "this", kind: "required", type: "unknown" },
+      { name: "attribute", kind: "required", type: "string" },
+    ];
+    // Both the shorthand and the renamed alias must carry the real 1-1 arity
+    // (post `this`-strip) into the candidate pool, not an empty list.
+    expect(byName["readonlyAttributeQ"]).toEqual(expected);
+    expect(byName["isReadonlyAttribute"]).toEqual(expected);
   });
 });
 

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1189,6 +1189,25 @@ function extractDefinePropertyForOf(
  * Used both for `export const Mod = { ... }` module discovery and for
  * resolving inline / property-access mod args to `include(Host, Mod)`.
  */
+/**
+ * Params of the function an identifier / property-access reference points at,
+ * or null when the expression isn't callable. Mirrors the alias resolution the
+ * named-export path does for `export { foo }` so that a binding like
+ * `isReadonlyAttribute: readonlyAttributeQ` reports the target's real arity
+ * instead of an empty list.
+ */
+export function paramsOfCallableRef(
+  expr: ts.Expression,
+  checker: ts.TypeChecker,
+): ParamInfo[] | null {
+  const type = checker.getTypeAtLocation(expr);
+  const signatures = type.getCallSignatures();
+  if (signatures.length === 0) return null;
+  const decl = signatures[0].declaration;
+  if (decl && ts.isFunctionLike(decl)) return extractParameters(decl.parameters);
+  return [];
+}
+
 export function harvestObjectLiteralMethods(
   obj: ts.ObjectLiteralExpression,
   checker: ts.TypeChecker,
@@ -1197,9 +1216,10 @@ export function harvestObjectLiteralMethods(
   const out: MethodInfo[] = [];
   for (const prop of obj.properties) {
     let mname: string | null = null;
-    // Params are recoverable for inline method/function forms; left empty for
-    // identifier references (`qux,` / `foo: NS.bar`) whose signature lives
-    // elsewhere — the arity check tolerates that via its global candidate pool.
+    // Params are recoverable for inline method/function forms; identifier
+    // references (`qux,` / `foo: NS.bar`) are resolved through the checker to
+    // the target function's signature, so an alias-only binding still carries
+    // the real arity into the candidate pool.
     let params: ParamInfo[] = [];
     let optionKeys: string[] | null | undefined;
     let calls: string[] | undefined;
@@ -1210,6 +1230,7 @@ export function harvestObjectLiteralMethods(
       calls = extractCalls(prop.body);
     } else if (ts.isShorthandPropertyAssignment(prop)) {
       mname = prop.name.text;
+      params = paramsOfCallableRef(prop.name, checker) ?? [];
     } else if (ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name)) {
       const init = prop.initializer;
       if (ts.isFunctionExpression(init) || ts.isArrowFunction(init)) {
@@ -1221,8 +1242,11 @@ export function harvestObjectLiteralMethods(
         // `foo: bar` / `foo: NS.bar` — count if the RHS resolves to a
         // callable. Catches `readAttributeForValidation:
         // _Validations.readAttributeForValidation` etc.
-        const t = checker.getTypeAtLocation(init);
-        if (t.getCallSignatures().length > 0) mname = prop.name.text;
+        const resolved = paramsOfCallableRef(init, checker);
+        if (resolved) {
+          mname = prop.name.text;
+          params = resolved;
+        }
       }
     }
     if (!mname) continue;

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1036,16 +1036,39 @@ function classInfoForPrototype(
 }
 
 /** Push a method name onto classInfo if not already present. */
-function pushDefinePropertyMethod(classInfo: ClassInfo, name: string, line: number): void {
+function pushDefinePropertyMethod(
+  classInfo: ClassInfo,
+  name: string,
+  line: number,
+  params: ParamInfo[] = [],
+): void {
   if (classInfo.instanceMethods.some((m) => m.name === name)) return;
   classInfo.instanceMethods.push({
     name,
     visibility: "private",
     internal: true,
-    params: [],
+    params,
     line,
     file: classInfo.file,
   });
+}
+
+/** Params behind an `Object.defineProperty` `value:` — inline function or alias. */
+function paramsOfDescriptorValue(value: ts.Expression, checker: ts.TypeChecker): ParamInfo[] {
+  if (ts.isFunctionExpression(value) || ts.isArrowFunction(value)) {
+    return extractParameters(value.parameters);
+  }
+  return paramsOfCallableRef(value, checker) ?? [];
+}
+
+/** The `value:` initializer of an `Object.defineProperty` descriptor, if any. */
+function definePropertyValue(descriptor: ts.ObjectLiteralExpression): ts.Expression | null {
+  for (const p of descriptor.properties) {
+    if (ts.isPropertyAssignment(p) && ts.isIdentifier(p.name) && p.name.text === "value") {
+      return p.initializer;
+    }
+  }
+  return null;
 }
 
 /**
@@ -1068,14 +1091,17 @@ function extractDefinePropertyDirect(
   const [target, propNameExpr, descriptor] = expr.arguments;
   if (!ts.isStringLiteral(propNameExpr)) return;
   if (!ts.isObjectLiteralExpression(descriptor)) return;
-  const hasValue = descriptor.properties.some(
-    (p) => ts.isPropertyAssignment(p) && ts.isIdentifier(p.name) && p.name.text === "value",
-  );
-  if (!hasValue) return;
+  const value = definePropertyValue(descriptor);
+  if (!value) return;
   const classInfo = classInfoForPrototype(target, info, checker, srcDir);
   if (!classInfo) return;
   const line = expr.getSourceFile().getLineAndCharacterOfPosition(expr.getStart()).line + 1;
-  pushDefinePropertyMethod(classInfo, propNameExpr.text, line);
+  pushDefinePropertyMethod(
+    classInfo,
+    propNameExpr.text,
+    line,
+    paramsOfDescriptorValue(value, checker),
+  );
 }
 
 /**
@@ -1109,14 +1135,17 @@ function extractDefinePropertyForOf(
   if (!ts.isArrayLiteralExpression(iterable)) return;
 
   // Each element must be an array literal whose first element is a string literal.
-  const methodNames: string[] = [];
+  // The tuple's second element is the function bound to that name, so each
+  // entry carries its own arity rather than sharing an empty list.
+  const entries: { name: string; params: ParamInfo[] }[] = [];
   for (const el of iterable.elements) {
     if (!ts.isArrayLiteralExpression(el) || el.elements.length < 1) return;
     const first = el.elements[0];
     if (!ts.isStringLiteral(first)) return;
-    methodNames.push(first.text);
+    const fn = el.elements[1];
+    entries.push({ name: first.text, params: fn ? paramsOfDescriptorValue(fn, checker) : [] });
   }
-  if (methodNames.length === 0) return;
+  if (entries.length === 0) return;
 
   // Find `Object.defineProperty(Cls.prototype, nameVar, { value: ... })` in body.
   if (!ts.isBlock(node.statement)) return;
@@ -1133,18 +1162,15 @@ function extractDefinePropertyForOf(
     const [target, propNameExpr, descriptor] = expr.arguments;
     if (!ts.isIdentifier(propNameExpr) || propNameExpr.text !== nameVar) continue;
     if (!ts.isObjectLiteralExpression(descriptor)) continue;
-    const hasValue = descriptor.properties.some(
-      (p) => ts.isPropertyAssignment(p) && ts.isIdentifier(p.name) && p.name.text === "value",
-    );
-    if (!hasValue) continue;
+    if (!definePropertyValue(descriptor)) continue;
     classInfo = classInfoForPrototype(target, info, checker, srcDir);
     break;
   }
   if (!classInfo) return;
 
   const line = node.getSourceFile().getLineAndCharacterOfPosition(node.getStart()).line + 1;
-  for (const name of methodNames) {
-    pushDefinePropertyMethod(classInfo, name, line);
+  for (const entry of entries) {
+    pushDefinePropertyMethod(classInfo, entry.name, line, entry.params);
   }
 }
 
@@ -1175,6 +1201,25 @@ function extractDefinePropertyForOf(
  * Caller must already have ensured `node` is not exported.
  */
 /**
+ * Params of the function an identifier / property-access reference points at,
+ * or null when the expression isn't callable. Mirrors the alias resolution the
+ * named-export path does for `export { foo }` so that a binding like
+ * `isReadonlyAttribute: readonlyAttributeQ` reports the target's real arity
+ * instead of an empty list. Returns `[]` for a callable with no reachable
+ * declaration (a synthesized/ambient signature), which is what the pre-alias
+ * behavior recorded.
+ */
+export function paramsOfCallableRef(
+  expr: ts.Expression,
+  checker: ts.TypeChecker,
+): ParamInfo[] | null {
+  const signatures = checker.getTypeAtLocation(expr).getCallSignatures();
+  if (signatures.length === 0) return null;
+  const decl = signatures[0].declaration;
+  return decl && ts.isFunctionLike(decl) ? extractParameters(decl.parameters) : [];
+}
+
+/**
  * Extract method names from an object literal — covers the four shapes
  * Rails-style mixin modules use:
  *
@@ -1189,25 +1234,6 @@ function extractDefinePropertyForOf(
  * Used both for `export const Mod = { ... }` module discovery and for
  * resolving inline / property-access mod args to `include(Host, Mod)`.
  */
-/**
- * Params of the function an identifier / property-access reference points at,
- * or null when the expression isn't callable. Mirrors the alias resolution the
- * named-export path does for `export { foo }` so that a binding like
- * `isReadonlyAttribute: readonlyAttributeQ` reports the target's real arity
- * instead of an empty list.
- */
-export function paramsOfCallableRef(
-  expr: ts.Expression,
-  checker: ts.TypeChecker,
-): ParamInfo[] | null {
-  const type = checker.getTypeAtLocation(expr);
-  const signatures = type.getCallSignatures();
-  if (signatures.length === 0) return null;
-  const decl = signatures[0].declaration;
-  if (decl && ts.isFunctionLike(decl)) return extractParameters(decl.parameters);
-  return [];
-}
-
 export function harvestObjectLiteralMethods(
   obj: ts.ObjectLiteralExpression,
   checker: ts.TypeChecker,

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1215,7 +1215,11 @@ export function paramsOfCallableRef(
 ): ParamInfo[] | null {
   const signatures = checker.getTypeAtLocation(expr).getCallSignatures();
   if (signatures.length === 0) return null;
-  const decl = signatures[0].declaration;
+  // An overloaded target exposes one signature per overload; take the widest so
+  // the recorded arity spans every call the alias admits rather than silently
+  // truncating to whichever overload was declared first.
+  const widest = signatures.reduce((a, b) => (b.parameters.length > a.parameters.length ? b : a));
+  const decl = widest.declaration;
   return decl && ts.isFunctionLike(decl) ? extractParameters(decl.parameters) : [];
 }
 


### PR DESCRIPTION
## What

`harvestObjectLiteralMethods` recorded identifier-reference bindings
(`qux,` / `isReadonlyAttribute: readonlyAttributeQ`) with `params: []`, so when
a Rails name reached TS only through such an alias the real signature never
entered the arity candidate pool — and `matchArityAgainst` reported the FIRST
candidate, so genuine mismatches displayed a misleading `ts() [0-0]`.

- `paramsOfCallableRef` resolves an identifier/property-access initializer
  through the checker to the target function's parameters (the same resolution
  the named-export path already does for `export { foo }`), used for shorthand
  and `name: target` bindings, and for `Object.defineProperty(..., { value: fn })`
  descriptors (Pattern A and the per-tuple fn of Pattern B).
- `matchArityAgainst` reports the *closest* candidate — smallest gap to Ruby's
  range, tie-broken by the longest parameter list — instead of the first.
- Calls-parity's "is this a ported method that takes arguments" gate now strips
  a leading `this:` receiver. That gate reads the same param records; without
  the strip, every mixin function's `this:` param would have counted as an
  argument the moment aliases started carrying real params.

## Effect on `output/arity-mismatches.json`

Total stays at 183; three deltas:

- gone: `readonly_attributes.rb readonly_attribute?` (the alias now carries the
  real 1-1 signature) and `html_safe_translation.rb html_safe_translation`.
- newly flagged: `create_or_find_by!` (base.rb + querying.rb pairs). This is the
  unmasking the story asked for, not a regression: its non-bang sibling
  `create_or_find_by` was already flagged with the identical shape
  (`ruby() [0-0]` from the Ruby-side `delegate` vs `ts(conditions, extra = …)`);
  the bang variant "matched" only because the 0-param
  `createOrFindByBang: performCreateOrFindByBang` alias in
  `relation/finder-methods.ts` was in the pool.

Mismatches that reported a bogus `ts()` drop from 35 to 18 — including every
case the story named:

| pair | before | after |
| --- | --- | --- |
| `perform_query` (4 adapters) | `()` | `(_rawConnection, _sql, _binds, _typeCastedBinds, _options = …)` |
| `cache_sql` | `()` | `(sql, name, binds, execute)` |
| `association_valid?` | `()` | `(reflection, record, owner, association)` |
| `compute_primary_key` | `()` | `(reflection)` |

No pair that legitimately matched before regresses.

## Calls-parity baselines

The `this:`-strip makes the wide calls gate accurate, which prunes **383 stale
baseline entries** (2.6k lines of generated
`call-mismatches-wide-exclude/` JSON) and surfaces 5 real ones. Four are the
`readonly_attribute?` delegation gaps (TS reads `_readonlyAttributes` directly
where Rails calls the predicate); they are baselined with a reason pointing at
the follow-up story `converge-readonly-attribute-predicate-callers`, filed on
this RFC. Both ratchets are green (`OK (5103 baselined)` / `OK (19 baselined)`).

Hand-written diff is 157/-36 across 5 files; the rest is regenerated baseline.

## Tests

`extract-ts-api.test.ts` covers shorthand + renamed alias resolution and the
two `Object.defineProperty` wiring patterns; `arity.test.ts` covers
closest-candidate reporting and the length tiebreak.

Closes-story: arity-resolve-ts-alias-bindings-to-target-params
