### PR TITLE
refactor(associations): route collection callbacks through CollectionAssociation#callback

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -92,7 +92,6 @@ import {
   pluralize,
   camelize,
   foreignKey as deriveForeignKey,
-  isAbortSignal,
 } from "@blazetrails/activesupport";
 import {
   getInheritanceColumn,
@@ -3012,41 +3011,6 @@ export async function loadHabtm(
 }
 
 /**
- * Fire one or more association callbacks (before_add, after_add, etc.).
- */
-export function fireAssocCallbacks(
-  cbs:
-    | ((owner: Base, record: Base) => void | false)
-    | ((owner: Base, record: Base) => void | false)[]
-    | undefined,
-  owner: Base,
-  record: Base,
-  catchAbort = false,
-): boolean {
-  if (!cbs) return true;
-  const arr = Array.isArray(cbs) ? cbs : [cbs];
-  for (const cb of arr) {
-    // Rails wraps only `before_add`/`before_remove` in `catch(:abort)`
-    // (collection_association.rb:400-402, 462-464). Those callers pass
-    // `catchAbort=true`; an after callback runs outside the catch, so a
-    // `throw :abort` from after_add/after_remove propagates (Rails parity).
-    if (catchAbort) {
-      try {
-        cb(owner, record);
-      } catch (e) {
-        if (!isAbortSignal(e)) throw e;
-        return false;
-      }
-    } else {
-      // after_add/after_remove run outside the catch; their return value is
-      // ignored (Rails 5+ only halts on `throw :abort`, never on `false`).
-      cb(owner, record);
-    }
-  }
-  return true;
-}
-
-/**
  * Factory to get a CollectionProxy for a has_many association.
  * Returns a cached proxy if one exists on the record.
  */
@@ -3456,47 +3420,6 @@ export function reflectLockVersionBump(record: Base): void {
   const lc = ctor.lockingColumn;
   const bumped = (Number((record as any).readAttribute?.(lc)) || 0) + 1;
   (record as any)._attributes?.writeFromDatabase(lc, bumped);
-}
-
-/**
- * Touch parent associations after a record is saved or destroyed.
- *
- * Mirrors: ActiveRecord::Associations::Builder::BelongsTo touch option
- */
-export async function touchBelongsToParents(record: Base): Promise<void> {
-  const ctor = record.constructor as typeof Base;
-  const associations: AssociationDefinition[] = ctor._associations ?? [];
-
-  for (const assoc of associations) {
-    if (assoc.type !== "belongsTo" || !assoc.options.touch) continue;
-
-    const foreignKey = assoc.options.foreignKey ?? `${underscore(assoc.name)}_id`;
-    const fkValue = record._readAttribute(foreignKey as string);
-    if (fkValue === null || fkValue === undefined) continue;
-
-    let targetModel: typeof Base;
-    if (assoc.options.polymorphic) {
-      const typeCol = assoc.options.foreignType ?? `${underscore(assoc.name)}_type`;
-      const typeName = record._readAttribute(typeCol) as string | null;
-      if (!typeName) continue;
-      targetModel = ctor.polymorphicClassFor(typeName);
-    } else {
-      const className = assoc.options.className ?? camelize(assoc.name);
-      targetModel = resolveAssocClass(record, assoc.name, className);
-    }
-
-    const parent = await targetModel.findBy({ [targetModel.primaryKey as string]: fkValue });
-    if (!parent) continue;
-
-    const touchOpt = assoc.options.touch;
-    if (touchOpt === true) {
-      await parent.touch();
-    } else if (typeof touchOpt === "string") {
-      await parent.touch(touchOpt);
-    } else if (Array.isArray(touchOpt) && touchOpt.length > 0) {
-      await parent.touch(...touchOpt);
-    }
-  }
 }
 
 /**

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -113,6 +113,17 @@ import { foreignKeyPresentFor } from "./associations/foreign-association.js";
 import { throughForeignKeyPresent } from "./associations/through-association.js";
 
 /**
+ * One `before_add`/`after_add`/`before_remove`/`after_remove` entry. Mirrors
+ * the three arms Rails' `Builder::CollectionAssociation.define_callback`
+ * accepts (builder/collection_association.rb:44-52): a method name on the
+ * owner, a callable, or an object that responds to the callback kind itself.
+ */
+export type CollectionCallback<K extends string> =
+  | string
+  | ((owner: Base, record: Base) => void | false)
+  | { [P in K]: (owner: Base, record: Base) => void | false };
+
+/**
  * Association options.
  */
 export interface AssociationOptions {
@@ -143,14 +154,10 @@ export interface AssociationOptions {
    * resolved in an async pre-validation phase on save; a synchronous block also
    * fires during a standalone `valid?`. */
   default?: (owner: Base) => Base | null | Promise<Base | null>;
-  beforeAdd?:
-    | ((owner: Base, record: Base) => void | false)
-    | ((owner: Base, record: Base) => void | false)[];
-  afterAdd?: ((owner: Base, record: Base) => void) | ((owner: Base, record: Base) => void)[];
-  beforeRemove?:
-    | ((owner: Base, record: Base) => void | false)
-    | ((owner: Base, record: Base) => void | false)[];
-  afterRemove?: ((owner: Base, record: Base) => void) | ((owner: Base, record: Base) => void)[];
+  beforeAdd?: CollectionCallback<"beforeAdd"> | CollectionCallback<"beforeAdd">[];
+  afterAdd?: CollectionCallback<"afterAdd"> | CollectionCallback<"afterAdd">[];
+  beforeRemove?: CollectionCallback<"beforeRemove"> | CollectionCallback<"beforeRemove">[];
+  afterRemove?: CollectionCallback<"afterRemove"> | CollectionCallback<"afterRemove">[];
   /** Mixes methods into the association's CollectionProxy and every
    * relation spawned from it, mirroring Rails' `has_many :things,
    * extend: ModA` / `extend: [ModA, ModB]`. A module is an object whose

--- a/packages/activerecord/src/associations/builder/collection-association.ts
+++ b/packages/activerecord/src/associations/builder/collection-association.ts
@@ -77,13 +77,22 @@ export class CollectionAssociation extends Association {
       return;
     }
 
+    // Mirrors Rails' three arms (builder/collection_association.rb:44-52). All
+    // three take `(method, owner, record)` — the `method` (callback kind) is
+    // unused by the symbol/proc arms but IS what the object arm dispatches on,
+    // so it has to be threaded through rather than bound here.
     const normalized = callbackValues.map((callback: any) => {
       if (typeof callback === "string" || typeof callback === "symbol") {
-        return (owner: any, record: any) => owner[callback](record);
+        // Rails: `->(method, owner, record) { owner.send(callback, record) }`
+        return (_method: string, owner: any, record: any) => owner[callback](record);
       } else if (typeof callback === "function") {
-        return (owner: any, record: any) => callback(owner, record);
+        // Rails: `->(method, owner, record) { callback.call(owner, record) }`
+        return (_method: string, owner: any, record: any) => callback(owner, record);
       } else {
-        return (owner: any, record: any) => callback.call(owner, record);
+        // Rails: `->(method, owner, record) { callback.send(method, owner, record) }`
+        // — an object callback responds to the callback kind itself, e.g.
+        // `before_add: SomeAuditor` invokes `SomeAuditor.before_add(owner, record)`.
+        return (method: string, owner: any, record: any) => callback[method](owner, record);
       }
     });
 
@@ -94,7 +103,8 @@ export class CollectionAssociation extends Association {
     model[fullCallbackName] = [...prior, ...normalized];
 
     // Also store normalized callbacks in the association options so
-    // fireAssocCallbacks (which reads options.beforeAdd etc.) finds them
+    // `CollectionAssociation#callback`'s `callbacksFor` fallback (which reads
+    // options.beforeAdd etc.) finds them
     const assocs: any[] = model._associations ?? [];
     const assocDef = assocs.find((a: any) => a.name === name);
     if (assocDef) {

--- a/packages/activerecord/src/associations/callbacks.trails.test.ts
+++ b/packages/activerecord/src/associations/callbacks.trails.test.ts
@@ -1,0 +1,56 @@
+/**
+ * trails-only extras for `associations/callbacks.test.ts`. Rails' own
+ * `AssociationCallbacksTest` has no coverage for the object-callback arm of
+ * `Builder::CollectionAssociation.define_callback`
+ * (builder/collection_association.rb:51), so this guards it here rather than
+ * under a Rails test name.
+ */
+import { describe, it, expect } from "vitest";
+import { Base, association, registerModel } from "../index.js";
+import type { Base as BaseRecord } from "../base.js";
+
+import { fixtures } from "../test-helpers/fixtures.js";
+import { Author } from "../test-helpers/models/author.js";
+import { Post } from "../test-helpers/models/post.js";
+
+registerModel(Author);
+registerModel(Post);
+
+describe("association callbacks — object callbacks (trails)", () => {
+  fixtures({});
+
+  it("dispatches the callback kind as a method on an object callback", async () => {
+    const log: string[] = [];
+    // Rails' third `define_callback` arm: a callback that is neither a Symbol
+    // nor a Proc responds to the callback kind itself —
+    // `callback.send(method, owner, record)`.
+    const auditor = {
+      beforeAdd(_owner: BaseRecord, record: BaseRecord) {
+        log.push(`beforeAdd:${(record as unknown as { title: string }).title}`);
+      },
+      afterAdd(_owner: BaseRecord, record: BaseRecord) {
+        log.push(`afterAdd:${(record as unknown as { title: string }).title}`);
+      },
+    };
+
+    class ObjectCbAuthor extends Base {
+      static {
+        this.tableName = "authors";
+        this.attribute("name", "string");
+        this.hasMany("posts", {
+          className: "Post",
+          foreignKey: "author_id",
+          beforeAdd: auditor,
+          afterAdd: auditor,
+        });
+      }
+    }
+    registerModel("ObjectCbAuthor", ObjectCbAuthor);
+
+    const author = await ObjectCbAuthor.create({ name: "David" });
+    const proxy = association(author, "posts");
+    await proxy.push(new Post({ title: "Hello", body: "Body", author_id: author.id }));
+
+    expect(log).toEqual(["beforeAdd:Hello", "afterAdd:Hello"]);
+  });
+});

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -1388,7 +1388,8 @@ export interface CallbackHost {
 
 /**
  * Unified association-callback dispatch. Mirrors Rails'
- * `CollectionAssociation#callback`: looks up the registered callbacks for
+ * `CollectionAssociation#callback` (collection_association.rb:492), whose
+ * lookup half is `callbacks_for` (:498): looks up the registered callbacks for
  * `kind` (`beforeAdd`/`afterAdd`/`beforeRemove`/`afterRemove`) and invokes
  * each. Returns `false` if any callback aborts (Rails `throw :abort`,
  * modelled here as a callback returning `false`), so callers can halt the
@@ -1403,9 +1404,7 @@ export interface CallbackHost {
  * sites share one proc array; passing `kind` here would break the proxy's
  * `cb(owner, record)` call site.
  *
- * Mirrors: ActiveRecord::Associations::CollectionAssociation#callback
- * (collection_association.rb:492).
- *
+ * `callback` is private in Rails, hence `@internal`.
  * @internal
  */
 export function callback(assoc: CallbackHost, kind: string, record: Base): boolean {

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -1395,14 +1395,12 @@ export interface CallbackHost {
  * modelled here as a callback returning `false`), so callers can halt the
  * add/remove like Rails' `catch(:abort) ... || return`.
  *
- * Arity note: Rails procs take `(method, owner, record)` and `callback`
- * passes the kind through (so the symbol case can `callback.send(method, ...)`).
- * Here the builder binds the method/symbol at registration time, so the
- * stored procs take `(owner, record)` — the same 2-arg shape consumed by
- * this dispatcher on the CollectionProxy add/remove paths, which read the
- * identical callback array. Keeping the 2-arg convention lets both dispatch
- * sites share one proc array; passing `kind` here would break the proxy's
- * `cb(owner, record)` call site.
+ * Arity note: like Rails, the stored procs take `(method, owner, record)` and
+ * this dispatcher passes `kind` through as `method`. The symbol and proc arms
+ * ignore it, but the object arm needs it — Rails' `callback.send(method, owner,
+ * record)` (builder/collection_association.rb:51) dispatches the callback kind
+ * as a method ON the callback object, so binding it at registration time would
+ * silently drop object callbacks.
  *
  * `callback` is private in Rails, hence `@internal`.
  * @internal
@@ -1419,14 +1417,14 @@ export function callback(assoc: CallbackHost, kind: string, record: Base): boole
     // (faithful `throw :abort`); a `false` return no longer halts (Rails 5+).
     if (catchAbort) {
       try {
-        (cb as any)(assoc.owner, record);
+        (cb as any)(kind, assoc.owner, record);
       } catch (e) {
         if (!isAbortSignal(e)) throw e;
         return false;
       }
     } else {
       // after callbacks run outside the catch; their return value is ignored.
-      (cb as any)(assoc.owner, record);
+      (cb as any)(kind, assoc.owner, record);
     }
   }
   return true;

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -1376,6 +1376,17 @@ async function replaceOnTargetAsync(
 }
 
 /**
+ * The owner + reflection pair {@link callback} needs. Both the
+ * `CollectionAssociation` and the `CollectionProxy` (which holds the same two
+ * pieces under different field names) satisfy it.
+ * @internal
+ */
+export interface CallbackHost {
+  owner: Base;
+  reflection: { name: string; options: object };
+}
+
+/**
  * Unified association-callback dispatch. Mirrors Rails'
  * `CollectionAssociation#callback`: looks up the registered callbacks for
  * `kind` (`beforeAdd`/`afterAdd`/`beforeRemove`/`afterRemove`) and invokes
@@ -1387,13 +1398,17 @@ async function replaceOnTargetAsync(
  * passes the kind through (so the symbol case can `callback.send(method, ...)`).
  * Here the builder binds the method/symbol at registration time, so the
  * stored procs take `(owner, record)` — the same 2-arg shape consumed by
- * `fireAssocCallbacks` on the CollectionProxy add/remove paths, which read
- * the identical callback array. Keeping the 2-arg convention lets both
- * dispatch sites share one proc array; passing `kind` here would break the
- * proxy's `cb(owner, record)` call site.
+ * this dispatcher on the CollectionProxy add/remove paths, which read the
+ * identical callback array. Keeping the 2-arg convention lets both dispatch
+ * sites share one proc array; passing `kind` here would break the proxy's
+ * `cb(owner, record)` call site.
+ *
+ * Mirrors: ActiveRecord::Associations::CollectionAssociation#callback
+ * (collection_association.rb:492).
+ *
  * @internal
  */
-function callback(assoc: CollectionAssociation, kind: string, record: Base): boolean {
+export function callback(assoc: CallbackHost, kind: string, record: Base): boolean {
   // Rails wraps only `before_add`/`before_remove` in `catch(:abort)`
   // (collection_association.rb:400-402, 462-464); after callbacks run outside
   // the catch (:408, :485), so a `throw :abort` from after_add/after_remove
@@ -1419,7 +1434,7 @@ function callback(assoc: CollectionAssociation, kind: string, record: Base): boo
 }
 
 /** @internal */
-function callbacksFor(assoc: CollectionAssociation, callbackName: string): unknown[] {
+function callbacksFor(assoc: CallbackHost, callbackName: string): unknown[] {
   // The builder stores normalized callbacks both as the
   // `<kind>For<Name>` class attribute (Rails parity) and on the reflection
   // options; either is the same array. Prefer the class attribute, matching
@@ -1429,7 +1444,7 @@ function callbacksFor(assoc: CollectionAssociation, callbackName: string): unkno
   const stored = owner[fullName];
   if (typeof stored === "function") return stored();
   if (Array.isArray(stored)) return stored;
-  const fromOptions = (assoc.reflection.options as any)[callbackName];
+  const fromOptions = (assoc.reflection.options as Record<string, unknown>)[callbackName];
   return Array.isArray(fromOptions) ? fromOptions : fromOptions != null ? [fromOptions] : [];
 }
 

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -4,8 +4,8 @@ import {
   CollectionAssociation,
   callback as assocCallback,
   concatRecordsLoop,
+  type CallbackHost,
 } from "./collection-association.js";
-import type { CallbackHost } from "./collection-association.js";
 import type { PrettyPrinter } from "../pretty-print.js";
 import type { AssociationRelation as AssociationRelationType } from "../association-relation.js";
 import {

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1,6 +1,11 @@
 import type { Base } from "../base.js";
 import { Relation } from "../relation.js";
-import { CollectionAssociation, concatRecordsLoop } from "./collection-association.js";
+import {
+  CollectionAssociation,
+  callback as assocCallback,
+  concatRecordsLoop,
+} from "./collection-association.js";
+import type { CallbackHost } from "./collection-association.js";
 import type { PrettyPrinter } from "../pretty-print.js";
 import type { AssociationRelation as AssociationRelationType } from "../association-relation.js";
 import {
@@ -61,7 +66,6 @@ import {
   association,
   resolveModel,
   resolveAssocClass,
-  fireAssocCallbacks,
   buildHasManyRelation,
   buildThroughJoinScope,
   loadHasMany,
@@ -280,6 +284,15 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   /** @internal Association definition — used by AssociationRelation. */
   get reflection(): AssociationDefinition {
     return this._assocDef;
+  }
+
+  /**
+   * The owner/reflection pair `CollectionAssociation#callback` dispatches on.
+   * The proxy holds the same two pieces under different field names.
+   * @internal
+   */
+  private get _callbackHost(): CallbackHost {
+    return { owner: this._record, reflection: this._assocDef };
   }
 
   /** @internal Association name — used by AssociationRelation. */
@@ -1495,16 +1508,13 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   ): Promise<T | null> {
     const { skipCallbacks = false, replace = false } = options;
     const index = this._targetReplaceIndex(record, replace);
-    if (
-      !skipCallbacks &&
-      !fireAssocCallbacks(this._assocDef.options.beforeAdd, this._record, record, true)
-    ) {
+    if (!skipCallbacks && !assocCallback(this._callbackHost, "beforeAdd", record)) {
       return null;
     }
     _setCollectionInverseInstance(this._record, this._assocName, this._assocDef.options, record);
     if (save) await save();
     this._commitToTarget(record, index);
-    if (!skipCallbacks) fireAssocCallbacks(this._assocDef.options.afterAdd, this._record, record);
+    if (!skipCallbacks) assocCallback(this._callbackHost, "afterAdd", record);
     return record;
   }
 
@@ -1522,15 +1532,12 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   ): T | null {
     const { skipCallbacks = false, replace = false } = options;
     const index = this._targetReplaceIndex(record, replace);
-    if (
-      !skipCallbacks &&
-      !fireAssocCallbacks(this._assocDef.options.beforeAdd, this._record, record, true)
-    ) {
+    if (!skipCallbacks && !assocCallback(this._callbackHost, "beforeAdd", record)) {
       return null;
     }
     _setCollectionInverseInstance(this._record, this._assocName, this._assocDef.options, record);
     this._commitToTarget(record, index);
-    if (!skipCallbacks) fireAssocCallbacks(this._assocDef.options.afterAdd, this._record, record);
+    if (!skipCallbacks) assocCallback(this._callbackHost, "afterAdd", record);
     return record;
   }
 
@@ -2651,7 +2658,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       // return`: if any record's before_remove halts, the entire operation aborts
       // and nothing is deleted (the transaction commits with no work done).
       for (const record of modelRecords) {
-        if (!fireAssocCallbacks(this._assocDef.options.beforeRemove, this._record, record, true)) {
+        if (!assocCallback(this._callbackHost, "beforeRemove", record)) {
           aborted = true;
           return;
         }
@@ -2722,7 +2729,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       // Remove from target first, then fire after_remove for all records.
       this._removeFromTarget(modelRecords as Base[]);
       for (const record of modelRecords) {
-        fireAssocCallbacks(this._assocDef.options.afterRemove, this._record, record);
+        assocCallback(this._callbackHost, "afterRemove", record);
       }
     };
 
@@ -4098,7 +4105,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     if (this._isThrough) {
       const record = this._buildThrough(attrs) as T;
       if (block) block(record);
-      if (!fireAssocCallbacks(this._assocDef.options.beforeAdd, this._record, record, true)) {
+      if (!assocCallback(this._callbackHost, "beforeAdd", record)) {
         throw new RecordNotSaved("Callback prevented record creation", record);
       }
       const saved = await record.save();
@@ -4108,7 +4115,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       if (this._target.length === targetBefore) {
         throw new RecordNotSaved("Failed to create join record for through association", record);
       }
-      fireAssocCallbacks(this._assocDef.options.afterAdd, this._record, record);
+      assocCallback(this._callbackHost, "afterAdd", record);
       return record;
     }
     const record = this._buildRaw(attrs) as T;

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -59,7 +59,6 @@ export {
   isAssociationCached,
   loadHabtm,
   updateCounterCaches,
-  touchBelongsToParents,
   eagerLoadBang,
 } from "./associations.js";
 export { CollectionProxy } from "./associations/collection-proxy.js";

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/collection-association.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/collection-association.json
@@ -11,7 +11,7 @@
     "tsFile": "associations/collection-association.ts",
     "rubyName": "callback",
     "call": "call",
-    "reason": "Satisfied by a different path: Ruby's `callback.call(method, owner, record)` (collection_association.rb:494) is proc invocation, which in JS is the bare `cb(owner, record)` this body already does; the `method` argument is bound at registration by Builder::CollectionAssociation.define_callback, so the stored procs are 2-arg (see the arity note on `callback`)."
+    "reason": "Syntax-only: Ruby needs `proc.call(...)` to invoke a Proc (collection_association.rb:494); JS invokes bare. The substantive part of that line \u2014 threading `method` so the object-callback arm can dispatch it \u2014 IS implemented (see callbacks.trails.test.ts)."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/collection-association.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/collection-association.json
@@ -9,6 +9,13 @@
   {
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
+    "rubyName": "callback",
+    "call": "call",
+    "reason": "Satisfied by a different path: Ruby's `callback.call(method, owner, record)` (collection_association.rb:494) is proc invocation, which in JS is the bare `cb(owner, record)` this body already does; the `method` argument is bound at registration by Builder::CollectionAssociation.define_callback, so the stored procs are 2-arg (see the arity note on `callback`)."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/collection-association.ts",
     "rubyName": "concat",
     "call": "skip_strict_loading",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Classifies and clears two `associations.ts` novel extras from RFC 0072
(`extra-surface-relocate-touch-and-callbacks`).

## `fireAssocCallbacks` → `CollectionAssociation#callback`

`associations/collection-association.ts` already had a faithful, private
`callback(assoc, kind, record)` + `callbacksFor` pair (Rails
`collection_association.rb:492` / `:498`) — `fireAssocCallbacks` was a second
dispatcher over the same normalized proc arrays, reached only by
`CollectionProxy`. Rather than move the duplicate body, this deletes it and
exports the existing Rails-named `callback`, widening its first parameter to a
structural `CallbackHost { owner, reflection }` so the proxy (which holds the
same two pieces as `_record` / `_assocDef`) can call it. Abort semantics are
unchanged: the proxy's explicit `catchAbort` argument is now derived from
`kind.startsWith("before")`, which is exactly what every call site passed.

## `touchBelongsToParents` → dead

Its Rails home, `Builder::BelongsTo.touch_record` / `.add_touch_callbacks`
(`builder/belongs_to.rb:44`, `:79`), is already ported as
`BelongsTo.touchRecord` / `BelongsTo.addTouchCallbacks` in
`associations/builder/belongs-to.ts`. `touchBelongsToParents` had no callers
anywhere in the repo — only the `index.ts` re-export kept it alive. Deleted,
along with the re-export (Rails exposes nothing at `ActiveRecord::` here).

## Extra-surface counts

`pnpm api:compare && pnpm api:extra --package activerecord --novel-only`:

- before: `associations.ts — 14 novel, 0 moved`
- after: `associations.ts — 12 novel, 0 moved`

Nothing added to the allowlist.

## Tests

`associations/callbacks.test.ts`, `associations/collection-proxy.test.ts`,
`nested-attributes-with-callbacks.test.ts`, `associations.test.ts`,
`associations/has-many-associations.test.ts`,
`associations/has-many-through-associations.test.ts` — all pass, no renames.

Closes-story: extra-surface-relocate-touch-and-callbacks

## Follow-up: object-callback arm (Codex review)

Exporting `callback` enrolled it in the wide call ratchet, which flagged the
`callback.call(method, owner, record)` Rails makes
(`collection_association.rb:494`). The first attempt baselined it as harmless
proc-invocation syntax; that was wrong, and review caught it.

Rails' `Builder::CollectionAssociation.define_callback`
(`builder/collection_association.rb:44-52`) has three arms, and the third —
`->(method, owner, record) { callback.send(method, owner, record) }` — needs the
`method` argument: an object callback responds to the callback *kind* itself.
Our procs were 2-arg with the kind bound at registration, and the object arm
did `callback.call(owner, record)`, which on a plain JS object throws
`TypeError: callback.call is not a function`.

Fixed rather than baselined:

- Stored procs are now 3-arg `(method, owner, record)`, matching Rails; the
  dispatcher passes `kind` through.
- The object arm dispatches `callback[method](owner, record)`.
- `AssociationOptions`' four callback keys now type all three Rails arms via
  `CollectionCallback<K>` (they previously admitted only callables).
- `associations/callbacks.trails.test.ts` covers the object arm — Rails'
  `AssociationCallbacksTest` has no test for it, hence a trails-only file
  rather than a Rails test name. Verified it fails on the pre-fix code with
  `callback.call is not a function`.

The baseline entry remains, with a corrected reason: what's left is purely that
Ruby needs `proc.call(...)` to invoke a Proc while JS invokes bare.
