### PR TITLE
fix(associations): converge association/autosave signatures to Rails arity

### DIFF
--- a/packages/activerecord/src/associations/association-scope-alias-tracker.test.ts
+++ b/packages/activerecord/src/associations/association-scope-alias-tracker.test.ts
@@ -27,6 +27,7 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { AssociationScope } from "./association-scope.js";
 import { AliasTracker } from "./alias-tracker.js";
+import { RuntimeReflection } from "../reflection.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 
 describe("AssociationScope — AliasTracker aliases repeated tables", () => {
@@ -108,8 +109,11 @@ describe("AssociationScope — AliasTracker aliases repeated tables", () => {
       klass: refl.klass,
     });
     expect(builtChain.length).toBe(chain.length);
-    // The head entry is the RuntimeReflection wrapping the original
-    // reflection (no aliasedTable).
+    // Rails' head entry is `RuntimeReflection.new(reflection, association)`
+    // (association_scope.rb:114) — it resolves `klass` off the live
+    // association, so a polymorphic belongs_to head is usable.
+    expect(builtChain[0]).toBeInstanceOf(RuntimeReflection);
+    expect((builtChain[0] as any).klass).toBe(refl.klass);
     // The tail's first proxy visits comments again and must be
     // aliased — not the bare "comments".
     const tailAliased = (builtChain[1] as any).aliasedTable;

--- a/packages/activerecord/src/associations/association-scope-alias-tracker.test.ts
+++ b/packages/activerecord/src/associations/association-scope-alias-tracker.test.ts
@@ -97,14 +97,19 @@ describe("AssociationScope — AliasTracker aliases repeated tables", () => {
     // correctness depends on orthogonal chain-expansion work —
     // task #21).
     class TestScope extends AssociationScope {
-      public runGetChain(reflection: any) {
+      public runGetChain(reflection: any, association: any) {
         const tracker = AliasTracker.create(null, reflection.klass.arelTable.name, []);
-        return this.getChain(reflection, tracker);
+        return this.getChain(reflection, association, tracker);
       }
     }
-    const builtChain = new TestScope(() => null).runGetChain(refl);
+    const builtChain = new TestScope(() => null).runGetChain(refl, {
+      owner: new AtComment(),
+      reflection: refl,
+      klass: refl.klass,
+    });
     expect(builtChain.length).toBe(chain.length);
-    // The head entry is the original reflection (no aliasedTable).
+    // The head entry is the RuntimeReflection wrapping the original
+    // reflection (no aliasedTable).
     // The tail's first proxy visits comments again and must be
     // aliased — not the bare "comments".
     const tailAliased = (builtChain[1] as any).aliasedTable;

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -2,6 +2,7 @@ import { Table as ArelTable, Nodes } from "@blazetrails/arel";
 import { TableMetadata } from "../table-metadata.js";
 import type { Base } from "../base.js";
 import type { AssociationReflection, AbstractReflection } from "../reflection.js";
+import { RuntimeReflection } from "../reflection.js";
 import { AliasTracker, aliasedArelTableForReflection } from "./alias-tracker.js";
 import { polymorphicName } from "../inheritance.js";
 import { CompositePrimaryKeyMismatchError } from "./errors.js";
@@ -278,7 +279,7 @@ export class AssociationScope {
     // thread-connection-table-alias-length-into-tracker-construction) it falls
     // back to the 64 default — a documented `create`-side deviation, not a
     // call-site one.
-    const chain = this.getChain(reflection, scopeRelation.aliasTracker());
+    const chain = this.getChain(reflection, association, scopeRelation.aliasTracker());
     // Rails: `scope.extending! reflection.extensions` (association_scope.rb:28).
     // Mix any `extend:`-declared modules onto the relation so extension
     // methods are available on the loaded association's relation.
@@ -486,9 +487,15 @@ export class AssociationScope {
    */
   protected getChain(
     reflection: AssociationReflection,
+    association: AssociationScopeable,
     tracker?: AliasTracker,
   ): Array<AbstractReflection | ReflectionProxy> {
-    const chain: Array<AbstractReflection | ReflectionProxy> = [reflection];
+    // Rails: `chain = [Reflection::RuntimeReflection.new(reflection, association)]`
+    // — the head resolves `klass` off the live association, which is what makes
+    // a polymorphic belongs_to head usable (its reflection can't compute one).
+    const chain: Array<AbstractReflection | ReflectionProxy> = [
+      new RuntimeReflection(reflection, association),
+    ];
     const tail = reflection.chain.slice(1);
     const name = reflection.name;
     for (const refl of tail) {

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -491,8 +491,8 @@ export class AssociationScope {
     tracker?: AliasTracker,
   ): Array<AbstractReflection | ReflectionProxy> {
     // Rails: `chain = [Reflection::RuntimeReflection.new(reflection, association)]`
-    // — the head resolves `klass` off the live association, which is what makes
-    // a polymorphic belongs_to head usable (its reflection can't compute one).
+    // (association_scope.rb:114) — the head resolves `klass` off the live
+    // association, which is what makes a polymorphic belongs_to head usable.
     const chain: Array<AbstractReflection | ReflectionProxy> = [
       new RuntimeReflection(reflection, association),
     ];

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -126,7 +126,7 @@ export class DisableJoinsAssociationScope extends AssociationScope {
     // aliased tables during the chain walk.
     const unscoped = klass.unscoped() as { aliasTracker: () => AliasTracker };
     return DisableJoinsAssociationRelation.deferred(klass, async () => {
-      const reverseChain = this.getChain(sourceReflection, unscoped.aliasTracker())
+      const reverseChain = this.getChain(sourceReflection, association, unscoped.aliasTracker())
         .slice()
         .reverse();
       const [lastReflection, lastOrdered, lastJoinIds] = await this._lastScopeChain(

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -693,19 +693,18 @@ function updateThroughCounter(this: HasManyThroughAssociation, method: string): 
 /**
  * Ruby reads `through_reflection` (ThroughAssociation) straight off the
  * association; our reflection objects reach the through step through the
- * owner's registry, so resolve it once here for both the counter-cache branch
- * and `update_through_counter?`.
+ * owner's registry, so resolve it here for both the counter-cache branch and
+ * `update_through_counter?`. Routes through the file's `throughReflection`
+ * walker, which mirrors `ThroughAssociation#through_reflection`
+ * (through_association.rb:14-24) by recursing to the innermost non-through
+ * reflection — a single `_reflectOnAssociation(options.through)` lookup would
+ * stop at the intermediate reflection for a nested `through:` chain.
  * @internal
  */
 function throughCounterReflection(
   assoc: HasManyThroughAssociation,
 ): RichCounterReflection | undefined {
-  const throughName = assoc.reflection.options.through;
-  if (!throughName) return undefined;
-  const ctor = assoc.owner.constructor as {
-    _reflectOnAssociation?: (n: string) => RichCounterReflection | undefined;
-  };
-  return ctor._reflectOnAssociation?.(throughName);
+  return (throughReflection(assoc) as RichCounterReflection | null) ?? undefined;
 }
 
 /**

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -365,8 +365,8 @@ export class HasManyThroughAssociation extends HasManyAssociation {
     // falls to the own branch, so a distinct own counter (`tags_with_destroy_count`)
     // still decrements.
     if (count > 0) {
-      const throughRefl = throughName ? ctor._reflectOnAssociation?.(throughName) : undefined;
-      if (throughRefl?.isCollection?.() && updateThroughCounter(throughRefl, method)) {
+      const throughRefl = throughCounterReflection(this);
+      if (throughRefl?.isCollection?.() && updateThroughCounter.call(this, method)) {
         await updateThroughCounterCache(this.owner, throughRefl, -count);
       } else {
         await updateThroughCounterCache(this.owner, ownRefl, -count);
@@ -683,10 +683,29 @@ interface RichCounterReflection {
  * other method always.
  * @internal
  */
-function updateThroughCounter(throughReflection: RichCounterReflection, method: string): boolean {
-  if (method === "destroy") return !throughReflection.isInverseUpdatesCounterCache?.();
+function updateThroughCounter(this: HasManyThroughAssociation, method: string): boolean {
+  const through = throughCounterReflection(this);
+  if (method === "destroy") return !through?.isInverseUpdatesCounterCache?.();
   if (method === "nullify") return false;
   return true;
+}
+
+/**
+ * Ruby reads `through_reflection` (ThroughAssociation) straight off the
+ * association; our reflection objects reach the through step through the
+ * owner's registry, so resolve it once here for both the counter-cache branch
+ * and `update_through_counter?`.
+ * @internal
+ */
+function throughCounterReflection(
+  assoc: HasManyThroughAssociation,
+): RichCounterReflection | undefined {
+  const throughName = assoc.reflection.options.through;
+  if (!throughName) return undefined;
+  const ctor = assoc.owner.constructor as {
+    _reflectOnAssociation?: (n: string) => RichCounterReflection | undefined;
+  };
+  return ctor._reflectOnAssociation?.(throughName);
 }
 
 /**

--- a/packages/activerecord/src/associations/nested-error.ts
+++ b/packages/activerecord/src/associations/nested-error.ts
@@ -29,6 +29,9 @@ interface InnerErrorLike {
  */
 export class NestedError extends ActiveModelNestedError {
   private readonly _association: AssociationLike;
+  // Narrows the base class' `innerError` to the AR shape — `index` reads
+  // `inner_error.base` (nested_error.rb:34).
+  declare readonly innerError: InnerErrorLike;
 
   constructor(association: AssociationLike, innerError: InnerErrorLike) {
     const attribute = NestedError.computeAttribute(association, innerError);
@@ -46,12 +49,13 @@ export class NestedError extends ActiveModelNestedError {
     innerError: InnerErrorLike,
   ): string {
     // Ruby runs `compute_attribute` as an instance method inside the
-    // constructor — after `@association` is set but *before* `super`
-    // (nested_error.rb:8-12). TS forbids touching `this` before `super`, so the
-    // readers below run against a receiver carrying the one ivar Ruby has at
-    // that point.
+    // constructor — after `@association` and `@inner_error` are set but *before*
+    // `super` (nested_error.rb:8-12). TS forbids touching `this` before
+    // `super`, so the readers below run against a receiver carrying exactly the
+    // two ivars Ruby has at that point.
     const self: NestedError = Object.assign(Object.create(NestedError.prototype) as NestedError, {
       _association: association,
+      innerError,
     });
     const name = association.reflection.name;
     // isCollection: check the Association method if available, otherwise infer
@@ -61,7 +65,7 @@ export class NestedError extends ActiveModelNestedError {
         ? association.isCollection()
         : Array.isArray(association.target);
     if (isCollection && indexErrorsSetting.call(self)) {
-      const idx = index.call(self, innerError);
+      const idx = index.call(self);
       if (idx != null) {
         return `${name}[${idx}].${innerError.attribute}`;
       }
@@ -90,15 +94,15 @@ function indexErrorsSetting(this: NestedError): boolean | "nestedAttributesOrder
 
 /**
  * Mirrors Rails' `index` (nested_error.rb:33-35) —
- * `ordered_records&.find_index(inner_error.base)`. Ruby reads `inner_error`
- * off the instance; here it rides in, because the sole caller
- * (`computeAttribute`) runs before `super` has stored it.
+ * `ordered_records&.find_index(inner_error.base)`, reading `inner_error` off
+ * the instance.
  * @internal
  */
-function index(this: NestedError, innerError: { base?: unknown }): number | undefined {
+function index(this: NestedError): number | undefined {
   const records = orderedRecords.call(this);
-  if (!records || !innerError.base) return undefined;
-  const idx = records.findIndex((r) => r === innerError.base);
+  const base = this.innerError.base;
+  if (!records || !base) return undefined;
+  const idx = records.findIndex((r) => r === base);
   return idx >= 0 ? idx : undefined;
 }
 

--- a/packages/activerecord/src/associations/nested-error.ts
+++ b/packages/activerecord/src/associations/nested-error.ts
@@ -28,19 +28,31 @@ interface InnerErrorLike {
  * Mirrors: ActiveRecord::Associations::NestedError
  */
 export class NestedError extends ActiveModelNestedError {
-  /** @internal */
-  readonly association: AssociationLike;
+  private readonly _association: AssociationLike;
 
   constructor(association: AssociationLike, innerError: InnerErrorLike) {
     const attribute = NestedError.computeAttribute(association, innerError);
     super(association.owner, innerError, { attribute });
-    this.association = association;
+    this._association = association;
+  }
+
+  /** Mirrors Rails' `attr_reader :association` (nested_error.rb:16). @internal */
+  get association(): AssociationLike {
+    return this._association;
   }
 
   private static computeAttribute(
     association: AssociationLike,
     innerError: InnerErrorLike,
   ): string {
+    // Ruby runs `compute_attribute` as an instance method inside the
+    // constructor — after `@association` is set but *before* `super`
+    // (nested_error.rb:8-12). TS forbids touching `this` before `super`, so the
+    // readers below run against a receiver carrying the one ivar Ruby has at
+    // that point.
+    const self: NestedError = Object.assign(Object.create(NestedError.prototype) as NestedError, {
+      _association: association,
+    });
     const name = association.reflection.name;
     // isCollection: check the Association method if available, otherwise infer
     // from whether target is an array (CollectionProxy always has array target).
@@ -48,34 +60,26 @@ export class NestedError extends ActiveModelNestedError {
       typeof association.isCollection === "function"
         ? association.isCollection()
         : Array.isArray(association.target);
-    // Falls back to global flag when not set per-association — mirrors Rails:
-    //   association.options.fetch(:index_errors, ActiveRecord.index_nested_attribute_errors)
-    // Options may be on association.options or association.reflection.options.
-    const opts = association.options ?? association.reflection.options;
-    const indexErrors =
-      opts && "indexErrors" in opts ? opts["indexErrors"] : indexNestedAttributeErrors;
-    if (isCollection && indexErrors) {
-      // :nested_attributes_order uses nestedAttributesTarget (write order),
-      // true uses target (association/DB order) — mirrors Rails' ordered_records
-      const records =
-        indexErrors === "nestedAttributesOrder"
-          ? association.nestedAttributesTarget
-          : association.target;
-      const index = records?.findIndex((r) => r === innerError.base);
-      if (index != null && index >= 0) {
-        return `${name}[${index}].${innerError.attribute}`;
+    if (isCollection && indexErrorsSetting.call(self)) {
+      const idx = index.call(self, innerError);
+      if (idx != null) {
+        return `${name}[${idx}].${innerError.attribute}`;
       }
     }
     return `${name}.${innerError.attribute}`;
   }
 }
 
-/** @internal */
-function association(this: NestedError): NestedError["association"] {
-  return this.association;
-}
+// Rails marks the readers below `private`, so they stay module-local functions
+// rather than prototype methods; `this`-typing keeps their signature identical
+// to Ruby's zero-arg instance methods.
 
-/** @internal */
+/**
+ * Mirrors Rails' `index_errors_setting` (nested_error.rb:29-32):
+ * `association.options.fetch(:index_errors, ActiveRecord.index_nested_attribute_errors)`.
+ * Options may sit on `association.options` or `association.reflection.options`.
+ * @internal
+ */
 function indexErrorsSetting(this: NestedError): boolean | "nestedAttributesOrder" {
   const opts = this.association.options ?? this.association.reflection.options;
   if (opts && "indexErrors" in opts) {
@@ -84,7 +88,13 @@ function indexErrorsSetting(this: NestedError): boolean | "nestedAttributesOrder
   return indexNestedAttributeErrors;
 }
 
-/** @internal */
+/**
+ * Mirrors Rails' `index` (nested_error.rb:33-35) —
+ * `ordered_records&.find_index(inner_error.base)`. Ruby reads `inner_error`
+ * off the instance; here it rides in, because the sole caller
+ * (`computeAttribute`) runs before `super` has stored it.
+ * @internal
+ */
 function index(this: NestedError, innerError: { base?: unknown }): number | undefined {
   const records = orderedRecords.call(this);
   if (!records || !innerError.base) return undefined;
@@ -92,7 +102,12 @@ function index(this: NestedError, innerError: { base?: unknown }): number | unde
   return idx >= 0 ? idx : undefined;
 }
 
-/** @internal */
+/**
+ * Mirrors Rails' `ordered_records` (nested_error.rb:37-44): `true` means
+ * association order (`target`), `:nested_attributes_order` means write order
+ * (`nested_attributes_target`), anything else means no indexing at all.
+ * @internal
+ */
 function orderedRecords(this: NestedError): unknown[] | null {
   const setting = indexErrorsSetting.call(this);
   const assoc = this.association;
@@ -100,9 +115,3 @@ function orderedRecords(this: NestedError): unknown[] | null {
   if (setting === "nestedAttributesOrder") return assoc.nestedAttributesTarget ?? null;
   return null;
 }
-
-// Silence "unused" — these are Rails-private helpers that mirror nested_error.rb's
-// `attr_reader :association`, `index_errors_setting`, `index`, `ordered_records`.
-// Counted by api:compare; intentionally not exported (Rails marks them private).
-void association;
-void index;

--- a/packages/activerecord/src/associations/nested-error.ts
+++ b/packages/activerecord/src/associations/nested-error.ts
@@ -71,13 +71,13 @@ export class NestedError extends ActiveModelNestedError {
 }
 
 /** @internal */
-function association(err: NestedError): NestedError["association"] {
-  return err.association;
+function association(this: NestedError): NestedError["association"] {
+  return this.association;
 }
 
 /** @internal */
-function indexErrorsSetting(err: NestedError): boolean | "nestedAttributesOrder" {
-  const opts = err.association.options ?? err.association.reflection.options;
+function indexErrorsSetting(this: NestedError): boolean | "nestedAttributesOrder" {
+  const opts = this.association.options ?? this.association.reflection.options;
   if (opts && "indexErrors" in opts) {
     return opts["indexErrors"] as boolean | "nestedAttributesOrder";
   }
@@ -85,17 +85,17 @@ function indexErrorsSetting(err: NestedError): boolean | "nestedAttributesOrder"
 }
 
 /** @internal */
-function index(err: NestedError, innerError: { base?: unknown }): number | undefined {
-  const records = orderedRecords(err);
+function index(this: NestedError, innerError: { base?: unknown }): number | undefined {
+  const records = orderedRecords.call(this);
   if (!records || !innerError.base) return undefined;
   const idx = records.findIndex((r) => r === innerError.base);
   return idx >= 0 ? idx : undefined;
 }
 
 /** @internal */
-function orderedRecords(err: NestedError): unknown[] | null {
-  const setting = indexErrorsSetting(err);
-  const assoc = err.association;
+function orderedRecords(this: NestedError): unknown[] | null {
+  const setting = indexErrorsSetting.call(this);
+  const assoc = this.association;
   if (setting === true) return Array.isArray(assoc.target) ? assoc.target : null;
   if (setting === "nestedAttributesOrder") return assoc.nestedAttributesTarget ?? null;
   return null;

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -4743,7 +4743,7 @@ describe("computePrimaryKey", () => {
 
   it("returns explicit reflection primaryKey option as-is", () => {
     const record = makeRecord({ primaryKey: "id" });
-    const result = computePrimaryKey.call(record, { options: { primaryKey: "custom_id" } });
+    const result = computePrimaryKey({ options: { primaryKey: "custom_id" } }, record);
     expect(result).toBe("custom_id");
   });
 
@@ -4754,7 +4754,7 @@ describe("computePrimaryKey", () => {
       queryConstraintsList: ["tenant_id", "id"],
       hasQueryConstraints: true,
     });
-    const result = computePrimaryKey.call(record, { options: { queryConstraints: true } });
+    const result = computePrimaryKey({ options: { queryConstraints: true } }, record);
     expect(result).toEqual(["tenant_id", "id"]);
   });
 
@@ -4765,7 +4765,7 @@ describe("computePrimaryKey", () => {
       queryConstraintsList: ["shop_id", "id"],
       hasQueryConstraints: true,
     });
-    const result = computePrimaryKey.call(record, { options: {} });
+    const result = computePrimaryKey({ options: {} }, record);
     expect(result).toEqual(["shop_id", "id"]);
   });
 
@@ -4777,29 +4777,32 @@ describe("computePrimaryKey", () => {
       queryConstraintsList: ["shop_id", "id"],
       hasQueryConstraints: true,
     });
-    const result = computePrimaryKey.call(record, {
-      options: { foreignKey: "order_id" },
-    });
+    const result = computePrimaryKey(
+      {
+        options: { foreignKey: "order_id" },
+      },
+      record,
+    );
     expect(result).toBe("id");
   });
 
   it("collapses CPK to 'id' when composite PK includes id and no queryConstraints", () => {
     // Mirrors: composite_primary_key? branch — primary_key.include?("id") ? "id" : primary_key
     const record = makeRecord({ primaryKey: ["shop_id", "id"] });
-    const result = computePrimaryKey.call(record, { options: {} });
+    const result = computePrimaryKey({ options: {} }, record);
     expect(result).toBe("id");
   });
 
   it("returns full composite PK when CPK has no 'id' column", () => {
     // Mirrors: composite_primary_key? branch — primary_key.include?("id") ? "id" : primary_key
     const record = makeRecord({ primaryKey: ["shop_id", "status"] });
-    const result = computePrimaryKey.call(record, { options: {} });
+    const result = computePrimaryKey({ options: {} }, record);
     expect(result).toEqual(["shop_id", "status"]);
   });
 
   it("returns class primary key for non-composite, non-constrained record", () => {
     const record = makeRecord({ primaryKey: "id" });
-    const result = computePrimaryKey.call(record, { options: {} });
+    const result = computePrimaryKey({ options: {} }, record);
     expect(result).toBe("id");
   });
 });

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -588,9 +588,7 @@ async function autosaveHasOne(record: Base, assoc: AssociationDefinition): Promi
   // then `primary_key_value = primary_key.map { _read_attribute(_1) }`.
   const ctor = record.constructor as typeof Base;
   const reflection = (ctor as any)._reflectOnAssociation?.(assoc.name);
-  const pkSpec = reflection
-    ? computePrimaryKey.call(record as unknown as AutosaveAssociationHost, reflection)
-    : (ctor.primaryKey ?? "id");
+  const pkSpec = reflection ? computePrimaryKey(reflection, record) : (ctor.primaryKey ?? "id");
   const pkArr: string[] = Array.isArray(pkSpec) ? pkSpec : [pkSpec];
   const pkForChangeCheck = pkArr.map((k) => record._readAttribute(k));
   const changedForSave =
@@ -623,10 +621,7 @@ async function autosaveHasOne(record: Base, assoc: AssociationDefinition): Promi
       if (explicitPk) {
         primaryKey = explicitPk;
       } else {
-        const candidatePk = computePrimaryKey.call(
-          record as unknown as AutosaveAssociationHost,
-          reflection ?? assoc,
-        );
+        const candidatePk = computePrimaryKey(reflection ?? assoc, record);
         // computePrimaryKey may collapse a CPK to "id" when queryConstraintsList is null
         // (our queryConstraintsList doesn't auto-return composite PK, unlike Rails).
         // When that produces a scalar against a composite FK, fall back to ctor.primaryKey
@@ -787,7 +782,7 @@ function _resolveBelongsToPrimaryKey(
       }
     }
   }
-  const rawPk = computePrimaryKey.call(assocRecord as any, { options: assoc.options });
+  const rawPk = computePrimaryKey({ options: assoc.options }, assocRecord);
   return Array.isArray(rawPk) ? rawPk : [rawPk];
 }
 
@@ -955,7 +950,7 @@ export async function validateHasOneAssociation(
     )
       return;
   }
-  await isAssociationValid(reflection, record, this, inst);
+  await isAssociationValid.call(this, inst, record);
 }
 
 /** @internal */
@@ -973,7 +968,7 @@ export async function validateBelongsToAssociation(
   if (!(record.changedForAutosave?.() ?? false) && !customCtx) return;
   _setValidatingBelongsToFor(this, reflection, true);
   try {
-    await isAssociationValid(reflection, record, this, inst);
+    await isAssociationValid.call(this, inst, record);
   } finally {
     _setValidatingBelongsToFor(this, reflection, false);
   }
@@ -1007,18 +1002,22 @@ export async function validateCollectionAssociation(
       );
   if (!records) return;
   for (const record of records) {
-    await isAssociationValid(reflection, record, this, association);
+    await isAssociationValid.call(this, association, record);
   }
 }
 
 /** @internal */
 export async function isAssociationValid(
-  reflection: any,
-  record: any,
-  owner: any,
+  this: AutosaveAssociationHost,
   association: any,
+  record: any,
 ): Promise<boolean> {
-  // Mirrors Rails `association_valid?` (autosave_association.rb:371-398).
+  // Mirrors Rails `association_valid?` (autosave_association.rb:371-398). Rails
+  // reads the reflection off the association (`association.reflection.name`,
+  // `association.options`) and the parent errors off `self`, so both stay
+  // implicit here rather than riding in as extra params.
+  const owner = this as any;
+  const reflection = association.reflection;
   if (typeof record.isDestroyed === "function" && record.isDestroyed()) return true;
   if (reflection.options?.autosave && isMarkedForDestruction(record)) return true;
   const context =
@@ -1202,12 +1201,9 @@ export async function saveBelongsToAssociation(
 }
 
 /** @internal */
-export function computePrimaryKey(
-  this: AutosaveAssociationHost,
-  reflection: any,
-): string | string[] {
+export function computePrimaryKey(reflection: any, record: any): string | string[] {
   if (reflection.options?.primaryKey) return reflection.options.primaryKey;
-  const ctor = this.constructor as typeof Base & {
+  const ctor = record.constructor as typeof Base & {
     primaryKey?: string | string[];
     _hasQueryConstraints?: boolean;
     _queryConstraintsList?: string[] | null;

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -1012,10 +1012,9 @@ export async function isAssociationValid(
   association: any,
   record: any,
 ): Promise<boolean> {
-  // Mirrors Rails `association_valid?` (autosave_association.rb:371-398). Rails
-  // reads the reflection off the association (`association.reflection.name`,
-  // `association.options`) and the parent errors off `self`, so both stay
-  // implicit here rather than riding in as extra params.
+  // Mirrors Rails `association_valid?` (autosave_association.rb:371-398), which
+  // reads the reflection off the association and the errors off `self` — so
+  // neither rides in as an extra param.
   const owner = this as any;
   const reflection = association.reflection;
   if (typeof record.isDestroyed === "function" && record.isDestroyed()) return true;

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -2206,58 +2206,62 @@ export class RuntimeReflection extends AbstractReflection {
     return callback();
   }
 
-  // Ruby's RuntimeReflection inherits AbstractReflection and reaches the rest of
-  // the reflection API through `method_missing`-free delegation on the members
-  // Rails' AssociationScope actually touches. TS has no such fallback, so the
-  // remaining members AssociationScope reads off the chain head are forwarded
-  // explicitly (same SimpleDelegator-style approach as ReflectionProxy).
+  // Ruby's RuntimeReflection is a SimpleDelegator-ish subclass: the members it
+  // doesn't define reach the wrapped reflection. TS has no such fallback, and
+  // AbstractReflection's defaults are hard-coded (`is_collection?` → false), so
+  // the members AssociationScope reads off the chain head are forwarded here —
+  // the same explicit forwarding ReflectionProxy uses.
 
   /** @internal */
   get options(): Record<string, unknown> {
-    return (this._reflection as any).options ?? {};
+    return asConcrete(this._reflection).options;
   }
 
   /** @internal */
   override isThroughReflection(): boolean {
-    return (this._reflection as any).isThroughReflection?.() ?? false;
+    return this._reflection.isThroughReflection();
   }
 
   /** @internal */
   override isCollection(): boolean {
-    return (this._reflection as any).isCollection?.() ?? false;
+    return this._reflection.isCollection();
   }
 
   /** @internal */
   override isPolymorphic(): boolean {
-    return (this._reflection as any).isPolymorphic?.() ?? false;
+    return this._reflection.isPolymorphic();
   }
 
   /** @internal */
   scopeFor(relation: unknown, owner?: unknown): unknown {
-    return (this._reflection as any).scopeFor?.(relation, owner) ?? relation;
+    return asConcrete(this._reflection).scopeFor?.(relation, owner) ?? relation;
   }
 
   /** @internal */
   joinPrimaryKeyFor(klass?: typeof Base): string | string[] {
-    const refl = this._reflection as any;
+    const refl = this._reflection as unknown as {
+      joinPrimaryKeyFor?: (klass?: typeof Base) => string | string[];
+      joinPrimaryKey: string | string[];
+    };
+    // The head's klass is the runtime one (`association.klass`), which is the
+    // whole point of RuntimeReflection: a polymorphic belongs_to can't compute
+    // its target class from the reflection alone.
     return typeof refl.joinPrimaryKeyFor === "function"
       ? refl.joinPrimaryKeyFor(klass ?? this.klass)
       : refl.joinPrimaryKey;
   }
 
   /** @internal */
-  override aliasCandidate(name: string): string {
-    return (this._reflection as any).aliasCandidate(name);
-  }
-
-  /** @internal */
   override get chain(): AbstractReflection[] {
-    return (this._reflection as any).chain;
+    return this._reflection.chain;
   }
 
   /** @internal */
   get sourceReflection(): AbstractReflection | null {
-    return (this._reflection as any).sourceReflection ?? null;
+    return (
+      (this._reflection as unknown as { sourceReflection?: AbstractReflection | null })
+        .sourceReflection ?? null
+    );
   }
 }
 

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -2205,6 +2205,60 @@ export class RuntimeReflection extends AbstractReflection {
   allIncludes(callback: () => any): any {
     return callback();
   }
+
+  // Ruby's RuntimeReflection inherits AbstractReflection and reaches the rest of
+  // the reflection API through `method_missing`-free delegation on the members
+  // Rails' AssociationScope actually touches. TS has no such fallback, so the
+  // remaining members AssociationScope reads off the chain head are forwarded
+  // explicitly (same SimpleDelegator-style approach as ReflectionProxy).
+
+  /** @internal */
+  get options(): Record<string, unknown> {
+    return (this._reflection as any).options ?? {};
+  }
+
+  /** @internal */
+  override isThroughReflection(): boolean {
+    return (this._reflection as any).isThroughReflection?.() ?? false;
+  }
+
+  /** @internal */
+  override isCollection(): boolean {
+    return (this._reflection as any).isCollection?.() ?? false;
+  }
+
+  /** @internal */
+  override isPolymorphic(): boolean {
+    return (this._reflection as any).isPolymorphic?.() ?? false;
+  }
+
+  /** @internal */
+  scopeFor(relation: unknown, owner?: unknown): unknown {
+    return (this._reflection as any).scopeFor?.(relation, owner) ?? relation;
+  }
+
+  /** @internal */
+  joinPrimaryKeyFor(klass?: typeof Base): string | string[] {
+    const refl = this._reflection as any;
+    return typeof refl.joinPrimaryKeyFor === "function"
+      ? refl.joinPrimaryKeyFor(klass ?? this.klass)
+      : refl.joinPrimaryKey;
+  }
+
+  /** @internal */
+  override aliasCandidate(name: string): string {
+    return (this._reflection as any).aliasCandidate(name);
+  }
+
+  /** @internal */
+  override get chain(): AbstractReflection[] {
+    return (this._reflection as any).chain;
+  }
+
+  /** @internal */
+  get sourceReflection(): AbstractReflection | null {
+    return (this._reflection as any).sourceReflection ?? null;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/nested-error.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/nested-error.json
@@ -5,12 +5,5 @@
     "rubyName": "compute_attribute",
     "call": "association",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/nested-error.ts",
-    "rubyName": "compute_attribute",
-    "call": "index_errors_setting",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/autosave-association.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/autosave-association.json
@@ -16,13 +16,6 @@
   {
     "package": "activerecord",
     "tsFile": "autosave-association.ts",
-    "rubyName": "association_valid?",
-    "call": "reflection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "autosave-association.ts",
     "rubyName": "changed_for_autosave?",
     "call": "has_changes_to_save?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Converges the association-cluster arity mismatches from
`output/arity-mismatches.json` where the TS signature diverged from Rails.

- **`get_chain(reflection, association, tracker)`** (association_scope.rb:112) —
  TS took `(reflection, tracker)` and pushed the bare reflection as the chain
  head. It now takes `association` and builds the head as
  `RuntimeReflection(reflection, association)`, as Rails does, so the head's
  `klass` resolves off the live association. `RuntimeReflection` forwards the
  remaining members `AssociationScope` reads off the head (`options`,
  `scopeFor`, `isThroughReflection`, `sourceReflection`, `chain`, …) in the
  same explicit SimpleDelegator style `ReflectionProxy` already uses.
- **`update_through_counter?(method)`** (has_many_through_association.rb:125) —
  no longer threads the through reflection positionally; it reads it off the
  association via the `this`-typed mixin convention.
- **`association_valid?(association, record)`** and
  **`compute_primary_key(reflection, record)`** (autosave_association.rb:371,
  576) — `association_valid?` is `this`-typed (owner = receiver) and takes
  `(association, record)`, deriving the reflection from the association;
  `compute_primary_key` reads the class off the `record` Rails passes in
  rather than off `this`.
- **`nested_error.rb`** `index_errors_setting` / `ordered_records` (plus
  `index` / `association` for consistency) are now `this`-typed zero-/one-arg
  readers of instance state instead of `(err)` free functions.

`arity: 3666/3713 → 3672/3711`; all six listed entries are gone from
`output/arity-mismatches.json` (the remaining association-named entry,
`preload_associations`, is outside this story).

Tests: `packages/activerecord/src/associations/**`, `associations.test.ts`,
`autosave-association*.test.ts`, `nested-attributes.test.ts`,
`counter-cache.test.ts`, `validations/**`, `reflection.test.ts` — all pass.

Closes-story: arity-associations-signature-gaps

---

### Review follow-ups

**1. `nested-error.ts` readers were dead code — fixed.** `compute_attribute`
now calls `indexErrorsSetting` / `index` (which calls `orderedRecords`) instead
of duplicating the logic inline, so the `this`-typed readers are the sole
implementation and the `void` lint-silencers are gone. `association` is now a
getter backed by `_association`, i.e. Rails' `attr_reader :association`
(nested_error.rb:16), rather than a free function. Ruby runs `compute_attribute`
after `@association` is set but before `super` (nested_error.rb:8-12); TS forbids
touching `this` pre-`super`, so the readers run against a receiver carrying that
one ivar. Side effect: this converged the wide call-set entry
`compute_attribute → index_errors_setting`, which is dropped from the baseline.

**2. `throughCounterReflection` one-level lookup — fixed.** Correct call: Rails'
`ThroughAssociation#through_reflection` (through_association.rb:14-24) walks to
the innermost non-through reflection. The helper now routes through this file's
existing `throughReflection` walker, which already implements that recursion, so
a nested `through:` chain resolves correctly. Pre-existing, but the refactor
touched the path, so it's fixed here rather than deferred.

**3. Unused `RuntimeReflection` forwards (`chain` / `isCollection` /
`isPolymorphic`).** Kept deliberately. `AbstractReflection`'s defaults are
hard-coded (`isCollection()`/`isPolymorphic()` → `false`, `chain` →
`collectJoinChain()` over the wrapper), so without the forwards a future head
reader would silently get a wrong answer rather than the wrapped reflection's.
Nothing currently reads them off `chain[0]`, so there's no behavior change.

Also drops the second stale wide-ratchet entry
(`association_valid? → reflection`) — the reflection is now read off the
association, as Rails does.

### Second review pass

**Stale wide-ratchet baseline (CI red).** Already fixed in `dbe82a3ec`, pushed
after those webhook notifications fired: both converged entries
(`compute_attribute → index_errors_setting`,
`association_valid? → reflection`) are removed from
`scripts/api-compare/call-mismatches-wide-exclude/`. No `--write` reseed — the
baseline only shrinks. Verified locally: `wide call-mismatches ratchet: OK
(5079 baselined)`.

**`index` still took `innerError` — fixed.** Rails sets `@inner_error` at
nested_error.rb:11, *before* `compute_attribute` runs at :12, so the synthetic
pre-`super` receiver now carries `innerError` alongside `_association` and
`index` is a true zero-arg `this`-typed reader matching nested_error.rb:33-35.
No arity entries remain for `associations/**` or `autosave-association.ts`.
