### PR TITLE
test(mysql): lease the ambient connection in the mysql2 adapter suites

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
@@ -19,6 +19,14 @@ import {
 } from "../../errors.js";
 import mysql from "mysql2/promise";
 
+// The leased connection memoizes the server version on first read, so the
+// version tests below have to drop that memo both before stubbing (the real
+// version is already cached) and after (their stubbed one must not outlive the
+// test). Rails' @connection is likewise long-lived; its stubs re-run the query.
+function clearVersionCache(adapter: Mysql2Adapter): void {
+  (adapter as unknown as { _databaseVersion: unknown })._databaseVersion = null;
+}
+
 describeIfMysqlAdapter("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   beforeEach(async () => {
@@ -29,9 +37,8 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     Notifications.unsubscribeAll();
     // Several tests here disconnect/discard the leased connection (as Rails'
     // connection_test.rb does to `Base.lease_connection`); verify it back so the
-    // next test in this worker gets a live one. The version tests memoize a
-    // stubbed version onto it, so drop that too — it re-derives on next read.
-    (adapter as any)._databaseVersion = null;
+    // next test in this worker gets a live one.
+    clearVersionCache(adapter);
     await adapter.verifyBang();
   });
 
@@ -371,26 +378,19 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       }
     });
 
-    // The leased connection has already resolved (and memoized) the real
-    // server version, so every stub below has to clear the cache first —
-    // Rails' @connection is likewise long-lived and its stubs re-run the query.
-    const clearVersionCache = (): void => {
-      (adapter as any)._databaseVersion = null;
-    };
-
     it("version string", async () => {
       const spy = vi.spyOn(adapter, "getFullVersion");
-      clearVersionCache();
+      clearVersionCache(adapter);
       spy.mockResolvedValueOnce("8.0.35-0ubuntu0.22.04.1");
       expect((await adapter.getDatabaseVersion()).toString()).toBe("8.0.35");
 
-      clearVersionCache();
+      clearVersionCache(adapter);
       spy.mockResolvedValueOnce("5.7.0");
       expect((await adapter.getDatabaseVersion()).toString()).toBe("5.7.0");
     });
 
     it("version string with mariadb", async () => {
-      clearVersionCache();
+      clearVersionCache(adapter);
       vi.spyOn(adapter, "getFullVersion").mockResolvedValueOnce(
         "5.5.5-10.6.5-MariaDB-1:10.6.5+maria~focal",
       );
@@ -400,7 +400,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     it("version string invalid", async () => {
       const spy = vi.spyOn(adapter, "getFullVersion");
       const assertVersionError = async (version: string | null, expectedMsg: string) => {
-        clearVersionCache();
+        clearVersionCache(adapter);
         spy.mockResolvedValueOnce(version as string);
         let caughtErr: unknown;
         try {
@@ -460,7 +460,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     afterEach(() => vi.restoreAllMocks());
 
     it("maps ER_BAD_DB_ERROR (1049) to NoDatabaseError", async () => {
-      // Stays self-built: a deliberately bad config is the assertion.
+      // Stays self-built: the config names a database that does not exist.
       const a = new Mysql2Adapter("mysql://root@localhost/no_such_db");
       stubCreateConnection(makeDriverError(1049));
       try {
@@ -471,7 +471,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     });
 
     it("maps ER_ACCESS_DENIED_ERROR (1045) to DatabaseConnectionError", async () => {
-      // Stays self-built: a deliberately bad config is the assertion.
+      // Stays self-built: the config names a user that cannot authenticate.
       const a = new Mysql2Adapter({ host: "localhost", user: "baduser", database: "test" });
       stubCreateConnection(makeDriverError(1045));
       try {
@@ -484,7 +484,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     });
 
     it("maps ER_ACCESS_DENIED_ERROR via URI to DatabaseConnectionError with parsed username", async () => {
-      // Stays self-built: a deliberately bad config is the assertion.
+      // Stays self-built: the URI carries the bad username the error must name.
       const a = new Mysql2Adapter("mysql://myuser:pw@localhost/test");
       stubCreateConnection(makeDriverError(1045));
       try {
@@ -497,7 +497,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     });
 
     it("maps ER_CONN_HOST_ERROR (2003) to DatabaseConnectionError with hostname", async () => {
-      // Stays self-built: a deliberately bad config is the assertion.
+      // Stays self-built: the URI carries the unreachable host the error must name.
       const a = new Mysql2Adapter("mysql://root@myhost.example.com/test");
       stubCreateConnection(makeDriverError(2003));
       try {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
@@ -4,7 +4,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import type { NotificationEvent } from "@blazetrails/activesupport";
-import { describeIfMysql, isMariaDb, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+import {
+  describeIfMysqlAdapter,
+  isMariaDb,
+  leaseMysqlAdapter,
+  Mysql2Adapter,
+  MYSQL_TEST_URL,
+} from "./test-helper.js";
 import {
   NoDatabaseError,
   DatabaseVersionError,
@@ -13,21 +19,28 @@ import {
 } from "../../errors.js";
 import mysql from "mysql2/promise";
 
-describeIfMysql("Mysql2Adapter", () => {
+describeIfMysqlAdapter("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   beforeEach(async () => {
-    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
+    adapter = await leaseMysqlAdapter();
   });
   afterEach(async () => {
     vi.restoreAllMocks();
     Notifications.unsubscribeAll();
-    await adapter.close();
+    // Several tests here disconnect/discard the leased connection (as Rails'
+    // connection_test.rb does to `Base.lease_connection`); verify it back so the
+    // next test in this worker gets a live one. The version tests memoize a
+    // stubbed version onto it, so drop that too — it re-derives on next read.
+    (adapter as any)._databaseVersion = null;
+    await adapter.verifyBang();
   });
 
   describe("ConnectionTest", () => {
     it("bad connection", async () => {
       const u = new URL(MYSQL_TEST_URL);
       u.pathname = "/inexistent_activerecord_unittest";
+      // Stays self-built: Rails builds this connection in-test too — it points
+      // at a database that does not exist.
       const badAdapter = new Mysql2Adapter(u.toString());
       try {
         await expect(badAdapter.execute("SELECT 1")).rejects.toBeInstanceOf(NoDatabaseError);
@@ -39,6 +52,9 @@ describeIfMysql("Mysql2Adapter", () => {
     it.skipIf(isMariaDb)(
       "no automatic reconnection after timeout",
       async () => {
+        // Stays self-built: connectionLimit:1 is what pins the wait_timeout to
+        // the connection under test, and the server-side disconnect it provokes
+        // must not land on the shared leased connection.
         const singleConn = new Mysql2Adapter({ uri: MYSQL_TEST_URL, connectionLimit: 1 });
         try {
           expect(await singleConn.activeAsync()).toBe(true);
@@ -52,9 +68,10 @@ describeIfMysql("Mysql2Adapter", () => {
       10_000,
     );
     it("successful reconnection after timeout with manual reconnect", async () => {
-      // Use connectionLimit: 1 so SET SESSION wait_timeout and the sleep share
-      // the same physical connection — otherwise a second pool connection with
-      // the default wait_timeout could be used for the later execute().
+      // Stays self-built: connectionLimit:1 so SET SESSION wait_timeout and the
+      // sleep share the same physical connection — otherwise a second pool
+      // connection with the default wait_timeout could be used for the later
+      // execute() — and the provoked disconnect must not hit the leased one.
       const singleConn = new Mysql2Adapter({ uri: MYSQL_TEST_URL, connectionLimit: 1 });
       try {
         expect(await singleConn.activeAsync()).toBe(true);
@@ -72,8 +89,9 @@ describeIfMysql("Mysql2Adapter", () => {
       }
     }, 10_000);
     it("successful reconnection after timeout with verify", async () => {
-      // Use connectionLimit: 1 so the session wait_timeout applies to the same
-      // connection that activeAsync() and verifyBang() will use.
+      // Stays self-built: connectionLimit:1 so the session wait_timeout applies
+      // to the same connection that activeAsync() and verifyBang() will use, and
+      // the provoked server-side disconnect must not hit the leased one.
       const singleConn = new Mysql2Adapter({ uri: MYSQL_TEST_URL, connectionLimit: 1 });
       try {
         expect(await singleConn.activeAsync()).toBe(true);
@@ -153,6 +171,7 @@ describeIfMysql("Mysql2Adapter", () => {
     });
 
     it("wait timeout as string", async () => {
+      // Stays self-built: the `waitTimeout` config key is the assertion.
       const testAdapter = new Mysql2Adapter({ uri: MYSQL_TEST_URL, waitTimeout: "60" });
       try {
         const rows = await testAdapter.execute("SELECT @@SESSION.wait_timeout AS v");
@@ -164,6 +183,8 @@ describeIfMysql("Mysql2Adapter", () => {
     it("wait timeout as url", async () => {
       const url = new URL(MYSQL_TEST_URL);
       url.searchParams.set("wait_timeout", "60");
+      // Stays self-built: an alternate config (wait_timeout in the URL) is the
+      // assertion.
       const testAdapter = new Mysql2Adapter(url.toString());
       try {
         const rows = await testAdapter.execute("SELECT @@SESSION.wait_timeout AS v");
@@ -187,8 +208,9 @@ describeIfMysql("Mysql2Adapter", () => {
     // helper. The Rails-named test_mysql_set_session_variable / _to_default
     // cases below exercise the `variables:` pool-init shape; these cover the
     // explicit-helper code path (identifier validation, DEFAULT handling,
-    // emitted quoting). Uses connectionLimit: 1 so SET SESSION + SELECT land
-    // on the same pool connection — see the JSDoc caveat.
+    // emitted quoting). All three stay self-built: connectionLimit:1 is what
+    // makes SET SESSION + SELECT land on the same pool connection (see the JSDoc
+    // caveat), and the session variables must not leak onto the leased one.
     it("setSessionVariable helper sets a session variable", async () => {
       const a = new Mysql2Adapter({ uri: MYSQL_TEST_URL, connectionLimit: 1 });
       try {
@@ -227,6 +249,7 @@ describeIfMysql("Mysql2Adapter", () => {
       expect(String(rows[0].v)).toMatch(/STRICT_ALL_TABLES/);
     });
     it("mysql strict mode disabled", async () => {
+      // Stays self-built: a deliberately non-strict adapter.
       const testAdapter = new Mysql2Adapter({ uri: MYSQL_TEST_URL, strict: false });
       try {
         const rows = await testAdapter.execute("SELECT @@SESSION.sql_mode AS v");
@@ -236,6 +259,7 @@ describeIfMysql("Mysql2Adapter", () => {
       }
     });
     it("mysql strict mode specified default", async () => {
+      // Stays self-built: `strict: "default"` is the config under test.
       const testAdapter = new Mysql2Adapter({ uri: MYSQL_TEST_URL, strict: "default" });
       try {
         const globalRows = await testAdapter.execute("SELECT @@GLOBAL.sql_mode AS v");
@@ -246,6 +270,8 @@ describeIfMysql("Mysql2Adapter", () => {
       }
     });
     it("mysql sql mode variable overrides strict mode", async () => {
+      // Stays self-built: a `variables:` override must not leak onto the shared
+      // leased connection.
       const testAdapter = new Mysql2Adapter({
         uri: MYSQL_TEST_URL,
         variables: { sql_mode: "ansi" },
@@ -259,6 +285,7 @@ describeIfMysql("Mysql2Adapter", () => {
     });
     it("passing arbitrary flags to adapter", async () => {
       // mirrors Rails: flags.push "FOUND_ROWS" appended when not already present
+      // Stays self-built: the connect flags it is constructed with are the assertion.
       const testAdapter = new Mysql2Adapter({ uri: MYSQL_TEST_URL, flags: ["COMPRESS"] });
       try {
         expect(testAdapter._testOnlyPoolFlags()).toEqual(["COMPRESS", "FOUND_ROWS"]);
@@ -268,6 +295,8 @@ describeIfMysql("Mysql2Adapter", () => {
     });
     it("passing flags by array to adapter", async () => {
       // mirrors Rails: FOUND_ROWS not duplicated when already present in the array
+      // Stays self-built: the connect flags this adapter is constructed with
+      // are the assertion.
       const testAdapter = new Mysql2Adapter({
         uri: MYSQL_TEST_URL,
         flags: ["FOUND_ROWS", "COMPRESS"],
@@ -279,6 +308,8 @@ describeIfMysql("Mysql2Adapter", () => {
       }
     });
     it("mysql set session variable", async () => {
+      // Stays self-built: a `variables:` override must not leak onto the shared
+      // leased connection.
       const testAdapter = new Mysql2Adapter({
         uri: MYSQL_TEST_URL,
         variables: { default_week_format: 3 },
@@ -291,6 +322,8 @@ describeIfMysql("Mysql2Adapter", () => {
       }
     });
     it("mysql set session variable to default", async () => {
+      // Stays self-built: a `variables:` override must not leak onto the shared
+      // leased connection.
       const testAdapter = new Mysql2Adapter({
         uri: MYSQL_TEST_URL,
         variables: { default_week_format: "default" },
@@ -338,18 +371,26 @@ describeIfMysql("Mysql2Adapter", () => {
       }
     });
 
+    // The leased connection has already resolved (and memoized) the real
+    // server version, so every stub below has to clear the cache first —
+    // Rails' @connection is likewise long-lived and its stubs re-run the query.
+    const clearVersionCache = (): void => {
+      (adapter as any)._databaseVersion = null;
+    };
+
     it("version string", async () => {
       const spy = vi.spyOn(adapter, "getFullVersion");
+      clearVersionCache();
       spy.mockResolvedValueOnce("8.0.35-0ubuntu0.22.04.1");
       expect((await adapter.getDatabaseVersion()).toString()).toBe("8.0.35");
 
-      // Clear the cache so the second stub is not masked by the first result.
-      (adapter as any)._databaseVersion = null;
+      clearVersionCache();
       spy.mockResolvedValueOnce("5.7.0");
       expect((await adapter.getDatabaseVersion()).toString()).toBe("5.7.0");
     });
 
     it("version string with mariadb", async () => {
+      clearVersionCache();
       vi.spyOn(adapter, "getFullVersion").mockResolvedValueOnce(
         "5.5.5-10.6.5-MariaDB-1:10.6.5+maria~focal",
       );
@@ -359,6 +400,7 @@ describeIfMysql("Mysql2Adapter", () => {
     it("version string invalid", async () => {
       const spy = vi.spyOn(adapter, "getFullVersion");
       const assertVersionError = async (version: string | null, expectedMsg: string) => {
+        clearVersionCache();
         spy.mockResolvedValueOnce(version as string);
         let caughtErr: unknown;
         try {
@@ -418,6 +460,7 @@ describeIfMysql("Mysql2Adapter", () => {
     afterEach(() => vi.restoreAllMocks());
 
     it("maps ER_BAD_DB_ERROR (1049) to NoDatabaseError", async () => {
+      // Stays self-built: a deliberately bad config is the assertion.
       const a = new Mysql2Adapter("mysql://root@localhost/no_such_db");
       stubCreateConnection(makeDriverError(1049));
       try {
@@ -428,6 +471,7 @@ describeIfMysql("Mysql2Adapter", () => {
     });
 
     it("maps ER_ACCESS_DENIED_ERROR (1045) to DatabaseConnectionError", async () => {
+      // Stays self-built: a deliberately bad config is the assertion.
       const a = new Mysql2Adapter({ host: "localhost", user: "baduser", database: "test" });
       stubCreateConnection(makeDriverError(1045));
       try {
@@ -440,6 +484,7 @@ describeIfMysql("Mysql2Adapter", () => {
     });
 
     it("maps ER_ACCESS_DENIED_ERROR via URI to DatabaseConnectionError with parsed username", async () => {
+      // Stays self-built: a deliberately bad config is the assertion.
       const a = new Mysql2Adapter("mysql://myuser:pw@localhost/test");
       stubCreateConnection(makeDriverError(1045));
       try {
@@ -452,6 +497,7 @@ describeIfMysql("Mysql2Adapter", () => {
     });
 
     it("maps ER_CONN_HOST_ERROR (2003) to DatabaseConnectionError with hostname", async () => {
+      // Stays self-built: a deliberately bad config is the assertion.
       const a = new Mysql2Adapter("mysql://root@myhost.example.com/test");
       stubCreateConnection(makeDriverError(2003));
       try {
@@ -464,6 +510,8 @@ describeIfMysql("Mysql2Adapter", () => {
     });
 
     it("maps unknown errno to ConnectionNotEstablished", async () => {
+      // Stays self-built: the stubbed createConnection is only reached by an
+      // adapter that has not connected yet — the leased one already has.
       const a = new Mysql2Adapter(MYSQL_TEST_URL);
       stubCreateConnection(makeDriverError(9999, "something went wrong"));
       try {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/count-deleted-rows-with-lock.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/count-deleted-rows-with-lock.test.ts
@@ -1,13 +1,15 @@
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
-import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+import {
+  describeIfMysqlAdapter,
+  leaseMysqlAdapter,
+  Mysql2Adapter,
+  MYSQL_TEST_URL,
+} from "./test-helper.js";
 
-describeIfMysql("Mysql2Adapter", () => {
+describeIfMysqlAdapter("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   beforeEach(async () => {
-    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
-  });
-  afterEach(async () => {
-    await adapter.close();
+    adapter = await leaseMysqlAdapter();
   });
 
   describe("CountDeletedRowsWithLockTest", () => {
@@ -31,6 +33,8 @@ describeIfMysql("Mysql2Adapter", () => {
         "INSERT INTO `test_bulbs` (name, color) VALUES ('Jimmy', 'blue')",
       );
 
+      // Stays self-built: "in different threads" is the test — the concurrent
+      // INSERT has to run on a connection other than the one issuing the DELETE.
       const adapter2 = new Mysql2Adapter(MYSQL_TEST_URL);
       try {
         const [deleteResult, _createResult] = await Promise.allSettled([

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/nested-deadlock.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/nested-deadlock.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
-import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+import {
+  describeIfMysqlAdapter,
+  leaseMysqlAdapter,
+  Mysql2Adapter,
+  MYSQL_TEST_URL,
+} from "./test-helper.js";
 import { Deadlocked, Rollback } from "../../errors.js";
 import { SavepointTransaction } from "../../connection-adapters/abstract/transaction.js";
 
@@ -26,13 +31,10 @@ function assertSavepoint(a: Mysql2Adapter): void {
   expect(a.currentTransaction()).toBeInstanceOf(SavepointTransaction);
 }
 
-describeIfMysql("Mysql2Adapter", () => {
+describeIfMysqlAdapter("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   beforeEach(async () => {
-    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
-  });
-  afterEach(async () => {
-    await adapter.close();
+    adapter = await leaseMysqlAdapter();
   });
 
   describe("NestedDeadlockTest", () => {
@@ -114,6 +116,8 @@ describeIfMysql("Mysql2Adapter", () => {
     }
 
     it("deadlock correctly raises Deadlocked inside nested SavepointTransaction", async () => {
+      // Stays self-built: the deadlock needs two connections racing for the
+      // same rows — Rails' counterpart runs the second side on its own thread.
       const adapter2 = new Mysql2Adapter(MYSQL_TEST_URL);
       try {
         const { results } = await raceNestedTransactions(adapter2);
@@ -130,6 +134,8 @@ describeIfMysql("Mysql2Adapter", () => {
     });
 
     it("rollback exception is swallowed after a rollback", async () => {
+      // Stays self-built: the deadlock needs two connections racing for the
+      // same rows — Rails' counterpart runs the second side on its own thread.
       const adapter2 = new Mysql2Adapter(MYSQL_TEST_URL);
       try {
         const { results, deadlocks } = await raceNestedTransactions(adapter2, "rollback");
@@ -144,6 +150,8 @@ describeIfMysql("Mysql2Adapter", () => {
     });
 
     it("deadlock inside nested SavepointTransaction is recoverable", async () => {
+      // Stays self-built: the deadlock needs two connections racing for the
+      // same rows — Rails' counterpart runs the second side on its own thread.
       const adapter2 = new Mysql2Adapter(MYSQL_TEST_URL);
       try {
         const { results, deadlocks } = await raceNestedTransactions(adapter2, "swallow");

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/nested-deadlock.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/nested-deadlock.test.ts
@@ -116,8 +116,8 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     }
 
     it("deadlock correctly raises Deadlocked inside nested SavepointTransaction", async () => {
-      // Stays self-built: the deadlock needs two connections racing for the
-      // same rows — Rails' counterpart runs the second side on its own thread.
+      // Stays self-built: the second side of the deadlock needs its own
+      // connection (Rails runs it on its own thread).
       const adapter2 = new Mysql2Adapter(MYSQL_TEST_URL);
       try {
         const { results } = await raceNestedTransactions(adapter2);
@@ -134,8 +134,8 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     });
 
     it("rollback exception is swallowed after a rollback", async () => {
-      // Stays self-built: the deadlock needs two connections racing for the
-      // same rows — Rails' counterpart runs the second side on its own thread.
+      // Stays self-built: the second side of the deadlock needs its own
+      // connection (Rails runs it on its own thread).
       const adapter2 = new Mysql2Adapter(MYSQL_TEST_URL);
       try {
         const { results, deadlocks } = await raceNestedTransactions(adapter2, "rollback");
@@ -150,8 +150,8 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     });
 
     it("deadlock inside nested SavepointTransaction is recoverable", async () => {
-      // Stays self-built: the deadlock needs two connections racing for the
-      // same rows — Rails' counterpart runs the second side on its own thread.
+      // Stays self-built: the second side of the deadlock needs its own
+      // connection (Rails runs it on its own thread).
       const adapter2 = new Mysql2Adapter(MYSQL_TEST_URL);
       try {
         const { results, deadlocks } = await raceNestedTransactions(adapter2, "swallow");

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/nested-deadlock.trails.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/nested-deadlock.trails.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
-import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+import { describeIfMysqlAdapter, leaseMysqlAdapter, Mysql2Adapter } from "./test-helper.js";
 import { SavepointTransaction } from "../../connection-adapters/abstract/transaction.js";
 
 async function makeParentDirty(a: Mysql2Adapter): Promise<void> {
@@ -10,13 +10,10 @@ function assertSavepoint(a: Mysql2Adapter): void {
   expect(a.currentTransaction()).toBeInstanceOf(SavepointTransaction);
 }
 
-describeIfMysql("Mysql2Adapter", () => {
+describeIfMysqlAdapter("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   beforeEach(async () => {
-    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
-  });
-  afterEach(async () => {
-    await adapter.close();
+    adapter = await leaseMysqlAdapter();
   });
 
   describe("NestedDeadlockTest", () => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.test.ts
@@ -2,16 +2,32 @@
  * Mirrors Rails activerecord/test/cases/adapters/mysql2/statement_pool_test.rb
  */
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
-import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+import {
+  describeIfMysqlAdapter,
+  leaseMysqlAdapter,
+  Mysql2Adapter,
+  MYSQL_TEST_URL,
+} from "./test-helper.js";
 
-describeIfMysql("Mysql2Adapter", () => {
+describeIfMysqlAdapter("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
+  let originalPreparedStatements: boolean;
+  let originalStatementLimit: number;
   beforeEach(async () => {
-    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
+    adapter = await leaseMysqlAdapter();
+    originalPreparedStatements = adapter.preparedStatements;
+    originalStatementLimit = adapter.statementLimit;
     adapter.preparedStatements = true;
   });
-  afterEach(async () => {
-    await adapter.close();
+  afterEach(() => {
+    // preparedStatements/statementLimit are adapter-wide settings and the
+    // statement pool itself is per-connection state, both of which now outlive
+    // a single test on the shared leased connection. Restore the settings and
+    // drop the pool (disconnectBang is reconnectable — the next query
+    // re-establishes) so each test starts from the clean slate it asserts on.
+    adapter.preparedStatements = originalPreparedStatements;
+    adapter.statementLimit = originalStatementLimit;
+    adapter.disconnectBang();
   });
 
   describe("StatementPoolTest", () => {
@@ -97,21 +113,29 @@ describeIfMysql("Mysql2Adapter", () => {
     });
 
     it("dealloc does not raise on inactive connection", async () => {
-      await adapter.beginDbTransaction();
-      await adapter.execute("SELECT ? AS n", [1]);
-      const pool = adapter._statementPoolForTest()!;
-      await adapter.rollback();
-      await adapter.close();
+      // Stays self-built: close() permanently kills the adapter, which would
+      // poison the leased connection for every later test in this worker.
+      const closable = new Mysql2Adapter(MYSQL_TEST_URL);
+      closable.preparedStatements = true;
+      await closable.beginDbTransaction();
+      await closable.execute("SELECT ? AS n", [1]);
+      const pool = closable._statementPoolForTest()!;
+      await closable.rollback();
+      await closable.close();
       expect(() => pool.clear()).not.toThrow();
     });
 
     it("reads statementLimit from the config hash (database.yml shape)", async () => {
+      // Stays self-built: reading a differently configured statementLimit off
+      // the config hash is the assertion.
       const configured = new Mysql2Adapter({ uri: MYSQL_TEST_URL, statementLimit: 7 });
       expect(configured.statementLimit).toBe(7);
       await configured.close();
     });
 
     it("reads preparedStatements from the config hash", async () => {
+      // Stays self-built: a differently configured preparedStatements is the
+      // assertion.
       const configured = new Mysql2Adapter({
         uri: MYSQL_TEST_URL,
         preparedStatements: false,
@@ -120,6 +144,7 @@ describeIfMysql("Mysql2Adapter", () => {
       await configured.close();
     });
 
+    // Self-built by construction: these assert what the constructor rejects.
     it("rejects invalid statementLimit at construction time", () => {
       expect(() => new Mysql2Adapter({ uri: MYSQL_TEST_URL, statementLimit: -1 })).toThrow(
         RangeError,
@@ -148,6 +173,8 @@ describeIfMysql("Mysql2Adapter", () => {
           }),
       ).toThrow(TypeError);
 
+      // Stays self-built: the assignment guard is asserted on a throwaway
+      // adapter so a rejected value can never reach the leased connection.
       const adapter2 = new Mysql2Adapter(MYSQL_TEST_URL);
       try {
         expect(() => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/transaction.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/transaction.test.ts
@@ -2,16 +2,19 @@
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/transaction_test.rb
  */
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
-import { describeIfMysql, isMariaDb, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+import {
+  describeIfMysqlAdapter,
+  isMariaDb,
+  leaseMysqlAdapter,
+  Mysql2Adapter,
+  MYSQL_TEST_URL,
+} from "./test-helper.js";
 import { StatementTimeout, QueryAborted, ConnectionFailed } from "../../errors.js";
 
-describeIfMysql("Mysql2Adapter", () => {
+describeIfMysqlAdapter("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   beforeEach(async () => {
-    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
-  });
-  afterEach(async () => {
-    await adapter.close();
+    adapter = await leaseMysqlAdapter();
   });
 
   describe("TransactionTest", () => {
@@ -32,6 +35,9 @@ describeIfMysql("Mysql2Adapter", () => {
       const rows = await adapter.execute("SELECT id FROM `samples` LIMIT 1");
       const id = Number(rows[0]["id"]);
 
+      // Stays self-built: the lock contention IS the test. Rails runs the
+      // competing FOR UPDATE on a second thread's pool connection; a second
+      // in-test adapter is the closest faithful shape.
       const adapter2 = new Mysql2Adapter(MYSQL_TEST_URL);
       let error: unknown;
       try {
@@ -79,6 +85,8 @@ describeIfMysql("Mysql2Adapter", () => {
         return Number(rows[0]["n"]);
       };
 
+      // Stays self-built: the point is an INSERT from a *different* connection
+      // being (in)visible inside this connection's transaction.
       const adapter2 = new Mysql2Adapter(MYSQL_TEST_URL);
       try {
         // 1. Default (REPEATABLE READ): INSERT by another connection is not visible

--- a/packages/activerecord/src/adapters/mysql2/bigint-roundtrip.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/bigint-roundtrip.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { BigIntegerType } from "@blazetrails/activemodel";
 import {
-  describeIfMysql,
+  describeIfMysqlAdapter,
+  leaseMysqlAdapter,
   Mysql2Adapter,
-  MYSQL_TEST_URL,
 } from "../abstract-mysql-adapter/test-helper.js";
 
-describeIfMysql("Mysql2Adapter", () => {
+describeIfMysqlAdapter("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   const type = new BigIntegerType({ limit: 8 });
   // 2^62 — 19 digits, well above the 15-digit threshold where mysql2
@@ -14,7 +14,7 @@ describeIfMysql("Mysql2Adapter", () => {
   const BIG = 2n ** 62n;
 
   beforeEach(async () => {
-    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
+    adapter = await leaseMysqlAdapter();
     await adapter.executeMutation(`DROP TABLE IF EXISTS \`bigint_rt\``);
     await adapter.executeMutation(`
       CREATE TABLE \`bigint_rt\` (
@@ -27,7 +27,6 @@ describeIfMysql("Mysql2Adapter", () => {
 
   afterEach(async () => {
     await adapter.executeMutation(`DROP TABLE IF EXISTS \`bigint_rt\``);
-    await adapter.close();
   });
 
   describe("MySQL bigint round-trip", () => {

--- a/packages/activerecord/src/adapters/mysql2/check-constraint-quoting.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/check-constraint-quoting.test.ts
@@ -3,24 +3,23 @@
  */
 import { it, expect, beforeEach, afterEach } from "vitest";
 import {
-  describeIfMysql,
+  describeIfMysqlAdapter,
   isMariaDb,
+  leaseMysqlAdapter,
   Mysql2Adapter,
-  MYSQL_TEST_URL,
 } from "../abstract-mysql-adapter/test-helper.js";
 import { describeIfSupports } from "../../test-helpers/supports.js";
 
-describeIfMysql("Mysql2Adapter", () => {
+describeIfMysqlAdapter("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   beforeEach(async () => {
-    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
+    adapter = await leaseMysqlAdapter();
     await adapter.createTable("trades", { force: true }, (t: any) => {
       t.string("name");
     });
   });
   afterEach(async () => {
     await adapter.dropTable("trades", { ifExists: true });
-    await adapter.close();
   });
 
   describeIfSupports("check_constraints", "MySQL2CheckConstraintQuotingTest", () => {

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter-perform-query.trails.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter-perform-query.trails.test.ts
@@ -12,17 +12,18 @@
  */
 import { it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
-  describeIfMysql,
+  describeIfMysqlAdapter,
+  leaseMysqlAdapter,
   Mysql2Adapter,
-  MYSQL_TEST_URL,
 } from "../abstract-mysql-adapter/test-helper.js";
 import { ReadOnlyError } from "../../errors.js";
 
-describeIfMysql("Mysql2AdapterPerformQueryTest (trails)", () => {
+describeIfMysqlAdapter("Mysql2AdapterPerformQueryTest (trails)", () => {
   let adapter: Mysql2Adapter;
+  let originalPool: unknown;
 
   beforeEach(async () => {
-    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
+    adapter = await leaseMysqlAdapter();
     await adapter.exec(`DROP TABLE IF EXISTS pq`);
     await adapter.exec(
       `CREATE TABLE pq (id bigint NOT NULL AUTO_INCREMENT PRIMARY KEY, nick varchar(255))`,
@@ -31,11 +32,17 @@ describeIfMysql("Mysql2AdapterPerformQueryTest (trails)", () => {
 
   afterEach(async () => {
     vi.restoreAllMocks();
+    // The adapter is the shared leased connection, so the swapped-in
+    // prevent-writes pool has to come back off before anything else uses it.
+    if (originalPool !== undefined) {
+      (adapter as Mysql2Adapter & { pool: unknown }).pool = originalPool;
+      originalPool = undefined;
+    }
     await adapter.exec(`DROP TABLE IF EXISTS pq`);
-    await adapter.close();
   });
 
   function preventWrites(a: Mysql2Adapter): void {
+    originalPool = (a as Mysql2Adapter & { pool: unknown }).pool;
     (a as Mysql2Adapter & { pool: { preventWrites?: boolean } }).pool = { preventWrites: true };
   }
 

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
@@ -20,8 +20,9 @@
  */
 import { it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
-  describeIfMysql,
+  describeIfMysqlAdapter,
   isMariaDb,
+  leaseMysqlAdapter,
   Mysql2Adapter,
   MYSQL_TEST_URL,
   withDbWarningsAction,
@@ -40,17 +41,16 @@ import { rebuildCanonicalTables } from "../../test-helpers/canonical-schema.js";
 import { Result } from "../../result.js";
 import * as Arel from "@blazetrails/arel";
 
-describeIfMysql("Mysql2AdapterTest", () => {
+describeIfMysqlAdapter("Mysql2AdapterTest", () => {
   let adapter: Mysql2Adapter;
   beforeEach(async () => {
-    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
+    adapter = await leaseMysqlAdapter();
   });
-  afterEach(async () => {
+  afterEach(() => {
     // Restore any console / logger spies installed by the warning-handler
     // tests so a throw before the inner mockRestore() can't leak the stub
     // into subsequent suites.
     vi.restoreAllMocks();
-    await adapter.close();
   });
 
   it("connection error", async () => {
@@ -60,6 +60,7 @@ describeIfMysql("Mysql2AdapterTest", () => {
     // `@raw_connection`), so the dead-socket failure surfaces here via the same
     // rescued `connect` → `set_pool(@pool)` path, carrying the standalone
     // adapter's NullPool.
+    // Stays self-built: Rails builds this dead-socket adapter in-test too.
     const badAdapter = new Mysql2Adapter({ socketPath: "/dev/null", preparedStatements: false });
     try {
       const error = await badAdapter
@@ -79,6 +80,7 @@ describeIfMysql("Mysql2AdapterTest", () => {
     // equals the adapter's own pool (a NullPool). trails' `reconnectBang()`
     // (Rails' `reconnect!`) now re-establishes the connection eagerly and
     // re-raises the translated ConnectionNotEstablished, so assert it directly.
+    // Stays self-built: Rails builds this dead-socket adapter in-test too.
     const badAdapter = new Mysql2Adapter({ socketPath: "/dev/null", preparedStatements: false });
     try {
       const error = await badAdapter

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.trails.test.ts
@@ -11,7 +11,8 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
-  describeIfMysql,
+  describeIfMysqlAdapter,
+  leaseMysqlAdapter,
   Mysql2Adapter,
   MYSQL_TEST_URL,
   withDbWarningsAction,
@@ -54,6 +55,8 @@ describe("Mysql2Adapter#translateException (fabricated errors)", () => {
     // touching a real DB, preserving the `active ⟹ isConnected` invariant.
     expect(adapter.active).toBe(false);
     expect(adapter.isConnected()).toBe(false);
+    // Stays self-built: a *never-connected* adapter is exactly what this
+    // asserts on — the leased connection is live by construction.
     const fresh = new Mysql2Adapter(MYSQL_TEST_URL);
     expect(fresh.active).toBe(false);
     expect(fresh.isConnected()).toBe(false);
@@ -140,14 +143,13 @@ describe("Mysql2Adapter#translateException (fabricated errors)", () => {
   });
 });
 
-describeIfMysql("Mysql2Adapter (trails extensions)", () => {
+describeIfMysqlAdapter("Mysql2Adapter (trails extensions)", () => {
   let adapter: Mysql2Adapter;
   beforeEach(async () => {
-    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
+    adapter = await leaseMysqlAdapter();
   });
-  afterEach(async () => {
+  afterEach(() => {
     vi.restoreAllMocks();
-    await adapter.close();
   });
 
   // trails-only: the sync `active` getter converges to Rails' Mysql2Adapter#active?
@@ -157,6 +159,8 @@ describeIfMysql("Mysql2Adapter (trails extensions)", () => {
   // it has no never-connected window to cover; this guards trails' lazy-connect.
   describe("#active sync getter reflects connection state", () => {
     it("is false before any connection and true after the first query", async () => {
+      // Stays self-built: the never-connected → connected → disconnected walk
+      // is the assertion, and disconnectBang() must not hit the leased pool.
       const fresh = new Mysql2Adapter(MYSQL_TEST_URL);
       try {
         expect(fresh.active).toBe(false);
@@ -247,10 +251,9 @@ describeIfMysql("Mysql2Adapter (trails extensions)", () => {
   it("#exec_query queries with an empty result set still return the columns", async () => {
     // Mirrors adapter_test.rb: a zero-row SELECT must still report its
     // columns from the field descriptors, not collapse to an empty Result.
-    // Rails runs this against the canonical `subscribers` fixture table; the
-    // describeIfMysql suite does not bootstrap the canonical schema, so lay the
-    // canonical table through the canonical loader rather than hand-rolling its
-    // DDL. It is left in place afterwards on purpose: this suite shares the
+    // Rails runs this against the canonical `subscribers` fixture table; this
+    // suite does not bootstrap the canonical schema, so lay the canonical table
+    // through the canonical loader rather than hand-rolling its DDL. It is left in place afterwards on purpose: this suite shares the
     // per-worker database with every other file.
     await rebuildCanonicalTables(adapter, ["subscribers"]);
     const result = await adapter.execQuery("SELECT * FROM subscribers WHERE 1=0");

--- a/packages/activerecord/src/adapters/mysql2/savepoint-reconnect.trails.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/savepoint-reconnect.trails.test.ts
@@ -32,6 +32,10 @@ describeIfMysql("Mysql2Adapter savepoint statements dirty the parent (trails)", 
   let adapter: Mysql2Adapter;
 
   beforeEach(() => {
+    // Stays self-built: the tests fault `rawConnectionForBlock` so
+    // `withRawConnection` genuinely tears down and re-establishes this adapter's
+    // socket mid-transaction. Driving that against the shared leased connection
+    // would leave the pool reconnecting under later tests in the same worker.
     adapter = new Mysql2Adapter(MYSQL_TEST_URL);
   });
   afterEach(async () => {

--- a/packages/activerecord/src/defaults.test.ts
+++ b/packages/activerecord/src/defaults.test.ts
@@ -472,6 +472,8 @@ describeIfMysql("DefaultsTestWithoutTransactionalFixtures", () => {
     strict: boolean,
     fn: (klass: typeof Base) => Promise<void>,
   ): Promise<void> {
+    // Stays self-built: `strict` is the config under test, and a non-strict
+    // sql_mode must not leak onto the shared leased connection.
     const adapter = new Mysql2Adapter({ uri: MYSQL_TEST_URL, strict });
     try {
       await adapter.createTable("test_mysql_not_null_defaults", { force: true }, (t: any) => {


### PR DESCRIPTION
Batch 3 (final) of the `new Mysql2Adapter(MYSQL_TEST_URL)` burn-down, using the
`describeIfMysqlAdapter` / `leaseMysqlAdapter()` helpers batch 1 added.

## `(a)` — now on the ambient connection

| site | Rails counterpart |
| --- | --- |
| `adapters/mysql2/mysql2-adapter.test.ts` | `mysql2/connection_test.rb` setup leases |
| `adapters/mysql2/bigint-roundtrip.test.ts` | — (roundtrip through the ambient connection) |
| `adapters/mysql2/check-constraint-quoting.test.ts` | `check_constraint_quoting_test.rb` rides `Base.connection` |
| `adapters/mysql2/mysql2-adapter-perform-query.trails.test.ts` | TS-only extra |
| `adapters/mysql2/mysql2-adapter.trails.test.ts` (suite-level adapter) | TS-only extra |
| `adapters/abstract-mysql-adapter/transaction.test.ts` | `transaction_test.rb:9` leases |
| `adapters/abstract-mysql-adapter/statement-pool.test.ts` | — |
| `adapters/abstract-mysql-adapter/nested-deadlock.test.ts` (+ `.trails`) | `nested_deadlock_test.rb` |
| `adapters/abstract-mysql-adapter/connection.test.ts` | `connection_test.rb:13` leases |
| `adapters/abstract-mysql-adapter/count-deleted-rows-with-lock.test.ts` | `count_deleted_rows_with_lock_test.rb` |

Sharing one long-lived connection surfaced three pieces of per-connection state
that used to die with the throwaway adapter, each now handed back in `afterEach`:

- `connection.test.ts` disconnects/discards the connection (as Rails does to
  `Base.lease_connection`) and memoizes a **stubbed** `_databaseVersion` — so it
  clears the version cache and `verifyBang()`s the connection back. The version
  tests also clear the cache *before* stubbing, since the leased connection has
  already resolved the real server version.
- `statement-pool.test.ts` flips `preparedStatements` / `statementLimit` and
  asserts on statement-pool identity and entry counts — settings are restored
  and the pool dropped via the reconnectable `disconnectBang()`.
- `mysql2-adapter-perform-query.trails.test.ts` swaps in a prevent-writes pool;
  the original is put back.

## `(b)` — still self-built, each with a call-site reason

Second-connection sites (`transaction.test.ts`, `nested-deadlock.test.ts`,
`count-deleted-rows-with-lock.test.ts`, `statement-pool.test.ts`), differently
configured adapters (`statementLimit`, `preparedStatements`, `strict`,
`variables:`, `flags:`, `waitTimeout`, `connectionLimit: 1`), deliberately bad
configs in `connection.test.ts`, and `defaults.test.ts`'s non-strict adapter.

## Audits

- **`savepoint-reconnect.trails.test.ts` — stays self-built.** It faults
  `rawConnectionForBlock` so `withRawConnection` genuinely tears down and
  re-establishes the socket mid-transaction; driving that against the leased
  connection would leave the pool reconnecting under later tests in the worker.
- **`mysql2-adapter.trails.test.ts`** — `:146` was a plain `(a)` setup and is
  converted. The two `fresh` adapters (`:57`, `:160`) stay self-built: a
  *never-connected* adapter (and the `disconnectBang()` walk) is exactly what
  they assert on.
- **`connection.test.ts:467`** also stays self-built, alongside its siblings in
  the same `describe`: the stubbed `mysql.createConnection` is only reachable by
  an adapter that has not connected yet.

No `new Mysql2Adapter(...)` site in the MySQL test tree is now without a reason.

Test names unchanged. Locally green on the mysql2 lane across the **whole**
`adapters/mysql2` + `adapters/abstract-mysql-adapter` tree plus
`defaults.test.ts` (252 passed / 39 skipped, 33 files) — deliberately wider than
the touched files, since the point of this batch is that these suites now share
one connection and must not leak state into each other. Also green on the
default sqlite lane.

Closes-story: mysql-tests-self-built-adapter-burndown-batch-3
