### PR TITLE
refactor(inheritance): converge instantiateSti into the ported _instantiate

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -40,8 +40,7 @@ import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/a
 import type { ExplainOption } from "./connection-adapters/abstract/database-statements.js";
 import type { Relation } from "./relation.js";
 import {
-  getStiBase,
-  instantiateSti,
+  discriminateClassForRecord,
   stiName,
   polymorphicName as inheritancePolymorphicName,
   computeType as inheritanceComputeType,
@@ -2942,18 +2941,15 @@ export class Base extends Model {
     columnTypes?: Record<string, { deserialize(value: unknown): unknown }>,
     overrideTypes?: Record<string, { deserialize(value: unknown): unknown }>,
   ): InstanceType<T> {
-    // Delegate to the correct STI subclass when the row carries a present
-    // inheritance-column value that names a different class. `inheritance_column`
-    // resolves to a name (default "type") unless STI is disabled; a present `row[inheritanceCol]`
-    // key proves the column is a real attribute (Rails' `_has_attribute?`), so no
-    // `stiEnabled` short-circuit is needed — instantiateSti resolves within the
-    // base's own tracked subtree and is a no-op for plain models with a stray
-    // `type` column.
-    const stiBase = getStiBase(this);
-    const inheritanceCol = stiBase.inheritanceColumn;
-    if (inheritanceCol !== null && row[inheritanceCol] && row[inheritanceCol] !== this.name) {
-      return instantiateSti(
-        stiBase,
+    // Guard on class identity, not on `row[type] !== this.name`: the stored value
+    // is `sti_name`, which for a `store_full_sti_class` namespaced model
+    // ("ClothingItem::Used") never equals the flattened JS class name
+    // (`ClothingItemUsed`). Re-entry terminates because the resolution is
+    // idempotent. Receiver is `this`, as in Rails, not `base_class` — a projected
+    // row that omits the inheritance column must stay on the receiver.
+    const klass = discriminateClassForRecord(this, row);
+    if (klass !== this) {
+      return klass._instantiate(
         row,
         block as ((record: Base) => void) | undefined,
         columnTypes,

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -135,7 +135,7 @@ export {
 } from "./ar-config.js";
 export { defineEnum, readEnumValue, castEnumValue } from "./enum.js";
 export type { EnumMacroOptions } from "./enum.js";
-export { instantiateSti, registerSubclass, findStiClass } from "./inheritance.js";
+export { registerSubclass, findStiClass } from "./inheritance.js";
 // hasSecurePassword requires node:crypto — use subpath: @blazetrails/activerecord/secure-password
 // CounterCache, ReadonlyAttributes, Timestamp, Locking::Pessimistic, and
 // Translation are consumed via the Base mixins — class methods like

--- a/packages/activerecord/src/inheritance-namespaced.test.ts
+++ b/packages/activerecord/src/inheritance-namespaced.test.ts
@@ -87,7 +87,7 @@ describe("NamingTest (Admin::User model_name)", () => {
 // A name guard (`row[type] !== this.name`) mis-fires for every namespaced STI
 // row, because `sti_name` never equals the flattened JS class name. That was
 // latent while a second hydration path absorbed it; with one path the identity
-// guard is what makes re-entry terminate, so both halves are pinned here.
+// guard is the only thing making re-entry terminate here.
 describe("namespaced STI hydration goes through the single instantiate path", () => {
   fixtures([]);
 
@@ -102,14 +102,5 @@ describe("namespaced STI hydration goes through the single instantiate path", ()
 
     expect(record).toBeInstanceOf(ClothingItemSized);
     expect(record.id).toBe(5);
-  });
-
-  it("keeps a projected row without the inheritance column on the receiver", () => {
-    // `discriminateClassForRecord` runs against `this`, as in Rails, not
-    // `base_class` — otherwise a SELECT that omits `type` would demote the
-    // subclass receiver to the STI base.
-    const record = ClothingItemUsed._instantiate({ id: "7", clothing_type: "pants" });
-
-    expect(record).toBeInstanceOf(ClothingItemUsed);
   });
 });

--- a/packages/activerecord/src/inheritance-namespaced.test.ts
+++ b/packages/activerecord/src/inheritance-namespaced.test.ts
@@ -83,3 +83,33 @@ describe("NamingTest (Admin::User model_name)", () => {
     expect(AdminUser.modelName.paramKey).toBe("user");
   });
 });
+
+// A name guard (`row[type] !== this.name`) mis-fires for every namespaced STI
+// row, because `sti_name` never equals the flattened JS class name. That was
+// latent while a second hydration path absorbed it; with one path the identity
+// guard is what makes re-entry terminate, so both halves are pinned here.
+describe("namespaced STI hydration goes through the single instantiate path", () => {
+  fixtures([]);
+
+  it("terminates on the namespaced subclass instead of re-dispatching", () => {
+    const record = ClothingItemSized._instantiate({
+      id: "5",
+      clothing_type: "pants",
+      color: "blue",
+      size: "M",
+      type: "ClothingItem::Sized",
+    });
+
+    expect(record).toBeInstanceOf(ClothingItemSized);
+    expect(record.id).toBe(5);
+  });
+
+  it("keeps a projected row without the inheritance column on the receiver", () => {
+    // `discriminateClassForRecord` runs against `this`, as in Rails, not
+    // `base_class` — otherwise a SELECT that omits `type` would demote the
+    // subclass receiver to the STI base.
+    const record = ClothingItemUsed._instantiate({ id: "7", clothing_type: "pants" });
+
+    expect(record).toBeInstanceOf(ClothingItemUsed);
+  });
+});

--- a/packages/activerecord/src/inheritance.trails.test.ts
+++ b/packages/activerecord/src/inheritance.trails.test.ts
@@ -1,0 +1,22 @@
+/**
+ * trails-only invariants for the single STI hydration path in
+ * `Base._instantiate`. See inheritance.test.ts for the Rails-mirrored suite.
+ */
+import { describe, it, expect } from "vitest";
+import { fixtures } from "./test-helpers/fixtures.js";
+import { Client } from "./test-helpers/models/company.js";
+
+describe("_instantiate STI dispatch", () => {
+  fixtures([]);
+
+  // `discriminateClassForRecord` runs against `this`, as in Rails, not
+  // `base_class`. Discriminating from the base resolves a row with no
+  // inheritance column back to the base, which under the class-identity guard
+  // would demote the receiver: `Client.select("id")` would hydrate `Company`
+  // instances.
+  it("keeps a row without the inheritance column on the receiver subclass", () => {
+    const record = Client._instantiate({ id: "7", name: "Acme" });
+
+    expect(record).toBeInstanceOf(Client);
+  });
+});

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -8,7 +8,7 @@ import type { Base } from "./base.js";
 import { modelRegistry } from "./associations.js";
 import { ActiveRecordError, NameError, SubclassNotFound } from "./errors.js";
 import { camelize, isPresent, underscore } from "@blazetrails/activesupport";
-import { ArgumentError, runAfterCallbacksOnProto } from "@blazetrails/activemodel";
+import { ArgumentError } from "@blazetrails/activemodel";
 import { applicationRecordClass, setApplicationRecordClass } from "./ar-config.js";
 
 /**
@@ -524,7 +524,7 @@ export function findStiClass(baseClass: typeof Base, typeName: string): typeof B
  * regardless of STI, matching the net result of Rails'
  * `instantiate_instance_of`. (Rails narrows in `build_from_database` before
  * `discriminate_class_for_record`; trails resolves the STI subclass first in
- * `instantiateSti` and narrows here per concrete class — same end state.)
+ * `_instantiate` and narrows here per concrete class — same end state.)
  *
  * `column_names` is the right narrowing set here: in trails every declared
  * attribute is a real DB column (an `attribute()` with no backing column fails
@@ -656,93 +656,6 @@ export function defineDynamicSelectReaders(record: Base): void {
       writable: false,
     });
   }
-}
-
-/**
- * Directly instantiate a record without STI delegation (avoids recursion).
- */
-function directInstantiate(
-  klass: typeof Base,
-  row: Record<string, unknown>,
-  block?: (record: Base) => void,
-  columnTypes?: Record<string, { deserialize(value: unknown): unknown }>,
-  overrideTypes?: Record<string, { deserialize(value: unknown): unknown }>,
-): Base {
-  const hadOwnSuppress = Object.prototype.hasOwnProperty.call(klass, "_suppressInitializeCallback");
-  const prevSuppress = klass._suppressInitializeCallback;
-  klass._suppressInitializeCallback = true;
-  const hadOwnAbstractSuppress = Object.prototype.hasOwnProperty.call(
-    klass,
-    "_suppressAbstractCheck",
-  );
-  const prevAbstractSuppress = (klass as any)._suppressAbstractCheck;
-  (klass as any)._suppressAbstractCheck = true;
-  let record: Base;
-  try {
-    record = new klass();
-  } finally {
-    if (hadOwnSuppress) {
-      klass._suppressInitializeCallback = prevSuppress;
-    } else {
-      delete (klass as any)._suppressInitializeCallback;
-    }
-    if (hadOwnAbstractSuppress) {
-      (klass as any)._suppressAbstractCheck = prevAbstractSuppress;
-    } else {
-      delete (klass as any)._suppressAbstractCheck;
-    }
-  }
-  // Load DB values through deserialize (not the user cast) so encrypted types
-  // decrypt and raw DB representations (e.g. an enum's integer `0`) are accepted
-  // — mirrors the non-STI Base._instantiate path. Building via `new klass(row)`
-  // instead ran every column through the user cast, which rejects raw DB values.
-  for (const [key, value] of Object.entries(row)) {
-    const override = overrideTypes?.[key];
-    if (override) {
-      record._attributes.overrideFromDatabase(key, value, override);
-    } else {
-      record._attributes.writeFromDatabase(key, value, columnTypes?.[key]);
-    }
-  }
-  narrowToProjectedColumns(klass, record, row, overrideTypes);
-  defineDynamicSelectReaders(record);
-  record._newRecord = false;
-  (record as any)._dirty.snapshot(record._attributes);
-  record.changesApplied();
-  if ((klass as any)._strictLoadingByDefault) {
-    (record as any)._strictLoading = true;
-  }
-  // Rails' init_with_attributes yields to the loader block (inverse wiring)
-  // before firing after_find then after_initialize.
-  block?.(record);
-  // strict:"sync" guarantees synchronous completion — void the settled result.
-  void runAfterCallbacksOnProto((klass as any).prototype, "find", record, { strict: "sync" });
-  void runAfterCallbacksOnProto((klass as any).prototype, "initialize", record, { strict: "sync" });
-  return record;
-}
-
-/**
- * Instantiate the correct STI subclass from a database row.
- *
- * Mirrors Rails' single STI dispatch path: `instantiate` →
- * `discriminate_class_for_record` → `find_sti_class`. The class decision lives
- * entirely in {@link discriminateClassForRecord}; this wrapper only constructs
- * the resolved class.
- */
-export function instantiateSti(
-  baseClass: typeof Base,
-  row: Record<string, unknown>,
-  block?: (record: Base) => void,
-  columnTypes?: Record<string, { deserialize(value: unknown): unknown }>,
-  overrideTypes?: Record<string, { deserialize(value: unknown): unknown }>,
-): Base {
-  return directInstantiate(
-    discriminateClassForRecord(baseClass, row),
-    row,
-    block,
-    columnTypes,
-    overrideTypes,
-  );
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -845,8 +845,16 @@ export function discriminateClassForRecord(
   if (usingSingleTableInheritance(modelClass, record)) {
     const inheritCol = modelClass.inheritanceColumn;
     if (inheritCol === null) return modelClass;
-    // Rails: subclass = base_class.type_for_attribute(inheritCol).cast(record[inheritCol])
-    const castValue = castInheritanceColumnValue(modelClass, inheritCol, record[inheritCol]);
+    // Rails casts through `base_class`, not the receiver (find_sti_class,
+    // inheritance.rb:312), so a subclass that overrides the inheritance column's
+    // attribute type still resolves against the hierarchy's own type. Only the
+    // subclass lookup and its `subclass == self || descendants.include?` check
+    // stay on the receiver.
+    const castValue = castInheritanceColumnValue(
+      baseClass.call(modelClass),
+      inheritCol,
+      record[inheritCol],
+    );
     // A present-but-unmapped enum value casts to null; Rails keeps such values
     // (EnumType#cast's `value.presence` fallback) so find_sti_class still
     // raises SubclassNotFound rather than masking it as the base class.


### PR DESCRIPTION
## Summary

Rails has exactly one hydration entry point (`persistence.rb:100-103`):
`instantiate` resolves the class via `discriminate_class_for_record`, then
hydrates it. Both helpers are private class methods — STI dispatch lives
*inside* `instantiate`, not beside it.

trails carried a second path: `instantiateSti` wrapping a private
`directInstantiate` ("avoids recursion"). It existed solely because of the
recursion guard in `Base._instantiate`:

```ts
row[inheritanceCol] !== this.name
```

`this.name` is the JS class name; the stored value is `sti_name`. For a
`store_full_sti_class` namespaced model those never match
(`"ClothingItem::Used"` vs `ClothingItemUsed`), so the guard mis-fired on every
namespaced STI row — which is exactly why re-entering `_instantiate` could not
terminate and a duplicate hydration routine was needed.

This replaces it with a class-identity guard against what
`discriminateClassForRecord` resolves and deletes both duplicates. Re-entry
terminates because the resolution is idempotent: resolving from the
already-resolved class returns that same class.

```ts
const klass = discriminateClassForRecord(this, row);
if (klass !== this) {
  return klass._instantiate(row, block, columnTypes, overrideTypes) as InstanceType<T>;
}
```

Net **-59 LOC** across 5 files.

## The discrimination receiver is `this`, not `base_class`

The old code discriminated against `getStiBase(this)`. That was harmless under a
name guard, which *also* required a truthy `row[inheritanceCol]`. Under an
identity guard it is not: a projected row that omits the inheritance column —
`Client.select("id").first()` — resolves back to the STI base and would demote
the receiver from `Client` to `Company`.

Rails calls `discriminate_class_for_record` on `self`, and
`using_single_table_inheritance?` already gates on the column being present, so
the receiver is now `this` — both more faithful and correct. This was caught by
`belongs-to-associations.test.ts` ("missing attribute error is raised when no
foreign key attribute"), not by inspection.

## Review: casting via `base_class` (fixed)

Codex was right, and the same Rails source confirms the receiver decision above.
`find_sti_class` (`inheritance.rb:311-320`) splits the two concerns:

```ruby
def find_sti_class(type_name)
  type_name = base_class.type_for_attribute(inheritance_column).cast(type_name)
  subclass = sti_class_for(type_name)
  unless subclass == self || descendants.include?(subclass)
    raise SubclassNotFound, ...
```

The **cast** goes through `base_class`; the **lookup and its subclass check**
use `self`. trails' comment at that line already cited `base_class` but the code
passed the receiver through. That was inert while `discriminateClassForRecord`
was only ever called on the STI base — my switch to a `this` receiver is what
made it reachable, so it is mine to fix. Now casts via `baseClass.call(modelClass)`
while `findStiClassForRow` keeps the receiver.

I did not add a test for it: the only way to exercise it is a subclass that
overrides the inheritance column's attribute type, which needs a bespoke STI
model, and the repo mandates canonical models/tables only. The justification
lives at the call site per the repo convention instead. Rails has no test for
this either.

## On the regression test

The story asks for a test that fails on baseline "if the identity guard is what
fixes it". It isn't — **the guard bug was latent, not observable**.
`directInstantiate` and the inline body of `_instantiate` were behaviourally
equivalent (the sole difference, a `loadSchema` call, is already covered by
construction), so the mis-fire selected a different path that produced an
identical record. I tried to build a failing-on-baseline case — cold-schema type
casting on a namespaced subclass — and verified against a detached `origin/main`
checkout that **it passes on baseline**. I removed it rather than ship a test
that only looks like a regression test.

Two tests pin the invariants that are newly load-bearing instead:

- `inheritance-namespaced.test.ts` — namespaced STI hydration terminates on the
  resolved subclass rather than re-dispatching. This is what the identity guard
  now carries alone.
- `inheritance.trails.test.ts` (new) — a row without the inheritance column
  stays on the receiver subclass, pinning the `this`-vs-`base_class` choice.

I mutation-tested the second one rather than assuming it worked: reverting the
receiver to `getStiBase(this)` makes it fail. My first attempt at this test used
`ClothingItemUsed` and passed under the mutation — `ClothingItem` never calls
`enableSti`, so `getStiBase` returns the class itself and the test never
exercised the invariant. It now uses `Client`, whose base `Company` is
explicitly STI-enabled.

## Allowlist

There is no `instantiateSti` entry in
`scripts/api-compare/extra-surface-allow.json` and no `@noRailsEquivalent` tag
for it on `origin/main`, so that acceptance criterion is a no-op. Verified by
grep and by running `pnpm api:extra` on both this branch and a detached
`origin/main` — both fail identically on one pre-existing, unrelated stale entry
(`globalid locator.ts lookupClass`).

## Performance note

`discriminateClassForRecord` now runs on every `_instantiate`, where the old
name guard short-circuited on a string compare. When `type` is absent it still
short-circuits cheaply (`isPresent`); when present it does the cast plus a
hierarchy walk. That is precisely the work Rails does per row in `instantiate`,
so this is the faithful cost rather than a regression against the port target.

## Verification

- `api:compare` and `test:compare` totals byte-identical to baseline (both run
  against a detached `origin/main` checkout for comparison).
- Suites named in the story, all passing: `inheritance.test.ts`,
  `inheritance-namespaced.test.ts`, `sti-attribute-routing.test.ts`,
  `model-schema-load.test.ts`, `persistence.test.ts`, plus
  `instantiate-schema-types.test.ts`.
- Full `associations/`, `relation/`, `associations.test.ts`, `base.test.ts`,
  `delegated-type.test.ts`, `finder.test.ts` sweep.
- `pnpm lint` and `tsc --build` clean.

Closes-story: converge-instantiatesti-into-ported-instantiate
