### PR TITLE
fix(api-compare): stop attributing mixin pseudo-module host surface to the declaring file

### DIFF
--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import * as fs from "fs/promises";
 import * as path from "path";
 import { tmpdir } from "os";
-import type { ApiManifest, ClassInfo, MethodInfo } from "./types.js";
+import * as ts from "typescript";
+import type { ApiManifest, ClassInfo, MethodInfo, PackageInfo } from "./types.js";
 import {
   buildGlobalRubyCandidates,
   buildReport,
@@ -10,7 +11,9 @@ import {
   loadAllowlist,
   resolveAllowlist,
   parseArgs,
+  collectTsFileNames,
 } from "./extra-surface.js";
+import { extractFromProgram } from "./extract-ts-api.js";
 import type { AllowEntry } from "./extra-surface.js";
 
 function method(name: string, internal = false): MethodInfo {
@@ -1314,5 +1317,86 @@ describe("resolveAllowlist", () => {
     };
     const r = await resolveAllowlist(await writeAllow(JSON.stringify([entry])));
     expect(r).toEqual({ allow: [entry], problems: [] });
+  });
+});
+
+describe("collectTsFileNames — `__mixin` pseudo-modules", () => {
+  /** Compile a virtual multi-file package and run the real TS extractor. */
+  function extract(files: Record<string, string>): PackageInfo {
+    const srcDir = "/p";
+    const all: Record<string, string> = {};
+    for (const [rel, src] of Object.entries(files)) all[`${srcDir}/${rel}`] = src;
+    const names = Object.keys(all);
+    const host: ts.CompilerHost = {
+      getSourceFile: (name) =>
+        all[name] === undefined
+          ? undefined
+          : ts.createSourceFile(name, all[name], ts.ScriptTarget.Latest, true),
+      getDefaultLibFileName: () => "lib.d.ts",
+      writeFile: () => undefined,
+      getCurrentDirectory: () => "/",
+      getCanonicalFileName: (n) => n,
+      useCaseSensitiveFileNames: () => true,
+      getNewLine: () => "\n",
+      fileExists: (name) => name in all,
+      readFile: (name) => all[name],
+      resolveModuleNames: (moduleNames, containingFile) =>
+        moduleNames.map((m) => {
+          if (!m.startsWith("./") && !m.startsWith("../")) return undefined;
+          const dir = path.posix.dirname(containingFile);
+          const candidate = path.posix.normalize(`${dir}/${m.replace(/\.js$/, "")}.ts`);
+          return candidate in all
+            ? { resolvedFileName: candidate, extension: ts.Extension.Ts }
+            : undefined;
+        }),
+    };
+    const program = ts.createProgram(
+      names,
+      { noLib: true, target: ts.ScriptTarget.Latest, module: ts.ModuleKind.ESNext },
+      host,
+    );
+    return extractFromProgram(program, srcDir);
+  }
+
+  const FILES = {
+    "base.ts": `
+      export class Base {
+        toSlug(): string { return ""; }
+      }
+    `,
+    "inheritance.ts": `
+      import { Base } from "./base.js";
+      export function stiClassFor(this: typeof Base, typeName: string): typeof Base {
+        return Base;
+      }
+    `,
+  };
+
+  it("drops host-interface members that inheritance.ts does not declare", () => {
+    const info = extract(FILES);
+    const mixin = info.modules["inheritance.ts:stiClassFor__mixin"];
+    expect(mixin?.synthesizedMixin).toBe(true);
+    // The extractor still carries the host surface (the Rails-layout check
+    // relies on the pseudo-module); it is tagged with its real declaring file.
+    expect(mixin.instanceMethods.find((m) => m.name === "toSlug")?.declaredIn).toBe("base.ts");
+
+    const names = collectTsFileNames(
+      "inheritance.ts",
+      [],
+      Object.values(info.modules),
+      info.fileFunctions?.["inheritance.ts"],
+    );
+    expect(names.has("toSlug")).toBe(false);
+  });
+
+  it("still counts the mixin function's own name as inheritance.ts surface", () => {
+    const info = extract(FILES);
+    const names = collectTsFileNames(
+      "inheritance.ts",
+      [],
+      Object.values(info.modules),
+      info.fileFunctions?.["inheritance.ts"],
+    );
+    expect(names.has("stiClassFor")).toBe(true);
   });
 });

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -1321,7 +1321,6 @@ describe("resolveAllowlist", () => {
 });
 
 describe("collectTsFileNames — `__mixin` pseudo-modules", () => {
-  /** Compile a virtual multi-file package and run the real TS extractor. */
   function extract(files: Record<string, string>): PackageInfo {
     const srcDir = "/p";
     const all: Record<string, string> = {};
@@ -1376,8 +1375,6 @@ describe("collectTsFileNames — `__mixin` pseudo-modules", () => {
     const info = extract(FILES);
     const mixin = info.modules["inheritance.ts:stiClassFor__mixin"];
     expect(mixin?.synthesizedMixin).toBe(true);
-    // The extractor still carries the host surface (the Rails-layout check
-    // relies on the pseudo-module); it is tagged with its real declaring file.
     expect(mixin.instanceMethods.find((m) => m.name === "toSlug")?.declaredIn).toBe("base.ts");
 
     const names = collectTsFileNames(

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -392,7 +392,7 @@ export function parseArgs(argv: string[]): CliArgs {
  * and `@internal` JSDoc set `internal: true`). The Rails-private
  * convention in this repo means we filter `_`-prefix here too.
  */
-function collectTsFileNames(
+export function collectTsFileNames(
   file: string,
   classes: ClassInfo[],
   modules: ClassInfo[],
@@ -412,8 +412,19 @@ function collectTsFileNames(
   }
   for (const m of modules) {
     if (m.file !== file) continue;
-    for (const im of m.instanceMethods) push(im);
-    for (const cm of m.classMethods) push(cm);
+    // `<file>:<fn>__mixin` pseudo-modules carry the instance surface of the
+    // class the mixin function returns, most of which is declared in other
+    // files. A member declared elsewhere is by definition not this file's
+    // surface. The mixin function's own name still arrives via fileFunctions.
+    const skipForeign = m.synthesizedMixin === true;
+    for (const im of m.instanceMethods) {
+      if (skipForeign && im.declaredIn !== undefined) continue;
+      push(im);
+    }
+    for (const cm of m.classMethods) {
+      if (skipForeign && cm.declaredIn !== undefined) continue;
+      push(cm);
+    }
   }
   for (const fn of fileFunctions ?? []) push(fn);
   return out;

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -412,10 +412,6 @@ export function collectTsFileNames(
   }
   for (const m of modules) {
     if (m.file !== file) continue;
-    // `<file>:<fn>__mixin` pseudo-modules carry the instance surface of the
-    // class the mixin function returns, most of which is declared in other
-    // files. A member declared elsewhere is by definition not this file's
-    // surface. The mixin function's own name still arrives via fileFunctions.
     const skipForeign = m.synthesizedMixin === true;
     for (const im of m.instanceMethods) {
       if (skipForeign && im.declaredIn !== undefined) continue;

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -547,6 +547,11 @@ export function extractFromProgram(program: ts.Program, srcDir: string): Package
           isPrivateField || hasPrivateMod ? "private" : hasProtectedMod ? "protected" : "public";
         const internal = visibility !== "public";
         const line = decl.getSourceFile().getLineAndCharacterOfPosition(decl.getStart()).line + 1;
+        // Functions returning `typeof Base` (STI helpers, association loaders)
+        // drag the whole returned class's instance surface in here. Record
+        // where each member is really declared so surface-attribution
+        // consumers can drop the ones this file does not own.
+        const declFile = path.relative(srcDir, decl.getSourceFile().fileName).replace(/\\/g, "/");
         mixinMethods.push({
           name: prop.name,
           visibility,
@@ -554,6 +559,7 @@ export function extractFromProgram(program: ts.Program, srcDir: string): Package
           isStatic: false,
           line,
           file: relPath,
+          ...(declFile !== relPath ? { declaredIn: declFile } : {}),
           ...(internal ? { internal: true } : {}),
         });
       }
@@ -578,6 +584,7 @@ export function extractFromProgram(program: ts.Program, srcDir: string): Package
           extends: [],
           instanceMethods: mixinMethods,
           classMethods: [],
+          synthesizedMixin: true,
         };
         fileHasClassOrModule = true;
       }

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -547,10 +547,6 @@ export function extractFromProgram(program: ts.Program, srcDir: string): Package
           isPrivateField || hasPrivateMod ? "private" : hasProtectedMod ? "protected" : "public";
         const internal = visibility !== "public";
         const line = decl.getSourceFile().getLineAndCharacterOfPosition(decl.getStart()).line + 1;
-        // Functions returning `typeof Base` (STI helpers, association loaders)
-        // drag the whole returned class's instance surface in here. Record
-        // where each member is really declared so surface-attribution
-        // consumers can drop the ones this file does not own.
         const declFile = path.relative(srcDir, decl.getSourceFile().fileName).replace(/\\/g, "/");
         mixinMethods.push({
           name: prop.name,

--- a/scripts/api-compare/extractor-schema.test.ts
+++ b/scripts/api-compare/extractor-schema.test.ts
@@ -49,6 +49,10 @@ describe("extractorSchemaToken", () => {
     expect(EXTRACTOR_OUTPUT_FIELDS).toContain("calls");
   });
 
+  it("includes declaredIn in the declared output field set", () => {
+    expect(EXTRACTOR_OUTPUT_FIELDS).toContain("declaredIn");
+  });
+
   it("tolerates a missing extractor source (best-effort hash)", async () => {
     const dir = mkDir();
     fs.rmSync(path.join(dir, EXTRACTOR_SOURCES[0]));

--- a/scripts/api-compare/extractor-schema.ts
+++ b/scripts/api-compare/extractor-schema.ts
@@ -48,6 +48,16 @@ export const SCHEMA_VERSION_BASE = 8;
  * types.ts). Adding a property to `MethodInfo` that the extractor populates?
  * Add its emitted key here too, so the schema token changes and stale cache
  * entries missing the field are evicted automatically.
+ *
+ * Scope is per-METHOD by construction: entity-level `ClassInfo` fields
+ * (`includes`, `extends`, `superclass`, `synthesizedMixin`, …) are NOT tracked
+ * here and never have been. An entity-level field only needs its own token
+ * input when it can change WITHOUT any per-method field changing; every one
+ * added so far has shipped alongside the per-method field its consumer reads
+ * (`synthesizedMixin` pairs with `declaredIn`), so registering the method-side
+ * key already evicts entries predating the pair. Extending the token to
+ * entity-level fields is tracked separately — see the
+ * `extractor-schema-entity-level-fields` story.
  */
 export const EXTRACTOR_OUTPUT_FIELDS = [
   "name",

--- a/scripts/api-compare/extractor-schema.ts
+++ b/scripts/api-compare/extractor-schema.ts
@@ -62,6 +62,7 @@ export const EXTRACTOR_OUTPUT_FIELDS = [
   "internal",
   "option_keys",
   "optionKeys",
+  "declaredIn",
 ] as const;
 
 /**

--- a/scripts/api-compare/types.ts
+++ b/scripts/api-compare/types.ts
@@ -83,6 +83,15 @@ export interface MethodInfo {
    * false-missing pinned to base.ts. See extract-ruby-api.rb#scan_umbrella_file.
    */
   umbrellaConfig?: boolean;
+  /**
+   * TS-side only, on `synthesizedMixin` pseudo-modules: the file that actually
+   * declares this member, when it is NOT the file the pseudo-module is keyed
+   * under. A mixin function returning `typeof Base` drags Base's entire
+   * instance surface into the pseudo-module; those members are declared
+   * elsewhere and are not the pseudo-module file's own surface.
+   * See extract-ts-api.ts and extra-surface.ts `collectTsFileNames`.
+   */
+  declaredIn?: string;
 }
 
 export interface ClassInfo {
@@ -93,6 +102,15 @@ export interface ClassInfo {
   extends: string[];
   instanceMethods: MethodInfo[];
   classMethods: MethodInfo[];
+  /**
+   * TS-side only: this entry is not a real declared class/module but a
+   * pseudo-module synthesized from an exported function whose return type has
+   * construct signatures (`<file>:<fn>__mixin`). Its members come from the
+   * returned constructor's instance type, which usually includes surface
+   * declared in other files. Consumers that attribute surface to a file must
+   * consult `MethodInfo.declaredIn`. See extract-ts-api.ts.
+   */
+  synthesizedMixin?: boolean;
 }
 
 export interface PackageInfo {


### PR DESCRIPTION
## Problem

`extract-ts-api.ts` synthesizes a `<file>:<fn>__mixin` pseudo-module for every
exported function whose return type has construct signatures — e.g.
`inheritance.ts`'s `stiClassFor(...): typeof Base`. The pseudo-module's
`instanceMethods` is the *entire instance surface of the returned class*, ~136
members, none of which `inheritance.ts` declares.

`extra-surface.ts`'s `collectTsFileNames` buckets modules by `ClassInfo.file`,
so that borrowed surface was attributed to whichever file happened to declare
the mixin function. A member declared elsewhere is by definition not this
file's surface, so all of it was fabricated drift: **340 of activerecord's 2084
moved extras and 14 of 776 novel**.

## Fix

- Tag the pseudo-module `synthesizedMixin: true` — a real marker field, not a
  `__mixin` substring match on user-controllable names.
- Tag each harvested member with `declaredIn` when its declaration lives in a
  different file than the pseudo-module's.
- `collectTsFileNames` skips members carrying `declaredIn` on
  `synthesizedMixin` modules. The mixin function's own name still counts — it
  arrives via `fileFunctions`, asserted explicitly so the fix can't over-filter.
- Register `declaredIn` in `EXTRACTOR_OUTPUT_FIELDS`. That list is the
  auditable half of the ts-api cache token (the #4020 trap); the source-hash
  backstop covers this edit, but not a later one that touches only the consumer.

The extractor still emits the full member list, so the api:compare Rails-layout
check — the legitimate consumer of these entries — and `compare.ts` see exactly
what they saw before. Only surface attribution changed. `__mixin` appears
nowhere else under `scripts/`.

Filtering by `declaredIn` rather than dropping the pseudo-module wholesale also
keeps genuine class-factory mixins
(`export function Attributes(Base) { class M {…} return M }`) counting the
members they really declare.

## Measured

`pnpm api:compare && pnpm api:extra --package activerecord`:

|       | before | after |
| ----- | ------ | ----- |
| moved | 2084   | 1744  |
| novel | 776    | 762   |

Per file (moved), matching the story's projections:

| file                         | before | after |
| ---------------------------- | ------ | ----- |
| `associations.ts`            | 94     | 1     |
| `inheritance.ts`             | 98     | 4     |
| `relation/delegation.ts`     | 97     | 5     |
| `migration/compatibility.ts` | 63     | 2     |

`api:compare` totals are unchanged: 7473/7473 data layer, 11426/16974 overall
(67.3%), inheritance 532/587, arity 7209/7313.

Other packages are unaffected — none of them declare `__mixin` pseudo-modules
with foreign members (`actiondispatch` 181/165, `activesupport` 152/147,
`activemodel` 100/175, `arel` 66/123, all unchanged).

## Tests

Two tests in `extra-surface.test.ts` compile a virtual two-file package
(`base.ts` declaring `toSlug`, `inheritance.ts` declaring only `stiClassFor`)
through the real extractor: `toSlug` is absent from `inheritance.ts`'s name set
while carrying `declaredIn: "base.ts"` on the pseudo-module, and `stiClassFor`
is present. Plus a cache-token test pinning `declaredIn` in
`EXTRACTOR_OUTPUT_FIELDS`.

## Review follow-up

**Why `synthesizedMixin` is not in `EXTRACTOR_OUTPUT_FIELDS`.** That list is
per-METHOD by construction — no entity-level `ClassInfo` field (`includes`,
`extends`, `superclass`, …) has ever been tracked, and `synthesizedMixin` is
one. There is no live eviction gap: an entity-level field only needs its own
token input when it can change without any per-method field changing, and
`synthesizedMixin` ships with `declaredIn` (`collectTsFileNames` gates on
both), so registering the method-side key already evicts every entry predating
the pair. The invariant is now stated on the `EXTRACTOR_OUTPUT_FIELDS` JSDoc
where the next author will hit it.

The forward-looking half of the question is real but wider than this PR — a
future entity-level field added alone, or a consumer-only change that starts
depending on one, would not bust the token, and the `EXTRACTOR_SOURCES`
source-hash backstop does not cover edits confined to a consumer like
`extra-surface.ts`. Registered as
`0072-api-compare-parity-burndown/extractor-schema-entity-level-fields` rather
than expanding this PR's scope.

Closes-story: extra-surface-mixin-pseudo-module-host-leak
