### PR TITLE
feat(activesupport): port Messages::Codec and route encryptor/verifier through it

### DIFF
--- a/packages/activesupport/src/message-encryptor.ts
+++ b/packages/activesupport/src/message-encryptor.ts
@@ -84,7 +84,7 @@ export class MessageEncryptor extends Codec {
     const encrypted = message.slice(0, lastDash);
     const signature = message.slice(lastDash + 2);
 
-    if (!this.verifySignature(encrypted, signature)) {
+    if (!this.verify(encrypted, signature)) {
       throw new Thrown("invalid_message_format", "mismatched digest");
     }
 
@@ -137,7 +137,7 @@ export class MessageEncryptor extends Codec {
     return getCrypto().createHmac(this.digest, this.signSecret).update(data).digest("hex");
   }
 
-  private verifySignature(data: string, signature: string): boolean {
+  private verify(data: string, signature: string): boolean {
     try {
       const expected = this.sign(data);
       const expectedBuf = Buffer.from(expected, "hex");

--- a/packages/activesupport/src/message-encryptor.ts
+++ b/packages/activesupport/src/message-encryptor.ts
@@ -4,6 +4,8 @@
  */
 
 import { getCrypto } from "./crypto-adapter.js";
+import { Codec, type MessageSerializer } from "./messages/codec.js";
+import type { Format } from "./messages/serializer-with-fallback.js";
 
 export class InvalidMessage extends Error {
   constructor(message = "Invalid message") {
@@ -12,32 +14,24 @@ export class InvalidMessage extends Error {
   }
 }
 
-interface Serializer {
-  dump(value: unknown): string;
-  load(value: string): unknown;
-}
-
-const JSONSerializer: Serializer = {
-  dump(v) {
-    return JSON.stringify(v);
-  },
-  load(s) {
-    return JSON.parse(s);
-  },
-};
-
 interface MessageEncryptorOptions {
   cipher?: string;
   digest?: string;
-  serializer?: Serializer;
+  /** A `SerializerWithFallback` format name (`"json"`, `"marshal"`, …) or a serializer object. */
+  serializer?: Format | MessageSerializer;
 }
 
-export class MessageEncryptor {
+export class MessageEncryptor extends Codec {
+  // Rails' Codec defaults to `:marshal`; trails keeps `:json` here because
+  // encrypted credentials and every message this class has already written are
+  // JSON payloads — flipping the default would make them undecryptable.
+  // Callers wanting Rails' default pass `serializer: "marshal"` explicitly.
+  static override defaultSerializer: Format | MessageSerializer = "json";
+
   private secret: Buffer;
   private signSecret: Buffer;
   private cipher: string;
   private digest: string;
-  private serializer: Serializer;
 
   constructor(
     secret: string | Buffer,
@@ -58,9 +52,10 @@ export class MessageEncryptor {
       opts = options ?? {};
     }
 
+    super({ serializer: opts.serializer });
+
     this.cipher = opts.cipher ?? "aes-256-cbc";
     this.digest = opts.digest ?? "sha1";
-    this.serializer = opts.serializer ?? JSONSerializer;
 
     this.secret = typeof secret === "string" ? Buffer.from(secret) : secret;
 
@@ -72,7 +67,7 @@ export class MessageEncryptor {
   }
 
   encryptAndSign(value: unknown): string {
-    const serialized = this.serializer.dump(value);
+    const serialized = this.serialize(value);
     const encrypted = this.encrypt(serialized);
     const signature = this.sign(encrypted);
     return `${encrypted}--${signature}`;
@@ -94,7 +89,7 @@ export class MessageEncryptor {
     }
 
     const decrypted = this.decrypt(encrypted);
-    return this.serializer.load(decrypted);
+    return this.deserialize(decrypted);
   }
 
   private encrypt(plaintext: string): string {

--- a/packages/activesupport/src/message-encryptor.ts
+++ b/packages/activesupport/src/message-encryptor.ts
@@ -1,8 +1,3 @@
-/**
- * MessageEncryptor - encrypts and signs messages.
- * Mirrors ActiveSupport::MessageEncryptor.
- */
-
 import { getCrypto } from "./crypto-adapter.js";
 import { Codec, type MessageSerializer } from "./messages/codec.js";
 import type { Format } from "./messages/serializer-with-fallback.js";
@@ -17,15 +12,10 @@ export class InvalidMessage extends Error {
 interface MessageEncryptorOptions {
   cipher?: string;
   digest?: string;
-  /** A `SerializerWithFallback` format name (`"json"`, `"marshal"`, …) or a serializer object. */
   serializer?: Format | MessageSerializer;
 }
 
 export class MessageEncryptor extends Codec {
-  // Rails' Codec defaults to `:marshal`; trails keeps `:json` here because
-  // encrypted credentials and every message this class has already written are
-  // JSON payloads — flipping the default would make them undecryptable.
-  // Callers wanting Rails' default pass `serializer: "marshal"` explicitly.
   static override defaultSerializer: Format | MessageSerializer = "json";
 
   private secret: Buffer;
@@ -115,7 +105,6 @@ export class MessageEncryptor extends Codec {
 
     if (!encryptedB64 || !ivB64) throw new InvalidMessage();
 
-    // Validate strict base64 (no newlines or special chars)
     if (!/^[A-Za-z0-9+/=]+$/.test(encryptedB64) || !/^[A-Za-z0-9+/=]+$/.test(ivB64)) {
       throw new InvalidMessage("Invalid encoding");
     }
@@ -152,7 +141,6 @@ export class MessageEncryptor extends Codec {
   }
 
   private keyLength(): number {
-    // Extract key length from cipher name (e.g. aes-256-cbc -> 32 bytes)
     const match = this.cipher.match(/(\d+)/);
     if (match) return parseInt(match[1], 10) / 8;
     return 32;

--- a/packages/activesupport/src/message-encryptor.ts
+++ b/packages/activesupport/src/message-encryptor.ts
@@ -1,5 +1,5 @@
 import { getCrypto } from "./crypto-adapter.js";
-import { Codec, type MessageSerializer } from "./messages/codec.js";
+import { Codec, Thrown, type MessageSerializer } from "./messages/codec.js";
 import type { Format } from "./messages/serializer-with-fallback.js";
 
 export class InvalidMessage extends Error {
@@ -64,22 +64,31 @@ export class MessageEncryptor extends Codec {
   }
 
   decryptAndVerify(message: string): unknown {
+    return this.catchAndRaise("invalid_message_format", { as: InvalidMessage }, () =>
+      this.catchAndRaise("invalid_message_serialization", { as: InvalidMessage }, () =>
+        this.catchAndIgnore("invalid_message_content", () => this.readMessage(message)),
+      ),
+    );
+  }
+
+  private readMessage(message: string): unknown {
     if (!message || typeof message !== "string") {
-      throw new InvalidMessage();
+      throw new Thrown("invalid_message_format", "invalid message string");
     }
 
     const lastDash = message.lastIndexOf("--");
-    if (lastDash === -1) throw new InvalidMessage();
+    if (lastDash === -1) {
+      throw new Thrown("invalid_message_format", "missing message digest");
+    }
 
     const encrypted = message.slice(0, lastDash);
     const signature = message.slice(lastDash + 2);
 
     if (!this.verifySignature(encrypted, signature)) {
-      throw new InvalidMessage("Signature mismatch");
+      throw new Thrown("invalid_message_format", "mismatched digest");
     }
 
-    const decrypted = this.decrypt(encrypted);
-    return this.deserialize(decrypted);
+    return this.deserialize(this.decrypt(encrypted));
   }
 
   private encrypt(plaintext: string): string {
@@ -89,28 +98,28 @@ export class MessageEncryptor extends Codec {
     const iv = getCrypto().randomBytes(ivLength);
 
     const cipher = getCrypto().createCipheriv(this.cipher, key, iv);
-    const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+    const encrypted = Buffer.concat([cipher.update(plaintext, "latin1"), cipher.final()]);
 
-    const encryptedB64 = encrypted.toString("base64");
-    const ivB64 = iv.toString("base64");
+    const encryptedB64 = this.encode(encrypted);
+    const ivB64 = this.encode(iv);
 
     return `${encryptedB64}--${ivB64}`;
   }
 
   private decrypt(encrypted: string): string {
     const parts = encrypted.split("--");
-    if (parts.length !== 2) throw new InvalidMessage();
+    if (parts.length !== 2) {
+      throw new Thrown("invalid_message_format", "invalid message format");
+    }
 
     const [encryptedB64, ivB64] = parts;
 
-    if (!encryptedB64 || !ivB64) throw new InvalidMessage();
-
-    if (!/^[A-Za-z0-9+/=]+$/.test(encryptedB64) || !/^[A-Za-z0-9+/=]+$/.test(ivB64)) {
-      throw new InvalidMessage("Invalid encoding");
+    if (!encryptedB64 || !ivB64) {
+      throw new Thrown("invalid_message_format", "invalid message format");
     }
 
-    const encryptedBuf = Buffer.from(encryptedB64, "base64");
-    const iv = Buffer.from(ivB64, "base64");
+    const encryptedBuf = this.decode(encryptedB64);
+    const iv = this.decode(ivB64);
 
     const keyLength = this.keyLength();
     const key = this.secret.slice(0, keyLength);
@@ -118,9 +127,9 @@ export class MessageEncryptor extends Codec {
     try {
       const decipher = getCrypto().createDecipheriv(this.cipher, key, iv);
       const decrypted = Buffer.concat([decipher.update(encryptedBuf), decipher.final()]);
-      return decrypted.toString("utf8");
+      return decrypted.toString("latin1");
     } catch {
-      throw new InvalidMessage("Decryption failed");
+      throw new Thrown("invalid_message_format", "decryption failed");
     }
   }
 

--- a/packages/activesupport/src/message-verifier.ts
+++ b/packages/activesupport/src/message-verifier.ts
@@ -4,6 +4,8 @@
  */
 
 import { getCrypto } from "./crypto-adapter.js";
+import { Codec, type MessageSerializer } from "./messages/codec.js";
+import type { Format } from "./messages/serializer-with-fallback.js";
 import { Temporal } from "./temporal.js";
 // Use the travel-aware clock so expiry honors ActiveSupport::Testing::TimeHelpers
 // (`travel`/`travelTo`). With no travel active this is identical to
@@ -17,23 +19,10 @@ export class InvalidSignature extends Error {
   }
 }
 
-interface Serializer {
-  dump(value: unknown): string;
-  load(value: string): unknown;
-}
-
-const JSONSerializer: Serializer = {
-  dump(v) {
-    return JSON.stringify(v);
-  },
-  load(s) {
-    return JSON.parse(s);
-  },
-};
-
 interface MessageVerifierOptions {
   digest?: string;
-  serializer?: Serializer;
+  /** A `SerializerWithFallback` format name (`"json"`, `"marshal"`, …) or a serializer object. */
+  serializer?: Format | MessageSerializer;
   url_safe?: boolean;
 }
 
@@ -47,17 +36,21 @@ interface VerifyOptions {
   purpose?: string | null;
 }
 
-export class MessageVerifier {
+export class MessageVerifier extends Codec {
+  // Rails' Codec defaults to `:marshal`; trails keeps `:json` here because the
+  // signed payloads this class produces are consumed as JSON envelopes by
+  // GlobalID, ActiveRecord signed ids, and credentials — switching the default
+  // would invalidate every message already in the wild. Callers wanting Rails'
+  // default pass `serializer: "marshal"` explicitly.
+  static override defaultSerializer: Format | MessageSerializer = "json";
+
   private secret: string | Buffer;
   private digest: string;
-  private serializer: Serializer;
-  private urlSafe: boolean;
 
   constructor(secret: string | Buffer, options: MessageVerifierOptions = {}) {
+    super({ serializer: options.serializer, urlSafe: options.url_safe });
     this.secret = secret;
     this.digest = options.digest ?? "sha1";
-    this.serializer = options.serializer ?? JSONSerializer;
-    this.urlSafe = options.url_safe ?? false;
   }
 
   generate(value: unknown, options: GenerateOptions = {}): string {
@@ -81,7 +74,7 @@ export class MessageVerifier {
       payload._purpose = options.purpose;
     }
 
-    const serialized = this.serializer.dump(payload);
+    const serialized = this.serialize(payload);
     const encoded = this.encode(Buffer.from(serialized));
     const signature = this.sign(encoded);
     return `${encoded}--${signature}`;
@@ -105,7 +98,7 @@ export class MessageVerifier {
     try {
       const [encoded] = message.split("--");
       const decoded = this.decode(encoded);
-      const parsed = this.serializer.load(decoded.toString());
+      const parsed = this.deserialize(decoded.toString());
 
       if (typeof parsed !== "object" || parsed === null || !("value" in parsed)) {
         throw new InvalidSignature("Missing value key");
@@ -170,14 +163,15 @@ export class MessageVerifier {
   // them (Ruby private methods are still overridable). TS forbids
   // redeclaring a private base member in a subclass, so they're protected
   // here to keep that override path open.
-  protected encode(buf: Buffer): string {
+  protected override encode(data: string | Buffer): string {
+    const buf = typeof data === "string" ? Buffer.from(data, "latin1") : data;
     if (this.urlSafe) {
       return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
     }
     return buf.toString("base64");
   }
 
-  protected decode(str: string): Buffer {
+  protected override decode(str: string): Buffer {
     // Support both url-safe and standard base64
     const normalized = str.replace(/-/g, "+").replace(/_/g, "/");
     // Add padding if needed

--- a/packages/activesupport/src/message-verifier.ts
+++ b/packages/activesupport/src/message-verifier.ts
@@ -1,5 +1,5 @@
 import { getCrypto } from "./crypto-adapter.js";
-import { Codec, type MessageSerializer } from "./messages/codec.js";
+import { Codec, Thrown, type MessageSerializer } from "./messages/codec.js";
 import type { Format } from "./messages/serializer-with-fallback.js";
 import { Temporal } from "./temporal.js";
 import { currentTimeInstant } from "./time-travel.js";
@@ -56,77 +56,84 @@ export class MessageVerifier extends Codec {
     }
 
     const serialized = this.serialize(payload);
-    const encoded = this.encode(Buffer.from(serialized));
+    const encoded = this.encode(serialized);
     const signature = this.sign(encoded);
     return `${encoded}--${signature}`;
   }
 
   verify(message: string, options: VerifyOptions = {}): unknown {
-    const result = this.verified(message, options);
-    if (result === null && !this.validMessage(message)) {
-      throw new InvalidSignature();
-    }
-    return this._verifiedOrThrow(message, options);
-  }
-
-  private _verifiedOrThrow(message: string, options: VerifyOptions = {}): unknown {
-    if (!this.validMessage(message)) {
-      throw new InvalidSignature();
-    }
-
-    try {
-      const [encoded] = message.split("--");
-      const decoded = this.decode(encoded);
-      const parsed = this.deserialize(decoded.toString());
-
-      if (typeof parsed !== "object" || parsed === null || !("value" in parsed)) {
-        throw new InvalidSignature("Missing value key");
-      }
-
-      const payload = parsed as Record<string, unknown>;
-
-      if (payload._expiresAt) {
-        const expiresAt = Temporal.Instant.from(payload._expiresAt as string);
-        if (Temporal.Instant.compare(expiresAt, currentTimeInstant()) <= 0) {
-          throw new InvalidSignature("Expired message");
-        }
-      }
-
-      if (options.purpose && payload._purpose !== options.purpose) {
-        throw new InvalidSignature("Purpose mismatch");
-      }
-
-      return payload.value;
-    } catch (e) {
-      if (e instanceof InvalidSignature) throw e;
-      throw new InvalidSignature();
-    }
+    return this.catchAndRaise("invalid_message_format", { as: InvalidSignature }, () =>
+      this.catchAndRaise("invalid_message_serialization", {}, () =>
+        this.catchAndRaise("invalid_message_content", { as: InvalidSignature }, () =>
+          this.readMessage(message, options),
+        ),
+      ),
+    );
   }
 
   verified(message: string, options: VerifyOptions = {}): unknown | null {
-    try {
-      return this._verifiedOrThrow(message, options);
-    } catch {
-      return null;
-    }
+    return this.catchAndIgnore("invalid_message_format", () =>
+      this.catchAndRaise("invalid_message_serialization", {}, () =>
+        this.catchAndIgnore("invalid_message_content", () => this.readMessage(message, options)),
+      ),
+    );
   }
 
   validMessage(message: string): boolean {
-    if (!message || typeof message !== "string") return false;
+    return !!this.catchAndIgnore("invalid_message_format", () => this.extractEncoded(message));
+  }
 
-    const parts = message.split("--");
-    if (parts.length < 2) return false;
+  private readMessage(message: string, options: VerifyOptions): unknown {
+    const encoded = this.extractEncoded(message);
+    const parsed = this.deserialize(this.decode(encoded).toString("latin1"));
+    return this.verifyMetadata(parsed, options);
+  }
 
-    const signature = parts[parts.length - 1];
+  private verifyMetadata(parsed: unknown, options: VerifyOptions): unknown {
+    if (typeof parsed !== "object" || parsed === null || !("value" in parsed)) {
+      throw new Thrown("invalid_message_content", "missing value key");
+    }
+
+    const payload = parsed as Record<string, unknown>;
+
+    if (payload._expiresAt) {
+      const expiresAt = Temporal.Instant.from(payload._expiresAt as string);
+      if (Temporal.Instant.compare(expiresAt, currentTimeInstant()) <= 0) {
+        throw new Thrown("invalid_message_content", "expired message");
+      }
+    }
+
+    if (options.purpose && payload._purpose !== options.purpose) {
+      throw new Thrown("invalid_message_content", "mismatched purpose");
+    }
+
+    return payload.value;
+  }
+
+  private extractEncoded(signed: string): string {
+    if (!signed || typeof signed !== "string") {
+      throw new Thrown("invalid_message_format", "invalid message string");
+    }
+
+    const parts = signed.split("--");
+    const signature = parts.length < 2 ? undefined : parts[parts.length - 1];
     const encoded = parts.slice(0, -1).join("--");
 
-    if (!encoded || !signature) return false;
+    if (!encoded || !signature) {
+      throw new Thrown("invalid_message_format", "missing message digest");
+    }
 
+    if (!this.digestMatches(encoded, signature)) {
+      throw new Thrown("invalid_message_format", "mismatched digest");
+    }
+
+    return encoded;
+  }
+
+  private digestMatches(encoded: string, signature: string): boolean {
     try {
-      const expectedSig = this.sign(encoded);
       const sigBuf = Buffer.from(signature, "hex");
-      const expectedBuf = Buffer.from(expectedSig, "hex");
-
+      const expectedBuf = Buffer.from(this.sign(encoded), "hex");
       if (sigBuf.length !== expectedBuf.length) return false;
       return getCrypto().timingSafeEqual(sigBuf, expectedBuf);
     } catch {
@@ -138,17 +145,14 @@ export class MessageVerifier extends Codec {
     return getCrypto().createHmac(this.digest, this.secret).update(data).digest("hex");
   }
 
-  protected override encode(data: string | Buffer): string {
-    const buf = typeof data === "string" ? Buffer.from(data, "latin1") : data;
-    if (this.urlSafe) {
-      return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+  protected override decode(encoded: string, urlSafe: boolean = this.urlSafe): Buffer {
+    try {
+      return super.decode(encoded, urlSafe);
+    } catch (error) {
+      if (error instanceof Thrown && error.tag === "invalid_message_format") {
+        return super.decode(encoded, !urlSafe);
+      }
+      throw error;
     }
-    return buf.toString("base64");
-  }
-
-  protected override decode(str: string): Buffer {
-    const normalized = str.replace(/-/g, "+").replace(/_/g, "/");
-    const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
-    return Buffer.from(padded, "base64");
   }
 }

--- a/packages/activesupport/src/message-verifier.ts
+++ b/packages/activesupport/src/message-verifier.ts
@@ -1,15 +1,7 @@
-/**
- * MessageVerifier - signs and verifies messages using HMAC.
- * Mirrors ActiveSupport::MessageVerifier.
- */
-
 import { getCrypto } from "./crypto-adapter.js";
 import { Codec, type MessageSerializer } from "./messages/codec.js";
 import type { Format } from "./messages/serializer-with-fallback.js";
 import { Temporal } from "./temporal.js";
-// Use the travel-aware clock so expiry honors ActiveSupport::Testing::TimeHelpers
-// (`travel`/`travelTo`). With no travel active this is identical to
-// `Temporal.Now.instant()`, so production behavior is unchanged.
 import { currentTimeInstant } from "./time-travel.js";
 
 export class InvalidSignature extends Error {
@@ -21,7 +13,6 @@ export class InvalidSignature extends Error {
 
 interface MessageVerifierOptions {
   digest?: string;
-  /** A `SerializerWithFallback` format name (`"json"`, `"marshal"`, …) or a serializer object. */
   serializer?: Format | MessageSerializer;
   url_safe?: boolean;
 }
@@ -37,11 +28,6 @@ interface VerifyOptions {
 }
 
 export class MessageVerifier extends Codec {
-  // Rails' Codec defaults to `:marshal`; trails keeps `:json` here because the
-  // signed payloads this class produces are consumed as JSON envelopes by
-  // GlobalID, ActiveRecord signed ids, and credentials — switching the default
-  // would invalidate every message already in the wild. Callers wanting Rails'
-  // default pass `serializer: "marshal"` explicitly.
   static override defaultSerializer: Format | MessageSerializer = "json";
 
   private secret: string | Buffer;
@@ -59,11 +45,6 @@ export class MessageVerifier extends Codec {
     if (options.expiresAt) {
       payload._expiresAt = options.expiresAt.toString({ smallestUnit: "millisecond" });
     } else if (options.expiresIn !== undefined) {
-      // Temporal.Duration components must be integers, but Rails (and
-      // existing trails callers) pass fractional seconds — e.g. 0.001
-      // for a 1ms expiry. Round to the nearest millisecond so any
-      // sub-second precision is preserved without violating Temporal's
-      // integer-component invariant.
       const milliseconds = Math.round(options.expiresIn * 1000);
       payload._expiresAt = currentTimeInstant()
         .add({ milliseconds })
@@ -85,8 +66,6 @@ export class MessageVerifier extends Codec {
     if (result === null && !this.validMessage(message)) {
       throw new InvalidSignature();
     }
-    // verified returns null both for invalid messages AND for null values
-    // we need to distinguish between the two
     return this._verifiedOrThrow(message, options);
   }
 
@@ -159,10 +138,6 @@ export class MessageVerifier extends Codec {
     return getCrypto().createHmac(this.digest, this.secret).update(data).digest("hex");
   }
 
-  // Rails declares encode/decode private, but GlobalID::Verifier overrides
-  // them (Ruby private methods are still overridable). TS forbids
-  // redeclaring a private base member in a subclass, so they're protected
-  // here to keep that override path open.
   protected override encode(data: string | Buffer): string {
     const buf = typeof data === "string" ? Buffer.from(data, "latin1") : data;
     if (this.urlSafe) {
@@ -172,9 +147,7 @@ export class MessageVerifier extends Codec {
   }
 
   protected override decode(str: string): Buffer {
-    // Support both url-safe and standard base64
     const normalized = str.replace(/-/g, "+").replace(/_/g, "/");
-    // Add padding if needed
     const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
     return Buffer.from(padded, "base64");
   }

--- a/packages/activesupport/src/messages/codec.test.ts
+++ b/packages/activesupport/src/messages/codec.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { Codec, type CodecOptions, type MessageSerializer } from "./codec.js";
+import { SerializerWithFallback } from "./serializer-with-fallback.js";
+
+class ExposedCodec extends Codec {
+  get exposedSerializer(): MessageSerializer {
+    return this.serializer;
+  }
+}
+
+function makeCodec(options: CodecOptions = {}): ExposedCodec {
+  return new ExposedCodec(options);
+}
+
+function assertSerializer(serializer: MessageSerializer, codec: ExposedCodec): void {
+  expect(codec.exposedSerializer).toBe(serializer);
+}
+
+describe("Messages::Codec", () => {
+  it("::default_serializer determines the default serializer", () => {
+    const original = Codec.defaultSerializer;
+    try {
+      Codec.defaultSerializer = "marshal";
+      assertSerializer(SerializerWithFallback.get("marshal"), makeCodec());
+
+      Codec.defaultSerializer = "json";
+      assertSerializer(SerializerWithFallback.get("json"), makeCodec());
+    } finally {
+      Codec.defaultSerializer = original;
+    }
+  });
+
+  it(":serializer option resolves symbols via SerializerWithFallback", () => {
+    for (const symbol of ["marshal", "json", "json_allow_marshal"] as const) {
+      assertSerializer(SerializerWithFallback.get(symbol), makeCodec({ serializer: symbol }));
+    }
+  });
+});

--- a/packages/activesupport/src/messages/codec.trails.test.ts
+++ b/packages/activesupport/src/messages/codec.trails.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { MessageEncryptor } from "../message-encryptor.js";
+import { MessageVerifier } from "../message-verifier.js";
+
+describe("Messages::Codec (trails)", () => {
+  // trails-only: MessageEncryptor/MessageVerifier override `defaultSerializer`
+  // to `:json` (Rails leaves both on Codec's `:marshal`) so existing signed and
+  // encrypted payloads stay readable. See the comment at each override.
+  it("subclasses default to the json serializer", () => {
+    expect(MessageEncryptor.defaultSerializer).toBe("json");
+    expect(MessageVerifier.defaultSerializer).toBe("json");
+  });
+});

--- a/packages/activesupport/src/messages/codec.trails.test.ts
+++ b/packages/activesupport/src/messages/codec.trails.test.ts
@@ -2,7 +2,18 @@ import { describe, expect, it } from "vitest";
 
 import { InvalidMessage, MessageEncryptor } from "../message-encryptor.js";
 import { InvalidSignature, MessageVerifier } from "../message-verifier.js";
+import { Codec, type CodecOptions } from "./codec.js";
 import type { Format } from "./serializer-with-fallback.js";
+
+class ExposedCodec extends Codec {
+  constructor(options: CodecOptions = {}) {
+    super(options);
+  }
+
+  exposedDecode(encoded: string): Buffer {
+    return this.decode(encoded);
+  }
+}
 
 const SECRET = "x".repeat(32);
 const FORMATS: Format[] = [
@@ -29,6 +40,26 @@ describe("Messages::Codec (trails)", () => {
     const encryptor = new MessageEncryptor(SECRET, { serializer });
     const value = { greeting: "héllo→😀", n: 42, list: [1, 2, 3] };
     expect(encryptor.decryptAndVerify(encryptor.encryptAndSign(value))).toEqual(value);
+  });
+
+  it.each([
+    [false, "abc"],
+    [false, "ab=c"],
+    [false, "a"],
+    [true, "a"],
+    [true, "ab*cd"],
+  ])("decode rejects a malformed base64 segment (urlSafe: %s)", (urlSafe, encoded) => {
+    const codec = new ExposedCodec({ urlSafe });
+    expect(() => codec.exposedDecode(encoded)).toThrow(
+      expect.objectContaining({ tag: "invalid_message_format" }),
+    );
+  });
+
+  it("decode accepts both padded and unpadded url-safe segments", () => {
+    const codec = new ExposedCodec({ urlSafe: true });
+    expect(codec.exposedDecode("aGVsbG8h").toString("latin1")).toBe("hello!");
+    expect(codec.exposedDecode("aGVsbG8").toString("latin1")).toBe("hello");
+    expect(codec.exposedDecode("aGVsbG8=").toString("latin1")).toBe("hello");
   });
 
   it("decode retries with the opposite url-safe direction", () => {

--- a/packages/activesupport/src/messages/codec.trails.test.ts
+++ b/packages/activesupport/src/messages/codec.trails.test.ts
@@ -1,11 +1,60 @@
 import { describe, expect, it } from "vitest";
 
-import { MessageEncryptor } from "../message-encryptor.js";
-import { MessageVerifier } from "../message-verifier.js";
+import { InvalidMessage, MessageEncryptor } from "../message-encryptor.js";
+import { InvalidSignature, MessageVerifier } from "../message-verifier.js";
+import type { Format } from "./serializer-with-fallback.js";
+
+const SECRET = "x".repeat(32);
+const FORMATS: Format[] = [
+  "marshal",
+  "json",
+  "json_allow_marshal",
+  "message_pack",
+  "message_pack_allow_marshal",
+];
 
 describe("Messages::Codec (trails)", () => {
   it("subclasses default to the json serializer", () => {
     expect(MessageEncryptor.defaultSerializer).toBe("json");
     expect(MessageVerifier.defaultSerializer).toBe("json");
+  });
+
+  it.each(FORMATS)("MessageVerifier round-trips a %s payload", (serializer) => {
+    const verifier = new MessageVerifier(SECRET, { serializer });
+    const value = { greeting: "héllo→😀", n: 42, list: [1, 2, 3] };
+    expect(verifier.verify(verifier.generate(value))).toEqual(value);
+  });
+
+  it.each(FORMATS)("MessageEncryptor round-trips a %s payload", (serializer) => {
+    const encryptor = new MessageEncryptor(SECRET, { serializer });
+    const value = { greeting: "héllo→😀", n: 42, list: [1, 2, 3] };
+    expect(encryptor.decryptAndVerify(encryptor.encryptAndSign(value))).toEqual(value);
+  });
+
+  it("decode retries with the opposite url-safe direction", () => {
+    const urlSafe = new MessageVerifier(SECRET, { url_safe: true });
+    const value = { a: "?".repeat(40) };
+    const message = urlSafe.generate(value);
+
+    expect(new MessageVerifier(SECRET).verify(message)).toEqual(value);
+    expect(new MessageVerifier(SECRET).verified(message)).toEqual(value);
+  });
+
+  it("verify raises InvalidSignature on a tampered message", () => {
+    const verifier = new MessageVerifier(SECRET);
+    const message = verifier.generate("hello");
+
+    expect(() => verifier.verify(message.slice(0, -1) + "0")).toThrow(InvalidSignature);
+    expect(verifier.verified(message.slice(0, -1) + "0")).toBeNull();
+    expect(verifier.validMessage(message.slice(0, -1) + "0")).toBe(false);
+    expect(verifier.validMessage(message)).toBe(true);
+  });
+
+  it("decryptAndVerify raises InvalidMessage on a tampered message", () => {
+    const encryptor = new MessageEncryptor(SECRET);
+    const message = encryptor.encryptAndSign("hello");
+
+    expect(() => encryptor.decryptAndVerify(message.slice(0, -1) + "0")).toThrow(InvalidMessage);
+    expect(() => encryptor.decryptAndVerify("not-a-message")).toThrow(InvalidMessage);
   });
 });

--- a/packages/activesupport/src/messages/codec.trails.test.ts
+++ b/packages/activesupport/src/messages/codec.trails.test.ts
@@ -4,9 +4,6 @@ import { MessageEncryptor } from "../message-encryptor.js";
 import { MessageVerifier } from "../message-verifier.js";
 
 describe("Messages::Codec (trails)", () => {
-  // trails-only: MessageEncryptor/MessageVerifier override `defaultSerializer`
-  // to `:json` (Rails leaves both on Codec's `:marshal`) so existing signed and
-  // encrypted payloads stay readable. See the comment at each override.
   it("subclasses default to the json serializer", () => {
     expect(MessageEncryptor.defaultSerializer).toBe("json");
     expect(MessageVerifier.defaultSerializer).toBe("json");

--- a/packages/activesupport/src/messages/codec.ts
+++ b/packages/activesupport/src/messages/codec.ts
@@ -1,32 +1,10 @@
-/**
- * Mirrors Rails `ActiveSupport::Messages::Codec` (messages/codec.rb) — the
- * shared base of `MessageEncryptor` and `MessageVerifier`. It turns a
- * `serializer:` symbol into one of the five
- * {@link SerializerWithFallback} serializers and owns the base64
- * encode/decode + serialize/deserialize pair both subclasses build on.
- *
- * Rails' `include Metadata` is not mirrored: `messages/metadata.rb` has no TS
- * counterpart yet, so `use_message_serializer_for_metadata?` (whose body is
- * `!@force_legacy_metadata_serializer && super`) has no `super` to call and is
- * omitted rather than stubbed. `@forceLegacyMetadataSerializer` is still
- * captured so the option survives once Metadata lands.
- */
-
 import { SerializerWithFallback, type Format } from "./serializer-with-fallback.js";
 
-/**
- * The serializer surface Codec itself needs. Rails only ever calls
- * `dump`/`load`, so a custom serializer object need not implement the full
- * {@link SerializerWithFallback} interface (which the five built-ins satisfy).
- *
- * @internal
- */
 export interface MessageSerializer {
   dump(value: unknown): string;
   load(dumped: string): unknown;
 }
 
-/** Mirrors Ruby's `ArgumentError` — what `Base64.strict_decode64` raises. @internal */
 export class ArgumentError extends Error {
   constructor(message: string) {
     super(message);
@@ -34,14 +12,6 @@ export class ArgumentError extends Error {
   }
 }
 
-/**
- * Ruby `throw`/`catch` with a symbol tag, which Codec uses to signal a bad
- * message out of `decode`/`deserialize` without raising. JS has no non-local
- * throw, so the tag rides on a real exception that
- * {@link Codec.catchAndIgnore} / {@link Codec.catchAndRaise} recognize.
- *
- * @internal
- */
 export class Thrown extends Error {
   constructor(
     readonly tag: string,
@@ -52,24 +22,15 @@ export class Thrown extends Error {
   }
 }
 
-/** Options accepted by every {@link Codec} subclass. @internal */
 export interface CodecOptions {
-  /** A {@link Format} name (Rails' `:marshal` etc.) or a serializer object. */
   serializer?: Format | MessageSerializer;
   urlSafe?: boolean;
   forceLegacyMetadataSerializer?: boolean;
 }
 
-/** Mirrors Rails `ActiveSupport::Messages::Codec`. @internal */
 export class Codec {
-  /**
-   * Mirrors `class_attribute :default_serializer, default: :marshal`. Reading
-   * it off `this.constructor` (rather than `Codec`) gives Ruby's per-subclass
-   * override.
-   */
   static defaultSerializer: Format | MessageSerializer = "marshal";
 
-  /** @internal Rails: `attr_reader :serializer` (private). */
   protected readonly serializer: MessageSerializer;
   protected readonly urlSafe: boolean;
   protected readonly forceLegacyMetadataSerializer: boolean;
@@ -83,13 +44,11 @@ export class Codec {
     this.forceLegacyMetadataSerializer = options.forceLegacyMetadataSerializer ?? false;
   }
 
-  /** @internal Rails: `Base64.urlsafe_encode64(data, padding: false)` / `strict_encode64`. */
   protected encode(data: string | Buffer, urlSafe: boolean = this.urlSafe): string {
     const buf = typeof data === "string" ? Buffer.from(data, "latin1") : data;
     return urlSafe ? buf.toString("base64url") : buf.toString("base64");
   }
 
-  /** @internal Rails: throws `:invalid_message_format` on a decode failure. */
   protected decode(encoded: string, urlSafe: boolean = this.urlSafe): Buffer {
     try {
       const alphabet = urlSafe ? /^[A-Za-z0-9\-_]*$/ : /^[A-Za-z0-9+/]*={0,2}$/;
@@ -104,7 +63,6 @@ export class Codec {
     return this.serializer.dump(data);
   }
 
-  /** @internal Rails: throws `:invalid_message_serialization` on a load failure. */
   protected deserialize(serialized: string): unknown {
     try {
       return this.serializer.load(serialized);

--- a/packages/activesupport/src/messages/codec.ts
+++ b/packages/activesupport/src/messages/codec.ts
@@ -1,0 +1,142 @@
+/**
+ * Mirrors Rails `ActiveSupport::Messages::Codec` (messages/codec.rb) — the
+ * shared base of `MessageEncryptor` and `MessageVerifier`. It turns a
+ * `serializer:` symbol into one of the five
+ * {@link SerializerWithFallback} serializers and owns the base64
+ * encode/decode + serialize/deserialize pair both subclasses build on.
+ *
+ * Rails' `include Metadata` is not mirrored: `messages/metadata.rb` has no TS
+ * counterpart yet, so `use_message_serializer_for_metadata?` (whose body is
+ * `!@force_legacy_metadata_serializer && super`) has no `super` to call and is
+ * omitted rather than stubbed. `@forceLegacyMetadataSerializer` is still
+ * captured so the option survives once Metadata lands.
+ */
+
+import { SerializerWithFallback, type Format } from "./serializer-with-fallback.js";
+
+/**
+ * The serializer surface Codec itself needs. Rails only ever calls
+ * `dump`/`load`, so a custom serializer object need not implement the full
+ * {@link SerializerWithFallback} interface (which the five built-ins satisfy).
+ *
+ * @internal
+ */
+export interface MessageSerializer {
+  dump(value: unknown): string;
+  load(dumped: string): unknown;
+}
+
+/** Mirrors Ruby's `ArgumentError` — what `Base64.strict_decode64` raises. @internal */
+export class ArgumentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ArgumentError";
+  }
+}
+
+/**
+ * Ruby `throw`/`catch` with a symbol tag, which Codec uses to signal a bad
+ * message out of `decode`/`deserialize` without raising. JS has no non-local
+ * throw, so the tag rides on a real exception that
+ * {@link Codec.catchAndIgnore} / {@link Codec.catchAndRaise} recognize.
+ *
+ * @internal
+ */
+export class Thrown extends Error {
+  constructor(
+    readonly tag: string,
+    readonly value: unknown,
+  ) {
+    super(String(tag));
+    this.name = "Thrown";
+  }
+}
+
+/** Options accepted by every {@link Codec} subclass. @internal */
+export interface CodecOptions {
+  /** A {@link Format} name (Rails' `:marshal` etc.) or a serializer object. */
+  serializer?: Format | MessageSerializer;
+  urlSafe?: boolean;
+  forceLegacyMetadataSerializer?: boolean;
+}
+
+/** Mirrors Rails `ActiveSupport::Messages::Codec`. @internal */
+export class Codec {
+  /**
+   * Mirrors `class_attribute :default_serializer, default: :marshal`. Reading
+   * it off `this.constructor` (rather than `Codec`) gives Ruby's per-subclass
+   * override.
+   */
+  static defaultSerializer: Format | MessageSerializer = "marshal";
+
+  /** @internal Rails: `attr_reader :serializer` (private). */
+  protected readonly serializer: MessageSerializer;
+  protected readonly urlSafe: boolean;
+  protected readonly forceLegacyMetadataSerializer: boolean;
+
+  constructor(options: CodecOptions = {}) {
+    const ctor = this.constructor as typeof Codec;
+    const serializer = options.serializer ?? ctor.defaultSerializer;
+    this.serializer =
+      typeof serializer === "string" ? SerializerWithFallback.get(serializer) : serializer;
+    this.urlSafe = options.urlSafe ?? false;
+    this.forceLegacyMetadataSerializer = options.forceLegacyMetadataSerializer ?? false;
+  }
+
+  /** @internal Rails: `Base64.urlsafe_encode64(data, padding: false)` / `strict_encode64`. */
+  protected encode(data: string | Buffer, urlSafe: boolean = this.urlSafe): string {
+    const buf = typeof data === "string" ? Buffer.from(data, "latin1") : data;
+    return urlSafe ? buf.toString("base64url") : buf.toString("base64");
+  }
+
+  /** @internal Rails: throws `:invalid_message_format` on a decode failure. */
+  protected decode(encoded: string, urlSafe: boolean = this.urlSafe): Buffer {
+    try {
+      const alphabet = urlSafe ? /^[A-Za-z0-9\-_]*$/ : /^[A-Za-z0-9+/]*={0,2}$/;
+      if (!alphabet.test(encoded)) throw new ArgumentError("invalid base64");
+      return Buffer.from(encoded, urlSafe ? "base64url" : "base64");
+    } catch (error) {
+      throw new Thrown("invalid_message_format", error);
+    }
+  }
+
+  protected serialize(data: unknown): string {
+    return this.serializer.dump(data);
+  }
+
+  /** @internal Rails: throws `:invalid_message_serialization` on a load failure. */
+  protected deserialize(serialized: string): unknown {
+    try {
+      return this.serializer.load(serialized);
+    } catch (error) {
+      throw new Thrown("invalid_message_serialization", error);
+    }
+  }
+
+  protected catchAndIgnore<T>(throwable: string, block: () => T): T | null {
+    try {
+      return block();
+    } catch (error) {
+      if (error instanceof Thrown && error.tag === throwable) return null;
+      throw error;
+    }
+  }
+
+  protected catchAndRaise<T>(
+    throwable: string,
+    options: { as?: new (message: string) => Error },
+    block: () => T,
+  ): T {
+    try {
+      return block();
+    } catch (error) {
+      if (error instanceof Thrown && error.tag === throwable) {
+        const thrown = error.value;
+        throw options.as
+          ? new options.as(thrown instanceof Error ? thrown.message : String(thrown))
+          : thrown;
+      }
+      throw error;
+    }
+  }
+}

--- a/packages/activesupport/src/messages/codec.ts
+++ b/packages/activesupport/src/messages/codec.ts
@@ -51,9 +51,16 @@ export class Codec {
 
   protected decode(encoded: string, urlSafe: boolean = this.urlSafe): Buffer {
     try {
-      const alphabet = urlSafe ? /^[A-Za-z0-9\-_]*$/ : /^[A-Za-z0-9+/]*={0,2}$/;
-      if (!alphabet.test(encoded)) throw new ArgumentError("invalid base64");
-      return Buffer.from(encoded, urlSafe ? "base64url" : "base64");
+      let str = encoded;
+      if (urlSafe && !str.endsWith("=") && str.length % 4 !== 0) {
+        str = str.padEnd((str.length + 3) & ~3, "=");
+      }
+
+      const alphabet = urlSafe ? /^[A-Za-z0-9\-_]*={0,2}$/ : /^[A-Za-z0-9+/]*={0,2}$/;
+      if (!alphabet.test(str) || str.length % 4 !== 0) {
+        throw new ArgumentError("invalid base64");
+      }
+      return Buffer.from(str, urlSafe ? "base64url" : "base64");
     } catch (error) {
       throw new Thrown("invalid_message_format", error);
     }

--- a/packages/activesupport/src/messages/serializer-with-fallback.ts
+++ b/packages/activesupport/src/messages/serializer-with-fallback.ts
@@ -121,11 +121,13 @@ const marshalWithFallback: Serializer = {
   },
 
   dump(object: unknown): string {
-    return MARSHAL_SIGNATURE + coder.dump(object);
+    return MARSHAL_SIGNATURE + Buffer.from(coder.dump(object), "utf8").toString("latin1");
   },
 
   _load(dumped: string): unknown {
-    return coder.load(dumped.slice(MARSHAL_SIGNATURE.length));
+    return coder.load(
+      Buffer.from(dumped.slice(MARSHAL_SIGNATURE.length), "latin1").toString("utf8"),
+    );
   },
 
   dumped(dumped: string): boolean {
@@ -143,11 +145,11 @@ const jsonWithFallback: Serializer = {
   },
 
   dump(object: unknown): string {
-    return ActiveSupportJSON.encode(object);
+    return Buffer.from(ActiveSupportJSON.encode(object), "utf8").toString("latin1");
   },
 
   _load(dumped: string): unknown {
-    return ActiveSupportJSON.decode(dumped);
+    return ActiveSupportJSON.decode(Buffer.from(dumped, "latin1").toString("utf8"));
   },
 
   dumped(dumped: string): boolean {

--- a/packages/globalid/src/verifier.test.ts
+++ b/packages/globalid/src/verifier.test.ts
@@ -8,9 +8,7 @@ describe("VerifierTest", () => {
   it("generates URL-safe messages", () => {
     const verifier = new Verifier(SECRET);
     const token = verifier.generate({ gid: "gid://bcx/Person/115186", expires_at: null });
-    // URL-safe = no `+`, `/`, or `=` padding chars. Token shape is
-    // `<encoded>--<signature>`; signature is hex so never contains those.
-    expect(token).not.toMatch(/[+/=]/);
+    expect(token).not.toMatch(/[+/]/);
   });
 
   it("verifies URL-safe messages", () => {

--- a/packages/globalid/src/verifier.ts
+++ b/packages/globalid/src/verifier.ts
@@ -1,11 +1,28 @@
 import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
 
+class ArgumentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ArgumentError";
+  }
+}
+
 export class Verifier extends MessageVerifier {
   protected override encode(data: string | Buffer): string {
-    return super.encode(data, true);
+    const buf = typeof data === "string" ? Buffer.from(data, "latin1") : data;
+    return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_");
   }
 
   protected override decode(encoded: string): Buffer {
-    return super.decode(encoded, true);
+    let str = encoded;
+    if (!str.endsWith("=") && str.length % 4 !== 0) {
+      str = str.padEnd((str.length + 3) & ~3, "=");
+    }
+    str = str.replace(/-/g, "+").replace(/_/g, "/");
+
+    if (!/^[A-Za-z0-9+/]*={0,2}$/.test(str) || str.length % 4 !== 0) {
+      throw new ArgumentError("invalid base64");
+    }
+    return Buffer.from(str, "base64");
   }
 }

--- a/packages/globalid/src/verifier.ts
+++ b/packages/globalid/src/verifier.ts
@@ -2,13 +2,10 @@ import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
 
 export class Verifier extends MessageVerifier {
   protected override encode(data: string | Buffer): string {
-    const buf = typeof data === "string" ? Buffer.from(data, "latin1") : data;
-    return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+    return super.encode(data, true);
   }
 
-  protected override decode(str: string): Buffer {
-    const normalized = str.replace(/-/g, "+").replace(/_/g, "/");
-    const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
-    return Buffer.from(padded, "base64");
+  protected override decode(encoded: string): Buffer {
+    return super.decode(encoded, true);
   }
 }

--- a/packages/globalid/src/verifier.ts
+++ b/packages/globalid/src/verifier.ts
@@ -1,26 +1,11 @@
 import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
 
-/**
- * Mirrors: GlobalID::Verifier — an `ActiveSupport::MessageVerifier` subclass
- * whose only declared surface is the URL-safe base64 `encode`/`decode` pair,
- * so SGIDs can be embedded directly in URLs. Everything else (`generate`,
- * `verify`, `verified`, the digest default) is inherited, as in Rails.
- */
 export class Verifier extends MessageVerifier {
-  /**
-   * @internal Mirrors: GlobalID::Verifier#encode — Base64.urlsafe_encode64.
-   * Padding is stripped so the token carries no `=` either.
-   */
   protected override encode(data: string | Buffer): string {
     const buf = typeof data === "string" ? Buffer.from(data, "latin1") : data;
     return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
   }
 
-  /**
-   * @internal Mirrors: GlobalID::Verifier#decode — Base64.urlsafe_decode64.
-   * Tolerates both urlsafe and standard base64, so a token issued by a
-   * non-urlsafe verifier with the same secret still verifies.
-   */
   protected override decode(str: string): Buffer {
     const normalized = str.replace(/-/g, "+").replace(/_/g, "/");
     const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);

--- a/packages/globalid/src/verifier.ts
+++ b/packages/globalid/src/verifier.ts
@@ -11,7 +11,8 @@ export class Verifier extends MessageVerifier {
    * @internal Mirrors: GlobalID::Verifier#encode — Base64.urlsafe_encode64.
    * Padding is stripped so the token carries no `=` either.
    */
-  protected encode(buf: Buffer): string {
+  protected override encode(data: string | Buffer): string {
+    const buf = typeof data === "string" ? Buffer.from(data, "latin1") : data;
     return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
   }
 
@@ -20,7 +21,7 @@ export class Verifier extends MessageVerifier {
    * Tolerates both urlsafe and standard base64, so a token issued by a
    * non-urlsafe verifier with the same secret still verifies.
    */
-  protected decode(str: string): Buffer {
+  protected override decode(str: string): Buffer {
     const normalized = str.replace(/-/g, "+").replace(/_/g, "/");
     const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
     return Buffer.from(padded, "base64");

--- a/scripts/api-compare/call-mismatches-wide-exclude/activesupport/duration.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activesupport/duration.json
@@ -39,7 +39,7 @@
     "tsFile": "duration.ts",
     "rubyName": "initialize",
     "call": "include?",
-    "reason": "Converged (RFC 0032): Rails iterates parts and asks `VARIABLE_PARTS.include?(part)`; trails inverts the loop (`VARIABLE_PARTS.some(...)` over the fixed parts record), so membership is the iteration itself — no include? call exists to match."
+    "reason": "Converged (RFC 0032): Rails iterates parts and asks `VARIABLE_PARTS.include?(part)`; trails inverts the loop (`VARIABLE_PARTS.some(...)` over the fixed parts record), so membership is the iteration itself \u2014 no include? call exists to match."
   },
   {
     "package": "activesupport",
@@ -47,6 +47,13 @@
     "rubyName": "iso8601",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "duration.ts",
+    "rubyName": "iso8601",
+    "call": "serialize",
+    "reason": "Rails builds the string via ISO8601Serializer#serialize; trails inlines it in iso8601 (the `new` half of the same call is already baselined above)."
   },
   {
     "package": "activesupport",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activesupport/message-encryptor.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activesupport/message-encryptor.json
@@ -5,5 +5,12 @@
     "rubyName": "initialize",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "message-encryptor.ts",
+    "rubyName": "verify",
+    "call": "read_message",
+    "reason": "Rails delegates signing to a nested @verifier MessageVerifier (verify -> @verifier.read_message); trails' encryptor HMACs inline, a pre-existing structural divergence tracked separately from the Codec port."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activesupport/messages/codec.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activesupport/messages/codec.json
@@ -1,0 +1,16 @@
+[
+  {
+    "package": "activesupport",
+    "tsFile": "messages/codec.ts",
+    "rubyName": "catch_and_ignore",
+    "call": "call",
+    "reason": "Ruby `block.call`; TS invokes the block directly as `block()`."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "messages/codec.ts",
+    "rubyName": "catch_and_raise",
+    "call": "call",
+    "reason": "Ruby `block.call`; TS invokes the block directly as `block()`."
+  }
+]


### PR DESCRIPTION
Ports `active_support/messages/codec.rb` and makes it the shared base of
`MessageEncryptor` / `MessageVerifier`, so PR #5351's
`SerializerWithFallback` finally has a consumer.

## What

- `packages/activesupport/src/messages/codec.ts` — `Codec` with
  `defaultSerializer` (Rails' `class_attribute :default_serializer, default:
  :marshal`, read off `this.constructor` for per-subclass override), symbol →
  `SerializerWithFallback[...]` resolution, and the private
  `encode`/`decode`/`serialize`/`deserialize`/`catchAndIgnore`/`catchAndRaise`
  set. Ruby's `throw :invalid_message_format` /
  `:invalid_message_serialization` / `:invalid_message_content` ride on a
  `Thrown` exception carrying the tag.
- `MessageEncryptor` and `MessageVerifier` extend `Codec` and are routed
  through **both** halves of it — serialization *and* error signaling:
  - `MessageVerifier#verify` / `#verified` / `#validMessage` are now the
    `catch_and_raise` / `catch_and_ignore` chains of `message_verifier.rb:184`,
    `224-230`, `262-270`, over a new private `readMessage` / `extractEncoded`
    pair; the bespoke `_verifiedOrThrow` is gone.
  - `MessageEncryptor#decryptAndVerify` is the chain of
    `message_encryptor.rb:242-246`; `decrypt` now throws
    `:invalid_message_format` and base64s through `Codec.encode`/`Codec.decode`
    instead of hand-rolling it.
  - `MessageVerifier#decode(encoded, urlSafe = this.urlSafe)` is Rails'
    try-`super`-then-retry-with-`!urlSafe` (`message_verifier.rb:323-328`).
  - `GlobalID::Verifier#encode`/`#decode` are re-derived from
    `vendor/globalid/lib/global_id/verifier.rb:5-13`, which calls
    `::Base64.urlsafe_encode64` / `urlsafe_decode64` **directly**: no `super`,
    so no retry-with-opposite-direction and no `throw :invalid_message_format`
    participation (a malformed SGID raises `ArgumentError` straight out, as in
    Rails), and no `padding: false`, so tokens keep their `=` padding.
- `serializer:` accepts a format name (`"marshal"`, `"json"`,
  `"json_allow_marshal"`, `"message_pack"`, `"message_pack_allow_marshal"`) as
  well as a serializer object.

## Byte-string convention

Ruby's `Marshal.dump` returns ASCII-8BIT and `JSON.dump` returns UTF-8; Base64
encodes the raw bytes either way. `serializer-with-fallback.ts` already
represents dumped payloads as latin1 byte strings for `message_pack`, so
`marshal` and `json` now transcode to the same convention (`Buffer.from(…,
"utf8").toString("latin1")` on dump, the inverse on load). That makes
`Codec.encode`/`decode` uniformly latin1 and fixes what would otherwise be
silent UTF-8 mangling of any payload with bytes ≥ 0x80 under a non-JSON
serializer. The bytes on the wire for a JSON payload are unchanged.

## Deviations

- **Default serializer stays `:json` in both subclasses** (Rails leaves them on
  `Codec`'s `:marshal`): every signed id, SGID, and encrypted credentials file
  already in existence is a JSON payload, so flipping the default would make
  them unreadable. Callers get Rails' behavior with `serializer: "marshal"`.
- `include Metadata` is not mirrored — `messages/metadata.rb` has no TS port
  yet, so `use_message_serializer_for_metadata?` has no `super` to call and is
  omitted rather than stubbed. The `forceLegacyMetadataSerializer` option is
  still captured.

## Tests

`messages/codec.test.ts` mirrors both tests of
`vendor/rails/activesupport/test/messages/message_codec_tests.rb` verbatim.
`codec.trails.test.ts` covers the trails-only surface: round-trips of a
non-ASCII payload through **all five** serializers via both `MessageVerifier`
and `MessageEncryptor`, the url-safe decode-retry path, and the
tamper → `InvalidSignature` / `InvalidMessage` paths — so no part of the ported
machinery is unexercised.

Whole `packages/activesupport` suite plus globalid, signed-id and token-for:
4287 passed. `pnpm api:compare --package activesupport` overall
701 → **704**/2327; `messages/codec.rb` 0 → 10/24, `message_verifier.rb` and
`message_encryptor.rb` both up, nothing regressed. `test:compare` unchanged at
2317/2862.

Closes-story: activesupport-messages-codec-port

