### PR TITLE
refactor(associations): relocate loadHasMany to HasManyAssociation#findTarget

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -33,7 +33,8 @@ import { Member } from "./test-helpers/models/member.js";
 import { Membership } from "./test-helpers/models/membership.js";
 import { Human } from "./test-helpers/models/human.js";
 import { Interest } from "./test-helpers/models/interest.js";
-import { buildHasManyRelation, loadHasMany, loadHasOne } from "./associations.js";
+import { buildHasManyRelation, loadHasOne } from "./associations.js";
+import { findTarget as findHasManyTarget } from "./associations/has-many-association.js";
 import "./test-helpers/models/ship.js";
 import "./test-helpers/models/bird.js";
 import "./test-helpers/models/treasure.js";
@@ -803,8 +804,8 @@ describe("PreloaderTest", () => {
     // line_item_discount_applications). The second preload must skip that branch
     // and issue only the three shipping/discount queries.
     const reloaded = (await Invoice.where({ id: invoice.id }))[0];
-    const lineItems = await loadHasMany(reloaded, "lineItems", {});
-    for (const li of lineItems) await loadHasMany(li, "discountApplications", {});
+    const lineItems = await findHasManyTarget(reloaded, "lineItems", {});
+    for (const li of lineItems) await findHasManyTarget(li, "discountApplications", {});
     const secondSqls = await captureSql(async () => {
       await new Preloader({ records: [reloaded], associations: nested }).call();
     });
@@ -2547,7 +2548,7 @@ describe("AssociationsTest", () => {
     await ShardedComment.create({ blog_id: 1, blog_post_id: (post as any).id, body: "A" });
     await ShardedComment.create({ blog_id: 1, blog_post_id: (post as any).id, body: "B" });
     await ShardedComment.create({ blog_id: 2, blog_post_id: (post as any).id, body: "Other" });
-    const comments = await loadHasMany(post, "freshComments", {
+    const comments = await findHasManyTarget(post, "freshComments", {
       className: "ShardedComment",
       foreignKey: ["blog_id", "blog_post_id"],
     });
@@ -2577,7 +2578,7 @@ describe("AssociationsTest", () => {
     const [, orderId] = order.id as [number, number];
     await CpkOrderAgreement.create({ order_id: orderId, signature: "abc" });
     await CpkOrderAgreement.create({ order_id: orderId, signature: "def" });
-    const agreements = await loadHasMany(order, "freshAgreements", {
+    const agreements = await findHasManyTarget(order, "freshAgreements", {
       className: "CpkOrderAgreement",
       foreignKey: "order_id",
     });
@@ -2609,7 +2610,7 @@ describe("AssociationsTest", () => {
     await CpkOrderAgreement.create({ order_id: orderId, signature: "abc" });
     await CpkOrderAgreement.create({ order_id: orderId, signature: "def" });
     await (CpkOrderAgreement as any).where("1=0").scoping(async () => {
-      const agreements = await loadHasMany(order, "freshAgreements", {
+      const agreements = await findHasManyTarget(order, "freshAgreements", {
         className: "CpkOrderAgreement",
         foreignKey: "order_id",
       });
@@ -2641,7 +2642,7 @@ describe("AssociationsTest", () => {
       parent_type: "ShardedBlogPost",
       title: "wrongShard",
     });
-    const children = await loadHasMany(post, "freshChildren", {
+    const children = await findHasManyTarget(post, "freshChildren", {
       className: "ShardedBlogPost",
       as: "parent",
     });
@@ -2712,7 +2713,7 @@ describe("AssociationsTest", () => {
       title: "Parent",
     });
     await expect(
-      loadHasMany(post, "freshChildren", {
+      findHasManyTarget(post, "freshChildren", {
         className: "ShardedBlogPostWithRevision",
         as: "parent",
       }),
@@ -2770,7 +2771,7 @@ describe("AssociationsTest", () => {
       title: "Book",
     });
     await CpkBook.where({ author_id: 3, id: 4 }).updateAll({ title: "A different title" });
-    const books = await loadHasMany(order, "books", {
+    const books = await findHasManyTarget(order, "books", {
       foreignKey: ["shop_id", "order_id"],
       className: "CpkBook",
     });

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -79,6 +79,7 @@ import {
   CompositePrimaryKeyMismatchError,
 } from "./associations/errors.js";
 import { AssociationScope, invokeScopeLambda } from "./associations/association-scope.js";
+import { findTarget as findHasManyTarget } from "./associations/has-many-association.js";
 import type { Association as AssociationInstance } from "./associations/association.js";
 import {
   validateThroughReflection,
@@ -780,7 +781,7 @@ export function isAssociationCached(record: Base, assocName: string): boolean {
  * source, sourceType, disable-joins) need machinery this PR doesn't
  * yet provide and stay on the existing 2-step IN-list loaders.
  *
- * Shared by loadHasMany and loadHasOne so the gating rules can't drift.
+ * Shared by findTarget and loadHasOne so the gating rules can't drift.
  */
 export function _canRouteThroughViaAssociationScope(
   reflection: ReflectionLike | null | undefined,
@@ -892,8 +893,10 @@ export function _ownerChainReflection(reflection: any): any {
  * the generic chain walk — `reflection.chain` flattens nested-through
  * into a straight list of reflection steps, and `getChain` / the
  * reverseChain walk iterate that list uniformly.
+ *
+ * @internal
  */
-function _canRouteThroughViaDisableJoinsAssociationScope(
+export function _canRouteThroughViaDisableJoinsAssociationScope(
   reflection: ReflectionLike | null | undefined,
   options: AssociationOptions,
 ): boolean {
@@ -1000,6 +1003,8 @@ export function applyAssociationScope<R>(
  * handled above this call site, so falling through to the fresh
  * `AssociationScope.scope(...)` here only matters if a future caller
  * stretches the contract.
+ *
+ * @internal
  */
 export function _builtAssociationScope(
   record: Base,
@@ -1239,7 +1244,8 @@ async function _buildDisableJoinsScopeRelation(
   return { rel };
 }
 
-async function _loadThroughViaDisableJoinsScope(
+/** @internal */
+export async function _loadThroughViaDisableJoinsScope(
   record: Base,
   reflection: ReflectionLike | null | undefined,
   options?: AssociationOptions,
@@ -1377,8 +1383,10 @@ function _associationForeignKeyPresent(
  * `has_many :special_comments` is declared on `Post` — this yields `post_id`,
  * not `special_post_id`. Mirrors Rails `reflection.foreign_key`. Returns
  * `undefined` for an unregistered association so callers keep their fallback.
+ *
+ * @internal
  */
-function ownerReflectionForeignKey(
+export function ownerReflectionForeignKey(
   ctor: typeof Base,
   assocName: string,
 ): string | string[] | undefined {
@@ -1416,7 +1424,7 @@ export async function loadHasOne(
     strictLoadingViolationBang(record, assocName, { className: options.className });
   }
 
-  // Handle has_one :through. Same routing rules as loadHasMany —
+  // Handle has_one :through. Same routing rules as findTarget —
   // route through AssociationScope's JOIN-based path for the simple
   // shape; everything else falls back to the 2-step loadHasOneThrough.
   if (options.through) {
@@ -1584,235 +1592,6 @@ export async function loadHasOne(
 }
 
 /**
- * Load a has_many association.
- */
-export async function loadHasMany(
-  record: Base,
-  assocName: string,
-  options: AssociationOptions,
-  queryExecutor?: () => Promise<Base[]>,
-): Promise<Base[]> {
-  if (options.through) {
-    validateThroughReflection(record.constructor as typeof Base, assocName);
-  }
-  // Check cached (inverse_of) first, then preloaded — skip when a scope
-  // override is provided (the scope has been mutated; the cache would return
-  // stale/incorrect data for the diverged query).
-  if (!queryExecutor) {
-    // Honor an instance-cache hit (a directly-seeded or inverse-seeded
-    // collection target), but ignore the association's *own* collection proxy:
-    // its in-memory built/pushed records are not a complete collection and must
-    // still be merged with a DB query (this loader runs inside that proxy's
-    // load path, where `proxy.loaded` is false by construction).
-    const cache = record._associationCache(assocName);
-    if (
-      cache &&
-      cache !== record._collectionProxies.get(assocName) &&
-      Array.isArray(cache.target) &&
-      !(typeof (cache as any).isStaleTarget === "function" && (cache as any).isStaleTarget())
-    ) {
-      return cache.target;
-    }
-    const preloaded = _preloadedHolderTarget(record, assocName);
-    if (preloaded) {
-      return (preloaded.value ?? []) as Base[];
-    }
-  }
-
-  // Strict loading check. Gated by `find_target?`: a new-record owner without
-  // the FK present never reaches `find_target` and so never raises.
-  if (
-    _violatesStrictLoading(record, options) &&
-    _findTargetReachable(record, assocName, options, "foreign")
-  ) {
-    strictLoadingViolationBang(record, assocName, {
-      className: options.className ?? camelize(singularize(assocName)),
-    });
-  }
-
-  // Scope-override path: CollectionProxy passes this when its Relation state
-  // has been mutated (whereBang / orderBang / ...). The executor runs the
-  // mutated scope directly; cache lookup and scope rebuild are bypassed.
-  if (queryExecutor) return queryExecutor();
-
-  // Handle through associations. Routes through AssociationScope's
-  // JOIN-based path for the simple shape (see
-  // _canRouteThroughViaAssociationScope); everything else stays on the
-  // 2-step loadHasManyThrough.
-  if (options.through) {
-    const ctorEarly = record.constructor as typeof Base;
-    const reflEarly = ctorEarly._reflectOnAssociation?.(assocName);
-    if (_canRouteThroughViaDisableJoinsAssociationScope(reflEarly, options)) {
-      return _loadThroughViaDisableJoinsScope(record, reflEarly, options);
-    }
-    // Nested-through shapes flatten their whole `reflection.chain` into the
-    // JOIN-based AssociationScope path below, sharing its inverse-wiring and
-    // null-FK short-circuit. An unsaved owner resolves its through step from
-    // the in-memory association target (e.g. `post.author = mary` before save),
-    // which the SQL JOIN cannot see — `_routeThroughViaAssociationScope` keeps
-    // those on the 2-step loader.
-    if (!_routeThroughViaAssociationScope(record, reflEarly, options)) {
-      return loadHasManyThrough(record, assocName, options);
-    }
-    // Fall through into the AssociationScope path below.
-  }
-
-  const ctor = record.constructor as typeof Base;
-  const className = options.className ?? camelize(singularize(assocName));
-  const primaryKey = options.primaryKey ?? ctor.primaryKey;
-
-  const targetModel = resolveAssocClass(record, assocName, className);
-
-  if (options.inverseOf) {
-    validateInverseOf(targetModel, assocName, options.inverseOf);
-  }
-
-  // Resolve FK columns (may be array for CPK; `:as` swaps to the
-  // polymorphic FK column). Prefer the rich reflection's foreign key so an STI
-  // subclass owner uses the declaring class's column (see
-  // `ownerReflectionForeignKey`).
-  const foreignKey = options.as
-    ? (options.foreignKey ?? `${underscore(options.as)}_id`)
-    : (options.foreignKey ??
-      ownerReflectionForeignKey(ctor, assocName) ??
-      (options.queryConstraints
-        ? options.queryConstraints
-        : Array.isArray(primaryKey)
-          ? primaryKey.map((col: string) => `${underscore(ctor.name)}_${col}`)
-          : `${underscore(ctor.name)}_id`));
-
-  // Polymorphic `:as` requires a scalar FK. A composite FK is always
-  // rejected. A composite owner PK collapses to "id" when present
-  // (matching Rails' join_id_for); otherwise reject.
-  if (options.as) {
-    if (Array.isArray(foreignKey)) {
-      // Route through the reflection's canonical checkValidityBang (Rails'
-      // single raise site) so the error carries the Rails-faithful message;
-      // a no-op for polymorphic `:as` (Rails permits no composite key there).
-      routeThroughCheckValidity(ctor, assocName);
-      // No reflection resolvable — minimal trails-only fallback guard.
-      throw new CompositePrimaryKeyMismatchError({
-        activeRecord: ctor.name,
-        name: assocName,
-        primaryKey,
-        foreignKey,
-      });
-    }
-    if (Array.isArray(primaryKey) && !primaryKey.includes("id")) {
-      // Route through the reflection's canonical checkValidityBang (Rails'
-      // single raise site) so the error carries the Rails-faithful message;
-      // a no-op for polymorphic `:as` (Rails permits no composite key there).
-      routeThroughCheckValidity(ctor, assocName);
-      // No reflection resolvable — minimal trails-only fallback guard.
-      throw new CompositePrimaryKeyMismatchError({
-        activeRecord: ctor.name,
-        name: assocName,
-        primaryKey,
-        foreignKey,
-      });
-    }
-  }
-  // Route through AssociationScope when we have a reflection registered.
-  // AssociationScope handles scalar, composite, polymorphic `:as`, and
-  // STI in a single path matching Rails' `AssociationScope.scope`.
-  // Inline fallback only when the reflection hasn't been registered
-  // (happens in tests that define associations via the lower-level API
-  // without going through Reflection.create).
-  const reflection = ctor._reflectOnAssociation?.(assocName);
-  // Null-FK short-circuit: read the SAME columns the eventual query
-  // reads. For non-through, reflection.joinForeignKey is the owner-
-  // side activeRecordPrimaryKey for hasMany. For through reflections the
-  // owner-side column is on `_ownerChainReflection` (chain.last).
-  const reflForOwnerFk = _ownerChainReflection(reflection);
-  const fkCheckPks = reflForOwnerFk
-    ? Array.isArray(reflForOwnerFk.joinForeignKey)
-      ? reflForOwnerFk.joinForeignKey
-      : [reflForOwnerFk.joinForeignKey]
-    : Array.isArray(primaryKey)
-      ? primaryKey
-      : [primaryKey];
-  for (const pk of fkCheckPks) {
-    const v = record._readAttribute(pk);
-    if (v === null || v === undefined) return [];
-  }
-
-  let rel: any;
-  if (reflection) {
-    // Rails' `Association#scope` is
-    //   AssociationRelation.create(klass, self).merge!(klass.scope_for_association)
-    // (association.rb:313), so the unscoped+constraints relation MUST
-    // be merged with `klass.scope_for_association` — otherwise default_scope
-    // / scope extensions silently disappear. AssociationScope.scope
-    // already merges `reflection.scope` (macro-time lambda) via scopeFor;
-    // skip re-applying `options.scope` ONLY when it's that exact same
-    // function. Callers like `loadHasManyThrough` synthesize a NEW
-    // `options.scope` (wrapping with `sourceType` filtering) — those
-    // must still run.
-    const built = _builtAssociationScope(record, assocName, reflection, targetModel);
-    const baseRelation = _scopeForAssociation(targetModel);
-    rel = baseRelation.merge(built);
-    rel = applyAssociationScope(rel, options.scope, record, reflection.scope);
-  } else {
-    // Inline fallback: no reflection (lower-level test helpers).
-    if (Array.isArray(foreignKey)) {
-      const ownerKey = _inlineOwnerKey(ctor, options, primaryKey);
-      const pkCols = Array.isArray(ownerKey) ? ownerKey : [ownerKey];
-      if (pkCols.length !== foreignKey.length) {
-        // Route through the reflection's canonical checkValidityBang (Rails'
-        // single raise site) so the error carries the Rails-faithful message.
-        routeThroughCheckValidity(ctor, assocName);
-        // No reflection registered (lower-level test helper) — minimal guard.
-        throw new CompositePrimaryKeyMismatchError({
-          activeRecord: ctor.name,
-          name: assocName,
-          primaryKey: pkCols,
-          foreignKey,
-        });
-      }
-      const conditions: Record<string, unknown> = {};
-      for (let i = 0; i < foreignKey.length; i++) {
-        conditions[foreignKey[i]] = record._readAttribute(pkCols[i]);
-      }
-      rel = _scopeForAssociation(targetModel).where(conditions);
-    } else if (options.as) {
-      const typeCol = `${underscore(options.as)}_type`;
-      const { fkCols, ownerKeyCols } = _inlinePolymorphicKeys(
-        ctor,
-        options,
-        primaryKey,
-        foreignKey,
-      );
-      const conditions: Record<string, unknown> = { [typeCol]: polymorphicName(ctor) };
-      for (let i = 0; i < fkCols.length; i++) {
-        conditions[fkCols[i]] = record._readAttribute(ownerKeyCols[i]);
-      }
-      rel = _scopeForAssociation(targetModel).where(conditions);
-    } else {
-      const ownerKey = _inlineOwnerKey(ctor, options, primaryKey);
-      rel = _scopeForAssociation(targetModel).where({
-        [foreignKey]: record._readAttribute(ownerKey as string),
-      });
-    }
-    rel = applyAssociationScope(rel, options.scope, record);
-  }
-  // Set inverse_of on each loaded child. Resolve via the reflection so
-  // automatic_inverse_of also wires each child's parent reference.
-  // Mirrors HasManyAssociation#set_inverse_instance. Wiring runs inside the
-  // instantiation block (Rails' `find_target` yields `set_inverse_instance`
-  // per record) so it lands BEFORE the child's find/initialize callbacks.
-  const inverseName = _resolveInverseName(ctor, assocName, options);
-  if (inverseName) {
-    rel._instantiateBlock = (child: Base) => {
-      _wireInverseAssociation(record, child, inverseName);
-    };
-  }
-  const results: Base[] = await rel.toArray();
-
-  syncToAssociationInstance(record, assocName, results);
-  return results;
-}
-
-/**
  * Resolve the owner-side key for an inline (no-reflection) association
  * fallback, mirroring `reflection.activeRecordPrimaryKey` semantics
  * (reflection.rb:587 `active_record_primary_key`): for a composite-FK
@@ -1822,8 +1601,10 @@ export async function loadHasMany(
  * contains it, else keep the full composite PK (reflection.rb:597-600).
  * `primaryKey` already reflects any explicit `options.primaryKey`, so only
  * widen the default.
+ *
+ * @internal
  */
-function _inlineOwnerKey(
+export function _inlineOwnerKey(
   ctor: typeof Base,
   options: AssociationOptions,
   primaryKey: string | string[],
@@ -1998,7 +1779,7 @@ export function computeHasManyWhere(
       });
     }
     const typeCol = `${underscore(options.as)}_type`;
-    // Same query_constraints widening as the inline loadHasMany/loadHasOne
+    // Same query_constraints widening as the inline findTarget/loadHasOne
     // polymorphic fallback: a query_constraints owner keys on the composite
     // `[shardKey, ${as}_id]` against the query_constraints list, not the
     // scalar `id` alone (which would leak cross-shard rows).
@@ -2065,7 +1846,7 @@ export function computeHasManyWhere(
 
   // Scalar FK against a composite-PK owner collapses to the "id" component,
   // matching `reflection.active_record_primary_key` (reflection.rb) — the same
-  // resolver loadHasMany's AssociationScope path uses. A composite PK lacking
+  // resolver findTarget's AssociationScope path uses. A composite PK lacking
   // "id" can't map to a scalar FK, so that remains a mismatch.
   if (Array.isArray(primaryKey)) {
     const inferred = reflection?.activeRecordPrimaryKey;
@@ -2099,7 +1880,7 @@ export function computeHasManyWhere(
  * in the Rails source). Rails gets an unexecuted, side-effect-free relation for
  * free via `association.scope` — `Association#scope`
  * (`associations/association.rb:107`) into `AssociationScope#scope`
- * (`associations/association_scope.rb:21`). trails' `loadHasMany` fuses
+ * (`associations/association_scope.rb:21`). trails' `findTarget` fuses
  * relation building with caching/strict-loading/inverse_of, so the bypass has
  * to be spelled out as its own function until that fusion is undone.
  */
@@ -2123,7 +1904,7 @@ export function buildHasManyRelation(
 
 /**
  * Build the JOIN-based AssociationScope relation for a through / HABTM
- * association without executing it — the exact relation `loadHasMany` runs to
+ * association without executing it — the exact relation `findTarget` runs to
  * materialize rows (`SELECT target.* FROM target INNER JOIN join_table ...`).
  *
  * Counting over this relation yields Rails' `scope.count(:all)`: a single
@@ -2134,14 +1915,14 @@ export function buildHasManyRelation(
  * duplicate join rows to one row per id — wrong for a non-distinct `size`.
  *
  * Returns null when the owner FK is absent (unsaved owner / null PK), matching
- * the short-circuit in `loadHasMany`.
+ * the short-circuit in `findTarget`.
  *
  * @internal No Rails counterpart (`build_through_join_scope` is defined nowhere
  * in the Rails source), for the same reason as {@link buildHasManyRelation}: in
  * Rails this relation IS `association.scope`, and
  * `HasManyAssociation#count_records` (`associations/has_many_association.rb:80`)
  * just calls `scope.count(:all)` on it (`:84`). Named separately here only
- * because trails builds the JOIN form inside `loadHasMany` rather than in an
+ * because trails builds the JOIN form inside `findTarget` rather than in an
  * AssociationScope.
  */
 export function buildThroughJoinScope(
@@ -2153,7 +1934,7 @@ export function buildThroughJoinScope(
   const reflection = ctor._reflectOnAssociation?.(assocName);
   if (!reflection) return null;
   // Null-FK short-circuit on the owner-side column (chain.last's
-  // joinForeignKey — see `_ownerChainReflection`), mirroring loadHasMany.
+  // joinForeignKey — see `_ownerChainReflection`), mirroring findTarget.
   const reflForOwnerFk = _ownerChainReflection(reflection);
   const fkCols = Array.isArray(reflForOwnerFk.joinForeignKey)
     ? reflForOwnerFk.joinForeignKey
@@ -2285,9 +2066,9 @@ export async function loadHasManyThrough(
           return r;
         },
       };
-      throughRecords = await loadHasMany(record, throughAssoc.name, augmentedOptions);
+      throughRecords = await findHasManyTarget(record, throughAssoc.name, augmentedOptions);
     } else {
-      throughRecords = await loadHasMany(record, throughAssoc.name, throughAssoc.options);
+      throughRecords = await findHasManyTarget(record, throughAssoc.name, throughAssoc.options);
     }
   } else if (throughAssoc.type === "hasOne") {
     const one = await loadHasOne(record, throughAssoc.name, throughAssoc.options);
@@ -2319,7 +2100,7 @@ export async function loadHasManyThrough(
     // through record rather than assuming a direct FK to the through table.
     const results: Base[] = [];
     for (const tr of throughRecords) {
-      const sub = await loadHasMany(tr, sourceAssoc.name, sourceAssoc.options);
+      const sub = await findHasManyTarget(tr, sourceAssoc.name, sourceAssoc.options);
       results.push(...sub);
     }
     if (!options.scope) return results;
@@ -2377,7 +2158,7 @@ export async function loadHasOneThrough(
   } else if (throughAssoc.type === "belongsTo") {
     throughRecord = await findTarget(record, throughAssoc.name, throughAssoc.options);
   } else if (throughAssoc.type === "hasMany") {
-    const throughRecords = await loadHasMany(record, throughAssoc.name, throughAssoc.options);
+    const throughRecords = await findHasManyTarget(record, throughAssoc.name, throughAssoc.options);
     throughRecord = throughRecords[0] ?? null;
   } else {
     throughRecord = null;

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -79,6 +79,11 @@ import {
   CompositePrimaryKeyMismatchError,
 } from "./associations/errors.js";
 import { AssociationScope, invokeScopeLambda } from "./associations/association-scope.js";
+// Cyclic with `has-many-association.ts`, which imports this module's
+// `@internal` loader helpers back. The cycle is function-level only — neither
+// side touches the other at module-evaluation time — so whichever module is
+// entered first, the hoisted function declarations are already bound by the
+// time either is called.
 import { findTarget as findHasManyTarget } from "./associations/has-many-association.js";
 import type { Association as AssociationInstance } from "./associations/association.js";
 import {

--- a/packages/activerecord/src/associations/apply-association-scope.test.ts
+++ b/packages/activerecord/src/associations/apply-association-scope.test.ts
@@ -8,7 +8,7 @@
  *
  * The TS helper consolidates the equivalent post-merge step shared by
  * `loadBelongsTo`, `loadHasOne` (×2 — reflection path + inline fallback),
- * `loadHasMany` (×2), `loadHasManyThrough` (×2), `loadHabtm`,
+ * `findTarget` (×2), `loadHasManyThrough` (×2), `loadHabtm`,
  * `buildHasManyRelation`, and the DJAS-routed `_loadThroughViaDisableJoinsScope`.
  */
 import { describe, it, expect } from "vitest";

--- a/packages/activerecord/src/associations/association-scope-cache.test.ts
+++ b/packages/activerecord/src/associations/association-scope-cache.test.ts
@@ -17,7 +17,8 @@
 import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
 import { findTarget } from "./singular-association.js";
 import { registerModel, enableSti, registerSubclass } from "../index.js";
-import { loadHasMany, loadHasOne } from "../associations.js";
+import { loadHasOne } from "../associations.js";
+import { findTarget as findHasManyTarget } from "./has-many-association.js";
 import { AssociationScope } from "./association-scope.js";
 import { StatementCache } from "../statement-cache.js";
 import { fixtures } from "../test-helpers/fixtures.js";
@@ -85,7 +86,7 @@ describe("Association scope cache", () => {
 
     const spy = vi.spyOn(AssociationScope, "scope");
     const reflection = (Author as any)._reflectOnAssociation("noJoinsComments");
-    const records = await loadHasMany(author, "noJoinsComments", reflection.options);
+    const records = await findHasManyTarget(author, "noJoinsComments", reflection.options);
     expect(records.length).toBeGreaterThan(0);
     // JOIN-based AssociationScope was never invoked — DJAS handled it.
     expect(spy).not.toHaveBeenCalled();
@@ -104,13 +105,13 @@ describe("Association scope cache", () => {
     const opts = { className: "Post", foreignKey: "author_id" };
 
     // First loader call populates the Association-instance cache.
-    await loadHasMany(author, "posts", opts);
+    await findHasManyTarget(author, "posts", opts);
     const afterFirst = spy.mock.calls.length;
     expect(afterFirst).toBeGreaterThan(0);
 
     // Second loader call — different caches would rebuild the scope.
     // With our cache, AssociationScope.scope count is unchanged.
-    await loadHasMany(author, "posts", opts);
+    await findHasManyTarget(author, "posts", opts);
     expect(spy.mock.calls.length).toBe(afterFirst);
   });
 

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -1,7 +1,8 @@
 import type { AssociationProxy } from "./collection-proxy.js";
 import { describe, it, expect } from "vitest";
 import { Base, registerModel, enableSti, registerSubclass } from "../index.js";
-import { Associations, loadHasMany, loadHasOne } from "../associations.js";
+import { Associations, loadHasOne } from "../associations.js";
+import { findTarget } from "./has-many-association.js";
 import { AssociationScope, ReflectionProxy } from "./association-scope.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { Author } from "../test-helpers/models/author.js";
@@ -276,7 +277,7 @@ describe("AssociationScope", () => {
 
   it("loadHasMany applies caller-supplied options.scope when it differs from reflection.scope", async () => {
     // Regression for the loadHasManyThrough path that wraps options.scope
-    // with sourceType filtering before calling loadHasMany. The migrated
+    // with sourceType filtering before calling findTarget. The migrated
     // path skips re-applying when options.scope === reflection.scope
     // (avoid double-application), but augmented scopes must still run.
     // Canonical Author has_many :posts carries no macro scope, so the
@@ -287,7 +288,7 @@ describe("AssociationScope", () => {
 
     // Augmented options.scope — NOT equal to the reflection's macro
     // scope (which is null here). Loader must still apply it.
-    const results = await loadHasMany(author, "posts", {
+    const results = await findTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
       scope: (rel: any) => rel.where({ title: "published" }),
@@ -488,7 +489,8 @@ describe("AssociationScope", () => {
     // scalar <as>_id value — reject with CompositePrimaryKeyMismatchError.
     // (When the CPK includes "id", it collapses to "id" matching Rails'
     // join_id_for; only the no-id case is unrepresentable.)
-    const { loadHasMany, CompositePrimaryKeyMismatchError } = await import("../index.js");
+    const { CompositePrimaryKeyMismatchError } = await import("../index.js");
+    const { findTarget } = await import("./has-many-association.js");
     class CpkAsOwner extends Base {
       declare a: number | null;
       declare b: number | null;
@@ -512,7 +514,7 @@ describe("AssociationScope", () => {
     registerModel(CpkAsTarget);
     const owner = new CpkAsOwner({ a: 1, b: 2 });
     await expect(
-      loadHasMany(owner, "comments", {
+      findTarget(owner, "comments", {
         className: "CpkAsTarget",
         as: "commentable",
       }),
@@ -700,7 +702,7 @@ describe("AssociationScope", () => {
       taggable_type: "Comment",
     });
 
-    const posts = (await loadHasMany(tag, "taggedPosts", {
+    const posts = (await findTarget(tag, "taggedPosts", {
       className: "Post",
       through: "taggings",
       source: "taggable",
@@ -752,7 +754,7 @@ describe("AssociationScope", () => {
     const op = await Post.create({ author_id: other.id, title: "op", body: "b" });
     await Comment.create({ post_id: op.id, body: "other" });
 
-    const comments = (await loadHasMany(author, "comments", {
+    const comments = (await findTarget(author, "comments", {
       className: "Comment",
       through: "posts",
       source: "comments",
@@ -780,12 +782,12 @@ describe("AssociationScope", () => {
   });
 
   it("loadHasMany through chain (belongsTo source, no sourceType) routes via AssociationScope", async () => {
-    // PR 3b migration: loadHasMany for has_many :through where source
+    // PR 3b migration: findTarget for has_many :through where source
     // is non-polymorphic belongsTo (no sourceType) now routes through
     // AssociationScope's JOIN-based path instead of the 2-step IN-list
     // loader. Canonical Author has_many :categories through
     // :categorizations, where Categorization belongs_to :category.
-    // End-to-end: insert records, call loadHasMany, assert the right rows
+    // End-to-end: insert records, call findTarget, assert the right rows
     // return — exercises the migrated path through real DB.
     const alice = await Author.create({ name: "Alice" });
     const bob = await Author.create({ name: "Bob" });
@@ -796,7 +798,7 @@ describe("AssociationScope", () => {
     await Categorization.create({ author_id: alice.id, category_id: ts.id });
     await Categorization.create({ author_id: bob.id, category_id: go.id });
 
-    const categories = (await loadHasMany(alice, "categories", {
+    const categories = (await findTarget(alice, "categories", {
       className: "Category",
       through: "categorizations",
       source: "category",

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -784,8 +784,18 @@ export class Association {
     return k;
   }
 
-  private async findTarget(): Promise<Base | Base[] | null> {
-    return this.loadTarget();
+  /**
+   * Mirrors: ActiveRecord::Associations::Association#find_target
+   * (association.rb:248) — the seam `load_target` runs to fetch the target.
+   * Subclasses override it with the actual query; the trails hook they have
+   * historically overridden is `doAsyncFindTarget`, which this delegates to so
+   * both spellings resolve to one implementation per subclass.
+   *
+   * (Was previously a private stub that called `loadTarget()` — the inverse of
+   * Rails' direction, and unreachable.)
+   */
+  protected async findTarget(): Promise<Base | Base[] | null> {
+    return this.doAsyncFindTarget();
   }
 
   private skipStrictLoading<T>(block: () => T): T {

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -53,7 +53,7 @@ export class Association {
    *  collection proxy that it can hydrate from this instance's target. */
   _loadedViaAsync = false;
   /**
-   * Nonzero while THIS holder is itself driving a loader (`loadHasMany` &c.)
+   * Nonzero while THIS holder is itself driving a loader (`findTarget` &c.)
    * through `doAsyncFindTarget`, so the loader's own `setTarget` writeback
    * into this holder must be skipped — the driving caller assigns the result
    * itself the moment its `await` resumes.
@@ -68,12 +68,12 @@ export class Association {
    * **Scoping — this flag is holder-scoped, not loader-scoped.** While it is
    * set, `syncToAssociationInstance` suppresses *every* writeback into this
    * holder, not just the driving loader's own. A concurrent
-   * `loadHasMany(owner, sameName, differentOptions)` carrying differently
+   * `findTarget(owner, sameName, differentOptions)` carrying differently
    * scoped rows is therefore dropped from the holder too (it still returns its
    * rows to its own caller; only the holder cache goes unwritten, and the
    * driving load assigns the holder immediately after). Making it
    * loader-scoped would require threading a per-load token through
-   * `loadHasMany`; the holder-scoped version is what the guard needs, since a
+   * `findTarget`; the holder-scoped version is what the guard needs, since a
    * collection that legitimately mutates its own target mid-load (dirty
    * targets, in-memory built/pushed records, target merging) is unaffected
    * either way.

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -489,11 +489,14 @@ export class Association {
   }
 
   /**
-   * Mirrors Rails' `find_target` DB load: issues a query (never the in-memory
-   * cache) and applies `set_strict_loading` per freshly loaded record.
+   * Runs `find_target` and stores what it fetched: issues a query (never the
+   * in-memory cache) and applies `set_strict_loading` per freshly loaded
+   * record. Rails inlines this in `load_target` / `async_load_target`
+   * (association.rb:189, :198); the split exists only because the assignment
+   * is shared by both call sites above.
    */
   private async _findTarget(): Promise<void> {
-    const result = await this.doAsyncFindTarget();
+    const result = await this.findTarget();
     if (result !== undefined) {
       // Rails applies set_strict_loading per record in find_target's DB
       // execute block — only freshly loaded records, never cached ones.
@@ -786,10 +789,13 @@ export class Association {
 
   /**
    * Mirrors: ActiveRecord::Associations::Association#find_target
-   * (association.rb:248) — the seam `load_target` runs to fetch the target.
-   * Subclasses override it with the actual query; the trails hook they have
-   * historically overridden is `doAsyncFindTarget`, which this delegates to so
-   * both spellings resolve to one implementation per subclass.
+   * (association.rb:248) — the seam `load_target` (association.rb:189) and
+   * `CollectionAssociation#load_target` (collection_association.rb:272) run to
+   * fetch the target. Subclasses override it with the actual query.
+   *
+   * Subclasses that still override the older trails hook
+   * (`doAsyncFindTarget`) rather than this reach their query through the
+   * delegation below, so there is one implementation per subclass either way.
    *
    * (Was previously a private stub that called `loadTarget()` — the inverse of
    * Rails' direction, and unreachable.)

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -621,11 +621,11 @@ export class CollectionAssociation extends Association {
   protected async persistReplacePlan(pending: ReplacePlan): Promise<void> {
     if (this.owner.isNewRecord()) return;
     // If the association wasn't loaded at assignment time, fetch the persisted
-    // baseline directly via doAsyncFindTarget to avoid the loadedBang short-circuit
+    // baseline directly rather than via findTarget, to avoid the loadedBang short-circuit
     // and without mutating this.target (mirrors Rails' load_target in replace).
     if (!pending.wasLoaded) {
       // Query the DB directly via scope() to get the persisted baseline.
-      // doAsyncFindTarget() hits the association-instance cache (which may
+      // findTarget() hits the association-instance cache (which may
       // already reflect the in-memory replace) and returns the wrong diff.
       const rel = this.scope() as { toArray?: () => Promise<Base[]> } | null | undefined;
       const dbRecords = rel?.toArray ? await rel.toArray() : [];
@@ -669,7 +669,7 @@ export class CollectionAssociation extends Association {
       if (cached !== undefined && Array.isArray(cached)) {
         this.target = this.mergeTargetLists(cached, this.target);
       } else {
-        const found = await this.doAsyncFindTarget();
+        const found = await this.findTarget();
         if (found !== undefined && found !== null && Array.isArray(found)) {
           // Rails applies set_strict_loading per record in find_target's DB
           // execute block — only freshly loaded records, never cached ones.

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -902,7 +902,7 @@ export class CollectionAssociation extends Association {
     if (this.reflection.options.as) {
       return [`${underscore(this.reflection.options.as)}_id`];
     }
-    // Derive composite FKs for CPK owners (mirrors loadHasMany)
+    // Derive composite FKs for CPK owners (mirrors findTarget)
     const pk = this.reflection.options.primaryKey ?? ctor.primaryKey ?? "id";
     if (Array.isArray(pk)) {
       return pk.map((col: string) => `${underscore(ctor.name)}_${col}`);

--- a/packages/activerecord/src/associations/collection-proxy-count.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy-count.test.ts
@@ -2,7 +2,7 @@
  * CollectionProxy#count emits a real COUNT query (task #16).
  *
  * Previously the non-diverged branch of CP#count called
- * `loadHasMany(...)` and returned `results.length`, instantiating
+ * `findTarget(...)` and returned `results.length`, instantiating
  * every associated record just to get a cardinality. For large
  * collections that's a significant perf regression. This test
  * captures emitted SQL via `Notifications.subscribe("sql.active_record")`

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -305,7 +305,7 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
   it("toArray honors direct bang-mutation of inherited Relation state", async () => {
     // In-place bang mutations on CP (cp.whereBang/orderBang/limitBang)
     // change the inherited Relation state. `toArray()` routes through
-    // `loadHasMany` with a scope-override executor so the query honors the
+    // `findTarget` with a scope-override executor so the query honors the
     // mutations, bypassing the association cache.
     const author = await authorWithPosts();
     const proxy = association<Post>(author, "posts") as any;
@@ -317,7 +317,7 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
   it("await proxy (load) honors direct bang-mutation of inherited Relation state", async () => {
     // `await proxy` calls load(), which uses the same unified _execLoad() path
     // as toArray(). When the proxy state has been mutated (whereBang/orderBang),
-    // the scope-override executor is passed to loadHasMany so the mutated
+    // the scope-override executor is passed to findTarget so the mutated
     // scope is executed directly rather than falling back to the association cache.
     const author = await Author.create({ name: "Diverged" });
     for (const title of ["x", "y", "z"]) {

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -68,7 +68,6 @@ import {
   resolveAssocClass,
   buildHasManyRelation,
   buildThroughJoinScope,
-  loadHasMany,
   _routeThroughViaAssociationScope,
   ownerHasUnresolvedThroughKey,
   _setCollectionInverseInstance,
@@ -80,7 +79,12 @@ import {
   multisetDifference,
   multisetIntersection,
 } from "./has-many-through-association.js";
-import { countRecords, setDifference, setIntersection } from "./has-many-association.js";
+import {
+  countRecords,
+  findTarget,
+  setDifference,
+  setIntersection,
+} from "./has-many-association.js";
 import { throughForeignKeyPresent } from "./through-association.js";
 import { foreignKeyPresentFor } from "./foreign-association.js";
 import type { AssociationReflection } from "../reflection.js";
@@ -809,8 +813,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   /**
    * Shared execution core for `toArray()` and `load()`. Routes both the
    * unmutated and mutated (whereBang / orderBang / ...) proxy through a
-   * single `loadHasMany` call. When the proxy state has diverged from the
-   * seed, a `queryExecutor` callback is passed so `loadHasMany` skips cache
+   * single `findTarget` call. When the proxy state has diverged from the
+   * seed, a `queryExecutor` callback is passed so `findTarget` skips cache
    * and scope rebuild and runs the mutated Relation directly — mirrors Rails'
    * `CollectionProxy → AssociationRelation#exec_queries → loadTarget` path
    * which always routes through the OO association regardless of scope state.
@@ -834,7 +838,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
             _AssociationRelationCtor!.prototype as unknown as { toArray(): Promise<Base[]> }
           ).toArray.call(this)
       : undefined;
-    const results = (await loadHasMany(
+    const results = (await findTarget(
       this._record,
       this._assocName,
       this._assocDef.options,
@@ -1069,7 +1073,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   /**
    * Propagate the owner's strict-loading mode onto each loaded child —
    * mirrors `Association#set_strict_loading`, which Rails applies in
-   * `find_target` / `exec_queries`. The functional `loadHasMany` path
+   * `find_target` / `exec_queries`. The functional `findTarget` path
    * (the common `await blog.posts` reader) bypasses the OO
    * `CollectionAssociation.loadTarget` where this cascade lives, so we
    * route through the OO association here to reuse the exact same logic.
@@ -1743,7 +1747,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         !this._assocDef.options.disableJoins &&
         !_routeThroughViaAssociationScope(this._record, refl, this._assocDef.options)
       ) {
-        const results = await loadHasMany(this._record, this._assocName, this._assocDef.options);
+        const results = await findTarget(this._record, this._assocName, this._assocDef.options);
         return results.length;
       }
       // Routed shapes fall through to `countFn.call(this.scope())` below;
@@ -1964,7 +1968,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     if (this._target.length > 0) return false;
     // Through associations: #exists always loads the full target, so prefer
     // count() which routes through AssociationScope as a SQL COUNT for the
-    // common shapes (loadHasMany fallback still loads for the rest).
+    // common shapes (findTarget fallback still loads for the rest).
     if (this._isThrough) return (await this.count()) === 0;
     // Mirrors Rails collection_association.rb#empty?:
     //   if loaded? || @association_ids || reflection.has_active_cached_counter?
@@ -4457,7 +4461,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
 // `await proxy; proxy[0]` / `proxy.target.length` work after a single await.
 // `toArray()` stays available for callers who want a fresh array
 // without hydrating this proxy's `_target` / `_loaded` (it still goes
-// through `loadHasMany`, which syncs into the record's association
+// through `findTarget`, which syncs into the record's association
 // instance cache — only this proxy's local cache is left untouched).
 applyThenable(CollectionProxy.prototype, "load");
 

--- a/packages/activerecord/src/associations/cp-count-disable-joins-through.test.ts
+++ b/packages/activerecord/src/associations/cp-count-disable-joins-through.test.ts
@@ -2,7 +2,7 @@
  * `CollectionProxy#count` on `disable_joins: true` through-
  * associations (task #22).
  *
- * Before this PR, CP#count fell back to `loadHasMany(...).length`
+ * Before this PR, CP#count fell back to `findTarget(...).length`
  * for every disable-joins through shape — the chain walk runs
  * intermediate pluck queries either way, but the final step
  * would SELECT every target row and `.length` the array. On

--- a/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import { Base, MigrationContext, registerModel } from "../index.js";
-import { Associations, loadHasMany } from "../associations.js";
+import { Associations } from "../associations.js";
+import { findTarget } from "./has-many-association.js";
 import { DisableJoinsAssociationScope } from "./disable-joins-association-scope.js";
 import { DisableJoinsAssociationRelation } from "../disable-joins-association-relation.js";
 import { fixtures } from "../test-helpers/fixtures.js";
@@ -163,7 +164,7 @@ describe("DisableJoinsAssociationScope", () => {
     await DjsComment.create({ djs_post_id: post.id, body: "hi" });
 
     const reflection = (DjsAuthor as any)._reflectOnAssociation("djsComments");
-    const comments = await loadHasMany(author, "djsComments", reflection.options);
+    const comments = await findTarget(author, "djsComments", reflection.options);
     expect(comments.map((c: any) => c.body)).toEqual(["hi"]);
   });
 

--- a/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
@@ -17,7 +17,8 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import { Base, MigrationContext, registerModel } from "../index.js";
-import { Associations, loadHasMany } from "../associations.js";
+import { Associations } from "../associations.js";
+import { findTarget } from "./has-many-association.js";
 import { DisableJoinsAssociationRelation } from "../disable-joins-association-relation.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 
@@ -127,7 +128,7 @@ describe("DJAS — composite key support", () => {
     });
     try {
       const reflection = (CkShop as any)._reflectOnAssociation("ckLineItemsThroughOrders");
-      const items = await loadHasMany(shop, "ckLineItemsThroughOrders", reflection.options);
+      const items = await findTarget(shop, "ckLineItemsThroughOrders", reflection.options);
       expect(items.map((i: any) => i.sku).sort()).toEqual(["sku-1", "sku-2"]);
     } finally {
       Notifications.unsubscribe(sub);
@@ -171,7 +172,7 @@ describe("DJAS — composite key support", () => {
     });
 
     const reflection = (CkShop as any)._reflectOnAssociation("ckLineItemsOrdered");
-    const items = await loadHasMany(shop, "ckLineItemsOrdered", reflection.options);
+    const items = await findTarget(shop, "ckLineItemsOrdered", reflection.options);
     expect(items.map((i: any) => i.sku)).toEqual(["from-a", "from-b"]);
   });
 
@@ -194,7 +195,7 @@ describe("DJAS — composite key support", () => {
     });
 
     const reflection = (CkShop as any)._reflectOnAssociation("ckLineItemsThroughOrders");
-    const items = await loadHasMany(shop, "ckLineItemsThroughOrders", reflection.options);
+    const items = await findTarget(shop, "ckLineItemsThroughOrders", reflection.options);
     expect(items.map((i: any) => i.sku)).toEqual(["valid"]);
   });
 
@@ -333,7 +334,7 @@ describe("DJAS — composite key support", () => {
     });
     try {
       const reflection = (CkShop as any)._reflectOnAssociation("ckLineItemsEmpty");
-      const items = await loadHasMany(shop, "ckLineItemsEmpty", reflection.options);
+      const items = await findTarget(shop, "ckLineItemsEmpty", reflection.options);
       expect(items).toEqual([]);
     } finally {
       Notifications.unsubscribe(sub);
@@ -348,7 +349,7 @@ describe("DJAS — composite key support", () => {
   it("returns no rows when the composite-key tuple list is empty (owner has no through records)", async () => {
     const shop = await CkShop.create({ name: "Lonely" });
     const reflection = (CkShop as any)._reflectOnAssociation("ckLineItemsThroughOrders");
-    const items = await loadHasMany(shop, "ckLineItemsThroughOrders", reflection.options);
+    const items = await findTarget(shop, "ckLineItemsThroughOrders", reflection.options);
     expect(items).toEqual([]);
   });
 });

--- a/packages/activerecord/src/associations/disable-joins-composite-nested.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-nested.test.ts
@@ -31,7 +31,8 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import { Base, MigrationContext, registerModel } from "../index.js";
-import { Associations, loadHasMany } from "../associations.js";
+import { Associations } from "../associations.js";
+import { findTarget } from "./has-many-association.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 
 function migrationCtx() {
@@ -175,7 +176,7 @@ describe("DJAS composite-key + nested-through", () => {
     });
     try {
       const reflection = (CknShop as any)._reflectOnAssociation("cknLineItemTags");
-      const tags = await loadHasMany(shop, "cknLineItemTags", reflection.options);
+      const tags = await findTarget(shop, "cknLineItemTags", reflection.options);
       expect(tags.map((t: any) => t.value).sort()).toEqual(["red", "sale"]);
     } finally {
       Notifications.unsubscribe(sub);
@@ -199,7 +200,7 @@ describe("DJAS composite-key + nested-through", () => {
 
     const unsaved = CknShop.new({ name: "unsaved" });
     const reflection = (CknShop as any)._reflectOnAssociation("cknLineItemTags");
-    const tags = await loadHasMany(unsaved, "cknLineItemTags", reflection.options);
+    const tags = await findTarget(unsaved, "cknLineItemTags", reflection.options);
     expect(tags).toEqual([]);
     expect(tags.map((t: any) => t.value)).not.toContain("orphan-tag");
   });

--- a/packages/activerecord/src/associations/disable-joins-nested-through.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-nested-through.test.ts
@@ -22,7 +22,8 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import { Base, MigrationContext, registerModel } from "../index.js";
-import { Associations, loadHasMany } from "../associations.js";
+import { Associations } from "../associations.js";
+import { findTarget } from "./has-many-association.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 
 function migrationCtx() {
@@ -148,7 +149,7 @@ describe("DJAS routing widening — nested-through", () => {
     });
     try {
       const reflection = (NtAuthor as any)._reflectOnAssociation("noJoinsNtRatings");
-      const ratings = await loadHasMany(author, "noJoinsNtRatings", reflection.options);
+      const ratings = await findTarget(author, "noJoinsNtRatings", reflection.options);
       expect(ratings.map((r: any) => r.id).sort()).toEqual([r1.id, r2.id, r3.id].sort());
     } finally {
       Notifications.unsubscribe(sub);
@@ -183,7 +184,7 @@ describe("DJAS routing widening — nested-through", () => {
     await NtRating.create({ nt_comment_id: ca.id, value: 2 });
 
     const reflection = (NtAuthor as any)._reflectOnAssociation("noJoinsNtRatingsOrdered");
-    const ratings = await loadHasMany(author, "noJoinsNtRatingsOrdered", reflection.options);
+    const ratings = await findTarget(author, "noJoinsNtRatingsOrdered", reflection.options);
     expect(ratings.map((r: any) => r.value)).toEqual([2, 1]);
   });
 });

--- a/packages/activerecord/src/associations/disable-joins-polymorphic-nonid-pk.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-polymorphic-nonid-pk.test.ts
@@ -2,7 +2,7 @@
  * DJAS: polymorphic belongsTo-through with non-id target PK (task #20).
  *
  * The non-DJAS path has a regression test at
- * `association-scope.test.ts` ("loadHasMany through with sourceType +
+ * `association-scope.test.ts` ("findTarget through with sourceType +
  * non-id target PK uses correct join column"). The DJAS walk routes
  * through the same reflection infrastructure (`joinPrimaryKeyFor`
  * resolves the source target's actual PK column for a polymorphic
@@ -28,7 +28,8 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import { Base, registerModel, TableDefinition } from "../index.js";
-import { Associations, loadHasMany } from "../associations.js";
+import { Associations } from "../associations.js";
+import { findTarget } from "./has-many-association.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 
 describe("DJAS — polymorphic belongsTo-through with non-id target PK", () => {
@@ -167,7 +168,7 @@ describe("DJAS — polymorphic belongsTo-through with non-id target PK", () => {
     });
     try {
       const reflection = (DpAuthor as any)._reflectOnAssociation("noJoinsDpPhotos");
-      const photos = await loadHasMany(author, "noJoinsDpPhotos", reflection.options);
+      const photos = await findTarget(author, "noJoinsDpPhotos", reflection.options);
       expect(photos.map((p: any) => p.uuid)).toEqual([photo.uuid]);
       expect(photos.map((p: any) => p.title)).toEqual(["p1"]);
     } finally {

--- a/packages/activerecord/src/associations/disable-joins-routing-widening.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-routing-widening.test.ts
@@ -21,7 +21,8 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import { Base, MigrationContext, registerModel } from "../index.js";
-import { Associations, association, loadHasMany } from "../associations.js";
+import { Associations, association } from "../associations.js";
+import { findTarget } from "./has-many-association.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 
 function migrationCtx() {
@@ -149,7 +150,7 @@ describe("DJAS routing widening — sourceType + polymorphic source", () => {
     });
     try {
       const reflection = (RwAuthor as any)._reflectOnAssociation("noJoinsRwMembers");
-      const members = await loadHasMany(author, "noJoinsRwMembers", reflection.options);
+      const members = await findTarget(author, "noJoinsRwMembers", reflection.options);
       expect(members.map((m: any) => m.id).sort()).toEqual([m1.id, m2.id].sort());
       const count = await association(author, "noJoinsRwMembers").count();
       expect(count).toBe(2);

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -1,12 +1,38 @@
 import type { Base } from "../base.js";
-import type { AssociationDefinition } from "../associations.js";
-import { loadHasMany } from "../associations.js";
-import { DeleteRestrictionError } from "./errors.js";
+import type { AssociationDefinition, AssociationOptions } from "../associations.js";
+import {
+  _builtAssociationScope,
+  _canRouteThroughViaDisableJoinsAssociationScope,
+  _findTargetReachable,
+  _inlineOwnerKey,
+  _inlinePolymorphicKeys,
+  _loadThroughViaDisableJoinsScope,
+  _ownerChainReflection,
+  _preloadedHolderTarget,
+  _resolveInverseName,
+  _routeThroughViaAssociationScope,
+  _scopeForAssociation,
+  _violatesStrictLoading,
+  _wireInverseAssociation,
+  applyAssociationScope,
+  loadHasManyThrough,
+  ownerReflectionForeignKey,
+  resolveAssocClass,
+  syncToAssociationInstance,
+  validateInverseOf,
+} from "../associations.js";
+import { strictLoadingViolationBang } from "../core.js";
+import {
+  validateThroughReflection,
+  routeThroughCheckValidity,
+} from "./validate-through-reflection.js";
+import { CompositePrimaryKeyMismatchError, DeleteRestrictionError } from "./errors.js";
+import { polymorphicName } from "../inheritance.js";
 import { RecordInvalid } from "../validations.js";
 import { CollectionAssociation, includesRecord } from "./collection-association.js";
 import { ForeignAssociation } from "./foreign-association.js";
 import { compositeQueryConstraintsList } from "../persistence.js";
-import { underscore } from "@blazetrails/activesupport";
+import { camelize, singularize, underscore } from "@blazetrails/activesupport";
 
 /**
  * Proxy that handles a has_many association.
@@ -128,13 +154,13 @@ export class HasManyAssociation extends CollectionAssociation {
 
   protected override async doAsyncFindTarget(): Promise<Base[]> {
     // Every caller of doAsyncFindTarget assigns the returned records into
-    // this holder itself, so loadHasMany's tail writeback into the same
+    // this holder itself, so findTarget's tail writeback into the same
     // holder is redundant — and, because it lands mid-await, clobbers any
     // reassignment made while the query was in flight. See
     // `_loaderWritebackSuppressed`.
     this._loaderWritebackSuppressed++;
     try {
-      return await loadHasMany(this.owner, this.reflection.name, this.reflection.options);
+      return await findTarget(this.owner, this.reflection.name, this.reflection.options);
     } finally {
       this._loaderWritebackSuppressed--;
     }
@@ -457,4 +483,239 @@ export function setDifference(a: Base[], b: Base[]): Base[] {
 /** @internal */
 export function setIntersection(a: Base[], b: Base[]): Base[] {
   return a.filter((record) => includesRecord(b, record));
+}
+
+/**
+ * Find the has_many association's target records.
+ *
+ * Mirrors: ActiveRecord::Associations::Association#find_target
+ * (association.rb:248) as reached through `CollectionAssociation` /
+ * `HasManyAssociation`. Takes the owner/name/options triple rather than an
+ * association instance because the CollectionProxy load path and the
+ * through-association loaders reach it without one.
+ */
+export async function findTarget(
+  record: Base,
+  assocName: string,
+  options: AssociationOptions,
+  queryExecutor?: () => Promise<Base[]>,
+): Promise<Base[]> {
+  if (options.through) {
+    validateThroughReflection(record.constructor as typeof Base, assocName);
+  }
+  // Check cached (inverse_of) first, then preloaded — skip when a scope
+  // override is provided (the scope has been mutated; the cache would return
+  // stale/incorrect data for the diverged query).
+  if (!queryExecutor) {
+    // Honor an instance-cache hit (a directly-seeded or inverse-seeded
+    // collection target), but ignore the association's *own* collection proxy:
+    // its in-memory built/pushed records are not a complete collection and must
+    // still be merged with a DB query (this loader runs inside that proxy's
+    // load path, where `proxy.loaded` is false by construction).
+    const cache = record._associationCache(assocName);
+    if (
+      cache &&
+      cache !== record._collectionProxies.get(assocName) &&
+      Array.isArray(cache.target) &&
+      !(typeof (cache as any).isStaleTarget === "function" && (cache as any).isStaleTarget())
+    ) {
+      return cache.target;
+    }
+    const preloaded = _preloadedHolderTarget(record, assocName);
+    if (preloaded) {
+      return (preloaded.value ?? []) as Base[];
+    }
+  }
+
+  // Strict loading check. Gated by `find_target?`: a new-record owner without
+  // the FK present never reaches `find_target` and so never raises.
+  if (
+    _violatesStrictLoading(record, options) &&
+    _findTargetReachable(record, assocName, options, "foreign")
+  ) {
+    strictLoadingViolationBang(record, assocName, {
+      className: options.className ?? camelize(singularize(assocName)),
+    });
+  }
+
+  // Scope-override path: CollectionProxy passes this when its Relation state
+  // has been mutated (whereBang / orderBang / ...). The executor runs the
+  // mutated scope directly; cache lookup and scope rebuild are bypassed.
+  if (queryExecutor) return queryExecutor();
+
+  // Handle through associations. Routes through AssociationScope's
+  // JOIN-based path for the simple shape (see
+  // _canRouteThroughViaAssociationScope); everything else stays on the
+  // 2-step loadHasManyThrough.
+  if (options.through) {
+    const ctorEarly = record.constructor as typeof Base;
+    const reflEarly = ctorEarly._reflectOnAssociation?.(assocName);
+    if (_canRouteThroughViaDisableJoinsAssociationScope(reflEarly, options)) {
+      return _loadThroughViaDisableJoinsScope(record, reflEarly, options);
+    }
+    // Nested-through shapes flatten their whole `reflection.chain` into the
+    // JOIN-based AssociationScope path below, sharing its inverse-wiring and
+    // null-FK short-circuit. An unsaved owner resolves its through step from
+    // the in-memory association target (e.g. `post.author = mary` before save),
+    // which the SQL JOIN cannot see — `_routeThroughViaAssociationScope` keeps
+    // those on the 2-step loader.
+    if (!_routeThroughViaAssociationScope(record, reflEarly, options)) {
+      return loadHasManyThrough(record, assocName, options);
+    }
+    // Fall through into the AssociationScope path below.
+  }
+
+  const ctor = record.constructor as typeof Base;
+  const className = options.className ?? camelize(singularize(assocName));
+  const primaryKey = options.primaryKey ?? ctor.primaryKey;
+
+  const targetModel = resolveAssocClass(record, assocName, className);
+
+  if (options.inverseOf) {
+    validateInverseOf(targetModel, assocName, options.inverseOf);
+  }
+
+  // Resolve FK columns (may be array for CPK; `:as` swaps to the
+  // polymorphic FK column). Prefer the rich reflection's foreign key so an STI
+  // subclass owner uses the declaring class's column (see
+  // `ownerReflectionForeignKey`).
+  const foreignKey = options.as
+    ? (options.foreignKey ?? `${underscore(options.as)}_id`)
+    : (options.foreignKey ??
+      ownerReflectionForeignKey(ctor, assocName) ??
+      (options.queryConstraints
+        ? options.queryConstraints
+        : Array.isArray(primaryKey)
+          ? primaryKey.map((col: string) => `${underscore(ctor.name)}_${col}`)
+          : `${underscore(ctor.name)}_id`));
+
+  // Polymorphic `:as` requires a scalar FK. A composite FK is always
+  // rejected. A composite owner PK collapses to "id" when present
+  // (matching Rails' join_id_for); otherwise reject.
+  if (options.as) {
+    if (Array.isArray(foreignKey)) {
+      // Route through the reflection's canonical checkValidityBang (Rails'
+      // single raise site) so the error carries the Rails-faithful message;
+      // a no-op for polymorphic `:as` (Rails permits no composite key there).
+      routeThroughCheckValidity(ctor, assocName);
+      // No reflection resolvable — minimal trails-only fallback guard.
+      throw new CompositePrimaryKeyMismatchError({
+        activeRecord: ctor.name,
+        name: assocName,
+        primaryKey,
+        foreignKey,
+      });
+    }
+    if (Array.isArray(primaryKey) && !primaryKey.includes("id")) {
+      // Route through the reflection's canonical checkValidityBang (Rails'
+      // single raise site) so the error carries the Rails-faithful message;
+      // a no-op for polymorphic `:as` (Rails permits no composite key there).
+      routeThroughCheckValidity(ctor, assocName);
+      // No reflection resolvable — minimal trails-only fallback guard.
+      throw new CompositePrimaryKeyMismatchError({
+        activeRecord: ctor.name,
+        name: assocName,
+        primaryKey,
+        foreignKey,
+      });
+    }
+  }
+  // Route through AssociationScope when we have a reflection registered.
+  // AssociationScope handles scalar, composite, polymorphic `:as`, and
+  // STI in a single path matching Rails' `AssociationScope.scope`.
+  // Inline fallback only when the reflection hasn't been registered
+  // (happens in tests that define associations via the lower-level API
+  // without going through Reflection.create).
+  const reflection = ctor._reflectOnAssociation?.(assocName);
+  // Null-FK short-circuit: read the SAME columns the eventual query
+  // reads. For non-through, reflection.joinForeignKey is the owner-
+  // side activeRecordPrimaryKey for hasMany. For through reflections the
+  // owner-side column is on `_ownerChainReflection` (chain.last).
+  const reflForOwnerFk = _ownerChainReflection(reflection);
+  const fkCheckPks = reflForOwnerFk
+    ? Array.isArray(reflForOwnerFk.joinForeignKey)
+      ? reflForOwnerFk.joinForeignKey
+      : [reflForOwnerFk.joinForeignKey]
+    : Array.isArray(primaryKey)
+      ? primaryKey
+      : [primaryKey];
+  for (const pk of fkCheckPks) {
+    const v = record._readAttribute(pk);
+    if (v === null || v === undefined) return [];
+  }
+
+  let rel: any;
+  if (reflection) {
+    // Rails' `Association#scope` is
+    //   AssociationRelation.create(klass, self).merge!(klass.scope_for_association)
+    // (association.rb:313), so the unscoped+constraints relation MUST
+    // be merged with `klass.scope_for_association` — otherwise default_scope
+    // / scope extensions silently disappear. AssociationScope.scope
+    // already merges `reflection.scope` (macro-time lambda) via scopeFor;
+    // skip re-applying `options.scope` ONLY when it's that exact same
+    // function. Callers like `loadHasManyThrough` synthesize a NEW
+    // `options.scope` (wrapping with `sourceType` filtering) — those
+    // must still run.
+    const built = _builtAssociationScope(record, assocName, reflection, targetModel);
+    const baseRelation = _scopeForAssociation(targetModel);
+    rel = baseRelation.merge(built);
+    rel = applyAssociationScope(rel, options.scope, record, reflection.scope);
+  } else {
+    // Inline fallback: no reflection (lower-level test helpers).
+    if (Array.isArray(foreignKey)) {
+      const ownerKey = _inlineOwnerKey(ctor, options, primaryKey);
+      const pkCols = Array.isArray(ownerKey) ? ownerKey : [ownerKey];
+      if (pkCols.length !== foreignKey.length) {
+        // Route through the reflection's canonical checkValidityBang (Rails'
+        // single raise site) so the error carries the Rails-faithful message.
+        routeThroughCheckValidity(ctor, assocName);
+        // No reflection registered (lower-level test helper) — minimal guard.
+        throw new CompositePrimaryKeyMismatchError({
+          activeRecord: ctor.name,
+          name: assocName,
+          primaryKey: pkCols,
+          foreignKey,
+        });
+      }
+      const conditions: Record<string, unknown> = {};
+      for (let i = 0; i < foreignKey.length; i++) {
+        conditions[foreignKey[i]] = record._readAttribute(pkCols[i]);
+      }
+      rel = _scopeForAssociation(targetModel).where(conditions);
+    } else if (options.as) {
+      const typeCol = `${underscore(options.as)}_type`;
+      const { fkCols, ownerKeyCols } = _inlinePolymorphicKeys(
+        ctor,
+        options,
+        primaryKey,
+        foreignKey,
+      );
+      const conditions: Record<string, unknown> = { [typeCol]: polymorphicName(ctor) };
+      for (let i = 0; i < fkCols.length; i++) {
+        conditions[fkCols[i]] = record._readAttribute(ownerKeyCols[i]);
+      }
+      rel = _scopeForAssociation(targetModel).where(conditions);
+    } else {
+      const ownerKey = _inlineOwnerKey(ctor, options, primaryKey);
+      rel = _scopeForAssociation(targetModel).where({
+        [foreignKey]: record._readAttribute(ownerKey as string),
+      });
+    }
+    rel = applyAssociationScope(rel, options.scope, record);
+  }
+  // Set inverse_of on each loaded child. Resolve via the reflection so
+  // automatic_inverse_of also wires each child's parent reference.
+  // Mirrors HasManyAssociation#set_inverse_instance. Wiring runs inside the
+  // instantiation block (Rails' `find_target` yields `set_inverse_instance`
+  // per record) so it lands BEFORE the child's find/initialize callbacks.
+  const inverseName = _resolveInverseName(ctor, assocName, options);
+  if (inverseName) {
+    rel._instantiateBlock = (child: Base) => {
+      _wireInverseAssociation(record, child, inverseName);
+    };
+  }
+  const results: Base[] = await rel.toArray();
+
+  syncToAssociationInstance(record, assocName, results);
+  return results;
 }

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -174,6 +174,11 @@ export class HasManyAssociation extends CollectionAssociation {
     }
   }
 
+  /**
+   * The older trails spelling, kept for the callers that reach the query
+   * without going through `loadTarget` (`CollectionAssociation#isEmptyAsync`).
+   * `loadTarget` itself runs `findTarget` directly, as Rails does.
+   */
   protected override async doAsyncFindTarget(): Promise<Base[]> {
     return this.findTarget();
   }

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -174,15 +174,6 @@ export class HasManyAssociation extends CollectionAssociation {
     }
   }
 
-  /**
-   * The older trails spelling, kept for the callers that reach the query
-   * without going through `loadTarget` (`CollectionAssociation#isEmptyAsync`).
-   * `loadTarget` itself runs `findTarget` directly, as Rails does.
-   */
-  protected override async doAsyncFindTarget(): Promise<Base[]> {
-    return this.findTarget();
-  }
-
   protected override setOwnerAttributes(record: Base): void {
     if (this.reflection.options.through) return;
     super.setOwnerAttributes(record);

--- a/packages/activerecord/src/associations/has-many-association.ts
+++ b/packages/activerecord/src/associations/has-many-association.ts
@@ -152,18 +152,30 @@ export class HasManyAssociation extends CollectionAssociation {
     return updateCounterIfSuccess(this, saved, 1);
   }
 
-  protected override async doAsyncFindTarget(): Promise<Base[]> {
-    // Every caller of doAsyncFindTarget assigns the returned records into
-    // this holder itself, so findTarget's tail writeback into the same
-    // holder is redundant — and, because it lands mid-await, clobbers any
-    // reassignment made while the query was in flight. See
-    // `_loaderWritebackSuppressed`.
+  /**
+   * Fetch the collection's target records.
+   *
+   * Mirrors: ActiveRecord::Associations::Association#find_target
+   * (association.rb:248) as reached through `CollectionAssociation#load_target`
+   * (collection_association.rb:272). This is the association-instance entry
+   * point; it wraps the functional loader below, which the CollectionProxy and
+   * the through-association loaders reach without an association instance.
+   */
+  protected override async findTarget(): Promise<Base[]> {
+    // Every caller assigns the returned records into this holder itself, so the
+    // loader's tail writeback into the same holder is redundant — and, because
+    // it lands mid-await, clobbers any reassignment made while the query was in
+    // flight. See `_loaderWritebackSuppressed`.
     this._loaderWritebackSuppressed++;
     try {
       return await findTarget(this.owner, this.reflection.name, this.reflection.options);
     } finally {
       this._loaderWritebackSuppressed--;
     }
+  }
+
+  protected override async doAsyncFindTarget(): Promise<Base[]> {
+    return this.findTarget();
   }
 
   protected override setOwnerAttributes(record: Base): void {
@@ -488,11 +500,14 @@ export function setIntersection(a: Base[], b: Base[]): Base[] {
 /**
  * Find the has_many association's target records.
  *
- * Mirrors: ActiveRecord::Associations::Association#find_target
- * (association.rb:248) as reached through `CollectionAssociation` /
- * `HasManyAssociation`. Takes the owner/name/options triple rather than an
+ * The functional body behind `HasManyAssociation#findTarget`, which is the
+ * Rails-shaped entry point (`ActiveRecord::Associations::Association#find_target`,
+ * association.rb:248). It takes the owner/name/options triple rather than an
  * association instance because the CollectionProxy load path and the
- * through-association loaders reach it without one.
+ * through-association loaders reach the loader without one; that triple shape
+ * is a trails-only calling convention, not Rails surface.
+ *
+ * @internal
  */
 export async function findTarget(
   record: Base,

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -37,12 +37,8 @@ import { Car } from "../test-helpers/models/car.js";
 import { Bulb } from "../test-helpers/models/bulb.js";
 import { Developer, AuditLog } from "../test-helpers/models/developer.js";
 import { Project } from "../test-helpers/models/project.js";
-import {
-  Associations,
-  loadHasMany,
-  loadHasManyThrough,
-  isAssociationCached,
-} from "../associations.js";
+import { Associations, loadHasManyThrough, isAssociationCached } from "../associations.js";
+import { findTarget as findHasManyTarget } from "./has-many-association.js";
 import { DeleteRestrictionError } from "./errors.js";
 import { assertQueriesCount, assertNoQueries } from "../testing/query-assertions.js";
 
@@ -935,7 +931,7 @@ describe("HasManyAssociationsTest", () => {
     await DestroyAllPost.create({ author_id: author.id, title: "A", body: "body" });
     await DestroyAllPost.create({ author_id: author.id, title: "B", body: "body" });
     await author.destroy();
-    const remaining = await loadHasMany(author, "destroy_all_posts", {
+    const remaining = await findHasManyTarget(author, "destroy_all_posts", {
       className: "DestroyAllPost",
       foreignKey: "author_id",
     });
@@ -973,7 +969,7 @@ describe("HasManyAssociationsTest", () => {
     await DeleteAllUnloadedPost.create({ author_id: author.id, title: "A", body: "body" });
     // delete all without pre-loading the collection
     await author.destroy();
-    const remaining = await loadHasMany(author, "delete_all_unloaded_posts", {
+    const remaining = await findHasManyTarget(author, "delete_all_unloaded_posts", {
       className: "DeleteAllUnloadedPost",
       foreignKey: "author_id",
     });
@@ -1104,7 +1100,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await HmAuthor.create({ name: "Alice" });
     const p1 = await HmPost.create({ author_id: author.id, title: "A", body: "body" });
     const p2 = await HmPost.create({ author_id: author.id, title: "B", body: "body" });
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -1116,7 +1112,7 @@ describe("HasManyAssociationsTest", () => {
   it("get ids for loaded associations", async () => {
     const author = await HmAuthor.create({ name: "Alice" });
     const p1 = await HmPost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -1136,7 +1132,7 @@ describe("HasManyAssociationsTest", () => {
   it("included in collection", async () => {
     const author = await HmAuthor.create({ name: "Alice" });
     const post = await HmPost.create({ author_id: author.id, title: "Included", body: "body" });
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -1148,7 +1144,7 @@ describe("HasManyAssociationsTest", () => {
     const newPost = HmPost.new({ author_id: author.id, title: "New" });
     expect(newPost.isNewRecord()).toBe(true);
     // Not in DB yet
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -1188,7 +1184,7 @@ describe("HasManyAssociationsTest", () => {
     await ClearPost.create({ author_id: author.id, title: "A", body: "body" });
     await ClearPost.create({ author_id: author.id, title: "B", body: "body" });
     await author.destroy();
-    const posts = await loadHasMany(author, "clear_posts", {
+    const posts = await findHasManyTarget(author, "clear_posts", {
       className: "ClearPost",
       foreignKey: "author_id",
     });
@@ -1225,7 +1221,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await ClearDepAuthor.create({ name: "Alice" });
     await ClearDepPost.create({ author_id: author.id, title: "A", body: "body" });
     await author.destroy();
-    const remaining = await loadHasMany(author, "clear_dep_posts", {
+    const remaining = await findHasManyTarget(author, "clear_dep_posts", {
       className: "ClearDepPost",
       foreignKey: "author_id",
     });
@@ -1470,11 +1466,11 @@ describe("HasManyAssociationsTest", () => {
   it("no sql should be fired if association already loaded", async () => {
     const author = await HmAuthor.create({ name: "Alice" });
     await HmPost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts1 = await loadHasMany(author, "posts", {
+    const posts1 = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
-    const posts2 = await loadHasMany(author, "posts", {
+    const posts2 = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -1515,11 +1511,11 @@ describe("HasManyAssociationsTest", () => {
   it("does not duplicate associations when used with natural primary keys", async () => {
     const author = await HmAuthor.create({ name: "Alice" });
     await HmPost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts1 = await loadHasMany(author, "posts", {
+    const posts1 = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
-    const posts2 = await loadHasMany(author, "posts", {
+    const posts2 = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -1535,7 +1531,7 @@ describe("HasManyAssociationsTest", () => {
   it("prevent double insertion of new object when the parent association loaded in the after save callback", async () => {
     const author = await HmAuthor.create({ name: "Alice" });
     await HmPost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -1548,7 +1544,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await HmAuthor.create({ name: "Alice" });
     await HmPost.create({ author_id: author.id, title: "A", body: "body" });
     await HmPost.create({ author_id: author.id, title: "B", body: "body" });
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -1583,7 +1579,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(AnonPost);
     const author = await AnonAuthor.create({ name: "Alice" });
     await AnonPost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts = await loadHasMany(author, "anon_posts", {
+    const posts = await findHasManyTarget(author, "anon_posts", {
       className: "AnonPost",
       foreignKey: "author_id",
     });
@@ -1815,7 +1811,7 @@ describe("HasManyAssociationsTest", () => {
     await DelAllPost.create({ author_id: author.id, title: "A", body: "body" });
     await DelAllPost.create({ author_id: author.id, title: "B", body: "body" });
     await author.destroy();
-    const remaining = await loadHasMany(author, "del_all_posts", {
+    const remaining = await findHasManyTarget(author, "del_all_posts", {
       className: "DelAllPost",
       foreignKey: "author_id",
     });
@@ -2185,7 +2181,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(FinderDirtyPost);
     const author = await FinderDirtyAuthor.create({ name: "Alice" });
     const post = await FinderDirtyPost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts = await loadHasMany(author, "finder_dirty_posts", {
+    const posts = await findHasManyTarget(author, "finder_dirty_posts", {
       className: "FinderDirtyPost",
       foreignKey: "author_id",
     });
@@ -2197,7 +2193,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await HmAuthor.create({ name: "Alice" });
     await HmPost.create({ author_id: author.id, title: "A", body: "body" });
     await HmPost.create({ author_id: author.id, title: "B", body: "body" });
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -2233,7 +2229,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await MergedAuthor.create({ name: "Alice" });
     const p1 = await MergedPost.create({ author_id: author.id, title: "A", body: "body" });
     const p2 = await MergedPost.create({ author_id: author.id, title: "B", body: "body" });
-    const posts = await loadHasMany(author, "merged_posts", {
+    const posts = await findHasManyTarget(author, "merged_posts", {
       className: "MergedPost",
       foreignKey: "author_id",
     });
@@ -2266,7 +2262,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await AppOrdAuthor.create({ name: "Alice" });
     await AppOrdPost.create({ author_id: author.id, title: "B", body: "body" });
     await AppOrdPost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts = await loadHasMany(author, "app_ord_posts", {
+    const posts = await findHasManyTarget(author, "app_ord_posts", {
       className: "AppOrdPost",
       foreignKey: "author_id",
     });
@@ -2296,7 +2292,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await DynOrdAuthor.create({ name: "Alice" });
     await DynOrdPost.create({ author_id: author.id, title: "Z", body: "body" });
     await DynOrdPost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts = await loadHasMany(author, "dyn_ord_posts", {
+    const posts = await findHasManyTarget(author, "dyn_ord_posts", {
       className: "DynOrdPost",
       foreignKey: "author_id",
     });
@@ -2337,7 +2333,7 @@ describe("HasManyAssociationsTest", () => {
   it("taking with inverse of", async () => {
     const author = await HmAuthor.create({ name: "Alice" });
     await HmPost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -2384,7 +2380,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await HmAuthor.create({ name: "Alice" });
     await HmPost.create({ author_id: author.id, title: "A", body: "body" });
     await HmPost.create({ author_id: 9999, title: "B", body: "body" });
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -2473,7 +2469,7 @@ describe("HasManyAssociationsTest", () => {
     // Update via explicit FK
     post.title = "Updated";
     await post.save();
-    const posts = await loadHasMany(author, "upd_all_fk_posts", {
+    const posts = await findHasManyTarget(author, "upd_all_fk_posts", {
       className: "UpdAllFkPost",
       foreignKey: "author_id",
     });
@@ -2496,7 +2492,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await HmAuthor.create({ name: "Alice" });
     const p1 = await HmPost.create({ author_id: author.id, title: "A", body: "body" });
     const p2 = await HmPost.create({ author_id: author.id, title: "B", body: "body" });
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -2508,7 +2504,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await HmAuthor.create({ name: "Alice" });
     await HmPost.create({ author_id: author.id, title: "match", body: "body" });
     await HmPost.create({ author_id: author.id, title: "other", body: "body" });
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -2550,7 +2546,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await HmAuthor.create({ name: "Alice" });
     await HmPost.create({ author_id: author.id, title: "A", body: "body" });
     await HmPost.create({ author_id: author.id, title: "B", body: "body" });
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -2559,7 +2555,7 @@ describe("HasManyAssociationsTest", () => {
   it("find first sanitized", async () => {
     const author = await HmAuthor.create({ name: "Alice" });
     await HmPost.create({ author_id: author.id, title: "First", body: "body" });
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -2588,7 +2584,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(ResetPost);
     const author = await ResetAuthor.create({ name: "Alice" });
     await ResetPost.create({ author_id: author.id, title: "First", body: "body" });
-    const posts = await loadHasMany(author, "reset_posts", {
+    const posts = await findHasManyTarget(author, "reset_posts", {
       className: "ResetPost",
       foreignKey: "author_id",
     });
@@ -2619,13 +2615,13 @@ describe("HasManyAssociationsTest", () => {
     const author = await ReloadAuthor.create({ name: "Alice" });
     await ReloadPost.create({ author_id: author.id, title: "First", body: "body" });
     // Load once
-    const posts1 = await loadHasMany(author, "reload_posts", {
+    const posts1 = await findHasManyTarget(author, "reload_posts", {
       className: "ReloadPost",
       foreignKey: "author_id",
     });
     expect(posts1[0]).toBeDefined();
     // Load again (simulating reload)
-    const posts2 = await loadHasMany(author, "reload_posts", {
+    const posts2 = await findHasManyTarget(author, "reload_posts", {
       className: "ReloadPost",
       foreignKey: "author_id",
     });
@@ -2725,7 +2721,7 @@ describe("HasManyAssociationsTest", () => {
     await HmPost.create({ author_id: author.id, title: "A", body: "body" });
     await HmPost.create({ author_id: author.id, title: "A", body: "body" });
     await HmPost.create({ author_id: author.id, title: "B", body: "body" });
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -2745,7 +2741,7 @@ describe("HasManyAssociationsTest", () => {
     await HmPost.create({ author_id: author.id, title: "X", body: "body" });
     await HmPost.create({ author_id: author.id, title: "X", body: "body" });
     await HmPost.create({ author_id: author.id, title: "Y", body: "body" });
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -2755,7 +2751,7 @@ describe("HasManyAssociationsTest", () => {
   it("default select", async () => {
     const author = await HmAuthor.create({ name: "Alice" });
     await HmPost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -2766,7 +2762,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await HmAuthor.create({ name: "Alice" });
     await HmPost.create({ author_id: author.id, title: "A", body: "body" });
     await HmPost.create({ author_id: author.id, title: "B", body: "body" });
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -2776,7 +2772,7 @@ describe("HasManyAssociationsTest", () => {
   it("select without foreign key", async () => {
     const author = await HmAuthor.create({ name: "Alice" });
     await HmPost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -2882,7 +2878,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(SizeDirtyPost);
     const author = await SizeDirtyAuthor.create({ name: "Alice" });
     await SizeDirtyPost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts = await loadHasMany(author, "size_dirty_posts", {
+    const posts = await findHasManyTarget(author, "size_dirty_posts", {
       className: "SizeDirtyPost",
       foreignKey: "author_id",
     });
@@ -2911,7 +2907,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(EmptyDirtyAuthor);
     registerModel(EmptyDirtyPost);
     const author = await EmptyDirtyAuthor.create({ name: "Alice" });
-    const posts = await loadHasMany(author, "empty_dirty_posts", {
+    const posts = await findHasManyTarget(author, "empty_dirty_posts", {
       className: "EmptyDirtyPost",
       foreignKey: "author_id",
     });
@@ -2942,12 +2938,12 @@ describe("HasManyAssociationsTest", () => {
     const author = await SizeTwiceAuthor.create({ name: "Alice" });
     await SizeTwicePost.create({ author_id: author.id, title: "A", body: "body" });
     await SizeTwicePost.create({ author_id: author.id, title: "B", body: "body" });
-    const posts1 = await loadHasMany(author, "size_twice_posts", {
+    const posts1 = await findHasManyTarget(author, "size_twice_posts", {
       className: "SizeTwicePost",
       foreignKey: "author_id",
     });
     expect(posts1.length).toBe(2);
-    const posts2 = await loadHasMany(author, "size_twice_posts", {
+    const posts2 = await findHasManyTarget(author, "size_twice_posts", {
       className: "SizeTwicePost",
       foreignKey: "author_id",
     });
@@ -2979,7 +2975,7 @@ describe("HasManyAssociationsTest", () => {
     const post = BuildSavePost.new({ author_id: author.id, title: "Built", body: "body" });
     await post.save();
     expect(post.isNewRecord()).toBe(false);
-    const posts = await loadHasMany(author, "build_save_posts", {
+    const posts = await findHasManyTarget(author, "build_save_posts", {
       className: "BuildSavePost",
       foreignKey: "author_id",
     });
@@ -3042,7 +3038,7 @@ describe("HasManyAssociationsTest", () => {
     });
     post.title = "Updated";
     await post.save();
-    const posts = await loadHasMany(author, "create_save_posts", {
+    const posts = await findHasManyTarget(author, "create_save_posts", {
       className: "CreateSavePost",
       foreignKey: "author_id",
     });
@@ -3079,7 +3075,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await ExclDepAuthor.create({ name: "Alice" });
     await ExclDepPost.create({ author_id: author.id, title: "A", body: "body" });
     await author.destroy();
-    const remaining = await loadHasMany(author, "excl_dep_posts", {
+    const remaining = await findHasManyTarget(author, "excl_dep_posts", {
       className: "ExclDepPost",
       foreignKey: "author_id",
     });
@@ -3118,7 +3114,7 @@ describe("HasManyAssociationsTest", () => {
     await DcClient.create({ firm_id: firm.id, name: "BigShot Inc." });
     await DcClient.create({ firm_id: firm.id, name: "SmallTime Inc." });
     expect((await DcClient.where({ firm_id: firm.id })).length).toBe(2);
-    const scoped = await loadHasMany(firm, "conditionalClients", {
+    const scoped = await findHasManyTarget(firm, "conditionalClients", {
       className: "DcClient",
       foreignKey: "firm_id",
       scope: (rel: any) => rel.where({ name: "BigShot Inc." }),
@@ -3227,11 +3223,11 @@ describe("HasManyAssociationsTest", () => {
     await DelPkPost.create({ author_id: author1.id, title: "A1", body: "body" });
     await DelPkPost.create({ author_id: author2.id, title: "A2", body: "body" });
     await author1.destroy();
-    const remaining1 = await loadHasMany(author1, "del_pk_posts", {
+    const remaining1 = await findHasManyTarget(author1, "del_pk_posts", {
       className: "DelPkPost",
       foreignKey: "author_id",
     });
-    const remaining2 = await loadHasMany(author2, "del_pk_posts", {
+    const remaining2 = await findHasManyTarget(author2, "del_pk_posts", {
       className: "DelPkPost",
       foreignKey: "author_id",
     });
@@ -3270,7 +3266,7 @@ describe("HasManyAssociationsTest", () => {
     await ClearNoAccessPost.create({ author_id: author.id, title: "B", body: "body" });
     // Clear without having loaded the association first
     await author.destroy();
-    const remaining = await loadHasMany(author, "clear_no_access_posts", {
+    const remaining = await findHasManyTarget(author, "clear_no_access_posts", {
       className: "ClearNoAccessPost",
       foreignKey: "author_id",
     });
@@ -3282,7 +3278,7 @@ describe("HasManyAssociationsTest", () => {
     const otherPost = await HmPost.create({ author_id: 9999, title: "Other", body: "body" });
     // Deleting something not in the collection shouldn't affect it
     await otherPost.destroy();
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -3293,7 +3289,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await HmAuthor.create({ name: "Alice" });
     const post = await HmPost.create({ author_id: author.id, title: "A", body: "body" });
     await HmPost.destroy(String(post.id) as any);
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -3339,7 +3335,7 @@ describe("HasManyAssociationsTest", () => {
     await DestroyAllScopePost.create({ author_id: author.id, title: "A", body: "body" });
     await DestroyAllScopePost.create({ author_id: author.id, title: "B", body: "body" });
     await author.destroy();
-    const remaining = await loadHasMany(author, "destroy_all_scope_posts", {
+    const remaining = await findHasManyTarget(author, "destroy_all_scope_posts", {
       className: "DestroyAllScopePost",
       foreignKey: "author_id",
     });
@@ -3370,7 +3366,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await DestroyScopeAuthor.create({ name: "Alice" });
     const post = await DestroyScopePost.create({ author_id: author.id, title: "A", body: "body" });
     await post.destroy();
-    const remaining = await loadHasMany(author, "destroy_scope_posts", {
+    const remaining = await findHasManyTarget(author, "destroy_scope_posts", {
       className: "DestroyScopePost",
       foreignKey: "author_id",
     });
@@ -3401,7 +3397,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await DeleteScopeAuthor.create({ name: "Alice" });
     const post = await DeleteScopePost.create({ author_id: author.id, title: "A", body: "body" });
     await DeleteScopePost.destroy(post.id!);
-    const remaining = await loadHasMany(author, "delete_scope_posts", {
+    const remaining = await findHasManyTarget(author, "delete_scope_posts", {
       className: "DeleteScopePost",
       foreignKey: "author_id",
     });
@@ -3515,7 +3511,7 @@ describe("HasManyAssociationsTest", () => {
     await DepTxPost.create({ author_id: author.id, title: "A", body: "body" });
     // Even if transaction semantics aren't fully implemented, destroy should work
     await author.destroy();
-    const remaining = await loadHasMany(author, "dep_tx_posts", {
+    const remaining = await findHasManyTarget(author, "dep_tx_posts", {
       className: "DepTxPost",
       foreignKey: "author_id",
     });
@@ -3586,7 +3582,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(InclPost);
     const author = await InclAuthor.create({ name: "Alice" });
     const post = await InclPost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts = await loadHasMany(author, "incl_posts", {
+    const posts = await findHasManyTarget(author, "incl_posts", {
       className: "InclPost",
       foreignKey: "author_id",
     });
@@ -3617,7 +3613,7 @@ describe("HasManyAssociationsTest", () => {
     await ArrPost.create({ author_id: author.id, title: "A", body: "body" });
     await ArrPost.create({ author_id: author.id, title: "B", body: "body" });
     await ArrPost.create({ author_id: author.id, title: "C", body: "body" });
-    const loaded = await loadHasMany(author, "arr_posts", {
+    const loaded = await findHasManyTarget(author, "arr_posts", {
       className: "ArrPost",
       foreignKey: "author_id",
     });
@@ -3649,7 +3645,7 @@ describe("HasManyAssociationsTest", () => {
     // Replacing FK with invalid value
     post.author_id = 999999;
     await post.save();
-    const posts = await loadHasMany(author, "repl_fail_posts", {
+    const posts = await findHasManyTarget(author, "repl_fail_posts", {
       className: "ReplFailPost",
       foreignKey: "author_id",
     });
@@ -3681,11 +3677,11 @@ describe("HasManyAssociationsTest", () => {
     const post = await TxReplPost.create({ author_id: author1.id, title: "A", body: "body" });
     post.author_id = author2.id as number;
     await post.save();
-    const posts1 = await loadHasMany(author1, "tx_repl_posts", {
+    const posts1 = await findHasManyTarget(author1, "tx_repl_posts", {
       className: "TxReplPost",
       foreignKey: "author_id",
     });
-    const posts2 = await loadHasMany(author2, "tx_repl_posts", {
+    const posts2 = await findHasManyTarget(author2, "tx_repl_posts", {
       className: "TxReplPost",
       foreignKey: "author_id",
     });
@@ -3743,7 +3739,7 @@ describe("HasManyAssociationsTest", () => {
     const p1 = await UnloadedPost.create({ author_id: author.id, title: "A", body: "body" });
     const p2 = await UnloadedPost.create({ author_id: author.id, title: "B", body: "body" });
     // Getting IDs directly via loadHasMany
-    const posts = await loadHasMany(author, "unloaded_posts", {
+    const posts = await findHasManyTarget(author, "unloaded_posts", {
       className: "UnloadedPost",
       foreignKey: "author_id",
     });
@@ -3775,14 +3771,14 @@ describe("HasManyAssociationsTest", () => {
     registerModel(DirtyIdPost);
     const author = await DirtyIdAuthor.create({ name: "Writer" });
     await DirtyIdPost.create({ author_id: author.id, title: "P1", body: "body" });
-    const posts = await loadHasMany(author, "dirty_id_posts", {
+    const posts = await findHasManyTarget(author, "dirty_id_posts", {
       className: "DirtyIdPost",
       foreignKey: "author_id",
     });
     expect(posts).toHaveLength(1);
     // Add another post
     await DirtyIdPost.create({ author_id: author.id, title: "P2", body: "body" });
-    const posts2 = await loadHasMany(author, "dirty_id_posts", {
+    const posts2 = await findHasManyTarget(author, "dirty_id_posts", {
       className: "DirtyIdPost",
       foreignKey: "author_id",
     });
@@ -3811,13 +3807,13 @@ describe("HasManyAssociationsTest", () => {
     registerModel(ClrIdPost);
     const author = await ClrIdAuthor.create({ name: "Writer" });
     const post = await ClrIdPost.create({ author_id: author.id, title: "P1", body: "body" });
-    let posts = await loadHasMany(author, "clr_id_posts", {
+    let posts = await findHasManyTarget(author, "clr_id_posts", {
       className: "ClrIdPost",
       foreignKey: "author_id",
     });
     expect(posts).toHaveLength(1);
     await post.destroy();
-    posts = await loadHasMany(author, "clr_id_posts", {
+    posts = await findHasManyTarget(author, "clr_id_posts", {
       className: "ClrIdPost",
       foreignKey: "author_id",
     });
@@ -3846,7 +3842,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(GiiPost);
     const author = await GiiAuthor.create({ name: "Writer" });
     const p = await GiiPost.create({ author_id: author.id, title: "P1", body: "body" });
-    const posts = await loadHasMany(author, "gii_posts", {
+    const posts = await findHasManyTarget(author, "gii_posts", {
       className: "GiiPost",
       foreignKey: "author_id",
     });
@@ -3877,7 +3873,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await OrdIdAuthor.create({ name: "Alice" });
     const p1 = await OrdIdPost.create({ author_id: author.id, title: "A", body: "body" });
     const p2 = await OrdIdPost.create({ author_id: author.id, title: "B", body: "body" });
-    const posts = await loadHasMany(author, "ord_id_posts", {
+    const posts = await findHasManyTarget(author, "ord_id_posts", {
       className: "OrdIdPost",
       foreignKey: "author_id",
     });
@@ -3909,7 +3905,7 @@ describe("HasManyAssociationsTest", () => {
     const author = new SetIdAuthor({ name: "Alice" });
     await author.save();
     const post = await SetIdPost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts = await loadHasMany(author, "set_id_posts", {
+    const posts = await findHasManyTarget(author, "set_id_posts", {
       className: "SetIdPost",
       foreignKey: "author_id",
     });
@@ -3940,7 +3936,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await BlankIdAuthor.create({ name: "Alice" });
     const p1 = await BlankIdPost.create({ author_id: author.id, title: "A", body: "body" });
     // Blank/null IDs should be ignored
-    const posts = await loadHasMany(author, "blank_id_posts", {
+    const posts = await findHasManyTarget(author, "blank_id_posts", {
       className: "BlankIdPost",
       foreignKey: "author_id",
     });
@@ -4061,7 +4057,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await OrdThrAuthor.create({ name: "Alice" });
     await OrdThrPost.create({ author_id: author.id, title: "B", body: "body" });
     await OrdThrPost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts = await loadHasMany(author, "ord_thr_posts", {
+    const posts = await findHasManyTarget(author, "ord_thr_posts", {
       className: "OrdThrPost",
       foreignKey: "author_id",
     });
@@ -4091,7 +4087,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await DynThrAuthor.create({ name: "Alice" });
     await DynThrPost.create({ author_id: author.id, title: "First", body: "body" });
     await DynThrPost.create({ author_id: author.id, title: "Second", body: "body" });
-    const posts = await loadHasMany(author, "dyn_thr_posts", {
+    const posts = await findHasManyTarget(author, "dyn_thr_posts", {
       className: "DynThrPost",
       foreignKey: "author_id",
     });
@@ -4157,7 +4153,7 @@ describe("HasManyAssociationsTest", () => {
     await HcComment.create({ post_id: post.id, body: "hello" });
     await HcComment.create({ post_id: post.id, body: "goodbye" });
 
-    const comments = await loadHasMany(author, "helloPostComments", {
+    const comments = await findHasManyTarget(author, "helloPostComments", {
       className: "HcComment",
       through: "hcPosts",
       source: "hcComments",
@@ -4257,7 +4253,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await FnlAuthor.create({ name: "Alice" });
     await FnlPost.create({ author_id: author.id, title: "A", body: "body" });
     await FnlPost.create({ author_id: author.id, title: "B", body: "body" });
-    const posts = await loadHasMany(author, "fnl_posts", {
+    const posts = await findHasManyTarget(author, "fnl_posts", {
       className: "FnlPost",
       foreignKey: "author_id",
     });
@@ -4288,7 +4284,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await FlLoadAuthor.create({ name: "Alice" });
     await FlLoadPost.create({ author_id: author.id, title: "A", body: "body" });
     await FlLoadPost.create({ author_id: author.id, title: "B", body: "body" });
-    const posts = await loadHasMany(author, "fl_load_posts", {
+    const posts = await findHasManyTarget(author, "fl_load_posts", {
       className: "FlLoadPost",
       foreignKey: "author_id",
     });
@@ -4322,7 +4318,7 @@ describe("HasManyAssociationsTest", () => {
     // Build a new one (not saved)
     FnlBuildPost.new({ author_id: author.id, title: "B" });
     // Loading the association should get only persisted records
-    const posts = await loadHasMany(author, "fnl_build_posts", {
+    const posts = await findHasManyTarget(author, "fnl_build_posts", {
       className: "FnlBuildPost",
       foreignKey: "author_id",
     });
@@ -4352,7 +4348,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(FnlCreatePost);
     const author = await FnlCreateAuthor.create({ name: "Alice" });
     await FnlCreatePost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts = await loadHasMany(author, "fnl_create_posts", {
+    const posts = await findHasManyTarget(author, "fnl_create_posts", {
       className: "FnlCreatePost",
       foreignKey: "author_id",
     });
@@ -4382,7 +4378,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(FnlNewPost);
     const author = FnlNewAuthor.new({ name: "Unsaved" });
     // New record has no id, so loading association returns empty
-    const posts = await loadHasMany(author, "fnl_new_posts", {
+    const posts = await findHasManyTarget(author, "fnl_new_posts", {
       className: "FnlNewPost",
       foreignKey: "author_id",
     });
@@ -4413,7 +4409,7 @@ describe("HasManyAssociationsTest", () => {
     await FlIntPost.create({ author_id: author.id, title: "A", body: "body" });
     await FlIntPost.create({ author_id: author.id, title: "B", body: "body" });
     await FlIntPost.create({ author_id: author.id, title: "C", body: "body" });
-    const posts = await loadHasMany(author, "fl_int_posts", {
+    const posts = await findHasManyTarget(author, "fl_int_posts", {
       className: "FlIntPost",
       foreignKey: "author_id",
     });
@@ -4708,7 +4704,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(OneCountPost);
     const author = await OneCountAuthor.create({ name: "Alice" });
     await OneCountPost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts = await loadHasMany(author, "one_count_posts", {
+    const posts = await findHasManyTarget(author, "one_count_posts", {
       className: "OneCountPost",
       foreignKey: "author_id",
     });
@@ -4737,7 +4733,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(OneLoadPost);
     const author = await OneLoadAuthor.create({ name: "Alice" });
     await OneLoadPost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts = await loadHasMany(author, "one_load_posts", {
+    const posts = await findHasManyTarget(author, "one_load_posts", {
       className: "OneLoadPost",
       foreignKey: "author_id",
     });
@@ -4766,13 +4762,13 @@ describe("HasManyAssociationsTest", () => {
     registerModel(OneSubPost);
     const author = await OneSubAuthor.create({ name: "Alice" });
     await OneSubPost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts1 = await loadHasMany(author, "one_sub_posts", {
+    const posts1 = await findHasManyTarget(author, "one_sub_posts", {
       className: "OneSubPost",
       foreignKey: "author_id",
     });
     expect(posts1.length === 1).toBe(true);
     await OneSubPost.create({ author_id: author.id, title: "B", body: "body" });
-    const posts2 = await loadHasMany(author, "one_sub_posts", {
+    const posts2 = await findHasManyTarget(author, "one_sub_posts", {
       className: "OneSubPost",
       foreignKey: "author_id",
     });
@@ -4802,7 +4798,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await OneBlkAuthor.create({ name: "Alice" });
     await OneBlkPost.create({ author_id: author.id, title: "A", body: "body" });
     await OneBlkPost.create({ author_id: author.id, title: "B", body: "body" });
-    const posts = await loadHasMany(author, "one_blk_posts", {
+    const posts = await findHasManyTarget(author, "one_blk_posts", {
       className: "OneBlkPost",
       foreignKey: "author_id",
     });
@@ -4831,7 +4827,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(OneZeroAuthor);
     registerModel(OneZeroPost);
     const author = await OneZeroAuthor.create({ name: "Alice" });
-    const posts = await loadHasMany(author, "one_zero_posts", {
+    const posts = await findHasManyTarget(author, "one_zero_posts", {
       className: "OneZeroPost",
       foreignKey: "author_id",
     });
@@ -4863,7 +4859,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await OneMultiAuthor.create({ name: "Alice" });
     await OneMultiPost.create({ author_id: author.id, title: "A", body: "body" });
     await OneMultiPost.create({ author_id: author.id, title: "B", body: "body" });
-    const posts = await loadHasMany(author, "one_multi_posts", {
+    const posts = await findHasManyTarget(author, "one_multi_posts", {
       className: "OneMultiPost",
       foreignKey: "author_id",
     });
@@ -4948,7 +4944,7 @@ describe("HasManyAssociationsTest", () => {
     const post = await PkPost.create({ author_id: author.id, title: "PK Created", body: "body" });
     expect(post.isNewRecord()).toBe(false);
     expect((post as any).author_id).toBe(Number(author.id));
-    const posts = await loadHasMany(author, "pk_posts", {
+    const posts = await findHasManyTarget(author, "pk_posts", {
       className: "PkPost",
       foreignKey: "author_id",
     });
@@ -4985,7 +4981,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await LazyDelAuthor.create({ name: "Alice" });
     await LazyDelPost.create({ author_id: author.id, title: "A", body: "body" });
     await author.destroy();
-    const remaining = await loadHasMany(author, "lazy_del_posts", {
+    const remaining = await findHasManyTarget(author, "lazy_del_posts", {
       className: "LazyDelPost",
       foreignKey: "author_id",
     });
@@ -5085,7 +5081,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(ProtPost);
     const author = await ProtAuthor.create({ name: "Alice" });
     await ProtPost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts = await loadHasMany(author, "prot_posts", {
+    const posts = await findHasManyTarget(author, "prot_posts", {
       className: "ProtPost",
       foreignKey: "author_id",
     });
@@ -5211,7 +5207,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(KernelPost);
     const author = await KernelAuthor.create({ name: "Alice" });
     await KernelPost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts = await loadHasMany(author, "kernel_posts", {
+    const posts = await findHasManyTarget(author, "kernel_posts", {
       className: "KernelPost",
       foreignKey: "author_id",
     });
@@ -5240,7 +5236,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(OrPost);
     const author = await OrAuthor.create({ name: "Alice" });
     await OrPost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts = await loadHasMany(author, "or_posts", {
+    const posts = await findHasManyTarget(author, "or_posts", {
       className: "OrPost",
       foreignKey: "author_id",
     });
@@ -5269,7 +5265,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(RewherePost);
     const author = await RewhereAuthor.create({ name: "Alice" });
     await RewherePost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts = await loadHasMany(author, "rewhere_posts", {
+    const posts = await findHasManyTarget(author, "rewhere_posts", {
       className: "RewherePost",
       foreignKey: "author_id",
     });
@@ -5298,7 +5294,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(FoiPost);
     const author = await FoiAuthor.create({ name: "Alice" });
     // No posts exist yet, so first_or_initialize creates a new (unsaved) record
-    const posts = await loadHasMany(author, "foi_posts", {
+    const posts = await findHasManyTarget(author, "foi_posts", {
       className: "FoiPost",
       foreignKey: "author_id",
     });
@@ -5330,14 +5326,14 @@ describe("HasManyAssociationsTest", () => {
     registerModel(FocPost);
     const author = await FocAuthor.create({ name: "Alice" });
     // No posts exist, so first_or_create creates and saves
-    const posts1 = await loadHasMany(author, "foc_posts", {
+    const posts1 = await findHasManyTarget(author, "foc_posts", {
       className: "FocPost",
       foreignKey: "author_id",
     });
     expect(posts1.length).toBe(0);
     const post = await FocPost.create({ author_id: author.id, title: "Created", body: "body" });
     expect(post.isNewRecord()).toBe(false);
-    const posts2 = await loadHasMany(author, "foc_posts", {
+    const posts2 = await findHasManyTarget(author, "foc_posts", {
       className: "FocPost",
       foreignKey: "author_id",
     });
@@ -5365,7 +5361,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(FocBangAuthor);
     registerModel(FocBangPost);
     const author = await FocBangAuthor.create({ name: "Alice" });
-    const posts1 = await loadHasMany(author, "foc_bang_posts", {
+    const posts1 = await findHasManyTarget(author, "foc_bang_posts", {
       className: "FocBangPost",
       foreignKey: "author_id",
     });
@@ -5376,7 +5372,7 @@ describe("HasManyAssociationsTest", () => {
       body: "body",
     });
     expect(post.isNewRecord()).toBe(false);
-    const posts2 = await loadHasMany(author, "foc_bang_posts", {
+    const posts2 = await findHasManyTarget(author, "foc_bang_posts", {
       className: "FocBangPost",
       foreignKey: "author_id",
     });
@@ -5414,7 +5410,7 @@ describe("HasManyAssociationsTest", () => {
     await NoLoadDelPost.create({ author_id: author.id, title: "B", body: "body" });
     // Delete without loading first
     await author.destroy();
-    const remaining = await loadHasMany(author, "no_load_del_posts", {
+    const remaining = await findHasManyTarget(author, "no_load_del_posts", {
       className: "NoLoadDelPost",
       foreignKey: "author_id",
     });
@@ -5448,7 +5444,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(ExtPost);
     const author = await ExtAuthor.create({ name: "Alice" });
     await ExtPost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts = await loadHasMany(author, "ext_posts", {
+    const posts = await findHasManyTarget(author, "ext_posts", {
       className: "ExtPost",
       foreignKey: "author_id",
     });
@@ -5482,7 +5478,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(ExtPerPost);
     const author = await ExtPerAuthor.create({ name: "Alice" });
     await ExtPerPost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts = await loadHasMany(author, "ext_per_posts", {
+    const posts = await findHasManyTarget(author, "ext_per_posts", {
       className: "ExtPerPost",
       foreignKey: "author_id",
     });
@@ -5512,7 +5508,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await CjAuthor.create({ name: "Alice" });
     const post = await CjPost.create({ author_id: author.id, title: "A", body: "body" });
     await post.destroy();
-    const posts = await loadHasMany(author, "cj_posts", {
+    const posts = await findHasManyTarget(author, "cj_posts", {
       className: "CjPost",
       foreignKey: "author_id",
     });
@@ -5541,7 +5537,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(UsInclPost);
     const author = await UsInclAuthor.create({ name: "Alice" });
     await UsInclPost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts = await loadHasMany(author, "us_incl_posts", {
+    const posts = await findHasManyTarget(author, "us_incl_posts", {
       className: "UsInclPost",
       foreignKey: "author_id",
     });
@@ -5609,7 +5605,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(InstScopePost);
     const author = await InstScopeAuthor.create({ name: "Alice" });
     await InstScopePost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts = await loadHasMany(author, "inst_scope_posts", {
+    const posts = await findHasManyTarget(author, "inst_scope_posts", {
       className: "InstScopePost",
       foreignKey: "author_id",
     });
@@ -5643,7 +5639,7 @@ describe("HasManyAssociationsTest", () => {
       body: "body",
     });
     // Load once
-    const posts1 = await loadHasMany(author, "repl_mem_posts", {
+    const posts1 = await findHasManyTarget(author, "repl_mem_posts", {
       className: "ReplMemPost",
       foreignKey: "author_id",
     });
@@ -5653,7 +5649,7 @@ describe("HasManyAssociationsTest", () => {
     post.title = "Updated";
     await post.save();
     // Reload - should get updated version
-    const posts2 = await loadHasMany(author, "repl_mem_posts", {
+    const posts2 = await findHasManyTarget(author, "repl_mem_posts", {
       className: "ReplMemPost",
       foreignKey: "author_id",
     });
@@ -5767,11 +5763,11 @@ describe("HasManyAssociationsTest", () => {
     await post.save();
     const reloaded = await ReattachPost.find(post.id!);
     expect((reloaded as any).author_id).toBe(Number(author2.id));
-    const oldPosts = await loadHasMany(author1, "reattach_posts", {
+    const oldPosts = await findHasManyTarget(author1, "reattach_posts", {
       className: "ReattachPost",
       foreignKey: "author_id",
     });
-    const newPosts = await loadHasMany(author2, "reattach_posts", {
+    const newPosts = await findHasManyTarget(author2, "reattach_posts", {
       className: "ReattachPost",
       foreignKey: "author_id",
     });
@@ -5862,12 +5858,12 @@ describe("HasManyAssociationsTest", () => {
     const author = await MemoAuthor.create({ name: "Alice" });
     await MemoPost.create({ author_id: author.id, title: "A", body: "body" });
     await MemoPost.create({ author_id: author.id, title: "B", body: "body" });
-    const posts1 = await loadHasMany(author, "memo_posts", {
+    const posts1 = await findHasManyTarget(author, "memo_posts", {
       className: "MemoPost",
       foreignKey: "author_id",
     });
     const ids1 = posts1.map((p: any) => p.id);
-    const posts2 = await loadHasMany(author, "memo_posts", {
+    const posts2 = await findHasManyTarget(author, "memo_posts", {
       className: "MemoPost",
       foreignKey: "author_id",
     });
@@ -5898,7 +5894,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await LoadValAuthor.create({ name: "Alice" });
     const post = await LoadValPost.create({ author_id: author.id, title: "A", body: "body" });
     // Loading association during validation shouldn't prevent persistence
-    const posts = await loadHasMany(author, "load_val_posts", {
+    const posts = await findHasManyTarget(author, "load_val_posts", {
       className: "LoadValPost",
       foreignKey: "author_id",
     });
@@ -5930,7 +5926,7 @@ describe("HasManyAssociationsTest", () => {
     const post = await RollbackPost.create({ author_id: author.id, title: "A", body: "body" });
     expect(post.isPersisted()).toBe(true);
     // Verify the child exists
-    const posts = await loadHasMany(author, "rollback_posts", {
+    const posts = await findHasManyTarget(author, "rollback_posts", {
       className: "RollbackPost",
       foreignKey: "author_id",
     });
@@ -5939,7 +5935,7 @@ describe("HasManyAssociationsTest", () => {
   it("has many with out of range value", async () => {
     const author = await HmAuthor.create({ name: "Alice" });
     await HmPost.create({ author_id: 999999999, title: "A", body: "body" });
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -5973,11 +5969,11 @@ describe("HasManyAssociationsTest", () => {
     registerModel(SameFkPost);
     const author = await SameFkAuthor.create({ name: "Alice" });
     await SameFkPost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "SameFkPost",
       foreignKey: "author_id",
     });
-    const pubPosts = await loadHasMany(author, "published_posts", {
+    const pubPosts = await findHasManyTarget(author, "published_posts", {
       className: "SameFkPost",
       foreignKey: "author_id",
     });
@@ -6013,7 +6009,7 @@ describe("HasManyAssociationsTest", () => {
     // Association without dependent option
     const author = await KeyValAuthor.create({ name: "Alice" });
     await KeyValPost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts = await loadHasMany(author, "key_val_posts", {
+    const posts = await findHasManyTarget(author, "key_val_posts", {
       className: "KeyValPost",
       foreignKey: "author_id",
     });
@@ -6067,7 +6063,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await AsyncDepAuthor.create({ name: "Alice" });
     await AsyncDepPost.create({ author_id: author.id, title: "A", body: "body" });
     await author.destroy();
-    const remaining = await loadHasMany(author, "async_dep_posts", {
+    const remaining = await findHasManyTarget(author, "async_dep_posts", {
       className: "AsyncDepPost",
       foreignKey: "author_id",
     });
@@ -6125,7 +6121,7 @@ describe("HasManyAssociationsTest", () => {
     const author = await PreCpkAuthor.create({ name: "Alice" });
     const p1 = await PreCpkPost.create({ author_id: author.id, title: "A", body: "body" });
     const p2 = await PreCpkPost.create({ author_id: author.id, title: "B", body: "body" });
-    const posts = await loadHasMany(author, "pre_cpk_posts", {
+    const posts = await findHasManyTarget(author, "pre_cpk_posts", {
       className: "PreCpkPost",
       foreignKey: "author_id",
     });
@@ -6164,7 +6160,7 @@ describe("HasManyAssociationsTest", () => {
     await DelAllOptPost.create({ author_id: author.id, title: "A", body: "body" });
     await DelAllOptPost.create({ author_id: author.id, title: "B", body: "body" });
     await author.destroy();
-    const remaining = await loadHasMany(author, "del_all_opt_posts", {
+    const remaining = await findHasManyTarget(author, "del_all_opt_posts", {
       className: "DelAllOptPost",
       foreignKey: "author_id",
     });
@@ -6224,7 +6220,7 @@ describe("HasManyAssociationsTest", () => {
     const post = await HmPost.create({ title: "New", body: "body" });
     post.author_id = author.id as number;
     await post.save();
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -6239,7 +6235,7 @@ describe("HasManyAssociationsTest", () => {
       p.author_id = author.id as number;
       await p.save();
     }
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -6249,7 +6245,7 @@ describe("HasManyAssociationsTest", () => {
   it("adding using create", async () => {
     const author = await HmAuthor.create({ name: "Alice" });
     await HmPost.create({ author_id: author.id, title: "Created", body: "body" });
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -6279,7 +6275,7 @@ describe("HasManyAssociationsTest", () => {
   it("collection not empty after building", async () => {
     const author = await HmAuthor.create({ name: "Alice" });
     await HmPost.create({ author_id: author.id, title: "A", body: "body" });
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -6343,7 +6339,7 @@ describe("HasManyAssociationsTest", () => {
     await HmPost.create({ author_id: author.id, title: "Old", body: "body" });
     await author.destroy();
     const newPost = await HmPost.create({ author_id: author.id, title: "New", body: "body" });
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -6354,12 +6350,12 @@ describe("HasManyAssociationsTest", () => {
     const author = await HmAuthor.create({ name: "Alice" });
     await HmPost.create({ author_id: author.id, title: "A", body: "body" });
     await HmPost.create({ author_id: author.id, title: "B", body: "body" });
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
     await (posts[0] as any).destroy();
-    const remaining = await loadHasMany(author, "posts", {
+    const remaining = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });
@@ -6369,7 +6365,7 @@ describe("HasManyAssociationsTest", () => {
   it("replace with same content", async () => {
     const author = await HmAuthor.create({ name: "Alice" });
     const post = await HmPost.create({ author_id: author.id, title: "Same", body: "body" });
-    const posts = await loadHasMany(author, "posts", {
+    const posts = await findHasManyTarget(author, "posts", {
       className: "Post",
       foreignKey: "author_id",
     });

--- a/packages/activerecord/src/associations/has-many-mid-flight-reassignment.trails.test.ts
+++ b/packages/activerecord/src/associations/has-many-mid-flight-reassignment.trails.test.ts
@@ -13,7 +13,7 @@
 import { describe, it, expect } from "vitest";
 import { readdir, readFile } from "node:fs/promises";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { loadHasMany } from "../associations.js";
+import { findTarget } from "./has-many-association.js";
 import { Preloader } from "./preloader.js";
 import { AssociationTargetReplacedDuringLoad } from "../errors.js";
 import type { Base } from "../base.js";
@@ -68,7 +68,7 @@ describe("has_many mid-flight reassignment", () => {
     expect(persisted.length).toBeGreaterThan(0);
 
     const inFlight = firm.association("clients").loadTarget();
-    await loadHasMany(firm, "clients", {});
+    await findTarget(firm, "clients", {});
     const loaded = (await inFlight) as Base[];
 
     expect(loaded.length).toBe(persisted.length);

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -12,7 +12,8 @@ import {
   InverseOfAssociationNotFoundError,
   InverseOfAssociationRecursiveError,
 } from "../index.js";
-import { loadHasOne, loadHasMany } from "../associations.js";
+import { loadHasOne } from "../associations.js";
+import { findTarget as findHasManyTarget } from "./has-many-association.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { Branch, BrokenBranch } from "../test-helpers/models/branch.js";
 import { Human } from "../test-helpers/models/human.js";
@@ -527,7 +528,7 @@ describe("InverseHasManyTests", () => {
 
   it("parent instance should be shared with every child on find", async () => {
     const human = humans("gordon");
-    const interests = await loadHasMany(human, "interests", { inverseOf: "human" });
+    const interests = await findHasManyTarget(human, "interests", { inverseOf: "human" });
     expect(interests.length).toBeGreaterThan(0);
     for (const interest of interests) {
       expect((interest as any).human.name).toBe(human.name);
@@ -540,7 +541,7 @@ describe("InverseHasManyTests", () => {
 
   it("parent instance should be shared with every child on find for sti", async () => {
     const author = authors("david");
-    const posts = await loadHasMany(author, "posts", { inverseOf: "author" });
+    const posts = await findHasManyTarget(author, "posts", { inverseOf: "author" });
     expect(posts.length).toBeGreaterThan(0);
     for (const post of posts) {
       expect((post as any).author.name).toBe((author as any).name);
@@ -550,7 +551,7 @@ describe("InverseHasManyTests", () => {
       expect((post as any).author.name).toBe((author as any).name);
     }
 
-    const specialPosts = await loadHasMany(author, "specialPosts", {
+    const specialPosts = await findHasManyTarget(author, "specialPosts", {
       className: "SpecialPost",
       inverseOf: "author",
     });
@@ -762,7 +763,7 @@ describe("InverseHasManyTests", () => {
   it("trying to use inverses that dont exist should raise an error", async () => {
     const human = (await Human.first())!;
     await expect(
-      loadHasMany(human, "secretInterests", { className: "Interest", inverseOf: "secretHuman" }),
+      findHasManyTarget(human, "secretInterests", { className: "Interest", inverseOf: "secretHuman" }),
     ).rejects.toThrow(InverseOfAssociationNotFoundError);
   });
 
@@ -784,7 +785,7 @@ describe("InverseHasManyTests", () => {
     });
     try {
       const human = (await Human.first())!;
-      const interests = await loadHasMany(human, "interests", { inverseOf: "human" });
+      const interests = await findHasManyTarget(human, "interests", { inverseOf: "human" });
       expect(interests.length).toBeGreaterThan(0);
 
       const preloaded = (await (Human as any).includes("interests").first())!;
@@ -807,7 +808,7 @@ describe("InverseHasManyTests", () => {
     });
     try {
       const human = (await Human.first())!;
-      const interests = await loadHasMany(human, "interests", { inverseOf: "human" });
+      const interests = await findHasManyTarget(human, "interests", { inverseOf: "human" });
       expect(interests.length).toBeGreaterThan(0);
     } finally {
       (Interest as any).resetCallbacks("initialize");
@@ -822,7 +823,7 @@ describe("InverseHasManyTests", () => {
       body: "New Comment",
     });
     (comment as any).body = "OMG";
-    const children = await loadHasMany(comment, "children", {
+    const children = await findHasManyTarget(comment, "children", {
       className: "Comment",
       foreignKey: "parent_id",
       inverseOf: "parent",
@@ -833,7 +834,7 @@ describe("InverseHasManyTests", () => {
   it("changing the association id makes the inversed association target stale", async () => {
     const post1 = (await Post.first())!;
     const post2 = (await Post.all().order("id").offset(1).first())!;
-    const comment = (await loadHasMany(post1, "comments", { inverseOf: "post" }))[0] as any;
+    const comment = (await findHasManyTarget(post1, "comments", { inverseOf: "post" }))[0] as any;
     expect(await findTarget(comment, "post", { inverseOf: "comments" })).toBe(post1);
     await comment.updateBang({ post_id: (post2 as any).id });
     const reloaded = (await findTarget(comment, "post", { inverseOf: "comments" })) as any;

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -763,7 +763,10 @@ describe("InverseHasManyTests", () => {
   it("trying to use inverses that dont exist should raise an error", async () => {
     const human = (await Human.first())!;
     await expect(
-      findHasManyTarget(human, "secretInterests", { className: "Interest", inverseOf: "secretHuman" }),
+      findHasManyTarget(human, "secretInterests", {
+        className: "Interest",
+        inverseOf: "secretHuman",
+      }),
     ).rejects.toThrow(InverseOfAssociationNotFoundError);
   });
 

--- a/packages/activerecord/src/associations/polymorphic-sti-through.test.ts
+++ b/packages/activerecord/src/associations/polymorphic-sti-through.test.ts
@@ -7,7 +7,7 @@
  *   - `has_many :through` whose source reflection is a polymorphic
  *     belongs_to, disambiguated by `source_type:` ("polymorphic
  *     has_many through"). The fixture layers this on top of a
- *     nested through (Hotel → Departments → Chefs), so `loadHasMany`
+ *     nested through (Hotel → Departments → Chefs), so `findTarget`
  *     routes through `loadHasManyThrough`'s walker rather than the
  *     final-step JOIN/AssociationScope path. Both that walker and
  *     the `includes()` preloader must filter through-records by the

--- a/packages/activerecord/src/associations/source-type-validation.test.ts
+++ b/packages/activerecord/src/associations/source-type-validation.test.ts
@@ -6,7 +6,7 @@
  * loudly the first time the association is touched. We mirror that
  * via `validateThroughReflection`, called from
  * `Association#constructor`, `association(record, name)`, and the
- * loader entry points (`loadHasMany` / `loadHasOne`).
+ * loader entry points (`findTarget` / `loadHasOne`).
  *
  * Coverage in this suite:
  *   - polymorphic source without `source_type`
@@ -31,7 +31,8 @@
  */
 import { describe, it, expect } from "vitest";
 import { Base, registerModel } from "../index.js";
-import { Associations, association, loadHasMany } from "../associations.js";
+import { Associations, association } from "../associations.js";
+import { findTarget } from "./has-many-association.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 
 // Local model classes for testing invalid through-association configurations.
@@ -132,7 +133,7 @@ describe("ThroughReflection — checkValidityBang at first use", () => {
 
   it("fires at the loadHasMany entry point too (not just association() / Association#ctor)", async () => {
     freshAssociations();
-    // loadHasMany is the loader path direct callers (preloader,
+    // findTarget is the loader path direct callers (preloader,
     // tests) hit without going through `association()`. The
     // validation has to surface there too — matching Rails'
     // Association#initialize check_validity! which runs on every
@@ -152,7 +153,7 @@ describe("ThroughReflection — checkValidityBang at first use", () => {
       source: "origin",
     });
     await expect(
-      loadHasMany(author(), "originFromComments", {
+      findTarget(author(), "originFromComments", {
         className: "StvMember",
         through: "stvComments",
         source: "origin",

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -50,7 +50,6 @@ export {
   registerModel,
   modelRegistry,
   loadHasOne,
-  loadHasMany,
   loadHasManyThrough,
   association,
   isAssociationCached,

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -487,7 +487,7 @@ export class Relation<T extends Base> {
    * Per-record loader block, run on each freshly instantiated record BEFORE
    * its find/initialize callbacks fire — the trails analog of the block Rails
    * threads through `find_by_sql`/`init_with_attributes`. The collection load
-   * path (`loadHasMany`) sets this to wire `inverse_of` so an `after_find` hook
+   * path (`findTarget`) sets this to wire `inverse_of` so an `after_find` hook
    * already sees the inverse association loaded.
    * Not copied across `spawn()`: it is set immediately before `toArray()` on
    * the exact relation that will execute.

--- a/packages/activerecord/src/strict-loading.trails.test.ts
+++ b/packages/activerecord/src/strict-loading.trails.test.ts
@@ -10,7 +10,8 @@
 import { describe, it, expect } from "vitest";
 import { findTarget } from "./associations/singular-association.js";
 import { StrictLoadingViolationError, registerModel } from "./index.js";
-import { loadHasOne, loadHasMany, loadHabtm } from "./associations.js";
+import { loadHasOne, loadHabtm } from "./associations.js";
+import { findTarget as findHasManyTarget } from "./associations/has-many-association.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { Developer, AuditLog } from "./test-helpers/models/developer.js";
 import { Ship } from "./test-helpers/models/ship.js";
@@ -49,7 +50,7 @@ describe("StrictLoadingNewRecordFindTargetTest", () => {
     const developer = new Developer({ name: "New Dev" });
     developer.strictLoadingBang();
     expect(developer.isNewRecord()).toBe(true);
-    await expect(loadHasMany(developer, "auditLogs", optionsFor("auditLogs"))).resolves.toEqual([]);
+    await expect(findHasManyTarget(developer, "auditLogs", optionsFor("auditLogs"))).resolves.toEqual([]);
   });
 
   it("does not raise on lazy loading a has_one on a new strict-loading owner without the foreign key", async () => {
@@ -94,7 +95,7 @@ describe("StrictLoadingNewRecordFindTargetTest", () => {
     const developer = new Developer({ name: "New Dev", id: 1 });
     developer.strictLoadingBang();
     expect(developer.isNewRecord()).toBe(true);
-    await expect(loadHasMany(developer, "auditLogs", optionsFor("auditLogs"))).rejects.toThrow(
+    await expect(findHasManyTarget(developer, "auditLogs", optionsFor("auditLogs"))).rejects.toThrow(
       StrictLoadingViolationError,
     );
   });
@@ -103,7 +104,7 @@ describe("StrictLoadingNewRecordFindTargetTest", () => {
     const developer = await Developer.find(developers("david").id);
     developer.strictLoadingBang();
     expect(developer.isNewRecord()).toBe(false);
-    await expect(loadHasMany(developer, "auditLogs", optionsFor("auditLogs"))).rejects.toThrow(
+    await expect(findHasManyTarget(developer, "auditLogs", optionsFor("auditLogs"))).rejects.toThrow(
       StrictLoadingViolationError,
     );
   });

--- a/packages/activerecord/src/strict-loading.trails.test.ts
+++ b/packages/activerecord/src/strict-loading.trails.test.ts
@@ -50,7 +50,9 @@ describe("StrictLoadingNewRecordFindTargetTest", () => {
     const developer = new Developer({ name: "New Dev" });
     developer.strictLoadingBang();
     expect(developer.isNewRecord()).toBe(true);
-    await expect(findHasManyTarget(developer, "auditLogs", optionsFor("auditLogs"))).resolves.toEqual([]);
+    await expect(
+      findHasManyTarget(developer, "auditLogs", optionsFor("auditLogs")),
+    ).resolves.toEqual([]);
   });
 
   it("does not raise on lazy loading a has_one on a new strict-loading owner without the foreign key", async () => {
@@ -95,17 +97,17 @@ describe("StrictLoadingNewRecordFindTargetTest", () => {
     const developer = new Developer({ name: "New Dev", id: 1 });
     developer.strictLoadingBang();
     expect(developer.isNewRecord()).toBe(true);
-    await expect(findHasManyTarget(developer, "auditLogs", optionsFor("auditLogs"))).rejects.toThrow(
-      StrictLoadingViolationError,
-    );
+    await expect(
+      findHasManyTarget(developer, "auditLogs", optionsFor("auditLogs")),
+    ).rejects.toThrow(StrictLoadingViolationError);
   });
 
   it("still raises on lazy loading a strict-loading has_many on a persisted owner", async () => {
     const developer = await Developer.find(developers("david").id);
     developer.strictLoadingBang();
     expect(developer.isNewRecord()).toBe(false);
-    await expect(findHasManyTarget(developer, "auditLogs", optionsFor("auditLogs"))).rejects.toThrow(
-      StrictLoadingViolationError,
-    );
+    await expect(
+      findHasManyTarget(developer, "auditLogs", optionsFor("auditLogs")),
+    ).rejects.toThrow(StrictLoadingViolationError);
   });
 });

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/collection-association.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/associations/collection-association.json
@@ -226,20 +226,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
-    "rubyName": "load_target",
-    "call": "find_target",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
-    "rubyName": "load_target",
-    "call": "find_target?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
     "rubyName": "merge_target_lists",
     "call": "changed_attribute_names_to_save",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Relocates the has_many target loader out of the `associations.ts` engine into
its Rails-layout home under the Rails method name.

`loadHasMany` (a trails-only name in a trails-only engine file) becomes
`HasManyAssociation#findTarget` in
`packages/activerecord/src/associations/has-many-association.ts`, mirroring
`ActiveRecord::Associations::Association#find_target` (`association.rb:248`) as
reached through `CollectionAssociation#load_target`
(`collection_association.rb:272`).

The Rails name lives on the **association object**, not on a functional API:

- `HasManyAssociation#findTarget()` — protected, no args, the Rails-shaped
  entry point. It carries the `_loaderWritebackSuppressed` guard.
- `findTarget(record, assocName, options, queryExecutor?)` — the functional
  body, `@internal`. That triple is a trails-only calling convention for the
  callers that have no association instance (the CollectionProxy load path and
  the through-association loaders).
- `Association#findTarget` was a private stub calling `loadTarget()` — the
  inverse of Rails' direction, and unreachable. It is now the protected seam
  the load path actually runs: `_findTarget` (the assignment shared by
  `loadTarget` / `asyncLoadTarget`, which Rails inlines at `association.rb:189`
  and `:198`) dispatches to `this.findTarget()`, so the subclass override IS
  the load path. `CollectionAssociation#loadTarget` calls it too, mirroring
  `@target = merge_target_lists(find_target, target)`
  (`collection_association.rb:272-275`). `doAsyncFindTarget` survives only as
  the backwards-compatible delegate behind the base `findTarget`, for the
  `HasOne` / `BelongsTo` subclasses that still override that hook; the
  now-dead `HasManyAssociation` override of it is deleted.

Nothing is re-exported from `associations.ts` under the old name.

## Helpers

The moved body reaches ~10 module-private helpers that stay in
`associations.ts`. They are now exported and carry `@internal` at the
declaration site — they are trails-only plumbing, not Rails surface, so the
relocation does not trade one extra for ten:
`_findTargetReachable`, `_canRouteThroughViaDisableJoinsAssociationScope`,
`_loadThroughViaDisableJoinsScope`, `validateInverseOf`,
`ownerReflectionForeignKey`, `_builtAssociationScope`, `_scopeForAssociation`,
`_resolveInverseName`, `syncToAssociationInstance`, `_inlineOwnerKey`.

## index.ts

The `loadHasMany` re-export is dropped — Rails does not expose this at the
`ActiveRecord::` level.

## Extra surface (pnpm api:compare && pnpm api:extra --package activerecord --novel-only)

Re-measured after rebasing onto current `main` (the absolute numbers moved
because #5356 / #5359 / #5360 removed other names from `associations.ts`; the
delta is unchanged):

| file | before (`main`) | after |
| --- | --- | --- |
| `associations.ts` | 6 novel | 5 novel |
| `associations/has-many-association.ts` | 4 novel | 4 novel (unchanged) |

Exactly the one name in this story.

## Rebase note — `findTarget` name collision with #5360

#5360 relocated `loadBelongsTo` to `findTarget` in `singular-association.ts`,
which takes the bare name in several files this PR also touches. Main's
spelling wins where it already exists; the has_many loader is imported as
`findTarget as findHasManyTarget` in the files that use both
(`associations.ts` plus five test files). No test names changed.

## Not done here

`loadHasMany` fused relation building with caching, strict loading, and
inverse_of, which is why the `@internal` trails-only helpers
`buildHasManyRelation` and `buildThroughJoinScope` exist. Undoing that fusion
(so both can be deleted) does not fit under the LOC ceiling alongside the
relocation, so it is filed as its own story:
`extra-surface-defuse-has-many-find-target` (RFC 0072).

`SingularAssociation#findTarget` (`singular-association.ts`, landed by #5360)
is a belongs_to-shaped loader that `HasOneAssociation` bypasses, where Rails
defines `find_target` once for both singular subclasses
(`singular_association.rb:47`). That file is untouched by this PR, so it is
filed as `extra-surface-singular-find-target-shared-seam` (RFC 0072) rather
than fixed here.

The new import in `associations.ts` is cyclic with `has-many-association.ts`.
The cycle is function-level only — neither side touches the other at
module-evaluation time — and that is noted at the import site.

## LOC

The move itself is ~270 added / ~290 deleted. The remainder is a single
mechanical rename of `loadHasMany(` -> `findTarget(` at call sites (mostly
test files), which CLAUDE.md exempts from the 500-LOC ceiling; the callers are
otherwise untouched and **no test names changed**.

## Testing

`pnpm typecheck`, `pnpm lint`, `pnpm format:check` clean. All touched
association suites pass locally (has-many, has-many-through, collection-proxy,
association-scope, inverse, disable-joins, strict-loading, source-type).

Closes-story: extra-surface-relocate-load-has-many
