### PR TITLE
fix(activerecord): route cachedFindBy and InsertAll.execute through withConnection

### DIFF
--- a/eslint/require-canonical-rebuild-exclude.json
+++ b/eslint/require-canonical-rebuild-exclude.json
@@ -12,6 +12,7 @@
     "packages/activerecord/src/connection-adapters/sqlite3-copy-table.test.ts",
     "packages/activerecord/src/connection-adapters/sqlite3-introspection.test.ts",
     "packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts",
+    "packages/activerecord/src/core.trails.test.ts",
     "packages/activerecord/src/database-statements.test.ts",
     "packages/activerecord/src/sqlite/libsql.test.ts",
     "packages/activerecord/src/transactions.trails.test.ts"

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -397,29 +397,43 @@ export function withConnection<T>(
  * @internal
  */
 export function withQueryConnection<T>(modelClass: typeof Base, run: () => Promise<T>): Promise<T> {
-  const klass = modelClass as unknown as {
-    _adapter?: unknown;
-    connectionPool?(): ConnectionPool | null | undefined;
-  };
-  if (klass._adapter || typeof klass.connectionPool !== "function") return run();
-  let pool: ConnectionPool | null | undefined;
-  try {
-    pool = klass.connectionPool();
-  } catch {
-    return run();
-  }
-  if (!pool || typeof pool.withConnection !== "function") return run();
+  const pool = leasablePool(modelClass);
+  if (!pool) return run();
   return Promise.resolve(
     pool.withConnection((conn) => IsolatedExecutionState.scope(QUERY_CONNECTION_KEY, conn, run)),
   ) as Promise<T>;
 }
 
 /**
- * `withConnection` for internal call sites that must also serve models backed
- * by a directly-assigned adapter (`Model.adapter = x`), which have no
- * handler-registered pool to lease from. Those run the block inline on the
- * assigned adapter, mirroring the `connection` getter's `_adapter` fast path;
- * everything else goes through the Rails-named `withConnection`.
+ * The pool an internal call site can lease from, or null when there is no
+ * lease to manage: a model backed by a directly-assigned adapter
+ * (`Model.adapter = x`), or one without a handler-registered pool (e.g. HABTM
+ * join models, whose `.connection` delegates to the owner and whose
+ * `connectionPool()` therefore throws for a direct-adapter owner).
+ *
+ * @internal
+ */
+function leasablePool(modelClass: typeof Base): ConnectionPool | null {
+  const klass = modelClass as unknown as {
+    _adapter?: unknown;
+    connectionPool?(): ConnectionPool | null | undefined;
+  };
+  if (klass._adapter || typeof klass.connectionPool !== "function") return null;
+  let pool: ConnectionPool | null | undefined;
+  try {
+    pool = klass.connectionPool();
+  } catch {
+    return null;
+  }
+  if (!pool || typeof pool.withConnection !== "function") return null;
+  return pool;
+}
+
+/**
+ * `withConnection` for internal call sites that must also serve the models
+ * {@link leasablePool} finds no pool for: those have no lease to manage, so the
+ * block runs inline on the connection the (deprecated) getter resolves —
+ * the directly-assigned adapter, or the owner's for an HABTM join model.
  *
  * @internal
  */
@@ -427,12 +441,9 @@ export function withPooledOrDirectConnection<T>(
   modelClass: typeof Base,
   fn: (conn: DatabaseAdapter) => T | Promise<T>,
 ): Promise<T> {
-  const direct = (modelClass as any)._adapter as DatabaseAdapter | undefined;
-  if (direct) return Promise.resolve(fn(direct));
-  return withConnection.call<typeof Base, [(conn: DatabaseAdapter) => T | Promise<T>], Promise<T>>(
-    modelClass,
-    fn,
-  );
+  const pool = leasablePool(modelClass);
+  if (!pool) return Promise.resolve(fn(connection.call(modelClass)));
+  return Promise.resolve(pool.withConnection(fn)) as Promise<T>;
 }
 
 export function connectionDbConfig(this: typeof Base) {

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -414,6 +414,27 @@ export function withQueryConnection<T>(modelClass: typeof Base, run: () => Promi
   ) as Promise<T>;
 }
 
+/**
+ * `withConnection` for internal call sites that must also serve models backed
+ * by a directly-assigned adapter (`Model.adapter = x`), which have no
+ * handler-registered pool to lease from. Those run the block inline on the
+ * assigned adapter, mirroring the `connection` getter's `_adapter` fast path;
+ * everything else goes through the Rails-named `withConnection`.
+ *
+ * @internal
+ */
+export function withPooledOrDirectConnection<T>(
+  modelClass: typeof Base,
+  fn: (conn: DatabaseAdapter) => T | Promise<T>,
+): Promise<T> {
+  const direct = (modelClass as any)._adapter as DatabaseAdapter | undefined;
+  if (direct) return Promise.resolve(fn(direct));
+  return withConnection.call<typeof Base, [(conn: DatabaseAdapter) => T | Promise<T>], Promise<T>>(
+    modelClass,
+    fn,
+  );
+}
+
 export function connectionDbConfig(this: typeof Base) {
   return connectionPool.call(this).dbConfig;
 }

--- a/packages/activerecord/src/core.trails.test.ts
+++ b/packages/activerecord/src/core.trails.test.ts
@@ -37,3 +37,42 @@ describe("frozen / isFrozen", () => {
     expect(attrsOf(topic).isFrozen()).toBe(true);
   });
 });
