### PR TITLE
feat(api-compare): honor @noRailsEquivalent JSDoc tags as justified extra surface

### DIFF
--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -12,6 +12,7 @@ import {
   resolveAllowlist,
   parseArgs,
   collectTsFileNames,
+  collectTaggedEntries,
 } from "./extra-surface.js";
 import { extractFromProgram } from "./extract-ts-api.js";
 import type { AllowEntry } from "./extra-surface.js";
@@ -1531,5 +1532,147 @@ describe("buildReport — re-export clones", () => {
     const byFile = new Map(report.packages[0].extraFiles.map((f) => [f.tsFile, f]));
     expect(byFile.get("foo.ts")!.extras.map((e) => e.name)).toEqual(["declaredOnFoo"]);
     expect(byFile.get("barrel.ts")!.extras.map((e) => e.name)).toEqual(["declaredOnBarrel"]);
+  });
+});
+
+describe("buildReport — @noRailsEquivalent tags", () => {
+  function makeManifests(reason?: string): { ruby: ApiManifest; ts: ApiManifest } {
+    const ruby: ApiManifest = {
+      source: "ruby",
+      generatedAt: "",
+      packages: {
+        activemodel: {
+          classes: {
+            "ActiveModel::Foo": rubyClass({
+              name: "Foo",
+              file: "foo.rb",
+              instance: [method("bar")],
+            }),
+          },
+          modules: {},
+        },
+      },
+    };
+    const tagged: MethodInfo = { ...method("tsOnlyHelper") };
+    if (reason !== undefined) tagged.noRailsEquivalent = reason;
+    const ts: ApiManifest = {
+      source: "typescript",
+      generatedAt: "",
+      packages: {
+        activemodel: {
+          classes: {
+            Foo: {
+              name: "Foo",
+              file: "foo.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [method("bar"), tagged],
+              classMethods: [],
+            },
+          },
+          modules: {},
+        },
+      },
+    };
+    return { ruby, ts };
+  }
+
+  const run = (m: { ruby: ApiManifest; ts: ApiManifest }, allow: AllowEntry[] = []) =>
+    buildReport(m.ruby, m.ts, {
+      filterPkg: null,
+      excludeGlobs: [],
+      novelOnly: false,
+      topN: 50,
+      allow,
+    });
+
+  it("counts a tagged extra as allowlisted instead of novel", () => {
+    const report = run(makeManifests("public registry seam, no Rails counterpart"));
+    const pkg = report.packages[0];
+    expect(pkg.totalNovel).toBe(0);
+    expect(pkg.totalAllowlisted).toBe(1);
+    expect(pkg.extraFiles).toEqual([]);
+    expect(report.tagged).toEqual({ total: 1, matched: 1, stale: [] });
+    expect(report.allowlist).toEqual({ total: 0, matched: 0, stale: [] });
+  });
+
+  it("reports the tagged extra as novel when the tag is absent", () => {
+    const pkg = run(makeManifests()).packages[0];
+    expect(pkg.totalNovel).toBe(1);
+    expect(pkg.totalAllowlisted).toBe(0);
+  });
+
+  it("reports a tag on a name that does not flag as extra surface as stale", () => {
+    const m = makeManifests("no counterpart");
+    m.ts.packages.activemodel.classes.Foo.instanceMethods[0].noRailsEquivalent = "no counterpart";
+    const report = run(m);
+    expect(report.tagged.stale.map((e) => e.name)).toEqual(["bar"]);
+    expect(report.tagged.matched).toBe(1);
+  });
+
+  it("counts a name justified by both the JSON allowlist and a tag once", () => {
+    const allow: AllowEntry[] = [
+      {
+        package: "activemodel",
+        tsFile: "foo.ts",
+        name: "tsOnlyHelper",
+        reason: "migrating to the inline tag.",
+      },
+    ];
+    const report = run(makeManifests("public registry seam"), allow);
+    expect(report.packages[0].totalAllowlisted).toBe(1);
+    expect(report.allowlist.stale).toEqual([]);
+    expect(report.tagged.stale).toEqual([]);
+  });
+
+  it("does not judge tags of packages this run never scanned", () => {
+    const report = buildReport(
+      makeManifests("no counterpart").ruby,
+      makeManifests("no counterpart").ts,
+      {
+        filterPkg: "activerecord",
+        excludeGlobs: [],
+        novelOnly: false,
+        topN: 50,
+        allow: [],
+      },
+    );
+    expect(report.tagged.stale).toEqual([]);
+  });
+});
+
+describe("collectTaggedEntries", () => {
+  it("collects tags from class members and file functions, deduping repeated keys", () => {
+    const ts: ApiManifest = {
+      source: "typescript",
+      generatedAt: "",
+      packages: {
+        activerecord: {
+          classes: {
+            Foo: {
+              name: "Foo",
+              file: "foo.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [{ ...method("helper"), noRailsEquivalent: "why" }],
+              classMethods: [{ ...method("helper"), noRailsEquivalent: "why" }],
+            },
+          },
+          modules: {},
+          fileFunctions: {
+            "associations.ts": [{ ...method("registerModel"), noRailsEquivalent: "public seam" }],
+          },
+        },
+      },
+    };
+    expect(collectTaggedEntries(ts)).toEqual([
+      { package: "activerecord", tsFile: "foo.ts", name: "helper", reason: "why" },
+      {
+        package: "activerecord",
+        tsFile: "associations.ts",
+        name: "registerModel",
+        reason: "public seam",
+      },
+    ]);
   });
 });

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -1676,3 +1676,80 @@ describe("collectTaggedEntries", () => {
     ]);
   });
 });
