### PR TITLE
fix(associations): port replace's load_target into has_one _createRecord

### DIFF
--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -344,13 +344,27 @@ export class HasOneAssociation extends SingularAssociation {
     // it here. Capture the loaded target BEFORE `super._createRecord`, which
     // builds the new record first — an invalid build (e.g. an inexistent foreign
     // key) must raise before any removal runs, exactly as Rails' `build_record`
-    // raises before `set_new_record`. An UNLOADED target is not removed at all,
-    // and nothing defers it either — RFC 0068 retired the queue that used to
-    // pick it up at the owner's next `save`. Rails would surface it here via
-    // `replace`'s leading `load_target`, which this path does not issue; until
-    // that load is ported, `create#{name}` over an unloaded persisted child
-    // leaves the old row attached.
-    const displaced = this.loaded ? this.target : null;
+    // raises before `set_new_record`. An UNLOADED target is surfaced by
+    // `replace`'s leading `load_target`, ported here through
+    // `loadTargetForBuild` (the same seam the `build#{name}` accessor uses):
+    // gated by `needsTargetLoadForBuild` so the SELECT runs only when Rails'
+    // `find_target?` would, and overridden by has_one_through to load the
+    // *through* proxy — Rails' through `replace` issues no target load.
+    let displaced = this.loaded ? this.target : null;
+    if (this.needsTargetLoadForBuild()) {
+      try {
+        displaced = (await this.loadTargetForBuild()) as Base | null;
+      } catch {
+        // Rails builds the record BEFORE `set_new_record` → `replace` →
+        // `load_target`, so a malformed association (e.g. an inexistent foreign
+        // key) raises out of `build_record`, never out of the load. We must load
+        // first — the load is what surfaces the row to remove, and it has to
+        // happen before the new record's FK is written — so swallow a failing
+        // load and let `super._createRecord`'s build raise the error Rails
+        // raises. Nothing was surfaced, so nothing is displaced.
+        displaced = null;
+      }
+    }
     const record = await super._createRecord(attributes, shouldRaise, block);
     // `super._createRecord` ran `setNewRecord` → `replace`, so `this.target` is
     // now the freshly created record; detach the displaced (previously attached)

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -345,32 +345,39 @@ export class HasOneAssociation extends SingularAssociation {
     // builds the new record first — an invalid build (e.g. an inexistent foreign
     // key) must raise before any removal runs, exactly as Rails' `build_record`
     // raises before `set_new_record`. An UNLOADED target is surfaced by
-    // `replace`'s leading `load_target`, ported here through
-    // `loadTargetForBuild` (the same seam the `build#{name}` accessor uses):
-    // gated by `needsTargetLoadForBuild` so the SELECT runs only when Rails'
-    // `find_target?` would, and overridden by has_one_through to load the
-    // *through* proxy — Rails' through `replace` issues no target load.
-    let displaced = this.loaded ? this.target : null;
-    if (this.needsTargetLoadForBuild()) {
-      try {
-        displaced = (await this.loadTargetForBuild()) as Base | null;
-      } catch {
-        // Rails builds the record BEFORE `set_new_record` → `replace` →
-        // `load_target`, so a malformed association (e.g. an inexistent foreign
-        // key) raises out of `build_record`, never out of the load. We must load
-        // first — the load is what surfaces the row to remove, and it has to
-        // happen before the new record's FK is written — so swallow a failing
-        // load and let `super._createRecord`'s build raise the error Rails
-        // raises. Nothing was surfaced, so nothing is displaced.
-        displaced = null;
-      }
-    }
+    // `replace`'s leading `load_target`, ported through
+    // `loadDisplacedTargetForCreate`.
+    const displaced = await this.loadDisplacedTargetForCreate();
     const record = await super._createRecord(attributes, shouldRaise, block);
     // `super._createRecord` ran `setNewRecord` → `replace`, so `this.target` is
     // now the freshly created record; detach the displaced (previously attached)
     // one, matching `remove_target!` inside Rails' `replace`.
     await this.detachDisplacedTarget(displaced, record);
     return record;
+  }
+
+  /**
+   * The record `create#{name}` displaces: Rails' `replace` opens with
+   * `load_target` (has_one_association.rb:59), so `remove_target!` detaches a row
+   * that only ever existed in the DB. Routed through `loadTargetForBuild` — gated
+   * by `needsTargetLoadForBuild` (Rails' `find_target?`) so the SELECT runs only
+   * when Rails' would, and overridden by has_one_through to load the *through*
+   * proxy, since Rails' through `replace` issues no target load.
+   *
+   * A load that raises yields no displaced record: Rails reaches `load_target`
+   * only from `set_new_record`, i.e. *after* `build_record`, so a malformed
+   * association (an inexistent foreign key) must surface the build error from
+   * `super._createRecord`, not an error from this earlier load.
+   *
+   * @internal
+   */
+  private async loadDisplacedTargetForCreate(): Promise<Base | null> {
+    if (!this.needsTargetLoadForBuild()) return this.loaded ? this.target : null;
+    try {
+      return (await this.loadTargetForBuild()) as Base | null;
+    } catch {
+      return null;
+    }
   }
 
   /**

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -347,8 +347,13 @@ export class HasOneAssociation extends SingularAssociation {
     // raises before `set_new_record`. An UNLOADED target is surfaced by
     // `replace`'s leading `load_target`, ported through
     // `loadDisplacedTargetForCreate`.
-    const displaced = await this.loadDisplacedTargetForCreate();
+    const [displaced, loadError] = await this.loadDisplacedTargetForCreate();
     const record = await super._createRecord(attributes, shouldRaise, block);
+    // The build succeeded, so Rails would have reached `load_target` — and every
+    // exception but `RecordNotFound` propagates out of it (association.rb:189-195).
+    // Re-raise here, at the point Rails raises: after `build_record` and
+    // `record.save`, before `remove_target!` detaches anything.
+    if (loadError) throw loadError;
     // `super._createRecord` ran `setNewRecord` → `replace`, so `this.target` is
     // now the freshly created record; detach the displaced (previously attached)
     // one, matching `remove_target!` inside Rails' `replace`.
@@ -364,19 +369,26 @@ export class HasOneAssociation extends SingularAssociation {
    * when Rails' would, and overridden by has_one_through to load the *through*
    * proxy, since Rails' through `replace` issues no target load.
    *
-   * A load that raises yields no displaced record: Rails reaches `load_target`
-   * only from `set_new_record`, i.e. *after* `build_record`, so a malformed
-   * association (an inexistent foreign key) must surface the build error from
-   * `super._createRecord`, not an error from this earlier load.
+   * Returns the displaced record and, separately, any error the load raised —
+   * the caller re-raises it only once `super._createRecord` has succeeded. The
+   * load must run FIRST (it is what surfaces the row to detach, and it has to
+   * precede the new record's FK write), but Rails reaches `load_target` only
+   * from `set_new_record`, i.e. *after* `build_record`. So a malformed
+   * association (an inexistent foreign key) surfaces the build error, while a
+   * genuine load failure unrelated to the build — a dropped connection, an
+   * unrelated SQL error — still propagates out of `create#{name}` exactly as it
+   * does in Rails, rather than being swallowed into `displaced = null`.
+   * `load_target` itself rescues only `RecordNotFound` (association.rb:189-195),
+   * which `loadTargetForBuild` already handles by returning null.
    *
    * @internal
    */
-  private async loadDisplacedTargetForCreate(): Promise<Base | null> {
-    if (!this.needsTargetLoadForBuild()) return this.loaded ? this.target : null;
+  private async loadDisplacedTargetForCreate(): Promise<[Base | null, unknown]> {
+    if (!this.needsTargetLoadForBuild()) return [this.loaded ? this.target : null, null];
     try {
-      return (await this.loadTargetForBuild()) as Base | null;
-    } catch {
-      return null;
+      return [(await this.loadTargetForBuild()) as Base | null, null];
+    } catch (error) {
+      return [null, error];
     }
   }
 

--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -566,6 +566,29 @@ describe("HasOneAssociationsTest", () => {
     expect((await readHasOne(firm, "account")).id).toBe(created.id);
   });
 
+  // Trails deviation guard (no Rails counterpart, RFC 0068 story
+  // has-one-create-record-unloaded-target-not-removed): Rails' `replace` opens
+  // with `load_target` (has_one_association.rb:59), so `remove_target!` detaches
+  // a row that was only ever in the DB. `_createRecord` ports that leading load,
+  // so the never-loaded prior account is nullified / destroyed too.
+  it("create over an unloaded target nullifies the prior account", async () => {
+    const company = (await Company.create({ name: "UnloadedCo" })) as any;
+    const original = await Account.create({ firm_id: Number(company.id), credit_limit: 50 });
+    const found = (await Company.find(company.id)) as any;
+    const created = await found.createAccount({ credit_limit: 70 });
+    expect((await Account.find(original.id)).firm_id).toBeNull();
+    expect(await Account.where({ firm_id: Number(company.id) }).count()).toBe(1);
+    expect((await readHasOne(found, "account")).id).toBe(created.id);
+  });
+
+  it("create over an unloaded target destroys the prior dependent account", async () => {
+    const firm = (await Firm.find(Number((companies("first_firm") as any).id))) as any;
+    const originalId = Number((await Account.where({ firm_id: Number(firm.id) }).first())!.id);
+    const created = await firm.createAccount({ credit_limit: 70 });
+    await expect(Account.find(originalId)).rejects.toThrow(RecordNotFound);
+    expect((await readHasOne(firm, "account")).id).toBe(created.id);
+  });
+
   // Same root cause on the build path: `set_new_record` → `replace(record, false)`
   // still runs `remove_target!` on the loaded target (has_one_association.rb:69),
   // whose else-branch nullifies+saves the old row even though the new record is

--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -569,8 +569,7 @@ describe("HasOneAssociationsTest", () => {
   // Trails deviation guard (no Rails counterpart, RFC 0068 story
   // has-one-create-record-unloaded-target-not-removed): Rails' `replace` opens
   // with `load_target` (has_one_association.rb:59), so `remove_target!` detaches
-  // a row that was only ever in the DB. `_createRecord` ports that leading load,
-  // so the never-loaded prior account is nullified / destroyed too.
+  // a row that was only ever in the DB — never loaded through the association.
   it("create over an unloaded target nullifies the prior account", async () => {
     const company = (await Company.create({ name: "UnloadedCo" })) as any;
     const original = await Account.create({ firm_id: Number(company.id), credit_limit: 50 });


### PR DESCRIPTION
## Summary

`HasOneAssociation#_createRecord` captured the displaced target as
`this.loaded ? this.target : null`, so a persisted child that had never been
loaded was never detached — it kept its foreign key and stayed attached. Rails'
`HasOneAssociation#replace` opens with `load_target`
(has_one_association.rb:59), so `remove_target!` detaches whatever the load
surfaces, including a DB-only row. RFC 0068 retired the deferral flag that used
to (badly) cover this case without porting the real load.

This ports that leading `load_target` in a new private
`loadDisplacedTargetForCreate`, routed through the seam the `build#{name}`
accessor already uses: `needsTargetLoadForBuild()` (Rails' `find_target?` gate)
plus `loadTargetForBuild()`, which has_one_through overrides to load the
*through* proxy — Rails' through `replace` issues no target load, so the through
path issues no new query.

The pre-load has to run before `super._createRecord` (it is what surfaces the
row to detach, and it must precede the new record's FK write), but Rails reaches
`load_target` only from `set_new_record`, i.e. *after* `build_record`. So the
load's error is captured, not discarded: if the build fails, the build error
wins (pinned by the existing `create with inexistent foreign key failing` test);
if the build succeeds, the load error is re-raised at exactly the point Rails
raises it — after `record.save`, before `remove_target!`. A transient load
failure unrelated to the build therefore still propagates out of `create#{name}`
as it does in Rails, instead of silently yielding `displaced = null`.
`load_target` itself rescues only `RecordNotFound` (association.rb:189-195),
which `loadTargetForBuild` already handles by returning null.

## Tests

Two regression tests, both verified failing on baseline:
- `create over an unloaded target nullifies the prior account`
- `create over an unloaded target destroys the prior dependent account`

has_one / has_one_through / nested-attributes / autosave suites green (513
passed). `test:compare` delta non-negative.

## Follow-up registered

While probing the through path I found `create#{name}` on a has_one_through with
an **unloaded existing join row** leaves the join row's `club_id` on the old
target (the `build` + `save` counterpart reconciles correctly). Out of scope
here; filed as story
`0068-awaitable-has-one-setter/has-one-through-create-unloaded-join-row-not-reconciled`.

Closes-story: has-one-create-record-unloaded-target-not-removed
