### PR TITLE
refactor(api-compare): stop charging re-export barrels with re-exported class surface

### DIFF
--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -1397,3 +1397,67 @@ describe("collectTsFileNames — `__mixin` pseudo-modules", () => {
     expect(names.has("stiClassFor")).toBe(true);
   });
 });
+
+describe("buildReport — re-export clones", () => {
+  it("charges a barrel only with the classes it declares itself", () => {
+    const ruby: ApiManifest = {
+      source: "ruby",
+      generatedAt: "",
+      packages: {
+        activemodel: {
+          classes: {
+            "ActiveModel::Foo": rubyClass({ name: "Foo", file: "foo.rb" }),
+            "ActiveModel::Barrel": rubyClass({ name: "Barrel", file: "barrel.rb" }),
+          },
+          modules: {},
+        },
+      },
+    };
+    const ts: ApiManifest = {
+      source: "typescript",
+      generatedAt: "",
+      packages: {
+        activemodel: {
+          classes: {
+            "foo.ts:Foo": {
+              name: "Foo",
+              file: "foo.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [method("declaredOnFoo")],
+              classMethods: [],
+            },
+            "barrel.ts:Foo": {
+              name: "Foo",
+              file: "barrel.ts",
+              reExportedFrom: "foo.ts:Foo",
+              includes: [],
+              extends: [],
+              instanceMethods: [method("declaredOnFoo")],
+              classMethods: [],
+            },
+            "barrel.ts:Barrel": {
+              name: "Barrel",
+              file: "barrel.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [method("declaredOnBarrel")],
+              classMethods: [],
+            },
+          },
+          modules: {},
+        },
+      },
+    };
+
+    const report = buildReport(ruby, ts, {
+      filterPkg: null,
+      excludeGlobs: [],
+      novelOnly: false,
+      topN: 50,
+    });
+    const byFile = new Map(report.packages[0].extraFiles.map((f) => [f.tsFile, f]));
+    expect(byFile.get("foo.ts")!.extras.map((e) => e.name)).toEqual(["declaredOnFoo"]);
+    expect(byFile.get("barrel.ts")!.extras.map((e) => e.name)).toEqual(["declaredOnBarrel"]);
+  });
+});

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -686,10 +686,6 @@ function buildPackageReport(
 
   const tsClassesByFile = new Map<string, ClassInfo[]>();
   const tsModulesByFile = new Map<string, ClassInfo[]>();
-  // A barrel that merely re-exports a class carries a cloned entry with the
-  // full method list of the declaring file's class. Charging both files
-  // double-counts every name (and every real drift) — the declaring file's
-  // entry already covers them — so re-export clones are skipped here.
   for (const c of Object.values(tsPkg.classes) as ClassInfo[]) {
     if (!c.file || c.reExportedFrom) continue;
     pushTo(tsClassesByFile, c.file, c);

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -686,12 +686,16 @@ function buildPackageReport(
 
   const tsClassesByFile = new Map<string, ClassInfo[]>();
   const tsModulesByFile = new Map<string, ClassInfo[]>();
+  // A barrel that merely re-exports a class carries a cloned entry with the
+  // full method list of the declaring file's class. Charging both files
+  // double-counts every name (and every real drift) — the declaring file's
+  // entry already covers them — so re-export clones are skipped here.
   for (const c of Object.values(tsPkg.classes) as ClassInfo[]) {
-    if (!c.file) continue;
+    if (!c.file || c.reExportedFrom) continue;
     pushTo(tsClassesByFile, c.file, c);
   }
   for (const m of Object.values(tsPkg.modules) as ClassInfo[]) {
-    if (!m.file) continue;
+    if (!m.file || m.reExportedFrom) continue;
     pushTo(tsModulesByFile, m.file, m);
   }
   const tsFileFunctions = tsPkg.fileFunctions ?? {};

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1263,8 +1263,6 @@ describe("extractFromProgram — re-export attribution", () => {
     expect(info.modules["adapters.ts:ConnectionPool"].reExportedFrom).toBe(
       "adapters/pool.ts:ConnectionPool",
     );
-    // A file that declares its own class alongside re-exports keeps that
-    // class attributed to itself.
     expect(info.classes["adapters.ts:LocalHelper"].reExportedFrom).toBeUndefined();
   });
 });

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1241,3 +1241,30 @@ describe("extractFromProgram — @internal JSDoc on top-level functions", () => 
     expect(info.fileFunctions["key-normalization.ts"].every((f) => f.internal)).toBe(true);
   });
 });
