### PR TITLE
refactor(associations): relocate loadBelongsTo to SingularAssociation#findTarget

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -6,6 +6,7 @@
  * GeneratedMethodsTest, and WithAnnotationsTest.
  */
 import { describe, it, expect, afterEach, beforeAll, beforeEach, vi } from "vitest";
+import { findTarget } from "./associations/singular-association.js";
 import { Base, association, reflectOnAssociation, registerModel, NameError, pp } from "./index.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { captureSql } from "./testing/sql-capture.js";
@@ -32,7 +33,7 @@ import { Member } from "./test-helpers/models/member.js";
 import { Membership } from "./test-helpers/models/membership.js";
 import { Human } from "./test-helpers/models/human.js";
 import { Interest } from "./test-helpers/models/interest.js";
-import { buildHasManyRelation, loadBelongsTo, loadHasMany, loadHasOne } from "./associations.js";
+import { buildHasManyRelation, loadHasMany, loadHasOne } from "./associations.js";
 import "./test-helpers/models/ship.js";
 import "./test-helpers/models/bird.js";
 import "./test-helpers/models/treasure.js";
@@ -877,10 +878,10 @@ describe("PreloaderTest", () => {
     // that on `has_many_inversing` (BelongsToAssociation#invertible_for?), which
     // is unset here, so the loaded author carries no inverse collection.
     spy.mockClear();
-    const reloadedAuthor = (await loadBelongsTo(fav, "author", {
+    const reloadedAuthor = (await findTarget(fav, "author", {
       inverseOf: "authorFavorites",
     })) as any;
-    const reloadedFavorite = (await loadBelongsTo(fav, "favoriteAuthor", {})) as any;
+    const reloadedFavorite = (await findTarget(fav, "favoriteAuthor", {})) as any;
     expect(reloadedAuthor.name).toBe("Mary");
     expect(reloadedFavorite.name).toBe("Bob");
     expect(spy).not.toHaveBeenCalled();
@@ -1118,7 +1119,7 @@ describe("PreloaderTest", () => {
     const maryPost = (await Post.where({ id: maryPostId }))[0];
 
     // Force-load bob's author; mary's stays unloaded.
-    const loadedBob = await loadBelongsTo(bobPost, "author", {});
+    const loadedBob = await findTarget(bobPost, "author", {});
     expect(bobPost.association("author").isLoaded()).toBe(true);
     expect(maryPost.association("author").isLoaded()).toBe(false);
 
@@ -1365,7 +1366,7 @@ describe("PreloaderTest", () => {
     });
 
     // Load the blogPost on the comment instance first (warms the association cache).
-    await loadBelongsTo(comment, "blogPost", { className: "ShardedBlogPost" });
+    await findTarget(comment, "blogPost", { className: "ShardedBlogPost" });
 
     // Preloading on the already-loaded record must not fire any SQL queries
     // (mirrors Rails' assert_no_queries block).

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -112,7 +112,7 @@ import type { AssociationReflection } from "./reflection.js";
 import { hasQueryConstraints, queryConstraintsList } from "./persistence.js";
 import { foreignKeyPresentFor } from "./associations/foreign-association.js";
 import { throughForeignKeyPresent } from "./associations/through-association.js";
-import { findTarget as findBelongsToTarget } from "./associations/singular-association.js";
+import { findTarget } from "./associations/singular-association.js";
 
 /**
  * Association options.
@@ -2420,7 +2420,7 @@ export async function loadHasManyThrough(
     const one = await loadHasOne(record, throughAssoc.name, throughAssoc.options);
     throughRecords = one ? [one] : [];
   } else if (throughAssoc.type === "belongsTo") {
-    const one = await findBelongsToTarget(record, throughAssoc.name, throughAssoc.options);
+    const one = await findTarget(record, throughAssoc.name, throughAssoc.options);
     throughRecords = one ? [one] : [];
   } else {
     throughRecords = [];
@@ -2502,7 +2502,7 @@ export async function loadHasOneThrough(
   if (throughAssoc.type === "hasOne") {
     throughRecord = await loadHasOne(record, throughAssoc.name, throughAssoc.options);
   } else if (throughAssoc.type === "belongsTo") {
-    throughRecord = await findBelongsToTarget(record, throughAssoc.name, throughAssoc.options);
+    throughRecord = await findTarget(record, throughAssoc.name, throughAssoc.options);
   } else if (throughAssoc.type === "hasMany") {
     const throughRecords = await loadHasMany(record, throughAssoc.name, throughAssoc.options);
     throughRecord = throughRecords[0] ?? null;
@@ -2520,7 +2520,7 @@ export async function loadHasOneThrough(
 
   if (sourceAssoc) {
     if (sourceAssoc.type === "belongsTo") {
-      return findBelongsToTarget(throughRecord, sourceName, sourceAssoc.options);
+      return findTarget(throughRecord, sourceName, sourceAssoc.options);
     } else if (sourceAssoc.type === "hasOne") {
       return loadHasOne(throughRecord, sourceName, sourceAssoc.options);
     }

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -112,6 +112,7 @@ import type { AssociationReflection } from "./reflection.js";
 import { hasQueryConstraints, queryConstraintsList } from "./persistence.js";
 import { foreignKeyPresentFor } from "./associations/foreign-association.js";
 import { throughForeignKeyPresent } from "./associations/through-association.js";
+import { findTarget as findBelongsToTarget } from "./associations/singular-association.js";
 
 /**
  * Association options.
@@ -202,7 +203,7 @@ export interface AssociationDefinition {
  * Reflection namespace for HABTM registration, but that's value-side only).
  * @internal
  */
-interface ReflectionLike {
+export interface ReflectionLike {
   joinForeignKey: string | string[];
   throughReflection?: { joinForeignKey: string | string[] } | null;
   scope?: ((...args: any[]) => any) | null;
@@ -445,8 +446,14 @@ export function resolveAssocClass(
 /**
  * Validate that an inverse_of association exists on the target model.
  * Throws InverseOfAssociationNotFoundError if not found.
+ *
+ * @internal
  */
-function validateInverseOf(targetModel: typeof Base, assocName: string, inverseOf: string): void {
+export function validateInverseOf(
+  targetModel: typeof Base,
+  assocName: string,
+  inverseOf: string,
+): void {
   const targetAssocs: AssociationDefinition[] = targetModel._associations ?? [];
   if (targetAssocs.length === 0) return;
   if (targetAssocs.some((a) => a.name === inverseOf)) return;
@@ -465,7 +472,7 @@ function validateInverseOf(targetModel: typeof Base, assocName: string, inverseO
  *
  * @internal
  */
-function _resolveInverseName(
+export function _resolveInverseName(
   ownerCtor: typeof Base,
   assocName: string,
   options: AssociationOptions,
@@ -992,7 +999,7 @@ function _canRouteThroughViaDisableJoinsAssociationScope(
  * repeating the cast at every loader.
  * @internal
  */
-function _scopeForAssociation(model: typeof Base): Relation<Base> {
+export function _scopeForAssociation(model: typeof Base): Relation<Base> {
   return (
     (model as unknown as { scopeForAssociation?(): Relation<Base> }).scopeForAssociation?.() ??
     model.all()
@@ -1055,7 +1062,7 @@ export function applyAssociationScope<R>(
  * `AssociationScope.scope(...)` here only matters if a future caller
  * stretches the contract.
  */
-function _builtAssociationScope(
+export function _builtAssociationScope(
   record: Base,
   assocName: string,
   reflection: ReflectionLike,
@@ -1118,7 +1125,7 @@ function _builtAssociationScope(
  * the join model's STI `type_condition`), so the compiled SQL is complete and
  * stable across owners.
  */
-function _skipSingularStatementCache(
+export function _skipSingularStatementCache(
   reflection: ReflectionLike,
   targetModel: typeof Base,
   options: AssociationOptions,
@@ -1165,7 +1172,7 @@ function _skipSingularStatementCache(
  * AST/SQL rebuild. Emitted SQL and the unordered LIMIT-1 semantics are
  * identical to the `take()` path this replaces.
  */
-async function _loadSingularViaStatementCache(
+export async function _loadSingularViaStatementCache(
   record: Base,
   assocName: string,
   reflection: ReflectionLike,
@@ -1327,8 +1334,10 @@ async function _loadSingularThroughViaDisableJoinsScope(
 
 /**
  * Sync loaded result to the association instance if one exists.
+ *
+ * @internal
  */
-function syncToAssociationInstance(record: Base, assocName: string, result: unknown): void {
+export function syncToAssociationInstance(record: Base, assocName: string, result: unknown): void {
   const holder = record._associationInstances.get(assocName) as
     | { _setTargetFromLoader(t: Base | Base[] | null): void; _loaderWritebackSuppressed?: number }
     | undefined;
@@ -1387,7 +1396,7 @@ export function _violatesStrictLoading(record: Base, options: AssociationOptions
  *
  * @internal
  */
-function _findTargetReachable(
+export function _findTargetReachable(
   record: Base,
   assocName: string,
   options: AssociationOptions,
@@ -1419,220 +1428,6 @@ function _associationForeignKeyPresent(
     return fkNames.every((name) => record._readAttribute(name) != null);
   }
   return reflection ? foreignKeyPresentFor(reflection as AssociationReflection, record) : false;
-}
-
-/**
- * Load a belongs_to association.
- */
-export async function loadBelongsTo(
-  record: Base,
-  assocName: string,
-  options: AssociationOptions,
-): Promise<Base | null> {
-  // Rails runs `reflection.check_validity!` in `Association#initialize`
-  // (now mirrored in the `Association` constructor via
-  // `validateReflectionValidity`), so a recursive/missing `inverse_of` already
-  // surfaced at first access. No load-path recursion shim is needed here.
-
-  // Check cached (inverse_of) first, then preloaded.
-  // Even for cached/preloaded hits, wire inverseOf so the parent's association
-  // cache points back to this child instance (mirrors Rails behavior).
-  // For non-polymorphic associations, validate inverseOf before checking whether
-  // the value is null: an invalid name must throw even when the cached value is
-  // null (e.g. preloader stored null for a missing row), consistent with the
-  // cache-miss path that validates before the FK/null short-circuit.
-  // Read the loaded target off the singular holder (Rails' @target), with the
-  // legacy mirror + preload fallback for direct-loader calls on undeclared
-  // names. A loaded-nil target (null) is distinguished from "not loaded".
-  const loaded = _loadedSingularTarget(record, assocName);
-  if (loaded) {
-    const cached = loaded.value;
-    if (options.inverseOf && !options.polymorphic) {
-      // Resolve target class from instance if available, otherwise from options.
-      const targetModel =
-        (cached?.constructor as typeof Base | undefined) ??
-        resolveAssocClass(record, assocName, options.className ?? camelize(assocName));
-      validateInverseOf(targetModel, assocName, options.inverseOf);
-    }
-    if (cached) {
-      // Honor staleness (Rails' `stale_target?`): if the owner's FK changed so
-      // it no longer points at the cached target, the cache is stale — fall
-      // through to re-query. `_cacheSingularTarget` routes singular inverse
-      // writes through `inversedFrom` (→ `replace_keys` → `loadedBang`), so the
-      // holder's `isStaleTarget()` snapshot is now authoritative.
-      const holder = record._associationInstances.get(assocName) as
-        | { isStaleTarget?: () => boolean }
-        | undefined;
-      const stale = typeof holder?.isStaleTarget === "function" && holder.isStaleTarget();
-      if (!stale) {
-        const inverseName = _resolveInverseName(
-          record.constructor as typeof Base,
-          assocName,
-          options,
-        );
-        if (inverseName) _wireInverseAssociation(record, cached, inverseName);
-        return cached;
-      }
-    } else {
-      return cached;
-    }
-  }
-
-  // Strict loading check: this is a lazy load. Gated by `find_target?` — a
-  // new-record owner without the FK present never reaches `find_target` and so
-  // never raises (it falls through to the null-FK short-circuit below).
-  if (
-    _violatesStrictLoading(record, options) &&
-    _findTargetReachable(record, assocName, options, "belongsTo")
-  ) {
-    strictLoadingViolationBang(record, assocName, {
-      polymorphic: options.polymorphic,
-      className: options.className,
-    });
-  }
-
-  const ctor = record.constructor as typeof Base;
-  const defaultFk = `${underscore(assocName)}_id`;
-
-  // Polymorphic: use the _type column to determine the target model
-  let targetModel: typeof Base;
-  if (options.polymorphic) {
-    const typeCol = options.foreignType ?? `${underscore(assocName)}_type`;
-    const typeName = record._readAttribute(typeCol) as string | null;
-    if (!typeName) return null;
-    // Rails resolves a polymorphic belongs_to's target via the owner class's
-    // polymorphic_class_for, which honors store_full_class_name and (when off)
-    // namespace-relative compute_type — not a bare global registry lookup.
-    targetModel = ctor.polymorphicClassFor(typeName);
-  } else {
-    const className = options.className ?? camelize(assocName);
-    targetModel = resolveAssocClass(record, assocName, className);
-  }
-
-  if (options.inverseOf && !options.polymorphic) {
-    validateInverseOf(targetModel, assocName, options.inverseOf);
-  }
-
-  // Resolve foreign key and primary key (may be arrays for CPK).
-  const foreignKey =
-    options.foreignKey ??
-    (options.queryConstraints
-      ? options.queryConstraints
-      : Array.isArray(targetModel.primaryKey) && !options.primaryKey
-        ? targetModel.primaryKey.map((col: string) => `${underscore(assocName)}_${col}`)
-        : defaultFk);
-  const primaryKey = options.primaryKey ?? targetModel.primaryKey;
-
-  // Route through AssociationScope when reflection is registered.
-  // For polymorphic belongsTo, AssociationScope receives the
-  // runtime-resolved klass; the reflection's own joinPrimaryKey
-  // returns associationPrimaryKey (target's PK) and joinForeignKey
-  // returns the owner-side FK, so the WHERE shape is identical to
-  // the non-polymorphic case.
-  const reflection = ctor._reflectOnAssociation?.(assocName);
-  // Null-FK short-circuit: avoid a query when owner's FK column is null.
-  // The check must read the SAME columns the eventual query uses —
-  // reflection.joinForeignKey when routing through AssociationScope,
-  // options-derived foreignKey otherwise. Reading from a different
-  // column would silently return null while a real query would have
-  // found the row (or vice versa).
-  const fkColsForCheck = reflection
-    ? Array.isArray(reflection.joinForeignKey)
-      ? reflection.joinForeignKey
-      : [reflection.joinForeignKey]
-    : Array.isArray(foreignKey)
-      ? foreignKey
-      : [foreignKey];
-  for (const fk of fkColsForCheck) {
-    const v = record._readAttribute(fk);
-    if (v === null || v === undefined) return null;
-  }
-  // The staleness key mirrors Rails' `stale_state`: the FK column(s), plus the
-  // `foreign_type` for a polymorphic belongs_to
-  // (belongs_to_polymorphic_association.rb:43-46), so a reassignment that keeps
-  // the same id but changes the target class is still detected below.
-  const staleCols = options.polymorphic
-    ? [...fkColsForCheck, options.foreignType ?? `${underscore(assocName)}_type`]
-    : fkColsForCheck;
-  const staleSnapshot = staleCols.map((col) => record._readAttribute(col));
-
-  let result: Base | null;
-  if (reflection) {
-    if (!_skipSingularStatementCache(reflection, targetModel, options)) {
-      // Statement-cache path (Rails `Association#find_target` via
-      // `reflection.association_scope_cache` / `sc.execute(binds, c)`).
-      result = await _loadSingularViaStatementCache(record, assocName, reflection, targetModel);
-    } else {
-      const built = _builtAssociationScope(record, assocName, reflection, targetModel);
-      const baseRelation = _scopeForAssociation(targetModel);
-      let rel = baseRelation.merge(built);
-      rel = applyAssociationScope(rel, options.scope, record, reflection.scope);
-      // Rails' normal singular-load path (`Association#find_target` via the
-      // statement cache) returns an array and calls `Array#first` — no ORDER BY
-      // in SQL. `take` (unordered LIMIT 1) is the closest equivalent; `first`
-      // would route through `ordered_relation` and add a spurious ORDER BY. See
-      // has_one_associations_test `test_has_one_does_not_use_order_by`.
-      result = await rel.take();
-    }
-  } else {
-    // Inline fallback: no reflection registered.
-    if (Array.isArray(foreignKey)) {
-      const pkCols = Array.isArray(primaryKey) ? primaryKey : [primaryKey];
-      if (pkCols.length !== foreignKey.length) {
-        // Route through the reflection's canonical checkValidityBang (Rails'
-        // single raise site) so the error carries the Rails-faithful message.
-        routeThroughCheckValidity(ctor, assocName);
-        // No reflection registered (lower-level test helper) — minimal guard.
-        throw new CompositePrimaryKeyMismatchError({
-          activeRecord: ctor.name,
-          name: assocName,
-          primaryKey: pkCols,
-          foreignKey,
-        });
-      }
-      const conditions: Record<string, unknown> = {};
-      for (let i = 0; i < foreignKey.length; i++) {
-        conditions[pkCols[i]] = record._readAttribute(foreignKey[i]);
-      }
-      result = await targetModel.findBy(conditions);
-    } else {
-      result = await targetModel.findBy({
-        [primaryKey as string]: record._readAttribute(foreignKey),
-      });
-    }
-  }
-
-  // Rails' `find_target` is synchronous, so it never observes the owner's
-  // foreign key change mid-load. Our loader awaits DB I/O: an in-flight reader
-  // query (e.g. `node.parent` accessed but never awaited) can still be pending
-  // when the caller synchronously reassigns the association
-  // (`node.parent = other`) with a new FK. Once RFC 0063 made `save` genuinely
-  // await the validation chain, that window widened enough for the stale query
-  // to resolve mid-save and `syncToAssociationInstance` clobber the
-  // freshly-assigned holder target with the old record — dropping the FK change
-  // from `previousChanges`. If the owner's stale key moved off the snapshot we
-  // queried, the fetched record is stale: leave the holder's newer target
-  // intact and return it instead of the stale row.
-  const fkMovedDuringLoad = staleCols.some(
-    (col, i) => record._readAttribute(col) !== staleSnapshot[i],
-  );
-  if (fkMovedDuringLoad) {
-    const holder = record._associationInstances.get(assocName) as
-      | { isLoaded?: () => boolean; target?: Base | null }
-      | undefined;
-    if (holder?.isLoaded?.()) return holder.target ?? null;
-  }
-
-  // Set inverse_of: store reference back to the owner. Resolve via the
-  // reflection so automatic_inverse_of also wires the parent — mirrors
-  // ActiveRecord::Associations::Association#set_inverse_instance.
-  if (result) {
-    const inverseName = _resolveInverseName(ctor, assocName, options);
-    if (inverseName) _wireInverseAssociation(record, result, inverseName);
-  }
-
-  syncToAssociationInstance(record, assocName, result);
-  return result;
 }
 
 /**
@@ -2625,7 +2420,7 @@ export async function loadHasManyThrough(
     const one = await loadHasOne(record, throughAssoc.name, throughAssoc.options);
     throughRecords = one ? [one] : [];
   } else if (throughAssoc.type === "belongsTo") {
-    const one = await loadBelongsTo(record, throughAssoc.name, throughAssoc.options);
+    const one = await findBelongsToTarget(record, throughAssoc.name, throughAssoc.options);
     throughRecords = one ? [one] : [];
   } else {
     throughRecords = [];
@@ -2707,7 +2502,7 @@ export async function loadHasOneThrough(
   if (throughAssoc.type === "hasOne") {
     throughRecord = await loadHasOne(record, throughAssoc.name, throughAssoc.options);
   } else if (throughAssoc.type === "belongsTo") {
-    throughRecord = await loadBelongsTo(record, throughAssoc.name, throughAssoc.options);
+    throughRecord = await findBelongsToTarget(record, throughAssoc.name, throughAssoc.options);
   } else if (throughAssoc.type === "hasMany") {
     const throughRecords = await loadHasMany(record, throughAssoc.name, throughAssoc.options);
     throughRecord = throughRecords[0] ?? null;
@@ -2725,7 +2520,7 @@ export async function loadHasOneThrough(
 
   if (sourceAssoc) {
     if (sourceAssoc.type === "belongsTo") {
-      return loadBelongsTo(throughRecord, sourceName, sourceAssoc.options);
+      return findBelongsToTarget(throughRecord, sourceName, sourceAssoc.options);
     } else if (sourceAssoc.type === "hasOne") {
       return loadHasOne(throughRecord, sourceName, sourceAssoc.options);
     }

--- a/packages/activerecord/src/associations/association-scope-cache.test.ts
+++ b/packages/activerecord/src/associations/association-scope-cache.test.ts
@@ -15,8 +15,9 @@
  * synthetic `cache_*` tables.
  */
 import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
+import { findTarget } from "./singular-association.js";
 import { registerModel, enableSti, registerSubclass } from "../index.js";
-import { loadHasMany, loadBelongsTo, loadHasOne } from "../associations.js";
+import { loadHasMany, loadHasOne } from "../associations.js";
 import { AssociationScope } from "./association-scope.js";
 import { StatementCache } from "../statement-cache.js";
 import { fixtures } from "../test-helpers/fixtures.js";
@@ -126,13 +127,13 @@ describe("Association scope cache", () => {
 
     const spy = vi.spyOn(StatementCache, "create");
 
-    const r1 = await loadBelongsTo(p1, "author", opts);
+    const r1 = await findTarget(p1, "author", opts);
     expect((r1 as any)?.id).toBe(authors("david").id);
     const afterFirst = spy.mock.calls.length;
     expect(afterFirst).toBe(1);
 
     // Second owner's load reuses the cached statement — no recompile.
-    const r2 = await loadBelongsTo(p2, "author", opts);
+    const r2 = await findTarget(p2, "author", opts);
     expect((r2 as any)?.id).toBe(authors("bob").id);
     expect(spy.mock.calls.length).toBe(afterFirst);
   });

--- a/packages/activerecord/src/associations/belongs-to-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-association.ts
@@ -1,10 +1,10 @@
 import type { Base } from "../base.js";
 import type { AssociationDefinition } from "../associations.js";
-import { loadBelongsTo, reflectLockVersionBump } from "../associations.js";
+import { reflectLockVersionBump } from "../associations.js";
 import { underscore } from "@blazetrails/activesupport";
 import { belongsToCounterCacheColumn } from "../reflection.js";
 import { hasQueryConstraints, queryConstraintsList } from "../persistence.js";
-import { SingularAssociation } from "./singular-association.js";
+import { SingularAssociation, findTarget } from "./singular-association.js";
 import { Rollback } from "../errors.js";
 import { MissingAttributeError } from "@blazetrails/activemodel";
 
@@ -320,7 +320,7 @@ export class BelongsToAssociation extends SingularAssociation {
     // which the stale-key check cannot see. See `_loaderWritebackSuppressed`.
     this._loaderWritebackSuppressed++;
     try {
-      return await loadBelongsTo(this.owner, this.reflection.name, this.reflection.options);
+      return await findTarget(this.owner, this.reflection.name, this.reflection.options);
     } finally {
       this._loaderWritebackSuppressed--;
     }

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -3,6 +3,7 @@
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
 import type { AssociationProxy } from "./collection-proxy.js";
+import { findTarget } from "./singular-association.js";
 import { describe, it, expect, beforeAll } from "vitest";
 import { Notifications, throwAbort } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
@@ -38,7 +39,6 @@ import { Developer, AuditLog } from "../test-helpers/models/developer.js";
 import { Project } from "../test-helpers/models/project.js";
 import {
   Associations,
-  loadBelongsTo,
   loadHasMany,
   loadHasManyThrough,
   isAssociationCached,
@@ -2851,7 +2851,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(InvValPost);
     const author = await InvValAuthor.create({ name: "Alice" });
     const post = await InvValPost.create({ author_id: author.id, title: "A", body: "body" });
-    const loaded = await loadBelongsTo(post, "author", {
+    const loaded = await findTarget(post, "author", {
       className: "InvValAuthor",
       foreignKey: "author_id",
       inverseOf: "inv_val_posts",

--- a/packages/activerecord/src/associations/instance-methods.ts
+++ b/packages/activerecord/src/associations/instance-methods.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Base } from "../base.js";
+import { findTarget as _findBelongsToTarget } from "./singular-association.js";
 import { Association as AssociationInstance } from "./association.js";
 import { BelongsToAssociation } from "./belongs-to-association.js";
 import { BelongsToPolymorphicAssociation } from "./belongs-to-polymorphic-association.js";
@@ -15,7 +16,6 @@ import { HasManyThroughAssociation } from "./has-many-through-association.js";
 import { HasOneAssociation } from "./has-one-association.js";
 import { HasOneThroughAssociation } from "./has-one-through-association.js";
 import {
-  loadBelongsTo as _loadBelongsToOnce,
   loadHasOne as _loadHasOneOnce,
   _associationNotFound,
   _preloadedHolderTarget,
@@ -155,7 +155,7 @@ export function association(this: Base, name: string): AssociationInstance {
 export async function loadBelongsTo(this: Base, name: string): Promise<Base | null> {
   const assocDef = assertSingularAssociation.call(this, name, "belongsTo");
   const result = await bypassStrictLoading.call(this, () =>
-    _loadBelongsToOnce(this, name, (assocDef.options ?? {}) as any),
+    _findBelongsToTarget(this, name, (assocDef.options ?? {}) as any),
   );
   // Loader writeback: this is the tail of this function's own query, not a
   // caller replacing the target. See Association#_setTargetFromLoader.

--- a/packages/activerecord/src/associations/instance-methods.ts
+++ b/packages/activerecord/src/associations/instance-methods.ts
@@ -7,7 +7,7 @@
  */
 
 import type { Base } from "../base.js";
-import { findTarget as _findBelongsToTarget } from "./singular-association.js";
+import { findTarget } from "./singular-association.js";
 import { Association as AssociationInstance } from "./association.js";
 import { BelongsToAssociation } from "./belongs-to-association.js";
 import { BelongsToPolymorphicAssociation } from "./belongs-to-polymorphic-association.js";
@@ -155,7 +155,7 @@ export function association(this: Base, name: string): AssociationInstance {
 export async function loadBelongsTo(this: Base, name: string): Promise<Base | null> {
   const assocDef = assertSingularAssociation.call(this, name, "belongsTo");
   const result = await bypassStrictLoading.call(this, () =>
-    _findBelongsToTarget(this, name, (assocDef.options ?? {}) as any),
+    findTarget(this, name, (assocDef.options ?? {}) as any),
   );
   // Loader writeback: this is the tail of this function's own query, not a
   // caller replacing the target. See Association#_setTargetFromLoader.

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -2,6 +2,7 @@
  * Mirrors Rails activerecord/test/cases/associations/inverse_associations_test.rb
  */
 import { describe, it, expect, beforeAll } from "vitest";
+import { findTarget } from "./singular-association.js";
 import {
   Base,
   association,
@@ -11,7 +12,7 @@ import {
   InverseOfAssociationNotFoundError,
   InverseOfAssociationRecursiveError,
 } from "../index.js";
-import { loadBelongsTo, loadHasOne, loadHasMany } from "../associations.js";
+import { loadHasOne, loadHasMany } from "../associations.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { Branch, BrokenBranch } from "../test-helpers/models/branch.js";
 import { Human } from "../test-helpers/models/human.js";
@@ -259,7 +260,7 @@ describe("AutomaticInverseFindingTests", () => {
     const comment = (await Comment.first())!;
     const rating = await Rating.createBang({ comment_id: (comment as any).id });
 
-    const ratingComment = (await loadBelongsTo(rating, "comment", { inverseOf: "ratings" })) as any;
+    const ratingComment = (await findTarget(rating, "comment", { inverseOf: "ratings" })) as any;
     expect(ratingComment.id).toBe((comment as any).id);
 
     ratingComment.body = "Fennec foxes are the smallest of the foxes.";
@@ -269,7 +270,7 @@ describe("AutomaticInverseFindingTests", () => {
   it("has many and belongs to automatic inverse shares objects on comment", async () => {
     const rating = await Rating.createBang({});
     const comment = (await Comment.first())!;
-    await loadBelongsTo(rating, "comment", { inverseOf: "ratings" });
+    await findTarget(rating, "comment", { inverseOf: "ratings" });
     (rating as any).comment = comment;
 
     expect((rating as any).comment).toBe(comment);
@@ -833,9 +834,9 @@ describe("InverseHasManyTests", () => {
     const post1 = (await Post.first())!;
     const post2 = (await Post.all().order("id").offset(1).first())!;
     const comment = (await loadHasMany(post1, "comments", { inverseOf: "post" }))[0] as any;
-    expect(await loadBelongsTo(comment, "post", { inverseOf: "comments" })).toBe(post1);
+    expect(await findTarget(comment, "post", { inverseOf: "comments" })).toBe(post1);
     await comment.updateBang({ post_id: (post2 as any).id });
-    const reloaded = (await loadBelongsTo(comment, "post", { inverseOf: "comments" })) as any;
+    const reloaded = (await findTarget(comment, "post", { inverseOf: "comments" })) as any;
     expect(reloaded.id).toBe((post2 as any).id);
   });
 });
@@ -848,7 +849,7 @@ describe("InverseBelongsToTests", () => {
 
   it("child instance should be shared with parent on find", async () => {
     const face = faces("trusting");
-    const human = (await loadBelongsTo(face, "human", { inverseOf: "face" }))!;
+    const human = (await findTarget(face, "human", { inverseOf: "face" }))!;
     expect((human as any).face.description).toBe((face as any).description);
     (face as any).description = "gormless";
     expect((human as any).face.description).toBe((face as any).description);
@@ -900,7 +901,7 @@ describe("InverseBelongsToTests", () => {
 
   it("should not try to set inverse instances when the inverse is a has many", async () => {
     const interest = interests("trainspotting");
-    const human = (await loadBelongsTo(interest, "human", { inverseOf: "interests" }))!;
+    const human = (await findTarget(interest, "human", { inverseOf: "interests" }))!;
     // Rails: human.interests.detect { |_iz| _iz.id == interest.id } — block-find
     // over the CollectionProxy (Enumerable#detect loads the target), not the AR
     // PK finder.
@@ -916,7 +917,7 @@ describe("InverseBelongsToTests", () => {
   it("with has many inversing should try to set inverse instances when the inverse is a has many", async () => {
     await withHasManyInversing(Human, async () => {
       const interest = interests("trainspotting");
-      const human = (await loadBelongsTo(interest, "human", { inverseOf: "interests" })) as any;
+      const human = (await findTarget(interest, "human", { inverseOf: "interests" })) as any;
       const cached = human._associationCache("interests")?.target as any[];
       const iz = cached.find((i: any) => i.id === (interest as any).id);
       expect(iz).toBeDefined();
@@ -941,7 +942,7 @@ describe("InverseBelongsToTests", () => {
   it("with has many inversing does not trigger association callbacks on set when the inverse is a has many", async () => {
     await withHasManyInversing(Interest, async () => {
       const interest = interests("trainspotting");
-      const human = (await loadBelongsTo(interest, "humanWithCallbacks", {
+      const human = (await findTarget(interest, "humanWithCallbacks", {
         className: "Human",
         foreignKey: "human_id",
         inverseOf: "interestsWithCallbacks",
@@ -983,23 +984,23 @@ describe("InverseBelongsToTests", () => {
 
   it("unscope does not set inverse when incorrect", async () => {
     const interest = interests("trainspotting");
-    const human = (await loadBelongsTo(interest, "human", { inverseOf: "interests" }))!;
+    const human = (await findTarget(interest, "human", { inverseOf: "interests" }))!;
     const createdHuman = await Human.create({ name: "wrong human" });
     const foundInterest = await (createdHuman as any).interests
       .or((human as any).interests)
       .detect((thisInterest: any) => (interest as any).id === thisInterest.id);
-    const foundHuman = await loadBelongsTo(foundInterest, "human", { inverseOf: "interests" });
+    const foundHuman = await findTarget(foundInterest, "human", { inverseOf: "interests" });
     expect((foundHuman as any).id).toBe((human as any).id);
   });
 
   it("or does not set inverse when incorrect", async () => {
     const interest = interests("trainspotting");
-    const human = (await loadBelongsTo(interest, "human", { inverseOf: "interests" }))!;
+    const human = (await findTarget(interest, "human", { inverseOf: "interests" }))!;
     const createdHuman = await Human.create({ name: "wrong human" });
     const foundInterest = await (createdHuman as any).interests
       .unscope("where")
       .detect((thisInterest: any) => (interest as any).id === thisInterest.id);
-    const foundHuman = await loadBelongsTo(foundInterest, "human", { inverseOf: "interests" });
+    const foundHuman = await findTarget(foundInterest, "human", { inverseOf: "interests" });
     expect((foundHuman as any).id).toBe((human as any).id);
   });
 
@@ -1018,13 +1019,13 @@ describe("InverseBelongsToTests", () => {
   it("trying to use inverses that dont exist should raise an error", async () => {
     const face = (await Face.first())!;
     await expect(
-      loadBelongsTo(face, "confusedHuman", { className: "Human", inverseOf: "cnffusedFace" }),
+      findTarget(face, "confusedHuman", { className: "Human", inverseOf: "cnffusedFace" }),
     ).rejects.toThrow(InverseOfAssociationNotFoundError);
   });
 
   it("trying to use inverses that dont exist should have suggestions for fix", async () => {
     const face = (await Face.first())!;
-    const err = await loadBelongsTo(face, "confusedHuman", {
+    const err = await findTarget(face, "confusedHuman", {
       className: "Human",
       inverseOf: "cnffusedFace",
     }).catch((e) => e);
@@ -1052,7 +1053,7 @@ describe("InversePolymorphicBelongsToTests", () => {
 
   it("child instance should be shared with parent on find", async () => {
     const face = faces("confused");
-    const human = (await loadBelongsTo(face, "polymorphicHuman", {
+    const human = (await findTarget(face, "polymorphicHuman", {
       polymorphic: true,
       inverseOf: "polymorphicFace",
     })) as any;
@@ -1065,7 +1066,7 @@ describe("InversePolymorphicBelongsToTests", () => {
 
   it("eager loaded child instance should be shared with parent on find", async () => {
     let face = (await Face.where({ description: "confused" }).includes("human"))[0] as any;
-    let human = (await loadBelongsTo(face, "polymorphicHuman", {
+    let human = (await findTarget(face, "polymorphicHuman", {
       polymorphic: true,
       inverseOf: "polymorphicFace",
     })) as any;
@@ -1078,7 +1079,7 @@ describe("InversePolymorphicBelongsToTests", () => {
     face = (
       await Face.where({ description: "confused" }).includes("human").order("humans.id")
     )[0] as any;
-    human = (await loadBelongsTo(face, "polymorphicHuman", {
+    human = (await findTarget(face, "polymorphicHuman", {
       polymorphic: true,
       inverseOf: "polymorphicFace",
     })) as any;
@@ -1160,7 +1161,7 @@ describe("InversePolymorphicBelongsToTests", () => {
 
   it("should not try to set inverse instances when the inverse is a has many", async () => {
     const interest = interests("llama_wrangling");
-    const human = (await loadBelongsTo(interest, "polymorphicHuman", {
+    const human = (await findTarget(interest, "polymorphicHuman", {
       polymorphic: true,
       inverseOf: "polymorphicInterests",
     })) as any;
@@ -1177,7 +1178,7 @@ describe("InversePolymorphicBelongsToTests", () => {
   it("with has many inversing should try to set inverse instances when the inverse is a has many", async () => {
     await withHasManyInversing(Human, async () => {
       const interest = interests("llama_wrangling");
-      const human = (await loadBelongsTo(interest, "polymorphicHuman", {
+      const human = (await findTarget(interest, "polymorphicHuman", {
         polymorphic: true,
         inverseOf: "polymorphicInterests",
       })) as any;
@@ -1202,7 +1203,7 @@ describe("InversePolymorphicBelongsToTests", () => {
 
   it("trying to access inverses that dont exist shouldnt raise an error", async () => {
     const face = (await Face.first())!;
-    await loadBelongsTo(face, "puzzledPolymorphicHuman", {
+    await findTarget(face, "puzzledPolymorphicHuman", {
       polymorphic: true,
       inverseOf: "puzzledPolymorphicFace",
     });
@@ -1240,8 +1241,8 @@ describe("InverseMultipleHasManyInversesForSameModel", () => {
 
   it("that we can load associations that have the same reciprocal name from different models", async () => {
     const interest = (await Interest.first())!;
-    await loadBelongsTo(interest, "zine", { inverseOf: "interests" });
-    await loadBelongsTo(interest, "human", { inverseOf: "interests" });
+    await findTarget(interest, "zine", { inverseOf: "interests" });
+    await findTarget(interest, "human", { inverseOf: "interests" });
   });
 
   it("that we can create associations that have the same reciprocal name from different models", async () => {
@@ -1276,7 +1277,7 @@ describe("InverseBelongsToTests", () => {
       const main = await BrokenBranch.create({});
       const feature = await association(main, "branches").create({});
       const topic = association(feature, "branches").build({});
-      const err = await loadBelongsTo(topic, "branch", {
+      const err = await findTarget(topic, "branch", {
         className: "BrokenBranch",
         inverseOf: "branch",
       }).catch((e) => e);

--- a/packages/activerecord/src/associations/join-model.test.ts
+++ b/packages/activerecord/src/associations/join-model.test.ts
@@ -8,9 +8,10 @@
  * self-referential groups) are tracked as sibling stories.
  */
 import { describe, it, expect } from "vitest";
+import { findTarget } from "./singular-association.js";
 import { registerModel } from "../index.js";
 import { Base } from "../base.js";
-import { association, loadBelongsTo } from "../associations.js";
+import { association } from "../associations.js";
 import { AssociationTypeMismatch, ConfigurationError } from "../errors.js";
 import {
   HasManyThroughAssociationNotFoundError,
@@ -307,7 +308,7 @@ describe("AssociationsJoinModelTest", () => {
 
     expect(tagging.taggable_type).toBe("Post");
     expect(tagging.taggable_id).toBe(Number(thinking.id));
-    const taggable = (await loadBelongsTo(tagging, "taggable", { polymorphic: true })) as Base;
+    const taggable = (await findTarget(tagging, "taggable", { polymorphic: true })) as Base;
     expect(taggable.id).toBe(thinking.id);
   });
 
@@ -320,7 +321,7 @@ describe("AssociationsJoinModelTest", () => {
 
     expect(tagging.taggable_type).toBe("Post");
     expect(tagging.taggable_id).toBe(Number(post.id));
-    const taggable = (await loadBelongsTo(tagging, "taggable", { polymorphic: true })) as Base;
+    const taggable = (await findTarget(tagging, "taggable", { polymorphic: true })) as Base;
     expect(taggable.id).toBe(post.id);
   });
 
@@ -1144,7 +1145,7 @@ describe("AssociationsJoinModelTest", () => {
 
   it("polymorphic has many going through join model with custom foreign key", async () => {
     const tagging = await Tagging.find(taggings("welcome_general").id);
-    const superTag = (await loadBelongsTo(tagging, "superTag", {
+    const superTag = (await findTarget(tagging, "superTag", {
       className: "Tag",
       foreignKey: "super_tag_id",
     })) as Base;

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -241,6 +241,12 @@ function scopeForCreate(assoc: SingularAssociation): Record<string, unknown> {
  * `BelongsToAssociation#find_target?` (`belongs_to_association.rb:124`) —
  * the reachability gate is `_findTargetReachable(..., "belongsTo")` below.
  *
+ * It lives here rather than in `belongs-to-association.ts` because
+ * `belongs_to_association.rb` defines no `find_target` of its own: Rails
+ * inherits the singular one and specializes only the `find_target?` predicate.
+ * Putting the loader under the belongs_to file would name a method Rails does
+ * not declare there.
+ *
  * @internal
  */
 export async function findTarget(

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -1,6 +1,24 @@
 import type { Base } from "../base.js";
-import type { AssociationDefinition } from "../associations.js";
+import type { AssociationDefinition, AssociationOptions } from "../associations.js";
+import {
+  _builtAssociationScope,
+  _findTargetReachable,
+  _loadSingularViaStatementCache,
+  _loadedSingularTarget,
+  _resolveInverseName,
+  _scopeForAssociation,
+  _skipSingularStatementCache,
+  _violatesStrictLoading,
+  _wireInverseAssociation,
+  applyAssociationScope,
+  resolveAssocClass,
+  syncToAssociationInstance,
+  validateInverseOf,
+} from "../associations.js";
 import { Association } from "./association.js";
+import { CompositePrimaryKeyMismatchError } from "./errors.js";
+import { routeThroughCheckValidity } from "./validate-through-reflection.js";
+import { camelize, underscore } from "@blazetrails/activesupport";
 import { strictLoadingViolationBang } from "../core.js";
 import { RecordInvalid } from "../validations.js";
 
@@ -215,7 +233,223 @@ function scopeForCreate(assoc: SingularAssociation): Record<string, unknown> {
   return (assoc as any).scope?.()?.scopeForCreate?.() ?? {};
 }
 
-/** @internal */
-function findTarget(assoc: SingularAssociation): Promise<Base | null> {
-  return assoc.loadTarget() as Promise<Base | null>;
+/**
+ * Load a belongs_to association's target.
+ *
+ * Mirrors: ActiveRecord::Associations::SingularAssociation#find_target
+ * (`singular_association.rb:47`), as specialized for belongs_to by
+ * `BelongsToAssociation#find_target?` (`belongs_to_association.rb:124`) —
+ * the reachability gate is `_findTargetReachable(..., "belongsTo")` below.
+ *
+ * @internal
+ */
+export async function findTarget(
+  record: Base,
+  assocName: string,
+  options: AssociationOptions,
+): Promise<Base | null> {
+  // Rails runs `reflection.check_validity!` in `Association#initialize`
+  // (now mirrored in the `Association` constructor via
+  // `validateReflectionValidity`), so a recursive/missing `inverse_of` already
+  // surfaced at first access. No load-path recursion shim is needed here.
+
+  // Check cached (inverse_of) first, then preloaded.
+  // Even for cached/preloaded hits, wire inverseOf so the parent's association
+  // cache points back to this child instance (mirrors Rails behavior).
+  // For non-polymorphic associations, validate inverseOf before checking whether
+  // the value is null: an invalid name must throw even when the cached value is
+  // null (e.g. preloader stored null for a missing row), consistent with the
+  // cache-miss path that validates before the FK/null short-circuit.
+  // Read the loaded target off the singular holder (Rails' @target), with the
+  // legacy mirror + preload fallback for direct-loader calls on undeclared
+  // names. A loaded-nil target (null) is distinguished from "not loaded".
+  const loaded = _loadedSingularTarget(record, assocName);
+  if (loaded) {
+    const cached = loaded.value;
+    if (options.inverseOf && !options.polymorphic) {
+      // Resolve target class from instance if available, otherwise from options.
+      const targetModel =
+        (cached?.constructor as typeof Base | undefined) ??
+        resolveAssocClass(record, assocName, options.className ?? camelize(assocName));
+      validateInverseOf(targetModel, assocName, options.inverseOf);
+    }
+    if (cached) {
+      // Honor staleness (Rails' `stale_target?`): if the owner's FK changed so
+      // it no longer points at the cached target, the cache is stale — fall
+      // through to re-query. `_cacheSingularTarget` routes singular inverse
+      // writes through `inversedFrom` (→ `replace_keys` → `loadedBang`), so the
+      // holder's `isStaleTarget()` snapshot is now authoritative.
+      const holder = record._associationInstances.get(assocName) as
+        | { isStaleTarget?: () => boolean }
+        | undefined;
+      const stale = typeof holder?.isStaleTarget === "function" && holder.isStaleTarget();
+      if (!stale) {
+        const inverseName = _resolveInverseName(
+          record.constructor as typeof Base,
+          assocName,
+          options,
+        );
+        if (inverseName) _wireInverseAssociation(record, cached, inverseName);
+        return cached;
+      }
+    } else {
+      return cached;
+    }
+  }
+
+  // Strict loading check: this is a lazy load. Gated by `find_target?` — a
+  // new-record owner without the FK present never reaches `find_target` and so
+  // never raises (it falls through to the null-FK short-circuit below).
+  if (
+    _violatesStrictLoading(record, options) &&
+    _findTargetReachable(record, assocName, options, "belongsTo")
+  ) {
+    strictLoadingViolationBang(record, assocName, {
+      polymorphic: options.polymorphic,
+      className: options.className,
+    });
+  }
+
+  const ctor = record.constructor as typeof Base;
+  const defaultFk = `${underscore(assocName)}_id`;
+
+  // Polymorphic: use the _type column to determine the target model
+  let targetModel: typeof Base;
+  if (options.polymorphic) {
+    const typeCol = options.foreignType ?? `${underscore(assocName)}_type`;
+    const typeName = record._readAttribute(typeCol) as string | null;
+    if (!typeName) return null;
+    // Rails resolves a polymorphic belongs_to's target via the owner class's
+    // polymorphic_class_for, which honors store_full_class_name and (when off)
+    // namespace-relative compute_type — not a bare global registry lookup.
+    targetModel = ctor.polymorphicClassFor(typeName);
+  } else {
+    const className = options.className ?? camelize(assocName);
+    targetModel = resolveAssocClass(record, assocName, className);
+  }
+
+  if (options.inverseOf && !options.polymorphic) {
+    validateInverseOf(targetModel, assocName, options.inverseOf);
+  }
+
+  // Resolve foreign key and primary key (may be arrays for CPK).
+  const foreignKey =
+    options.foreignKey ??
+    (options.queryConstraints
+      ? options.queryConstraints
+      : Array.isArray(targetModel.primaryKey) && !options.primaryKey
+        ? targetModel.primaryKey.map((col: string) => `${underscore(assocName)}_${col}`)
+        : defaultFk);
+  const primaryKey = options.primaryKey ?? targetModel.primaryKey;
+
+  // Route through AssociationScope when reflection is registered.
+  // For polymorphic belongsTo, AssociationScope receives the
+  // runtime-resolved klass; the reflection's own joinPrimaryKey
+  // returns associationPrimaryKey (target's PK) and joinForeignKey
+  // returns the owner-side FK, so the WHERE shape is identical to
+  // the non-polymorphic case.
+  const reflection = ctor._reflectOnAssociation?.(assocName);
+  // Null-FK short-circuit: avoid a query when owner's FK column is null.
+  // The check must read the SAME columns the eventual query uses —
+  // reflection.joinForeignKey when routing through AssociationScope,
+  // options-derived foreignKey otherwise. Reading from a different
+  // column would silently return null while a real query would have
+  // found the row (or vice versa).
+  const fkColsForCheck = reflection
+    ? Array.isArray(reflection.joinForeignKey)
+      ? reflection.joinForeignKey
+      : [reflection.joinForeignKey]
+    : Array.isArray(foreignKey)
+      ? foreignKey
+      : [foreignKey];
+  for (const fk of fkColsForCheck) {
+    const v = record._readAttribute(fk);
+    if (v === null || v === undefined) return null;
+  }
+  // The staleness key mirrors Rails' `stale_state`: the FK column(s), plus the
+  // `foreign_type` for a polymorphic belongs_to
+  // (belongs_to_polymorphic_association.rb:43-46), so a reassignment that keeps
+  // the same id but changes the target class is still detected below.
+  const staleCols = options.polymorphic
+    ? [...fkColsForCheck, options.foreignType ?? `${underscore(assocName)}_type`]
+    : fkColsForCheck;
+  const staleSnapshot = staleCols.map((col) => record._readAttribute(col));
+
+  let result: Base | null;
+  if (reflection) {
+    if (!_skipSingularStatementCache(reflection, targetModel, options)) {
+      // Statement-cache path (Rails `Association#find_target` via
+      // `reflection.association_scope_cache` / `sc.execute(binds, c)`).
+      result = await _loadSingularViaStatementCache(record, assocName, reflection, targetModel);
+    } else {
+      const built = _builtAssociationScope(record, assocName, reflection, targetModel);
+      const baseRelation = _scopeForAssociation(targetModel);
+      let rel = baseRelation.merge(built);
+      rel = applyAssociationScope(rel, options.scope, record, reflection.scope);
+      // Rails' normal singular-load path (`Association#find_target` via the
+      // statement cache) returns an array and calls `Array#first` — no ORDER BY
+      // in SQL. `take` (unordered LIMIT 1) is the closest equivalent; `first`
+      // would route through `ordered_relation` and add a spurious ORDER BY. See
+      // has_one_associations_test `test_has_one_does_not_use_order_by`.
+      result = await rel.take();
+    }
+  } else {
+    // Inline fallback: no reflection registered.
+    if (Array.isArray(foreignKey)) {
+      const pkCols = Array.isArray(primaryKey) ? primaryKey : [primaryKey];
+      if (pkCols.length !== foreignKey.length) {
+        // Route through the reflection's canonical checkValidityBang (Rails'
+        // single raise site) so the error carries the Rails-faithful message.
+        routeThroughCheckValidity(ctor, assocName);
+        // No reflection registered (lower-level test helper) — minimal guard.
+        throw new CompositePrimaryKeyMismatchError({
+          activeRecord: ctor.name,
+          name: assocName,
+          primaryKey: pkCols,
+          foreignKey,
+        });
+      }
+      const conditions: Record<string, unknown> = {};
+      for (let i = 0; i < foreignKey.length; i++) {
+        conditions[pkCols[i]] = record._readAttribute(foreignKey[i]);
+      }
+      result = await targetModel.findBy(conditions);
+    } else {
+      result = await targetModel.findBy({
+        [primaryKey as string]: record._readAttribute(foreignKey),
+      });
+    }
+  }
+
+  // Rails' `find_target` is synchronous, so it never observes the owner's
+  // foreign key change mid-load. Our loader awaits DB I/O: an in-flight reader
+  // query (e.g. `node.parent` accessed but never awaited) can still be pending
+  // when the caller synchronously reassigns the association
+  // (`node.parent = other`) with a new FK. Once RFC 0063 made `save` genuinely
+  // await the validation chain, that window widened enough for the stale query
+  // to resolve mid-save and `syncToAssociationInstance` clobber the
+  // freshly-assigned holder target with the old record — dropping the FK change
+  // from `previousChanges`. If the owner's stale key moved off the snapshot we
+  // queried, the fetched record is stale: leave the holder's newer target
+  // intact and return it instead of the stale row.
+  const fkMovedDuringLoad = staleCols.some(
+    (col, i) => record._readAttribute(col) !== staleSnapshot[i],
+  );
+  if (fkMovedDuringLoad) {
+    const holder = record._associationInstances.get(assocName) as
+      | { isLoaded?: () => boolean; target?: Base | null }
+      | undefined;
+    if (holder?.isLoaded?.()) return holder.target ?? null;
+  }
+
+  // Set inverse_of: store reference back to the owner. Resolve via the
+  // reflection so automatic_inverse_of also wires the parent — mirrors
+  // ActiveRecord::Associations::Association#set_inverse_instance.
+  if (result) {
+    const inverseName = _resolveInverseName(ctor, assocName, options);
+    if (inverseName) _wireInverseAssociation(record, result, inverseName);
+  }
+
+  syncToAssociationInstance(record, assocName, result);
+  return result;
 }

--- a/packages/activerecord/src/delegate.ts
+++ b/packages/activerecord/src/delegate.ts
@@ -1,5 +1,6 @@
 import type { Base } from "./base.js";
-import { loadBelongsTo, loadHasOne } from "./associations.js";
+import { loadHasOne } from "./associations.js";
+import { findTarget } from "./associations/singular-association.js";
 import type { AssociationDefinition } from "./associations.js";
 import { upcaseFirst } from "@blazetrails/activesupport";
 
@@ -38,7 +39,7 @@ export function delegate(
 
         let target: Base | null = null;
         if (assocDef.type === "belongsTo") {
-          target = await loadBelongsTo(this, assocName, assocDef.options);
+          target = await findTarget(this, assocName, assocDef.options);
         } else if (assocDef.type === "hasOne") {
           target = await loadHasOne(this, assocName, assocDef.options);
         }

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -49,7 +49,6 @@ export {
   Associations,
   registerModel,
   modelRegistry,
-  loadBelongsTo,
   loadHasOne,
   buildHasOne,
   buildBelongsTo,

--- a/packages/activerecord/src/strict-loading.test.ts
+++ b/packages/activerecord/src/strict-loading.test.ts
@@ -4,6 +4,7 @@
  * Targets: vendor/rails/activerecord/test/cases/strict_loading_test.rb
  */
 import { describe, it, expect, beforeAll } from "vitest";
+import { findTarget } from "./associations/singular-association.js";
 import { Notifications } from "@blazetrails/activesupport";
 import {
   Base,
@@ -12,7 +13,7 @@ import {
   actionOnStrictLoadingViolation,
   setActionOnStrictLoadingViolation,
 } from "./index.js";
-import { association, loadBelongsTo, loadHasOne } from "./associations.js";
+import { association, loadHasOne } from "./associations.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { Developer, AuditLog, AuditLogRequired } from "./test-helpers/models/developer.js";
 import { Ship } from "./test-helpers/models/ship.js";
@@ -568,7 +569,7 @@ describe("StrictLoadingTest", () => {
     await developer!.updateColumn("mentor_id", mentor.id);
 
     await expect(
-      loadBelongsTo(developer!, "strictLoadingMentor", {
+      findTarget(developer!, "strictLoadingMentor", {
         className: "Mentor",
         foreignKey: "mentor_id",
         strictLoading: true,
@@ -583,7 +584,7 @@ describe("StrictLoadingTest", () => {
       const developer = await Developer.first();
       await developer!.updateColumn("mentor_id", mentor.id);
 
-      await expect(loadBelongsTo(developer!, "mentor", { className: "Mentor" })).rejects.toThrow(
+      await expect(findTarget(developer!, "mentor", { className: "Mentor" })).rejects.toThrow(
         StrictLoadingViolationError,
       );
     });
@@ -596,7 +597,7 @@ describe("StrictLoadingTest", () => {
       const developer = await Developer.first();
       await developer!.updateColumn("mentor_id", mentor.id);
 
-      const loaded = await loadBelongsTo(developer!, "strictLoadingOffMentor", {
+      const loaded = await findTarget(developer!, "strictLoadingOffMentor", {
         className: "Mentor",
         foreignKey: "mentor_id",
         strictLoading: false,
@@ -613,7 +614,7 @@ describe("StrictLoadingTest", () => {
 
     const developer = (await Developer.all().includes("strictLoadingMentor").first())!;
 
-    const loaded = await loadBelongsTo(developer, "strictLoadingMentor", {
+    const loaded = await findTarget(developer, "strictLoadingMentor", {
       className: "Mentor",
       foreignKey: "mentor_id",
       strictLoading: true,
@@ -629,7 +630,7 @@ describe("StrictLoadingTest", () => {
       await first!.updateColumn("mentor_id", mentor.id);
 
       const developer = (await Developer.all().includes("mentor").first())!;
-      const loaded = await loadBelongsTo(developer, "mentor", { className: "Mentor" });
+      const loaded = await findTarget(developer, "mentor", { className: "Mentor" });
       expect(loaded?.id).toBe(mentor.id);
     });
   });
@@ -832,7 +833,7 @@ describe("StrictLoadingTest", () => {
     treasure.strictLoadingBang();
     expect(treasure.isStrictLoading()).toBe(true);
 
-    await expect(loadBelongsTo(treasure, "looter", { polymorphic: true })).rejects.toThrow(
+    await expect(findTarget(treasure, "looter", { polymorphic: true })).rejects.toThrow(
       "`Treasure` is marked for strict_loading. " +
         "The polymorphic association named `:looter` cannot be lazily loaded.",
     );
@@ -853,7 +854,7 @@ describe("StrictLoadingTest", () => {
       logged = event.payload.reflection.strictLoadingViolationMessage(event.payload.owner);
     });
     try {
-      await loadBelongsTo(treasure, "looter", { polymorphic: true });
+      await findTarget(treasure, "looter", { polymorphic: true });
       expect(logged).toBe(
         "`Treasure` is marked for strict_loading. " +
           "The polymorphic association named `:looter` cannot be lazily loaded.",

--- a/packages/activerecord/src/strict-loading.trails.test.ts
+++ b/packages/activerecord/src/strict-loading.trails.test.ts
@@ -8,8 +8,9 @@
  * convention file tracks Rails 1:1.
  */
 import { describe, it, expect } from "vitest";
+import { findTarget } from "./associations/singular-association.js";
 import { StrictLoadingViolationError, registerModel } from "./index.js";
-import { loadBelongsTo, loadHasOne, loadHasMany, loadHabtm } from "./associations.js";
+import { loadHasOne, loadHasMany, loadHabtm } from "./associations.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { Developer, AuditLog } from "./test-helpers/models/developer.js";
 import { Ship } from "./test-helpers/models/ship.js";
@@ -60,7 +61,7 @@ describe("StrictLoadingNewRecordFindTargetTest", () => {
   it("does not raise on lazy loading a belongs_to on a new strict-loading owner without the foreign key", async () => {
     const developer = new Developer({ name: "New Dev" });
     developer.strictLoadingBang();
-    await expect(loadBelongsTo(developer, "firm", optionsFor("firm"))).resolves.toBeNull();
+    await expect(findTarget(developer, "firm", optionsFor("firm"))).resolves.toBeNull();
   });
 
   it("does not raise on lazy loading a habtm on a new strict-loading owner without the foreign key", async () => {
@@ -77,14 +78,14 @@ describe("StrictLoadingNewRecordFindTargetTest", () => {
     developer.firm_id = null as unknown as number;
     developer.strictLoadingBang();
     expect(developer.isNewRecord()).toBe(false);
-    await expect(loadBelongsTo(developer, "firm", optionsFor("firm"))).resolves.toBeNull();
+    await expect(findTarget(developer, "firm", optionsFor("firm"))).resolves.toBeNull();
   });
 
   it("raises on lazy loading a belongs_to on a new strict-loading owner with the foreign key present", async () => {
     const developer = new Developer({ name: "New Dev", firm_id: 1 });
     developer.strictLoadingBang();
     expect(developer.isNewRecord()).toBe(true);
-    await expect(loadBelongsTo(developer, "firm", optionsFor("firm"))).rejects.toThrow(
+    await expect(findTarget(developer, "firm", optionsFor("firm"))).rejects.toThrow(
       StrictLoadingViolationError,
     );
   });

--- a/packages/activerecord/src/test-helpers/models/bulb.ts
+++ b/packages/activerecord/src/test-helpers/models/bulb.ts
@@ -3,7 +3,8 @@ import type { Relation } from "../../relation.js";
 import type { Car } from "./car.js";
 // vendor/rails/activerecord/test/models/bulb.rb
 import { Base } from "../../base.js";
-import { association, loadBelongsTo } from "../../associations.js";
+import { association } from "../../associations.js";
+import { findTarget } from "../../associations/singular-association.js";
 
 export class Bulb extends Base {
   declare car: Car | null;
@@ -35,7 +36,7 @@ export class Bulb extends Base {
     });
     this.afterCreate(async (record: Bulb) => {
       record.countAfterCreate = await Bulb.unscoped(async () => {
-        const car = await loadBelongsTo(record, "car", {});
+        const car = await findTarget(record, "car", {});
         return car ? await association(car, "bulbs").count() : undefined;
       });
     });

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/singular-association.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/singular-association.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "associations/singular-association.ts",
+    "rubyName": "find_target",
+    "call": "first",
+    "reason": "Rails' `super.then(&:first)` is Array#first over the array Association#find_target already loaded, not Relation#first; the take() (unordered LIMIT 1) here is the SQL-level equivalent — Relation#first would route through ordered_relation and add the ORDER BY that has_one_associations_test `test_has_one_does_not_use_order_by` forbids. The statement-cache branch's literal .first() lives in the extracted _loadSingularViaStatementCache helper (associations.ts)."
+  }
+]


### PR DESCRIPTION
Relocates the `loadBelongsTo` engine function out of `associations.ts` into its
Rails-layout home and renames it to the Rails method name.

## What moved

`loadBelongsTo` (~210 LOC, the belongs_to target load) →
`packages/activerecord/src/associations/singular-association.ts` as
`findTarget`, mirroring
`ActiveRecord::Associations::SingularAssociation#find_target`
(`vendor/rails/activerecord/lib/active_record/associations/singular_association.rb:47`).
The body is moved verbatim; only the name and the file changed.

### Why `singular-association.ts` and not `belongs-to-association.ts`

`belongs_to_association.rb` defines no `find_target` of its own — Rails inherits
the singular one and specializes only the `find_target?` predicate
(`belongs_to_association.rb:124`), which is already ported as the
`_findTargetReachable(..., "belongsTo")` gate inside the moved body and as
`BelongsToAssociation#findTargetNeeded`. `api:compare` matches on name +
Rails-layout file and does not consult ancestor files, so naming a `findTarget`
under the belongs_to file would have created a *new* novel extra rather than
clearing one. The rationale is recorded at the declaration site, not just here.

It replaces the `@internal` `findTarget` stub that previously held the name in
that file. The tag is retained (auto-applied by the `rails-private-jsdoc` lint
rule, since Rails' `find_target` is private).

### Supporting changes

- Helpers the body needs are now exported from `associations.ts`. All are either
  `_`-prefixed (the repo's Rails-private convention) or carry `@internal`, so
  none of them add extra surface.
- The `loadBelongsTo` re-export is dropped from `index.ts` — Rails does not
  expose the loader at the `ActiveRecord::` level.
- Every call site uses the unaliased Rails name `findTarget`.
- The generated `record.loadBelongsTo(name)` reader sugar
  (`associations/instance-methods.ts`) is unchanged and out of scope per the
  story.

## Wide call-set ratchet

Converging the body onto `find_target` makes it eligible for wide call-set
comparison for the first time (as a novel extra under `associations.ts` it was
never matched to a Rails method, so no call comparison ran). That surfaced one
new flag: Rails' `super.then(&:first)` (`singular_association.rb:53`).

That `first` is `Array#first` over the array `Association#find_target` has
already loaded — not `Relation#first`. Our `take()` (unordered `LIMIT 1`) is the
SQL-level equivalent; `Relation#first` would route through `ordered_relation`
and add the `ORDER BY` that `has_one_associations_test`
`test_has_one_does_not_use_order_by` forbids — which is why the moved body
already carried exactly that comment. The statement-cache branch's literal
`.first()` lives in the extracted `_loadSingularViaStatementCache` helper.

Recorded in
`call-mismatches-wide-exclude/activerecord/associations/singular-association.json`
with that reason, following the existing `foreign_key_present?` "satisfied via
the extracted helper" precedent in the sibling `has-one-association.json`. This
is a satisfied-by-another-path entry, not deferred work.

## Extra-surface delta

`pnpm api:compare && pnpm api:extra --package activerecord --novel-only`:

| | before | after |
| --- | --- | --- |
| `associations.ts` novel extras | 14 | 13 |
| `associations/singular-association.ts` novel extras | 0 | 0 |

`api:compare` totals unchanged: `Overall: 11678/17484 (66.8%) | files: 763/1019
| arity: 7432/7515`. `associations/singular_association.rb` stays 10/10 matched,
`associations/belongs_to_association.rb` stays 21/21.

## Verification

- `pnpm typecheck` and `pnpm lint` clean.
- Every gate in the `Rails API/Test Comparison` CI job re-run locally in CI
  order: compare, compare --privates, call-mismatches ratchet (15 baselined),
  arity excludes, body pins, wide call ratchet (4972 baselined), conventions
  doc — all green.
- Suites run (1394 passing, 4 pre-existing skips): `associations.test.ts`,
  `associations/join-model.test.ts`, `associations/inverse-associations.test.ts`,
  `associations/belongs-to-associations.test.ts`,
  `associations/has-one-associations.test.ts`,
  `associations/has-many-associations.test.ts`, `associations/eager.test.ts`,
  `associations/association-scope-cache.test.ts`, `autosave-association.test.ts`,
  `strict-loading.test.ts`, `strict-loading.trails.test.ts`.
- No test renames; only direct functional call sites were retargeted.
- **Module-init check.** The move adds an `associations.ts` →
  `associations/singular-association.ts` import edge, closing an ESM cycle, so I
  probed direct-entry import of every module in the cycle against a
  built `origin/main` baseline. `dist/index.js` and `dist/base.js` (the real
  entry points) import cleanly both before and after; the deep-submodule
  direct-entry TDZ errors are byte-identical to baseline and therefore
  pre-existing, not introduced here.

## Size

622 LOC changed (332+/290-), above the 500 ceiling. ~420 of that is the same
~210-line body deleted from one file and re-added to another — an unavoidable
floor for a relocation story of this size (the story itself scopes it at
"~210 LOC"). The remaining ~200 lines are the call-site and import updates
across 14 files. No behavior change; `git diff -M` reads it as a move.

Closes-story: extra-surface-relocate-load-belongs-to
