### PR TITLE
fix(api-compare): key ts extraction cache on workspace dependency fingerprints

### DIFF
--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -21,7 +21,15 @@ import type {
   LiteralValue,
 } from "./types.js";
 import { ROOT_DIR, OUTPUT_DIR, PACKAGES, PACKAGE_DIR_OVERRIDES, packageSrcDir } from "./config.js";
-import { sharedCacheDir, contentFingerprint, readShared, writeShared } from "./shared-cache.js";
+import {
+  sharedCacheDir,
+  contentFingerprint,
+  widenKeyWithDeps,
+  readShared,
+  writeShared,
+  readWorkspaceGraph,
+  transitiveDeps,
+} from "./shared-cache.js";
 import { extractorSchemaToken } from "./extractor-schema.js";
 
 // Per-package cache: extracting all packages with the TS Compiler API
@@ -31,7 +39,10 @@ import { extractorSchemaToken } from "./extractor-schema.js";
 // (SHA-1 over sorted (relPath, mtimeMs, size) triples) plus the
 // extractor SCHEMA_VERSION token (see extractor-schema.ts), which changes
 // whenever a new per-method output field is added so stale entries missing
-// the field are evicted automatically. Set `API_COMPARE_FORCE=1` to skip the
+// the field are evicted automatically. Both keys are widened with the
+// TRANSITIVE workspace dependencies' fingerprints — a package's extraction
+// resolves imports into sibling packages, so its surface changes when they do.
+// Set `API_COMPARE_FORCE=1` to skip the
 // cache entirely. The token is computed async (it hashes the extractor
 // sources), so it lives on `main()` rather than as a module const.
 const CACHE_DIR = path.join(OUTPUT_DIR, "ts-api-cache");
