### PR TITLE
refactor(attribute-methods): delegate attributesForUpdate filters to the ported predicates

### DIFF
--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -572,7 +572,7 @@ export function attributesForUpdate(this: InstanceMethodHost, attributeNames: st
   const colNames = new Set<string>(mc.columnNames?.() ?? []);
   return attributeNames.filter((name) => {
     if (!colNames.has(name)) return false;
-    if (mc._readonlyAttributes?.has?.(name)) return false;
+    if (mc.readonlyAttributeQ?.(name)) return false;
     if (mc._counterCacheColumns?.has?.(name)) return false;
     // Rails: column_for_attribute(name).virtual?
     const col = mc.columnForAttribute?.(name);

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -573,7 +573,7 @@ export function attributesForUpdate(this: InstanceMethodHost, attributeNames: st
   return attributeNames.filter((name) => {
     if (!colNames.has(name)) return false;
     if (mc.readonlyAttributeQ?.(name)) return false;
-    if (mc._counterCacheColumns?.has?.(name)) return false;
+    if (mc.isCounterCacheColumn?.(name)) return false;
     // Rails: column_for_attribute(name).virtual?
     const col = mc.columnForAttribute?.(name);
     if (col?.virtual || col?.isVirtual?.()) return false;

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/attribute-methods.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/attribute-methods.json
@@ -213,13 +213,6 @@
     "package": "activerecord",
     "tsFile": "attribute-methods.ts",
     "rubyName": "attributes_for_update",
-    "call": "counter_cache_column?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "attributes_for_update",
     "call": "delete_if",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
`attributes_for_update` (Rails `attribute_methods.rb:508-515`) filters via two
class predicates — `self.class.readonly_attribute?(name)` and
`self.class.counter_cache_column?(name)`. Our `attributesForUpdate` reached into
the backing sets instead (`mc._readonlyAttributes?.has?.(name)`,
`mc._counterCacheColumns?.has?.(name)`). Both now delegate to the ported
predicates `readonlyAttributeQ` / `isCounterCacheColumn`, so the calls-parity
gate sees the calls and `isCounterCacheColumn`'s inheritance + pending-flush
resolution applies here too.

The `counter_cache_column?` entry is dropped from
`call-mismatches-wide-exclude/activerecord/attribute-methods.json`;
`lint-call-mismatches-wide.ts` is OK (5479 baselined, down from 5480).

The other three call sites named in the story (`verifyReadonlyAttribute` in
`persistence.ts`, `writeAttribute` / `_writeAttribute` in
`readonly-attributes.ts`) already delegate on `main`, and no
`readonly_attribute?` entries existed in the wide-exclude baselines — nothing to
unbaseline there.

Tests: `attribute-methods`, `persistence`, `readonly`, `counter-cache`,
`counter-cache.trails`, `dirty` — 423 passed.

Closes-story: converge-readonly-attribute-predicate-callers
