### PR TITLE
refactor(activemodel): converge apply_seconds_precision and Decimal#changed? wide call set

### DIFF
--- a/packages/activemodel/src/type/date-time.test.ts
+++ b/packages/activemodel/src/type/date-time.test.ts
@@ -159,6 +159,15 @@ describe("DateTimeTest", () => {
     expect(zdt.hour).toBe(0);
     expect(zdt.minute).toBe(0);
   });
+  it("serialize_cast_value is equivalent to serialize after cast", () => {
+    const type = new Types.DateTimeType({ precision: 1 });
+    const value = type.cast("1999-12-31T12:34:56.789-10:00");
+
+    expect(type.serializeCastValue(value)).toEqual(type.serialize(value));
+    expect((type.serializeCastValue(value) as Temporal.Instant).toString()).toBe(
+      "1999-12-31T22:34:56.7Z",
+    );
+  });
 });
 
 describe("DateTimeType#isChanged", () => {
@@ -225,15 +234,5 @@ describe("DateTimeType#isChanged", () => {
     const t = new Types.DateTimeType();
     expect(t.isChanged(null, null)).toBe(false);
     expect(t.isChanged(null, "2024-01-01")).toBe(true);
-  });
-
-  it("serialize_cast_value is equivalent to serialize after cast", () => {
-    const type = new Types.DateTimeType({ precision: 1 });
-    const value = type.cast("1999-12-31T12:34:56.789-10:00");
-
-    expect(type.serializeCastValue(value)).toEqual(type.serialize(value));
-    expect((type.serializeCastValue(value) as Temporal.Instant).toString()).toBe(
-      "1999-12-31T22:34:56.7Z",
-    );
   });
 });

--- a/packages/activemodel/src/type/date-time.test.ts
+++ b/packages/activemodel/src/type/date-time.test.ts
@@ -226,4 +226,14 @@ describe("DateTimeType#isChanged", () => {
     expect(t.isChanged(null, null)).toBe(false);
     expect(t.isChanged(null, "2024-01-01")).toBe(true);
   });
+
+  it("serialize_cast_value is equivalent to serialize after cast", () => {
+    const type = new Types.DateTimeType({ precision: 1 });
+    const value = type.cast("1999-12-31T12:34:56.789-10:00");
+
+    expect(type.serializeCastValue(value)).toEqual(type.serialize(value));
+    expect((type.serializeCastValue(value) as Temporal.Instant).toString()).toBe(
+      "1999-12-31T22:34:56.7Z",
+    );
+  });
 });

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -23,10 +23,10 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
   protected castValue(value: unknown): DateTimeCastResult | null {
     if (value === DateInfinity) return DateInfinity;
     if (value === DateNegativeInfinity) return DateNegativeInfinity;
-    if (value instanceof Temporal.Instant) return this._applySecondsPrecision(value);
+    if (value instanceof Temporal.Instant) return this.applySecondsPrecision(value);
     // boundary: JS Date assigned to a datetime attribute (e.g. aircraft.manufactured_at = new Date())
     if (value instanceof Date) {
-      return this._applySecondsPrecision(Temporal.Instant.fromEpochMilliseconds(value.getTime()));
+      return this.applySecondsPrecision(Temporal.Instant.fromEpochMilliseconds(value.getTime()));
     }
     if (isHash(value)) return this.valueFromMultiparameterAssignment(value);
     const str = String(value).trim();
@@ -127,7 +127,7 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
     return isHash(value);
   }
 
