### PR TITLE
refactor(activerecord): classify STI/schema-registry extra surface

### DIFF
--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -280,7 +280,7 @@ export function registerModuleTableNameSuffix(moduleName: string, suffix: string
  * caller then falls back to `self.table_name_prefix`/`_suffix`). Mirrors the
  * `module_parents.detect { |p| p.respond_to?(:table_name_prefix) }` walk in
  * `ActiveRecord::ModelSchema::ClassMethods#full_table_name_{prefix,suffix}`
- * (model_schema.rb:301-307).
+ * (model_schema.rb:302-307).
  *
  * Two kinds of parent "respond to" the decorator and thus stop the walk:
  * a module that registered one (`registered`), or an *AR-model-class* parent —

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -231,6 +231,8 @@ export function qualifiedName(modelClass: typeof Base): string {
 
 /**
  * The namespace segments for `modelClass` — `moduleName.split("::")` or `[]`.
+ *
+ * @internal
  */
 export function namespaceSegments(modelClass: typeof Base): string[] {
   const moduleName = (modelClass as typeof Base & { moduleName?: string }).moduleName;
@@ -242,6 +244,8 @@ export function namespaceSegments(modelClass: typeof Base): string[] {
  * `"MyApplication::Business::Prefixed"` →
  * `["MyApplication::Business::Prefixed", "MyApplication::Business", "MyApplication"]`.
  * Mirrors Ruby's `Module#module_parents` (sans `Object`).
+ *
+ * @internal
  */
 export function moduleParentChain(moduleName: string | undefined): string[] {
   if (!moduleName) return [];
@@ -298,6 +302,7 @@ function lookupModuleDecoration(
   return undefined;
 }
 
+/** @internal */
 export function lookupModuleTableNamePrefix(moduleName: string | undefined): string | undefined {
   return lookupModuleDecoration(
     moduleName,
@@ -306,6 +311,7 @@ export function lookupModuleTableNamePrefix(moduleName: string | undefined): str
   );
 }
 
+/** @internal */
 export function lookupModuleTableNameSuffix(moduleName: string | undefined): string | undefined {
   return lookupModuleDecoration(
     moduleName,
@@ -463,6 +469,8 @@ export function stiEnabled(modelClass: object): boolean {
 
 /**
  * Check if a model class is an STI subclass (not the base STI class).
+ *
+ * @internal
  */
 export function isStiSubclass(modelClass: object): boolean {
   // Walk up the prototype chain to find if any parent has _inheritanceColumn
@@ -515,6 +523,8 @@ export function abstractClass(this: typeof Base, value?: boolean): boolean {
 
 /**
  * Get the STI base class for a model.
+ *
+ * @internal
  */
 export function getStiBase(modelClass: object): typeof Base {
   let current = modelClass as typeof Base;
@@ -631,6 +641,8 @@ const SELECT_ALIAS_READERS = Symbol.for("activerecord.selectAliasReaders");
  * `@attributes.key?`, so once `reload` swaps in a plain `SELECT *` attribute set
  * `record.post_count` raises `NoMethodError` — we mirror that by deleting the
  * stale getter (property access then yields `undefined`, the trails analog).
+ *
+ * @internal
  */
 export function defineDynamicSelectReaders(record: Base): void {
   const attrs = (record as any)._attributes as { keys(): Iterable<string> };

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -118,6 +118,8 @@ function ownSchemaMemo<K extends keyof SchemaHost>(
  * inherit the base class's table name.
  *
  * Mirrors: ActiveRecord::ModelSchema::ClassMethods#table_name
+ *
+ * @internal
  */
 export function resolveTableName(this: typeof Base): string {
   if ((this as any)._tableName != null) return (this as any)._tableName;
@@ -175,7 +177,7 @@ function containedTableNamePrefix(this: typeof Base): string {
 /**
  * Build a WHERE clause string for the primary key of a given record.
  *
- * Mirrors: used throughout ActiveRecord persistence internals
+ * @internal
  */
 export function buildPkWhere(this: typeof Base, idValue: unknown): string {
   const pk = this.primaryKey;
@@ -197,7 +199,7 @@ export function buildPkWhere(this: typeof Base, idValue: unknown): string {
 /**
  * Build an Arel node for a primary key WHERE condition.
  *
- * Mirrors: used with Arel managers for type-safe SQL generation
+ * @internal
  */
 export function buildPkWhereNode(
   this: typeof Base,
@@ -239,6 +241,8 @@ export function buildPkWhereNode(
  *
  * Mirrors: how `ActiveRecord::Persistence#_update_record` / `#_delete_record`
  * turn `_query_constraints_hash` into the predicate WHERE.
+ *
+ * @internal
  */
 export function buildWhereNodeFromConstraints(
   this: typeof Base,
@@ -280,9 +284,10 @@ export function columnNames(this: typeof Base): string[] {
 }
 
 /**
- * Check if a model class has a given attribute defined.
+ * Check if a model class has a given attribute defined. Backs the Rails-named
+ * public accessor `Base.hasAttribute` (Rails' `has_attribute?`, attribute_methods.rb).
  *
- * Mirrors: ActiveRecord::ModelSchema::ClassMethods#has_attribute?
+ * @internal
  */
 export function hasAttributeDefinition(this: typeof Base, name: string): boolean {
   // Rails: `attr_name = attribute_aliases[attr_name] || attr_name`
@@ -382,6 +387,8 @@ type DatabaseAdapterLike = { schemaCache?: unknown };
  * whose default matters here has already pinned a connection via the
  * `!_schemaLoaded` reflection in `_defaultAttributes`, so `{}` is only reached for
  * columns that carry no client-side default anyway.
+ *
+ * @internal
  */
 export function cachedColumnsHash(klass: typeof Base): Record<string, ColumnLike> {
   const cachedFrom = (conn: { schemaCache?: unknown } | null | undefined) => {
@@ -437,7 +444,7 @@ export function contentColumns(this: typeof Base): any[] {
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#native_database_types
  */
-export function sqlTypeFor(typeName: string, adapterName?: string): string {
+function sqlTypeFor(typeName: string, adapterName?: string): string {
   if (adapterName === "postgres") {
     switch (typeName) {
       case "integer":
@@ -772,6 +779,7 @@ export function columns(this: SchemaHost): any[] {
   return this._columns;
 }
 
+/** @internal */
 export function attributeSetCoder(this: SchemaHost): AttributeSetCoder {
   return new AttributeSetCoder(typeRegistry);
 }
@@ -1213,6 +1221,8 @@ function applyColumnsHash(
  * Populates the schema cache if needed (async). User-declared attributes
  * (`userProvided: true`) are NEVER overwritten — matching Rails where
  * `attribute :foo, :bar` always wins over schema-reflected types.
+ *
+ * @internal
  */
 export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   if (getAbstractClass.call(this as any)) return;

--- a/scripts/api-compare/extra-surface-allow.json
+++ b/scripts/api-compare/extra-surface-allow.json
@@ -163,6 +163,48 @@
   },
   {
     "package": "activerecord",
+    "tsFile": "inheritance.ts",
+    "name": "qualifiedName",
+    "reason": "Ruby resolves a model's namespace through the constant path (`Module#name`, `Module#module_parents`) and reads a module-level `table_name_prefix`/`table_name_suffix` off the enclosing module object — see `full_table_name_prefix` in model_schema.rb:301-307. JS classes carry no module path and there are no module objects to respond to those readers, so trails substitutes an explicit registry: namespaced models declare `static moduleName` and their wrapping module registers its decoration here. There is no Ruby `def` to match because Ruby gets this from the object model."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "inheritance.ts",
+    "name": "registerModuleTableNamePrefix",
+    "reason": "Ruby resolves a model's namespace through the constant path (`Module#name`, `Module#module_parents`) and reads a module-level `table_name_prefix`/`table_name_suffix` off the enclosing module object — see `full_table_name_prefix` in model_schema.rb:301-307. JS classes carry no module path and there are no module objects to respond to those readers, so trails substitutes an explicit registry: namespaced models declare `static moduleName` and their wrapping module registers its decoration here. There is no Ruby `def` to match because Ruby gets this from the object model."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "inheritance.ts",
+    "name": "registerModuleTableNameSuffix",
+    "reason": "Ruby resolves a model's namespace through the constant path (`Module#name`, `Module#module_parents`) and reads a module-level `table_name_prefix`/`table_name_suffix` off the enclosing module object — see `full_table_name_prefix` in model_schema.rb:301-307. JS classes carry no module path and there are no module objects to respond to those readers, so trails substitutes an explicit registry: namespaced models declare `static moduleName` and their wrapping module registers its decoration here. There is no Ruby `def` to match because Ruby gets this from the object model."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "inheritance.ts",
+    "name": "registerSubclass",
+    "reason": "Stands in for Ruby's `inherited` hook (inheritance.rb:287), which Rails uses to register each subclass with the DescendantsTracker. TypeScript has no class-definition hook, so subclasses call `registerSubclass(Klass)` from a static initializer block instead. CLAUDE.md already routes Ruby lifecycle hooks to a no-TS-equivalent skip; SKIP_GROUPS is keyed by *Ruby* name and only suppresses the missing-method direction, so the extra TS surface it creates is recorded here."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "inheritance.ts",
+    "name": "enableSti",
+    "reason": "Setter for the `inheritance_column` class_attribute (`class_attribute :inheritance_column, instance_writer: false, default: \"type\"`, model_schema.rb). Rails generates the `inheritance_column=` writer metaprogrammatically, so the Ruby extractor — which records only literal `def`s — has no counterpart to match. trails additionally uses the slot's presence as the STI-enabled sentinel (`stiEnabled`), which is why the writer is named for the effect rather than the attribute."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "inheritance.ts",
+    "name": "getInheritanceColumn",
+    "reason": "Reader for the `inheritance_column` class_attribute (model_schema.rb). Rails generates the reader metaprogrammatically via `class_attribute`, so the Ruby extractor records no literal `def inheritance_column` to match against."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "inheritance.ts",
+    "name": "instantiateSti",
+    "reason": "Free-function form of Rails' STI construction path `instantiate` -> `discriminate_class_for_record` -> `find_sti_class` (inheritance.rb:299-321). Rails overrides `Persistence::ClassMethods#instantiate` in place; trails cannot override a static across the mixin boundary, so the STI-dispatching constructor is a separate named entry point and `instantiate` stays the plain one. The class decision itself lives in the ported `discriminateClassForRecord`."
+  },
+  {
+    "package": "activerecord",
     "tsFile": "associations.ts",
     "name": "registerModel",
     "reason": "trails-only model registry with no Rails analogue: `register_model` is defined nowhere in the Rails source (verified by grep over vendor/rails). Ruby resolves an association's class through constant lookup — Reflection#compute_class (reflection.rb:434 and :490) into Object.const_get, backed by ActiveSupport autoloading — so Rails never registers models anywhere. ESM has no constant namespace to walk and no autoload hook, so trails must be told which classes exist. Deliberately public (re-exported from index.ts) because application code has to call it, which is why @internal would be a lie rather than a fix. Kept in associations.ts because association class resolution is its only consumer path."

--- a/scripts/api-compare/extra-surface-allow.json
+++ b/scripts/api-compare/extra-surface-allow.json
@@ -189,19 +189,19 @@
     "package": "activerecord",
     "tsFile": "inheritance.ts",
     "name": "enableSti",
-    "reason": "Setter for the `inheritance_column` class_attribute (`class_attribute :inheritance_column, instance_writer: false, default: \"type\"`, model_schema.rb). Rails generates the `inheritance_column=` writer metaprogrammatically, so the Ruby extractor — which records only literal `def`s — has no counterpart to match. trails additionally uses the slot's presence as the STI-enabled sentinel (`stiEnabled`), which is why the writer is named for the effect rather than the attribute."
+    "reason": "CONVERGENCE PENDING — story `converge-enablesti-onto-inheritance-column-setter`. Rails has no `enable_sti`: STI is implicit and the column is named by assignment (`self.inheritance_column = 'zoink'`, model_schema.rb:146-151; `class_attribute :inheritance_column, instance_accessor: false, default: \"type\"` at model_schema.rb:172). The faithful writer is already ported and wired — `ModelSchema.inheritanceColumn` behind the Rails-named `Base.inheritanceColumn` setter (base.ts:1653) — so `enableSti(X)` is spelled `X.inheritanceColumn = ...`. Allowlisted to hold the count while the 93 call sites migrate; not a permanent exemption."
   },
   {
     "package": "activerecord",
     "tsFile": "inheritance.ts",
     "name": "getInheritanceColumn",
-    "reason": "Reader for the `inheritance_column` class_attribute (model_schema.rb). Rails generates the reader metaprogrammatically via `class_attribute`, so the Ruby extractor records no literal `def inheritance_column` to match against."
+    "reason": "CONVERGENCE PENDING — story `converge-inheritance-column-reader-onto-ported-nullable`. The faithful reader is already ported: `ModelSchema.inheritanceColumn` (model-schema.ts) returns `null` for `self.inheritance_column = nil` and is exposed as `Base.inheritanceColumn` (base.ts:1649). `getInheritanceColumn` flattens that `null` to `\"type\"`, which is why trails also needs the Rails-less `inheritanceColumnDisabled` predicate to recover the discarded information. Allowlisted to hold the count while callers move to the nullable reader; not a permanent exemption."
   },
   {
     "package": "activerecord",
     "tsFile": "inheritance.ts",
     "name": "instantiateSti",
-    "reason": "Free-function form of Rails' STI construction path `instantiate` -> `discriminate_class_for_record` -> `find_sti_class` (inheritance.rb:299-321). Rails overrides `Persistence::ClassMethods#instantiate` in place; trails cannot override a static across the mixin boundary, so the STI-dispatching constructor is a separate named entry point and `instantiate` stays the plain one. The class decision itself lives in the ported `discriminateClassForRecord`."
+    "reason": "CONVERGENCE PENDING — story `converge-instantiatesti-into-ported-instantiate`. Rails has one entry point, not two: `Persistence::ClassMethods#instantiate` (persistence.rb:100-103) is `discriminate_class_for_record` + `instantiate_instance_of`, and trails' persistence.ts `instantiate` already reproduces that. `instantiateSti` is a second hydration path wrapping the private `directInstantiate`, kept only because the recursion guard in `base.ts:_instantiate` compares the stored type value against the JS class `name` — which diverges from `stiName` for a `storeFullStiClass` namespaced model. Allowlisted to hold the count while the guard is converged to an identity comparison; not a permanent exemption."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/extra-surface-allow.json
+++ b/scripts/api-compare/extra-surface-allow.json
@@ -165,19 +165,19 @@
     "package": "activerecord",
     "tsFile": "inheritance.ts",
     "name": "qualifiedName",
-    "reason": "Ruby resolves a model's namespace through the constant path (`Module#name`, `Module#module_parents`) and reads a module-level `table_name_prefix`/`table_name_suffix` off the enclosing module object — see `full_table_name_prefix` in model_schema.rb:301-307. JS classes carry no module path and there are no module objects to respond to those readers, so trails substitutes an explicit registry: namespaced models declare `static moduleName` and their wrapping module registers its decoration here. There is no Ruby `def` to match because Ruby gets this from the object model."
+    "reason": "Ruby resolves a model's namespace through the constant path (`Module#name`, `Module#module_parents`) and reads a module-level `table_name_prefix`/`table_name_suffix` off the enclosing module object — see `full_table_name_prefix` in model_schema.rb:302-307. JS classes carry no module path and there are no module objects to respond to those readers, so trails substitutes an explicit registry: namespaced models declare `static moduleName` and their wrapping module registers its decoration here. There is no Ruby `def` to match because Ruby gets this from the object model."
   },
   {
     "package": "activerecord",
     "tsFile": "inheritance.ts",
     "name": "registerModuleTableNamePrefix",
-    "reason": "Ruby resolves a model's namespace through the constant path (`Module#name`, `Module#module_parents`) and reads a module-level `table_name_prefix`/`table_name_suffix` off the enclosing module object — see `full_table_name_prefix` in model_schema.rb:301-307. JS classes carry no module path and there are no module objects to respond to those readers, so trails substitutes an explicit registry: namespaced models declare `static moduleName` and their wrapping module registers its decoration here. There is no Ruby `def` to match because Ruby gets this from the object model."
+    "reason": "Ruby resolves a model's namespace through the constant path (`Module#name`, `Module#module_parents`) and reads a module-level `table_name_prefix`/`table_name_suffix` off the enclosing module object — see `full_table_name_prefix` in model_schema.rb:302-307. JS classes carry no module path and there are no module objects to respond to those readers, so trails substitutes an explicit registry: namespaced models declare `static moduleName` and their wrapping module registers its decoration here. There is no Ruby `def` to match because Ruby gets this from the object model."
   },
   {
     "package": "activerecord",
     "tsFile": "inheritance.ts",
     "name": "registerModuleTableNameSuffix",
-    "reason": "Ruby resolves a model's namespace through the constant path (`Module#name`, `Module#module_parents`) and reads a module-level `table_name_prefix`/`table_name_suffix` off the enclosing module object — see `full_table_name_prefix` in model_schema.rb:301-307. JS classes carry no module path and there are no module objects to respond to those readers, so trails substitutes an explicit registry: namespaced models declare `static moduleName` and their wrapping module registers its decoration here. There is no Ruby `def` to match because Ruby gets this from the object model."
+    "reason": "Ruby resolves a model's namespace through the constant path (`Module#name`, `Module#module_parents`) and reads a module-level `table_name_prefix`/`table_name_suffix` off the enclosing module object — see `full_table_name_prefix` in model_schema.rb:302-307. JS classes carry no module path and there are no module objects to respond to those readers, so trails substitutes an explicit registry: namespaced models declare `static moduleName` and their wrapping module registers its decoration here. There is no Ruby `def` to match because Ruby gets this from the object model."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/extra-surface-allow.json
+++ b/scripts/api-compare/extra-surface-allow.json
@@ -187,24 +187,6 @@
   },
   {
     "package": "activerecord",
-    "tsFile": "inheritance.ts",
-    "name": "enableSti",
-    "reason": "CONVERGENCE PENDING — story `converge-enablesti-onto-inheritance-column-setter`. Rails has no `enable_sti`: STI is implicit and the column is named by assignment (`self.inheritance_column = 'zoink'`, model_schema.rb:146-151; `class_attribute :inheritance_column, instance_accessor: false, default: \"type\"` at model_schema.rb:172). The faithful writer is already ported and wired — `ModelSchema.inheritanceColumn` behind the Rails-named `Base.inheritanceColumn` setter (base.ts:1653) — so `enableSti(X)` is spelled `X.inheritanceColumn = ...`. Allowlisted to hold the count while the 93 call sites migrate; not a permanent exemption."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
-    "name": "getInheritanceColumn",
-    "reason": "CONVERGENCE PENDING — story `converge-inheritance-column-reader-onto-ported-nullable`. The faithful reader is already ported: `ModelSchema.inheritanceColumn` (model-schema.ts) returns `null` for `self.inheritance_column = nil` and is exposed as `Base.inheritanceColumn` (base.ts:1649). `getInheritanceColumn` flattens that `null` to `\"type\"`, which is why trails also needs the Rails-less `inheritanceColumnDisabled` predicate to recover the discarded information. Allowlisted to hold the count while callers move to the nullable reader; not a permanent exemption."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
-    "name": "instantiateSti",
-    "reason": "CONVERGENCE PENDING — story `converge-instantiatesti-into-ported-instantiate`. Rails has one entry point, not two: `Persistence::ClassMethods#instantiate` (persistence.rb:100-103) is `discriminate_class_for_record` + `instantiate_instance_of`, and trails' persistence.ts `instantiate` already reproduces that. `instantiateSti` is a second hydration path wrapping the private `directInstantiate`, kept only because the recursion guard in `base.ts:_instantiate` compares the stored type value against the JS class `name` — which diverges from `stiName` for a `storeFullStiClass` namespaced model. Allowlisted to hold the count while the guard is converged to an identity comparison; not a permanent exemption."
-  },
-  {
-    "package": "activerecord",
     "tsFile": "associations.ts",
     "name": "registerModel",
     "reason": "trails-only model registry with no Rails analogue: `register_model` is defined nowhere in the Rails source (verified by grep over vendor/rails). Ruby resolves an association's class through constant lookup — Reflection#compute_class (reflection.rb:434 and :490) into Object.const_get, backed by ActiveSupport autoloading — so Rails never registers models anywhere. ESM has no constant namespace to walk and no autoload hook, so trails must be told which classes exist. Deliberately public (re-exported from index.ts) because application code has to call it, which is why @internal would be a lie rather than a fix. Kept in associations.ts because association class resolution is its only consumer path."

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -70,6 +70,31 @@ function objectLiteralMethods(source: string): MethodInfo[] {
 }
 
 describe("harvestObjectLiteralMethods", () => {
+  it("reads @internal off the declaration a mixin entry references", () => {
+    const methods = objectLiteralMethods(
+      `/** @internal */
+      function hidden(a: number): void {}
+      function shown(a: number): void {}
+      const NS = { aliased: hidden };
+      export const Reg = {
+        hidden,
+        shown,
+        viaProperty: hidden,
+        viaNamespace: NS.aliased,
+        /** @internal */
+        inline(a: number): void {},
+      };`,
+    );
+    const byName = Object.fromEntries(methods.map((m) => [m.name, m.internal === true]));
+    expect(byName).toEqual({
+      hidden: true,
+      shown: false,
+      viaProperty: true,
+      viaNamespace: true,
+      inline: true,
+    });
+  });
+
   it("captures params for inline method and function-property forms", () => {
     const methods = objectLiteralMethods(
       `export const Reg = {

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1251,24 +1251,26 @@ export function hasInternalJsDocTag(node: ts.Node): boolean {
 }
 
 /**
- * True when the callable a mixin-object entry references (`qux,` /
- * `foo: NS.bar`) is itself declared `@internal`. A Rails-style mixin object
- * re-exports one declaration under many hosts — model-schema.ts's
- * `ClassMethods` entry, base.ts's `Base` class surface, index.ts's re-export —
- * so the internal-ness has to be read off the single declaration rather than
- * re-tagged at every install site.
+ * True when `symbol` resolves to a declaration tagged `@internal`. A mixin
+ * object re-exports one declaration under many hosts (ClassMethods, the Base
+ * class surface, the index re-export), so the tag is read once at the
+ * declaration rather than re-applied at every install site. Callers must pass
+ * the *value* symbol — a shorthand's own name resolves to the property symbol.
  */
 function isInternalSymbol(symbol: ts.Symbol | undefined, checker: ts.TypeChecker): boolean {
-  // A shorthand's own name resolves to the *property* symbol, so callers must
-  // hand in the value symbol; an import binding resolves to an alias, whose
-  // JSDoc lives on the aliased declaration.
   let target = symbol;
   if (target && target.flags & ts.SymbolFlags.Alias) target = checker.getAliasedSymbol(target);
   return (target?.declarations ?? []).some((d) => hasInternalJsDocTag(d));
 }
 
 function isInternalCallableRef(expr: ts.Expression, checker: ts.TypeChecker): boolean {
-  return isInternalSymbol(checker.getSymbolAtLocation(expr), checker);
+  if (isInternalSymbol(checker.getSymbolAtLocation(expr), checker)) return true;
+  // A property access resolves to the property, not the function it holds;
+  // fall through to the call signature's declaration, as paramsOfCallableRef does.
+  return checker
+    .getTypeAtLocation(expr)
+    .getCallSignatures()
+    .some((sig) => sig.declaration != null && hasInternalJsDocTag(sig.declaration));
 }
 
 /**

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1251,6 +1251,27 @@ export function hasInternalJsDocTag(node: ts.Node): boolean {
 }
 
 /**
+ * True when the callable a mixin-object entry references (`qux,` /
+ * `foo: NS.bar`) is itself declared `@internal`. A Rails-style mixin object
+ * re-exports one declaration under many hosts — model-schema.ts's
+ * `ClassMethods` entry, base.ts's `Base` class surface, index.ts's re-export —
+ * so the internal-ness has to be read off the single declaration rather than
+ * re-tagged at every install site.
+ */
+function isInternalSymbol(symbol: ts.Symbol | undefined, checker: ts.TypeChecker): boolean {
+  // A shorthand's own name resolves to the *property* symbol, so callers must
+  // hand in the value symbol; an import binding resolves to an alias, whose
+  // JSDoc lives on the aliased declaration.
+  let target = symbol;
+  if (target && target.flags & ts.SymbolFlags.Alias) target = checker.getAliasedSymbol(target);
+  return (target?.declarations ?? []).some((d) => hasInternalJsDocTag(d));
+}
+
+function isInternalCallableRef(expr: ts.Expression, checker: ts.TypeChecker): boolean {
+  return isInternalSymbol(checker.getSymbolAtLocation(expr), checker);
+}
+
+/**
  * Extract method names from an object literal — covers the four shapes
  * Rails-style mixin modules use:
  *
@@ -1280,6 +1301,7 @@ export function harvestObjectLiteralMethods(
     let params: ParamInfo[] = [];
     let optionKeys: string[] | null | undefined;
     let calls: string[] | undefined;
+    let internal = hasInternalJsDocTag(prop);
     if (ts.isMethodDeclaration(prop) && prop.name && ts.isIdentifier(prop.name)) {
       mname = prop.name.text;
       params = extractParameters(prop.parameters);
@@ -1288,6 +1310,7 @@ export function harvestObjectLiteralMethods(
     } else if (ts.isShorthandPropertyAssignment(prop)) {
       mname = prop.name.text;
       params = paramsOfCallableRef(prop.name, checker) ?? [];
+      internal = isInternalSymbol(checker.getShorthandAssignmentValueSymbol(prop), checker);
     } else if (ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name)) {
       const init = prop.initializer;
       if (ts.isFunctionExpression(init) || ts.isArrowFunction(init)) {
@@ -1303,6 +1326,7 @@ export function harvestObjectLiteralMethods(
         if (resolved) {
           mname = prop.name.text;
           params = resolved;
+          internal = isInternalCallableRef(init, checker);
         }
       }
     }
@@ -1314,6 +1338,7 @@ export function harvestObjectLiteralMethods(
       params,
       line,
       file,
+      ...(internal ? { internal: true } : {}),
       ...(optionKeys !== undefined ? { optionKeys } : {}),
       ...(calls !== undefined ? { calls } : {}),
     });


### PR DESCRIPTION
Classifies the STI / schema-host registry extra surface found by the
`extra-surface-activerecord-top-files-inventory` spike.

## Novel extra surface, per file

| File | before | after |
| --- | --- | --- |
| `inheritance.ts` | 14 | **3** |
| `model-schema.ts` | 9 | **0** |
| package total (`activerecord`) | 536 | **514** |

The three left standing on `inheritance.ts` are deliberate — see
"Convergence pending" below. They are *not* allowlisted, so the counter keeps
showing the debt until it is paid.

Baseline re-measured on `origin/main` after rebasing onto `ff1924ee8` (#5341
landed the sibling `associations.ts` classification and moved the package
total), so the before-column is the current main, not this PR's first revision.

`api:compare` parity is unchanged: `inheritance.rb` 28/28, `model_schema.rb`
65/65, data layer 7714/7810 (98.8%), overall 11678/17484 — identical on
`origin/main` and on this branch.

## How each name was classified

**`@internal`** — internal machinery, not Rails-facing surface:
`namespaceSegments`, `moduleParentChain`, `lookupModuleTableNamePrefix`,
`lookupModuleTableNameSuffix`, `isStiSubclass`, `getStiBase`,
`defineDynamicSelectReaders`, `resolveTableName`, `buildPkWhere`,
`buildPkWhereNode`, `buildWhereNodeFromConstraints`, `attributeSetCoder`,
`cachedColumnsHash`, `hasAttributeDefinition`, `loadSchemaFromAdapter`.

Three of those carried a `Mirrors:` line that named no real Rails method
(`Mirrors: used throughout ActiveRecord persistence internals`); those are
dropped rather than left as false anchors. `hasAttributeDefinition`'s comment
pointed at `ModelSchema::ClassMethods#has_attribute?`, which does not exist —
`has_attribute?` lives in `attribute_methods.rb` and is already credited to
`Base.hasAttribute`, so the comment now says what the helper actually backs.

**Un-exported** — `sqlTypeFor` had no caller outside `model-schema.ts`.

**`extra-surface-allow.json`** (4 entries) — irreducible Ruby object-model
substitutes, with no Ruby `def` for the extractor to match:

- `qualifiedName`, `registerModuleTableNamePrefix`,
  `registerModuleTableNameSuffix` — Ruby reads a module-level
  `table_name_prefix`/`table_name_suffix` off the enclosing module object via
  constant lookup (`full_table_name_prefix`, model_schema.rb:302-307). JS
  classes carry no module path and there are no module objects to respond, so
  trails substitutes an explicit registry. Converging `qualifiedName` would mean
  overriding `static name` on `Base`, which is not worth the blast radius.
- `registerSubclass` — stands in for the `inherited` hook (inheritance.rb:287).

*Deliberately NOT allowlisted — three names turned out not to be irreducible.*
Each duplicates a Rails method trails has **already ported**, so the honest
classification is "remove", not "exempt". The allowlist is a justified-exemptions
ratchet that only ever shrinks; parking deferred work in it would launder debt
through the very counter that is supposed to measure it, and a future reader
could not tell an exemption from an IOU. So these three stay on the novel list
(hence 3, not 0) and are tracked as stories instead:

| Name | Already-ported faithful form | Story |
| --- | --- | --- |
| `getInheritanceColumn` | `ModelSchema.inheritanceColumn` / `Base.inheritanceColumn` (base.ts:1649) — returns `null` for `inheritance_column = nil`, which this reader flattens to `"type"`, forcing the Rails-less `inheritanceColumnDisabled` predicate to exist to recover it | `converge-inheritance-column-reader-onto-ported-nullable` |
| `enableSti` | the `Base.inheritanceColumn` setter (base.ts:1653) — Rails spells this `self.inheritance_column = 'zoink'` (model_schema.rb:146-151, 172); there is no `enable_sti`. 93 call sites, ~190 LOC | `converge-enablesti-onto-inheritance-column-setter` |
| `instantiateSti` | `persistence.ts:instantiate`, which already reproduces `discriminate_class_for_record` + `instantiate_instance_of` (persistence.rb:100-103). Blocked on the recursion guard in `base.ts:_instantiate` comparing the stored type value to the JS class `name`, which diverges from `stiName` under `storeFullStiClass` | `converge-instantiatesti-into-ported-instantiate` |

`instantiateSti`'s reason in the first revision of this PR was **factually
wrong** — it claimed Rails overrides `instantiate` in inheritance.rb and that
trails cannot override a static across the mixin boundary. Rails has one entry
point and puts the dispatch inside it.

This deviates from the story's acceptance criteria, which asked that every
remaining name land in one of removed / `SKIP_GROUPS` / `@internal` /
allowlist-with-reason. Three land in none of them on purpose: allowlisting
unconverged duplication is worse than leaving the count honest. `pnpm api:extra`
fails only on malformed or stale allowlist entries, never on a nonzero novel
count, so nothing is gated by this and CI is unaffected.

**Not `SKIP_GROUPS`.** The story asked whether the CLAUDE.md
"Ruby-lifecycle-hook → SKIP_GROUPS" route was the right home for
`registerSubclass` and the `module_parents` substitutes. It is not:
`SKIP_GROUPS` is keyed by *Ruby* method name and feeds the missing-method
direction only. It cannot suppress an extra *TypeScript* name, so the
extra surface those substitutes create is recorded in the allowlist instead.

On the "STI schema-host redirect is a trails invention" warning: none of these
23 names are that scaffolding — the redirect lives in the `SchemaHost` /
`_schemaHost` plumbing, which this PR does not touch. The only name removable
outright here was the `sqlTypeFor` export; the three convergences above are
removals too, just ones that need their own PRs.

Net effect on the ratchet: 20 of 23 names resolved (15 `@internal`, 1 unexported,
4 allowlisted with reasons), 3 left visible and owned by stories.

## Extractor fix

`harvestObjectLiteralMethods` hardcoded `visibility: "public"` and never looked
at the referenced declaration, so a name installed on `model-schema.ts`'s
`ClassMethods` object surfaced as novel on `ClassMethods`, on `base.ts:Base`,
and on `index.ts:Base` — three reports of one declaration, and `@internal` at
the declaration suppressed none of them. It now reads `@internal` off the
symbol the entry resolves to (via `getShorthandAssignmentValueSymbol` for the
shorthand form, the aliased symbol for imports), so the tag is honored once at
the declaration. This is what dropped `loadSchemaFromAdapter` from `base.ts`'s
novel list too.

`attributeSetCoder` and `hasAttributeDefinition` still appear on `base.ts`'s
list from its own `declare static` re-declarations. Class *members* are a
separate extractor path that likewise ignores `@internal` JSDoc; widening that
would shift counts across every package, so it belongs with the base.ts
inventory story rather than here.

## Testing

- `pnpm vitest run` over inheritance.test.ts, inheritance-namespaced.test.ts,
  model-schema.test.ts, model-schema-load.test.ts, sti-attribute-routing.test.ts,
  select-alias-reader.trails.test.ts, modules.test.ts — 119 passed, 11 skipped.
- `pnpm vitest run` over extract-ts-api.test.ts, extra-surface.test.ts,
  extractor-skew.test.ts, conventions.test.ts — 158 passed, including a new case
  covering the extractor fix (shorthand, property-assignment, namespace-property
  and inline forms).
- `pnpm test:compare` — 14606/21663 (67.4%), unchanged; no test file under
  `packages/` is touched.
- `pnpm typecheck` clean.

## Rebase note

Rebased onto `ff1924ee8`. The only conflict was `extra-surface-allow.json`,
where #5341 appended `associations.ts` entries to the same array. Resolved as a
union — all 29 main-side entries preserved (verified programmatically: 0 lost,
both #5341 `associations.ts` entries intact), plus this branch's 4. No sibling
entry was dropped or reworded.

Closes-story: extra-surface-sti-and-schema-registry-names
