### PR TITLE
refactor(api-compare): migrate activerecord allow entries + global-id finders to @noRailsEquivalent

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -51,6 +51,17 @@ export async function eagerLoadBang(): Promise<void> {
  * Uses a dynamic `import()` so it doesn't participate in the static
  * dependency cycle (associations → CP → Relation → Base →
  * associations) that forced the late-binding in the first place.
+ *
+ * @noRailsEquivalent trails-only ESM module-cycle escape hatch with no Rails
+ * analogue: `initialize_associations` is defined nowhere in the Rails source
+ * (verified by grep over vendor/rails). The associations -> CollectionProxy ->
+ * Relation -> Base -> associations cycle forces CollectionProxy registration to
+ * be late-bound; the package entry does it eagerly, and this is the supported
+ * explicit hook for consumers who deep-import
+ * `@blazetrails/activerecord/associations` without touching the entry. Ruby's
+ * require/autoload resolves such cycles at load time, so there is nothing to
+ * port. Public by intent (documented consumer hook), so an `\@internal` tag
+ * would be inaccurate.
  */
 export async function initializeAssociations(): Promise<void> {
   // Load all late-binding slots. `association-relation.js` imports
@@ -301,6 +312,17 @@ function guardCanonicalNameShadow(name: string, model: typeof Base): void {
  *   routed through {@link registerSubclass} so it lands in its parent's
  *   `_subclasses`. STI on the parent must still be enabled explicitly via
  *   `Parent.inheritanceColumn = ...` — the array form does not set it.
+ *
+ * @noRailsEquivalent trails-only model registry with no Rails analogue:
+ * `register_model` is defined nowhere in the Rails source (verified by grep over
+ * vendor/rails). Ruby resolves an association's class through constant lookup —
+ * Reflection#compute_class (reflection.rb:434 and :490) into Object.const_get,
+ * backed by ActiveSupport autoloading — so Rails never registers models
+ * anywhere. ESM has no constant namespace to walk and no autoload hook, so
+ * trails must be told which classes exist. Deliberately public (re-exported from
+ * index.ts) because application code has to call it, which is why an
+ * `\@internal` tag would be a lie rather than a fix. Kept in associations.ts
+ * because association class resolution is its only consumer path.
  */
 export function registerModel(model: typeof Base): void;
 export function registerModel(name: string, model: typeof Base): void;

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -60,7 +60,7 @@ export async function eagerLoadBang(): Promise<void> {
  * explicit hook for consumers who deep-import
  * `@blazetrails/activerecord/associations` without touching the entry. Ruby's
  * require/autoload resolves such cycles at load time, so there is nothing to
- * port. Public by intent (documented consumer hook), so an `\@internal` tag
+ * port. Public by intent (a documented consumer hook), so marking it internal
  * would be inaccurate.
  */
 export async function initializeAssociations(): Promise<void> {
@@ -320,9 +320,9 @@ function guardCanonicalNameShadow(name: string, model: typeof Base): void {
  * backed by ActiveSupport autoloading — so Rails never registers models
  * anywhere. ESM has no constant namespace to walk and no autoload hook, so
  * trails must be told which classes exist. Deliberately public (re-exported from
- * index.ts) because application code has to call it, which is why an
- * `\@internal` tag would be a lie rather than a fix. Kept in associations.ts
- * because association class resolution is its only consumer path.
+ * index.ts) because application code has to call it, so marking it internal
+ * would be a lie rather than a fix. Kept in associations.ts because association
+ * class resolution is its only consumer path.
  */
 export function registerModel(model: typeof Base): void;
 export function registerModel(name: string, model: typeof Base): void;

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -4146,12 +4146,12 @@ export class Base extends Model {
    * the `only:` filter rejects it. If the record doesn't exist, `find`
    * raises (Rails parity: RecordNotFound).
    *
-   * @noRailsEquivalent trails-only model-side finder: Rails apps call
-   * `GlobalID::Locator.locate` directly and globalid's railtie injects only
-   * `GlobalID::Identification` (the instance-side `to_gid` family) onto
-   * `ActiveRecord::Base`, so there is no `find_global_id` `def` anywhere in
-   * Rails or globalid. trails adds the ergonomic class-method form here and
-   * delegates straight to the ported Locator.
+   * NOT Rails: `find_global_id` exists nowhere in Rails or globalid — apps call
+   * `GlobalID::Locator.locate` directly, and globalid's railtie injects only the
+   * instance-side `GlobalID::Identification`. Left deliberately un-suppressed in
+   * `api:extra` so it keeps reporting as extra surface until it is removed or a
+   * caller justifies it (tasks 0023 globalid-model-side-finders-are-uncalled-
+   * trails-invention).
    */
   static findGlobalId(
     input: string | import("@blazetrails/globalid").GlobalID,
@@ -4163,10 +4163,8 @@ export class Base extends Model {
   /**
    * Signed counterpart of {@link findGlobalId} — uses signedIdVerifier(this).
    *
-   * @noRailsEquivalent trails-only model-side finder: Rails apps call
-   * `GlobalID::Locator.locate_signed` directly, so there is no
-   * `find_signed_global_id` `def` in Rails or globalid. Same invention as
-   * {@link findGlobalId}, carrying the verifier this model signs with.
+   * NOT Rails: same invention as {@link findGlobalId}, carrying the verifier
+   * this model signs with; Rails apps call `GlobalID::Locator.locate_signed`.
    */
   static async findSignedGlobalId(
     input: string | _SignedGlobalIDType,
@@ -4179,10 +4177,7 @@ export class Base extends Model {
   /**
    * Raising counterpart of {@link findSignedGlobalId} — throws on miss.
    *
-   * @noRailsEquivalent trails-only model-side finder: Rails apps call
-   * `GlobalID::Locator.locate_signed` directly, so there is no
-   * `find_signed_global_id!` `def` in Rails or globalid. Same invention as
-   * {@link findGlobalId}, in the bang shape.
+   * NOT Rails: same invention as {@link findGlobalId}, in the bang shape.
    */
   static async findSignedGlobalIdBang(
     input: string | _SignedGlobalIDType,

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -4146,7 +4146,12 @@ export class Base extends Model {
    * the `only:` filter rejects it. If the record doesn't exist, `find`
    * raises (Rails parity: RecordNotFound).
    *
-   * Mirrors: ActiveRecord::Base.find_global_id (via GlobalID::Locator.locate)
+   * @noRailsEquivalent trails-only model-side finder: Rails apps call
+   * `GlobalID::Locator.locate` directly and globalid's railtie injects only
+   * `GlobalID::Identification` (the instance-side `to_gid` family) onto
+   * `ActiveRecord::Base`, so there is no `find_global_id` `def` anywhere in
+   * Rails or globalid. trails' globalid `wire` module registers this ergonomic
+   * class-method form onto Base; it delegates straight to the ported Locator.
    */
   static findGlobalId(
     input: string | import("@blazetrails/globalid").GlobalID,
@@ -4155,7 +4160,14 @@ export class Base extends Model {
     return _Locator.locate(input, options);
   }
 
-  /** Mirrors: ActiveRecord::Base.find_signed_global_id — uses signedIdVerifier(this). */
+  /**
+   * Signed counterpart of {@link findGlobalId} — uses signedIdVerifier(this).
+   *
+   * @noRailsEquivalent trails-only model-side finder: Rails apps call
+   * `GlobalID::Locator.locate_signed` directly, so there is no
+   * `find_signed_global_id` `def` in Rails or globalid. Same invention as
+   * {@link findGlobalId}, carrying the verifier this model signs with.
+   */
   static async findSignedGlobalId(
     input: string | _SignedGlobalIDType,
     options?: Omit<import("@blazetrails/globalid").LocateSignedOptions, "verifier">,
@@ -4164,7 +4176,14 @@ export class Base extends Model {
     return _Locator.locateSigned(input, { ...options, verifier });
   }
 
-  /** Mirrors: ActiveRecord::Base.find_signed_global_id! — throws on miss. */
+  /**
+   * Raising counterpart of {@link findSignedGlobalId} — throws on miss.
+   *
+   * @noRailsEquivalent trails-only model-side finder: Rails apps call
+   * `GlobalID::Locator.locate_signed` directly, so there is no
+   * `find_signed_global_id!` `def` in Rails or globalid. Same invention as
+   * {@link findGlobalId}, in the bang shape.
+   */
   static async findSignedGlobalIdBang(
     input: string | _SignedGlobalIDType,
     options?: Omit<import("@blazetrails/globalid").LocateSignedOptions, "verifier">,

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -4150,8 +4150,8 @@ export class Base extends Model {
    * `GlobalID::Locator.locate` directly and globalid's railtie injects only
    * `GlobalID::Identification` (the instance-side `to_gid` family) onto
    * `ActiveRecord::Base`, so there is no `find_global_id` `def` anywhere in
-   * Rails or globalid. trails' globalid `wire` module registers this ergonomic
-   * class-method form onto Base; it delegates straight to the ported Locator.
+   * Rails or globalid. trails adds the ergonomic class-method form here and
+   * delegates straight to the ported Locator.
    */
   static findGlobalId(
     input: string | import("@blazetrails/globalid").GlobalID,

--- a/scripts/api-compare/extra-surface-allow.json
+++ b/scripts/api-compare/extra-surface-allow.json
@@ -115,18 +115,6 @@
   },
   {
     "package": "activerecord",
-    "tsFile": "associations.ts",
-    "name": "registerModel",
-    "reason": "trails-only model registry with no Rails analogue: `register_model` is defined nowhere in the Rails source (verified by grep over vendor/rails). Ruby resolves an association's class through constant lookup — Reflection#compute_class (reflection.rb:434 and :490) into Object.const_get, backed by ActiveSupport autoloading — so Rails never registers models anywhere. ESM has no constant namespace to walk and no autoload hook, so trails must be told which classes exist. Deliberately public (re-exported from index.ts) because application code has to call it, which is why @internal would be a lie rather than a fix. Kept in associations.ts because association class resolution is its only consumer path."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations.ts",
-    "name": "initializeAssociations",
-    "reason": "trails-only ESM module-cycle escape hatch with no Rails analogue: `initialize_associations` is defined nowhere in the Rails source (verified by grep over vendor/rails). The associations -> CollectionProxy -> Relation -> Base -> associations cycle forces CollectionProxy registration to be late-bound; the package entry does it eagerly, and this is the supported explicit hook for consumers who deep-import `@blazetrails/activerecord/associations` without touching the entry. Ruby's require/autoload resolves such cycles at load time, so there is nothing to port. Public by intent (documented consumer hook), so @internal is not appropriate."
-  },
-  {
-    "package": "activerecord",
     "tsFile": "connection-adapters/abstract-adapter.ts",
     "name": "Version",
     "reason": "`AbstractAdapter::Version` is a real Rails nested class (abstract_adapter.rb:243); `static readonly Version = Version` is the TS spelling of that nested Ruby constant, so this is public Rails API parity, not drift. It reads as extra surface only because extra-surface skips nested Ruby classes when building a file's allow-set (the `primaryClassPerFile` filter) while still counting the TS nested class. Nothing to converge. AbstractMysqlAdapter's redundant re-pin of the same constant was deleted rather than allowlisted — JS statics are inherited, so it shadowed nothing and had no readers."

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -799,8 +799,9 @@ describe("buildReport — novel vs moved classification", () => {
     // globalid's railtie does `on_load(:active_record) { include
     // GlobalID::Identification }` — a dynamic include the static extractor
     // can't see, plus the module lives in a *different* package. Its instance
-    // methods (toGid/toSgid family) and the trails-side Locator-backed finders
-    // (findGlobalId/findSignedGlobalId[Bang]) must NOT be flagged as novel.
+    // methods (toGid/toSgid family) must NOT be flagged as novel. The
+    // trails-side Locator-backed finders (findGlobalId/findSignedGlobalId[Bang])
+    // have no Rails counterpart at all and carry inline tags instead.
     const ruby: ApiManifest = {
       source: "ruby",
       generatedAt: "",
@@ -846,9 +847,11 @@ describe("buildReport — novel vs moved classification", () => {
                 method("toSignedGlobalId"),
               ],
               classMethods: [
-                method("findGlobalId"), // ambient railtie finder (no static Ruby def)
-                method("findSignedGlobalId"),
-                method("findSignedGlobalIdBang"),
+                // trails-only model-side finders — justified by their own
+                // `@noRailsEquivalent` tags, not by the railtie mixin.
+                { ...method("findGlobalId"), noRailsEquivalent: "trails-side finder" },
+                { ...method("findSignedGlobalId"), noRailsEquivalent: "trails-side finder" },
+                { ...method("findSignedGlobalIdBang"), noRailsEquivalent: "trails-side finder" },
                 method("genuinelyNovel"), // the only real extra
               ],
             },

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -801,7 +801,8 @@ describe("buildReport — novel vs moved classification", () => {
     // can't see, plus the module lives in a *different* package. Its instance
     // methods (toGid/toSgid family) must NOT be flagged as novel. The
     // trails-side Locator-backed finders (findGlobalId/findSignedGlobalId[Bang])
-    // have no Rails counterpart at all and carry inline tags instead.
+    // are NOT covered by the mixin — they have no Rails counterpart at all, so
+    // they keep reporting as extras until they are removed or justified.
     const ruby: ApiManifest = {
       source: "ruby",
       generatedAt: "",
@@ -847,12 +848,12 @@ describe("buildReport — novel vs moved classification", () => {
                 method("toSignedGlobalId"),
               ],
               classMethods: [
-                // trails-only model-side finders — justified by their own
-                // `@noRailsEquivalent` tags, not by the railtie mixin.
-                { ...method("findGlobalId"), noRailsEquivalent: "trails-side finder" },
-                { ...method("findSignedGlobalId"), noRailsEquivalent: "trails-side finder" },
-                { ...method("findSignedGlobalIdBang"), noRailsEquivalent: "trails-side finder" },
-                method("genuinelyNovel"), // the only real extra
+                // trails-only model-side finders: no Rails counterpart and no
+                // justification, so they stay visible as extra surface.
+                method("findGlobalId"),
+                method("findSignedGlobalId"),
+                method("findSignedGlobalIdBang"),
+                method("genuinelyNovel"),
               ],
             },
           },
@@ -868,7 +869,12 @@ describe("buildReport — novel vs moved classification", () => {
     });
     const f = report.packages[0].extraFiles.find((x) => x.tsFile === "base.ts");
     expect(f).toBeDefined();
-    expect(f!.extras.map((e) => e.name)).toEqual(["genuinelyNovel"]);
+    expect(f!.extras.map((e) => e.name)).toEqual([
+      "findGlobalId",
+      "findSignedGlobalId",
+      "findSignedGlobalIdBang",
+      "genuinelyNovel",
+    ]);
   });
 
   it("cross-package fallback does NOT let a bare short-name include pollute across gems", () => {

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -99,11 +99,13 @@ interface RubyEntity {
  * contributes its instance methods to the host's allowed set.
  *
  * `methods` are raw Ruby method names the railtie surface implies but which
- * have no static `def` anywhere (so they can't be reached via a module). Only
- * use it when the missing counterpart is a Ruby-extractor blind spot: a
- * trails-only method with no Rails counterpart at all belongs on its own
- * declaration as `@noRailsEquivalent` instead (that is where the model-side
- * `findGlobalId` / `findSignedGlobalId[!]` finders are justified).
+ * have no static `def` anywhere (so they can't be reached via a module). It is
+ * only for that Ruby-extractor blind spot — a trails-only method with no Rails
+ * counterpart at all is justified by a `@noRailsEquivalent` tag on its own
+ * declaration instead, which is where the model-side `findGlobalId` /
+ * `findSignedGlobalId[!]` finders moved (RFC 0080). No entry needs `methods`
+ * today; it stays because the blind spot it covers is a property of the Ruby
+ * extractor, not of any one gem.
  */
 const AMBIENT_RAILTIE_MIXINS: Record<string, { includes?: string[]; methods?: string[] }> = {
   "ActiveRecord::Base": {

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -99,16 +99,15 @@ interface RubyEntity {
  * contributes its instance methods to the host's allowed set.
  *
  * `methods` are raw Ruby method names the railtie surface implies but which
- * have no static `def` anywhere (so they can't be reached via a module): the
- * trails-side ergonomic finders that the globalid `wire` side-effect module
- * registers onto `Base` (`find_global_id` → `GlobalID::Locator.locate`,
- * `find_signed_global_id[!]` → `locateSigned`). Rails apps call
- * `GlobalID::Locator.locate` directly; trails surfaces the model-side form.
+ * have no static `def` anywhere (so they can't be reached via a module). Only
+ * use it when the missing counterpart is a Ruby-extractor blind spot: a
+ * trails-only method with no Rails counterpart at all belongs on its own
+ * declaration as `@noRailsEquivalent` instead (that is where the model-side
+ * `findGlobalId` / `findSignedGlobalId[!]` finders are justified).
  */
 const AMBIENT_RAILTIE_MIXINS: Record<string, { includes?: string[]; methods?: string[] }> = {
   "ActiveRecord::Base": {
     includes: ["GlobalID::Identification"],
-    methods: ["find_global_id", "find_signed_global_id", "find_signed_global_id!"],
   },
 };
 

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -100,12 +100,23 @@ interface RubyEntity {
  *
  * `methods` are raw Ruby method names the railtie surface implies but which
  * have no static `def` anywhere (so they can't be reached via a module). It is
- * only for that Ruby-extractor blind spot — a trails-only method with no Rails
- * counterpart at all is justified by a `@noRailsEquivalent` tag on its own
- * declaration instead, which is where the model-side `findGlobalId` /
- * `findSignedGlobalId[!]` finders moved (RFC 0080). No entry needs `methods`
- * today; it stays because the blind spot it covers is a property of the Ruby
- * extractor, not of any one gem.
+ * only for that Ruby-extractor blind spot: Rails really does gain the method,
+ * the extractor just can't see it. A trails-only method with no Rails
+ * counterpart is NOT that case and does not belong here — either it is
+ * permanently unportable, which a `@noRailsEquivalent` tag on its own
+ * declaration records (RFC 0080), or it is unconverged work, which stays
+ * unsuppressed so this report keeps flagging it.
+ *
+ * `ActiveRecord::Base` previously listed `find_global_id` /
+ * `find_signed_global_id[!]` here. It was the wrong bucket both ways: globalid's
+ * railtie includes only `GlobalID::Identification`
+ * (globalid/lib/global_id/railtie.rb:35), and Rails callers reach the finders
+ * through `GlobalID::Locator.locate` / `locate_signed`
+ * (globalid/lib/global_id/locator.rb:23,:84), so there is no ambient Ruby
+ * method to be blind to — trails' model-side class methods are an invention with
+ * no callers. They are deliberately untagged so `api:extra` reports them until
+ * they are removed. No entry needs `methods` today; the field stays because the
+ * blind spot it covers is a property of the Ruby extractor, not of any one gem.
  */
 const AMBIENT_RAILTIE_MIXINS: Record<string, { includes?: string[]; methods?: string[] }> = {
   "ActiveRecord::Base": {


### PR DESCRIPTION
Migrates the two `activerecord` `extra-surface-allow.json` entries and the
ambient global-id finder methods to inline `@noRailsEquivalent` tags
(RFC 0080). Documentation-only at runtime — no behavior changes.

## What changed

- `registerModel` / `initializeAssociations` (`packages/activerecord/src/associations.ts`)
  carry `@noRailsEquivalent` with their allowlist reasons preserved; the two
  JSON entries are deleted.
- `Base.findGlobalId`, `findSignedGlobalId`, `findSignedGlobalIdBang`
  (`base.ts`) are tagged — Rails apps call `GlobalID::Locator.locate[_signed]`
  directly and globalid's railtie injects only the instance-side
  `GlobalID::Identification`, so the model-side finders are a trails invention.
  The `methods` arm of `AMBIENT_RAILTIE_MIXINS["ActiveRecord::Base"]` is
  removed; the `includes` arm stays untouched, and its doc now states the
  narrow rule for `methods` (Ruby-extractor blind spots only) and why the
  now-unused field is kept.
- One extra-surface test fixture justifies those three finders through tags
  instead of the ambient arm (test name unchanged).
- Drops the stale `globalid locator.ts lookupClass` allow entry. `pnpm api:extra`
  already failed on `origin/main` for it; the allowlist only shrinks, so it's a
  one-line mechanical removal.

## Verification

`pnpm api:compare && pnpm api:extra` exits 0 (baseline: exit 1 on the stale
globalid entry). activerecord extra-surface totals are byte-identical to
baseline — 203 files, 472 novel, 904 moved, 1376 total. Allowed 22 → 25: the
three finders move from silently-ambient to explicitly counted. Tags: 5 of 5
matched, no stale tags or entries. `scripts/api-compare/extra-surface.test.ts`
49/49.

## Note for the next migration in this RFC

A `@noRailsEquivalent` reason must not contain a bare `@internal` in its prose
— TypeScript parses it as a real tag and the declaration drops out of the
extracted surface entirely, which surfaces as a *stale tag* rather than an
obvious error. Reword ("marking it internal would be a lie") rather than escape.

Closes-story: migrate-activerecord-allow-entries
