### PR TITLE
feat(api-compare): feed Ruby file constants into the extra-surface allow-set

### DIFF
--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -106,6 +106,27 @@ describe("buildGlobalRubyCandidates", () => {
     // visibility divergence (the method exists in Rails), not novel surface.
     expect(set.has("privateOne")).toBe(true);
   });
+
+  it("includes file-level constant names verbatim so a relocated constant is moved, not novel", () => {
+    const ruby: ApiManifest = {
+      source: "ruby",
+      generatedAt: "",
+      packages: {
+        activerecord: {
+          classes: {},
+          modules: {},
+          fileConstants: {
+            "connection_adapters/abstract_mysql_adapter.rb": {
+              ER_DUP_ENTRY: { kind: "int", value: "1062" },
+            },
+          },
+        },
+      },
+    };
+    const set = buildGlobalRubyCandidates(ruby);
+    expect(set.has("ER_DUP_ENTRY")).toBe(true);
+    expect(set.has("erDupEntry")).toBe(true);
+  });
 });
 
 describe("buildReport — novel vs moved classification", () => {
@@ -189,6 +210,33 @@ describe("buildReport — novel vs moved classification", () => {
     expect(pkg.totalNovel).toBe(1);
     expect(pkg.totalMoved).toBe(0);
     expect(pkg.extraFiles[0].extras.map((e) => e.name)).toEqual(["tsOnlyHelper"]);
+  });
+
+  it("allows a constant declared in the matched Ruby file, moves one from another file", () => {
+    const { ruby, ts } = makeManifests();
+    ruby.packages["activemodel"].fileConstants = {
+      "foo.rb": { ER_DUP_ENTRY: { kind: "int", value: "1062" } },
+      "baz.rb": { SHARED_MESSAGE: { kind: "string", value: "boom" } },
+    };
+    // A ported constant surfaces on the TS side as a static class member.
+    ts.packages["activemodel"].classes["Foo"].classMethods = [
+      method("ER_DUP_ENTRY"),
+      method("SHARED_MESSAGE"),
+      method("TS_ONLY_CONST"),
+    ];
+    const report = buildReport(ruby, ts, {
+      filterPkg: null,
+      excludeGlobs: [],
+      novelOnly: false,
+      topN: 50,
+    });
+    const f = report.packages[0].extraFiles[0];
+    expect(f.extras.map((e) => [e.name, e.kind])).toEqual([
+      ["TS_ONLY_CONST", "novel"],
+      ["tsOnlyHelper", "novel"],
+      ["quux", "moved"],
+      ["SHARED_MESSAGE", "moved"],
+    ]);
   });
 
   it("a TS public method mirroring a Rails-PRIVATE method is not extra surface", () => {

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -127,6 +127,26 @@ describe("buildGlobalRubyCandidates", () => {
     expect(set.has("ER_DUP_ENTRY")).toBe(true);
     expect(set.has("erDupEntry")).toBe(true);
   });
+
+  it("does not camelize a CamelCase constant into a bare method-like name", () => {
+    const ruby: ApiManifest = {
+      source: "ruby",
+      generatedAt: "",
+      packages: {
+        activerecord: {
+          classes: {},
+          modules: {},
+          fileConstants: {
+            "connection_adapters/abstract_adapter.rb": { Version: { kind: "expr" } },
+          },
+        },
+      },
+    };
+    const set = buildGlobalRubyCandidates(ruby);
+    expect(set.has("Version")).toBe(true);
+    // `version` would absolve any novel TS method of that name, everywhere.
+    expect(set.has("version")).toBe(false);
+  });
 });
 
 describe("buildReport — novel vs moved classification", () => {

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -128,7 +128,7 @@ describe("buildGlobalRubyCandidates", () => {
     expect(set.has("erDupEntry")).toBe(true);
   });
 
-  it("does not camelize a CamelCase constant into a bare method-like name", () => {
+  it("does not camelize a single-token constant into a bare method-like name", () => {
     const ruby: ApiManifest = {
       source: "ruby",
       generatedAt: "",
@@ -138,12 +138,16 @@ describe("buildGlobalRubyCandidates", () => {
           modules: {},
           fileConstants: {
             "connection_adapters/abstract_adapter.rb": { Version: { kind: "expr" } },
+            // arel.rb:29 — SCREAMING, but single-token, so it camelizes to the
+            // same bare `version` a CamelCase constant would.
+            "arel.rb": { VERSION: { kind: "string", value: "10.0.0" } },
           },
         },
       },
     };
     const set = buildGlobalRubyCandidates(ruby);
     expect(set.has("Version")).toBe(true);
+    expect(set.has("VERSION")).toBe(true);
     // `version` would absolve any novel TS method of that name, everywhere.
     expect(set.has("version")).toBe(false);
   });

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -191,13 +191,20 @@ function rubyMethodCandidates(rubyName: string): string[] | null {
 /**
  * TS-candidate names for a Ruby file-level constant. Constants aren't
  * case-transformed on the way over — `ER_DUP_ENTRY` ports verbatim — so the
- * name itself is the primary candidate. The camelized-lowercase form is the
- * second candidate purely to stay in lockstep with `constantNameMatches`
+ * name itself is always a candidate. The camelized form is the second
+ * candidate, keeping scoring in lockstep with `constantNameMatches`
  * (literals.ts), which the literal-value comparison already uses to pair a
  * Ruby constant with its TS counterpart; scoring the two passes off different
  * name rules would let a constant compare as a value yet still read as drift.
+ *
+ * The camelized form is emitted for SCREAMING_SNAKE names only. A CamelCase
+ * constant (`Version = Gem::Version`, `Cipher = OpenSSL::Cipher`) camelizes to
+ * a bare lowercase word that is indistinguishable from an ordinary method
+ * name, so admitting it would silently absolve a genuinely novel TS `version`
+ * / `cipher` — a far worse trade than the one drift-read it saves.
  */
 function rubyConstantCandidates(name: string): string[] {
+  if (!/^[A-Z0-9_]+$/.test(name)) return [name];
   const camel = snakeToCamel(name.toLowerCase());
   return camel === name ? [name] : [name, camel];
 }

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -59,7 +59,7 @@ import * as path from "path";
 import { fileURLToPath } from "url";
 import type { ApiManifest, ClassInfo, MethodInfo } from "./types.js";
 import { OUTPUT_DIR } from "./config.js";
-import { rubyFileToTs, rubyMethodToTs } from "./conventions.js";
+import { rubyFileToTs, rubyMethodToTs, snakeToCamel } from "./conventions.js";
 import { resolveModuleName } from "./compare.js";
 import { isSourceUnported } from "./unported-files.js";
 
@@ -186,6 +186,20 @@ function rubyMethodCandidates(rubyName: string): string[] | null {
   if (!base) return null;
   if (!rubyName.endsWith("?")) return base;
   return [...base, ...base.map((c) => c + "Q")];
+}
+
+/**
+ * TS-candidate names for a Ruby file-level constant. Constants aren't
+ * case-transformed on the way over — `ER_DUP_ENTRY` ports verbatim — so the
+ * name itself is the primary candidate. The camelized-lowercase form is the
+ * second candidate purely to stay in lockstep with `constantNameMatches`
+ * (literals.ts), which the literal-value comparison already uses to pair a
+ * Ruby constant with its TS counterpart; scoring the two passes off different
+ * name rules would let a constant compare as a value yet still read as drift.
+ */
+function rubyConstantCandidates(name: string): string[] {
+  const camel = snakeToCamel(name.toLowerCase());
+  return camel === name ? [name] : [name, camel];
 }
 
 /** Get-or-init helper: replaces the `(get() ?? set([]).get()!).push(v)` idiom. */
@@ -468,6 +482,11 @@ function foldClassMethodsModules(modules: Record<string, ClassInfo>): Set<string
  *     its methods never enter `allowed` — matching the `isSourceUnported`
  *     guard at compare.ts:507. The check uses the module's *owning* package.
  *
+ * The matched file's `fileConstants` names join `allowed` too (see
+ * `rubyConstantCandidates`): a faithfully-ported `ER_DUP_ENTRY` is not extra
+ * surface. Constants have no mixin routing — they belong to the file, not to
+ * an entity — so they're added once up front rather than per entity.
+ *
  * Since `allowed` is a flat name set (instance vs class collapsed on the TS
  * side anyway), we simply union both `instanceMethods` and `classMethods`
  * for the *host* entity, but ONLY `instanceMethods` for walked-into mixins.
@@ -484,8 +503,15 @@ function collectAllowedNames(
   moduleFqnByShort: Map<string, string[]>,
   crossPackageModules: Record<string, ClassInfo>,
   crossPackagePkgByFqn: Record<string, string>,
+  fileConstantNames: string[],
 ): Set<string> {
   const allowed = new Set<string>();
+  // File-level constants are declared per Ruby *file*, not per entity, so they
+  // enter the allow-set once for the whole file rather than through the
+  // entity/mixin walk below.
+  for (const name of fileConstantNames) {
+    for (const c of rubyConstantCandidates(name)) allowed.add(c);
+  }
   const visited = new Set<string>();
 
   const addMethods = (methods: MethodInfo[]): void => {
@@ -563,10 +589,23 @@ function collectAllowedNames(
  * Rails-private method that lives in a *different* `.rb` is "moved" (it exists
  * in Rails, just elsewhere), not "novel". Treating private mirrors as novel
  * would inflate the high-signal tier with methods Rails actually defines.
+ *
+ * File-level constants join the oracle on the same rule as methods: a Ruby
+ * constant declared in a *different* `.rb` than the matched one scores as
+ * `moved`, not `novel`. Rails does relocate constants (a shared error-code or
+ * message constant reachable from several adapters), so the alternative —
+ * leaving constants out of the oracle — would re-mint every constant that
+ * doesn't sit in its own file as novel-by-omission, which is exactly the
+ * miscount this pass exists to remove.
  */
 export function buildGlobalRubyCandidates(ruby: ApiManifest): Set<string> {
   const all = new Set<string>();
   for (const pkg of Object.values(ruby.packages)) {
+    for (const consts of Object.values(pkg.fileConstants ?? {})) {
+      for (const name of Object.keys(consts)) {
+        for (const c of rubyConstantCandidates(name)) all.add(c);
+      }
+    }
     const entities = [...Object.values(pkg.classes), ...Object.values(pkg.modules)] as ClassInfo[];
     for (const e of entities) {
       for (const m of [...e.instanceMethods, ...e.classMethods]) {
@@ -705,6 +744,7 @@ function buildPackageReport(
       moduleFqnByShort,
       crossPackageModules,
       crossPackagePkgByFqn,
+      Object.keys(rubyPkg.fileConstants?.[rubyFile] ?? {}),
     );
 
     const extras: ExtraName[] = [];

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -197,14 +197,23 @@ function rubyMethodCandidates(rubyName: string): string[] | null {
  * Ruby constant with its TS counterpart; scoring the two passes off different
  * name rules would let a constant compare as a value yet still read as drift.
  *
- * The camelized form is emitted for SCREAMING_SNAKE names only. A CamelCase
- * constant (`Version = Gem::Version`, `Cipher = OpenSSL::Cipher`) camelizes to
- * a bare lowercase word that is indistinguishable from an ordinary method
- * name, so admitting it would silently absolve a genuinely novel TS `version`
- * / `cipher` — a far worse trade than the one drift-read it saves.
+ * The camelized form is emitted only for multi-token SCREAMING_SNAKE names —
+ * the ones where camelizing produces a case transition (`ER_DUP_ENTRY` →
+ * `erDupEntry`) that could only have come from a constant. A single-token name
+ * camelizes to a bare lowercase word indistinguishable from an ordinary method
+ * name, whether it started CamelCase (`Version = Gem::Version`) or SCREAMING
+ * (`VERSION = "10.0.0"`, arel.rb:29) — `snakeToCamel` is a no-op without a `_`
+ * to drive capitalization, so both collapse to `version`. Admitting that would
+ * silently absolve a genuinely novel TS `version` everywhere the allow-set is
+ * unioned in, a far worse trade than the one drift-read it saves.
+ *
+ * This is deliberately narrower than `constantNameMatches`, which may pair
+ * `VERSION` with a TS `version` for value comparison. Pairing a *known* TS
+ * constant to diff its value is safe; minting a lowercase allow-set entry that
+ * any method name can collide with is not.
  */
 function rubyConstantCandidates(name: string): string[] {
-  if (!/^[A-Z0-9_]+$/.test(name)) return [name];
+  if (!/^[A-Z0-9]+(_[A-Z0-9]+)+$/.test(name)) return [name];
   const camel = snakeToCamel(name.toLowerCase());
   return camel === name ? [name] : [name, camel];
 }

--- a/scripts/api-compare/extract-ruby-api.rb
+++ b/scripts/api-compare/extract-ruby-api.rb
@@ -272,7 +272,10 @@ class ApiExtractor
   def initialize
     @classes = {}
     @modules = {}
-    # rel_path → { CONST_NAME => literal_value } for literal-valued constants.
+    # rel_path → { CONST_NAME => literal_value }. Non-literal RHSs (hashes with
+    # content, regexps, procs, `Struct.new`) are recorded as {kind: "expr"} so
+    # the map is a complete declared-constant *name* index for extra-surface
+    # scoring; the literal-value diff (compare.ts) skips "expr" on either side.
     @file_constants = {}
     @namespace_stack = []
     @visibility_stack = [:public]
@@ -1752,14 +1755,16 @@ class ApiExtractor
     elems.all? { |e| e.is_a?(Array) && [:symbol_literal, :dyna_symbol].include?(e[0]) }
   end
 
-  # Record a constant with a literal RHS, keyed file → NAME (unwrapping `.freeze`).
+  # Record a constant keyed file → NAME (unwrapping `.freeze`). A non-literal
+  # RHS still gets an entry, as {kind: "expr"} — the name is what extra-surface
+  # scoring needs, and "expr" is already the uncomparable marker for literals.
   def maybe_record_constant(lhs, rhs)
     return unless lhs.is_a?(Array) && lhs[0] == :var_field
     const = lhs[1]
     return unless const.is_a?(Array) && const[0] == :@const
     rhs = unwrap_freeze(rhs)
     lit = literal_value(rhs)
-    return if lit.nil? || lit[:kind] == "expr"
+    return if lit.nil?
     (@file_constants[@current_file] ||= {})[const[1]] = lit
   end
 

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -933,3 +933,38 @@ describe("Ruby extractor option-key const expansion", () => {
     expect(r["Bar::Rel#build"]).toEqual(["top_a", "top_b"]);
   });
 });
+
+describe("Ruby extractor file constants", () => {
+  const RUBY_SCRIPT = path.join(HERE, "extract-ruby-api.rb");
+
+  function rubyFileConstants(src: string): Record<string, { kind: string }> {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "consts-rb-"));
+    try {
+      fs.writeFileSync(path.join(dir, "adapter.rb"), src);
+      const driver = `
+        require_relative ${JSON.stringify(RUBY_SCRIPT)}
+        require "json"
+        ex = ApiExtractor.new
+        ex.process_file(File.join(${JSON.stringify(dir)}, "adapter.rb"), ${JSON.stringify(dir)})
+        puts JSON.generate(ex.file_constants["adapter.rb"] || {})
+      `;
+      return JSON.parse(execFileSync("ruby", ["-e", driver], { encoding: "utf-8" }));
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("records non-literal constants as expr so the name index is complete", () => {
+    const c = rubyFileConstants(`
+      class Adapter
+        ER_DUP_ENTRY = 1062
+        NATIVE_DATABASE_TYPES = { primary_key: "bigserial primary key" }
+        VALID_OPTIONS = [:class_name, :foreign_key].freeze
+      end
+    `);
+    expect(c["ER_DUP_ENTRY"]).toEqual({ kind: "int", value: "1062" });
+    // Names extra-surface scoring needs; the literal diff skips "expr" values.
+    expect(c["NATIVE_DATABASE_TYPES"]).toEqual({ kind: "expr" });
+    expect(c["VALID_OPTIONS"]).toEqual({ kind: "expr" });
+  });
+});


### PR DESCRIPTION
## What

`collectAllowedNames` (`scripts/api-compare/extra-surface.ts`) only unioned
`instanceMethods` / `classMethods` off entities and walked mixins — it never
looked at constants. So a faithfully ported Rails constant scored as novel
extra surface: `ER_DUP_ENTRY` and friends on
`connection-adapters/abstract-mysql-adapter.ts`,
`migration.ts:RELEASE_LOCK_FAILED_MESSAGE`,
`relation/batches.ts:ORDER_IGNORE_MESSAGE`,
`encryption/cipher/aes256-gcm.ts:CIPHER_TYPE`, … all of which Rails declares
verbatim.

- The matched Ruby file's `fileConstants` names now join the allow-set, via
  `rubyConstantCandidates` (verbatim name + the camelized-lowercase form, so
  scoring stays in lockstep with `literals.constantNameMatches`, which the
  literal-value diff already uses to pair a Ruby constant with its TS twin).
- `buildGlobalRubyCandidates` learns constants too, so a constant Rails
  declares in a **different** `.rb` scores `moved`, not `novel` — the same
  rule methods already follow. Leaving constants out of the oracle would
  re-mint every relocated constant as novel-by-omission, which is the exact
  miscount this pass removes.
- Ruby extractor widened: a constant with a non-literal RHS (hash with
  content, regexp, `Struct.new`) is recorded as `{kind: "expr"}` rather than
  dropped, making `fileConstants` a complete declared-constant *name* index
  (23 → 77 activerecord files). The literal-value diff already treats `expr`
  as uncomparable on either side, so parity and literal counts are unchanged:
  overall 11426/16974 methods before and after, literals 577 compared /
  0 differ.

`rubyConstantCandidates` emits the camelized form only for **multi-token
SCREAMING_SNAKE** names — the ones where camelizing produces a case transition
(`ER_DUP_ENTRY` → `erDupEntry`) that could only have come from a constant. A
single-token name camelizes to a bare lowercase word indistinguishable from a
method name, whether it started CamelCase (`Version = Gem::Version`) or
SCREAMING (`VERSION = "10.0.0"`, `vendor/rails/activerecord/lib/arel.rb:29`) —
`snakeToCamel` is a no-op without a `_` to drive capitalization, so both
collapse to `version`. Admitting that would absolve a genuinely novel TS
`version` everywhere the allow-set is unioned in.

This is deliberately narrower than `constantNameMatches`: pairing a *known* TS
constant to diff its value is safe, minting a lowercase allow-set entry that any
method name can collide with is not. The guard is not free — it recovers 5
extras that the naive camelization was wrongly absolving.

## Numbers

`pnpm api:compare && pnpm api:extra --package activerecord`:

| | before | after |
| --- | ---: | ---: |
| novel | 776 | **741** |
| moved | 2084 | 2085 |
| total extras | 2860 | 2826 |
| `connection-adapters/abstract-mysql-adapter.ts` novel | 30 | **13** |

Novel drops by 35 (story predicted ≥22); the mysql adapter lands exactly at
the predicted ~13.

## Out of scope

`Version` on `connection-adapters.ts`, `abstract-adapter.ts` and
`abstract-mysql-adapter.ts` is **not** a constants case: Rails declares
`ActiveRecord::ConnectionAdapters::AbstractAdapter::Version` as a nested
*class* in `abstract_adapter.rb`, so it is neither a method nor a
`fileConstants` entry. Admitting nested class/module short names is a
different rule (and interacts with the existing nested-class method filter),
so it is registered as its own story:
`0072-api-compare-parity-burndown/stories/extra-surface-allow-nested-class-names`.

## Tests

- `extra-surface.test.ts`: constant in the matched Ruby file (allowed),
  constant in a different Ruby file (moved), TS-only constant (novel); plus
  a `buildGlobalRubyCandidates` case for constant names entering the oracle.
- `extract-ruby-api.test.ts`: non-literal constants are recorded as `expr`.
- Guard test: `Version` and `VERSION` contribute verbatim but never `version`.

All 506 `scripts/api-compare` tests pass. `pnpm api:compare` is byte-stable on
every gate it prints: 11426/16974 methods, 104 arity mismatches, 577 literals /
0 differ, 2819 call pairs / 16 omissions, 89 option-key pairs / 15 likely-real.

Closes-story: extra-surface-allow-ruby-file-constants
