### PR TITLE
fix(api-compare): scope includer-graph include resolution to Ruby constant lookup

### DIFF
--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -7,6 +7,7 @@ import {
   tsShouldIncludeInIndex,
   flattenIncludedMethodInfos,
   resolveModuleName,
+  buildModuleIncluderFqns,
   dedupeRubyMethodInto,
   selectMisplacedFile,
   MISPLACED_MIN_HITS,
@@ -913,10 +914,7 @@ describe("resolveModuleName", () => {
 
   it("binds a class's own nested module over an identically-named sibling's", () => {
     // `class Rack::Request; include Helpers; end` where both Request and
-    // Response nest a `Helpers`: Ruby binds Request's. The includer-graph
-    // builder relies on this — the broad lookup it used to do made
-    // Response's TS file count as an implementation site for Request's
-    // methods.
+    // Response nest a `Helpers`: Ruby binds Request's.
     const byShort = new Map([["Helpers", ["Rack::Request::Helpers", "Rack::Response::Helpers"]]]);
     expect(resolveModuleName("Helpers", "Rack::Request", byShort)).toEqual([
       "Rack::Request::Helpers",
@@ -924,6 +922,49 @@ describe("resolveModuleName", () => {
     expect(resolveModuleName("Helpers", "Rack::Response::Raw", byShort)).toEqual([
       "Rack::Response::Helpers",
     ]);
+  });
+});
+
+describe("buildModuleIncluderFqns", () => {
+  function entity(name: string, includes: string[] = [], extendsList: string[] = []): ClassInfo {
+    return {
+      name: name.split("::").pop()!,
+      file: `${name.split("::").pop()!.toLowerCase()}.rb`,
+      includes,
+      extends: extendsList,
+      instanceMethods: [],
+      classMethods: [],
+    };
+  }
+
+  const byShort = new Map([
+    ["Helpers", ["Rack::Request::Helpers", "Rack::Response::Helpers"]],
+    ["Env", ["Rack::Request::Env"]],
+  ]);
+
+  it("registers an includer only against the module Ruby's lookup binds", () => {
+    // Regression: resolving unqualified names against the raw short-name map
+    // registered Rack::Request as an includer of Rack::Response::Helpers,
+    // which made response.ts an implementation site for Request's headers.
+    const graph = buildModuleIncluderFqns(
+      [
+        { fqn: "Rack::Request", info: entity("Rack::Request", ["Env", "Helpers"]) },
+        { fqn: "Rack::Response", info: entity("Rack::Response", ["Helpers"]) },
+      ],
+      byShort,
+    );
+    expect([...(graph.get("Rack::Request::Helpers") ?? [])]).toEqual(["Rack::Request"]);
+    expect([...(graph.get("Rack::Response::Helpers") ?? [])]).toEqual(["Rack::Response"]);
+    expect([...(graph.get("Rack::Request::Env") ?? [])]).toEqual(["Rack::Request"]);
+  });
+
+  it("registers extends alongside includes and keeps unknown names verbatim", () => {
+    const graph = buildModuleIncluderFqns(
+      [{ fqn: "Rack::Request", info: entity("Rack::Request", ["Helpers"], ["Comparable"]) }],
+      byShort,
+    );
+    expect([...(graph.get("Comparable") ?? [])]).toEqual(["Rack::Request"]);
+    expect(graph.has("Rack::Response::Helpers")).toBe(false);
   });
 });
 

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -910,6 +910,21 @@ describe("resolveModuleName", () => {
     );
     expect(result).toEqual(["AR::ConnectionAdapters::PostgreSQL::Quoting"]);
   });
+
+  it("binds a class's own nested module over an identically-named sibling's", () => {
+    // `class Rack::Request; include Helpers; end` where both Request and
+    // Response nest a `Helpers`: Ruby binds Request's. The includer-graph
+    // builder relies on this — the broad lookup it used to do made
+    // Response's TS file count as an implementation site for Request's
+    // methods.
+    const byShort = new Map([["Helpers", ["Rack::Request::Helpers", "Rack::Response::Helpers"]]]);
+    expect(resolveModuleName("Helpers", "Rack::Request", byShort)).toEqual([
+      "Rack::Request::Helpers",
+    ]);
+    expect(resolveModuleName("Helpers", "Rack::Response::Raw", byShort)).toEqual([
+      "Rack::Response::Helpers",
+    ]);
+  });
 });
 
 describe("dedupeRubyMethodInto", () => {

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -698,6 +698,12 @@ function nearestNamespaceMatch(
  * namespace-prefix walking picks the nearest enclosing match; if none of the
  * candidates share a namespace prefix with the context the full candidate list
  * is returned (original behavior, safe fallback).
+ *
+ * Every consumer of `moduleFqnByShort` resolves through here — both the
+ * expected-surface flattener (`flattenIncludedMethodInfos`) and the
+ * includer-graph builder in `main`. They must not disagree: a broader lookup
+ * in one of them lets a method count as implemented in a file that Ruby's
+ * constant lookup never binds.
  */
 export function resolveModuleName(
   incName: string,
@@ -1271,13 +1277,19 @@ export function main() {
     for (const { fqn, info } of allClassesAndModules) {
       if (info.file) fqnToFile.set(fqn, info.file);
       for (const inc of [...(info.includes || []), ...(info.extends || [])]) {
-        // Qualified names need the namespace walk (`PostgreSQL::Quoting` is not
-        // a key here); unqualified ones stay deliberately broad — narrowing them
-        // to the scoped match drops 21 methods that this graph legitimately
-        // credits to a sibling includer's file.
-        const resolved = inc.includes("::")
-          ? resolveModuleName(inc, fqn, moduleFqnByShort)
-          : moduleFqnByShort.get(inc) || [inc];
+        // Same Ruby constant lookup as `flattenIncludedMethodInfos` — the two
+        // consumers of `moduleFqnByShort` must agree on which module an
+        // `include` binds. This builder used to be deliberately broad
+        // (`moduleFqnByShort.get(inc)`, i.e. every module sharing the short
+        // name became an includer). That credited 21 methods to a file Ruby
+        // would never reach: `Rack::Request`'s `get_header`/`set_header`/
+        // `has_header?`/`body` were matched in `response.ts` via
+        // `Rack::Response::Helpers`, `ActionView::ViewPaths`' surface in
+        // `lookup-context.ts` via `LookupContext::ViewPaths`, and
+        // `MySQL::TableDefinition#charset`/`collation` in the abstract
+        // `TableDefinition`. All of them are real gaps, so the narrowing
+        // surfaces them instead of hiding them.
+        const resolved = resolveModuleName(inc, fqn, moduleFqnByShort);
         for (const modFqn of resolved) {
           const includers = moduleIncluderFqns.get(modFqn) || new Set();
           includers.add(fqn);

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -699,11 +699,10 @@ function nearestNamespaceMatch(
  * candidates share a namespace prefix with the context the full candidate list
  * is returned (original behavior, safe fallback).
  *
- * Every consumer of `moduleFqnByShort` resolves through here — both the
- * expected-surface flattener (`flattenIncludedMethodInfos`) and the
- * includer-graph builder in `main`. They must not disagree: a broader lookup
- * in one of them lets a method count as implemented in a file that Ruby's
- * constant lookup never binds.
+ * Every consumer of `moduleFqnByShort` resolves through here —
+ * `flattenIncludedMethodInfos` (expected surface) and `buildModuleIncluderFqns`
+ * (where that surface may be implemented). A broader lookup in either one lets
+ * a method count as implemented in a file Ruby's constant lookup never binds.
  */
 export function resolveModuleName(
   incName: string,
@@ -724,6 +723,35 @@ export function resolveModuleName(
   const nearest = nearestNamespaceMatch(incName, contextFqn, candidates);
   // No prefix match — fall back to all candidates (original behavior).
   return nearest ? [nearest] : candidates;
+}
+
+/**
+ * Build the direct `include`/`extend` graph: module FQN → FQNs that mix it in.
+ *
+ * Downstream this becomes "TS files a module's methods may legitimately live
+ * in", so a wrong edge here is a false match, not just noise. `include` names
+ * resolve through `resolveModuleName` — the same Ruby constant lookup
+ * `flattenIncludedMethodInfos` uses, and the reason both live in this file.
+ * The two must never diverge: this builder once resolved unqualified names
+ * against the raw short-name map, which made `Rack::Response::Helpers`'
+ * `response.ts` an implementation site for `Rack::Request`'s headers even
+ * though `class Rack::Request; include Helpers` binds its own nested module.
+ */
+export function buildModuleIncluderFqns(
+  entities: { fqn: string; info: ClassInfo }[],
+  moduleFqnByShort: Map<string, string[]>,
+): Map<string, Set<string>> {
+  const moduleIncluderFqns = new Map<string, Set<string>>();
+  for (const { fqn, info } of entities) {
+    for (const inc of [...(info.includes || []), ...(info.extends || [])]) {
+      for (const modFqn of resolveModuleName(inc, fqn, moduleFqnByShort)) {
+        const includers = moduleIncluderFqns.get(modFqn) || new Set<string>();
+        includers.add(fqn);
+        moduleIncluderFqns.set(modFqn, includers);
+      }
+    }
+  }
+  return moduleIncluderFqns;
 }
 
 /**
@@ -1262,7 +1290,6 @@ export function main() {
     // Named's methods should also be checked against base.ts.
 
     // Step 1: build direct include/extend graph (module FQN → includer FQNs)
-    const moduleIncluderFqns = new Map<string, Set<string>>();
     const allClassesAndModules = [
       ...Object.entries(rubyPkg.classes).map(([fqn, info]) => ({
         fqn,
@@ -1276,27 +1303,8 @@ export function main() {
     const fqnToFile = new Map<string, string>();
     for (const { fqn, info } of allClassesAndModules) {
       if (info.file) fqnToFile.set(fqn, info.file);
-      for (const inc of [...(info.includes || []), ...(info.extends || [])]) {
-        // Same Ruby constant lookup as `flattenIncludedMethodInfos` — the two
-        // consumers of `moduleFqnByShort` must agree on which module an
-        // `include` binds. This builder used to be deliberately broad
-        // (`moduleFqnByShort.get(inc)`, i.e. every module sharing the short
-        // name became an includer). That credited 21 methods to a file Ruby
-        // would never reach: `Rack::Request`'s `get_header`/`set_header`/
-        // `has_header?`/`body` were matched in `response.ts` via
-        // `Rack::Response::Helpers`, `ActionView::ViewPaths`' surface in
-        // `lookup-context.ts` via `LookupContext::ViewPaths`, and
-        // `MySQL::TableDefinition#charset`/`collation` in the abstract
-        // `TableDefinition`. All of them are real gaps, so the narrowing
-        // surfaces them instead of hiding them.
-        const resolved = resolveModuleName(inc, fqn, moduleFqnByShort);
-        for (const modFqn of resolved) {
-          const includers = moduleIncluderFqns.get(modFqn) || new Set();
-          includers.add(fqn);
-          moduleIncluderFqns.set(modFqn, includers);
-        }
-      }
     }
+    const moduleIncluderFqns = buildModuleIncluderFqns(allClassesAndModules, moduleFqnByShort);
 
     // Step 2: transitively resolve includer files (DFS with memoization)
     const moduleIncluderFiles = new Map<string, Set<string>>();


### PR DESCRIPTION
`compare.ts` had two consumers of `moduleFqnByShort` that disagreed on how
scoped an `include` resolution should be. `flattenIncludedMethodInfos` went
through `resolveModuleName` (Ruby's constant lookup: walk the enclosing
namespaces nearest-outward); the includer-graph builder did a raw
`moduleFqnByShort.get(inc)`, so every module sharing the short name got the
includer registered against it.

This routes the graph builder through `resolveModuleName` too. The divergence
is removed rather than documented, because all 21 methods it was crediting are
real gaps.

## The 21 methods, audited

Narrowing changes exactly these include edges (whole corpus). Each `kept`
binding was verified against `vendor/rails/` / `vendor/rack/` nesting:

| Includer | `include` | Broad also bound | Ruby binds |
| --- | --- | --- | --- |
| `Rack::Request` | `Helpers` | `Rack::Response::Helpers` | `Rack::Request::Helpers` |
| `ActionView::LookupContext` | `ViewPaths` | `ActionView::ViewPaths` | `ActionView::LookupContext::ViewPaths` |
| `AR::CA::{MySQL,PostgreSQL}::{TableDefinition,Table}` | `ColumnMethods` | `AR::CA::ColumnMethods` + the other adapter's | own adapter's `ColumnMethods` |
| `AS::Messages::SerializerWithFallback::*` | `SerializerWithFallback` | `AS::Cache::SerializerWithFallback` | `AS::Messages::SerializerWithFallback` |

(`AR::Base include Serialization`, `AR::CA::AbstractAdapter include
Quoting`/`DatabaseStatements`/`SchemaStatements` also narrow, but they lost no
matches.)

Where the TS actually lives, per cluster:

- **rack `request.rb` (4)** — `get_header` / `set_header` / `has_header?` /
  `body` are **not** in `packages/rack/src/request.ts`; that class exposes
  `get`/`set`/`has` instead, and has no `body`. The matches came from
  `response.ts`. Real gap.
- **actionview `view_paths.rb` (9)** — there is no `view-paths.ts` at all;
  `ActionView::ViewPaths` is unported. The matches came from `lookup-context.ts`,
  which implements the *other* `ViewPaths` module. Real gap.
- **activesupport `messages/serializer_with_fallback.rb` (5)** — no
  `messages/serializer-with-fallback.ts`; matches came from the unrelated
  `Cache::SerializerWithFallback` port. Real gap.
- **activerecord (3)** — `MySQL::TableDefinition#charset`/`collation` are
  `attr_reader`s in Rails but only constructor params in our TS (matched against
  the abstract `TableDefinition`'s fields); `PostgreSQL::TableDefinition#integer_like_primary_key_type`
  is an `@internal` NIE stub in `postgresql/schema-definitions.ts` and was being
  credited to the abstract class's real implementation. Real gaps.

## Totals

`pnpm api:compare`:

- Overall **11678/17484 (66.8%) → 11657/17484 (66.7%)**, denominator unchanged.
- Data layer 7717/7810 → 7714/7810; files 761/1019 and inheritance 533/587 unchanged.
- Arity 7433/7516 → 7423/7506 (no new mismatch; 83 either way).
- `pnpm api:calls` and `pnpm api:arity` ratchets both still OK.

## Keeping the two consumers aligned

The graph was built inline in `main()`, so nothing structurally kept it in step
with `flattenIncludedMethodInfos` — which is why the divergence survived review
in the first place. It is now an exported `buildModuleIncluderFqns` sitting
directly beside the flattener, with two tests pinning the
`Rack::Request` / `Rack::Response::Helpers` shape the broad lookup got wrong.
`resolveModuleName`'s doc names both callers as the invariant. Behaviour is
identical to the one-line version (same 11657).

## Follow-ups registered

The 21 gaps are real but out of scope here, so they are owned stories under
this RFC rather than orphans:

- `rack-request-env-header-accessors` (4)
- `actionview-view-paths-module-port` (9)
- `activesupport-messages-serializer-with-fallback-port` (5)
- `ar-mysql-table-definition-charset-collation-readers` (2)

The remaining one, PG `integer_like_primary_key_type`, is already an `@nie`
stub in the `pg-long-tail` cluster.

Closes-story: api-compare-scope-includer-graph-resolution
