### PR TITLE
refactor(associations): delete dead loadHabtm

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1,7 +1,5 @@
 import type { Base } from "./base.js";
 import type { Relation } from "./relation.js";
-import { Table as ArelTable } from "@blazetrails/arel";
-import { Connection as TypeCasterConnection } from "./type-caster/connection.js";
 import { SpellChecker } from "@blazetrails/did-you-mean";
 import type { CollectionProxy, AssociationProxy } from "./associations/collection-proxy.js";
 import { _CollectionProxyCtor } from "./associations/collection-proxy-slot.js";
@@ -2326,25 +2324,6 @@ function singleFk(fk: string | string[] | undefined, fallback: string): string {
 }
 
 /**
- * Resolve the owner primary key column for HABTM.
- *
- * Rails' `Builder::HasAndBelongsToMany` does not forward `:primary_key`
- * to the generated middle `has_many :through` or to the rhs `belongs_to`
- * (see `middle_options` / `belongs_to_options` —
- * activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb).
- * The owner-side join always resolves to the model's primary key.
- *
- * @internal
- */
-function habtmOwnerPk(_options: AssociationOptions, ctor: typeof Base): string {
-  const pk = ctor.primaryKey;
-  if (Array.isArray(pk)) {
-    throw new ConfigurationError("HABTM associations do not support composite primary keys");
-  }
-  return pk;
-}
-
-/**
  * Compute the default HABTM join-table name.
  *
  * Mirrors ActiveRecord::Associations::Builder::HasAndBelongsToMany#table_name:
@@ -2389,80 +2368,38 @@ export function habtmTargetFk(
 }
 
 /**
- * Load a has_and_belongs_to_many association.
+ * Fire one or more association callbacks (before_add, after_add, etc.).
  */