+
+describe("extractFromProgram — re-export attribution", () => {
+  it("marks barrel clones with reExportedFrom and leaves local declarations bare", () => {
+    const info = extractFromFiles("/p", {
+      "adapters/abstract-adapter.ts": `export class AbstractAdapter { quoteTableName(): void {} }`,
+      "adapters/pool.ts": `export const ConnectionPool = { checkout() {} };`,
+      "adapters.ts": `
+        export { AbstractAdapter } from "./adapters/abstract-adapter.js";
+        export { ConnectionPool } from "./adapters/pool.js";
+        export class LocalHelper { helpMe(): void {} }
+      `,
+    });
+
+    expect(
+      info.classes["adapters/abstract-adapter.ts:AbstractAdapter"].reExportedFrom,
+    ).toBeUndefined();
+    expect(info.classes["adapters.ts:AbstractAdapter"].reExportedFrom).toBe(
+      "adapters/abstract-adapter.ts:AbstractAdapter",
+    );
+    expect(info.modules["adapters.ts:ConnectionPool"].reExportedFrom).toBe(
+      "adapters/pool.ts:ConnectionPool",
+    );
+    // A file that declares its own class alongside re-exports keeps that
+    // class attributed to itself.
+    expect(info.classes["adapters.ts:LocalHelper"].reExportedFrom).toBeUndefined();
+  });
+});

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -699,12 +699,22 @@ export function extractFromProgram(program: ts.Program, srcDir: string): Package
     const sourceKey = `${targetRel}:${re.sourceName}`;
     const sourceClass = info.classes[sourceKey];
     if (sourceClass) {
-      info.classes[key] = { ...sourceClass, name: re.localName, file: re.fromFile };
+      info.classes[key] = {
+        ...sourceClass,
+        name: re.localName,
+        file: re.fromFile,
+        reExportedFrom: sourceKey,
+      };
       continue;
     }
     const sourceModule = info.modules[sourceKey];
     if (sourceModule) {
-      info.modules[key] = { ...sourceModule, name: re.localName, file: re.fromFile };
+      info.modules[key] = {
+        ...sourceModule,
+        name: re.localName,
+        file: re.fromFile,
+        reExportedFrom: sourceKey,
+      };
     }
   }
 

--- a/scripts/api-compare/types.ts
+++ b/scripts/api-compare/types.ts
@@ -98,6 +98,15 @@ export interface ClassInfo {
   name: string;
   superclass?: string;
   file?: string;
+  /**
+   * Set only on entries the extractor cloned because `file` merely
+   * re-exports the class (`export { X } from "./y.js"`); holds the
+   * `<declaringFile>:<Name>` key of the real declaration. compare.ts
+   * still needs the clone (Rails often expects the class at the barrel's
+   * path), but surface accounting must not charge the barrel with the
+   * declaring file's methods a second time — see extra-surface.ts.
+   */
+  reExportedFrom?: string;
   includes: string[];
   extends: string[];
   instanceMethods: MethodInfo[];

--- a/scripts/api-compare/types.ts
+++ b/scripts/api-compare/types.ts
@@ -98,14 +98,6 @@ export interface ClassInfo {
   name: string;
   superclass?: string;
   file?: string;
-  /**
-   * Set only on entries the extractor cloned because `file` merely
-   * re-exports the class (`export { X } from "./y.js"`); holds the
-   * `<declaringFile>:<Name>` key of the real declaration. compare.ts
-   * still needs the clone (Rails often expects the class at the barrel's
-   * path), but surface accounting must not charge the barrel with the
-   * declaring file's methods a second time — see extra-surface.ts.
-   */
   reExportedFrom?: string;
   includes: string[];
   extends: string[];


### PR DESCRIPTION
`extract-ts-api.ts` clones a full `ClassInfo` — every instance and class
method — under each file that re-exports a class, so a barrel such as
`connection-adapters.ts` inherited the method lists of all 18 classes it
re-exports and was scored against a 120-line `connection_adapters.rb`.
`extra-surface.ts` buckets by `ClassInfo.file`, so every name (and every real
drift) on a re-exported class was reported twice.

Fix, at the extractor: the re-export post-pass now stamps each cloned entry
with `reExportedFrom: "<declaringFile>:<Name>"`. `compare.ts` still sees the
clone (Rails often expects the class at the barrel's path); `extra-surface.ts`
skips clones when bucketing by file. No file is special-cased by name, and a
file that declares its own class alongside re-exports still reports that
class's drift.

## Numbers

Measured after rebasing onto `main` at `f0a` (`@internal` JSDoc extractor
change shifted the baseline, so these supersede the earlier figures).

`connection-adapters.ts`: **614 extras → 0** (46 novel → 0, 568 moved → 0) —
it leaves the report entirely.

Per-package totals (novel / moved / total), before → after:

| Package | Before | After |
| --- | --- | --- |
| activerecord | 664 / 1556 / 2220 | 608 / 904 / 1512 |
| actiondispatch | 177 / 163 / 340 | 177 / 158 / 335 |
| activesupport | 147 / 147 / 294 | 145 / 141 / 286 |
| arel | 66 / 111 / 177 | 66 / 104 / 170 |
| rack | 48 / 76 / 124 | 47 / 65 / 112 |
| actionview | 42 / 71 / 113 | 36 / 55 / 91 |
| abstractcontroller | 0 / 12 / 12 | 0 / 11 / 11 |
| activemodel, trailties, actioncontroller | — | unchanged |

Reported ranking shift (not suppressed): `connection-adapters.ts` was the #1
most-divergent file overall and disappears; `http/content-security-policy.ts`
(actiondispatch, 30 novel) becomes #1. Contributing file counts drop where a
barrel's only extras were clones: activerecord 207→206, activesupport 50→49,
actionview 22→21.

`index.ts` gains no extra-surface entries in any package (no Rails counterpart
file maps to it), so it was unaffected either way.

## Tests

Two fixture-backed cases:

- `extract-ts-api.test.ts` — a declaring file plus a barrel that re-exports it
  (class and module forms): the clone carries `reExportedFrom`, the
  declaration and the barrel's own locally declared class do not.
- `extra-surface.test.ts` — `buildReport` charges a barrel only with the class
  it declares itself, not the one it re-exports. Verified to fail on the
  pre-fix bucketing (`expected ['declaredOnBarrel', 'declaredOnFoo'] to deeply
  equal ['declaredOnBarrel']`).

Full `scripts/api-compare/` suite passes (513 tests).

Closes-story: extra-surface-skip-reexported-class-entries
