### PR TITLE
feat(api-compare): honor @internal JSDoc on top-level exported functions

### DIFF
--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -19,7 +19,8 @@
  *      class/module's *own* methods (skipping inherited surface so the
  *      diff measures this file's drift, not its ancestor's) plus top-level
  *      `fileFunctions`. Filter out `internal: true` (Ruby private/protected,
- *      TS private/protected, TS `#`-prefixed fields, `@internal` JSDoc) and
+ *      TS private/protected, TS `#`-prefixed fields, and `@internal` JSDoc
+ *      on a top-level exported function) and
  *      separately filter `_`-prefixed names — the extractor keeps those as
  *      public exports; the Rails-private convention in this repo means they
  *      should not count toward extra surface.
@@ -389,7 +390,9 @@ export function parseArgs(argv: string[]): CliArgs {
  *
  * The extractor keeps `_`-prefixed exports as public (only Ruby
  * `private`/`protected`, TS `private`/`protected`, `#`-prefixed fields,
- * and `@internal` JSDoc set `internal: true`). The Rails-private
+ * and `@internal` JSDoc on a top-level exported function set
+ * `internal: true`; class/module members take the flag from their TS
+ * visibility modifier only). The Rails-private
  * convention in this repo means we filter `_`-prefix here too.
  */
 function collectTsFileNames(

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1227,4 +1227,17 @@ describe("extractFromProgram — @internal JSDoc on top-level functions", () => 
     expect(fns.find((f) => f.name === "dispatchQuote")!.internal).toBe(true);
     expect(fns.find((f) => f.name === "quote")!.internal).toBeUndefined();
   });
+
+  it("skips the fabricated module for a file whose exported functions are all @internal", () => {
+    const info = extractFromFiles("/p", {
+      "key-normalization.ts": `
+        /** @internal */
+        export function normalizeKey(k: string): string { return k; }
+        /** @internal */
+        export function denormalizeKey(k: string): string { return k; }
+      `,
+    });
+    expect(info.modules["key-normalization.ts:KeyNormalization"]).toBeUndefined();
+    expect(info.fileFunctions["key-normalization.ts"].every((f) => f.internal)).toBe(true);
+  });
 });

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1207,3 +1207,24 @@ describe("tsLiteralValue — negative numbers", () => {
     expect(tsLiteralValue(parseExpr("-x"))).toBeUndefined();
   });
 });
+
+describe("extractFromProgram — @internal JSDoc on top-level functions", () => {
+  it("tags an @internal-tagged export function and leaves its untagged sibling public", () => {
+    const info = extractFromFiles("/p", {
+      "quoting.ts": `
+        /**
+         * Wiring seam, not Rails surface.
+         *
+         * @internal
+         */
+        export function dispatchQuote(value: unknown): string { return ""; }
+
+        /** Rails-facing. */
+        export function quote(value: unknown): string { return ""; }
+      `,
+    });
+    const fns = info.fileFunctions["quoting.ts"];
+    expect(fns.find((f) => f.name === "dispatchQuote")!.internal).toBe(true);
+    expect(fns.find((f) => f.name === "quote")!.internal).toBeUndefined();
+  });
+});

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -471,6 +471,7 @@ export function extractFromProgram(program: ts.Program, srcDir: string): Package
         const line = node.getSourceFile().getLineAndCharacterOfPosition(node.getStart()).line + 1;
         const fnOptionKeys = extractOptionKeys(node.parameters, checker);
         const fnCalls = extractCalls(node.body);
+        const internal = hasInternalJsDocTag(node);
         fileFunctions.push({
           name: node.name.text,
           visibility: "public",
@@ -478,6 +479,7 @@ export function extractFromProgram(program: ts.Program, srcDir: string): Package
           isStatic: false,
           line,
           file: relPath,
+          ...(internal ? { internal: true } : {}),
           ...(fnOptionKeys !== undefined ? { optionKeys: fnOptionKeys } : {}),
           ...(fnCalls !== undefined ? { calls: fnCalls } : {}),
         });
