### PR TITLE
refactor(core): converge Base.configurations onto the Rails accessor

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2348,6 +2348,15 @@ export class Base extends Model {
   declare static cachedFindByStatement: typeof _Core.cachedFindByStatement;
   declare static _findByStatementCache?: Map<boolean, Map<string, unknown>>;
 
+  /**
+   * Mirrors: ActiveRecord::Base.configurations / .configurations=
+   *
+   * Ruby's reader/writer pair collapses to the repo's optional-argument
+   * accessor: `Model.configurations(raw)` writes, `Model.configurations()`
+   * reads, and the reader always answers a `DatabaseConfigurations`.
+   */
+  declare static configurations: typeof _Core.configurations;
+
   // Mirrors Rails `find_by!(arg, *args)`: a Hash of conditions or a raw SQL
   // fragment (`Post.find_by!("1 = 0")`) plus optional bind args.
   declare static findByBang: <T extends typeof Base>(
@@ -4787,6 +4796,10 @@ Object.defineProperty(Base, "connection", {
 
 extend(Base, { collectionCacheKey: _collectionCacheKey });
 extend(Base, { find: _Core.find, findBy: _Core.findBy, findByBang: _Core.findByBang });
+extend(Base, { configurations: _Core.configurations });
+// Mirrors core.rb:74 — `self.configurations = {}` runs at load, so the reader
+// hands back a real (empty) registry before any app config is assigned.
+Base.configurations({});
 extend(Base, {
   initializeFindByCache: _Core.initializeFindByCache,
   cachedFindByStatement: _Core.cachedFindByStatement,

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2348,13 +2348,8 @@ export class Base extends Model {
   declare static cachedFindByStatement: typeof _Core.cachedFindByStatement;
   declare static _findByStatementCache?: Map<boolean, Map<string, unknown>>;
 
-  /**
-   * Mirrors: ActiveRecord::Base.configurations / .configurations=
-   *
-   * Ruby's reader/writer pair collapses to the repo's optional-argument
-   * accessor: `Model.configurations(raw)` writes, `Model.configurations()`
-   * reads, and the reader always answers a `DatabaseConfigurations`.
-   */
+  // Mirrors Rails' `Base.configurations` / `.configurations=` pair, collapsed
+  // into one optional-argument accessor.
   declare static configurations: typeof _Core.configurations;
 
   // Mirrors Rails `find_by!(arg, *args)`: a Hash of conditions or a raw SQL
@@ -4797,8 +4792,7 @@ Object.defineProperty(Base, "connection", {
 extend(Base, { collectionCacheKey: _collectionCacheKey });
 extend(Base, { find: _Core.find, findBy: _Core.findBy, findByBang: _Core.findByBang });
 extend(Base, { configurations: _Core.configurations });
-// Mirrors core.rb:74 — `self.configurations = {}` runs at load, so the reader
-// hands back a real (empty) registry before any app config is assigned.
+// Mirrors core.rb:74 — `self.configurations = {}` runs at load.
 Base.configurations({});
 extend(Base, {
   initializeFindByCache: _Core.initializeFindByCache,

--- a/packages/activerecord/src/connection-adapters/connection-handlers-multi-db.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handlers-multi-db.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { ConnectionHandler } from "./abstract/connection-handler.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
-import { DatabaseConfigurations } from "../database-configurations.js";
+import { DatabaseConfigurations, type RawConfigurations } from "../database-configurations.js";
 import { Base } from "../base.js";
 import { currentRole } from "../core.js";
 
@@ -30,21 +30,21 @@ describe("ConnectionHandlersMultiDbTest", () => {
   });
 
   function withBaseConfigs(
-    raw: Record<string, unknown>,
+    raw: RawConfigurations,
     fn: () => void,
     opts: { defaultEnv?: string } = {},
   ): void {
-    const prevConfigs = (Base as any).configurations;
+    const prevConfigs = Base.configurations();
     const prevDefaultEnv = DatabaseConfigurations.defaultEnv;
     if (opts.defaultEnv) {
       DatabaseConfigurations.defaultEnv = opts.defaultEnv;
       vi.stubEnv("TRAILS_ENV", opts.defaultEnv);
     }
-    (Base as any).configurations = raw;
+    Base.configurations(raw);
     try {
       fn();
     } finally {
-      (Base as any).configurations = prevConfigs;
+      Base.configurations(prevConfigs);
       DatabaseConfigurations.defaultEnv = prevDefaultEnv;
       if (opts.defaultEnv) vi.unstubAllEnvs();
       // Sync helper (fn: () => void); the async clearAllConnectionsBang tears

--- a/packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts
@@ -5,27 +5,27 @@ import * as fs from "node:fs";
 import { randomUUID } from "node:crypto";
 import { Base } from "../base.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
-import { DatabaseConfigurations } from "../database-configurations.js";
+import { DatabaseConfigurations, type RawConfigurations } from "../database-configurations.js";
 import { BetterSQLite3Adapter } from "./better-sqlite3-adapter.js";
 import { currentRole, connectedToStack } from "../core.js";
 
 async function withBaseConfigs(
-  raw: Record<string, unknown>,
+  raw: RawConfigurations,
   fn: () => void | Promise<void>,
   opts: { defaultEnv?: string } = {},
 ): Promise<void> {
-  const prevConfigs = (Base as any).configurations;
+  const prevConfigs = Base.configurations();
   const prevDefaultEnv = DatabaseConfigurations.defaultEnv;
   const prevCurrent = (DatabaseConfigurations as any).current;
   if (opts.defaultEnv) {
     DatabaseConfigurations.defaultEnv = opts.defaultEnv;
     vi.stubEnv("TRAILS_ENV", opts.defaultEnv);
   }
-  (Base as any).configurations = raw;
+  Base.configurations(raw);
   try {
     await fn();
   } finally {
-    (Base as any).configurations = prevConfigs;
+    Base.configurations(prevConfigs);
     DatabaseConfigurations.defaultEnv = prevDefaultEnv;
     (DatabaseConfigurations as any).current = prevCurrent;
     if (opts.defaultEnv) vi.unstubAllEnvs();

--- a/packages/activerecord/src/connection-adapters/connection-swapping-nested.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-swapping-nested.test.ts
@@ -24,7 +24,7 @@ describe("ConnectionSwappingNestedTest", () => {
 
   class ModelInheritingFromNonConnectionAbstractClass extends NonConnectionAbstractClass {}
 
-  let prevConfigs: unknown;
+  let prevConfigs: DatabaseConfigurations;
   let prevDefaultEnv: string;
   let prevCurrent: unknown;
 
@@ -71,7 +71,7 @@ describe("ConnectionSwappingNestedTest", () => {
       await fs.writeFile(dbPaths[name], "");
     }
 
-    prevConfigs = (Base as any).configurations;
+    prevConfigs = Base.configurations();
     prevDefaultEnv = DatabaseConfigurations.defaultEnv;
     prevCurrent = (DatabaseConfigurations as any).current;
     DatabaseConfigurations.defaultEnv = "default_env";
@@ -80,7 +80,7 @@ describe("ConnectionSwappingNestedTest", () => {
 
   afterEach(async () => {
     await Base.connectionHandler.clearAllConnectionsBang();
-    (Base as any).configurations = prevConfigs;
+    Base.configurations(prevConfigs);
     DatabaseConfigurations.defaultEnv = prevDefaultEnv;
     (DatabaseConfigurations as any).current = prevCurrent;
     (PrimaryBase as any).connectionClass = false;
@@ -97,14 +97,14 @@ describe("ConnectionSwappingNestedTest", () => {
   });
 
   it("roles can be swapped granularly", () => {
-    (Base as any).configurations = {
+    Base.configurations({
       default_env: {
         primary: sqliteDb("primary"),
         primary_replica: sqliteDb("primary", { replica: true }),
         secondary: sqliteDb("secondary"),
         secondary_replica: sqliteDb("secondary_replica", { replica: true }),
       },
-    };
+    });
 
     PrimaryBase.connectsTo({ database: { writing: "primary", reading: "primary_replica" } });
     SecondaryBase.connectsTo({ database: { writing: "secondary", reading: "secondary_replica" } });
@@ -156,7 +156,7 @@ describe("ConnectionSwappingNestedTest", () => {
   });
 
   it("shards can be swapped granularly", () => {
-    (Base as any).configurations = {
+    Base.configurations({
       default_env: {
         primary: sqliteDb("primary"),
         primary_replica: sqliteDb("primary", { replica: true }),
@@ -169,7 +169,7 @@ describe("ConnectionSwappingNestedTest", () => {
         secondary_shard_two: sqliteDb("secondary_shard_two"),
         secondary_shard_two_replica: sqliteDb("secondary_shard_two", { replica: true }),
       },
-    };
+    });
 
     PrimaryBase.connectsTo({
       shards: {
@@ -229,7 +229,7 @@ describe("ConnectionSwappingNestedTest", () => {
   });
 
   it("roles and shards can be swapped granularly", () => {
-    (Base as any).configurations = {
+    Base.configurations({
       default_env: {
         primary: sqliteDb("primary"),
         primary_replica: sqliteDb("primary", { replica: true }),
@@ -242,7 +242,7 @@ describe("ConnectionSwappingNestedTest", () => {
         secondary_shard_two: sqliteDb("secondary_shard_two"),
         secondary_shard_two_replica: sqliteDb("secondary_shard_two", { replica: true }),
       },
-    };
+    });
 
     PrimaryBase.connectsTo({
       shards: {
@@ -300,7 +300,7 @@ describe("ConnectionSwappingNestedTest", () => {
   });
 
   it("connected to many", () => {
-    (Base as any).configurations = {
+    Base.configurations({
       default_env: {
         primary: sqliteDb("primary"),
         primary_replica: sqliteDb("primary", { replica: true }),
@@ -309,7 +309,7 @@ describe("ConnectionSwappingNestedTest", () => {
         tertiary: sqliteDb("tertiary"),
         tertiary_replica: sqliteDb("tertiary", { replica: true }),
       },
-    };
+    });
 
     PrimaryBase.connectsTo({ database: { writing: "primary", reading: "primary_replica" } });
     SecondaryBase.connectsTo({ database: { writing: "secondary", reading: "secondary_replica" } });
@@ -339,14 +339,14 @@ describe("ConnectionSwappingNestedTest", () => {
   });
 
   it("prevent writes can be changed granularly", () => {
-    (Base as any).configurations = {
+    Base.configurations({
       default_env: {
         primary: sqliteDb("primary"),
         primary_replica: sqliteDb("primary"),
         secondary: sqliteDb("secondary"),
         secondary_replica: sqliteDb("secondary_replica"),
       },
-    };
+    });
 
     PrimaryBase.connectsTo({ database: { writing: "primary", reading: "primary_replica" } });
     SecondaryBase.connectsTo({ database: { writing: "secondary", reading: "secondary_replica" } });
@@ -395,11 +395,11 @@ describe("ConnectionSwappingNestedTest", () => {
     const prevAppRecord = (globalThis as any).ApplicationRecord;
     (globalThis as any).ApplicationRecord = AppRecord;
 
-    (Base as any).configurations = {
+    Base.configurations({
       default_env: {
         arunit: sqliteDb("arunit"),
       },
-    };
+    });
 
     try {
       AppRecord.connectsTo({ database: { writing: "arunit", reading: "arunit" } });
@@ -422,11 +422,11 @@ describe("ConnectionSwappingNestedTest", () => {
   });
 
   it("prevent writes handles class reloading", async () => {
-    (Base as any).configurations = {
+    Base.configurations({
       default_env: {
         arunit: sqliteDb("arunit"),
       },
-    };
+    });
 
     class ReloadedRecordV1 extends Base {
       static override abstractClass = true;

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -492,7 +492,7 @@ describe("ConnectionHandlingTest", () => {
       ]);
 
       class InMemoryModel extends Base {}
-      (InMemoryModel as any).configurations = inMemory;
+      InMemoryModel.configurations(inMemory);
 
       await InMemoryModel.establishConnection();
       expect(InMemoryModel.connectionPool().dbConfig.database).toBe("db/common.sqlite3");
@@ -518,7 +518,7 @@ describe("ConnectionHandlingTest", () => {
       const inMemory = new DatabaseConfigurations([url]);
 
       class WorkerModel extends Base {}
-      (WorkerModel as any).configurations = inMemory;
+      WorkerModel.configurations(inMemory);
 
       await WorkerModel.establishConnection();
       // The connection pool's resolved dbConfig must point at the
@@ -710,12 +710,12 @@ describe("AbstractAdapter#isPreventingWrites stack matching", () => {
 
 describe("resolveConfigForConnection / connectsTo with unset configurations", () => {
   let prevCurrentConfigs: unknown;
-  let prevBaseConfigs: unknown;
+  let prevBaseConfigs: DatabaseConfigurations;
 
   beforeEach(async () => {
     const { DatabaseConfigurations } = await import("./database-configurations.js");
     prevCurrentConfigs = (DatabaseConfigurations as any).current;
-    prevBaseConfigs = (Base as any).configurations;
+    prevBaseConfigs = Base.configurations();
   });
 
   afterEach(async () => {
@@ -724,7 +724,7 @@ describe("resolveConfigForConnection / connectsTo with unset configurations", ()
     // registry HashConfig#isPrimary consults), so save and restore it here
     // — clearing connections alone leaves a stale primary registry behind.
     (DatabaseConfigurations as any).current = prevCurrentConfigs;
-    (Base as any).configurations = prevBaseConfigs;
+    Base.configurations(prevBaseConfigs);
     await Base.connectionHandler.clearAllConnectionsBang();
     delete (Base as any)._connectionSpecificationName;
   });
@@ -737,7 +737,7 @@ describe("resolveConfigForConnection / connectsTo with unset configurations", ()
         this.abstractClass = true;
       }
     }
-    // No `Untouched.configurations` assigned — normalizeConfigurations falls
+    // No `Untouched.configurations` assigned — the empty default registry falls
     // back to DatabaseConfigurations.fromEnv({}), so resolving an unknown
     // env name must surface AdapterNotSpecified rather than passing the
     // string through.
@@ -766,10 +766,10 @@ describe("resolveConfigForConnection / connectsTo with unset configurations", ()
       __resetPrimaryAbstractClass();
       primaryAbstractClass(AppRecord);
       const env = DatabaseConfigurations.currentEnv();
-      (AppRecord as any).configurations = {
+      AppRecord.configurations({
         [env]: { primary: { adapter: "sqlite3", database: "db/primary.sqlite3" } },
-      };
-      (SecondaryAbstract as any).configurations = (AppRecord as any).configurations;
+      });
+      SecondaryAbstract.configurations(AppRecord.configurations());
 
       // Exercises the public connectsTo path so the
       // resolveConfigForConnection side effect (planting
@@ -919,7 +919,6 @@ describe("loadConfigFile resolves config/database.* against Trails.root", () => 
     setTrailsRoot(tmpRoot);
 
     class RootConfigModel extends Base {}
-    (RootConfigModel as any).configurations = undefined;
 
     await RootConfigModel.establishConnection();
 

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -483,6 +483,7 @@ describe("ConnectionHandlingTest", () => {
     // DatabaseConfigurations constructor mutates as a side effect.
     // Snapshot it so test ordering can't pin the wrong registry.
     const priorCurrent = (DatabaseConfigurations as any).current;
+    const priorConfigs = Base.configurations();
     try {
       const inMemory = new DatabaseConfigurations([
         new HashConfig(env, "primary", {
@@ -491,13 +492,16 @@ describe("ConnectionHandlingTest", () => {
         }),
       ]);
 
+      // Rails' registry is one class variable, so the config goes on Base
+      // even though the connection is established on the subclass.
+      Base.configurations(inMemory);
       class InMemoryModel extends Base {}
-      InMemoryModel.configurations(inMemory);
 
       await InMemoryModel.establishConnection();
       expect(InMemoryModel.connectionPool().dbConfig.database).toBe("db/common.sqlite3");
       expect(await InMemoryModel.adapterClass()).toBe(await Base.adapterClass());
     } finally {
+      Base.configurations(priorConfigs);
       (DatabaseConfigurations as any).current = priorCurrent;
     }
   });
@@ -512,13 +516,14 @@ describe("ConnectionHandlingTest", () => {
     const env = process.env.NODE_ENV || DatabaseConfigurations.defaultEnv;
 
     const priorCurrent = (DatabaseConfigurations as any).current;
+    const priorConfigs = Base.configurations();
     try {
       const url = new UrlConfig(env, "primary", "sqlite3:db/foo.sqlite3");
       url._database = "db/foo-2.sqlite3"; // mimic worker-suffix mutation
       const inMemory = new DatabaseConfigurations([url]);
 
+      Base.configurations(inMemory);
       class WorkerModel extends Base {}
-      WorkerModel.configurations(inMemory);
 
       await WorkerModel.establishConnection();
       // The connection pool's resolved dbConfig must point at the
@@ -533,6 +538,7 @@ describe("ConnectionHandlingTest", () => {
         await import("./connection-adapters/better-sqlite3-adapter.js");
       expect(Klass).toBe(BetterSQLite3Adapter);
     } finally {
+      Base.configurations(priorConfigs);
       (DatabaseConfigurations as any).current = priorCurrent;
     }
   });
@@ -765,10 +771,9 @@ describe("resolveConfigForConnection / connectsTo with unset configurations", ()
       __resetPrimaryAbstractClass();
       primaryAbstractClass(AppRecord);
       const env = DatabaseConfigurations.currentEnv();
-      AppRecord.configurations({
+      Base.configurations({
         [env]: { primary: { adapter: "sqlite3", database: "db/primary.sqlite3" } },
       });
-      SecondaryAbstract.configurations(AppRecord.configurations());
 
       // Exercises the public connectsTo path so the
       // resolveConfigForConnection side effect (planting

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -737,10 +737,9 @@ describe("resolveConfigForConnection / connectsTo with unset configurations", ()
         this.abstractClass = true;
       }
     }
-    // No `Untouched.configurations` assigned — the empty default registry falls
-    // back to DatabaseConfigurations.fromEnv({}), so resolving an unknown
-    // env name must surface AdapterNotSpecified rather than passing the
-    // string through.
+    // No `Untouched.configurations` assigned — resolving an unknown env name
+    // against the empty default registry must surface AdapterNotSpecified
+    // rather than passing the string through.
     expect(() => resolveConfigForConnection.call(Untouched, "missing_env")).toThrow(
       AdapterNotSpecified,
     );

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -963,14 +963,10 @@ async function autoConnect(modelClass: typeof Base): Promise<void> {
   // `TestDatabases.create_and_load_schema` (which suffixes `_database`
   // per worker before reconnect). Falling back to disk would re-read
   // unmutated configs and reconnect to the wrong database.
-  const inMemory = (modelClass as any).configurations;
+  const inMemory = modelClass.configurations();
   let configs: DatabaseConfigurations;
-  if (inMemory instanceof DatabaseConfigurations) {
+  if (!inMemory.empty) {
     configs = inMemory;
-  } else if (inMemory && typeof inMemory.toH === "function") {
-    configs = DatabaseConfigurations.fromEnv(inMemory.toH());
-  } else if (inMemory && typeof inMemory === "object") {
-    configs = DatabaseConfigurations.fromEnv(inMemory);
   } else {
     const raw = await loadConfigFile(modelClass);
     configs = DatabaseConfigurations.fromEnv(raw);
@@ -1119,38 +1115,5 @@ export function resolveConfigForConnection(
   // an own-property check so writing here doesn't bleed through JS static
   // inheritance into unrelated subclasses.
   (this as any)._connectionSpecificationName = isPrimaryClass.call(this) ? "Base" : this.name;
-  return normalizeConfigurations(this).resolve(configOrEnv);
-}
-
-/**
- * Normalize a class's `configurations` static into a DatabaseConfigurations
- * instance. Mirror Rails' `Base.configurations.resolve(...)` entry point by
- * always returning a real configurations object — string env names then
- * surface AdapterNotSpecified with the available-configs hint instead of
- * silently passing through.
- *
- * Not cached: `DatabaseConfigurations.fromEnv(...)` also folds in
- * `DATABASE_URL`/`TRAILS_ENV` and updates `DatabaseConfigurations.current`,
- * so a (class, rawConfigs) cache key would miss later env-state changes
- * and leave `HashConfig.isPrimary()` consulting a stale registry.
- * Rebuilding per resolve mirrors Rails' `Base.configurations.resolve(...)`
- * and keeps the multi-shard `connectsTo` loop honest against later
- * configuration or env shifts — `fromEnv` is a thin per-call build.
- *
- * @internal
- */
-function normalizeConfigurations(klass: typeof Base): DatabaseConfigurations {
-  const rawConfigs = (klass as any).configurations;
-  if (rawConfigs instanceof DatabaseConfigurations) return rawConfigs;
-  if (rawConfigs && typeof rawConfigs === "object") {
-    // Guard the `toH` call: raw config maps can carry arbitrary top-level
-    // keys, so a non-function `toH` entry is real config data — not a
-    // hash-like accessor to unwrap. Mirrors the same guard used in
-    // `establishConnection`'s in-memory branch and in `test-databases.ts`.
-    const toH = (rawConfigs as { toH?: unknown }).toH;
-    const raw =
-      typeof toH === "function" ? (toH.call(rawConfigs) as RawConfigurations) : rawConfigs;
-    return DatabaseConfigurations.fromEnv(raw as RawConfigurations);
-  }
-  return DatabaseConfigurations.fromEnv({});
+  return this.configurations().resolve(configOrEnv);
 }

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -92,6 +92,19 @@ function isBaseClass(klass: typeof Base): boolean {
   return Object.prototype.hasOwnProperty.call(klass, "_isActiveRecordBase");
 }
 
+// Ruby's `ActiveRecord::Base` constant, reached by walking the static
+// prototype chain rather than importing base.js (a runtime cycle). Rails'
+// registry is one class variable, so the sites Rails spells
+// `Base.configurations` must not pick up a subclass-local shadow.
+function activeRecordBase(klass: typeof Base): typeof Base {
+  for (let current: typeof Base = klass; ; ) {
+    if (isBaseClass(current)) return current;
+    const parent: unknown = Object.getPrototypeOf(current);
+    if (typeof parent !== "function") return current;
+    current = parent as typeof Base;
+  }
+}
+
 export function connectsTo(
   this: typeof Base,
   options: {
@@ -963,7 +976,7 @@ async function autoConnect(modelClass: typeof Base): Promise<void> {
   // `TestDatabases.create_and_load_schema` (which suffixes `_database`
   // per worker before reconnect). Falling back to disk would re-read
   // unmutated configs and reconnect to the wrong database.
-  const inMemory = modelClass.configurations();
+  const inMemory = activeRecordBase(modelClass).configurations();
   let configs: DatabaseConfigurations;
   if (!inMemory.empty) {
     configs = inMemory;
@@ -1115,5 +1128,7 @@ export function resolveConfigForConnection(
   // an own-property check so writing here doesn't bleed through JS static
   // inheritance into unrelated subclasses.
   (this as any)._connectionSpecificationName = isPrimaryClass.call(this) ? "Base" : this.name;
-  return this.configurations().resolve(configOrEnv);
+  // Rails: `Base.configurations.resolve(config_or_env)` — the global registry,
+  // not the receiver's (connection_handling.rb:391).
+  return activeRecordBase(this).configurations().resolve(configOrEnv);
 }

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -8,6 +8,8 @@ import { getApplicationRecordClass } from "./inheritance.js";
 import { RecordNotFound, StatementInvalid, StrictLoadingViolationError } from "./errors.js";
 import { actionOnStrictLoadingViolation } from "./ar-config.js";
 import { WRITING_ROLE } from "./roles.js";
+import { DatabaseConfigurations, type RawConfigurations } from "./database-configurations.js";
+import type { DatabaseConfig } from "./database-configurations/database-config.js";
 import {
   Notifications,
   IsolatedExecutionState,
@@ -407,7 +409,7 @@ interface CoreHost {
   _destroyAssociationAsyncJob?: any;
   _findByStatementCache?: Map<boolean, Map<string, any>>;
   _generatedAssociationMethods?: Set<string>;
-  _configurations?: any;
+  _configurations?: DatabaseConfigurations;
   _predicateBuilder?: any;
   arelTable?: any;
   prototype: any;
@@ -429,11 +431,33 @@ export function destroyAssociationAsyncJob(this: CoreHost, value?: any): any {
   return this._destroyAssociationAsyncJob ?? null;
 }
 
-export function configurations(this: CoreHost, config?: any): any {
+/**
+ * Reader/writer for the database configuration registry.
+ *
+ * Rails normalizes on assignment (`@@configurations =
+ * ActiveRecord::DatabaseConfigurations.new(config)`) and its reader therefore
+ * always hands back a `DatabaseConfigurations`. Callers get that guarantee
+ * here too, so nothing downstream has to re-sniff a raw hash.
+ *
+ * Mirrors: ActiveRecord::Base.configurations / .configurations=
+ */
+export function configurations(
+  this: CoreHost,
+  config?: RawConfigurations | DatabaseConfigurations | DatabaseConfig[],
+): DatabaseConfigurations {
   if (config !== undefined) {
-    this._configurations = config;
+    this._configurations =
+      config instanceof DatabaseConfigurations
+        ? config
+        : Array.isArray(config)
+          ? new DatabaseConfigurations(config)
+          : // `fromEnv` is trails' build entry point: like Rails'
+            // `DatabaseConfigurations.new` it folds `DATABASE_URL` in, but it
+            // resolves the env through `currentEnv()`, which is what every
+            // runtime config selector looks the result up by.
+            DatabaseConfigurations.fromEnv(config);
   }
-  return this._configurations ?? {};
+  return this._configurations ?? DatabaseConfigurations.fromEnv({});
 }
 
 export function isApplicationRecordClass(this: CoreHost): boolean {

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -432,13 +432,6 @@ export function destroyAssociationAsyncJob(this: CoreHost, value?: any): any {
 }
 
 /**
- * Reader/writer for the database configuration registry.
- *
- * Rails normalizes on assignment (`@@configurations =
- * ActiveRecord::DatabaseConfigurations.new(config)`) and its reader therefore
- * always hands back a `DatabaseConfigurations`. Callers get that guarantee
- * here too, so nothing downstream has to re-sniff a raw hash.
- *
  * Mirrors: ActiveRecord::Base.configurations / .configurations=
  */
 export function configurations(
@@ -451,11 +444,7 @@ export function configurations(
         ? config
         : Array.isArray(config)
           ? new DatabaseConfigurations(config)
-          : // `fromEnv` is trails' build entry point: like Rails'
-            // `DatabaseConfigurations.new` it folds `DATABASE_URL` in, but it
-            // resolves the env through `currentEnv()`, which is what every
-            // runtime config selector looks the result up by.
-            DatabaseConfigurations.fromEnv(config);
+          : DatabaseConfigurations.fromEnv(config);
   }
   return this._configurations ?? DatabaseConfigurations.fromEnv({});
 }

--- a/packages/activerecord/src/database-configurations.test.ts
+++ b/packages/activerecord/src/database-configurations.test.ts
@@ -8,12 +8,8 @@ describe("DatabaseConfigurationsTest", () => {
     DatabaseConfigurations.defaultEnv = "development";
   });
 
-  // Rails round-trips through the `Base.configurations=` writer, which
-  // normalizes the raw hash into a DatabaseConfigurations, and then asserts
-  // the reader answers `empty?` — the pair trails spells as the
-  // optional-argument `Base.configurations()` accessor. Rails' second
-  // assertion (`blank?`) is Object#blank?, an ActiveSupport alias of the same
-  // predicate on this receiver, so `empty` covers both.
+  // Rails' second assertion (`blank?`) is Object#blank?, an ActiveSupport
+  // alias of the same predicate on this receiver, so `empty` covers both.
   it("empty returns true when db configs are empty", () => {
     const oldConfig = Base.configurations();
     const config = {};

--- a/packages/activerecord/src/database-configurations.test.ts
+++ b/packages/activerecord/src/database-configurations.test.ts
@@ -1,15 +1,30 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { DatabaseConfig } from "./database-configurations/database-config.js";
 import { DatabaseConfigurations } from "./database-configurations.js";
+import { Base } from "./base.js";
 
 describe("DatabaseConfigurationsTest", () => {
   beforeEach(() => {
     DatabaseConfigurations.defaultEnv = "development";
   });
 
+  // Rails round-trips through the `Base.configurations=` writer, which
+  // normalizes the raw hash into a DatabaseConfigurations, and then asserts
+  // the reader answers `empty?` — the pair trails spells as the
+  // optional-argument `Base.configurations()` accessor. Rails' second
+  // assertion (`blank?`) is Object#blank?, an ActiveSupport alias of the same
+  // predicate on this receiver, so `empty` covers both.
   it("empty returns true when db configs are empty", () => {
-    const configs = new DatabaseConfigurations({});
-    expect(configs.empty).toBe(true);
+    const oldConfig = Base.configurations();
+    const config = {};
+
+    Base.configurations(config);
+
+    try {
+      expect(Base.configurations().empty).toBe(true);
+    } finally {
+      Base.configurations(oldConfig);
+    }
   });
 
   it("configs for getter with env name", () => {

--- a/packages/activerecord/src/query-cache.test.ts
+++ b/packages/activerecord/src/query-cache.test.ts
@@ -584,9 +584,8 @@ describe("QueryCacheTest", () => {
     // `Base.configurations` from config.yml, so the not-connected branch still
     // caches. The trails harness establishes connections without registering
     // configurations, so supply that precondition here and restore after.
-    const baseWithConfigs = Base as unknown as { configurations: unknown };
-    const priorConfigurations = baseWithConfigs.configurations;
-    baseWithConfigs.configurations = { arunit: dbConfig.configuration };
+    const priorConfigurations = Base.configurations();
+    Base.configurations({ arunit: dbConfig.configuration });
 
     await Base.establishConnection(dbConfig);
     expect(Task.isConnectedQ()).toBe(false);
@@ -601,7 +600,7 @@ describe("QueryCacheTest", () => {
         });
       });
     } finally {
-      baseWithConfigs.configurations = priorConfigurations;
+      Base.configurations(priorConfigurations);
       await Base.establishConnection(originalConnection);
     }
   });

--- a/packages/activerecord/src/query-cache.ts
+++ b/packages/activerecord/src/query-cache.ts
@@ -12,7 +12,6 @@
 // Import under the qualified TS name so the public surface doesn't leak the
 // generic `Store` symbol into the generated `.d.ts`.
 import { Store as QueryCacheStore } from "./connection-adapters/abstract/query-cache.js";
-import { DatabaseConfigurations } from "./database-configurations.js";
 import type { Base } from "./base.js";
 
 // Deep-import convenience: consumers doing
@@ -124,21 +123,6 @@ export class QueryCache {
 }
 
 /**
- * Mirrors Rails' `connected? || !configurations.empty?` guard. The raw
- * `configurations` static can hold a `DatabaseConfigurations`, a raw config
- * map, an array of configs, or nothing; normalize all of them to the
- * emptiness check Rails performs on its always-`DatabaseConfigurations` reader.
- */
-function configurationsEmpty(klass: typeof Base): boolean {
-  const configs = (klass as { configurations?: unknown }).configurations;
-  if (configs == null) return true;
-  if (configs instanceof DatabaseConfigurations) return configs.empty;
-  if (Array.isArray(configs)) return configs.length === 0;
-  if (typeof configs === "object") return Object.keys(configs).length === 0;
-  return true;
-}
-
-/**
  * Model-level query-cache delegation, mixed into `Base` via `extend`.
  *
  * Mirrors: ActiveRecord::QueryCache::ClassMethods (lib/active_record/query_cache.rb).
@@ -151,7 +135,7 @@ export const ClassMethods = {
    * Mirrors: ActiveRecord::QueryCache::ClassMethods#cache
    */
   async cache<T>(this: typeof Base, block: () => T | Promise<T>): Promise<T> {
-    if (this.isConnected() || !configurationsEmpty(this)) {
+    if (this.isConnected() || !this.configurations().empty) {
       const pool = this.connectionPool();
       const wasEnabled = pool.queryCacheEnabled;
       try {
@@ -174,7 +158,7 @@ export const ClassMethods = {
     block: () => T | Promise<T>,
     options: { dirties?: boolean } = {},
   ): Promise<T> {
-    if (this.isConnected() || !configurationsEmpty(this)) {
+    if (this.isConnected() || !this.configurations().empty) {
       return this.connectionPool().disableQueryCache(block, options);
     }
     return Promise.resolve(block());

--- a/packages/activerecord/src/shard-keys.test.ts
+++ b/packages/activerecord/src/shard-keys.test.ts
@@ -13,17 +13,17 @@ describe("ShardsKeysTest", () => {
   }
   class ShardedModel extends ShardedBase {}
 
-  let prevConfigs: unknown;
+  let prevConfigs: DatabaseConfigurations;
   let prevDefaultEnv: string;
   let prevCurrent: unknown;
 
   beforeEach(() => {
-    prevConfigs = (Base as any).configurations;
+    prevConfigs = Base.configurations();
     prevDefaultEnv = DatabaseConfigurations.defaultEnv;
     prevCurrent = (DatabaseConfigurations as any).current;
     DatabaseConfigurations.defaultEnv = "default_env";
     vi.stubEnv("TRAILS_ENV", "default_env");
-    (Base as any).configurations = {
+    Base.configurations({
       default_env: {
         primary: { adapter: "sqlite3", database: ":memory:" },
         shard_one: { adapter: "sqlite3", database: ":memory:" },
@@ -31,7 +31,7 @@ describe("ShardsKeysTest", () => {
         shard_two: { adapter: "sqlite3", database: ":memory:" },
         shard_two_reading: { adapter: "sqlite3", database: ":memory:", replica: true },
       },
-    };
+    });
     (Base as any)._shardKeys = undefined;
 
     UnshardedBase.connectsTo({ database: { writing: "primary" } });
@@ -45,7 +45,7 @@ describe("ShardsKeysTest", () => {
 
   afterEach(async () => {
     await Base.connectionHandler.clearAllConnectionsBang();
-    (Base as any).configurations = prevConfigs;
+    Base.configurations(prevConfigs);
     DatabaseConfigurations.defaultEnv = prevDefaultEnv;
     (DatabaseConfigurations as any).current = prevCurrent;
     (Base as any)._shardKeys = undefined;

--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -26,10 +26,15 @@ afterAll(() => {
 describe("TestDatabasesTest", () => {
   fixtures({});
   let priorCurrent: DatabaseConfigurations | null;
+  let priorConfigs: DatabaseConfigurations;
   beforeEach(() => {
     priorCurrent = DatabaseConfigurations.current;
+    priorConfigs = Base.configurations();
   });
+  // Mirrors the Rails case's `ensure ActiveRecord::Base.configurations =
+  // prev_configs` (test_databases_test.rb:51).
   afterEach(() => {
+    Base.configurations(priorConfigs);
     DatabaseConfigurations.current = priorCurrent;
     vi.restoreAllMocks();
   });
@@ -58,11 +63,9 @@ describe("TestDatabasesTest", () => {
 
     const mockConfigurations = stubConfigurations([mockConfig]);
 
-    const mockModelClass = {
-      configurations: () => mockConfigurations,
-    } as any as typeof Base;
+    Base.configurations(mockConfigurations);
 
-    await createAndLoadSchema(mockModelClass, 2, { envName: "arunit" });
+    await createAndLoadSchema(2, { envName: "arunit" });
 
     expect(mockConfig.database).toBe("test/db/primary.sqlite3-2");
     expect(mockReconstructFromSchema).toHaveBeenCalledWith(
@@ -70,7 +73,7 @@ describe("TestDatabasesTest", () => {
       DatabaseTasks.schemaFormat,
       undefined,
     );
-    expect(mockEstablishConnection).toHaveBeenCalledWith(mockModelClass);
+    expect(mockEstablishConnection).toHaveBeenCalledWith(Base);
   });
 
   it("create databases after fork", async () => {
@@ -97,11 +100,9 @@ describe("TestDatabasesTest", () => {
 
     const mockConfigurations = stubConfigurations([mockConfig]);
 
-    const mockModelClass = {
-      configurations: () => mockConfigurations,
-    } as any as typeof Base;
+    Base.configurations(mockConfigurations);
 
-    await createAndLoadSchema(mockModelClass, 42, { envName: "arunit" });
+    await createAndLoadSchema(42, { envName: "arunit" });
 
     expect(mockConfig.database).toBe("test/db/primary.sqlite3-42");
     expect(mockReconstructFromSchema).toHaveBeenCalled();
@@ -122,11 +123,9 @@ describe("TestDatabasesTest", () => {
 
     const mockConfigurations = stubConfigurations(configs);
 
-    const mockModelClass = {
-      configurations: () => mockConfigurations,
-    } as any as typeof Base;
+    Base.configurations(mockConfigurations);
 
-    await createAndLoadSchema(mockModelClass, 42, { envName: "arunit" });
+    await createAndLoadSchema(42, { envName: "arunit" });
 
     expect(mockReconstructFromSchema).toHaveBeenCalledTimes(configs.length);
     const reconstructedNames = mockReconstructFromSchema.mock.calls.map(
@@ -150,11 +149,9 @@ describe("TestDatabasesTest", () => {
       adapter: "sqlite3",
     });
 
-    const mockModelClass = {
-      configurations: () => stubConfigurations([dbConfig]),
-    } as any as typeof Base;
+    Base.configurations(stubConfigurations([dbConfig]));
 
-    await createAndLoadSchema(mockModelClass, 5, { envName: "arunit" });
+    await createAndLoadSchema(5, { envName: "arunit" });
     expect(dbConfig.database).toBe("test/db/primary.sqlite3-5");
   });
 
@@ -175,11 +172,9 @@ describe("TestDatabasesTest", () => {
     });
     Object.defineProperty(mockConfig, "database", { get: () => ":memory:" });
 
-    const mockModelClass = {
-      configurations: () => stubConfigurations([mockConfig]),
-    } as any as typeof Base;
+    Base.configurations(stubConfigurations([mockConfig]));
 
-    await createAndLoadSchema(mockModelClass, 7, { envName: "arunit" });
+    await createAndLoadSchema(7, { envName: "arunit" });
     // _database setter must NOT have been called for an in-memory DB —
     // suffixing `:memory:` would turn it into an on-disk path.
     expect(suffixed).toBeUndefined();
@@ -197,8 +192,8 @@ describe("TestDatabasesTest", () => {
     // Nothing configured — defensive early return; nothing to suffix.
     // In Rails this never occurs (app boot sets configurations first).
     const empty = new DatabaseConfigurations({});
-    const mockModelClass = { configurations: () => empty } as any as typeof Base;
-    await createAndLoadSchema(mockModelClass, 1, { envName: "arunit" });
+    Base.configurations(empty);
+    await createAndLoadSchema(1, { envName: "arunit" });
     expect(empty.empty).toBe(true);
     expect(mockReconstructFromSchema).not.toHaveBeenCalled();
   });
@@ -213,11 +208,9 @@ describe("TestDatabasesTest", () => {
     Object.defineProperty(mockConfig, "_database", { set() {} });
     Object.defineProperty(mockConfig, "database", { get: () => undefined });
 
-    const mockModelClass = {
-      configurations: () => stubConfigurations([mockConfig]),
-    } as any as typeof Base;
+    Base.configurations(stubConfigurations([mockConfig]));
 
-    await expect(createAndLoadSchema(mockModelClass, 1, { envName: "arunit" })).rejects.toThrow(
+    await expect(createAndLoadSchema(1, { envName: "arunit" })).rejects.toThrow(
       /Cannot suffix database name/,
     );
   });
@@ -245,18 +238,14 @@ describe("TestDatabasesTest", () => {
     });
     mockConfig.adapter = "sqlite3";
 
-    const mockModelClass = {
-      configurations: () => stubConfigurations([mockConfig]),
-    } as any as typeof Base;
+    Base.configurations(stubConfigurations([mockConfig]));
 
     const originalVerbose = process.env.VERBOSE;
     process.env.VERBOSE = "1";
 
     try {
-      await expect(createAndLoadSchema(mockModelClass, 7, { envName: "arunit" })).rejects.toThrow(
-        error,
-      );
-      expect(mockEstablishConnection).toHaveBeenCalledWith(mockModelClass);
+      await expect(createAndLoadSchema(7, { envName: "arunit" })).rejects.toThrow(error);
+      expect(mockEstablishConnection).toHaveBeenCalledWith(Base);
       expect(process.env.VERBOSE).toBe("1");
     } finally {
       if (originalVerbose === undefined) {

--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -8,12 +8,12 @@ import { fixtures } from "./test-helpers/fixtures.js";
 import { SchemaMigration } from "./schema-migration.js";
 
 // Build a (minimal) DatabaseConfigurations whose `configsFor` returns the
-// supplied stubbed configs. Mirrors the production shape — production code
-// calls `(this as any).configurations?.toH?.()` then `fromEnv(...)`, so the
-// real Base.configurations is a raw hash; createAndLoadSchema normalizes
-// either input. Tests use the post-normalization instance directly.
+// supplied stubbed configs. `Base.configurations()` always hands back a
+// DatabaseConfigurations, so the stubbed model class returns one too. The
+// configs are seeded through the array constructor arm as well as the
+// `configsFor` spy, so the registry reports itself non-empty.
 const stubConfigurations = (configs: unknown[]): DatabaseConfigurations => {
-  const dc = new DatabaseConfigurations([]);
+  const dc = new DatabaseConfigurations(configs as never);
   vi.spyOn(dc, "configsFor").mockReturnValue(configs as never);
   return dc;
 };
@@ -61,7 +61,7 @@ describe("TestDatabasesTest", () => {
     const mockConfigurations = stubConfigurations([mockConfig]);
 
     const mockModelClass = {
-      configurations: mockConfigurations,
+      configurations: () => mockConfigurations,
     } as any as typeof Base;
 
     await createAndLoadSchema(mockModelClass, 2, { envName: "arunit" });
@@ -100,7 +100,7 @@ describe("TestDatabasesTest", () => {
     const mockConfigurations = stubConfigurations([mockConfig]);
 
     const mockModelClass = {
-      configurations: mockConfigurations,
+      configurations: () => mockConfigurations,
     } as any as typeof Base;
 
     await createAndLoadSchema(mockModelClass, 42, { envName: "arunit" });
@@ -125,7 +125,7 @@ describe("TestDatabasesTest", () => {
     const mockConfigurations = stubConfigurations(configs);
 
     const mockModelClass = {
-      configurations: mockConfigurations,
+      configurations: () => mockConfigurations,
     } as any as typeof Base;
 
     await createAndLoadSchema(mockModelClass, 42, { envName: "arunit" });
@@ -153,7 +153,7 @@ describe("TestDatabasesTest", () => {
     });
 
     const mockModelClass = {
-      configurations: stubConfigurations([dbConfig]),
+      configurations: () => stubConfigurations([dbConfig]),
     } as any as typeof Base;
 
     await createAndLoadSchema(mockModelClass, 5, { envName: "arunit" });
@@ -178,7 +178,7 @@ describe("TestDatabasesTest", () => {
     Object.defineProperty(mockConfig, "database", { get: () => ":memory:" });
 
     const mockModelClass = {
-      configurations: stubConfigurations([mockConfig]),
+      configurations: () => stubConfigurations([mockConfig]),
     } as any as typeof Base;
 
     await createAndLoadSchema(mockModelClass, 7, { envName: "arunit" });
@@ -189,16 +189,20 @@ describe("TestDatabasesTest", () => {
   });
 
   it("does not overwrite an unset Base.configurations with an empty registry", async () => {
-    vi.spyOn(DatabaseTasks, "reconstructFromSchema").mockResolvedValue(undefined);
+    const mockReconstructFromSchema = vi
+      .spyOn(DatabaseTasks, "reconstructFromSchema")
+      .mockResolvedValue(undefined);
     vi.spyOn(await import("./connection-handling.js"), "establishConnection").mockResolvedValue(
       undefined,
     );
 
-    // No `configurations` — defensive early return; nothing to suffix.
+    // Nothing configured — defensive early return; nothing to suffix.
     // In Rails this never occurs (app boot sets configurations first).
-    const mockModelClass = { configurations: undefined } as any as typeof Base;
+    const empty = new DatabaseConfigurations({});
+    const mockModelClass = { configurations: () => empty } as any as typeof Base;
     await createAndLoadSchema(mockModelClass, 1, { envName: "arunit" });
-    expect((mockModelClass as any).configurations).toBeUndefined();
+    expect(empty.empty).toBe(true);
+    expect(mockReconstructFromSchema).not.toHaveBeenCalled();
   });
 
   it("throws a clear error when neither database nor URL yields a name", async () => {
@@ -212,7 +216,7 @@ describe("TestDatabasesTest", () => {
     Object.defineProperty(mockConfig, "database", { get: () => undefined });
 
     const mockModelClass = {
-      configurations: stubConfigurations([mockConfig]),
+      configurations: () => stubConfigurations([mockConfig]),
     } as any as typeof Base;
 
     await expect(createAndLoadSchema(mockModelClass, 1, { envName: "arunit" })).rejects.toThrow(
@@ -244,7 +248,7 @@ describe("TestDatabasesTest", () => {
     mockConfig.adapter = "sqlite3";
 
     const mockModelClass = {
-      configurations: stubConfigurations([mockConfig]),
+      configurations: () => stubConfigurations([mockConfig]),
     } as any as typeof Base;
 
     const originalVerbose = process.env.VERBOSE;

--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -8,10 +8,8 @@ import { fixtures } from "./test-helpers/fixtures.js";
 import { SchemaMigration } from "./schema-migration.js";
 
 // Build a (minimal) DatabaseConfigurations whose `configsFor` returns the
-// supplied stubbed configs. `Base.configurations()` always hands back a
-// DatabaseConfigurations, so the stubbed model class returns one too. The
-// configs are seeded through the array constructor arm as well as the
-// `configsFor` spy, so the registry reports itself non-empty.
+// supplied stubbed configs. They also go through the array constructor arm so
+// the registry reports itself non-empty.
 const stubConfigurations = (configs: unknown[]): DatabaseConfigurations => {
   const dc = new DatabaseConfigurations(configs as never);
   vi.spyOn(dc, "configsFor").mockReturnValue(configs as never);

--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -181,21 +181,24 @@ describe("TestDatabasesTest", () => {
     expect(mockReconstructFromSchema).toHaveBeenCalled();
   });
 
-  it("does not overwrite an unset Base.configurations with an empty registry", async () => {
+  // Rails has no empty-registry guard: `create_and_load_schema` iterates
+  // whatever `configs_for` yields (possibly nothing) and still runs the
+  // `ensure ActiveRecord::Base.establish_connection`
+  // (test_databases.rb:11-21).
+  it("reconnects through the ensure even when the registry is empty", async () => {
     const mockReconstructFromSchema = vi
       .spyOn(DatabaseTasks, "reconstructFromSchema")
       .mockResolvedValue(undefined);
-    vi.spyOn(await import("./connection-handling.js"), "establishConnection").mockResolvedValue(
-      undefined,
-    );
+    const mockEstablishConnection = vi
+      .spyOn(await import("./connection-handling.js"), "establishConnection")
+      .mockResolvedValue(undefined);
 
-    // Nothing configured — defensive early return; nothing to suffix.
-    // In Rails this never occurs (app boot sets configurations first).
-    const empty = new DatabaseConfigurations({});
-    Base.configurations(empty);
+    Base.configurations({});
+
     await createAndLoadSchema(1, { envName: "arunit" });
-    expect(empty.empty).toBe(true);
+
     expect(mockReconstructFromSchema).not.toHaveBeenCalled();
+    expect(mockEstablishConnection).toHaveBeenCalledWith(Base);
   });
 
   it("throws a clear error when neither database nor URL yields a name", async () => {

--- a/packages/activerecord/src/test-databases.ts
+++ b/packages/activerecord/src/test-databases.ts
@@ -65,9 +65,7 @@ export async function createAndLoadSchema(
   { envName }: { envName: string } = { envName: "test" },
 ): Promise<void> {
   // Rails: configurations is always set before create_and_load_schema is
-  // called (app boots first). Guard here is defensive — with nothing
-  // configured there is nothing to suffix and the finally reconnect handles
-  // the rest.
+  // called (app boots first); this guard is defensive.
   const configurations = modelClass.configurations();
   if (configurations.empty) return;
 

--- a/packages/activerecord/src/test-databases.ts
+++ b/packages/activerecord/src/test-databases.ts
@@ -8,7 +8,6 @@ import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/a
 import type { MigrationProxy } from "./migration.js";
 import { Migrator } from "./migration.js";
 import type { Base } from "./base.js";
-import { DatabaseConfigurations } from "./database-configurations.js";
 import { DatabaseTasks } from "./tasks/database-tasks.js";
 
 /**
@@ -66,18 +65,11 @@ export async function createAndLoadSchema(
   { envName }: { envName: string } = { envName: "test" },
 ): Promise<void> {
   // Rails: configurations is always set before create_and_load_schema is
-  // called (app boots first). Guard here is defensive — if null, there is
-  // nothing to suffix and the finally reconnect handles the rest.
-  const raw = (modelClass as any).configurations;
-  if (raw == null) return;
-
-  // Normalize to a DatabaseConfigurations instance. Persist it back so
-  // _database mutations and the finally reconnect see the same registry.
-  const configurations =
-    raw instanceof DatabaseConfigurations
-      ? raw
-      : DatabaseConfigurations.fromEnv(typeof raw.toH === "function" ? raw.toH() : raw);
-  (modelClass as any).configurations = configurations;
+  // called (app boots first). Guard here is defensive — with nothing
+  // configured there is nothing to suffix and the finally reconnect handles
+  // the rest.
+  const configurations = modelClass.configurations();
+  if (configurations.empty) return;
 
   const old = process.env.VERBOSE;
   process.env.VERBOSE = "false";

--- a/packages/activerecord/src/test-databases.ts
+++ b/packages/activerecord/src/test-databases.ts
@@ -7,7 +7,7 @@
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import type { MigrationProxy } from "./migration.js";
 import { Migrator } from "./migration.js";
-import type { Base } from "./base.js";
+import { Base } from "./base.js";
 import { DatabaseTasks } from "./tasks/database-tasks.js";
 
 /**
@@ -60,13 +60,12 @@ function isInMemorySqlite(name: string): boolean {
  * Mirrors: ActiveRecord::TestDatabases.create_and_load_schema
  */
 export async function createAndLoadSchema(
-  modelClass: typeof Base,
   index: number,
   { envName }: { envName: string } = { envName: "test" },
 ): Promise<void> {
   // Rails: configurations is always set before create_and_load_schema is
   // called (app boots first); this guard is defensive.
-  const configurations = modelClass.configurations();
+  const configurations = Base.configurations();
   if (configurations.empty) return;
 
   const old = process.env.VERBOSE;
@@ -99,7 +98,7 @@ export async function createAndLoadSchema(
     // it always runs even if establishConnection throws.
     const { establishConnection } = await import("./connection-handling.js");
     try {
-      await establishConnection(modelClass);
+      await establishConnection(Base);
     } finally {
       if (old !== undefined) {
         process.env.VERBOSE = old;

--- a/packages/activerecord/src/test-databases.ts
+++ b/packages/activerecord/src/test-databases.ts
@@ -63,16 +63,11 @@ export async function createAndLoadSchema(
   index: number,
   { envName }: { envName: string } = { envName: "test" },
 ): Promise<void> {
-  // Rails: configurations is always set before create_and_load_schema is
-  // called (app boots first); this guard is defensive.
-  const configurations = Base.configurations();
-  if (configurations.empty) return;
-
   const old = process.env.VERBOSE;
   process.env.VERBOSE = "false";
 
   try {
-    const configs = configurations.configsFor({ envName });
+    const configs = Base.configurations().configsFor({ envName });
     for (const dbConfig of configs) {
       // `dbConfig.database` falls back to URL parsing for URL-only configs
       // (UrlConfig.database override landed in #957). Only fails for configs

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/base.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/base.json
@@ -23,13 +23,6 @@
   {
     "package": "activerecord",
     "tsFile": "base.ts",
-    "rubyName": "cache",
-    "call": "configurations",
-    "reason": "Bucket (b): Rails' `configurations.empty?` is a call on the `Base.configurations` class_attribute reader; trails stores it as a plain static property, so `configurationsEmpty(this)` reads it — there is no `configurations()` call to match. Converges when the Core.configurations accessor (core.ts:432, currently unwired) becomes the real read path."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
     "rubyName": "changed_for_autosave?",
     "call": "has_changes_to_save?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -208,13 +201,6 @@
     "rubyName": "to_param",
     "call": "join",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
-    "rubyName": "uncached",
-    "call": "configurations",
-    "reason": "Bucket (b): Rails' `configurations.empty?` is a call on the `Base.configurations` class_attribute reader; trails stores it as a plain static property, so `configurationsEmpty(this)` reads it — there is no `configurations()` call to match. Converges when the Core.configurations accessor (core.ts:432, currently unwired) becomes the real read path."
   },
   {
     "package": "activerecord",

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-handling.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-handling.json
@@ -37,13 +37,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-handling.ts",
-    "rubyName": "resolve_config_for_connection",
-    "call": "configurations",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-handling.ts",
     "rubyName": "sharded?",
     "call": "any?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/core.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/core.json
@@ -16,13 +16,6 @@
   {
     "package": "activerecord",
     "tsFile": "core.ts",
-    "rubyName": "configurations=",
-    "call": "new",
-    "reason": "Constructor idiom: Ruby `X.new` ports to TS `new X()`, which extractCalls records as a construction/type reference rather than a named call. The construction is present in the port. Cluster-vetted: representative entries in this cluster were read against the vendored Rails body; the rest share the same mechanism and were classified by it, not line-diffed individually."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "core.ts",
     "rubyName": "connected_to_stack",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/query-cache.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/query-cache.json
@@ -2,13 +2,6 @@
   {
     "package": "activerecord",
     "tsFile": "query-cache.ts",
-    "rubyName": "cache",
-    "call": "configurations",
-    "reason": "Bucket (b): Rails' `configurations.empty?` is a call on the `Base.configurations` class_attribute reader; trails stores it as a plain static property, so `configurationsEmpty(this)` reads it — there is no `configurations()` call to match. Converges when the Core.configurations accessor (core.ts:432, currently unwired) becomes the real read path."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "query-cache.ts",
     "rubyName": "run",
     "call": "connection_handler",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -26,12 +19,5 @@
     "rubyName": "run",
     "call": "query_cache",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "query-cache.ts",
-    "rubyName": "uncached",
-    "call": "configurations",
-    "reason": "Bucket (b): Rails' `configurations.empty?` is a call on the `Base.configurations` class_attribute reader; trails stores it as a plain static property, so `configurationsEmpty(this)` reads it — there is no `configurations()` call to match. Converges when the Core.configurations accessor (core.ts:432, currently unwired) becomes the real read path."
   }
 ]


### PR DESCRIPTION
`ActiveRecord::Base.configurations` is a reader/writer pair in Rails
(core.rb:71-79) that normalizes on assignment
(`@@configurations = DatabaseConfigurations.new(config)`), so the reader always
answers a `DatabaseConfigurations`. trails had ported the reader as
`Core.configurations(config?)` but never wired it onto `Base`: every producer
and consumer poked a plain static property, so the raw value could be a
`DatabaseConfigurations`, a raw hash, an array, or `undefined` — and each
consumer re-sniffed it.

## Changes

- `Core.configurations` normalizes on write (instance passthrough, array arm,
  `fromEnv` for a raw hash) and always returns a `DatabaseConfigurations`;
  wired onto `Base` and seeded with `Base.configurations({})` at load, as
  core.rb:74 does.
- `query-cache.ts`: deleted the `configurationsEmpty` sniffing helper — the
  guard is now Rails' `connected? || !configurations.empty?` spelled
  `this.isConnectedQ() || !this.configurations().empty`.
- `connection-handling.ts`: deleted `normalizeConfigurations` (its whole job
  was the sniffing the accessor now owns); `resolveConfigForConnection` is
  `this.configurations().resolve(configOrEnv)`, and `autoConnect` falls back to
  disk on an empty registry.
- `test-databases.ts`: reads through the accessor and drops both the
  normalize-and-write-back dance and the invented empty-registry early return
  — Rails has no such guard and always runs its `ensure
  Base.establish_connection` (test_databases.rb:11-21).
- All in-tree producers/consumers, including tests, go through the accessor.
- `database-configurations.test.ts`'s `empty returns true when db configs are
  empty` now round-trips through `Base.configurations` like the Rails case it
  is named after.

## Behavior notes

- **Normalization moves from read-time to write-time**, matching Rails.
  `normalizeConfigurations` deliberately rebuilt via `fromEnv` on *every*
  resolve so a later `TRAILS_ENV` / `DATABASE_URL` change could not leave a
  stale registry behind; Rails instead builds once, at assignment. Every
  in-tree caller already sets env before assigning configurations (both
  `withBaseConfigs` helpers stub `TRAILS_ENV`/`defaultEnv` first), so this is
  a fidelity gain, not a behavior loss — but it is the substantive change in
  this PR, not just a call-shape swap.
- **The two sites Rails spells `Base.configurations` now resolve globally.**
  `resolve_config_for_connection` sets the *receiver's*
  connection_specification_name but resolves through
  `Base.configurations.resolve(...)` (connection_handling.rb:385-391), and
  `create_and_load_schema` iterates and mutates
  `ActiveRecord::Base.configurations` (test_databases.rb:11-21, asserted in
  test_databases_test.rb:48-49). Both go through `activeRecordBase()` — a
  static prototype-chain walk, so no runtime `base.js` import / cycle. The
  tests that assigned configs to a subclass (something Rails cannot express)
  were converged onto Base with save/restore mirroring the Rails ensure.
  `createAndLoadSchema`'s vestigial `modelClass` parameter is gone; Rails
  takes only `(i, env_name:)`.
- **Backing storage stays per-class.** Rails' `@@configurations` is one class
  variable; `configurations` here writes `this._configurations`, so a
  subclass assignment still shadows `Base` for readers other than the two
  above. Converging the storage itself is registered as story
  `converge-configurations-storage-onto-a-single-global-registry`.

## Verification

- `pnpm typecheck`, `pnpm lint` clean.
- `pnpm api:calls:wide`: 6 entries converged and dropped from the baseline —
  the four `cache`/`uncached` → `configurations` this story targets, plus
  `resolve_config_for_connection` → `configurations` and `configurations=`
  → `new`. Baseline reseeded strictly smaller against rebased main (4925); gate passes.
- `pnpm api:extra --package activerecord`: no new novel surface
  (`configurations` is a real Rails name).
- Suites: query-cache, connection-handling, connection-pool,
  connection-management, database-configurations, test-databases, shard-keys,
  primary-class, database-tasks, connection-swapping-nested,
  connection-handlers-multi-db, connection-handlers-sharding-db — all pass.

Closes-story: converge-base-configurations-onto-the-rails-accessor