@@ -164,6 +175,46 @@ export async function main() {
   const sharedTag = path.basename(ROOT_DIR);
   const sharedHits = new Set<string>();
 
+  // Cross-package inputs. `extractPackage` compiles with the real module
+  // resolver, so a package's extracted surface also depends on the workspace
+  // packages it imports from (see readWorkspaceGraph). Fingerprint every
+  // package DIRECTORY once, then fold each package's transitive dependency
+  // fingerprints into its cache keys — otherwise an activesupport edit leaves
+  // actionview's entry cached and stale, and a cached run disagrees with an
+  // `API_COMPARE_FORCE=1` one on an unchanged tree.
+  const PACKAGES_DIR = path.join(ROOT_DIR, "packages");
+  const graph = await readWorkspaceGraph(PACKAGES_DIR);
+  const dirFingerprints = new Map<string, Promise<{ mtime: string; content: string }>>();
+  function dirFingerprint(dir: string): Promise<{ mtime: string; content: string }> {
+    let pending = dirFingerprints.get(dir);
+    if (!pending) {
+      pending = (async () => {
+        const root = path.join(PACKAGES_DIR, dir);
+        const inputs = getAllTsFiles(path.join(root, "src"));
+        const tsConfig = path.join(root, "tsconfig.json");
+        if (fs.existsSync(tsConfig)) inputs.push(tsConfig);
+        return {
+          mtime: packageFingerprint(inputs, root),
+          content: await contentFingerprint(inputs, root),
+        };
+      })();
+      dirFingerprints.set(dir, pending);
+    }
+    return pending;
+  }
+  /** `own` key widened with the transitive dependency dirs' fingerprints. */
+  async function withDeps(
+    own: string,
+    dirName: string,
+    kind: "mtime" | "content",
+  ): Promise<string> {
+    const deps = transitiveDeps(graph, dirName);
+    const pairs = await Promise.all(
+      deps.map(async (dep) => [dep, (await dirFingerprint(dep))[kind]] as [string, string]),
+    );
+    return widenKeyWithDeps(own, pairs);
+  }
+
   // Pass 1: serve every cache hit synchronously and record the
   // metadata needed to extract the misses below.
   interface PendingExtract {
@@ -186,7 +237,11 @@ export async function main() {
     // Anchor relative paths at the package root so tsconfig.json
     // doesn't show up as `../tsconfig.json` (which it would if we
     // anchored at the src dir).
-    const fingerprint = packageFingerprint(fingerprintInputs, pkgRoot);
+    const fingerprint = await withDeps(
+      packageFingerprint(fingerprintInputs, pkgRoot),
+      dirName,
+      "mtime",
+    );
     const cachePath = path.join(CACHE_DIR, `${pkg}.json`);
 
     if (!force && fs.existsSync(cachePath)) {
@@ -208,7 +263,8 @@ export async function main() {
     // mtime-keyed cache so the next same-worktree run takes the fast path.
     let sharedKey: string | null = null;
     if (sharedDir) {
-      const contentKey = `${SCHEMA_VERSION}-${await contentFingerprint(fingerprintInputs, pkgRoot)}`;
+      const ownContent = await contentFingerprint(fingerprintInputs, pkgRoot);
+      const contentKey = `${SCHEMA_VERSION}-${await withDeps(ownContent, dirName, "content")}`;
       const body = await readShared(sharedDir, `ts-${pkg}`, contentKey);
       if (body) {
         try {

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -20,7 +20,14 @@ import type {
   ParamInfo,
   LiteralValue,
 } from "./types.js";
-import { ROOT_DIR, OUTPUT_DIR, PACKAGES, PACKAGE_DIR_OVERRIDES, packageSrcDir } from "./config.js";
+import {
+  ROOT_DIR,
+  OUTPUT_DIR,
+  PACKAGES,
+  PACKAGE_DIR_OVERRIDES,
+  PACKAGE_SRC_SUBDIR,
+  packageSrcDir,
+} from "./config.js";
 import {
   sharedCacheDir,
   contentFingerprint,
@@ -43,8 +50,8 @@ import { extractorSchemaToken } from "./extractor-schema.js";
 // the field are evicted automatically. Both keys are widened with the
 // TRANSITIVE workspace dependencies' fingerprints — a package's extraction
 // resolves imports into sibling packages, so its surface changes when they do.
-// Set `API_COMPARE_FORCE=1` to skip the
-// cache entirely. The token is computed async (it hashes the extractor
+// Set `API_COMPARE_FORCE=1` to skip the cache entirely. The token is computed
+// async (it hashes the extractor
 // sources), so it lives on `main()` rather than as a module const.
 const CACHE_DIR = path.join(OUTPUT_DIR, "ts-api-cache");
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -215,13 +222,8 @@ export async function main() {
     }
     return pending;
   }
-  /** `own` key widened with the transitive dependency dirs' fingerprints. */
-  async function withDeps(
-    own: string,
-    dirName: string,
-    kind: "mtime" | "content",
-  ): Promise<string> {
-    const deps = transitiveDeps(graph, dirName);
+  /** `own` key widened with the fingerprints of `deps` (package DIRECTORIES). */
+  async function withDeps(own: string, deps: string[], kind: "mtime" | "content"): Promise<string> {
     const pairs = await Promise.all(
       deps.map(
         async (dep) =>
@@ -256,9 +258,15 @@ export async function main() {
     // Anchor relative paths at the package root so tsconfig.json
     // doesn't show up as `../tsconfig.json` (which it would if we
     // anchored at the src dir).
+    // Packages that share a directory (actionpack hosts abstractcontroller,
+    // actioncontroller, actiondispatch) import across the sibling src subdirs
+    // that their own fingerprint — scoped to one subdir — doesn't cover, so the
+    // whole directory joins their dependency set.
+    const inputDirs = transitiveDeps(graph, dirName);
+    if (PACKAGE_SRC_SUBDIR[pkg]) inputDirs.push(dirName);
     const fingerprint = await withDeps(
       packageFingerprint(fingerprintInputs, pkgRoot),
-      dirName,
+      inputDirs,
       "mtime",
     );
     const cachePath = path.join(CACHE_DIR, `${pkg}.json`);
@@ -283,7 +291,7 @@ export async function main() {
     let sharedKey: string | null = null;
     if (sharedDir) {
       const ownContent = await contentFingerprint(fingerprintInputs, pkgRoot);
-      const contentKey = `${SCHEMA_VERSION}-${await withDeps(ownContent, dirName, "content")}`;
+      const contentKey = `${SCHEMA_VERSION}-${await withDeps(ownContent, inputDirs, "content")}`;
       const body = await readShared(sharedDir, `ts-${pkg}`, contentKey);
       if (body) {
         try {

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -25,6 +25,7 @@ import {
   sharedCacheDir,
   contentFingerprint,
   widenKeyWithDeps,
+  dependencyInputFiles,
   readShared,
   writeShared,
   readWorkspaceGraph,
@@ -184,21 +185,33 @@ export async function main() {
   // `API_COMPARE_FORCE=1` one on an unchanged tree.
   const PACKAGES_DIR = path.join(ROOT_DIR, "packages");
   const graph = await readWorkspaceGraph(PACKAGES_DIR);
-  const dirFingerprints = new Map<string, Promise<{ mtime: string; content: string }>>();
-  function dirFingerprint(dir: string): Promise<{ mtime: string; content: string }> {
-    let pending = dirFingerprints.get(dir);
+  const dirInputs = new Map<string, Promise<{ root: string; files: string[] }>>();
+  function dependencyInputs(dir: string): Promise<{ root: string; files: string[] }> {
+    let pending = dirInputs.get(dir);
     if (!pending) {
-      pending = (async () => {
-        const root = path.join(PACKAGES_DIR, dir);
-        const inputs = getAllTsFiles(path.join(root, "src"));
-        const tsConfig = path.join(root, "tsconfig.json");
-        if (fs.existsSync(tsConfig)) inputs.push(tsConfig);
-        return {
-          mtime: packageFingerprint(inputs, root),
-          content: await contentFingerprint(inputs, root),
-        };
-      })();
-      dirFingerprints.set(dir, pending);
+      const root = path.join(PACKAGES_DIR, dir);
+      pending = dependencyInputFiles(root).then((files) => ({ root, files }));
+      dirInputs.set(dir, pending);
+    }
+    return pending;
+  }
+  const dirMtimeFingerprints = new Map<string, Promise<string>>();
+  function dirMtimeFingerprint(dir: string): Promise<string> {
+    let pending = dirMtimeFingerprints.get(dir);
+    if (!pending) {
+      pending = dependencyInputs(dir).then(({ root, files }) => packageFingerprint(files, root));
+      dirMtimeFingerprints.set(dir, pending);
+    }
+    return pending;
+  }
+  // Content hashing reads every byte of the dependency, so it stays lazy: only
+  // a LOCAL cache miss (which then consults the shared cache) ever needs it.
+  const dirContentFingerprints = new Map<string, Promise<string>>();
+  function dirContentFingerprint(dir: string): Promise<string> {
+    let pending = dirContentFingerprints.get(dir);
+    if (!pending) {
+      pending = dependencyInputs(dir).then(({ root, files }) => contentFingerprint(files, root));
+      dirContentFingerprints.set(dir, pending);
     }
     return pending;
   }
@@ -210,7 +223,13 @@ export async function main() {
   ): Promise<string> {
     const deps = transitiveDeps(graph, dirName);
     const pairs = await Promise.all(
-      deps.map(async (dep) => [dep, (await dirFingerprint(dep))[kind]] as [string, string]),
+      deps.map(
+        async (dep) =>
+          [
+            dep,
+            kind === "mtime" ? await dirMtimeFingerprint(dep) : await dirContentFingerprint(dep),
+          ] as [string, string],
+      ),
     );
     return widenKeyWithDeps(own, pairs);
   }

--- a/scripts/api-compare/shared-cache.test.ts
+++ b/scripts/api-compare/shared-cache.test.ts
@@ -16,6 +16,9 @@ import {
   readShared,
   writeShared,
   pruneSharedCache,
+  readWorkspaceGraph,
+  transitiveDeps,
+  widenKeyWithDeps,
   CACHE_VERSION,
 } from "./shared-cache.js";
 
@@ -190,5 +193,80 @@ describe("readShared / writeShared", () => {
     expect(await readShared(dir, "ts-arel", "key1")).toBe('{"v":1}');
     // readShared awaits its own touch, so the new mtime is observable immediately.
     expect((await fs.promises.stat(file)).mtimeMs).toBeGreaterThan(0);
+  });
+});
+
+describe("cross-package cache inputs", () => {
+  function writePackage(packagesDir: string, dir: string, deps: string[]): void {
+    fs.mkdirSync(path.join(packagesDir, dir), { recursive: true });
+    fs.writeFileSync(
+      path.join(packagesDir, dir, "package.json"),
+      JSON.stringify({
+        name: `@blazetrails/${dir}`,
+        dependencies: Object.fromEntries(
+          deps.map((d) => [`@blazetrails/${d}`, "workspace:*"] as const),
+        ),
+      }),
+    );
+  }
+
+  it("resolves workspace dependency names to directories", async () => {
+    const packagesDir = mkTmp();
+    writePackage(packagesDir, "actionview", ["activesupport"]);
+    writePackage(packagesDir, "activesupport", []);
+    const graph = await readWorkspaceGraph(packagesDir);
+    expect(graph.dirOfName["@blazetrails/activesupport"]).toBe("activesupport");
+    expect(graph.depsOfDir.actionview).toEqual(["activesupport"]);
+  });
+
+  it("ignores non-workspace dependencies", async () => {
+    const packagesDir = mkTmp();
+    writePackage(packagesDir, "activesupport", []);
+    fs.writeFileSync(
+      path.join(packagesDir, "activesupport", "package.json"),
+      JSON.stringify({ name: "@blazetrails/activesupport", dependencies: { yaml: "^2" } }),
+    );
+    const graph = await readWorkspaceGraph(packagesDir);
+    expect(graph.depsOfDir.activesupport).toEqual([]);
+  });
+
+  it("closes over transitive dependencies without looping on cycles", async () => {
+    const packagesDir = mkTmp();
+    writePackage(packagesDir, "trailties", ["activerecord"]);
+    writePackage(packagesDir, "activerecord", ["arel", "trailties"]);
+    writePackage(packagesDir, "arel", ["activesupport"]);
+    writePackage(packagesDir, "activesupport", []);
+    const graph = await readWorkspaceGraph(packagesDir);
+    expect(transitiveDeps(graph, "trailties")).toEqual(
+      ["activerecord", "arel", "activesupport"].sort(),
+    );
+  });
+
+  it("widens a package key when a dependency's fingerprint changes", () => {
+    // The divergence this pins: actionview re-exports activesupport symbols, so
+    // its extracted surface moves when activesupport does. A key built from
+    // actionview's own files alone kept serving the pre-change extraction from
+    // cache while API_COMPARE_FORCE=1 produced the post-change one.
+    const own = "actionview-own-fingerprint";
+    const before = widenKeyWithDeps(own, [["activesupport", "aaa"]]);
+    const after = widenKeyWithDeps(own, [["activesupport", "bbb"]]);
+    expect(before).not.toBe(own);
+    expect(after).not.toBe(before);
+  });
+
+  it("is order-independent and a no-op without dependencies", () => {
+    const own = "own";
+    expect(widenKeyWithDeps(own, [])).toBe(own);
+    expect(
+      widenKeyWithDeps(own, [
+        ["arel", "a"],
+        ["activesupport", "b"],
+      ]),
+    ).toBe(
+      widenKeyWithDeps(own, [
+        ["activesupport", "b"],
+        ["arel", "a"],
+      ]),
+    );
   });
 });

--- a/scripts/api-compare/shared-cache.test.ts
+++ b/scripts/api-compare/shared-cache.test.ts
@@ -19,6 +19,7 @@ import {
   readWorkspaceGraph,
   transitiveDeps,
   widenKeyWithDeps,
+  dependencyInputFiles,
   CACHE_VERSION,
 } from "./shared-cache.js";
 
@@ -268,5 +269,34 @@ describe("cross-package cache inputs", () => {
         ["arel", "a"],
       ]),
     );
+  });
+});
+
+describe("dependencyInputFiles", () => {
+  it("collects src sources and built declarations, skipping tests", async () => {
+    const root = mkTmp();
+    fs.mkdirSync(path.join(root, "src", "core-ext"), { recursive: true });
+    fs.mkdirSync(path.join(root, "dist", "core-ext"), { recursive: true });
+    fs.writeFileSync(path.join(root, "src", "core-ext", "string.ts"), "export const a = 1;");
+    fs.writeFileSync(path.join(root, "src", "core-ext", "string.test.ts"), "");
+    fs.writeFileSync(
+      path.join(root, "dist", "core-ext", "string.d.ts"),
+      "export declare const a: number;",
+    );
+    fs.writeFileSync(path.join(root, "dist", "core-ext", "string.js"), "");
+    fs.writeFileSync(path.join(root, "tsconfig.json"), "{}");
+    const files = (await dependencyInputFiles(root)).map((f) => path.relative(root, f)).sort();
+    expect(files).toEqual([
+      path.join("dist", "core-ext", "string.d.ts"),
+      path.join("src", "core-ext", "string.ts"),
+      "tsconfig.json",
+    ]);
+  });
+
+  it("tolerates an unbuilt package with no dist and no tsconfig", async () => {
+    const root = mkTmp();
+    fs.mkdirSync(path.join(root, "src"));
+    fs.writeFileSync(path.join(root, "src", "index.ts"), "");
+    expect(await dependencyInputFiles(root)).toEqual([path.join(root, "src", "index.ts")]);
   });
 });

--- a/scripts/api-compare/shared-cache.ts
+++ b/scripts/api-compare/shared-cache.ts
@@ -94,6 +94,91 @@ export async function fileHash(file: string): Promise<string | null> {
   }
 }
 
+/**
+ * Workspace dependency graph over `packages/`, keyed by DIRECTORY name.
+ *
+ * The TS extractor compiles a package with the real module resolver, so an
+ * `import { htmlEscapeOnce } from "@blazetrails/activesupport"` pulls the
+ * DECLARING file out of a sibling package and the extracted surface for the
+ * importer (e.g. actionview's `h` / `htmlEscapeOnce`) depends on that sibling's
+ * sources. A cache key built from the package's OWN files alone therefore
+ * survives an edit that changes its extraction — which is exactly how a cached
+ * run and an `API_COMPARE_FORCE=1` run came to disagree. Callers fold the
+ * dependencies' fingerprints into the key so they can't.
+ */
+export interface WorkspaceGraph {
+  /** npm package name (`@blazetrails/actionview`) → directory name (`actionview`). */
+  dirOfName: Record<string, string>;
+  /** directory name → directly-depended-on workspace directory names. */
+  depsOfDir: Record<string, string[]>;
+}
+
+/** Read every `packages/<dir>/package.json` and build the workspace graph. */
+export async function readWorkspaceGraph(packagesDir: string): Promise<WorkspaceGraph> {
+  const graph: WorkspaceGraph = { dirOfName: {}, depsOfDir: {} };
+  let dirs: string[];
+  try {
+    dirs = await fs.readdir(packagesDir);
+  } catch {
+    return graph;
+  }
+  const manifests = await Promise.all(
+    dirs.map(async (dir) => {
+      try {
+        const raw = await fs.readFile(path.join(packagesDir, dir, "package.json"), "utf-8");
+        return { dir, json: JSON.parse(raw) as { name?: string; dependencies?: object } };
+      } catch {
+        return null;
+      }
+    }),
+  );
+  for (const entry of manifests) {
+    if (!entry) continue;
+    if (entry.json.name) graph.dirOfName[entry.json.name] = entry.dir;
+  }
+  for (const entry of manifests) {
+    if (!entry) continue;
+    graph.depsOfDir[entry.dir] = Object.keys(entry.json.dependencies ?? {});
+  }
+  // Second pass: names resolve to dirs only once every manifest has been read.
+  for (const dir of Object.keys(graph.depsOfDir)) {
+    graph.depsOfDir[dir] = graph.depsOfDir[dir]
+      .map((name) => graph.dirOfName[name])
+      .filter((d): d is string => Boolean(d) && d !== dir);
+  }
+  return graph;
+}
+
+/**
+ * Transitive workspace dependencies of `dirName`, sorted and excluding itself.
+ * Cycles are tolerated (the visited set stops the walk).
+ */
+export function transitiveDeps(graph: WorkspaceGraph, dirName: string): string[] {
+  const seen = new Set<string>();
+  const stack = [...(graph.depsOfDir[dirName] ?? [])];
+  while (stack.length > 0) {
+    const dir = stack.pop() as string;
+    if (dir === dirName || seen.has(dir)) continue;
+    seen.add(dir);
+    stack.push(...(graph.depsOfDir[dir] ?? []));
+  }
+  return [...seen].sort();
+}
+
+/**
+ * Widen a package's own cache key with its dependencies' fingerprints, as
+ * `[dirName, fingerprint]` pairs. Empty deps return `own` unchanged so
+ * dependency-free packages keep their historical keys (and cache entries).
+ */
+export function widenKeyWithDeps(own: string, depFingerprints: [string, string][]): string {
+  if (depFingerprints.length === 0) return own;
+  const parts = [own];
+  for (const [dir, fingerprint] of [...depFingerprints].sort(([a], [b]) => (a < b ? -1 : 1))) {
+    parts.push(`${dir}\t${fingerprint}`);
+  }
+  return hashParts(parts);
+}
+
 function entryPath(dir: string, name: string, key: string): string {
   return path.join(dir, `${name}-${key}.json`);
 }

--- a/scripts/api-compare/shared-cache.ts
+++ b/scripts/api-compare/shared-cache.ts
@@ -165,6 +165,53 @@ export function transitiveDeps(graph: WorkspaceGraph, dirName: string): string[]
   return [...seen].sort();
 }
 
+async function filesUnder(dir: string, keep: (name: string) => boolean): Promise<string[]> {
+  let entries;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const nested = await Promise.all(
+    entries.map(async (entry) => {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) return filesUnder(full, keep);
+      return keep(entry.name) ? [full] : [];
+    }),
+  );
+  return nested.flat();
+}
+
+/**
+ * Every file of `packageRoot` that can feed a DEPENDENT package's extraction.
+ *
+ * With no `paths` mapping in the root tsconfig, `@blazetrails/<dep>` resolves
+ * through the dep's `exports` to its BUILT `dist/*.d.ts` — those declarations,
+ * not the dep's `src`, are what the compiler actually reads. Both are included:
+ * `dist` because it's the real input (a rebuild with unchanged `src` still
+ * changes the dependent's extraction), `src` because an edit that hasn't been
+ * built yet still changes what a later run will see. A missing `src` or `dist`
+ * simply contributes nothing.
+ */
+export async function dependencyInputFiles(packageRoot: string): Promise<string[]> {
+  const [src, dist] = await Promise.all([
+    filesUnder(
+      path.join(packageRoot, "src"),
+      (name) => name.endsWith(".ts") && !name.endsWith(".test.ts") && !name.endsWith(".d.ts"),
+    ),
+    filesUnder(path.join(packageRoot, "dist"), (name) => name.endsWith(".d.ts")),
+  ]);
+  const files = [...src, ...dist];
+  const tsConfig = path.join(packageRoot, "tsconfig.json");
+  try {
+    await fs.stat(tsConfig);
+    files.push(tsConfig);
+  } catch {
+    // no tsconfig — nothing to fold in
+  }
+  return files;
+}
+
 /**
  * Widen a package's own cache key with its dependencies' fingerprints, as
  * `[dirName, fingerprint]` pairs. Empty deps return `own` unchanged so


### PR DESCRIPTION
## Problem

With no source change between runs, `pnpm api:compare` produced different
`extra-surface` reports depending on whether it reused its caches or ran under
`API_COMPARE_FORCE=1` — the forced run added four "moved" extras
(`actionview helpers/output-safety-helper.ts h` / `htmlEscapeOnce`,
`trailties generators/base.ts tableize` / `underscore`). That makes any
before/after extra-surface measurement untrustworthy.

## Root cause

`extractPackage` builds a real `ts.Program`, so resolving
`import { htmlEscapeOnce } from "@blazetrails/activesupport"` pulls the
declaring file out of a sibling package: a package's extracted surface depends
on sources it does not own. Both cache layers — the local mtime-keyed
`output/ts-api-cache/<pkg>.json` and the shared content-keyed cross-worktree
cache — keyed only on the package's OWN `src` plus its `tsconfig.json`, so an
activesupport change left actionview's and trailties' entries looking fresh
while their extraction had actually changed.

Two input classes were missing from the keys:

1. **Workspace dependencies.** With no `paths` mapping in the root tsconfig,
   `@blazetrails/<dep>` resolves through `exports` to the dep's built
   `dist/*.d.ts`, so both its `dist` declarations (the literal compiler input —
   a rebuild alone changes a dependent's extraction) and its `src` (an edit not
   yet built still changes what the next run sees) are real inputs.
2. **Sibling src subdirs of directory-sharing packages.**
   `abstractcontroller` / `actioncontroller` / `actiondispatch` all live in
   `packages/actionpack` and import across each other's subdirs — invisible to
   a subdir-scoped own fingerprint AND to the workspace graph, which sees one
   directory.

## Fix

Fold each package's transitive workspace-dependency fingerprints (and, for
directory-sharing packages, its own whole directory) into both cache keys.
`readWorkspaceGraph` / `transitiveDeps` / `dependencyInputFiles` /
`widenKeyWithDeps` live in `shared-cache.ts` (async fs, no `node:` specifiers,
no new deps). Directory fingerprints are memoized, and the content hash stays
lazy so a full local cache hit never reads the dependencies' bytes — a warm
cached run is unchanged at ~2s.

## Verification

On this tree, cached and `API_COMPARE_FORCE=1` runs now produce identical
`output/ts-api.json` (modulo `generatedAt`), and each previously-missed input
now invalidates its dependents (all three re-extract where they were served
`(cached)` before):

| change | invalidates |
| --- | --- |
| `activesupport/src/core-ext/string/output-safety.ts` | actionview + all dependents |
| `activesupport/dist/core-ext/string/output-safety.d.ts` | actionview + all dependents |
| `actionpack/src/abstract-controller/deprecator.ts` | abstractcontroller, actioncontroller |

Regression tests in `scripts/api-compare/shared-cache.test.ts` pin the graph
resolution (workspace deps only, cycle-tolerant transitive closure), the input
set (`src` sources + `dist` declarations + tsconfig, tests excluded, unbuilt
package tolerated), and that a changed dependency fingerprint changes the key
while an empty dependency set leaves it untouched.

Cost: an activesupport edit now invalidates its dependents — a full ~10s
extraction. That is the price of a measurement you can trust.

Closes-story: api-compare-cached-vs-fresh-extraction-divergence
