### PR TITLE
refactor(internal-metadata): thread connection through private helpers per Rails

### DIFF
--- a/packages/activerecord/src/internal-metadata.trails.test.ts
+++ b/packages/activerecord/src/internal-metadata.trails.test.ts
@@ -1,7 +1,6 @@
 // trails-only InternalMetadata cases — vendor/rails/activerecord/test/cases has
 // no internal_metadata_test.rb, so these have no Rails counterpart to mirror.
-import { describe, it, expect } from "vitest";
-import { Temporal } from "@blazetrails/activesupport/temporal";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { InternalMetadata } from "./internal-metadata.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 
@@ -19,7 +18,25 @@ function currentTime(defaultTimezone: string): string {
   return metadataBuiltOverLocalAdapter.currentTime(fakeAdapter(defaultTimezone));
 }
 
+// 2026-07-25T23:25:21.123Z is 19:25:21.123 in New York — a fixed instant and a
+// fixed non-UTC zone, so the utc and local branches differ by a whole 4 hours
+// no matter what zone the host (or CI) runs in.
+const FIXED_INSTANT = "2026-07-25T23:25:21.123Z";
+const FIXED_UTC = "2026-07-25 23:25:21.123";
+const FIXED_LOCAL = "2026-07-25 19:25:21.123";
+
 describe("InternalMetadata#currentTime", () => {
+  beforeAll(() => {
+    vi.stubEnv("TZ", "America/New_York");
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(FIXED_INSTANT));
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+  });
+
   it("formats as YYYY-MM-DD HH:mm:ss.SSS with no zone designator", () => {
     for (const tz of ["utc", "local"]) {
       expect(currentTime(tz)).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}$/);
@@ -27,16 +44,7 @@ describe("InternalMetadata#currentTime", () => {
   });
 
   it("reads the clock the connection's default timezone selects", () => {
-    const utcNow = Temporal.Now.instant().toString({
-      smallestUnit: "minute",
-      roundingMode: "trunc",
-    });
-    expect(currentTime("utc").slice(0, 16)).toBe(utcNow.slice(0, 16).replace("T", " "));
-
-    const localNow = Temporal.Now.plainDateTimeISO().toString({
-      smallestUnit: "minute",
-      roundingMode: "trunc",
-    });
-    expect(currentTime("local").slice(0, 16)).toBe(localNow.slice(0, 16).replace("T", " "));
+    expect(currentTime("utc")).toBe(FIXED_UTC);
+    expect(currentTime("local")).toBe(FIXED_LOCAL);
   });
 });

--- a/packages/activerecord/src/internal-metadata.trails.test.ts
+++ b/packages/activerecord/src/internal-metadata.trails.test.ts
@@ -1,0 +1,39 @@
+// trails-only InternalMetadata cases — vendor/rails/activerecord/test/cases has
+// no internal_metadata_test.rb, so these have no Rails counterpart to mirror.
+import { describe, it, expect } from "vitest";
+import { Temporal } from "@blazetrails/activesupport/temporal";
+import { InternalMetadata } from "./internal-metadata.js";
+import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
+
+function fakeAdapter(defaultTimezone: string): DatabaseAdapter {
+  return { defaultTimezone } as unknown as DatabaseAdapter;
+}
+
+type CurrentTimeHost = { currentTime(connection: DatabaseAdapter): string };
+
+function currentTime(defaultTimezone: string): string {
+  const im = new InternalMetadata(fakeAdapter(defaultTimezone));
+  return (im as unknown as CurrentTimeHost).currentTime(fakeAdapter(defaultTimezone));
+}
+
+describe("InternalMetadata#currentTime", () => {
+  it("formats as YYYY-MM-DD HH:mm:ss.SSS with no zone designator", () => {
+    for (const tz of ["utc", "local"]) {
+      expect(currentTime(tz)).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}$/);
+    }
+  });
+
+  it("reads the clock the connection's default timezone selects", () => {
+    const utcNow = Temporal.Now.instant().toString({
+      smallestUnit: "minute",
+      roundingMode: "trunc",
+    });
+    expect(currentTime("utc").slice(0, 16)).toBe(utcNow.slice(0, 16).replace("T", " "));
+
+    const localNow = Temporal.Now.plainDateTimeISO().toString({
+      smallestUnit: "minute",
+      roundingMode: "trunc",
+    });
+    expect(currentTime("local").slice(0, 16)).toBe(localNow.slice(0, 16).replace("T", " "));
+  });
+});

