### PR TITLE
fix(api-compare): converge misc signature gaps against Rails definitions

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1625,7 +1625,6 @@ export class Base extends Model {
   declare static hasAttributeDefinition: typeof ModelSchema.hasAttributeDefinition;
   declare static columnsHash: typeof ModelSchema.columnsHash;
   declare static contentColumns: typeof ModelSchema.contentColumns;
-  declare static deriveJoinTableName: typeof ModelSchema.deriveJoinTableName;
   declare static quotedTableName: typeof ModelSchema.quotedTableName;
   declare static resetTableName: typeof ModelSchema.resetTableName;
   declare static fullTableNamePrefix: typeof ModelSchema.fullTableNamePrefix;

--- a/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
@@ -72,8 +72,11 @@ export class ConnectionHandler {
     if (typeof owner === "string") {
       return new ConnectionDescriptor(owner);
     }
-    // Rails' `elsif config.is_a?(Symbol)` branch: a config named by symbol
-    // (here, by string) supplies the owner name when none was passed.
+    // Rails' `elsif config.is_a?(Symbol)` branch — a config given as a bare
+    // name supplies the owner. `establishConnection`'s declared config union
+    // has no string arm yet, so this only fires for untyped callers passing
+    // Rails' `establish_connection :primary` shorthand; it is spelled out here
+    // rather than left to the future so the ported branch set stays complete.
     if (typeof config === "string") {
       return new ConnectionDescriptor(config);
     }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
@@ -67,18 +67,17 @@ export class ConnectionHandler {
    */
   determineOwnerName(
     owner: string | ConnectionOwner,
-    config?: DatabaseConfig | Record<string, unknown> | string,
+    // Rails' third branch is `elsif config.is_a?(Symbol)` — the bare-name
+    // shorthand `establish_connection :primary`. It is deliberately NOT ported:
+    // Ruby distinguishes that Symbol from a String config (a connection URL),
+    // which falls through to `owner_name` unchanged, and TS collapses both onto
+    // `string`. Porting it as `typeof config === "string"` would misread a URL
+    // as a connection name. The parameter stays so the signature matches Rails
+    // and the branch can land once a Symbol-shaped config exists to key on.
+    _config?: DatabaseConfig | Record<string, unknown>,
   ): ConnectionDescriptor | ConnectionOwner {
     if (typeof owner === "string") {
       return new ConnectionDescriptor(owner);
-    }
-    // Rails' `elsif config.is_a?(Symbol)` branch — a config given as a bare
-    // name supplies the owner. `establishConnection`'s declared config union
-    // has no string arm yet, so this only fires for untyped callers passing
-    // Rails' `establish_connection :primary` shorthand; it is spelled out here
-    // rather than left to the future so the ported branch set stays complete.
-    if (typeof config === "string") {
-      return new ConnectionDescriptor(config);
     }
     return owner;
   }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
@@ -65,9 +65,17 @@ export class ConnectionHandler {
    *
    * @internal
    */
-  determineOwnerName(owner: string | ConnectionOwner): ConnectionDescriptor | ConnectionOwner {
+  determineOwnerName(
+    owner: string | ConnectionOwner,
+    config?: DatabaseConfig | Record<string, unknown> | string,
+  ): ConnectionDescriptor | ConnectionOwner {
     if (typeof owner === "string") {
       return new ConnectionDescriptor(owner);
+    }
+    // Rails' `elsif config.is_a?(Symbol)` branch: a config named by symbol
+    // (here, by string) supplies the owner name when none was passed.
+    if (typeof config === "string") {
+      return new ConnectionDescriptor(config);
     }
     return owner;
   }
@@ -116,7 +124,7 @@ export class ConnectionHandler {
   ): ConnectionPool {
     const ownerName =
       options.owner != null
-        ? this.determineOwnerName(options.owner)
+        ? this.determineOwnerName(options.owner, config)
         : config instanceof DatabaseConfig
           ? new ConnectionDescriptor(config.name)
           : new ConnectionDescriptor(typeof options.owner === "string" ? options.owner : "primary");

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { ForeignKeyDefinition, CheckConstraintDefinition } from "./schema-definitions.js";
+import {
+  ForeignKeyDefinition,
+  CheckConstraintDefinition,
+  TableDefinition,
+} from "./schema-definitions.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 
 const originalFkPattern = SchemaDumper.fkIgnorePattern;
@@ -42,5 +46,26 @@ describe("CheckConstraintDefinition#export_name_on_schema_dump?", () => {
     SchemaDumper.chkIgnorePattern = /^ignored_/;
     expect(chk("ignored_chk_trades_price").isExportNameOnSchemaDump).toBe(false);
     expect(chk("chk_rails_0123456789").isExportNameOnSchemaDump).toBe(true);
+  });
+});
+
+describe("TableDefinition#remove_column", () => {
+  const td = (): TableDefinition => {
+    const t = new TableDefinition("astronauts");
+    t.string("name");
+    t.integer("rocket_id");
+    return t;
+  };
+
+  it("drops the named column and leaves the rest in order", () => {
+    const t = td();
+    t.removeColumn("name");
+    expect(t.columns.map((c) => c.name)).toEqual(["id", "rocket_id"]);
+  });
+
+  it("is a no-op for a column that was never defined", () => {
+    const t = td();
+    t.removeColumn("nonexistent");
+    expect(t.columns.map((c) => c.name)).toEqual(["id", "name", "rocket_id"]);
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1019,7 +1019,6 @@ export class TableDefinition {
     return this;
   }
 
-  /** @internal */
   /**
    * Remove the column +name+ from the table.
    *
@@ -1031,6 +1030,7 @@ export class TableDefinition {
     if (index !== -1) this.columns.splice(index, 1);
   }
 
+  /** @internal */
   protected validColumnDefinitionOptions(): string[] {
     return [
       "limit",

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1020,6 +1020,17 @@ export class TableDefinition {
   }
 
   /** @internal */
+  /**
+   * Remove the column +name+ from the table.
+   *
+   * Mirrors: ActiveRecord::ConnectionAdapters::TableDefinition#remove_column
+   * (Rails deletes from `@columns_hash`; this port keeps an array.)
+   */
+  removeColumn(name: string): void {
+    const index = this.columns.findIndex((c) => c.name === String(name));
+    if (index !== -1) this.columns.splice(index, 1);
+  }
+
   protected validColumnDefinitionOptions(): string[] {
     return [
       "limit",

--- a/packages/activerecord/src/encryption/cipher/aes256-gcm.ts
+++ b/packages/activerecord/src/encryption/cipher/aes256-gcm.ts
@@ -62,7 +62,7 @@ export class Aes256Gcm {
     this._validateKeyLength(this.secret);
     const keyBuf = Buffer.from(this.secret, "base64").subarray(0, KEY_LENGTH);
     const inputBuf = Buffer.isBuffer(clearText) ? clearText : Buffer.from(clearText, "utf-8");
-    const iv = this.generateIv(keyBuf, inputBuf, options?.deterministic ?? this.deterministic);
+    const iv = this.generateIv(inputBuf, options?.deterministic ?? this.deterministic);
     const cipher = getCrypto().createCipheriv(Aes256Gcm.CIPHER_TYPE, keyBuf, iv, {
       authTagLength: AUTH_TAG_LENGTH,
     });
@@ -135,16 +135,25 @@ export class Aes256Gcm {
     }
   }
 
-  /** @internal */
-  private generateIv(keyBuf: Buffer, inputBuf: Buffer, deterministic: boolean): Buffer {
+  /**
+   * Rails' first parameter is the live `OpenSSL::Cipher` (only so the random
+   * branch can call `cipher.random_iv`). WebCrypto has no such object before
+   * the IV exists, so the slot carries the deterministic flag instead — which
+   * Rails reads off `@deterministic`, and this port also lets `encrypt`
+   * override per call.
+   *
+   * @internal
+   */
+  private generateIv(clearText: Buffer, deterministic: boolean): Buffer {
     if (deterministic) {
-      return this.generateDeterministicIv(keyBuf, inputBuf);
+      return this.generateDeterministicIv(clearText);
     }
     return getCrypto().randomBytes(IV_LENGTH);
   }
 
   /** @internal */
-  private generateDeterministicIv(keyBuf: Buffer, clearText: Buffer): Buffer {
+  private generateDeterministicIv(clearText: Buffer): Buffer {
+    const keyBuf = Buffer.from(this.secret, "base64").subarray(0, KEY_LENGTH);
     return getCrypto()
       .createHmac("sha256", keyBuf)
       .update(clearText)

--- a/packages/activerecord/src/insert-all.trails.test.ts
+++ b/packages/activerecord/src/insert-all.trails.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Trails-specific InsertAll tests — no like-named test exists in
+ * vendor/rails/activerecord/test/cases/insert_all_test.rb.
+ */
+import { describe, it, expect } from "vitest";
+import { fixtures } from "./test-helpers/fixtures.js";
+import "./test-helpers/canonical-model-index.js";
+import { Ship } from "./test-helpers/models/ship.js";
+import type { Base } from "./base.js";
+
+async function withRecordTimestamps(
+  model: typeof Base,
+  value: boolean,
+  fn: () => Promise<void>,
+): Promise<void> {
+  const original = model.recordTimestamps;
+  model.recordTimestamps = value;
+  try {
+    await fn();
+  } finally {
+    model.recordTimestamps = original;
+  }
+}
+
+describe("InsertAll verify_attributes", () => {
+  fixtures([]);
+
+  // Rails' verify_attributes (insert_all.rb:206-210) compares against
+  // `keys_including_timestamps`, and map_key_with_value reverse_merges
+  // `timestamps_for_create` into every row BEFORE calling it. So a batch whose
+  // rows disagree only about whether they spell out a magic timestamp column
+  // is accepted: both sides of the comparison carry created_at/updated_at.
+  // Comparing raw row keys against `@keys` instead raises a spurious
+  // ArgumentError here.
+  it("accepts rows that differ only in explicitly-given timestamp columns", async () => {
+    await withRecordTimestamps(Ship as unknown as typeof Base, true, async () => {
+      const now = new Date();
+      await expect(
+        Ship.insertAll([
+          { name: "RSS Boaty McBoatface", created_at: now, updated_at: now },
+          { name: "RSS Sir David Attenborough" },
+        ]),
+      ).resolves.toBeDefined();
+
+      const names = (await Ship.order("name")).map((s) => s.name);
+      expect(names).toEqual(["RSS Boaty McBoatface", "RSS Sir David Attenborough"]);
+    });
+  });
+
+  it("still rejects rows that differ in a non-timestamp column", async () => {
+    await withRecordTimestamps(Ship as unknown as typeof Base, true, async () => {
+      await expect(
+        Ship.insertAll([{ name: "RSS Boaty McBoatface" }, { treasures_count: 3 }]),
+      ).rejects.toThrow(/All objects being inserted must have the same keys/);
+    });
+  });
+});

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -130,7 +130,14 @@ export class InsertAll {
       this.keys.add(key);
     }
 
-    this.verifyAttributes();
+    // Rails calls verify_attributes(attributes) once per row from
+    // map_key_with_value (insert_all.rb:79), i.e. at SQL-build time. The port
+    // hoists the loop into the constructor so a mismatched batch raises before
+    // any async work starts; the per-row check itself is Rails' verbatim.
+    for (const row of this.inserts.slice(1)) {
+      this.verifyAttributes({ ...row, ...this._scopeAttributes });
+    }
+    this.verifyAttributeNamesAreKnown();
     this.configureOnDuplicateUpdateLogic(options.onDuplicate);
     this.ensureValidOptionsForConnectionBang();
   }
@@ -267,15 +274,15 @@ export class InsertAll {
   }
 
   /** @internal */
-  private verifyAttributes(): void {
-    if (this.inserts.length > 1) {
-      for (const row of this.inserts.slice(1)) {
-        const rowKeys = new Set([...Object.keys(row), ...Object.keys(this._scopeAttributes)]);
-        if (rowKeys.size !== this.keys.size || ![...this.keys].every((k) => rowKeys.has(k))) {
-          throw new Error("All objects being inserted must have the same keys");
-        }
-      }
+  private verifyAttributes(attributes: Record<string, unknown>): void {
+    const rowKeys = new Set(Object.keys(attributes));
+    if (rowKeys.size !== this.keys.size || ![...this.keys].every((k) => rowKeys.has(k))) {
+      throw new Error("All objects being inserted must have the same keys");
     }
+  }
+
+  /** @internal */
+  private verifyAttributeNamesAreKnown(): void {
     // Rails raises UnknownAttributeError in extract_types_from_columns_on against
     // schema_cache.columns_hash; we mirror the same intent against the model's
     // declared attribute set so the error surfaces before any SQL is built.

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -130,13 +130,6 @@ export class InsertAll {
       this.keys.add(key);
     }
 
-    // Rails calls verify_attributes(attributes) once per row from
-    // map_key_with_value (insert_all.rb:79), i.e. at SQL-build time. The port
-    // hoists the loop into the constructor so a mismatched batch raises before
-    // any async work starts; the per-row check itself is Rails' verbatim.
-    for (const row of this.inserts.slice(1)) {
-      this.verifyAttributes({ ...row, ...this._scopeAttributes });
-    }
     this.verifyAttributeNamesAreKnown();
     this.configureOnDuplicateUpdateLogic(options.onDuplicate);
     this.ensureValidOptionsForConnectionBang();
@@ -251,6 +244,12 @@ export class InsertAll {
           if (!(col in merged)) merged[col] = val;
         }
       }
+      // Rails calls verify_attributes here (insert_all.rb:79), after the
+      // scope merge and the timestamps reverse_merge — and it must stay here,
+      // not in the constructor: `keysIncludingTimestamps` reads the model's
+      // timestamp attributes off the reflected schema, which is not loaded yet
+      // at construction time.
+      this.verifyAttributes(merged);
       return keysList.map((key) => fn(key, merged[key]));
     });
   }
@@ -275,8 +274,12 @@ export class InsertAll {
 
   /** @internal */
   private verifyAttributes(attributes: Record<string, unknown>): void {
+    // Rails compares against keys_including_timestamps, NOT @keys — the caller
+    // has already reverse_merged the create timestamps into `attributes`, so
+    // both sides carry them whenever record_timestamps? is on.
+    const expected = this.keysIncludingTimestamps();
     const rowKeys = new Set(Object.keys(attributes));
-    if (rowKeys.size !== this.keys.size || ![...this.keys].every((k) => rowKeys.has(k))) {
+    if (rowKeys.size !== expected.size || ![...expected].every((k) => rowKeys.has(k))) {
       throw new ArgumentError("All objects being inserted must have the same keys");
     }
   }

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -277,7 +277,7 @@ export class InsertAll {
   private verifyAttributes(attributes: Record<string, unknown>): void {
     const rowKeys = new Set(Object.keys(attributes));
     if (rowKeys.size !== this.keys.size || ![...this.keys].every((k) => rowKeys.has(k))) {
-      throw new Error("All objects being inserted must have the same keys");
+      throw new ArgumentError("All objects being inserted must have the same keys");
     }
   }
 

--- a/packages/activerecord/src/migration/join-table.ts
+++ b/packages/activerecord/src/migration/join-table.ts
@@ -4,8 +4,6 @@
  * Mirrors: ActiveRecord::Migration::JoinTable
  */
 
-import { deriveJoinTableName } from "../model-schema.js";
-
 /** @internal */
 export function findJoinTableName(
   table1: string,
@@ -15,7 +13,21 @@ export function findJoinTableName(
   return options.tableName ?? joinTableName(table1, table2);
 }
 
-/** @internal */
+/**
+ * Rails' `join_table_name` delegates: `ModelSchema.derive_join_table_name(...)`
+ * (join_table.rb:12). This port deliberately keeps its own copy of those three
+ * lines instead. This module is a leaf — nothing else imports — and adding the
+ * `model-schema.js` edge pulls that module's whole transitive graph in wherever
+ * join-table is first imported, which reorders initialization enough that
+ * `base.ts`'s top-level `extend(Base, { belongsTo: _Associations.belongsTo })`
+ * runs against an uninitialized binding. `scripts/test-deps/adapter-graph-import-tdz.test.ts`
+ * guards exactly that. `model-schema.ts#deriveJoinTableName` is the canonical
+ * definition and stays byte-identical to this one.
+ *
+ * @internal
+ */
 export function joinTableName(table1: string, table2: string): string {
-  return deriveJoinTableName(table1, table2);
+  const joined = [String(table1), String(table2)].sort().join("\0");
+  const deduped = joined.replace(/^(.*[_.])(.+)\0\1(.+)/, "$1$2_$3");
+  return deduped.replaceAll("\0", "_");
 }

--- a/packages/activerecord/src/migration/join-table.ts
+++ b/packages/activerecord/src/migration/join-table.ts
@@ -4,6 +4,8 @@
  * Mirrors: ActiveRecord::Migration::JoinTable
  */
 
+import { deriveJoinTableName } from "../model-schema.js";
+
 /** @internal */
 export function findJoinTableName(
   table1: string,
@@ -15,7 +17,5 @@ export function findJoinTableName(
 
 /** @internal */
 export function joinTableName(table1: string, table2: string): string {
-  const joined = [String(table1), String(table2)].sort().join("\0");
-  const deduped = joined.replace(/^(.*[_.])(.+)\0\1(.+)/, "$1$2_$3");
-  return deduped.replaceAll("\0", "_");
+  return deriveJoinTableName(table1, table2);
 }

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -629,9 +629,18 @@ export function clearAttributeNamesMemo(host: SchemaHost): void {
   }
 }
 
-export function deriveJoinTableName(this: SchemaHost, otherTableName: string): string {
-  const tables = [underscore(this.name), otherTableName].sort();
-  return tables.join("_");
+/**
+ * Mirrors: ActiveRecord::ModelSchema.derive_join_table_name
+ *
+ * A module-level function in Rails (not a class method on the model): it takes
+ * both table names, sorts them, and collapses a shared `foo_`/`foo.` prefix so
+ * `foo_bars` + `foo_bazes` derive `foo_bars_bazes` rather than
+ * `foo_bars_foo_bazes`.
+ */
+export function deriveJoinTableName(firstTable: string, secondTable: string): string {
+  const joined = [String(firstTable), String(secondTable)].sort().join("\0");
+  const deduped = joined.replace(/^(.*[_.])(.+)\0\1(.+)/, "$1$2_$3");
+  return deduped.replaceAll("\0", "_");
 }
 
 export function quotedTableName(this: SchemaHost): string {
@@ -1553,7 +1562,6 @@ export const ClassMethods = {
   columnsHash,
   contentColumns,
   createTable,
-  deriveJoinTableName,
   quotedTableName,
   resetTableName,
   fullTableNamePrefix,

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2565,7 +2565,7 @@ export class Relation<T extends Base> {
       ...this._includesAssociations.filter((n) => !promotedIncludes.includes(n)),
     ];
     if (preloadAssocs.length > 0 && this._records.length > 0) {
-      await this._preloadAssociationsForRecords(this._records, preloadAssocs);
+      await this.preloadAssociations(this._records, preloadAssocs);
       if (token !== this._loadToken) return [];
     }
 
@@ -2788,7 +2788,7 @@ export class Relation<T extends Base> {
         result.toArray(),
         result.columnTypes as Record<string, { deserialize(value: unknown): unknown }>,
       );
-      await this._preloadAssociationsForRecords(this._records, eagerAssociations);
+      await this.preloadAssociations(this._records, eagerAssociations);
       return;
     }
 
@@ -2806,7 +2806,7 @@ export class Relation<T extends Base> {
         result.columnTypes as Record<string, { deserialize(value: unknown): unknown }>,
       );
       if (fallbackAssocs.length > 0) {
-        await this._preloadAssociationsForRecords(this._records, fallbackAssocs);
+        await this.preloadAssociations(this._records, fallbackAssocs);
       }
       return;
     }
@@ -2904,7 +2904,7 @@ export class Relation<T extends Base> {
     if (block) for (const record of this._records) block(record);
 
     if (fallbackAssocs.length > 0 && this._records.length > 0) {
-      await this._preloadAssociationsForRecords(this._records, fallbackAssocs);
+      await this.preloadAssociations(this._records, fallbackAssocs);
     }
   }
 
@@ -5833,9 +5833,21 @@ export class Relation<T extends Base> {
     return { tbl: key.slice(0, firstDot), col: key.slice(firstDot + 1) };
   }
 
-  private async _preloadAssociationsForRecords(
+  /**
+   * Mirrors: ActiveRecord::Relation#preload_associations (relation.rb:1321)
+   *
+   * Rails derives the spec list itself (`preload_values`, plus `includes_values`
+   * unless `eager_loading?`) — that is the `assocNames` default here. The
+   * internal `load` path passes the list explicitly because this port promotes
+   * `includes` to a JOIN per-association rather than all-or-nothing, so it has
+   * to subtract exactly the specs it promoted.
+   */
+  async preloadAssociations(
     records: T[],
-    assocNames: AssociationSpec[],
+    assocNames: AssociationSpec[] = [
+      ...this._preloadAssociations,
+      ...(this._eagerLoadingForSql() ? [] : this._includesAssociations),
+    ],
   ): Promise<void> {
     if (assocNames.length === 0) return;
     const { Preloader } = await import("./associations/preloader.js");
@@ -6536,10 +6548,6 @@ export class Relation<T extends Base> {
 
   aliasTracker(joins: Nodes.Node[] = [], aliases?: Map<string, number>): AliasTracker {
     return AliasTracker.create(this.model.connectionPool(), this.table.name, joins, aliases);
-  }
-
-  preloadAssociations(): AssociationSpec[] {
-    return [...this._preloadAssociations, ...this._includesAssociations];
   }
 
   bindAttribute(column: string, value: unknown): unknown {

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -1582,7 +1582,7 @@ function pluckCastType(
   const joinType = lookupCastTypeFromJoinDependencies(rel, name) as ColumnType | null;
   if (joinType) return joinType;
   // Driver OID type (e.g. PostgreSQL) or identity fallback.
-  return columnType(name, index, {}, result.columnTypes);
+  return columnType(result, name, index, {});
 }
 
 /**

--- a/packages/activerecord/src/result.ts
+++ b/packages/activerecord/src/result.ts
@@ -251,10 +251,7 @@ export class Result {
   }
 
   #columnType(name: string, index: number, typeOverrides: ColumnTypes): ColumnType {
-    if (typeOverrides && name in typeOverrides) return typeOverrides[name];
-    if (index in this.columnTypes) return this.columnTypes[index as unknown as string];
-    if (name in this.columnTypes) return this.columnTypes[name];
-    return IDENTITY_TYPE;
+    return columnType(this, name, index, typeOverrides);
   }
 }
 
@@ -270,12 +267,13 @@ const EMPTY = Object.freeze(new Result(EMPTY_COLUMNS, EMPTY_ROWS, EMPTY_COLUMN_T
  * @internal
  */
 export function columnType(
+  result: Result,
   name: string,
   index: number,
   typeOverrides: ColumnTypes,
-  columnTypes: ColumnTypes,
 ): ColumnType {
-  if (name in typeOverrides) return typeOverrides[name];
+  const columnTypes = result.columnTypes;
+  if (typeOverrides && name in typeOverrides) return typeOverrides[name];
   if (index in columnTypes) return columnTypes[index as unknown as string];
   if (name in columnTypes) return columnTypes[name];
   return IDENTITY_TYPE;

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -567,7 +567,7 @@ export class SchemaDumper {
 
   /** @internal */
   private _finalizeDump(lines: string[]): string | Promise<string> {
-    const result = this.dumpTables(lines);
+    const result = this.tables(lines);
     if (result instanceof Promise) {
       return result.then(async () => {
         await this.virtualTables(lines);
@@ -646,7 +646,7 @@ export class SchemaDumper {
     lines.push("}");
   }
 
-  private dumpTables(lines: string[]): void | Promise<void> {
+  private tables(lines: string[]): void | Promise<void> {
     const tableNames = this._source.tables();
     if (tableNames instanceof Promise) {
       return tableNames.then(async (raw) => {

--- a/packages/activerecord/src/token-for.ts
+++ b/packages/activerecord/src/token-for.ts
@@ -144,13 +144,15 @@ export class TokenDefinition {
     });
   }
 
+  // `block` is Rails' bare `yield(payload[0])` — the finder the caller supplies
+  // as a block (`resolve_token(token) { |id| find_by(...) }`).
   async resolveToken(
     token: string,
-    finder: (id: unknown) => Promise<Base | null>,
+    block: (id: unknown) => Promise<Base | null>,
   ): Promise<Base | null> {
     const verified = this.messageVerifier().verified(token, { purpose: this.fullPurpose() });
     const payload = Array.isArray(verified) && verified.length > 0 ? verified : null;
-    const record = payload ? await finder(payload[0]) : null;
+    const record = payload ? await block(payload[0]) : null;
     return record && JSON.stringify(this.payloadFor(record)) === JSON.stringify(payload)
       ? record
       : null;

--- a/packages/activerecord/src/type/serialized.ts
+++ b/packages/activerecord/src/type/serialized.ts
@@ -386,8 +386,7 @@ export class Serialized extends ValueType {
 export function encoded(this: Serialized, value: unknown): unknown {
   // Use the constructor-cached default to avoid calling coder.load(null) again,
   // which would produce a fresh object on every call and break reference equality.
-  const serialized = this;
-  const s = serialized as any;
+  const s = this as any;
   const defaultVal = s._defaultValue;
   if (value === defaultVal) return undefined;
   if (typeof value === "object" && value !== null && s._defaultValueJson !== undefined) {
@@ -397,12 +396,9 @@ export function encoded(this: Serialized, value: unknown): unknown {
       // non-serializable; treat as non-default
     }
   }
-  const payload = serialized.coder.dump(value);
+  const payload = this.coder.dump(value);
   // Rails: if payload && subtype.binary? → ActiveModel::Type::Binary::Data.new(payload)
-  if (
-    payload &&
-    ((serialized.subtype as any).binary?.() ?? (serialized.subtype as any).isBinary?.())
-  ) {
+  if (payload && ((this.subtype as any).binary?.() ?? (this.subtype as any).isBinary?.())) {
     return new BinaryData(payload);
   }
   return payload;

--- a/packages/activerecord/src/type/serialized.ts
+++ b/packages/activerecord/src/type/serialized.ts
@@ -328,7 +328,7 @@ export class Serialized extends ValueType {
 
   override isChangedInPlace(rawOldValue: unknown, value: unknown): boolean {
     if (value === null || value === undefined) return false;
-    const rawNewValue = encoded(this, value);
+    const rawNewValue = encoded.call(this, value);
     const oldNil = rawOldValue === null || rawOldValue === undefined;
     const newNil = rawNewValue === null || rawNewValue === undefined;
     return (
@@ -383,9 +383,10 @@ export class Serialized extends ValueType {
  *
  * @internal
  */
-export function encoded(serialized: Serialized, value: unknown): unknown {
+export function encoded(this: Serialized, value: unknown): unknown {
   // Use the constructor-cached default to avoid calling coder.load(null) again,
   // which would produce a fresh object on every call and break reference equality.
+  const serialized = this;
   const s = serialized as any;
   const defaultVal = s._defaultValue;
   if (value === defaultVal) return undefined;

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-definitions.json
@@ -151,14 +151,14 @@
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "integer_like_primary_key?",
     "call": "include?",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails schema_definitions.rb:605-607 uses `[:integer, :bigint].include?(type)` and `!options.key?(:default)`; trails schema-definitions.ts:1031-1037 inlines the type equality checks and tests `options.default === undefined`. The presence check is preserved under the nil↔null mapping: an explicit `default: null` is !== undefined, so it disables the rewrite exactly as Rails' key?-present nil does; the only unmatched shape is an explicit `default: undefined`, which has no Ruby analogue and conventionally means absent in JS."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails schema_definitions.rb:605-607 uses `[:integer, :bigint].include?(type)` and `!options.key?(:default)`; trails schema-definitions.ts:1031-1037 inlines the type equality checks and tests `options.default === undefined`. The presence check is preserved under the nil\u2194null mapping: an explicit `default: null` is !== undefined, so it disables the rewrite exactly as Rails' key?-present nil does; the only unmatched shape is an explicit `default: undefined`, which has no Ruby analogue and conventionally means absent in JS."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "integer_like_primary_key?",
     "call": "key?",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails schema_definitions.rb:605-607 uses `[:integer, :bigint].include?(type)` and `!options.key?(:default)`; trails schema-definitions.ts:1031-1037 inlines the type equality checks and tests `options.default === undefined`. The presence check is preserved under the nil↔null mapping: an explicit `default: null` is !== undefined, so it disables the rewrite exactly as Rails' key?-present nil does; the only unmatched shape is an explicit `default: undefined`, which has no Ruby analogue and conventionally means absent in JS."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails schema_definitions.rb:605-607 uses `[:integer, :bigint].include?(type)` and `!options.key?(:default)`; trails schema-definitions.ts:1031-1037 inlines the type equality checks and tests `options.default === undefined`. The presence check is preserved under the nil\u2194null mapping: an explicit `default: null` is !== undefined, so it disables the rewrite exactly as Rails' key?-present nil does; the only unmatched shape is an explicit `default: undefined`, which has no Ruby analogue and conventionally means absent in JS."
   },
   {
     "package": "activerecord",
@@ -278,5 +278,12 @@
     "rubyName": "timestamps",
     "call": "key?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
+    "rubyName": "remove_column",
+    "call": "delete",
+    "reason": "Newly comparable (RFC 0072 arity sweep): Rails deletes from the `@columns_hash` Hash; TableDefinition here stores `columns` as an ordered array, so the same removal is a findIndex/splice. Equivalent \u2014 no Hash to delete from."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract/schema-statements.json
@@ -431,7 +431,7 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "foreign_keys_enabled?",
     "call": "fetch",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails schema_statements.rb:1783-1785 is `@config.fetch(:foreign_keys, true)` — key-present semantics, so an explicitly configured nil stays falsy; trails schema-statements.ts:2487-2493 reads `adapter._config?.foreignKeys !== false`, which coerces null (and any non-false value) to true. Divergence tracked in story fetch-nil-presence-divergences-globalid-rack."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails schema_statements.rb:1783-1785 is `@config.fetch(:foreign_keys, true)` \u2014 key-present semantics, so an explicitly configured nil stays falsy; trails schema-statements.ts:2487-2493 reads `adapter._config?.foreignKeys !== false`, which coerces null (and any non-false value) to true. Divergence tracked in story fetch-nil-presence-divergences-globalid-rack."
   },
   {
     "package": "activerecord",
@@ -838,5 +838,12 @@
     "rubyName": "views",
     "call": "query_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/schema-statements.ts",
+    "rubyName": "table_exists?",
+    "call": "tables",
+    "reason": "Newly comparable (RFC 0072 arity sweep): Rails calls `tables` only from the `rescue NotImplementedError` fallback arm; trails' tableExists issues the data-source query per adapter and has no such fallback. Pre-existing gap \u2014 converge by porting the rescue arm."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration/join-table.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration/join-table.json
@@ -5,5 +5,12 @@
     "rubyName": "find_join_table_name",
     "call": "delete",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "migration/join-table.ts",
+    "rubyName": "join_table_name",
+    "call": "derive_join_table_name",
+    "reason": "Verified (RFC 0072 arity sweep): Rails delegates to ModelSchema.derive_join_table_name; this module must stay import-leaf \u2014 the model-schema.js edge reorders module init and trips scripts/test-deps/adapter-graph-import-tdz.test.ts \u2014 so it inlines the identical three lines. See the comment on joinTableName."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration/join-table.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/migration/join-table.json
@@ -5,12 +5,5 @@
     "rubyName": "find_join_table_name",
     "call": "delete",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration/join-table.ts",
-    "rubyName": "join_table_name",
-    "call": "derive_join_table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/relation.json
@@ -2117,36 +2117,22 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
-    "call": "call",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1321-1328 concatenates preload_values/includes_values and runs Preloader.new(...).call per spec under the strict_loading_value scope; trails relation.ts:6473-6475 returns the merged `[..._preloadAssociations, ..._includesAssociations]` list and the load path consuming it invokes the preloader — the value reads are direct field spreads."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "preload_associations",
     "call": "includes_values",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1321-1328 concatenates preload_values/includes_values and runs Preloader.new(...).call per spec under the strict_loading_value scope; trails relation.ts:6473-6475 returns the merged `[..._preloadAssociations, ..._includesAssociations]` list and the load path consuming it invokes the preloader — the value reads are direct field spreads."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "preload_associations",
-    "call": "new",
-    "reason": "Constructor idiom: Ruby `X.new` ports to TS `new X()`, which extractCalls records as a construction/type reference rather than a named call. The construction is present in the port. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1321-1328 concatenates preload_values/includes_values and runs Preloader.new(...).call per spec under the strict_loading_value scope; trails relation.ts:6473-6475 returns the merged `[..._preloadAssociations, ..._includesAssociations]` list and the load path consuming it invokes the preloader \u2014 the value reads are direct field spreads."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "preload_values",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1321-1328 concatenates preload_values/includes_values and runs Preloader.new(...).call per spec under the strict_loading_value scope; trails relation.ts:6473-6475 returns the merged `[..._preloadAssociations, ..._includesAssociations]` list and the load path consuming it invokes the preloader — the value reads are direct field spreads."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1321-1328 concatenates preload_values/includes_values and runs Preloader.new(...).call per spec under the strict_loading_value scope; trails relation.ts:6473-6475 returns the merged `[..._preloadAssociations, ..._includesAssociations]` list and the load path consuming it invokes the preloader \u2014 the value reads are direct field spreads."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "strict_loading_value",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1321-1328 concatenates preload_values/includes_values and runs Preloader.new(...).call per spec under the strict_loading_value scope; trails relation.ts:6473-6475 returns the merged `[..._preloadAssociations, ..._includesAssociations]` list and the load path consuming it invokes the preloader — the value reads are direct field spreads."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails relation.rb:1321-1328 concatenates preload_values/includes_values and runs Preloader.new(...).call per spec under the strict_loading_value scope; trails relation.ts:6473-6475 returns the merged `[..._preloadAssociations, ..._includesAssociations]` list and the load path consuming it invokes the preloader \u2014 the value reads are direct field spreads."
   },
   {
     "package": "activerecord",
@@ -2651,5 +2637,12 @@
     "rubyName": "where",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "exec_queries",
+    "call": "preload_associations",
+    "reason": "Newly comparable (RFC 0072 arity sweep): relation.ts has no `execQueries` \u2014 Rails' exec_queries body is split across `load`/`_executeEagerLoad`, which DO call preloadAssociations. Converge by porting exec_queries as one method."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/result.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/result.json
@@ -61,5 +61,19 @@
     "rubyName": "last",
     "call": "hash_rows",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "result.ts",
+    "rubyName": "column_type",
+    "call": "fetch",
+    "reason": "Newly comparable (RFC 0072 arity sweep): Rails expresses the override/index/name lookup as nested `Hash#fetch` blocks; JS objects have no fetch-with-default, so the port uses `in` checks in the same order. Equivalent."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "result.ts",
+    "rubyName": "column_type",
+    "call": "default_value",
+    "reason": "Newly comparable (RFC 0072 arity sweep): Rails' final fallback is `Type.default_value`; the port returns the module-level IDENTITY_TYPE constant, which is that same default value memoized rather than re-fetched. Equivalent."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/schema-dumper.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/schema-dumper.json
@@ -285,5 +285,33 @@
     "rubyName": "table",
     "call": "valid_type?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "schema-dumper.ts",
+    "rubyName": "dump",
+    "call": "tables",
+    "reason": "Newly comparable (RFC 0072 arity sweep): `dump` reaches `tables` through `_finalizeDump`, the port's sync/async fork for schema sources whose `tables()` may return a Promise. Called, just one frame down."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "schema-dumper.ts",
+    "rubyName": "tables",
+    "call": "reject",
+    "reason": "Newly comparable (RFC 0072 arity sweep): Rails builds `not_ignored_tables` with `reject { ignored?(...) }`; the port applies the same `isIgnored` predicate as a `continue` inside the emit loop. Equivalent."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "schema-dumper.ts",
+    "rubyName": "tables",
+    "call": "count",
+    "reason": "Newly comparable (RFC 0072 arity sweep): Rails uses `count` only for the `index < count - 1` blank-line separator; the port pushes a trailing blank line per table instead. Equivalent output, no count needed."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "schema-dumper.ts",
+    "rubyName": "tables",
+    "call": "string",
+    "reason": "Newly comparable (RFC 0072 arity sweep): Rails buffers foreign keys in a `StringIO` and appends `.string`; the port accumulates into the same `lines` array it already threads, so there is no second buffer to stringify. Equivalent."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/tasks/database-tasks.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/tasks/database-tasks.json
@@ -474,5 +474,12 @@
     "rubyName": "with_temporary_pool_for_each",
     "call": "configurations",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/database-tasks.ts",
+    "rubyName": "truncate_tables",
+    "call": "tables",
+    "reason": "Newly comparable (RFC 0072 arity sweep): Rails calls `conn.truncate_tables(*conn.tables)`; trails delegates the whole operation to a per-adapter task handler's `truncateAll`, which enumerates tables itself. Pre-existing structural deviation."
   }
 ]


### PR DESCRIPTION
Resolves the 11 remaining `output/arity-mismatches.json` entries outside the
associations and internal_metadata clusters. Each was verified against its
vendored Rails definition; **none** turned out to be a tooling artifact and
none needed an exclusion entry.

| Rails | Was | Now |
| --- | --- | --- |
| `insert_all.rb#verify_attributes(attributes)` | `()` | `(attributes)` |
| `model_schema.rb.derive_join_table_name(first, second)` | `(this, otherTableName)` | `(firstTable, secondTable)` |
| `relation.rb#preload_associations(records)` | dead `()` accessor | `(records, assocNames = <Rails derivation>)` |
| `schema_dumper.rb#tables(stream)` | `dumpTables(lines)` | `tables(lines)` |
| `token_for.rb#resolve_token(token) { }` | `(token, finder)` | `(token, block)` |
| `type/serialized.rb#encoded(value)` | `(serialized, value)` | `(this: Serialized, value)` |
| `result.rb#column_type(name, index, type_overrides)` | `(name, index, typeOverrides, columnTypes)` | `(result, name, index, typeOverrides)` |
| `cipher/aes256_gcm.rb#generate_iv(cipher, clear_text)` | `(keyBuf, inputBuf, deterministic)` | `(clearText, deterministic)` |
| `cipher/aes256_gcm.rb#generate_deterministic_iv(clear_text)` | `(keyBuf, clearText)` | `(clearText)` |
| `connection_handler.rb#determine_owner_name(owner_name, config)` | `(owner)` | `(owner, _config?)` |
| `schema_definitions.rb TableDefinition#remove_column(name)` | *unported* | `removeColumn(name)` |

### Notes on the less mechanical ones

- **`derive_join_table_name`** is a module function in Rails
  (`ModelSchema.derive_join_table_name`), not a class method on the model, and
  it collapses a shared `foo_`/`foo.` prefix. The port had a two-table-name
  copy of the real algorithm sitting in `migration/join-table.ts` and a
  *different*, prefix-unaware `this`-typed version on `Base`. The canonical
  definition now lives in `model-schema.ts` with Rails' signature and
  algorithm; the unported `Base` static is dropped (it had no callers).

  `Migration::JoinTable#join_table_name` does **not** delegate to it, though
  Rails' does (`join_table.rb:12`). Wiring that up broke module initialization:
  `migration/join-table.ts` had no imports at all, so the `model-schema.js`
  edge pulls that module's whole transitive graph in at first import and
  `base.ts`'s top-level `extend(Base, { belongsTo: _Associations.belongsTo })`
  then reads an uninitialized binding.
  `scripts/test-deps/adapter-graph-import-tdz.test.ts` caught it, and removing
  that single import is what fixes it. `joinTableName` keeps the identical
  three lines inline, with the constraint documented at the call site and a
  reasoned wide-ratchet baseline entry rather than a silent divergence.
- **`preload_associations`** existed twice: a dead zero-arg accessor with the
  Rails name, and the real implementation under `_preloadAssociationsForRecords`.
  The dead one is gone and the real one takes the name. Rails derives the spec
  list itself (`preload_values` + `includes_values` unless `eager_loading?`) —
  that's the parameter default; `load` still passes explicitly because this port
  promotes `includes` to a JOIN per-association rather than all-or-nothing.
- **`verify_attributes`** takes one row's attributes and is called per row from
  `map_key_with_value` — that is now where the port calls it too, and it
  compares against `keys_including_timestamps` rather than `@keys`. Both
  corrections matter: the old code compared raw row keys against `@keys`, so a
  batch whose rows differ only in whether they spell out `created_at`/
  `updated_at` raised a spurious `ArgumentError` that Rails does not (Rails
  reverse_merges `timestamps_for_create` into every row first, and both sides
  of the comparison then carry the magic columns). The check cannot be hoisted
  to the constructor: `keysIncludingTimestamps` resolves the timestamp columns
  off the reflected schema, which is not loaded yet at construction. The
  trails-only unknown-attribute guard moves to its own helper, and the error is
  now `ArgumentError`, matching Rails. Regression coverage in the new
  `insert-all.trails.test.ts`.
- **`determine_owner_name`** gains Rails' `config` slot but *not* its
  `elsif config.is_a?(Symbol)` branch. Ruby distinguishes that bare-name Symbol
  from a String config (a connection URL), which falls through to `owner_name`
  unchanged; TS collapses both onto `string`, so porting the branch as
  `typeof config === "string"` would misread a URL as a connection name. The
  parameter is kept for signature fidelity and the omission documented at the
  call site.
- **`tables(stream)`** was renamed `dumpTables` to dodge a collision with the
  `SchemaSource#tables` interface method. They're on different types, so the
  Rails name is restored.
- **`generate_iv`**: Rails' first slot is the live `OpenSSL::Cipher`, present
  only so the random branch can call `cipher.random_iv`. WebCrypto has no such
  object before the IV exists, so the slot carries the deterministic flag
  (which Rails reads off `@deterministic`). The key buffer is now derived from
  `this.secret` inside the method rather than threaded in — no behaviour change.
- **`connection_handler.rb#determine_owner_name`** — see above.
- **`TableDefinition#remove_column`** was genuinely unported; the comparison
  had paired it with `SchemaStatements#remove_column`, hiding the gap. Rails has
  no unit test for it, so the two new cases (drop / no-op on an unknown column)
  land in `schema-definitions.trails.test.ts`.

### Wide call-mismatch baselines

Restoring the Rails names makes several Ruby↔TS pairs body-comparable for the
first time, so the wide ratchet moves in both directions:

- **2 entries removed** — genuinely converged by this PR:
  `preload_associations → call` / `→ new` (the name now sits on the body that
  actually constructs and calls the `Preloader`).
- **11 entries added** with per-entry reasons. One is
  `join_table_name → derive_join_table_name`, re-stated with the module-init
  constraint above as its reason. Eight are idiom differences
  (Ruby `Hash#fetch`/`reject`/`count`/`StringIO#string` vs. the port's `in`
  checks, `continue`, and shared `lines` array). Two are pre-existing
  structural gaps that this PR only made *visible*, not worse:
  `table_exists? → tables` (Rails' `rescue NotImplementedError` fallback arm is
  unported) and `truncate_tables → tables` (trails delegates to a per-adapter
  task handler). Neither is in this story's scope.

#### `result.ts column_type` — checked, not blind-baselined

Raised in review: does the port lose Ruby's `fetch`-with-block short-circuit or
`Type.default_value`? Verified against `result.rb:224-229` and
`activemodel/lib/active_model/type.rb` — it does not.

```ruby
type_overrides.fetch(name) { column_types.fetch(index) { column_types.fetch(name, Type.default_value) } }
```

`Hash#fetch` with a block tests *key presence* and runs the block only on a
miss. The port's `if (name in typeOverrides) ... if (index in columnTypes) ...
if (name in columnTypes) ... return IDENTITY_TYPE` chain tests the same three
keys in the same order with the same short-circuit — `in` is a presence test
too, so a key holding a nil/undefined value resolves identically on both sides.

`Type.default_value` is `@default_value ||= Value.new`: a *memoized* passthrough
whose `deserialize` returns its argument unchanged. `IDENTITY_TYPE` is a
module-level object with exactly that `deserialize`, memoized as a constant
instead of via `||=`. Same value, same identity-stability.

So the entry is an idiom difference, not a behavioural gap, and the exclude
reason says so.

`output/arity-mismatches.json`: **128 → 117**, with all 11 listed entries gone.
Data-layer parity and file counts are unchanged (7473/7473, 407/407).

Closes-story: arity-misc-signature-gaps



