### PR TITLE
feat(encryption): install extended deterministic query support at boot and suite-wide

### DIFF
--- a/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-uniqueness-validator.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { EncryptedUniquenessValidator } from "./extended-deterministic-uniqueness-validator.js";
+import { ExtendedDeterministicQueries } from "./extended-deterministic-queries.js";
 import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
 import { Scheme } from "./scheme.js";
 import { isEncryptionDisabled } from "./context.js";
@@ -36,6 +37,13 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicUniquenessValidatorTest
     };
     const record = { constructor: klass };
 
+    // The suite boots with ExtendedDeterministicQueries installed (helper.rb:104-107),
+    // which suppresses the extra previous-scheme query. Pin it off so this test
+    // exercises the un-extended branch it is about.
+    const installedSpy = vi
+      .spyOn(ExtendedDeterministicQueries, "installed", "get")
+      .mockReturnValue(false);
+
     const calls: Array<{ attribute: string; value: unknown; encryptionDisabled: boolean }> = [];
     const originalValidateEach = (_record: any, attribute: string, value: unknown) => {
       calls.push({ attribute, value, encryptionDisabled: isEncryptionDisabled() });
@@ -56,6 +64,8 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicUniquenessValidatorTest
     expect(calls[1]).toBeDefined();
     expect(calls[1].value).toEqual([type.previousTypes[0].serialize("user@example.com")]);
     expect(calls[1].encryptionDisabled).toBe(true);
+
+    installedSpy.mockRestore();
   });
 
   it("validateEach skips non-deterministic attributes", async () => {

--- a/packages/activerecord/src/encryption/install.ts
+++ b/packages/activerecord/src/encryption/install.ts
@@ -17,7 +17,7 @@ import {
  * Also installs `EncryptedUniquenessValidator` into `UniquenessValidator`
  * so uniqueness checks cover all previous encryption schemes.
  *
- * Mirrors: the Rails railtie that calls
+ * Mirrors: railtie.rb:349-355 — the `on_load(:active_record)` block that calls
  * `ActiveRecord::Encryption::ExtendedDeterministicQueries.install_support`
  * and `ActiveRecord::Encryption::ExtendedDeterministicUniquenessValidator.install_support`
  * when `config.active_record.encryption.extend_queries` is set.

--- a/packages/activerecord/src/test-setup-ar.ts
+++ b/packages/activerecord/src/test-setup-ar.ts
@@ -19,6 +19,7 @@ import { setRaiseOnAssignToAttrReadonly } from "./ar-config.js";
 import { resetTestAdapterState } from "./test-adapter.js";
 import { shouldSkipGlobalReset } from "./test-helpers/skip-global-reset.js";
 import { Configurable as EncryptionConfigurable } from "./encryption/configurable.js";
+import { installExtendedQueriesIfConfigured } from "./encryption/install.js";
 import {
   TEST_PRIMARY_KEY,
   TEST_DETERMINISTIC_KEY,
@@ -57,6 +58,12 @@ EncryptionConfigurable.configure({
   deterministicKey: TEST_DETERMINISTIC_KEY,
   keyDerivationSalt: TEST_KEY_DERIVATION_SALT,
 });
+
+// Mirror Rails activerecord/test/cases/helper.rb:104-107 — the suite runs with
+// deterministic-encryption query support installed, standing in for what the
+// railtie does in a real app (railtie.rb:349-355).
+EncryptionConfigurable.config.extendQueries = true;
+installExtendedQueriesIfConfigured();
 
 // Wipe shared test-adapter state before every test so each test starts
 // from a clean slate.

--- a/packages/activerecord/src/trailtie.test.ts
+++ b/packages/activerecord/src/trailtie.test.ts
@@ -6,6 +6,9 @@ import { SchemaReflection } from "./connection-adapters/schema-cache.js";
 import { AbstractSQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
 import { PostgreSQLAdapter } from "./connection-adapters/postgresql-adapter.js";
 import { Configurable as EncryptionConfigurable } from "./encryption/configurable.js";
+import { ExtendedDeterministicUniquenessValidator } from "./encryption/extended-deterministic-uniqueness-validator.js";
+import { installExtendedQueriesIfConfigured } from "./encryption/install.js";
+import { UniquenessValidator } from "./validations.js";
 import { deprecator } from "./deprecator.js";
 import { raiseOnAssignToAttrReadonly, setRaiseOnAssignToAttrReadonly } from "./ar-config.js";
 
@@ -23,6 +26,7 @@ describe("RailtieTest", () => {
   let savedEncryptionSupportUnencryptedData: boolean;
   let savedPartialInserts: boolean;
   let savedRaiseOnAssignToAttrReadonly: boolean;
+  let savedExtendQueries: boolean;
 
   beforeEach(() => {
     savedSubclasses = [...BaseRailtie.subclasses];
@@ -36,6 +40,7 @@ describe("RailtieTest", () => {
     savedEncryptionSupportUnencryptedData = EncryptionConfigurable.config.supportUnencryptedData;
     savedPartialInserts = Base.partialInserts;
     savedRaiseOnAssignToAttrReadonly = raiseOnAssignToAttrReadonly;
+    savedExtendQueries = EncryptionConfigurable.config.extendQueries;
 
     // Simulate a fresh app boot for each test: clear the load-hook registry
     // and re-emit the load events that base.ts / the adapter files would
@@ -59,6 +64,11 @@ describe("RailtieTest", () => {
     EncryptionConfigurable.config.supportUnencryptedData = savedEncryptionSupportUnencryptedData;
     Base.partialInserts = savedPartialInserts;
     setRaiseOnAssignToAttrReadonly(savedRaiseOnAssignToAttrReadonly);
+    // The suite boots with extended query support installed
+    // (test-setup-ar.ts, mirroring helper.rb:104-107); tests here uninstall it
+    // to observe the initializer doing the install, so put it back.
+    EncryptionConfigurable.config.extendQueries = savedExtendQueries;
+    installExtendedQueriesIfConfigured();
     for (const key of Object.keys(deprecators)) {
       delete deprecators[key];
     }
@@ -143,6 +153,26 @@ describe("RailtieTest", () => {
     cfg.encryption = { supportUnencryptedData: true };
     Trailtie.runInitializers();
     expect(EncryptionConfigurable.config.supportUnencryptedData).toBe(true);
+  });
+
+  it("runInitializers installs extended deterministic query support when extend_queries is set", () => {
+    ExtendedDeterministicUniquenessValidator.resetSupport(UniquenessValidator);
+    EncryptionConfigurable.config.extendQueries = true;
+
+    Trailtie.runInitializers();
+    runLoadHooks("active_record", Base);
+
+    expect(ExtendedDeterministicUniquenessValidator.installed).toBe(true);
+  });
+
+  it("runInitializers does not install extended deterministic query support when extend_queries is unset", () => {
+    ExtendedDeterministicUniquenessValidator.resetSupport(UniquenessValidator);
+    EncryptionConfigurable.config.extendQueries = false;
+
+    Trailtie.runInitializers();
+    runLoadHooks("active_record", Base);
+
+    expect(ExtendedDeterministicUniquenessValidator.installed).toBe(false);
   });
 
   it("load_defaults: partial_inserts is true without any version load", () => {

--- a/packages/activerecord/src/trailtie.ts
+++ b/packages/activerecord/src/trailtie.ts
@@ -27,6 +27,7 @@
 import { onLoad, Railtie as BaseRailtie, registerRailtie } from "@blazetrails/activesupport";
 import { Base } from "./base.js";
 import { Configurable as EncryptionConfigurable } from "./encryption/configurable.js";
+import { installExtendedQueriesIfConfigured } from "./encryption/install.js";
 import { SchemaReflection } from "./connection-adapters/schema-cache.js";
 import type { AbstractSQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
 import type { PostgreSQLAdapter } from "./connection-adapters/postgresql-adapter.js";
@@ -160,6 +161,10 @@ const onPostgresqlAdapterLoadedPushTimestamptz = (): void => {
   onLoad("active_record", { once: true }, pushTimestamptzToTimeZoneAwareTypes);
 };
 
+const installEncryptionExtendedQueries = (): void => {
+  installExtendedQueriesIfConfigured();
+};
+
 const setSqlite3StrictStringsByDefault = (adapter: typeof AbstractSQLite3Adapter): void => {
   adapter.strictStringsByDefault = true;
 };
@@ -251,6 +256,18 @@ export class Trailtie extends BaseRailtie {
       if (enc && Object.keys(enc).length > 0) {
         EncryptionConfigurable.configure(enc);
       }
+
+      // Rails (railtie.rb:349-355):
+      //   ActiveSupport.on_load(:active_record) do
+      //     # Support extended queries for deterministic attributes and validations
+      //     if ActiveRecord::Encryption.config.extend_queries
+      //       ActiveRecord::Encryption::ExtendedDeterministicQueries.install_support
+      //       ActiveRecord::Encryption::ExtendedDeterministicUniquenessValidator.install_support
+      //     end
+      //   end
+      // The `extend_queries` gate is read when the hook fires, not now; our
+      // installer re-checks the flag itself, so it stays faithful.
+      onLoad("active_record", { once: true }, installEncryptionExtendedQueries);
     });
   }
 }


### PR DESCRIPTION
Ports the deterministic-encryption query-extension install into the two places
Rails does it, closing the two gaps found by the RFC 0064 spike (#5309).

**Production side** — `trailtie.ts` had no `extendQueries` handling at all.
Added the `railtie.rb:349-355` arm to the `active_record_encryption.configuration`
initializer: an `onLoad("active_record", …)` hook that calls the existing
`installExtendedQueriesIfConfigured()` boot entrypoint. The `extendQueries`
gate is read when the hook fires (the installer re-checks the flag itself),
matching Rails, where the `if` lives inside the `on_load` block.

**Test side** — `test-setup-ar.ts` now mirrors
`activerecord/test/cases/helper.rb:104-107`: sets
`Encryption.config.extendQueries = true` and installs support suite-wide,
right after the existing `helper.rb:98-102` encryption config.

**Coverage** — two new `RailtieTest` cases assert the initializer installs
support when `extend_queries` is set and leaves it uninstalled when it isn't.
Verified the positive case fails on the pre-change trailtie (commenting out the
`onLoad` line reproduces the failure), so it is a real regression guard.

One existing test needed adjusting:
`extended-deterministic-uniqueness-validator.test.ts`'s "validateEach calls
originalValidateEach for current and previous scheme ciphertexts" exercises the
branch taken when `ExtendedDeterministicQueries` is *not* installed —
unreachable now that the suite boots with it installed. It pins
`ExtendedDeterministicQueries.installed` off for the duration of that test so
the branch stays covered. No test names changed.

Verified locally: `encryption/`, `trailtie.test.ts`, `validations/`,
`relation/` — 93 files, 1620 tests passing.

Closes-story: encryption-extend-queries-suite-wide