-export async function loadHabtm(
+export function fireAssocCallbacks(
+  cbs:
+    | ((owner: Base, record: Base) => void | false)
+    | ((owner: Base, record: Base) => void | false)[]
+    | undefined,
+  owner: Base,
   record: Base,
-  assocName: string,
-  options: AssociationOptions & { joinTable?: string },
-): Promise<Base[]> {
-  // Check preloaded cache first — an eager-loaded (preloaded) HABTM
-  // association is reachable without a strict-loading violation.
-  const preloaded = _preloadedHolderTarget(record, assocName);
-  if (preloaded) {
-    return (preloaded.value ?? []) as Base[];
+  catchAbort = false,
+): boolean {
+  if (!cbs) return true;
+  const arr = Array.isArray(cbs) ? cbs : [cbs];
+  for (const cb of arr) {
+    // Rails wraps only `before_add`/`before_remove` in `catch(:abort)`
+    // (collection_association.rb:400-402, 462-464). Those callers pass
+    // `catchAbort=true`; an after callback runs outside the catch, so a
+    // `throw :abort` from after_add/after_remove propagates (Rails parity).
+    if (catchAbort) {
+      try {
+        cb(owner, record);
+      } catch (e) {
+        if (!isAbortSignal(e)) throw e;
+        return false;
+      }
+    } else {
+      // after_add/after_remove run outside the catch; their return value is
+      // ignored (Rails 5+ only halts on `throw :abort`, never on `false`).
+      cb(owner, record);
+    }
   }
-
-  // Lazily loading a HABTM on a strict-loading owner (or a reflection marked
-  // `strictLoading: true`) is a violation, just like the other macros. Gated by
-  // `find_target?`: a *new* strict owner without the FK present never reaches
-  // `find_target`, so it returns `[]` without raising.
-  if (
-    _violatesStrictLoading(record, options) &&
-    _findTargetReachable(record, assocName, options, "foreign")
-  ) {
-    strictLoadingViolationBang(record, assocName, {
-      className: options.className ?? camelize(singularize(assocName)),
-    });
-  }
-
-  const ctor = record.constructor as typeof Base;
-  const className = options.className ?? camelize(singularize(assocName));
-  const targetModel = resolveAssocClass(record, assocName, className);
-  const joinTable = options.joinTable ?? defaultJoinTableName(ctor, assocName, options);
-  // Prefer the rich reflection's foreignKey (derived from the class that
-  // *declared* the HABTM, not the STI subclass owner) before the owner-class
-  // fallback — mirrors Rails `reflection.foreign_key`.
-  const ownerFk = singleFk(
-    options.foreignKey ?? ctor._reflectOnAssociation?.(assocName)?.foreignKey,
-    `${underscore(ctor.name)}_id`,
-  );
-  const targetFk = habtmTargetFk(assocName, options as { className?: unknown });
-  const ownerPkCol = habtmOwnerPk(options, ctor);
-  const pkValue = record._readAttribute(ownerPkCol);
-  if (pkValue === null || pkValue === undefined) return [];
-
-  // Reject composite target PKs
-  const targetPkCol = targetModel.primaryKey;
-  if (Array.isArray(targetPkCol)) {
-    throw new Error("HABTM associations do not support composite primary keys on the target model");
-  }
-
-  // Use Arel subquery: SELECT target_fk FROM join_table WHERE owner_fk = ?
-  // The HABTM join table has no model, so its caster comes from the connection
-  // — the same shape as the no-klass branch of `associated_table`
-  // (table_metadata.rb:47-48). `.get(ownerFk).eq(pkValue)` builds a `Casted`,
-  // which reaches the table's caster.
-  const joinArelTable = new ArelTable(joinTable, {
-    typeCaster: new TypeCasterConnection(ctor as never, joinTable),
-  });
-  const subquery = joinArelTable
-    .project(joinArelTable.get(targetFk))
-    .where(joinArelTable.get(ownerFk).eq(pkValue));
-
-  const targetArelTable = targetModel.arelTable;
-  const inNode = targetArelTable.get(targetPkCol).in(subquery);
-
-  // Start from `klass.scope_for_association` so target-model default_scope
-  // / current_scope are honored — matches Rails' `Association#scope` which
-  // builds via `AssociationRelation.create(klass, self).merge!(klass.scope_for_association)`
-  // (collection_association.rb / association.rb). Then apply the join-IN
-  // filter and the caller-supplied scope lambda for query-method
-  // composition (where/order/select/group/having/unscope).
-  let rel: any = _scopeForAssociation(targetModel).where(inNode);
-  rel = applyAssociationScope(rel, options.scope, record);
-
-  return rel.toArray();
+  return true;
 }
 
 /**

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -2368,41 +2368,6 @@ export function habtmTargetFk(
 }
 
 /**
- * Fire one or more association callbacks (before_add, after_add, etc.).
- */
-export function fireAssocCallbacks(
-  cbs:
-    | ((owner: Base, record: Base) => void | false)
-    | ((owner: Base, record: Base) => void | false)[]
-    | undefined,
-  owner: Base,
-  record: Base,
-  catchAbort = false,
-): boolean {
-  if (!cbs) return true;
-  const arr = Array.isArray(cbs) ? cbs : [cbs];
-  for (const cb of arr) {
-    // Rails wraps only `before_add`/`before_remove` in `catch(:abort)`
-    // (collection_association.rb:400-402, 462-464). Those callers pass
-    // `catchAbort=true`; an after callback runs outside the catch, so a
-    // `throw :abort` from after_add/after_remove propagates (Rails parity).
-    if (catchAbort) {
-      try {
-        cb(owner, record);
-      } catch (e) {
-        if (!isAbortSignal(e)) throw e;
-        return false;
-      }
-    } else {
-      // after_add/after_remove run outside the catch; their return value is
-      // ignored (Rails 5+ only halts on `throw :abort`, never on `false`).
-      cb(owner, record);
-    }
-  }
-  return true;
-}
-
-/**
  * Factory to get a CollectionProxy for a has_many association.
  * Returns a cached proxy if one exists on the record.
  */

--- a/packages/activerecord/src/associations/apply-association-scope.test.ts
+++ b/packages/activerecord/src/associations/apply-association-scope.test.ts
@@ -8,7 +8,7 @@
  *
  * The TS helper consolidates the equivalent post-merge step shared by
  * `loadBelongsTo`, `loadHasOne` (×2 — reflection path + inline fallback),
- * `findTarget` (×2), `loadHasManyThrough` (×2), `loadHabtm`,
+ * `findTarget` (×2), `loadHasManyThrough` (×2),
  * `buildHasManyRelation`, and the DJAS-routed `_loadThroughViaDisableJoinsScope`.
  */
 import { describe, it, expect } from "vitest";

--- a/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
+++ b/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
@@ -264,8 +264,8 @@ export class HasAndBelongsToMany {
     // We additionally retain `foreignKey` because our public HABTM
     // reflection plays the dual role Rails splits between
     // `habtm_reflection` (which keeps the full options) and the generated
-    // through-`has_many` — join-key resolution (`_resolveHabtmJoin`)
-    // reads this directly off the public reflection.
+    // through-`has_many` — join-key resolution (`_resolveHabtmJoin`) reads
+    // this directly off the public reflection.
     // `primaryKey` is intentionally NOT forwarded: Rails'
     // `Builder::HasAndBelongsToMany` does not pass `:primary_key` to the
     // middle has_many or rhs belongs_to, so the owner join always uses
@@ -296,10 +296,9 @@ export class HasAndBelongsToMany {
     // `undefined` when callers pass `joinTable: undefined` explicitly.
     // `associationForeignKey` is retained on the reflection options to
     // mirror Rails' `habtm_reflection` (which keeps the full options
-    // hash); note however that `_build` and `_resolveHabtmJoin`
-    // currently hard-code the target FK as
-    // `${singular(name)}_id` — full plumbing into the generated join
-    // model and join SQL is a follow-up.
+    // hash); note however that `_build` and `_resolveHabtmJoin` currently
+    // hard-code the target FK as `${singular(name)}_id` — full plumbing into
+    // the generated join model and join SQL is a follow-up.
     const habtmOptions: Record<string, unknown> = {
       joinTable: joinTableName,
       through: middleName,
@@ -330,9 +329,9 @@ export class HasAndBelongsToMany {
     // Pull `scope:` off the options bag and forward it as the dedicated
     // scope arg on the reflection. Mirrors Rails' Builder::Association,
     // which captures `scope` as a positional arg to `has_and_belongs_to_many`
-    // rather than treating it as a generic option. The through-routing
-    // loaders already check `options.scope` — keeping it
-    // there too means callers who don't go through reflection still see it.
+    // rather than treating it as a generic option. The through-routing loaders
+    // already check `options.scope` — keeping it there too means callers who
+    // don't go through reflection still see it.
     const habtmScope =
       typeof habtmOptions.scope === "function"
         ? (habtmOptions.scope as (...args: any[]) => any)

--- a/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
+++ b/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
@@ -264,8 +264,8 @@ export class HasAndBelongsToMany {
     // We additionally retain `foreignKey` because our public HABTM
     // reflection plays the dual role Rails splits between
     // `habtm_reflection` (which keeps the full options) and the generated
-    // through-`has_many` — join-key resolution (`_resolveHabtmJoin`,
-    // `loadHabtm`) reads this directly off the public reflection.
+    // through-`has_many` — join-key resolution (`_resolveHabtmJoin`)
+    // reads this directly off the public reflection.
     // `primaryKey` is intentionally NOT forwarded: Rails'
     // `Builder::HasAndBelongsToMany` does not pass `:primary_key` to the
     // middle has_many or rhs belongs_to, so the owner join always uses
@@ -296,8 +296,8 @@ export class HasAndBelongsToMany {
     // `undefined` when callers pass `joinTable: undefined` explicitly.
     // `associationForeignKey` is retained on the reflection options to
     // mirror Rails' `habtm_reflection` (which keeps the full options
-    // hash); note however that `_build`, `_resolveHabtmJoin`, and
-    // `loadHabtm` currently hard-code the target FK as
+    // hash); note however that `_build` and `_resolveHabtmJoin`
+    // currently hard-code the target FK as
     // `${singular(name)}_id` — full plumbing into the generated join
     // model and join SQL is a follow-up.
     const habtmOptions: Record<string, unknown> = {
@@ -330,8 +330,8 @@ export class HasAndBelongsToMany {
     // Pull `scope:` off the options bag and forward it as the dedicated
     // scope arg on the reflection. Mirrors Rails' Builder::Association,
     // which captures `scope` as a positional arg to `has_and_belongs_to_many`
-    // rather than treating it as a generic option. `loadHabtm` (and the
-    // through-routing loaders) already check `options.scope` — keeping it
+    // rather than treating it as a generic option. The through-routing
+    // loaders already check `options.scope` — keeping it
     // there too means callers who don't go through reflection still see it.
     const habtmScope =
       typeof habtmOptions.scope === "function"

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -53,7 +53,6 @@ export {
   loadHasManyThrough,
   association,
   isAssociationCached,
-  loadHabtm,
   updateCounterCaches,
   eagerLoadBang,
 } from "./associations.js";

--- a/packages/activerecord/src/strict-loading.trails.test.ts
+++ b/packages/activerecord/src/strict-loading.trails.test.ts
@@ -1,9 +1,9 @@
 /**
  * trails-specific strict-loading invariants with no Rails counterpart.
  *
- * These guard the functional loaders' `find_target?` gate (a new-record
- * strict-loading owner WITHOUT the foreign key present returns nil/[] silently
- * instead of raising). They were relocated verbatim out of
+ * These guard the `find_target?` gate (a new-record strict-loading owner
+ * WITHOUT the foreign key present returns nil/[] silently instead of
+ * raising). They were relocated verbatim out of
  * strict-loading.test.ts (which mirrors strict_loading_test.rb) so the
  * convention file tracks Rails 1:1.
  */
@@ -22,7 +22,7 @@ interface ReflectionHost {
   _reflectOnAssociation(name: string): { options: Record<string, unknown> };
 }
 
-// The functional loaders mirror Rails' `find_target?` gate (association.rb:320):
+// The loaders mirror Rails' `find_target?` gate (association.rb:320):
 // `violates_strict_loading?` is reached only from inside `find_target`, which
 // `find_target?` enters when `!owner.new_record? || foreign_key_present?`. So a
 // new-record strict-loading owner WITHOUT the foreign key present returns nil/[]
@@ -70,9 +70,6 @@ describe("StrictLoadingNewRecordFindTargetTest", () => {
   it("does not raise on lazy loading a habtm on a new strict-loading owner without the foreign key", async () => {
     const developer = new Developer({ name: "New Dev" });
     developer.strictLoadingBang();
-    // HABTM has no association class of its own: `Builder::HasAndBelongsToMany`
-    // rewrites it into a `has_many :through`, so the load runs through the
-    // through association's `find_target` rather than a bespoke habtm loader.
     await expect(developer.projects.toArray()).resolves.toEqual([]);
   });
 

--- a/packages/activerecord/src/strict-loading.trails.test.ts
+++ b/packages/activerecord/src/strict-loading.trails.test.ts
@@ -22,13 +22,25 @@ interface ReflectionHost {
   _reflectOnAssociation(name: string): { options: Record<string, unknown> };
 }
 
-// The loaders mirror Rails' `find_target?` gate (association.rb:320):
-// `violates_strict_loading?` is reached only from inside `find_target`, which
-// `find_target?` enters when `!owner.new_record? || foreign_key_present?`. So a
-// new-record strict-loading owner WITHOUT the foreign key present returns nil/[]
-// silently instead of raising; once the FK (belongs_to) or owner PK
-// (has_one/has_many/habtm via `ForeignAssociation#foreign_key_present?`) is
-// present, it raises again. Uses the canonical `Developer` and friends — the
+// The loaders mirror Rails' `find_target?` gate
+// (association.rb:320-321): `violates_strict_loading?` is reached only from
+// inside `find_target`, which `find_target?` enters when
+// `!owner.new_record? || foreign_key_present?`. So a new-record strict-loading
+// owner WITHOUT the foreign key present returns nil/[] silently instead of
+// raising; once the FK (belongs_to) or owner PK (has_one/has_many via
+// `ForeignAssociation#foreign_key_present?`) is present, it raises again.
+//
+// HABTM is NOT in that second group. Rails installs it as
+// `has_many name, scope, **hm_options` through a generated middle reflection
+// (associations.rb:1896-1905), so the runtime association is
+// `HasManyThroughAssociation` and `foreign_key_present?` comes from
+// `ThroughAssociation` (through_association.rb:90-93), which is true only when
+// the through reflection is a `belongs_to`. The middle reflection is a
+// `has_many` onto the join model, so it is always false — a new HABTM owner
+// never reaches `find_target` no matter what the owner PK holds, and only a
+// persisted owner raises.
+//
+// Uses the canonical `Developer` and friends — the
 // same models Rails' strict_loading_test.rb drives (`has_many :audit_logs`,
 // `has_one :ship`, `belongs_to :firm`, `has_and_belongs_to_many :projects`).
 describe("StrictLoadingNewRecordFindTargetTest", () => {

--- a/packages/activerecord/src/strict-loading.trails.test.ts
+++ b/packages/activerecord/src/strict-loading.trails.test.ts
@@ -10,7 +10,7 @@
 import { describe, it, expect } from "vitest";
 import { findTarget } from "./associations/singular-association.js";
 import { StrictLoadingViolationError, registerModel } from "./index.js";
-import { loadHasOne, loadHabtm } from "./associations.js";
+import { loadHasOne } from "./associations.js";
 import { findTarget as findHasManyTarget } from "./associations/has-many-association.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { Developer, AuditLog } from "./test-helpers/models/developer.js";
@@ -70,7 +70,10 @@ describe("StrictLoadingNewRecordFindTargetTest", () => {
   it("does not raise on lazy loading a habtm on a new strict-loading owner without the foreign key", async () => {
     const developer = new Developer({ name: "New Dev" });
     developer.strictLoadingBang();
-    await expect(loadHabtm(developer, "projects", optionsFor("projects"))).resolves.toEqual([]);
+    // HABTM has no association class of its own: `Builder::HasAndBelongsToMany`
+    // rewrites it into a `has_many :through`, so the load runs through the
+    // through association's `find_target` rather than a bespoke habtm loader.
+    await expect(developer.projects.toArray()).resolves.toEqual([]);
   });
 
   it("does not raise on lazy loading a belongs_to on a persisted strict-loading owner without the foreign key", async () => {


### PR DESCRIPTION
## What

`loadHabtm` (`associations.ts`, ~73 LOC) is **dead code**. Rails has no HABTM
association class: `Builder::HasAndBelongsToMany` rewrites `has_and_belongs_to_many`
into a `has_many :through`, and trails already does the same at `declare` time
(`associations.ts:797`, `HabtmBuilder.build`). Every real HABTM load therefore runs
through the has_many-through path — `loadHabtm` had **no production callers**, only
the `index.ts` re-export and one trails-only test.

So neither relocation option from the story applies: there is no distinct body to
fold into a through `findTarget`, and giving it a home in
`builder/has-and-belongs-to-many.ts` would preserve an invention. It is deleted.

- Deleted `loadHabtm` and its now-unused private helper `habtmOwnerPk`.
- Dropped the `loadHabtm` re-export from `packages/activerecord/src/index.ts`.
- `strict-loading.trails.test.ts`'s habtm case now drives the real path
  (`developer.projects.toArray()`) instead of the deleted loader. Test name unchanged.
- Refreshed the comments that referenced `loadHabtm`.

No repo-wide references to `loadHabtm` remain (source, tests, manifests, docs).

## Coverage is preserved, not just kept compiling

The habtm case guards the `find_target?` gate: a *new* strict-loading owner without
the key present must return `[]` silently rather than raising. Verified the rewritten
test is still a real gate by temporarily asserting the opposite on a **persisted**
strict-loading owner — `developer.projects.toArray()` does reject with
`StrictLoadingViolationError` there, so the new-record case is not vacuously passing.
The probe was removed before commit.

## api:extra (activerecord, `--novel-only`)

| | `associations.ts` novel |
|---|---|
| before | 5 |
| after | 4 |

Drop of exactly 1, matching the single name in this story. (Re-measured against
`origin/main` after the rebase — sibling stories have since cleared other names
from this file, so the absolute counts are lower than at first push.)

## Tests

`strict-loading.trails.test.ts`, `strict-loading.test.ts`, `associations/habtm.test.ts`,
`associations/has-and-belongs-to-many-associations.test.ts` — all pass (157 tests).
ESLint and `tsc --build` clean on the touched files.

Closes-story: extra-surface-relocate-load-habtm
