### PR TITLE
refactor(actionpack): converge cacheStore writer onto an accessor pair

### DIFF
--- a/packages/actionpack/src/abstract-controller/caching.test.ts
+++ b/packages/actionpack/src/abstract-controller/caching.test.ts
@@ -24,8 +24,6 @@ class HostClass {
   greeting = "hello";
 }
 
-// Rails: `include ConfigMethods` / `extend ConfigMethods` in Caching's
-// `included` block — installs the `cacheStore` accessor pair on the host.
 include(HostClass, ConfigMethods);
 
 function makeHost(store?: MemoryStore | null): HostClass & CachingHost & ConfigMethods {

--- a/packages/actionpack/src/abstract-controller/caching.test.ts
+++ b/packages/actionpack/src/abstract-controller/caching.test.ts
@@ -1,14 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { MemoryStore } from "@blazetrails/activesupport";
+import { include, MemoryStore } from "@blazetrails/activesupport";
 
 import {
   cache,
   cacheConfigured,
-  cacheStore,
+  ConfigMethods,
   CACHING_DEFAULTS,
   CACHING_SLOTS,
   readFragment,
-  setCacheStore,
   viewCacheDependencies,
   viewCacheDependency,
   writeFragment,
@@ -25,11 +24,15 @@ class HostClass {
   greeting = "hello";
 }
 
-function makeHost(store?: MemoryStore | null): HostClass & CachingHost {
+// Rails: `include ConfigMethods` / `extend ConfigMethods` in Caching's
+// `included` block — installs the `cacheStore` accessor pair on the host.
+include(HostClass, ConfigMethods);
+
+function makeHost(store?: MemoryStore | null): HostClass & CachingHost & ConfigMethods {
   HostClass.cacheStore = store ?? null;
   HostClass.performCaching = true;
   HostClass._viewCacheDependencies = undefined;
-  return new HostClass() as unknown as HostClass & CachingHost;
+  return new HostClass() as unknown as HostClass & CachingHost & ConfigMethods;
 }
 
 describe("AbstractController::Caching", () => {
@@ -52,17 +55,17 @@ describe("AbstractController::Caching", () => {
     it("reads the class-level slot", () => {
       const store = new MemoryStore();
       const host = makeHost(store);
-      expect(cacheStore.call(host)).toBe(store);
+      expect(host.cacheStore).toBe(store);
     });
     it("returns null when no store is wired up", () => {
-      expect(cacheStore.call(makeHost())).toBeNull();
+      expect(makeHost().cacheStore).toBeNull();
     });
-    it("setCacheStore assigns onto the class slot", () => {
+    it("cacheStore= assigns onto the class slot", () => {
       const host = makeHost();
       const store = new MemoryStore();
-      setCacheStore.call(host, store);
+      host.cacheStore = store;
       expect(HostClass.cacheStore).toBe(store);
-      expect(cacheStore.call(host)).toBe(store);
+      expect(host.cacheStore).toBe(store);
     });
   });
 

--- a/packages/actionpack/src/abstract-controller/caching.ts
+++ b/packages/actionpack/src/abstract-controller/caching.ts
@@ -57,23 +57,30 @@ export interface CachingHost {
 }
 
 /**
- * `ConfigMethods#cache_store` reader. Rails delegates to `config.cache_store`;
- * trails stores the slot directly on the class, so this is a thin lookup
- * that walks the prototype chain via `host.constructor`.
+ * `AbstractController::Caching::ConfigMethods` — the `cache_store` /
+ * `cache_store=` pair. Rails delegates both to `config.cache_store`; trails
+ * stores the slot directly on the class, so each half walks the prototype
+ * chain via `host.constructor`.
+ *
+ * It's a class rather than two exported functions so the reader and writer
+ * share one name, which is the repo-wide mapping for a Ruby `foo=` writer
+ * (see `scripts/api-compare/conventions.ts`). Mix it into a host with
+ * `include(HostClass, ConfigMethods)` — `include` copies accessor
+ * descriptors from class modules intact.
  */
-export function cacheStore(this: CachingHost): CacheStore | null {
-  return this.constructor.cacheStore ?? null;
-}
+export class ConfigMethods {
+  get cacheStore(): CacheStore | null {
+    return (this as unknown as CachingHost).constructor.cacheStore ?? null;
+  }
 
-/**
- * `ConfigMethods#cache_store=` writer. Rails wraps via
- * `ActiveSupport::Cache.lookup_store(*store)`; that helper isn't ported
- * yet, so for now we accept a fully-constructed `CacheStore` (or `null`)
- * and assign it onto the class slot directly. The signature stays
- * Rails-shaped so future wiring of `lookupStore` is a drop-in upgrade.
- */
-export function setCacheStore(this: CachingHost, store: CacheStore | null): void {
-  this.constructor.cacheStore = store;
+  /**
+   * Rails wraps the assignment via `ActiveSupport::Cache.lookup_store(*store)`;
+   * that helper isn't ported yet, so for now we accept a fully-constructed
+   * `CacheStore` (or `null`) and assign it onto the class slot directly.
+   */
+  set cacheStore(store: CacheStore | null) {
+    (this as unknown as CachingHost).constructor.cacheStore = store;
+  }
 }
 
 /**

--- a/packages/actionpack/src/abstract-controller/caching.ts
+++ b/packages/actionpack/src/abstract-controller/caching.ts
@@ -56,28 +56,11 @@ export interface CachingHost {
   constructor: CachingClassMethods;
 }
 
-/**
- * `AbstractController::Caching::ConfigMethods` — the `cache_store` /
- * `cache_store=` pair. Rails delegates both to `config.cache_store`; trails
- * stores the slot directly on the class, so each half walks the prototype
- * chain via `host.constructor`.
- *
- * It's a class rather than two exported functions so the reader and writer
- * share one name, which is the repo-wide mapping for a Ruby `foo=` writer
- * (see `scripts/api-compare/conventions.ts`). Mix it into a host with
- * `include(HostClass, ConfigMethods)` — `include` copies accessor
- * descriptors from class modules intact.
- */
 export class ConfigMethods {
   get cacheStore(): CacheStore | null {
     return (this as unknown as CachingHost).constructor.cacheStore ?? null;
   }
 
-  /**
-   * Rails wraps the assignment via `ActiveSupport::Cache.lookup_store(*store)`;
-   * that helper isn't ported yet, so for now we accept a fully-constructed
-   * `CacheStore` (or `null`) and assign it onto the class slot directly.
-   */
   set cacheStore(store: CacheStore | null) {
     (this as unknown as CachingHost).constructor.cacheStore = store;
   }

--- a/packages/actionpack/src/abstract-controller/index.ts
+++ b/packages/actionpack/src/abstract-controller/index.ts
@@ -45,8 +45,7 @@ export {
 export {
   cache,
   cacheConfigured,
-  cacheStore,
-  setCacheStore,
+  ConfigMethods,
   CACHING_DEFAULTS,
   CACHING_SLOTS,
   viewCacheDependencies,

--- a/scripts/api-compare/extra-surface-allow.json
+++ b/scripts/api-compare/extra-surface-allow.json
@@ -73,12 +73,6 @@
   },
   {
     "package": "abstractcontroller",
-    "tsFile": "caching.ts",
-    "name": "setCacheStore",
-    "reason": "Writer half of Rails' `ConfigMethods#cache_store` / `cache_store=` accessor pair. `cache_store=` camelizes to `cacheStore`, which the reader in the same file already declares — two exported functions cannot share a name, so the writer takes the `set` prefix."
-  },
-  {
-    "package": "abstractcontroller",
     "tsFile": "trailties/routes-helpers.ts",
     "name": "withRoutesHelpers",
     "reason": "Rails `AbstractController::Railties::RoutesHelpers.with`. `with` is a reserved word in ES strict mode, so the declaration cannot be named `with`; it is declared as `withRoutesHelpers` and re-exported as `with` at the bottom of the file."


### PR DESCRIPTION
`scripts/api-compare/conventions.ts` documents the repo-wide rule for Ruby
writers: `foo=` maps to the SAME camelCase name as the reader. `caching.ts`
broke it — the reader was `export function cacheStore` and the writer
`export function setCacheStore`, since two exported functions in one module
can't share a name.

Both halves now live on an exported `ConfigMethods` class (Rails'
`AbstractController::Caching::ConfigMethods`) as a real `get cacheStore()` /
`set cacheStore(store)` accessor pair, mixed into hosts with `include()` from
`@blazetrails/activesupport` — which copies accessor descriptors from class
modules intact. The `setCacheStore` export and its extra-surface allowlist
entry are deleted.

Verified:
- `api:compare` still matches `cache_store` and `cache_store=` (abstract_controller/caching.rb unchanged at 12/18).
- `api:extra` reports no new extras for the file and no stale tags (the one stale allowlist entry, `setCacheStore`, is removed here).
- `test:compare` delta zero — `abstract-controller/caching.test.ts` is not matched to a Rails test file (`controller/caching_test.rb` maps to `action-controller/caching.test.ts`).
- `caching.test.ts` passes (13 tests); repo typecheck and eslint clean.

## Review responses

**`extend ConfigMethods` (class-level half).** Rails needs both `include` and
`extend` because the storage is `config.cache_store` — an object distinct from
the accessor, so the same accessor works from either side. Trails does not
model `config`: the slot IS a static property on the host class
(`CachingClassMethods.cacheStore`, see the `HostClass` in `caching.test.ts`
and the `this.constructor.cacheStore` reads in `caching.ts` / `caching/fragments.ts`).
So `Controller.cacheStore` and `Controller.cacheStore = store` already behave
exactly like Rails' `Controller.cache_store` / `cache_store=` with no mixin at
all. Extending this accessor onto the constructor would be actively wrong, not
merely redundant: the getter would resolve `this.cacheStore` to itself and
recurse, because the accessor and the storage would occupy the same property.
The instance half is what needs `include`, and that's what this PR installs.

**`lookup_store` normalization.** Correct that Rails runs every assignment
through `ActiveSupport::Cache.lookup_store(*store)`, and that
`self.cache_store = :file_store, path` therefore works there. That helper is
not ported — `packages/activesupport/src/cache.ts` re-exports only `Store`, its
error classes and `WriteOptions`; neither `lookupStore` nor
`retrieve_store_class` exists. The gap is pre-existing and byte-for-byte
unchanged by this PR (the deleted `setCacheStore` assigned the raw argument the
same way); closing it means porting two ActiveSupport::Cache module functions
plus the store registry, which is a different file and a different story.
Registered as `port-cache-lookup-store-for-cache-store-writer` under RFC 0072
with the `file:line` anchors.

The wider `setX`-writer pattern (~95 `export function setX` declarations vs
Rails' 633 `foo=` writers) is registered as
`audit-set-prefixed-writers-for-accessor-convergence`.

Closes-story: converge-cache-store-writer-onto-accessor
