### PR TITLE
refactor(inheritance): converge enableSti onto the inheritanceColumn setter

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -307,7 +307,7 @@ function guardCanonicalNameShadow(name: string, model: typeof Base): void {
  *   prototype is another AR model rather than `Base` itself) is additionally
  *   routed through {@link registerSubclass} so it lands in its parent's
  *   `_subclasses`. STI on the parent must still be enabled explicitly via
- *   `enableSti` — the array form does not call it.
+ *   `Parent.inheritanceColumn = ...` — the array form does not set it.
  */
 export function registerModel(model: typeof Base): void;
 export function registerModel(name: string, model: typeof Base): void;

--- a/packages/activerecord/src/associations/association-scope-cache.test.ts
+++ b/packages/activerecord/src/associations/association-scope-cache.test.ts
@@ -16,7 +16,7 @@
  */
 import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
 import { findTarget } from "./singular-association.js";
-import { registerModel, enableSti, registerSubclass } from "../index.js";
+import { registerModel, registerSubclass } from "../index.js";
 import { loadHasOne } from "../associations.js";
 import { findTarget as findHasManyTarget } from "./has-many-association.js";
 import { AssociationScope } from "./association-scope.js";
@@ -159,7 +159,7 @@ describe("Association scope cache — through singular loads", () => {
   beforeAll(async () => {
     registerModel(Member);
     registerModel(Club);
-    enableSti(Membership);
+    Membership.inheritanceColumn = "type";
     registerModel(Membership);
     registerModel(CurrentMembership);
     registerSubclass(CurrentMembership);

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -1,6 +1,6 @@
 import type { AssociationProxy } from "./collection-proxy.js";
 import { describe, it, expect } from "vitest";
-import { Base, registerModel, enableSti, registerSubclass } from "../index.js";
+import { Base, registerModel, registerSubclass } from "../index.js";
 import { Associations, loadHasOne } from "../associations.js";
 import { findTarget } from "./has-many-association.js";
 import { AssociationScope, ReflectionProxy } from "./association-scope.js";
@@ -207,7 +207,7 @@ describe("AssociationScope", () => {
         this.attribute("type", "string");
         this.attribute("sti_owner_id", "integer");
         this._tableName = "sti_things";
-        enableSti(StiBase);
+        StiBase.inheritanceColumn = "type";
       }
     }
     class StiSpecial extends StiBase {
@@ -388,7 +388,7 @@ describe("AssociationScope", () => {
       }
     }
     class StiAsSubOwner extends StiAsOwner {}
-    enableSti(StiAsOwner);
+    StiAsOwner.inheritanceColumn = "type";
     registerSubclass(StiAsSubOwner);
     class StiAsComment extends Base {
       declare commentable_id: number | null;

--- a/packages/activerecord/src/associations/callbacks.test.ts
+++ b/packages/activerecord/src/associations/callbacks.test.ts
@@ -3,7 +3,7 @@
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
 import { describe, it, expect, beforeAll } from "vitest";
-import { Base, association, registerModel, enableSti, registerSubclass } from "../index.js";
+import { Base, association, registerModel, registerSubclass } from "../index.js";
 import { throwAbort } from "@blazetrails/activesupport";
 
 import { fixtures } from "../test-helpers/fixtures.js";
@@ -536,7 +536,7 @@ describe("AssociationCallbacksTest", () => {
     registerModel(Firm);
     registerModel(Client);
     registerModel(Account);
-    enableSti(Company);
+    Company.inheritanceColumn = "type";
     registerSubclass(Firm);
     registerSubclass(Client);
   });

--- a/packages/activerecord/src/associations/cascaded-eager-loading.test.ts
+++ b/packages/activerecord/src/associations/cascaded-eager-loading.test.ts
@@ -8,7 +8,7 @@
  * one `fixtures` call seeding the canonical association tables.
  */
 import { describe, it, expect } from "vitest";
-import { registerModel, enableSti, registerSubclass, resetCallbacks } from "../index.js";
+import { registerModel, registerSubclass, resetCallbacks } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { Base } from "../base.js";
 import { Author } from "../test-helpers/models/author.js";
@@ -46,13 +46,13 @@ describe("CascadedEagerLoadingTest", () => {
     "people",
   ]);
 
-  enableSti(Topic);
+  Topic.inheritanceColumn = "type";
   registerModel(Person);
   registerModel(Author);
   registerModel(Post);
   registerModel(SpecialPost);
   registerModel(FirstPost);
-  enableSti(Comment);
+  Comment.inheritanceColumn = "type";
   registerModel(Comment);
   registerModel(SpecialComment);
   registerSubclass(SpecialComment);

--- a/packages/activerecord/src/associations/destroy-preload-arrow-field-helper.trails.test.ts
+++ b/packages/activerecord/src/associations/destroy-preload-arrow-field-helper.trails.test.ts
@@ -12,7 +12,7 @@
  * loaded `Company`, not the async reader's Promise.
  */
 import { describe, it, expect, beforeAll } from "vitest";
-import { Base, registerModel, enableSti, registerSubclass } from "../index.js";
+import { Base, registerModel, registerSubclass } from "../index.js";
 import {
   Company,
   Firm,
@@ -87,7 +87,7 @@ describe("destroy belongs_to preload through arrow-field helper", () => {
     registerModel(RestrictedWithExceptionFirm);
     registerModel(RestrictedWithErrorFirm);
     registerModel(Client);
-    enableSti(Company);
+    Company.inheritanceColumn = "type";
     registerSubclass(Firm);
     registerSubclass(DependentFirm);
     registerSubclass(ExclusivelyDependentFirm);

--- a/packages/activerecord/src/associations/eager.test.ts
+++ b/packages/activerecord/src/associations/eager.test.ts
@@ -5,7 +5,6 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import {
   Base,
   registerModel,
-  enableSti,
   registerSubclass,
   AssociationNotFoundError,
   EagerLoadPolymorphicError,
@@ -2369,8 +2368,8 @@ describe("EagerAssociationTest", () => {
     });
   });
 
-  enableSti(Post);
-  enableSti(Comment);
+  Post.inheritanceColumn = "type";
+  Comment.inheritanceColumn = "type";
   registerSubclass(SpecialPost);
   registerSubclass(StiPost);
   registerSubclass(SpecialComment);
@@ -2418,9 +2417,9 @@ describe("EagerAssociationTest", () => {
     expect(author.association("specialNonexistentPostComments").target).toEqual([]);
   });
 
-  enableSti(Post);
+  Post.inheritanceColumn = "type";
   registerSubclass(SpecialPost);
-  enableSti(Comment);
+  Comment.inheritanceColumn = "type";
   registerSubclass(SpecialComment);
   registerSubclass(SubSpecialComment);
   registerSubclass(VerySpecialComment);
@@ -2444,7 +2443,7 @@ describe("EagerAssociationTest", () => {
     }
   });
 
-  enableSti(Post);
+  Post.inheritanceColumn = "type";
   registerSubclass(SpecialPost);
   registerSubclass(StiPost);
 
@@ -2555,14 +2554,14 @@ describe("EagerAssociationTest", () => {
     expect(error).toBeUndefined();
   });
 
-  enableSti(Membership);
+  Membership.inheritanceColumn = "type";
 
   it("eager with has one through join model with conditions on the through", async () => {
     const member = await Member.all().includes("favoriteClub").find(members("some_other_guy").id);
     expect(member.association("favoriteClub").target ?? null).toBeNull();
   });
 
-  enableSti(Company);
+  Company.inheritanceColumn = "type";
   registerSubclass(Firm);
   registerSubclass(Client);
 
@@ -2582,8 +2581,8 @@ describe("EagerAssociationTest", () => {
     );
   });
 
-  enableSti(Comment);
-  enableSti(Membership);
+  Comment.inheritanceColumn = "type";
+  Membership.inheritanceColumn = "type";
 
   it("preloading has many through with implicit source", async () => {
     const authorList = (await Author.includes("verySpecialComments")).sort(

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -13,7 +13,6 @@ import {
   CollectionProxy,
   association,
   registerModel,
-  enableSti,
   registerSubclass,
   RecordNotFound,
   RecordNotSaved,
@@ -191,7 +190,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(HmFirm);
     registerModel(Client);
     registerModel(Account);
-    enableSti(Company);
+    Company.inheritanceColumn = "type";
     registerSubclass(HmFirm);
     registerSubclass(Client);
     await Company.loadSchema();
@@ -433,7 +432,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(HmTag);
     registerModel(HmTagging);
     registerModel(PersonWithPolymorphicDependentNullifyComments);
-    enableSti(HmEssay);
+    HmEssay.inheritanceColumn = "type";
     registerSubclass(TypedEssay);
     await HmPost.loadSchema();
     await Comment.loadSchema();
@@ -580,7 +579,7 @@ describe("HasManyAssociationsTest", () => {
   registerModel(Client);
   registerModel(Account);
   registerModel(RestrictedWithErrorFirm);
-  enableSti(Company);
+  Company.inheritanceColumn = "type";
   registerSubclass(HmFirm);
   registerSubclass(Client);
   registerSubclass(RestrictedWithErrorFirm);
@@ -642,7 +641,7 @@ describe("HasManyAssociationsTest", () => {
   registerModel(Developer);
   registerModel(AuditLog);
   registerModel(Project);
-  enableSti(Company);
+  Company.inheritanceColumn = "type";
   registerSubclass(HmFirm);
   registerSubclass(Client);
 
@@ -1268,7 +1267,7 @@ describe("HasManyAssociationsTest", () => {
   registerModel(Company);
   registerModel(HmFirm);
   registerModel(Client);
-  enableSti(Company);
+  Company.inheritanceColumn = "type";
   registerSubclass(HmFirm);
   registerSubclass(Client);
   // -- Calling size/empty --
@@ -1370,7 +1369,7 @@ describe("HasManyAssociationsTest", () => {
   registerModel(Comment);
   registerModel(Car);
   registerModel(Bulb);
-  enableSti(Company);
+  Company.inheritanceColumn = "type";
   registerSubclass(HmFirm);
   registerSubclass(Client);
 
@@ -1865,7 +1864,7 @@ describe("HasManyAssociationsTest", () => {
         this.attribute("firm_id", "integer");
       }
     }
-    enableSti(StiCompany);
+    StiCompany.inheritanceColumn = "type";
     class StiFirm extends StiCompany {}
     registerSubclass(StiFirm);
     class StiClient extends StiCompany {}
@@ -1914,7 +1913,7 @@ describe("HasManyAssociationsTest", () => {
         this.attribute("firm_id", "integer");
       }
     }
-    enableSti(StiCompany2);
+    StiCompany2.inheritanceColumn = "type";
     class StiClient2 extends StiCompany2 {}
     registerSubclass(StiClient2);
     registerModel(StiCompany2);
@@ -1952,7 +1951,7 @@ describe("HasManyAssociationsTest", () => {
         this.attribute("firm_id", "integer");
       }
     }
-    enableSti(StiCompany3);
+    StiCompany3.inheritanceColumn = "type";
     class StiClient3 extends StiCompany3 {}
     registerSubclass(StiClient3);
     registerModel(StiCompany3);
@@ -1990,7 +1989,7 @@ describe("HasManyAssociationsTest", () => {
         this.attribute("firm_id", "integer");
       }
     }
-    enableSti(StiCompany4);
+    StiCompany4.inheritanceColumn = "type";
     registerModel(StiCompany4);
 
     class DepFirm4 extends Base {
@@ -2024,7 +2023,7 @@ describe("HasManyAssociationsTest", () => {
         this.attribute("firm_id", "integer");
       }
     }
-    enableSti(StiCompany5);
+    StiCompany5.inheritanceColumn = "type";
     class UnrelatedModel extends Base {
       declare name: string | null;
 
@@ -6556,7 +6555,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(Client);
     registerModel(DependentFirm);
     registerModel(Account);
-    enableSti(Company);
+    Company.inheritanceColumn = "type";
     registerSubclass(HmFirm);
     registerSubclass(Client);
     registerSubclass(DependentFirm);
@@ -6568,7 +6567,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(HmSillyReply);
     registerModel(HmUniqueReply);
     registerModel(HmSillyUniqueReply);
-    enableSti(HmTopic);
+    HmTopic.inheritanceColumn = "type";
     registerSubclass(HmReply);
     registerSubclass(HmSillyReply);
     registerSubclass(HmUniqueReply);
@@ -6793,7 +6792,7 @@ describe("AsyncHasManyAssociationsTest", () => {
     registerModel(HmFirm);
     registerModel(Client);
     registerModel(Account);
-    enableSti(Company);
+    Company.inheritanceColumn = "type";
     registerSubclass(HmFirm);
     registerSubclass(Client);
     await Company.loadSchema();
@@ -6825,7 +6824,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(Client);
     registerModel(DependentFirm);
     registerModel(RestrictedWithExceptionFirm);
-    enableSti(Company);
+    Company.inheritanceColumn = "type";
     registerSubclass(HmFirm);
     registerSubclass(Client);
     registerSubclass(DependentFirm);
@@ -6833,7 +6832,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(HmTopic);
     registerModel(HmReply);
     registerModel(HmDefaultRejectedTopic);
-    enableSti(HmTopic);
+    HmTopic.inheritanceColumn = "type";
     registerSubclass(HmReply);
     registerSubclass(HmDefaultRejectedTopic);
   });
@@ -6928,7 +6927,7 @@ describe("HasManyAssociationsTest", () => {
     registerModel(HmReply);
     registerModel(HmPost);
     registerModel(Comment);
-    enableSti(HmTopic);
+    HmTopic.inheritanceColumn = "type";
     registerSubclass(HmReply);
   });
 

--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -12,7 +12,6 @@ import { throwAbort } from "@blazetrails/activesupport";
 import {
   Base,
   registerModel,
-  enableSti,
   registerSubclass,
   SubclassNotFound,
   AssociationTypeMismatch,
@@ -82,7 +81,7 @@ function registerCompanyModels(): void {
   registerModel(RestrictedWithErrorFirm);
   registerModel(Client);
   registerModel(Account);
-  enableSti(Company);
+  Company.inheritanceColumn = "type";
   registerSubclass(Firm);
   registerSubclass(DependentFirm);
   registerSubclass(ExclusivelyDependentFirm);

--- a/packages/activerecord/src/associations/has-one-set-accessor-sugar.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-set-accessor-sugar.trails.test.ts
@@ -13,7 +13,6 @@
 import { describe, it, expect, beforeAll, vi } from "vitest";
 import {
   registerModel,
-  enableSti,
   registerSubclass,
   RecordNotSaved,
   RecordNotFound,
@@ -60,7 +59,7 @@ describe("has_one set#{Name} awaitable accessor", () => {
     registerModel(RestrictedWithErrorFirm);
     registerModel(Client);
     registerModel(Account);
-    enableSti(Company);
+    Company.inheritanceColumn = "type";
     registerSubclass(Firm);
     registerSubclass(DependentFirm);
     registerSubclass(ExclusivelyDependentFirm);
@@ -133,7 +132,7 @@ describe("has_one :through set#{Name} awaitable accessor", () => {
   beforeAll(() => {
     registerModel(Member);
     registerModel(Club);
-    enableSti(Membership);
+    Membership.inheritanceColumn = "type";
     registerModel(Membership);
     registerModel(CurrentMembership);
   });

--- a/packages/activerecord/src/associations/has-one-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-through-associations.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { ArgumentError } from "@blazetrails/activemodel";
-import { Base, registerModel, enableSti, registerSubclass, RecordInvalid } from "../index.js";
+import { Base, registerModel, registerSubclass, RecordInvalid } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { assertQueriesMatch, assertQueriesCount } from "../testing/query-assertions.js";
 import {
@@ -93,7 +93,7 @@ describe("HasOneThroughAssociationsTest", () => {
 
   registerModel(Member);
   registerModel(Club);
-  enableSti(Membership);
+  Membership.inheritanceColumn = "type";
   registerModel(Membership);
   registerModel(CurrentMembership);
   registerModel(SuperMembership);
@@ -106,7 +106,7 @@ describe("HasOneThroughAssociationsTest", () => {
   registerModel(Minivan);
   registerModel(Dashboard);
   registerModel(Speedometer);
-  enableSti(Category);
+  Category.inheritanceColumn = "type";
   registerModel(Category);
   registerModel(SpecialCategory);
   registerSubclass(SpecialCategory);

--- a/packages/activerecord/src/associations/has-one-through-build.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-through-build.trails.test.ts
@@ -13,7 +13,7 @@
  * dedicated shape assertion here.
  */
 import { describe, it, expect } from "vitest";
-import { registerModel, enableSti } from "../index.js";
+import { registerModel } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { Notifications, NotificationEvent } from "@blazetrails/activesupport";
 import { SQLCounter, type SqlPayload } from "../testing/query-assertions.js";
@@ -26,7 +26,7 @@ describe("HasOneThroughBuildTrails", () => {
 
   registerModel(Member);
   registerModel(Club);
-  enableSti(Membership);
+  Membership.inheritanceColumn = "type";
   registerModel(Membership);
   registerModel(CurrentMembership);
 

--- a/packages/activerecord/src/associations/has-one-through-disable-joins-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-through-disable-joins-associations.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
-import { registerModel, enableSti, registerSubclass } from "../index.js";
+import { registerModel, registerSubclass } from "../index.js";
 import { Member } from "../test-helpers/models/member.js";
 import { Organization } from "../test-helpers/models/organization.js";
 import { MemberDetail } from "../test-helpers/models/member-detail.js";
@@ -33,7 +33,7 @@ registerModel(Member);
 registerModel(Organization);
 registerModel(MemberDetail);
 registerModel(Club);
-enableSti(Membership);
+Membership.inheritanceColumn = "type";
 registerModel(Membership);
 registerModel(CurrentMembership);
 registerModel(SuperMembership);
@@ -50,7 +50,7 @@ registerModel(Account);
 registerModel(Project);
 registerModel(Developer);
 registerModel(AuditLog);
-enableSti(Company);
+Company.inheritanceColumn = "type";
 registerSubclass(Firm);
 registerSubclass(DependentFirm);
 registerSubclass(ExclusivelyDependentFirm);

--- a/packages/activerecord/src/associations/has-one-through-setter.trails.test.ts
+++ b/packages/activerecord/src/associations/has-one-through-setter.trails.test.ts
@@ -20,7 +20,7 @@
  * never calls `member.save()`, so a deferred implementation fails outright.
  */
 import { describe, it, expect } from "vitest";
-import { registerModel, enableSti } from "../index.js";
+import { registerModel } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { Member } from "../test-helpers/models/member.js";
 import { Club } from "../test-helpers/models/club.js";
@@ -33,7 +33,7 @@ describe("HasOneThroughSetterTrails", () => {
 
   registerModel(Member);
   registerModel(Club);
-  enableSti(Membership);
+  Membership.inheritanceColumn = "type";
   registerModel(Membership);
   registerModel(CurrentMembership);
 

--- a/packages/activerecord/src/associations/inner-join-association.test.ts
+++ b/packages/activerecord/src/associations/inner-join-association.test.ts
@@ -9,7 +9,7 @@
  * canonical association tables.
  */
 import { describe, it, expect, beforeAll } from "vitest";
-import { registerModel, registerSubclass, enableSti } from "../index.js";
+import { registerModel, registerSubclass } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { Table, Nodes } from "@blazetrails/arel";
 import { captureSql } from "../testing/sql-capture.js";
@@ -49,11 +49,11 @@ describe("InnerJoinAssociationTest", () => {
       "shardedBlogPosts",
     ]);
 
-  enableSti(Category);
+  Category.inheritanceColumn = "type";
   registerModel(Author);
   registerModel(AuthorAddress);
   registerModel(Post);
-  enableSti(Comment);
+  Comment.inheritanceColumn = "type";
   registerModel(Comment);
   registerModel(SpecialComment);
   registerSubclass(SpecialComment);

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -8,7 +8,6 @@ import {
   association,
   registerModel,
   registerSubclass,
-  enableSti,
   InverseOfAssociationNotFoundError,
   InverseOfAssociationRecursiveError,
 } from "../index.js";
@@ -331,7 +330,7 @@ describe("InverseAssociationTests", () => {
     [Human, Face, Interest, Club, Sponsor, Company, Firm, Developer, Project, AuditLog].forEach(
       (m) => registerModel(m),
     );
-    enableSti(Company);
+    Company.inheritanceColumn = "type";
     registerSubclass(Firm);
   });
 

--- a/packages/activerecord/src/associations/join-dependency-quoting.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-quoting.test.ts
@@ -8,7 +8,7 @@
  * join-dependency-through-aliasing.test.ts.
  */
 import { describe, it, expect, beforeEach } from "vitest";
-import { Base, registerModel, enableSti, registerSubclass } from "../index.js";
+import { Base, registerModel, registerSubclass } from "../index.js";
 import { Associations } from "../associations.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { JoinDependency } from "./join-dependency.js";
@@ -84,7 +84,7 @@ describe("JoinDependency Arel node construction", () => {
       }
     }
     class StiSubOwner extends StiOwner {}
-    enableSti(StiOwner);
+    StiOwner.inheritanceColumn = "type";
     registerSubclass(StiSubOwner);
     (StiOwner as any)._associations = [];
     (StiSubOwner as any)._associations = [];
@@ -120,7 +120,7 @@ describe("JoinDependency Arel node construction", () => {
     }
     class Car extends Vehicle {}
     class ElectricCar extends Car {}
-    enableSti(Vehicle);
+    Vehicle.inheritanceColumn = "type";
     registerSubclass(Car);
     registerSubclass(ElectricCar);
     (Vehicle as any)._associations = [];

--- a/packages/activerecord/src/associations/preloader/through-association-hasmany-raw-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-hasmany-raw-join-scope.test.ts
@@ -29,7 +29,7 @@
  * raw-join equivalent by declaring one on the canonical Member model.
  */
 import { describe, it, expect } from "vitest";
-import { registerModel, enableSti } from "../../index.js";
+import { registerModel } from "../../index.js";
 import { ConfigurationError } from "../../errors.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
 import { Preloader } from "../preloader.js";
@@ -41,10 +41,10 @@ import { Category } from "../../test-helpers/models/category.js";
 
 registerModel(Member);
 registerModel(Club);
-enableSti(Membership);
+Membership.inheritanceColumn = "type";
 registerModel(Membership);
 registerModel(CurrentMembership);
-enableSti(Category);
+Category.inheritanceColumn = "type";
 registerModel(Category);
 
 type JoinWhere = {

--- a/packages/activerecord/src/associations/preloader/through-association-nested-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-nested-join-scope.test.ts
@@ -19,7 +19,7 @@
  * the canonical Member model (mirroring `general_club`).
  */
 import { describe, it, expect } from "vitest";
-import { registerModel, enableSti } from "../../index.js";
+import { registerModel } from "../../index.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
 import { Preloader } from "../preloader.js";
 import { ThroughAssociation } from "./through-association.js";
@@ -32,10 +32,10 @@ import { quoteTableName, escapeRegExp } from "../../test-helpers/quote-regex.js"
 
 registerModel(Member);
 registerModel(Club);
-enableSti(Membership);
+Membership.inheritanceColumn = "type";
 registerModel(Membership);
 registerModel(CurrentMembership);
-enableSti(Category);
+Category.inheritanceColumn = "type";
 registerModel(Category);
 registerModel(Categorization);
 

--- a/packages/activerecord/src/associations/preloader/through-association-nested-raw-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-nested-raw-join-scope.test.ts
@@ -22,7 +22,7 @@
  * pins the behavior by declaring the chain on the canonical Member/Club models.
  */
 import { describe, it, expect } from "vitest";
-import { registerModel, enableSti } from "../../index.js";
+import { registerModel } from "../../index.js";
 import { ConfigurationError } from "../../errors.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
 import { Preloader } from "../preloader.js";
@@ -34,10 +34,10 @@ import { Category } from "../../test-helpers/models/category.js";
 
 registerModel(Member);
 registerModel(Club);
-enableSti(Membership);
+Membership.inheritanceColumn = "type";
 registerModel(Membership);
 registerModel(CurrentMembership);
-enableSti(Category);
+Category.inheritanceColumn = "type";
 registerModel(Category);
 
 type JoinWhere = {

--- a/packages/activerecord/src/associations/preloader/through-association-raw-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-raw-join-scope.test.ts
@@ -29,7 +29,7 @@
  * raw-join equivalent by declaring one on the canonical Member model.
  */
 import { describe, it, expect } from "vitest";
-import { registerModel, enableSti } from "../../index.js";
+import { registerModel } from "../../index.js";
 import { ConfigurationError } from "../../errors.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
 import { Preloader } from "../preloader.js";
@@ -41,10 +41,10 @@ import { Category } from "../../test-helpers/models/category.js";
 
 registerModel(Member);
 registerModel(Club);
-enableSti(Membership);
+Membership.inheritanceColumn = "type";
 registerModel(Membership);
 registerModel(CurrentMembership);
-enableSti(Category);
+Category.inheritanceColumn = "type";
 registerModel(Category);
 
 type JoinWhere = {

--- a/packages/activerecord/src/associations/singular-reader-stale-target.test.ts
+++ b/packages/activerecord/src/associations/singular-reader-stale-target.test.ts
@@ -9,7 +9,7 @@
  * `companies` fixtures — no `defineSchema`.
  */
 import { describe, it, expect, beforeAll } from "vitest";
-import { registerModel, enableSti, registerSubclass } from "../index.js";
+import { registerModel, registerSubclass } from "../index.js";
 import { Company, Firm, Client } from "../test-helpers/models/company.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 
@@ -26,7 +26,7 @@ describe("BelongsToAssociationsTest", () => {
     registerModel(Company);
     registerModel(Firm);
     registerModel(Client);
-    enableSti(Company);
+    Company.inheritanceColumn = "type";
     registerSubclass(Firm);
     registerSubclass(Client);
     await Company.loadSchema();

--- a/packages/activerecord/src/base.trails.test.ts
+++ b/packages/activerecord/src/base.trails.test.ts
@@ -180,8 +180,7 @@ describe("_applyScopeAttributes — STI type column wins over scope", () => {
         this.attribute("type", "string");
       }
     }
-    const { enableSti } = await import("./inheritance.js");
-    enableSti(Vehicle);
+    Vehicle.inheritanceColumn = "type";
     class Car extends Vehicle {}
 
     // Scope includes type: "Vehicle" — but new Car() should still have type: "Car"

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2228,7 +2228,7 @@ export class Base extends Model {
    *  default-scoped path carry it; we layer it onto the base relation. */
   private static _applyStiTypeCondition(rel: any): any {
     // Rails gates the finder type-condition on `finder_needs_type_condition?`
-    // (hierarchical + inheritance-column presence), not on an explicit enableSti
+    // (hierarchical + inheritance-column presence), not on an explicit inheritanceColumn assignment
     // sentinel — so any non-abstract subclass over a `type`-bearing table scopes
     // by type. The column resolves on the subclass itself (default "type").
     if (isFinderNeedsTypeCondition(this)) {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2228,8 +2228,9 @@ export class Base extends Model {
    *  default-scoped path carry it; we layer it onto the base relation. */
   private static _applyStiTypeCondition(rel: any): any {
     // Rails gates the finder type-condition on `finder_needs_type_condition?`
-    // (hierarchical + inheritance-column presence), not on an explicit inheritanceColumn assignment
-    // sentinel — so any non-abstract subclass over a `type`-bearing table scopes
+    // (hierarchical + inheritance-column presence), not on an explicit
+    // `inheritanceColumn` assignment — so any non-abstract subclass over a
+    // `type`-bearing table scopes
     // by type. The column resolves on the subclass itself (default "type").
     if (isFinderNeedsTypeCondition(this)) {
       const col = getInheritanceColumn(this);

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -138,7 +138,6 @@ export {
 export { defineEnum, readEnumValue, castEnumValue } from "./enum.js";
 export type { EnumMacroOptions } from "./enum.js";
 export {
-  enableSti,
   getInheritanceColumn,
   instantiateSti,
   registerSubclass,

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -129,7 +129,7 @@ export function descendants(modelClass: typeof Base): (typeof Base)[] {
  * {@link isFinderNeedsTypeCondition} memoize the stable structural answer without
  * caching a transient cold-schema column miss.
  *
- * Independent of the explicit `enableSti` sentinel that {@link isStiSubclass}
+ * Independent of the explicit `inheritanceColumn` sentinel that {@link isStiSubclass}
  * keys off — that sentinel still gates the registry-resolved row-dispatch paths.
  *
  * @internal
@@ -154,7 +154,7 @@ function descendsFromActiveRecordByHierarchy(modelClass: typeof Base): boolean {
  * actually carry the inheritance column, or STI is disabled. trails uses the
  * column-aware {@link classHasAttribute} (declared attribute or reflected column)
  * in place of Rails' `columns_hash.include?`, since schema reflection is lazy.
- * Decoupled from the explicit `enableSti` sentinel ({@link isStiSubclass}), which
+ * Decoupled from the explicit `inheritanceColumn` sentinel ({@link isStiSubclass}), which
  * still gates the registry-resolved row-dispatch paths.
  *
  * Mirrors: ActiveRecord::Inheritance::ClassMethods#descends_from_active_record?
@@ -385,15 +385,6 @@ export function registerSubclass(klass: typeof Base): void {
  *
  * Mirrors: ActiveRecord::Inheritance
  */
-
-/**
- * Configure STI on a base model class.
- * Call this on the parent class to enable STI.
- */
-export function enableSti(modelClass: typeof Base, options: { column?: string } = {}): void {
-  const column = options.column ?? "type";
-  (modelClass as any)._inheritanceColumn = column;
-}
 
 /**
  * Get the inheritance column for a model.
@@ -1193,7 +1184,7 @@ function namesSelfOrStiAncestor(modelClass: typeof Base, typeName: string): bool
  *     uniquely-named subclass registered via `registerModel` or raises
  *     `SubclassNotFound` for a genuinely bad type, mirroring Rails' `find_sti_class`.
  *   - A canonical base that merely reflects a `type` column and tracks subclasses
- *     (no explicit `enableSti`): DEGRADE to the base class on a miss rather than
+ *     (no explicit `inheritanceColumn` assignment): DEGRADE to the base class on a miss rather than
  *     raise. trails has no autoloader, so an unloaded-but-valid subclass (e.g. a
  *     `type: "Reply"` row when `reply.ts` hasn't been imported) is
  *     indistinguishable from a genuinely bad type; raising would break unrelated
@@ -1230,10 +1221,11 @@ function findStiClassForRow(baseClass: typeof Base, typeName: string): typeof Ba
  * `Company.new(type: "Account")` or an unknown `"InvalidType"`) rather than
  * silently building the receiver as-is. The no-match handling mirrors the row
  * path ({@link findStiClassForRow}): the subtree walk resolves in-hierarchy
- * types registry-safely, then only an `enableSti` hierarchy defers to the
+ * types registry-safely, then only an explicitly STI-enabled hierarchy defers to the
  * global `find_sti_class` (which also resolves a registered subclass not tracked
  * as a descendant, and raises for a genuine out-of-hierarchy/unknown type). A
- * model that merely reflects a `type` column without `enableSti` degrades to
+ * model that merely reflects a `type` column without an explicit
+ * `inheritanceColumn` assignment degrades to
  * build-as-is — trails has no autoloader to tell an unloaded-but-valid subclass
  * from a bad type, the same graceful deviation the row path takes.
  *
@@ -1275,7 +1267,8 @@ export function subclassFromAttributesForNew(
     // resolves a registered subclass (incl. one not tracked as a descendant) or
     // raises SubclassNotFound for an out-of-hierarchy/unknown type — matching Rails'
     // Inheritance#new → subclass_from_attributes → find_sti_class. A model that
-    // merely reflects a `type` column without enableSti degrades to build-as-is:
+    // merely reflects a `type` column without an explicit inheritanceColumn assignment
+    // degrades to build-as-is:
     // trails has no autoloader, so an unloaded-but-valid subclass is indistinguishable
     // from a genuinely bad type, and raising would break unrelated construction.
     if (stiEnabled(modelClass)) return findStiClass(modelClass, typeName);

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -129,8 +129,9 @@ export function descendants(modelClass: typeof Base): (typeof Base)[] {
  * {@link isFinderNeedsTypeCondition} memoize the stable structural answer without
  * caching a transient cold-schema column miss.
  *
- * Independent of the explicit `inheritanceColumn` sentinel that {@link isStiSubclass}
- * keys off — that sentinel still gates the registry-resolved row-dispatch paths.
+ * Independent of the explicit `inheritanceColumn` sentinel that
+ * {@link isStiSubclass} keys off — that sentinel still gates the
+ * registry-resolved row-dispatch paths.
  *
  * @internal
  */
@@ -154,8 +155,9 @@ function descendsFromActiveRecordByHierarchy(modelClass: typeof Base): boolean {
  * actually carry the inheritance column, or STI is disabled. trails uses the
  * column-aware {@link classHasAttribute} (declared attribute or reflected column)
  * in place of Rails' `columns_hash.include?`, since schema reflection is lazy.
- * Decoupled from the explicit `inheritanceColumn` sentinel ({@link isStiSubclass}), which
- * still gates the registry-resolved row-dispatch paths.
+ * Decoupled from the explicit `inheritanceColumn` sentinel
+ * ({@link isStiSubclass}), which still gates the registry-resolved row-dispatch
+ * paths.
  *
  * Mirrors: ActiveRecord::Inheritance::ClassMethods#descends_from_active_record?
  */
@@ -376,15 +378,6 @@ export function registerSubclass(klass: typeof Base): void {
     (parent as any)._subclasses.push(klass);
   }
 }
-
-/**
- * Single Table Inheritance support.
- *
- * When a model has an inheritance column (default: "type"), subclasses
- * share the parent's table and auto-set the type column.
- *
- * Mirrors: ActiveRecord::Inheritance
- */
 
 /**
  * Get the inheritance column for a model.
@@ -1184,9 +1177,10 @@ function namesSelfOrStiAncestor(modelClass: typeof Base, typeName: string): bool
  *     uniquely-named subclass registered via `registerModel` or raises
  *     `SubclassNotFound` for a genuinely bad type, mirroring Rails' `find_sti_class`.
  *   - A canonical base that merely reflects a `type` column and tracks subclasses
- *     (no explicit `inheritanceColumn` assignment): DEGRADE to the base class on a miss rather than
- *     raise. trails has no autoloader, so an unloaded-but-valid subclass (e.g. a
- *     `type: "Reply"` row when `reply.ts` hasn't been imported) is
+ *     (no explicit `inheritanceColumn` assignment): DEGRADE to the base class
+ *     on a miss rather than raise. trails has no autoloader, so an
+ *     unloaded-but-valid subclass (e.g. a `type: "Reply"` row when `reply.ts`
+ *     hasn't been imported) is
  *     indistinguishable from a genuinely bad type; raising would break unrelated
  *     queries over a shared table (`Topic.all` seeing a `Reply` row). This is the
  *     same graceful-degradation deviation the `new` path takes.
@@ -1221,13 +1215,13 @@ function findStiClassForRow(baseClass: typeof Base, typeName: string): typeof Ba
  * `Company.new(type: "Account")` or an unknown `"InvalidType"`) rather than
  * silently building the receiver as-is. The no-match handling mirrors the row
  * path ({@link findStiClassForRow}): the subtree walk resolves in-hierarchy
- * types registry-safely, then only an explicitly STI-enabled hierarchy defers to the
- * global `find_sti_class` (which also resolves a registered subclass not tracked
+ * types registry-safely, then only an explicitly STI-enabled hierarchy defers to
+ * the global `find_sti_class` (which also resolves a registered subclass not tracked
  * as a descendant, and raises for a genuine out-of-hierarchy/unknown type). A
  * model that merely reflects a `type` column without an explicit
- * `inheritanceColumn` assignment degrades to
- * build-as-is — trails has no autoloader to tell an unloaded-but-valid subclass
- * from a bad type, the same graceful deviation the row path takes.
+ * `inheritanceColumn` assignment degrades to build-as-is — trails has no
+ * autoloader to tell an unloaded-but-valid subclass from a bad type, the same
+ * graceful deviation the row path takes.
  *
  * @internal Used by Base's constructor to dispatch `new` to a subclass.
  */
@@ -1267,9 +1261,9 @@ export function subclassFromAttributesForNew(
     // resolves a registered subclass (incl. one not tracked as a descendant) or
     // raises SubclassNotFound for an out-of-hierarchy/unknown type — matching Rails'
     // Inheritance#new → subclass_from_attributes → find_sti_class. A model that
-    // merely reflects a `type` column without an explicit inheritanceColumn assignment
-    // degrades to build-as-is:
-    // trails has no autoloader, so an unloaded-but-valid subclass is indistinguishable
+    // merely reflects a `type` column without an explicit inheritanceColumn
+    // assignment degrades to build-as-is: trails has no autoloader, so an
+    // unloaded-but-valid subclass is indistinguishable
     // from a genuinely bad type, and raising would break unrelated construction.
     if (stiEnabled(modelClass)) return findStiClass(modelClass, typeName);
     return null;

--- a/packages/activerecord/src/test-helpers/models/company.ts
+++ b/packages/activerecord/src/test-helpers/models/company.ts
@@ -12,7 +12,7 @@ import { throwAbort } from "@blazetrails/activesupport";
 // vendor/rails/activerecord/test/models/company.rb
 import { acceptsNestedAttributesFor } from "../../nested-attributes.js";
 import { registerModel } from "../../associations.js";
-import { enableSti, registerSubclass } from "../../inheritance.js";
+import { registerSubclass } from "../../inheritance.js";
 import { Rollback } from "../../errors.js";
 import { Base } from "../../base.js";
 import type { CollectionProxy } from "../../associations/collection-proxy.js";
@@ -665,8 +665,8 @@ for (const klass of [NamespacedCompany, NamespacedFirm, NamespacedClient]) {
 }
 
 // Rails: companies.type column drives STI across the Company hierarchy
-// (Firm/Client/etc.). enableSti scopes `Firm.all` to `WHERE type IN (...)`.
-enableSti(Company);
+// (Firm/Client/etc.). Setting the column scopes `Firm.all` to `WHERE type IN (...)`.
+Company.inheritanceColumn = "type";
 
 // Track the STI subtree so registry-safe subclass resolution (STI dispatch at
 // `new`, `descendants`) can find these classes through Company's own subtree

--- a/packages/activerecord/src/test-helpers/models/company.ts
+++ b/packages/activerecord/src/test-helpers/models/company.ts
@@ -664,8 +664,12 @@ for (const klass of [NamespacedCompany, NamespacedFirm, NamespacedClient]) {
   registerModel(klass);
 }
 
-// Rails: companies.type column drives STI across the Company hierarchy
-// (Firm/Client/etc.). Setting the column scopes `Firm.all` to `WHERE type IN (...)`.
+// Rails: companies.type drives STI across the Company hierarchy (Firm/Client/etc.)
+// with no assignment in company.rb — `inheritance_column` already defaults to
+// "type" and the autoloader resolves a row's type name on demand. trails has no
+// autoloader, so the assignment doubles as the sentinel that opts this hierarchy
+// into registry-resolved dispatch (`stiEnabled` in inheritance.ts) and scopes
+// `Firm.all` to `WHERE type IN (...)`.
 Company.inheritanceColumn = "type";
 
 // Track the STI subtree so registry-safe subclass resolution (STI dispatch at

--- a/packages/activerecord/src/test-helpers/models/post.ts
+++ b/packages/activerecord/src/test-helpers/models/post.ts
@@ -1007,7 +1007,7 @@ export class PostRecord extends Base {
 // classes through Post's own subtree rather than the global model registry.
 // Rails: `posts` carries a `type` column, so Post's non-abstract descendants
 // auto-layer a `type IN (...)` finder condition (`finder_needs_type_condition?`,
-// column-presence detected) with no explicit enableSti opt-in.
+// column-presence detected) with no explicit inheritanceColumn assignment.
 for (const klass of [
   SpecialPost,
   StiPost,


### PR DESCRIPTION
Rails has no `enable_sti`. STI is implicit — a model participates as soon as its
table carries the inheritance column, and the column is named by assignment
(`self.inheritance_column = 'zoink'`, model_schema.rb:146-151, backed by
`class_attribute :inheritance_column, instance_accessor: false, default: "type"`
at model_schema.rb:172).

trails' `enableSti` (`inheritance.ts:393`) was a duplicate writer for that same
class_attribute:

```ts
export function enableSti(modelClass: typeof Base, options: { column?: string } = {}): void {
  (modelClass as any)._inheritanceColumn = options.column ?? "type";
}
```

The faithful writer was already ported and wired — `ModelSchema.inheritanceColumn`
(`model-schema.ts:1472`, incl. the explicit-null arm) behind the Rails-named
`Base.inheritanceColumn` setter (`base.ts:1653`) — so every `enableSti(X)` call is
spelled `X.inheritanceColumn = "type"`.

## Changes

- Replaced all 59 `enableSti(X)` calls (every call site used the bare form; no
  call passed `{ column }`) with `X.inheritanceColumn = "type"`, including the
  test-helper model `company.ts`.
- Deleted `enableSti` and dropped it from `index.ts`'s export list.
- Reworded the JSDoc/comment references to `enableSti` in `inheritance.ts`,
  `associations.ts`, `base.ts`, and the two test-helper models to name the
  `inheritanceColumn` assignment instead.

Behavior-preserving: a JS static accessor inherited from `Base` is invoked on
assignment to a subclass with `this` bound to that subclass, so
`_inheritanceColumn` still lands as an own property on the assigned-to class.

## Verification

- `pnpm typecheck`, `pnpm lint` clean.
- STI suites (`inheritance.test.ts`, `inheritance-namespaced.test.ts`,
  `sti-attribute-routing.test.ts`, `base.trails.test.ts`) and every touched
  association suite pass — 1074 tests across 26 files.
- `pnpm api:extra --package activerecord` inheritance.ts novel count is unchanged
  (2: `getInheritanceColumn`, `instantiateSti` — both separate stories);
  `enableSti` had no `extra-surface-allow.json` entry to remove.

Closes-story: converge-enablesti-onto-inheritance-column-setter