+
+describe("@noRailsEquivalent — extractor to report", () => {
+  function extract(files: Record<string, string>): PackageInfo {
+    const srcDir = "/p";
+    const all: Record<string, string> = {};
+    for (const [rel, src] of Object.entries(files)) all[`${srcDir}/${rel}`] = src;
+    const host: ts.CompilerHost = {
+      getSourceFile: (name) =>
+        all[name] === undefined
+          ? undefined
+          : ts.createSourceFile(name, all[name], ts.ScriptTarget.Latest, true),
+      getDefaultLibFileName: () => "lib.d.ts",
+      writeFile: () => undefined,
+      getCurrentDirectory: () => "/",
+      getCanonicalFileName: (n) => n,
+      useCaseSensitiveFileNames: () => true,
+      getNewLine: () => "\n",
+      fileExists: (name) => name in all,
+      readFile: (name) => all[name],
+    };
+    const program = ts.createProgram(
+      Object.keys(all),
+      { noLib: true, noResolve: true, target: ts.ScriptTarget.Latest },
+      host,
+    );
+    return extractFromProgram(program, srcDir);
+  }
+
+  it("carries a tag written in TS source through to the Allowed totals", () => {
+    const tsPkg = extract({
+      "associations.ts": `
+        export class Associations {
+          hasMany(): void {}
+
+          /** @noRailsEquivalent public model registry, no Rails counterpart */
+          registerModel(): void {}
+        }
+      `,
+    });
+    const ruby: ApiManifest = {
+      source: "ruby",
+      generatedAt: "",
+      packages: {
+        activerecord: {
+          classes: {
+            "ActiveRecord::Associations": rubyClass({
+              name: "Associations",
+              file: "associations.rb",
+              instance: [method("has_many")],
+            }),
+          },
+          modules: {},
+        },
+      },
+    };
+    const ts_: ApiManifest = {
+      source: "typescript",
+      generatedAt: "",
+      packages: { activerecord: tsPkg },
+    };
+    const report = buildReport(ruby, ts_, {
+      filterPkg: null,
+      excludeGlobs: [],
+      novelOnly: false,
+      topN: 50,
+      allow: [],
+    });
+    expect(report.tagged).toEqual({
+      total: 1,
+      matched: 1,
+      stale: [],
+    });
+    expect(report.packages[0].totalAllowlisted).toBe(1);
+    expect(report.packages[0].totalNovel).toBe(0);
+    expect(report.packages[0].extraFiles).toEqual([]);
+  });
+});

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -258,6 +258,9 @@ export function allowKeyOf(e: { package: string; tsFile: string; name: string })
  * extra-surface-allow.json: both sources are honored during the migration
  * window and both feed the same `Allowed` totals. Keyed by the CONTAINER's
  * file, matching how `collectTsFileNames` gathers the names it compares.
