### PR TITLE
docs(associations): classify associations.ts novel extra surface (26 → 19)

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -396,6 +396,13 @@ export function lookupModelWithAutoload(name: string): typeof Base | undefined {
 
 /**
  * Resolve a model class by name.
+ *
+ * @internal Registry lookup, not a Rails method. Ruby resolves association
+ * class names through constant lookup (`compute_class` / `Object.const_get`),
+ * so there is no `resolve_model` anywhere in Rails; trails needs an explicit
+ * registry because ESM has no constant namespace to walk. Sits between the
+ * already-`@internal` {@link lookupModelWithAutoload} and
+ * {@link resolveAssocClass}, which are the same invention.
  */
 export function resolveModel(name: string): typeof Base {
   const model = lookupModelWithAutoload(name);
@@ -1233,6 +1240,11 @@ async function _loadSingularViaStatementCache(
  * target. `isNewRecord()` covers unsaved records; the explicit
  * PK-null check covers the defensive edge where a saved record
  * somehow has a null composite-PK component.
+ *
+ * @internal No Rails counterpart: Rails spells this guard inline at each site
+ * (`if owner.new_record?` / `null_scope?` in ThroughAssociation), so there is
+ * no method to port. Extracted here only because trails has several entry
+ * points into the DJAS chain walk that must not diverge on the guard.
  */
 export function ownerHasUnresolvedThroughKey(
   record: Base,
@@ -2266,6 +2278,11 @@ export function _inlinePolymorphicKeys(
  * Shared by `buildHasManyRelation` (which wraps it in `all().where(...)`)
  * and CollectionProxy's constructor (which seeds its own where-clause
  * via the same condition).
+ *
+ * @internal No Rails counterpart. Rails never materializes the owner-scoping
+ * hash on its own: `AssociationScope#add_constraints` writes the predicate
+ * straight onto the relation being built. This is a trails-only factoring so
+ * the two construction sites can't drift.
  */
 export function computeHasManyWhere(
   record: Base,
@@ -2416,6 +2433,12 @@ export function computeHasManyWhere(
  * Skips caching, strict loading, and inverse_of — used by countHasMany
  * so resetCounters works under strict loading.
  * Returns null if primary key values are missing.
+ *
+ * @internal No Rails counterpart. Rails gets an unexecuted, side-effect-free
+ * relation for free via `association.scope` (`Association#scope` ->
+ * `AssociationScope.scope`); trails' `loadHasMany` fuses relation building
+ * with caching/strict-loading/inverse_of, so the bypass has to be spelled out
+ * as its own function until that fusion is undone.
  */
 export function buildHasManyRelation(
   record: Base,
@@ -2449,6 +2472,12 @@ export function buildHasManyRelation(
  *
  * Returns null when the owner FK is absent (unsaved owner / null PK), matching
  * the short-circuit in `loadHasMany`.
+ *
+ * @internal No Rails counterpart, for the same reason as
+ * {@link buildHasManyRelation}: in Rails this relation IS
+ * `association.scope`, and `CollectionAssociation#count_records` just calls
+ * `scope.count(:all)` on it. Named separately here only because trails builds
+ * the JOIN form inside `loadHasMany` rather than in an AssociationScope.
  */
 export function buildThroughJoinScope(
   record: Base,

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -398,9 +398,10 @@ export function lookupModelWithAutoload(name: string): typeof Base | undefined {
  * Resolve a model class by name.
  *
  * @internal Registry lookup, not a Rails method. Ruby resolves association
- * class names through constant lookup (`compute_class` / `Object.const_get`),
- * so there is no `resolve_model` anywhere in Rails; trails needs an explicit
- * registry because ESM has no constant namespace to walk. Sits between the
+ * class names through constant lookup — `Reflection#compute_class`
+ * (`reflection.rb:434` and `:490`) into `Object.const_get` — so `resolve_model`
+ * is defined nowhere in the Rails source; trails needs an explicit registry
+ * because ESM has no constant namespace to walk. Sits between the
  * already-`@internal` {@link lookupModelWithAutoload} and
  * {@link resolveAssocClass}, which are the same invention.
  */
@@ -1241,10 +1242,12 @@ async function _loadSingularViaStatementCache(
  * PK-null check covers the defensive edge where a saved record
  * somehow has a null composite-PK component.
  *
- * @internal No Rails counterpart: Rails spells this guard inline at each site
- * (`if owner.new_record?` / `null_scope?` in ThroughAssociation), so there is
- * no method to port. Extracted here only because trails has several entry
- * points into the DJAS chain walk that must not diverge on the guard.
+ * @internal No Rails counterpart (`owner_has_unresolved_through_key` is defined
+ * nowhere in the Rails source). Rails spells this guard inline at each site —
+ * `if owner.new_record?`, or `CollectionAssociation#null_scope?`
+ * (`associations/collection_association.rb:304`) — so there is no method to
+ * port. Extracted here only because trails has several entry points into the
+ * DJAS chain walk that must not diverge on the guard.
  */
 export function ownerHasUnresolvedThroughKey(
   record: Base,
@@ -2279,10 +2282,12 @@ export function _inlinePolymorphicKeys(
  * and CollectionProxy's constructor (which seeds its own where-clause
  * via the same condition).
  *
- * @internal No Rails counterpart. Rails never materializes the owner-scoping
- * hash on its own: `AssociationScope#add_constraints` writes the predicate
- * straight onto the relation being built. This is a trails-only factoring so
- * the two construction sites can't drift.
+ * @internal No Rails counterpart (`compute_has_many_where` is defined nowhere
+ * in the Rails source). Rails never materializes the owner-scoping hash on its
+ * own: `AssociationScope#add_constraints`
+ * (`associations/association_scope.rb:124`) writes the predicate straight onto
+ * the relation being built. This is a trails-only factoring so the two
+ * construction sites can't drift.
  */
 export function computeHasManyWhere(
   record: Base,
@@ -2434,11 +2439,13 @@ export function computeHasManyWhere(
  * so resetCounters works under strict loading.
  * Returns null if primary key values are missing.
  *
- * @internal No Rails counterpart. Rails gets an unexecuted, side-effect-free
- * relation for free via `association.scope` (`Association#scope` ->
- * `AssociationScope.scope`); trails' `loadHasMany` fuses relation building
- * with caching/strict-loading/inverse_of, so the bypass has to be spelled out
- * as its own function until that fusion is undone.
+ * @internal No Rails counterpart (`build_has_many_relation` is defined nowhere
+ * in the Rails source). Rails gets an unexecuted, side-effect-free relation for
+ * free via `association.scope` — `Association#scope`
+ * (`associations/association.rb:107`) into `AssociationScope#scope`
+ * (`associations/association_scope.rb:21`). trails' `loadHasMany` fuses
+ * relation building with caching/strict-loading/inverse_of, so the bypass has
+ * to be spelled out as its own function until that fusion is undone.
  */
 export function buildHasManyRelation(
   record: Base,
@@ -2473,11 +2480,13 @@ export function buildHasManyRelation(
  * Returns null when the owner FK is absent (unsaved owner / null PK), matching
  * the short-circuit in `loadHasMany`.
  *
- * @internal No Rails counterpart, for the same reason as
- * {@link buildHasManyRelation}: in Rails this relation IS
- * `association.scope`, and `CollectionAssociation#count_records` just calls
- * `scope.count(:all)` on it. Named separately here only because trails builds
- * the JOIN form inside `loadHasMany` rather than in an AssociationScope.
+ * @internal No Rails counterpart (`build_through_join_scope` is defined nowhere
+ * in the Rails source), for the same reason as {@link buildHasManyRelation}: in
+ * Rails this relation IS `association.scope`, and
+ * `HasManyAssociation#count_records` (`associations/has_many_association.rb:80`)
+ * just calls `scope.count(:all)` on it (`:84`). Named separately here only
+ * because trails builds the JOIN form inside `loadHasMany` rather than in an
+ * AssociationScope.
  */
 export function buildThroughJoinScope(
   record: Base,

--- a/scripts/api-compare/extra-surface-allow.json
+++ b/scripts/api-compare/extra-surface-allow.json
@@ -165,12 +165,12 @@
     "package": "activerecord",
     "tsFile": "associations.ts",
     "name": "registerModel",
-    "reason": "trails-only model registry with no Rails analogue. Ruby resolves an association's class through constant lookup (Reflection#compute_class -> Object.const_get / ActiveSupport autoloading), so Rails never registers models anywhere and `register_model` exists nowhere in the source. ESM has no constant namespace to walk and no autoload hook, so trails must be told which classes exist. It is deliberately public (re-exported from index.ts) because application code has to call it; @internal would be a lie. Kept in associations.ts because association class resolution is its only consumer path."
+    "reason": "trails-only model registry with no Rails analogue: `register_model` is defined nowhere in the Rails source (verified by grep over vendor/rails). Ruby resolves an association's class through constant lookup — Reflection#compute_class (reflection.rb:434 and :490) into Object.const_get, backed by ActiveSupport autoloading — so Rails never registers models anywhere. ESM has no constant namespace to walk and no autoload hook, so trails must be told which classes exist. Deliberately public (re-exported from index.ts) because application code has to call it, which is why @internal would be a lie rather than a fix. Kept in associations.ts because association class resolution is its only consumer path."
   },
   {
     "package": "activerecord",
     "tsFile": "associations.ts",
     "name": "initializeAssociations",
-    "reason": "trails-only ESM module-cycle escape hatch with no Rails analogue. The associations -> CollectionProxy -> Relation -> Base -> associations cycle forces CollectionProxy registration to be late-bound; the package entry does it eagerly, and this is the supported explicit hook for consumers who deep-import `@blazetrails/activerecord/associations` without touching the entry. Ruby's require/autoload resolves such cycles at load time so there is nothing to port. Public by intent (documented consumer hook), so @internal is not appropriate."
+    "reason": "trails-only ESM module-cycle escape hatch with no Rails analogue: `initialize_associations` is defined nowhere in the Rails source (verified by grep over vendor/rails). The associations -> CollectionProxy -> Relation -> Base -> associations cycle forces CollectionProxy registration to be late-bound; the package entry does it eagerly, and this is the supported explicit hook for consumers who deep-import `@blazetrails/activerecord/associations` without touching the entry. Ruby's require/autoload resolves such cycles at load time, so there is nothing to port. Public by intent (documented consumer hook), so @internal is not appropriate."
   }
 ]

--- a/scripts/api-compare/extra-surface-allow.json
+++ b/scripts/api-compare/extra-surface-allow.json
@@ -160,5 +160,17 @@
     "tsFile": "locator.ts",
     "name": "where",
     "reason": "Member of the duck-typed `LocatorModel` interface, not a locator method: it declares the Active Record relation Rails' BaseLocator calls as `model_class.where(primary_key => ids)` on the ignore_missing path. Ruby needs no such declaration."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations.ts",
+    "name": "registerModel",
+    "reason": "trails-only model registry with no Rails analogue. Ruby resolves an association's class through constant lookup (Reflection#compute_class -> Object.const_get / ActiveSupport autoloading), so Rails never registers models anywhere and `register_model` exists nowhere in the source. ESM has no constant namespace to walk and no autoload hook, so trails must be told which classes exist. It is deliberately public (re-exported from index.ts) because application code has to call it; @internal would be a lie. Kept in associations.ts because association class resolution is its only consumer path."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations.ts",
+    "name": "initializeAssociations",
+    "reason": "trails-only ESM module-cycle escape hatch with no Rails analogue. The associations -> CollectionProxy -> Relation -> Base -> associations cycle forces CollectionProxy registration to be late-bound; the package entry does it eagerly, and this is the supported explicit hook for consumers who deep-import `@blazetrails/activerecord/associations` without touching the entry. Ruby's require/autoload resolves such cycles at load time so there is nothing to port. Public by intent (documented consumer hook), so @internal is not appropriate."
   }
 ]


### PR DESCRIPTION
Classifies the novel `api:extra` surface on
`packages/activerecord/src/associations.ts` — trails' functional association
engine, a file whose Rails counterpart (`lib/active_record/associations.rb`) is
almost entirely documentation plus the small `Associations` module.

Both blocking tooling fixes have landed, so the list was re-derived rather than
inherited from the spike: #5335 (`@internal` on top-level exported functions)
and #5336 (mixin pseudo-module host leak) took the file from 33 novel / 94
moved down to **26 novel / 0 moved**. This PR works from that 26.

## associations.ts novel surface

| | novel | moved |
|---|---|---|
| before (this PR) | 26 | 0 |
| after | **19** | 0 |

Reproduce: `pnpm api:compare && pnpm api:extra --package activerecord --novel-only --max-detail 0 --top 100`

## Classification

### How the "no Rails counterpart" claims were checked

Every (b) name was grepped for as a Ruby `def` across the **whole** vendored
Rails tree, not just `activerecord`:

```
$ cd vendor/rails
$ for n in resolve_model owner_has_unresolved_through_key compute_has_many_where \
           build_has_many_relation build_through_join_scope register_model \
           initialize_associations; do
    printf '%-38s ' "$n"
    echo "defs=$(grep -rn "def $n\b\|def self\.$n\b" --include=*.rb . | wc -l)"
  done
resolve_model                          defs=0
owner_has_unresolved_through_key       defs=0
compute_has_many_where                 defs=0
build_has_many_relation                defs=0
build_through_join_scope               defs=0
register_model                         defs=0
initialize_associations                defs=0
```

Every *positive* Rails reference in the reasons was likewise confirmed to exist
and now carries a verified `file:line`. Two references were wrong in the first
push and are corrected in the second commit:

- `null_scope?` is `CollectionAssociation` (`collection_association.rb:304`),
  **not** `ThroughAssociation`.
- `count_records` is `HasManyAssociation` (`has_many_association.rb:80`),
  **not** `CollectionAssociation`.

### (b) `@internal`, applied here — internal plumbing with no Rails counterpart

Each carries a written reason at the declaration.

| name | line | why it is not a port |
|---|---|---|
| `resolveModel` | `associations.ts:408` | Ruby resolves association classes by constant lookup — `Reflection#compute_class` (`reflection.rb:434`, `:490`) into `Object.const_get`. Sits between the already-`@internal` `lookupModelWithAutoload` and `resolveAssocClass`, which are the same invention — the missing tag was an oversight. |
| `ownerHasUnresolvedThroughKey` | `:1237` | Rails spells this guard inline at each site (`if owner.new_record?`, or `CollectionAssociation#null_scope?` at `collection_association.rb:304`). Extracted only because trails has several entry points into the DJAS chain walk that must not diverge. |
| `computeHasManyWhere` | `:2270` | Rails never materializes the owner-scoping hash — `AssociationScope#add_constraints` (`association_scope.rb:124`) writes the predicate straight onto the relation. |
| `buildHasManyRelation` | `:2420` | In Rails this relation IS `association.scope` — `Association#scope` (`association.rb:107`) into `AssociationScope#scope` (`association_scope.rb:21`). Needed here only because trails' `loadHasMany` fuses relation building with caching / strict loading / inverse_of. |
| `buildThroughJoinScope` | `:2453` | Same root cause; `HasManyAssociation#count_records` (`has_many_association.rb:80`) just calls `scope.count(:all)` on it (`:84`). |

### (b) reasoned allowlist — public by intent, so `@internal` would be a lie

Added to `scripts/api-compare/extra-surface-allow.json`; both entries match
(no stale entries).

- **`registerModel`** — trails-only model registry. ESM has no constant
  namespace and no autoload hook, so trails must be told which classes exist.
  Re-exported from `index.ts` because application code has to call it.
- **`initializeAssociations`** — ESM module-cycle escape hatch
  (associations → CollectionProxy → Relation → Base → associations). Ruby's
  `require`/autoload resolves such cycles at load time, so there is nothing to
  port. Documented consumer hook for deep-importers.

### (c) misplaced ports — registered as follow-up stories, not opened here

The remaining 19 are real ports living in the wrong file. Several already say so
in their own JSDoc (`buildHasOne` → "Mirrors:
`ActiveRecord::Associations::HasOneAssociation#build_record`").

**Relocation alone does not clear them.** `api:compare` matches on name *and*
Rails-layout file, so each must be renamed to the Rails method name *and* moved.
None of `findTarget`, `buildRecord`, `countRecords` exist yet under
`src/associations/` — those classes are currently thin shells delegating into
this engine — so each move is real work, not a cut-and-paste. Total ~1,600 LOC
relocated, far past the 500 LOC ceiling, hence 11 stories rather than sibling PRs.

| story | names (`associations.ts:` line) | Rails home |
|---|---|---|
| `extra-surface-relocate-load-belongs-to` | `loadBelongsTo` (:1428) | `Association#find_target` (association.rb:248) / `BelongsToAssociation` |
| `extra-surface-relocate-load-has-one` | `loadHasOne` (:1662) | `SingularAssociation#find_target` (singular_association.rb:47) |
| `extra-surface-relocate-load-has-many` | `loadHasMany` (:1933) | `Association#find_target` via `HasManyAssociation` |
| `extra-surface-relocate-load-through` | `loadHasManyThrough` (:2571), `loadHasOneThrough` (:2694) | `HasManyThroughAssociation#find_target` (:225) |
| `extra-surface-relocate-load-habtm` | `loadHabtm` (:2941) | `Builder::HasAndBelongsToMany` rewrites HABTM to has_many-through |
| `extra-surface-relocate-build-record-singular` | `buildHasOne` (:1858), `buildBelongsTo` (:1912) | `Association#build_record` (association.rb:383) |
| `extra-surface-relocate-build-through` | `buildThroughAssociation` (:3057), `createThroughAssociation` (:3156) | `ThroughAssociation#build_record` (:116) |
| `extra-surface-relocate-association-writers` | `setBelongsTo` (:3695), `setHasOne` (:3820), `setHasMany` (:3875) | `#replace` on belongs_to / has_one / collection associations |
| `extra-surface-relocate-counter-cache-helpers` | `resolveCounterColumn` (:684), `countHasMany` (:2523), `reflectLockVersionBump` (:3675) | `Reflection#counter_cache_column` (reflection.rb:244), `HasManyAssociation#count_records` (:80) |
| `extra-surface-relocate-update-counter-caches` | `updateCounterCaches` (:3510) | `Builder::BelongsTo.add_counter_cache_callbacks` (belongs_to.rb:27) + `counter_cache.rb` |
| `extra-surface-relocate-touch-and-callbacks` | `touchBelongsToParents` (:3893), `fireAssocCallbacks` (:3018) | `Builder::BelongsTo.touch_record` (:44), `CollectionAssociation#callback` (:492) |

All `associations.ts:` line refs above and in the story bodies are as of this
branch's HEAD; each story also carries a `grep -n` re-derivation hint so the
refs degrade gracefully as the file moves.

Two findings worth calling out, recorded in the story bodies:

- **`resolveCounterColumn` is probably (a) invention-to-delete, not (c).**
  `AssociationReflection#counterCacheColumn` already exists at
  `reflection.ts:337` (memoized per `:176`) and is the direct port of
  `reflection.rb:244`. The story asks the implementer to confirm they agree and
  delete the duplicate rather than move it.
- **`setHasMany` is already a two-line forward** to
  `record.association(name).writer(targets)`, and `collection-association.ts`
  already defines `replace` — so it is likely deletable too.

## Notes

- The diff to `associations.ts` is **JSDoc only** — `git diff` contains zero
  non-comment lines. No runtime behavior changes.
- `loadBelongsTo` / `loadHasOne` are also generated *instance-method* names on
  models (`post.loadBelongsTo("author")`). That reader sugar is separate trails
  surface and is explicitly out of scope of the relocation stories.

## Verification

Tooling gates (all green):

| command | result |
|---|---|
| `pnpm api:compare` | exit 0 |
| `pnpm api:extra --package activerecord --novel-only` | `associations.ts — 19 novel, 0 moved`; allowlist 29 entries, **2 matched** (no stale) |
| `pnpm api:calls` | OK (19 baselined) |
| `pnpm api:calls:wide` | OK (5433 baselined) |
| `pnpm api:arity` | OK (0 reasoned exclusions) |
| `pnpm api:pins` | OK (0 pinned) |

The wide ratchet was re-run deliberately: `@internal` changes what
`extract-ts-api` emits, which is exactly how wide-gate entries have gone stale
before. It did not move here.

Tests:

- `pnpm vitest run scripts/api-compare/extra-surface.test.ts` — 38 passed
- `pnpm vitest run packages/activerecord/src/associations.test.ts packages/activerecord/src/counter-cache.test.ts` — 203 passed
- No test renames.

Size: 50 LOC (`git diff --shortstat origin/main...HEAD` excluding lockfiles /
snapshots / `.md`), against the 500 ceiling.

Closes-story: extra-surface-associations-engine-classify