--- a/packages/activerecord/src/internal-metadata.trails.test.ts
+++ b/packages/activerecord/src/internal-metadata.trails.test.ts
@@ -11,9 +11,12 @@ function fakeAdapter(defaultTimezone: string): DatabaseAdapter {
 
 type CurrentTimeHost = { currentTime(connection: DatabaseAdapter): string };
 
+const metadataBuiltOverLocalAdapter = new InternalMetadata(
+  fakeAdapter("local"),
+) as unknown as CurrentTimeHost;
+
 function currentTime(defaultTimezone: string): string {
-  const im = new InternalMetadata(fakeAdapter(defaultTimezone));
-  return (im as unknown as CurrentTimeHost).currentTime(fakeAdapter(defaultTimezone));
+  return metadataBuiltOverLocalAdapter.currentTime(fakeAdapter(defaultTimezone));
 }
 
 describe("InternalMetadata#currentTime", () => {

--- a/packages/activerecord/src/internal-metadata.ts
+++ b/packages/activerecord/src/internal-metadata.ts
@@ -108,8 +108,10 @@ export class InternalMetadata {
   async createTableAndSetFlags(environment: string, schemaSha1?: string): Promise<void> {
     if (!this._enabled) return;
     await this.createTable();
-    await this.set("environment", environment);
-    if (schemaSha1 !== undefined) await this.set("schema_sha1", schemaSha1);
+    await this.updateOrCreateEntry(this._connection, "environment", environment);
+    if (schemaSha1 !== undefined) {
+      await this.updateOrCreateEntry(this._connection, "schema_sha1", schemaSha1);
+    }
   }
 
   async dropTable(): Promise<void> {
@@ -127,7 +129,7 @@ export class InternalMetadata {
     // probing ar_internal_metadata — callers shouldn't observe stale
     // rows from a previous run that had the flag enabled.
     if (!this._enabled) return null;
-    const entry = await this.selectEntry(key);
+    const entry = await this.selectEntry(this._connection, key);
     if (!entry) return null;
     const value = entry[this.valueKey];
     if (value == null) return null;
@@ -143,18 +145,22 @@ export class InternalMetadata {
       // migration.ts (the cycle is ESM-safe because EnvironmentStorageError is only used in method bodies).
       throw new EnvironmentStorageError();
     }
-    await this.updateOrCreateEntry(key, value);
+    await this.updateOrCreateEntry(this._connection, key, value);
   }
 
   /** @internal */
-  private async updateOrCreateEntry(key: string, value: string): Promise<void> {
-    const entry = await this.selectEntry(key);
+  private async updateOrCreateEntry(
+    connection: DatabaseAdapter,
+    key: string,
+    value: string,
+  ): Promise<void> {
+    const entry = await this.selectEntry(connection, key);
     if (entry) {
       if (entry[this.valueKey] !== value) {
-        await this.updateEntry(key, value);
+        await this.updateEntry(connection, key, value);
       }
     } else {
-      await this.createEntry(key, value);
+      await this.createEntry(connection, key, value);
     }
   }
 
@@ -208,28 +214,37 @@ export class InternalMetadata {
     return this.deleteAllEntries();
   }
 
-  private currentTime(): string {
+  private currentTime(connection: DatabaseAdapter): string {
+    // Rails: connection.default_timezone == :utc ? Time.now.utc : Time.now.
     // Format: "YYYY-MM-DD HH:mm:ss.SSS" — drop the trailing 'Z' and swap 'T' for ' '.
     // Truncate sub-ms (Rails uses ms-precise updated_at strings; default Temporal
     // rounding is halfExpand which would otherwise round up).
-    return Temporal.Now.instant()
-      .toString({ smallestUnit: "millisecond", roundingMode: "trunc" })
-      .replace("T", " ")
-      .replace("Z", "");
+    const opts = { smallestUnit: "millisecond", roundingMode: "trunc" } as const;
+    if (connection.defaultTimezone === "utc") {
+      return Temporal.Now.instant().toString(opts).replace("T", " ").replace("Z", "");
+    }
+    return Temporal.Now.plainDateTimeISO().toString(opts).replace("T", " ");
   }
 
-  private async selectEntry(key: string): Promise<Record<string, unknown> | null> {
+  private async selectEntry(
+    connection: DatabaseAdapter,
+    key: string,
+  ): Promise<Record<string, unknown> | null> {
     const sm = new SelectManager(this.arelTable);
     sm.project(star);
     sm.where(this.arelTable.get(this.primaryKey).eq(key));
     sm.order(this.arelTable.get(this.primaryKey).asc());
     sm.take(1);
-    const rows = await this._connection.execute(this._connection.toSql(sm));
+    const rows = await connection.execute(connection.toSql(sm));
     return rows[0] ?? null;
   }
 
-  private async createEntry(key: string, value: string): Promise<void> {
-    const now = this.currentTime();
+  private async createEntry(
+    connection: DatabaseAdapter,
+    key: string,
+    value: string,
+  ): Promise<void> {
+    const now = this.currentTime(connection);
     const im = new InsertManager(this.arelTable);
     im.insert([
       [this.arelTable.get(this.primaryKey), key],
@@ -237,11 +252,15 @@ export class InternalMetadata {
       [this.arelTable.get("created_at"), now],
       [this.arelTable.get("updated_at"), now],
     ]);
-    await this._connection.execute(this._connection.toSql(im));
+    await connection.execute(connection.toSql(im));
   }
 
-  private async updateEntry(key: string, newValue: string): Promise<void> {
-    const now = this.currentTime();
+  private async updateEntry(
+    connection: DatabaseAdapter,
+    key: string,
+    newValue: string,
+  ): Promise<void> {
+    const now = this.currentTime(connection);
     const um = new UpdateManager();
     um.table(this.arelTable);
     um.set([
@@ -249,6 +268,6 @@ export class InternalMetadata {
       [this.arelTable.get("updated_at"), now],
     ]);
     um.where(this.arelTable.get(this.primaryKey).eq(key));
-    await this._connection.execute(this._connection.toSql(um));
+    await connection.execute(connection.toSql(um));
   }
 }

--- a/packages/activerecord/src/internal-metadata.ts
+++ b/packages/activerecord/src/internal-metadata.ts
@@ -215,7 +215,6 @@ export class InternalMetadata {
   }
 
   private currentTime(connection: DatabaseAdapter): string {
-    // Rails: connection.default_timezone == :utc ? Time.now.utc : Time.now.
     // Format: "YYYY-MM-DD HH:mm:ss.SSS" — drop the trailing 'Z' and swap 'T' for ' '.
     // Truncate sub-ms (Rails uses ms-precise updated_at strings; default Temporal
     // rounding is halfExpand which would otherwise round up).

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/internal-metadata.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/internal-metadata.json
@@ -31,13 +31,6 @@
     "package": "activerecord",
     "tsFile": "internal-metadata.ts",
     "rubyName": "create_table_and_set_flags",
-    "call": "update_or_create_entry",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "internal-metadata.ts",
-    "rubyName": "create_table_and_set_flags",
     "call": "with_connection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
Rails 7.2+ threads the `connection` explicitly through `InternalMetadata`'s
private helpers; trails reached for `this._connection` inside each one. That
produced all 5 `internal_metadata.rb` entries in `arity-mismatches.json`.

- `updateOrCreateEntry`, `createEntry`, `updateEntry`, `selectEntry` and
  `currentTime` now take a leading `connection` param and use it for every
  `execute` / `toSql`, matching Rails' private section.
- Public callers (`get`, `set`, `createTableAndSetFlags`) pass the connection
  down. `createTableAndSetFlags` calls `updateOrCreateEntry` directly, as Rails
  does, rather than routing back through the public `[]=` analogue — that path
  was previously reachable only when `enabled?`, so behavior is unchanged.
- `currentTime(connection)` picks up Rails' `connection.default_timezone ==
  :utc ? Time.now.utc : Time.now` branch. Without it the new param would be
  unused — a signature that satisfies the arity check while the body still
  ignores the connection.

New `internal-metadata.trails.test.ts` (no `internal_metadata_test.rb` exists in
vendored Rails to mirror) is fully deterministic: `vi.setSystemTime` pins the
instant and `vi.stubEnv("TZ", ...)` pins the zone to `America/New_York`, so the
utc and local branches differ by a fixed 4 hours regardless of host zone, and
both expectations are literal strings. It also pins `currentTime` to its
*argument* connection — the instance is built over a `local` adapter, so the
`utc` case would read the wrong clock if the helper fell back to
`this._connection`.

Verified the test discriminates rather than just passing: with the timezone
branch reverted to the old unconditional `Temporal.Now.instant()`, it fails
under `TZ=UTC` (`expected '2026-07-25 23:25:21.123' to be
'2026-07-25 19:25:21.123'`), so it catches a dropped or swapped branch on UTC
CI, not only on a non-UTC dev host.

No comments were added to `internal-metadata.ts` by this change.

`arity-mismatches.json` regenerated: 0 `internal_metadata.rb` entries remain
(overall arity 7189/7312, 98.3%); call-parity and overall coverage unchanged.
Tests: `internal-metadata.trails`, `migration`, `migrator.trails`,
`schema-dumper.trails`, `model-codegen` — 153 passed, 25 skipped.

Because `createTableAndSetFlags` now calls `updateOrCreateEntry` directly, the
wide call-mismatch baseline entry `create_table_and_set_flags →
update_or_create_entry` stopped flagging, and that ratchet only shrinks. Removed
the converged entry from
`scripts/api-compare/call-mismatches-wide-exclude/activerecord/internal-metadata.json`
(one entry; the rest of the cluster still flags and is untouched). `pnpm
api:compare` alone does not run the wide ratchet lint — verified with the full
CI sequence: `compare.ts --privates`, `lint-call-mismatches`, `lint-body-pins`,
`compare.ts --wide-calls`, `lint-call-mismatches-wide` (OK, 5080 baselined),
`conventions-doc --check`, `lint-deps` — all green.

Closes-story: arity-internal-metadata-connection-param

