### PR TITLE
perf(api-compare): key the TS extraction cache on the resolved read-set

### DIFF
--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -29,6 +29,8 @@ import {
   normalizeReadSet,
   hashReadSet,
   readSetMatches,
+  resolutionShapeKey,
+  hashParts,
   type ReadSet,
 } from "./shared-cache.js";
 import { extractorSchemaToken } from "./extractor-schema.js";
@@ -191,6 +193,9 @@ export async function main() {
   // packages resolve many of the same declarations, and validating every
   // package's read-set must not read the same file 13 times.
   const inputHashes = new Map<string, Promise<string | null>>();
+  // Read-sets record what WAS resolvable; this covers what BECOMES resolvable
+  // (an unbuilt dependency gaining a `dist`) — see resolutionShapeKey.
+  const shapeKey = await resolutionShapeKey(path.join(ROOT_DIR, "packages"));
 
   // Pass 1: serve every cache hit and record the metadata needed to extract the
   // misses below. `ownRel` is the package's own fingerprint inputs (already
@@ -216,7 +221,7 @@ export async function main() {
     // Anchor relative paths at the package root so tsconfig.json
     // doesn't show up as `../tsconfig.json` (which it would if we
     // anchored at the src dir).
-    const fingerprint = packageFingerprint(fingerprintInputs, pkgRoot);
+    const fingerprint = hashParts([packageFingerprint(fingerprintInputs, pkgRoot), shapeKey]);
     const ownRel = new Set(
       fingerprintInputs.map((file) => path.relative(ROOT_DIR, file).replace(/\\/g, "/")),
     );
@@ -246,7 +251,8 @@ export async function main() {
     // mtime-keyed cache so the next same-worktree run takes the fast path.
     let sharedKey: string | null = null;
     if (sharedDir) {
-      const contentKey = `${SCHEMA_VERSION}-${await contentFingerprint(fingerprintInputs, pkgRoot)}`;
+      const ownContent = await contentFingerprint(fingerprintInputs, pkgRoot);
+      const contentKey = `${SCHEMA_VERSION}-${hashParts([ownContent, shapeKey])}`;
       const body = await readShared(sharedDir, `ts-${pkg}`, contentKey);
       if (body) {
         try {

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -20,23 +20,16 @@ import type {
   ParamInfo,
   LiteralValue,
 } from "./types.js";
-import {
-  ROOT_DIR,
-  OUTPUT_DIR,
-  PACKAGES,
-  PACKAGE_DIR_OVERRIDES,
-  PACKAGE_SRC_SUBDIR,
-  packageSrcDir,
-} from "./config.js";
+import { ROOT_DIR, OUTPUT_DIR, PACKAGES, PACKAGE_DIR_OVERRIDES, packageSrcDir } from "./config.js";
 import {
   sharedCacheDir,
   contentFingerprint,
-  widenKeyWithDeps,
-  dependencyInputFiles,
   readShared,
   writeShared,
-  readWorkspaceGraph,
-  transitiveDeps,
+  normalizeReadSet,
+  hashReadSet,
+  readSetMatches,
+  type ReadSet,
 } from "./shared-cache.js";
 import { extractorSchemaToken } from "./extractor-schema.js";
 
@@ -47,9 +40,11 @@ import { extractorSchemaToken } from "./extractor-schema.js";
 // (SHA-1 over sorted (relPath, mtimeMs, size) triples) plus the
 // extractor SCHEMA_VERSION token (see extractor-schema.ts), which changes
 // whenever a new per-method output field is added so stale entries missing
-// the field are evicted automatically. Both keys are widened with the
-// TRANSITIVE workspace dependencies' fingerprints — a package's extraction
-// resolves imports into sibling packages, so its surface changes when they do.
+// the field are evicted automatically. A package's extraction also resolves
+// imports into sibling packages, which its own fingerprint can't see; each
+// entry therefore records the RESOLVED READ-SET of the extraction that produced
+// it (see shared-cache.ts) and is served only while every recorded input still
+// hashes the same.
 // Set `API_COMPARE_FORCE=1` to skip the cache entirely. The token is computed
 // async (it hashes the extractor
 // sources), so it lives on `main()` rather than as a module const.
@@ -68,6 +63,14 @@ let currentImportAliases: ReadonlyMap<string, string> | undefined;
 interface CacheEntry {
   schemaVersion: string;
   fingerprint: string;
+  /**
+   * Cross-package inputs the compiler actually read during this extraction,
+   * repo-relative → content hash. Files covered by `fingerprint` itself (the
+   * package's own sources) are excluded, so this is exactly the remainder the
+   * own-fingerprint can't see. Absent on a pre-read-set entry, which is then
+   * treated as a miss.
+   */
+  inputs?: ReadSet;
   package: PackageInfo;
 }
 
@@ -109,11 +112,12 @@ interface WorkerInput {
 }
 interface WorkerOutput {
   package: PackageInfo;
+  /** Absolute file names of every source file the program read. */
+  inputs: string[];
 }
 if (!isMainThread && parentPort) {
   const { package: pkgName, srcDir } = workerData as WorkerInput;
-  const data = extractPackage(pkgName, srcDir);
-  const out: WorkerOutput = { package: data };
+  const out: WorkerOutput = extractPackage(pkgName, srcDir);
   parentPort.postMessage(out);
 }
 
@@ -124,12 +128,12 @@ if (!isMainThread && parentPort) {
 // extractPackage and posts the result back.
 const WORKER_BOOTSTRAP = path.join(SCRIPT_DIR, "extract-ts-api-worker.mjs");
 
-function extractInWorker(pkgName: string, srcDir: string): Promise<PackageInfo> {
+function extractInWorker(pkgName: string, srcDir: string): Promise<WorkerOutput> {
   return new Promise((resolve, reject) => {
     const worker = new Worker(WORKER_BOOTSTRAP, {
       workerData: { package: pkgName, srcDir } satisfies WorkerInput,
     });
-    worker.once("message", (msg: WorkerOutput) => resolve(msg.package));
+    worker.once("message", (msg: WorkerOutput) => resolve(msg));
     worker.once("error", reject);
     worker.once("exit", (code) => {
       if (code !== 0)
@@ -183,66 +187,20 @@ export async function main() {
   const sharedTag = path.basename(ROOT_DIR);
   const sharedHits = new Set<string>();
 
-  // Cross-package inputs. `extractPackage` compiles with the real module
-  // resolver, so a package's extracted surface also depends on the workspace
-  // packages it imports from (see readWorkspaceGraph). Fingerprint every
-  // package DIRECTORY once, then fold each package's transitive dependency
-  // fingerprints into its cache keys — otherwise an activesupport edit leaves
-  // actionview's entry cached and stale, and a cached run disagrees with an
-  // `API_COMPARE_FORCE=1` one on an unchanged tree.
-  const PACKAGES_DIR = path.join(ROOT_DIR, "packages");
-  const graph = await readWorkspaceGraph(PACKAGES_DIR);
-  const dirInputs = new Map<string, Promise<{ root: string; files: string[] }>>();
-  function dependencyInputs(dir: string): Promise<{ root: string; files: string[] }> {
-    let pending = dirInputs.get(dir);
-    if (!pending) {
-      const root = path.join(PACKAGES_DIR, dir);
-      pending = dependencyInputFiles(root).then((files) => ({ root, files }));
-      dirInputs.set(dir, pending);
-    }
-    return pending;
-  }
-  const dirMtimeFingerprints = new Map<string, Promise<string>>();
-  function dirMtimeFingerprint(dir: string): Promise<string> {
-    let pending = dirMtimeFingerprints.get(dir);
-    if (!pending) {
-      pending = dependencyInputs(dir).then(({ root, files }) => packageFingerprint(files, root));
-      dirMtimeFingerprints.set(dir, pending);
-    }
-    return pending;
-  }
-  // Content hashing reads every byte of the dependency, so it stays lazy: only
-  // a LOCAL cache miss (which then consults the shared cache) ever needs it.
-  const dirContentFingerprints = new Map<string, Promise<string>>();
-  function dirContentFingerprint(dir: string): Promise<string> {
-    let pending = dirContentFingerprints.get(dir);
-    if (!pending) {
-      pending = dependencyInputs(dir).then(({ root, files }) => contentFingerprint(files, root));
-      dirContentFingerprints.set(dir, pending);
-    }
-    return pending;
-  }
-  /** `own` key widened with the fingerprints of `deps` (package DIRECTORIES). */
-  async function withDeps(own: string, deps: string[], kind: "mtime" | "content"): Promise<string> {
-    const pairs = await Promise.all(
-      deps.map(
-        async (dep) =>
-          [
-            dep,
-            kind === "mtime" ? await dirMtimeFingerprint(dep) : await dirContentFingerprint(dep),
-          ] as [string, string],
-      ),
-    );
-    return widenKeyWithDeps(own, pairs);
-  }
+  // Content hashes of read-set files, memoised per absolute path: sibling
+  // packages resolve many of the same declarations, and validating every
+  // package's read-set must not read the same file 13 times.
+  const inputHashes = new Map<string, Promise<string | null>>();
 
-  // Pass 1: serve every cache hit synchronously and record the
-  // metadata needed to extract the misses below.
+  // Pass 1: serve every cache hit and record the metadata needed to extract the
+  // misses below. `ownRel` is the package's own fingerprint inputs (already
+  // covered by `fingerprint`), excluded from the recorded read-set.
   interface PendingExtract {
     pkg: string;
     srcDir: string;
     fingerprint: string;
     cachePath: string;
+    ownRel: Set<string>;
     sharedKey: string | null;
   }
   const pending: PendingExtract[] = [];
@@ -258,23 +216,21 @@ export async function main() {
     // Anchor relative paths at the package root so tsconfig.json
     // doesn't show up as `../tsconfig.json` (which it would if we
     // anchored at the src dir).
-    // Packages that share a directory (actionpack hosts abstractcontroller,
-    // actioncontroller, actiondispatch) import across the sibling src subdirs
-    // that their own fingerprint — scoped to one subdir — doesn't cover, so the
-    // whole directory joins their dependency set.
-    const inputDirs = transitiveDeps(graph, dirName);
-    if (PACKAGE_SRC_SUBDIR[pkg]) inputDirs.push(dirName);
-    const fingerprint = await withDeps(
-      packageFingerprint(fingerprintInputs, pkgRoot),
-      inputDirs,
-      "mtime",
+    const fingerprint = packageFingerprint(fingerprintInputs, pkgRoot);
+    const ownRel = new Set(
+      fingerprintInputs.map((file) => path.relative(ROOT_DIR, file).replace(/\\/g, "/")),
     );
     const cachePath = path.join(CACHE_DIR, `${pkg}.json`);
 
     if (!force && fs.existsSync(cachePath)) {
       try {
         const cached = JSON.parse(fs.readFileSync(cachePath, "utf-8")) as CacheEntry;
-        if (cached.schemaVersion === SCHEMA_VERSION && cached.fingerprint === fingerprint) {
+        if (
+          cached.schemaVersion === SCHEMA_VERSION &&
+          cached.fingerprint === fingerprint &&
+          cached.inputs &&
+          (await readSetMatches(cached.inputs, ROOT_DIR, inputHashes))
+        ) {
           manifest.packages[pkg] = cached.package;
           cacheHits.add(pkg);
           continue;
@@ -290,20 +246,26 @@ export async function main() {
     // mtime-keyed cache so the next same-worktree run takes the fast path.
     let sharedKey: string | null = null;
     if (sharedDir) {
-      const ownContent = await contentFingerprint(fingerprintInputs, pkgRoot);
-      const contentKey = `${SCHEMA_VERSION}-${await withDeps(ownContent, inputDirs, "content")}`;
+      const contentKey = `${SCHEMA_VERSION}-${await contentFingerprint(fingerprintInputs, pkgRoot)}`;
       const body = await readShared(sharedDir, `ts-${pkg}`, contentKey);
       if (body) {
         try {
           const cached = JSON.parse(body) as CacheEntry;
-          manifest.packages[pkg] = cached.package;
-          fs.writeFileSync(
-            cachePath,
-            JSON.stringify({ schemaVersion: SCHEMA_VERSION, fingerprint, package: cached.package }),
-          );
-          cacheHits.add(pkg);
-          sharedHits.add(pkg);
-          continue;
+          if (cached.inputs && (await readSetMatches(cached.inputs, ROOT_DIR, inputHashes))) {
+            manifest.packages[pkg] = cached.package;
+            fs.writeFileSync(
+              cachePath,
+              JSON.stringify({
+                schemaVersion: SCHEMA_VERSION,
+                fingerprint,
+                inputs: cached.inputs,
+                package: cached.package,
+              } satisfies CacheEntry),
+            );
+            cacheHits.add(pkg);
+            sharedHits.add(pkg);
+            continue;
+          }
         } catch {
           // Corrupt shared entry — fall through to re-extract.
         }
@@ -311,26 +273,36 @@ export async function main() {
       sharedKey = contentKey;
     }
 
-    pending.push({ pkg, srcDir: pkgDir, fingerprint, cachePath, sharedKey });
+    pending.push({ pkg, srcDir: pkgDir, fingerprint, cachePath, ownRel, sharedKey });
   }
 
   // Pass 2: extract cache misses in parallel via worker threads.
   if (pending.length > 0) {
     const concurrency = Math.max(1, Math.min(pending.length, cpus().length));
     const tasks = pending.map((p) => async () => {
-      const data = await extractInWorker(p.pkg, p.srcDir);
+      const { package: data, inputs } = await extractInWorker(p.pkg, p.srcDir);
+      const readSet = await hashReadSet(
+        await normalizeReadSet(inputs, ROOT_DIR, p.ownRel),
+        ROOT_DIR,
+        inputHashes,
+      );
       const entry: CacheEntry = {
         schemaVersion: SCHEMA_VERSION,
         fingerprint: p.fingerprint,
+        inputs: readSet,
         package: data,
       };
       fs.writeFileSync(p.cachePath, JSON.stringify(entry));
       // Publish to the shared cache under the content key so sibling worktrees
       // reuse this extraction (the shared entry's fingerprint is the content key).
+      // The key covers only the package's own files, so a worktree whose
+      // dependencies differ can overwrite this entry — harmless, because the
+      // recorded read-set is what decides whether a reader may serve it.
       if (sharedDir && p.sharedKey) {
         const shared: CacheEntry = {
           schemaVersion: SCHEMA_VERSION,
           fingerprint: p.sharedKey,
+          inputs: readSet,
           package: data,
         };
         await writeShared(sharedDir, `ts-${p.pkg}`, p.sharedKey, JSON.stringify(shared), sharedTag);
@@ -378,7 +350,7 @@ interface PendingReExport {
   moduleSpecifier: string; // e.g. "./migration-errors.js"
 }
 
-function extractPackage(pkgName: string, srcDir: string): PackageInfo {
+function extractPackage(pkgName: string, srcDir: string): WorkerOutput {
   const files = getAllTsFiles(srcDir);
 
   // Create a TypeScript program
@@ -407,7 +379,10 @@ function extractPackage(pkgName: string, srcDir: string): PackageInfo {
   }
 
   const program = ts.createProgram(files, compilerOptions);
-  return extractFromProgram(program, srcDir);
+  return {
+    package: extractFromProgram(program, srcDir),
+    inputs: program.getSourceFiles().map((sourceFile) => sourceFile.fileName),
+  };
 }
 
 /**

--- a/scripts/api-compare/shared-cache.test.ts
+++ b/scripts/api-compare/shared-cache.test.ts
@@ -20,6 +20,7 @@ import {
   normalizeReadSet,
   hashReadSet,
   readSetMatches,
+  resolutionShapeKey,
   CACHE_VERSION,
 } from "./shared-cache.js";
 
@@ -273,5 +274,45 @@ describe("resolved read-set", () => {
     fs.writeFileSync(path.join(root, "here.ts"), "y");
     expect(await readSetMatches(recorded, root, cache)).toBe(true);
     expect(await readSetMatches(recorded, root)).toBe(false);
+  });
+});
+
+describe("resolutionShapeKey", () => {
+  function writeDist(packagesDir: string, dir: string, files: Record<string, string>): void {
+    for (const [name, body] of Object.entries(files)) {
+      const file = path.join(packagesDir, dir, "dist", name);
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      fs.writeFileSync(file, body);
+    }
+  }
+
+  it("tracks which declarations exist, not what they say", async () => {
+    const packagesDir = mkTmp();
+    writeDist(packagesDir, "activesupport", { "index.d.ts": "export declare const a: number;" });
+    const built = await resolutionShapeKey(packagesDir);
+
+    // A rebuild that only changes contents leaves the shape alone — those
+    // changes are the read-set's job, and re-keying on them would invalidate
+    // every package again.
+    writeDist(packagesDir, "activesupport", { "index.d.ts": "export declare const a: string;" });
+    expect(await resolutionShapeKey(packagesDir)).toBe(built);
+
+    // A dependency that was unbuilt at extraction time resolves to nothing, so
+    // no read-set can see it become resolvable — the shape must.
+    const unbuilt = mkTmp();
+    fs.mkdirSync(path.join(unbuilt, "activesupport"), { recursive: true });
+    expect(await resolutionShapeKey(unbuilt)).not.toBe(built);
+
+    writeDist(packagesDir, "activesupport", { "extra.d.ts": "export declare const b: number;" });
+    expect(await resolutionShapeKey(packagesDir)).not.toBe(built);
+  });
+
+  it("ignores non-declaration output and a missing packages dir", async () => {
+    const packagesDir = mkTmp();
+    writeDist(packagesDir, "arel", { "index.d.ts": "" });
+    const before = await resolutionShapeKey(packagesDir);
+    writeDist(packagesDir, "arel", { "index.js": "", "nested/index.js.map": "" });
+    expect(await resolutionShapeKey(packagesDir)).toBe(before);
+    expect(await resolutionShapeKey(path.join(packagesDir, "nope"))).toMatch(/^[0-9a-f]{40}$/);
   });
 });

--- a/scripts/api-compare/shared-cache.test.ts
+++ b/scripts/api-compare/shared-cache.test.ts
@@ -1,8 +1,9 @@
 /**
  * Tests for the cross-worktree shared cache helpers: content-keying
  * (mtime-independent, so hits survive across checkouts), git-common-dir
- * resolution for a main checkout and a linked worktree, and the read/write
- * round-trip.
+ * resolution for a main checkout and a linked worktree, the read/write
+ * round-trip, and read-set validation (an entry is served only while every
+ * input its extraction actually resolved still hashes the same).
  */
 import { describe, it, expect, afterEach } from "vitest";
 import * as fs from "node:fs";
@@ -16,10 +17,9 @@ import {
   readShared,
   writeShared,
   pruneSharedCache,
-  readWorkspaceGraph,
-  transitiveDeps,
-  widenKeyWithDeps,
-  dependencyInputFiles,
+  normalizeReadSet,
+  hashReadSet,
+  readSetMatches,
   CACHE_VERSION,
 } from "./shared-cache.js";
 
@@ -197,106 +197,81 @@ describe("readShared / writeShared", () => {
   });
 });
 
-describe("cross-package cache inputs", () => {
-  function writePackage(packagesDir: string, dir: string, deps: string[]): void {
-    fs.mkdirSync(path.join(packagesDir, dir), { recursive: true });
-    fs.writeFileSync(
-      path.join(packagesDir, dir, "package.json"),
-      JSON.stringify({
-        name: `@blazetrails/${dir}`,
-        dependencies: Object.fromEntries(
-          deps.map((d) => [`@blazetrails/${d}`, "workspace:*"] as const),
+describe("resolved read-set", () => {
+  it("keeps repo files, drops node_modules, symlinks, and own inputs", async () => {
+    const root = mkTmp();
+    fs.mkdirSync(path.join(root, "packages", "activesupport", "dist"), { recursive: true });
+    fs.mkdirSync(path.join(root, "packages", "actionview", "src"), { recursive: true });
+    fs.mkdirSync(path.join(root, "packages", "actionview", "node_modules", "@blazetrails"), {
+      recursive: true,
+    });
+    fs.mkdirSync(path.join(root, "node_modules", "typescript"), { recursive: true });
+    const dist = path.join(root, "packages", "activesupport", "dist", "index.d.ts");
+    fs.writeFileSync(dist, "export declare const a: number;");
+    fs.writeFileSync(path.join(root, "packages", "actionview", "src", "own.ts"), "");
+    fs.writeFileSync(path.join(root, "node_modules", "typescript", "lib.d.ts"), "");
+    fs.symlinkSync(
+      path.join(root, "packages", "activesupport"),
+      path.join(root, "packages", "actionview", "node_modules", "@blazetrails", "activesupport"),
+    );
+    const outside = path.join(mkTmp(), "elsewhere.ts");
+    fs.writeFileSync(outside, "");
+
+    const readSet = await normalizeReadSet(
+      [
+        // resolved through the pnpm workspace symlink — recorded by real path
+        path.join(
+          root,
+          "packages/actionview/node_modules/@blazetrails/activesupport/dist/index.d.ts",
         ),
-      }),
+        path.join(root, "packages/actionview/src/own.ts"),
+        path.join(root, "node_modules/typescript/lib.d.ts"),
+        outside,
+      ],
+      root,
+      new Set(["packages/actionview/src/own.ts"]),
     );
-  }
-
-  it("resolves workspace dependency names to directories", async () => {
-    const packagesDir = mkTmp();
-    writePackage(packagesDir, "actionview", ["activesupport"]);
-    writePackage(packagesDir, "activesupport", []);
-    const graph = await readWorkspaceGraph(packagesDir);
-    expect(graph.dirOfName["@blazetrails/activesupport"]).toBe("activesupport");
-    expect(graph.depsOfDir.actionview).toEqual(["activesupport"]);
+    expect(readSet).toEqual(["packages/activesupport/dist/index.d.ts"]);
   });
 
-  it("ignores non-workspace dependencies", async () => {
-    const packagesDir = mkTmp();
-    writePackage(packagesDir, "activesupport", []);
-    fs.writeFileSync(
-      path.join(packagesDir, "activesupport", "package.json"),
-      JSON.stringify({ name: "@blazetrails/activesupport", dependencies: { yaml: "^2" } }),
-    );
-    const graph = await readWorkspaceGraph(packagesDir);
-    expect(graph.depsOfDir.activesupport).toEqual([]);
-  });
-
-  it("closes over transitive dependencies without looping on cycles", async () => {
-    const packagesDir = mkTmp();
-    writePackage(packagesDir, "trailties", ["activerecord"]);
-    writePackage(packagesDir, "activerecord", ["arel", "trailties"]);
-    writePackage(packagesDir, "arel", ["activesupport"]);
-    writePackage(packagesDir, "activesupport", []);
-    const graph = await readWorkspaceGraph(packagesDir);
-    expect(transitiveDeps(graph, "trailties")).toEqual(
-      ["activerecord", "arel", "activesupport"].sort(),
-    );
-  });
-
-  it("widens a package key when a dependency's fingerprint changes", () => {
-    // The divergence this pins: actionview re-exports activesupport symbols, so
-    // its extracted surface moves when activesupport does. A key built from
-    // actionview's own files alone kept serving the pre-change extraction from
-    // cache while API_COMPARE_FORCE=1 produced the post-change one.
-    const own = "actionview-own-fingerprint";
-    const before = widenKeyWithDeps(own, [["activesupport", "aaa"]]);
-    const after = widenKeyWithDeps(own, [["activesupport", "bbb"]]);
-    expect(before).not.toBe(own);
-    expect(after).not.toBe(before);
-  });
-
-  it("is order-independent and a no-op without dependencies", () => {
-    const own = "own";
-    expect(widenKeyWithDeps(own, [])).toBe(own);
-    expect(
-      widenKeyWithDeps(own, [
-        ["arel", "a"],
-        ["activesupport", "b"],
-      ]),
-    ).toBe(
-      widenKeyWithDeps(own, [
-        ["activesupport", "b"],
-        ["arel", "a"],
-      ]),
-    );
-  });
-});
-
-describe("dependencyInputFiles", () => {
-  it("collects src sources and built declarations, skipping tests", async () => {
+  it("serves an entry only while every recorded input hashes the same", async () => {
     const root = mkTmp();
-    fs.mkdirSync(path.join(root, "src", "core-ext"), { recursive: true });
-    fs.mkdirSync(path.join(root, "dist", "core-ext"), { recursive: true });
-    fs.writeFileSync(path.join(root, "src", "core-ext", "string.ts"), "export const a = 1;");
-    fs.writeFileSync(path.join(root, "src", "core-ext", "string.test.ts"), "");
-    fs.writeFileSync(
-      path.join(root, "dist", "core-ext", "string.d.ts"),
-      "export declare const a: number;",
-    );
-    fs.writeFileSync(path.join(root, "dist", "core-ext", "string.js"), "");
-    fs.writeFileSync(path.join(root, "tsconfig.json"), "{}");
-    const files = (await dependencyInputFiles(root)).map((f) => path.relative(root, f)).sort();
-    expect(files).toEqual([
-      path.join("dist", "core-ext", "string.d.ts"),
-      path.join("src", "core-ext", "string.ts"),
-      "tsconfig.json",
-    ]);
+    fs.mkdirSync(path.join(root, "pkg"));
+    const read = path.join(root, "pkg", "read.ts");
+    const unread = path.join(root, "pkg", "unread.ts");
+    fs.writeFileSync(read, "export const a = 1;");
+    fs.writeFileSync(unread, "export const b = 1;");
+    const recorded = await hashReadSet(["pkg/read.ts"], root);
+    expect(await readSetMatches(recorded, root)).toBe(true);
+
+    // The output-safety case: editing a file this package never resolved must
+    // NOT invalidate its entry.
+    fs.writeFileSync(unread, "export const b = 2;");
+    expect(await readSetMatches(recorded, root)).toBe(true);
+
+    fs.writeFileSync(read, "export const a = 2;");
+    expect(await readSetMatches(recorded, root)).toBe(false);
   });
 
-  it("tolerates an unbuilt package with no dist and no tsconfig", async () => {
+  it("invalidates when a recorded input disappears", async () => {
     const root = mkTmp();
-    fs.mkdirSync(path.join(root, "src"));
-    fs.writeFileSync(path.join(root, "src", "index.ts"), "");
-    expect(await dependencyInputFiles(root)).toEqual([path.join(root, "src", "index.ts")]);
+    fs.writeFileSync(path.join(root, "dep.d.ts"), "declare const a: number;");
+    const recorded = await hashReadSet(["dep.d.ts"], root);
+    fs.rmSync(path.join(root, "dep.d.ts"));
+    expect(await readSetMatches(recorded, root)).toBe(false);
+  });
+
+  it("omits inputs that no longer exist and hashes through the memo cache", async () => {
+    const root = mkTmp();
+    fs.writeFileSync(path.join(root, "here.ts"), "x");
+    const cache = new Map<string, Promise<string | null>>();
+    const recorded = await hashReadSet(["here.ts", "gone.ts"], root, cache);
+    expect(Object.keys(recorded)).toEqual(["here.ts"]);
+    expect(cache.size).toBe(2);
+    // A cached hash is reused even after the file changes underneath — the memo
+    // is per-run, which is what keeps one run's view of the tree consistent.
+    fs.writeFileSync(path.join(root, "here.ts"), "y");
+    expect(await readSetMatches(recorded, root, cache)).toBe(true);
+    expect(await readSetMatches(recorded, root)).toBe(false);
   });
 });

--- a/scripts/api-compare/shared-cache.ts
+++ b/scripts/api-compare/shared-cache.ts
@@ -117,6 +117,53 @@ export async function fileHash(file: string): Promise<string | null> {
 export type ReadSet = Record<string, string>;
 
 /**
+ * Hash of the SHAPE of what the workspace can resolve: the sorted names (not
+ * contents) of every built `packages/<dir>/dist/**\/*.d.ts`.
+ *
+ * A read-set records what the compiler DID read, so it cannot notice a file
+ * that was not resolvable at extraction time and is now. An unbuilt dependency
+ * is exactly that case: with no `dist`, the import resolves to nothing and the
+ * entry records nothing for it; a later `tsc --build` would silently change the
+ * extraction while every recorded hash still matched. Folding this key into the
+ * cache keys closes that hole without giving up the read-set's precision —
+ * building or rebuilding does not change the file NAMES, so the common case
+ * (contents changed) still invalidates only the packages that read them.
+ */
+export async function resolutionShapeKey(packagesDir: string): Promise<string> {
+  let dirs: string[];
+  try {
+    dirs = await fs.readdir(packagesDir);
+  } catch {
+    return hashParts([]);
+  }
+  const perPackage = await Promise.all(
+    dirs.map(async (dir) => {
+      const dist = path.join(packagesDir, dir, "dist");
+      const files = await declarationsUnder(dist);
+      return files.map((file) => `${dir}/${path.relative(dist, file).replace(/\\/g, "/")}`);
+    }),
+  );
+  return hashParts(perPackage.flat().sort());
+}
+
+async function declarationsUnder(dir: string): Promise<string[]> {
+  let entries;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const nested = await Promise.all(
+    entries.map(async (entry) => {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) return declarationsUnder(full);
+      return entry.name.endsWith(".d.ts") ? [full] : [];
+    }),
+  );
+  return nested.flat();
+}
+
+/**
  * Reduce raw `program.getSourceFiles()` file names to the repo-relative paths
  * worth validating: real paths (pnpm resolves `@blazetrails/<dep>` through a
  * `node_modules` symlink into `packages/<dep>/dist`, and the symlinked spelling

--- a/scripts/api-compare/shared-cache.ts
+++ b/scripts/api-compare/shared-cache.ts
@@ -17,7 +17,7 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import { createHash } from "crypto";
 
-export const CACHE_VERSION = 1;
+export const CACHE_VERSION = 2;
 
 /**
  * Default staleness horizon for cache entries: an entry whose mtime is older
@@ -95,135 +95,105 @@ export async function fileHash(file: string): Promise<string | null> {
 }
 
 /**
- * Workspace dependency graph over `packages/`, keyed by DIRECTORY name.
+ * The RESOLVED READ-SET of one extraction: repo-relative POSIX path → sha1 of
+ * the file's contents at extraction time.
  *
  * The TS extractor compiles a package with the real module resolver, so an
  * `import { htmlEscapeOnce } from "@blazetrails/activesupport"` pulls the
- * DECLARING file out of a sibling package and the extracted surface for the
- * importer (e.g. actionview's `h` / `htmlEscapeOnce`) depends on that sibling's
- * sources. A cache key built from the package's OWN files alone therefore
- * survives an edit that changes its extraction — which is exactly how a cached
- * run and an `API_COMPARE_FORCE=1` run came to disagree. Callers fold the
- * dependencies' fingerprints into the key so they can't.
+ * DECLARING file out of a sibling package, and the extracted surface for the
+ * importer depends on that sibling. A cache key built from the package's OWN
+ * files alone therefore survives an edit that changes its extraction — which is
+ * exactly how a cached run and an `API_COMPARE_FORCE=1` run came to disagree.
+ *
+ * Widening the key with each dependency PACKAGE's fingerprint fixes that but is
+ * far too coarse: one line appended to an activesupport core-ext invalidates 12
+ * of 13 packages, nearly all of which never resolve that file. `ts.Program`
+ * already knows the truth — `program.getSourceFiles()` enumerates exactly what
+ * the compiler read — so we record those paths' hashes in the cache entry and
+ * serve the entry only while every one of them still hashes the same. The
+ * read-set is known only AFTER an extraction, hence entries carry their own
+ * input list (a first run on a package still extracts).
  */
-export interface WorkspaceGraph {
-  /** npm package name (`@blazetrails/actionview`) → directory name (`actionview`). */
-  dirOfName: Record<string, string>;
-  /** directory name → directly-depended-on workspace directory names. */
-  depsOfDir: Record<string, string[]>;
-}
+export type ReadSet = Record<string, string>;
 
-/** Read every `packages/<dir>/package.json` and build the workspace graph. */
-export async function readWorkspaceGraph(packagesDir: string): Promise<WorkspaceGraph> {
-  const graph: WorkspaceGraph = { dirOfName: {}, depsOfDir: {} };
-  let dirs: string[];
-  try {
-    dirs = await fs.readdir(packagesDir);
-  } catch {
-    return graph;
-  }
-  const manifests = await Promise.all(
-    dirs.map(async (dir) => {
+/**
+ * Reduce raw `program.getSourceFiles()` file names to the repo-relative paths
+ * worth validating: real paths (pnpm resolves `@blazetrails/<dep>` through a
+ * `node_modules` symlink into `packages/<dep>/dist`, and the symlinked spelling
+ * would be an unstable key), inside `rootDir`, and outside `node_modules` —
+ * third-party declarations only move on an install, which rewrites the lockfile
+ * and the packages themselves. `exclude` drops paths already covered by the
+ * caller's own fingerprint, so the recorded set is the CROSS-package remainder.
+ */
+export async function normalizeReadSet(
+  fileNames: string[],
+  rootDir: string,
+  exclude: ReadonlySet<string> = new Set(),
+): Promise<string[]> {
+  const prefix = rootDir.endsWith(path.sep) ? rootDir : rootDir + path.sep;
+  const resolved = await Promise.all(
+    fileNames.map(async (file) => {
       try {
-        const raw = await fs.readFile(path.join(packagesDir, dir, "package.json"), "utf-8");
-        return { dir, json: JSON.parse(raw) as { name?: string; dependencies?: object } };
+        return await fs.realpath(file);
       } catch {
-        return null;
+        return file;
       }
     }),
   );
-  for (const entry of manifests) {
-    if (!entry) continue;
-    if (entry.json.name) graph.dirOfName[entry.json.name] = entry.dir;
+  const rels = new Set<string>();
+  for (const file of resolved) {
+    if (!file.startsWith(prefix)) continue;
+    const rel = path.relative(rootDir, file).replace(/\\/g, "/");
+    if (rel.split("/").includes("node_modules")) continue;
+    if (exclude.has(rel)) continue;
+    rels.add(rel);
   }
-  for (const entry of manifests) {
-    if (!entry) continue;
-    graph.depsOfDir[entry.dir] = Object.keys(entry.json.dependencies ?? {});
-  }
-  // Second pass: names resolve to dirs only once every manifest has been read.
-  for (const dir of Object.keys(graph.depsOfDir)) {
-    graph.depsOfDir[dir] = graph.depsOfDir[dir]
-      .map((name) => graph.dirOfName[name])
-      .filter((d): d is string => Boolean(d) && d !== dir);
-  }
-  return graph;
+  return [...rels].sort();
 }
 
 /**
- * Transitive workspace dependencies of `dirName`, sorted and excluding itself.
- * Cycles are tolerated (the visited set stops the walk).
+ * Hash every path of a read-set. Missing files are omitted — a path that can't
+ * be read now was not one of the inputs that produced the entry, and recording
+ * a placeholder would make the entry permanently unservable.
  */
-export function transitiveDeps(graph: WorkspaceGraph, dirName: string): string[] {
-  const seen = new Set<string>();
-  const stack = [...(graph.depsOfDir[dirName] ?? [])];
-  while (stack.length > 0) {
-    const dir = stack.pop() as string;
-    if (dir === dirName || seen.has(dir)) continue;
-    seen.add(dir);
-    stack.push(...(graph.depsOfDir[dir] ?? []));
-  }
-  return [...seen].sort();
-}
-
-async function filesUnder(dir: string, keep: (name: string) => boolean): Promise<string[]> {
-  let entries;
-  try {
-    entries = await fs.readdir(dir, { withFileTypes: true });
-  } catch {
-    return [];
-  }
-  const nested = await Promise.all(
-    entries.map(async (entry) => {
-      const full = path.join(dir, entry.name);
-      if (entry.isDirectory()) return filesUnder(full, keep);
-      return keep(entry.name) ? [full] : [];
-    }),
-  );
-  return nested.flat();
+export async function hashReadSet(
+  relPaths: string[],
+  rootDir: string,
+  cache?: Map<string, Promise<string | null>>,
+): Promise<ReadSet> {
+  const hashes = await Promise.all(relPaths.map((rel) => hashOf(path.join(rootDir, rel), cache)));
+  const readSet: ReadSet = {};
+  relPaths.forEach((rel, i) => {
+    const hash = hashes[i];
+    if (hash !== null) readSet[rel] = hash;
+  });
+  return readSet;
 }
 
 /**
- * Every file of `packageRoot` that can feed a DEPENDENT package's extraction.
- *
- * With no `paths` mapping in the root tsconfig, `@blazetrails/<dep>` resolves
- * through the dep's `exports` to its BUILT `dist/*.d.ts` — those declarations,
- * not the dep's `src`, are what the compiler actually reads. Both are included:
- * `dist` because it's the real input (a rebuild with unchanged `src` still
- * changes the dependent's extraction), `src` because an edit that hasn't been
- * built yet still changes what a later run will see. A missing `src` or `dist`
- * simply contributes nothing.
+ * Whether every recorded input still hashes to the value it had when the entry
+ * was written. A vanished file fails (its hash is null), which is right: the
+ * compiler would resolve something else now.
  */
-export async function dependencyInputFiles(packageRoot: string): Promise<string[]> {
-  const [src, dist] = await Promise.all([
-    filesUnder(
-      path.join(packageRoot, "src"),
-      (name) => name.endsWith(".ts") && !name.endsWith(".test.ts") && !name.endsWith(".d.ts"),
-    ),
-    filesUnder(path.join(packageRoot, "dist"), (name) => name.endsWith(".d.ts")),
-  ]);
-  const files = [...src, ...dist];
-  const tsConfig = path.join(packageRoot, "tsconfig.json");
-  try {
-    await fs.stat(tsConfig);
-    files.push(tsConfig);
-  } catch {
-    // no tsconfig — nothing to fold in
-  }
-  return files;
+export async function readSetMatches(
+  recorded: ReadSet,
+  rootDir: string,
+  cache?: Map<string, Promise<string | null>>,
+): Promise<boolean> {
+  const entries = Object.entries(recorded);
+  const current = await Promise.all(entries.map(([rel]) => hashOf(path.join(rootDir, rel), cache)));
+  return entries.every(([, hash], i) => current[i] === hash);
 }
 
-/**
- * Widen a package's own cache key with its dependencies' fingerprints, as
- * `[dirName, fingerprint]` pairs. Empty deps return `own` unchanged so
- * dependency-free packages keep their historical keys (and cache entries).
- */
-export function widenKeyWithDeps(own: string, depFingerprints: [string, string][]): string {
-  if (depFingerprints.length === 0) return own;
-  const parts = [own];
-  for (const [dir, fingerprint] of [...depFingerprints].sort(([a], [b]) => (a < b ? -1 : 1))) {
-    parts.push(`${dir}\t${fingerprint}`);
+/** `fileHash` memoised per absolute path across the packages of one run. */
+function hashOf(file: string, cache?: Map<string, Promise<string | null>>): Promise<string | null> {
+  if (!cache) return fileHash(file);
+  let pending = cache.get(file);
+  if (!pending) {
+    pending = fileHash(file);
+    cache.set(file, pending);
   }
-  return hashParts(parts);
+  return pending;
 }
 
 function entryPath(dir: string, name: string, key: string): string {


### PR DESCRIPTION
## What

`api:compare`'s TS extraction cache entries now record the **resolved read-set**
of the extraction that produced them — the cross-package files `ts.Program`
actually read, as repo-relative path → content hash — and an entry is served
only while every recorded input still hashes the same.

This replaces the transitive workspace-dependency fingerprints that #5375 folded
into both cache keys. That fix was correct but package-coarse: measured on its
merge commit, appending one line to
`packages/activesupport/src/core-ext/string/output-safety.ts` invalidated 12 of
13 packages, forcing a ~10s full extraction for a change almost nothing reads.

`program.getSourceFiles()` already enumerates the true input set, so the worker
ships those file names back and the main thread records the remainder not
already covered by the package's own fingerprint. Paths are real-path'd (pnpm
resolves `@blazetrails/<dep>` through a `node_modules` symlink into
`packages/<dep>/dist`) and `node_modules` is excluded — third-party
declarations only move on an install. Since a read-set is known only *after* an
extraction, entries carry their own input list and a first run on a new package
still extracts. `CACHE_VERSION` bumps to 2 to retire pre-read-set shared
entries.

`readWorkspaceGraph` / `transitiveDeps` / `dependencyInputFiles` /
`widenKeyWithDeps` and their tests are removed — nothing else used them.

## The one thing a read-set can't see

A read-set records what the compiler **did** read, so it is blind to a file that
was *not resolvable at extraction time and now is*. With a dependency's `dist`
absent the import resolves to nothing and the entry records nothing for it; a
later `tsc --build` would change that package's extraction while every recorded
hash still matched — a fresh cached-vs-forced divergence, verified to be a real
state of this repo (extraction with and without `packages/activesupport/dist`
produces different `ts-api.json`).

Second commit closes it: both keys fold in `resolutionShapeKey`, a hash of the
sorted **names** (not contents) of every `packages/*/dist/**/*.d.ts`. A rebuild
that only rewrites contents leaves the shape untouched, so the precision above
is preserved; a `dist` appearing, vanishing, or gaining a file re-keys.

## Measured on this branch

| change | packages re-extracted (was, with #5375 keying) |
| --- | --- |
| append a line to `output-safety.ts` (src only, `dist` not rebuilt) | 1 of 13 (was 12) |
| same edit, after rebuilding activesupport's `dist` | 9 of 13 (was 12) |

The src-only case is now exactly right: an unbuilt edit genuinely cannot change
what any other package's compile resolves, and the forced run agrees.

Cached-vs-forced parity re-verified (`output/ts-api.json` byte-identical modulo
`generatedAt`) in four states: cold, warm, after the src edit + `dist` rebuild,
and in the `dist`-appears scenario above — where the local entries correctly
invalidate and the shared cross-worktree layer serves the right ones.

Known and unchanged limitation: third-party `node_modules` declarations are not
tracked by any key, here or before this PR. They move only on an install.

## Tests

`scripts/api-compare/shared-cache.test.ts` gains two blocks: `resolved read-set`
(normalization — repo files kept, `node_modules` dropped, symlinks resolved, own
inputs excluded; the pin that editing an unresolved file leaves an entry valid;
invalidation on content change and on a vanished input; the per-run hash memo)
and `resolutionShapeKey` (contents ignored, presence and additions tracked,
non-declaration output and a missing dir ignored).

Closes-story: api-compare-cache-key-resolved-read-set
