### PR TITLE
refactor(activerecord): move charset/collation readers to MySQL TableDefinition

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -849,8 +849,6 @@ export class TableDefinition {
   readonly as?: string;
   readonly options?: string;
   readonly comment?: string;
-  readonly charset?: string;
-  readonly collation?: string;
   readonly compositePrimaryKey?: string[];
   private _id: boolean | PrimaryKeyType | IdHashOptions;
   private _adapterName: "sqlite" | "postgres" | "mysql";
@@ -898,8 +896,6 @@ export class TableDefinition {
     this.as = tdOptions.as;
     this.options = tdOptions.options;
     this.comment = tdOptions.comment;
-    this.charset = tdOptions.charset;
-    this.collation = tdOptions.collation;
     if (hasCompositePk) {
       this.compositePrimaryKey = tdOptions.primaryKey as string[];
     }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
@@ -55,6 +55,9 @@ export interface ColumnMethods {
 }
 
 export class TableDefinition extends AbstractTableDefinition {
+  readonly charset?: string;
+  readonly collation?: string;
+
   constructor(
     tableName: string,
     options: {
@@ -79,6 +82,8 @@ export class TableDefinition extends AbstractTableDefinition {
       adapterName: "mysql",
       adapter: mysqlSchemaQuoter(adapter),
     });
+    this.charset = rest.charset ?? undefined;
+    this.collation = rest.collation ?? undefined;
   }
 
   blob(name: string, options: ColumnOptions & { limit?: number } = {}): this {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
@@ -74,16 +74,14 @@ export class TableDefinition extends AbstractTableDefinition {
       adapterName?: "sqlite" | "postgres" | "mysql";
     } = {},
   ) {
-    const { adapter, adapterName: _ignoredAdapterName, ...rest } = options;
+    const { adapter, adapterName: _ignoredAdapterName, charset, collation, ...rest } = options;
     super(tableName, {
       ...rest,
-      charset: rest.charset ?? undefined,
-      collation: rest.collation ?? undefined,
       adapterName: "mysql",
       adapter: mysqlSchemaQuoter(adapter),
     });
-    this.charset = rest.charset ?? undefined;
-    this.collation = rest.collation ?? undefined;
+    this.charset = charset ?? undefined;
+    this.collation = collation ?? undefined;
   }
 
   blob(name: string, options: ColumnOptions & { limit?: number } = {}): this {


### PR DESCRIPTION
Rails declares `attr_reader :charset, :collation` on
`ActiveRecord::ConnectionAdapters::MySQL::TableDefinition`
(`connection_adapters/mysql/schema_definitions.rb:58`) — and *only* there;
the abstract `TableDefinition` (`abstract/schema_definitions.rb:369`) has no
such attributes.

trails had it backwards: the abstract class carried `readonly charset` /
`readonly collation` fields, and the MySQL subclass took the options but
exposed no readers. Since class fields are defined on the instance under
`useDefineForClassFields`, a subclass accessor could not have shadowed them —
so the storage itself moves down to MySQL.

- `abstract/schema-definitions.ts`: drop the two fields and their assignments
  (the constructor option keys stay, matching Rails' `**` swallow, so the
  shared `tdOpts` object in `migration.ts` still typechecks).
- `mysql/schema-definitions.ts`: declare and assign `charset`/`collation`.

The only reader of these was MySQL's `addTableOptionsBang`, which already casts
to the MySQL definition type.

`pnpm api:compare --package activerecord`:
`connection_adapters/mysql/schema_definitions.rb` 18/18 100%,
`connection_adapters/abstract/schema_definitions.rb` 113/113 100%.

Closes-story: ar-mysql-table-definition-charset-collation-readers
