### PR TITLE
refactor(activerecord): classify relation/finder-methods perform* extras as @internal

### DIFF
--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -78,6 +78,9 @@ export interface NormalizedFindIds {
  * Does NOT do the actual lookup or the "couldn't find all" aggregate
  * error — that stays at the call site (SQL vs in-memory each have
  * their own count-comparison logic).
+ * @internal Package-private argument normalizer shared by `performFind` and
+ * `CollectionProxy#find`; Rails inlines this in `find` itself, so there is no
+ * Rails counterpart to match against.
  */
 export function normalizeFindArgs(
   modelName: string,
@@ -188,6 +191,11 @@ export function normalizeFindArgs(
  *
  * `notFoundIds` (Rails' `ids_writer` passes `ids - found_ids`) appends the
  * trailing "Couldn't find <Model> with <key> <ids>." sentence.
+ * @internal Message-composition half of Rails'
+ * `raise_record_not_found_exception!`; the Rails-named port is
+ * `raiseRecordNotFoundExceptionBang` below, which needs a bound relation.
+ * This form takes plain arguments so the in-memory collection paths can
+ * reuse the identical message without one.
  */
 export function raiseNotFoundAll(
   modelName: string,
@@ -244,6 +252,8 @@ function formatNotFoundAllMessage(
 /**
  * Raise the single-id not-found error for a simple PK.
  * Matches `Relation.performFind`'s `"with 'pk'=<id>"` message.
+ * @internal Sibling of `raiseNotFoundAll` for the single-id message; see
+ * `raiseRecordNotFoundExceptionBang` for the Rails-named entry point.
  */
 export function raiseNotFoundSingle(
   modelName: string,
@@ -308,6 +318,10 @@ function buildPkWhere(pk: string[], tuple: unknown[]): Record<string, unknown> {
   return conditions;
 }
 
+/**
+ * @internal Async-split implementation behind the public `find` finder;
+ * the Rails-matched name is the `finderMethods` key, not this one.
+ */
 export async function performFind(this: FinderRelation, ...args: unknown[]): Promise<any> {
   const pk = this._modelClass.primaryKey;
   const modelName = this._modelClass.name;
@@ -371,6 +385,10 @@ export async function performFind(this: FinderRelation, ...args: unknown[]): Pro
   return records;
 }
 
+/**
+ * @internal Async-split implementation behind the public `findBy` finder;
+ * the Rails-matched name is the `finderMethods` key, not this one.
+ */
 export async function performFindBy(
   this: FinderRelation,
   conditions: unknown,
@@ -393,6 +411,10 @@ export async function performFindBy(
   }
 }
 
+/**
+ * @internal Async-split implementation behind the public `findBy!` finder;
+ * the Rails-matched name is the `finderMethods` key, not this one.
+ */
 export async function performFindByBang(
   this: FinderRelation,
   conditions: unknown,
@@ -408,6 +430,10 @@ export async function performFindByBang(
   return record;
 }
 
+/**
+ * @internal Async-split implementation behind the public `findSoleBy` finder;
+ * the Rails-matched name is the `finderMethods` key, not this one.
+ */
 export async function performFindSoleBy(
   this: FinderRelation,
   ...conditions: unknown[]
@@ -426,6 +452,10 @@ function hasReversibleOrder(rel: FinderRelation): boolean {
   return rel._orderClauses.length > 0;
 }
 
+/**
+ * @internal Async-split implementation behind the public `first` finder;
+ * the Rails-matched name is the `finderMethods` key, not this one.
+ */
 export async function performFirst(this: FinderRelation, n?: number): Promise<any> {
   // `_isEmptyRelation()` is the shared none-short-circuit chokepoint: on an
   // AssociationRelation it first rebases a stale new-owner `1=0` seed onto the
@@ -441,6 +471,10 @@ export async function performFirst(this: FinderRelation, n?: number): Promise<an
   return (await this.findNthWithLimit(0, 1))[0] ?? null;
 }
 
+/**
+ * @internal Async-split implementation behind the public `first!` finder;
+ * the Rails-matched name is the `finderMethods` key, not this one.
+ */
 export async function performFirstBang(this: FinderRelation): Promise<any> {
   const record = await performFirst.call(this);
   if (!record) {
@@ -457,6 +491,10 @@ function orderByPk(rel: FinderRelation, direction: "asc" | "desc"): any {
   return rel.order({ [pk]: direction });
 }
 
+/**
+ * @internal Async-split implementation behind the public `last` finder;
+ * the Rails-matched name is the `finderMethods` key, not this one.
+ */
 export async function performLast(this: FinderRelation, n?: number): Promise<any> {
   // See performFirst: `_isEmptyRelation()` rebases a stale new-owner seed before
   // reporting the none short-circuit.
@@ -493,6 +531,10 @@ export async function performLast(this: FinderRelation, n?: number): Promise<any
   return records[0] ?? null;
 }
 
+/**
+ * @internal Async-split implementation behind the public `last!` finder;
+ * the Rails-matched name is the `finderMethods` key, not this one.
+ */
 export async function performLastBang(this: FinderRelation): Promise<any> {
   const record = await performLast.call(this);
   if (!record) {
@@ -501,6 +543,10 @@ export async function performLastBang(this: FinderRelation): Promise<any> {
   return record;
 }
 
+/**
+ * @internal Async-split implementation behind the public `sole` finder;
+ * the Rails-matched name is the `finderMethods` key, not this one.
+ */
 export async function performSole(this: FinderRelation): Promise<any> {
   const rel = this._clone();
   rel._limitValue = 2;
@@ -516,6 +562,10 @@ export async function performSole(this: FinderRelation): Promise<any> {
   return records[0];
 }
 
+/**
+ * @internal Async-split implementation behind the public `take` finder;
+ * the Rails-matched name is the `finderMethods` key, not this one.
+ */
 export async function performTake(this: FinderRelation, limit?: number): Promise<any> {
   const rel = this._clone();
   if (limit !== undefined) {
@@ -527,6 +577,10 @@ export async function performTake(this: FinderRelation, limit?: number): Promise
   return records[0] ?? null;
 }
 
+/**
+ * @internal Async-split implementation behind the public `take!` finder;
+ * the Rails-matched name is the `finderMethods` key, not this one.
+ */
 export async function performTakeBang(this: FinderRelation): Promise<any> {
   const record = await performTake.call(this);
   if (!record) {
@@ -572,34 +626,65 @@ export async function findNthFromLast(this: FinderRelation, index: number): Prom
   return relation.reverseOrder().offset(index).first();
 }
 
+/**
+ * @internal Async-split implementation behind the public `second` finder;
+ * the Rails-matched name is the `finderMethods` key, not this one.
+ */
 export async function performSecond(this: FinderRelation): Promise<any | null> {
   return (await this.findNthWithLimit(1, 1))[0] ?? null;
 }
 
+/**
+ * @internal Async-split implementation behind the public `third` finder;
+ * the Rails-matched name is the `finderMethods` key, not this one.
+ */
 export async function performThird(this: FinderRelation): Promise<any | null> {
   return (await this.findNthWithLimit(2, 1))[0] ?? null;
 }
 
+/**
+ * @internal Async-split implementation behind the public `fourth` finder;
+ * the Rails-matched name is the `finderMethods` key, not this one.
+ */
 export async function performFourth(this: FinderRelation): Promise<any | null> {
   return (await this.findNthWithLimit(3, 1))[0] ?? null;
 }
 
+/**
+ * @internal Async-split implementation behind the public `fifth` finder;
+ * the Rails-matched name is the `finderMethods` key, not this one.
+ */
 export async function performFifth(this: FinderRelation): Promise<any | null> {
   return (await this.findNthWithLimit(4, 1))[0] ?? null;
 }
 
+/**
+ * @internal Async-split implementation behind the public `fortyTwo` finder;
+ * the Rails-matched name is the `finderMethods` key, not this one.
+ */
 export async function performFortyTwo(this: FinderRelation): Promise<any | null> {
   return (await this.findNthWithLimit(41, 1))[0] ?? null;
 }
 
+/**
+ * @internal Async-split implementation behind the public `secondToLast` finder;
+ * the Rails-matched name is the `finderMethods` key, not this one.
+ */
 export async function performSecondToLast(this: FinderRelation): Promise<any | null> {
   return this.findNthFromLast(1);
 }
 
+/**
+ * @internal Async-split implementation behind the public `thirdToLast` finder;
+ * the Rails-matched name is the `finderMethods` key, not this one.
+ */
 export async function performThirdToLast(this: FinderRelation): Promise<any | null> {
   return this.findNthFromLast(2);
 }
 
+// The `perform*Bang` consts below are `@internal`: each is the async-split
+// implementation behind the like-named public finder (`second!`, `third!`, …).
+// The Rails-matched names are the `finderMethods` keys, not these.
 function bangFinder(finder: (this: FinderRelation) => Promise<any | null>) {
   return async function (this: FinderRelation): Promise<any> {
     const record = await finder.call(this);
@@ -610,14 +695,25 @@ function bangFinder(finder: (this: FinderRelation) => Promise<any | null>) {
   };
 }
 
+/** @internal */
 export const performSecondBang = bangFinder(performSecond);
+/** @internal */
 export const performThirdBang = bangFinder(performThird);
+/** @internal */
 export const performFourthBang = bangFinder(performFourth);
+/** @internal */
 export const performFifthBang = bangFinder(performFifth);
+/** @internal */
 export const performFortyTwoBang = bangFinder(performFortyTwo);
+/** @internal */
 export const performSecondToLastBang = bangFinder(performSecondToLast);
+/** @internal */
 export const performThirdToLastBang = bangFinder(performThirdToLast);
 
+/**
+ * @internal Async-split implementation behind the public `findOrCreateBy!` finder;
+ * the Rails-matched name is the `finderMethods` key, not this one.
+ */
 export async function performFindOrCreateByBang(
   this: FinderRelation,
   conditions: Record<string, unknown>,
@@ -631,6 +727,10 @@ export async function performFindOrCreateByBang(
   return performCreateOrFindByBang.call(this, conditions, extra);
 }
 
+/**
+ * @internal Async-split implementation behind the public `createOrFindBy!` finder;
+ * the Rails-matched name is the `finderMethods` key, not this one.
+ */
 export async function performCreateOrFindByBang(
   this: FinderRelation,
   conditions: Record<string, unknown>,

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -78,9 +78,7 @@ export interface NormalizedFindIds {
  * Does NOT do the actual lookup or the "couldn't find all" aggregate
  * error — that stays at the call site (SQL vs in-memory each have
  * their own count-comparison logic).
- * @internal Package-private argument normalizer shared by `performFind` and
- * `CollectionProxy#find`; Rails inlines this in `find` itself, so there is no
- * Rails counterpart to match against.
+ * @internal Rails inlines this in `find`; no counterpart to match against.
  */
 export function normalizeFindArgs(
   modelName: string,
@@ -191,11 +189,7 @@ export function normalizeFindArgs(
  *
  * `notFoundIds` (Rails' `ids_writer` passes `ids - found_ids`) appends the
  * trailing "Couldn't find <Model> with <key> <ids>." sentence.
- * @internal Message-composition half of Rails'
- * `raise_record_not_found_exception!`; the Rails-named port is
- * `raiseRecordNotFoundExceptionBang` below, which needs a bound relation.
- * This form takes plain arguments so the in-memory collection paths can
- * reuse the identical message without one.
+ * @internal Relation-free form of `raiseRecordNotFoundExceptionBang` below.
  */
 export function raiseNotFoundAll(
   modelName: string,
@@ -252,8 +246,7 @@ function formatNotFoundAllMessage(
 /**
  * Raise the single-id not-found error for a simple PK.
  * Matches `Relation.performFind`'s `"with 'pk'=<id>"` message.
- * @internal Sibling of `raiseNotFoundAll` for the single-id message; see
- * `raiseRecordNotFoundExceptionBang` for the Rails-named entry point.
+ * @internal Relation-free form of `raiseRecordNotFoundExceptionBang` below.
  */
 export function raiseNotFoundSingle(
   modelName: string,
@@ -318,10 +311,7 @@ function buildPkWhere(pk: string[], tuple: unknown[]): Record<string, unknown> {
   return conditions;
 }
 
-/**
- * @internal Async-split implementation behind the public `find` finder;
- * the Rails-matched name is the `finderMethods` key, not this one.
- */
+/** @internal */
 export async function performFind(this: FinderRelation, ...args: unknown[]): Promise<any> {
   const pk = this._modelClass.primaryKey;
   const modelName = this._modelClass.name;
@@ -385,10 +375,7 @@ export async function performFind(this: FinderRelation, ...args: unknown[]): Pro
   return records;
 }
 
-/**
- * @internal Async-split implementation behind the public `findBy` finder;
- * the Rails-matched name is the `finderMethods` key, not this one.
- */
+/** @internal */
 export async function performFindBy(
   this: FinderRelation,
   conditions: unknown,
@@ -411,10 +398,7 @@ export async function performFindBy(
   }
 }
 
-/**
- * @internal Async-split implementation behind the public `findBy!` finder;
- * the Rails-matched name is the `finderMethods` key, not this one.
- */
+/** @internal */
 export async function performFindByBang(
   this: FinderRelation,
   conditions: unknown,
@@ -430,10 +414,7 @@ export async function performFindByBang(
   return record;
 }
 
-/**
- * @internal Async-split implementation behind the public `findSoleBy` finder;
- * the Rails-matched name is the `finderMethods` key, not this one.
- */
+/** @internal */
 export async function performFindSoleBy(
   this: FinderRelation,
   ...conditions: unknown[]
@@ -452,10 +433,7 @@ function hasReversibleOrder(rel: FinderRelation): boolean {
   return rel._orderClauses.length > 0;
 }
 
-/**
- * @internal Async-split implementation behind the public `first` finder;
- * the Rails-matched name is the `finderMethods` key, not this one.
- */
+/** @internal */
 export async function performFirst(this: FinderRelation, n?: number): Promise<any> {
   // `_isEmptyRelation()` is the shared none-short-circuit chokepoint: on an
   // AssociationRelation it first rebases a stale new-owner `1=0` seed onto the
@@ -471,10 +449,7 @@ export async function performFirst(this: FinderRelation, n?: number): Promise<an
   return (await this.findNthWithLimit(0, 1))[0] ?? null;
 }
 
-/**
- * @internal Async-split implementation behind the public `first!` finder;
- * the Rails-matched name is the `finderMethods` key, not this one.
- */
+/** @internal */
 export async function performFirstBang(this: FinderRelation): Promise<any> {
   const record = await performFirst.call(this);
   if (!record) {
@@ -491,10 +466,7 @@ function orderByPk(rel: FinderRelation, direction: "asc" | "desc"): any {
   return rel.order({ [pk]: direction });
 }
 
-/**
- * @internal Async-split implementation behind the public `last` finder;
- * the Rails-matched name is the `finderMethods` key, not this one.
- */
+/** @internal */
 export async function performLast(this: FinderRelation, n?: number): Promise<any> {
   // See performFirst: `_isEmptyRelation()` rebases a stale new-owner seed before
   // reporting the none short-circuit.
@@ -531,10 +503,7 @@ export async function performLast(this: FinderRelation, n?: number): Promise<any
   return records[0] ?? null;
 }
 
-/**
- * @internal Async-split implementation behind the public `last!` finder;
- * the Rails-matched name is the `finderMethods` key, not this one.
- */
+/** @internal */
 export async function performLastBang(this: FinderRelation): Promise<any> {
   const record = await performLast.call(this);
   if (!record) {
@@ -543,10 +512,7 @@ export async function performLastBang(this: FinderRelation): Promise<any> {
   return record;
 }
 
-/**
- * @internal Async-split implementation behind the public `sole` finder;
- * the Rails-matched name is the `finderMethods` key, not this one.
- */
+/** @internal */
 export async function performSole(this: FinderRelation): Promise<any> {
   const rel = this._clone();
   rel._limitValue = 2;
@@ -562,10 +528,7 @@ export async function performSole(this: FinderRelation): Promise<any> {
   return records[0];
 }
 
-/**
- * @internal Async-split implementation behind the public `take` finder;
- * the Rails-matched name is the `finderMethods` key, not this one.
- */
+/** @internal */
 export async function performTake(this: FinderRelation, limit?: number): Promise<any> {
   const rel = this._clone();
   if (limit !== undefined) {
@@ -577,10 +540,7 @@ export async function performTake(this: FinderRelation, limit?: number): Promise
   return records[0] ?? null;
 }
 
-/**
- * @internal Async-split implementation behind the public `take!` finder;
- * the Rails-matched name is the `finderMethods` key, not this one.
- */
+/** @internal */
 export async function performTakeBang(this: FinderRelation): Promise<any> {
   const record = await performTake.call(this);
   if (!record) {
@@ -626,65 +586,41 @@ export async function findNthFromLast(this: FinderRelation, index: number): Prom
   return relation.reverseOrder().offset(index).first();
 }
 
-/**
- * @internal Async-split implementation behind the public `second` finder;
- * the Rails-matched name is the `finderMethods` key, not this one.
- */
+/** @internal */
 export async function performSecond(this: FinderRelation): Promise<any | null> {
   return (await this.findNthWithLimit(1, 1))[0] ?? null;
 }
 
-/**
- * @internal Async-split implementation behind the public `third` finder;
- * the Rails-matched name is the `finderMethods` key, not this one.
- */
+/** @internal */
 export async function performThird(this: FinderRelation): Promise<any | null> {
   return (await this.findNthWithLimit(2, 1))[0] ?? null;
 }
 
-/**
- * @internal Async-split implementation behind the public `fourth` finder;
- * the Rails-matched name is the `finderMethods` key, not this one.
- */
+/** @internal */
 export async function performFourth(this: FinderRelation): Promise<any | null> {
   return (await this.findNthWithLimit(3, 1))[0] ?? null;
 }
 
-/**
- * @internal Async-split implementation behind the public `fifth` finder;
- * the Rails-matched name is the `finderMethods` key, not this one.
- */
+/** @internal */
 export async function performFifth(this: FinderRelation): Promise<any | null> {
   return (await this.findNthWithLimit(4, 1))[0] ?? null;
 }
 
-/**
- * @internal Async-split implementation behind the public `fortyTwo` finder;
- * the Rails-matched name is the `finderMethods` key, not this one.
- */
+/** @internal */
 export async function performFortyTwo(this: FinderRelation): Promise<any | null> {
   return (await this.findNthWithLimit(41, 1))[0] ?? null;
 }
 
-/**
- * @internal Async-split implementation behind the public `secondToLast` finder;
- * the Rails-matched name is the `finderMethods` key, not this one.
- */
+/** @internal */
 export async function performSecondToLast(this: FinderRelation): Promise<any | null> {
   return this.findNthFromLast(1);
 }
 
-/**
- * @internal Async-split implementation behind the public `thirdToLast` finder;
- * the Rails-matched name is the `finderMethods` key, not this one.
- */
+/** @internal */
 export async function performThirdToLast(this: FinderRelation): Promise<any | null> {
   return this.findNthFromLast(2);
 }
 
-// The `perform*Bang` consts below are `@internal`: each is the async-split
-// implementation behind the like-named public finder (`second!`, `third!`, …).
-// The Rails-matched names are the `finderMethods` keys, not these.
 function bangFinder(finder: (this: FinderRelation) => Promise<any | null>) {
   return async function (this: FinderRelation): Promise<any> {
     const record = await finder.call(this);
@@ -710,10 +646,7 @@ export const performSecondToLastBang = bangFinder(performSecondToLast);
 /** @internal */
 export const performThirdToLastBang = bangFinder(performThirdToLast);
 
-/**
- * @internal Async-split implementation behind the public `findOrCreateBy!` finder;
- * the Rails-matched name is the `finderMethods` key, not this one.
- */
+/** @internal */
 export async function performFindOrCreateByBang(
   this: FinderRelation,
   conditions: Record<string, unknown>,
@@ -727,10 +660,7 @@ export async function performFindOrCreateByBang(
   return performCreateOrFindByBang.call(this, conditions, extra);
 }
 
-/**
- * @internal Async-split implementation behind the public `createOrFindBy!` finder;
- * the Rails-matched name is the `finderMethods` key, not this one.
- */
+/** @internal */
 export async function performCreateOrFindByBang(
   this: FinderRelation,
   conditions: Record<string, unknown>,

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1240,4 +1240,21 @@ describe("extractFromProgram — @internal JSDoc on top-level functions", () => 
     expect(info.modules["key-normalization.ts:KeyNormalization"]).toBeUndefined();
     expect(info.fileFunctions["key-normalization.ts"].every((f) => f.internal)).toBe(true);
   });
+
+  it("tags an @internal-tagged exported function-valued const and leaves its sibling public", () => {
+    const info = extractFromFiles("/p", {
+      "finder-methods.ts": `
+        function bangFinder(f: () => number) { return () => f(); }
+        function base(): number { return 1; }
+
+        /** @internal */
+        export const performSecondBang = bangFinder(base);
+
+        export const secondBang = bangFinder(base);
+      `,
+    });
+    const fns = info.fileFunctions["finder-methods.ts"];
+    expect(fns.find((f) => f.name === "performSecondBang")!.internal).toBe(true);
+    expect(fns.find((f) => f.name === "secondBang")!.internal).toBeUndefined();
+  });
 });

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -636,6 +636,11 @@ export function extractFromProgram(program: ts.Program, srcDir: string): Package
                 ? decl.initializer.body
                 : undefined;
             const calls = extractCalls(body);
+            // `export const foo = makeFoo(...)` reaches fileFunctions only
+            // through this export-symbol path, so the `@internal` tag has to
+            // be read here too — for a VariableDeclaration the JSDoc hangs off
+            // the enclosing VariableStatement, which getJSDocTags walks up to.
+            const internal = hasInternalJsDocTag(decl);
             fileFunctions.push({
               name: sym.name,
               visibility: "public",
@@ -643,6 +648,7 @@ export function extractFromProgram(program: ts.Program, srcDir: string): Package
               isStatic: false,
               line,
               file: relPath,
+              ...(internal ? { internal: true } : {}),
               ...(calls !== undefined ? { calls } : {}),
             });
           }

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -636,10 +636,6 @@ export function extractFromProgram(program: ts.Program, srcDir: string): Package
                 ? decl.initializer.body
                 : undefined;
             const calls = extractCalls(body);
-            // `export const foo = makeFoo(...)` reaches fileFunctions only
-            // through this export-symbol path, so the `@internal` tag has to
-            // be read here too — for a VariableDeclaration the JSDoc hangs off
-            // the enclosing VariableStatement, which getJSDocTags walks up to.
             const internal = hasInternalJsDocTag(decl);
             fileFunctions.push({
               name: sym.name,


### PR DESCRIPTION
## What

Classifies all 30 novel extras in `packages/activerecord/src/relation/finder-methods.ts`
— the highest-purity drift file in activerecord (30 novel, 0 moved).

Disposition per name:

- **28 `perform*`** — `@internal`. Each is the async-split implementation behind
  a public finder; the Rails-matched name is the `finderMethods` key
  (`find`, `first`, `take`, `sole`, …), not the `perform*` symbol.
- **`normalizeFindArgs`** — `@internal`. Package-private argument normalizer
  shared by `performFind` and `CollectionProxy#find`; Rails inlines this inside
  `find`, so there is no counterpart to relocate toward.
- **`raiseNotFoundAll` / `raiseNotFoundSingle`** — `@internal`, *not* renamed.
  Checked against `raise_record_not_found_exception!`
  (`vendor/rails/activerecord/lib/active_record/relation/finder_methods.rb:417`)
  first, as the story asked: the Rails-named port **already exists** in this file
  as `raiseRecordNotFoundExceptionBang` and is already matched. These two are
  plain-argument message composers the in-memory collection paths
  (`collection-association.ts`, `collection-proxy.ts`) reuse *without* a bound
  relation, which `raiseRecordNotFoundExceptionBang` requires. Merging them
  would be a behavior refactor, not a rename.

No `extra-surface-allow.json` entries needed. Zero callers outside the package
for any of the 30.

Rails-source check: `grep 'def perform_\|def raise_not_found\|def normalize_find'`
over `vendor/rails/activerecord/lib/` returns no counterpart for any of these —
the only Rails `perform_*` methods are `perform_query`, `perform_calculation`,
`perform_fetch`, `perform_validations`, none in `finder_methods.rb`.

## Extractor fix

Seven names (`performSecondBang`, `performThirdBang`, …) are
`export const x = bangFinder(y)`. Those reach `fileFunctions` through the
export-symbol resolution path, not the `FunctionDeclaration` path that #5335
taught to read `@internal` — so the tag was silently ignored there. Added the
same `hasInternalJsDocTag` read on that path, plus a unit test (tagged const +
untagged sibling in one fixture).

## Numbers

Both runs with `API_COMPARE_FORCE=1` (the ts-api cache under-reports).
`pnpm api:extra --package activerecord`:

| | files | novel | moved | total |
|---|---|---|---|---|
| main | 207 | 664 | 1556 | 2220 |
| this PR | 206 | **633** | 1556 | 2189 |

`relation/finder-methods.ts` drops off the report entirely: **30 novel → 0**.
The 31st novel and the one-file drop are the knock-on from the const path — a
file whose exported functions are all `@internal` no longer fabricates a
synthetic module.

**api:compare delta: 0.** Byte-identical on main and on this branch (both forced):

```
Data layer: 7717/7810 methods (98.8%)  |  files: 409/409
Overall: 11678/17484 methods (66.8%)  |  files: 761/1019  |  inheritance: 533/587 (90.8%)  |  arity: 7426/7530 (98.6%)
```

**test:compare delta: 0.** No file under `packages/activerecord/**` test paths
is touched — the only test change is `scripts/api-compare/extract-ts-api.test.ts`,
which test:compare does not index. No test renames.

## No stubs, no behavior change

Nothing added but JSDoc tags and one extractor `internal` flag. No empty
placeholders, no new exports, no signature changes.

`pnpm vitest run packages/activerecord/src/relation/finder-methods.test.ts` —
44 passed, unchanged. `scripts/api-compare/extract-ts-api.test.ts` — 73 passed
(72 + the new one).

## Comments

Per review instruction, the explanatory prose added in the first commit was
stripped in `021298df7`. The mechanical `perform*` sites now carry a bare
`/** @internal */`; only the three non-obvious helpers keep a one-line reason,
since the repo's justify-deviations-at-the-call-site rule and this story's
acceptance criteria both require the reason to live at the declaration. The
`@internal` tags themselves are load-bearing — they are the mechanism the PR
implements, not commentary.

Closes-story: extra-surface-finder-methods-perform-helpers
