### PR TITLE
test(mysql): lease the ambient connection in schema/DDL adapter suites

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts
@@ -1,19 +1,16 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/active_schema_test.rb
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { ArgumentError } from "@blazetrails/activemodel";
-import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+import { describeIfMysqlAdapter, leaseMysqlAdapter, Mysql2Adapter } from "./test-helper.js";
 import { captureSql } from "../../testing/sql-capture.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
 
-describeIfMysql("Mysql2Adapter", () => {
+describeIfMysqlAdapter("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   beforeEach(async () => {
-    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
-  });
-  afterEach(async () => {
-    await adapter.close();
+    adapter = await leaseMysqlAdapter();
   });
 
   describe("ActiveSchemaTest", () => {
@@ -22,9 +19,9 @@ describeIfMysql("Mysql2Adapter", () => {
     // via the fixtures framework so its lifecycle (and teardown) is owned by the
     // canonical-schema machinery rather than a destructive create/drop here.
     // "add index" opts out of transactional fixtures: its real addIndex/
-    // removeIndex DDL runs through this file's separate adapter connection, which
-    // must not happen while Base.connection holds a fixture transaction on
-    // `people` (MySQL DDL implicitly commits and would strand that state).
+    // removeIndex DDL must not run while the leased connection holds a fixture
+    // transaction on `people` (MySQL DDL implicitly commits and would strand
+    // that state).
     fixtures(["people"], {
       usesTransaction: ["add index"],
     });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/bind-parameter.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/bind-parameter.test.ts
@@ -16,15 +16,12 @@
  * it degrades to a string-equality bind.
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+import { describeIfMysqlAdapter, leaseMysqlAdapter, Mysql2Adapter } from "./test-helper.js";
 
-describeIfMysql("AbstractMySQLAdapter", () => {
+describeIfMysqlAdapter("AbstractMySQLAdapter", () => {
   let adapter: Mysql2Adapter;
   beforeEach(async () => {
-    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
-  });
-  afterEach(async () => {
-    await adapter.close();
+    adapter = await leaseMysqlAdapter();
   });
 
   describe("BindParameterTest", () => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-boolean.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-boolean.test.ts
@@ -2,14 +2,14 @@
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_boolean_test.rb
  */
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
-import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+import { describeIfMysqlAdapter, leaseMysqlAdapter, Mysql2Adapter } from "./test-helper.js";
 import { Base } from "../../index.js";
 
 class BooleanType extends Base {
   static tableName = "mysql_booleans";
 }
 
-describeIfMysql("Mysql2Adapter", () => {
+describeIfMysqlAdapter("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   let savedEmulateBooleans: boolean;
 
@@ -28,7 +28,7 @@ describeIfMysql("Mysql2Adapter", () => {
   }
 
   beforeEach(async () => {
-    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
+    adapter = await leaseMysqlAdapter();
     await adapter.createTable("mysql_booleans", { force: true }, (t: any) => {
       t.boolean("archived");
       t.string("published", { limit: 1 });
@@ -41,7 +41,6 @@ describeIfMysql("Mysql2Adapter", () => {
   afterEach(async () => {
     await emulateBooleans(savedEmulateBooleans);
     await adapter.dropTable("mysql_booleans", { ifExists: true });
-    await adapter.close();
   });
 
   describe("MysqlBooleanTest", () => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
@@ -11,8 +11,12 @@ import {
 import { Base } from "../../base.js";
 import { rebuildCanonicalTables } from "../../test-helpers/canonical-schema.js";
 
+// Both suites below drop/recreate canonical tables (`posts`; `students` /
+// `lessons_students` / `topics`) in the shape their assertions need, so each
+// puts them back on the leased connection before handing the worker on.
 async function restoreCanonicalTables(names: readonly string[]): Promise<void> {
-  await rebuildCanonicalTables(await leaseMysqlAdapter(), names);
+  const adapter = await leaseMysqlAdapter();
+  await rebuildCanonicalTables(adapter, names);
 }
 
 describeIfMysqlAdapter("Mysql2Adapter", () => {
@@ -181,16 +185,17 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
 });
 
 // Top-level suite mirrors Rails: MysqlAnsiQuotesTest is a separate test class
-// (not nested inside SchemaTest's module). Keeping it outside the "Mysql2Adapter"
-// describe also avoids spinning up the SchemaTest adapter pool for ANSI tests.
+// (not nested inside SchemaTest's module).
 describeIfMysqlAdapter("MySQLAnsiQuotesTest", () => {
-  // Build a fresh adapter with sql_mode='ANSI_QUOTES' applied in the pool init SQL
-  // so it persists across every checked-out connection — Rails uses
-  // `execute("SET SESSION sql_mode='ANSI_QUOTES'")` on its single leased connection;
-  // we apply the variable per-connection via the pool init hook (newClient).
+  // The one adapter in this file that stays self-built rather than riding
+  // leaseMysqlAdapter(): sql_mode='ANSI_QUOTES' must not leak onto the shared
+  // leased connection the other suites (and every later test in this worker)
+  // run on. Rails likewise reconfigures a connection in-test from the primary
+  // config. Applying the variable in the pool init SQL (the newClient hook)
+  // makes it stick across every checked-out connection, where Rails gets away
+  // with a single `execute("SET SESSION sql_mode='ANSI_QUOTES'")` because it
+  // has exactly one leased connection to set it on.
   let ansi: Mysql2Adapter | undefined;
-  // Stays self-built: Rails also builds this connection in-test from the primary
-  // config, because ANSI_QUOTES must not leak onto the shared leased connection.
   beforeEach(() => {
     ansi = new Mysql2Adapter({ uri: MYSQL_TEST_URL, variables: { sql_mode: "ANSI_QUOTES" } });
   });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
@@ -2,29 +2,26 @@
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/schema_test.rb
  */
 import { describe, it, beforeEach, afterEach, afterAll, expect } from "vitest";
-import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+import {
+  describeIfMysqlAdapter,
+  leaseMysqlAdapter,
+  Mysql2Adapter,
+  MYSQL_TEST_URL,
+} from "./test-helper.js";
 import { Base } from "../../base.js";
 import { rebuildCanonicalTables } from "../../test-helpers/canonical-schema.js";
 
-async function restoreCanonicalOnPlainAdapter(names: readonly string[]): Promise<void> {
-  const restorer = new Mysql2Adapter(MYSQL_TEST_URL);
-  try {
-    await rebuildCanonicalTables(restorer, names);
-  } finally {
-    await restorer.close();
-  }
+async function restoreCanonicalTables(names: readonly string[]): Promise<void> {
+  await rebuildCanonicalTables(await leaseMysqlAdapter(), names);
 }
 
-describeIfMysql("Mysql2Adapter", () => {
+describeIfMysqlAdapter("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   beforeEach(async () => {
-    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
-  });
-  afterEach(async () => {
-    await adapter.close();
+    adapter = await leaseMysqlAdapter();
   });
   afterAll(async () => {
-    await restoreCanonicalOnPlainAdapter(["posts"]);
+    await restoreCanonicalTables(["posts"]);
   });
 
   describe("SchemaTest", () => {
@@ -186,12 +183,14 @@ describeIfMysql("Mysql2Adapter", () => {
 // Top-level suite mirrors Rails: MysqlAnsiQuotesTest is a separate test class
 // (not nested inside SchemaTest's module). Keeping it outside the "Mysql2Adapter"
 // describe also avoids spinning up the SchemaTest adapter pool for ANSI tests.
-describeIfMysql("MySQLAnsiQuotesTest", () => {
+describeIfMysqlAdapter("MySQLAnsiQuotesTest", () => {
   // Build a fresh adapter with sql_mode='ANSI_QUOTES' applied in the pool init SQL
   // so it persists across every checked-out connection — Rails uses
   // `execute("SET SESSION sql_mode='ANSI_QUOTES'")` on its single leased connection;
   // we apply the variable per-connection via the pool init hook (newClient).
   let ansi: Mysql2Adapter | undefined;
+  // Stays self-built: Rails also builds this connection in-test from the primary
+  // config, because ANSI_QUOTES must not leak onto the shared leased connection.
   beforeEach(() => {
     ansi = new Mysql2Adapter({ uri: MYSQL_TEST_URL, variables: { sql_mode: "ANSI_QUOTES" } });
   });
@@ -205,7 +204,7 @@ describeIfMysql("MySQLAnsiQuotesTest", () => {
     ansi = undefined;
   });
   afterAll(async () => {
-    await restoreCanonicalOnPlainAdapter(["students", "lessons_students", "topics"]);
+    await restoreCanonicalTables(["students", "lessons_students", "topics"]);
   });
 
   it("primary key method with ansi quotes", async () => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/virtual-column.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/virtual-column.test.ts
@@ -2,18 +2,18 @@
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/virtual_column_test.rb
  */
 import { it, expect, beforeEach, afterEach } from "vitest";
-import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+import { describeIfMysqlAdapter, leaseMysqlAdapter, Mysql2Adapter } from "./test-helper.js";
 import { describeIfSupports } from "../../test-helpers/supports.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 
-describeIfMysql("Mysql2Adapter", () => {
+describeIfMysqlAdapter("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
 
   // The table is built per test (in beforeEach, after the global drop-all reset)
   // because the adapter dir runs under the AR setup, which wipes all tables before
   // every test. Mirrors Rails' `setup`/`teardown` create_table/drop_table dance.
   beforeEach(async () => {
-    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
+    adapter = await leaseMysqlAdapter();
     await adapter.dropTable("virtual_columns", { ifExists: true }).catch(() => {});
     await adapter.createTable("virtual_columns", { force: "cascade" }, (t: any) => {
       t.string("name");
@@ -34,7 +34,6 @@ describeIfMysql("Mysql2Adapter", () => {
 
   afterEach(async () => {
     await adapter.dropTable("virtual_columns", { ifExists: true }).catch(() => {});
-    await adapter.close();
   });
 
   describeIfSupports("virtual_columns", "VirtualColumnTest", () => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/warnings.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/warnings.test.ts
@@ -3,20 +3,19 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
-  describeIfMysql,
+  describeIfMysqlAdapter,
+  leaseMysqlAdapter,
   Mysql2Adapter,
-  MYSQL_TEST_URL,
   withDbWarningsAction,
 } from "./test-helper.js";
 import { SQLWarning } from "../../errors.js";
 
-describeIfMysql("Mysql2Adapter", () => {
+describeIfMysqlAdapter("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   beforeEach(async () => {
-    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
+    adapter = await leaseMysqlAdapter();
   });
-  afterEach(async () => {
-    await adapter.close();
+  afterEach(() => {
     vi.restoreAllMocks();
   });
 

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -39,9 +39,9 @@ import { loadSchemaFromAdapter } from "./model-schema.js";
 import { itIfSupports, describeIfSupports } from "./test-helpers/supports.js";
 import { describeIfPg } from "./adapters/postgresql/test-helper.js";
 import {
-  describeIfMysql,
+  describeIfMysqlAdapter,
+  leaseMysqlAdapter,
   Mysql2Adapter,
-  MYSQL_TEST_URL,
 } from "./adapters/abstract-mysql-adapter/test-helper.js";
 
 async function freshContext(): Promise<{ adapter: DatabaseAdapter; ctx: MigrationContext }> {
@@ -2313,16 +2313,15 @@ describe("BulkAlterTableMigrationsTest", () => {
   });
 });
 
-describeIfMysql("BulkAlterTableMigrationsTest", () => {
+describeIfMysqlAdapter("BulkAlterTableMigrationsTest", () => {
   let adapter: Mysql2Adapter;
   beforeEach(async () => {
-    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
+    adapter = await leaseMysqlAdapter();
     await adapter.exec("DROP TABLE IF EXISTS delete_me");
     await adapter.exec("CREATE TABLE delete_me (id INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (id))");
   });
   afterEach(async () => {
     await adapter.exec("DROP TABLE IF EXISTS delete_me");
-    await adapter.close();
   });
 
   itIfSupports("bulk_alter", "updating auto increment", async () => {


### PR DESCRIPTION
Batch 2 of the `new Mysql2Adapter(MYSQL_TEST_URL)` burn-down started in the
batch-1 PR, using the two helpers it added.

Every `(a)` site — the ones whose Rails counterpart's `setup` is
`@connection = ActiveRecord::Base.lease_connection` — now rides
`leaseMysqlAdapter()` under `describeIfMysqlAdapter` (the port of
`current_adapter?(:Mysql2Adapter)`) rather than a self-built adapter under
`describeIfMysql` (a server-reachability probe that ran these MySQL suites
under every `ARCONN`). The close-only `afterEach` hooks go away with them.

| site | Rails counterpart |
| --- | --- |
| `abstract-mysql-adapter/active-schema.test.ts` | `active_schema_test.rb` setup |
| `abstract-mysql-adapter/virtual-column.test.ts` | `virtual_column_test.rb` setup |
| `abstract-mysql-adapter/mysql-boolean.test.ts` | `boolean_test.rb` setup |
| `abstract-mysql-adapter/bind-parameter.test.ts` | `bind_parameter_test.rb` setup |
| `abstract-mysql-adapter/warnings.test.ts` | `warnings_test.rb` setup |
| `abstract-mysql-adapter/schema.test.ts` (suite + canonical restorer) | `schema_test.rb` setup |
| `migration.test.ts` `BulkAlterTableMigrationsTest` | the MySQL-gated block in `migration_test.rb` |

`bind-parameter.test.ts` is the highest-value one: `preparedStatements` is
exactly the pool config the self-built adapter was skipping.

`MySQLAnsiQuotesTest` (`schema.test.ts`) deliberately stays self-built — Rails
also builds that differently-configured connection in-test, and `ANSI_QUOTES`
must not leak onto the shared leased connection. A one-line comment at the call
site says so.

Test names are unchanged. Locally green on the mysql2 lane: 51 tests across the
six adapter suites, plus `BulkAlterTableMigrationsTest`.

Closes-story: mysql-tests-self-built-adapter-burndown-batch-2
