### PR TITLE
feat(actionview): port ActionView::ViewPaths

### DIFF
--- a/packages/actionview/src/actionpack/controller/view-paths.test.ts
+++ b/packages/actionview/src/actionpack/controller/view-paths.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeAll, describe, expect, test } from "vitest";
 import { getPathAsync } from "@blazetrails/activesupport";
-import { PathRegistry } from "./path-registry.js";
-import { PathSet } from "./path-set.js";
-import { FileSystemResolver } from "./resolver/file-system-resolver.js";
+import { PathRegistry } from "../../path-registry.js";
+import { PathSet } from "../../path-set.js";
+import { FileSystemResolver } from "../../resolver/file-system-resolver.js";
 import {
   ClassMethods,
   appendViewPath,
@@ -11,7 +11,7 @@ import {
   viewPaths,
   type ViewPaths,
   type ViewPathsClass,
-} from "./view-paths.js";
+} from "../../view-paths.js";
 
 const FIXTURE_LOAD_PATH = "/fixtures";
 
@@ -22,10 +22,6 @@ beforeAll(async () => {
   expand = (paths) => paths.map((p) => path.resolve(p));
 });
 
-/**
- * Stands in for `ActionController::Base` — the ViewPaths surface assigned onto
- * a class that supplies `abstract?` and `controller_path`.
- */
 class TestController implements ViewPaths {
   declare readonly ["constructor"]: ViewPathsClass;
 
@@ -61,12 +57,12 @@ afterEach(() => {
 });
 
 describe("ViewLoadPathsTest", () => {
-  test("test_template_load_path_was_set_correctly", () => {
+  test("template load path was set correctly", () => {
     TestController.viewPaths([FIXTURE_LOAD_PATH]);
     assertPaths(new TestController().viewPaths(), FIXTURE_LOAD_PATH);
   });
 
-  test("test_controller_appends_view_path_correctly", () => {
+  test("controller appends view path correctly", () => {
     TestController.viewPaths([FIXTURE_LOAD_PATH]);
     const controller = new TestController();
 
@@ -80,7 +76,7 @@ describe("ViewLoadPathsTest", () => {
     assertPaths(controller.viewPaths(), FIXTURE_LOAD_PATH, "foo", "bar", "baz", FIXTURE_LOAD_PATH);
   });
 
-  test("test_controller_prepends_view_path_correctly", () => {
+  test("controller prepends view path correctly", () => {
     TestController.viewPaths([FIXTURE_LOAD_PATH]);
     const controller = new TestController();
 
@@ -94,7 +90,7 @@ describe("ViewLoadPathsTest", () => {
     assertPaths(controller.viewPaths(), FIXTURE_LOAD_PATH, "foo", "bar", "baz", FIXTURE_LOAD_PATH);
   });
 
-  test("test_inheritance", () => {
+  test("inheritance", () => {
     const originalLoadPaths = [FIXTURE_LOAD_PATH];
     TestController.viewPaths(originalLoadPaths);
 
@@ -113,7 +109,7 @@ describe("ViewLoadPathsTest", () => {
     assertPaths(C.viewPaths(), "c/path");
   });
 
-  test("test_lookup_context_accessor", () => {
+  test("lookup context accessor", () => {
     TestController.viewPaths([FIXTURE_LOAD_PATH]);
     expect(new TestController().lookupContext().prefixes).toEqual(["test"]);
   });

--- a/packages/actionview/src/index.ts
+++ b/packages/actionview/src/index.ts
@@ -36,10 +36,11 @@ export type {
   Rendering,
   Layouts,
   LayoutsClass,
-  ViewPaths,
-  ViewPathsClass,
   RenderOptions as RenderingOptions,
 } from "./rendering.js";
+
+export { ClassMethods as ViewPathsClassMethods } from "./view-paths.js";
+export type { ViewPaths, ViewPathsClass, ViewPathsInput } from "./view-paths.js";
 
 export { Renderer, RenderedTemplate } from "./renderer.js";
 export type { ViewContext, RenderOptions as RendererOptions } from "./renderer.js";

--- a/packages/actionview/src/path-registry.test.ts
+++ b/packages/actionview/src/path-registry.test.ts
@@ -3,6 +3,7 @@ import { getPathAsync } from "@blazetrails/activesupport";
 import { FileSystemResolver } from "./resolver/file-system-resolver.js";
 import { InMemoryResolver } from "./resolver/in-memory-resolver.js";
 import { PathRegistry } from "./path-registry.js";
+import { PathSet } from "./path-set.js";
 
 beforeAll(async () => {
   await getPathAsync();
@@ -44,7 +45,7 @@ describe("PathRegistry", () => {
 
   test("setViewPaths + getViewPaths round-trips per class", () => {
     class MyController {}
-    const paths = [new InMemoryResolver()];
+    const paths = new PathSet([new InMemoryResolver()]);
     PathRegistry.setViewPaths(MyController, paths);
     expect(PathRegistry.getViewPaths(MyController)).toBe(paths);
   });
@@ -52,7 +53,7 @@ describe("PathRegistry", () => {
   test("getViewPaths walks the prototype chain", () => {
     class Base {}
     class Child extends Base {}
-    const paths = [new InMemoryResolver()];
+    const paths = new PathSet([new InMemoryResolver()]);
     PathRegistry.setViewPaths(Base, paths);
     expect(PathRegistry.getViewPaths(Child)).toBe(paths);
   });

--- a/packages/actionview/src/path-registry.ts
+++ b/packages/actionview/src/path-registry.ts
@@ -15,17 +15,15 @@ import type { TemplateResolver } from "./resolver/resolver.js";
 
 type ClassLike = new (...args: unknown[]) => unknown;
 
-export type RegisteredViewPaths = PathSet | TemplateResolver[];
-
 export class PathRegistry {
   /** @internal Hooks fired whenever a new FileSystemResolver is built via castFileSystemResolvers. */
   static readonly fileSystemResolverHooks: Array<() => void> = [];
 
   private static _fileSystemResolvers = new Map<string, FileSystemResolver>();
-  private static _viewPathsByClass = new Map<ClassLike, RegisteredViewPaths>();
+  private static _viewPathsByClass = new Map<ClassLike, PathSet>();
 
   /** @internal */
-  static getViewPaths(klass: ClassLike): RegisteredViewPaths | undefined {
+  static getViewPaths(klass: ClassLike): PathSet | undefined {
     if (this._viewPathsByClass.has(klass)) return this._viewPathsByClass.get(klass);
     const proto = Object.getPrototypeOf(klass) as ClassLike | null;
     return proto && typeof proto === "function" && proto !== Function.prototype
@@ -34,7 +32,7 @@ export class PathRegistry {
   }
 
   /** @internal */
-  static setViewPaths(klass: ClassLike, paths: RegisteredViewPaths): void {
+  static setViewPaths(klass: ClassLike, paths: PathSet): void {
     this._viewPathsByClass.set(klass, paths);
   }
 
@@ -80,9 +78,7 @@ export class PathRegistry {
     };
     for (const r of this._fileSystemResolvers.values()) add(r);
     for (const paths of this._viewPathsByClass.values()) {
-      const list =
-        paths instanceof PathSet ? (paths.toArray() as unknown as TemplateResolver[]) : paths;
-      for (const r of list) add(r);
+      for (const r of paths.toArray() as unknown as TemplateResolver[]) add(r);
     }
     return out;
   }

--- a/packages/actionview/src/path-registry.ts
+++ b/packages/actionview/src/path-registry.ts
@@ -9,20 +9,28 @@
  */
 
 import { getPath } from "@blazetrails/activesupport";
+import { PathSet } from "./path-set.js";
 import { FileSystemResolver } from "./resolver/file-system-resolver.js";
 import type { TemplateResolver } from "./resolver/resolver.js";
 
 type ClassLike = new (...args: unknown[]) => unknown;
+
+/**
+ * What a class's registered view paths can be: Rails always stores a
+ * `PathSet` (see `ViewPaths` and `path_registry.rb`'s `map(&:to_a)`); the
+ * bare resolver array is the shape ActionView's own callers still pass.
+ */
+export type RegisteredViewPaths = PathSet | TemplateResolver[];
 
 export class PathRegistry {
   /** @internal Hooks fired whenever a new FileSystemResolver is built via castFileSystemResolvers. */
   static readonly fileSystemResolverHooks: Array<() => void> = [];
 
   private static _fileSystemResolvers = new Map<string, FileSystemResolver>();
-  private static _viewPathsByClass = new Map<ClassLike, TemplateResolver[]>();
+  private static _viewPathsByClass = new Map<ClassLike, RegisteredViewPaths>();
 
   /** @internal */
-  static getViewPaths(klass: ClassLike): TemplateResolver[] | undefined {
+  static getViewPaths(klass: ClassLike): RegisteredViewPaths | undefined {
     if (this._viewPathsByClass.has(klass)) return this._viewPathsByClass.get(klass);
     const proto = Object.getPrototypeOf(klass) as ClassLike | null;
     return proto && typeof proto === "function" && proto !== Function.prototype
@@ -31,7 +39,7 @@ export class PathRegistry {
   }
 
   /** @internal */
-  static setViewPaths(klass: ClassLike, paths: TemplateResolver[]): void {
+  static setViewPaths(klass: ClassLike, paths: RegisteredViewPaths): void {
     this._viewPathsByClass.set(klass, paths);
   }
 
@@ -77,7 +85,11 @@ export class PathRegistry {
     };
     for (const r of this._fileSystemResolvers.values()) add(r);
     for (const paths of this._viewPathsByClass.values()) {
-      for (const r of paths) add(r);
+      // PathSet holds the `findAll` protocol, `TemplateResolver` the `find`
+      // one; Rails has a single Resolver protocol, so both are resolvers here.
+      const list =
+        paths instanceof PathSet ? (paths.toArray() as unknown as TemplateResolver[]) : paths;
+      for (const r of list) add(r);
     }
     return out;
   }

--- a/packages/actionview/src/path-registry.ts
+++ b/packages/actionview/src/path-registry.ts
@@ -15,11 +15,6 @@ import type { TemplateResolver } from "./resolver/resolver.js";
 
 type ClassLike = new (...args: unknown[]) => unknown;
 
-/**
- * What a class's registered view paths can be: Rails always stores a
- * `PathSet` (see `ViewPaths` and `path_registry.rb`'s `map(&:to_a)`); the
- * bare resolver array is the shape ActionView's own callers still pass.
- */
 export type RegisteredViewPaths = PathSet | TemplateResolver[];
 
 export class PathRegistry {
@@ -85,8 +80,6 @@ export class PathRegistry {
     };
     for (const r of this._fileSystemResolvers.values()) add(r);
     for (const paths of this._viewPathsByClass.values()) {
-      // PathSet holds the `findAll` protocol, `TemplateResolver` the `find`
-      // one; Rails has a single Resolver protocol, so both are resolvers here.
       const list =
         paths instanceof PathSet ? (paths.toArray() as unknown as TemplateResolver[]) : paths;
       for (const r of list) add(r);

--- a/packages/actionview/src/path-set.ts
+++ b/packages/actionview/src/path-set.ts
@@ -139,15 +139,14 @@ export class PathSet implements Iterable<PathSetResolver> {
    * @internal
    * Validates incoming paths. `String`/`Pathname` wrapping happens up front in
    * `PathRegistry.castFileSystemResolvers` (`ViewPaths#_build_view_paths`), so
-   * only resolvers reach this point — either protocol, `findAll` or `find`.
+   * only resolvers reach this point.
    */
   private typecast(paths: ReadonlyArray<PathSetResolver | unknown>): PathSetResolver[] {
     return paths.map((path) => {
       if (
         path !== null &&
         typeof path === "object" &&
-        (typeof (path as PathSetResolver).findAll === "function" ||
-          typeof (path as { find?: unknown }).find === "function")
+        typeof (path as PathSetResolver).findAll === "function"
       ) {
         return path as PathSetResolver;
       }

--- a/packages/actionview/src/path-set.ts
+++ b/packages/actionview/src/path-set.ts
@@ -137,13 +137,9 @@ export class PathSet implements Iterable<PathSetResolver> {
 
   /**
    * @internal
-   * Validates incoming paths. Rails additionally wraps `String`/`Pathname`
-   * entries in a `FileSystemResolver`; here that wrapping happens up front in
-   * `PathRegistry.castFileSystemResolvers` (see `ViewPaths#_build_view_paths`),
-   * so only resolvers reach this point. Both resolver protocols are accepted:
-   * `findAll` (PathSet's own lookup shape) and `find` (`Resolver`/
-   * `FileSystemResolver`) — Rails has a single Resolver protocol, and the two
-   * here are still to be unified.
+   * Validates incoming paths. `String`/`Pathname` wrapping happens up front in
+   * `PathRegistry.castFileSystemResolvers` (`ViewPaths#_build_view_paths`), so
+   * only resolvers reach this point — either protocol, `findAll` or `find`.
    */
   private typecast(paths: ReadonlyArray<PathSetResolver | unknown>): PathSetResolver[] {
     return paths.map((path) => {

--- a/packages/actionview/src/path-set.ts
+++ b/packages/actionview/src/path-set.ts
@@ -138,20 +138,25 @@ export class PathSet implements Iterable<PathSetResolver> {
   /**
    * @internal
    * Validates incoming paths. Rails additionally wraps `String`/`Pathname`
-   * entries in a `FileSystemResolver`; that wrapping lands with the resolver
-   * port in Phase 1c. Until then non-Resolver entries throw.
+   * entries in a `FileSystemResolver`; here that wrapping happens up front in
+   * `PathRegistry.castFileSystemResolvers` (see `ViewPaths#_build_view_paths`),
+   * so only resolvers reach this point. Both resolver protocols are accepted:
+   * `findAll` (PathSet's own lookup shape) and `find` (`Resolver`/
+   * `FileSystemResolver`) — Rails has a single Resolver protocol, and the two
+   * here are still to be unified.
    */
   private typecast(paths: ReadonlyArray<PathSetResolver | unknown>): PathSetResolver[] {
     return paths.map((path) => {
       if (
         path !== null &&
         typeof path === "object" &&
-        typeof (path as PathSetResolver).findAll === "function"
+        (typeof (path as PathSetResolver).findAll === "function" ||
+          typeof (path as { find?: unknown }).find === "function")
       ) {
         return path as PathSetResolver;
       }
       throw new TypeError(
-        `${String(path)} is not a valid path: must be a Resolver (string/Pathname wrapping lands in Phase 1c)`,
+        `${String(path)} is not a valid path: must be a Resolver (strings are wrapped by PathRegistry.castFileSystemResolvers)`,
       );
     });
   }

--- a/packages/actionview/src/rendering.ts
+++ b/packages/actionview/src/rendering.ts
@@ -7,7 +7,6 @@
  */
 
 import type { LookupContext } from "./lookup-context.js";
-import type { TemplateResolver } from "./resolver/resolver.js";
 
 export interface RenderOptions {
   template?: string;
@@ -49,19 +48,4 @@ export interface LayoutsClass {
     name: string | symbol | false | null | ((...args: unknown[]) => unknown),
     conditions?: { only?: string | string[]; except?: string | string[] },
   ): void;
-}
-
-/** @internal stub - real impl in Phase 4 */
-export interface ViewPaths {
-  viewPaths: TemplateResolver[];
-  prependViewPath(path: string | TemplateResolver | string[]): void;
-  appendViewPath(path: string | TemplateResolver | string[]): void;
-  detailsFor(name: string): Record<string, unknown>;
-}
-
-/** @internal stub - real impl in Phase 4 */
-export interface ViewPathsClass {
-  viewPaths: TemplateResolver[];
-  prependViewPath(path: string | TemplateResolver | string[]): void;
-  appendViewPath(path: string | TemplateResolver | string[]): void;
 }

--- a/packages/actionview/src/resolver/resolver.ts
+++ b/packages/actionview/src/resolver/resolver.ts
@@ -6,6 +6,9 @@
  * (e.g., app views + gem views + database-backed views).
  */
 
+import type { LookupDetails, PathSetResolver } from "../path-set.js";
+import { TemplateHandlers } from "../template/handlers.js";
+import type { TemplatePath } from "../template-path.js";
 import type { Template } from "../template.js";
 
 export interface TemplateResolver {
@@ -28,13 +31,34 @@ export interface TemplateResolver {
   allTemplatePaths?(): readonly string[];
 }
 
-export abstract class Resolver implements TemplateResolver {
+export abstract class Resolver implements TemplateResolver, PathSetResolver {
   abstract find(
     name: string,
     prefix: string,
     format: string,
     extensions: string[],
   ): Template | null;
+
+  findAll(
+    path: TemplatePath | string,
+    prefix: string,
+    partial: boolean,
+    details: LookupDetails,
+    _detailsKey?: unknown,
+    _locals: ReadonlyArray<string> = [],
+  ): Template[] {
+    const extensions = TemplateHandlers.extensions();
+    if (extensions.length === 0) return [];
+
+    const bare = typeof path === "string" ? path : path.name;
+    const name = partial ? `_${bare}` : bare;
+
+    for (const format of requestedFormats(details)) {
+      const template = this.find(name, prefix, format, extensions);
+      if (template) return [template];
+    }
+    return [];
+  }
 
   /** @internal */
   findLayout(name: string, format: string, extensions: string[]): Template | null {
@@ -44,4 +68,10 @@ export abstract class Resolver implements TemplateResolver {
 
   /** @internal Subclasses with internal caches override this. */
   clearCache(): void {}
+}
+
+function requestedFormats(details: LookupDetails): string[] {
+  const formats = (details as { formats?: ReadonlyArray<string | symbol> }).formats ?? [];
+  const named = formats.filter((f): f is string => typeof f === "string");
+  return named.length > 0 ? named : ["*"];
 }

--- a/packages/actionview/src/view-paths.test.ts
+++ b/packages/actionview/src/view-paths.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeAll, describe, expect, test } from "vitest";
+import { getPathAsync } from "@blazetrails/activesupport";
+import { PathRegistry } from "./path-registry.js";
+import { PathSet } from "./path-set.js";
+import { FileSystemResolver } from "./resolver/file-system-resolver.js";
+import {
+  ClassMethods,
+  appendViewPath,
+  lookupContext,
+  prependViewPath,
+  viewPaths,
+  type ViewPaths,
+  type ViewPathsClass,
+} from "./view-paths.js";
+
+const FIXTURE_LOAD_PATH = "/fixtures";
+
+let expand: (paths: string[]) => string[];
+
+beforeAll(async () => {
+  const path = await getPathAsync();
+  expand = (paths) => paths.map((p) => path.resolve(p));
+});
+
+/**
+ * Stands in for `ActionController::Base` — the ViewPaths surface assigned onto
+ * a class that supplies `abstract?` and `controller_path`.
+ */
+class TestController implements ViewPaths {
+  declare readonly ["constructor"]: ViewPathsClass;
+
+  static isAbstract(): boolean {
+    return false;
+  }
+  static controllerPath(): string {
+    return "test";
+  }
+
+  static _viewPaths = ClassMethods._viewPaths;
+  static _prefixes = ClassMethods._prefixes;
+  static _buildViewPaths = ClassMethods._buildViewPaths;
+  static appendViewPath = ClassMethods.appendViewPath;
+  static prependViewPath = ClassMethods.prependViewPath;
+  static viewPaths = ClassMethods.viewPaths;
+  static localPrefixes = ClassMethods.localPrefixes;
+
+  lookupContext = lookupContext;
+  viewPaths = viewPaths;
+  appendViewPath = appendViewPath;
+  prependViewPath = prependViewPath;
+}
+
+function assertPaths(actual: PathSet, ...paths: string[]): void {
+  expect(actual.toArray().map((r) => (r as unknown as FileSystemResolver).path())).toEqual(
+    expand(paths),
+  );
+}
+
+afterEach(() => {
+  PathRegistry.reset();
+});
+
+describe("ViewLoadPathsTest", () => {
+  test("test_template_load_path_was_set_correctly", () => {
+    TestController.viewPaths([FIXTURE_LOAD_PATH]);
+    assertPaths(new TestController().viewPaths(), FIXTURE_LOAD_PATH);
+  });
+
+  test("test_controller_appends_view_path_correctly", () => {
+    TestController.viewPaths([FIXTURE_LOAD_PATH]);
+    const controller = new TestController();
+
+    controller.appendViewPath("foo");
+    assertPaths(controller.viewPaths(), FIXTURE_LOAD_PATH, "foo");
+
+    controller.appendViewPath(["bar", "baz"]);
+    assertPaths(controller.viewPaths(), FIXTURE_LOAD_PATH, "foo", "bar", "baz");
+
+    controller.appendViewPath(FIXTURE_LOAD_PATH);
+    assertPaths(controller.viewPaths(), FIXTURE_LOAD_PATH, "foo", "bar", "baz", FIXTURE_LOAD_PATH);
+  });
+
+  test("test_controller_prepends_view_path_correctly", () => {
+    TestController.viewPaths([FIXTURE_LOAD_PATH]);
+    const controller = new TestController();
+
+    controller.prependViewPath("baz");
+    assertPaths(controller.viewPaths(), "baz", FIXTURE_LOAD_PATH);
+
+    controller.prependViewPath(["foo", "bar"]);
+    assertPaths(controller.viewPaths(), "foo", "bar", "baz", FIXTURE_LOAD_PATH);
+
+    controller.prependViewPath(FIXTURE_LOAD_PATH);
+    assertPaths(controller.viewPaths(), FIXTURE_LOAD_PATH, "foo", "bar", "baz", FIXTURE_LOAD_PATH);
+  });
+
+  test("test_inheritance", () => {
+    const originalLoadPaths = [FIXTURE_LOAD_PATH];
+    TestController.viewPaths(originalLoadPaths);
+
+    class A extends TestController {}
+    class B extends A {}
+    class C extends TestController {}
+
+    A.viewPaths(["a/path"]);
+
+    assertPaths(A.viewPaths(), "a/path");
+    assertPaths(B.viewPaths(), "a/path");
+    assertPaths(C.viewPaths(), ...originalLoadPaths);
+
+    C.viewPaths([]);
+    expect(() => C.appendViewPath("c/path")).not.toThrow();
+    assertPaths(C.viewPaths(), "c/path");
+  });
+
+  test("test_lookup_context_accessor", () => {
+    TestController.viewPaths([FIXTURE_LOAD_PATH]);
+    expect(new TestController().lookupContext().prefixes).toEqual(["test"]);
+  });
+});

--- a/packages/actionview/src/view-paths.trails.test.ts
+++ b/packages/actionview/src/view-paths.trails.test.ts
@@ -1,0 +1,97 @@
+/**
+ * TS-only coverage for the parts of `ActionView::ViewPaths` whose Rails tests
+ * live in controller integration suites (rendering through a real
+ * `ActionController::Base`) that ActionView cannot host on its own.
+ */
+import { afterEach, describe, expect, test } from "vitest";
+import { PathRegistry } from "./path-registry.js";
+import {
+  ClassMethods,
+  _prefixes,
+  detailsForLookup,
+  formats,
+  isAnyTemplates,
+  isTemplateExists,
+  locale,
+  lookupContext,
+  type ViewPaths,
+  type ViewPathsClass,
+} from "./view-paths.js";
+
+class BaseController implements ViewPaths {
+  declare readonly ["constructor"]: ViewPathsClass;
+
+  static abstract = true;
+  static isAbstract(): boolean {
+    return this.abstract;
+  }
+  static controllerPath(): string {
+    return "base";
+  }
+
+  static _prefixes = ClassMethods._prefixes;
+  static viewPaths = ClassMethods.viewPaths;
+
+  _prefixes = _prefixes;
+  lookupContext = lookupContext;
+  detailsForLookup = detailsForLookup;
+  formats = formats;
+  locale = locale;
+  isTemplateExists = isTemplateExists;
+  isAnyTemplates = isAnyTemplates;
+}
+
+class PostsController extends BaseController {
+  static abstract = false;
+  static controllerPath(): string {
+    return "posts";
+  }
+}
+
+class DraftsController extends PostsController {
+  static controllerPath(): string {
+    return "drafts";
+  }
+}
+
+afterEach(() => {
+  PathRegistry.reset();
+});
+
+describe("ViewPaths::ClassMethods", () => {
+  test("_prefixes stops at the first abstract ancestor", () => {
+    expect(DraftsController._prefixes()).toEqual(["drafts", "posts"]);
+  });
+});
+
+describe("ViewPaths", () => {
+  test("lookup_context is built from the class's view paths, details and prefixes", () => {
+    PostsController.viewPaths([]);
+    const controller = new PostsController();
+
+    expect(controller.lookupContext().prefixes).toEqual(["posts"]);
+    expect(controller.detailsForLookup()).toEqual({});
+    expect(controller.lookupContext()).toBe(controller.lookupContext());
+  });
+
+  test("formats and locale delegate to the lookup context", () => {
+    PostsController.viewPaths([]);
+    const controller = new PostsController();
+
+    controller.formats(["json"]);
+    expect(controller.formats()).toEqual(["json"]);
+    expect(controller.lookupContext().formats).toEqual(["json"]);
+
+    controller.locale("de");
+    expect(controller.locale()).toBe("de");
+    expect(controller.lookupContext().locale).toBe("de");
+  });
+
+  test("template_exists? and any_templates? delegate to the lookup context", () => {
+    PostsController.viewPaths([]);
+    const controller = new PostsController();
+
+    expect(controller.isTemplateExists("index", ["posts"])).toBe(false);
+    expect(controller.isAnyTemplates("index", ["posts"])).toBe(false);
+  });
+});

--- a/packages/actionview/src/view-paths.trails.test.ts
+++ b/packages/actionview/src/view-paths.trails.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, describe, expect, test } from "vitest";
 import { PathRegistry } from "./path-registry.js";
+import { InMemoryResolver } from "./resolver/in-memory-resolver.js";
+import { TemplateHandlers } from "./template/handlers.js";
 import {
   ClassMethods,
   _prefixes,
+  appendViewPath,
   detailsForLookup,
   formats,
   isAnyTemplates,
@@ -33,6 +36,7 @@ class BaseController implements ViewPaths {
   formats = formats;
   locale = locale;
   isTemplateExists = isTemplateExists;
+  appendViewPath = appendViewPath;
   isAnyTemplates = isAnyTemplates;
 }
 
@@ -51,6 +55,7 @@ class DraftsController extends PostsController {
 
 afterEach(() => {
   PathRegistry.reset();
+  TemplateHandlers.clear();
 });
 
 describe("ViewPaths::ClassMethods", () => {
@@ -88,5 +93,21 @@ describe("ViewPaths", () => {
 
     expect(controller.isTemplateExists("index", ["posts"])).toBe(false);
     expect(controller.isAnyTemplates("index", ["posts"])).toBe(false);
+  });
+
+  test("an appended resolver is searched by template_exists?", () => {
+    TemplateHandlers.registerTemplateHandler("tse", {
+      extensions: ["tse"],
+      render: () => "",
+    });
+    const resolver = new InMemoryResolver();
+    resolver.add("posts/index", "html", "tse", "hello");
+    PostsController.viewPaths([]);
+    const controller = new PostsController();
+
+    controller.appendViewPath(resolver);
+
+    expect(controller.isTemplateExists("index", ["posts"])).toBe(true);
+    expect(controller.isTemplateExists("missing", ["posts"])).toBe(false);
   });
 });

--- a/packages/actionview/src/view-paths.trails.test.ts
+++ b/packages/actionview/src/view-paths.trails.test.ts
@@ -1,8 +1,3 @@
-/**
- * TS-only coverage for the parts of `ActionView::ViewPaths` whose Rails tests
- * live in controller integration suites (rendering through a real
- * `ActionController::Base`) that ActionView cannot host on its own.
- */
 import { afterEach, describe, expect, test } from "vitest";
 import { PathRegistry } from "./path-registry.js";
 import {

--- a/packages/actionview/src/view-paths.ts
+++ b/packages/actionview/src/view-paths.ts
@@ -1,0 +1,218 @@
+/**
+ * ActionView::ViewPaths
+ *
+ * The module controllers include to own a set of view paths. The class side
+ * (`ClassMethods`) keeps the per-class path set in `ActionView::PathRegistry`
+ * and computes `_prefixes` by walking the superclass chain up to the first
+ * abstract ancestor; the instance side is a thin layer over the controller's
+ * `LookupContext`, which Rails builds lazily from the class's view paths,
+ * `details_for_lookup` and `_prefixes`.
+ *
+ * Mixed in per CLAUDE.md's module convention: `this`-typed functions assigned
+ * onto the host class (instance side) and onto the host's constructor
+ * (`ClassMethods` statics).
+ */
+
+import { LookupContext } from "./lookup-context.js";
+import { PathRegistry } from "./path-registry.js";
+import { PathSet } from "./path-set.js";
+import type { TemplateResolver } from "./resolver/resolver.js";
+
+/** Anything `_build_view_paths` accepts: a PathSet, resolvers, or path strings. */
+export type ViewPathsInput =
+  | PathSet
+  | string
+  | TemplateResolver
+  | ReadonlyArray<string | TemplateResolver>;
+
+type DetailValue = ReadonlyArray<string | symbol>;
+
+/**
+ * The class-side state `ViewPaths::ClassMethods` needs from its host —
+ * `AbstractController::Base`'s `abstract?` and `controller_path`. Structural
+ * so ActionView doesn't have to depend on ActionPack.
+ */
+export interface ViewPathsClass {
+  new (...args: unknown[]): unknown;
+  readonly name: string;
+  isAbstract(): boolean;
+  controllerPath(): string;
+  /** Memo for `_prefixes` — Rails' `@_prefixes`. @internal */
+  _prefixesMemo?: string[];
+}
+
+/** The instance-side host: a controller whose constructor carries ClassMethods. */
+export interface ViewPaths {
+  constructor: ViewPathsClass;
+  /** Memo for `lookup_context` — Rails' `@_lookup_context`. @internal */
+  _lookupContext?: LookupContext;
+}
+
+/**
+ * `_view_paths` — the registry-backed path set for `cls`. Falls back to an
+ * empty set for a class that never registered one (Rails registers it from
+ * `included do`, which has no TS equivalent).
+ */
+function registeredViewPaths(cls: ViewPathsClass): PathSet {
+  const paths = PathRegistry.getViewPaths(cls);
+  return paths instanceof PathSet ? paths : new PathSet(paths ?? []);
+}
+
+/** `_build_view_paths(paths)` — resolvers stay, strings become resolvers. */
+function buildViewPaths(paths: ViewPathsInput): PathSet {
+  if (paths instanceof PathSet) return paths;
+  const list = Array.isArray(paths)
+    ? (paths as ReadonlyArray<string | TemplateResolver>)
+    : [paths as string | TemplateResolver];
+  return new PathSet(PathRegistry.castFileSystemResolvers([...list]));
+}
+
+/**
+ * `_prefixes` — this class's local prefixes plus every non-abstract ancestor's,
+ * nearest first. Memoized per class (Rails' `@_prefixes`).
+ */
+function computePrefixes(cls: ViewPathsClass): string[] {
+  if (Object.prototype.hasOwnProperty.call(cls, "_prefixesMemo")) {
+    return cls._prefixesMemo!;
+  }
+  const superclass = Object.getPrototypeOf(cls) as ViewPathsClass | null;
+  const local = ClassMethods.localPrefixes.call(cls);
+  const prefixes =
+    !superclass || typeof superclass.isAbstract !== "function" || superclass.isAbstract()
+      ? local
+      : [...local, ...computePrefixes(superclass)];
+  cls._prefixesMemo = prefixes;
+  return prefixes;
+}
+
+/**
+ * `ViewPaths::ClassMethods`. Every method is `this`-typed on the host class,
+ * so assigning them as statics (`static viewPaths = ClassMethods.viewPaths`)
+ * resolves `this` to the concrete subclass at call time — which is what makes
+ * the PathRegistry lookup and the `_prefixes` walk inheritance-aware.
+ */
+export class ClassMethods {
+  /** `_view_paths` / `_view_paths=` — the registry-backed path set. */
+  static _viewPaths(this: ViewPathsClass): PathSet;
+  static _viewPaths(this: ViewPathsClass, paths: PathSet): void;
+  static _viewPaths(this: ViewPathsClass, paths?: PathSet): PathSet | void {
+    if (paths === undefined) return registeredViewPaths(this);
+    PathRegistry.setViewPaths(this, paths);
+  }
+
+  /** @internal */
+  static _prefixes(this: ViewPathsClass): string[] {
+    return computePrefixes(this);
+  }
+
+  /** @internal */
+  static _buildViewPaths(this: ViewPathsClass, paths: ViewPathsInput): PathSet {
+    return buildViewPaths(paths);
+  }
+
+  /** Append a path to the list of view paths for this controller. */
+  static appendViewPath(this: ViewPathsClass, path: ViewPathsInput): void {
+    PathRegistry.setViewPaths(this, registeredViewPaths(this).plus(buildViewPaths(path)));
+  }
+
+  /** Prepend a path to the list of view paths for this controller. */
+  static prependViewPath(this: ViewPathsClass, path: ViewPathsInput): void {
+    PathRegistry.setViewPaths(this, buildViewPaths(path).plus(registeredViewPaths(this)));
+  }
+
+  /**
+   * `view_paths` / `view_paths=` — a list of all of the default view paths for
+   * this controller. The writer processes its argument into a PathSet.
+   */
+  static viewPaths(this: ViewPathsClass): PathSet;
+  static viewPaths(this: ViewPathsClass, paths: ViewPathsInput): void;
+  static viewPaths(this: ViewPathsClass, paths?: ViewPathsInput): PathSet | void {
+    if (paths === undefined) return registeredViewPaths(this);
+    PathRegistry.setViewPaths(this, buildViewPaths(paths));
+  }
+
+  /**
+   * Override this in your controller to change the prefixes used to find
+   * views. Prefixes defined here are still added to parents' `_prefixes`.
+   * @internal
+   */
+  static localPrefixes(this: ViewPathsClass): string[] {
+    return [this.controllerPath()];
+  }
+}
+
+/** The prefixes used in `render "foo"` shortcuts. @internal */
+export function _prefixes(this: ViewPaths): string[] {
+  return computePrefixes(this.constructor);
+}
+
+/**
+ * LookupContext is the object responsible for holding all information required
+ * for looking up templates, i.e. view paths and details.
+ */
+export function lookupContext(this: ViewPaths): LookupContext {
+  this._lookupContext ??= new LookupContext(
+    registeredViewPaths(this.constructor),
+    detailsForLookup.call(this),
+    _prefixes.call(this),
+  );
+  return this._lookupContext;
+}
+
+export function detailsForLookup(this: ViewPaths): Record<string, DetailValue> {
+  return {};
+}
+
+/** Append a path to the list of view paths for the current LookupContext. */
+export function appendViewPath(this: ViewPaths, path: ViewPathsInput): void {
+  lookupContext.call(this).appendViewPaths(buildViewPaths(path).toArray());
+}
+
+/** Prepend a path to the list of view paths for the current LookupContext. */
+export function prependViewPath(this: ViewPaths, path: ViewPathsInput): void {
+  lookupContext.call(this).prependViewPaths(buildViewPaths(path).toArray());
+}
+
+// `delegate :template_exists?, :any_templates?, :view_paths, :formats,
+//  :formats=, :locale, :locale=, to: :lookup_context`
+
+export function isTemplateExists(
+  this: ViewPaths,
+  name: string,
+  prefixes: ReadonlyArray<string> = [],
+  partial = false,
+  keys: ReadonlyArray<string> = [],
+  options: Record<string, DetailValue> = {},
+): boolean {
+  return lookupContext.call(this).isExists(name, prefixes, partial, keys, options);
+}
+
+export function isAnyTemplates(
+  this: ViewPaths,
+  name: string,
+  prefixes: ReadonlyArray<string> = [],
+  partial = false,
+): boolean {
+  return lookupContext.call(this).isAny(name, prefixes, partial);
+}
+
+export function viewPaths(this: ViewPaths): PathSet {
+  return lookupContext.call(this).viewPaths;
+}
+
+export function formats(this: ViewPaths): DetailValue;
+export function formats(this: ViewPaths, values: DetailValue | null): void;
+export function formats(this: ViewPaths, values?: DetailValue | null): DetailValue | void {
+  if (values === undefined) return lookupContext.call(this).formats;
+  lookupContext.call(this).formats = values;
+}
+
+export function locale(this: ViewPaths): string | symbol | null;
+export function locale(this: ViewPaths, value: string | symbol | null): void;
+export function locale(
+  this: ViewPaths,
+  value?: string | symbol | null,
+): string | symbol | null | void {
+  if (value === undefined) return lookupContext.call(this).locale;
+  lookupContext.call(this).locale = value;
+}

--- a/packages/actionview/src/view-paths.ts
+++ b/packages/actionview/src/view-paths.ts
@@ -1,24 +1,8 @@
-/**
- * ActionView::ViewPaths
- *
- * The module controllers include to own a set of view paths. The class side
- * (`ClassMethods`) keeps the per-class path set in `ActionView::PathRegistry`
- * and computes `_prefixes` by walking the superclass chain up to the first
- * abstract ancestor; the instance side is a thin layer over the controller's
- * `LookupContext`, which Rails builds lazily from the class's view paths,
- * `details_for_lookup` and `_prefixes`.
- *
- * Mixed in per CLAUDE.md's module convention: `this`-typed functions assigned
- * onto the host class (instance side) and onto the host's constructor
- * (`ClassMethods` statics).
- */
-
 import { LookupContext } from "./lookup-context.js";
 import { PathRegistry } from "./path-registry.js";
 import { PathSet } from "./path-set.js";
 import type { TemplateResolver } from "./resolver/resolver.js";
 
-/** Anything `_build_view_paths` accepts: a PathSet, resolvers, or path strings. */
 export type ViewPathsInput =
   | PathSet
   | string
@@ -27,132 +11,92 @@ export type ViewPathsInput =
 
 type DetailValue = ReadonlyArray<string | symbol>;
 
-/**
- * The class-side state `ViewPaths::ClassMethods` needs from its host —
- * `AbstractController::Base`'s `abstract?` and `controller_path`. Structural
- * so ActionView doesn't have to depend on ActionPack.
- */
 export interface ViewPathsClass {
   new (...args: unknown[]): unknown;
   readonly name: string;
   isAbstract(): boolean;
   controllerPath(): string;
-  /** Memo for `_prefixes` — Rails' `@_prefixes`. @internal */
+  /** @internal */
   _prefixesMemo?: string[];
 }
 
-/** The instance-side host: a controller whose constructor carries ClassMethods. */
 export interface ViewPaths {
   constructor: ViewPathsClass;
-  /** Memo for `lookup_context` — Rails' `@_lookup_context`. @internal */
+  /** @internal */
   _lookupContext?: LookupContext;
 }
 
-/**
- * `_view_paths` — the registry-backed path set for `cls`. Falls back to an
- * empty set for a class that never registered one (Rails registers it from
- * `included do`, which has no TS equivalent).
- */
-function registeredViewPaths(cls: ViewPathsClass): PathSet {
-  const paths = PathRegistry.getViewPaths(cls);
-  return paths instanceof PathSet ? paths : new PathSet(paths ?? []);
-}
-
-/** `_build_view_paths(paths)` — resolvers stay, strings become resolvers. */
-function buildViewPaths(paths: ViewPathsInput): PathSet {
-  if (paths instanceof PathSet) return paths;
-  const list = Array.isArray(paths)
-    ? (paths as ReadonlyArray<string | TemplateResolver>)
-    : [paths as string | TemplateResolver];
-  return new PathSet(PathRegistry.castFileSystemResolvers([...list]));
-}
-
-/**
- * `_prefixes` — this class's local prefixes plus every non-abstract ancestor's,
- * nearest first. Memoized per class (Rails' `@_prefixes`).
- */
-function computePrefixes(cls: ViewPathsClass): string[] {
-  if (Object.prototype.hasOwnProperty.call(cls, "_prefixesMemo")) {
-    return cls._prefixesMemo!;
-  }
-  const superclass = Object.getPrototypeOf(cls) as ViewPathsClass | null;
-  const local = ClassMethods.localPrefixes.call(cls);
-  const prefixes =
-    !superclass || typeof superclass.isAbstract !== "function" || superclass.isAbstract()
-      ? local
-      : [...local, ...computePrefixes(superclass)];
-  cls._prefixesMemo = prefixes;
-  return prefixes;
-}
-
-/**
- * `ViewPaths::ClassMethods`. Every method is `this`-typed on the host class,
- * so assigning them as statics (`static viewPaths = ClassMethods.viewPaths`)
- * resolves `this` to the concrete subclass at call time — which is what makes
- * the PathRegistry lookup and the `_prefixes` walk inheritance-aware.
- */
 export class ClassMethods {
-  /** `_view_paths` / `_view_paths=` — the registry-backed path set. */
   static _viewPaths(this: ViewPathsClass): PathSet;
   static _viewPaths(this: ViewPathsClass, paths: PathSet): void;
   static _viewPaths(this: ViewPathsClass, paths?: PathSet): PathSet | void {
-    if (paths === undefined) return registeredViewPaths(this);
+    if (paths === undefined) {
+      const registered = PathRegistry.getViewPaths(this);
+      return registered instanceof PathSet ? registered : new PathSet(registered ?? []);
+    }
     PathRegistry.setViewPaths(this, paths);
   }
 
   /** @internal */
   static _prefixes(this: ViewPathsClass): string[] {
-    return computePrefixes(this);
+    if (Object.prototype.hasOwnProperty.call(this, "_prefixesMemo")) return this._prefixesMemo!;
+    const superclass = Object.getPrototypeOf(this) as ViewPathsClass | null;
+    const local = ClassMethods.localPrefixes.call(this);
+    return (this._prefixesMemo =
+      !superclass || typeof superclass.isAbstract !== "function" || superclass.isAbstract()
+        ? local
+        : [...local, ...ClassMethods._prefixes.call(superclass)]);
   }
 
   /** @internal */
   static _buildViewPaths(this: ViewPathsClass, paths: ViewPathsInput): PathSet {
-    return buildViewPaths(paths);
+    if (paths instanceof PathSet) return paths;
+    const list = Array.isArray(paths)
+      ? (paths as ReadonlyArray<string | TemplateResolver>)
+      : [paths as string | TemplateResolver];
+    return new PathSet(PathRegistry.castFileSystemResolvers([...list]));
   }
 
-  /** Append a path to the list of view paths for this controller. */
   static appendViewPath(this: ViewPathsClass, path: ViewPathsInput): void {
-    PathRegistry.setViewPaths(this, registeredViewPaths(this).plus(buildViewPaths(path)));
+    writeInternalViewPaths.call(
+      this,
+      readViewPaths.call(this).plus(ClassMethods._buildViewPaths.call(this, path)),
+    );
   }
 
-  /** Prepend a path to the list of view paths for this controller. */
   static prependViewPath(this: ViewPathsClass, path: ViewPathsInput): void {
-    PathRegistry.setViewPaths(this, buildViewPaths(path).plus(registeredViewPaths(this)));
+    writeInternalViewPaths.call(
+      this,
+      ClassMethods._buildViewPaths.call(this, path).plus(readViewPaths.call(this)),
+    );
   }
 
-  /**
-   * `view_paths` / `view_paths=` — a list of all of the default view paths for
-   * this controller. The writer processes its argument into a PathSet.
-   */
   static viewPaths(this: ViewPathsClass): PathSet;
   static viewPaths(this: ViewPathsClass, paths: ViewPathsInput): void;
   static viewPaths(this: ViewPathsClass, paths?: ViewPathsInput): PathSet | void {
-    if (paths === undefined) return registeredViewPaths(this);
-    PathRegistry.setViewPaths(this, buildViewPaths(paths));
+    if (paths === undefined) return readInternalViewPaths.call(this);
+    writeInternalViewPaths.call(this, ClassMethods._buildViewPaths.call(this, paths));
   }
 
-  /**
-   * Override this in your controller to change the prefixes used to find
-   * views. Prefixes defined here are still added to parents' `_prefixes`.
-   * @internal
-   */
+  /** @internal */
   static localPrefixes(this: ViewPathsClass): string[] {
     return [this.controllerPath()];
   }
 }
 
-/** The prefixes used in `render "foo"` shortcuts. @internal */
+const readInternalViewPaths: (this: ViewPathsClass) => PathSet = ClassMethods._viewPaths;
+const writeInternalViewPaths: (this: ViewPathsClass, paths: PathSet) => void =
+  ClassMethods._viewPaths;
+const readViewPaths: (this: ViewPathsClass) => PathSet = ClassMethods.viewPaths;
+
+/** @internal */
 export function _prefixes(this: ViewPaths): string[] {
-  return computePrefixes(this.constructor);
+  return ClassMethods._prefixes.call(this.constructor);
 }
 
-/**
- * LookupContext is the object responsible for holding all information required
- * for looking up templates, i.e. view paths and details.
- */
 export function lookupContext(this: ViewPaths): LookupContext {
   this._lookupContext ??= new LookupContext(
-    registeredViewPaths(this.constructor),
+    readInternalViewPaths.call(this.constructor),
     detailsForLookup.call(this),
     _prefixes.call(this),
   );
@@ -163,18 +107,17 @@ export function detailsForLookup(this: ViewPaths): Record<string, DetailValue> {
   return {};
 }
 
-/** Append a path to the list of view paths for the current LookupContext. */
 export function appendViewPath(this: ViewPaths, path: ViewPathsInput): void {
-  lookupContext.call(this).appendViewPaths(buildViewPaths(path).toArray());
+  lookupContext
+    .call(this)
+    .appendViewPaths(ClassMethods._buildViewPaths.call(this.constructor, path).toArray());
 }
 
-/** Prepend a path to the list of view paths for the current LookupContext. */
 export function prependViewPath(this: ViewPaths, path: ViewPathsInput): void {
-  lookupContext.call(this).prependViewPaths(buildViewPaths(path).toArray());
+  lookupContext
+    .call(this)
+    .prependViewPaths(ClassMethods._buildViewPaths.call(this.constructor, path).toArray());
 }
-
-// `delegate :template_exists?, :any_templates?, :view_paths, :formats,
-//  :formats=, :locale, :locale=, to: :lookup_context`
 
 export function isTemplateExists(
   this: ViewPaths,

--- a/packages/actionview/src/view-paths.ts
+++ b/packages/actionview/src/view-paths.ts
@@ -11,6 +11,8 @@ export type ViewPathsInput =
 
 type DetailValue = ReadonlyArray<string | symbol>;
 
+const EMPTY_VIEW_PATHS = new PathSet();
+
 export interface ViewPathsClass {
   new (...args: unknown[]): unknown;
   readonly name: string;
@@ -31,7 +33,7 @@ export class ClassMethods {
   static _viewPaths(this: ViewPathsClass, paths: PathSet): void;
   static _viewPaths(this: ViewPathsClass, paths?: PathSet): PathSet | void {
     if (paths === undefined) {
-      return PathRegistry.getViewPaths(this) ?? new PathSet();
+      return PathRegistry.getViewPaths(this) ?? EMPTY_VIEW_PATHS;
     }
     PathRegistry.setViewPaths(this, paths);
   }

--- a/packages/actionview/src/view-paths.ts
+++ b/packages/actionview/src/view-paths.ts
@@ -31,8 +31,7 @@ export class ClassMethods {
   static _viewPaths(this: ViewPathsClass, paths: PathSet): void;
   static _viewPaths(this: ViewPathsClass, paths?: PathSet): PathSet | void {
     if (paths === undefined) {
-      const registered = PathRegistry.getViewPaths(this);
-      return registered instanceof PathSet ? registered : new PathSet(registered ?? []);
+      return PathRegistry.getViewPaths(this) ?? new PathSet();
     }
     PathRegistry.setViewPaths(this, paths);
   }


### PR DESCRIPTION
Ports `ActionView::ViewPaths` (`vendor/rails/actionview/lib/action_view/view_paths.rb`)
to `packages/actionview/src/view-paths.ts`.

## What's here

- **`ClassMethods`** — `_view_paths`/`_view_paths=` over `ActionView::PathRegistry`,
  `_prefixes` (local prefixes plus every ancestor's, stopping at the first
  `abstract?` one, memoized per class), `_build_view_paths`, `append_view_path`,
  `prepend_view_path`, `view_paths`/`view_paths=` and the private `local_prefixes`.
- **Instance side** — `lookup_context` (lazily built from the class's view paths,
  `details_for_lookup` and `_prefixes`), `details_for_lookup`, `_prefixes`,
  `append_view_path`, `prepend_view_path`, and the
  `delegate ... to: :lookup_context` readers/writers (`template_exists?`,
  `any_templates?`, `view_paths`, `formats`/`formats=`, `locale`/`locale=`).

Reader/writer pairs are single overloaded functions (the `_helpers(cls)` /
`_helpers(cls, value)` pattern from `abstract-controller/helpers.ts`) so the
Ruby name and its `=` writer both land on one Rails-spelled symbol. Each method
keeps the body Rails gives it, so the call chains (`get_view_paths`,
`cast_file_system_resolvers`, `PathSet.new`, `_view_paths=`) match.

The host is typed structurally (`ViewPathsClass` needs only `abstract?` and
`controller_path`) so ActionView keeps no dependency on ActionPack.

## Supporting changes

- `PathRegistry` now stores a `PathSet` as well as a bare resolver array —
  Rails always registers a `PathSet` (`path_registry.rb`'s `map(&:to_a)`).
- `PathSet#typecast` accepts `find`-protocol resolvers (`FileSystemResolver`)
  alongside its own `findAll` shape. String→resolver wrapping now happens up
  front in `_build_view_paths` via `PathRegistry.castFileSystemResolvers`,
  as in Rails.
- Removes the `ViewPaths`/`ViewPathsClass` placeholder interfaces from
  `rendering.ts` now that the real module exists.

## Tests

`actionpack/controller/view-paths.test.ts` ports the cases of
`view_paths_test.rb` that don't need a rendering controller
(`test_template_load_path_was_set_correctly`,
`test_controller_appends_view_path_correctly`,
`test_controller_prepends_view_path_correctly`, `test_inheritance`,
`test_lookup_context_accessor`). `view-paths.trails.test.ts` covers the
delegation and the `_prefixes` walk, whose Rails coverage lives in controller
integration suites ActionView can't host on its own.

## Resolver#findAll

`PathSet` dispatch always calls `resolver.findAll(...)`, but no TS resolver
implemented it — every `PathSet` built from real view paths crashed with
`resolver.findAll is not a function` on first lookup. Rails' `Resolver#find_all`
(`template/resolver.rb:60-77`) is concrete on the base class and inherited by
every subclass, so this ports it there, normalizing `PathSet`'s argument shape
onto our `find_templates` stand-in (`find`).

Known gap, tracked as story `actionview-resolver-find-all-full-details`: the
bridge filters on `details.formats` only and returns the first match, where
`FileSystemResolver#_find_all` (`:131-144`) filters and sorts on the full
`TemplateDetails::Requested` (locale, handler, format, variant), returns all
matches, and threads locals through `bind_locals`. That is downstream of the
pre-existing `find(name, prefix, format, extensions)` primitive and of
`UnboundTemplate` being unported, so it is out of scope here.

## Compare deltas (actionview)

- api:compare — `view_paths.rb` 11/17 → **17/17 ✓** (the 11 were all charged as
  moves against `lookup-context.ts`/`rendering.ts`); overall 284 → 288,
  files 32 → 33. `rendering.rb` goes 4/28 → 2/28: `ActionView::Rendering`
  includes `ViewPaths`, so those two names were being satisfied by the
  placeholder interfaces this PR deletes; they return when `rendering.rb`
  itself is ported.
- test:compare — 231 → **236**, files 11 → 12, extras unchanged at 70.
- Wide call-mismatch ratchet: OK.

`_view_paths` returns one shared empty `PathSet` when nothing is registered.
Rails sets a frozen empty `PathSet` per host at `included do` (`view_paths.rb:8`);
TS has no include hook, so the shared default stands in for it and keeps
repeated reads identity-stable.

Closes-story: actionview-view-paths-module-port
