### PR TITLE
refactor(relation): route Rails-counterpart model reads through the model accessor

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -975,9 +975,9 @@ export class Relation<T extends Base> {
       .flat(1)
       .filter((r) => r != null);
 
-    const model = this._modelClass;
+    const model = this.model;
     const recordsOk = recs.every((r) => r instanceof model);
-    const relationsOk = relations.every((rel) => rel._modelClass === model);
+    const relationsOk = relations.every((rel) => rel.model === model);
     if (!recordsOk || !relationsOk) {
       throw new ArgumentError(
         `You must only pass a single or collection of ${model.name} objects to #${callee}.`,
@@ -1178,7 +1178,7 @@ export class Relation<T extends Base> {
     // column (e.g. enum integer mappings, date/time serialization) instead of the
     // JS-native string/number form. column.to_s drives the type lookup; an Arel node
     // (SqlLiteral) finds no attribute type and falls through to ValueType (no-op cast).
-    const typeCaster = new TypeCasterMap(this._modelClass);
+    const typeCaster = new TypeCasterMap(this.model);
     const columnName = typeof column === "string" ? column : String(column);
     // Normalize undefined → null so eq(null) emits IS NULL (not the invalid = NULL).
     const normalized = values.map((v) => {
@@ -2529,7 +2529,7 @@ export class Relation<T extends Base> {
       const allowRetry = this._lastSelectRetryable;
       const result = await this._conn().selectAll(
         sql,
-        `${this._modelClass.name} Load`,
+        `${this.model.name} Load`,
         this._lastSelectBinds,
         { allowRetry, preparable: this._lastSelectPreparable },
       );
@@ -3500,7 +3500,7 @@ export class Relation<T extends Base> {
     // `cache` block are served from the query cache. Routing through the raw
     // `execute()` here would bypass the cached `selectAll` override.
     const rows = await this._withQueryConnection(() =>
-      this._conn().selectRows(existsSql, `${this._modelClass.name} Exists?`, existsBinds),
+      this._conn().selectRows(existsSql, `${this.model.name} Exists?`, existsBinds),
     );
     // Rails: `select_rows(...).size == 1` — with LIMIT 1 the probe returns at
     // most one row, so a non-empty result means a match.
@@ -3800,11 +3800,7 @@ export class Relation<T extends Base> {
     this._applyCtesAndAnnotationsToManager(manager);
 
     const [pluckSql, pluckBinds] = this._compileAstWithBinds(manager.ast);
-    const result = await this._conn().selectAll(
-      pluckSql,
-      `${this._modelClass.name} Pluck`,
-      pluckBinds,
-    );
+    const result = await this._conn().selectAll(pluckSql, `${this.model.name} Pluck`, pluckBinds);
 
     // Type-cast results positionally through each result column's type
     // (model attribute type → join dependency → driver OID → identity),
@@ -3818,7 +3814,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#ids
    */
   async ids(): Promise<unknown[]> {
-    return this.pluck(this._modelClass.primaryKey as string);
+    return this.pluck(this.model.primaryKey as string);
   }
 
   /**
@@ -3865,8 +3861,8 @@ export class Relation<T extends Base> {
     );
     // Mirrors Rails relation.rb#update_all: bump locking_column when omitted.
     // Uses _incrementAttribute (COALESCE(col, 0) + 1) for NULL-safe increment.
-    if (this._modelClass.lockingEnabled) {
-      const lockingCol = this._modelClass.lockingColumn;
+    if (this.model.lockingEnabled) {
+      const lockingCol = this.model.lockingColumn;
       if (!Object.prototype.hasOwnProperty.call(updates, lockingCol)) {
         updateValues.push([table.get(lockingCol), this._incrementAttribute(lockingCol)]);
       }
@@ -3901,7 +3897,7 @@ export class Relation<T extends Base> {
     const [updateSql, updateBinds] = this._compileAstWithBinds(stmtAst);
     const count = await this._conn().execUpdate(
       updateSql,
-      `${this._modelClass.name} Update All`,
+      `${this.model.name} Update All`,
       updateBinds,
     );
     this.reset();
@@ -3945,7 +3941,7 @@ export class Relation<T extends Base> {
     }
 
     const table = this._modelClass.arelTable;
-    const primaryKey = this._modelClass.primaryKey;
+    const primaryKey = this.model.primaryKey;
     let stmtAst;
     if (typeof primaryKey === "string" || Array.isArray(primaryKey)) {
       // Mirrors Rails `delete_all`: always run `build_arel` + `compile_delete`
@@ -3992,7 +3988,7 @@ export class Relation<T extends Base> {
     const [deleteSql, deleteBinds] = this._compileAstWithBinds(stmtAst);
     const count = await this._conn().execDelete(
       deleteSql,
-      `${this._modelClass.name} Delete All`,
+      `${this.model.name} Delete All`,
       deleteBinds,
     );
     this.reset();
@@ -4016,7 +4012,7 @@ export class Relation<T extends Base> {
     // (e.g. Developer.updated_at → legacy_updated_at). Route through updateAll
     // so optimistic locking (lock_version increment) is applied — mirrors Rails
     // touch_all which calls update_all internally (relation.rb).
-    const touchUpdates = touchAttributesWithTime.call(this._modelClass, ...names, time);
+    const touchUpdates = touchAttributesWithTime.call(this.model, ...names, time);
     const updates: Record<string, unknown> = {};
     for (const [col, touchedAt] of Object.entries(touchUpdates)) {
       updates[col] = new Nodes.Quoted(touchedAt);
@@ -6127,7 +6123,7 @@ export class Relation<T extends Base> {
       // hash form; `touch: []` → no names), then touch the update-timestamp
       // columns via touchAttributesWithTime — same call Rails makes.
       const { names, time } = parseCounterCacheTouch(touchOption);
-      const touchUpdates = touchAttributesWithTime.call(this._modelClass, ...names, time);
+      const touchUpdates = touchAttributesWithTime.call(this.model, ...names, time);
       for (const [col, t] of Object.entries(touchUpdates)) {
         updates[col] = new Nodes.Quoted(t);
       }
@@ -6147,7 +6143,7 @@ export class Relation<T extends Base> {
     if (id == null) return 0;
     if (Array.isArray(id) && id.length === 0) return 0;
 
-    const primaryKey = this._modelClass.primaryKey;
+    const primaryKey = this.model.primaryKey;
     if (Array.isArray(primaryKey)) {
       const idArr = Array.isArray(id) ? id : [id];
       if (idArr.length !== primaryKey.length) return 0;
@@ -6347,7 +6343,7 @@ export class Relation<T extends Base> {
    * materializing every row.
    */
   async include(record: T): Promise<boolean> {
-    if (!(record instanceof this._modelClass)) return false;
+    if (!(record instanceof this.model)) return false;
     if (
       this.isLoaded ||
       this._offsetValue !== null ||
@@ -6393,12 +6389,10 @@ export class Relation<T extends Base> {
       return this._predicateBuilder;
     }
     let pb: PredicateBuilder;
-    const modelPbAccessor = (this._modelClass as any).predicateBuilder;
+    const modelPbAccessor = (this.model as any).predicateBuilder;
     const modelPb =
-      typeof modelPbAccessor === "function"
-        ? modelPbAccessor.call(this._modelClass)
-        : modelPbAccessor;
-    const metadata = new TableMetadata(this._modelClass, this.table);
+      typeof modelPbAccessor === "function" ? modelPbAccessor.call(this.model) : modelPbAccessor;
+    const metadata = new TableMetadata(this.model, this.table);
     if (modelPb && typeof modelPb.with === "function") {
       pb = modelPb.with(metadata);
     } else {
@@ -6578,7 +6572,7 @@ export class Relation<T extends Base> {
     const allQueries =
       typeof optionsOrCallback === "function" ? null : (optionsOrCallback.allQueries ?? null);
 
-    const modelClass = this._modelClass as any;
+    const modelClass = this.model as any;
     const registry = ScopeRegistry.instance();
 
     // Rails: global_scope? && all_queries == false → raise.
@@ -6689,8 +6683,8 @@ export class Relation<T extends Base> {
 
   /** @internal */
   async computeCacheKey(timestampColumn = "updated_at"): Promise<string> {
-    const key = `${this._modelClass.tableName}/query-${hexdigest(this.toSql())}`;
-    if (this._modelClass.collectionCacheVersioning) {
+    const key = `${this.model.tableName}/query-${hexdigest(this.toSql())}`;
+    if (this.model.collectionCacheVersioning) {
       return key;
     }
     const version = await this.computeCacheVersion(timestampColumn);
@@ -6703,7 +6697,7 @@ export class Relation<T extends Base> {
    * Mirrors: ActiveRecord::Relation#cache_version
    */
   async cacheVersion(timestampColumn = "updated_at"): Promise<string | null> {
-    if (!this._modelClass.collectionCacheVersioning) return null;
+    if (!this.model.collectionCacheVersioning) return null;
     this._cacheVersions ??= new Map();
     if (!this._cacheVersions.has(timestampColumn)) {
       this._cacheVersions.set(
@@ -6903,7 +6897,7 @@ export class Relation<T extends Base> {
         }
       }
       if (ts != null) {
-        const fmt = this._modelClass.cacheTimestampFormat;
+        const fmt = this.model.cacheTimestampFormat;
         const formatted = formatCacheTimestamp(ts, fmt);
         return `${size}-${formatted}`;
       }
@@ -7041,7 +7035,7 @@ export class Relation<T extends Base> {
   }
 
   private currentScopeRestoringBlock(block?: (record: T) => void): (record: T) => void {
-    const modelClass = this._modelClass;
+    const modelClass = this.model;
     const currentScope = ScopeRegistry.currentScope(modelClass as any);
     return (record: T) => {
       ScopeRegistry.setCurrentScope(modelClass as any, currentScope ?? null);
@@ -7050,24 +7044,24 @@ export class Relation<T extends Base> {
   }
 
   private _new(attributes: Record<string, unknown>): T {
-    return new (this._modelClass as any)(attributes) as T;
+    return new (this.model as any)(attributes) as T;
   }
 
   private _create(attributes: Record<string, unknown>): Promise<T> {
-    return (this._modelClass as any).create(attributes);
+    return (this.model as any).create(attributes);
   }
 
   private _createBang(attributes: Record<string, unknown>): Promise<T> {
-    return (this._modelClass as any).createBang(attributes);
+    return (this.model as any).createBang(attributes);
   }
 
   private _scoping<R>(scope: any, registry: any, fn: () => R): R {
-    const previous = registry?.currentScope?.(this._modelClass, true);
-    registry?.setCurrentScope?.(this._modelClass, scope);
+    const previous = registry?.currentScope?.(this.model, true);
+    registry?.setCurrentScope?.(this.model, scope);
     try {
       return fn();
     } finally {
-      registry?.setCurrentScope?.(this._modelClass, previous);
+      registry?.setCurrentScope?.(this.model, previous);
     }
   }
 
@@ -7092,7 +7086,7 @@ export class Relation<T extends Base> {
       // RAW values and rely on that — so routing a cast value through
       // `buildBindAttribute` would cast twice. `withCastValue` is the preserving
       // constructor that matches Rails' semantics.
-      const type = this._modelClass.typeForAttribute(attr.name);
+      const type = this.model.typeForAttribute(attr.name);
       return [attr, QueryAttribute.withCastValue(attr.name, type.cast(value), type)];
     });
   }
@@ -7120,7 +7114,7 @@ export class Relation<T extends Base> {
 
   private instantiateRecords(rows: Record<string, unknown>[]): T[] {
     if (rows.length === 0) return [];
-    return rows.map((row) => this._modelClass._instantiate(row) as T);
+    return rows.map((row) => this.model._instantiate(row) as T);
   }
 
   private skipQueryCacheIfNecessary<R>(block: () => R): R {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -4216,7 +4216,7 @@ export class Relation<T extends Base> {
    * (e.g. `HasManyThroughAssociation#through_scope_attributes` passing the
    * through model's table).
    */
-  whereValuesHash(relationTableName: string = this._modelClass.tableName): Record<string, unknown> {
+  whereValuesHash(relationTableName: string = this.model.tableName): Record<string, unknown> {
     return this._whereClause.toH(relationTableName);
   }
 
@@ -4562,7 +4562,7 @@ export class Relation<T extends Base> {
 
   /** @internal */
   protected _scopeAttributes(): Record<string, unknown> {
-    return this._whereClause.toH(this._modelClass.tableName, { equalityOnly: true });
+    return this._whereClause.toH(this.model.tableName, { equalityOnly: true });
   }
 
   // -- Batches --

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
@@ -2,20 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "_create",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "_create!",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "_exec_scope",
     "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -44,22 +30,8 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "_new",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "_scoping",
     "call": "global_current_scope",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "_scoping",
-    "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -75,13 +47,6 @@
     "rubyName": "_substitute_values",
     "call": "build_bind_attribute",
     "reason": "Satisfied by QueryAttribute.withCastValue: Rails build_bind_attribute (predicate_builder.rb:67-69) is a PRESERVING constructor because QueryAttribute#type_cast is identity (query_attribute.rb:22-24); trails QueryAttribute#typeCast casts its input, so calling buildBindAttribute here would cast twice."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "_substitute_values",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -723,13 +688,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "cache_version",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "calculate",
     "call": "any?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -814,13 +772,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "compute_cache_key",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "compute_cache_version",
     "call": "arel",
     "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
@@ -858,13 +809,6 @@
     "tsFile": "relation.ts",
     "rubyName": "compute_cache_version",
     "call": "loaded?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "compute_cache_version",
-    "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -982,20 +926,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "current_scope_restoring_block",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "delete",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "delete_all",
     "call": "arel",
     "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
@@ -1026,13 +956,6 @@
     "tsFile": "relation.ts",
     "rubyName": "delete_all",
     "call": "having_clause",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "delete_all",
-    "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -1676,13 +1599,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "exists?",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "exists?",
     "call": "size",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -1851,13 +1767,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "ids",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "ids",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -1935,13 +1844,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "in_order_of",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "in_order_of",
     "call": "or",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -1969,22 +1871,8 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "include?",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "instantiate_records",
     "call": "instantiate",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "instantiate_records",
-    "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -2354,13 +2242,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "scoping",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "select",
     "call": "any?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -2510,13 +2391,6 @@
     "tsFile": "relation.ts",
     "rubyName": "to_sql",
     "call": "with_connection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "touch_all",
-    "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -2691,13 +2565,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "update_all",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "update_all",
     "call": "primary_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -2755,13 +2622,6 @@
     "tsFile": "relation.ts",
     "rubyName": "update_counters",
     "call": "merge!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "update_counters",
-    "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
@@ -4,7 +4,7 @@
     "tsFile": "relation.ts",
     "rubyName": "_exec_scope",
     "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Per-entry verified (RFC 0072 model-accessor sweep): Rails relation.rb:552-558 resolves the registry via `model.scope_registry`; trails relation.ts `_execScope` reads the process-wide `ScopeRegistry.instance()` and never touches the model. Converge by porting the per-model registry accessor."
   },
   {
     "package": "activerecord",
@@ -186,7 +186,7 @@
     "tsFile": "relation.ts",
     "rubyName": "apply_join_dependency",
     "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Per-entry verified (RFC 0072 model-accessor sweep): the `model` read lives in `construct_join_dependency` (query_methods.rb:1598-1602), which `apply_join_dependency` merely calls; trails' `applyJoinDependency` likewise holds no direct model read. Tracked under converge-relation-subfile-model-accessor-reads."
   },
   {
     "package": "activerecord",
@@ -634,7 +634,7 @@
     "tsFile": "relation.ts",
     "rubyName": "bind_attribute",
     "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Per-entry verified (RFC 0072 model-accessor sweep): not a model-read routing gap. Rails relation.rb:102-110 calls `model._reflect_on_association(name)` to swap an association name for its foreign key; trails relation.ts has no such branch at all, so this is a missing behavior, not a `_modelClass`-vs-`model` read. Converge by porting the reflection branch."
   },
   {
     "package": "activerecord",
@@ -991,7 +991,7 @@
     "tsFile": "relation.ts",
     "rubyName": "destroy",
     "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Per-entry verified (RFC 0072 model-accessor sweep): Rails relation.rb:1083-1092 branches on `model.composite_primary_key?` to decide whether the argument is a list of ids; trails relation.ts `destroy` has no multiple-id branch. Missing behavior, not a read-routing gap."
   },
   {
     "package": "activerecord",
@@ -2377,7 +2377,7 @@
     "tsFile": "relation.ts",
     "rubyName": "to_sql",
     "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Per-entry verified (RFC 0072 model-accessor sweep): Rails relation.rb:1217-1218 wraps the render in `model.with_connection { |c| c.unprepared_statement { ... } }`; trails routes through `_toSqlViaConnection`/`_conn`, a trails-invented connection helper. The divergence is the connection-acquisition shape, not the model read."
   },
   {
     "package": "activerecord",
@@ -2503,14 +2503,14 @@
     "tsFile": "relation.ts",
     "rubyName": "update",
     "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Per-entry verified (RFC 0072 model-accessor sweep): Rails relation.rb:620-627 dispatches the by-id form to `model.update(id, attributes)`; trails relation.ts `update` does `find(id)` then `record.update(...)`. A different code path, not a read-routing gap."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "update!",
     "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Per-entry verified (RFC 0072 model-accessor sweep): Rails relation.rb:629-636 dispatches the by-id form to `model.update!(id, attributes)`; trails relation.ts `updateBang` does `find(id)` then `record.updateBang(...)`. A different code path, not a read-routing gap."
   },
   {
     "package": "activerecord",


### PR DESCRIPTION
Rails' `Relation` never reads `@model` outside `initialize` (relation.rb:85) —
every other read goes through the `model` accessor (`klass` is just
`alias :klass :model`, relation.rb:73). trails reaches past it to the private
`_modelClass` field, so ported bodies omit a call Rails makes. PR #5315 fixed
two instances (`isAlreadyInScope`, `isGlobalScope`); this is the deliberate
sweep of the rest in `relation.ts`.

`model` is a plain accessor (`relation.ts:6242`, `return this._modelClass`), so
every rewrite is value-identical and behavior-preserving. The win is call-graph
fidelity, which keeps the wide ratchet honest as these methods become public.

## Converged

Routed through `this.model`, each checked against its Rails body:

- `currentScopeRestoringBlock`, `_new`, `_create`, `_createBang`, `_scoping`
  (relation.rb:1345-1377) — the three cases named in the story plus the two
  siblings in the same block.
- `_substituteValues` (relation.rb:1389 `model.type_for_attribute`).
- `instantiateRecords` (relation.rb:1462 `model._load_from_sql`).
- `scoping` (relation.rb:542 `model.scope_registry`).
- `updateAll` (relation.rb:594-617 `model.locking_enabled?` /
  `model.locking_column` / `"#{model} Update All"`), `deleteAll`
  (relation.rb:1028-1035), `touchAll` (relation.rb:970),
  `updateCounters` (relation.rb:939), `delete` (relation.rb:1060).
- `computeCacheKey` / `cacheVersion` / `computeCacheVersion`
  (relation.rb:445-511).
- `exists?`, `include?` (finder_methods.rb:392 `record.is_a?(model)`),
  `ids`, `pluck`, `inOrderOf`, `excluding` (query_methods.rb:1579
  `relation.model == model`), `predicateBuilder` (relation.rb:79-82),
  and the `exec_main_query` query-name read.
- `whereValuesHash` (relation.rb:1227 — the default argument is
  `model.table_name`) and `scopeForCreate`'s where-clause read
  (relation.rb:1232).

Baseline: 20 stale `model` entries dropped from
`call-mismatches-wide-exclude/activerecord/relation.json`;
`pnpm api:calls:wide` is green (5081 baselined, no growth).

## Deliberately left as `this._modelClass`

Recorded so the next audit does not re-derive them. The per-entry findings are
written into the surviving baseline `reason` fields (not just this PR body), so
they travel with the gate:

- `bind_attribute` — the flag is a genuinely missing
  `model._reflect_on_association` call (relation.rb:103), not a read-routing
  issue; rewriting the `arelTable` read would paper over it.
- `to_sql` — Rails wraps in `model.with_connection` (relation.rb:1217-1218);
  trails routes through the invented `_toSqlViaConnection` / `_conn` helpers.
- `update` / `update!` / `destroy` — Rails dispatches by id to
  `model.update` / `model.update!` and branches on
  `model.composite_primary_key?` (relation.rb:625, 633, 1084); trails goes
  through `find(id)` and has no multiple-id branch. Different code paths.
- `_exec_scope` — Rails reads `model.scope_registry` (relation.rb:554); trails
  uses the process-wide `ScopeRegistry.instance()`.
- `apply_join_dependency` — the `model` read is inside
  `construct_join_dependency` (query_methods.rb:1600), not this body.

Structural exclusions:

- The field declaration, the constructor assignment, and the `model` / `klass`
  getters themselves — Rails' `@model = model` (relation.rb:85) and the
  `attr_reader`.
- Reads whose Rails counterpart uses the `table` attr_reader, not `model`:
  `updateAll` / `deleteAll` / `_substituteValues` / `updateCounters` all do
  `table[name]` in Rails (relation.rb:597, 931, 1383), so
  `this._modelClass.arelTable` there is a *different* divergence (should be
  `this.table`) and is out of scope for an accessor-routing sweep.
- `bindAttribute` — its wide flag is a genuinely missing
  `model._reflect_on_association` call (relation.rb:103), not a read-routing
  issue; rewriting the `arelTable` read would paper over it.
- Trails-invented helpers with no Rails counterpart body: the eager-load
  machinery (`_executeEagerLoad`, `_buildEager*`, `_materializeDistinctPkIds`,
  `_checkEagerLoadable`, `_eager*AreLimitable`), `_conn` /
  `_withQueryConnection`, `_isKnownColumn`, `_whereChainReflection`,
  `_isAssociationName`, `_resolveAssociationJoin`, `_newRelation`,
  `_modelTokenForMethod`, `_instrumentInstantiation`, `_joinedTableNames`.
- `relation/*.ts` (query-methods, calculations, finder-methods, merger,
  batches, spawn-methods, delegation) — same class of fix, but outside this
  PR's LOC budget; registered as follow-up story
  `converge-relation-subfile-model-accessor-reads`.

Closes-story: converge-relation-model-accessor-reads