+ * Keys are deduped: one declaration reaches many hosts (the mixin object, the
+ * install site, the auto-synthesized file module), so the same key arrives
+ * repeatedly and would otherwise inflate the tag total.
  */
 export function collectTaggedEntries(ts: ApiManifest): AllowEntry[] {
   const out: AllowEntry[] = [];
@@ -266,8 +269,6 @@ export function collectTaggedEntries(ts: ApiManifest): AllowEntry[] {
     if (m.noRailsEquivalent === undefined) return;
     const entry = { package: pkg, tsFile, name: m.name, reason: m.noRailsEquivalent };
     const key = allowKeyOf(entry);
-    // One declaration reaches many hosts (mixin object + install site + the
-    // auto-synthesized file module), so the same key arrives repeatedly.
     if (seen.has(key)) return;
     seen.add(key);
     out.push(entry);
@@ -821,8 +822,9 @@ function buildPackageReport(
     for (const name of tsNames) {
       if (allowed.has(name)) continue;
       const allowKey = allowKeyOf({ package: pkg, tsFile: expectedTs, name });
-      // A name may be justified by either source during the migration window;
-      // record the match on both so neither reads as stale when both exist.
+      // Both sources are consulted during the migration window: record the
+      // match on each that has it, so a doubly-justified name leaves neither
+      // the JSON entry nor the tag looking stale.
       const jsonAllowed = allowKeys.has(allowKey);
       const tagAllowed = tagKeys.has(allowKey);
       if (jsonAllowed) matchedAllowKeys.add(allowKey);
@@ -948,6 +950,10 @@ function printHumanReport(report: Report, topN: number, maxDetail: number): void
   console.log(
     `\n${p.dim}Allowlist (extra-surface-allow.json): ${report.allowlist.total} entr(ies), ` +
       `${report.allowlist.matched} matched — allowed extras are subtracted from the counts above.${p.reset}`,
+  );
+  console.log(
+    `${p.dim}@noRailsEquivalent tags: ${report.tagged.total} tag(s), ` +
+      `${report.tagged.matched} matched — counted in Allowed alongside the allowlist.${p.reset}`,
   );
 
   console.log(
@@ -1120,6 +1126,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
 
   // Stale entries can't be judged when --exclude-glob hides whole TS files.
   if (args.excludeGlobs.length > 0) return;
+  const { stale } = report.allowlist;
   const staleTagged = report.tagged.stale;
   if (staleTagged.length > 0) {
     console.error(
@@ -1131,7 +1138,6 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
         "\n",
     );
   }
-  const { stale } = report.allowlist;
   if (stale.length === 0) {
     if (staleTagged.length > 0) process.exit(1);
     return;

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -1132,8 +1132,9 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     console.error(
       `\nextra-surface: ${staleTagged.length} STALE @noRailsEquivalent tag(s) on ` +
         "methods that no longer flag as extra surface — Rails gained the method, " +
-        "the file mapping changed, or the tag covers a moved (misplaced) port. " +
-        "Delete the tag next to the code:\n" +
+        "the file mapping changed, the declaration is internal or `_`-prefixed " +
+        "(never counted), or the tag covers a moved (misplaced) port that belongs " +
+        "in its Rails-layout file. Delete the tag next to the code:\n" +
         staleTagged.map((e) => `  - ${e.package}  ${e.tsFile}  ${e.name}`).join("\n") +
         "\n",
     );

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -252,6 +252,41 @@ export function allowKeyOf(e: { package: string; tsFile: string; name: string })
   return `${e.package} ${e.tsFile} ${e.name}`;
 }
 
+/**
+ * Every `@noRailsEquivalent`-tagged declaration in the TS manifest, as
+ * allowlist entries (RFC 0080). The tag is the inline successor of
+ * extra-surface-allow.json: both sources are honored during the migration
+ * window and both feed the same `Allowed` totals. Keyed by the CONTAINER's
+ * file, matching how `collectTsFileNames` gathers the names it compares.
+ */
+export function collectTaggedEntries(ts: ApiManifest): AllowEntry[] {
+  const out: AllowEntry[] = [];
+  const seen = new Set<string>();
+  const push = (pkg: string, tsFile: string, m: MethodInfo): void => {
+    if (m.noRailsEquivalent === undefined) return;
+    const entry = { package: pkg, tsFile, name: m.name, reason: m.noRailsEquivalent };
+    const key = allowKeyOf(entry);
+    // One declaration reaches many hosts (mixin object + install site + the
+    // auto-synthesized file module), so the same key arrives repeatedly.
+    if (seen.has(key)) return;
+    seen.add(key);
+    out.push(entry);
+  };
+  for (const [pkg, tsPkg] of Object.entries(ts.packages)) {
+    for (const container of [tsPkg.classes, tsPkg.modules]) {
+      for (const c of Object.values(container) as ClassInfo[]) {
+        if (!c.file || c.reExportedFrom) continue;
+        for (const m of c.instanceMethods) push(pkg, c.file, m);
+        for (const m of c.classMethods) push(pkg, c.file, m);
+      }
+    }
+    for (const [file, fns] of Object.entries(tsPkg.fileFunctions ?? {})) {
+      for (const fn of fns) push(pkg, file, fn);
+    }
+  }
+  return out;
+}
+
 export function findInvalidAllowEntries(entries: AllowEntry[]): string[] {
   const problems: string[] = [];
   const seen = new Set<string>();
@@ -323,6 +358,12 @@ interface Report {
   packages: PackageTotals[];
   topN: ExtraFile[];
   allowlist: AllowlistSummary;
+  /**
+   * `@noRailsEquivalent` tags found in the TS manifest. Additive to the
+   * existing shape — the `allowlist` summary and every count above keep
+   * their meaning for the stats-DB consumer.
+   */
+  tagged: AllowlistSummary;
 }
 
 const HELP = `extra-surface — TS files with public API exceeding their Rails counterpart
@@ -682,6 +723,8 @@ function buildPackageReport(
   novelOnly: boolean,
   allowKeys: Set<string>,
   matchedAllowKeys: Set<string>,
+  tagKeys: Set<string>,
+  matchedTagKeys: Set<string>,
 ): PackageTotals {
   const rubyPkg = ruby.packages[pkg];
   const tsPkg = ts.packages[pkg];
@@ -778,8 +821,13 @@ function buildPackageReport(
     for (const name of tsNames) {
       if (allowed.has(name)) continue;
       const allowKey = allowKeyOf({ package: pkg, tsFile: expectedTs, name });
-      if (allowKeys.has(allowKey)) {
-        matchedAllowKeys.add(allowKey);
+      // A name may be justified by either source during the migration window;
+      // record the match on both so neither reads as stale when both exist.
+      const jsonAllowed = allowKeys.has(allowKey);
+      const tagAllowed = tagKeys.has(allowKey);
+      if (jsonAllowed) matchedAllowKeys.add(allowKey);
+      if (tagAllowed) matchedTagKeys.add(allowKey);
+      if (jsonAllowed || tagAllowed) {
         allowlistedCount++;
         continue;
       }
@@ -957,6 +1005,9 @@ export function buildReport(
   const allow = opts.allow ?? [];
   const allowKeys = new Set(allow.map(allowKeyOf));
   const matchedAllowKeys = new Set<string>();
+  const tagged = collectTaggedEntries(ts);
+  const tagKeys = new Set(tagged.map(allowKeyOf));
+  const matchedTagKeys = new Set<string>();
   const globalRubyCandidates = buildGlobalRubyCandidates(ruby);
   const { modules: crossPackageModules, pkgByFqn: crossPackagePkgByFqn } =
     buildCrossPackageModules(ruby);
@@ -979,6 +1030,8 @@ export function buildReport(
         opts.novelOnly,
         allowKeys,
         matchedAllowKeys,
+        tagKeys,
+        matchedTagKeys,
       ),
     );
   }
@@ -995,12 +1048,16 @@ export function buildReport(
   const stale = allow.filter(
     (e) => scannedPkgs.has(e.package) && !matchedAllowKeys.has(allowKeyOf(e)),
   );
+  const staleTagged = tagged.filter(
+    (e) => scannedPkgs.has(e.package) && !matchedTagKeys.has(allowKeyOf(e)),
+  );
 
   return {
     generatedAt: new Date().toISOString(),
     packages,
     topN: allExtras.slice(0, opts.topN),
     allowlist: { total: allow.length, matched: matchedAllowKeys.size, stale },
+    tagged: { total: tagged.length, matched: matchedTagKeys.size, stale: staleTagged },
   };
 }
 
@@ -1063,8 +1120,22 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
 
   // Stale entries can't be judged when --exclude-glob hides whole TS files.
   if (args.excludeGlobs.length > 0) return;
+  const staleTagged = report.tagged.stale;
+  if (staleTagged.length > 0) {
+    console.error(
+      `\nextra-surface: ${staleTagged.length} STALE @noRailsEquivalent tag(s) on ` +
+        "methods that no longer flag as extra surface — Rails gained the method, " +
+        "the file mapping changed, or the tag covers a moved (misplaced) port. " +
+        "Delete the tag next to the code:\n" +
+        staleTagged.map((e) => `  - ${e.package}  ${e.tsFile}  ${e.name}`).join("\n") +
+        "\n",
+    );
+  }
   const { stale } = report.allowlist;
-  if (stale.length === 0) return;
+  if (stale.length === 0) {
+    if (staleTagged.length > 0) process.exit(1);
+    return;
+  }
   console.error(
     `\nextra-surface allowlist: ${stale.length} STALE entr(ies) that no longer ` +
       "flag as extra surface. The allowlist only shrinks — remove them from " +

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1461,6 +1461,26 @@ describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
     expect(reasonOf("locate")).toBeUndefined();
   });
 
+  it("records the reason on a tagged interface method signature", () => {
+    const info = extractFromFiles("/p", {
+      "quoting.ts": `
+        export interface Quoting {
+          /** @noRailsEquivalent async quoting seam, no Rails counterpart */
+          quoteAsync(value: unknown): Promise<string>;
+
+          quote(value: unknown): string;
+        }
+      `,
+    });
+    const iface = info.classes["quoting.ts:Quoting"] ?? info.modules["quoting.ts:Quoting"];
+    expect(iface.instanceMethods.find((m) => m.name === "quoteAsync")!.noRailsEquivalent).toBe(
+      "async quoting seam, no Rails counterpart",
+    );
+    expect(
+      iface.instanceMethods.find((m) => m.name === "quote")!.noRailsEquivalent,
+    ).toBeUndefined();
+  });
+
   it("throws when the tag carries no reason", () => {
     expect(() =>
       extractFromSource(`

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1308,3 +1308,99 @@ describe("extractFromProgram — re-export attribution", () => {
     expect(info.classes["adapters.ts:LocalHelper"].reExportedFrom).toBeUndefined();
   });
 });
+
+describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
+  it("records the reason on a tagged class member and leaves its sibling bare", () => {
+    const info = extractFromSource(`
+      class Foo {
+        /**
+         * Registry hook — public by design; @internal would be a lie.
+         *
+         * @noRailsEquivalent trails-only model registry seam
+         */
+        registerModel(): void {}
+
+        save(): void {}
+      }
+    `);
+    const registerModel = info.instanceMethods.find((m) => m.name === "registerModel")!;
+    expect(registerModel.noRailsEquivalent).toBe("trails-only model registry seam");
+    expect(registerModel.internal).toBeUndefined();
+    expect(info.instanceMethods.find((m) => m.name === "save")!.noRailsEquivalent).toBeUndefined();
+  });
+
+  it("records the reason on a tagged getter and a tagged static method", () => {
+    const info = extractFromSource(`
+      class Foo {
+        /** @noRailsEquivalent JS thenable protocol */
+        get pending(): boolean { return true; }
+
+        /** @noRailsEquivalent TS-only ergonomic finder */
+        static findGlobalId(): void {}
+      }
+    `);
+    expect(info.instanceMethods.find((m) => m.name === "pending")!.noRailsEquivalent).toBe(
+      "JS thenable protocol",
+    );
+    expect(info.classMethods.find((m) => m.name === "findGlobalId")!.noRailsEquivalent).toBe(
+      "TS-only ergonomic finder",
+    );
+  });
+
+  it("records the reason on a tagged top-level exported function", () => {
+    const info = extractFromFiles("/p", {
+      "associations.ts": `
+        /** @noRailsEquivalent public registration surface, no Rails counterpart */
+        export function registerModel(): void {}
+
+        export function hasMany(): void {}
+      `,
+    });
+    const fns = info.fileFunctions["associations.ts"];
+    expect(fns.find((f) => f.name === "registerModel")!.noRailsEquivalent).toBe(
+      "public registration surface, no Rails counterpart",
+    );
+    expect(fns.find((f) => f.name === "hasMany")!.noRailsEquivalent).toBeUndefined();
+  });
+
+  it("records the reason on a tagged object-literal module member", () => {
+    const methods = objectLiteralMethods(`
+      export const QueryMethods = {
+        /** @noRailsEquivalent async iteration protocol, JS-only */
+        eachAsync() {},
+        where() {},
+      };
+    `);
+    expect(methods.find((m) => m.name === "eachAsync")!.noRailsEquivalent).toBe(
+      "async iteration protocol, JS-only",
+    );
+    expect(methods.find((m) => m.name === "where")!.noRailsEquivalent).toBeUndefined();
+  });
+
+  it("joins continuation lines into one reason", () => {
+    const info = extractFromSource(`
+      class Foo {
+        /**
+         * @noRailsEquivalent Rails reaches this through the connection
+         *   adapter; trails exposes it directly because the pool is async.
+         */
+        withConnection(): void {}
+      }
+    `);
+    expect(info.instanceMethods.find((m) => m.name === "withConnection")!.noRailsEquivalent).toBe(
+      "Rails reaches this through the connection adapter; trails exposes it " +
+        "directly because the pool is async.",
+    );
+  });
+
+  it("throws when the tag carries no reason", () => {
+    expect(() =>
+      extractFromSource(`
+        class Foo {
+          /** @noRailsEquivalent */
+          registerModel(): void {}
+        }
+      `),
+    ).toThrow(/@noRailsEquivalent needs a reason/);
+  });
+});

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1481,6 +1481,28 @@ describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
     ).toBeUndefined();
   });
 
