### PR TITLE
fix(associations): reconcile has_one_through join row before RecordInvalid

### DIFF
--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -6,6 +6,7 @@ import {
   HasOneThroughNestedAssociationsAreReadonly,
 } from "./errors.js";
 import { compositeQueryConstraintsList } from "../persistence.js";
+import { RecordInvalid } from "../validations.js";
 import {
   sourceReflection,
   staleStateImpl as throughStaleState,
@@ -118,24 +119,24 @@ export class HasOneThroughAssociation extends HasOneAssociation {
    * picks Rails' own branches: `update` an existing *persisted* join row inline
    * (:33), or merely `build` when absent (:36-37), leaving that row for the
    * owner's next save.
+   *
+   * Rails runs `set_new_record` BEFORE `raise RecordInvalid` (:69-70), so a
+   * `create#{name}!` whose child fails validation still reconciles the join
+   * row — `update` writes the unsaved record, blanking the join foreign key.
+   * `super` raises from inside itself, hence the reconcile in the `catch`.
    */
   protected override async _createRecord(
     attributes?: Record<string, unknown>,
     shouldRaise = false,
     block?: (record: Base) => void,
   ): Promise<Base | null> {
-    // Rails runs `set_new_record` — hence all of `create_through_record` —
-    // BEFORE `raise RecordInvalid.new(record) if !saved && raise_error`
-    // (singular_association.rb:67-70), so a `create#{name}!` whose child fails
-    // validation STILL reconciles the join row: `through_record.update(club:
-    // record)` (:33) runs with the unsaved record, blanking the join row's
-    // foreign key. Our `super` raises that error from inside itself, so the
-    // reconcile has to be driven from the catch to keep Rails' ordering.
     let record: Base | null;
     try {
       record = await super._createRecord(attributes, shouldRaise, block);
     } catch (error) {
-      if (this._pendingReplace) await this.persistReplace(false);
+      if (error instanceof RecordInvalid && this._pendingReplace) {
+        await this.persistReplace(false);
+      }
       throw error;
     }
     if (record && this._pendingReplace) {

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -124,7 +124,20 @@ export class HasOneThroughAssociation extends HasOneAssociation {
     shouldRaise = false,
     block?: (record: Base) => void,
   ): Promise<Base | null> {
-    const record = await super._createRecord(attributes, shouldRaise, block);
+    // Rails runs `set_new_record` — hence all of `create_through_record` —
+    // BEFORE `raise RecordInvalid.new(record) if !saved && raise_error`
+    // (singular_association.rb:67-70), so a `create#{name}!` whose child fails
+    // validation STILL reconciles the join row: `through_record.update(club:
+    // record)` (:33) runs with the unsaved record, blanking the join row's
+    // foreign key. Our `super` raises that error from inside itself, so the
+    // reconcile has to be driven from the catch to keep Rails' ordering.
+    let record: Base | null;
+    try {
+      record = await super._createRecord(attributes, shouldRaise, block);
+    } catch (error) {
+      if (this._pendingReplace) await this.persistReplace(false);
+      throw error;
+    }
     if (record && this._pendingReplace) {
       await this.persistReplace(false);
     }

--- a/packages/activerecord/src/associations/has-one-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-through-associations.test.ts
@@ -116,10 +116,8 @@ describe("HasOneThroughAssociationsTest", () => {
   registerModel(Owner);
   registerModel(Post);
   registerModel(FirstPost);
-  enableSti(Comment);
   registerModel(Comment);
   registerModel(SpecialComment);
-  registerSubclass(SpecialComment);
   registerModel(Categorization);
   registerModel(Customer);
   registerModel(Carrier);
@@ -333,20 +331,17 @@ describe("HasOneThroughAssociationsTest", () => {
   });
 
   it("raising create with an invalid record still reconciles an unloaded join row", async () => {
-    // Rails' `SingularAssociation#_create_record` (singular_association.rb:63-71)
-    // runs the whole of `set_new_record` — i.e. `create_through_record`, join-row
-    // `update` included — BEFORE `raise RecordInvalid`. `Author` validates
-    // `name`, so `create_author!` with no name fails and the join row (the post)
-    // is still updated toward the unsaved author, blanking its `author_id`.
     const author = await Author.create({ name: "David" });
     const post = await Post.create({ title: "t", body: "b", author_id: author.id });
     const comment = await SpecialComment.create({ post_id: post.id, body: "sc" });
 
     const refetched = await SpecialComment.find(comment.id);
+    const authorsBefore = await Author.count();
     await expect((refetched.association("author") as any).createBang({})).rejects.toThrow(
       RecordInvalid,
     );
 
+    expect(await Author.count()).toBe(authorsBefore);
     expect((await Post.find(post.id)).author_id).toBeNull();
   });
 

--- a/packages/activerecord/src/associations/has-one-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-through-associations.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { ArgumentError } from "@blazetrails/activemodel";
-import { Base, registerModel, enableSti, registerSubclass } from "../index.js";
+import { Base, registerModel, enableSti, registerSubclass, RecordInvalid } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { assertQueriesMatch, assertQueriesCount } from "../testing/query-assertions.js";
 import {
@@ -36,7 +36,7 @@ import { Author, AuthorAddress } from "../test-helpers/models/author.js";
 import { Essay } from "../test-helpers/models/essay.js";
 import { Owner } from "../test-helpers/models/owner.js";
 import { Post, FirstPost } from "../test-helpers/models/post.js";
-import { Comment } from "../test-helpers/models/comment.js";
+import { Comment, SpecialComment } from "../test-helpers/models/comment.js";
 import { Categorization } from "../test-helpers/models/categorization.js";
 import { Customer } from "../test-helpers/models/customer.js";
 import { Carrier } from "../test-helpers/models/carrier.js";
@@ -116,7 +116,10 @@ describe("HasOneThroughAssociationsTest", () => {
   registerModel(Owner);
   registerModel(Post);
   registerModel(FirstPost);
+  enableSti(Comment);
   registerModel(Comment);
+  registerModel(SpecialComment);
+  registerSubclass(SpecialComment);
   registerModel(Categorization);
   registerModel(Customer);
   registerModel(Carrier);
@@ -327,6 +330,24 @@ describe("HasOneThroughAssociationsTest", () => {
     const reloaded = await Membership.find(membershipId);
     expect(Number(reloaded.club_id)).toBe(Number(newClub.id));
     expect(Number(reloaded.club_id)).not.toBe(Number(oldClub.id));
+  });
+
+  it("raising create with an invalid record still reconciles an unloaded join row", async () => {
+    // Rails' `SingularAssociation#_create_record` (singular_association.rb:63-71)
+    // runs the whole of `set_new_record` — i.e. `create_through_record`, join-row
+    // `update` included — BEFORE `raise RecordInvalid`. `Author` validates
+    // `name`, so `create_author!` with no name fails and the join row (the post)
+    // is still updated toward the unsaved author, blanking its `author_id`.
+    const author = await Author.create({ name: "David" });
+    const post = await Post.create({ title: "t", body: "b", author_id: author.id });
+    const comment = await SpecialComment.create({ post_id: post.id, body: "sc" });
+
+    const refetched = await SpecialComment.find(comment.id);
+    await expect((refetched.association("author") as any).createBang({})).rejects.toThrow(
+      RecordInvalid,
+    );
+
+    expect((await Post.find(post.id)).author_id).toBeNull();
   });
 
   it("creating with no existing join row only builds the join record", async () => {


### PR DESCRIPTION
Rails' `SingularAssociation#_create_record` (`singular_association.rb:63-71`)
runs `set_new_record(record)` — and therefore the whole of
`HasOneThroughAssociation#create_through_record`, including the persisted
join-row `through_record.update(attributes)` arm
(`has_one_through_association.rb:33`) — BEFORE
`raise RecordInvalid.new(record) if !saved && raise_error`.

Our `_createRecord` ran the deferred reconcile (`persistReplace(false)`) only
after `super._createRecord` returned. `RecordInvalid` is thrown from inside that
`super` call, so a `create#{name}!` whose child fails validation skipped the
reconcile entirely and left an existing persisted-but-unloaded join row
untouched. Drive the reconcile from the `catch` as well, then rethrow.

The catch is narrowed to `RecordInvalid` on purpose: that is the only error
Rails raises *after* `set_new_record`. A build-time failure (unknown attribute,
type mismatch) raises before `set_new_record` in Rails too, so it must not flush
a pending join-row write.

Verified against vendored Rails: `construct_join_attributes` yields
`{ source: record }` with the *unsaved* record, so the join row's foreign key is
rewritten toward it — i.e. blanked. Odd, but that is what Rails writes, and the
test pins exactly that.

Regression test in `has-one-through-associations.test.ts` uses canonical models
only — `SpecialComment#author` through `post` (source `Author`, which
`validates :name, presence: true`; the canonical `Club` has no validations, so
the Member/Club shape cannot express this). Fails on baseline
(`expected 4 to be null`).

has_one + has_one_through suites green locally.

Closes-story: has-one-through-raising-create-skips-join-row-reconcile
