### PR TITLE
fix(test-helpers): lease the fixture connection from the pool

### DIFF
--- a/packages/activerecord/src/test-helpers/fixture-connection.test.ts
+++ b/packages/activerecord/src/test-helpers/fixture-connection.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Regression coverage for the fixture machinery's connection source.
+ *
+ * Rails bans the soft-deprecated `Base.connection` getter suite-wide
+ * (`test/cases/helper.rb:27`, `permanent_connection_checkout = :disallowed`) and
+ * its fixture setup leases from the pool instead (`test_fixtures.rb:179/194`).
+ * These tests pin that the trails fixture default does the same: they fail
+ * against the previous `() => Base.connection` default, which raises under
+ * `"disallowed"`.
+ *
+ * Run this file only (not the whole suite):
+ *   pnpm vitest run packages/activerecord/src/test-helpers/fixture-connection.test.ts
+ */
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
+import { Base } from "../base.js";
+import { setPermanentConnectionCheckout } from "../ar-config.js";
+import { establishFromTestConfig } from "./test-database-config.js";
+import { leaseFixtureConnection } from "./fixture-connection.js";
+
+describe("fixture connection source", () => {
+  beforeAll(async () => {
+    await establishFromTestConfig();
+  });
+
+  afterEach(() => {
+    setPermanentConnectionCheckout(true);
+  });
+
+  it("leases without tripping permanentConnectionCheckout = disallowed", () => {
+    setPermanentConnectionCheckout("disallowed");
+
+    expect(() => leaseFixtureConnection()).not.toThrow();
+  });
+
+  it("resolves the same connection the pool holds", () => {
+    const leased = leaseFixtureConnection();
+
+    expect(leased).toBe(Base.connectionPool().activeConnection);
+  });
+
+  it("returns a directly-assigned adapter without consulting the pool", () => {
+    const sentinel = { marker: "direct-adapter" } as never;
+    const previous = Base._adapter;
+    Base._adapter = sentinel;
+    try {
+      setPermanentConnectionCheckout("disallowed");
+
+      expect(leaseFixtureConnection()).toBe(sentinel);
+    } finally {
+      Base._adapter = previous;
+    }
+  });
+});

--- a/packages/activerecord/src/test-helpers/fixture-connection.ts
+++ b/packages/activerecord/src/test-helpers/fixture-connection.ts
@@ -1,0 +1,32 @@
+import { Base } from "../base.js";
+import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
+
+/**
+ * The connection the fixture machinery seeds and pins through.
+ *
+ * Rails' fixture setup leases from the pool — `pool.lease_connection` at
+ * `test_fixtures.rb:179` and `:194` — and never reads the soft-deprecated
+ * `Base.connection` getter, which `test/cases/helper.rb:27` bans suite-wide with
+ * `permanent_connection_checkout = :disallowed`. Reading the getter from the
+ * fixture default made it the single largest source of banned checkouts in the
+ * trails suite.
+ *
+ * The two arms below are the getter's own (`connection-handling.ts`
+ * `connection()`) minus its deprecation gate, so the connection handed to
+ * fixtures is exactly the one they resolved before: a permanent lease
+ * establishes one synchronously, and an already-pinned or already-wrapped lease
+ * returns the active connection without mutating stickiness. Leasing
+ * unconditionally would flip a `withConnection` wrap's `sticky = false` to
+ * `true` and leak the connection past the wrap.
+ *
+ * The `_adapter` arm has no Rails counterpart: it mirrors the getter's fast path
+ * for a directly-assigned adapter (`Base.adapter = x`), which has no pool to
+ * lease from and whose `connectionPool()` therefore throws.
+ */
+export function leaseFixtureConnection(): DatabaseAdapter {
+  const direct = (Base as unknown as { _adapter?: DatabaseAdapter })._adapter;
+  if (direct) return direct;
+  const pool = Base.connectionPool();
+  if (pool.isPermanentLease()) return pool.leaseConnectionSync();
+  return pool.activeConnection!;
+}

--- a/packages/activerecord/src/test-helpers/repair-validations.test.ts
+++ b/packages/activerecord/src/test-helpers/repair-validations.test.ts
@@ -3,11 +3,12 @@ import { Base } from "../index.js";
 import { setupHandlerSuite } from "./setup-handler-suite.js";
 import { withTransactionalFixtures } from "./with-transactional-fixtures.js";
 import { repairValidations } from "./repair-validations.js";
+import { leaseFixtureConnection } from "./fixture-connection.js";
 
 // interests and zines are canonical schema.rb tables laid by the boot schema;
 // the inline models ride them rather than recreating a bespoke shape.
 setupHandlerSuite();