+  it("carries a tag through an interface's resolved extends members", () => {
+    const info = extractFromFiles("/p", {
+      "relation-base.ts": `
+        export interface RelationBase {
+          /** @noRailsEquivalent JS thenable protocol on Relation */
+          then(onFulfilled: () => void): void;
+
+          where(): void;
+        }
+      `,
+      "relation.ts": `
+        import type { RelationBase } from "./relation-base.js";
+        export interface Relation extends RelationBase {}
+      `,
+    });
+    const rel = info.classes["relation.ts:Relation"] ?? info.modules["relation.ts:Relation"];
+    expect(rel.instanceMethods.find((m) => m.name === "then")!.noRailsEquivalent).toBe(
+      "JS thenable protocol on Relation",
+    );
+    expect(rel.instanceMethods.find((m) => m.name === "where")!.noRailsEquivalent).toBeUndefined();
+  });
+
   it("throws when the tag carries no reason", () => {
     expect(() =>
       extractFromSource(`

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1411,6 +1411,34 @@ describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
     );
   });
 
+  it("leaves an inherited __mixin member's tag on its declaring file only", () => {
+    const info = extractFromFiles("/p", {
+      "base.ts": `
+        export class Base {
+          /** @noRailsEquivalent JS-only lifecycle hook */
+          dispose(): void {}
+        }
+      `,
+      "attributes.ts": `
+        import { Base } from "./base.js";
+        export function Attributes(B: typeof Base) {
+          class M extends B {
+            loadAttributes(): void {}
+          }
+          return M;
+        }
+      `,
+    });
+    const mixin = info.modules["attributes.ts:Attributes__mixin"];
+    const dispose = mixin.instanceMethods.find((m) => m.name === "dispose")!;
+    expect(dispose.declaredIn).toBe("base.ts");
+    expect(dispose.noRailsEquivalent).toBeUndefined();
+    expect(
+      info.classes["base.ts:Base"].instanceMethods.find((m) => m.name === "dispose")!
+        .noRailsEquivalent,
+    ).toBe("JS-only lifecycle hook");
+  });
+
   it("throws when the tag carries no reason", () => {
     expect(() =>
       extractFromSource(`

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1393,6 +1393,24 @@ describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
     );
   });
 
+  it("records the reason on a synthesized __mixin member", () => {
+    const info = extractFromFiles("/p", {
+      "attributes.ts": `
+        export function Attributes(Base: new () => object) {
+          class M extends Base {
+            /** @noRailsEquivalent async attribute hydration, JS-only */
+            loadAttributes(): void {}
+          }
+          return M;
+        }
+      `,
+    });
+    const mixin = info.modules["attributes.ts:Attributes__mixin"];
+    expect(mixin.instanceMethods.find((m) => m.name === "loadAttributes")!.noRailsEquivalent).toBe(
+      "async attribute hydration, JS-only",
+    );
+  });
+
   it("throws when the tag carries no reason", () => {
     expect(() =>
       extractFromSource(`

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1439,6 +1439,28 @@ describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
     ).toBe("JS-only lifecycle hook");
   });
 
+  it("records the reason on tagged namespace members", () => {
+    const info = extractFromFiles("/p", {
+      "locator.ts": `
+        export namespace Locator {
+          /** @noRailsEquivalent trails-side model-facing finder */
+          export function findGlobalId(): void {}
+
+          /** @noRailsEquivalent JS-only signed-id ergonomic */
+          export const findSignedGlobalId = (): void => {};
+
+          export function locate(): void {}
+        }
+      `,
+    });
+    const ns = info.modules["locator.ts:Locator"];
+    const reasonOf = (name: string) =>
+      ns.instanceMethods.find((m) => m.name === name)!.noRailsEquivalent;
+    expect(reasonOf("findGlobalId")).toBe("trails-side model-facing finder");
+    expect(reasonOf("findSignedGlobalId")).toBe("JS-only signed-id ergonomic");
+    expect(reasonOf("locate")).toBeUndefined();
+  });
+
   it("throws when the tag carries no reason", () => {
     expect(() =>
       extractFromSource(`

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1735,15 +1735,19 @@ function extractNamespace(
     for (const stmt of node.body.statements) {
       if (ts.isFunctionDeclaration(stmt) && stmt.name && isExported(stmt)) {
         const line = stmt.getSourceFile().getLineAndCharacterOfPosition(stmt.getStart()).line + 1;
+        const noRailsEquivalent = noRailsEquivalentReason(stmt);
         instanceMethods.push({
           name: stmt.name.text,
           visibility: "public",
           params: extractParameters(stmt.parameters),
           line,
           file,
+          ...(noRailsEquivalent !== undefined ? { noRailsEquivalent } : {}),
         });
       } else if (ts.isVariableStatement(stmt) && isExported(stmt)) {
         const line = stmt.getSourceFile().getLineAndCharacterOfPosition(stmt.getStart()).line + 1;
+        // JSDoc attaches to the statement, not the individual declarator.
+        const stmtReason = noRailsEquivalentReason(stmt);
         for (const decl of stmt.declarationList.declarations) {
           if (!ts.isIdentifier(decl.name)) continue;
           const init = decl.initializer;
@@ -1764,12 +1768,14 @@ function extractNamespace(
             }
           }
           if (isFunctionLike) {
+            const noRailsEquivalent = noRailsEquivalentReason(decl) ?? stmtReason;
             instanceMethods.push({
               name: decl.name.text,
               visibility: "public",
               params,
               line,
               file,
+              ...(noRailsEquivalent !== undefined ? { noRailsEquivalent } : {}),
             });
           }
         }

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -550,6 +550,7 @@ export function extractFromProgram(program: ts.Program, srcDir: string): Package
         const visibility: "public" | "private" | "protected" =
           isPrivateField || hasPrivateMod ? "private" : hasProtectedMod ? "protected" : "public";
         const internal = visibility !== "public";
+        const noRailsEquivalent = noRailsEquivalentReason(decl);
         const line = decl.getSourceFile().getLineAndCharacterOfPosition(decl.getStart()).line + 1;
         const declFile = path.relative(srcDir, decl.getSourceFile().fileName).replace(/\\/g, "/");
         mixinMethods.push({
@@ -561,6 +562,7 @@ export function extractFromProgram(program: ts.Program, srcDir: string): Package
           file: relPath,
           ...(declFile !== relPath ? { declaredIn: declFile } : {}),
           ...(internal ? { internal: true } : {}),
+          ...(noRailsEquivalent !== undefined ? { noRailsEquivalent } : {}),
         });
       }
 

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1679,12 +1679,18 @@ function extractInterface(
               const propType = checker.getTypeOfSymbolAtLocation(prop, type);
               const signatures = propType.getCallSignatures();
               if (signatures.length > 0) {
+                // Unlike the `__mixin` and inherited-interface-property cases
+                // elsewhere, these entries carry no `declaredIn`, so
+                // `collectTsFileNames` counts them as THIS file's surface —
+                // they need the resolved declaration's tag to be justifiable.
+                const noRailsEquivalent = noRailsEquivalentOfSymbol(prop, checker);
                 instanceMethods.push({
                   name: propName,
                   visibility: "public",
                   params: [],
                   line: 0,
                   file,
+                  ...(noRailsEquivalent !== undefined ? { noRailsEquivalent } : {}),
                 });
               }
             }

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -472,6 +472,7 @@ export function extractFromProgram(program: ts.Program, srcDir: string): Package
         const fnOptionKeys = extractOptionKeys(node.parameters, checker);
         const fnCalls = extractCalls(node.body);
         const internal = hasInternalJsDocTag(node);
+        const noRailsEquivalent = noRailsEquivalentReason(node);
         fileFunctions.push({
           name: node.name.text,
           visibility: "public",
@@ -480,6 +481,7 @@ export function extractFromProgram(program: ts.Program, srcDir: string): Package
           line,
           file: relPath,
           ...(internal ? { internal: true } : {}),
+          ...(noRailsEquivalent !== undefined ? { noRailsEquivalent } : {}),
           ...(fnOptionKeys !== undefined ? { optionKeys: fnOptionKeys } : {}),
           ...(fnCalls !== undefined ? { calls: fnCalls } : {}),
         });
@@ -637,6 +639,7 @@ export function extractFromProgram(program: ts.Program, srcDir: string): Package
                 : undefined;
             const calls = extractCalls(body);
             const internal = hasInternalJsDocTag(decl);
+            const noRailsEquivalent = noRailsEquivalentReason(decl);
             fileFunctions.push({
               name: sym.name,
               visibility: "public",
@@ -645,6 +648,7 @@ export function extractFromProgram(program: ts.Program, srcDir: string): Package
               line,
               file: relPath,
               ...(internal ? { internal: true } : {}),
+              ...(noRailsEquivalent !== undefined ? { noRailsEquivalent } : {}),
               ...(calls !== undefined ? { calls } : {}),
             });
           }
@@ -1251,6 +1255,51 @@ export function hasInternalJsDocTag(node: ts.Node): boolean {
 }
 
 /**
+ * Reason prose of a declaration's `@noRailsEquivalent` tag, or undefined when
+ * the tag is absent. Unlike `@internal` (which removes the method from the
+ * compared surface), this tag keeps the method counted and justifies it as
+ * deliberate trails-only surface — extra-surface.ts reports it as allowlisted.
+ * Continuation lines belong to the tag and are joined into one line; the prose
+ * is otherwise preserved verbatim. An empty reason is a hard error: an
+ * unjustified tag is exactly what the allowlist's empty-reason rejection
+ * refuses (RFC 0080).
+ */
+export function noRailsEquivalentReason(node: ts.Node): string | undefined {
+  for (const tag of ts.getJSDocTags(node)) {
+    if (tag.tagName.text !== "noRailsEquivalent") continue;
+    const reason = (ts.getTextOfJSDocComment(tag.comment) ?? "").replace(/\s+/g, " ").trim();
+    if (reason === "") {
+      const sf = node.getSourceFile();
+      const line = sf.getLineAndCharacterOfPosition(node.getStart()).line + 1;
+      throw new Error(
+        `@noRailsEquivalent needs a reason: ${sf.fileName}:${line} — ` +
+          "state why this surface has no Rails counterpart.",
+      );
+    }
+    return reason;
+  }
+  return undefined;
+}
+
+/**
+ * `@noRailsEquivalent` reason reached through a symbol, for object-literal
+ * bindings (`{ foo }` / `{ foo: NS.bar }`) whose tag lives on the referenced
+ * declaration rather than the property. Mirrors `isInternalSymbol`.
+ */
+function noRailsEquivalentOfSymbol(
+  symbol: ts.Symbol | undefined,
+  checker: ts.TypeChecker,
+): string | undefined {
+  let target = symbol;
+  if (target && target.flags & ts.SymbolFlags.Alias) target = checker.getAliasedSymbol(target);
+  for (const d of target?.declarations ?? []) {
+    const reason = noRailsEquivalentReason(d);
+    if (reason !== undefined) return reason;
+  }
+  return undefined;
+}
+
+/**
  * True when `symbol` resolves to a declaration tagged `@internal`. A mixin
  * object re-exports one declaration under many hosts (ClassMethods, the Base
  * class surface, the index re-export), so the tag is read once at the
@@ -1304,6 +1353,7 @@ export function harvestObjectLiteralMethods(
     let optionKeys: string[] | null | undefined;
     let calls: string[] | undefined;
     let internal = hasInternalJsDocTag(prop);
+    let noRailsEquivalent = noRailsEquivalentReason(prop);
     if (ts.isMethodDeclaration(prop) && prop.name && ts.isIdentifier(prop.name)) {
       mname = prop.name.text;
       params = extractParameters(prop.parameters);
@@ -1312,7 +1362,9 @@ export function harvestObjectLiteralMethods(
     } else if (ts.isShorthandPropertyAssignment(prop)) {
       mname = prop.name.text;
       params = paramsOfCallableRef(prop.name, checker) ?? [];
-      internal = isInternalSymbol(checker.getShorthandAssignmentValueSymbol(prop), checker);
+      const valueSymbol = checker.getShorthandAssignmentValueSymbol(prop);
+      internal = isInternalSymbol(valueSymbol, checker);
+      noRailsEquivalent ??= noRailsEquivalentOfSymbol(valueSymbol, checker);
     } else if (ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name)) {
       const init = prop.initializer;
       if (ts.isFunctionExpression(init) || ts.isArrowFunction(init)) {
@@ -1329,6 +1381,10 @@ export function harvestObjectLiteralMethods(
           mname = prop.name.text;
           params = resolved;
           internal = isInternalCallableRef(init, checker);
+          noRailsEquivalent ??= noRailsEquivalentOfSymbol(
+            checker.getSymbolAtLocation(init),
+            checker,
+          );
         }
       }
     }
@@ -1341,6 +1397,7 @@ export function harvestObjectLiteralMethods(
       line,
       file,
       ...(internal ? { internal: true } : {}),
+      ...(noRailsEquivalent !== undefined ? { noRailsEquivalent } : {}),
       ...(optionKeys !== undefined ? { optionKeys } : {}),
       ...(calls !== undefined ? { calls } : {}),
     });
@@ -1453,6 +1510,8 @@ export function extractClass(
     const memberName = getMemberName(member);
     const visibility = memberVisibility(member);
     const internal = visibility !== "public";
+    const noRailsEquivalent = noRailsEquivalentReason(member);
+    const tagged = noRailsEquivalent !== undefined ? { noRailsEquivalent } : {};
     const isStatic = hasModifier(member, ts.SyntaxKind.StaticKeyword);
     const line = member.getSourceFile().getLineAndCharacterOfPosition(member.getStart()).line + 1;
 
@@ -1481,6 +1540,7 @@ export function extractClass(
         file,
         isStatic,
         ...(internal ? { internal: true } : {}),
+        ...tagged,
         ...(optionKeys !== undefined ? { optionKeys } : {}),
         ...(calls !== undefined ? { calls } : {}),
       };
@@ -1508,6 +1568,7 @@ export function extractClass(
         line,
         file,
         ...(internal ? { internal: true } : {}),
+        ...tagged,
         ...(calls !== undefined ? { calls } : {}),
       });
     } else if (ts.isGetAccessorDeclaration(member) && memberName) {
@@ -1519,6 +1580,7 @@ export function extractClass(
         file,
         isStatic,
         ...(internal ? { internal: true } : {}),
+        ...tagged,
       };
       if (isStatic) {
         classMethods.push(method);
@@ -1535,6 +1597,7 @@ export function extractClass(
         file,
         isStatic,
         ...(internal ? { internal: true } : {}),
+        ...tagged,
       };
       if (isStatic) {
         classMethods.push(method);
@@ -1552,6 +1615,7 @@ export function extractClass(
         file,
         isStatic,
         ...(internal ? { internal: true } : {}),
+        ...tagged,
       };
       if (isStatic) {
         classMethods.push(method);

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1703,12 +1703,14 @@ function extractInterface(
     const line = member.getSourceFile().getLineAndCharacterOfPosition(member.getStart()).line + 1;
 
     if (ts.isMethodSignature(member)) {
+      const noRailsEquivalent = noRailsEquivalentReason(member);
       instanceMethods.push({
         name: memberName,
         visibility: "public",
         params: member.parameters ? extractParameters(member.parameters) : [],
         line,
         file,
+        ...(noRailsEquivalent !== undefined ? { noRailsEquivalent } : {}),
       });
     }
   }

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -550,9 +550,13 @@ export function extractFromProgram(program: ts.Program, srcDir: string): Package
         const visibility: "public" | "private" | "protected" =
           isPrivateField || hasPrivateMod ? "private" : hasProtectedMod ? "protected" : "public";
         const internal = visibility !== "public";
-        const noRailsEquivalent = noRailsEquivalentReason(decl);
         const line = decl.getSourceFile().getLineAndCharacterOfPosition(decl.getStart()).line + 1;
         const declFile = path.relative(srcDir, decl.getSourceFile().fileName).replace(/\\/g, "/");
+        // Only a member DECLARED in this file carries its tag into the mixin
+        // entry: `collectTsFileNames` skips foreign synthesized members, so a
+        // tag copied off an inherited base-class method would never match here
+        // and would read as stale on top of its correct match on the base file.
+        const noRailsEquivalent = declFile === relPath ? noRailsEquivalentReason(decl) : undefined;
         mixinMethods.push({
           name: prop.name,
           visibility,

--- a/scripts/api-compare/extractor-schema.test.ts
+++ b/scripts/api-compare/extractor-schema.test.ts
@@ -53,6 +53,10 @@ describe("extractorSchemaToken", () => {
     expect(EXTRACTOR_OUTPUT_FIELDS).toContain("declaredIn");
   });
 
+  it("includes noRailsEquivalent in the declared output field set", () => {
+    expect(EXTRACTOR_OUTPUT_FIELDS).toContain("noRailsEquivalent");
+  });
+
   it("tolerates a missing extractor source (best-effort hash)", async () => {
     const dir = mkDir();
     fs.rmSync(path.join(dir, EXTRACTOR_SOURCES[0]));

--- a/scripts/api-compare/extractor-schema.ts
+++ b/scripts/api-compare/extractor-schema.ts
@@ -73,6 +73,7 @@ export const EXTRACTOR_OUTPUT_FIELDS = [
   "option_keys",
   "optionKeys",
   "declaredIn",
+  "noRailsEquivalent",
 ] as const;
 
 /**

--- a/scripts/api-compare/types.ts
+++ b/scripts/api-compare/types.ts
@@ -52,6 +52,13 @@ export interface MethodInfo {
    */
   internal?: boolean;
   /**
+   * TS-side only: reason prose from a `@noRailsEquivalent` JSDoc tag —
+   * deliberate trails-only surface with no Rails counterpart (RFC 0080).
+   * Unlike `internal`, the method stays part of the compared surface;
+   * extra-surface.ts counts it as allowlisted instead of novel/moved.
+   */
+  noRailsEquivalent?: string;
+  /**
    * Ruby-side only: how the extractor synthesized this entry when it was NOT a
    * literal `def` — `"delegate"`, `"alias"`, `"scope"`, `"class_attribute"`,
    * `"define_column_methods"`, `"class_eval"`. See extract-ruby-api.rb. The


### PR DESCRIPTION
Foundation story for RFC 0080's extra-surface half: the `@noRailsEquivalent`
JSDoc tag — the inline successor to `extra-surface-allow.json` — is now read by
the extractor and honored by `api:extra`.

## Extractor (`extract-ts-api.ts`)

- `noRailsEquivalentReason(node)` reads the tag via `ts.getJSDocTags` (same
  path as `hasInternalJsDocTag`) and records `noRailsEquivalent: "<reason>"`
  on `MethodInfo` for class members (methods, getters, setters, properties),
  object-literal module members, and top-level exported functions — including
  the shorthand/alias object-literal forms, where the tag is resolved through
  the symbol as `isInternalSymbol` does.
- Continuation lines belong to the tag and are joined into one reason.
- An empty reason is a hard error, mirroring the allowlist's empty-reason
  rejection in `findInvalidAllowEntries`.

Distinct from `@internal`: the method stays counted and visible, it is just
justified.

## Consumer (`extra-surface.ts`)

- `collectTaggedEntries` turns tagged declarations into `AllowEntry` shapes,
  keyed by the container's file so the keys line up with `collectTsFileNames`,
  deduping the repeats that come from one declaration reaching several hosts.
- Tagged extras count as `allowlisted` exactly as JSON-allowed extras do —
  same `Allowed` column, same per-file `allowlistedCount`. The JSON allowlist
  is still honored during the migration window, and a name justified by both
  sources is counted once and marks neither source stale.
- Stale-tag gate: a tag on a method that no longer flags as extra surface
  fails the run with a package/file/name listing, as stale JSON entries do.
- Report shape is additive only — a new `tagged` summary alongside
  `allowlist`; every existing field keeps its meaning for the stats-DB
  consumer. The human report prints the tag totals under the allowlist line.

Tests cover both halves plus the seam: an end-to-end case extracts real TS
source carrying a tag and asserts it lands in the report's `Allowed` totals.

No manifest carries the tag yet, so this PR is behavior-neutral for the current
`api:extra` numbers; the per-package migrations follow as separate stories.

Closes-story: no-rails-equivalent-tag-extractor-support