-  private _applySecondsPrecision(value: Temporal.Instant): Temporal.Instant {
+  private applySecondsPrecision(value: Temporal.Instant): Temporal.Instant {
     if (
       this.precision == null ||
       !Number.isInteger(this.precision) ||
@@ -184,7 +184,7 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
     return oldValue !== newValue;
   }
 
-  // Truncate epoch nanoseconds to column precision, matching _applySecondsPrecision /
+  // Truncate epoch nanoseconds to column precision, matching applySecondsPrecision /
   // Temporal.toString() floor-style sub-second truncation. Used by isChanged so that
   // sub-precision nanosecond noise from Temporal.Now (when precision=null) doesn't
   // produce spurious dirty marks after serialize → cast round-trips.
@@ -215,6 +215,6 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
   // Mirrors ActiveModel::Type::Helpers::TimeValue#serialize_cast_value (apply_seconds_precision).
   serializeCastValue(value: DateTimeCastResult | null): DateTimeCastResult | null {
     if (value === null || value === DateInfinity || value === DateNegativeInfinity) return value;
-    return this._applySecondsPrecision(value as Temporal.Instant);
+    return this.applySecondsPrecision(value as Temporal.Instant);
   }
 }

--- a/packages/activemodel/src/type/decimal.test.ts
+++ b/packages/activemodel/src/type/decimal.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { BigDecimal } from "@blazetrails/activesupport";
-import { Model, Types } from "../index.js";
+import { Types } from "../index.js";
 
 // DecimalType#cast returns a BigDecimal (Rails: cast_value -> BigDecimal), so
 // decimal binds quote in fixed "F" form rather than as a 'string' literal.
@@ -110,25 +110,10 @@ describe("DecimalTest", () => {
     expect(type.isChanged(5.0, 5.0, "5.0")).toBe(false);
     expect(type.isChanged(-5.0, -5.0, "-5.0")).toBe(false);
     expect(type.isChanged(5.0, 5.0, "0.5e+1")).toBe(false);
-    // Rails passes `BigDecimal("0.0") / 0` here. Trails' BigDecimal carries no
-    // non-finite state, so a NaN decimal cast round-trips as the sentinel
-    // string "NaN" (see `_castWithoutScale`) — that sentinel stands in for
-    // Ruby's BigDecimal NaN on both sides of the comparison.
+    // Rails passes `BigDecimal("0.0") / 0`; trails' NaN decimal is the "NaN" sentinel.
     expect(type.isChanged("NaN", "NaN", "NaN")).toBe(false);
-    // ...and a Float NaN written over a BigDecimal NaN is still a change,
-    // because Rails' `equal_nan?` requires `old_value.instance_of?(new_value.class)`.
+    // Float NaN over BigDecimal NaN: still a change (`instance_of?` guard).
     expect(type.isChanged("NaN", NaN, NaN)).toBe(true);
-  });
-
-  it("dirty tracking treats a reverted decimal as unchanged", () => {
-    class MyModel extends Model {
-      static {
-        this.attribute("price", "decimal");
-      }
-    }
-    const m = new MyModel({ price: "1.0" });
-    m.writeAttribute("price", "1.0");
-    expect(m.attributeChanged("price")).toBe(false);
   });
 
   it("type cast decimal from float with large precision", () => {

--- a/packages/activemodel/src/type/decimal.test.ts
+++ b/packages/activemodel/src/type/decimal.test.ts
@@ -102,6 +102,25 @@ describe("DecimalTest", () => {
   });
 
   it("changed?", () => {
+    const type = new Types.DecimalType();
+
+    expect(type.isChanged(0.0, 0, "wibble")).toBe(true);
+    expect(type.isChanged(5.0, 0, "wibble")).toBe(true);
+    expect(type.isChanged(5.0, 5.0, "5.0wibble")).toBe(false);
+    expect(type.isChanged(5.0, 5.0, "5.0")).toBe(false);
+    expect(type.isChanged(-5.0, -5.0, "-5.0")).toBe(false);
+    expect(type.isChanged(5.0, 5.0, "0.5e+1")).toBe(false);
+    // Rails passes `BigDecimal("0.0") / 0` here. Trails' BigDecimal carries no
+    // non-finite state, so a NaN decimal cast round-trips as the sentinel
+    // string "NaN" (see `_castWithoutScale`) — that sentinel stands in for
+    // Ruby's BigDecimal NaN on both sides of the comparison.
+    expect(type.isChanged("NaN", "NaN", "NaN")).toBe(false);
+    // ...and a Float NaN written over a BigDecimal NaN is still a change,
+    // because Rails' `equal_nan?` requires `old_value.instance_of?(new_value.class)`.
+    expect(type.isChanged("NaN", NaN, NaN)).toBe(true);
+  });
+
+  it("dirty tracking treats a reverted decimal as unchanged", () => {
     class MyModel extends Model {
       static {
         this.attribute("price", "decimal");

--- a/packages/activemodel/src/type/decimal.trails.test.ts
+++ b/packages/activemodel/src/type/decimal.trails.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { Model } from "../index.js";
+
+describe("DecimalTypeTrails", () => {
+  it("treats a reverted decimal as unchanged", () => {
+    class MyModel extends Model {
+      static {
+        this.attribute("price", "decimal");
+      }
+    }
+    const m = new MyModel({ price: "1.0" });
+    m.writeAttribute("price", "1.0");
+    expect(m.attributeChanged("price")).toBe(false);
+  });
+});

--- a/packages/activemodel/src/type/decimal.ts
+++ b/packages/activemodel/src/type/decimal.ts
@@ -121,22 +121,6 @@ export class DecimalType extends NumericValueType {
     return roundHalfUpToScale(value, this.scale);
   }
 
-  /**
-   * Dirty-tracking compares cast values for equality. Cast decimals are
-   * {@link BigDecimal} instances, so a bare `!==` (object identity) would
-   * report every revert as a change. Rails compares with `==` (value
-   * equality); normalize both operands to their fixed-form string before
-   * delegating to the numeric mixin's `isChanged`.
-   */
-  override isChanged(
-    oldValue: unknown,
-    newValue: unknown,
-    newValueBeforeTypeCast?: unknown,
-  ): boolean {
-    const normalize = (v: unknown) => (v instanceof BigDecimal ? v.toString("F") : v);
-    return super.isChanged(normalize(oldValue), normalize(newValue), newValueBeforeTypeCast);
-  }
-
   private _castWithoutScale(value: unknown): string | null {
     if (value === null || value === undefined) return null;
     // A BigDecimal re-cast (e.g. through serialize) round-trips via its

--- a/packages/activemodel/src/type/helpers/numeric.test.ts
+++ b/packages/activemodel/src/type/helpers/numeric.test.ts
@@ -69,7 +69,6 @@ describe("Helpers::Numeric private predicates", () => {
     it("returns false for non-number inputs", () => {
       expect(isEqualNan(null, null)).toBe(false);
       expect(isEqualNan("nan", "nan")).toBe(false);
-      // Mixed representations fail Rails' `old_value.instance_of?(new_value.class)` guard.
       expect(isEqualNan("NaN", NaN)).toBe(false);
       expect(isEqualNan(NaN, "NaN")).toBe(false);
     });

--- a/packages/activemodel/src/type/helpers/numeric.test.ts
+++ b/packages/activemodel/src/type/helpers/numeric.test.ts
@@ -67,8 +67,15 @@ describe("Helpers::Numeric private predicates", () => {
     });
 
     it("returns false for non-number inputs", () => {
-      expect(isEqualNan("NaN", "NaN")).toBe(false);
       expect(isEqualNan(null, null)).toBe(false);
+      expect(isEqualNan("nan", "nan")).toBe(false);
+      // Mixed representations fail Rails' `old_value.instance_of?(new_value.class)` guard.
+      expect(isEqualNan("NaN", NaN)).toBe(false);
+      expect(isEqualNan(NaN, "NaN")).toBe(false);
+    });
+
+    it('treats the decimal "NaN" sentinel as BigDecimal NaN on both sides', () => {
+      expect(isEqualNan("NaN", "NaN")).toBe(true);
     });
   });
 });

--- a/packages/activemodel/src/type/helpers/numeric.ts
+++ b/packages/activemodel/src/type/helpers/numeric.ts
@@ -3,27 +3,36 @@
  *
  * Mirrors: ActiveModel::Type::Helpers::Numeric (numeric.rb:7-34)
  */
+import { BigDecimal } from "@blazetrails/activesupport";
 import { ValueType } from "../value.js";
-
-/** Mirrors: ActiveModel::Type::Helpers::Numeric::NUMERIC_REGEX */
-const NUMERIC_REGEX = /^\s*[+-]?\d/;
 
 /**
  * Mirrors: ActiveModel::Type::Helpers::Numeric#equal_nan?
  *
- * Trails has no BigDecimal class, so the constructor-equality check
- * collapses to "both are JS numbers and both are NaN".
+ *   (old_value.is_a?(::Float) || old_value.is_a?(BigDecimal)) &&
+ *     old_value.nan? && old_value.instance_of?(new_value.class) && new_value.nan?
+ *
+ * Trails passes the CAST new value here rather than Rails'
+ * `new_value_before_type_cast` — a pre-existing deviation locked in by
+ * `float.test.ts` ("equal_nan? uses cast value"), left alone here.
+ *
+ * Rails' `instance_of?(new_value.class)` guard means a Float NaN written over
+ * a BigDecimal NaN still counts as a change. Trails' `BigDecimal` carries no
+ * non-finite state, so `DecimalType#cast` represents a NaN decimal as the
+ * sentinel string `"NaN"` — that sentinel IS this port's BigDecimal NaN, and
+ * the class guard maps to requiring the same representation on both sides.
  *
  * @internal Rails-private helper.
  */
 export function isEqualNan(oldValue: unknown, newValue: unknown): boolean {
-  return (
-    typeof oldValue === "number" &&
-    Number.isNaN(oldValue) &&
-    typeof newValue === "number" &&
-    Number.isNaN(newValue)
-  );
+  if (typeof oldValue === "number") {
+    return Number.isNaN(oldValue) && typeof newValue === "number" && Number.isNaN(newValue);
+  }
+  return oldValue === "NaN" && newValue === "NaN";
 }
+
+/** Mirrors: ActiveModel::Type::Helpers::Numeric::NUMERIC_REGEX */
+const NUMERIC_REGEX = /^\s*[+-]?\d/;
 
 /**
  * Mirrors: ActiveModel::Type::Helpers::Numeric#number_to_non_number?
@@ -45,6 +54,14 @@ export function isNumberToNonNumber(oldValue: unknown, newValueBeforeTypeCast: u
  */
 export function isNonNumericString(value: unknown): boolean {
   return !NUMERIC_REGEX.test(String(value));
+}
+
+/**
+ * Cast decimals are {@link BigDecimal} instances; compare them by their fixed
+ * ("F") form so JS identity does not stand in for Ruby's value equality.
+ */
+function normalizeBigDecimal(value: unknown): unknown {
+  return value instanceof BigDecimal ? value.toString("F") : value;
 }
 
 // Constructor rest args must be `any[]` — idiomatic in TypeScript mixin
@@ -108,10 +125,16 @@ export function applyNumericMixin<TBase extends AbstractValueTypeCtor>(
       newValue: unknown,
       newValueBeforeTypeCast?: unknown,
     ): boolean {
+      // Rails' `super` here is `Value#changed?` (`old_value != new_value`) —
+      // Ruby `!=` on BigDecimal is value equality, so a cast decimal reverted
+      // to its previous value is unchanged. JS `!==` is object identity, so
+      // normalize BigDecimal operands to their fixed form first.
+      const old = normalizeBigDecimal(oldValue);
+      const fresh = normalizeBigDecimal(newValue);
       return (
-        (super.isChanged(oldValue, newValue, newValueBeforeTypeCast) ||
-          isNumberToNonNumber(oldValue, newValueBeforeTypeCast)) &&
-        !isEqualNan(oldValue, newValue)
+        (super.isChanged(old, fresh, newValueBeforeTypeCast) ||
+          isNumberToNonNumber(old, newValueBeforeTypeCast)) &&
+        !isEqualNan(old, fresh)
       );
     }
   }

--- a/packages/activemodel/src/type/helpers/numeric.ts
+++ b/packages/activemodel/src/type/helpers/numeric.ts
@@ -6,21 +6,20 @@
 import { BigDecimal } from "@blazetrails/activesupport";
 import { ValueType } from "../value.js";
 
+/** Mirrors: ActiveModel::Type::Helpers::Numeric::NUMERIC_REGEX */
+const NUMERIC_REGEX = /^\s*[+-]?\d/;
+
 /**
  * Mirrors: ActiveModel::Type::Helpers::Numeric#equal_nan?
  *
- *   (old_value.is_a?(::Float) || old_value.is_a?(BigDecimal)) &&
- *     old_value.nan? && old_value.instance_of?(new_value.class) && new_value.nan?
+ * Trails' BigDecimal carries no non-finite state, so `DecimalType#cast`
+ * represents a NaN decimal as the sentinel string `"NaN"` — that sentinel is
+ * this port's BigDecimal NaN. Requiring the same representation on both sides
+ * is how Rails' `old_value.instance_of?(new_value.class)` guard lands here.
  *
- * Trails passes the CAST new value here rather than Rails'
- * `new_value_before_type_cast` — a pre-existing deviation locked in by
- * `float.test.ts` ("equal_nan? uses cast value"), left alone here.
- *
- * Rails' `instance_of?(new_value.class)` guard means a Float NaN written over
- * a BigDecimal NaN still counts as a change. Trails' `BigDecimal` carries no
- * non-finite state, so `DecimalType#cast` represents a NaN decimal as the
- * sentinel string `"NaN"` — that sentinel IS this port's BigDecimal NaN, and
- * the class guard maps to requiring the same representation on both sides.
+ * Deviation: the second argument is the CAST new value, not Rails'
+ * `new_value_before_type_cast` — pre-existing, pinned by `float.test.ts`
+ * ("equal_nan? uses cast value") and five `dirty.test.ts` cases.
  *
  * @internal Rails-private helper.
  */
@@ -30,9 +29,6 @@ export function isEqualNan(oldValue: unknown, newValue: unknown): boolean {
   }
   return oldValue === "NaN" && newValue === "NaN";
 }
-
-/** Mirrors: ActiveModel::Type::Helpers::Numeric::NUMERIC_REGEX */
-const NUMERIC_REGEX = /^\s*[+-]?\d/;
 
 /**
  * Mirrors: ActiveModel::Type::Helpers::Numeric#number_to_non_number?
@@ -56,10 +52,6 @@ export function isNonNumericString(value: unknown): boolean {
   return !NUMERIC_REGEX.test(String(value));
 }
 
-/**
- * Cast decimals are {@link BigDecimal} instances; compare them by their fixed
- * ("F") form so JS identity does not stand in for Ruby's value equality.
- */
 function normalizeBigDecimal(value: unknown): unknown {
   return value instanceof BigDecimal ? value.toString("F") : value;
 }
@@ -125,10 +117,8 @@ export function applyNumericMixin<TBase extends AbstractValueTypeCtor>(
       newValue: unknown,
       newValueBeforeTypeCast?: unknown,
     ): boolean {
-      // Rails' `super` here is `Value#changed?` (`old_value != new_value`) —
-      // Ruby `!=` on BigDecimal is value equality, so a cast decimal reverted
-      // to its previous value is unchanged. JS `!==` is object identity, so
-      // normalize BigDecimal operands to their fixed form first.
+      // `super` is Value#changed? — Ruby `!=` on BigDecimal is value equality,
+      // JS `!==` is object identity, so normalize before comparing.
       const old = normalizeBigDecimal(oldValue);
       const fresh = normalizeBigDecimal(newValue);
       return (

--- a/packages/activemodel/src/type/time.test.ts
+++ b/packages/activemodel/src/type/time.test.ts
@@ -154,7 +154,6 @@ describe("TimeTest", () => {
     const value = type.cast("1999-12-31T12:34:56.789-10:00");
 
     expect(type.serializeCastValue(value)).toEqual(type.serialize(value));
-    // precision: 1 truncates everything past the first sub-second digit.
     expect(type.serializeCastValue(value)?.toString()).toBe("12:34:56.7");
   });
 });

--- a/packages/activemodel/src/type/time.test.ts
+++ b/packages/activemodel/src/type/time.test.ts
@@ -148,4 +148,13 @@ describe("TimeTest", () => {
     expect(result).toBeInstanceOf(Temporal.PlainTime);
     expect((result as Temporal.PlainTime).hour).toBe(10);
   });
+
+  it("serialize_cast_value is equivalent to serialize after cast", () => {
+    const type = new Types.TimeType({ precision: 1 });
+    const value = type.cast("1999-12-31T12:34:56.789-10:00");
+
+    expect(type.serializeCastValue(value)).toEqual(type.serialize(value));
+    // precision: 1 truncates everything past the first sub-second digit.
+    expect(type.serializeCastValue(value)?.toString()).toBe("12:34:56.7");
+  });
 });

--- a/packages/activemodel/src/type/time.ts
+++ b/packages/activemodel/src/type/time.ts
@@ -37,10 +37,10 @@ export class TimeType extends ValueType<Temporal.PlainTime> {
 
   /** @internal Rails-private helper. */
   protected castValue(value: unknown): Temporal.PlainTime | null {
-    if (value instanceof Temporal.PlainTime) return this._applySecondsPrecision(value);
+    if (value instanceof Temporal.PlainTime) return this.applySecondsPrecision(value);
     // Accept PlainDateTime from multiparameter assignment — extract the time part.
     if (value instanceof Temporal.PlainDateTime)
-      return this._applySecondsPrecision(value.toPlainTime());
+      return this.applySecondsPrecision(value.toPlainTime());
     if (isHash(value)) return this.valueFromMultiparameterAssignment(value);
     const str = String(value).trim();
     if (str === "") return null;
@@ -62,7 +62,7 @@ export class TimeType extends ValueType<Temporal.PlainTime> {
     }
   }
 
-  private _applySecondsPrecision(value: Temporal.PlainTime): Temporal.PlainTime {
+  private applySecondsPrecision(value: Temporal.PlainTime): Temporal.PlainTime {
     if (
       this.precision == null ||
       !Number.isInteger(this.precision) ||
@@ -94,7 +94,7 @@ export class TimeType extends ValueType<Temporal.PlainTime> {
 
   // Mirrors ActiveModel::Type::Helpers::TimeValue#serialize_cast_value (apply_seconds_precision).
   serializeCastValue(value: Temporal.PlainTime | null): Temporal.PlainTime | null {
-    return value === null ? null : this._applySecondsPrecision(value);
+    return value === null ? null : this.applySecondsPrecision(value);
   }
 
   /**

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -167,7 +167,7 @@ export class TimeZoneConverter extends ValueType<unknown> {
     return oldValue !== newValue;
   }
 
-  // Same floor-style truncation as DateTimeType._nsAtPrecision / _applySecondsPrecision.
+  // Same floor-style truncation as DateTimeType._nsAtPrecision / applySecondsPrecision.
   // Uses the wrapped subtype's precision so behavior matches the column's serialize output.
   private _nsAtPrecision(ns: bigint): bigint {
     const raw = this._subtype.precision ?? 6;

--- a/scripts/api-compare/call-mismatches-wide-exclude/activemodel/type/date-time.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activemodel/type/date-time.json
@@ -2,9 +2,9 @@
   {
     "package": "activemodel",
     "tsFile": "type/date-time.ts",
-    "rubyName": "cast_value",
-    "call": "apply_seconds_precision",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "apply_seconds_precision",
+    "call": "change",
+    "reason": "Converged: `applySecondsPrecision` truncates the sub-second components directly via `Temporal.PlainTime#with` / `Temporal.Instant.fromEpochNanoseconds`, which is this port's analogue of Ruby's `Time#change(nsec:)` — Temporal has no `change` method."
   },
   {
     "package": "activemodel",
@@ -45,15 +45,8 @@
     "package": "activemodel",
     "tsFile": "type/date-time.ts",
     "rubyName": "serialize_cast_value",
-    "call": "apply_seconds_precision",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "type/date-time.ts",
-    "rubyName": "serialize_cast_value",
     "call": "getlocal",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Not applicable: Rails' `serialize_cast_value` calls `getutc`/`getlocal` to re-attach a zone to a Ruby Time. The cast value here is a zoneless Temporal.PlainTime / absolute Temporal.Instant, so both branches are identity; trails resolves `default_timezone` at parse time (`configuredTimezone`) and again at quote time in the adapter's `quotedDate`."
   },
   {
     "package": "activemodel",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activemodel/type/decimal.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activemodel/type/decimal.json
@@ -16,20 +16,6 @@
   {
     "package": "activemodel",
     "tsFile": "type/decimal.ts",
-    "rubyName": "changed?",
-    "call": "equal_nan?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "type/decimal.ts",
-    "rubyName": "changed?",
-    "call": "number_to_non_number?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "type/decimal.ts",
     "rubyName": "convert_float_to_big_decimal",
     "call": "apply_scale",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activemodel/type/time.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activemodel/type/time.json
@@ -2,9 +2,9 @@
   {
     "package": "activemodel",
     "tsFile": "type/time.ts",
-    "rubyName": "cast_value",
-    "call": "apply_seconds_precision",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "apply_seconds_precision",
+    "call": "change",
+    "reason": "Converged: `applySecondsPrecision` truncates the sub-second components directly via `Temporal.PlainTime#with` / `Temporal.Instant.fromEpochNanoseconds`, which is this port's analogue of Ruby's `Time#change(nsec:)` — Temporal has no `change` method."
   },
   {
     "package": "activemodel",
@@ -31,15 +31,8 @@
     "package": "activemodel",
     "tsFile": "type/time.ts",
     "rubyName": "serialize_cast_value",
-    "call": "apply_seconds_precision",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "type/time.ts",
-    "rubyName": "serialize_cast_value",
     "call": "getlocal",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Not applicable: Rails' `serialize_cast_value` calls `getutc`/`getlocal` to re-attach a zone to a Ruby Time. The cast value here is a zoneless Temporal.PlainTime / absolute Temporal.Instant, so both branches are identity; trails resolves `default_timezone` at parse time (`configuredTimezone`) and again at quote time in the adapter's `quotedDate`."
   },
   {
     "package": "activemodel",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/abstract-mysql-adapter.json
@@ -39,14 +39,14 @@
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "build_explain_clause",
     "call": "include?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Deliberate: `AbstractMysqlAdapter#buildExplainClause` builds the printed EXPLAIN *header* (`\"... for:\"`) and routes option rendering through `_validateExplainOptions`, which rejects unknown flags/formats instead of blindly `join`ing them; the faithful `join` + `include?(\"ANALYZE\")` body lives in the Rails-layout file `connection-adapters/mysql/database-statements.ts` (`buildExplainClause`)."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "build_explain_clause",
     "call": "join",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Deliberate: `AbstractMysqlAdapter#buildExplainClause` builds the printed EXPLAIN *header* (`\"... for:\"`) and routes option rendering through `_validateExplainOptions`, which rejects unknown flags/formats instead of blindly `join`ing them; the faithful `join` + `include?(\"ANALYZE\")` body lives in the Rails-layout file `connection-adapters/mysql/database-statements.ts` (`buildExplainClause`)."
   },
   {
     "package": "activerecord",
@@ -417,7 +417,7 @@
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "returning_column_values",
     "call": "first",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Include stand-in: `MySQL::DatabaseStatements#returning_column_values` is ported in the Rails-layout file `connection-adapters/mysql/database-statements.ts` (`returningColumnValues`, which does read `result.rows[0]`); the adapter method is the `include` resolution point and only delegates."
   },
   {
     "package": "activerecord",
@@ -501,20 +501,20 @@
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "type_cast",
     "call": "getlocal",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Include stand-in plus Temporal semantics: `MySQL::Quoting#type_cast` is ported in `connection-adapters/mysql/quoting.ts` and the adapter method only delegates. Ruby's `getlocal`/`utc?` re-attach a zone to a Time; a Temporal.Instant is absolute and a PlainDateTime zoneless, so the `default_timezone` branch is resolved by `quotedDate` instead."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "type_cast",
     "call": "utc?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Include stand-in plus Temporal semantics: `MySQL::Quoting#type_cast` is ported in `connection-adapters/mysql/quoting.ts` and the adapter method only delegates. Ruby's `getlocal`/`utc?` re-attach a zone to a Time; a Temporal.Instant is absolute and a PlainDateTime zoneless, so the `default_timezone` branch is resolved by `quotedDate` instead."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "write_query?",
     "call": "match?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Include stand-in: `MySQL::DatabaseStatements#write_query?` is ported in the Rails-layout file `connection-adapters/mysql/database-statements.ts` (`isWriteQuery`, which does run `READ_QUERY.test(sql)`); the adapter method is the `include` resolution point and only delegates."
   }
 ]


### PR DESCRIPTION
Tail of the #5334 include-resolution reseed for `activemodel/type/{time,date-time,decimal}` and `abstract-mysql-adapter`. Wide baseline **4971 → 4967**.

## `apply_seconds_precision` (time, date-time)

`TimeType`/`DateTimeType` already truncated sub-second digits on both `cast_value` and `serialize_cast_value` — the story's suspected fidelity gap is not real. The call was invisible to the gate only because the helper was named `_applySecondsPrecision`. Renamed to `applySecondsPrecision`, which clears four entries; the remaining `change` call (Ruby `Time#change(nsec:)`) is baselined with a reason, since Temporal has no `change` and the truncation is done via `PlainTime#with` / `Instant.fromEpochNanoseconds`.

`getlocal` on both `serialize_cast_value` bodies is baselined with a reason: the cast value is a zoneless `Temporal.PlainTime` or an absolute `Temporal.Instant`, so Ruby's `getutc`/`getlocal` zone re-attachment is identity on both branches. `default_timezone` is resolved at parse time (`configuredTimezone`) and again at quote time in the adapter's `quotedDate`.

## `Decimal#changed?` — real bug fixed

Trails represents a NaN decimal as the sentinel string `"NaN"` (its `BigDecimal` carries no non-finite state), which `isEqualNan` did not recognise, so a NaN-to-NaN decimal write reported a **spurious change**. `isEqualNan` now treats that sentinel as this port's BigDecimal NaN while still requiring the same representation on both sides — mirroring Rails' `old_value.instance_of?(new_value.class)` guard, so a Float NaN written over a decimal NaN is still a change.

`DecimalType#isChanged` is deleted: Rails' `Decimal` defines no `changed?` at all. The BigDecimal value-equality normalisation it existed for (Ruby `!=` is value equality, JS `!==` is identity) moves into the `Helpers::Numeric` mixin, alongside the `equal_nan?` / `number_to_non_number?` predicates it belongs with.

`isEqualNan`'s second argument stays the cast new value rather than Rails' `new_value_before_type_cast`. That deviation is pre-existing and deliberately locked in by `float.test.ts` ("equal_nan? uses cast value") plus five `dirty.test.ts` cases; converging it is a separate change and is now documented at the call site.

## abstract-mysql-adapter — per-entry reasons

All six bodies are ported in their Rails-layout files; the adapter methods are the `include` resolution points:

| entry | where the call actually lives |
| --- | --- |
| `write_query?` / `match?` | `mysql/database-statements.ts#isWriteQuery` |
| `returning_column_values` / `first` | `mysql/database-statements.ts#returningColumnValues` |
| `type_cast` / `getlocal`, `utc?` | `mysql/quoting.ts#typeCast` (plus the Temporal note above) |
| `build_explain_clause` / `include?`, `join` | `mysql/database-statements.ts#buildExplainClause` |

`AbstractMysqlAdapter#buildExplainClause` deliberately differs: it builds the printed EXPLAIN *header* (`"... for:"`) and routes options through `_validateExplainOptions`, which rejects unknown flags/formats rather than blindly `join`ing them.

## Tests

Named verbatim after `activemodel/test/cases/type/{time,date_time,decimal}_test.rb`:

- `serialize_cast_value is equivalent to serialize after cast` (time, date-time) — new, with an explicit `precision: 1` truncation assertion.
- `changed?` (decimal) — body replaced with Rails' `test_changed?` assertions, including both BigDecimal-NaN cases. The NaN-to-NaN assertion fails on baseline (verified).

Closes-story: converge-abstract-mysql-and-activemodel-type-wide-call-set

## Verified deltas

| gate | before | after |
| --- | --- | --- |
| `api:compare` activemodel | 685/716 methods, arity 434/434 | **686/716**, arity 435/435 |
| `api:compare` overall | 11692 methods | **11693** |
| `api:calls:wide` | 4971 baselined | **4967 baselined** |
| `test:compare` matched | 14620 | 14620 |
| `test:compare` extra (TS only) | 3944 | 3944 |
| `test:compare` wrong describe | 163 | 163 |

Measured by rebuilding both artifacts against `HEAD~` sources in this worktree. No stubs added; the only surface change is a deletion (`DecimalType#isChanged`), which api:compare scores as +1 because `applySecondsPrecision` now matches Rails' `apply_seconds_precision`.
