### PR TITLE
feat(activesupport): port Messages::SerializerWithFallback

### DIFF
--- a/packages/activesupport/src/json.ts
+++ b/packages/activesupport/src/json.ts
@@ -109,8 +109,10 @@ function filterHashKeys(keys: unknown[], options: NormalizedOptions): Set<unknow
   return new Set(keys);
 }
 
-// String-aware comment removal: quoted spans (and their backslash escapes) are
-// copied verbatim so a `//` or `/*` inside a JSON string survives.
+/**
+ * String-aware comment removal: quoted spans (and their backslash escapes) are
+ * copied verbatim so a comment marker inside a JSON string survives.
+ */
 function stripJsonComments(value: string): string {
   let out = "";
   let index = 0;
@@ -145,14 +147,16 @@ export namespace ActiveSupportJSON {
     return JSON.stringify(resolved) ?? "null";
   }
 
+  /**
+   * Ruby's JSON parser — what `ActiveSupport::JSON.decode` delegates to — skips
+   * block and line comments anywhere whitespace is allowed, while `JSON.parse`
+   * rejects them. The retry runs only after a parse failure, so valid documents
+   * (where a comment marker can only be inside a string) are untouched.
+   */
   export function decode(value: string): unknown {
     try {
       return JSON.parse(value);
     } catch (error) {
-      // Ruby's JSON parser — what `ActiveSupport::JSON.decode` delegates to —
-      // skips `/* … */` and `// …` comments anywhere whitespace is allowed;
-      // `JSON.parse` rejects them. Only retry on a parse failure so valid
-      // documents (where a `//` may only appear inside a string) are untouched.
       if (!(error instanceof SyntaxError)) throw error;
       return JSON.parse(stripJsonComments(value));
     }

--- a/packages/activesupport/src/json.ts
+++ b/packages/activesupport/src/json.ts
@@ -109,6 +109,33 @@ function filterHashKeys(keys: unknown[], options: NormalizedOptions): Set<unknow
   return new Set(keys);
 }
 
+// String-aware comment removal: quoted spans (and their backslash escapes) are
+// copied verbatim so a `//` or `/*` inside a JSON string survives.
+function stripJsonComments(value: string): string {
+  let out = "";
+  let index = 0;
+  while (index < value.length) {
+    const char = value[index];
+    if (char === '"') {
+      const start = index++;
+      while (index < value.length && value[index] !== '"') {
+        index += value[index] === "\\" ? 2 : 1;
+      }
+      out += value.slice(start, ++index);
+    } else if (char === "/" && value[index + 1] === "*") {
+      const end = value.indexOf("*/", index + 2);
+      index = end === -1 ? value.length : end + 2;
+    } else if (char === "/" && value[index + 1] === "/") {
+      const end = value.indexOf("\n", index + 2);
+      index = end === -1 ? value.length : end;
+    } else {
+      out += char;
+      index++;
+    }
+  }
+  return out;
+}
+
 export namespace ActiveSupportJSON {
   // Rails: `ActiveSupport::JSON.encode` runs the `as_json` traversal
   // unconditionally, options or not (encoding.rb:22-25) — the options-only
@@ -119,6 +146,15 @@ export namespace ActiveSupportJSON {
   }
 
   export function decode(value: string): unknown {
-    return JSON.parse(value);
+    try {
+      return JSON.parse(value);
+    } catch (error) {
+      // Ruby's JSON parser — what `ActiveSupport::JSON.decode` delegates to —
+      // skips `/* … */` and `// …` comments anywhere whitespace is allowed;
+      // `JSON.parse` rejects them. Only retry on a parse failure so valid
+      // documents (where a `//` may only appear inside a string) are untouched.
+      if (!(error instanceof SyntaxError)) throw error;
+      return JSON.parse(stripJsonComments(value));
+    }
   }
 }

--- a/packages/activesupport/src/messages/serializer-with-fallback.test.ts
+++ b/packages/activesupport/src/messages/serializer-with-fallback.test.ts
@@ -1,21 +1,117 @@
-import { describe, it } from "vitest";
+import { describe, it, expect } from "vitest";
+import { Notifications } from "../notifications.js";
+import { ActiveSupportJSON } from "../json.js";
+import { coder } from "../cache/coder.js";
+import { MessagePack } from "../message-pack/index.js";
+import {
+  KeyError,
+  SERIALIZERS,
+  SerializerWithFallback,
+  type Format,
+  type Serializer,
+} from "./serializer-with-fallback.js";
+
+const FORMATS = Object.keys(SERIALIZERS) as Format[];
+
+function serializer(format: Format): Serializer {
+  return SerializerWithFallback.get(format);
+}
+
+// The Rails test passes the bare `Marshal` / `ActiveSupport::JSON` /
+// `ActiveSupport::MessagePack` modules as the deserializer; those expose
+// `load`/`decode` rather than our Serializer surface, so wrap them here.
+const MARSHAL_SIGNATURE = "\x04\x08";
+const marshalModule = {
+  load: (dumped: string) => coder.load(dumped.slice(MARSHAL_SIGNATURE.length)),
+};
+const jsonModule = { load: (dumped: string) => ActiveSupportJSON.decode(dumped) };
+const messagePackModule = {
+  load: (dumped: string) => MessagePack.load(Buffer.from(dumped, "latin1")),
+};
+
+function assertRoundtrip(
+  serializerUnderTest: Serializer,
+  deserializer: { load(dumped: string): unknown } = serializerUnderTest,
+): void {
+  const value = [{ a_boolean: false, a_number: 123 }];
+  expect(deserializer.load(serializerUnderTest.dump(value))).toEqual(value);
+}
 
 describe("MessagesSerializerWithFallbackTest", () => {
-  it.skip(":marshal serializer dumps objects using Marshal format");
+  it(":marshal serializer dumps objects using Marshal format", () => {
+    assertRoundtrip(serializer("marshal"), marshalModule);
+  });
 
-  it.skip(":json serializer dumps objects using JSON format");
+  it(":json serializer dumps objects using JSON format", () => {
+    assertRoundtrip(serializer("json"), jsonModule);
+    assertRoundtrip(serializer("json_allow_marshal"), jsonModule);
+  });
 
-  it.skip(":message_pack serializer dumps objects using MessagePack format");
+  it(":message_pack serializer dumps objects using MessagePack format", () => {
+    assertRoundtrip(serializer("message_pack"), messagePackModule);
+    assertRoundtrip(serializer("message_pack_allow_marshal"), messagePackModule);
+  });
 
-  it.skip("every serializer can load every non-Marshal format");
+  it("every serializer can load every non-Marshal format", () => {
+    for (const dumping of FORMATS.filter((format) => format !== "marshal")) {
+      for (const loading of FORMATS) {
+        assertRoundtrip(serializer(dumping), serializer(loading));
+      }
+    }
+  });
 
-  it.skip("only :marshal and :*_allow_marshal serializers can load Marshal format");
+  it("only :marshal and :*_allow_marshal serializers can load Marshal format", () => {
+    const marshalLoadingFormats = FORMATS.filter((format) => /(?:^|_allow_)marshal/.test(format));
+    expect(marshalLoadingFormats.length).toBeGreaterThan(1);
 
-  it.skip(":json serializer recognizes regular JSON");
+    for (const loading of marshalLoadingFormats) {
+      assertRoundtrip(serializer("marshal"), serializer(loading));
+    }
 
-  it.skip(":json serializer can load irregular JSON");
+    const marshalled = serializer("marshal").dump({});
 
-  it.skip("notifies when serializer falls back to loading an alternate format");
+    for (const loading of FORMATS.filter((format) => !marshalLoadingFormats.includes(format))) {
+      expect(() => serializer(loading).load(marshalled)).toThrow(/unsupported/i);
+    }
+  });
 
-  it.skip("raises on invalid format name");
+  it(":json serializer recognizes regular JSON", () => {
+    for (const value of [null, false, true, 0, 1, -1, 0.0, 1.0, -1.0, 0.1, -0.1, "", [], {}]) {
+      const dumped = serializer("json").dump(value);
+      expect(serializer("json").dumped(dumped)).toBe(true);
+    }
+  });
+
+  it(":json serializer can load irregular JSON", () => {
+    const value = { foo: "bar" };
+    const dumped = serializer("json").dump(value);
+
+    expect(serializer("json").load(` /* comment */ ${dumped}`)).toEqual(value);
+  });
+
+  it("notifies when serializer falls back to loading an alternate format", async () => {
+    const value = { foo: "bar" };
+    const dumped = serializer("json").dump(value);
+
+    const payloads: Record<string, unknown>[] = [];
+    await Notifications.subscribed(
+      (_name, _start, _finish, _id, payload) => {
+        payloads.push(payload as Record<string, unknown>);
+      },
+      "message_serializer_fallback.active_support",
+      () => {
+        serializer("marshal").load(dumped);
+      },
+    );
+
+    expect(payloads.length).toBe(1);
+    expect(payloads[0].serializer).toBe("marshal");
+    expect(payloads[0].fallback).toBe("json");
+    expect(payloads[0].serialized).toBe(dumped);
+    expect(payloads[0].deserialized).toEqual(value);
+  });
+
+  it("raises on invalid format name", () => {
+    expect(() => SerializerWithFallback.get("invalid_format")).toThrow(KeyError);
+  });
 });

--- a/packages/activesupport/src/messages/serializer-with-fallback.test.ts
+++ b/packages/activesupport/src/messages/serializer-with-fallback.test.ts
@@ -17,9 +17,6 @@ function serializer(format: Format): Serializer {
   return SerializerWithFallback.get(format);
 }
 
-// The Rails test passes the bare `Marshal` / `ActiveSupport::JSON` /
-// `ActiveSupport::MessagePack` modules as the deserializer; those expose
-// `load`/`decode` rather than our Serializer surface, so wrap them here.
 const MARSHAL_SIGNATURE = "\x04\x08";
 const marshalModule = {
   load: (dumped: string) => coder.load(dumped.slice(MARSHAL_SIGNATURE.length)),

--- a/packages/activesupport/src/messages/serializer-with-fallback.ts
+++ b/packages/activesupport/src/messages/serializer-with-fallback.ts
@@ -1,0 +1,220 @@
+/**
+ * Mirrors Rails `ActiveSupport::Messages::SerializerWithFallback`
+ * (messages/serializer_with_fallback.rb).
+ *
+ * Five serializers (marshal, json, json_allow_marshal, message_pack,
+ * message_pack_allow_marshal) that share a `load` which sniffs the dumped
+ * payload's format and, when it isn't the serializer's own, deserializes it
+ * through the matching serializer while instrumenting
+ * `message_serializer_fallback.active_support`.
+ *
+ * trails has no Ruby Marshal runtime, so the `:marshal` format is backed by the
+ * fidelity `coder` (`cache/coder.ts`) — the same trails Marshal-equivalent the
+ * cache serializers use — behind Rails' `\x04\x08` Marshal signature so
+ * cross-format detection still works.
+ */
+
+import { Notifications } from "../notifications.js";
+import { ActiveSupportJSON } from "../json.js";
+import { coder } from "../cache/coder.js";
+import { MessagePack } from "../message-pack/index.js";
+
+/** Format names keyed in {@link SERIALIZERS}. @internal */
+export type Format =
+  | "marshal"
+  | "json"
+  | "json_allow_marshal"
+  | "message_pack"
+  | "message_pack_allow_marshal";
+
+/**
+ * Mirror of Ruby's `RuntimeError` — what Rails' bare
+ * `raise "Unsupported serialization format"` produces. @internal
+ */
+export class RuntimeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RuntimeError";
+  }
+}
+
+/** Thrown by `SerializerWithFallback.get` on an unknown format. @internal */
+export class KeyError extends Error {
+  constructor(key: string) {
+    super(`key not found: ${JSON.stringify(key)}`);
+    this.name = "KeyError";
+  }
+}
+
+/** The surface every serializer in {@link SERIALIZERS} exposes. @internal */
+export interface Serializer {
+  /**
+   * The serializer's own key in {@link SERIALIZERS}. Rails recovers this with
+   * `SERIALIZERS.key(self)`; the `*_allow_marshal` variants inherit `format`
+   * from the serializer they wrap, so the key is a separate field here.
+   */
+  key: Format;
+  format(): Format;
+  dump(object: unknown): string;
+  _load(dumped: string): unknown;
+  dumped(dumped: string): boolean;
+  load(dumped: string): unknown;
+  /** @internal */
+  detectFormat(dumped: string): Format | undefined;
+  /** @internal */
+  fallback(format: Format): boolean;
+}
+
+function load(this: Serializer, dumped: string): unknown {
+  const format = this.detectFormat(dumped);
+
+  if (format === this.format()) {
+    return this._load(dumped);
+  } else if (format && this.fallback(format)) {
+    const payload: Record<string, unknown> = {
+      serializer: this.key,
+      fallback: format,
+      serialized: dumped,
+    };
+    return Notifications.instrument(
+      "message_serializer_fallback.active_support",
+      payload,
+      (p) => (p.deserialized = SERIALIZERS[format]._load(dumped)),
+    );
+  } else {
+    throw new RuntimeError("Unsupported serialization format");
+  }
+}
+
+/** @internal */
+function detectFormat(dumped: string): Format | undefined {
+  if (messagePackWithFallback.dumped(dumped)) {
+    return "message_pack";
+  } else if (marshalWithFallback.dumped(dumped)) {
+    return "marshal";
+  } else if (jsonWithFallback.dumped(dumped)) {
+    return "json";
+  }
+  return undefined;
+}
+
+/** @internal */
+function fallback(format: Format): boolean {
+  return format !== "marshal";
+}
+
+// Rails' `AllowMarshal` module: `super || format == :marshal`.
+function allowMarshalFallback(format: Format): boolean {
+  return fallback(format) || format === "marshal";
+}
+
+const serializerWithFallback = { load, detectFormat, fallback };
+
+const MARSHAL_SIGNATURE = "\x04\x08";
+
+const marshalWithFallback: Serializer = {
+  ...serializerWithFallback,
+  key: "marshal",
+  format(): Format {
+    return "marshal";
+  },
+
+  dump(object: unknown): string {
+    return MARSHAL_SIGNATURE + coder.dump(object);
+  },
+
+  _load(dumped: string): unknown {
+    return coder.load(dumped.slice(MARSHAL_SIGNATURE.length));
+  },
+
+  dumped(dumped: string): boolean {
+    return dumped.startsWith(MARSHAL_SIGNATURE);
+  },
+};
+
+const JSON_START_WITH = /^(?:[{["]|-?\d|true|false|null)/;
+
+const jsonWithFallback: Serializer = {
+  ...serializerWithFallback,
+  key: "json",
+  format(): Format {
+    return "json";
+  },
+
+  dump(object: unknown): string {
+    return ActiveSupportJSON.encode(object);
+  },
+
+  _load(dumped: string): unknown {
+    return ActiveSupportJSON.decode(dumped);
+  },
+
+  dumped(dumped: string): boolean {
+    return JSON_START_WITH.test(dumped);
+  },
+
+  // Assume JSON format if format could not be determined.
+  detectFormat(dumped: string): Format | undefined {
+    return detectFormat(dumped) ?? "json";
+  },
+};
+
+const jsonWithFallbackAllowMarshal: Serializer = {
+  ...jsonWithFallback,
+  key: "json_allow_marshal",
+  fallback: allowMarshalFallback,
+};
+
+const messagePackWithFallback: Serializer = {
+  ...serializerWithFallback,
+  key: "message_pack",
+  format(): Format {
+    return "message_pack";
+  },
+
+  dump(object: unknown): string {
+    return MessagePack.dump(object).toString("latin1");
+  },
+
+  _load(dumped: string): unknown {
+    return MessagePack.load(Buffer.from(dumped, "latin1"));
+  },
+
+  dumped(dumped: string): boolean {
+    return isAvailable() && MessagePack.isSignature(Buffer.from(dumped, "latin1"));
+  },
+};
+
+// Mirrors Rails MessagePackWithFallback#available?: message_pack is a bundled
+// dep in trails, so this always returns true (no dynamic require to rescue).
+/** @internal */
+function isAvailable(): boolean {
+  return true;
+}
+
+const messagePackWithFallbackAllowMarshal: Serializer = {
+  ...messagePackWithFallback,
+  key: "message_pack_allow_marshal",
+  fallback: allowMarshalFallback,
+};
+
+/** @internal */
+export const SERIALIZERS: Record<Format, Serializer> = {
+  marshal: marshalWithFallback,
+  json: jsonWithFallback,
+  json_allow_marshal: jsonWithFallbackAllowMarshal,
+  message_pack: messagePackWithFallback,
+  message_pack_allow_marshal: messagePackWithFallbackAllowMarshal,
+};
+
+/** Mirrors Rails `ActiveSupport::Messages::SerializerWithFallback`. @internal */
+export const SerializerWithFallback = {
+  SERIALIZERS,
+
+  /** Mirrors Rails' `SerializerWithFallback[format]`. */
+  get(format: string): Serializer {
+    const serializer = SERIALIZERS[format as Format];
+    if (!serializer) throw new KeyError(format);
+    return serializer;
+  },
+};

--- a/packages/activesupport/src/messages/serializer-with-fallback.ts
+++ b/packages/activesupport/src/messages/serializer-with-fallback.ts
@@ -11,7 +11,9 @@
  * trails has no Ruby Marshal runtime, so the `:marshal` format is backed by the
  * fidelity `coder` (`cache/coder.ts`) — the same trails Marshal-equivalent the
  * cache serializers use — behind Rails' `\x04\x08` Marshal signature so
- * cross-format detection still works.
+ * cross-format detection still works. `MessagePackWithFallback#available?` is
+ * likewise constant-true: message_pack is a bundled dep here, with no dynamic
+ * require to rescue.
  */
 
 import { Notifications } from "../notifications.js";
@@ -103,7 +105,6 @@ function fallback(format: Format): boolean {
   return format !== "marshal";
 }
 
-// Rails' `AllowMarshal` module: `super || format == :marshal`.
 function allowMarshalFallback(format: Format): boolean {
   return fallback(format) || format === "marshal";
 }
@@ -153,7 +154,6 @@ const jsonWithFallback: Serializer = {
     return JSON_START_WITH.test(dumped);
   },
 
-  // Assume JSON format if format could not be determined.
   detectFormat(dumped: string): Format | undefined {
     return detectFormat(dumped) ?? "json";
   },
@@ -185,8 +185,6 @@ const messagePackWithFallback: Serializer = {
   },
 };
 
-// Mirrors Rails MessagePackWithFallback#available?: message_pack is a bundled
-// dep in trails, so this always returns true (no dynamic require to rescue).
 /** @internal */
 function isAvailable(): boolean {
   return true;


### PR DESCRIPTION
Ports `activesupport/lib/active_support/messages/serializer_with_fallback.rb`,
which had no TS counterpart (0/8 in `api:compare`; now 8/8).

`packages/activesupport/src/messages/serializer-with-fallback.ts` provides the
five with-fallback serializers — `marshal`, `json`, `json_allow_marshal`,
`message_pack`, `message_pack_allow_marshal` — sharing a `load` that sniffs the
dumped payload's format and, when it isn't the serializer's own, deserializes
through the matching serializer inside a
`message_serializer_fallback.active_support` instrumentation. `AllowMarshal`'s
`fallback?` override and `JsonWithFallback`'s "assume JSON" `detect_format`
override are both mirrored.

Notes:

- trails has no Ruby Marshal runtime, so the `:marshal` format is backed by the
  fidelity `coder` (`cache/coder.ts`) — the same Marshal-equivalent the cache
  serializers already use — behind Rails' `\x04\x08` signature, so cross-format
  detection still works.
- Rails recovers a serializer's own name with `SERIALIZERS.key(self)`; the
  `*_allow_marshal` variants inherit `format` from the serializer they wrap, so
  the port carries a separate `key` field alongside `format()`.
- `ActiveSupport::JSON.decode` now retries with comments stripped after a parse
  failure, matching Ruby's JSON parser. This is what the Rails test
  ":json serializer can load irregular JSON" exercises.

All nine Rails tests in `MessagesSerializerWithFallbackTest` are ported
verbatim (previously nine `it.skip` placeholders) and pass.

Closes-story: activesupport-messages-serializer-with-fallback-port
