### PR TITLE
feat(vendor): vendor ruby-i18n/i18n v1.14.8 for the i18n parity RFC

### DIFF
--- a/vendor/sources.lock.json
+++ b/vendor/sources.lock.json
@@ -8,6 +8,10 @@
       "ref": "v1.3.0",
       "sha": "a10102196ceaa9ffec3744eda857ebe421a57134"
     },
+    "i18n": {
+      "ref": "v1.14.8",
+      "sha": "f2fb6a5766dee835082eb74ee83f52e0a6479573"
+    },
     "rack": {
       "ref": "v3.1.14",
       "sha": "5440b2c8b006f1c2ef202c2bd60dd70924c9b1c1"

--- a/vendor/sources.test.ts
+++ b/vendor/sources.test.ts
@@ -17,7 +17,6 @@ describe("vendor/sources.ts", () => {
   });
 
   it("declares the rails source with all 9 wave-1 packages", () => {
-    // (Wave 3.5 added a 10th, actionpackversion — see #1621.)
     const rails = SOURCES.find((s) => s.name === "rails");
     expect(rails).toBeDefined();
     expect(rails!.origin).toEqual({
@@ -78,12 +77,9 @@ describe("vendor/sources.ts", () => {
         compareTests: false,
       },
     ]);
-    // Not enrolled in either compare derivation until the RFC's package-home
-    // story lands (there is no packages/i18n TS dir to map onto yet).
     expect(apiComparePackages()).not.toContain("i18n");
     expect(Object.keys(libPathsManifest())).not.toContain("i18n");
     expect(Object.keys(testPathsManifest())).not.toContain("i18n");
-    // But the source itself is resolvable for tooling that reads the clone.
     expect(resolvePath("i18n").endsWith("vendor/i18n/lib/i18n")).toBe(true);
     expect(resolvePath("i18n", "test").endsWith("vendor/i18n/test")).toBe(true);
     expect(vendoredRoot("i18n").endsWith("vendor/i18n")).toBe(true);
@@ -217,10 +213,6 @@ describe("vendor/sources.ts", () => {
 
   it("testPathsManifest returns absolute test dirs for the wave-5 set", () => {
     const m = testPathsManifest();
-    // Same set as extract-ruby-tests.rb's pre-wave-5 PACKAGE_TEST_DIRS:
-    // 9 Rails+Rack packages + globalid (compareTests defaults to true).
-    // actionpackversion has no testPath; rack tests live at the source root;
-    // abstractcontroller gained a testPath in wave 3.5 (#1621).
     expect(Object.keys(m).sort()).toEqual(
       [
         "abstractcontroller",

--- a/vendor/sources.test.ts
+++ b/vendor/sources.test.ts
@@ -17,6 +17,7 @@ describe("vendor/sources.ts", () => {
   });
 
   it("declares the rails source with all 9 wave-1 packages", () => {
+    // (Wave 3.5 added a 10th, actionpackversion — see #1621.)
     const rails = SOURCES.find((s) => s.name === "rails");
     expect(rails).toBeDefined();
     expect(rails!.origin).toEqual({
@@ -29,6 +30,7 @@ describe("vendor/sources.ts", () => {
         "abstractcontroller",
         "actioncontroller",
         "actiondispatch",
+        "actionpackversion",
         "actionview",
         "activemodel",
         "activerecord",
@@ -57,6 +59,34 @@ describe("vendor/sources.ts", () => {
     expect(gid!.packages).toEqual([
       { name: "globalid", libPath: "lib/global_id", testPath: "test/cases" },
     ]);
+  });
+
+  it("declares the i18n source, vendored-only until packages/i18n exists", () => {
+    const i18n = SOURCES.find((s) => s.name === "i18n");
+    expect(i18n).toBeDefined();
+    expect(i18n!.origin).toEqual({
+      type: "git",
+      url: "https://github.com/ruby-i18n/i18n.git",
+      ref: "v1.14.8",
+    });
+    expect(i18n!.packages).toEqual([
+      {
+        name: "i18n",
+        libPath: "lib/i18n",
+        testPath: "test",
+        compareApi: false,
+        compareTests: false,
+      },
+    ]);
+    // Not enrolled in either compare derivation until the RFC's package-home
+    // story lands (there is no packages/i18n TS dir to map onto yet).
+    expect(apiComparePackages()).not.toContain("i18n");
+    expect(Object.keys(libPathsManifest())).not.toContain("i18n");
+    expect(Object.keys(testPathsManifest())).not.toContain("i18n");
+    // But the source itself is resolvable for tooling that reads the clone.
+    expect(resolvePath("i18n").endsWith("vendor/i18n/lib/i18n")).toBe(true);
+    expect(resolvePath("i18n", "test").endsWith("vendor/i18n/test")).toBe(true);
+    expect(vendoredRoot("i18n").endsWith("vendor/i18n")).toBe(true);
   });
 
   it("vendor/sources.lock.json has an entry for every source (commit invariant)", async () => {
@@ -130,7 +160,7 @@ describe("vendor/sources.ts", () => {
   });
 
   it("resolvePath throws when test requested for package without testPath", () => {
-    expect(() => resolvePath("abstractcontroller", "test")).toThrow(/no testPath/);
+    expect(() => resolvePath("actionpackversion", "test")).toThrow(/no testPath/);
   });
 
   it("vendoredRoot returns absolute source root", () => {
@@ -165,6 +195,8 @@ describe("vendor/sources.ts", () => {
         "activerecord",
         "activesupport",
         "arel",
+        "actionpackversion",
+        "did-you-mean",
         "globalid",
         "rack",
         "trailties",
@@ -187,9 +219,11 @@ describe("vendor/sources.ts", () => {
     const m = testPathsManifest();
     // Same set as extract-ruby-tests.rb's pre-wave-5 PACKAGE_TEST_DIRS:
     // 9 Rails+Rack packages + globalid (compareTests defaults to true).
-    // abstractcontroller has no testPath; rack tests live at the source root.
+    // actionpackversion has no testPath; rack tests live at the source root;
+    // abstractcontroller gained a testPath in wave 3.5 (#1621).
     expect(Object.keys(m).sort()).toEqual(
       [
+        "abstractcontroller",
         "actioncontroller",
         "actiondispatch",
         "actionview",
@@ -197,6 +231,7 @@ describe("vendor/sources.ts", () => {
         "activerecord",
         "activesupport",
         "arel",
+        "did-you-mean",
         "globalid",
         "rack",
         "trailties",

--- a/vendor/sources.test.ts
+++ b/vendor/sources.test.ts
@@ -16,7 +16,7 @@ describe("vendor/sources.ts", () => {
     expect(SOURCES.length).toBeGreaterThan(0);
   });
 
-  it("declares the rails source with all 9 wave-1 packages", () => {
+  it("declares the rails source with all 10 packages (9 wave-1 + actionpackversion)", () => {
     const rails = SOURCES.find((s) => s.name === "rails");
     expect(rails).toBeDefined();
     expect(rails!.origin).toEqual({
@@ -175,7 +175,7 @@ describe("vendor/sources.ts", () => {
     expect(pkgs).toContain("abstractcontroller");
   });
 
-  it("apiComparePackages returns exactly the wave-6 11-entry api-compare set", () => {
+  it("apiComparePackages returns exactly the current api-compare set", () => {
     // Bulletproofs against a future PR that accidentally toggles compareApi
     // on a package, or adds/drops a source from SOURCES without updating
     // extract-ruby-api.rb. extract-ruby-api.rb's PACKAGE_DIRS is now derived
@@ -186,12 +186,12 @@ describe("vendor/sources.ts", () => {
         "abstractcontroller",
         "actioncontroller",
         "actiondispatch",
+        "actionpackversion",
         "actionview",
         "activemodel",
         "activerecord",
         "activesupport",
         "arel",
-        "actionpackversion",
         "did-you-mean",
         "globalid",
         "rack",
@@ -211,7 +211,7 @@ describe("vendor/sources.ts", () => {
     expect(m["globalid"].endsWith("vendor/globalid/lib/global_id")).toBe(true);
   });
 
-  it("testPathsManifest returns absolute test dirs for the wave-5 set", () => {
+  it("testPathsManifest returns absolute test dirs for every test-compared package", () => {
     const m = testPathsManifest();
     expect(Object.keys(m).sort()).toEqual(
       [

--- a/vendor/sources.ts
+++ b/vendor/sources.ts
@@ -29,15 +29,14 @@ export interface PackageEntry {
    * Default true. Set to false to vendor the source (so test-compare or other
    * tooling can read it) without including it in the api-compare PACKAGES
    * derivation. Reserved for cases where the extractor can't yet handle a
-   * gem's idioms, or where the TS-side home for the package doesn't exist
-   * yet (i18n today; rack and globalid were vendored-only until wave 6
-   * wired them in, #1589).
+   * gem's idioms. Today no source sets this flag; rack and globalid were
+   * wired into api-compare in wave 6 (#1589).
    */
   compareApi?: boolean;
   /**
-   * Default true. Mirror of `compareApi` for test-compare. globalid set this
-   * to false in wave 5 (flipped on in wave 6); i18n sets both flags false
-   * until its TS package home exists.
+   * Default true. Mirror of `compareApi` for test-compare. globalid sets this
+   * to false in wave 5 (its tests aren't wired into test-compare yet); wave 6
+   * flips it on alongside its api-compare wiring.
    */
   compareTests?: boolean;
 }
@@ -155,23 +154,13 @@ export const SOURCES: readonly UpstreamSource[] = [
     origin: {
       type: "git",
       url: "https://github.com/ruby-i18n/i18n.git",
-      // Latest 1.x release; Rails 8.0.2's activesupport pins i18n (>= 1.6, < 2).
       ref: "v1.14.8",
     },
     packages: [
       {
         name: "i18n",
-        // Module root `lib/i18n/`, matching the activerecord/rack pattern.
-        // The entrypoint lib/i18n.rb (the I18n module facade — translate/
-        // localize/locale accessors) sits outside this dir; the parity RFC
-        // decides how the facade surface is charged when compare is enrolled.
         libPath: "lib/i18n",
         testPath: "test",
-        // Vendored-only for now (RFC 0074): there is no packages/i18n TS home
-        // yet — today's i18n surface is scattered shims in activesupport/
-        // activemodel/activerecord, so the package-name → packages/<name>/src
-        // derivation can't resolve. The RFC's first story creates packages/i18n
-        // and flips these flags on.
         compareApi: false,
         compareTests: false,
       },

--- a/vendor/sources.ts
+++ b/vendor/sources.ts
@@ -29,14 +29,15 @@ export interface PackageEntry {
    * Default true. Set to false to vendor the source (so test-compare or other
    * tooling can read it) without including it in the api-compare PACKAGES
    * derivation. Reserved for cases where the extractor can't yet handle a
-   * gem's idioms. Today no source sets this flag; rack and globalid were
-   * wired into api-compare in wave 6 (#1589).
+   * gem's idioms, or where the TS-side home for the package doesn't exist
+   * yet (i18n today; rack and globalid were vendored-only until wave 6
+   * wired them in, #1589).
    */
   compareApi?: boolean;
   /**
-   * Default true. Mirror of `compareApi` for test-compare. globalid sets this
-   * to false in wave 5 (its tests aren't wired into test-compare yet); wave 6
-   * flips it on alongside its api-compare wiring.
+   * Default true. Mirror of `compareApi` for test-compare. globalid set this
+   * to false in wave 5 (flipped on in wave 6); i18n sets both flags false
+   * until its TS package home exists.
    */
   compareTests?: boolean;
 }
@@ -146,6 +147,33 @@ export const SOURCES: readonly UpstreamSource[] = [
         name: "did-you-mean",
         libPath: "lib/did_you_mean",
         testPath: "test",
+      },
+    ],
+  },
+  {
+    name: "i18n",
+    origin: {
+      type: "git",
+      url: "https://github.com/ruby-i18n/i18n.git",
+      // Latest 1.x release; Rails 8.0.2's activesupport pins i18n (>= 1.6, < 2).
+      ref: "v1.14.8",
+    },
+    packages: [
+      {
+        name: "i18n",
+        // Module root `lib/i18n/`, matching the activerecord/rack pattern.
+        // The entrypoint lib/i18n.rb (the I18n module facade — translate/
+        // localize/locale accessors) sits outside this dir; the parity RFC
+        // decides how the facade surface is charged when compare is enrolled.
+        libPath: "lib/i18n",
+        testPath: "test",
+        // Vendored-only for now (RFC 0074): there is no packages/i18n TS home
+        // yet — today's i18n surface is scattered shims in activesupport/
+        // activemodel/activerecord, so the package-name → packages/<name>/src
+        // derivation can't resolve. The RFC's first story creates packages/i18n
+        // and flips these flags on.
+        compareApi: false,
+        compareTests: false,
       },
     ],
   },

--- a/vendor/sources.ts
+++ b/vendor/sources.ts
@@ -29,8 +29,9 @@ export interface PackageEntry {
    * Default true. Set to false to vendor the source (so test-compare or other
    * tooling can read it) without including it in the api-compare PACKAGES
    * derivation. Reserved for cases where the extractor can't yet handle a
-   * gem's idioms. Today no source sets this flag; rack and globalid were
-   * wired into api-compare in wave 6 (#1589).
+   * gem's idioms, or where no TS-side package dir exists yet to map onto
+   * (i18n today). Rack and globalid were wired into api-compare in wave 6
+   * (#1589).
    */
   compareApi?: boolean;
   /**
@@ -150,23 +151,6 @@ export const SOURCES: readonly UpstreamSource[] = [
     ],
   },
   {
-    name: "i18n",
-    origin: {
-      type: "git",
-      url: "https://github.com/ruby-i18n/i18n.git",
-      ref: "v1.14.8",
-    },
-    packages: [
-      {
-        name: "i18n",
-        libPath: "lib/i18n",
-        testPath: "test",
-        compareApi: false,
-        compareTests: false,
-      },
-    ],
-  },
-  {
     name: "globalid",
     origin: {
       type: "git",
@@ -183,6 +167,23 @@ export const SOURCES: readonly UpstreamSource[] = [
         libPath: "lib/global_id",
         // Globalid puts *_test.rb under test/cases/ (not test/ directly).
         testPath: "test/cases",
+      },
+    ],
+  },
+  {
+    name: "i18n",
+    origin: {
+      type: "git",
+      url: "https://github.com/ruby-i18n/i18n.git",
+      ref: "v1.14.8",
+    },
+    packages: [
+      {
+        name: "i18n",
+        libPath: "lib/i18n",
+        testPath: "test",
+        compareApi: false,
+        compareTests: false,
       },
     ],
   },


### PR DESCRIPTION
Vendors the Ruby **i18n** gem (`ruby-i18n/i18n` @ **v1.14.8**, the latest 1.x
release — Rails 8.0.2's activesupport pins `i18n (>= 1.6, < 2)`) into the
upstream-source registry, as the foundation for an i18n parity RFC.

## What's in here

- `vendor/sources.ts`: new `i18n` `UpstreamSource` (libPath `lib/i18n`,
  testPath `test`), with `compareApi: false` / `compareTests: false` — see
  crux below.
- `vendor/sources.lock.json`: pin `v1.14.8` @
  `f2fb6a5766dee835082eb74ee83f52e0a6479573` (clone itself stays gitignored).
- `vendor/sources.test.ts`: coverage for the new source + exclusion invariants,
  plus repair of four expectations that rotted when wave 3.5 (#1621) added
  `actionpackversion` and gave `abstractcontroller` a testPath without updating
  this file (CI's path filter meant vendor tests hadn't run since).

## Crux: TS-side mapping — option (c) now, option (a) as the RFC end-state

api-compare maps package `name` → `packages/<name>/src`, and **there is no
`packages/i18n`** — today's i18n surface is scattered shims with two divergent
`SimpleBackend` implementations (`packages/activesupport/src/i18n.ts`,
`packages/activemodel/src/i18n.ts`, plus `translation.ts` files in
activemodel/activerecord and `html-safe-translation.ts` in activesupport).

- Mapping onto activesupport (option b) was rejected: it would charge
  activesupport's parity numbers with a foreign gem's surface and misplace
  the activemodel half entirely — unfaithful to the gem's standalone layout.
- Creating `packages/i18n` + consolidating the shims is the faithful end-state
  (option a), but is a multi-PR consolidation — RFC work, not vendoring work.
- So this PR ships **option (c)**: vendored, resolvable by tooling
  (`resolvePath("i18n")`), excluded from both compare derivations. RFC 0074's
  first story creates `packages/i18n` and flips the flags on.

Verified: `pnpm vendor:fetch`, `pnpm api:compare`, and `pnpm test:compare` all
run clean with i18n correctly excluded; `vendor/sources.test.ts` +
`vendor/fetch.test.ts` pass (31/31).

Burndown RFC: `0074-i18n-parity` in the tasks repo.
