### PR TITLE
fix(activesupport): resolve node fs adapter synchronously under pure ESM

### DIFF
--- a/packages/activesupport/src/fs-adapter.test.ts
+++ b/packages/activesupport/src/fs-adapter.test.ts
@@ -1,0 +1,21 @@
+import { describe, test, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const fsAdapterPath = fileURLToPath(new URL("./fs-adapter.ts", import.meta.url));
+
+describe("fs-adapter auto-registration", () => {
+  test("sync getFs resolves the node adapter under pure ESM", () => {
+    // Vitest's module runner supplies a `require` shim, so the sync path only
+    // proves anything in a real ESM child process where `require` is absent.
+    const script = `
+      if (typeof require !== "undefined") { console.error("not pure ESM"); process.exit(2); }
+      const { getFs, getPath } = await import(${JSON.stringify(fsAdapterPath)});
+      console.log(typeof getFs().readFileSync, typeof getPath().join);
+    `;
+    const out = execFileSync(process.execPath, ["--input-type=module", "--eval", script], {
+      encoding: "utf-8",
+    });
+    expect(out.trim()).toBe("function function");
+  });
+});

--- a/packages/activesupport/src/fs-adapter.test.ts
+++ b/packages/activesupport/src/fs-adapter.test.ts
@@ -6,8 +6,6 @@ const fsAdapterPath = fileURLToPath(new URL("./fs-adapter.ts", import.meta.url))
 
 describe("fs-adapter auto-registration", () => {
   test("sync getFs resolves the node adapter under pure ESM", () => {
-    // Vitest's module runner supplies a `require` shim, so the sync path only
-    // proves anything in a real ESM child process where `require` is absent.
     const script = `
       if (typeof require !== "undefined") { console.error("not pure ESM"); process.exit(2); }
       const { getFs, getPath } = await import(${JSON.stringify(fsAdapterPath)});

--- a/packages/activesupport/src/fs-adapter.ts
+++ b/packages/activesupport/src/fs-adapter.ts
@@ -133,6 +133,29 @@ export function registerFsAdapter(name: string, fs: FsAdapter, path: PathAdapter
 let nodeAttempted = false;
 let nodeAsyncPromise: Promise<boolean> | null = null;
 
+/**
+ * Synchronous access to a Node builtin without a static `node:*` import.
+ * Under pure ESM there is no `require`, so `process.getBuiltinModule` (Node
+ * >= 22.3) is the only synchronous door; CommonJS hosts and older runtimes
+ * fall back to `createRequire`. Returns null on non-Node hosts, which keeps
+ * browsers on the "not configured" error rather than a crash.
+ */
+function syncBuiltinLoader(): ((id: string) => unknown) | null {
+  const proc = globalThis.process as
+    | (typeof globalThis.process & { getBuiltinModule?: (id: string) => unknown })
+    | undefined;
+  const getBuiltinModule = proc?.getBuiltinModule;
+  if (typeof getBuiltinModule === "function") return (id) => getBuiltinModule.call(proc, id);
+  if (typeof require === "undefined") return null;
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const nodeModule = require("node:module") as {
+    createRequire(p: string): (id: string) => unknown;
+  };
+  return nodeModule.createRequire(
+    typeof __filename !== "undefined" ? __filename : "file:///activesupport",
+  );
+}
+
 function tryAutoRegisterNode(): boolean {
   if (registry.has("node")) return true;
   if (nodeAttempted) return false;
@@ -141,15 +164,8 @@ function tryAutoRegisterNode(): boolean {
     if (typeof globalThis.process === "undefined" || !globalThis.process.versions?.node) {
       return false;
     }
-    const nodeModule =
-      typeof require !== "undefined"
-        ? // eslint-disable-next-line @typescript-eslint/no-require-imports
-          require("node:module")
-        : null;
-    if (!nodeModule) return false;
-    const req = nodeModule.createRequire(
-      typeof __filename !== "undefined" ? __filename : "file:///activesupport",
-    );
+    const req = syncBuiltinLoader();
+    if (!req) return false;
     const nodeFs = req("node:fs") as Omit<FsAdapter, "cwd" | "exists" | "stat" | "lstat">;
     const fsPromises = req("node:fs/promises") as {
       access(p: string): Promise<void>;

--- a/packages/activesupport/src/fs-adapter.ts
+++ b/packages/activesupport/src/fs-adapter.ts
@@ -133,13 +133,6 @@ export function registerFsAdapter(name: string, fs: FsAdapter, path: PathAdapter
 let nodeAttempted = false;
 let nodeAsyncPromise: Promise<boolean> | null = null;
 
-/**
- * Synchronous access to a Node builtin without a static `node:*` import.
- * Under pure ESM there is no `require`, so `process.getBuiltinModule` (Node
- * >= 22.3) is the only synchronous door; CommonJS hosts and older runtimes
- * fall back to `createRequire`. Returns null on non-Node hosts, which keeps
- * browsers on the "not configured" error rather than a crash.
- */
 function syncBuiltinLoader(): ((id: string) => unknown) | null {
   const proc = globalThis.process as
     | (typeof globalThis.process & { getBuiltinModule?: (id: string) => unknown })

--- a/scripts/parity/schema/node/dump.ts
+++ b/scripts/parity/schema/node/dump.ts
@@ -24,7 +24,6 @@ import {
   introspectIndexes,
   introspectPrimaryKey,
 } from "../../../../packages/activerecord/src/schema-introspection.js";
-import { getFsAsync } from "@blazetrails/activesupport";
 import { canonicalize } from "./canonicalize.js";
 import type { NativeDump, NativeColumn, NativeIndex } from "./canonicalize.js";
 
@@ -58,10 +57,6 @@ async function main(): Promise<void> {
 
   const fixtureDirAbs = resolve(fixtureDir);
   const outPathAbs = resolve(outPath);
-
-  // The sync node fs auto-register relies on `require`, which is absent under
-  // pure ESM; awaiting the async path registers the adapter up front.
-  await getFsAsync();
 
   const tmpDir = mkdtempSync(join(tmpdir(), "parity-node-"));
   const dbPath = join(tmpDir, "schema.db");


### PR DESCRIPTION
`getFs()` / `getPath()` auto-register the node adapter via
`require("node:module").createRequire(...)`, guarded by
`typeof require !== "undefined"`. Under pure ESM there is no `require`, so
`tryAutoRegisterNode()` bailed and `resolve()` threw
`No filesystem adapter configured.` for every Node ESM consumer that reached a
sync `getFs()` without a prior `getFsAsync()`. Vitest's module runner supplies a
`require` shim, which is why the suite never saw it; the Schema Parity job did,
and PR #4991 papered over it with an `await getFsAsync()` at script startup.

Fix: a small `syncBuiltinLoader()` helper prefers `process.getBuiltinModule`
(Node >= 22.3) — synchronous, no `require`, no static `node:*` import — and
keeps `createRequire` as the CJS fallback. Non-node hosts still get null and the
existing "not configured" error rather than a crash.

Regression test spawns a real pure-ESM child (`node --input-type=module`), asserts
`require` is absent there, and calls the sync `getFs()`/`getPath()`. Red on
`main` (`No filesystem adapter configured.`), green here.

The `await getFsAsync()` workaround is dropped from
`scripts/parity/schema/node/dump.ts`; `pnpm tsx scripts/parity/run.ts --side=trails`
passes without it.

Closes-story: fs-adapter-sync-autoregister-fails-under-esm
