### PR TITLE
refactor(api-compare): dissolve TS_ALWAYS_ALLOWED into file-scoped mapping and @noRailsEquivalent tags

### DIFF
--- a/packages/actionpack/src/action-dispatch/journey/routes.ts
+++ b/packages/actionpack/src/action-dispatch/journey/routes.ts
@@ -47,6 +47,7 @@ export class Routes implements Iterable<Route> {
     return this.routes[this.routes.length - 1];
   }
 
+  /** @noRailsEquivalent JS iteration protocol — Ruby reaches iteration through Enumerable#each */
   [Symbol.iterator](): Iterator<Route> {
     return this.routes[Symbol.iterator]();
   }

--- a/packages/actionpack/src/action-dispatch/middleware/cookies.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/cookies.ts
@@ -201,6 +201,7 @@ export class CookieJar implements Iterable<[string, string]> {
     return this;
   }
 
+  /** @noRailsEquivalent JS iteration protocol — Ruby reaches iteration through Enumerable#each */
   [Symbol.iterator](): Iterator<[string, string]> {
     return this._cookies[Symbol.iterator]();
   }

--- a/packages/actionpack/src/action-dispatch/middleware/stack.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/stack.ts
@@ -161,6 +161,7 @@ export class MiddlewareStack implements Iterable<MiddlewareEntry> {
     return [...this.entries];
   }
 
+  /** @noRailsEquivalent JS iteration protocol — Ruby reaches iteration through Enumerable#each */
   [Symbol.iterator](): Iterator<MiddlewareEntry> {
     return this.entries[Symbol.iterator]();
   }

--- a/packages/actionview/src/path-set.ts
+++ b/packages/actionview/src/path-set.ts
@@ -64,6 +64,7 @@ export class PathSet implements Iterable<PathSetResolver> {
     return this.paths.includes(resolver);
   }
 
+  /** @noRailsEquivalent JS iteration protocol — Ruby reaches iteration through Enumerable#each */
   *[Symbol.iterator](): IterableIterator<PathSetResolver> {
     for (const r of this.paths) yield r;
   }