-withTransactionalFixtures(() => Base.connection);
+withTransactionalFixtures(leaseFixtureConnection);
 
 describe("repairValidations", () => {
   it("removes a validator added inside the block after it returns", async () => {

--- a/packages/activerecord/src/test-helpers/use-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.test.ts
@@ -19,6 +19,7 @@ import { Post } from "./models/post.js";
 import { LiveParrot, DeadParrot } from "./models/parrot.js";
 import { Cucumber, Cabbage, RedCabbage } from "./models/vegetables.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
+import { leaseFixtureConnection } from "./fixture-connection.js";
 
 /**
  * Resolves an entry's model thunk to its table-bearing class, registering the
@@ -261,7 +262,7 @@ describe("useFixtures type contract", () => {
 
 describe("useFixtures by registry name", () => {
   setupHandlerSuite();
-  withTransactionalFixtures(() => Base.connection);
+  withTransactionalFixtures(leaseFixtureConnection);
 
   // author_addresses listed first: authors.author_address_id ref() resolves to its
   // declared ids, so the target set must load before its dependent.
@@ -319,7 +320,7 @@ describe("useFixtures by registry name", () => {
 
 describe("useFixtures seeds HABTM join tables (no model class)", () => {
   setupHandlerSuite();
-  withTransactionalFixtures(() => Base.connection);
+  withTransactionalFixtures(leaseFixtureConnection);
 
   // categories + posts declare explicit ids, so they load BEFORE the join set —
   // categoriesPosts' category_id/post_id ref()s then resolve to those declared ids.
@@ -359,7 +360,7 @@ describe("useFixtures seeds HABTM join tables (no model class)", () => {
 
 describe("useFixtures seeds a single-row HABTM join table", () => {
   setupHandlerSuite();
-  withTransactionalFixtures(() => Base.connection);
+  withTransactionalFixtures(leaseFixtureConnection);
 
   const { people, treasures, peoplesTreasures } = fixtures(
     ["people", "treasures", "peoplesTreasures"],
@@ -377,7 +378,7 @@ describe("useFixtures seeds a single-row HABTM join table", () => {
 
 describe("useFixtures vertices and edges", () => {
   setupHandlerSuite();
-  withTransactionalFixtures(() => Base.connection);
+  withTransactionalFixtures(leaseFixtureConnection);
 
   // vertices must load before edges so edge ref()s resolve to declared vertex ids.
   const { vertices, edges } = fixtures(["vertices", "edges"], {
@@ -403,7 +404,7 @@ describe("useFixtures vertices and edges", () => {
 
 describe("useFixtures auto-stamps NOT NULL timestamps", () => {
   setupHandlerSuite();
-  withTransactionalFixtures(() => Base.connection);
+  withTransactionalFixtures(leaseFixtureConnection);
 
   // people.michael declares neither created_at nor updated_at, but both columns
   // are NOT NULL — defineFixtures must fill them with the current time, mirroring
@@ -429,7 +430,7 @@ describe("useFixtures auto-stamps NOT NULL timestamps", () => {
 
 describe("useFixtures with a string primary key", () => {
   setupHandlerSuite();
-  withTransactionalFixtures(() => Base.connection);
+  withTransactionalFixtures(leaseFixtureConnection);
 
   // Subscriber sets `self.primary_key = "nick"` (a string column). The fixture
   // row declares `nick: "alterself"`; resolveDeclaredPk must use that string
@@ -458,7 +459,7 @@ describe("useFixtures with a string primary key", () => {
 
 describe("useFixtures reconciles the PK column against the schema", () => {
   setupHandlerSuite();
-  withTransactionalFixtures(() => Base.connection);
+  withTransactionalFixtures(leaseFixtureConnection);
 
   // Bulb declares no `primary_key`, so the model defaults to `id`, but the
   // `bulbs` table's PK column is `ID` (schema.rb: `primary_key: "ID"`). The
@@ -509,7 +510,7 @@ describe("useFixtures reconciles the PK column against the schema", () => {
 
 describe("useFixtures seeds composite-primary-key tables", () => {
   setupHandlerSuite();
-  withTransactionalFixtures(() => Base.connection);
+  withTransactionalFixtures(leaseFixtureConnection);
 
   // CpkOrder declares a composite model PK (`["shop_id", "id"]`) while the test
   // schema keeps a plain autoincrement `id`; Rails' composite_primary_key? is
@@ -559,7 +560,7 @@ describe("useFixtures seeds composite-primary-key tables", () => {
 
 describe("useFixtures resolves STI subclasses on standalone load", () => {
   setupHandlerSuite();
-  withTransactionalFixtures(() => Base.connection);
+  withTransactionalFixtures(leaseFixtureConnection);
 
   // parrots.yml rows carry a custom inheritance column (`parrot_sti_class`)
   // pointing at LiveParrot/DeadParrot. Loading the base `parrots` set must
@@ -752,7 +753,7 @@ describe("fixtures() loads multiple same-table fixture sets in one call", () => 
 // registry's gap list, not stay exposed.
 describe("fixtureRegistry seeds against TEST_SCHEMA", () => {
   setupHandlerSuite();
-  withTransactionalFixtures(() => Base.connection);
+  withTransactionalFixtures(leaseFixtureConnection);
   // Encrypted entries (encryptedBooks…) reload through the encrypted attribute
   // type, which needs keys + the cleartext fallback. Configure (scoped) so the
   // seed loop can reload them, and restore after so this describe doesn't leak
@@ -789,7 +790,7 @@ describe("fixtureRegistry seeds against TEST_SCHEMA", () => {
 
 describe("useFixtures bootstraps the encryption add-on for encrypted fixtures", () => {
   setupHandlerSuite();
-  withTransactionalFixtures(() => Base.connection);
+  withTransactionalFixtures(leaseFixtureConnection);
 
   // Reading encrypted fixtures back needs keys + the cleartext fallback. Configure
   // that here (scoped, with snapshot/restore) rather than in the addOn, so the

--- a/packages/activerecord/src/test-helpers/use-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.ts
@@ -23,6 +23,7 @@ import {
   withTransactionalFixtures,
   type WithTransactionalFixturesOptions,
 } from "./with-transactional-fixtures.js";
+import { leaseFixtureConnection } from "./fixture-connection.js";
 
 /**
  * A tableless fixture entry: seeds rows directly into the named table with no
@@ -607,7 +608,7 @@ export function fixtures(
   // Caller-supplied connection/adapter thunk wins over the default handler
   // connection: multi-database suites seed through a model-specific
   // `*.connection`, and adapter-owning suites seed through their own adapter.
-  const getConnection = connection ?? (() => Base.connection);
+  const getConnection = connection ?? leaseFixtureConnection;
 
   setupHandlerSuite();
   // Rails' `use_transactional_tests = false` (default is true): skip the

--- a/packages/activerecord/src/test-helpers/use-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.ts
@@ -91,7 +91,8 @@ export interface FixturesConnectionOpts {
   /**
    * Caller-supplied connection/adapter thunk. When set, {@link fixtures}
    * seeds, cleans, and (when transactional) pins fixtures
-   * through this connection instead of the default `() => Base.connection`.
+   * through this connection instead of the default pool lease
+   * ({@link leaseFixtureConnection}).
    *
    * Mirrors Rails loading a fixture set through a model-specific `connection`
    * (multi-database suites) or through a suite's own adapter. Composes with

--- a/packages/activerecord/src/test-helpers/use-transactional-tests.ts
+++ b/packages/activerecord/src/test-helpers/use-transactional-tests.ts
@@ -1,12 +1,12 @@
-import { Base } from "../base.js";
 import { establishFromTestConfig } from "./test-database-config.js";
+import { leaseFixtureConnection } from "./fixture-connection.js";
 import {
   withTransactionalFixtures,
   type WithTransactionalFixturesOptions,
 } from "./with-transactional-fixtures.js";
 
 /**
- * Opt-in per-test transaction isolation for the primary `Base.connection` path.
+ * Opt-in per-test transaction isolation for the primary pool-leased path.
  * Mirrors Rails' `use_transactional_tests = true` (default in `TestFixtures`).
  *
  * Each test body is wrapped in a transaction that rolls back in `afterEach`,
@@ -23,7 +23,7 @@ import {
  * **When to use this vs `setupHandlerSuite + withTransactionalFixtures`:**
  * Use `useTransactionalTests()` for self-contained test files that want the
  * handler bootstrapped automatically. Use `setupHandlerSuite()` +
- * `withTransactionalFixtures(() => Base.connection)` when the file is part of a suite that
+ * `withTransactionalFixtures(leaseFixtureConnection)` when the file is part of a suite that
  * shares a long-lived handler across multiple describes — `setupHandlerSuite`
  * keeps the adapter alive across files whereas `useTransactionalTests` fires
  * `resetTestAdapterState` on exit (depth reaches zero), tearing down the pool.
@@ -64,7 +64,7 @@ export function useTransactionalTests(options?: WithTransactionalFixturesOptions
   // (matches the idiom in setupHandlerSuite). establishFromTestConfig is
   // idempotent (guarded by Base.isConnectedQ()), so calling it from both
   // setupHandlerSuite and useTransactionalTests in the same file is safe.
-  withTransactionalFixtures(() => Base.connection, {
+  withTransactionalFixtures(leaseFixtureConnection, {
     ...options,
     _beforeAll: establishFromTestConfig,
   });


### PR DESCRIPTION
Routes the fixture machinery off the soft-deprecated `Base.connection` getter.

Rails' fixture setup leases from the pool — `pool.lease_connection` at
`test_fixtures.rb:179` and `:194` — and never reads the getter, which
`test/cases/helper.rb:27` bans suite-wide with
`permanent_connection_checkout = :disallowed`. The trails fixture default read
it, making it the single largest source of banned checkouts in the AR suite:
**1983 of 2077 hits (95.5%)**, measured by arming the gate and running all 129 AR
test files carrying a textual `.connection`.

**Measured before → after: 2077 → 57 hits, none from the fixture machinery.**

### Why not just lease

`leaseFixtureConnection` reproduces the getter's own two arms
(`connection-handling.ts` `connection()`) **minus its deprecation gate**, so the
connection handed to fixtures is unchanged. An unconditional
`leaseConnectionSync()` would not be equivalent — it flips a `withConnection`
wrap's `sticky = false` to `true` and leaks the connection past the wrap. The
`_adapter` arm mirrors the getter's fast path for `Base.adapter = x`, which has
no pool to lease from; that shape is trails-only and has no Rails counterpart.

### Scope

Two commits. The first changes the default; the second converts the fixture
helpers' **own tests**, which pass the thunk explicitly and so do not resolve
themselves when the default changes (11 sites in `use-fixtures.test.ts`, 1 in
`repair-validations.test.ts`), and corrects the `fixtures()` option JSDoc that
still documented the removed `() => Base.connection` default.

Four helper self-test sites are deliberately left: they read the getter for their
own purposes rather than as a fixture thunk, and belong to story C. Notably
`use-transactional-tests.test.ts:19`, whose file docstring says it proves
isolation "on the `Base.connection` path" — that intent needs reading before it
is changed.

### Verification

- `fixture-connection.test.ts` pins the behavior. The load-bearing assertion
  **fails on baseline** with `ActiveRecordError: Called deprecated
  ActiveRecord::Base.connection method`, verified by reverting the helper body to
  `Base.connection` and re-running.
- Diffing the residual sites before and after confirms **no new call sites were
  introduced**.
- Local suites: the fixture-helper suites plus `associations`, `persistence`,
  `transactions`, `base`, `dirty`, `locking` — 751 passed. The full 129-file
  sweep passes (2811 passed) under the armed gate.

Part of RFC 0073 (`permanent-connection-checkout-disallowed`) in the tasks repo.
Does not flip the flag; that is the terminal story
`arm-permanent-connection-checkout-disallowed`.

---

### CI note: the PG shard-2 failure is a pre-existing shared-DB flake

`use-fixtures.test.ts > fixtureRegistry seeds against TEST_SCHEMA` failed on
**Active Record PostgreSQL Tests (2)** with
`items: relation "items" does not exist`. Evidence it is not this diff:

- **Lane pattern.** SQLite, MariaDB (1) and (2), and PostgreSQL (1) all pass;
  only PG shard 2 failed. A wrong connection would fail on every lane, and would
  not surface as a single missing relation.
- **The failing assertion does not use the changed path.** It seeds via
  `Base.adapter`, and `Base.adapter` is literally `return this.connection`
  (`base.ts:1527`) — the same getter the old thunk called. The swap therefore
  cannot change the seeding connection.
- **Not reproducible.** On an isolated PostgreSQL stack (private port, so another
  worktree's containers cannot confound the result): `use-fixtures.test.ts` alone
  passed 54/54 including the failing assertion; the `items` consumers run
  together under `AR_DB_FORKS=4` to induce contention (`use-fixtures`,
  `readonly`, `reflection`, `persistence`, `calculations`, `batches`,
  `associations`, `named-scoping`) passed 848/848.

Since it does not reproduce, there is no fix I can verify — and a speculative
change to a shared-DB race would be worse than leaving it. The failed job has
been re-run.

The earlier "Active Record PostgreSQL Tests (1)" failure on this PR was
`The operation was canceled` (a superseded run), not a test failure.

Closes-story: route-fixture-machinery-off-deprecated-getter
