### PR TITLE
refactor(associations): relocate through-association target loads to their Rails homes

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -77,12 +77,6 @@ import {
   CompositePrimaryKeyMismatchError,
 } from "./associations/errors.js";
 import { AssociationScope, invokeScopeLambda } from "./associations/association-scope.js";
-// Cyclic with `has-many-association.ts`, which imports this module's
-// `@internal` loader helpers back. The cycle is function-level only — neither
-// side touches the other at module-evaluation time — so whichever module is
-// entered first, the hoisted function declarations are already bound by the
-// time either is called.
-import { findTarget as findHasManyTarget } from "./associations/has-many-association.js";
 import type { Association as AssociationInstance } from "./associations/association.js";
 import {
   validateThroughReflection,
@@ -109,7 +103,6 @@ import type { AssociationReflection } from "./reflection.js";
 import { hasQueryConstraints, queryConstraintsList } from "./persistence.js";
 import { foreignKeyPresentFor } from "./associations/foreign-association.js";
 import { throughForeignKeyPresent } from "./associations/through-association.js";
-import { findTarget } from "./associations/singular-association.js";
 
 /**
  * One `before_add`/`after_add`/`before_remove`/`after_remove` entry. Mirrors
@@ -840,7 +833,7 @@ export function _canRouteThroughViaAssociationScope(
  * gate.
  *
  * A nested-through association on an UNSAVED owner is kept on the 2-step
- * `loadHasManyThrough` / IN-subquery loader: the SQL JOIN can only see through
+ * `HasManyThroughAssociation#findTarget` / IN-subquery loader: the SQL JOIN can only see through
  * rows already in the database, not an in-memory-assigned through target
  * (`post.author = mary` before save). Rails resolves those from the loaded
  * through target via `find_target?`; our 2-step loader mirrors that. Once the
@@ -886,7 +879,7 @@ export function _ownerChainReflection(reflection: any): any {
  * Disable-joins routing gate. Mirrors `_canRouteThroughViaAssociationScope`
  * but for `disable_joins: true` through associations — runs the chain
  * via the Rails-faithful `DisableJoinsAssociationScope` (per-step pluck
- * + IN list) rather than the legacy `loadHasManyThrough` 2-step.
+ * + IN list) rather than the legacy `HasManyThroughAssociation#findTarget` 2-step.
  *
  * Currently routes: single-column and composite-key through
  * associations (PR #645), polymorphic-source + `sourceType`
@@ -971,7 +964,7 @@ export function _scopeForAssociation(model: typeof Base): Relation<Base> {
  * the exact same function reference. AssociationScope already merges
  * `reflection.scope` (the macro-time lambda) via `scopeFor`; re-applying
  * would double-merge. Callers that synthesize a NEW lambda (e.g.
- * `loadHasManyThrough` wrapping with `sourceType` filtering) pass a
+ * `HasManyThroughAssociation#findTarget` wrapping with `sourceType` filtering) pass a
  * different reference and still run.
  *
  * @internal
@@ -1429,7 +1422,7 @@ export async function loadHasOne(
 
   // Handle has_one :through. Same routing rules as findTarget —
   // route through AssociationScope's JOIN-based path for the simple
-  // shape; everything else falls back to the 2-step loadHasOneThrough.
+  // shape; everything else falls back to the 2-step `HasOneThroughAssociation#findTarget`.
   if (options.through) {
     const ctorEarly = record.constructor as typeof Base;
     const reflEarly = ctorEarly._reflectOnAssociation?.(assocName);
@@ -1437,7 +1430,8 @@ export async function loadHasOne(
       return _loadSingularThroughViaDisableJoinsScope(record, reflEarly, options);
     }
     if (!_routeThroughViaAssociationScope(record, reflEarly, options)) {
-      return loadHasOneThrough(record, assocName, options);
+      const { findTarget } = await import("./associations/has-one-through-association.js");
+      return findTarget(record, assocName, options);
     }
     // Fall through into the AssociationScope path below.
   }
@@ -1982,7 +1976,7 @@ export async function countHasMany(
     // loading so the count works on strict-loading models.
     record._strictLoadingBypassCount++;
     try {
-      // Preserve loadHasManyThrough's loud failure for a misconfigured through:
+      // Preserve `HasManyThroughAssociation#findTarget`'s loud failure for a misconfigured through:
       // buildThroughJoinScope returns null for a missing reflection, which would
       // otherwise silently count as 0.
       const ctor = record.constructor as typeof Base;
@@ -2014,182 +2008,6 @@ export async function countHasMany(
     );
   }
   return result;
-}
-
-/**
- * Load a has_many :through association.
- */
-export async function loadHasManyThrough(
-  record: Base,
-  assocName: string,
-  options: AssociationOptions,
-): Promise<Base[]> {
-  const ctor = record.constructor as typeof Base;
-  const associations: AssociationDefinition[] = ctor._associations ?? [];
-  const throughAssoc = associations.find((a) => a.name === options.through);
-  if (!throughAssoc) {
-    throw _hmtNotFound(ctor, assocName, options.through!);
-  }
-
-  // Resolve the target model
-  const className = options.className ?? camelize(singularize(assocName));
-  const targetModel = resolveAssocClass(record, assocName, className);
-
-  // The source defaults to the singularized association name
-  const sourceName = options.source ?? singularize(assocName);
-
-  // Look up the source association on the through model early so we can
-  // push sourceType filtering into the through query
-  const throughClassName =
-    throughAssoc.options.className ?? camelize(singularize(throughAssoc.name));
-  const throughModel = resolveAssocClass(record, throughAssoc.name, throughClassName);
-  const throughModelAssocs: AssociationDefinition[] = throughModel._associations ?? [];
-  const sourceAssoc =
-    throughModelAssocs.find((a) => a.name === sourceName) ??
-    throughModelAssocs.find((a) => a.name === pluralize(sourceName));
-  const sourceAssocKind = sourceAssoc?.type ?? "belongsTo";
-
-  // Load through records
-  let throughRecords: Base[];
-  if (throughAssoc.type === "hasMany") {
-    // If sourceType is set, add the type filter to the through query
-    if (
-      options.sourceType &&
-      sourceAssoc?.options?.polymorphic &&
-      sourceAssocKind === "belongsTo"
-    ) {
-      const resolvedSourceName = sourceAssoc?.name ?? sourceName;
-      const sourceTypeCol = `${underscore(resolvedSourceName)}_type`;
-      const originalScope = throughAssoc.options.scope;
-      const augmentedOptions = {
-        ...throughAssoc.options,
-        scope: (rel: any) => {
-          let r = rel.where({ [sourceTypeCol]: options.sourceType });
-          if (originalScope) r = originalScope(r);
-          return r;
-        },
-      };
-      throughRecords = await findHasManyTarget(record, throughAssoc.name, augmentedOptions);
-    } else {
-      throughRecords = await findHasManyTarget(record, throughAssoc.name, throughAssoc.options);
-    }
-  } else if (throughAssoc.type === "hasOne") {
-    const one = await loadHasOne(record, throughAssoc.name, throughAssoc.options);
-    throughRecords = one ? [one] : [];
-  } else if (throughAssoc.type === "belongsTo") {
-    const one = await findTarget(record, throughAssoc.name, throughAssoc.options);
-    throughRecords = one ? [one] : [];
-  } else {
-    throughRecords = [];
-  }
-
-  if (throughRecords.length === 0) return [];
-
-  if (sourceAssocKind === "belongsTo") {
-    // Through record has FK pointing to target (e.g., tagging.tag_id -> tag.id)
-    const targetFk = sourceAssoc?.options?.foreignKey ?? `${underscore(sourceName)}_id`;
-
-    const targetIds = throughRecords
-      .map((r) => r._readAttribute(targetFk as string))
-      .filter((v) => v !== null && v !== undefined);
-    if (targetIds.length === 0) return [];
-    let rel = targetModel.all().where({ [targetModel.primaryKey as string]: targetIds });
-    rel = applyAssociationScope(rel, options.scope, record);
-    return rel.toArray();
-  } else if (sourceAssoc?.options?.through) {
-    // Nested through: the source association is itself a :through association
-    // (e.g. Categorization.post_taggings -> author.taggings, where
-    // author.taggings is `through: :posts`). Resolve it recursively on each
-    // through record rather than assuming a direct FK to the through table.
-    const results: Base[] = [];
-    for (const tr of throughRecords) {
-      const sub = await findHasManyTarget(tr, sourceAssoc.name, sourceAssoc.options);
-      results.push(...sub);
-    }
-    if (!options.scope) return results;
-    // Re-apply the outer association's own scope (e.g. an `order`/`where` on
-    // the nested HMT) by reloading the resolved targets through it.
-    const ids = results
-      .map((r) => r._readAttribute(targetModel.primaryKey as string))
-      .filter((v) => v !== null && v !== undefined);
-    if (ids.length === 0) return [];
-    const rel3 = applyAssociationScope(
-      targetModel.all().where({ [targetModel.primaryKey as string]: ids }),
-      options.scope,
-      record,
-    );
-    return rel3.toArray();
-  } else {
-    // Source is has_many/has_one: target has FK pointing back to through record
-    const sourceAsName = sourceAssoc?.options?.as;
-    const throughClassName =
-      throughAssoc.options.className ?? camelize(singularize(throughAssoc.name));
-    const sourceFk = sourceAsName
-      ? (sourceAssoc?.options?.foreignKey ?? `${underscore(sourceAsName)}_id`)
-      : (sourceAssoc?.options?.foreignKey ?? `${underscore(throughClassName)}_id`);
-    const throughIds = throughRecords
-      .map((r) => r._readAttribute((r.constructor as typeof Base).primaryKey as string))
-      .filter((v) => v !== null && v !== undefined);
-    if (throughIds.length === 0) return [];
-    const whereConditions: Record<string, unknown> = { [sourceFk as string]: throughIds };
-    if (sourceAsName) whereConditions[`${underscore(sourceAsName)}_type`] = throughClassName;
-    let rel2 = targetModel.all().where(whereConditions);
-    rel2 = applyAssociationScope(rel2, options.scope, record);
-    return rel2.toArray();
-  }
-}
-
-/**
- * Load a has_one :through association.
- */
-export async function loadHasOneThrough(
-  record: Base,
-  assocName: string,
-  options: AssociationOptions,
-): Promise<Base | null> {
-  const ctor = record.constructor as typeof Base;
-  const associations: AssociationDefinition[] = ctor._associations ?? [];
-  const throughAssoc = associations.find((a) => a.name === options.through);
-  if (!throughAssoc) {
-    throw _hmtNotFound(ctor, assocName, options.through!);
-  }
-
-  // Load the through record (could be has_one or belongs_to)
-  let throughRecord: Base | null;
-  if (throughAssoc.type === "hasOne") {
-    throughRecord = await loadHasOne(record, throughAssoc.name, throughAssoc.options);
-  } else if (throughAssoc.type === "belongsTo") {
-    throughRecord = await findTarget(record, throughAssoc.name, throughAssoc.options);
-  } else if (throughAssoc.type === "hasMany") {
-    const throughRecords = await findHasManyTarget(record, throughAssoc.name, throughAssoc.options);
-    throughRecord = throughRecords[0] ?? null;
-  } else {
-    throughRecord = null;
-  }
-
-  if (!throughRecord) return null;
-
-  // Now load the source from the through record
-  const sourceName = options.source ?? assocName;
-  const throughCtor = throughRecord.constructor as typeof Base;
-  const throughAssociations: AssociationDefinition[] = throughCtor._associations ?? [];
-  const sourceAssoc = throughAssociations.find((a) => a.name === sourceName);
-
-  if (sourceAssoc) {
-    if (sourceAssoc.type === "belongsTo") {
-      return findTarget(throughRecord, sourceName, sourceAssoc.options);
-    } else if (sourceAssoc.type === "hasOne") {
-      return loadHasOne(throughRecord, sourceName, sourceAssoc.options);
-    }
-  }
-
-  // Fallback: try as belongs_to by convention
-  const className = options.className ?? camelize(sourceName);
-  const targetFk = `${underscore(sourceName)}_id`;
-  const fkValue = throughRecord._readAttribute(targetFk);
-  if (fkValue === null || fkValue === undefined) return null;
-  const targetModel = resolveAssocClass(throughRecord, sourceName, className);
-  return targetModel.findBy({ [targetModel.primaryKey as string]: fkValue });
 }
 
 /**
@@ -2280,7 +2098,7 @@ function createHabtmJoinModel(
     configurable: true,
   });
 
-  // Add belongsTo associations matching what loadHasManyThrough expects
+  // Add belongsTo associations matching what `HasManyThroughAssociation#findTarget` expects
   const joinAssocs: AssociationDefinition[] = [];
   joinAssocs.push({
     type: "belongsTo",

--- a/packages/activerecord/src/associations/apply-association-scope.test.ts
+++ b/packages/activerecord/src/associations/apply-association-scope.test.ts
@@ -8,7 +8,7 @@
  *
  * The TS helper consolidates the equivalent post-merge step shared by
  * `loadBelongsTo`, `loadHasOne` (×2 — reflection path + inline fallback),
- * `findTarget` (×2), `loadHasManyThrough` (×2),
+ * `HasManyAssociation#findTarget` (×2), `HasManyThroughAssociation#findTarget` (×2),
  * `buildHasManyRelation`, and the DJAS-routed `_loadThroughViaDisableJoinsScope`.
  */
 import { describe, it, expect } from "vitest";

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -276,8 +276,9 @@ describe("AssociationScope", () => {
   });
 
   it("loadHasMany applies caller-supplied options.scope when it differs from reflection.scope", async () => {
-    // Regression for the loadHasManyThrough path that wraps options.scope
-    // with sourceType filtering before calling findTarget. The migrated
+    // Regression for the `HasManyThroughAssociation#findTarget` path that wraps
+    // options.scope with sourceType filtering before calling
+    // `HasManyAssociation#findTarget`. The migrated
     // path skips re-applying when options.scope === reflection.scope
     // (avoid double-application), but augmented scopes must still run.
     // Canonical Author has_many :posts carries no macro scope, so the

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -15,7 +15,6 @@ import {
   _violatesStrictLoading,
   _wireInverseAssociation,
   applyAssociationScope,
-  loadHasManyThrough,
   ownerReflectionForeignKey,
   resolveAssocClass,
   syncToAssociationInstance,
@@ -571,7 +570,8 @@ export async function findTarget(
     // which the SQL JOIN cannot see — `_routeThroughViaAssociationScope` keeps
     // those on the 2-step loader.
     if (!_routeThroughViaAssociationScope(record, reflEarly, options)) {
-      return loadHasManyThrough(record, assocName, options);
+      const { findTarget: findThroughTarget } = await import("./has-many-through-association.js");
+      return findThroughTarget(record, assocName, options);
     }
     // Fall through into the AssociationScope path below.
   }

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -37,8 +37,9 @@ import { Car } from "../test-helpers/models/car.js";
 import { Bulb } from "../test-helpers/models/bulb.js";
 import { Developer, AuditLog } from "../test-helpers/models/developer.js";
 import { Project } from "../test-helpers/models/project.js";
-import { Associations, loadHasManyThrough, isAssociationCached } from "../associations.js";
+import { Associations, isAssociationCached } from "../associations.js";
 import { findTarget as findHasManyTarget } from "./has-many-association.js";
+import { findTarget as findHasManyThroughTarget } from "./has-many-through-association.js";
 import { DeleteRestrictionError } from "./errors.js";
 import { assertQueriesCount, assertNoQueries } from "../testing/query-assertions.js";
 
@@ -3995,7 +3996,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await ThrIdAuthor.create({ name: "Alice" });
     const post = await ThrIdPost.create({ author_id: author.id, title: "P", body: "body" });
     const comment = await ThrIdComment.create({ post_id: post.id, body: "C" });
-    const comments = await loadHasManyThrough(author, "thr_id_comments", {
+    const comments = await findHasManyThroughTarget(author, "thr_id_comments", {
       through: "thr_id_posts",
       className: "ThrIdComment",
       source: "thr_id_comments",

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -1,13 +1,20 @@
 import type { Base } from "../base.js";
-import type { AssociationDefinition } from "../associations.js";
-import { HasManyAssociation } from "./has-many-association.js";
+import type { AssociationDefinition, AssociationOptions } from "../associations.js";
+import { findTarget as findSingularTarget } from "./singular-association.js";
+import { HasManyAssociation, findTarget as findHasManyTarget } from "./has-many-association.js";
 import {
   HasManyThroughCantAssociateThroughHasOneOrManyReflection,
   HasManyThroughNestedAssociationsAreReadonly,
 } from "./errors.js";
 import { compositeQueryConstraintsList } from "../persistence.js";
-import { underscore, singularize, camelize } from "@blazetrails/activesupport";
-import { resolveAssocClass, association as collectionProxyFor } from "../associations.js";
+import { underscore, singularize, pluralize, camelize, isBlank } from "@blazetrails/activesupport";
+import {
+  resolveAssocClass,
+  association as collectionProxyFor,
+  applyAssociationScope,
+  loadHasOne,
+  _hmtNotFound,
+} from "../associations.js";
 import {
   sourceReflection,
   staleStateImpl as throughStaleState,
@@ -1029,5 +1036,132 @@ function ensureNotNested(assoc: HasManyThroughAssociation): void {
       (assoc.owner.constructor as { name: string }).name,
       assoc.reflection.name,
     );
+  }
+}
+
+/**
+ * Mirrors: HasManyThroughAssociation#target_reflection_has_associated_record?
+ * (has_many_through_association.rb:121).
+ *
+ * @internal
+ */
+function targetReflectionHasAssociatedRecord(
+  record: Base,
+  throughAssoc: AssociationDefinition,
+): boolean {
+  if (throughAssoc.type !== "belongsTo") return true;
+  const fk = throughAssoc.options.foreignKey ?? `${underscore(throughAssoc.name)}_id`;
+  const columns = Array.isArray(fk) ? fk : [fk];
+  return !columns.every((column) => isBlank(record._readAttribute(String(column))));
+}
+
+/**
+ * Mirrors: HasManyThroughAssociation#find_target
+ * (has_many_through_association.rb:225).
+ *
+ * @internal
+ */
+export async function findTarget(
+  record: Base,
+  assocName: string,
+  options: AssociationOptions,
+): Promise<Base[]> {
+  const ctor = record.constructor as typeof Base;
+  const associations: AssociationDefinition[] = ctor._associations ?? [];
+  const throughAssoc = associations.find((a) => a.name === options.through);
+  if (!throughAssoc) {
+    throw _hmtNotFound(ctor, assocName, options.through!);
+  }
+  if (!targetReflectionHasAssociatedRecord(record, throughAssoc)) return [];
+
+  const className = options.className ?? camelize(singularize(assocName));
+  const targetModel = resolveAssocClass(record, assocName, className);
+
+  const sourceName = options.source ?? singularize(assocName);
+
+  const throughClassName =
+    throughAssoc.options.className ?? camelize(singularize(throughAssoc.name));
+  const throughModel = resolveAssocClass(record, throughAssoc.name, throughClassName);
+  const throughModelAssocs: AssociationDefinition[] = throughModel._associations ?? [];
+  const sourceAssoc =
+    throughModelAssocs.find((a) => a.name === sourceName) ??
+    throughModelAssocs.find((a) => a.name === pluralize(sourceName));
+  const sourceAssocKind = sourceAssoc?.type ?? "belongsTo";
+
+  let throughRecords: Base[];
+  if (throughAssoc.type === "hasMany") {
+    if (
+      options.sourceType &&
+      sourceAssoc?.options?.polymorphic &&
+      sourceAssocKind === "belongsTo"
+    ) {
+      const resolvedSourceName = sourceAssoc?.name ?? sourceName;
+      const sourceTypeCol = `${underscore(resolvedSourceName)}_type`;
+      const originalScope = throughAssoc.options.scope;
+      const augmentedOptions = {
+        ...throughAssoc.options,
+        scope: (rel: any) => {
+          let r = rel.where({ [sourceTypeCol]: options.sourceType });
+          if (originalScope) r = originalScope(r);
+          return r;
+        },
+      };
+      throughRecords = await findHasManyTarget(record, throughAssoc.name, augmentedOptions);
+    } else {
+      throughRecords = await findHasManyTarget(record, throughAssoc.name, throughAssoc.options);
+    }
+  } else if (throughAssoc.type === "hasOne") {
+    const one = await loadHasOne(record, throughAssoc.name, throughAssoc.options);
+    throughRecords = one ? [one] : [];
+  } else if (throughAssoc.type === "belongsTo") {
+    const one = await findSingularTarget(record, throughAssoc.name, throughAssoc.options);
+    throughRecords = one ? [one] : [];
+  } else {
+    throughRecords = [];
+  }
+
+  if (throughRecords.length === 0) return [];
+
+  if (sourceAssocKind === "belongsTo") {
+    const targetFk = sourceAssoc?.options?.foreignKey ?? `${underscore(sourceName)}_id`;
+
+    const targetIds = throughRecords
+      .map((r) => r._readAttribute(targetFk as string))
+      .filter((v) => v !== null && v !== undefined);
+    if (targetIds.length === 0) return [];
+    let rel = targetModel.all().where({ [targetModel.primaryKey as string]: targetIds });
+    rel = applyAssociationScope(rel, options.scope, record);
+    return rel.toArray();
+  } else if (sourceAssoc?.options?.through) {
+    const results: Base[] = [];
+    for (const tr of throughRecords) {
+      const sub = await findHasManyTarget(tr, sourceAssoc.name, sourceAssoc.options);
+      results.push(...sub);
+    }
+    if (!options.scope) return results;
+    const ids = results
+      .map((r) => r._readAttribute(targetModel.primaryKey as string))
+      .filter((v) => v !== null && v !== undefined);
+    if (ids.length === 0) return [];
+    const rel = applyAssociationScope(
+      targetModel.all().where({ [targetModel.primaryKey as string]: ids }),
+      options.scope,
+      record,
+    );
+    return rel.toArray();
+  } else {
+    const sourceAsName = sourceAssoc?.options?.as;
+    const sourceFk = sourceAsName
+      ? (sourceAssoc?.options?.foreignKey ?? `${underscore(sourceAsName)}_id`)
+      : (sourceAssoc?.options?.foreignKey ?? `${underscore(throughClassName)}_id`);
+    const throughIds = throughRecords
+      .map((r) => r._readAttribute((r.constructor as typeof Base).primaryKey as string))
+      .filter((v) => v !== null && v !== undefined);
+    if (throughIds.length === 0) return [];
+    const whereConditions: Record<string, unknown> = { [sourceFk as string]: throughIds };
+    if (sourceAsName) whereConditions[`${underscore(sourceAsName)}_type`] = throughClassName;
+    let rel = targetModel.all().where(whereConditions);
+    rel = applyAssociationScope(rel, options.scope, record);
+    return rel.toArray();
   }
 }

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -1,5 +1,9 @@
 import type { Base } from "../base.js";
-import type { AssociationDefinition } from "../associations.js";
+import type { AssociationDefinition, AssociationOptions } from "../associations.js";
+import { findTarget as findSingularTarget } from "./singular-association.js";
+import { findTarget as findHasManyTarget } from "./has-many-association.js";
+import { camelize, underscore } from "@blazetrails/activesupport";
+import { resolveAssocClass, loadHasOne, _hmtNotFound } from "../associations.js";
 import { HasOneAssociation, sameRecord } from "./has-one-association.js";
 import {
   HasOneThroughCantAssociateThroughHasOneOrManyReflection,
@@ -682,4 +686,55 @@ function ensureNotNested(assoc: HasOneThroughAssociation): void {
       assoc.reflection.name,
     );
   }
+}
+
+/**
+ * Mirrors: SingularAssociation#find_target as inherited by
+ * HasOneThroughAssociation (has_one_through_association.rb).
+ */
+export async function findTarget(
+  record: Base,
+  assocName: string,
+  options: AssociationOptions,
+): Promise<Base | null> {
+  const ctor = record.constructor as typeof Base;
+  const associations: AssociationDefinition[] = ctor._associations ?? [];
+  const throughAssoc = associations.find((a) => a.name === options.through);
+  if (!throughAssoc) {
+    throw _hmtNotFound(ctor, assocName, options.through!);
+  }
+
+  let throughRecord: Base | null;
+  if (throughAssoc.type === "hasOne") {
+    throughRecord = await loadHasOne(record, throughAssoc.name, throughAssoc.options);
+  } else if (throughAssoc.type === "belongsTo") {
+    throughRecord = await findSingularTarget(record, throughAssoc.name, throughAssoc.options);
+  } else if (throughAssoc.type === "hasMany") {
+    const throughRecords = await findHasManyTarget(record, throughAssoc.name, throughAssoc.options);
+    throughRecord = throughRecords[0] ?? null;
+  } else {
+    throughRecord = null;
+  }
+
+  if (!throughRecord) return null;
+
+  const sourceName = options.source ?? assocName;
+  const throughCtor = throughRecord.constructor as typeof Base;
+  const throughAssociations: AssociationDefinition[] = throughCtor._associations ?? [];
+  const sourceAssoc = throughAssociations.find((a) => a.name === sourceName);
+
+  if (sourceAssoc) {
+    if (sourceAssoc.type === "belongsTo") {
+      return findSingularTarget(throughRecord, sourceName, sourceAssoc.options);
+    } else if (sourceAssoc.type === "hasOne") {
+      return loadHasOne(throughRecord, sourceName, sourceAssoc.options);
+    }
+  }
+
+  const className = options.className ?? camelize(sourceName);
+  const targetFk = `${underscore(sourceName)}_id`;
+  const fkValue = throughRecord._readAttribute(targetFk);
+  if (fkValue === null || fkValue === undefined) return null;
+  const targetModel = resolveAssocClass(throughRecord, sourceName, className);
+  return targetModel.findBy({ [targetModel.primaryKey as string]: fkValue });
 }

--- a/packages/activerecord/src/associations/polymorphic-sti-through.test.ts
+++ b/packages/activerecord/src/associations/polymorphic-sti-through.test.ts
@@ -7,8 +7,8 @@
  *   - `has_many :through` whose source reflection is a polymorphic
  *     belongs_to, disambiguated by `source_type:` ("polymorphic
  *     has_many through"). The fixture layers this on top of a
- *     nested through (Hotel → Departments → Chefs), so `findTarget`
- *     routes through `loadHasManyThrough`'s walker rather than the
+ *     nested through (Hotel → Departments → Chefs), so `HasManyAssociation#findTarget`
+ *     routes through `HasManyThroughAssociation#findTarget`'s walker rather than the
  *     final-step JOIN/AssociationScope path. Both that walker and
  *     the `includes()` preloader must filter through-records by the
  *     polymorphic discriminator (`*_type`) and only materialize the

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -50,7 +50,6 @@ export {
   registerModel,
   modelRegistry,
   loadHasOne,
-  loadHasManyThrough,
   association,
   isAssociationCached,
   updateCounterCaches,


### PR DESCRIPTION
Relocates the two through-association target loads out of the `associations.ts`
engine and into their Rails-layout homes, under their Rails method name.

- `loadHasManyThrough` → `findTarget` in
  `associations/has-many-through-association.ts`
  (Rails: `HasManyThroughAssociation#find_target`,
  `has_many_through_association.rb:225`).
- `loadHasOneThrough` → `findTarget` in
  `associations/has-one-through-association.ts`
  (Rails: `find_target` inherited from `SingularAssociation`).

`associations.ts` imports both under local aliases at the two dispatch sites;
no re-export under the old names (that would recreate the extra and add a
cycle). The `loadHasManyThrough` re-export from `index.ts` is dropped — Rails
does not expose these at the `ActiveRecord::` level.

## Extra-surface delta

`pnpm api:compare && pnpm api:extra --package activerecord --novel-only`:

| file | before | after |
| --- | --- | --- |
| `associations.ts` | 4 novel | 2 novel |
| `associations/has-many-through-association.ts` | 0 | 0 |
| `associations/has-one-through-association.ts` | 5 novel | 5 novel |

Drop of exactly 2, the number of names in this story; neither target file
gains an extra.

## Tests

`has-many-through-associations`, `has-one-through-associations`,
`nested-through-associations`, `has-many-associations`,
`polymorphic-sti-through`, `apply-association-scope` — all pass. No test
renames; the one direct-call test import switches to the new name/path.

Closes-story: extra-surface-relocate-load-through

## Residual gap (filed, not deferred silently)

In Rails `find_target` is a private *instance* method reading `owner` /
`reflection` off `self`; here it is still a module-level function with the
engine signature `(record, assocName, options)`, because the `loadHasOne` /
`loadHasMany` dispatch arms do not hold an association instance. Converting
the callers is its own change — filed as story
`through-find-target-becomes-instance-method` (RFC 0072).

Inline commentary inside the two relocated bodies was dropped; the one-line
Rails anchor on each function is kept.

## CI fixes after the first push

- **Import cycle.** The static `import` I added to `associations.ts` for the two
  relocated modules pulled the `Association` class chain in early, breaking
  `SingularAssociation`'s `extends` (`Class extends value undefined`) across all
  adapter jobs. Both call sites now use `await import(...)` (the pattern already
  used for `disable-joins-association-scope.js` at `associations.ts:1280`), so
  `associations.ts`'s static import graph is byte-identical to `origin/main`.
- **Wide call-mismatch ratchet.** Renaming to `findTarget` brought the body under
  the Rails `find_target` comparison, which flagged the missing
  `target_reflection_has_associated_record?` call. Ported it rather than
  baselining it: `targetReflectionHasAssociatedRecord` (Rails
  `has_many_through_association.rb:121`) now guards the top of `findTarget`.
  `lint-call-mismatches-wide` is back to OK (4971 baselined).

## Rebased onto main

Rebased past #5356, #5359, #5360, #5365 and then #5366. Two conflicts were real
rather than positional, both because sibling RFC 0072 stories relocated the
engine functions these bodies call:

- #5360 moved `loadBelongsTo` → `SingularAssociation#findTarget`; the relocated
  bodies now call `findTarget as findSingularTarget`.
- #5366 moved `loadHasMany` → `HasManyAssociation#findTarget`; the relocated
  bodies now call `findTarget as findHasManyTarget`, and
  `has-many-association.ts` — which had inherited the
  `return loadHasManyThrough(...)` dispatch — now reaches the through loader via
  `await import("./has-many-through-association.js")`. That pair is mutually
  recursive (`HasManyThroughAssociation extends HasManyAssociation`), so a
  static edge there is not an option. Main's now-unused
  `findTarget as findHasManyTarget` import in `associations.ts`, whose only
  caller was the `loadHasManyThrough` this PR deletes, is dropped along with its
  cycle-rationale comment.

Later rebased again past #5362 (dead `loadHabtm` deleted), which touched only a
doc comment this PR also edits.

Counts above are re-measured against the current `origin/main` (4 → 2); wide
ratchet OK (4955 baselined), eslint and prettier clean.
