### PR TITLE
refactor(relation): route subfile model reads through the model accessor

### DIFF
--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -67,6 +67,8 @@ interface CalculationConnection {
 }
 
 interface CalculationRelation {
+  /** Relation#model (relation.rb:85) — the accessor Rails reads everywhere. */
+  model: CalculationRelation["_modelClass"];
   _modelClass: {
     arelTable: any;
     primaryKey: string | string[];
@@ -462,7 +464,7 @@ async function singleAggregate(
   const sql =
     isBigintColumn(rel, fn, column) && needsBigintCast(rel) ? wrapBigintAgg(withCtes) : withCtes;
   const opName = fn.charAt(0).toUpperCase() + fn.slice(1);
-  const result = await rel._conn().selectAll(sql, `${rel._modelClass.name} ${opName}`, ctedBinds);
+  const result = await rel._conn().selectAll(sql, `${rel.model.name} ${opName}`, ctedBinds);
   const rows = result.toArray();
   const val = rows[0]?.val;
   if (val === undefined || val === null) {
@@ -570,9 +572,7 @@ async function groupedAggregate(
       ? wrapBigintAgg(withCtes, aliases, aggAlias)
       : withCtes;
   const opName = fn.charAt(0).toUpperCase() + fn.slice(1);
-  const queryResult = await rel
-    ._conn()
-    .selectAll(sql, `${rel._modelClass.name} ${opName}`, ctedBinds);
+  const queryResult = await rel._conn().selectAll(sql, `${rel.model.name} ${opName}`, ctedBinds);
   const rows = queryResult.toArray();
 
   const aggOf = (val: unknown): unknown =>
@@ -651,7 +651,7 @@ function qualifiedGroupFieldForModel(rel: CalculationRelation, field: unknown): 
  */
 function resolveGroupAssociation(rel: CalculationRelation, groupCol: unknown): any {
   if (typeof groupCol !== "string") return null;
-  const reflection = (rel._modelClass as any)._reflectOnAssociation?.(groupCol);
+  const reflection = (rel.model as any)._reflectOnAssociation?.(groupCol);
   if (!reflection || !reflection.belongsTo?.()) return null;
   // Rails (calculations.rb:521) does `group_fields = Array(association.foreign_key)`
   // and builds a multi-column GROUP BY for a composite-key belongs_to, keyed by
@@ -717,9 +717,7 @@ async function groupedCompositeAssoc(
       ? wrapBigintAgg(withCtes, aliases, aggAlias)
       : withCtes;
   const opName = fn.charAt(0).toUpperCase() + fn.slice(1);
-  const queryResult = await rel
-    ._conn()
-    .selectAll(sql, `${rel._modelClass.name} ${opName}`, ctedBinds);
+  const queryResult = await rel._conn().selectAll(sql, `${rel.model.name} ${opName}`, ctedBinds);
   const rows = queryResult.toArray();
 
   const aggOf = (val: unknown): unknown =>
@@ -876,7 +874,7 @@ export async function performCount(
           const [idWithCtes, idCtedBinds] = prependCtes(this, idSql, [...idBinds]);
           const idResult = await this._conn().selectAll(
             idWithCtes,
-            `${this._modelClass.name} Ids`,
+            `${this.model.name} Ids`,
             idCtedBinds,
           );
           const limitedIds = idResult.toArray().map((row) => row[pk]);
@@ -901,7 +899,7 @@ export async function performCount(
           const [withCtes, ctedBinds] = prependCtes(this, countSql, [...countBinds]);
           const limitedResult = await this._conn().selectAll(
             withCtes,
-            `${this._modelClass.name} Count`,
+            `${this.model.name} Count`,
             ctedBinds,
           );
           const limitedRows = limitedResult.toArray();
@@ -921,7 +919,7 @@ export async function performCount(
         const [withCtes, ctedBinds] = prependCtes(this, rawSql, managerBinds);
         const result = await this._conn().selectAll(
           withCtes,
-          `${this._modelClass.name} Count`,
+          `${this.model.name} Count`,
           ctedBinds,
         );
         const rows = result.toArray();
@@ -979,7 +977,7 @@ export async function performCount(
             const [idWithCtes, idCtedBinds] = prependCtes(this, idSql, [...idBinds]);
             const idResult = await this._conn().selectAll(
               idWithCtes,
-              `${this._modelClass.name} Ids`,
+              `${this.model.name} Ids`,
               idCtedBinds,
             );
             const tuples = idResult.toArray().map((row) => pk.map((c) => row[c]));
@@ -1003,7 +1001,7 @@ export async function performCount(
             const [withCtes, ctedBinds] = prependCtes(this, countSql, [...countBinds]);
             const result = await this._conn().selectAll(
               withCtes,
-              `${this._modelClass.name} Count`,
+              `${this.model.name} Count`,
               ctedBinds,
             );
             return Number(result.toArray()[0]?.count ?? 0);
@@ -1019,7 +1017,7 @@ export async function performCount(
           const [withCtes, ctedBinds] = prependCtes(this, rawSql, managerBinds);
           const result = await this._conn().selectAll(
             withCtes,
-            `${this._modelClass.name} Count`,
+            `${this.model.name} Count`,
             ctedBinds,
           );
           return Number(result.toArray()[0]?.count ?? 0);
@@ -1043,7 +1041,7 @@ export async function performCount(
         ]);
         const result = await this._conn().selectAll(
           withCtes,
-          `${this._modelClass.name} Count`,
+          `${this.model.name} Count`,
           ctedBinds,
         );
         return Number(result.toArray()[0]?.count ?? 0);
@@ -1149,11 +1147,7 @@ export async function performCount(
     if (this._optimizerHints.length > 0) outerManager.optimizerHints(...this._optimizerHints);
     const [outerSql, outerBinds] = compileManagerWithBinds(this, outerManager);
     const [withCtes, ctedBinds] = prependCtes(this, outerSql, [...allInnerBinds, ...outerBinds]);
-    const result = await this._conn().selectAll(
-      withCtes,
-      `${this._modelClass.name} Count`,
-      ctedBinds,
-    );
+    const result = await this._conn().selectAll(withCtes, `${this.model.name} Count`, ctedBinds);
     const rows = result.toArray();
     return Number(rows[0]?.count ?? 0);
   }
@@ -1184,11 +1178,7 @@ export async function performCount(
     applyHavingToManager(this, manager);
     const [rawSql, managerBinds] = compileManagerWithBinds(this, manager);
     const [withCtes, ctedBinds] = prependCtes(this, rawSql, managerBinds);
-    const result = await this._conn().selectAll(
-      withCtes,
-      `${this._modelClass.name} Count`,
-      ctedBinds,
-    );
+    const result = await this._conn().selectAll(withCtes, `${this.model.name} Count`, ctedBinds);
     const rows = result.toArray();
     return Number(rows[0]?.count ?? 0);
   }
@@ -1210,11 +1200,7 @@ export async function performCount(
       outerManager.from(new Nodes.SqlLiteral(`(${innerSqlWithFrom}) AS subquery`));
       const [outerSql, outerBinds] = compileManagerWithBinds(this, outerManager);
       const [withCtes, ctedBinds] = prependCtes(this, outerSql, [...allInnerBinds, ...outerBinds]);
-      const result = await this._conn().selectAll(
-        withCtes,
-        `${this._modelClass.name} Count`,
-        ctedBinds,
-      );
+      const result = await this._conn().selectAll(withCtes, `${this.model.name} Count`, ctedBinds);
       const rows = result.toArray();
       return Number(rows[0]?.count ?? 0);
     }
@@ -1226,11 +1212,7 @@ export async function performCount(
     applyHavingToManager(this, manager);
     const [rawSql, managerBinds] = compileManagerWithBinds(this, manager);
     const [withCtes, ctedBinds] = prependCtes(this, rawSql, managerBinds);
-    const result = await this._conn().selectAll(
-      withCtes,
-      `${this._modelClass.name} Count`,
-      ctedBinds,
-    );
+    const result = await this._conn().selectAll(withCtes, `${this.model.name} Count`, ctedBinds);
     const rows = result.toArray();
     return Number(rows[0]?.count ?? 0);
   }
@@ -1243,11 +1225,7 @@ export async function performCount(
   applyHavingToManager(this, manager);
   const [rawSql, managerBinds] = compileManagerWithBinds(this, manager);
   const [withCtes, ctedBinds] = prependCtes(this, rawSql, managerBinds);
-  const result = await this._conn().selectAll(
-    withCtes,
-    `${this._modelClass.name} Count`,
-    ctedBinds,
-  );
+  const result = await this._conn().selectAll(withCtes, `${this.model.name} Count`, ctedBinds);
   const rows = result.toArray();
   return Number(rows[0]?.count ?? 0);
 }
@@ -1429,7 +1407,7 @@ export function aggregateColumn(
 
 /** @internal */
 export function isAllAttributes(rel: CalculationRelation, columnNames: string[]): boolean {
-  const model = rel._modelClass as any;
+  const model = rel.model as any;
   const known = new Set<string>([
     ...(typeof model.attributeNames === "function" ? (model.attributeNames() as string[]) : []),
     ...Object.keys(model._attributeAliases ?? {}),
@@ -1591,7 +1569,7 @@ function pluckCastType(
  * Returns null when the model has no such attribute.
  */
 function pluckCastTypeForKnownColumn(rel: CalculationRelation, name: string): ColumnType | null {
-  const model = rel._modelClass;
+  const model = rel.model;
   if (!model._attributeDefinitions?.has(name)) return null;
   const coder = model._serializedAttributes?.get(name);
   if (coder) return { deserialize: (value) => coder.load(value) };

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -67,7 +67,6 @@ interface CalculationConnection {
 }
 
 interface CalculationRelation {
-  /** Relation#model (relation.rb:85) — the accessor Rails reads everywhere. */
   model: CalculationRelation["_modelClass"];
   _modelClass: {
     arelTable: any;

--- a/packages/activerecord/src/relation/finder-methods.test.ts
+++ b/packages/activerecord/src/relation/finder-methods.test.ts
@@ -334,6 +334,9 @@ function makeFindSomeRel(
   opts: { limit?: number; offset?: number; ordered?: boolean } = {},
 ): any {
   return {
+    get model(): any {
+      return this._modelClass;
+    },
     _modelClass: {
       primaryKey: "id",
       name: "Post",
@@ -392,6 +395,9 @@ describe("findSome — narrows to pk column when select_values non-empty (ordere
   it("calls .select(pk) when the relation has select values", async () => {
     let selectedCol: string | undefined;
     const rel: any = {
+      get model(): any {
+        return this._modelClass;
+      },
       _modelClass: {
         primaryKey: "id",
         name: "Post",
@@ -442,6 +448,9 @@ function makeFindSomeOrderedRel(
   opts: { limit?: number; offset?: number } = {},
 ): any {
   return {
+    get model(): any {
+      return this._modelClass;
+    },
     _modelClass: {
       primaryKey: "id",
       name: "Post",
@@ -582,7 +591,7 @@ function makeRelForOrder(mc: {
   implicitOrderColumn?: string | null;
   _queryConstraintsList?: string[] | null;
 }): any {
-  return { _modelClass: mc };
+  return { _modelClass: mc, model: mc };
 }
 
 describe("_orderColumns — Rails _order_columns precedence", () => {
@@ -625,6 +634,9 @@ describe("_orderColumns — Rails _order_columns precedence", () => {
 describe("finder not-found message fidelity", () => {
   it("test_find_one_message_on_primary_key", async () => {
     const rel: any = {
+      get model(): any {
+        return this._modelClass;
+      },
       _modelClass: { name: "Car", primaryKey: "id" },
       raiseRecordNotFoundExceptionBang,
       _whereClause: { isEmpty: () => true },
@@ -645,6 +657,9 @@ describe("finder not-found message fidelity", () => {
 
   it("test_find_some_message_with_custom_primary_key", async () => {
     const rel: any = {
+      get model(): any {
+        return this._modelClass;
+      },
       _modelClass: {
         name: "MercedesCar",
         primaryKey: "name",

--- a/packages/activerecord/src/relation/finder-methods.test.ts
+++ b/packages/activerecord/src/relation/finder-methods.test.ts
@@ -329,20 +329,29 @@ describe("raiseNotFoundSingle", () => {
 // findSome — expected_size accounting (Gap 1)
 // ---------------------------------------------------------------------------
 
+const postModelStub = {
+  primaryKey: "id",
+  name: "Post",
+  typeForAttribute: (_col: string) => ({ cast: (v: unknown) => v }),
+  arelTable: { get: (col: string) => col },
+};
+
+const carModelStub = { name: "Car", primaryKey: "id" };
+
+const mercedesModelStub = {
+  name: "MercedesCar",
+  primaryKey: "name",
+  typeForAttribute: (_col: string) => ({ cast: (v: unknown) => v }),
+  arelTable: { get: (col: string) => col },
+};
+
 function makeFindSomeRel(
   records: any[],
   opts: { limit?: number; offset?: number; ordered?: boolean } = {},
 ): any {
   return {
-    get model(): any {
-      return this._modelClass;
-    },
-    _modelClass: {
-      primaryKey: "id",
-      name: "Post",
-      typeForAttribute: (_col: string) => ({ cast: (v: unknown) => v }),
-      arelTable: { get: (col: string) => col },
-    },
+    _modelClass: postModelStub,
+    model: postModelStub,
     _limitValue: opts.limit ?? null,
     _offsetValue: opts.offset ?? null,
     // ordered=true simulates a relation with ORDER BY (findSome stays in the accounting path)
@@ -395,15 +404,8 @@ describe("findSome — narrows to pk column when select_values non-empty (ordere
   it("calls .select(pk) when the relation has select values", async () => {
     let selectedCol: string | undefined;
     const rel: any = {
-      get model(): any {
-        return this._modelClass;
-      },
-      _modelClass: {
-        primaryKey: "id",
-        name: "Post",
-        typeForAttribute: (_col: string) => ({ cast: (v: unknown) => v }),
-        arelTable: { get: (col: string) => col },
-      },
+      _modelClass: postModelStub,
+      model: postModelStub,
       _limitValue: null,
       _offsetValue: null,
       _orderClauses: ["id ASC"],
@@ -448,15 +450,8 @@ function makeFindSomeOrderedRel(
   opts: { limit?: number; offset?: number } = {},
 ): any {
   return {
-    get model(): any {
-      return this._modelClass;
-    },
-    _modelClass: {
-      primaryKey: "id",
-      name: "Post",
-      typeForAttribute: (_col: string) => ({ cast: (v: unknown) => v }),
-      arelTable: { get: (col: string) => col },
-    },
+    _modelClass: postModelStub,
+    model: postModelStub,
     _limitValue: opts.limit ?? null,
     _offsetValue: opts.offset ?? null,
     _orderClauses: [],
@@ -634,10 +629,8 @@ describe("_orderColumns — Rails _order_columns precedence", () => {
 describe("finder not-found message fidelity", () => {
   it("test_find_one_message_on_primary_key", async () => {
     const rel: any = {
-      get model(): any {
-        return this._modelClass;
-      },
-      _modelClass: { name: "Car", primaryKey: "id" },
+      _modelClass: carModelStub,
+      model: carModelStub,
       raiseRecordNotFoundExceptionBang,
       _whereClause: { isEmpty: () => true },
       findBy: async () => null,
@@ -657,15 +650,8 @@ describe("finder not-found message fidelity", () => {
 
   it("test_find_some_message_with_custom_primary_key", async () => {
     const rel: any = {
-      get model(): any {
-        return this._modelClass;
-      },
-      _modelClass: {
-        name: "MercedesCar",
-        primaryKey: "name",
-        typeForAttribute: (_col: string) => ({ cast: (v: unknown) => v }),
-        arelTable: { get: (col: string) => col },
-      },
+      _modelClass: mercedesModelStub,
+      model: mercedesModelStub,
       _limitValue: null,
       _offsetValue: null,
       selectValues: [],

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -263,6 +263,8 @@ export function raiseNotFoundSingle(
 }
 
 interface FinderRelation {
+  /** Relation#model (relation.rb:85) — the accessor Rails reads everywhere. */
+  model: FinderRelation["_modelClass"];
   _modelClass: {
     name: string;
     primaryKey: string | string[];
@@ -720,10 +722,10 @@ export function raiseRecordNotFoundExceptionBang(
   // wheres, which Ruby interpolates as "" — hence the `?? ""`.
   const conditions = this._whereClause.isEmpty()
     ? ""
-    : ` [${this.arel().whereSql(this._modelClass)?.value ?? ""}]`;
+    : ` [${this.arel().whereSql(this.model)?.value ?? ""}]`;
 
-  const name = this._modelClass.name;
-  const k = key ?? String(this._modelClass.primaryKey);
+  const name = this.model.name;
+  const k = key ?? String(this.model.primaryKey);
 
   if (ids === undefined || ids === null) {
     // Rails: `error << " with#{conditions}" if conditions`.
@@ -852,11 +854,7 @@ export function constructRelationForExists(rel: FinderRelation, conditions: unkn
 
 /** @internal */
 export async function findWithIds(rel: FinderRelation, ids: unknown[]): Promise<any> {
-  const normalized = normalizeFindArgs(
-    (rel as any)._modelClass.name,
-    (rel as any)._modelClass.primaryKey,
-    ids,
-  );
+  const normalized = normalizeFindArgs(rel.model.name, rel.model.primaryKey, ids);
   if (normalized.emptyArray) return [];
   if (normalized.wantArray) {
     return findSome(rel, normalized.ids);
@@ -866,8 +864,8 @@ export async function findWithIds(rel: FinderRelation, ids: unknown[]): Promise<
 
 /** @internal */
 export async function findOne(rel: FinderRelation, id: unknown): Promise<any> {
-  const pk = (rel as any)._modelClass.primaryKey;
-  const conditions = Array.isArray(pk) ? buildPkWhere(pk, id as unknown[]) : { [pk as string]: id };
+  const pk = rel.model.primaryKey;
+  const conditions = Array.isArray(pk) ? buildPkWhere(pk, id as unknown[]) : { [pk]: id };
   const record = await (rel as any).findBy(conditions);
   if (!record) {
     // Rails find_one: raise_record_not_found_exception!(id, 0, 1)
@@ -906,7 +904,7 @@ export async function findSome(rel: FinderRelation, ids: unknown[]): Promise<any
 
 /** @internal */
 export async function findSomeOrdered(rel: FinderRelation, ids: unknown[]): Promise<any[]> {
-  const pk = (rel as any)._modelClass.primaryKey as string;
+  const pk = rel.model.primaryKey as string;
   const offsetValue: number = (rel as any)._offsetValue ?? 0;
   const limitValue: number | null = (rel as any)._limitValue ?? null;
   ids = ids.slice(offsetValue, offsetValue + (limitValue ?? ids.length));
@@ -915,11 +913,11 @@ export async function findSomeOrdered(rel: FinderRelation, ids: unknown[]): Prom
   relation._limitValue = null;
   relation._offsetValue = null;
   if ((rel as any).selectValues.length > 0) {
-    relation = relation.select((rel as any)._modelClass.arelTable.get(pk));
+    relation = relation.select((rel.model as any).arelTable.get(pk));
   }
   const records: any[] = await relation.toArray();
 
-  const pkType = (rel as any)._modelClass.typeForAttribute(pk);
+  const pkType = (rel.model as any).typeForAttribute(pk);
   const castKey = (v: unknown) => String(pkType.cast(v));
 
   if (records.length !== ids.length) {
@@ -959,7 +957,7 @@ export async function findLast(rel: FinderRelation, limit?: number): Promise<any
 
 /** @internal */
 export function orderedRelation(rel: FinderRelation): any {
-  const mc = (rel as any)._modelClass;
+  const mc = rel.model as any;
   const pk = mc?.primaryKey;
   const implicitOrder: string | null | undefined = mc?.implicitOrderColumn;
   const constraintsList: string[] | null = mc ? _queryConstraintsListFn.call(mc) : null;
@@ -979,7 +977,7 @@ export function orderedRelation(rel: FinderRelation): any {
 
 /** @internal */
 export function _orderColumns(rel: FinderRelation): string[] {
-  const mc = (rel as any)._modelClass;
+  const mc = rel.model as any;
   const pk = mc?.primaryKey;
   const implicitOrder: string | null | undefined = mc?.implicitOrderColumn;
   const constraintsList: string[] | null = mc ? _queryConstraintsListFn.call(mc) : null;

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -263,7 +263,6 @@ export function raiseNotFoundSingle(
 }
 
 interface FinderRelation {
-  /** Relation#model (relation.rb:85) — the accessor Rails reads everywhere. */
   model: FinderRelation["_modelClass"];
   _modelClass: {
     name: string;

--- a/packages/activerecord/src/relation/merge-joins.ts
+++ b/packages/activerecord/src/relation/merge-joins.ts
@@ -14,7 +14,7 @@ import { constructJoinDependency, structuralUnionEq } from "./query-methods.js";
 // Relation. Kept local (rather than `any`) so the shared module stays off the
 // no-explicit-any burndown allowlist (RFC 0037).
 interface JoinFoldRelation {
-  _modelClass: unknown;
+  model: unknown;
   _joinClauses: unknown[];
   _joinValues: unknown[];
   _joinsValues: unknown[];
@@ -66,7 +66,7 @@ export function foldMergeJoins(target: JoinFoldRelation, source: JoinFoldRelatio
   const clauses = source._joinClauses ?? [];
   if (clauses.length > 0) target._joinClauses.push(...clauses);
 
-  const sameKlass = source._modelClass === target._modelClass;
+  const sameKlass = source.model === target.model;
   const crossKlassNamed: unknown[] = [];
   for (const v of source.joinsValues ?? []) {
     if (!source._isNamedJoinValue(v)) {
@@ -102,7 +102,7 @@ export function foldMergeOuterJoins(target: JoinFoldRelation, source: JoinFoldRe
   // Read via the public leftOuterJoinsValues accessor (PR #4675 convergence),
   // symmetric with foldMergeJoins reading source.joinsValues.
   const otherLeft = source.leftOuterJoinsValues ?? [];
-  const sameKlass = source._modelClass === target._modelClass;
+  const sameKlass = source.model === target.model;
   if (sameKlass) {
     for (const v of otherLeft) {
       if (!target._leftOuterJoinsValues.some((seen) => structuralUnionEq(seen, v)))

--- a/packages/activerecord/src/relation/merge-preloads.ts
+++ b/packages/activerecord/src/relation/merge-preloads.ts
@@ -9,7 +9,7 @@ import { structuralUnionEq } from "./query-methods.js";
 // Kept local (rather than `any`) so the shared module stays off the
 // no-explicit-any burndown allowlist (RFC 0037).
 interface PreloadFoldRelation {
-  _modelClass: {
+  model: {
     name?: string;
     reflectOnAllAssociations(): Array<{ name: string; className: string }>;
   };
@@ -53,16 +53,14 @@ export function foldMergePreloads(target: PreloadFoldRelation, source: PreloadFo
   const otherIncludes = source._includesAssociations ?? [];
   if (otherPreloads.length === 0 && otherIncludes.length === 0) return;
 
-  if (source._modelClass === target._modelClass) {
+  if (source.model === target.model) {
     unionAppend(target._preloadAssociations, otherPreloads);
     unionAppend(target._includesAssociations, otherIncludes);
     return;
   }
 
-  const otherName = source._modelClass?.name;
-  const reflection = target._modelClass
-    .reflectOnAllAssociations()
-    .find((r) => r.className === otherName);
+  const otherName = source.model?.name;
+  const reflection = target.model.reflectOnAllAssociations().find((r) => r.className === otherName);
   if (!reflection) return;
 
   if (otherPreloads.length > 0) {

--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -76,9 +76,7 @@ export class Merger {
     const otherSelect = this.other._selectColumns;
     if (otherSelect == null || otherSelect.length === 0) return;
     const columns =
-      this.other._modelClass === rel._modelClass
-        ? otherSelect
-        : arelColumns.call(this.other, otherSelect);
+      this.other.model === rel.model ? otherSelect : arelColumns.call(this.other, otherSelect);
     rel._selectBang(...columns);
   }
 
@@ -195,7 +193,7 @@ export class Merger {
       (!relationFrom || relationFrom.isEmpty()) &&
       !!otherFrom &&
       !otherFrom.isEmpty() &&
-      this.relation._modelClass?.baseClass === this.other._modelClass?.baseClass
+      this.relation.model?.baseClass === this.other.model?.baseClass
     );
   }
 }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -236,6 +236,8 @@ interface QueryMethodsHost {
   _skipPreloading: boolean;
   _skipQueryCache: boolean | undefined;
   _modelClass: typeof import("../base.js").Base;
+  /** Relation#model (relation.rb:85) — the accessor Rails reads everywhere. */
+  model: typeof import("../base.js").Base;
   predicateBuilder: import("./predicate-builder.js").PredicateBuilder;
 }
 
@@ -1034,7 +1036,7 @@ export function buildWhereClause(
     } else if (opts.includes("?")) {
       parts = [buildBoundSqlLiteral.call(this, opts, rest)];
     } else {
-      parts = [new Nodes.SqlLiteral(this._modelClass.sanitizeSqlArray(opts, ...rest))];
+      parts = [new Nodes.SqlLiteral(this.model.sanitizeSqlArray(opts, ...rest))];
     }
     return new WhereClause(parts);
   }
@@ -1044,7 +1046,7 @@ export function buildWhereClause(
     // auto-adds references for its nested-hash / dotted-key tables, so an
     // includes(...) with a WHERE on the joined table promotes to eager JOIN.
     referencesBang.call(this, ...referencesFromConditions(opts));
-    const mc = (this as any)._modelClass;
+    const mc = (this as any).model;
     const aliases: Record<string, string> = mc?._attributeAliases ?? {};
     // Rails never pre-casts hash values here — build_where_clause hands them
     // raw to PredicateBuilder, whose QueryAttribute bind casts/serializes at
@@ -1737,10 +1739,10 @@ export function constructJoinDependency(
   // The join type (InnerJoin for joins(), OuterJoin for eager_load/left_outer_joins)
   // is threaded into the JoinDependency so joinConstraints emits the requested join.
   const jd = new JoinDependency(
-    this._modelClass,
+    this.model,
     joinType as typeof Nodes.InnerJoin | typeof Nodes.OuterJoin | undefined,
   );
-  const modelName = (this._modelClass as any).name ?? "model";
+  const modelName = (this.model as any).name ?? "model";
   const specs = Array.isArray(associations) ? associations : [associations];
   const tree = makeAssocTree();
   for (const spec of specs) walkAssociationTree(spec, tree);
@@ -2087,7 +2089,7 @@ export function columnReferences(orderArgs: unknown[]): string[] {
 
 /** @internal */
 export function sanitizeOrderArguments(this: QueryMethodsHost, orderArgs: unknown[]): unknown[] {
-  return orderArgs.map((arg) => (this as any)._modelClass?.sanitizeSqlForOrder?.(arg) ?? arg);
+  return orderArgs.map((arg) => (this as any).model?.sanitizeSqlForOrder?.(arg) ?? arg);
 }
 
 function flattenedOrderKeysForRawSqlCheck(orderArgs: unknown[]): (string | symbol)[] {
@@ -2317,7 +2319,7 @@ function safeQuoteColumnName(modelClass: any, name: string): string {
 export function isTableNameMatches(this: QueryMethodsHost, from: unknown): boolean {
   const table: any = (this as any)._modelClass?.arelTable;
   if (!table) return false;
-  const modelClass: any = (this as any)._modelClass;
+  const modelClass: any = (this as any).model;
   const name = escapeRegex(table.name);
   const quotedTableName = safeQuoteTableName(modelClass, table.name);
   const quoted = escapeRegex(quotedTableName);
@@ -2332,7 +2334,7 @@ export function arelColumn(
   field: string | symbol | Nodes.Node,
   fallback?: (attr: string) => unknown,
 ): unknown {
-  const modelClass: any = (this as any)._modelClass;
+  const modelClass: any = (this as any).model;
   const table: any = modelClass?.arelTable;
   // Rails: a raw Arel node has no columns_hash/table.column form; it falls to
   // the block, else passes through unchanged (query_methods.rb:1996-2003).
@@ -2377,7 +2379,7 @@ export function arelColumnWithTable(
   const existing = (this as any)._referencesValues ?? [];
   if (!existing.includes(tableName)) (this as any)._referencesValues = [...existing, tableName];
   const colStr = typeof columnName === "symbol" ? symbolToName(columnName) : columnName;
-  const modelClass: any = (this as any)._modelClass;
+  const modelClass: any = (this as any).model;
   // Schema-qualified table names (e.g. "schema.table") must not be passed to
   // ArelTable — the visitor quotes the whole string as one identifier, producing
   // "schema.table"."col" instead of "schema"."table"."col".
@@ -2421,7 +2423,7 @@ export function arelColumnsFromHash(
 
 /** @internal */
 export function orderColumn(this: QueryMethodsHost, field: string): unknown {
-  const modelClass: any = (this as any)._modelClass;
+  const modelClass: any = (this as any).model;
   const table: any = modelClass?.arelTable;
   return arelColumn.call(this, field, (attrName: string) => {
     if (attrName === "count" && ((this as any)._groupColumns ?? []).length > 0) {
@@ -2458,7 +2460,7 @@ export function arelColumnAliasesFromHash(
   return Reflect.ownKeys(fields).flatMap((key) => {
     const columnsAliases = fields[key as any];
     const tableName = typeof key === "symbol" ? symbolToName(key) : key;
-    const modelClass: any = (this as any)._modelClass;
+    const modelClass: any = (this as any).model;
     const quoteAlias = (a: unknown): string =>
       safeQuoteColumnName(modelClass, typeof a === "symbol" ? symbolToName(a) : String(a));
     if (isPlainObject(columnsAliases)) {
@@ -3180,7 +3182,7 @@ export function buildWithJoinNode(
   name: string,
   kind: typeof Nodes.InnerJoin | typeof Nodes.OuterJoin = Nodes.InnerJoin,
 ): unknown {
-  const mc = (this as any)._modelClass;
+  const mc = (this as any).model;
   const table: any = mc?.arelTable;
   if (!table) throw new ActiveRecordError("Cannot build CTE join node: model has no arelTable");
   const withTable = new ArelTable(name);

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -236,8 +236,7 @@ interface QueryMethodsHost {
   _skipPreloading: boolean;
   _skipQueryCache: boolean | undefined;
   _modelClass: typeof import("../base.js").Base;
-  /** Relation#model (relation.rb:85) — the accessor Rails reads everywhere. */
-  model: typeof import("../base.js").Base;
+  model: QueryMethodsHost["_modelClass"];
   predicateBuilder: import("./predicate-builder.js").PredicateBuilder;
 }
 
@@ -1046,7 +1045,7 @@ export function buildWhereClause(
     // auto-adds references for its nested-hash / dotted-key tables, so an
     // includes(...) with a WHERE on the joined table promotes to eager JOIN.
     referencesBang.call(this, ...referencesFromConditions(opts));
-    const mc = (this as any).model;
+    const mc = this.model;
     const aliases: Record<string, string> = mc?._attributeAliases ?? {};
     // Rails never pre-casts hash values here — build_where_clause hands them
     // raw to PredicateBuilder, whose QueryAttribute bind casts/serializes at
@@ -2089,7 +2088,7 @@ export function columnReferences(orderArgs: unknown[]): string[] {
 
 /** @internal */
 export function sanitizeOrderArguments(this: QueryMethodsHost, orderArgs: unknown[]): unknown[] {
-  return orderArgs.map((arg) => (this as any).model?.sanitizeSqlForOrder?.(arg) ?? arg);
+  return orderArgs.map((arg) => (this.model as any)?.sanitizeSqlForOrder?.(arg) ?? arg);
 }
 
 function flattenedOrderKeysForRawSqlCheck(orderArgs: unknown[]): (string | symbol)[] {
@@ -2319,7 +2318,7 @@ function safeQuoteColumnName(modelClass: any, name: string): string {
 export function isTableNameMatches(this: QueryMethodsHost, from: unknown): boolean {
   const table: any = (this as any)._modelClass?.arelTable;
   if (!table) return false;
-  const modelClass: any = (this as any).model;
+  const modelClass: any = this.model;
   const name = escapeRegex(table.name);
   const quotedTableName = safeQuoteTableName(modelClass, table.name);
   const quoted = escapeRegex(quotedTableName);
@@ -2334,7 +2333,7 @@ export function arelColumn(
   field: string | symbol | Nodes.Node,
   fallback?: (attr: string) => unknown,
 ): unknown {
-  const modelClass: any = (this as any).model;
+  const modelClass: any = this.model;
   const table: any = modelClass?.arelTable;
   // Rails: a raw Arel node has no columns_hash/table.column form; it falls to
   // the block, else passes through unchanged (query_methods.rb:1996-2003).
@@ -2379,7 +2378,7 @@ export function arelColumnWithTable(
   const existing = (this as any)._referencesValues ?? [];
   if (!existing.includes(tableName)) (this as any)._referencesValues = [...existing, tableName];
   const colStr = typeof columnName === "symbol" ? symbolToName(columnName) : columnName;
-  const modelClass: any = (this as any).model;
+  const modelClass: any = this.model;
   // Schema-qualified table names (e.g. "schema.table") must not be passed to
   // ArelTable — the visitor quotes the whole string as one identifier, producing
   // "schema.table"."col" instead of "schema"."table"."col".
@@ -2423,7 +2422,7 @@ export function arelColumnsFromHash(
 
 /** @internal */
 export function orderColumn(this: QueryMethodsHost, field: string): unknown {
-  const modelClass: any = (this as any).model;
+  const modelClass: any = this.model;
   const table: any = modelClass?.arelTable;
   return arelColumn.call(this, field, (attrName: string) => {
     if (attrName === "count" && ((this as any)._groupColumns ?? []).length > 0) {
@@ -2460,7 +2459,7 @@ export function arelColumnAliasesFromHash(
   return Reflect.ownKeys(fields).flatMap((key) => {
     const columnsAliases = fields[key as any];
     const tableName = typeof key === "symbol" ? symbolToName(key) : key;
-    const modelClass: any = (this as any).model;
+    const modelClass: any = this.model;
     const quoteAlias = (a: unknown): string =>
       safeQuoteColumnName(modelClass, typeof a === "symbol" ? symbolToName(a) : String(a));
     if (isPlainObject(columnsAliases)) {
@@ -3182,7 +3181,7 @@ export function buildWithJoinNode(
   name: string,
   kind: typeof Nodes.InnerJoin | typeof Nodes.OuterJoin = Nodes.InnerJoin,
 ): unknown {
-  const mc = (this as any).model;
+  const mc = this.model;
   const table: any = mc?.arelTable;
   if (!table) throw new ActiveRecordError("Cannot build CTE join node: model has no arelTable");
   const withTable = new ArelTable(name);

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
@@ -79,13 +79,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "all_attributes?",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "apply_join_dependency",
     "call": "concat",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -220,13 +213,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "arel_column",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "arel_column",
     "call": "quote_table_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -249,13 +235,6 @@
     "tsFile": "relation.ts",
     "rubyName": "arel_column_with_table",
     "call": "match?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "arel_column_with_table",
-    "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -2125,13 +2104,6 @@
     "tsFile": "relation.ts",
     "rubyName": "table_name_matches?",
     "call": "match?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "table_name_matches?",
-    "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/calculations.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/calculations.json
@@ -16,13 +16,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation/calculations.ts",
-    "rubyName": "all_attributes?",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/calculations.ts",
     "rubyName": "distinct_select?",
     "call": "match?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/finder-methods.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/finder-methods.json
@@ -9,13 +9,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation/finder-methods.ts",
-    "rubyName": "_order_columns",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
     "rubyName": "construct_relation_for_exists",
     "call": "except",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -66,13 +59,6 @@
     "package": "activerecord",
     "tsFile": "relation/finder-methods.ts",
     "rubyName": "find_one",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "find_one",
     "call": "squish",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -116,13 +102,6 @@
     "tsFile": "relation/finder-methods.ts",
     "rubyName": "find_some_ordered",
     "call": "in_order_of",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "find_some_ordered",
-    "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -185,13 +164,6 @@
     "package": "activerecord",
     "tsFile": "relation/finder-methods.ts",
     "rubyName": "find_with_ids",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "find_with_ids",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -206,21 +178,7 @@
     "package": "activerecord",
     "tsFile": "relation/finder-methods.ts",
     "rubyName": "ordered_relation",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "ordered_relation",
     "call": "table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "raise_record_not_found_exception!",
-    "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/merger.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/merger.json
@@ -178,13 +178,6 @@
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_select_values",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/merger.ts",
-    "rubyName": "merge_select_values",
     "call": "select_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -207,13 +200,6 @@
     "tsFile": "relation/merger.ts",
     "rubyName": "replace_from_clause?",
     "call": "from_clause",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/merger.ts",
-    "rubyName": "replace_from_clause?",
-    "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/query-methods.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation/query-methods.json
@@ -17,13 +17,6 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "arel_column",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "arel_column",
     "call": "quote_table_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -52,13 +45,6 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "arel_column_aliases_from_hash",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "arel_column_aliases_from_hash",
     "call": "quote_column_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -67,13 +53,6 @@
     "tsFile": "relation/query-methods.ts",
     "rubyName": "arel_column_with_table",
     "call": "match?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "arel_column_with_table",
-    "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -388,13 +367,6 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_where_clause",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_where_clause",
     "call": "references",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -465,13 +437,6 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_with_join_node",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_with_join_node",
     "call": "table",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -501,13 +466,6 @@
     "tsFile": "relation/query-methods.ts",
     "rubyName": "column_references",
     "call": "sql",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "construct_join_dependency",
-    "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -570,13 +528,6 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "order_column",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "order_column",
     "call": "quote_table_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -632,13 +583,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
-    "rubyName": "sanitize_order_arguments",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
     "rubyName": "scope_association_reflection",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -683,13 +627,6 @@
     "tsFile": "relation/query-methods.ts",
     "rubyName": "table_name_matches?",
     "call": "match?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "table_name_matches?",
-    "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {


### PR DESCRIPTION
Sibling of `converge-relation-model-accessor-reads`, which converged `relation.ts`
only. Rails' `Relation` never reads `@model` outside `initialize`
(relation.rb:85) — every other read goes through the `model` accessor, and
`klass` is `alias :klass :model` (relation.rb:73). trails reached past it to the
private `_modelClass` field in the `relation/*.ts` subfiles, so ported bodies
omitted a call Rails makes. `model` is a plain accessor (relation.ts:6242), so
each rewrite is value-identical; the win is call-graph fidelity.

## Routed through the accessor

Each `this._modelClass` / `rel._modelClass` read was checked against its Rails
counterpart body; only those whose Rails body reads `model` were rewritten.

- `query-methods.ts` — `build_where_clause` (`model.sanitize_sql`,
  `model.attribute_aliases`), `construct_join_dependency`
  (`JoinDependency.new(model, …)`), `sanitize_order_arguments`
  (`model.sanitize_sql_for_order`), `table_name_matches?` / `arel_column` /
  `arel_column_with_table` / `order_column` / `arel_column_aliases_from_hash`
  (`model.adapter_class`, `model.attribute_aliases`, `model.columns_hash`),
  `build_with_join_node` (`model.model_name`, `model.primary_key`).
- `calculations.ts` — `all_attributes?` (`model.attribute_names` /
  `attribute_aliases`), `type_for` / `type_cast_pluck_values`
  (`model.attribute_types`), the `"#{model.name} #{operation}"` select_all log
  labels, and `execute_grouped_calculation`'s
  `model._reflect_on_association`.
- `finder-methods.ts` — `raise_record_not_found_exception!`, `find_with_ids`,
  `find_one`, `find_some_ordered`, `ordered_relation`, `_order_columns`.
- `merger.ts` — `merge_select_values` and `replace_from_clause?`
  (`relation.model.base_class == other.model.base_class`); the join/preload
  folders (`merge-joins.ts`, `merge-preloads.ts`) that back `merge_joins` /
  `merge_outer_joins` / `merge_preloads` likewise.

## Deliberately left alone

Each is filed as a follow-up story rather than widened into this PR.

- **`arelTable` reads.** Rails reads the `table` attr_reader there, not `model`
  (`aggregate_column`, `build_select`, `preprocess_order_args`,
  `batch_condition`, …). Routing them through `Relation#table` is a real
  convergence — and a latent bug fix, since `_table` is live (aliased-table
  relations, relation.ts:509/523/6940) and these reads bypass it — but it
  changes behavior, so it needs its own regression test.
  → `converge-relation-table-attr-reader-reads`
- **`primaryKey` reads.** Rails calls the bare delegated `primary_key`
  (delegation.rb:106), not `model.primary_key`, so `this.model.primaryKey`
  would be the wrong target. The right target is the delegate `this.primaryKey`,
  which trails does have (relation.ts:7726) — same class of infidelity as this
  PR, different accessor, so it gets its own pass alongside `table_name` /
  `unscoped`. → `converge-relation-primary-key-delegate-reads`
- **`batches.ts`** — all three flagged entries (`act_on_ignored_order`,
  `batch_on_unloaded_relation`, `ensure_valid_options_for_batching!`) miss the
  `model` call because the surrounding Rails behavior is unported
  (`model.logger` warn branch, `model.unscoped.all.to_sql` empty-scope check,
  the `schema_cache.indexes` unique-index guard) — not because the read is
  routed past the accessor. There is no `_modelClass` to reroute; the file is
  untouched. These are functional gaps (a non-unique `:cursor` is silently
  accepted; the `use_ranges` fast path is never selected), filed as
  → `port-batches-unported-model-behaviors`
- **Cross-function reads** — `execute_simple_calculation`,
  `type_cast_pluck_values`, `build_select`, `preprocess_order_args`,
  `build_join_buckets` and the three `merger.ts` fold wrappers keep their
  wide-gate entries: the model read lives in a trails helper in another
  function (or another file), so the gate still scores the mapped body as
  missing the call. Rerouting them would mean restructuring the helpers.
  → `converge-relation-cross-helper-model-reads` (low priority — #5346's
  delegation-following may dissolve several of these for free)

## Verification

- `pnpm api:calls:wide:reseed` — baseline shrinks 5209 → 5083 (126 fewer
  entries; nothing added). Unrelated `attribute-methods.json` unicode-escape
  churn reverted.
- `pnpm api:calls:wide` — OK.
- `pnpm typecheck`, `pnpm lint` clean; `packages/activerecord/src/relation`
  suite green (1367 passed).
- Behavior-preserving. The one test touch is stub-shaped: the hand-rolled fake
  relations in `finder-methods.test.ts` only defined `_modelClass`, so they now
  expose `model` the way a real `Relation` does — hoisted into three shared
  stub consts rather than repeated inline. No test names changed, no assertions
  altered.

Closes-story: converge-relation-subfile-model-accessor-reads
