### PR TITLE
refactor(api-compare): one decision per recurring adapter name across five files

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -545,7 +545,15 @@ export interface AbstractAdapter {
    * "This statement does not return data. Use run() instead" on a non-reader
    * statement, so `execute` must first grow the `column_count.zero?` branch.
    *
-   * Convergence is tracked as RFC 0023 `unify-execute-mutation-into-perform-query`.
+   * Convergence lives in **RFC 0076 `execute-primitive-convergence`** — e.g.
+   * `inline-mysql-exec-mutation-indirection`, `sqlite-truncate-through-execute`,
+   * `converge-vestigial-postgresql-perform-query`. Do NOT cite RFC 0023
+   * `unify-execute-mutation-into-perform-query` here: that story and its
+   * per-adapter siblings are already `done` (the shared `performQuery`
+   * primitive exists on all three adapters and DDL in
+   * `abstract/schema-statements.ts` already routes through `execute`), so it
+   * will not delete anything further and sends readers chasing a closed story.
+   *
    * The concrete adapters' `executeMutation` overrides (postgresql-adapter.ts,
    * sqlite3-adapter.ts) carry the same rationale by pointing here — do not
    * restate it there, and do not add a third primitive.
@@ -2389,9 +2397,13 @@ export class AbstractAdapter implements Quoting {
    * reports back by mutating it — which is how Rails' `raw_execute` hands
    * `notification_payload` to `perform_query` for `row_count`/`statement_name`.
    *
-   * trails' `rawExecute` does not call `log` yet; wiring that up is part of
-   * `unify-execute-mutation-into-perform-query` (RFC 0023), which first needs
-   * `performQuery` on sqlite3/mysql2 (only PG assigns one today).
+   * trails' `rawExecute` does not call `log` yet; wiring that up is RFC 0076
+   * `wire-raw-execute-through-log`. (This used to cite RFC 0023
+   * `unify-execute-mutation-into-perform-query` "which first needs performQuery
+   * on sqlite3/mysql2 (only PG assigns one today)" — both halves are now stale:
+   * that story is `done`, and all three adapters have the primitive, PG on the
+   * prototype, sqlite3 as `_performQuery`, mysql2 by calling the imported
+   * `performQuery` directly.)
    */
   async log<T>(
     sql: string,

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -155,18 +155,13 @@ export class Version {
     return this._version;
   }
 
-  get major(): number {
-    return this._parts[0] ?? 0;
-  }
-
-  get minor(): number {
-    return this._parts[1] ?? 0;
-  }
-
-  get patch(): number {
-    return this._parts[2] ?? 0;
-  }
-
+  /**
+   * Rails' Version `include Comparable` and defines only `<=>`; `>=` / `<`
+   * come from Comparable itself, so there is no `def gte` to mirror
+   * (abstract_adapter.rb:243-259). `gte`/`lt` are the TS spelling of those two
+   * Comparable operators — the only ones any caller uses — over the same
+   * dotted-part comparison `<=>` performs.
+   */
   gte(other: Version | string): boolean {
     const otherVersion = typeof other === "string" ? new Version(other) : other;
     for (let i = 0; i < Math.max(this._parts.length, otherVersion._parts.length); i++) {
@@ -532,6 +527,29 @@ export interface AbstractAdapter {
     name?: string,
     opts?: { allowRetry?: boolean },
   ): Promise<Record<string, unknown>[]>;
+  /**
+   * CANONICAL DEVIATION — `execute` / `executeMutation` split.
+   *
+   * Rails has ONE query primitive per adapter, `perform_query`, which branches
+   * on `stmt.column_count.zero?` to decide whether it returns rows
+   * (sqlite3/database_statements.rb:78-112; abstract/database_statements.rb:561,
+   * postgresql/database_statements.rb:135, mysql2/database_statements.rb:41).
+   * Affected-row counts come from a separate `raw_connection.changes` read, not
+   * from the result.
+   *
+   * trails splits that into two: `execute` (row-returning, wired to the dirty
+   * query cache) and `executeMutation` (row-count / lastInsertRowid, readonly
+   * guard, materializes transactions). **The split itself is the deviation** —
+   * it is not a naming difference. It cannot be collapsed by rerouting callers:
+   * sqlite's `execute` runs `stmt.all()`, and better-sqlite3 throws
+   * "This statement does not return data. Use run() instead" on a non-reader
+   * statement, so `execute` must first grow the `column_count.zero?` branch.
+   *
+   * Convergence is tracked as RFC 0023 `unify-execute-mutation-into-perform-query`.
+   * The concrete adapters' `executeMutation` overrides (postgresql-adapter.ts,
+   * sqlite3-adapter.ts) carry the same rationale by pointing here — do not
+   * restate it there, and do not add a third primitive.
+   */
   executeMutation(sql: string, binds?: unknown[], name?: string): Promise<number>;
   beginTransaction(): Promise<void>;
   commit(): Promise<void>;
@@ -1650,10 +1668,6 @@ export class AbstractAdapter implements Quoting {
     return false;
   }
 
-  verifyCalled(): boolean {
-    return true;
-  }
-
   /**
    * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#raw_connection
    * (abstract_adapter.rb). Materializes any pending transaction and disables
@@ -1885,12 +1899,13 @@ export class AbstractAdapter implements Quoting {
 
   async dropEnum(_name: string): Promise<void> {}
 
-  async createRange(
-    _name: string,
-    _options: { subtype: string; subtypeDiff?: string },
-  ): Promise<void> {}
-
-  async dropRange(_name: string, _options?: { ifExists?: boolean }): Promise<void> {}
+  // No `createRange`/`dropRange` here on purpose. Rails stubs only the enum
+  // quartet on the abstract base (create_enum/drop_enum/rename_enum/
+  // rename_enum_value, abstract_adapter.rb:576-595) — there is no range-type
+  // DDL anywhere in Rails, so a no-op base stub would be inventing an abstract
+  // hook Rails never had. The trails-only range helpers live where the DDL is
+  // actually emitted, PostgreSQL::SchemaStatements (postgresql/
+  // schema-statements-class.ts), with their justification at that call site.
 
   async renameEnum(_oldName: string, _newName: string): Promise<void> {}
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -194,8 +194,6 @@ const QUOTE_STRING_MAP: Record<string, string> = {
 };
 
 export class AbstractMysqlAdapter extends AbstractAdapter {
-  static readonly Version = Version;
-
   /**
    * Return Column objects for a table. Mirrors Rails'
    * `AbstractMysqlAdapter#columns` (via `SchemaStatements#columns`):

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1007,7 +1007,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   /** @internal Mirrors: AbstractMysqlAdapter#text_type? */
   isTextType(type: string): boolean {
-    const t = this.nativeTypeMap.lookup(type.toLowerCase().trim());
+    const t = this._nativeTypeMap.lookup(type.toLowerCase().trim());
     return t instanceof StringType || t instanceof TextType;
   }
 
@@ -1335,7 +1335,14 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return args;
   }
 
-  static buildTypeMap(
+  /**
+   * Rails builds the adapter's type map with `initialize_type_map(m)` on a
+   * fresh `TypeMap` (abstract_mysql_adapter.rb:711). trails keeps that Rails
+   * name for the registration pass and puts the allocate-then-register wrapper
+   * behind the Rails-private `_` prefix, matching the already-converged
+   * spelling on `AbstractSQLite3Adapter._buildTypeMap`.
+   */
+  protected static _buildTypeMap(
     this: typeof AbstractMysqlAdapter,
     options: { emulateBooleans?: boolean } = {},
   ): TypeMap {
@@ -1366,9 +1373,15 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     this._typeMap = null;
   }
 
-  get nativeTypeMap(): TypeMap {
+  /**
+   * The memoized native type map. Rails reaches it through the adapter's own
+   * `type_map` (abstract_adapter.rb) and never exposes a separate public
+   * accessor, so this stays Rails-private (`_` prefix) — the same spelling
+   * `AbstractSQLite3Adapter` uses for its `_nativeTypeMap` slot.
+   */
+  get _nativeTypeMap(): TypeMap {
     if (!this._typeMap) {
-      this._typeMap = (this.constructor as typeof AbstractMysqlAdapter).buildTypeMap({
+      this._typeMap = (this.constructor as typeof AbstractMysqlAdapter)._buildTypeMap({
         emulateBooleans: this._emulateBooleans,
       });
     }
@@ -1376,7 +1389,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   }
 
   lookupCastType(sqlType: string): import("@blazetrails/activemodel").Type {
-    return this.nativeTypeMap.lookup(sqlType.toLowerCase().trim());
+    return this._nativeTypeMap.lookup(sqlType.toLowerCase().trim());
   }
 
   lookupCastTypeFromColumn(column: {

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -484,8 +484,9 @@ export function columnNameWithOrderMatcher(): RegExp {
  * Rails writes this inline as `Arel::Nodes::SqlLiteral === value` at each
  * branch (abstract/quoting.rb `quote`/`type_cast`); there is no
  * `sql_literal?` predicate to mirror. Factored out here only because TS
- * cannot spell `===`-style case matching, so it is module-internal — same
- * treatment as the `dispatch*` helpers alongside it.
+ * cannot spell `===`-style case matching. Adapter-internal rather than public
+ * API — sqlite3-adapter.ts imports it for the same branch — so it carries the
+ * same `@internal` marking as the `dispatch*` helpers alongside it.
  *
  * @internal
  */

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -480,6 +480,15 @@ export function columnNameWithOrderMatcher(): RegExp {
   return /^((?:(?:\w+\.)?\w+|\w+\((?:|(?:(?:\w+\.)?\w+|\w+\((?:|(?:\w+\.)?\w+)\)))\))(?:\s+ASC|\s+DESC)?(?:\s+NULLS\s+(?:FIRST|LAST))?)(?:\s*,\s*(?:(?:\w+\.)?\w+|\w+\((?:|(?:(?:\w+\.)?\w+|\w+\((?:|(?:\w+\.)?\w+)\)))\))(?:\s+ASC|\s+DESC)?(?:\s+NULLS\s+(?:FIRST|LAST))?)*$/i;
 }
 
+/**
+ * Rails writes this inline as `Arel::Nodes::SqlLiteral === value` at each
+ * branch (abstract/quoting.rb `quote`/`type_cast`); there is no
+ * `sql_literal?` predicate to mirror. Factored out here only because TS
+ * cannot spell `===`-style case matching, so it is module-internal — same
+ * treatment as the `dispatch*` helpers alongside it.
+ *
+ * @internal
+ */
 export function isSqlLiteral(value: unknown): value is { value: string } {
   return (
     value !== null &&

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1919,6 +1919,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * For INSERT, if the statement includes a RETURNING clause the first column
    * of the first returned row is treated as the inserted ID. Otherwise, the
    * `rowCount` is returned.
+   *
+   * Rails has no `execute_mutation`; the `execute`/`executeMutation` split is a
+   * deliberate trails deviation justified once at the `AbstractAdapter`
+   * declaration (abstract-adapter.ts, `executeMutation` on the
+   * DatabaseStatements signature block) — read it there before changing this.
    */
   async executeMutation(sql: string, binds: unknown[] = [], name: string = "SQL"): Promise<number> {
     sql = this.preprocessQuery(sql);

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -615,6 +615,13 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   /**
    * Execute an INSERT/UPDATE/DELETE and return affected rows or insert ID.
    * Wrapped in a `sql.active_record` notification — see `execute`.
+   *
+   * Rails has no `execute_mutation`; the `execute`/`executeMutation` split is a
+   * deliberate trails deviation justified once at the `AbstractAdapter`
+   * declaration (abstract-adapter.ts, `executeMutation` on the
+   * DatabaseStatements signature block) — read it there before changing this.
+   * In particular, this cannot be rerouted through `execute`: better-sqlite3
+   * `.all()` throws on a non-reader statement.
    */
   async executeMutation(sql: string, binds: unknown[] = [], name: string = "SQL"): Promise<number> {
     // preprocessQuery runs Rails' check_if_write_query, which raises
@@ -1220,10 +1227,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     // factories at lookup time now, so — like Rails' SQLite3Adapter — no override
     // beyond `lookup_cast_type(column.sql_type)` is needed.
     return this.lookupCastType(column.sqlType ?? "");
-  }
-
-  get nativeTypeMap(): TypeMap {
-    return this._nativeTypeMap;
   }
 
   // Mirrors: ActiveRecord::ConnectionAdapters::SQLite3Adapter::SQLite3Integer

--- a/scripts/api-compare/extra-surface-allow.json
+++ b/scripts/api-compare/extra-surface-allow.json
@@ -172,5 +172,167 @@
     "tsFile": "associations.ts",
     "name": "initializeAssociations",
     "reason": "trails-only ESM module-cycle escape hatch with no Rails analogue: `initialize_associations` is defined nowhere in the Rails source (verified by grep over vendor/rails). The associations -> CollectionProxy -> Relation -> Base -> associations cycle forces CollectionProxy registration to be late-bound; the package entry does it eagerly, and this is the supported explicit hook for consumers who deep-import `@blazetrails/activerecord/associations` without touching the entry. Ruby's require/autoload resolves such cycles at load time, so there is nothing to port. Public by intent (documented consumer hook), so @internal is not appropriate."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "name": "executeMutation",
+    "reason": "Deliberate trails deviation, justified once at the AbstractAdapter declaration (connection-adapters/abstract-adapter.ts) and referenced from the concrete adapters. Rails has ONE query primitive per adapter, `perform_query`, which branches on `stmt.column_count.zero?` to decide whether it returns rows (sqlite3/database_statements.rb:78-112; abstract:561, postgresql:135, mysql2:41). trails splits it into row-returning `execute` and row-count `executeMutation`. The split cannot be undone by renaming: sqlite's `execute` runs `stmt.all()` and better-sqlite3 throws on a non-reader statement, so `execute` must first grow the `column_count.zero?` branch. Convergence is RFC 0023 `unify-execute-mutation-into-perform-query`."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "name": "executeMutation",
+    "reason": "Deliberate trails deviation, justified once at the AbstractAdapter declaration (connection-adapters/abstract-adapter.ts) and referenced from the concrete adapters. Rails has ONE query primitive per adapter, `perform_query`, which branches on `stmt.column_count.zero?` to decide whether it returns rows (sqlite3/database_statements.rb:78-112; abstract:561, postgresql:135, mysql2:41). trails splits it into row-returning `execute` and row-count `executeMutation`. The split cannot be undone by renaming: sqlite's `execute` runs `stmt.all()` and better-sqlite3 throws on a non-reader statement, so `execute` must first grow the `column_count.zero?` branch. Convergence is RFC 0023 `unify-execute-mutation-into-perform-query`."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "name": "executeMutation",
+    "reason": "Deliberate trails deviation, justified once at the AbstractAdapter declaration (connection-adapters/abstract-adapter.ts) and referenced from the concrete adapters. Rails has ONE query primitive per adapter, `perform_query`, which branches on `stmt.column_count.zero?` to decide whether it returns rows (sqlite3/database_statements.rb:78-112; abstract:561, postgresql:135, mysql2:41). trails splits it into row-returning `execute` and row-count `executeMutation`. The split cannot be undone by renaming: sqlite's `execute` runs `stmt.all()` and better-sqlite3 throws on a non-reader statement, so `execute` must first grow the `column_count.zero?` branch. Convergence is RFC 0023 `unify-execute-mutation-into-perform-query`."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "name": "exec",
+    "reason": "Bare-driver DDL hop, an artifact of the same execute/executeMutation split (see the deviation note at connection-adapters/abstract-adapter.ts). Rails has no `def exec`: its adapter-level `execute` calls the driver directly inside `perform_query`, so schema DDL and user SQL share one entry point. trails' `execute` is only the row-returning half of the split and rewrites binds, so schema statements need an unrewritten driver hop; `exec` is that hop, kept on the adapter so DDL callers do not each reach for `withRawConnection`. It disappears with RFC 0023 `unify-execute-mutation-into-perform-query`."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "name": "exec",
+    "reason": "Bare-driver DDL hop, an artifact of the same execute/executeMutation split (see the deviation note at connection-adapters/abstract-adapter.ts). Rails has no `def exec`: its adapter-level `execute` calls the driver directly inside `perform_query`, so schema DDL and user SQL share one entry point. trails' `execute` is only the row-returning half of the split and rewrites binds, so schema statements need an unrewritten driver hop; `exec` is that hop, kept on the adapter so DDL callers do not each reach for `withRawConnection`. It disappears with RFC 0023 `unify-execute-mutation-into-perform-query`."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "name": "Version",
+    "reason": "`AbstractAdapter::Version` is a real Rails nested class (abstract_adapter.rb:243); `static readonly Version = Version` is the TS spelling of that nested Ruby constant, and AbstractMysqlAdapter re-pins it exactly as Rails resolves `AbstractAdapter::Version` through inheritance. It reads as extra surface only because extra-surface skips nested Ruby classes when building a file's allow-set (the `primaryClassPerFile` filter) while still counting the TS nested class. Nothing to converge."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
+    "name": "Version",
+    "reason": "`AbstractAdapter::Version` is a real Rails nested class (abstract_adapter.rb:243); `static readonly Version = Version` is the TS spelling of that nested Ruby constant, and AbstractMysqlAdapter re-pins it exactly as Rails resolves `AbstractAdapter::Version` through inheritance. It reads as extra surface only because extra-surface skips nested Ruby classes when building a file's allow-set (the `primaryClassPerFile` filter) while still counting the TS nested class. Nothing to converge."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "name": "gte",
+    "reason": "Rails' `AbstractAdapter::Version` does `include Comparable` and defines only `<=>` (abstract_adapter.rb:243-259); `>=` and `<` come from Comparable, so there is no `def gte` for the extractor to match. `gte`/`lt` are the TS spelling of those two Comparable operators over the same dotted-part comparison `<=>` performs. Justified at the declaration. The non-Rails part-readers on the same class (`major`/`minor`/`patch`) were deleted rather than allowlisted — they had no callers."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "name": "quoteIdentifier",
+    "reason": "Rails' abstract quoting has no generic identifier quoter; `quote_table_name` simply delegates to `quote_column_name` (abstract/quoting.rb:66-67), which makes `quote_column_name` the de-facto one. trails names the shared primitive `quoteIdentifier` so `quoteColumnName`, `quoteTableName` and the schema-statement quoters (which quote neither a column nor a table) all delegate to one place. Resolved the same way on every adapter and on both quoting modules; renaming ~166 call sites to `quoteColumnName` would make them lie about what they quote."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
+    "name": "quoteIdentifier",
+    "reason": "Rails' abstract quoting has no generic identifier quoter; `quote_table_name` simply delegates to `quote_column_name` (abstract/quoting.rb:66-67), which makes `quote_column_name` the de-facto one. trails names the shared primitive `quoteIdentifier` so `quoteColumnName`, `quoteTableName` and the schema-statement quoters (which quote neither a column nor a table) all delegate to one place. Resolved the same way on every adapter and on both quoting modules; renaming ~166 call sites to `quoteColumnName` would make them lie about what they quote."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/quoting.ts",
+    "name": "quoteIdentifier",
+    "reason": "Rails' abstract quoting has no generic identifier quoter; `quote_table_name` simply delegates to `quote_column_name` (abstract/quoting.rb:66-67), which makes `quote_column_name` the de-facto one. trails names the shared primitive `quoteIdentifier` so `quoteColumnName`, `quoteTableName` and the schema-statement quoters (which quote neither a column nor a table) all delegate to one place. Resolved the same way on every adapter and on both quoting modules; renaming ~166 call sites to `quoteColumnName` would make them lie about what they quote."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/mysql/quoting.ts",
+    "name": "quoteIdentifier",
+    "reason": "Rails' abstract quoting has no generic identifier quoter; `quote_table_name` simply delegates to `quote_column_name` (abstract/quoting.rb:66-67), which makes `quote_column_name` the de-facto one. trails names the shared primitive `quoteIdentifier` so `quoteColumnName`, `quoteTableName` and the schema-statement quoters (which quote neither a column nor a table) all delegate to one place. Resolved the same way on every adapter and on both quoting modules; renaming ~166 call sites to `quoteColumnName` would make them lie about what they quote."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "name": "isNoDatabaseError",
+    "reason": "Rails recognizes the no-such-database condition inline at the connect site and raises `ActiveRecord::NoDatabaseError` there (postgresql_adapter.rb:63, sqlite3_adapter.rb:38,120) — there is no named predicate to mirror. trails needs the predicate separated from raising because `DatabaseTasks._isMissingDatabaseError` (tasks/database-tasks.ts) classifies an already-raised raw driver error, after the adapter failed to construct. Identical shape on all three: the base returns false, each concrete adapter overrides with its driver check."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "name": "isNoDatabaseError",
+    "reason": "Rails recognizes the no-such-database condition inline at the connect site and raises `ActiveRecord::NoDatabaseError` there (postgresql_adapter.rb:63, sqlite3_adapter.rb:38,120) — there is no named predicate to mirror. trails needs the predicate separated from raising because `DatabaseTasks._isMissingDatabaseError` (tasks/database-tasks.ts) classifies an already-raised raw driver error, after the adapter failed to construct. Identical shape on all three: the base returns false, each concrete adapter overrides with its driver check."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "name": "isNoDatabaseError",
+    "reason": "Rails recognizes the no-such-database condition inline at the connect site and raises `ActiveRecord::NoDatabaseError` there (postgresql_adapter.rb:63, sqlite3_adapter.rb:38,120) — there is no named predicate to mirror. trails needs the predicate separated from raising because `DatabaseTasks._isMissingDatabaseError` (tasks/database-tasks.ts) classifies an already-raised raw driver error, after the adapter failed to construct. Identical shape on all three: the base returns false, each concrete adapter overrides with its driver check."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
+    "name": "statementLimit",
+    "reason": "`statement_limit` is a `database.yml` config key Rails reads as `config[:statement_limit]` in each adapter's `initialize` (abstract_mysql_adapter.rb, postgresql_adapter.rb, sqlite3_adapter.rb) — a config option, never a Ruby `def`, so there is nothing for the extractor to match. trails exposes the same setting as a validated accessor on the adapter, identically on all three."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "name": "statementLimit",
+    "reason": "`statement_limit` is a `database.yml` config key Rails reads as `config[:statement_limit]` in each adapter's `initialize` (abstract_mysql_adapter.rb, postgresql_adapter.rb, sqlite3_adapter.rb) — a config option, never a Ruby `def`, so there is nothing for the extractor to match. trails exposes the same setting as a validated accessor on the adapter, identically on all three."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3-adapter.ts",
+    "name": "statementLimit",
+    "reason": "`statement_limit` is a `database.yml` config key Rails reads as `config[:statement_limit]` in each adapter's `initialize` (abstract_mysql_adapter.rb, postgresql_adapter.rb, sqlite3_adapter.rb) — a config option, never a Ruby `def`, so there is nothing for the extractor to match. trails exposes the same setting as a validated accessor on the adapter, identically on all three."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "name": "columnMethodNames",
+    "reason": "Rails spells this list as the `ColumnMethods` modules' `define_column_methods` metaprogramming (abstract/schema_definitions.rb:324 plus the per-adapter ColumnMethods modules), not as a `def`, so the Ruby extractor records no counterpart. TypeScript has no `define_method`, so trails reifies the list; each adapter appends to `super.columnMethodNames()` exactly where Rails' adapter-specific ColumnMethods module extends the abstract one."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
+    "name": "columnMethodNames",
+    "reason": "Rails spells this list as the `ColumnMethods` modules' `define_column_methods` metaprogramming (abstract/schema_definitions.rb:324 plus the per-adapter ColumnMethods modules), not as a `def`, so the Ruby extractor records no counterpart. TypeScript has no `define_method`, so trails reifies the list; each adapter appends to `super.columnMethodNames()` exactly where Rails' adapter-specific ColumnMethods module extends the abstract one."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "name": "columnMethodNames",
+    "reason": "Rails spells this list as the `ColumnMethods` modules' `define_column_methods` metaprogramming (abstract/schema_definitions.rb:324 plus the per-adapter ColumnMethods modules), not as a `def`, so the Ruby extractor records no counterpart. TypeScript has no `define_method`, so trails reifies the list; each adapter appends to `super.columnMethodNames()` exactly where Rails' adapter-specific ColumnMethods module extends the abstract one."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "name": "schemaStatements",
+    "reason": "Rails gains these bodies with `include SchemaStatements` on the adapter, so there is no accessor to mirror. The schema-statement surface is far too large for the repo's `this`-typed module-mixin pattern to stay readable, so trails keeps it in a companion class; `schemaStatements(host?)` is the accessor that returns it bound to a host adapter. It is the TS stand-in for the `include`, not new capability — mysql2-adapter.ts overrides it to return the MySQL companion the same way Rails includes `MySQL::SchemaStatements`."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "name": "schemaStatements",
+    "reason": "Rails gains these bodies with `include SchemaStatements` on the adapter, so there is no accessor to mirror. The schema-statement surface is far too large for the repo's `this`-typed module-mixin pattern to stay readable, so trails keeps it in a companion class; `schemaStatements(host?)` is the accessor that returns it bound to a host adapter. It is the TS stand-in for the `include`, not new capability — mysql2-adapter.ts overrides it to return the MySQL companion the same way Rails includes `MySQL::SchemaStatements`."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "name": "schemaQuery",
+    "reason": "Rails' equivalent is a call convention, not a method: `internal_exec_query(sql, \"SCHEMA\")` (abstract/database_statements.rb), where the \"SCHEMA\" name is what keeps adapter-internal reflection out of the log and out of the query cache. trails reifies the convention as one helper so the reflection call sites cannot forget the name, and so it can reach the pre-wrap `execute` body — necessary because the execute/executeMutation split leaves `execute` wearing the dirty-query-cache wrapper. Justified at the declaration."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "name": "schemaCacheBound",
+    "reason": "Rails' `AbstractAdapter#schema_cache` returns the pool's bound reflection handle (abstract_adapter.rb:298 → connection_pool.rb:285). trails' `schemaCache` getter returns the raw `SchemaCache` the adapter memoizes incidental introspection into, so the Rails-shaped bound handle needs a second name. The divergence is `schemaCache`'s return type, not this accessor; until that is converged, `schemaCacheBound` is what `insertAll` and the uniqueness validator read to get Rails' actual `schema_cache` semantics."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "name": "createRange",
+    "reason": "Rails has no range-type DDL helper anywhere — ranges are created with a raw `execute(\"CREATE TYPE … AS RANGE\")`. trails adds `createRange`/`dropRange` following Rails' own type-DDL helpers (create_enum/drop_enum/rename_enum, postgresql_adapter.rb:541-615), including their `reload_type_map` epilogue; the implementation and the full justification live at the emitting call site, connection-adapters/postgresql/schema-statements-class.ts. Deliberately PostgreSQL-only: the no-op stubs that shadowed these on AbstractAdapter were deleted rather than allowlisted, since Rails stubs only the enum quartet on the base."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "name": "dropRange",
+    "reason": "Rails has no range-type DDL helper anywhere — ranges are created with a raw `execute(\"CREATE TYPE … AS RANGE\")`. trails adds `createRange`/`dropRange` following Rails' own type-DDL helpers (create_enum/drop_enum/rename_enum, postgresql_adapter.rb:541-615), including their `reload_type_map` epilogue; the implementation and the full justification live at the emitting call site, connection-adapters/postgresql/schema-statements-class.ts. Deliberately PostgreSQL-only: the no-op stubs that shadowed these on AbstractAdapter were deleted rather than allowlisted, since Rails stubs only the enum quartet on the base."
   }
 ]

--- a/scripts/api-compare/extra-surface-allow.json
+++ b/scripts/api-compare/extra-surface-allow.json
@@ -176,36 +176,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-adapter.ts",
-    "name": "executeMutation",
-    "reason": "Deliberate trails deviation, justified once at the AbstractAdapter declaration (connection-adapters/abstract-adapter.ts) and referenced from the concrete adapters. Rails has ONE query primitive per adapter, `perform_query`, which branches on `stmt.column_count.zero?` to decide whether it returns rows (sqlite3/database_statements.rb:78-112; abstract:561, postgresql:135, mysql2:41). trails splits it into row-returning `execute` and row-count `executeMutation`. The split cannot be undone by renaming: sqlite's `execute` runs `stmt.all()` and better-sqlite3 throws on a non-reader statement, so `execute` must first grow the `column_count.zero?` branch. Convergence is RFC 0023 `unify-execute-mutation-into-perform-query`."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "name": "executeMutation",
-    "reason": "Deliberate trails deviation, justified once at the AbstractAdapter declaration (connection-adapters/abstract-adapter.ts) and referenced from the concrete adapters. Rails has ONE query primitive per adapter, `perform_query`, which branches on `stmt.column_count.zero?` to decide whether it returns rows (sqlite3/database_statements.rb:78-112; abstract:561, postgresql:135, mysql2:41). trails splits it into row-returning `execute` and row-count `executeMutation`. The split cannot be undone by renaming: sqlite's `execute` runs `stmt.all()` and better-sqlite3 throws on a non-reader statement, so `execute` must first grow the `column_count.zero?` branch. Convergence is RFC 0023 `unify-execute-mutation-into-perform-query`."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "name": "executeMutation",
-    "reason": "Deliberate trails deviation, justified once at the AbstractAdapter declaration (connection-adapters/abstract-adapter.ts) and referenced from the concrete adapters. Rails has ONE query primitive per adapter, `perform_query`, which branches on `stmt.column_count.zero?` to decide whether it returns rows (sqlite3/database_statements.rb:78-112; abstract:561, postgresql:135, mysql2:41). trails splits it into row-returning `execute` and row-count `executeMutation`. The split cannot be undone by renaming: sqlite's `execute` runs `stmt.all()` and better-sqlite3 throws on a non-reader statement, so `execute` must first grow the `column_count.zero?` branch. Convergence is RFC 0023 `unify-execute-mutation-into-perform-query`."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "name": "exec",
-    "reason": "Bare-driver DDL hop, an artifact of the same execute/executeMutation split (see the deviation note at connection-adapters/abstract-adapter.ts). Rails has no `def exec`: its adapter-level `execute` calls the driver directly inside `perform_query`, so schema DDL and user SQL share one entry point. trails' `execute` is only the row-returning half of the split and rewrites binds, so schema statements need an unrewritten driver hop; `exec` is that hop, kept on the adapter so DDL callers do not each reach for `withRawConnection`. It disappears with RFC 0023 `unify-execute-mutation-into-perform-query`."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "name": "exec",
-    "reason": "Bare-driver DDL hop, an artifact of the same execute/executeMutation split (see the deviation note at connection-adapters/abstract-adapter.ts). Rails has no `def exec`: its adapter-level `execute` calls the driver directly inside `perform_query`, so schema DDL and user SQL share one entry point. trails' `execute` is only the row-returning half of the split and rewrites binds, so schema statements need an unrewritten driver hop; `exec` is that hop, kept on the adapter so DDL callers do not each reach for `withRawConnection`. It disappears with RFC 0023 `unify-execute-mutation-into-perform-query`."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
     "name": "Version",
     "reason": "`AbstractAdapter::Version` is a real Rails nested class (abstract_adapter.rb:243); `static readonly Version = Version` is the TS spelling of that nested Ruby constant, so this is public Rails API parity, not drift. It reads as extra surface only because extra-surface skips nested Ruby classes when building a file's allow-set (the `primaryClassPerFile` filter) while still counting the TS nested class. Nothing to converge. AbstractMysqlAdapter's redundant re-pin of the same constant was deleted rather than allowlisted — JS statics are inherited, so it shadowed nothing and had no readers."
   },
@@ -218,30 +188,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-adapter.ts",
-    "name": "quoteIdentifier",
-    "reason": "Rails' abstract quoting has no generic identifier quoter; `quote_table_name` simply delegates to `quote_column_name` (abstract/quoting.rb:66-67), which makes `quote_column_name` the de-facto one. trails names the shared primitive `quoteIdentifier` so `quoteColumnName`, `quoteTableName` and the schema-statement quoters (which quote neither a column nor a table) all delegate to one place. Resolved the same way on every adapter and on both quoting modules; renaming ~166 call sites to `quoteColumnName` would make them lie about what they quote."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "name": "quoteIdentifier",
-    "reason": "Rails' abstract quoting has no generic identifier quoter; `quote_table_name` simply delegates to `quote_column_name` (abstract/quoting.rb:66-67), which makes `quote_column_name` the de-facto one. trails names the shared primitive `quoteIdentifier` so `quoteColumnName`, `quoteTableName` and the schema-statement quoters (which quote neither a column nor a table) all delegate to one place. Resolved the same way on every adapter and on both quoting modules; renaming ~166 call sites to `quoteColumnName` would make them lie about what they quote."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/quoting.ts",
-    "name": "quoteIdentifier",
-    "reason": "Rails' abstract quoting has no generic identifier quoter; `quote_table_name` simply delegates to `quote_column_name` (abstract/quoting.rb:66-67), which makes `quote_column_name` the de-facto one. trails names the shared primitive `quoteIdentifier` so `quoteColumnName`, `quoteTableName` and the schema-statement quoters (which quote neither a column nor a table) all delegate to one place. Resolved the same way on every adapter and on both quoting modules; renaming ~166 call sites to `quoteColumnName` would make them lie about what they quote."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/quoting.ts",
-    "name": "quoteIdentifier",
-    "reason": "Rails' abstract quoting has no generic identifier quoter; `quote_table_name` simply delegates to `quote_column_name` (abstract/quoting.rb:66-67), which makes `quote_column_name` the de-facto one. trails names the shared primitive `quoteIdentifier` so `quoteColumnName`, `quoteTableName` and the schema-statement quoters (which quote neither a column nor a table) all delegate to one place. Resolved the same way on every adapter and on both quoting modules; renaming ~166 call sites to `quoteColumnName` would make them lie about what they quote."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
     "name": "isNoDatabaseError",
     "reason": "Rails recognizes the no-such-database condition inline at the connect site and raises `ActiveRecord::NoDatabaseError` there (postgresql_adapter.rb:63, sqlite3_adapter.rb:38,120) — there is no named predicate to mirror. trails needs the predicate separated from raising because `DatabaseTasks._isMissingDatabaseError` (tasks/database-tasks.ts) classifies an already-raised raw driver error, after the adapter failed to construct. Identical shape on all three: the base returns false, each concrete adapter overrides with its driver check."
   },
@@ -304,12 +250,6 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "name": "schemaStatements",
     "reason": "Rails gains these bodies with `include SchemaStatements` on the adapter, so there is no accessor to mirror. The schema-statement surface is far too large for the repo's `this`-typed module-mixin pattern to stay readable, so trails keeps it in a companion class; `schemaStatements(host?)` is the accessor that returns it bound to a host adapter. It is the TS stand-in for the `include`, not new capability — mysql2-adapter.ts overrides it to return the MySQL companion the same way Rails includes `MySQL::SchemaStatements`."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
-    "name": "schemaQuery",
-    "reason": "Rails' equivalent is a call convention, not a method: `internal_exec_query(sql, \"SCHEMA\")` (abstract/database_statements.rb), where the \"SCHEMA\" name is what keeps adapter-internal reflection out of the log and out of the query cache. trails reifies the convention as one helper so the reflection call sites cannot forget the name, and so it can reach the pre-wrap `execute` body — necessary because the execute/executeMutation split leaves `execute` wearing the dirty-query-cache wrapper. Justified at the declaration."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/extra-surface-allow.json
+++ b/scripts/api-compare/extra-surface-allow.json
@@ -207,13 +207,7 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-adapter.ts",
     "name": "Version",
-    "reason": "`AbstractAdapter::Version` is a real Rails nested class (abstract_adapter.rb:243); `static readonly Version = Version` is the TS spelling of that nested Ruby constant, and AbstractMysqlAdapter re-pins it exactly as Rails resolves `AbstractAdapter::Version` through inheritance. It reads as extra surface only because extra-surface skips nested Ruby classes when building a file's allow-set (the `primaryClassPerFile` filter) while still counting the TS nested class. Nothing to converge."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "name": "Version",
-    "reason": "`AbstractAdapter::Version` is a real Rails nested class (abstract_adapter.rb:243); `static readonly Version = Version` is the TS spelling of that nested Ruby constant, and AbstractMysqlAdapter re-pins it exactly as Rails resolves `AbstractAdapter::Version` through inheritance. It reads as extra surface only because extra-surface skips nested Ruby classes when building a file's allow-set (the `primaryClassPerFile` filter) while still counting the TS nested class. Nothing to converge."
+    "reason": "`AbstractAdapter::Version` is a real Rails nested class (abstract_adapter.rb:243); `static readonly Version = Version` is the TS spelling of that nested Ruby constant, so this is public Rails API parity, not drift. It reads as extra surface only because extra-surface skips nested Ruby classes when building a file's allow-set (the `primaryClassPerFile` filter) while still counting the TS nested class. Nothing to converge. AbstractMysqlAdapter's redundant re-pin of the same constant was deleted rather than allowlisted — JS statics are inherited, so it shadowed nothing and had no readers."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -105,6 +105,14 @@ const TS_ALWAYS_ALLOWED = new Set([
   "toHash",
   "valueOf",
   "klasses",
+  // `lookup_cast_type` is a real Rails method — abstract/quoting.rb:234 and
+  // postgresql/quoting.rb:195 — but it sits on `conventions.SKIP` because the
+  // *PostgreSQL* one issues an async `SELECT oid` our standalone-function
+  // quoting module can't run. SKIP is global, so that one unportable adapter
+  // variant was making every faithful `lookupCastType` (abstract/quoting.ts,
+  // abstract-mysql-adapter.ts, sqlite3-adapter.ts) read as novel drift. This
+  // is exactly the carrying-the-pattern-through case the list exists for.
+  "lookupCastType",
   // JS-only protocol surface on the thenable/iterable Relation — Promise
   // (`catch`/`finally`; `then` is above) and the iteration protocols. Pure
   // language-level conventions with no Rails counterpart.


### PR DESCRIPTION
Resolves every extra-surface name that **recurs across** the connection-adapter
files, applying the same decision at every declaring site.

**No allowlist entry is added for a name that already has a registered
convergence story.** Suppressing drift we have already committed to deleting is
pure churn — it costs a review cycle now and another to remove it later, and in
between it makes the metric read as if the drift were resolved. So
`executeMutation` (×3), `exec` (×2), `quoteIdentifier` (×4) and `schemaQuery`
stay visible in the report, with their justification in a code comment at the
declaration instead. Their convergence stories are linked below.

## Per-file novel counts

| File | Before | After |
| --- | ---: | ---: |
| `connection-adapters/abstract-adapter.ts` | 14 | 3 |
| `connection-adapters/abstract/quoting.ts` | 3 | 1 |
| `connection-adapters/abstract-mysql-adapter.ts` | 12 | 6 |
| `connection-adapters/postgresql-adapter.ts` | 17 | 11 |
| `connection-adapters/sqlite3-adapter.ts` | 14 | 10 |
| `connection-adapters/mysql/quoting.ts` (rode along) | 1 | 1 |
| **Total** | **61** | **32** |

Everything still reported is either a per-file singleton (registered as
`extra-surface-adapter-per-file-singletons`) or a name with a convergence story
that will delete it outright. `pnpm api:extra` reports **0 STALE** entries.

Baselines are post-sequencing: the Ruby-constants and `@internal`-fileFunctions
tooling stories had already landed, so `abstract-mysql-adapter.ts` starts at 12,
not the 30 the spike recorded, and `abstract/quoting.ts` at 3, not 12.

## Decisions

**Deleted** — dead surface, so no justification was owed and no allowlist entry
was spent: `AbstractAdapter#verifyCalled`; `Version#major` / `#minor` /
`#patch`; `AbstractSQLite3Adapter#nativeTypeMap`; and
`AbstractMysqlAdapter.Version`, a redundant re-pin of the base class's constant
— JS statics are inherited, so it shadowed nothing and had no readers.
(`Version#gte` and `#lt` are kept: both have live callers.)

**`createRange` / `dropRange` on the abstract base — answered: they do not belong
there.** Rails stubs only the enum quartet on `AbstractAdapter`
(`abstract_adapter.rb:576-595`) and has no range-type DDL anywhere — ranges are
created with a raw `execute("CREATE TYPE … AS RANGE")`. The stubs were dead
(PostgreSQLAdapter never inherited them) and are deleted, with a comment in
their place recording why the hook is absent. The trails-only helpers keep their
home and justification in `postgresql/schema-statements-class.ts`.

**Renamed toward the Rails-private convention** — `AbstractMysqlAdapter`'s
`buildTypeMap` → `_buildTypeMap` (`protected static`) and `nativeTypeMap` →
`_nativeTypeMap`, matching the already-converged `AbstractSQLite3Adapter`
spelling. Rails' registration pass keeps its Rails name, `initializeTypeMap`
(`abstract_mysql_adapter.rb:711`).

**Tooling** — `lookupCastType` joins `TS_ALWAYS_ALLOWED`. `lookup_cast_type` is a
real Rails method (`abstract/quoting.rb:234`, `postgresql/quoting.rb:195`); it is
on `conventions.SKIP` only because the *PostgreSQL* variant issues an async
`SELECT oid` our standalone quoting module cannot run, and SKIP is global — so
one unportable adapter variant was making three faithful ports read as novel.
`isSqlLiteral` is marked `@internal` alongside the `dispatch*` helpers it serves.

**Allowlisted** (16 entries), one shared reason reused verbatim at every
declaring file so no name is resolved two ways: `Version`, `gte`,
`isNoDatabaseError` (×3), `statementLimit` (×3), `columnMethodNames` (×3),
`schemaStatements` (×2), `schemaCacheBound`, `createRange`, `dropRange`.

Eight of those sixteen are the comparator failing to see Rails rather than trails
diverging — `Version`/`gte` (nested Ruby classes are skipped from the allow-set
while the TS nested class is still counted; `include Comparable` has no `def` to
extract), `statementLimit` (a `database.yml` config key, never a `def`),
`columnMethodNames` (`define_column_methods` metaprogramming). Those want an
extractor fix, not an entry; the nested-class asymmetry alone accounts for 94
Ruby classes repo-wide.

## Convergence stories registered

- `converge-quote-identifier-into-quote-column-name` — on every concrete adapter
  `quoteIdentifier` is byte-for-byte identical to `quoteColumnName`
  (`mysql/quoting.ts:70` is a literal alias; PG and SQLite inherit the same ANSI
  body). Rails has no `quote_identifier`; `quote_table_name` delegates to
  `quote_column_name` (`abstract/quoting.rb:66-67`). 115 call sites.
- **RFC 0076 `execute-primitive-convergence`** — covers `executeMutation` and
  `exec`: `inline-mysql-exec-mutation-indirection`,
  `sqlite-truncate-through-execute`,
  `converge-vestigial-postgresql-perform-query`, all open.
- RFC 0076 `schema-query-converge-to-internal-exec-query` — covers `schemaQuery`.
  Status **blocked** on `pg-cast-result-oid-lookup-reentrancy-guard`: the direct
  route was attempted in #4977 and reverted (104 failed PG tests from
  `castResult -> getOidType -> loadAdditionalTypes -> schemaQuery` recursion).
  Blocked still means tracked, so the entry stays dropped.
- `extra-surface-adapter-per-file-singletons` — the remaining per-file names.

### Stale-citation fixes (review finding)

An earlier revision cited RFC 0023 `unify-execute-mutation-into-perform-query`
as the convergence home for `executeMutation`/`exec`. **That story and its
`-postgresql` / `-mysql2` siblings are already `done`** — the shared
`performQuery` primitive exists on all three adapters and DDL in
`abstract/schema-statements.ts` already routes through `execute`. Citing it sent
readers chasing a closed story that will not delete anything further. The
in-code comment now names the open RFC 0076 stories and says explicitly not to
re-cite RFC 0023.

Two follow-on corrections found while verifying that:

- `abstract-adapter.ts` `log()` carried the same stale RFC 0023 citation plus a
  premise that is no longer true ("only PG assigns a `performQuery` today" — all
  three now do). Re-pointed at RFC 0076 `wire-raw-execute-through-log`. This one
  predates this PR; fixed here because it is the identical defect one screen
  away, and it is comment-only.
- The `converge-schema-query-into-internal-exec-query` story I had registered
  under RFC 0072 was a **duplicate** of the better-specified, correctly-blocked
  RFC 0076 story above — and would have sent someone down a path already proven
  to fail. Closed as superseded.

## Deviation justification lives in the source

The `execute`/`executeMutation` rationale is stated **once** at the
`AbstractAdapter` declaration — Rails has one `perform_query` branching on
`stmt.column_count.zero?` (`sqlite3/database_statements.rb:78-112`; abstract:561,
postgresql:135, mysql2:41), the split is the deviation, and it cannot be undone
by renaming because better-sqlite3 `.all()` throws on a non-reader statement. The
PG and SQLite overrides point at that note rather than restating it. `gte`/`lt`
(Comparable), the absent range hook, and both type-map renames are likewise
commented at their declarations.

## Testing

`pnpm typecheck` and `pnpm lint` clean. Scoped `vitest run` (no full suite):
`abstract-adapter.test.ts`, `abstract-mysql-adapter.test.ts`,
`quoting-interface.test.ts`, `postgresql-adapter.type-map.test.ts`, four
`sqlite3-adapter.*` files, and `scripts/api-compare/extra-surface.test.ts` —
196 tests, all passing. MySQL/PostgreSQL server-backed suites verified by CI.

Closes-story: extra-surface-adapter-cross-file-recurring-names
