### PR TITLE
fix(associations): reconcile unloaded has_one_through join row on create

### DIFF
--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -105,6 +105,39 @@ export class HasOneThroughAssociation extends HasOneAssociation {
     // no-op — see JSDoc
   }
 
+  /**
+   * Mirrors Rails' `create#{name}` reaching
+   * `HasOneThroughAssociation#create_through_record`
+   * (has_one_through_association.rb:15-40) via `set_new_record` → `replace`.
+   * Two halves of that method are DB work our sync `replace` cannot do:
+   *
+   *   - `through_proxy.load_target` (:17) — materialize the join row, which on a
+   *     re-fetched owner is UNLOADED. Without it `constructThroughRecordInMemory`
+   *     sees no through target and builds a fresh one.
+   *   - `through_record.update(attributes)` (:33) — when that load turns up a
+   *     *persisted* join row, Rails rewrites its source foreign key inline, so
+   *     the join row points at the just-created target as soon as `create`
+   *     returns, with no owner `save`.
+   *
+   * The build-when-absent arm stays deferred: Rails reaches it through
+   * `owner.new_record? || !save` (:36-37, `set_new_record` passes `save = false`)
+   * and only *builds* the join record, leaving it for the owner's next save.
+   */
+  protected override async _createRecord(
+    attributes?: Record<string, unknown>,
+    shouldRaise = false,
+    block?: (record: Base) => void,
+  ): Promise<Base | null> {
+    await this.loadTargetForBuild();
+    const existing = (throughAssociation(this) as { target?: Base | null } | null)?.target ?? null;
+    const hasPersistedJoinRow = existing != null && (existing as any).isNewRecord?.() !== true;
+    const record = await super._createRecord(attributes, shouldRaise, block);
+    if (record && hasPersistedJoinRow && this._pendingReplace) {
+      await this.persistReplace();
+    }
+    return record;
+  }
+
   protected override setNewRecord(record: Base): void {
     this.replace(record, false);
   }

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -106,34 +106,27 @@ export class HasOneThroughAssociation extends HasOneAssociation {
   }
 
   /**
-   * Mirrors the two DB halves of Rails'
-   * `HasOneThroughAssociation#create_through_record`
-   * (has_one_through_association.rb:15-40), which our synchronous `replace`
-   * cannot run: `through_proxy.load_target` (:17), and — when that load turns
-   * up a *persisted* join row — `through_record.update(attributes)` (:33),
-   * which repoints the row at the just-created target inline, before `create`
-   * returns. The build-when-absent arm stays deferred to the owner's next
-   * save, which is Rails' own `owner.new_record? || !save` shape (:36-37).
+   * Runs the DB half of Rails' `create_through_record`
+   * (has_one_through_association.rb:15-40) that our synchronous `replace`
+   * cannot: `through_proxy.load_target` (:17) and the arm it selects. Rails
+   * reaches it from `set_new_record` → `replace(record, false)` *after*
+   * `build_record` + `record.save` (singular_association.rb:67-71), so the
+   * load runs here, after `super`, never before — an invalid build must raise
+   * before any join-model query, as it does in Rails.
+   *
+   * `save` is `false` on this path (`set_new_record`), so `createThroughRecord`
+   * picks Rails' own branches: `update` an existing *persisted* join row inline
+   * (:33), or merely `build` when absent (:36-37), leaving that row for the
+   * owner's next save.
    */
   protected override async _createRecord(
     attributes?: Record<string, unknown>,
     shouldRaise = false,
     block?: (record: Base) => void,
   ): Promise<Base | null> {
-    // An unpersisted owner has no join row to load and `super` raises
-    // RecordNotSaved for it, so the load must not run first.
-    const ownerPersisted = (this.owner as { isPersisted?: () => boolean }).isPersisted?.() ?? false;
-    let hasPersistedJoinRow = false;
-    if (ownerPersisted) {
-      await this.loadTargetForBuild();
-      const existing =
-        (throughAssociation(this) as { target?: Base | null } | null)?.target ?? null;
-      hasPersistedJoinRow =
-        existing != null && (existing as { isNewRecord?: () => boolean }).isNewRecord?.() !== true;
-    }
     const record = await super._createRecord(attributes, shouldRaise, block);
-    if (record && hasPersistedJoinRow && this._pendingReplace) {
-      await this.persistReplace();
+    if (record && this._pendingReplace) {
+      await this.persistReplace(false);
     }
     return record;
   }
@@ -422,7 +415,7 @@ export class HasOneThroughAssociation extends HasOneAssociation {
    * `persistThroughRecord` calls it from `autosaveHasOne` during the owner's
    * save for the sync `build`/`create` path that could not `await`.
    */
-  async persistReplace(): Promise<void> {
+  async persistReplace(save = true): Promise<void> {
     const pending = this._pendingReplace;
     // Clear before the first `await` — mirrors HasOneAssociation#persistReplace.
     // The new awaitable `writer` (inherited from HasOneAssociation) makes this
@@ -461,7 +454,7 @@ export class HasOneThroughAssociation extends HasOneAssociation {
     }
     if (!pending) return;
     await transaction(this, async () => {
-      await createThroughRecord(this, pending.record, true);
+      await createThroughRecord(this, pending.record, save);
     });
   }
 }

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -106,31 +106,31 @@ export class HasOneThroughAssociation extends HasOneAssociation {
   }
 
   /**
-   * Mirrors Rails' `create#{name}` reaching
+   * Mirrors the two DB halves of Rails'
    * `HasOneThroughAssociation#create_through_record`
-   * (has_one_through_association.rb:15-40) via `set_new_record` → `replace`.
-   * Two halves of that method are DB work our sync `replace` cannot do:
-   *
-   *   - `through_proxy.load_target` (:17) — materialize the join row, which on a
-   *     re-fetched owner is UNLOADED. Without it `constructThroughRecordInMemory`
-   *     sees no through target and builds a fresh one.
-   *   - `through_record.update(attributes)` (:33) — when that load turns up a
-   *     *persisted* join row, Rails rewrites its source foreign key inline, so
-   *     the join row points at the just-created target as soon as `create`
-   *     returns, with no owner `save`.
-   *
-   * The build-when-absent arm stays deferred: Rails reaches it through
-   * `owner.new_record? || !save` (:36-37, `set_new_record` passes `save = false`)
-   * and only *builds* the join record, leaving it for the owner's next save.
+   * (has_one_through_association.rb:15-40), which our synchronous `replace`
+   * cannot run: `through_proxy.load_target` (:17), and — when that load turns
+   * up a *persisted* join row — `through_record.update(attributes)` (:33),
+   * which repoints the row at the just-created target inline, before `create`
+   * returns. The build-when-absent arm stays deferred to the owner's next
+   * save, which is Rails' own `owner.new_record? || !save` shape (:36-37).
    */
   protected override async _createRecord(
     attributes?: Record<string, unknown>,
     shouldRaise = false,
     block?: (record: Base) => void,
   ): Promise<Base | null> {
-    await this.loadTargetForBuild();
-    const existing = (throughAssociation(this) as { target?: Base | null } | null)?.target ?? null;
-    const hasPersistedJoinRow = existing != null && (existing as any).isNewRecord?.() !== true;
+    // An unpersisted owner has no join row to load and `super` raises
+    // RecordNotSaved for it, so the load must not run first.
+    const ownerPersisted = (this.owner as { isPersisted?: () => boolean }).isPersisted?.() ?? false;
+    let hasPersistedJoinRow = false;
+    if (ownerPersisted) {
+      await this.loadTargetForBuild();
+      const existing =
+        (throughAssociation(this) as { target?: Base | null } | null)?.target ?? null;
+      hasPersistedJoinRow =
+        existing != null && (existing as { isNewRecord?: () => boolean }).isNewRecord?.() !== true;
+    }
     const record = await super._createRecord(attributes, shouldRaise, block);
     if (record && hasPersistedJoinRow && this._pendingReplace) {
       await this.persistReplace();

--- a/packages/activerecord/src/associations/has-one-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-through-associations.test.ts
@@ -311,6 +311,27 @@ describe("HasOneThroughAssociationsTest", () => {
     expect(Number(reloaded.club_id)).toBe(Number(newClub.id));
   });
 
+  it("creating with unloaded existing join row updates the join row without an owner save", async () => {
+    const newMember = await Member.create({ name: "Joe" });
+    const oldClub = await Club.create({ name: "Old Club" });
+    (newMember.association("club") as any).writer(oldClub);
+    await newMember.save();
+    const membershipId = (await readHasOne(newMember, "currentMembership")).id;
+
+    // Rails' create_through_record loads the through proxy and `update`s the
+    // existing (persisted) join row inline, so the join row points at the newly
+    // created club as soon as `create` returns — no owner `save` needed.
+    const refetched = await Member.find(newMember.id);
+    const countForMember = () => Membership.where({ member_id: refetched.id }).count();
+    const before = await countForMember();
+    const newClub = await (refetched.association("club") as any).create({ name: "New Club" });
+
+    expect(await countForMember()).toBe(before);
+    const reloaded = await Membership.find(membershipId);
+    expect(Number(reloaded.club_id)).toBe(Number(newClub.id));
+    expect(Number(reloaded.club_id)).not.toBe(Number(oldClub.id));
+  });
+
   it("building with unloaded existing join row reconciles regardless of through-proxy access order", async () => {
     const newMember = await Member.create({ name: "Joe" });
     (newMember.association("club") as any).writer(await Club.create({ name: "Old Club" }));

--- a/packages/activerecord/src/associations/has-one-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-through-associations.test.ts
@@ -329,6 +329,20 @@ describe("HasOneThroughAssociationsTest", () => {
     expect(Number(reloaded.club_id)).not.toBe(Number(oldClub.id));
   });
 
+  it("creating with no existing join row only builds the join record", async () => {
+    const newMember = await Member.create({ name: "Joe" });
+    const countForMember = () => Membership.where({ member_id: newMember.id }).count();
+
+    const newClub = await (newMember.association("club") as any).create({ name: "New Club" });
+    expect(await countForMember()).toBe(0);
+    expect(tgt(newMember, "currentMembership").isNewRecord()).toBe(true);
+
+    expect(await newMember.save()).toBe(true);
+    expect(await countForMember()).toBe(1);
+    const membership = await Membership.where({ member_id: newMember.id }).first();
+    expect(Number(membership?.club_id)).toBe(Number(newClub.id));
+  });
+
   it("building with unloaded existing join row reconciles regardless of through-proxy access order", async () => {
     const newMember = await Member.create({ name: "Joe" });
     (newMember.association("club") as any).writer(await Club.create({ name: "Old Club" }));

--- a/packages/activerecord/src/associations/has-one-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-through-associations.test.ts
@@ -318,9 +318,6 @@ describe("HasOneThroughAssociationsTest", () => {
     await newMember.save();
     const membershipId = (await readHasOne(newMember, "currentMembership")).id;
 
-    // Rails' create_through_record loads the through proxy and `update`s the
-    // existing (persisted) join row inline, so the join row points at the newly
-    // created club as soon as `create` returns — no owner `save` needed.
     const refetched = await Member.find(newMember.id);
     const countForMember = () => Membership.where({ member_id: refetched.id }).count();
     const before = await countForMember();


### PR DESCRIPTION
## Problem

`create#{name}` on a **has_one_through** whose join row exists in the DB but is
UNLOADED left the join row pointing at the OLD target. The `build` counterpart
already reconciles (via `constructThroughRecordInMemory`); `create` did not.

Rails' `HasOneThroughAssociation#create_through_record`
(`has_one_through_association.rb:15-40`) does the DB work our synchronous
`replace` cannot: `through_proxy.load_target` (:17), then either
`through_record.update(attributes)` on an existing persisted join row (:33) or a
mere `build` when absent (:36-37).

## Change

`HasOneThroughAssociation#_createRecord` calls `persistReplace(false)` after
`super._createRecord`. `persistReplace` gained a `save` parameter threaded into
`createThroughRecord`, so the arm selection is Rails' own rather than a
re-derived gate: an existing persisted join row is `update`d inline (the join
row points at the new target as soon as `create` returns, no owner `save`
needed), and an absent one is only `build`t, deferred to the owner's next save.

**Ordering** (per review): the join-row load runs *after* `super._createRecord`
— i.e. after `build_record` + `record.save` — matching Rails, which reaches
`create_through_record` from `set_new_record` → `replace(record, false)` at
`singular_association.rb:67-71`. An invalid build therefore still raises before
any join-model query, and no extra query fires for an unpersisted owner (`super`
raises `RecordNotSaved` first). `save` is `false` on this path because
`set_new_record` passes it that way.

## Tests

New regression test in `has-one-through-associations.test.ts` alongside the
build one; fails on baseline (the join row keeps the old `club_id`), passes
here. The deferred build-when-absent arm stays covered by the existing
"association create constructor creates through record" test.

Local: has_one_through, has_one, autosave, and the four has_one trails suites —
373 passed, 5 skipped.

Closes-story: has-one-through-create-unloaded-join-row-not-reconciled

## Review follow-ups

**Deferred build-when-absent arm was untested** — now covered by "creating with
no existing join row only builds the join record": `create#{name}` on a
persisted owner with no join row inserts nothing (`memberships` count stays 0,
the through record is `new_record?`), and the row lands only on the owner's next
`save`. That is Rails' `owner.new_record? || !save` arm (:36-37), reached because
`HasOneThroughAssociation` inherits `HasOneAssociation#set_new_record` =
`replace(record, false)` (has_one_association.rb:91).

**Raising-create ordering gap — out of scope, story filed.** Rails runs
`set_new_record` (hence the whole `create_through_record`) *before*
`raise RecordInvalid.new(record) if !saved && raise_error`
(singular_association.rb:63-71); here the throw happens inside
`super._createRecord`, so the reconcile is skipped for a failing
`create#{name}!` over an unloaded persisted join row. Real divergence, but it
predates this PR and cannot be pinned with a baseline-failing test using
canonical models — `Club` (test/models/club.rb) declares no validations, and
Rails has no test for this shape. Registered as
`0068-awaitable-has-one-setter/has-one-through-raising-create-skips-join-row-reconcile`,
which also flags that Rails' behavior here (rewriting `club_id` toward a
never-persisted record) should be verified before being enshrined.
