### PR TITLE
refactor(activerecord): retire resolveCounterColumn, mark counter-cache helpers internal

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -676,67 +676,6 @@ export function _correctNames(dictionary: string[], input: string): string[] {
 }
 
 /**
- * Resolve the counter cache column for a hasMany association by inspecting
- * the child model's belongsTo reflection for a counterCache option.
- * Falls back to `${assocName}_count` if no reflection is found.
- */
-export function resolveCounterColumn(
-  parentModel: typeof Base,
-  assoc: { type: string; name: string; options: any },
-  counterName: string,
-): string {
-  // If counter name was passed as a column name directly, use it
-  if (counterName.endsWith("_count")) return counterName;
-
-  const childClassName = assoc.options.className ?? camelize(singularize(assoc.name));
-  if (!modelRegistry.has(childClassName)) {
-    return `${assoc.name}_count`;
-  }
-  const childModel = resolveModel(childClassName);
-  const childAssocs = childModel._associations as AssociationDefinition[] | undefined;
-  if (childAssocs) {
-    // Check against parent name and STI base class name
-    const parentNames = new Set([parentModel.name]);
-    // Registry keys let namespaced (modular) class_name: "Mod::Name" resolve.
-    for (const key of (parentModel as any)._registryKeys ?? []) parentNames.add(key);
-    let proto = Object.getPrototypeOf(parentModel);
-    while (proto && proto.name && proto !== Function.prototype) {
-      parentNames.add(proto.name);
-      proto = Object.getPrototypeOf(proto);
-    }
-    // Mirror Rails: pick the child `belongs_to` whose foreign key matches the
-    // has_many's (so two associations to the same class resolve correctly).
-    const hmForeignKey = assoc.options.foreignKey ?? `${underscore(parentModel.name)}_id`;
-    const fkEq = (a: AssociationDefinition): boolean => {
-      const fk = a.options.foreignKey ?? `${underscore(a.name)}_id`;
-      const left = Array.isArray(fk) ? fk : [fk];
-      const right = Array.isArray(hmForeignKey) ? hmForeignKey : [hmForeignKey];
-      return left.length === right.length && left.every((k, i) => String(k) === String(right[i]));
-    };
-    const candidates = childAssocs.filter(
-      (a) =>
-        a.type === "belongsTo" &&
-        a.options.counterCache &&
-        (parentNames.has(a.options.className ?? "") || parentNames.has(camelize(a.name))),
-    );
-    const belongsTo = candidates.find(fkEq) ?? candidates[0];
-    if (belongsTo) {
-      if (typeof belongsTo.options.counterCache === "string") {
-        return belongsTo.options.counterCache;
-      }
-      // Delegate to the belongs_to reflection's counterCacheColumn(), which
-      // handles flat class names (CpkBook → books_count) via inverse lookup.
-      const col = (childModel as any)
-        ._reflectOnAssociation?.(belongsTo.name)
-        ?.counterCacheColumn?.();
-      if (col) return col;
-      return `${pluralize(underscore(childModel.name))}_count`;
-    }
-  }
-  return `${assoc.name}_count`;
-}
-
-/**
  * Associations mixin — adds belongsTo, hasOne, hasMany to a model class.
  *
  * Mirrors: ActiveRecord::Associations::ClassMethods
@@ -2518,6 +2457,17 @@ export function buildThroughJoinScope(
  * Count associated records for a hasMany association using COUNT(*)
  * without loading records into memory. Bypasses strict loading checks
  * so resetCounters works on strict-loading models.
+ *
+ * @internal No Rails counterpart. Rails' `reset_counters` counts with
+ * `object.send(counter_association).count(:all)` — the proxy delegates to
+ * `association.scope`, which is side-effect-free. The Rails-named
+ * `HasManyAssociation#count_records` already exists as `countRecords`
+ * (`associations/has-many-association.ts`) and is a *different* method (it
+ * reads the counter cache and trims the target). This function exists only
+ * because trails fuses relation building with caching/strict-loading inside
+ * `loadHasMany`, the same deviation documented on its two callees
+ * {@link buildHasManyRelation} and {@link buildThroughJoinScope}; it
+ * disappears when that fusion is undone.
  */
 export async function countHasMany(
   record: Base,
@@ -3449,6 +3399,13 @@ export async function updateCounterCaches(
  * which uses `updateColumn` and would bypass that override, is intentionally not
  * wired for instance dispatch; if a future change routes instance dispatch
  * through it, the DB bump disappears and this sync must be revisited.)
+ *
+ * @internal No Rails counterpart. Rails never needs an in-memory
+ * `lock_version` sync here: `Locking::Optimistic#update_counters` merges the
+ * locking-column bump into the same UPDATE, and the in-memory record is
+ * reconciled by the `_update_record` lock-version write rather than by a
+ * separate reflect step. This function only exists to close the in-memory gap
+ * described above and has no Rails method to converge onto.
  */
 export function reflectLockVersionBump(record: Base): void {
   const ctor = record.constructor as typeof Base;

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -151,43 +151,50 @@ export async function resetCounters(
   const assocDefs = (this as any)._associations as
     | Array<{ type: string; name: string; options: any }>
     | undefined;
-  const hasManyAssocs = assocDefs?.filter((a) => a.type === "hasMany") ?? [];
-  const { resolveCounterColumn, countHasMany } = await import("./associations.js");
+  const { countHasMany } = await import("./associations.js");
+  const { reflectOnAllAssociations } = await import("./reflection.js");
 
   const updates: Record<string, unknown> = {};
   for (const counterName of counterNames) {
-    let assoc = hasManyAssocs.find((a) => a.name === counterName);
-    let counterColumn: string;
-
-    if (assoc) {
-      counterColumn = resolveCounterColumn(this, assoc, counterName);
-    } else {
-      if (counterName.endsWith("_count")) {
-        assoc = hasManyAssocs.find((a) => a.name === counterName.slice(0, -6));
-      }
-      if (!assoc) {
-        for (const candidate of hasManyAssocs) {
-          const col = resolveCounterColumn(this, candidate, candidate.name);
-          if (col === counterName) {
-            assoc = candidate;
-            break;
-          }
-        }
-      }
-      if (!assoc) {
-        // Mirrors Rails' ArgumentError in CounterCache::ClassMethods#reset_counters.
-        throw new ArgumentError(`'${this.name}' has no association called '${counterName}'`);
-      }
-      counterColumn = resolveCounterColumn(this, assoc, assoc.name);
+    // Mirrors Rails' `counter_association` local: it starts as the passed
+    // symbol and is rewritten to the reflection's plural name when the symbol
+    // turned out to be a counter *column* rather than an association name.
+    let counterAssociation = counterName;
+    let hasManyAssociation: any = (this as any)._reflectOnAssociation?.(counterAssociation) ?? null;
+    if (!hasManyAssociation) {
+      hasManyAssociation =
+        reflectOnAllAssociations(this, "hasMany").find((association: any) => {
+          const column = association.counterCacheColumn();
+          return !!column && column === counterAssociation;
+        }) ?? null;
+      if (hasManyAssociation) counterAssociation = hasManyAssociation.pluralName;
+    }
+    if (!hasManyAssociation) {
+      // Mirrors Rails' ArgumentError in CounterCache::ClassMethods#reset_counters.
+      throw new ArgumentError(`'${this.name}' has no association called '${counterAssociation}'`);
     }
 
     // Mirrors Rails: for a `has_many :through`, the counter column comes from the
     // through (join) reflection, while the count still runs against the through.
-    if (assoc.options.through) {
-      const through = hasManyAssocs.find((a) => a.name === assoc.options.through);
-      if (through) counterColumn = resolveCounterColumn(this, through, through.name);
+    if (hasManyAssociation.isThroughReflection?.()) {
+      hasManyAssociation = hasManyAssociation.throughReflection;
     }
 
+    const foreignKey = String(hasManyAssociation.foreignKey);
+    const childClass = hasManyAssociation.klass;
+    const reflection = reflectOnAllAssociations(childClass, "belongsTo").find(
+      (e: any) => String(e.foreignKey) === foreignKey && !!e.options?.counterCache,
+    );
+    const counterColumn = (reflection as any)?.counterCacheColumn();
+    if (!counterColumn) {
+      throw new ArgumentError(`'${this.name}' has no association called '${counterAssociation}'`);
+    }
+
+    // Rails: `object.send(counter_association).count(:all)`.
+    const assoc = assocDefs?.find((a) => a.name === counterAssociation);
+    if (!assoc) {
+      throw new ArgumentError(`'${this.name}' has no association called '${counterAssociation}'`);
+    }
     const count = await countHasMany(record, assoc.name, assoc.options);
     // Mirrors Rails: `updates[counter_name] = count if count != count_was` — skip
     // the UPDATE entirely when the stored counter already matches the recount.

--- a/packages/activerecord/src/counter-cache.ts
+++ b/packages/activerecord/src/counter-cache.ts
@@ -147,35 +147,29 @@ export async function resetCounters(
     }
   }
 
-  const record = await this.find(id);
-  const assocDefs = (this as any)._associations as
-    | Array<{ type: string; name: string; options: any }>
-    | undefined;
+  const object = await this.find(id);
   const { countHasMany } = await import("./associations.js");
   const { reflectOnAllAssociations } = await import("./reflection.js");
 
   const updates: Record<string, unknown> = {};
-  for (const counterName of counterNames) {
-    // Mirrors Rails' `counter_association` local: it starts as the passed
-    // symbol and is rewritten to the reflection's plural name when the symbol
-    // turned out to be a counter *column* rather than an association name.
-    let counterAssociation = counterName;
+  for (const counter of counterNames) {
+    let counterAssociation = counter;
     let hasManyAssociation: any = (this as any)._reflectOnAssociation?.(counterAssociation) ?? null;
     if (!hasManyAssociation) {
+      const hasMany = reflectOnAllAssociations(this, "hasMany");
       hasManyAssociation =
-        reflectOnAllAssociations(this, "hasMany").find((association: any) => {
-          const column = association.counterCacheColumn();
-          return !!column && column === counterAssociation;
-        }) ?? null;
+        hasMany.find(
+          (association: any) =>
+            association.counterCacheColumn() &&
+            association.counterCacheColumn() === counterAssociation,
+        ) ?? null;
       if (hasManyAssociation) counterAssociation = hasManyAssociation.pluralName;
     }
     if (!hasManyAssociation) {
-      // Mirrors Rails' ArgumentError in CounterCache::ClassMethods#reset_counters.
       throw new ArgumentError(`'${this.name}' has no association called '${counterAssociation}'`);
     }
 
-    // Mirrors Rails: for a `has_many :through`, the counter column comes from the
-    // through (join) reflection, while the count still runs against the through.
+    const countReflection = hasManyAssociation;
     if (hasManyAssociation.isThroughReflection?.()) {
       hasManyAssociation = hasManyAssociation.throughReflection;
     }
@@ -184,44 +178,28 @@ export async function resetCounters(
     const childClass = hasManyAssociation.klass;
     const reflection = reflectOnAllAssociations(childClass, "belongsTo").find(
       (e: any) => String(e.foreignKey) === foreignKey && !!e.options?.counterCache,
-    );
-    const counterColumn = (reflection as any)?.counterCacheColumn();
-    if (!counterColumn) {
-      throw new ArgumentError(`'${this.name}' has no association called '${counterAssociation}'`);
-    }
+    ) as any;
+    const counterName = reflection.counterCacheColumn();
 
-    // Rails: `object.send(counter_association).count(:all)`.
-    const assoc = assocDefs?.find((a) => a.name === counterAssociation);
-    if (!assoc) {
-      throw new ArgumentError(`'${this.name}' has no association called '${counterAssociation}'`);
-    }
-    const count = await countHasMany(record, assoc.name, assoc.options);
-    // Mirrors Rails: `updates[counter_name] = count if count != count_was` — skip
-    // the UPDATE entirely when the stored counter already matches the recount.
-    // Ruby's `!=` is type-coercing across Integer/Bignum; in TS we have to match
-    // explicitly when the stored attribute is bigint (e.g. big_integer columns).
-    const countWas =
-      (record as any).readAttribute?.(counterColumn) ?? (record as any)[counterColumn];
+    const count = await countHasMany(object, countReflection.name, countReflection.options);
+    // Ruby's `!=` is type-coercing across Integer/Bignum; in TS the stored
+    // attribute of a big_integer column is a bigint and needs an explicit widen.
+    const countWas = (object as any).readAttribute?.(counterName) ?? (object as any)[counterName];
     const sameCount =
       typeof countWas === "bigint" ? countWas === BigInt(count) : count === countWas;
     if (!sameCount) {
-      updates[counterColumn] = typeof countWas === "bigint" ? BigInt(count) : count;
+      updates[counterName] = typeof countWas === "bigint" ? BigInt(count) : count;
     }
   }
 
   if (options.touch) {
-    // Mirror Rails counter_cache.rb: parse touch into names + time (`{ time: }`
-    // hash form; `touch: []` → no names), then touch via touchAttributesWithTime.
     const { names, time } = parseCounterCacheTouch(options.touch);
     const touchUpdates = touchAttributesWithTime.call(this, ...names, time);
     Object.assign(updates, touchUpdates);
   }
 
   if (Object.keys(updates).length > 0) {
-    // Mirrors Rails: `unscoped.where(primary_key => [object.id]).update_all(updates)`.
-    // `record.id` returns the CPK tuple via the PrimaryKey#id accessor, and
-    // matches the cast already applied by `find` for scalar PKs.
-    await this.unscoped().where(buildPkPredicate(this, record.id)).updateAll(updates);
+    await this.unscoped().where(buildPkPredicate(this, object.id)).updateAll(updates);
   }
 }
 

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/counter-cache.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/counter-cache.json
@@ -24,20 +24,6 @@
     "package": "activerecord",
     "tsFile": "counter-cache.ts",
     "rubyName": "reset_counters",
-    "call": "foreign_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "counter-cache.ts",
-    "rubyName": "reset_counters",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "counter-cache.ts",
-    "rubyName": "reset_counters",
     "call": "merge!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -46,20 +32,6 @@
     "tsFile": "counter-cache.ts",
     "rubyName": "reset_counters",
     "call": "primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "counter-cache.ts",
-    "rubyName": "reset_counters",
-    "call": "reflect_on_all_associations",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "counter-cache.ts",
-    "rubyName": "reset_counters",
-    "call": "through_reflection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {


### PR DESCRIPTION
Retires the counter-cache extras on `packages/activerecord/src/associations.ts`
(RFC 0072 extra-surface burndown, classification (c)/(b)).

## `resolveCounterColumn` — deleted

`resolveCounterColumn` reimplemented, on the parent side, the child-`belongs_to`
lookup that Rails performs inline in
`CounterCache::ClassMethods#reset_counters`
(`activerecord/lib/active_record/counter_cache.rb:34`), and then re-derived the
column that `AssociationReflection#counter_cache_column`
(`reflection.rb:244`) already returns — a method trails already ports as
`counterCacheColumn()` at `packages/activerecord/src/reflection.ts:337`.

`resetCounters` now follows the Rails body directly:

1. `_reflectOnAssociation(counterAssociation)`; on a miss, scan
   `reflectOnAllAssociations(this, "hasMany")` for one whose
   `counterCacheColumn()` equals the passed symbol, and rewrite
   `counterAssociation` to its `pluralName`; otherwise `ArgumentError`.
2. If it is a `ThroughReflection`, swap in `throughReflection`.
3. Find the child's `belongs_to` reflection by matching `foreignKey` and a
   present `counterCache`, and take its `counterCacheColumn()`.

`resolveCounterColumn` is then dead and is deleted. No behavior change:
all 55 `CounterCacheTest` tests pass unchanged (no test renames).

## `countHasMany`, `reflectLockVersionBump` — `@internal`, not relocated

The story proposed relocating `countHasMany` to
`associations/has-many-association.ts` as `countRecords`. That premise is
stale: **`countRecords` already exists there** (the real port of
`HasManyAssociation#count_records`, `has_many_association.rb:80` — it reads the
counter cache, trims the target, and clamps to `limit_value`). `countHasMany`
is a different thing: the side-effect-free `scope.count(:all)` that Rails gets
for free from `association.scope`. Relocating it under the Rails name would
create a same-name duplicate of a correct port. So it is tagged `@internal`
with that reasoning at the declaration, alongside its two callees
`buildHasManyRelation` / `buildThroughJoinScope`, which are already `@internal`
for the identical deviation (trails fuses relation-building with
caching/strict-loading inside `loadHasMany`). All three disappear together when
that fusion is undone.

`reflectLockVersionBump` is `@internal` per the story's own (b) escape hatch —
the investigation confirms no Rails counterpart; the reason is recorded at the
declaration next to the existing coupling note.

## api:compare

`pnpm api:compare && pnpm api:extra --package activerecord --novel-only`,
`associations.ts` row:

| | novel |
|---|---|
| before (`origin/main`) | 14 |
| after | 11 |

Drop of exactly 3 — the three names in this story.

Neither name was re-exported from `packages/activerecord/src/index.ts`, so
there was no re-export to drop.

## Review pass (all three gates)

1. **Matches Rails** — `resetCounters` now follows `counter_cache.rb:34`
   statement for statement, with Rails' own locals (`object`, `counter`,
   `counterAssociation`, `counterName`). The two defensive `ArgumentError`
   guards from the first push are gone (Rails lets a nil child reflection raise
   `NoMethodError`), and the raw `_associations` lookup is gone — the
   pre-through-swap reflection already carries `name`/`options`, so the count
   reads straight off it, matching Rails' `object.send(counter_association)`.
2. **No stubs** — nothing added; one function deleted, two documented.
3. **Compare deltas non-negative** — `associations.ts` novel extras 14 → 11
   (see table above); ported-method and file counts unchanged (`resolveCounterColumn`
   was never a matched method). `test:compare` unchanged at
   14620/21663 (67.5%), 754/1023 files — no test file is touched by this PR.

Narrating comments are removed. What remains is the `Mirrors:` header (repo
convention), the bigint-widen note (a real Ruby/JS divergence), and the two
`@internal` blocks — those are load-bearing: deleting them re-creates the
extras this PR retires.

## Wide call ratchet

Converging `resetCounters` onto the Rails body means it now makes four Rails
calls it previously omitted — `foreign_key`, `klass`,
`reflect_on_all_associations`, `through_reflection`. Their RFC 0047 baseline
entries in `call-mismatches-wide-exclude/activerecord/counter-cache.json`
therefore went stale, and the wide ratchet (which only shrinks) failed the
build. Exactly those four entries are removed; the other nine in that file
still flag and are left untouched. Ratchet now reports
`OK (4967 baselined)`.

## Checks

- `pnpm vitest run packages/activerecord/src/counter-cache.test.ts` — 55 passed.
- `pnpm vitest run packages/activerecord/src/reflection.test.ts` — 64 passed, 4 skipped.
- Under the 500 LOC ceiling.
- No `node:*` imports, no `process.*`, no new deps, camelCase only.

Closes-story: extra-surface-relocate-counter-cache-helpers