@@ -1200,6 +1202,17 @@ function extractDefinePropertyForOf(
  *
  * Caller must already have ensured `node` is not exported.
  */
+/**
+ * True when a declaration's leading JSDoc carries an `@internal` tag — the
+ * repo-wide convention (CONTRIBUTING.md) for "exported for wiring, not part
+ * of the Rails-facing surface". Exported top-level functions have no
+ * `private`/`protected` modifier to carry that signal, so the tag is the
+ * only marker; consumers filter on `internal: true` (see extra-surface.ts).
+ */
+export function hasInternalJsDocTag(node: ts.Node): boolean {
+  return ts.getJSDocTags(node).some((tag) => tag.tagName.text === "internal");
+}
+
 /**
  * Params of the function an identifier / property-access reference points at,
  * or null when the expression isn't callable. Mirrors the alias resolution the

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1203,17 +1203,6 @@ function extractDefinePropertyForOf(
  * Caller must already have ensured `node` is not exported.
  */
 /**
- * True when a declaration's leading JSDoc carries an `@internal` tag — the
- * repo-wide convention (CONTRIBUTING.md) for "exported for wiring, not part
- * of the Rails-facing surface". Exported top-level functions have no
- * `private`/`protected` modifier to carry that signal, so the tag is the
- * only marker; consumers filter on `internal: true` (see extra-surface.ts).
- */
-export function hasInternalJsDocTag(node: ts.Node): boolean {
-  return ts.getJSDocTags(node).some((tag) => tag.tagName.text === "internal");
-}
-
-/**
  * Params of the function an identifier / property-access reference points at,
  * or null when the expression isn't callable. Mirrors the alias resolution the
  * named-export path does for `export { foo }` so that a binding like
@@ -1234,6 +1223,16 @@ export function paramsOfCallableRef(
   const widest = signatures.reduce((a, b) => (b.parameters.length > a.parameters.length ? b : a));
   const decl = widest.declaration;
   return decl && ts.isFunctionLike(decl) ? extractParameters(decl.parameters) : [];
+}
+
+/**
+ * True when a declaration's leading JSDoc carries an `@internal` tag. An
+ * exported top-level function has no `private`/`protected` modifier to carry
+ * the "wiring seam, not Rails-facing surface" signal (CONTRIBUTING.md), so
+ * the tag is its only marker; consumers filter on `internal: true`.
+ */
+export function hasInternalJsDocTag(node: ts.Node): boolean {
+  return ts.getJSDocTags(node).some((tag) => tag.tagName.text === "internal");
 }
 
 /**


### PR DESCRIPTION
## What

`extract-ts-api.ts` never read leading JSDoc for top-level exported
functions, so `fileFunctions` entries always came out with
`internal: undefined` — even for functions explicitly tagged `@internal`
per the CONTRIBUTING.md convention. `extra-surface.ts` filters on
`internal === true` (and its header comment already claimed `@internal`
sets it), so every `@internal` file function was reported as novel drift.

New `hasInternalJsDocTag()` helper (`ts.getJSDocTags`) sets
`internal: true` on exported function declarations carrying the tag.
Two unit tests: a tagged `export function` plus an untagged sibling in
the same fixture file, and the knock-on that a file whose exported
functions are *all* `@internal` no longer fabricates a synthetic module.

Only `export function` declarations feed `fileFunctions`; exported arrow
consts never reach it, so there is no second tag path to cover here.

Note for reviewers: `@internal` JSDoc was honored *nowhere* in the
extractor before this — the acceptance criteria's "matching the existing
class/module-member behavior" refers to a behavior that didn't exist;
class/module members derive `internal` purely from TS visibility
modifiers. This PR adds the tag path only where the story scopes it
(file functions), and corrects the two `extra-surface.ts` doc comments
that overclaimed. Extending the tag to class members is a separate
change.

## Numbers

All runs with `API_COMPARE_FORCE=1` — the ts-api cache under-reports and
makes cached-vs-forced comparisons non-comparable (a cached main run
reported 776 novel; forced, the same tree reports 794).

`pnpm api:extra --package activerecord`, activerecord package:

| | files | novel | moved | total |
|---|---|---|---|---|
| main | 217 | 794 | 2315 | 3109 |
| this PR | 210 | **696** | 2310 | 3006 |

Novel drops by 98. `api:compare` parity is unchanged:
`Overall: 11426/16974 methods (67.3%) | files: 759/1017` before and after
(data layer 7473/7473, 100%).

The seven-file drop is the intended knock-on: a file whose exported
functions are *all* `@internal` no longer fabricates a synthetic module
entry (`hasPublicFn` in `extractFromProgram`), e.g.
`associations/key-normalization.ts:KeyNormalization`. `api:compare` exits
0 (all ratchets green).

Closes-story: extra-surface-honor-internal-jsdoc-on-file-functions
