### PR TITLE
fix(api-compare): skip arity for Ruby delegate/alias placeholder entries

### DIFF
--- a/scripts/api-compare/arity.test.ts
+++ b/scripts/api-compare/arity.test.ts
@@ -285,22 +285,29 @@ describe("shouldSkipArity", () => {
 });
 
 describe("isForwardingRubyEntry", () => {
-  it("skips a delegate entry recorded with placeholder zero arity", () => {
-    expect(isForwardingRubyEntry([], "delegate")).toBe(true);
+  it("skips a delegate entry (arity is the unseen target's)", () => {
+    expect(isForwardingRubyEntry({ notes: "delegate" })).toBe(true);
   });
 
   it("skips an alias whose target could not be resolved", () => {
-    expect(isForwardingRubyEntry([], "alias")).toBe(true);
+    expect(isForwardingRubyEntry({ notes: "alias" })).toBe(true);
   });
 
   it("checks an alias whose target params were resolved", () => {
-    expect(isForwardingRubyEntry([req("a")], "alias")).toBe(false);
+    expect(isForwardingRubyEntry({ notes: "alias", aliasResolved: true })).toBe(false);
   });
 
-  it("checks a plain zero-arg method and other extractor notes", () => {
-    expect(isForwardingRubyEntry([], undefined)).toBe(false);
-    expect(isForwardingRubyEntry([], "scope")).toBe(false);
-    expect(isForwardingRubyEntry([], "class_attribute")).toBe(false);
+  it("checks an alias resolved to a target that takes no arguments", () => {
+    // Resolution is read from the flag, not from a non-empty param list: this
+    // entry is shape-identical to the unresolved case above, but its arity IS
+    // known, so a TS side that grew a spurious param must still be flagged.
+    expect(isForwardingRubyEntry({ params: [], notes: "alias", aliasResolved: true })).toBe(false);
+  });
+
+  it("checks a plain method and other extractor notes", () => {
+    expect(isForwardingRubyEntry({})).toBe(false);
+    expect(isForwardingRubyEntry({ notes: "scope" })).toBe(false);
+    expect(isForwardingRubyEntry({ notes: "class_attribute" })).toBe(false);
   });
 });
 

--- a/scripts/api-compare/arity.test.ts
+++ b/scripts/api-compare/arity.test.ts
@@ -4,6 +4,7 @@ import {
   arityMatches,
   matchArityAgainst,
   shouldSkipArity,
+  isForwardingRubyEntry,
   renderSig,
 } from "./arity.js";
 import type { ParamInfo } from "./types.js";
@@ -280,6 +281,26 @@ describe("shouldSkipArity", () => {
   it("does not skip when either side takes args", () => {
     expect(shouldSkipArity([req("a")], [])).toBe(false);
     expect(shouldSkipArity([], [req("a")])).toBe(false);
+  });
+});
+
+describe("isForwardingRubyEntry", () => {
+  it("skips a delegate entry recorded with placeholder zero arity", () => {
+    expect(isForwardingRubyEntry([], "delegate")).toBe(true);
+  });
+
+  it("skips an alias whose target could not be resolved", () => {
+    expect(isForwardingRubyEntry([], "alias")).toBe(true);
+  });
+
+  it("checks an alias whose target params were resolved", () => {
+    expect(isForwardingRubyEntry([req("a")], "alias")).toBe(false);
+  });
+
+  it("checks a plain zero-arg method and other extractor notes", () => {
+    expect(isForwardingRubyEntry([], undefined)).toBe(false);
+    expect(isForwardingRubyEntry([], "scope")).toBe(false);
+    expect(isForwardingRubyEntry([], "class_attribute")).toBe(false);
   });
 });
 

--- a/scripts/api-compare/arity.ts
+++ b/scripts/api-compare/arity.ts
@@ -19,6 +19,11 @@
 // Every such strip is tried only as an *additional* candidate form alongside the
 // as-declared signature, and a match needs only ONE form to overlap — so a strip
 // can only ever gain a match, never manufacture a mismatch.
+//
+// Two classes of pair are dropped from the check entirely — and, so the summary
+// stays honest, from the `compared` denominator too: both-sides-zero-arg pairs
+// (shouldSkipArity) and Ruby entries whose recorded arity is a forwarding-macro
+// placeholder (isForwardingRubyEntry).
 
 import type { ParamInfo } from "./types.js";
 
@@ -264,6 +269,22 @@ function rangesOverlap(r: Arity, t: Arity): boolean {
   const slack = (r.hasKeywords ? 1 : 0) + (r.hasBlock ? 1 : 0);
   const rubyMax = r.max === Infinity ? Infinity : r.max + slack;
   return t.min <= rubyMax && r.min <= t.max;
+}
+
+/** Ruby entries the extractor synthesized from a forwarding macro, whose recorded
+ *  arity is a placeholder rather than a real signature.
+ *
+ *  `delegate :a, to: :b` generates `def a(...) = b.a(...)`: the true arity is the
+ *  TARGET's, which the static walker can't see, so `process_delegate` records
+ *  `params: []`. Same for an `alias`/`alias_method` whose target lives outside the
+ *  package — `resolve_aliases!` copies the target's params when it can find it and
+ *  leaves the entry empty when it can't. Comparing that placeholder `[0-0]` against
+ *  a faithfully-spelled TS signature is pure noise, so these pairs are dropped from
+ *  the check AND from the `compared` denominator (see compare.ts `checkArity`).
+ *
+ *  An alias whose target WAS resolved carries real params and is checked normally. */
+export function isForwardingRubyEntry(params: ParamInfo[], notes: string | undefined): boolean {
+  return params.length === 0 && (notes === "delegate" || notes === "alias");
 }
 
 /** Nothing to compare: both sides take zero positional args (reader/predicate ↔ getter). */

--- a/scripts/api-compare/arity.ts
+++ b/scripts/api-compare/arity.ts
@@ -25,7 +25,7 @@
 // (shouldSkipArity) and Ruby entries whose recorded arity is a forwarding-macro
 // placeholder (isForwardingRubyEntry).
 
-import type { ParamInfo } from "./types.js";
+import type { MethodInfo, ParamInfo } from "./types.js";
 
 /** TS host/receiver types — a leading param of one of these is the explicit host
  *  instance and is stripped. Leaf match also covers `Base<T>` / `ns.Relation`.
@@ -276,15 +276,20 @@ function rangesOverlap(r: Arity, t: Arity): boolean {
  *
  *  `delegate :a, to: :b` generates `def a(...) = b.a(...)`: the true arity is the
  *  TARGET's, which the static walker can't see, so `process_delegate` records
- *  `params: []`. Same for an `alias`/`alias_method` whose target lives outside the
- *  package — `resolve_aliases!` copies the target's params when it can find it and
- *  leaves the entry empty when it can't. Comparing that placeholder `[0-0]` against
- *  a faithfully-spelled TS signature is pure noise, so these pairs are dropped from
+ *  `params: []`. An `alias`/`alias_method` is the same shape until
+ *  `resolve_aliases!` copies the target's params — which it can only do for a
+ *  target inside the package. Comparing that placeholder `[0-0]` against a
+ *  faithfully-spelled TS signature is pure noise, so these pairs are dropped from
  *  the check AND from the `compared` denominator (see compare.ts `checkArity`).
  *
- *  An alias whose target WAS resolved carries real params and is checked normally. */
-export function isForwardingRubyEntry(params: ParamInfo[], notes: string | undefined): boolean {
-  return params.length === 0 && (notes === "delegate" || notes === "alias");
+ *  A RESOLVED alias is checked normally, and resolution is read from the
+ *  `aliasResolved` flag rather than from a non-empty param list: an alias to a
+ *  genuinely zero-arg method resolves to `params: []`, which is shape-identical
+ *  to a target that was never found. Keying on emptiness would drop that real,
+ *  checkable pair and mask a TS side that later grew a spurious extra parameter. */
+export function isForwardingRubyEntry(ruby: Pick<MethodInfo, "notes" | "aliasResolved">): boolean {
+  if (ruby.notes === "delegate") return true;
+  return ruby.notes === "alias" && !ruby.aliasResolved;
 }
 
 /** Nothing to compare: both sides take zero positional args (reader/predicate ↔ getter). */

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -1367,9 +1367,10 @@ export function main() {
       >();
       // First-sighting Ruby params per name (mirrors `seen`'s dedup) for arity.
       const rubyParamsByName = new Map<string, ParamInfo[]>();
-      // First-sighting Ruby extractor `notes` per name — recorded in lockstep with
-      // rubyParamsByName so the notes always describe the params being compared.
-      const rubyNotesByName = new Map<string, string>();
+      // Names whose first-sighting Ruby entry is a forwarding-macro placeholder
+      // (see arity.ts). Recorded in lockstep with rubyParamsByName so the verdict
+      // always describes the very params the arity check would compare.
+      const rubyForwardingNames = new Set<string>();
       // First-sighting Ruby option keys per name (mirrors rubyParamsByName).
       const rubyOptionKeysByName = new Map<string, string[]>();
       // First-sighting Ruby body call-set per name (advisory calls-parity check).
@@ -1384,7 +1385,7 @@ export function main() {
           dedupeRubyMethodInto(seen, rm, item.fqn, rubyFile);
           if (!rubyParamsByName.has(rm.name)) {
             rubyParamsByName.set(rm.name, rm.params);
-            if (rm.notes) rubyNotesByName.set(rm.name, rm.notes);
+            if (isForwardingRubyEntry(rm)) rubyForwardingNames.add(rm.name);
           }
           if (rm.option_keys && !rubyOptionKeysByName.has(rm.name)) {
             rubyOptionKeysByName.set(rm.name, rm.option_keys);
@@ -1498,7 +1499,7 @@ export function main() {
         // signature — comparing it against the real TS arity is noise, so it is
         // skipped before `arityCompared` counts it. Placed AFTER the no-candidate
         // guard so the tally means "pairs that would otherwise have been compared".
-        if (isForwardingRubyEntry(rubyParams, rubyNotesByName.get(rubyName))) {
+        if (rubyForwardingNames.has(rubyName)) {
           arityForwardingSkipped++;
           return;
         }

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -363,6 +363,11 @@ interface ArityMismatch {
 interface ArityResult {
   /** Pairs whose arity was actually compared (skips excluded). */
   compared: number;
+  /** Pairs dropped because the RUBY entry is a forwarding-macro placeholder
+   *  (`delegate`/unresolved `alias`, see arity.ts `isForwardingRubyEntry`).
+   *  Reported so the shrunken `compared` denominator is auditable rather than
+   *  silently absorbing the skip. */
+  forwardingSkipped: number;
   mismatched: number;
   mismatches: ArityMismatch[];
 }
@@ -1315,6 +1320,7 @@ export function main() {
     let filesExist = 0;
     let totalMisplaced = 0;
     let arityCompared = 0;
+    let arityForwardingSkipped = 0;
     const arityMismatches: ArityMismatch[] = [];
     let optionKeysCompared = 0;
     const optionKeyMismatches: OptionKeyMismatch[] = [];
@@ -1486,12 +1492,16 @@ export function main() {
         if (!rubyParams) return;
         // Every signature recorded for this TS name; a pair matches when it
         // overlaps ANY (see tsParamsByName above for why this is global).
-        // A `delegate`/unresolved-`alias` entry carries a placeholder `[0-0]`, not a
-        // signature — comparing it against the real TS arity is noise, so it is
-        // skipped before `arityCompared` counts it.
-        if (isForwardingRubyEntry(rubyParams, rubyNotesByName.get(rubyName))) return;
         const candidates = tsParamsByName.get(tsName) ?? [];
         if (candidates.length === 0) return;
+        // A `delegate`/unresolved-`alias` entry carries a placeholder `[0-0]`, not a
+        // signature — comparing it against the real TS arity is noise, so it is
+        // skipped before `arityCompared` counts it. Placed AFTER the no-candidate
+        // guard so the tally means "pairs that would otherwise have been compared".
+        if (isForwardingRubyEntry(rubyParams, rubyNotesByName.get(rubyName))) {
+          arityForwardingSkipped++;
+          return;
+        }
         if (candidates.every((c) => shouldSkipArity(rubyParams, c))) return;
         arityCompared++;
         const verdict = matchArityAgainst(rubyParams, candidates);
@@ -1820,6 +1830,7 @@ export function main() {
       inheritance,
       arity: {
         compared: arityCompared,
+        forwardingSkipped: arityForwardingSkipped,
         mismatched: arityMismatches.length,
         mismatches: arityMismatches,
       },
@@ -1875,6 +1886,7 @@ export function main() {
       {
         generatedAt: new Date().toISOString(),
         compared: results.reduce((n, r) => n + r.arity.compared, 0),
+        forwardingSkipped: results.reduce((n, r) => n + r.arity.forwardingSkipped, 0),
         mismatched: arityFlat.length,
         mismatches: arityFlat,
       },

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -81,6 +81,7 @@ import {
 import { SpellChecker } from "../../packages/did-you-mean/src/spell-checker.js";
 import { isArityOverridden, isScopedSkip, rubyFileToTs, rubyMethodToTs } from "./conventions.js";
 import {
+  isForwardingRubyEntry,
   matchArityAgainst,
   renderSig,
   shouldSkipArity,
@@ -1360,6 +1361,9 @@ export function main() {
       >();
       // First-sighting Ruby params per name (mirrors `seen`'s dedup) for arity.
       const rubyParamsByName = new Map<string, ParamInfo[]>();
+      // First-sighting Ruby extractor `notes` per name — recorded in lockstep with
+      // rubyParamsByName so the notes always describe the params being compared.
+      const rubyNotesByName = new Map<string, string>();
       // First-sighting Ruby option keys per name (mirrors rubyParamsByName).
       const rubyOptionKeysByName = new Map<string, string[]>();
       // First-sighting Ruby body call-set per name (advisory calls-parity check).
@@ -1372,7 +1376,10 @@ export function main() {
         for (const rm of rubyMethods) {
           if (!methodMatchesMode(rm)) continue;
           dedupeRubyMethodInto(seen, rm, item.fqn, rubyFile);
-          if (!rubyParamsByName.has(rm.name)) rubyParamsByName.set(rm.name, rm.params);
+          if (!rubyParamsByName.has(rm.name)) {
+            rubyParamsByName.set(rm.name, rm.params);
+            if (rm.notes) rubyNotesByName.set(rm.name, rm.notes);
+          }
           if (rm.option_keys && !rubyOptionKeysByName.has(rm.name)) {
             rubyOptionKeysByName.set(rm.name, rm.option_keys);
           }
@@ -1479,6 +1486,10 @@ export function main() {
         if (!rubyParams) return;
         // Every signature recorded for this TS name; a pair matches when it
         // overlaps ANY (see tsParamsByName above for why this is global).
+        // A `delegate`/unresolved-`alias` entry carries a placeholder `[0-0]`, not a
+        // signature — comparing it against the real TS arity is noise, so it is
+        // skipped before `arityCompared` counts it.
+        if (isForwardingRubyEntry(rubyParams, rubyNotesByName.get(rubyName))) return;
         const candidates = tsParamsByName.get(tsName) ?? [];
         if (candidates.length === 0) return;
         if (candidates.every((c) => shouldSkipArity(rubyParams, c))) return;

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -1091,6 +1091,14 @@ class ApiExtractor
             # A target that is ITSELF an as-yet-unresolved alias carries a
             # placeholder, not its real arity — wait for a later pass to fill it.
             next if tgt[:notes] == "alias" && !tgt[:aliasResolved]
+            # A `delegate`-generated target NEVER gains a real arity (it forwards
+            # to something the static walker can't see), so its empty params are a
+            # placeholder too. Resolving against it would stamp `aliasResolved` on
+            # a `[0-0]` that means "unknown", re-arming the very false mismatches
+            # this skip exists to remove — one hop removed, through the alias.
+            # Leaving the alias unresolved makes it forward-like in its own right,
+            # which is exactly what it is.
+            next if tgt[:notes] == "delegate"
             m[:params] = tgt[:params].map(&:dup)
             # Records that the target WAS found, even when it legitimately takes
             # no arguments. Without this flag an alias to a zero-arg method is

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -1048,7 +1048,9 @@ class ApiExtractor
   # be in a different file of a reopened class) and iterates to follow alias
   # chains (`alias a b; alias b c`). Cross-class/inherited targets that aren't in
   # the package stay empty (best-effort — the static walker can't see another
-  # gem's source). Drops the transient `alias_target` key afterward so it never
+  # gem's source) and are left WITHOUT the `aliasResolved` flag, which is what
+  # distinguishes them from an alias whose target legitimately takes zero
+  # arguments. Drops the transient `alias_target` key afterward so it never
   # reaches the manifest.
   # Public: invoked by `run` per package and by the extractor unit test.
   public def resolve_aliases!
@@ -1072,9 +1074,10 @@ class ApiExtractor
     # Fixpoint over ALL buckets at once, not per class: an alias may resolve to
     # an alias in an ancestor that is itself still unresolved, so a single
     # hash-ordered sweep would read an empty target and give up. Each
-    # non-breaking pass fills at least one previously-empty alias (filled
-    # aliases are skipped afterwards), so the unresolved count strictly
-    # decreases and the loop always terminates — no arbitrary iteration cap.
+    # non-breaking pass resolves at least one previously-unresolved alias (and
+    # resolved ones are skipped afterwards via `aliasResolved`), so the
+    # unresolved count strictly decreases and the loop always terminates — no
+    # arbitrary iteration cap.
     loop do
       changed = false
       all.each do |fqn, info|
@@ -1082,10 +1085,19 @@ class ApiExtractor
           by_name = tables[[fqn, bucket]]
           info[bucket].each do |m|
             next unless m[:notes] == "alias" && m[:alias_target]
-            next unless m[:params].nil? || m[:params].empty?
+            next if m[:aliasResolved]
             tgt = by_name[m[:alias_target]]
-            next unless tgt && tgt[:params] && !tgt[:params].empty?
+            next unless tgt && tgt[:params]
+            # A target that is ITSELF an as-yet-unresolved alias carries a
+            # placeholder, not its real arity — wait for a later pass to fill it.
+            next if tgt[:notes] == "alias" && !tgt[:aliasResolved]
             m[:params] = tgt[:params].map(&:dup)
+            # Records that the target WAS found, even when it legitimately takes
+            # no arguments. Without this flag an alias to a zero-arg method is
+            # shape-identical to one whose target was never found, and consumers
+            # (arity.ts `isForwardingRubyEntry`) would drop a genuinely checkable
+            # pair as if its arity were unknown.
+            m[:aliasResolved] = true
             changed = true
           end
         end

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -88,7 +88,10 @@ describe("Ruby extractor alias arity resolution", () => {
   // resolve_aliases!, plus the method's `notes`/`alias_target` keys.
   function aliasParams(
     fixtures: Record<string, string>,
-  ): Record<string, { params: string[]; notes?: string; hasAliasTarget: boolean }> {
+  ): Record<
+    string,
+    { params: string[]; notes?: string; aliasResolved?: boolean; hasAliasTarget: boolean }
+  > {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "alias-rb-"));
     try {
       for (const [rel, src] of Object.entries(fixtures)) {
@@ -111,6 +114,7 @@ describe("Ruby extractor alias arity resolution", () => {
             out["#{fqn}##{m[:name]}"] = {
               params: m[:params].map { |p| p[:name] },
               notes: m[:notes],
+              aliasResolved: m[:aliasResolved],
               hasAliasTarget: m.key?(:alias_target),
             }
           end
@@ -493,6 +497,24 @@ describe("Ruby extractor alias arity resolution", () => {
     expect(r["Reopened#alt"].params).toEqual(["p"]);
   });
 
+  it("flags an alias resolved to a zero-arg target as resolved", () => {
+    // `params: []` here is the TARGET's real (empty) arity, not a placeholder —
+    // `aliasResolved` is what tells arity.ts the pair is still checkable.
+    const r = aliasParams({
+      "z.rb": `
+        class Zero
+          def original; end
+          alias_method :renamed, :original
+        end
+      `,
+    });
+    expect(r["Zero#renamed"]).toMatchObject({
+      params: [],
+      notes: "alias",
+      aliasResolved: true,
+    });
+  });
+
   it("leaves an alias to an out-of-package target empty (best effort)", () => {
     const r = aliasParams({
       "u.rb": `
@@ -502,6 +524,8 @@ describe("Ruby extractor alias arity resolution", () => {
       `,
     });
     expect(r["Lonely#gone"]).toMatchObject({ params: [], notes: "alias" });
+    // Never resolved — the flag stays unset (the test driver renders nil as null).
+    expect(r["Lonely#gone"].aliasResolved).toBeFalsy();
   });
 
   // The `notes` tag is the CONTRACT the arity check keys off (arity.ts

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -503,6 +503,27 @@ describe("Ruby extractor alias arity resolution", () => {
     });
     expect(r["Lonely#gone"]).toMatchObject({ params: [], notes: "alias" });
   });
+
+  // The `notes` tag is the CONTRACT the arity check keys off (arity.ts
+  // `isForwardingRubyEntry` drops these pairs). Renaming the tag here without
+  // updating that predicate would silently re-arm ~22 false mismatches, so the
+  // exact string is pinned on both forwarding kinds.
+  it("tags a `delegate`-generated method with empty placeholder params", () => {
+    const r = aliasParams({
+      "d.rb": `
+        module Pkg
+          module Querying
+            delegate :create_or_find_by, :in_groups_of, to: :all
+          end
+        end
+      `,
+    });
+    expect(r["Pkg::Querying#create_or_find_by"]).toMatchObject({
+      params: [],
+      notes: "delegate",
+    });
+    expect(r["Pkg::Querying#in_groups_of"]).toMatchObject({ params: [], notes: "delegate" });
+  });
 });
 
 describe("Ruby extractor umbrella module-config scanning", () => {

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -515,6 +515,25 @@ describe("Ruby extractor alias arity resolution", () => {
     });
   });
 
+  it("leaves an alias to a `delegate`-generated target unresolved", () => {
+    // The delegate's `params: []` means "arity unknown", so an alias to it is
+    // just as unknown — marking it resolved would re-arm the false mismatches
+    // the arity skip removes, one hop away through the alias.
+    const r = aliasParams({
+      "c.rb": `
+        module Pkg
+          class Relation
+            delegate :in_groups_of, to: :records
+            alias_method :grouped, :in_groups_of
+          end
+        end
+      `,
+    });
+    expect(r["Pkg::Relation#in_groups_of"]).toMatchObject({ params: [], notes: "delegate" });
+    expect(r["Pkg::Relation#grouped"]).toMatchObject({ params: [], notes: "alias" });
+    expect(r["Pkg::Relation#grouped"].aliasResolved).toBeFalsy();
+  });
+
   it("leaves an alias to an out-of-package target empty (best effort)", () => {
     const r = aliasParams({
       "u.rb": `

--- a/scripts/api-compare/types.ts
+++ b/scripts/api-compare/types.ts
@@ -59,6 +59,14 @@ export interface MethodInfo {
    * signature (see arity.ts `isForwardingRubyEntry`).
    */
   notes?: string;
+  /**
+   * Ruby-side only, `notes: "alias"` entries: the alias target was found and its
+   * params copied onto this entry. Distinguishes an alias to a genuinely
+   * zero-arg method (resolved, `params: []`) from one whose target lives outside
+   * the package (unresolved, also `params: []`). See extract-ruby-api.rb
+   * `resolve_aliases!` and arity.ts `isForwardingRubyEntry`.
+   */
+  aliasResolved?: boolean;
   /** Ruby-side option symbols consumed from an `options`/`opts`/`**kwargs`
    *  param (raw snake_case); advisory under-approximation. See options-keys.ts. */
   option_keys?: string[];

--- a/scripts/api-compare/types.ts
+++ b/scripts/api-compare/types.ts
@@ -51,6 +51,14 @@ export interface MethodInfo {
    * out of normal coverage and only include them behind an opt-in flag.
    */
   internal?: boolean;
+  /**
+   * Ruby-side only: how the extractor synthesized this entry when it was NOT a
+   * literal `def` — `"delegate"`, `"alias"`, `"scope"`, `"class_attribute"`,
+   * `"define_column_methods"`, `"class_eval"`. See extract-ruby-api.rb. The
+   * forwarding kinds carry a placeholder empty param list rather than a real
+   * signature (see arity.ts `isForwardingRubyEntry`).
+   */
+  notes?: string;
   /** Ruby-side option symbols consumed from an `options`/`opts`/`**kwargs`
    *  param (raw snake_case); advisory under-approximation. See options-keys.ts. */
   option_keys?: string[];


### PR DESCRIPTION
The Ruby extractor synthesizes entries for the `delegate` macro and for
`alias`/`alias_method`, recording `params: []` — a placeholder, not a signature.
A delegate forwards `(...)` to a target the static walker can't see;
`resolve_aliases!` fills an alias's params only when the target is in-package.

The advisory arity check ignored the `notes` tag and compared that placeholder
`[0-0]` against the real TS signature, producing 24 false `ruby() [0-0]`
mismatches in activerecord (`create_or_find_by`/`!`, `type_to_sql`, the
`relation/delegation.rb` `delegate … to: :records` set, `within_new_transaction`,
`invert_add_belongs_to`, …).

`isForwardingRubyEntry` now drops those pairs.

**Resolved aliases stay checked — including zero-arg ones.** An alias whose target
genuinely takes no arguments also resolves to `params: []`, shape-identical to a
target that was never found. Keying the skip on emptiness would have dropped 7
real, checkable pairs and masked a TS side that later grew a spurious parameter.
`resolve_aliases!` now records `aliasResolved` whenever the target is found —
whatever its arity — and the predicate reads that flag instead of the param list.
(This also lets alias-chain resolution stop overloading "empty" as "not yet
resolved".)

An alias whose target is itself a `delegate` stays unresolved for the same
reason: the delegate's `[0-0]` means "unknown", so stamping `aliasResolved` on the
alias would re-arm this false-mismatch class one hop away. No such chain exists in
activerecord today (the artifact numbers are identical with and without the
guard), so this is purely a guard against a future `delegate` + `alias` pairing
regressing silently — pinned by a test that fails without it.

**Denominator honesty.** The skip runs before `arityCompared` counts the pair, so
the summary percentage isn't inflated by pairs that were never really checked —
and the count is published as `forwardingSkipped` in `arity-mismatches.json`
rather than vanishing silently. It sits after the no-TS-candidate guard so the
tally means exactly "pairs that would otherwise have been compared".

**Contract pinning.** The skip keys off the extractor's exact `notes` strings and
`aliasResolved` flag, so `extract-ruby-api.test.ts` pins all three shapes:
`delegate` (empty + tagged), alias resolved to a zero-arg target (empty + flagged),
unresolved alias (empty + unflagged), and alias-of-a-delegate (empty + unflagged). Renaming a tag upstream fails a test
instead of silently re-arming the false mismatches.

`pnpm api:compare --package activerecord`, against a freshly-rebased `origin/main`
baseline:

- `compared` 3987 → 3713, `mismatched` 71 → 47, `forwardingSkipped` 371
- 24 mismatches removed (exactly the delegate/unresolved-alias set), **0 added** —
  no previously matched pair regresses
- the 7 resolved-zero-arg aliases are checked, not skipped, and all match

`type.rb#add_modifier` turned out to be delegate-sourced too and is among the 24;
`migration.rb#run_without_lock` was not, and stays in the state-threading bucket.

Closes-story: arity-skip-ruby-delegate-entries
