### PR TITLE
refactor(globalid): reconcile extra TS surface against Rails

### DIFF
--- a/packages/activesupport/src/message-verifier.ts
+++ b/packages/activesupport/src/message-verifier.ts
@@ -166,14 +166,18 @@ export class MessageVerifier {
     return getCrypto().createHmac(this.digest, this.secret).update(data).digest("hex");
   }
 
-  private encode(buf: Buffer): string {
+  // Rails declares encode/decode private, but GlobalID::Verifier overrides
+  // them (Ruby private methods are still overridable). TS forbids
+  // redeclaring a private base member in a subclass, so they're protected
+  // here to keep that override path open.
+  protected encode(buf: Buffer): string {
     if (this.urlSafe) {
       return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
     }
     return buf.toString("base64");
   }
 
-  private decode(str: string): Buffer {
+  protected decode(str: string): Buffer {
     // Support both url-safe and standard base64
     const normalized = str.replace(/-/g, "+").replace(/_/g, "/");
     // Add padding if needed

--- a/packages/globalid/src/global-id.ts
+++ b/packages/globalid/src/global-id.ts
@@ -1,11 +1,5 @@
 import { getApp } from "./config.js";
-import {
-  buildGid,
-  normalizeModelId,
-  parseGid,
-  validateApp,
-  type GidComponents,
-} from "./uri/gid.js";
+import { GID, validateApp, type GidComponents } from "./uri/gid.js";
 import { Locator, lookupClass, type LocateOptions, type LocatorModel } from "./locator.js";
 // LAZY-IMPORT CYCLE: global-id ↔ signed-global-id ↔ locator. Safe because
 // every cross-module reference below happens inside a method body (runtime),
@@ -65,6 +59,15 @@ export class GlobalID {
     return this._components.params;
   }
 
+  /**
+   * @internal Rails' `GlobalID#initialize` stores the `URI::GID` itself and
+   * delegates app/model_name/model_id/params/to_s to it. We snapshot the
+   * components instead, so every entry point funnels through here.
+   */
+  private static fromGid(gid: GID): GlobalID {
+    return new GlobalID(gid.toString(), gid.deconstructKeys());
+  }
+
   /** Mirrors: GlobalID.create */
   static create(model: GlobalIDModel, options: GlobalIDOptions = {}): GlobalID {
     const app = options.app ?? getApp();
@@ -80,26 +83,19 @@ export class GlobalID {
     }
     const modelName = model.constructor.name;
     const params = Object.keys(filteredParams).length ? filteredParams : null;
-    const uri = buildGid(app, modelName, model.id, params);
-    const components: GidComponents = {
-      app,
-      modelName,
-      modelId: normalizeModelId(model.id, modelName),
-      params: params ?? {},
-    };
-    return new GlobalID(uri, components);
+    return GlobalID.fromGid(GID.build({ app, modelName, modelId: model.id, params }));
   }
 
   /** Mirrors: GlobalID.parse — falls back to base64-decoded form. */
   static parse(gid: string | GlobalID, _options: GlobalIDOptions = {}): GlobalID | null {
     if (gid instanceof GlobalID) return gid;
     try {
-      return new GlobalID(gid, parseGid(gid));
+      return GlobalID.fromGid(GID.parse(gid));
     } catch {
       try {
         const b64 = gid.replace(/-/g, "+").replace(/_/g, "/");
         const decoded = atob(b64 + "=".repeat((4 - (b64.length % 4)) % 4));
-        return new GlobalID(decoded, parseGid(decoded));
+        return GlobalID.fromGid(GID.parse(decoded));
       } catch {
         return null;
       }

--- a/packages/globalid/src/global-id.ts
+++ b/packages/globalid/src/global-id.ts
@@ -41,9 +41,14 @@ export class GlobalID {
   readonly uri: string;
   private readonly _components: GidComponents;
 
-  private constructor(uri: string, components: GidComponents) {
-    this.uri = uri;
-    this._components = components;
+  /**
+   * Rails' `GlobalID#initialize` stores the `URI::GID` and delegates
+   * app/model_name/model_id/params/to_s to it; we snapshot its components
+   * instead, so every entry point goes through a parsed GID.
+   */
+  private constructor(gid: GID) {
+    this.uri = gid.toString();
+    this._components = gid.deconstructKeys();
   }
 
   get app(): string {
@@ -57,15 +62,6 @@ export class GlobalID {
   }
   get params(): Record<string, string> {
     return this._components.params;
-  }
-
-  /**
-   * @internal Rails' `GlobalID#initialize` stores the `URI::GID` itself and
-   * delegates app/model_name/model_id/params/to_s to it. We snapshot the
-   * components instead, so every entry point funnels through here.
-   */
-  private static fromGid(gid: GID): GlobalID {
-    return new GlobalID(gid.toString(), gid.deconstructKeys());
   }
 
   /** Mirrors: GlobalID.create */
@@ -83,19 +79,19 @@ export class GlobalID {
     }
     const modelName = model.constructor.name;
     const params = Object.keys(filteredParams).length ? filteredParams : null;
-    return GlobalID.fromGid(GID.build({ app, modelName, modelId: model.id, params }));
+    return new GlobalID(GID.build({ app, modelName, modelId: model.id, params }));
   }
 
   /** Mirrors: GlobalID.parse — falls back to base64-decoded form. */
   static parse(gid: string | GlobalID, _options: GlobalIDOptions = {}): GlobalID | null {
     if (gid instanceof GlobalID) return gid;
     try {
-      return GlobalID.fromGid(GID.parse(gid));
+      return new GlobalID(GID.parse(gid));
     } catch {
       try {
         const b64 = gid.replace(/-/g, "+").replace(/_/g, "/");
         const decoded = atob(b64 + "=".repeat((4 - (b64.length % 4)) % 4));
-        return GlobalID.fromGid(GID.parse(decoded));
+        return new GlobalID(GID.parse(decoded));
       } catch {
         return null;
       }

--- a/packages/globalid/src/index.ts
+++ b/packages/globalid/src/index.ts
@@ -7,7 +7,11 @@ export { SignedGlobalID, ExpiredMessage } from "./signed-global-id.js";
 export { Verifier } from "./verifier.js";
 /** @internal */
 export { _resetSignedGlobalIDClassConfig } from "./signed-global-id.js";
-export type { SignedGlobalIDOptions, ParseOptions, FromUriOptions } from "./signed-global-id.js";
+export type {
+  SignedGlobalIDOptions,
+  ParseOptions,
+  SignedGlobalIDInitOptions,
+} from "./signed-global-id.js";
 export { validateApp, GID, MissingModelIdError, InvalidModelIdError } from "./uri/gid.js";
 export type { GidComponents } from "./uri/gid.js";
 export { Locator, BaseLocator, UnscopedLocator, BlockLocator, setModelFinder } from "./locator.js";

--- a/packages/globalid/src/index.ts
+++ b/packages/globalid/src/index.ts
@@ -8,14 +8,7 @@ export { Verifier } from "./verifier.js";
 /** @internal */
 export { _resetSignedGlobalIDClassConfig } from "./signed-global-id.js";
 export type { SignedGlobalIDOptions, ParseOptions, FromUriOptions } from "./signed-global-id.js";
-export {
-  parseGid,
-  buildGid,
-  validateApp,
-  GID,
-  MissingModelIdError,
-  InvalidModelIdError,
-} from "./uri/gid.js";
+export { validateApp, GID, MissingModelIdError, InvalidModelIdError } from "./uri/gid.js";
 export type { GidComponents } from "./uri/gid.js";
 export { Locator, BaseLocator, UnscopedLocator, BlockLocator, setModelFinder } from "./locator.js";
 /** @internal */

--- a/packages/globalid/src/signed-global-id.test.ts
+++ b/packages/globalid/src/signed-global-id.test.ts
@@ -105,12 +105,10 @@ describe("SignedGlobalIDPurposeTest", () => {
 
   it("new accepts a :for", () => {
     // Rails: SignedGlobalID.new(Person.new(5).to_gid.uri, for: 'login') —
-    // the URI-first initializer form. In Trails this is the static
-    // `fromUri(uri, options)` factory since constructors are kwargs-style
-    // through static methods, not direct `new`.
+    // the URI-first initializer form.
     const verifier = makeVerifier();
     const loginSgid = SignedGlobalID.create(person(5), { verifier, for: "login" });
-    const expected = SignedGlobalID.fromUri(`gid://${TEST_APP}/Person/5`, {
+    const expected = new SignedGlobalID(`gid://${TEST_APP}/Person/5`, {
       verifier,
       for: "login",
     });

--- a/packages/globalid/src/signed-global-id.trails.test.ts
+++ b/packages/globalid/src/signed-global-id.trails.test.ts
@@ -27,3 +27,21 @@ describe("SignedGlobalID pick_purpose explicit-null semantics", () => {
     expect(SignedGlobalID.parse(sgid.toString(), { verifier, for: null })?.uri).toBe(sgid.uri);
   });
 });
+
+describe("SignedGlobalID.parse verifier resolution", () => {
+  const verifier = new MessageVerifier("test-secret", { digest: "sha256", url_safe: true });
+  const person = { id: 5, constructor: { name: "Person" } };
+
+  beforeEach(() => setApp("bcx"));
+  afterEach(() => _resetApp());
+
+  it("parse raises when no verifier is configured", () => {
+    // The verify helpers swallow every error to return null, so without an
+    // explicit check `parse` would report a missing verifier as an invalid
+    // token. Rails raises — pick_verifier's ArgumentError is not rescued.
+    const sgid = SignedGlobalID.create(person, { verifier });
+    expect(() => SignedGlobalID.parse(sgid.toString())).toThrow(
+      /Pass a `verifier:` option .* SignedGlobalID\.verifier/,
+    );
+  });
+});

--- a/packages/globalid/src/signed-global-id.ts
+++ b/packages/globalid/src/signed-global-id.ts
@@ -44,12 +44,12 @@ export interface SignedGlobalIDOptions {
 }
 
 /**
- * Options accepted by the {@link SignedGlobalID} constructor. A narrower slice of
- * {@link SignedGlobalIDOptions} — only the knobs that affect verification
- * and the SGID instance fields, since the constructor takes a pre-built URI
- * and can't embed `app` or arbitrary extra URI params.
+ * Options accepted by the {@link SignedGlobalID} constructor — a narrower
+ * slice of {@link SignedGlobalIDOptions} holding only the knobs that affect
+ * verification and the SGID instance fields, since the constructor takes a
+ * pre-built URI and can't embed `app` or arbitrary extra URI params.
  */
-export interface FromUriOptions {
+export interface SignedGlobalIDInitOptions {
   for?: string | null;
   expiresIn?: number | null;
   expiresAt?: Temporal.Instant | null;
@@ -92,7 +92,7 @@ export class SignedGlobalID {
    * verifier/purpose/expiration are read; `app` and extra URI params can't
    * be threaded into an already-built URI string.
    */
-  constructor(uri: string, options: FromUriOptions = {}) {
+  constructor(uri: string, options: SignedGlobalIDInitOptions = {}) {
     // Rails' SignedGlobalID#initialize delegates to URI::GID.parse, which
     // raises on malformed URIs. Match that invariant here so callers get
     // an early error rather than deferred failures from modelId/modelName
@@ -141,6 +141,11 @@ export class SignedGlobalID {
    * Mirrors: SignedGlobalID.parse
    */
   static parse(sgid: string, options: ParseOptions = {}): SignedGlobalID | null {
+    // Rails' `verify` reaches `pick_verifier`, which raises when no verifier
+    // is available — only InvalidSignature is rescued. Our verify helpers
+    // swallow every error to return null, so assert the verifier here to keep
+    // "no verifier configured" a raise rather than a silent null.
+    SignedGlobalID.pickVerifier(options);
     const verified = SignedGlobalID.verify(sgid, options);
     if (verified === null) return null;
     // The token's own expiry wins over any class-level default: an explicit

--- a/packages/globalid/src/signed-global-id.ts
+++ b/packages/globalid/src/signed-global-id.ts
@@ -1,7 +1,7 @@
 import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { getApp } from "./config.js";
-import { buildGid, parseGid, type GidComponents } from "./uri/gid.js";
+import { GID, type GidComponents } from "./uri/gid.js";
 // LAZY-IMPORT CYCLE: signed-global-id ↔ global-id ↔ locator. The `GlobalID`
 // and `isOrExtends` runtime values are only referenced inside method bodies
 // below; don't promote those references to module level — native ESM throws
@@ -44,9 +44,9 @@ export interface SignedGlobalIDOptions {
 }
 
 /**
- * Options accepted by {@link SignedGlobalID.fromUri}. A narrower slice of
+ * Options accepted by the {@link SignedGlobalID} constructor. A narrower slice of
  * {@link SignedGlobalIDOptions} — only the knobs that affect verification
- * and the SGID instance fields, since fromUri operates on a pre-built URI
+ * and the SGID instance fields, since the constructor takes a pre-built URI
  * and can't embed `app` or arbitrary extra URI params.
  */
 export interface FromUriOptions {
@@ -81,32 +81,35 @@ export class SignedGlobalID {
 
   private readonly verifier: MessageVerifier;
   private _cached: string | undefined;
-  private _components: GidComponents | undefined;
+  private readonly _components: GidComponents;
   /** Stable per-instance hex id used by inspect(). Rails uses object_id. */
   private readonly _objectId: string;
 
-  private constructor(
-    uri: string,
-    purpose: string | null,
-    expiresAt: Temporal.Instant | undefined,
-    verifier: MessageVerifier,
-  ) {
+  /**
+   * Mirrors: SignedGlobalID#initialize(gid, options) — the URI-first entry
+   * point the Rails test `new accepts a :for` exercises. Use
+   * {@link SignedGlobalID.create} for the model-first form. Only
+   * verifier/purpose/expiration are read; `app` and extra URI params can't
+   * be threaded into an already-built URI string.
+   */
+  constructor(uri: string, options: FromUriOptions = {}) {
+    // Rails' SignedGlobalID#initialize delegates to URI::GID.parse, which
+    // raises on malformed URIs. Match that invariant here so callers get
+    // an early error rather than deferred failures from modelId/modelName
+    // getters reading garbage components.
+    this._components = GID.parse(uri).deconstructKeys();
     this.uri = uri;
-    this.purpose = purpose;
-    this.expiresAt = expiresAt;
-    this.verifier = verifier;
+    this.purpose = SignedGlobalID.pickPurpose(options);
+    this.expiresAt = pickExpiration(options);
+    this.verifier = SignedGlobalID.pickVerifier(options);
     this._objectId = (_nextObjectId++).toString(16).padStart(12, "0");
-  }
-
-  /** @internal — lazily parse and cache. */
-  private _parts(): GidComponents {
-    return (this._components ??= parseGid(this.uri));
   }
 
   /**
    * Create a SignedGlobalID for a model instance.
    *
-   * Mirrors: SignedGlobalID.new
+   * Mirrors: GlobalID.create — inherited by SignedGlobalID in Ruby, where
+   * `new` is polymorphic; declared here because the TS classes are peers.
    */
   static create(model: GlobalIDModel, options: SignedGlobalIDOptions = {}): SignedGlobalID {
     const app = options.app ?? getApp();
@@ -121,40 +124,14 @@ export class SignedGlobalID {
     for (const [k, v] of Object.entries(options)) {
       if (!KNOWN_SGID_KEYS.has(k) && v != null) filteredParams[k] = String(v);
     }
-    const uri = buildGid(
+    const gid = GID.build({
       app,
       modelName,
-      model.id,
-      Object.keys(filteredParams).length ? filteredParams : null,
-    );
+      modelId: model.id,
+      params: Object.keys(filteredParams).length ? filteredParams : null,
+    });
 
-    const verifier = SignedGlobalID.pickVerifier(options);
-    const purpose = SignedGlobalID.pickPurpose(options);
-    const expiresAt = pickExpiration(options);
-
-    return new SignedGlobalID(uri, purpose, expiresAt, verifier);
-  }
-
-  /**
-   * Build a SignedGlobalID from a raw GID URI plus options.
-   *
-   * Mirrors: SignedGlobalID.new(uri, options) — the Rails initializer that
-   * `SignedGlobalIDPurposeTest > 'new accepts a :for'` exercises. Use
-   * {@link create} for the model-first entry point; use this when you
-   * already have a URI string and want the SGID wrapper. Only
-   * verifier/purpose/expiration are read — `app` and extra URI params
-   * can't be threaded into an already-built URI string.
-   */
-  static fromUri(uri: string, options: FromUriOptions = {}): SignedGlobalID {
-    // Rails' SignedGlobalID#initialize delegates to URI::GID.parse, which
-    // raises on malformed URIs. Match that invariant here so callers get
-    // an early error rather than deferred failures from modelId/modelName
-    // getters reading garbage components.
-    parseGid(uri);
-    const verifier = SignedGlobalID.pickVerifier(options);
-    const purpose = SignedGlobalID.pickPurpose(options);
-    const expiresAt = pickExpiration(options);
-    return new SignedGlobalID(uri, purpose, expiresAt, verifier);
+    return new SignedGlobalID(gid.toString(), options);
   }
 
   /**
@@ -164,11 +141,11 @@ export class SignedGlobalID {
    * Mirrors: SignedGlobalID.parse
    */
   static parse(sgid: string, options: ParseOptions = {}): SignedGlobalID | null {
-    const verifier = SignedGlobalID.pickVerifier(options);
-    const purpose = SignedGlobalID.pickPurpose(options);
     const verified = SignedGlobalID.verify(sgid, options);
     if (verified === null) return null;
-    return new SignedGlobalID(verified.uri, purpose, verified.expiresAt, verifier);
+    // The token's own expiry wins over any class-level default: an explicit
+    // null tells pickExpiration "no expiration" (Rails: `expires_at: nil`).
+    return new SignedGlobalID(verified.uri, { ...options, expiresAt: verified.expiresAt ?? null });
   }
 
   // ─── Class-level config (Rails: attr_accessor :verifier, :expires_in) ─────
@@ -238,7 +215,7 @@ export class SignedGlobalID {
       const raw = verifier.verified(sgid, { purpose }) as SgidPayload | null;
       if (!raw || typeof raw !== "object" || typeof raw.gid !== "string") return null;
       if (raw.purpose !== purpose) return null;
-      parseGid(raw.gid);
+      GID.parse(raw.gid);
       let expiresAt: Temporal.Instant | undefined;
       if (raw.expires_at) {
         expiresAt = Temporal.Instant.from(raw.expires_at);
@@ -297,17 +274,17 @@ export class SignedGlobalID {
 
   /** Mirrors: GlobalID#model_id  — re-exposed on SignedGlobalID (peer class in TS, not a subclass). */
   get modelId(): string | string[] {
-    return this._parts().modelId;
+    return this._components.modelId;
   }
 
   /** Mirrors: GlobalID#model_name  — re-exposed on SignedGlobalID (peer class in TS, not a subclass). */
   get modelName(): string {
-    return this._parts().modelName;
+    return this._components.modelName;
   }
 
   /** Mirrors: GlobalID#params  — re-exposed on SignedGlobalID (peer class in TS, not a subclass). */
   get params(): Record<string, string> {
-    return this._parts().params;
+    return this._components.params;
   }
 
   /**

--- a/packages/globalid/src/signed-global-id.ts
+++ b/packages/globalid/src/signed-global-id.ts
@@ -99,9 +99,9 @@ export class SignedGlobalID {
     // getters reading garbage components.
     this._components = GID.parse(uri).deconstructKeys();
     this.uri = uri;
+    this.verifier = SignedGlobalID.pickVerifier(options);
     this.purpose = SignedGlobalID.pickPurpose(options);
     this.expiresAt = pickExpiration(options);
-    this.verifier = SignedGlobalID.pickVerifier(options);
     this._objectId = (_nextObjectId++).toString(16).padStart(12, "0");
   }
 

--- a/packages/globalid/src/uri-gid.test.ts
+++ b/packages/globalid/src/uri-gid.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  parseGid,
-  buildGid,
   validateApp,
   GID,
   MissingModelIdError,
@@ -11,44 +9,56 @@ import {
 
 describe("URI::GIDTest", () => {
   it("parsed", () => {
-    const gid = parseGid("gid://bcx/Person/5");
+    const gid = GID.parse("gid://bcx/Person/5");
     expect(gid.app).toBe("bcx");
     expect(gid.modelName).toBe("Person");
     expect(gid.modelId).toBe("5");
-    const cpkGid = parseGid("gid://bcx/CompositePrimaryKeyModel/tenant-key-value/id-value");
+    const cpkGid = GID.parse("gid://bcx/CompositePrimaryKeyModel/tenant-key-value/id-value");
     expect(cpkGid.modelId).toEqual(["tenant-key-value", "id-value"]);
   });
 
   it("parsed for non existing model class", () => {
-    const flatGid = parseGid("gid://bcx/NonExistingModel/1");
+    const flatGid = GID.parse("gid://bcx/NonExistingModel/1");
     expect(flatGid.modelId).toBe("1");
     expect(flatGid.modelName).toBe("NonExistingModel");
-    const compositeGid = parseGid("gid://bcx/NonExistingModel/tenant-key-value/id-value");
+    const compositeGid = GID.parse("gid://bcx/NonExistingModel/tenant-key-value/id-value");
     expect(compositeGid.modelId).toEqual(["tenant-key-value", "id-value"]);
     expect(compositeGid.modelName).toBe("NonExistingModel");
   });
 
   it("create", () => {
-    const uri = buildGid("bcx", "Person", "5");
+    const uri = GID.build({ app: "bcx", modelName: "Person", modelId: "5" }).toString();
     expect(uri).toBe("gid://bcx/Person/5");
   });
 
   it("create from a composite primary key model", () => {
-    const uri = buildGid("bcx", "CompositePrimaryKeyModel", ["tenant-key-value", "id-value"]);
+    const uri = GID.build({
+      app: "bcx",
+      modelName: "CompositePrimaryKeyModel",
+      modelId: ["tenant-key-value", "id-value"],
+    }).toString();
     expect(uri).toBe("gid://bcx/CompositePrimaryKeyModel/tenant-key-value/id-value");
   });
 
   it("build", () => {
-    const a = buildGid("bcx", "Person", "5");
-    const b = buildGid("bcx", "Person", "5");
+    const a = GID.build({ app: "bcx", modelName: "Person", modelId: "5" }).toString();
+    const b = GID.build({ app: "bcx", modelName: "Person", modelId: "5" }).toString();
     expect(a).toBeTruthy();
     expect(b).toBeTruthy();
     expect(a).toBe(b);
   });
 
   it("build with a composite primary key", () => {
-    const a = buildGid("bcx", "CompositePrimaryKeyModel", ["tenant-key-value", "id-value"]);
-    const b = buildGid("bcx", "CompositePrimaryKeyModel", ["tenant-key-value", "id-value"]);
+    const a = GID.build({
+      app: "bcx",
+      modelName: "CompositePrimaryKeyModel",
+      modelId: ["tenant-key-value", "id-value"],
+    }).toString();
+    const b = GID.build({
+      app: "bcx",
+      modelName: "CompositePrimaryKeyModel",
+      modelId: ["tenant-key-value", "id-value"],
+    }).toString();
     expect(a).toBeTruthy();
     expect(b).toBeTruthy();
     expect(a).toBe(b);
@@ -57,17 +67,19 @@ describe("URI::GIDTest", () => {
 
   it("as String", () => {
     const gidStr = "gid://bcx/Person/5";
-    const gid = parseGid(gidStr);
-    expect(buildGid(gid.app, gid.modelName, gid.modelId)).toBe(gidStr);
+    const gid = GID.parse(gidStr);
+    expect(
+      GID.build({ app: gid.app, modelName: gid.modelName, modelId: gid.modelId }).toString(),
+    ).toBe(gidStr);
   });
 
   it("equal", () => {
-    const a = parseGid("gid://bcx/Person/5");
-    const b = parseGid("gid://bcx/Person/5");
+    const a = GID.parse("gid://bcx/Person/5");
+    const b = GID.parse("gid://bcx/Person/5");
     expect(a.app).toBe(b.app);
     expect(a.modelName).toBe(b.modelName);
     expect(a.modelId).toBe(b.modelId);
-    const c = parseGid("gid://bcxxx/Persona/1");
+    const c = GID.parse("gid://bcxxx/Persona/1");
     expect(a.app).not.toBe(c.app);
   });
 
@@ -75,7 +87,7 @@ describe("URI::GIDTest", () => {
     // Rails: URI::GID.build(['Person', '5', 'bcx', nil]) misorders the
     // positional (app, modelName, modelId, params) tuple. The resulting
     // URI is not equal to the canonical gid://bcx/Person/5.
-    const wrong = buildGid("Person", "5", "bcx");
+    const wrong = GID.build({ app: "Person", modelName: "5", modelId: "bcx" }).toString();
     expect(wrong).toBe("gid://Person/5/bcx");
     expect(wrong).not.toBe("gid://bcx/Person/5");
   });
@@ -92,73 +104,81 @@ describe("URI::GIDTest", () => {
       params: {},
     });
     expect(synthetic).toBeTruthy();
-    expect(synthetic.uri).toBe("gid:///");
+    expect(synthetic.toString()).toBe("gid:///");
   });
 });
 
 describe("URI::GIDModelIDEncodingTest", () => {
   it("alphanumeric", () => {
-    const uri = buildGid("app", "Person", "John123");
+    const uri = GID.build({ app: "app", modelName: "Person", modelId: "John123" }).toString();
     expect(uri).toBe("gid://app/Person/John123");
   });
 
   it("non-alphanumeric", () => {
-    const uri = buildGid("app", "Person", "John Doe-Smith/Jones");
+    const uri = GID.build({
+      app: "app",
+      modelName: "Person",
+      modelId: "John Doe-Smith/Jones",
+    }).toString();
     expect(uri).toBe("gid://app/Person/John+Doe-Smith%2FJones");
   });
 
   it("every part of composite primary key is encoded", () => {
-    const uri = buildGid("app", "CompositePrimaryKeyModel", ["tenant key", "id value"]);
+    const uri = GID.build({
+      app: "app",
+      modelName: "CompositePrimaryKeyModel",
+      modelId: ["tenant key", "id value"],
+    }).toString();
     expect(uri).toBe("gid://app/CompositePrimaryKeyModel/tenant+key/id+value");
   });
 });
 
 describe("URI::GIDModelIDDecodingTest", () => {
   it("alphanumeric", () => {
-    expect(parseGid("gid://app/Person/John123").modelId).toBe("John123");
+    expect(GID.parse("gid://app/Person/John123").modelId).toBe("John123");
   });
 
   it("non-alphanumeric", () => {
-    expect(parseGid("gid://app/Person/John+Doe-Smith%2FJones").modelId).toBe(
+    expect(GID.parse("gid://app/Person/John+Doe-Smith%2FJones").modelId).toBe(
       "John Doe-Smith/Jones",
     );
   });
 
   it("every part of composite primary key is decoded", () => {
-    const gid = parseGid("gid://app/CompositePrimaryKeyModel/tenant+key+value/id+value");
+    const gid = GID.parse("gid://app/CompositePrimaryKeyModel/tenant+key+value/id+value");
     expect(gid.modelId).toEqual(["tenant key value", "id value"]);
   });
 });
 
 describe("URI::GIDValidationTest", () => {
   it("missing app", () => {
-    expect(() => parseGid("gid:///Person/1")).toThrow(InvalidComponentError);
+    expect(() => GID.parse("gid:///Person/1")).toThrow(InvalidComponentError);
   });
 
   it("missing path", () => {
-    expect(() => parseGid("gid://bcx/")).toThrow();
+    expect(() => GID.parse("gid://bcx/")).toThrow();
   });
 
   it("missing model id", () => {
-    expect(() => parseGid("gid://bcx/Person")).toThrow(MissingModelIdError);
-    expect(() => parseGid("gid://bcx/Person")).toThrow(/Unable to create a Global ID for Person/);
+    expect(() => GID.parse("gid://bcx/Person")).toThrow(MissingModelIdError);
+    expect(() => GID.parse("gid://bcx/Person")).toThrow(/Unable to create a Global ID for Person/);
   });
 
   it("missing model composite id", () => {
-    expect(() => parseGid("gid://bcx/CompositePrimaryKeyModel")).toThrow(MissingModelIdError);
-    expect(() => parseGid("gid://bcx/CompositePrimaryKeyModel")).toThrow(
+    expect(() => GID.parse("gid://bcx/CompositePrimaryKeyModel")).toThrow(MissingModelIdError);
+    expect(() => GID.parse("gid://bcx/CompositePrimaryKeyModel")).toThrow(
       /Unable to create a Global ID for CompositePrimaryKeyModel/,
     );
   });
 
   it("empty", () => {
-    expect(() => parseGid("gid:///")).toThrow();
+    expect(() => GID.parse("gid:///")).toThrow();
   });
 
   it("invalid schemes", () => {
-    expect(() => parseGid("http://bcx/Person/5")).toThrow(BadURIError);
-    expect(() => parseGid("gyd://bcx/Person/5")).toThrow(BadURIError);
-    expect(() => parseGid("//bcx/Person/5")).toThrow(BadURIError);
+    expect(() => GID.parse("http://bcx/Person/5")).toThrow(BadURIError);
+    expect(() => GID.parse("gyd://bcx/Person/5")).toThrow(BadURIError);
+    expect(() => GID.parse("//bcx/Person/5")).toThrow(BadURIError);
   });
 });
 
@@ -181,24 +201,39 @@ describe("URI::GIDAppValidationTest", () => {
 
 describe("URI::GIDParamsTest", () => {
   it("indifferent key access", () => {
-    const uri = buildGid("bcx", "Person", "5", { hello: "world" });
-    const gid = parseGid(uri);
+    const uri = GID.build({
+      app: "bcx",
+      modelName: "Person",
+      modelId: "5",
+      params: { hello: "world" },
+    }).toString();
+    const gid = GID.parse(uri);
     expect(gid.params["hello"]).toBe("world");
   });
 
   it("integer option", () => {
-    const uri = buildGid("bcx", "Person", "5", { integer: "20" });
-    const gid = parseGid(uri);
+    const uri = GID.build({
+      app: "bcx",
+      modelName: "Person",
+      modelId: "5",
+      params: { integer: "20" },
+    }).toString();
+    const gid = GID.parse(uri);
     expect(gid.params["integer"]).toBe("20");
   });
 
   it("multi value params returns last value", () => {
-    const gid = parseGid("gid://bcx/Person/5?multi=one&multi=two");
+    const gid = GID.parse("gid://bcx/Person/5?multi=one&multi=two");
     expect(gid.params["multi"]).toBe("two");
   });
 
   it("as String", () => {
-    const uri = buildGid("bcx", "Person", "5", { hello: "world" });
+    const uri = GID.build({
+      app: "bcx",
+      modelName: "Person",
+      modelId: "5",
+      params: { hello: "world" },
+    }).toString();
     expect(uri).toBe("gid://bcx/Person/5?hello=world");
   });
 

--- a/packages/globalid/src/uri/gid.ts
+++ b/packages/globalid/src/uri/gid.ts
@@ -16,9 +16,10 @@ const COMPOSITE_MODEL_ID_DELIMITER = "/";
 /**
  * Parse a `gid://app/ModelName/id` URI string.
  *
- * Mirrors: URI::GID.parse / URI::GID#set_model_components
+ * @internal Implementation behind {@link GID.parse}; module-private so the
+ * package's parse surface is spelled the Rails way (`URI::GID.parse`).
  */
-export function parseGid(uri: string): GidComponents {
+function parseGid(uri: string): GidComponents {
   if (!uri.startsWith("gid://")) {
     throw new BadURIError(`Not a gid:// URI scheme: ${uri}`);
   }
@@ -60,9 +61,10 @@ export function parseGid(uri: string): GidComponents {
 /**
  * Build a `gid://app/ModelName/id` URI string.
  *
- * Mirrors: URI::GID.build
+ * @internal Implementation behind {@link GID.build}; module-private so the
+ * package's build surface is spelled the Rails way (`URI::GID.build`).
  */
-export function buildGid(
+function buildGid(
   app: string,
   modelName: string,
   modelId: unknown,
@@ -140,7 +142,7 @@ function parseModelId(raw: string, modelName: string): string | string[] {
  * Shared by GlobalID.create and GID.build so their skip-parse paths
  * agree with the round-trip through parseGid(buildGid(...)).
  */
-export function normalizeModelId(raw: unknown, modelName: string): string | string[] {
+function normalizeModelId(raw: unknown, modelName: string): string | string[] {
   // Mirror parseModelId ordering: cap raw segments at
   // COMPOSITE_MODEL_ID_MAX_SIZE first, then filter empties. Reversing
   // the order would let a 21st non-empty segment slip past the cap
@@ -182,22 +184,27 @@ function cgiUnescape(s: string): string {
 // ─── URI::GID class wrapper (Rails parity) ─────────────────────────────────
 
 /**
- * Class form of the GID URI. Wraps {@link parseGid}/{@link buildGid} so the
- * Rails `URI::GID` method surface (parse / create / build / validate_app on
- * the class; modelName / modelId / params / toString / deconstructKeys on
- * the instance) is reachable for api:compare matching and for callers who
- * prefer an OO shape.
+ * The GID URI. Mirrors the Rails `URI::GID` surface — parse / create /
+ * build / validate_app on the class; app / modelName / modelId / params /
+ * toString / deconstructKeys on the instance — and is the only way into
+ * this module's parsing and building.
  *
  * Mirrors: URI::GID (vendor/globalid/lib/global_id/uri/gid.rb)
  */
 export class GID {
-  /** The raw GID URI string. */
-  readonly uri: string;
+  // Rails' URI::GID *is* the URI (it rebuilds `to_s` from its components);
+  // it has no `uri` member. We keep the raw string private and expose it
+  // through `toString()` only, so the public shape matches.
+  private readonly _uri: string;
   private readonly _components: GidComponents;
 
-  /** @internal — callers should use {@link GID.parse} / {@link GID.create} / {@link GID.build}. */
+  /**
+   * Rails' `URI::GID.new(*URI.split(str))` is public — it comes from
+   * `URI::Generic` and skips the `parse` argument checks. TS has no URI
+   * base class to inherit it from, so it's declared here.
+   */
   constructor(uri: string, components?: GidComponents) {
-    this.uri = uri;
+    this._uri = uri;
     this._components = components ?? parseGid(uri);
   }
 
@@ -220,7 +227,7 @@ export class GID {
 
   /** Mirrors: URI::GID#to_s */
   toString(): string {
-    return this.uri;
+    return this._uri;
   }
 
   /**

--- a/packages/globalid/src/uri/gid.ts
+++ b/packages/globalid/src/uri/gid.ts
@@ -139,8 +139,8 @@ function parseModelId(raw: string, modelName: string): string | string[] {
  * since buildGid joins sparse arrays into a `/`-only segment string
  * which is truthy and slips past its own guard.
  *
- * Shared by GlobalID.create and GID.build so their skip-parse paths
- * agree with the round-trip through parseGid(buildGid(...)).
+ * Used by GID.build so its skip-parse path agrees with the round-trip
+ * through parseGid(buildGid(...)).
  */
 function normalizeModelId(raw: unknown, modelName: string): string | string[] {
   // Mirror parseModelId ordering: cap raw segments at
@@ -181,7 +181,7 @@ function cgiUnescape(s: string): string {
   return decodeURIComponent(s.replace(/\+/g, "%20"));
 }
 
-// ─── URI::GID class wrapper (Rails parity) ─────────────────────────────────
+// ─── URI::GID ──────────────────────────────────────────────────────────────
 
 /**
  * The GID URI. Mirrors the Rails `URI::GID` surface — parse / create /

--- a/packages/globalid/src/verifier.test.ts
+++ b/packages/globalid/src/verifier.test.ts
@@ -27,7 +27,10 @@ describe("VerifierTest", () => {
     // URL-safe Verifier — the shared decode path normalizes both forms
     // before validating the signature.
     const verifier = new Verifier(SECRET);
-    const nonUrlSafe = new MessageVerifier(SECRET, { digest: "sha256", url_safe: false });
+    // Same digest as Verifier — which declares none, inheriting
+    // ActiveSupport::MessageVerifier's default exactly as Rails'
+    // GlobalID::Verifier does — so only the encoding differs.
+    const nonUrlSafe = new MessageVerifier(SECRET, { url_safe: false });
     const payload = { gid: "gid://bcx/Person/115186?expires_in", expires_at: null };
     const stdToken = nonUrlSafe.generate(payload);
     expect(verifier.verified(stdToken)).toEqual(payload);

--- a/packages/globalid/src/verifier.ts
+++ b/packages/globalid/src/verifier.ts
@@ -1,53 +1,27 @@
 import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
-import type { Temporal } from "@blazetrails/activesupport/temporal";
 
 /**
- * Mirrors: GlobalID::Verifier. Rails subclasses `ActiveSupport::MessageVerifier`
- * with SHA-256 + URL-safe base64 encoding so SGIDs can be embedded directly
- * in URLs. Our MessageVerifier already supports `url_safe: true` natively,
- * so Verifier here is a preset wrapper rather than a true subclass — TS
- * private fields make subclassing MessageVerifier's encode/decode hooks
- * impractical.
+ * Mirrors: GlobalID::Verifier — an `ActiveSupport::MessageVerifier` subclass
+ * whose only declared surface is the URL-safe base64 `encode`/`decode` pair,
+ * so SGIDs can be embedded directly in URLs. Everything else (`generate`,
+ * `verify`, `verified`, the digest default) is inherited, as in Rails.
  */
-export class Verifier {
-  private readonly inner: MessageVerifier;
-
-  constructor(secret: string) {
-    this.inner = new MessageVerifier(secret, { digest: "sha256", url_safe: true });
-  }
-
-  /** Sign and serialize `data` into a URL-safe token. */
-  generate(
-    data: unknown,
-    options?: { purpose?: string | null; expiresAt?: Temporal.Instant },
-  ): string {
-    return this.inner.generate(data, options);
-  }
-
-  /** Verify a token and return the decoded payload, or null on invalid signature. */
-  verified(message: string, options?: { purpose?: string | null }): unknown {
-    return this.inner.verified(message, options);
-  }
-
+export class Verifier extends MessageVerifier {
   /**
    * @internal Mirrors: GlobalID::Verifier#encode — Base64.urlsafe_encode64.
-   * Not called from the verify/generate path (MessageVerifier handles
-   * urlsafe encoding internally via `url_safe: true`); kept for api:compare
-   * parity and as a primitive callers can use directly if they need
-   * urlsafe encoding without the verifier signature.
+   * Padding is stripped so the token carries no `=` either.
    */
-  private encode(data: Buffer | string): string {
-    const buf = typeof data === "string" ? Buffer.from(data) : data;
+  protected encode(buf: Buffer): string {
     return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
   }
 
   /**
    * @internal Mirrors: GlobalID::Verifier#decode — Base64.urlsafe_decode64.
-   * Tolerates both urlsafe and standard base64 (matches what
-   * MessageVerifier does in its own decode).
+   * Tolerates both urlsafe and standard base64, so a token issued by a
+   * non-urlsafe verifier with the same secret still verifies.
    */
-  private decode(data: string): Buffer {
-    const normalized = data.replace(/-/g, "+").replace(/_/g, "/");
+  protected decode(str: string): Buffer {
+    const normalized = str.replace(/-/g, "+").replace(/_/g, "/");
     const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
     return Buffer.from(padded, "base64");
   }

--- a/scripts/api-compare/call-mismatches-wide-exclude/globalid/signed-global-id.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/globalid/signed-global-id.json
@@ -2,30 +2,9 @@
   {
     "package": "globalid",
     "tsFile": "signed-global-id.ts",
-    "rubyName": "initialize",
-    "call": "pick_expiration",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "globalid",
-    "tsFile": "signed-global-id.ts",
-    "rubyName": "initialize",
-    "call": "pick_purpose",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "globalid",
-    "tsFile": "signed-global-id.ts",
-    "rubyName": "initialize",
-    "call": "pick_verifier",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "globalid",
-    "tsFile": "signed-global-id.ts",
     "rubyName": "pick_purpose",
     "call": "fetch",
-    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails signed_global_id.rb:24-26 uses `options.fetch :for, DEFAULT_PURPOSE` — key-present semantics; trails pickPurpose mirrors it with `options.for !== undefined ? options.for : DEFAULT_PURPOSE`, so an explicit `for: null` yields a null purpose and only an absent key takes the default. Converged; no Hash#fetch analogue in TS, hence the flagged call."
+    "reason": "Per-entry verified (RFC 0032 wide-entry verification): Rails signed_global_id.rb:24-26 uses `options.fetch :for, DEFAULT_PURPOSE` \u2014 key-present semantics; trails pickPurpose mirrors it with `options.for !== undefined ? options.for : DEFAULT_PURPOSE`, so an explicit `for: null` yields a null purpose and only an absent key takes the default. Converged; no Hash#fetch analogue in TS, hence the flagged call."
   },
   {
     "package": "globalid",

--- a/scripts/api-compare/extra-surface-allow.json
+++ b/scripts/api-compare/extra-surface-allow.json
@@ -3,37 +3,37 @@
     "package": "abstractcontroller",
     "tsFile": "callbacks.ts",
     "name": "beforeAction",
-    "reason": "Rails defines `before_action` metaprogrammatically \u2014 `[:before, :after, :around].each { |cb| define_method \"#{cb}_action\" }` in abstract_controller/callbacks.rb (Callbacks::ClassMethods). The Ruby extractor only records literal `def`s, so no counterpart appears in rails-api.json even though this is the correct Rails-layout file for the macro."
+    "reason": "Rails defines `before_action` metaprogrammatically — `[:before, :after, :around].each { |cb| define_method \"#{cb}_action\" }` in abstract_controller/callbacks.rb (Callbacks::ClassMethods). The Ruby extractor only records literal `def`s, so no counterpart appears in rails-api.json even though this is the correct Rails-layout file for the macro."
   },
   {
     "package": "abstractcontroller",
     "tsFile": "callbacks.ts",
     "name": "afterAction",
-    "reason": "Rails defines `after_action` metaprogrammatically \u2014 `[:before, :after, :around].each { |cb| define_method \"#{cb}_action\" }` in abstract_controller/callbacks.rb (Callbacks::ClassMethods). The Ruby extractor only records literal `def`s, so no counterpart appears in rails-api.json even though this is the correct Rails-layout file for the macro."
+    "reason": "Rails defines `after_action` metaprogrammatically — `[:before, :after, :around].each { |cb| define_method \"#{cb}_action\" }` in abstract_controller/callbacks.rb (Callbacks::ClassMethods). The Ruby extractor only records literal `def`s, so no counterpart appears in rails-api.json even though this is the correct Rails-layout file for the macro."
   },
   {
     "package": "abstractcontroller",
     "tsFile": "callbacks.ts",
     "name": "aroundAction",
-    "reason": "Rails defines `around_action` metaprogrammatically \u2014 `[:before, :after, :around].each { |cb| define_method \"#{cb}_action\" }` in abstract_controller/callbacks.rb (Callbacks::ClassMethods). The Ruby extractor only records literal `def`s, so no counterpart appears in rails-api.json even though this is the correct Rails-layout file for the macro."
+    "reason": "Rails defines `around_action` metaprogrammatically — `[:before, :after, :around].each { |cb| define_method \"#{cb}_action\" }` in abstract_controller/callbacks.rb (Callbacks::ClassMethods). The Ruby extractor only records literal `def`s, so no counterpart appears in rails-api.json even though this is the correct Rails-layout file for the macro."
   },
   {
     "package": "abstractcontroller",
     "tsFile": "callbacks.ts",
     "name": "skipBeforeAction",
-    "reason": "Rails defines `skip_before_action` metaprogrammatically \u2014 `[:before, :after, :around].each { |cb| define_method \"#{cb}_action\" }` in abstract_controller/callbacks.rb (Callbacks::ClassMethods). The Ruby extractor only records literal `def`s, so no counterpart appears in rails-api.json even though this is the correct Rails-layout file for the macro."
+    "reason": "Rails defines `skip_before_action` metaprogrammatically — `[:before, :after, :around].each { |cb| define_method \"#{cb}_action\" }` in abstract_controller/callbacks.rb (Callbacks::ClassMethods). The Ruby extractor only records literal `def`s, so no counterpart appears in rails-api.json even though this is the correct Rails-layout file for the macro."
   },
   {
     "package": "abstractcontroller",
     "tsFile": "callbacks.ts",
     "name": "skipAfterAction",
-    "reason": "Rails defines `skip_after_action` metaprogrammatically \u2014 `[:before, :after, :around].each { |cb| define_method \"#{cb}_action\" }` in abstract_controller/callbacks.rb (Callbacks::ClassMethods). The Ruby extractor only records literal `def`s, so no counterpart appears in rails-api.json even though this is the correct Rails-layout file for the macro."
+    "reason": "Rails defines `skip_after_action` metaprogrammatically — `[:before, :after, :around].each { |cb| define_method \"#{cb}_action\" }` in abstract_controller/callbacks.rb (Callbacks::ClassMethods). The Ruby extractor only records literal `def`s, so no counterpart appears in rails-api.json even though this is the correct Rails-layout file for the macro."
   },
   {
     "package": "abstractcontroller",
     "tsFile": "callbacks.ts",
     "name": "skipAroundAction",
-    "reason": "Rails defines `skip_around_action` metaprogrammatically \u2014 `[:before, :after, :around].each { |cb| define_method \"#{cb}_action\" }` in abstract_controller/callbacks.rb (Callbacks::ClassMethods). The Ruby extractor only records literal `def`s, so no counterpart appears in rails-api.json even though this is the correct Rails-layout file for the macro."
+    "reason": "Rails defines `skip_around_action` metaprogrammatically — `[:before, :after, :around].each { |cb| define_method \"#{cb}_action\" }` in abstract_controller/callbacks.rb (Callbacks::ClassMethods). The Ruby extractor only records literal `def`s, so no counterpart appears in rails-api.json even though this is the correct Rails-layout file for the macro."
   },
   {
     "package": "abstractcontroller",
@@ -75,7 +75,7 @@
     "package": "abstractcontroller",
     "tsFile": "caching.ts",
     "name": "setCacheStore",
-    "reason": "Writer half of Rails' `ConfigMethods#cache_store` / `cache_store=` accessor pair. `cache_store=` camelizes to `cacheStore`, which the reader in the same file already declares \u2014 two exported functions cannot share a name, so the writer takes the `set` prefix."
+    "reason": "Writer half of Rails' `ConfigMethods#cache_store` / `cache_store=` accessor pair. `cache_store=` camelizes to `cacheStore`, which the reader in the same file already declares — two exported functions cannot share a name, so the writer takes the `set` prefix."
   },
   {
     "package": "abstractcontroller",
@@ -87,6 +87,78 @@
     "package": "abstractcontroller",
     "tsFile": "trailties/routes-helpers.ts",
     "name": "trailtieRoutesUrlHelpers",
-    "reason": "Trails spelling of Rails' `railtie_routes_url_helpers`, which `RoutesHelpers.with` calls on the namespace module (`namespace.railtie_routes_url_helpers(include_path_helpers)`). It is defined by Rails::Engine in railties, not by this file \u2014 here it is only the host-side hook slot the lookup probes for."
+    "reason": "Trails spelling of Rails' `railtie_routes_url_helpers`, which `RoutesHelpers.with` calls on the namespace module (`namespace.railtie_routes_url_helpers(include_path_helpers)`). It is defined by Rails::Engine in railties, not by this file — here it is only the host-side hook slot the lookup probes for."
+  },
+  {
+    "package": "globalid",
+    "tsFile": "uri/gid.ts",
+    "name": "constructor",
+    "reason": "URI::GID's public initializer comes from URI::Generic, so gid.rb declares none. TS has no URI base class to inherit it from, and the ported Rails test `new returns invalid gid when not checking` (uri_gid_test.rb) constructs one directly to bypass parse validation, so it is declared locally."
+  },
+  {
+    "package": "globalid",
+    "tsFile": "signed-global-id.ts",
+    "name": "[Symbol.toPrimitive]",
+    "reason": "TS analogue of Ruby's implicit string coercion: Rails relies on `to_s`/`to_param` being called whenever an SGID is interpolated into a string or a URL. `Symbol.toPrimitive` is the only hook that makes `String(sgid)` and template interpolation reach `toString()` for every hint."
+  },
+  {
+    "package": "globalid",
+    "tsFile": "signed-global-id.ts",
+    "name": "create",
+    "reason": "Rails' `SignedGlobalID < GlobalID` inherits `GlobalID.create` (polymorphic `new`). In TS the two are peer classes — SignedGlobalID's fields (verifier/purpose/expiresAt) come from options its base has no notion of — so `create` is re-declared here. Unifying them under real inheritance is tracked by the globalid-sgid-inherits-globalid story."
+  },
+  {
+    "package": "globalid",
+    "tsFile": "signed-global-id.ts",
+    "name": "modelClass",
+    "reason": "Inherited from GlobalID in Ruby; re-declared because the TS classes are peers, not a hierarchy. See the `create` entry for this file."
+  },
+  {
+    "package": "globalid",
+    "tsFile": "signed-global-id.ts",
+    "name": "modelId",
+    "reason": "Inherited from GlobalID in Ruby (`delegate :model_id, to: :uri`); re-declared because the TS classes are peers, not a hierarchy. See the `create` entry for this file."
+  },
+  {
+    "package": "globalid",
+    "tsFile": "signed-global-id.ts",
+    "name": "modelName",
+    "reason": "Inherited from GlobalID in Ruby (`delegate :model_name, to: :uri`); re-declared because the TS classes are peers, not a hierarchy. See the `create` entry for this file."
+  },
+  {
+    "package": "globalid",
+    "tsFile": "signed-global-id.ts",
+    "name": "params",
+    "reason": "Inherited from GlobalID in Ruby (`delegate :params, to: :uri`); re-declared because the TS classes are peers, not a hierarchy. See the `create` entry for this file."
+  },
+  {
+    "package": "globalid",
+    "tsFile": "signed-global-id.ts",
+    "name": "uri",
+    "reason": "Inherited from GlobalID in Ruby (`attr_reader :uri`); re-declared because the TS classes are peers, not a hierarchy. See the `create` entry for this file."
+  },
+  {
+    "package": "globalid",
+    "tsFile": "locator.ts",
+    "name": "setModelFinder",
+    "reason": "Stands in for Ruby's `model_name.constantize`, which GlobalID#model_class uses to turn a model name into a class. JS has no global constant table, so the host app registers a resolver instead. It lives next to the per-app locator registry it serves."
+  },
+  {
+    "package": "globalid",
+    "tsFile": "locator.ts",
+    "name": "lookupClass",
+    "reason": "The read side of the constantize stand-in registered through setModelFinder; the locators and GlobalID#modelClass call it wherever Rails writes `model_name.constantize`."
+  },
+  {
+    "package": "globalid",
+    "tsFile": "locator.ts",
+    "name": "find",
+    "reason": "Member of the duck-typed `LocatorModel` interface, not a locator method: it declares the Active Record finder Rails' BaseLocator calls as `model_class.find gid.model_id`. Ruby needs no such declaration."
+  },
+  {
+    "package": "globalid",
+    "tsFile": "locator.ts",
+    "name": "where",
+    "reason": "Member of the duck-typed `LocatorModel` interface, not a locator method: it declares the Active Record relation Rails' BaseLocator calls as `model_class.where(primary_key => ids)` on the ignore_missing path. Ruby needs no such declaration."
   }
 ]


### PR DESCRIPTION
`pnpm api:extra --package globalid` listed **7 novel + 13 moved** names across
four files, on a package that is otherwise at 100% method parity. Every one is
now reconciled — converged where the extra surface was a trails invention,
allowlisted with a written reason where TS genuinely needs it.

`pnpm api:extra --package globalid` → **0 unreconciled entries** (12 allowlisted).
`pnpm api:compare` globalid stays **63/63 (100%)**, and inheritance improves
0/4 → 1/4.

## Converged (12 of 20)

**`verifier.ts` (3)** — `Verifier` now extends `MessageVerifier` and declares
only the urlsafe `encode`/`decode` overrides, exactly like Rails'
`GlobalID::Verifier` (`vendor/globalid/lib/global_id/verifier.rb`).
`constructor` / `generate` / `verified` are inherited.

> **Behaviour note:** this drops the invented `digest: "sha256"` preset. Rails'
> `GlobalID::Verifier` declares no initializer, so it inherits
> ActiveSupport's default digest — Rails' own `verifier_test.rb` fixture
> signatures are 40-hex-char SHA1. `Verifier` is only constructed by its own
> test in this repo, so there is no token-compatibility blast radius.
> `MessageVerifier#encode`/`#decode` become `protected` (Ruby declares them
> private, but Ruby private methods are still overridable; TS forbids
> redeclaring a private base member).

**`uri/gid.ts` (2)** — `parseGid` / `buildGid` / `normalizeModelId` are now
module-private; the package's parse/build surface is `GID.parse` / `GID.build`,
as in Rails. The `uri` field is private: Rails' `URI::GID` *is* the URI and
exposes it through `to_s` only.

**`signed-global-id.ts` (1)** — the `fromUri` factory becomes the public
`constructor(uri, options)`, which is precisely what Rails'
`SignedGlobalID#initialize(gid, options)` is. It now resolves
purpose/expiration/verifier itself, exactly as Rails' initializer does, which
converges three `initialize → pick_*` entries in the wide call-mismatch
baseline (removed here — the baseline only shrinks).

## Allowlisted with reasons (8)

Via the `scripts/api-compare/extra-surface-allow.json` mechanism from
`extra-surface-reasoned-allowlist` (#5317):

- `uri/gid.ts` `constructor` — `URI::GID`'s public initializer is inherited
  from `URI::Generic`, so `gid.rb` declares none; the ported Rails test
  `new returns invalid gid when not checking` calls it directly to bypass
  parse validation.
- `signed-global-id.ts` `[Symbol.toPrimitive]` — the TS analogue of Ruby's
  implicit `to_s` string coercion.
- `signed-global-id.ts` `create`, `modelClass`, `modelId`, `modelName`,
  `params`, `uri` — inherited from `GlobalID` in Ruby
  (`class SignedGlobalID < GlobalID`), re-declared because the TS classes are
  peers. Registered as follow-up story
  `globalid-sgid-inherits-globalid` (RFC 0072) rather than fanned out here: it
  needs `GlobalID`'s constructor converged to the Rails `(gid, options)` shape,
  a decision on the `KNOWN_SGID_KEYS` param-filtering divergence, and removal
  of the `global-id` ↔ `signed-global-id` import cycle.
- `locator.ts` `setModelFinder` / `lookupClass` — the stand-in for
  `model_name.constantize`, which JS has no equivalent of.
- `locator.ts` `find` / `where` — members of the duck-typed `LocatorModel`
  interface (the AR finder surface `BaseLocator` calls), not locator methods.

## Behaviour guarded by a new test

Moving verifier resolution into the constructor let `SignedGlobalID.parse`
report "no verifier configured" as a null (an invalid token) instead of
raising, because the `verifyWith…` helpers swallow every error. Rails raises
there — `pick_verifier`'s ArgumentError is not among the rescued classes — so
`parse` asserts the verifier up front again, covered by
`parse raises when no verifier is configured` in
`signed-global-id.trails.test.ts` (verified to fail without the assert).

## Testing

`pnpm vitest run packages/globalid/src` (183 tests), the activesupport
message-verifier suites, and `scripts/api-compare/extra-surface.test.ts` all
pass, as do `packages/activerecord/src/signed-id.test.ts` and `token-for.test.ts`
(the MessageVerifier consumers). `pnpm typecheck`, `pnpm lint`,
`pnpm format:check`, both call-mismatch ratchets, the body-pins gate,
`lint-deps`, `compare.ts --privates` and the conventions-doc check are all
clean. No existing test names changed.

Closes-story: extra-surface-globalid-reconcile
