### PR TITLE
refactor(activerecord): converge inheritance column reader onto ported nullable

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -59,7 +59,7 @@ import {
 } from "./errors.js";
 import { routeThroughCheckValidity } from "./validate-through-reflection.js";
 import { rebaseNewOwnerSeed } from "./new-owner-seed-rebase.js";
-import { getInheritanceColumn, findStiClass, stiEnabled, polymorphicName } from "../inheritance.js";
+import { findStiClass, stiEnabled, polymorphicName } from "../inheritance.js";
 import { compositeQueryConstraintsList } from "../persistence.js";
 import type { AssociationDefinition } from "../associations.js";
 import {
@@ -1260,8 +1260,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // the subclass after scope-merge, so peek at scope here before
     // instantiation; the full scope_for_create filter still runs below.
     const sfcForSti = this._scopeForCreateRaw();
-    const inheritanceCol = getInheritanceColumn(targetModel);
-    if (stiEnabled(targetModel)) {
+    const inheritanceCol = targetModel.inheritanceColumn;
+    if (inheritanceCol !== null && stiEnabled(targetModel)) {
       const typeName = (buildAttrs[inheritanceCol] ?? sfcForSti[inheritanceCol]) as
         | string
         | undefined;
@@ -1280,8 +1280,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     let targetModel = this.model;
 
     const sfcForSti = this._scopeForCreateRaw();
-    const inheritanceCol = getInheritanceColumn(targetModel);
-    if (stiEnabled(targetModel)) {
+    const inheritanceCol = targetModel.inheritanceColumn;
+    if (inheritanceCol !== null && stiEnabled(targetModel)) {
       const typeName = (attrs[inheritanceCol] ?? sfcForSti[inheritanceCol]) as string | undefined;
       if (typeName) targetModel = findStiClass(targetModel, typeName);
     }

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -20,7 +20,7 @@ import {
 import { Table, Nodes, tableSqlName, type TableRef } from "@blazetrails/arel";
 import { modelRegistry, isAssociationCached } from "../associations.js";
 import { _reflectOnAssociation } from "../reflection.js";
-import { getInheritanceColumn, isStiSubclass } from "../inheritance.js";
+import { isStiSubclass } from "../inheritance.js";
 import { JoinBase } from "./join-dependency/join-base.js";
 import { JoinAssociation } from "./join-dependency/join-association.js";
 import { JoinPart } from "./join-dependency/join-part.js";
@@ -1170,7 +1170,7 @@ export class JoinDependency {
     model: typeof Base,
     arelTable: TableRef,
   ): Nodes.Node {
-    const inheritanceCol = getInheritanceColumn(model);
+    const inheritanceCol = model.inheritanceColumn;
     if (inheritanceCol && isStiSubclass(model)) {
       const stiNames = [model.name, ...((model as any).descendants ?? []).map((d: any) => d.name)];
       const quotedNames = stiNames.map((n: string) => new Nodes.Quoted(n));

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -40,8 +40,6 @@ import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/a
 import type { ExplainOption } from "./connection-adapters/abstract/database-statements.js";
 import type { Relation } from "./relation.js";
 import {
-  getInheritanceColumn,
-  inheritanceColumnDisabled,
   getStiBase,
   instantiateSti,
   stiName,
@@ -2232,8 +2230,8 @@ export class Base extends Model {
     // `inheritanceColumn` assignment — so any non-abstract subclass over a
     // `type`-bearing table scopes
     // by type. The column resolves on the subclass itself (default "type").
-    if (isFinderNeedsTypeCondition(this)) {
-      const col = getInheritanceColumn(this);
+    const col = this.inheritanceColumn;
+    if (col !== null && isFinderNeedsTypeCondition(this)) {
       // Rails: `([self] + descendants).map(&:sti_name)` (inheritance.rb#type_condition)
       // — `sti_name` honors `store_full_sti_class` / overrides, not the bare class name.
       const stiNames = [stiName(this), ...this.descendants.map((d: typeof Base) => stiName(d))];
@@ -2946,18 +2944,14 @@ export class Base extends Model {
   ): InstanceType<T> {
     // Delegate to the correct STI subclass when the row carries a present
     // inheritance-column value that names a different class. `inheritance_column`
-    // always resolves to a name now (default "type"); a present `row[inheritanceCol]`
+    // resolves to a name (default "type") unless STI is disabled; a present `row[inheritanceCol]`
     // key proves the column is a real attribute (Rails' `_has_attribute?`), so no
     // `stiEnabled` short-circuit is needed — instantiateSti resolves within the
     // base's own tracked subtree and is a no-op for plain models with a stray
     // `type` column.
     const stiBase = getStiBase(this);
-    const inheritanceCol = getInheritanceColumn(stiBase);
-    if (
-      !inheritanceColumnDisabled(stiBase) &&
-      row[inheritanceCol] &&
-      row[inheritanceCol] !== this.name
-    ) {
+    const inheritanceCol = stiBase.inheritanceColumn;
+    if (inheritanceCol !== null && row[inheritanceCol] && row[inheritanceCol] !== this.name) {
       return instantiateSti(
         stiBase,
         row,

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2230,8 +2230,9 @@ export class Base extends Model {
     // `inheritanceColumn` assignment — so any non-abstract subclass over a
     // `type`-bearing table scopes
     // by type. The column resolves on the subclass itself (default "type").
-    const col = this.inheritanceColumn;
-    if (col !== null && isFinderNeedsTypeCondition(this)) {
+    if (isFinderNeedsTypeCondition(this)) {
+      const col = this.inheritanceColumn;
+      if (col === null) return rel;
       // Rails: `([self] + descendants).map(&:sti_name)` (inheritance.rb#type_condition)
       // — `sti_name` honors `store_full_sti_class` / overrides, not the bare class name.
       const stiNames = [stiName(this), ...this.descendants.map((d: typeof Base) => stiName(d))];

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -137,12 +137,7 @@ export {
 } from "./ar-config.js";
 export { defineEnum, readEnumValue, castEnumValue } from "./enum.js";
 export type { EnumMacroOptions } from "./enum.js";
-export {
-  getInheritanceColumn,
-  instantiateSti,
-  registerSubclass,
-  findStiClass,
-} from "./inheritance.js";
+export { instantiateSti, registerSubclass, findStiClass } from "./inheritance.js";
 // hasSecurePassword requires node:crypto — use subpath: @blazetrails/activerecord/secure-password
 // CounterCache, ReadonlyAttributes, Timestamp, Locking::Pessimistic, and
 // Translation are consumed via the Base mixins — class methods like

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -163,10 +163,8 @@ function descendsFromActiveRecordByHierarchy(modelClass: typeof Base): boolean {
  */
 export function isDescendsFromActiveRecord(modelClass: typeof Base): boolean {
   if (descendsFromActiveRecordByHierarchy(modelClass)) return true;
-  return (
-    inheritanceColumnDisabled(modelClass) ||
-    !classHasAttribute(modelClass, getInheritanceColumn(modelClass))
-  );
+  const inheritCol = modelClass.inheritanceColumn;
+  return inheritCol === null || !classHasAttribute(modelClass, inheritCol);
 }
 
 /**
@@ -380,19 +378,6 @@ export function registerSubclass(klass: typeof Base): void {
 }
 
 /**
- * Get the inheritance column for a model.
- *
- * Mirrors Rails, where `inheritance_column` defaults to `"type"` for every
- * model (`class_attribute :inheritance_column, default: "type"`) regardless of
- * whether the model actually participates in STI. The column merely names where
- * STI *would* read/write the type; whether dispatch happens is gated separately
- * on `_has_attribute?(inheritance_column)` — see {@link classHasAttribute}.
- */
-export function getInheritanceColumn(modelClass: typeof Base): string {
-  return (modelClass as any)._inheritanceColumn ?? "type";
-}
-
-/**
  * Class-level column-aware `_has_attribute?`.
  *
  * Rails' `_has_attribute?(name)` is `attribute_types.key?(name)`, true for any
@@ -417,27 +402,11 @@ export function classHasAttribute(modelClass: typeof Base, name: string): boolea
 }
 
 /**
- * True when STI is explicitly disabled for this model — Rails'
- * `self.inheritance_column = nil`. trails stores an explicit `null` in
- * `_inheritanceColumn` (distinct from the `undefined` "unset" state, which still
- * defaults to "type"). A disabled model never dispatches STI even when its table
- * carries a real `type` column used for non-inheritance data, so every dispatch
- * gate short-circuits on this. {@link getInheritanceColumn} still resolves to the
- * column *name* "type" — disabling is about *whether* dispatch happens, not where
- * the column lives.
- *
- * @internal
- */
-export function inheritanceColumnDisabled(modelClass: object): boolean {
-  return (modelClass as any)._inheritanceColumn === null;
-}
-
-/**
  * True when STI was explicitly enabled on this class or an ancestor (the
- * inherited `_inheritanceColumn` sentinel). Distinct from {@link getInheritanceColumn},
- * which now always resolves to a name (default "type"): the column merely names
- * where STI *would* read the type; this reports whether the model actually
- * participates in STI.
+ * inherited `_inheritanceColumn` sentinel). Distinct from `inheritanceColumn`,
+ * which resolves to a name (default "type") for any model that hasn't disabled
+ * STI: the column merely names where STI *would* read the type; this reports
+ * whether the model actually participates in STI.
  *
  * Used to gate the database-row dispatch paths (instantiate, association build),
  * which resolve through the ambiguous global registry and so must stay scoped to
@@ -798,7 +767,7 @@ export function isFinderNeedsTypeCondition(modelClass: typeof Base): boolean {
   // `descends` is true. Memoize only the stable reasons (a hierarchy root, or STI
   // explicitly disabled); a non-root model that descends only because its `type`
   // column hasn't reflected yet must recompute once schema warms.
-  if (descendsFromActiveRecordByHierarchy(modelClass) || inheritanceColumnDisabled(modelClass)) {
+  if (descendsFromActiveRecordByHierarchy(modelClass) || modelClass.inheritanceColumn === null) {
     (modelClass as any)._finderNeedsTypeCondition = false;
   }
   return false;
@@ -885,7 +854,7 @@ export function stiClassFor(modelClass: typeof Base, typeName: string): typeof B
     if (!(cause instanceof NameError)) throw cause;
     throw new SubclassNotFound(
       `The single-table inheritance mechanism failed to locate the subclass: '${typeName}'. ` +
-        `This error is raised because the column '${getInheritanceColumn(modelClass)}' is reserved for storing the class in case of inheritance.`,
+        `This error is raised because the column '${modelClass.inheritanceColumn}' is reserved for storing the class in case of inheritance.`,
       { cause },
     );
   }
@@ -939,9 +908,9 @@ export function initializeInternalsCallback(this: Base): void {
  */
 export function ensureProperType(this: Base): void {
   const klass = this.constructor as typeof Base;
-  if (inheritanceColumnDisabled(klass)) return;
+  const inheritCol = klass.inheritanceColumn;
+  if (inheritCol === null) return;
   if (!isFinderNeedsTypeCondition(klass)) return;
-  const inheritCol = getInheritanceColumn(klass);
   // Only write when the column is a declared attribute — otherwise the value
   // wouldn't persist or serialize correctly. Mirrors usingSingleTableInheritance.
   if (!(klass as any)._attributeDefinitions?.has(inheritCol)) return;
@@ -960,8 +929,8 @@ export function discriminateClassForRecord(
   modelClass: typeof Base,
   record: Record<string, unknown>,
 ): typeof Base {
-  if (usingSingleTableInheritance(modelClass, record)) {
-    const inheritCol = getInheritanceColumn(modelClass);
+  const inheritCol = modelClass.inheritanceColumn;
+  if (inheritCol !== null && usingSingleTableInheritance(modelClass, record)) {
     // Rails: subclass = base_class.type_for_attribute(inheritCol).cast(record[inheritCol])
     const castValue = castInheritanceColumnValue(modelClass, inheritCol, record[inheritCol]);
     // A present-but-unmapped enum value casts to null; Rails keeps such values
@@ -990,8 +959,8 @@ function usingSingleTableInheritance(
   // itself in {@link findStiClassForRow} because its subtree tracks no subclass
   // and STI was never explicitly enabled, so dispatch is a no-op there.
   // `inheritance_column = nil` opts out entirely, even with a real `type` column.
-  if (inheritanceColumnDisabled(modelClass)) return false;
-  const inheritCol = getInheritanceColumn(modelClass);
+  const inheritCol = modelClass.inheritanceColumn;
+  if (inheritCol === null) return false;
   if (!isPresent(record[inheritCol])) return false;
   return stiColumnIsAttribute(modelClass, inheritCol, record);
 }
@@ -1031,7 +1000,12 @@ function stiColumnIsAttribute(
  * @internal Private method, used internally for STI type filtering in queries.
  */
 export function typeCondition(modelClass: typeof Base, arelTable?: any): any {
-  const inheritCol = getInheritanceColumn(modelClass);
+  const inheritCol = modelClass.inheritanceColumn;
+  // Unreachable with STI disabled: finderNeedsTypeCondition? is false there, and
+  // every caller gates on it.
+  if (inheritCol === null) {
+    throw new ActiveRecordError("Cannot build type condition without an inheritance column");
+  }
   const table = arelTable || (modelClass as any).arelTable;
   if (!table) throw new ActiveRecordError("Cannot build type condition without arel table");
 
@@ -1075,8 +1049,8 @@ export function subclassFromAttributes(
   if (!attrsHash || typeof attrsHash !== "object") return null;
 
   // `inheritance_column = nil` disables STI even when a real `type` column exists.
-  if (inheritanceColumnDisabled(modelClass)) return null;
-  const inheritCol = getInheritanceColumn(modelClass);
+  const inheritCol = modelClass.inheritanceColumn;
+  if (inheritCol === null) return null;
   // Rails gates STI dispatch on `_has_attribute?(inheritance_column)` — only
   // models that actually carry the column dispatch.
   if (!classHasAttribute(modelClass, inheritCol)) return null;
@@ -1240,8 +1214,8 @@ export function subclassFromAttributesForNew(
   // dispatch (it has no in-subtree match), so short-circuit the source probing —
   // including the non-memoized columnDefaults build — on the hot path.
   // `inheritance_column = nil` disables STI even when a real `type` column exists.
-  if (inheritanceColumnDisabled(modelClass)) return null;
-  const col = getInheritanceColumn(modelClass);
+  const col = modelClass.inheritanceColumn;
+  if (col === null) return null;
   if (!classHasAttribute(modelClass, col) && descendants(modelClass).length === 0) return null;
 
   const resolve = (source: unknown, fromScope = false): typeof Base | null => {

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -908,9 +908,9 @@ export function initializeInternalsCallback(this: Base): void {
  */
 export function ensureProperType(this: Base): void {
   const klass = this.constructor as typeof Base;
+  if (!isFinderNeedsTypeCondition(klass)) return;
   const inheritCol = klass.inheritanceColumn;
   if (inheritCol === null) return;
-  if (!isFinderNeedsTypeCondition(klass)) return;
   // Only write when the column is a declared attribute — otherwise the value
   // wouldn't persist or serialize correctly. Mirrors usingSingleTableInheritance.
   if (!(klass as any)._attributeDefinitions?.has(inheritCol)) return;
@@ -929,8 +929,9 @@ export function discriminateClassForRecord(
   modelClass: typeof Base,
   record: Record<string, unknown>,
 ): typeof Base {
-  const inheritCol = modelClass.inheritanceColumn;
-  if (inheritCol !== null && usingSingleTableInheritance(modelClass, record)) {
+  if (usingSingleTableInheritance(modelClass, record)) {
+    const inheritCol = modelClass.inheritanceColumn;
+    if (inheritCol === null) return modelClass;
     // Rails: subclass = base_class.type_for_attribute(inheritCol).cast(record[inheritCol])
     const castValue = castInheritanceColumnValue(modelClass, inheritCol, record[inheritCol]);
     // A present-but-unmapped enum value casts to null; Rails keeps such values
@@ -1001,8 +1002,6 @@ function stiColumnIsAttribute(
  */
 export function typeCondition(modelClass: typeof Base, arelTable?: any): any {
   const inheritCol = modelClass.inheritanceColumn;
-  // Unreachable with STI disabled: finderNeedsTypeCondition? is false there, and
-  // every caller gates on it.
   if (inheritCol === null) {
     throw new ActiveRecordError("Cannot build type condition without an inheritance column");
   }

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -35,7 +35,6 @@ import { assignAssociationIfMatch } from "./attribute-assignment.js";
 import { threadedConnectionFor } from "./connection-handling.js";
 import {
   getStiBase,
-  getInheritanceColumn,
   isStiSubclass,
   isDescendsFromActiveRecord,
   stiName,
@@ -902,7 +901,7 @@ export async function save<T extends SaveRecord>(
 
       // Auto-set STI type column on new records
       if (this._newRecord && isStiSubclass(ctor)) {
-        const col = getInheritanceColumn(getStiBase(ctor));
+        const col = getStiBase(ctor).inheritanceColumn;
         if (col && !this._readAttribute(col)) {
           this._attributes.set(col, this.constructor.name);
         }
@@ -1721,7 +1720,7 @@ export function becomesBang<
 >(this: T, klass: K): InstanceType<K> {
   const instance = this.becomes(klass);
   const base = getStiBase(klass);
-  const inheritanceCol = getInheritanceColumn(base);
+  const inheritanceCol = base.inheritanceColumn;
   if (inheritanceCol) {
     // Mirrors Rails: `became.public_send("#{inheritance_column}=", sti_type)` —
     // route through the public writer so the change is dirty-tracked and a

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -36,7 +36,7 @@ import {
   _cacheSingularTarget,
 } from "./associations.js";
 import { applyThenable, stripThenable } from "./relation/thenable.js";
-import { getInheritanceColumn, isStiSubclass } from "./inheritance.js";
+import { isStiSubclass } from "./inheritance.js";
 import { isBaseInstance } from "./relation/predicate-builder/is-base-instance.js";
 import { QueryAttribute } from "./relation/query-attribute.js";
 import {
@@ -748,7 +748,7 @@ export class Relation<T extends Base> {
       const typeCol = `${_toUnderscore(assocDef.options.as)}_type`;
       typeNodes.push(tgtTable.get(typeCol).eq(modelClass.name));
     }
-    const inheritanceCol = getInheritanceColumn(targetModel);
+    const inheritanceCol = targetModel.inheritanceColumn;
     if (inheritanceCol && isStiSubclass(targetModel)) {
       const stiNames = [
         targetModel.name,
@@ -782,7 +782,7 @@ export class Relation<T extends Base> {
     } else {
       onClause = `"${targetTable}"."${foreignKey}" = "${sourceTable}"."${pk}"`;
     }
-    const inheritanceCol = getInheritanceColumn(targetModel);
+    const inheritanceCol = targetModel.inheritanceColumn;
     if (inheritanceCol && isStiSubclass(targetModel)) {
       const stiNames = [
         targetModel.name,
@@ -1776,7 +1776,7 @@ export class Relation<T extends Base> {
       const predicates: Nodes.Node[] = pkArr.map((pk, i) => tgt.get(pk).eq(src.get(fkArr[i])));
 
       // STI type condition on target
-      const inheritanceCol = getInheritanceColumn(targetModel);
+      const inheritanceCol = targetModel.inheritanceColumn;
       if (inheritanceCol && isStiSubclass(targetModel)) {
         const stiNames = [
           targetModel.name,
@@ -1821,7 +1821,7 @@ export class Relation<T extends Base> {
       }
 
       // STI type condition on target
-      const inheritanceCol = getInheritanceColumn(targetModel);
+      const inheritanceCol = targetModel.inheritanceColumn;
       if (inheritanceCol && isStiSubclass(targetModel)) {
         const stiNames = [
           targetModel.name,

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/inheritance.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/inheritance.json
@@ -37,29 +37,8 @@
   {
     "package": "activerecord",
     "tsFile": "inheritance.ts",
-    "rubyName": "descends_from_active_record?",
-    "call": "inheritance_column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
     "rubyName": "discriminate_class_for_record",
     "call": "find_sti_class",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
-    "rubyName": "discriminate_class_for_record",
-    "call": "inheritance_column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
-    "rubyName": "ensure_proper_type",
-    "call": "inheritance_column",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -116,27 +95,6 @@
     "tsFile": "inheritance.ts",
     "rubyName": "sti_class_for",
     "call": "compute_type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
-    "rubyName": "sti_class_for",
-    "call": "inheritance_column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
-    "rubyName": "subclass_from_attributes",
-    "call": "inheritance_column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
-    "rubyName": "type_condition",
-    "call": "inheritance_column",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/persistence.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/persistence.json
@@ -72,13 +72,6 @@
   {
     "package": "activerecord",
     "tsFile": "persistence.ts",
-    "rubyName": "becomes!",
-    "call": "inheritance_column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
     "rubyName": "create",
     "call": "collect",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
trails carried **two** readers for Rails' `inheritance_column` class_attribute:

- `ModelSchema.inheritanceColumn` (exposed as the Rails-named
  `Base.inheritanceColumn` getter/setter) — faithful, returns `null` when STI is
  explicitly disabled (`self.inheritance_column = nil`), else `"type"`.
- `getInheritanceColumn` (`inheritance.ts`) — flattened `null` to `"type"`, so a
  model with STI explicitly disabled still reported `"type"`.

Because of that flattening trails needed a second, Rails-less predicate,
`inheritanceColumnDisabled`, purely to recover the information the reader threw
away. Rails has no such predicate — callers test `inheritance_column` for nil
directly.

This routes all 27 references to the ported nullable reader, handling the `null`
arm at each call site, and deletes both `getInheritanceColumn` and
`inheritanceColumnDisabled`. Most sites already gated on truthiness of the
column and needed no change beyond the reader swap; `base.ts:_instantiate` and
the `inheritance.ts` dispatch gates collapse their paired
`inheritanceColumnDisabled` check into a single `=== null` test.

`typeCondition` is the one site with no natural null arm — it is unreachable
with STI disabled (`finderNeedsTypeCondition?` is false there and every caller
gates on it), so it throws `ActiveRecordError` rather than silently defaulting.

No `extra-surface-allow.json` entries existed for either name, so nothing to
remove there. `pnpm api:extra --package activerecord` novel count for
`inheritance.ts` is unchanged (deletions only).

Tests: inheritance, inheritance-namespaced, sti-attribute-routing, modules,
base, base.trails, relation, persistence, attributes, collection-proxy, and the
model-schema suites all pass.

Closes-story: converge-inheritance-column-reader-onto-ported-nullable
