### PR TITLE
refactor(activerecord): converge Base query-cache and encryption facade bodies

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1936,7 +1936,7 @@ export class Base extends Model {
    * @internal
    */
   encryptedAttribute(attributeName: string): boolean {
-    return encryptionHooks.encryptedAttributeQ(this, attributeName);
+    return encryptionHooks.encryptedAttribute(this, attributeName);
   }
 
   /**
@@ -1956,7 +1956,7 @@ export class Base extends Model {
    * @internal
    */
   async encrypt(): Promise<void> {
-    return encryptionHooks.encryptRecord(this);
+    return encryptionHooks.encrypt(this);
   }
 
   /**
@@ -1966,7 +1966,7 @@ export class Base extends Model {
    * @internal
    */
   async decrypt(): Promise<void> {
-    return encryptionHooks.decryptRecord(this);
+    return encryptionHooks.decrypt(this);
   }
 
   static async suppress<R>(fn: () => R | Promise<R>): Promise<R> {

--- a/packages/activerecord/src/connection-pool.trails.test.ts
+++ b/packages/activerecord/src/connection-pool.trails.test.ts
@@ -19,7 +19,6 @@ import {
   withExecutionContext,
 } from "./connection-adapters/abstract/connection-pool.js";
 import { Store } from "./connection-adapters/abstract/query-cache.js";
-import { QueryCache } from "./query-cache.js";
 import { ConnectionDescriptor } from "./connection-adapters/abstract/connection-descriptor.js";
 import { PoolConfig } from "./connection-adapters/pool-config.js";
 import { SchemaReflection, BoundSchemaReflection } from "./connection-adapters/schema-cache.js";
@@ -994,10 +993,10 @@ describe("ConnectionPoolConfiguration query cache", () => {
       pool.checkin(conn);
     });
 
-    it("QueryCache.cache enables for the duration of fn and clears on exit", async () => {
+    it("enableQueryCache enables for the duration of fn and clears on exit", async () => {
       const pool = makePool(1);
       let observed: Store | null = null;
-      await QueryCache.cache(pool, async () => {
+      await pool.enableQueryCache(async () => {
         const conn = await pool.checkout();
         observed = (conn as unknown as { _queryCache: Store | null })._queryCache;
         expect(observed!.enabled).toBe(true);
@@ -1005,6 +1004,7 @@ describe("ConnectionPoolConfiguration query cache", () => {
         expect(observed!.size).toBe(1);
         pool.checkin(conn);
       });
+      pool.clearQueryCache();
       expect(observed!.enabled).toBe(false);
       expect(observed!.size).toBe(0);
     });

--- a/packages/activerecord/src/encryption-hooks.ts
+++ b/packages/activerecord/src/encryption-hooks.ts
@@ -32,13 +32,13 @@ export interface EncryptionHooks {
    */
   buildScheme?(options: any): any;
 
-  encryptedAttributeQ(klass: any, name: string): boolean;
+  encryptedAttribute(record: any, name: string): boolean;
 
   ciphertextFor(record: any, name: string): unknown;
 
-  encryptRecord(record: any): Promise<void>;
+  encrypt(record: any): Promise<void>;
 
-  decryptRecord(record: any): Promise<void>;
+  decrypt(record: any): Promise<void>;
 }
 
 function notLoaded(method: string): never {
@@ -51,10 +51,10 @@ function notLoaded(method: string): never {
 export const encryptionHooks: EncryptionHooks = {
   encrypts: (klass: any) => notLoaded(`${klass?.name ?? "Model"}.encrypts()`),
   applyPendingEncryptions: () => {},
-  encryptedAttributeQ: () => false,
+  encryptedAttribute: () => false,
   ciphertextFor: () => undefined,
-  encryptRecord: async () => {},
-  decryptRecord: async () => {},
+  encrypt: async () => {},
+  decrypt: async () => {},
 };
 
 /** @internal */

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -275,12 +275,6 @@ export function isEncryptedAttribute(klass: any, attr: string): boolean {
   return false;
 }
 
-// ─── Instance-level encryption API ──────────────────────────────────────────
-//
-// The bodies live in `encryption/encryptable-record.ts`, the file matching
-// Rails' `encryption/encryptable_record.rb`; base.ts reaches them through the
-// hook registry below.
-
 /** Mirrors: ActiveRecord::Encryption.key_length */
 export function keyLength(): number {
   return AesGcmCipher.keyLength;

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -24,15 +24,10 @@ import { Scheme, type SchemeOptions } from "./encryption/scheme.js";
 import type { EncryptorLike } from "./encryption/encryptor.js";
 import { Aes256Gcm as AesGcmCipher } from "./encryption/cipher/aes256-gcm.js";
 export { Cipher } from "./encryption/cipher.js";
-import {
-  EncryptableRecord,
-  getAttributeType,
-  encryptedTypeOf,
-} from "./encryption/encryptable-record.js";
+import { EncryptableRecord, encryptedTypeOf } from "./encryption/encryptable-record.js";
 import { Configurable } from "./encryption/configurable.js";
 import { Contexts } from "./encryption/contexts.js";
 import {
-  withoutEncryption as _withoutEncryption,
   getEncryptionContext,
   getDefaultContext,
   setDefaultContext,
@@ -281,81 +276,10 @@ export function isEncryptedAttribute(klass: any, attr: string): boolean {
 }
 
 // ─── Instance-level encryption API ──────────────────────────────────────────
-
-/**
- * Returns true if the attribute's current stored value is encrypted ciphertext.
- * Mirrors: ActiveRecord::Encryption::EncryptableRecord#encrypted_attribute?
- */
-export function encryptedAttributeQ(record: any, attributeName: string): boolean {
-  const klass = record.constructor;
-  // Resolve attribute aliases (mirrors Rails' attribute_aliases lookup).
-  const resolved = klass._attributeAliases?.[attributeName] ?? attributeName;
-  if (!klass._encryptedAttributes?.has(resolved)) return false;
-  const type = encryptedTypeOf(getAttributeType(klass, resolved));
-  if (!type) return false;
-  const rawValue = record.readAttributeBeforeTypeCast(resolved);
-  return type.isEncrypted(rawValue);
-}
-
-/**
- * Returns the ciphertext for the given attribute.
- * For encrypted attributes: returns the raw (before-type-cast) stored value.
- * For unencrypted attributes: returns the serialized DB value.
- *
- * Mirrors: ActiveRecord::Encryption::EncryptableRecord#ciphertext_for
- */
-export function ciphertextFor(record: any, attributeName: string): unknown {
-  const klass = record.constructor;
-  const resolved = klass._attributeAliases?.[attributeName] ?? attributeName;
-  if (encryptedAttributeQ(record, attributeName)) {
-    return record.readAttributeBeforeTypeCast(resolved);
-  }
-  return record._attributes.valuesForDatabase()[resolved];
-}
-
-/**
- * Encrypts all encryptable attributes and persists them via update_columns.
- * Mirrors: ActiveRecord::Encryption::EncryptableRecord#encrypt
- */
-export async function encryptRecord(record: any): Promise<void> {
-  const klass = record.constructor;
-  const encryptedAttrs: Set<string> = klass._encryptedAttributes ?? new Set();
-  if (encryptedAttrs.size === 0) return;
-
-  // Mirrors Rails encrypt_attributes' first line (encryptable_record.rb:188):
-  // raises Errors::Configuration when the context is frozen (protected mode).
-  EncryptableRecord.validateEncryptionAllowed(record);
-
-  // Mirrors Rails encrypt_attributes (encryptable_record.rb:187-191):
-  //   update_columns build_encrypt_attribute_assignments
-  // build_encrypt_attribute_assignments returns the *plaintext* attribute
-  // values (self[name]); update_columns writes them as the in-memory cast
-  // value and serializes each (via SerializeCastValue.serialize) to ciphertext
-  // for the DB write — encrypting exactly once. No pre-serialization here.
-  const assignments: Record<string, unknown> = {};
-  for (const attr of encryptedAttrs) {
-    assignments[attr] = record.readAttribute(attr);
-  }
-  await record.updateColumns(assignments);
-}
-
-/**
- * Decrypts all encryptable attributes and persists them via update_columns
- * (with encryption disabled, matching Rails' without_encryption block).
- * Mirrors: ActiveRecord::Encryption::EncryptableRecord#decrypt
- */
-export async function decryptRecord(record: any): Promise<void> {
-  const klass = record.constructor;
-  const encryptedAttrs: Set<string> = klass._encryptedAttributes ?? new Set();
-  if (encryptedAttrs.size === 0) return;
-
-  // Mirrors Rails decrypt_attributes' first line (encryptable_record.rb:194):
-  // raises Errors::Configuration when the context is frozen (protected mode).
-  EncryptableRecord.validateEncryptionAllowed(record);
-
-  const assignments = EncryptableRecord.buildDecryptAttributeAssignments(record);
-  await _withoutEncryption(() => record.updateColumns(assignments));
-}
+//
+// The bodies live in `encryption/encryptable-record.ts`, the file matching
+// Rails' `encryption/encryptable_record.rb`; base.ts reaches them through the
+// hook registry below.
 
 /** Mirrors: ActiveRecord::Encryption.key_length */
 export function keyLength(): number {
@@ -465,8 +389,9 @@ registerEncryptionHooks({
   requireOriginalColumnsAfterReflection: (klass: any, columnNames: string[]) =>
     EncryptableRecord.requireOriginalColumnsAfterReflection(klass, columnNames),
   buildScheme,
-  encryptedAttributeQ,
-  ciphertextFor,
-  encryptRecord,
-  decryptRecord,
+  encryptedAttribute: (record: any, name: string) =>
+    EncryptableRecord.encryptedAttribute(record, name),
+  ciphertextFor: (record: any, name: string) => EncryptableRecord.ciphertextFor(record, name),
+  encrypt: (record: any) => EncryptableRecord.encrypt(record),
+  decrypt: (record: any) => EncryptableRecord.decrypt(record),
 });

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -548,24 +548,34 @@ export class EncryptableRecord {
    * the stored value is actually encrypted (calls `type.isEncrypted`).
    * Distinct from `encryption.ts#isEncryptedAttribute(klass, attr)` which is
    * a class-level check (is the attribute declared encrypted on this class?).
+   *
+   * Mirrors: ActiveRecord::Encryption::EncryptableRecord#encrypted_attribute?
    * @internal
    */
-  static isEncryptedAttribute(record: any, attributeName: string): boolean {
+  static encryptedAttribute(record: any, attributeName: string): boolean {
     const klass = record.constructor;
     // Resolve attribute aliases before checking encrypted set.
-    const resolvedName = klass._attributeAliases?.[attributeName] ?? attributeName;
-    if (!klass._encryptedAttributes?.has(resolvedName)) return false;
-    const type = encryptedTypeOf(getAttributeType(klass, resolvedName));
+    const name = klass._attributeAliases?.[attributeName] ?? attributeName;
+    if (!this.encryptedAttributes(klass).has(name)) return false;
+    // `encryptedTypeOf` unwraps the resolved type: unlike Ruby's DelegateClass,
+    // a TS `Serialized(Encrypted(...))` does not forward `encrypted?`.
+    const type = encryptedTypeOf(
+      // Rails reads the type with `type_for_attribute(name)`; `getAttributeType`
+      // is the fallback for hosts that don't expose it (bare attribute-definition
+      // maps in unit tests).
+      typeof klass.typeForAttribute === "function"
+        ? klass.typeForAttribute(name)
+        : getAttributeType(klass, name),
+    );
     if (!type) return false;
-    const raw = record.readAttributeBeforeTypeCast?.(resolvedName);
-    return type.isEncrypted(raw);
+    return type.isEncrypted(record.readAttributeBeforeTypeCast?.(name));
   }
 
   /** @internal */
   static ciphertextFor(record: any, attributeName: string): unknown {
     const klass = record.constructor;
     const resolvedName = klass._attributeAliases?.[attributeName] ?? attributeName;
-    if (this.isEncryptedAttribute(record, attributeName)) {
+    if (this.encryptedAttribute(record, attributeName)) {
       return record.readAttributeBeforeTypeCast?.(resolvedName);
     }
     // Unencrypted — return the DB-serialized value (mirrors read_attribute_for_database).

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -544,29 +544,16 @@ export class EncryptableRecord {
   }
 
   /**
-   * Instance-level encrypted-attribute check: resolves aliases and verifies
-   * the stored value is actually encrypted (calls `type.isEncrypted`).
-   * Distinct from `encryption.ts#isEncryptedAttribute(klass, attr)` which is
-   * a class-level check (is the attribute declared encrypted on this class?).
-   *
    * Mirrors: ActiveRecord::Encryption::EncryptableRecord#encrypted_attribute?
    * @internal
    */
   static encryptedAttribute(record: any, attributeName: string): boolean {
     const klass = record.constructor;
-    // Resolve attribute aliases before checking encrypted set.
     const name = klass._attributeAliases?.[attributeName] ?? attributeName;
     if (!this.encryptedAttributes(klass).has(name)) return false;
     // `encryptedTypeOf` unwraps the resolved type: unlike Ruby's DelegateClass,
     // a TS `Serialized(Encrypted(...))` does not forward `encrypted?`.
-    const type = encryptedTypeOf(
-      // Rails reads the type with `type_for_attribute(name)`; `getAttributeType`
-      // is the fallback for hosts that don't expose it (bare attribute-definition
-      // maps in unit tests).
-      typeof klass.typeForAttribute === "function"
-        ? klass.typeForAttribute(name)
-        : getAttributeType(klass, name),
-    );
+    const type = encryptedTypeOf(klass.typeForAttribute(name));
     if (!type) return false;
     return type.isEncrypted(record.readAttributeBeforeTypeCast?.(name));
   }

--- a/packages/activerecord/src/encryption/encrypted-fixtures.test.ts
+++ b/packages/activerecord/src/encryption/encrypted-fixtures.test.ts
@@ -20,7 +20,7 @@ describe("ActiveRecord::Encryption::EncryptableFixtureTest", () => {
 
   it("fixtures get encrypted automatically", async () => {
     const { EncryptableRecord } = await import("./encryptable-record.js");
-    expect(EncryptableRecord.isEncryptedAttribute(encryptedBooks("awdr"), "name")).toBe(true);
+    expect(EncryptableRecord.encryptedAttribute(encryptedBooks("awdr"), "name")).toBe(true);
   });
 });
 
@@ -47,6 +47,6 @@ describe("ActiveRecord::Encryption::EncryptableFixtureTest", () => {
     const book = encryptedBookThatIgnoresCases("rfr");
     expect((book as any).name).toBe("Ruby for Rails");
     const { EncryptableRecord } = await import("./encryptable-record.js");
-    expect(EncryptableRecord.isEncryptedAttribute(book, "name")).toBe(true);
+    expect(EncryptableRecord.encryptedAttribute(book, "name")).toBe(true);
   });
 });

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -149,12 +149,6 @@ function configurationsEmpty(klass: typeof Base): boolean {
 export const ClassMethods = {
   /**
    * Mirrors: ActiveRecord::QueryCache::ClassMethods#cache
-   * (`pool = connection_pool; was_enabled = pool.query_cache_enabled;
-   * pool.enable_query_cache(&block) ensure pool.clear_query_cache unless
-   * was_enabled`). `enableQueryCache` already restores the prior
-   * enabled/dirties state in its own `finally` (matching Rails'
-   * `enable_query_cache`), so the only bookkeeping left here is the
-   * clear-on-exit.
    */
   async cache<T>(this: typeof Base, block: () => T | Promise<T>): Promise<T> {
     if (this.isConnected() || !configurationsEmpty(this)) {

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -42,65 +42,7 @@ export interface QueryCacheCompleteTarget {
   clearQueryCache(): void;
 }
 
-/**
- * A connection pool whose query cache `cache`/`uncached` block helpers can
- * drive. Mirrors the `connection_pool` that Rails'
- * `ActiveRecord::QueryCache::ClassMethods` operate on — the same four members
- * its `cache` / `uncached` touch.
- */
-export interface QueryCacheBlockPool {
-  readonly queryCacheEnabled: boolean;
-  enableQueryCache<T>(fn: () => T | Promise<T>): Promise<T>;
-  clearQueryCache(): void;
-  disableQueryCache<T>(fn: () => T | Promise<T>, options?: { dirties?: boolean }): Promise<T>;
-}
-
 export class QueryCache {
-  /**
-   * Enable the query cache on `pool` for the duration of `block`, then restore
-   * the prior state — clearing the cache on exit unless it was already enabled.
-   *
-   * Mirrors: ActiveRecord::QueryCache::ClassMethods#cache
-   * (`active_record/query_cache.rb:9-21`):
-   *
-   *     was_enabled = pool.query_cache_enabled
-   *     begin
-   *       pool.enable_query_cache(&block)
-   *     ensure
-   *       pool.clear_query_cache unless was_enabled
-   *     end
-   *
-   * The `was_enabled` bookkeeping lives here, as in Rails, rather than behind a
-   * pool-side helper: `enableQueryCache` already restores the prior
-   * enabled/dirties state in its own `finally` (matching Rails'
-   * `enable_query_cache`), so the only thing left for this layer is the
-   * clear-on-exit, and every member it needs is public pool surface.
-   */
-  static async cache<T>(pool: QueryCacheBlockPool, block: () => T | Promise<T>): Promise<T> {
-    const wasEnabled = pool.queryCacheEnabled;
-    try {
-      return await pool.enableQueryCache(block);
-    } finally {
-      if (!wasEnabled) pool.clearQueryCache();
-    }
-  }
-
-  /**
-   * Disable the query cache on `pool` within `block`. Pass `dirties: false` to
-   * stop write operations from clearing every connection's query cache (the
-   * default dirties them in case they are replicas with now-stale caches).
-   *
-   * Mirrors: ActiveRecord::QueryCache::ClassMethods#uncached
-   * (`connection_pool.disable_query_cache(dirties: dirties, &block)`).
-   */
-  static uncached<T>(
-    pool: QueryCacheBlockPool,
-    block: () => T | Promise<T>,
-    options: { dirties?: boolean } = {},
-  ): Promise<T> {
-    return pool.disableQueryCache(block, options);
-  }
-
   /**
    * Enable query cache on all provided pools/adapters that are not already
    * enabled, skipping (without enabling) those disabled by configuration.
@@ -207,16 +149,24 @@ function configurationsEmpty(klass: typeof Base): boolean {
 export const ClassMethods = {
   /**
    * Mirrors: ActiveRecord::QueryCache::ClassMethods#cache
-   * (`connection_pool.enable_query_cache(&block)` with the
-   * `clear_query_cache unless was_enabled` ensure — both owned by
-   * {@link QueryCache.cache}, which this delegates to once the
-   * "is Active Record configured?" guard passes).
+   * (`pool = connection_pool; was_enabled = pool.query_cache_enabled;
+   * pool.enable_query_cache(&block) ensure pool.clear_query_cache unless
+   * was_enabled`). `enableQueryCache` already restores the prior
+   * enabled/dirties state in its own `finally` (matching Rails'
+   * `enable_query_cache`), so the only bookkeeping left here is the
+   * clear-on-exit.
    */
-  cache<T>(this: typeof Base, block: () => T | Promise<T>): Promise<T> {
-    if (this.isConnectedQ() || !configurationsEmpty(this)) {
-      return QueryCache.cache(this.connectionPool(), block);
+  async cache<T>(this: typeof Base, block: () => T | Promise<T>): Promise<T> {
+    if (this.isConnected() || !configurationsEmpty(this)) {
+      const pool = this.connectionPool();
+      const wasEnabled = pool.queryCacheEnabled;
+      try {
+        return await pool.enableQueryCache(block);
+      } finally {
+        if (!wasEnabled) pool.clearQueryCache();
+      }
     }
-    return Promise.resolve(block());
+    return block();
   },
 
   /**
@@ -230,8 +180,8 @@ export const ClassMethods = {
     block: () => T | Promise<T>,
     options: { dirties?: boolean } = {},
   ): Promise<T> {
-    if (this.isConnectedQ() || !configurationsEmpty(this)) {
-      return QueryCache.uncached(this.connectionPool(), block, options);
+    if (this.isConnected() || !configurationsEmpty(this)) {
+      return this.connectionPool().disableQueryCache(block, options);
     }
     return Promise.resolve(block());
   },

--- a/packages/activerecord/src/test-helpers/use-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.test.ts
@@ -835,7 +835,7 @@ describe("useFixtures bootstraps the encryption add-on for encrypted fixtures", 
       expect(typeof rawDbValue).toBe("string");
       // The encrypted attribute type reports it as encrypted.
       const { EncryptableRecord } = await import("../encryption/encryptable-record.js");
-      expect(EncryptableRecord.isEncryptedAttribute(book, "name")).toBe(true);
+      expect(EncryptableRecord.encryptedAttribute(book, "name")).toBe(true);
     });
   });
 
@@ -861,7 +861,7 @@ describe("useFixtures bootstraps the encryption add-on for encrypted fixtures", 
       expect(rawOriginal).not.toBe("Ruby for Rails");
       expect(typeof rawOriginal).toBe("string");
       const { EncryptableRecord } = await import("../encryption/encryptable-record.js");
-      expect(EncryptableRecord.isEncryptedAttribute(book, "name")).toBe(true);
+      expect(EncryptableRecord.encryptedAttribute(book, "name")).toBe(true);
     });
   });
 });

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/base.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/base.json
@@ -25,21 +25,7 @@
     "tsFile": "base.ts",
     "rubyName": "cache",
     "call": "configurations",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
-    "rubyName": "cache",
-    "call": "connected?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
-    "rubyName": "cache",
-    "call": "enable_query_cache",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Bucket (b): Rails' `configurations.empty?` is a call on the `Base.configurations` class_attribute reader; trails stores it as a plain static property, so `configurationsEmpty(this)` reads it — there is no `configurations()` call to match. Converges when the Core.configurations accessor (core.ts:432, currently unwired) becomes the real read path."
   },
   {
     "package": "activerecord",
@@ -53,20 +39,6 @@
     "tsFile": "base.ts",
     "rubyName": "changed_for_autosave?",
     "call": "marked_for_destruction?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
-    "rubyName": "decrypt",
-    "call": "decrypt_attributes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
-    "rubyName": "decrypt",
-    "call": "has_encrypted_attributes?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -177,55 +149,6 @@
   {
     "package": "activerecord",
     "tsFile": "base.ts",
-    "rubyName": "encrypt",
-    "call": "encrypt_attributes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
-    "rubyName": "encrypt",
-    "call": "has_encrypted_attributes?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
-    "rubyName": "encrypted_attribute?",
-    "call": "encrypted?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
-    "rubyName": "encrypted_attribute?",
-    "call": "encrypted_attributes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
-    "rubyName": "encrypted_attribute?",
-    "call": "include?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
-    "rubyName": "encrypted_attribute?",
-    "call": "read_attribute_before_type_cast",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
-    "rubyName": "encrypted_attribute?",
-    "call": "type_for_attribute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
     "rubyName": "exec_explain",
     "call": "map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -291,21 +214,7 @@
     "tsFile": "base.ts",
     "rubyName": "uncached",
     "call": "configurations",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
-    "rubyName": "uncached",
-    "call": "connected?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
-    "rubyName": "uncached",
-    "call": "disable_query_cache",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Bucket (b): Rails' `configurations.empty?` is a call on the `Base.configurations` class_attribute reader; trails stores it as a plain static property, so `configurationsEmpty(this)` reads it — there is no `configurations()` call to match. Converges when the Core.configurations accessor (core.ts:432, currently unwired) becomes the real read path."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption/encryptable-record.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/encryption/encryptable-record.json
@@ -93,20 +93,6 @@
   {
     "package": "activerecord",
     "tsFile": "encryption/encryptable-record.ts",
-    "rubyName": "encrypted_attribute?",
-    "call": "encrypted_attributes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/encryptable-record.ts",
-    "rubyName": "encrypted_attribute?",
-    "call": "type_for_attribute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/encryptable-record.ts",
     "rubyName": "encrypts",
     "call": "new",
     "reason": "encrypt_attribute's `EncryptedAttributeType.new` is emitted from the shared registerEncryptedType primitive (immediate direct-set / durable decorator) after encrypts routes through encryptAttribute - same construction, different TS method."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/query-cache.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/query-cache.json
@@ -4,14 +4,7 @@
     "tsFile": "query-cache.ts",
     "rubyName": "cache",
     "call": "configurations",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "query-cache.ts",
-    "rubyName": "cache",
-    "call": "connected?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Bucket (b): Rails' `configurations.empty?` is a call on the `Base.configurations` class_attribute reader; trails stores it as a plain static property, so `configurationsEmpty(this)` reads it — there is no `configurations()` call to match. Converges when the Core.configurations accessor (core.ts:432, currently unwired) becomes the real read path."
   },
   {
     "package": "activerecord",
@@ -39,13 +32,6 @@
     "tsFile": "query-cache.ts",
     "rubyName": "uncached",
     "call": "configurations",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "query-cache.ts",
-    "rubyName": "uncached",
-    "call": "connected?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Bucket (b): Rails' `configurations.empty?` is a call on the `Base.configurations` class_attribute reader; trails stores it as a plain static property, so `configurationsEmpty(this)` reads it — there is no `configurations()` call to match. Converges when the Core.configurations accessor (core.ts:432, currently unwired) becomes the real read path."
   }
 ]


### PR DESCRIPTION
Burns down the #5334 include-resolution fallout for the two modules mixed into
`ActiveRecord::Base` — `QueryCache::ClassMethods` and
`Encryption::EncryptableRecord`.

## Query cache

`vendor/rails/activerecord/lib/active_record/query_cache.rb:9-33` is:

```ruby
def cache(&block)
  if connected? || !configurations.empty?
    pool = connection_pool
    was_enabled = pool.query_cache_enabled
    begin
      pool.enable_query_cache(&block)
    ensure
      pool.clear_query_cache unless was_enabled
    end
  else
    yield
  end
end
```

Note the story's premise ("Rails walks `configurations` and only toggles the
cache on pools that are `connected?`, so an idle pool can be forced open") does
not hold: `connected?`/`configurations` here are a single
is-Active-Record-configured-at-all guard on the receiver's own pool — there is
no multi-pool walk and no idle-pool hazard, so the acceptance criterion asking
for an idle-pool regression test has no behaviour to pin. trails already had
the guard; what diverged was the body underneath it:

- the `was_enabled` bookkeeping lived behind `QueryCache.cache` /
  `QueryCache.uncached` — trails-invented statics that Rails' `QueryCache`
  class does not have. Inlined into `ClassMethods`, statics deleted.
- `connected?` was read through `isConnectedQ`; now through the Rails-named
  `isConnected` alias.

## Encryption

The instance API had two ports: `encryption.ts`
(`encryptRecord` / `decryptRecord` / `encryptedAttributeQ`) and the
Rails-layout `EncryptableRecord` statics, which already mirror
`encryptable_record.rb` (`encrypt_attributes if has_encrypted_attributes?`).
The duplicates are deleted and the `EncryptableRecord` bodies registered into
the hook registry under the Rails names, so `base.ts`'s one-line facades
forward transparently. `EncryptableRecord.isEncryptedAttribute` is renamed to
`encryptedAttribute` (the Rails name for `encrypted_attribute?`) and its body
now reads through `encryptedAttributes()` and `typeForAttribute` as Rails does.

## Result

`call-mismatches-wide-exclude` drops 17 entries (4955 → 4938): all 12
encryption entries and 5 of the query-cache ones. The two `configurations`
entries survive with a precise bucket-(b) reason — Rails calls the
`Base.configurations` class_attribute reader, trails stores it as a plain
static property, so there is no `configurations()` call to match. Converging
that means routing every reader/writer through the (currently unwired)
`Core.configurations` accessor, registered as its own story
(`converge-base-configurations-onto-the-rails-accessor`).

Behaviour is unchanged throughout — both halves are same-semantics
restructurings onto the Rails bodies, so there is no baseline for a regression
test to fail on. Existing Rails-named coverage
(`query_cache_test.rb` → `query-cache.test.ts`, including
"cache is available when using a not connected connection", and the
`encryptable_record_test.rb` suites) exercises every touched path and passes.

Closes-story: converge-base-query-cache-and-encryption-facade-bodies
