### PR TITLE
fix(api-compare): bind one constant in resolveModuleName's ambiguous arm

### DIFF
--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -973,9 +973,19 @@ describe("resolveModuleName", () => {
     expect(resolveModuleName("::Foo::Bar", "Baz::Qux", new Map())).toEqual(["Foo::Bar"]);
   });
 
-  it("returns all candidates when context has no prefix match", () => {
+  it("returns the top-level reading when context has no prefix match", () => {
+    // Ruby binds one constant, never every same-named candidate: handing back
+    // both would give `Z::Bar` X::Foo's *and* Y::Foo's methods as expected
+    // surface, and both modules' includer files as legal homes for them.
     const byShort = new Map([["Foo", ["X::Foo", "Y::Foo"]]]);
-    expect(resolveModuleName("Foo", "Z::Bar", byShort)).toEqual(["X::Foo", "Y::Foo"]);
+    expect(resolveModuleName("Foo", "Z::Bar", byShort)).toEqual(["Foo"]);
+  });
+
+  it("never returns more than one binding", () => {
+    const byShort = new Map([["Foo", ["X::Foo", "Y::Foo", "X::Y::Foo"]]]);
+    for (const ctx of ["Z::Bar", "X::Bar", "X::Y::Bar", "Foo", "A::B::C::D"]) {
+      expect(resolveModuleName("Foo", ctx, byShort)).toHaveLength(1);
+    }
   });
 
   it("prefers nearest namespace prefix — abstract base wins over sibling adapter", () => {

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -915,11 +915,11 @@ describe("resolveModuleName", () => {
     const byShort = new Map([["Quoting", ["AR::ConnectionAdapters::Quoting"]]]);
     expect(
       resolveModuleName("Quoting", "AR::ConnectionAdapters::AbstractAdapter", byShort),
-    ).toEqual(["AR::ConnectionAdapters::Quoting"]);
+    ).toEqual("AR::ConnectionAdapters::Quoting");
   });
 
   it("falls back to the verbatim qualified name when nothing matches", () => {
-    expect(resolveModuleName("Foo::Bar", "Baz::Qux", new Map())).toEqual(["Foo::Bar"]);
+    expect(resolveModuleName("Foo::Bar", "Baz::Qux", new Map())).toEqual("Foo::Bar");
   });
 
   it("resolves a partially-qualified name through the enclosing namespace", () => {
@@ -930,7 +930,7 @@ describe("resolveModuleName", () => {
         "AR::ConnectionAdapters::PostgreSQLAdapter",
         byShort,
       ),
-    ).toEqual(["AR::ConnectionAdapters::PostgreSQL::Quoting"]);
+    ).toEqual("AR::ConnectionAdapters::PostgreSQL::Quoting");
   });
 
   it("returns a fully-qualified name that already matches a known module", () => {
@@ -939,7 +939,7 @@ describe("resolveModuleName", () => {
     ]);
     expect(
       resolveModuleName("Other::Quoting", "AR::ConnectionAdapters::PostgreSQLAdapter", byShort),
-    ).toEqual(["Other::Quoting"]);
+    ).toEqual("Other::Quoting");
   });
 
   it("prefers the nearest namespace prefix over a top-level qualified match", () => {
@@ -952,25 +952,25 @@ describe("resolveModuleName", () => {
         "AR::ConnectionAdapters::PostgreSQLAdapter",
         byShort,
       ),
-    ).toEqual(["AR::ConnectionAdapters::PostgreSQL::Quoting"]);
+    ).toEqual("AR::ConnectionAdapters::PostgreSQL::Quoting");
   });
 
   it("returns the verbatim qualified name when no namespace prefix matches", () => {
     const byShort = new Map([["Quoting", ["Somewhere::Else::Quoting"]]]);
-    expect(resolveModuleName("PostgreSQL::Quoting", "AR::Base", byShort)).toEqual([
+    expect(resolveModuleName("PostgreSQL::Quoting", "AR::Base", byShort)).toEqual(
       "PostgreSQL::Quoting",
-    ]);
+    );
   });
 
   it("strips a leading :: and resolves top-level, ignoring nearer candidates", () => {
     // `include ::Foo` is absolute: it must not bind to the lexically nearer
     // `Z::Foo` the unqualified form would pick.
     const byShort = new Map([["Foo", ["Z::Foo", "Foo"]]]);
-    expect(resolveModuleName("::Foo", "Z::Bar", byShort)).toEqual(["Foo"]);
+    expect(resolveModuleName("::Foo", "Z::Bar", byShort)).toEqual("Foo");
   });
 
   it("strips a leading :: from a qualified absolute name", () => {
-    expect(resolveModuleName("::Foo::Bar", "Baz::Qux", new Map())).toEqual(["Foo::Bar"]);
+    expect(resolveModuleName("::Foo::Bar", "Baz::Qux", new Map())).toEqual("Foo::Bar");
   });
 
   it("returns the top-level reading when context has no prefix match", () => {
@@ -978,14 +978,18 @@ describe("resolveModuleName", () => {
     // both would give `Z::Bar` X::Foo's *and* Y::Foo's methods as expected
     // surface, and both modules' includer files as legal homes for them.
     const byShort = new Map([["Foo", ["X::Foo", "Y::Foo"]]]);
-    expect(resolveModuleName("Foo", "Z::Bar", byShort)).toEqual(["Foo"]);
+    expect(resolveModuleName("Foo", "Z::Bar", byShort)).toEqual("Foo");
   });
 
-  it("never returns more than one binding", () => {
+  it("binds the nearest enclosing candidate or top-level, never an unrelated sibling", () => {
+    // Whatever the context, the binding is the innermost enclosing namespace
+    // that defines `Foo`, else top-level `Foo` — never a candidate the context
+    // does not enclose. `Y::Foo` is unreachable from every context here.
     const byShort = new Map([["Foo", ["X::Foo", "Y::Foo", "X::Y::Foo"]]]);
-    for (const ctx of ["Z::Bar", "X::Bar", "X::Y::Bar", "Foo", "A::B::C::D"]) {
-      expect(resolveModuleName("Foo", ctx, byShort)).toHaveLength(1);
-    }
+    expect(resolveModuleName("Foo", "X::Y::Bar", byShort)).toEqual("X::Y::Foo");
+    expect(resolveModuleName("Foo", "X::Bar", byShort)).toEqual("X::Foo");
+    expect(resolveModuleName("Foo", "Z::Bar", byShort)).toEqual("Foo");
+    expect(resolveModuleName("Foo", "A::B::C::D", byShort)).toEqual("Foo");
   });
 
   it("prefers nearest namespace prefix — abstract base wins over sibling adapter", () => {
@@ -996,7 +1000,7 @@ describe("resolveModuleName", () => {
     ];
     const byShort = new Map([["Quoting", candidates]]);
     const result = resolveModuleName("Quoting", "AR::ConnectionAdapters::AbstractAdapter", byShort);
-    expect(result).toEqual(["AR::ConnectionAdapters::Quoting"]);
+    expect(result).toEqual("AR::ConnectionAdapters::Quoting");
   });
 
   it("prefers adapter-specific namespace when including class is in that namespace", () => {
@@ -1010,19 +1014,19 @@ describe("resolveModuleName", () => {
       "AR::ConnectionAdapters::PostgreSQL::PostgreSQLAdapter",
       byShort,
     );
-    expect(result).toEqual(["AR::ConnectionAdapters::PostgreSQL::Quoting"]);
+    expect(result).toEqual("AR::ConnectionAdapters::PostgreSQL::Quoting");
   });
 
   it("binds a class's own nested module over an identically-named sibling's", () => {
     // `class Rack::Request; include Helpers; end` where both Request and
     // Response nest a `Helpers`: Ruby binds Request's.
     const byShort = new Map([["Helpers", ["Rack::Request::Helpers", "Rack::Response::Helpers"]]]);
-    expect(resolveModuleName("Helpers", "Rack::Request", byShort)).toEqual([
+    expect(resolveModuleName("Helpers", "Rack::Request", byShort)).toEqual(
       "Rack::Request::Helpers",
-    ]);
-    expect(resolveModuleName("Helpers", "Rack::Response::Raw", byShort)).toEqual([
+    );
+    expect(resolveModuleName("Helpers", "Rack::Response::Raw", byShort)).toEqual(
       "Rack::Response::Helpers",
-    ]);
+    );
   });
 });
 

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -769,8 +769,17 @@ function nearestNamespaceMatch(
  * If only one FQN matches an unqualified short name, that single candidate is
  * returned regardless of context. When multiple candidates exist,
  * namespace-prefix walking picks the nearest enclosing match; if none of the
- * candidates share a namespace prefix with the context the full candidate list
- * is returned (original behavior, safe fallback).
+ * candidates share a namespace prefix with the context the verbatim name is
+ * returned — the top-level reading, matching the qualified-name arm.
+ *
+ * This resolver always returns exactly one FQN, because Ruby's constant lookup
+ * binds exactly one. It once returned the whole candidate list on that last
+ * arm; measured against the real manifests that arm never fired (26 ambiguous
+ * unqualified include sites across all 13 packages, all of them resolved by
+ * the namespace walk), so narrowing it moved no method counts and removed a
+ * latent multi-bind — the same false-positive shape PR #5344 removed from the
+ * includer graph, where 21 methods were counting as implemented in files
+ * Ruby's lookup never reaches.
  *
  * Every consumer of `moduleFqnByShort` resolves through here —
  * `flattenIncludedMethodInfos` (expected surface) and `buildModuleIncluderFqns`
@@ -794,8 +803,12 @@ export function resolveModuleName(
   if (candidates.length === 1) return candidates;
 
   const nearest = nearestNamespaceMatch(incName, contextFqn, candidates);
-  // No prefix match — fall back to all candidates (original behavior).
-  return nearest ? [nearest] : candidates;
+  // No prefix match — take the top-level reading, the same fall-through the
+  // qualified-name arm above uses. Ruby binds exactly one constant here
+  // (lexical scope, then ancestry, then top-level, then NameError); returning
+  // every same-named candidate would hand each one's methods to the host's
+  // expected surface and each one's includers to the search set.
+  return nearest ? [nearest] : [incName];
 }
 
 /**

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -775,21 +775,20 @@ function nearestNamespaceMatch(
  * Returns exactly one FQN, because Ruby's constant lookup binds exactly one:
  * lexical scope, then the ancestry chain, then top-level, then `NameError`.
  * The return type is `string` rather than `string[]` to keep that structural.
- * This once returned the *whole* candidate list on the last arm ("original
- * behavior, safe fallback") — safe against false negatives, never measured
- * against false positives, which is the costly direction: each extra
- * candidate donates its methods to the host's expected surface and its
- * includers' files to the search set, so a wrong one is a false match.
- * Measured over the real manifests that arm never fired — 26 ambiguous
- * unqualified include sites across all 13 packages, every one resolved by the
- * namespace walk — so removing it moved no method counts. Same false-positive
- * shape PR #5344 removed from the includer graph, where 21 methods were
- * counting as implemented in files Ruby's lookup never reaches.
  *
  * Every consumer of `moduleFqnByShort` resolves through here —
  * `flattenIncludedMethodInfos` (expected surface) and `buildModuleIncluderFqns`
  * (where that surface may be implemented). A broader lookup in either one lets
  * a method count as implemented in a file Ruby's constant lookup never binds.
+ * That is why the last arm no longer returns the *whole* candidate list
+ * ("original behavior, safe fallback"): safe against false negatives, but each
+ * extra candidate donates its methods to the expected surface and its
+ * includers' files to the search set, so a wrong one is a false match.
+ * Measured over the real manifests, that arm never fired — 26 ambiguous
+ * unqualified include sites across all 13 packages, every one resolved by the
+ * namespace walk — so dropping it moved no method counts. Same false-positive
+ * shape PR #5344 removed from the includer graph, where 21 methods were
+ * counting as implemented in files Ruby's lookup never reaches.
  */
 export function resolveModuleName(
   incName: string,

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -772,14 +772,19 @@ function nearestNamespaceMatch(
  * candidates share a namespace prefix with the context the verbatim name is
  * returned — the top-level reading, matching the qualified-name arm.
  *
- * This resolver always returns exactly one FQN, because Ruby's constant lookup
- * binds exactly one. It once returned the whole candidate list on that last
- * arm; measured against the real manifests that arm never fired (26 ambiguous
- * unqualified include sites across all 13 packages, all of them resolved by
- * the namespace walk), so narrowing it moved no method counts and removed a
- * latent multi-bind — the same false-positive shape PR #5344 removed from the
- * includer graph, where 21 methods were counting as implemented in files
- * Ruby's lookup never reaches.
+ * Returns exactly one FQN, because Ruby's constant lookup binds exactly one:
+ * lexical scope, then the ancestry chain, then top-level, then `NameError`.
+ * The return type is `string` rather than `string[]` to keep that structural.
+ * This once returned the *whole* candidate list on the last arm ("original
+ * behavior, safe fallback") — safe against false negatives, never measured
+ * against false positives, which is the costly direction: each extra
+ * candidate donates its methods to the host's expected surface and its
+ * includers' files to the search set, so a wrong one is a false match.
+ * Measured over the real manifests that arm never fired — 26 ambiguous
+ * unqualified include sites across all 13 packages, every one resolved by the
+ * namespace walk — so removing it moved no method counts. Same false-positive
+ * shape PR #5344 removed from the includer graph, where 21 methods were
+ * counting as implemented in files Ruby's lookup never reaches.
  *
  * Every consumer of `moduleFqnByShort` resolves through here —
  * `flattenIncludedMethodInfos` (expected surface) and `buildModuleIncluderFqns`
@@ -790,25 +795,21 @@ export function resolveModuleName(
   incName: string,
   contextFqn: string,
   moduleFqnByShort: Map<string, string[]>,
-): string[] {
+): string {
   // A leading `::` is Ruby's absolute-reference marker, not a namespace
   // qualifier: `include ::Foo` names top-level `Foo` regardless of context.
-  if (incName.startsWith("::")) return [incName.slice(2)];
+  if (incName.startsWith("::")) return incName.slice(2);
   if (incName.includes("::")) {
     const candidates = moduleFqnByShort.get(incName.split("::").pop()!) ?? [];
-    return [nearestNamespaceMatch(incName, contextFqn, candidates) ?? incName];
+    return nearestNamespaceMatch(incName, contextFqn, candidates) ?? incName;
   }
   const candidates = moduleFqnByShort.get(incName);
-  if (!candidates || candidates.length === 0) return [incName];
-  if (candidates.length === 1) return candidates;
+  if (!candidates || candidates.length === 0) return incName;
+  if (candidates.length === 1) return candidates[0];
 
-  const nearest = nearestNamespaceMatch(incName, contextFqn, candidates);
   // No prefix match — take the top-level reading, the same fall-through the
-  // qualified-name arm above uses. Ruby binds exactly one constant here
-  // (lexical scope, then ancestry, then top-level, then NameError); returning
-  // every same-named candidate would hand each one's methods to the host's
-  // expected surface and each one's includers to the search set.
-  return nearest ? [nearest] : [incName];
+  // qualified-name arm above uses.
+  return nearestNamespaceMatch(incName, contextFqn, candidates) ?? incName;
 }
 
 /**
@@ -830,11 +831,10 @@ export function buildModuleIncluderFqns(
   const moduleIncluderFqns = new Map<string, Set<string>>();
   for (const { fqn, info } of entities) {
     for (const inc of [...(info.includes || []), ...(info.extends || [])]) {
-      for (const modFqn of resolveModuleName(inc, fqn, moduleFqnByShort)) {
-        const includers = moduleIncluderFqns.get(modFqn) || new Set<string>();
-        includers.add(fqn);
-        moduleIncluderFqns.set(modFqn, includers);
-      }
+      const modFqn = resolveModuleName(inc, fqn, moduleFqnByShort);
+      const includers = moduleIncluderFqns.get(modFqn) || new Set<string>();
+      includers.add(fqn);
+      moduleIncluderFqns.set(modFqn, includers);
     }
   }
   return moduleIncluderFqns;
@@ -881,22 +881,20 @@ export function flattenIncludedMethodInfos(
   const visited = new Set<string>();
 
   const walk = (incName: string, asClassMethods: boolean, contextFqn: string): void => {
-    const fqns = resolveModuleName(incName, contextFqn, moduleFqnByShort);
-    for (const fqn of fqns) {
-      if (visited.has(fqn)) continue;
-      visited.add(fqn);
-      const mod = rubyPkg.modules[fqn] as unknown as ClassInfo | undefined;
-      if (!mod) continue;
-      // A module whose source file we've explicitly declined to port should
-      // not contribute its methods to includers either — otherwise an
-      // unported mixin (e.g. Railties::ControllerRuntime, included into
-      // ActionController via an `on_load` block, not into Railtie itself)
-      // leaks expected methods onto the host. See UNPORTED_FILES.
-      if (mod.file && isSourceUnported(mod.file, pkg)) continue;
-      const sink = asClassMethods ? klass : instance;
-      for (const m of mod.instanceMethods) sink.push(m);
-      for (const inc of mod.includes ?? []) walk(inc, asClassMethods, fqn);
-    }
+    const fqn = resolveModuleName(incName, contextFqn, moduleFqnByShort);
+    if (visited.has(fqn)) return;
+    visited.add(fqn);
+    const mod = rubyPkg.modules[fqn] as unknown as ClassInfo | undefined;
+    if (!mod) return;
+    // A module whose source file we've explicitly declined to port should
+    // not contribute its methods to includers either — otherwise an
+    // unported mixin (e.g. Railties::ControllerRuntime, included into
+    // ActionController via an `on_load` block, not into Railtie itself)
+    // leaks expected methods onto the host. See UNPORTED_FILES.
+    if (mod.file && isSourceUnported(mod.file, pkg)) return;
+    const sink = asClassMethods ? klass : instance;
+    for (const m of mod.instanceMethods) sink.push(m);
+    for (const inc of mod.includes ?? []) walk(inc, asClassMethods, fqn);
   };
 
   for (const inc of entity.includes ?? []) walk(inc, false, entityFqn);

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -559,34 +559,32 @@ function collectAllowedNames(
   };
 
   const walkMixin = (incName: string, contextFqn: string): void => {
-    const fqns = resolveModuleName(incName, contextFqn, moduleFqnByShort);
-    for (const fqn of fqns) {
-      if (visited.has(fqn)) continue;
-      visited.add(fqn);
-      // Fall back to the cross-package map: a railtie-injected mixin (see
-      // AMBIENT_RAILTIE_MIXINS) or a fully-qualified cross-gem include lives
-      // in another package's modules, not this package's.
-      const localMod = rubyModules[fqn];
-      const mod = localMod ?? crossPackageModules[fqn];
-      if (!mod) continue;
-      // A module whose source file we've explicitly declined to port should
-      // not contribute its methods to the host's allowed set — otherwise an
-      // unported mixin still flips its TS ports from extra surface to allowed.
-      // Mirrors compare.flattenIncludedMethodInfos (compare.ts:507). Resolve
-      // `isSourceUnported` against the module's *owning* package: a local
-      // module's owner is the host `pkg`, a cross-package module's owner is
-      // the package it was extracted from (package-scoped unported patterns
-      // key off the owner, not the host).
-      const ownerPkg = localMod ? pkg : (crossPackagePkgByFqn[fqn] ?? pkg);
-      if (mod.file && isSourceUnported(mod.file, ownerPkg)) continue;
-      // Only the module's instance methods cross into the host. Class
-      // methods on the module itself stay on the module (Ruby `include`
-      // semantics; matches compare.flattenIncludedMethodInfos).
-      addMethods(mod.instanceMethods);
-      // Chain `include`s only — a module's own `extend` doesn't propagate
-      // (Ruby singleton-class semantics).
-      for (const inc of mod.includes ?? []) walkMixin(inc, fqn);
-    }
+    const fqn = resolveModuleName(incName, contextFqn, moduleFqnByShort);
+    if (visited.has(fqn)) return;
+    visited.add(fqn);
+    // Fall back to the cross-package map: a railtie-injected mixin (see
+    // AMBIENT_RAILTIE_MIXINS) or a fully-qualified cross-gem include lives
+    // in another package's modules, not this package's.
+    const localMod = rubyModules[fqn];
+    const mod = localMod ?? crossPackageModules[fqn];
+    if (!mod) return;
+    // A module whose source file we've explicitly declined to port should
+    // not contribute its methods to the host's allowed set — otherwise an
+    // unported mixin still flips its TS ports from extra surface to allowed.
+    // Mirrors compare.flattenIncludedMethodInfos (compare.ts:507). Resolve
+    // `isSourceUnported` against the module's *owning* package: a local
+    // module's owner is the host `pkg`, a cross-package module's owner is
+    // the package it was extracted from (package-scoped unported patterns
+    // key off the owner, not the host).
+    const ownerPkg = localMod ? pkg : (crossPackagePkgByFqn[fqn] ?? pkg);
+    if (mod.file && isSourceUnported(mod.file, ownerPkg)) return;
+    // Only the module's instance methods cross into the host. Class
+    // methods on the module itself stay on the module (Ruby `include`
+    // semantics; matches compare.flattenIncludedMethodInfos).
+    addMethods(mod.instanceMethods);
+    // Chain `include`s only — a module's own `extend` doesn't propagate
+    // (Ruby singleton-class semantics).
+    for (const inc of mod.includes ?? []) walkMixin(inc, fqn);
   };
 
   for (const { fqn, info } of entities) {


### PR DESCRIPTION
## What

`resolveModuleName` ended with a fall-through arm: when several modules share a
short name and *none* shares a namespace prefix with the including entity, it
returned the **full candidate list** rather than one binding — commented
"original behavior, safe fallback."

Safe against false *negatives*. It was never measured against false positives,
which is the expensive direction here: every returned candidate donates its
methods to the host's expected surface (`flattenIncludedMethodInfos`) and its
includers' files to the search set (`buildModuleIncluderFqns`). One wrong
candidate is a false match, not noise. PR #5344 removed the analogous broadness
from the includer-graph builder and found 21 methods counting as implemented in
files Ruby's constant lookup never reaches.

## Measurement

Simulated the resolver over `scripts/api-compare/output/rails-api.json` — every
`(contextFqn, includeName)` pair across all 13 packages, covering both the
direct-entity and nested-module walks (a module's own includes resolve with the
module as context, and modules are themselves entities, so enumerating
classes+modules covers every reachable pair):

| | count |
|---|---|
| ambiguous unqualified include sites (>=2 candidates) | 26 |
| resolved by the namespace walk | 26 |
| **fall-through arm fires** | **0** |

The arm is dead on the real manifests and carries zero matched methods today.
So this is the #5344 disposition (a) with a measured delta of zero: removal of
a latent multi-bind, no newly visible gaps to absorb.

<details>
<summary>Reproduce (run after <code>pnpm api:compare</code> has written the manifest)</summary>

```python
import json, collections
d = json.load(open("scripts/api-compare/output/rails-api.json"))

def nearest(inc, ctx, cands):
    parts = ctx.split("::")
    for i in range(len(parts), 0, -1):
        c = "::".join(parts[:i]) + "::" + inc
        if c in cands:
            return c
    return None

multi = fired = 0
for pkg in d["packages"].values():
    byshort = collections.defaultdict(list)
    for fqn in pkg["modules"]:
        byshort[fqn.split("::")[-1]].append(fqn)
    for fqn, info in list(pkg["classes"].items()) + list(pkg["modules"].items()):
        for inc in (info.get("includes") or []) + (info.get("extends") or []):
            if inc.startswith("::") or "::" in inc:
                continue  # absolute and qualified names take earlier arms
            c = byshort.get(inc)
            if not c or len(c) < 2:
                continue
            multi += 1
            fired += nearest(inc, fqn, c) is None
print("ambiguous sites:", multi, "fallback fires:", fired)  # 26 0
```

</details>

## Change

Two commits:

1. **Narrow the arm** to the verbatim/top-level reading — the same fall-through
   the qualified-name arm directly above already uses. Ruby's constant lookup
   binds exactly one constant: lexical scope, then ancestry, then top-level,
   then `NameError`.
2. **Return `string`, not `string[]`.** With the ambiguous arm gone the resolver
   provably yields one binding, but the signature still advertised "many",
   leaving the invariant enforced only by a test and inviting the multi-bind
   back. Making it structural also collapses the `for (const fqn of fqns)` loop
   at all three consumers — `buildModuleIncluderFqns`,
   `flattenIncludedMethodInfos`, and extra-surface's `walkMixin` — which are
   exactly the loops that turned an over-broad resolution into a false match.

The measurement is recorded in the doc comment at the call site so the next
reader doesn't have to re-derive it.

Test `returns all candidates when context has no prefix match` was pinning the
old shape; it now pins the top-level reading, alongside a new case asserting the
binding is the nearest enclosing candidate or top-level — never an unrelated
sibling.

## Totals

Unchanged before/after both commits, as the measurement predicted:

```
Data layer: 7714/7810 methods (98.8%)  |  files: 409/409
Overall: 11678/17484 methods (66.8%)  |  files: 763/1019  |  inheritance: 533/587 (90.8%)
```

All 532 `scripts/api-compare` tests pass.

Closes-story: api-compare-resolve-module-name-ambiguous-fallback
