### PR TITLE
test(ar-suite): mirror helper.rb:43 belongs_to_required_validates_foreign_key = false

### DIFF
--- a/packages/activerecord/src/ar-config.test.ts
+++ b/packages/activerecord/src/ar-config.test.ts
@@ -12,7 +12,10 @@ describe("ar-config module-level flags", () => {
     expect(arConfig.asyncQueryExecutor).toBeNull();
     expect(arConfig.queues).toEqual({});
     expect(arConfig.maintainTestSchema).toBeNull();
-    expect(arConfig.belongsToRequiredValidatesForeignKey).toBe(true);
+    // `belongsToRequiredValidatesForeignKey` is deliberately absent: the AR test
+    // harness flips it to false suite-wide (helper.rb:43), so the live binding
+    // never reads back the framework default here. `trailtie.test.ts` covers the
+    // `true` default via the untouched config hash.
     expect(arConfig.applicationRecordClass).toBeNull();
     expect(arConfig.errorOnIgnoredOrder).toBe(false);
     expect(arConfig.timestampedMigrations).toBe(true);

--- a/packages/activerecord/src/ar-config.test.ts
+++ b/packages/activerecord/src/ar-config.test.ts
@@ -15,7 +15,8 @@ describe("ar-config module-level flags", () => {
     // `belongsToRequiredValidatesForeignKey` is deliberately absent: the AR test
     // harness flips it to false suite-wide (helper.rb:43), so the live binding
     // never reads back the framework default here. `trailtie.test.ts` covers the
-    // `true` default via the untouched config hash.
+    // `true` default via the untouched versioned-defaults hash; the setter
+    // round-trip below covers the live binding.
     expect(arConfig.applicationRecordClass).toBeNull();
     expect(arConfig.errorOnIgnoredOrder).toBe(false);
     expect(arConfig.timestampedMigrations).toBe(true);
@@ -33,6 +34,9 @@ describe("ar-config module-level flags", () => {
       arConfig.setTimestampedMigrations(true);
       arConfig.setGenerateSecureTokenOn("create");
       arConfig.setRaiseIntWiderThan64bit(true);
+      // Back to the value the AR harness installs (helper.rb:43), not the
+      // framework default.
+      arConfig.setBelongsToRequiredValidatesForeignKey(false);
     });
 
     it("round-trip a written value", () => {
@@ -47,6 +51,9 @@ describe("ar-config module-level flags", () => {
 
       arConfig.setRaiseIntWiderThan64bit(false);
       expect(arConfig.raiseIntWiderThan64bit).toBe(false);
+
+      arConfig.setBelongsToRequiredValidatesForeignKey(true);
+      expect(arConfig.belongsToRequiredValidatesForeignKey).toBe(true);
     });
   });
 });

--- a/packages/activerecord/src/ar-config.ts
+++ b/packages/activerecord/src/ar-config.ts
@@ -208,7 +208,7 @@ export function setMaintainTestSchema(value: boolean | null): void {
  * When true (the default), a required `belongs_to` also validates that the
  * association's foreign key is present, not just the association object.
  * Mirrors `ActiveRecord.belongs_to_required_validates_foreign_key`
- * (active_record.rb:326-327, default true).
+ * (active_record.rb:345-346, default true).
  */
 export let belongsToRequiredValidatesForeignKey = true;
 

--- a/packages/activerecord/src/associations/belongs-to-associations.test.ts
+++ b/packages/activerecord/src/associations/belongs-to-associations.test.ts
@@ -2080,12 +2080,18 @@ describe("BelongsToAssociationsTest", () => {
     const ship = await ShipRequired.create({ name: "Medusa", developer_id: david.id });
     expect(Number((ship as any).developer_id)).toBe(Number(david.id));
 
-    await ship.update({ developer_id: jamis.id });
+    // UPDATE and SELECT to check developer presence
+    await assertQueriesCount(4, false, async () => {
+      await ship.update({ developer_id: jamis.id });
+    });
 
     await ship.updateColumns({ developer_id: null });
     await ship.reload();
 
-    await ship.update({ developer_id: david.id });
+    // UPDATE and SELECT to check developer presence
+    await assertQueriesCount(4, false, async () => {
+      await ship.update({ developer_id: david.id });
+    });
     expect(Number((ship as any).developer_id)).toBe(Number(david.id));
   });
 
@@ -2104,7 +2110,10 @@ describe("BelongsToAssociationsTest", () => {
     const ship = await ShipRequired.create({ name: "Medusa", developer_id: david.id });
     await ship.reload();
 
-    await ship.update({ name: "Leviathan" });
+    // UPDATE only, no SELECT to check developer presence
+    await assertQueriesCount(3, false, async () => {
+      await ship.update({ name: "Leviathan" });
+    });
     expect(ship.name).toBe("Leviathan");
   });
 
@@ -2127,7 +2136,10 @@ describe("BelongsToAssociationsTest", () => {
       const ship = await TempShip.create({ name: "Medusa", developer_id: david.id });
       await ship.reload();
 
-      await ship.update({ name: "Leviathan" });
+      // UPDATE and SELECT to check developer presence
+      await assertQueriesCount(4, false, async () => {
+        await ship.update({ name: "Leviathan" });
+      });
       expect(ship.name).toBe("Leviathan");
     } finally {
       setBelongsToRequiredValidatesForeignKey(original);

--- a/packages/activerecord/src/test-setup-ar.ts
+++ b/packages/activerecord/src/test-setup-ar.ts
@@ -15,7 +15,10 @@ import { beforeEach } from "vitest";
 import { Base } from "./base.js";
 import { DelegateCache } from "./relation/delegation.js";
 import { loadDefaults } from "./trailtie.js";
-import { setRaiseOnAssignToAttrReadonly } from "./ar-config.js";
+import {
+  setBelongsToRequiredValidatesForeignKey,
+  setRaiseOnAssignToAttrReadonly,
+} from "./ar-config.js";
 import { resetTestAdapterState } from "./test-adapter.js";
 import { shouldSkipGlobalReset } from "./test-helpers/skip-global-reset.js";
 import { Configurable as EncryptionConfigurable } from "./encryption/configurable.js";
@@ -45,6 +48,13 @@ Base.automaticallyInvertPluralAssociations = true;
 // raise-on-assign-to-readonly globally; the framework default (active_record.rb:343)
 // is false, flipped to true by load_defaults 7.1 (configuration.rb:286).
 setRaiseOnAssignToAttrReadonly(true);
+
+// Mirror Rails activerecord/test/cases/helper.rb:43 — the AR test suite turns
+// off the required-`belongs_to` foreign-key presence check globally, so the
+// presence validation only runs when the FK (or polymorphic type) is nil or
+// changed. Production keeps the Rails default of `true` (active_record.rb:327);
+// only the test harness flips it.
+setBelongsToRequiredValidatesForeignKey(false);
 
 // Mirror Rails activerecord/test/cases/helper.rb:98-102 — configure encryption
 // once, suite-wide, BEFORE any model class loads, so a model's `encrypts`

--- a/packages/activerecord/src/test-setup-ar.ts
+++ b/packages/activerecord/src/test-setup-ar.ts
@@ -52,7 +52,7 @@ setRaiseOnAssignToAttrReadonly(true);
 // Mirror Rails activerecord/test/cases/helper.rb:43 — the AR test suite turns
 // off the required-`belongs_to` foreign-key presence check globally, so the
 // presence validation only runs when the FK (or polymorphic type) is nil or
-// changed. Production keeps the Rails default of `true` (active_record.rb:327);
+// changed. Production keeps the Rails default of `true` (active_record.rb:345-346);
 // only the test harness flips it.
 setBelongsToRequiredValidatesForeignKey(false);
 


### PR DESCRIPTION
Mirrors `ActiveRecord.belongs_to_required_validates_foreign_key = false` from `vendor/rails/activerecord/test/cases/helper.rb:43` in the AR vitest setup file, alongside the existing `:29` / `:40` / `:42` mirrors.

With the flag on (trails' previous test-suite behavior), a required `belongs_to` presence check ran unconditionally; Rails' suite runs it only when the FK (or polymorphic type) is nil or changed. The production default stays `true` in both `ar-config.ts` and the `trailtie.ts` versioned-defaults hash — only the harness flips it, exactly as with `raiseOnAssignToAttrReadonly`.

### Making the flip observable

The three Rails tests that pin this behavior assert query counts (`assert_queries_count(3)` for the skip case, `(4)` for the two run cases); trails' ports had dropped those assertions, so they passed under either flag value. This PR restores them verbatim from `belongs_to_associations_test.rb:1745-1794`. Verified against the baseline: with the flag left at `true`, "skips parent presence check if parent has not changed" fails with 4 instead of 3 queries.

### ar-config.test.ts

It asserted the live module binding was `true`; the harness now flips it suite-wide, so that assertion can't hold. The default is still covered by `trailtie.test.ts` (untouched versioned-defaults hash), and the live binding is now covered by a setter round-trip in the existing "setters update the live binding" block. No test was renamed.

Ran locally (all green): belongs-to-associations, required, eager, autosave-association, nested-attributes, validations/**, ar-config, trailtie.

Closes-story: belongs-to-required-validates-fk-false