--- a/packages/activemodel/src/attribute-set.ts
+++ b/packages/activemodel/src/attribute-set.ts
@@ -313,6 +313,8 @@ export class AttributeSet {
   /**
    * Make AttributeSet iterable — yields [name, value] pairs for compatibility
    * with code that iterates `for (const [k, v] of _attributes)`.
+   *
+   * @noRailsEquivalent JS iteration protocol — Ruby reaches iteration through Enumerable#each
    */
   *[Symbol.iterator](): IterableIterator<[string, unknown]> {
     for (const name of this.keys()) {

--- a/packages/activemodel/src/errors.ts
+++ b/packages/activemodel/src/errors.ts
@@ -345,6 +345,8 @@ export class Errors<TBase extends object = object> {
    * its `def_delegators :@errors, :each, :clear, :empty?, :size, :uniq!`
    * (errors.rb:103) — `each` powers the Enumerable surface in Ruby; the
    * TS analog is the iterator protocol.
+   *
+   * @noRailsEquivalent JS iteration protocol — Ruby reaches iteration through Enumerable#each
    */
   [Symbol.iterator](): IterableIterator<ActiveModelError> {
     return this._errors[Symbol.iterator]();

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -115,9 +115,11 @@ export interface CollectionProxy<T extends Base = Base> {
     onfulfilled?: ((value: T[]) => TResult1 | PromiseLike<TResult1>) | null,
     onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null,
   ): Promise<TResult1 | TResult2>;
+  /** @noRailsEquivalent JS Promise protocol — Ruby has no thenable */
   catch<TResult = never>(
     onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null,
   ): Promise<T[] | TResult>;
+  /** @noRailsEquivalent JS Promise protocol — Ruby has no thenable */
   finally(onfinally?: (() => void) | null): Promise<T[]>;
 }
 
@@ -345,6 +347,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     return (await this.loadTarget()).length;
   }
 
+  /** @noRailsEquivalent JS iteration protocol — Ruby uses Enumerable#each */
   [Symbol.iterator](): IterableIterator<T> {
     return this._target[Symbol.iterator]();
   }
@@ -4424,7 +4427,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   /**
    * Async iterator — allows `for await (const record of proxy)`.
    *
-   * Mirrors: Ruby's Enumerable#each on CollectionProxy
+   * @noRailsEquivalent JS async-iteration protocol — Ruby's Enumerable#each
+   * is synchronous and has no async counterpart
    */
   async *[Symbol.asyncIterator](): AsyncIterableIterator<T> {
     const records = await this.loadTarget();

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -1131,6 +1131,7 @@ export class JoinDependency {
     this.nodes.forEach(callback);
   }
 
+  /** @noRailsEquivalent JS iteration protocol — Ruby reaches iteration through Enumerable#each */
   [Symbol.iterator](): Iterator<JoinPart> {
     return this.nodes[Symbol.iterator]();
   }

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -1319,6 +1319,7 @@ export class AbstractAdapter implements Quoting {
     return `#<${this.constructor.name}:${hex} env_name=${q(envName)}${nameField} role=${q(this.role)}${shardField}>`;
   }
 
+  /** @noRailsEquivalent Node inspection hook — a JS runtime protocol, not a Rails method */
   [Symbol.for("nodejs.util.inspect.custom")](): string {
     return this.inspect();
   }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -363,6 +363,7 @@ export class ConnectionPool implements ReapablePool {
     return this.inspect();
   }
 
+  /** @noRailsEquivalent Node inspection hook — a JS runtime protocol, not a Rails method */
   [Symbol.for("nodejs.util.inspect.custom")](): string {
     return this.inspect();
   }

--- a/packages/activerecord/src/encryption/cipher/aes256-gcm.ts
+++ b/packages/activerecord/src/encryption/cipher/aes256-gcm.ts
@@ -50,6 +50,7 @@ export class Aes256Gcm {
   // Mirrors Rails' inspect override — never expose the secret in debug output.
   // Symbol.for("nodejs.util.inspect.custom") is the stable public symbol
   // used by Node's util.inspect without importing "util" directly.
+  /** @noRailsEquivalent Node inspection hook — a JS runtime protocol, not a Rails method */
   [Symbol.for("nodejs.util.inspect.custom")](): string {
     return `Cipher {}`;
   }

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.ts
@@ -298,6 +298,7 @@ export class AdditionalValue {
     return String(this.value);
   }
 
+  /** @noRailsEquivalent JS primitive-coercion protocol — Ruby coerces through to_s/to_i instead */
   valueOf(): unknown {
     return this.value;
   }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2907,6 +2907,8 @@ export class Relation<T extends Base> {
 
   /**
    * Async iterator support — allows `for await (const record of relation)`.
+   *
+   * @noRailsEquivalent JS async-iteration protocol — Ruby's Enumerable#each is synchronous
    */
   async *[Symbol.asyncIterator](): AsyncIterableIterator<T> {
     const records = await this.toArray();
@@ -7630,9 +7632,11 @@ export interface Relation<T extends Base> {
     onfulfilled?: ((value: T[]) => TResult1 | PromiseLike<TResult1>) | null,
     onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null,
   ): Promise<TResult1 | TResult2>;
+  /** @noRailsEquivalent JS Promise protocol — Ruby has no thenable */
   catch<TResult = never>(
     onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null,
   ): Promise<T[] | TResult>;
+  /** @noRailsEquivalent JS Promise protocol — Ruby has no thenable */
   finally(onfinally?: (() => void) | null): Promise<T[]>;
 }
 

--- a/packages/activerecord/src/relation/batches/batch-enumerator.ts
+++ b/packages/activerecord/src/relation/batches/batch-enumerator.ts
@@ -44,6 +44,7 @@ export class BatchEnumerator<T extends BatchRelation> {
     this.relation = options?.relation ?? null;
   }
 
+  /** @noRailsEquivalent JS async-iteration protocol — Ruby's Enumerable#each is synchronous */
   async *[Symbol.asyncIterator](): AsyncIterableIterator<T> {
     yield* this._generator();
   }
@@ -140,9 +141,11 @@ export interface BatchEnumerator<T extends BatchRelation> {
     onfulfilled?: ((value: T[]) => TResult1 | PromiseLike<TResult1>) | null,
     onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null,
   ): Promise<TResult1 | TResult2>;
+  /** @noRailsEquivalent JS Promise protocol — Ruby has no thenable */
   catch<TResult = never>(
     onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null,
   ): Promise<T[] | TResult>;
+  /** @noRailsEquivalent JS Promise protocol — Ruby has no thenable */
   finally(onfinally?: (() => void) | null): Promise<T[]>;
 }
 

--- a/packages/activerecord/src/result.ts
+++ b/packages/activerecord/src/result.ts
@@ -116,6 +116,7 @@ export class Result {
     return new Result(columns, rowArrays);
   }
 
+  /** @noRailsEquivalent JS iteration protocol — Ruby reaches iteration through Enumerable#each */
   [Symbol.iterator](): IterableIterator<Record<string, unknown>> {
     return this.hashRows()[Symbol.iterator]();
   }

--- a/packages/activesupport/src/core-ext/string/output-safety.ts
+++ b/packages/activesupport/src/core-ext/string/output-safety.ts
@@ -145,6 +145,7 @@ export class SafeBuffer {
     return this._value.length;
   }
 
+  /** @noRailsEquivalent JS primitive-coercion protocol — Ruby coerces through to_s/to_i instead */
   valueOf(): string {
     return this._value;
   }

--- a/packages/activesupport/src/duration.ts
+++ b/packages/activesupport/src/duration.ts
@@ -568,6 +568,7 @@ export class Scalar {
     return String(this.value);
   }
 
+  /** @noRailsEquivalent JS primitive-coercion protocol — Ruby coerces through to_s/to_i instead */
   valueOf(): number {
     return this.value;
   }

--- a/packages/activesupport/src/string-inquirer.ts
+++ b/packages/activesupport/src/string-inquirer.ts
@@ -30,6 +30,7 @@ export class StringInquirer {
   toString(): string {
     return this._value;
   }
+  /** @noRailsEquivalent JS primitive-coercion protocol — Ruby coerces through to_s/to_i instead */
   valueOf(): string {
     return this._value;
   }

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -931,7 +931,12 @@ export class TimeWithZone {
     return this._epochMs;
   }
 
-  /** valueOf for comparison operators to work */
+  /**
+   * valueOf for comparison operators to work
+   *
+   * @noRailsEquivalent JS primitive-coercion protocol — Ruby coerces through
+   * to_s/to_i instead
+   */
   valueOf(): number {
     return this._epochMs;
   }

--- a/packages/rack/src/body-proxy.ts
+++ b/packages/rack/src/body-proxy.ts
@@ -24,6 +24,7 @@ export class BodyProxy {
     return this._closed;
   }
 
+  /** @noRailsEquivalent JS async-iteration protocol — Ruby's Enumerable#each is synchronous */
   async *[Symbol.asyncIterator](): AsyncIterator<any> {
     if (this.body && typeof this.body[Symbol.asyncIterator] === "function") {
       for await (const item of this.body) yield item;

--- a/packages/trailties/src/engine/trailties.ts
+++ b/packages/trailties/src/engine/trailties.ts
@@ -5,6 +5,7 @@ import { Trailtie } from "../trailtie.js";
 export class Trailties implements Iterable<Trailtie> {
   readonly all: Trailtie[] = Trailtie.subclasses().map((k) => k.instance());
 
+  /** @noRailsEquivalent JS iteration protocol — Ruby reaches iteration through Enumerable#each */
   [Symbol.iterator](): Iterator<Trailtie> {
     return this.all[Symbol.iterator]();
   }

--- a/scripts/api-compare/conventions.test.ts
+++ b/scripts/api-compare/conventions.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   snakeToCamel,
   rubyMethodToTs,
+  rubyMethodToTsIgnoringSkip,
+  SKIP_TS_MIRROR_IS_DRIFT,
   rubyFileToTs,
   SKIP,
   SKIP_GROUPS,
@@ -73,6 +75,27 @@ describe("snakeToCamel", () => {
     expect(snakeToCamel("verbatim_copy")).toBe("verbatimCopy");
     expect(snakeToCamel("http_verb")).toBe("httpVerb");
     expect(snakeToCamel("superb_thing")).toBe("superbThing");
+  });
+});
+
+describe("rubyMethodToTsIgnoringSkip", () => {
+  it("maps SKIP names that rubyMethodToTs refuses", () => {
+    expect(rubyMethodToTs("freeze")).toBeNull();
+    expect(rubyMethodToTsIgnoringSkip("freeze")).toEqual(["freeze"]);
+    expect(rubyMethodToTsIgnoringSkip("lookup_cast_type")).toEqual(["lookupCastType"]);
+    expect(rubyMethodToTsIgnoringSkip("pretty_print")).toEqual(["prettyPrint"]);
+  });
+
+  it("still refuses operators", () => {
+    expect(rubyMethodToTsIgnoringSkip("==")).toBeNull();
+  });
+});
+
+describe("SKIP_TS_MIRROR_IS_DRIFT", () => {
+  it("covers the Ruby hook groups only", () => {
+    expect([...SKIP_TS_MIRROR_IS_DRIFT].sort()).toEqual(
+      ["extended", "inherited", "included", "singleton_method_added"].sort(),
+    );
   });
 });
 

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -115,6 +115,20 @@ export interface SkipGroup {
   /** Why every name in this group is skipped. */
   reason: string;
   names: string[];
+  /**
+   * A TS declaration of these names is *drift*, not a faithful mirror, even
+   * when the matched Ruby file defines the method — so extra-surface must keep
+   * flagging it (`rubyMethodToTsIgnoringSkip` is not consulted for them).
+   *
+   * Set on the Ruby-hook groups: `included`/`extended`/`inherited` /
+   * `singleton_method_added` have no TS equivalent at all, so a same-named TS
+   * method isn't carrying the Rails pattern through — it's a trails invention
+   * that the group's `reason` exists to keep OUT of the port. Everything else
+   * on SKIP is a method that genuinely exists in Rails and whose skip is about
+   * *scoring* (one unportable variant, an ivar-reader shape), so a TS override
+   * in the file where Ruby defines it IS the port.
+   */
+  tsMirrorIsDrift?: true;
 }
 
 export const SKIP_GROUPS: SkipGroup[] = [
@@ -166,10 +180,12 @@ export const SKIP_GROUPS: SkipGroup[] = [
   {
     reason: "Ruby module lifecycle hooks — no TypeScript equivalent.",
     names: ["extended", "included", "inherited"],
+    tsMirrorIsDrift: true,
   },
   {
     reason: "Ruby object hooks — no TypeScript equivalent.",
     names: ["singleton_method_added"],
+    tsMirrorIsDrift: true,
   },
   {
     reason:
@@ -229,6 +245,11 @@ export const SKIP_GROUPS: SkipGroup[] = [
 ];
 
 export const SKIP = new Set<string>(SKIP_GROUPS.flatMap((g) => g.names));
+
+/** {@link SkipGroup.tsMirrorIsDrift} names, flattened. */
+export const SKIP_TS_MIRROR_IS_DRIFT = new Set<string>(
+  SKIP_GROUPS.filter((g) => g.tsMirrorIsDrift).flatMap((g) => g.names),
+);
 
 /**
  * Like {@link SkipGroup}, but the skip applies *only* within the listed Ruby
@@ -550,8 +571,22 @@ const CONTAINMENT_PREDICATE_ALIASES = new Map<string, string>([
  *     (`include?` → ["isInclude", "include", "includes"]).
  */
 export function rubyMethodToTs(name: string): string[] | null {
-  if (OPERATORS.has(name)) return null;
   if (SKIP.has(name)) return null;
+  return rubyMethodToTsIgnoringSkip(name);
+}
+
+/**
+ * {@link rubyMethodToTs} without the {@link SKIP} gate.
+ *
+ * A SKIP entry means "don't expect a TS counterpart" for *scoring coverage* —
+ * it does NOT mean the Ruby method is absent. extra-surface needs the opposite
+ * question answered: given that this Ruby file really does define `freeze` /
+ * `inspect` / `to_h`, what would a faithful TS override be called? Only this
+ * entry point answers it; the SKIP gate stays in place for compare.ts, so a
+ * skipped method still never counts as a missing port.
+ */
+export function rubyMethodToTsIgnoringSkip(name: string): string[] | null {
+  if (OPERATORS.has(name)) return null;
   if (name === "initialize" || name === "new") return ["constructor"];
   if (name === "to_s" || name === "to_str") return ["toString"];
   if (name === "to_json") return ["toJSON"];

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -357,6 +357,8 @@ describe("buildReport — novel vs moved classification", () => {
                 method("limit_value"), // Relation::VALUE_METHODS accessor
                 method("freeze"), // conventions.SKIP, but Rails defines it here
                 method("to_a"), // conventions.SKIP, spelled `toArray` in TS
+                method("=="), // operator — spelled `equals` in TS
+                method("initialize_copy"), // copy hook — spelled `clone`/`dup` in TS
               ],
             }),
           },
@@ -382,6 +384,8 @@ describe("buildReport — novel vs moved classification", () => {
                 method("limitValue"), // Relation::VALUE_METHODS accessor (matched in-file)
                 method("freeze"), // SKIP mirror — foo.rb defines `freeze`
                 method("toArray"), // SKIP mirror — foo.rb defines `to_a`
+                method("equals"), // SKIP mirror — foo.rb defines `==`
+                method("clone"), // SKIP mirror — foo.rb defines `initialize_copy`
                 method("catch"), // JS Promise protocol, no Ruby counterpart
                 method("genuinelyNovel"),
               ],

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -333,12 +333,14 @@ describe("buildReport — novel vs moved classification", () => {
     expect(pkg.totalMoved).toBe(1);
   });
 
-  it("doesn't flag predicate-Q, column-DSL, value-method, or JS-protocol names as novel", () => {
+  it("doesn't flag predicate-Q, column-DSL, value-method, or SKIP-mirror names as novel", () => {
     // Rails foo.rb defines a `?` predicate; the column-type DSL
     // (`define_column_methods`) and Relation value-method accessors
     // (`VALUE_METHODS.each`) are now modeled by the Ruby extractor, so they
-    // appear in the manifest like ordinary methods. JS-protocol methods are
-    // language-level and filtered TS-side.
+    // appear in the manifest like ordinary methods. A TS method mirroring a
+    // `conventions.SKIP` method the SAME Ruby file defines (`freeze`, `to_a`)
+    // is the faithful port, not drift — but a JS-only protocol name
+    // (`catch`) has no Ruby counterpart and stays flagged.
     const ruby: ApiManifest = {
       source: "ruby",
       generatedAt: "",
@@ -353,6 +355,8 @@ describe("buildReport — novel vs moved classification", () => {
                 method("bar"),
                 method("integer"), // define_column_methods macro
                 method("limit_value"), // Relation::VALUE_METHODS accessor
+                method("freeze"), // conventions.SKIP, but Rails defines it here
+                method("to_a"), // conventions.SKIP, spelled `toArray` in TS
               ],
             }),
           },
@@ -376,8 +380,10 @@ describe("buildReport — novel vs moved classification", () => {
                 method("connectedToQ"), // predicate `?` → Q suffix
                 method("integer"), // define_column_methods macro (matched in-file)
                 method("limitValue"), // Relation::VALUE_METHODS accessor (matched in-file)
-                method("catch"), // JS Promise protocol
-                method("genuinelyNovel"), // the only real extra
+                method("freeze"), // SKIP mirror — foo.rb defines `freeze`
+                method("toArray"), // SKIP mirror — foo.rb defines `to_a`
+                method("catch"), // JS Promise protocol, no Ruby counterpart
+                method("genuinelyNovel"),
               ],
               classMethods: [],
             },
@@ -392,7 +398,58 @@ describe("buildReport — novel vs moved classification", () => {
       novelOnly: false,
       topN: 50,
     });
-    expect(report.packages[0].extraFiles[0].extras.map((e) => e.name)).toEqual(["genuinelyNovel"]);
+    expect(report.packages[0].extraFiles[0].extras.map((e) => e.name)).toEqual([
+      "catch",
+      "genuinelyNovel",
+    ]);
+  });
+
+  it("keeps flagging Ruby-hook names — a TS `inherited` is drift, not a mirror", () => {
+    // `inherited` is on a SKIP group marked `tsMirrorIsDrift`: Ruby module
+    // hooks have no TS equivalent, so a same-named TS method is a trails
+    // invention even though validations.rb really does `def self.inherited`.
+    const ruby: ApiManifest = {
+      source: "ruby",
+      generatedAt: "",
+      packages: {
+        activerecord: {
+          classes: {
+            "ActiveRecord::Foo": rubyClass({
+              name: "Foo",
+              file: "foo.rb",
+              instance: [method("inherited"), method("freeze")],
+            }),
+          },
+          modules: {},
+        },
+      },
+    };
+    const ts: ApiManifest = {
+      source: "typescript",
+      generatedAt: "",
+      packages: {
+        activerecord: {
+          classes: {
+            Foo: {
+              name: "Foo",
+              file: "foo.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [method("inherited"), method("freeze")],
+              classMethods: [],
+            },
+          },
+          modules: {},
+        },
+      },
+    };
+    const report = buildReport(ruby, ts, {
+      filterPkg: null,
+      excludeGlobs: [],
+      novelOnly: false,
+      topN: 50,
+    });
+    expect(report.packages[0].extraFiles[0].extras.map((e) => e.name)).toEqual(["inherited"]);
   });
 
   it("skips _-prefixed and internal TS members, doesn't flag them as extras", () => {

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -60,7 +60,14 @@ import * as path from "path";
 import { fileURLToPath } from "url";
 import type { ApiManifest, ClassInfo, MethodInfo } from "./types.js";
 import { OUTPUT_DIR } from "./config.js";
-import { rubyFileToTs, rubyMethodToTs, snakeToCamel } from "./conventions.js";
+import {
+  SKIP,
+  SKIP_TS_MIRROR_IS_DRIFT,
+  rubyFileToTs,
+  rubyMethodToTs,
+  rubyMethodToTsIgnoringSkip,
+  snakeToCamel,
+} from "./conventions.js";
 import { resolveModuleName } from "./compare.js";
 import { isSourceUnported } from "./unported-files.js";
 
@@ -74,56 +81,6 @@ interface RubyEntity {
   fqn: string;
   info: ClassInfo;
 }
-
-/**
- * TS-side method names that mirror Ruby methods on `conventions.SKIP`.
- * `rubyMethodToTs` returns null for SKIP entries (they have no clean TS
- * mapping at scoring time), so they never enter `allowed` even when the
- * Ruby method exists in the matched file — but a TS override of e.g.
- * `freeze`/`inspect` IS Rails-faithful (Rails AR `Base#freeze` lives in
- * core.rb, AM `model#inspect` in attribute_methods.rb). Filtering these
- * from the TS-side name set prevents them from showing up as "novel
- * drift" when in fact they're carrying-the-pattern through.
- */
-const TS_ALWAYS_ALLOWED = new Set([
-  "dup",
-  "clone",
-  "freeze",
-  "inspect",
-  "prettyPrint",
-  "tap",
-  "then",
-  "eql",
-  "equals",
-  "initializeDup",
-  "initializeClone",
-  "initializeCopy",
-  "encodeWith",
-  "initWith",
-  "toArray",
-  "toH",
-  "toHash",
-  "valueOf",
-  "klasses",
-  // `lookup_cast_type` is a real Rails method — abstract/quoting.rb:234 and
-  // postgresql/quoting.rb:195 — but it sits on `conventions.SKIP` because the
-  // *PostgreSQL* one issues an async `SELECT oid` our standalone-function
-  // quoting module can't run. SKIP is global, so that one unportable adapter
-  // variant was making every faithful `lookupCastType` (abstract/quoting.ts,
-  // abstract-mysql-adapter.ts, sqlite3-adapter.ts) read as novel drift. This
-  // is exactly the carrying-the-pattern-through case the list exists for.
-  "lookupCastType",
-  // JS-only protocol surface on the thenable/iterable Relation — Promise
-  // (`catch`/`finally`; `then` is above) and the iteration protocols. Pure
-  // language-level conventions with no Rails counterpart.
-  "catch",
-  "finally",
-  "[Symbol.iterator]",
-  "[Symbol.asyncIterator]",
-  // Node.js / V8 inspection hook — the canonical TS analog of Ruby
-  // `inspect`. Pure language-level convention; never has a Rails counterpart.
-  '[Symbol.for("nodejs.util.inspect.custom")]',
-]);
 
 /**
  * Mixins (and methods) a host class gains at *runtime* via a gem's railtie
@@ -183,6 +140,42 @@ const PORTED_UNPORTED_MIXIN_METHODS: Record<string, string[]> = {
 };
 
 /**
+ * TS candidates a Ruby method on `conventions.SKIP` maps to.
+ *
+ * SKIP means api:compare never expects a TS counterpart — `rubyMethodToTs`
+ * returns null — but the Ruby method still EXISTS in the file, so a TS
+ * override of it (`freeze`, `inspect`, `lookupCastType`) is Rails-faithful,
+ * not drift. Resolving these through the normal name mapping keeps the
+ * allowance *file-scoped*: `freeze` is allowed in core.ts because core.rb
+ * defines `freeze`, and stays flagged anywhere Ruby doesn't.
+ *
+ * Only the case-transform is missing for most names; the map covers the few
+ * whose TS spelling isn't derivable (`to_a` → the JS `toArray`, Ruby `==` →
+ * `equals`, since TS has no operator overloading).
+ */
+const SKIP_MIRROR_CANDIDATES: Record<string, string[]> = {
+  to_a: ["toArray"],
+  to_ary: ["toArray"],
+  "==": ["equals"],
+  // Ruby copy semantics come from `Object#clone`/`#dup` (never `def`ed in
+  // Rails) plus the `initialize_copy` hook the class DOES define. JS has no
+  // Object#clone, so the faithful port of that pair is a `clone`/`dup` method
+  // on the class — allowed exactly where Ruby defines the hook.
+  initialize_copy: ["clone", "dup"],
+  initialize_dup: ["dup"],
+  initialize_clone: ["clone"],
+};
+
+function skipMirrorCandidates(rubyName: string): string[] | null {
+  if (SKIP_TS_MIRROR_IS_DRIFT.has(rubyName)) return null;
+  const extra = SKIP_MIRROR_CANDIDATES[rubyName];
+  if (!SKIP.has(rubyName) && !extra) return null;
+  const mapped = rubyMethodToTsIgnoringSkip(rubyName) ?? [];
+  const all = [...mapped, ...(extra ?? [])];
+  return all.length > 0 ? all : null;
+}
+
+/**
  * `rubyMethodToTs` for any method, plus the trails `Q`-suffix predicate form.
  * trails encodes a Ruby `?` predicate with a trailing `Q` in TS
  * (`connected_to?` → `connectedToQ`), sometimes stacked on the is-prefix form
@@ -191,7 +184,7 @@ const PORTED_UNPORTED_MIXIN_METHODS: Record<string, string[]> = {
  * mis-flagged as novel. Append `Q` to each candidate of a `?` method.
  */
 function rubyMethodCandidates(rubyName: string): string[] | null {
-  const base = rubyMethodToTs(rubyName);
+  const base = rubyMethodToTs(rubyName) ?? skipMirrorCandidates(rubyName);
   if (!base) return null;
   if (!rubyName.endsWith("?")) return base;
   return [...base, ...base.map((c) => c + "Q")];
@@ -485,7 +478,6 @@ export function collectTsFileNames(
   const push = (m: MethodInfo): void => {
     if (m.internal === true) return;
     if (m.name.startsWith("_")) return;
-    if (TS_ALWAYS_ALLOWED.has(m.name)) return;
     out.add(m.name);
   };
   for (const c of classes) {

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -14,7 +14,10 @@
  *      that Ruby file — any visibility, since a TS method mirroring a
  *      Rails-private method exists in Rails (a visibility divergence, not
  *      extra surface). Map each to its TS-candidate name set via
- *      `rubyMethodToTs`. Union = the "allowed" TS name set.
+ *      `rubyMethodCandidates`, which also resolves `conventions.SKIP`
+ *      mirrors (`freeze`, `to_a`, `lookup_cast_type`) so a TS override is
+ *      allowed in the file where Ruby defines the method. Union = the
+ *      "allowed" TS name set.
  *   3. Collect public TS names declared in the matching TS file — each
  *      class/module's *own* methods (skipping inherited surface so the
  *      diff measures this file's drift, not its ancestor's) plus top-level
@@ -140,43 +143,50 @@ const PORTED_UNPORTED_MIXIN_METHODS: Record<string, string[]> = {
 };
 
 /**
- * TS candidates a Ruby method on `conventions.SKIP` maps to.
+ * Extra TS candidates for Ruby names the normal case-transform can't spell.
  *
- * SKIP means api:compare never expects a TS counterpart — `rubyMethodToTs`
- * returns null — but the Ruby method still EXISTS in the file, so a TS
- * override of it (`freeze`, `inspect`, `lookupCastType`) is Rails-faithful,
- * not drift. Resolving these through the normal name mapping keeps the
- * allowance *file-scoped*: `freeze` is allowed in core.ts because core.rb
- * defines `freeze`, and stays flagged anywhere Ruby doesn't.
- *
- * Only the case-transform is missing for most names; the map covers the few
- * whose TS spelling isn't derivable (`to_a` → the JS `toArray`, Ruby `==` →
- * `equals`, since TS has no operator overloading).
+ * `to_a`/`to_ary` camelize to `toA`/`toAry`; the JS spelling of that protocol
+ * is `toArray`. `==` is an operator — TS has no operator overloading, so the
+ * port is a named `equals`. Ruby copy semantics come from `Object#clone`/`#dup`
+ * (never `def`ed in Rails) plus the `initialize_copy` hook the class DOES
+ * define; JS has no `Object#clone`, so the faithful port of that pair is a
+ * `clone`/`dup` method on the class.
  */
-const SKIP_MIRROR_CANDIDATES: Record<string, string[]> = {
+const MIRROR_CANDIDATE_OVERRIDES: Record<string, string[]> = {
   to_a: ["toArray"],
   to_ary: ["toArray"],
   "==": ["equals"],
-  // Ruby copy semantics come from `Object#clone`/`#dup` (never `def`ed in
-  // Rails) plus the `initialize_copy` hook the class DOES define. JS has no
-  // Object#clone, so the faithful port of that pair is a `clone`/`dup` method
-  // on the class — allowed exactly where Ruby defines the hook.
   initialize_copy: ["clone", "dup"],
   initialize_dup: ["dup"],
   initialize_clone: ["clone"],
 };
 
+/**
+ * TS candidates for a Ruby method `rubyMethodToTs` refuses to map.
+ *
+ * `conventions.SKIP` means api:compare never expects a TS counterpart, but the
+ * Ruby method still EXISTS in the file — so a TS override of it (`freeze`,
+ * `inspect`, `lookupCastType`) is Rails-faithful, not drift. Mapping those
+ * names here keeps the allowance *file-scoped*: `freeze` is allowed in core.ts
+ * because core.rb defines `freeze`, and stays flagged anywhere Ruby doesn't.
+ * That's strictly tighter than the blanket in-file allow-set this replaced.
+ *
+ * Two exclusions: `SKIP_TS_MIRROR_IS_DRIFT` names (Ruby hooks — a same-named
+ * TS method is a trails invention, not a port), and anything neither on SKIP
+ * nor in the override map, so ordinary unmapped names (operators other than
+ * `==`) stay unmapped.
+ */
 function skipMirrorCandidates(rubyName: string): string[] | null {
   if (SKIP_TS_MIRROR_IS_DRIFT.has(rubyName)) return null;
-  const extra = SKIP_MIRROR_CANDIDATES[rubyName];
-  if (!SKIP.has(rubyName) && !extra) return null;
-  const mapped = rubyMethodToTsIgnoringSkip(rubyName) ?? [];
-  const all = [...mapped, ...(extra ?? [])];
-  return all.length > 0 ? all : null;
+  const overrides = MIRROR_CANDIDATE_OVERRIDES[rubyName];
+  if (!SKIP.has(rubyName) && !overrides) return null;
+  const candidates = [...(rubyMethodToTsIgnoringSkip(rubyName) ?? []), ...(overrides ?? [])];
+  return candidates.length > 0 ? candidates : null;
 }
 
 /**
- * `rubyMethodToTs` for any method, plus the trails `Q`-suffix predicate form.
+ * `rubyMethodToTs` for any method, falling back to `skipMirrorCandidates` for
+ * the names it refuses, plus the trails `Q`-suffix predicate form.
  * trails encodes a Ruby `?` predicate with a trailing `Q` in TS
  * (`connected_to?` → `connectedToQ`), sometimes stacked on the is-prefix form
  * (`connected?` → `isConnectedQ`). The base mapper only emits the is-prefix


### PR DESCRIPTION
## What

`TS_ALWAYS_ALLOWED` in `scripts/api-compare/extra-surface.ts` was a
hand-maintained, blanket-applied allow-set of ~25 TS names: any file could
declare `freeze`, `inspect`, `toArray`, `catch` and never read as drift, whether
or not the matched Ruby file defined anything like it. Per RFC 0080 it dissolves
into two buckets, and the constant is deleted.

**Bucket 1 — Rails-faithful mirrors of `conventions.SKIP` methods.** These
methods DO exist in Rails; `rubyMethodToTs` returns null for SKIP entries (a
*scoring* decision), so they never reached `allowed`. They now resolve through
the candidate mapping instead: `conventions.rubyMethodToTsIgnoringSkip` (same
mapper, SKIP gate lifted) feeds a new `skipMirrorCandidates` arm in
extra-surface. The allowance is now **file-scoped** — `freeze` is allowed in
`core.ts` because `core.rb` defines `freeze`, and stays flagged everywhere Ruby
doesn't. A small `SKIP_MIRROR_CANDIDATES` map covers the spellings the case
transform can't derive: `to_a`/`to_ary` → `toArray`, Ruby `==` → `equals` (TS
has no operator overloading), and `initialize_copy`/`_dup`/`_clone` →
`clone`/`dup` (Ruby copy semantics are `Object#clone` plus the hook the class
defines; JS has no `Object#clone`, so the faithful port is a method).

The two Ruby-hook SKIP groups are excluded via a new `SkipGroup.tsMirrorIsDrift`
flag (`SKIP_TS_MIRROR_IS_DRIFT`): `included`/`extended`/`inherited`/
`singleton_method_added` have no TS equivalent at all, so a same-named TS method
is a trails invention the group exists to keep out — it must keep flagging.

**Bucket 2 — genuinely JS-only protocol surface.** 28 declarations tagged
`@noRailsEquivalent` at the site (comment-only changes to package sources):
Promise `catch`/`finally` on the thenables, `[Symbol.iterator]`,
`[Symbol.asyncIterator]`, `[Symbol.for("nodejs.util.inspect.custom")]`, and
`valueOf`.

## Audit table

| Name | Bucket | Action |
| --- | --- | --- |
| `dup`, `clone` | 1 (SKIP mirror) | via candidate mapping, incl. `initialize_copy`/`_dup`/`_clone` hook → `clone`/`dup` |
| `freeze`, `inspect`, `prettyPrint`, `tap`, `then` | 1 | via candidate mapping (`SKIP` names, mapped where Ruby defines them) |
| `eql` | 1 | via candidate mapping (`eql?`) |
| `equals` | 1 (ambiguous → resolved as mirror) | Ruby `==` is an OPERATOR, mapped to `equals` in `SKIP_MIRROR_CANDIDATES` |
| `initializeDup`, `initializeClone`, `initializeCopy`, `encodeWith`, `initWith` | 1 | via candidate mapping |
| `toH`, `toHash` | 1 | via candidate mapping (`to_h`, `to_hash`) |
| `toArray` | 1 | via candidate mapping (`to_a`/`to_ary` → `toArray`) |
| `klasses` | 1 (ambiguous → resolved as mirror) | `no_touching.rb` really defines `klasses`; allowed only there |
| `lookupCastType` | 1 | via candidate mapping; the SKIP is about the PG async variant, not existence |
| `catch`, `finally` | 2 (JS-only) | `@noRailsEquivalent` on Relation / CollectionProxy / BatchEnumerator thenable interfaces |
| `[Symbol.iterator]` | 2 | `@noRailsEquivalent` on 9 declarations |
| `[Symbol.asyncIterator]` | 2 | `@noRailsEquivalent` on 4 declarations |
| `[Symbol.for("nodejs.util.inspect.custom")]` | 2 | `@noRailsEquivalent` on 3 declarations |
| `valueOf` | 2 | `@noRailsEquivalent` on 5 declarations (JS primitive-coercion protocol) |

## Totals

`pnpm api:compare` clean; `pnpm api:extra` reports **28 tags, 28 matched, 0
stale** and **no new novel extras** in any package. Measured against a
freshly-extracted `origin/main` baseline (same manifests, scripts reverted):

| Package | Novel | Moved | Allowed |
| --- | --- | --- | --- |
| activerecord | 472 → 462 | 904 → 917 | 22 → 38 |
| activesupport | 131 → 122 | 149 → 155 | 0 → 4 |
| arel | 66 → 64 | 104 → 104 | 0 → 0 |
| trailties | 63 → 61 | 88 → 88 | 0 → 1 |
| rack | 44 → 43 | 66 → 73 | 0 → 1 |
| actiondispatch | 167 → 167 | 158 → 166 | 0 → 3 |
| actioncontroller | 57 → 57 | 77 → 80 | 0 → 0 |
| activemodel | 85 → 85 | 171 → 170 | 0 → 2 |
| actionview | 33 → 33 | 58 → 58 | 0 → 1 |

Novel drops where the blanket set had been masking a real mapping; `Allowed`
rises by the 28 tags. Moved rises by 44 — the sites the blanket set was hiding:
names Rails really defines, just in a *different* `.rb` than the TS file we put
them in (`dup`/`clone` in `base.ts`/`persistence.ts` vs Rails' `core.rb`,
`inspect` in 9 files, `toArray`/`toHash`/`toH` on the collection-ish types,
`then` on CollectionProxy/BatchEnumerator, `lookupCastType` on the
mysql/sqlite3 adapters). Tagging those `@noRailsEquivalent` would be false —
Rails has them — so they report as ordinary "moved" extras, which is exactly
the location divergence api:extra exists to surface. 32 previously-flagged
extras are now correctly allowed by the file-scoped mapping (`hash`,
`respondTo`, `methodMissing`, `isNil`, `start`/`finish`, `toI`/`toF`,
`loadSchemaBang`, …).

The one `api:extra` non-zero exit is pre-existing on `main` (stale allowlist
entry `globalid locator.ts lookupClass`) and unrelated to this change; left
alone.

Closes-story: ts-always-allowed-audit-dissolution