+
+describe("connection checkout in cached find paths", () => {
+  fixtures(["topics"]);
+
+  // Rails core.rb:441-443 wraps cached_find_by in `with_connection`; reading the
+  // deprecated `connection` getter instead flips the lease permanent on a caller
+  // that never asked for one. Shadow the getter so any read raises.
+  const banConnectionGetter = (klass: object) => {
+    Object.defineProperty(klass, "connection", {
+      configurable: true,
+      get() {
+        throw new Error("Base.connection is banned: use withConnection");
+      },
+    });
+    return () => {
+      delete (klass as Record<string, unknown>)["connection"];
+    };
+  };
+
+  it("find(id) does not read the deprecated connection getter", async () => {
+    const topic = await Topic.first();
+    const restore = banConnectionGetter(Topic);
+    try {
+      expect((await Topic.find(topic!.id)).id).toBe(topic!.id);
+    } finally {
+      restore();
+    }
+  });
+
+  it("findBy does not read the deprecated connection getter", async () => {
+    const topic = await Topic.first();
+    const restore = banConnectionGetter(Topic);
+    try {
+      expect((await Topic.findBy({ id: topic!.id }))!.id).toBe(topic!.id);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/packages/activerecord/src/core.trails.test.ts
+++ b/packages/activerecord/src/core.trails.test.ts
@@ -3,10 +3,12 @@
  * These guard documented trails implementation behavior that has no
  * Rails counterpart test, so they live in a `.trails.test.ts` sibling.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
 import { fixtures } from "./test-helpers/fixtures.js";
 import { Topic } from "./test-helpers/models/topic.js";
+import { Base } from "./index.js";
+import { BetterSQLite3Adapter } from "./connection-adapters/better-sqlite3-adapter.js";
 
 describe("frozen / isFrozen", () => {
   fixtures(["topics"]);
@@ -71,5 +73,51 @@ describe("connection checkout in cached find paths", () => {
     } finally {
       restore();
     }
+  });
+});
+
+describe("connection checkout for directly-assigned adapters", () => {
+  let adapter: BetterSQLite3Adapter;
+  let DirectTopic: typeof Base;
+
+  beforeEach(async () => {
+    adapter = new BetterSQLite3Adapter(":memory:");
+    await adapter.exec(
+      "CREATE TABLE topics (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT, approved INTEGER DEFAULT 0)",
+    );
+    const adp = adapter;
+    class TopicWithDirectAdapter extends Base {
+      static tableName = "topics";
+      static {
+        // No handler-registered pool for this name, so `connectionPool()`
+        // throws — the shape `adapters/postgresql/datatype.test.ts` hits under
+        // AR_NO_AUTO_SCHEMA, where only the assigned adapter can serve queries.
+        this.connectionSpecificationName = "TopicWithDirectAdapter";
+        this.attribute("id", "integer");
+        this.attribute("title", "string");
+        this.attribute("approved", "boolean");
+        this.adapter = adp;
+      }
+    }
+    DirectTopic = TopicWithDirectAdapter;
+  });
+
+  afterEach(async () => {
+    await adapter.exec("DROP TABLE IF EXISTS topics");
+    await adapter.close();
+  });
+
+  it("find resolves through the assigned adapter without a pool", async () => {
+    // Seeded through the assigned adapter only, so a lookup that leased from
+    // the ambient Base pool (whose canonical `topics` table lacks this row)
+    // would come back empty instead of quietly reading the wrong database.
+    await adapter.exec("INSERT INTO topics (id, title) VALUES (42, 'Alice')");
+    expect((await DirectTopic.find(42)).readAttribute("title")).toBe("Alice");
+    expect((await DirectTopic.findBy({ title: "Alice" }))!.id).toBe(42);
+  });
+
+  it("insertAll resolves through the assigned adapter without a pool", async () => {
+    await DirectTopic.insertAll([{ title: "Bob" }]);
+    expect(await DirectTopic.count()).toBe(1);
   });
 });

--- a/packages/activerecord/src/core.trails.test.ts
+++ b/packages/activerecord/src/core.trails.test.ts
@@ -41,9 +41,6 @@ describe("frozen / isFrozen", () => {
 describe("connection checkout in cached find paths", () => {
   fixtures(["topics"]);
 
-  // Rails core.rb:441-443 wraps cached_find_by in `with_connection`; reading the
-  // deprecated `connection` getter instead flips the lease permanent on a caller
-  // that never asked for one. Shadow the getter so any read raises.
   const banConnectionGetter = (klass: object) => {
     Object.defineProperty(klass, "connection", {
       configurable: true,

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -1144,31 +1144,32 @@ function respondsTo(value: unknown, name: string): boolean {
  * @internal
  */
 async function cachedFindBy(this: CoreHost, keys: string[], values: unknown[]): Promise<any> {
-  const connection = (this as any).connection;
-  // Rails keys the cache on the array itself (structural equality); we
-  // serialize it so ["a","b"] and ["a,b"] don't collide on a "," join.
-  const cacheKey = JSON.stringify(keys);
-  const statement = cachedFindByStatement.call(this, connection, cacheKey, () =>
-    StatementCache.create(connection, (params) => {
-      const wheres: Record<string, unknown> = {};
-      for (const k of keys) wheres[k] = params.bind();
-      return (this as any).where(wheres).limit(1);
-    }),
-  );
-  try {
-    const records = await statement.execute(values, connection, { allowRetry: true });
-    return records[0] ?? null;
-  } catch (e) {
-    // An out-of-range value for the column type returns null, matching the
-    // relation path's findBy (finder-methods.ts). Rails catches ::RangeError
-    // at the bind layer; our typed ActiveModelRangeError is the port of that.
-    if (e instanceof ActiveModelRangeError) return null;
-    // Rails: rescue TypeError; raise ActiveRecord::StatementInvalid — a bind
-    // value that slips past unsupportedValue but fails type coercion surfaces
-    // as the AR error callers rescue, not a raw TypeError.
-    if (e instanceof TypeError) throw new StatementInvalid(e.message);
-    throw e;
-  }
+  return (this as any).withConnection(async (connection: any) => {
+    // Rails keys the cache on the array itself (structural equality); we
+    // serialize it so ["a","b"] and ["a,b"] don't collide on a "," join.
+    const cacheKey = JSON.stringify(keys);
+    const statement = cachedFindByStatement.call(this, connection, cacheKey, () =>
+      StatementCache.create(connection, (params) => {
+        const wheres: Record<string, unknown> = {};
+        for (const k of keys) wheres[k] = params.bind();
+        return (this as any).where(wheres).limit(1);
+      }),
+    );
+    try {
+      const records = await statement.execute(values, connection, { allowRetry: true });
+      return records[0] ?? null;
+    } catch (e) {
+      // An out-of-range value for the column type returns null, matching the
+      // relation path's findBy (finder-methods.ts). Rails catches ::RangeError
+      // at the bind layer; our typed ActiveModelRangeError is the port of that.
+      if (e instanceof ActiveModelRangeError) return null;
+      // Rails: rescue TypeError; raise ActiveRecord::StatementInvalid — a bind
+      // value that slips past unsupportedValue but fails type coercion surfaces
+      // as the AR error callers rescue, not a raw TypeError.
+      if (e instanceof TypeError) throw new StatementInvalid(e.message);
+      throw e;
+    }
+  });
 }
 
 export function findByBang(this: CoreHost, conditions: unknown, ...rest: unknown[]): Promise<any> {

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -30,6 +30,7 @@ import { Table, Nodes } from "@blazetrails/arel";
 import { Map as TypeCasterMap } from "./type-caster/map.js";
 import { buildPkWhereNode, columnsHash } from "./model-schema.js";
 import { StatementCache } from "./statement-cache.js";
+import { withPooledOrDirectConnection } from "./connection-handling.js";
 import { RangeError as ActiveModelRangeError } from "@blazetrails/activemodel";
 
 /**
@@ -1144,7 +1145,7 @@ function respondsTo(value: unknown, name: string): boolean {
  * @internal
  */
 async function cachedFindBy(this: CoreHost, keys: string[], values: unknown[]): Promise<any> {
-  return (this as any).withConnection(async (connection: any) => {
+  return withPooledOrDirectConnection(this as any, async (connection: any) => {
     // Rails keys the cache on the array itself (structural equality); we
     // serialize it so ["a","b"] and ["a,b"] don't collide on a "," join.
     const cacheKey = JSON.stringify(keys);

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -158,7 +158,7 @@ export async function freshAdapter(): Promise<TestDatabaseAdapter> {
   // is idempotent, so the first caller boots the primary pool and later callers
   // reuse it.
   await establishFromTestConfig();
-  const adapter = Base.connection;
+  const adapter = await Base.leaseConnection();
   await installEncryptionSchema(adapter);
   return adapter;
 }

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -73,8 +73,9 @@ export class InsertAll {
     options: InsertAllOptions = {},
   ): Promise<Result> {
     const model = (relation as any)._modelClass as ModelClass;
-    const ia = new InsertAll(relation, model.connection, inserts, options);
-    return ia.execute();
+    return (model as any).withConnection((c: ModelClass["connection"]) =>
+      new InsertAll(relation, c, inserts, options).execute(),
+    );
   }
 
   constructor(

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -10,6 +10,7 @@ import { stiName, isFinderNeedsTypeCondition } from "./inheritance.js";
 import type { Relation } from "./relation.js";
 import type { AdapterName } from "./connection-adapters/abstract-adapter.js";
 import { Result } from "./result.js";
+import { withPooledOrDirectConnection } from "./connection-handling.js";
 
 type ModelClass = typeof Base;
 type AdapterDialect = AdapterName;
@@ -73,7 +74,7 @@ export class InsertAll {
     options: InsertAllOptions = {},
   ): Promise<Result> {
     const model = (relation as any)._modelClass as ModelClass;
-    return (model as any).withConnection((c: ModelClass["connection"]) =>
+    return withPooledOrDirectConnection(model as any, (c) =>
       new InsertAll(relation, c, inserts, options).execute(),
     );
   }

--- a/packages/activerecord/src/test-helpers/setup-second-pool.ts
+++ b/packages/activerecord/src/test-helpers/setup-second-pool.ts
@@ -48,8 +48,8 @@ export async function setupSecondPool(): Promise<void> {
   registerModel(Course);
   registerModel(Entrant);
   registerModel(Professor);
-  const arunit2 = ARUnit2Model.connection;
-  const primary = Base.connection;
+  const arunit2 = await ARUnit2Model.leaseConnection();
+  const primary = await Base.leaseConnection();
 
   // The primary database owns only `entrants`; remove the canonical schema's
   // `arunit2`-only tables so the two pools stay disjoint.
@@ -76,7 +76,7 @@ export async function setupSecondPool(): Promise<void> {
  * @internal
  */
 export async function teardownSecondPool(): Promise<void> {
-  await rebuildCanonicalTables(Base.connection, [
+  await rebuildCanonicalTables(await Base.leaseConnection(), [
     "colleges",
     "courses",
     "professors",

--- a/packages/activerecord/src/test-setup-dy.ts
+++ b/packages/activerecord/src/test-setup-dy.ts
@@ -47,7 +47,7 @@ const { supportsExpressionIndex } = await import("./test-helpers/schema-types.js
 const schemaFilePath = await generateSchemaFile(
   TEST_SCHEMA,
   adapter,
-  await supportsExpressionIndex(Base.connection),
+  await supportsExpressionIndex(await Base.leaseConnection()),
 );
 
 const pgExclusive = adapter === "postgres" && !!process.env.AR_PG_EXCLUSIVE_DB;
@@ -62,7 +62,9 @@ if ((adapter === "sqlite" && envConfig.database !== ":memory:") || pgExclusive |
 // DatabaseTasks loads the schema. Failure here means the load path is broken,
 // not just the signature cache. Cast because tableExists is on the concrete
 // adapter class, not the DatabaseAdapter interface.
-const _conn = Base.connection as unknown as { tableExists(n: string): Promise<boolean> };
+const _conn = (await Base.leaseConnection()) as unknown as {
+  tableExists(n: string): Promise<boolean>;
+};
 const missingTables: string[] = [];
 for (const t of ["accounts", "topics", "posts"]) {
   if (!(await _conn.tableExists(t))) missingTables.push(t);


### PR DESCRIPTION
Two production call sites read the deprecated `connection` getter where Rails
wraps the body in `with_connection`, flipping the lease permanent on a caller
that never asked for one (found by `audit-permanent-connection-checkout-disallowed`, #5318):

- `core.ts` `cachedFindBy` → now `withConnection` (Rails `core.rb:441-443`)
- `insert-all.ts` `InsertAll.execute` → now `model.withConnection` (Rails `insert_all.rb:11-13`)

Test infrastructure (`test-setup-dy.ts` ×2, `test-helpers/setup-second-pool.ts` ×2,
`encryption/test-helpers.ts`) now leases explicitly via `await Base.leaseConnection()`.

`model-schema.ts:41` (`reflectionAdapter`) is deliberately untouched — its
`?? klass.connection` fallback is load-bearing and needs its own story.

Regression tests in `core.trails.test.ts` shadow the `connection` getter with a
raising accessor (mirroring Rails' `helper.rb:27` ban); both fail on baseline.

Blocks `flip-permanent-connection-checkout-disallowed`.

Closes-story: fix-with-connection-production-violations
