### PR TITLE
refactor(postgresql): route DDL and quoting through the ported primitives

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -85,6 +85,7 @@ import type {
   Table,
   ForeignKeyDefinition,
   IndexDefinition,
+  CreateIndexDefinition,
   AddForeignKeyOptions,
   ForeignKeyLookupOptions,
   AddIndexOptions,
@@ -264,6 +265,19 @@ export interface AbstractAdapter {
     columnName: string | string[],
     options?: Record<string, unknown>,
   ): Promise<[IndexDefinition, string | undefined, boolean]>;
+  /**
+   * Concrete adapters may return `undefined` (MySQL short-circuits
+   * `ifNotExists` when the index already exists); the SchemaStatements base
+   * always returns a definition.
+   * @internal
+   */
+  buildCreateIndexDefinition(
+    tableName: string,
+    columnName: string | string[],
+    options?: Record<string, unknown>,
+  ): Promise<CreateIndexDefinition | undefined>;
+  /** @internal */
+  indexAlgorithm(algorithm?: string): string | undefined;
   /** @internal */
   quotedColumnsForIndex(columnNames: string[], options?: Record<string, unknown>): string;
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4129,69 +4129,29 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       comment?: string;
     } = {},
   ): Promise<void> {
-    const cols = Array.isArray(columns) ? columns : [columns];
-    const quotedTable = this.quoteTableName(tableName);
+    // Mirrors PostgreSQL::SchemaStatements#add_index: the CREATE INDEX statement
+    // is rendered by the schema-creation visitor off a CreateIndexDefinition
+    // rather than string-built here. The `algorithm: :copy` ArgumentError comes
+    // from index_algorithm inside add_index_options.
+    //
+    // Priming the cached database version is a trails addition: the visitor's
+    // supportsNullsNotDistinct/supportsIndexInclude predicates read
+    // `databaseVersion` synchronously and silently yield false on a cold
+    // connection.
+    await this.getDatabaseVersion();
+    this.schemaCache?.clearDataSourceCacheBang(this.pool, tableName);
 
-    if (options.algorithm && options.algorithm !== "concurrently") {
-      // Rails raises ArgumentError "Algorithm must be one of the following: :concurrently".
-      throw new ArgumentError(`Algorithm must be one of the following: :concurrently`);
-    }
-    if (options.algorithm === "concurrently" && this._inTransaction) {
-      throw new Error("CREATE INDEX CONCURRENTLY cannot run inside a transaction");
-    }
+    // Called on the adapter, not on pgSchemaStatements(): PG overrides
+    // add_index_options to quote a bare-column-name `:where`, and only the
+    // adapter's override is on this path.
+    const createIndex = (await this.buildCreateIndexDefinition(tableName, columns, options))!;
+    await this.execute(await this.schemaCreation.accept(createIndex));
 
-    // Route through addIndexOptions (Rails' add_index_options) so the
-    // bare-column-name `:where` quoting lives there, matching Rails' structure.
-    // idx.name is resolved via index_name → generate_index_name, applying the
-    // identifier-length/hash fallback so add_index and remove_index agree on the
-    // default name for over-long table+column combinations.
-    const [idx] = await this.addIndexOptions(tableName, columns, options);
-
-    const indexName = idx.name;
-
-    const unique = options.unique ? "UNIQUE " : "";
-    const concurrently = options.algorithm === "concurrently" ? "CONCURRENTLY " : "";
-    const ifNotExists = options.ifNotExists ? "IF NOT EXISTS " : "";
-    const using = options.using ? ` USING ${options.using}` : "";
-
-    const colDefs = cols.map((col) => {
-      const isExpression = col.includes("(") || col.includes(" ");
-      let result = isExpression ? col : this.quoteIdentifier(col);
-      if (options.opclass) {
-        const op = options.opclass[col];
-        if (op) result += ` ${op}`;
-      }
-      if (options.order) {
-        if (typeof options.order === "string") {
-          result += ` ${options.order}`;
-        } else {
-          const o = options.order[col];
-          if (o) result += ` ${o.toUpperCase()}`;
-        }
-      }
-      return result;
-    });
-
-    let sql = `CREATE ${unique}INDEX ${concurrently}${ifNotExists}${this.quoteIdentifier(indexName)} ON ${quotedTable}${using} (${colDefs.join(", ")})`;
-
-    if (options.include) {
-      sql += ` INCLUDE (${options.include.map((c) => this.quoteIdentifier(c)).join(", ")})`;
-    }
-    if (options.nullsNotDistinct) {
-      sql += " NULLS NOT DISTINCT";
-    }
-    if (idx.where) {
-      sql += ` WHERE ${idx.where}`;
-    }
-
-    await this.exec(sql);
-
-    if (options.comment?.trim()) {
-      const [schema] = this.extractSchemaQualifiedName(tableName);
-      const qualifiedIndex = schema
-        ? `${this.quoteIdentifier(schema)}.${this.quoteIdentifier(indexName)}`
-        : this.quoteIdentifier(indexName);
-      await this.exec(`COMMENT ON INDEX ${qualifiedIndex} IS ${this.quote(options.comment)}`);
+    const index = createIndex.index;
+    if (index.comment) {
+      await this.execute(
+        `COMMENT ON INDEX ${this.quoteColumnName(index.name)} IS ${this.quote(index.comment)}`,
+      );
     }
   }
 
@@ -4221,10 +4181,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       opts = columnOrOptions ?? {};
     }
 
-    if (opts.algorithm && opts.algorithm !== "concurrently") {
-      // Rails raises ArgumentError "Algorithm must be one of the following: :concurrently".
-      throw new ArgumentError(`Algorithm must be one of the following: :concurrently`);
-    }
+    // Mirrors Rails' `index_algorithm(options[:algorithm])`, which raises the
+    // ArgumentError for anything outside `index_algorithms`.
+    const algorithm = this.indexAlgorithm(opts.algorithm);
     if (opts.algorithm === "concurrently" && this._inTransaction) {
       throw new Error("DROP INDEX CONCURRENTLY cannot run inside a transaction");
     }
@@ -4265,11 +4224,13 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     }
     const indexName = indexNameForRemoveFrom(genName, all, bareTable, columnName, resolveOpts);
 
-    const concurrently = opts.algorithm === "concurrently" ? " CONCURRENTLY" : "";
-    const qualifiedIndex = dropSchema
-      ? `${this.quoteIdentifier(dropSchema)}.${this.quoteIdentifier(indexName)}`
-      : this.quoteIdentifier(indexName);
-    await this.exec(`DROP INDEX${concurrently} ${qualifiedIndex}`);
+    // Rails quotes a PostgreSQL::Name, which quotes the schema and the bare
+    // identifier separately — the index name itself can contain a dot (an index
+    // on a schema-qualified table), so it must not be re-split here.
+    const prefix = dropSchema ? `${this.quoteTableName(dropSchema)}.` : "";
+    await this.execute(
+      `DROP INDEX${algorithm ? ` ${algorithm}` : ""} ${prefix}${this.quoteColumnName(indexName)}`,
+    );
   }
 
   async addForeignKey(
@@ -4896,7 +4857,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     defaultValue?: unknown,
   ): unknown {
     if (defaultValue == null)
-      return `ALTER COLUMN ${this.quoteIdentifier(columnName)} ${nullable ? "DROP" : "SET"} NOT NULL`;
+      return `ALTER COLUMN ${this.quoteColumnName(columnName)} ${nullable ? "DROP" : "SET"} NOT NULL`;
     return () => this.changeColumnNull(tableName, columnName, nullable, defaultValue);
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4129,11 +4129,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       comment?: string;
     } = {},
   ): Promise<void> {
-    // Mirrors PostgreSQL::SchemaStatements#add_index: the CREATE INDEX statement
-    // is rendered by the schema-creation visitor off a CreateIndexDefinition
-    // rather than string-built here. The `algorithm: :copy` ArgumentError comes
-    // from index_algorithm inside add_index_options.
-    //
     // Priming the cached database version is a trails addition: the visitor's
     // supportsNullsNotDistinct/supportsIndexInclude predicates read
     // `databaseVersion` synchronously and silently yield false on a cold
@@ -4181,9 +4176,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       opts = columnOrOptions ?? {};
     }
 
-    // Mirrors Rails' `index_algorithm(options[:algorithm])`, which raises the
-    // ArgumentError for anything outside `index_algorithms`.
-    const algorithm = this.indexAlgorithm(opts.algorithm);
     if (opts.algorithm === "concurrently" && this._inTransaction) {
       throw new Error("DROP INDEX CONCURRENTLY cannot run inside a transaction");
     }
@@ -4228,6 +4220,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     // identifier separately — the index name itself can contain a dot (an index
     // on a schema-qualified table), so it must not be re-split here.
     const prefix = dropSchema ? `${this.quoteTableName(dropSchema)}.` : "";
+    const algorithm = this.indexAlgorithm(opts.algorithm);
     await this.execute(
       `DROP INDEX${algorithm ? ` ${algorithm}` : ""} ${prefix}${this.quoteColumnName(indexName)}`,
     );

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-creation.ts
@@ -4,6 +4,7 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaCreation
  */
 
+import { wrap } from "@blazetrails/activesupport";
 import { SchemaCreation as AbstractSchemaCreation } from "../abstract/schema-creation.js";
 import {
   type ForeignKeyDefinition,
@@ -165,7 +166,10 @@ export class SchemaCreation extends AbstractSchemaCreation {
     if (o.usingIndex) {
       p.push(`USING INDEX ${this.adapter.quoteIdentifier(o.usingIndex)}`);
     } else {
-      const cols = (Array.isArray(o.column) ? o.column : [o.column])
+      // Rails wraps with `Array(o.column)`, so a nil column renders `UNIQUE ()`
+      // and PostgreSQL owns the rejection — `[null]` would throw in the quoter
+      // first (add_unique_constraint has no pre-raise for the empty case).
+      const cols = wrap(o.column)
         .map((c) => this.adapter.quoteIdentifier(c))
         .join(", ");
       p.push(`(${cols})`);

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -252,9 +252,6 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   }
 
   quotedIncludeColumnsForIndex(columnNames: string | string[]): string {
-    // Mirrors PostgreSQL::SchemaStatements#quoted_include_columns_for_index: the
-    // quoted map is threaded through add_options_for_index_columns so the
-    // opclass/sort-order decoration is applied by the one shared helper.
     if (typeof columnNames === "string") return this.adapter.quoteColumnName(columnNames);
     const quotedColumns = new Map(
       columnNames.map((name) => [name, this.adapter.quoteColumnName(name)]),
@@ -1076,9 +1073,6 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
 
   /** @internal */
   async validateConstraint(tableName: string, constraintName: string): Promise<void> {
-    // Mirrors PostgreSQL::SchemaStatements#validate_constraint: the VALIDATE
-    // CONSTRAINT clause is rendered by the schema-creation visitor off an
-    // AlterTable node rather than being string-built here.
     const at = this.pg.createAlterTable(tableName) as PgAlterTable;
     at.validateConstraint(constraintName);
     await this.adapter.execute(await this.pg.schemaCreation.accept(at));
@@ -1278,8 +1272,6 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     expression: string,
     options: ExclusionConstraintOptions = {},
   ): Promise<void> {
-    // Mirrors PostgreSQL::SchemaStatements#add_exclusion_constraint: the EXCLUDE
-    // clause is rendered by the schema-creation visitor off an AlterTable node.
     const opts = this.exclusionConstraintOptions(tableName, expression, options);
     const at = this.pg.createAlterTable(tableName) as PgAlterTable;
     at.addExclusionConstraint(expression, opts);
@@ -1409,7 +1401,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   ): Record<string, unknown> {
     this.assertValidDeferrable(options.deferrable);
     if (columnName && options.usingIndex) {
-      throw new Error("Cannot specify both `columnName` and `usingIndex` options.");
+      throw new ArgumentError("Cannot specify both `columnName` and `usingIndex` options.");
     }
     const opts = { ...options };
     if (!opts.name) {
@@ -1424,12 +1416,10 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     options: UniqueConstraintOptions = {},
   ): Promise<void> {
     if (!columnName && !options.usingIndex) {
-      throw new Error("Either columnName or usingIndex must be provided for addUniqueConstraint.");
+      throw new ArgumentError(
+        "Either columnName or usingIndex must be provided for addUniqueConstraint.",
+      );
     }
-    // Mirrors Rails postgresql/schema_statements.rb#add_unique_constraint:
-    // build the constraint through create_alter_table + schema_creation so the
-    // UNIQUE clause (NULLS NOT DISTINCT, USING INDEX, deferrable) is rendered by
-    // the schema-creation visitor rather than inline SQL.
     const opts = this.uniqueConstraintOptions(tableName, columnName, options);
     const at = this.pg.createAlterTable(tableName) as PgAlterTable;
     at.addUniqueConstraint(columnName as string | string[], opts);

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -1401,7 +1401,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   ): Record<string, unknown> {
     this.assertValidDeferrable(options.deferrable);
     if (columnName && options.usingIndex) {
-      throw new ArgumentError("Cannot specify both `columnName` and `usingIndex` options.");
+      throw new ArgumentError("Cannot specify both column_name and :using_index options.");
     }
     const opts = { ...options };
     if (!opts.name) {
@@ -1415,11 +1415,6 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     columnName?: string | string[] | null,
     options: UniqueConstraintOptions = {},
   ): Promise<void> {
-    if (!columnName && !options.usingIndex) {
-      throw new ArgumentError(
-        "Either columnName or usingIndex must be provided for addUniqueConstraint.",
-      );
-    }
     const opts = this.uniqueConstraintOptions(tableName, columnName, options);
     const at = this.pg.createAlterTable(tableName) as PgAlterTable;
     at.addUniqueConstraint(columnName as string | string[], opts);

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -10,6 +10,7 @@ import {
   ForeignKeyDefinition,
   TableDefinition as AbstractTableDefinition,
   type AddForeignKeyOptions,
+  type ForeignKeyLookupOptions,
   type ColumnOptions,
   type ColumnType,
 } from "../abstract/schema-definitions.js";
@@ -54,7 +55,6 @@ interface PgSchemaAdapter {
     name?: string | null,
     options?: { type?: string },
   ): { schema: string; name: string | null; type: string | null };
-  deferrable(deferrable: "immediate" | "deferred" | undefined): string;
   readonly schemaCreation: {
     actionSql(action: string, dependency: string): string;
     accept(o: unknown): string;
@@ -252,12 +252,14 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   }
 
   quotedIncludeColumnsForIndex(columnNames: string | string[]): string {
-    if (typeof columnNames === "string") return this.pg.quoteIdentifier(columnNames);
-    const quoted: Record<string, string> = {};
-    for (const name of columnNames) {
-      quoted[name] = this.pg.quoteIdentifier(name);
-    }
-    return Object.values(quoted).join(", ");
+    // Mirrors PostgreSQL::SchemaStatements#quoted_include_columns_for_index: the
+    // quoted map is threaded through add_options_for_index_columns so the
+    // opclass/sort-order decoration is applied by the one shared helper.
+    if (typeof columnNames === "string") return this.adapter.quoteColumnName(columnNames);
+    const quotedColumns = new Map(
+      columnNames.map((name) => [name, this.adapter.quoteColumnName(name)]),
+    );
+    return Array.from(this.addOptionsForIndexColumns(quotedColumns).values()).join(", ");
   }
 
   // ---------------------------------------------------------------------------
@@ -1052,7 +1054,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     this.pg.clearCacheBang();
     const comment = this.extractNewCommentValue(commentOrChanges) as string | null;
     await this.adapter.execute(
-      `COMMENT ON COLUMN ${this._qt(tableName)}.${this._qi(columnName)} IS ${this.pg.quote(comment)}`,
+      `COMMENT ON COLUMN ${this.adapter.quoteTableName(tableName)}.${this.adapter.quoteColumnName(columnName)} IS ${this.pg.quote(comment)}`,
     );
   }
 
@@ -1074,41 +1076,31 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
 
   /** @internal */
   async validateConstraint(tableName: string, constraintName: string): Promise<void> {
-    await this.pg.exec(
-      `ALTER TABLE ${this._qt(tableName)} VALIDATE CONSTRAINT ${this.pg.quoteIdentifier(constraintName)}`,
-    );
+    // Mirrors PostgreSQL::SchemaStatements#validate_constraint: the VALIDATE
+    // CONSTRAINT clause is rendered by the schema-creation visitor off an
+    // AlterTable node rather than being string-built here.
+    const at = this.pg.createAlterTable(tableName) as PgAlterTable;
+    at.validateConstraint(constraintName);
+    await this.adapter.execute(await this.pg.schemaCreation.accept(at));
   }
 
   async validateCheckConstraint(
     tableName: string,
-    nameOrOptions: string | { name: string },
+    nameOrOptions: string | { name: string; expression?: string },
   ): Promise<void> {
-    const name = typeof nameOrOptions === "string" ? nameOrOptions : nameOrOptions.name;
-    await this.validateConstraint(tableName, name);
+    const options = typeof nameOrOptions === "string" ? { name: nameOrOptions } : nameOrOptions;
+    const chkNameToValidate = (await this.checkConstraintForBang(tableName, options)).name;
+    await this.validateConstraint(tableName, chkNameToValidate);
   }
 
   async validateForeignKey(
     fromTable: string,
     toTable?: string,
-    options?: { name?: string },
+    options: ForeignKeyLookupOptions = {},
   ): Promise<void> {
-    if (options?.name) {
-      await this.validateConstraint(fromTable, options.name);
-      return;
-    }
-    if (!toTable) throw new ArgumentError("validateForeignKey requires toTable or options.name");
-    const fks = await this.foreignKeys(fromTable);
-    const [toSchema, toTbl] = this.pg.extractSchemaQualifiedName(toTable);
-    const fk = (fks as any[]).find((f) => {
-      const [fSchema, fTbl] = this.pg.extractSchemaQualifiedName(String(f.toTable));
-      if (fTbl !== toTbl) return false;
-      // When the FK record has no schema prefix (PostgreSQL omits "public." when it
-      // is on the search_path), treat it as matching any schema lookup or "public".
-      if (!fSchema) return !toSchema || toSchema === "public";
-      return fSchema === toSchema;
-    });
-    if (!fk) throw new ArgumentError(`No foreign key found from ${fromTable} to ${toTable}`);
-    await this.validateConstraint(fromTable, fk.name);
+    const fkNameToValidate = (await this.foreignKeyForBang(fromTable, { ...options, toTable }))
+      .name;
+    await this.validateConstraint(fromTable, fkNameToValidate);
   }
 
   override foreignKeyColumnFor(tableName: string, columnName = "id"): string {
@@ -1243,7 +1235,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     // (now converged): it applies table_name_prefix/suffix and re-runs
     // foreign_key_options idempotently (column/name already filled above).
     at.addForeignKey(toTable, fkOptions as Partial<AddForeignKeyOptions>);
-    await this.pg.exec(await this.pg.schemaCreation.accept(at));
+    await this.adapter.execute(await this.pg.schemaCreation.accept(at));
   }
 
   override async checkConstraints(tableName: string): Promise<CheckConstraintDefinition[]> {
@@ -1286,14 +1278,12 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     expression: string,
     options: ExclusionConstraintOptions = {},
   ): Promise<void> {
+    // Mirrors PostgreSQL::SchemaStatements#add_exclusion_constraint: the EXCLUDE
+    // clause is rendered by the schema-creation visitor off an AlterTable node.
     const opts = this.exclusionConstraintOptions(tableName, expression, options);
-    const name = this.pg.quoteIdentifier(opts.name as string);
-    const using = opts.using ? ` USING ${opts.using}` : "";
-    const where = opts.where ? ` WHERE (${opts.where})` : "";
-    const deferParts = this.pg.deferrable(opts.deferrable as "immediate" | "deferred" | undefined);
-    await this.pg.exec(
-      `ALTER TABLE ${this._qt(tableName)} ADD CONSTRAINT ${name} EXCLUDE${using} (${expression})${where}${deferParts}`,
-    );
+    const at = this.pg.createAlterTable(tableName) as PgAlterTable;
+    at.addExclusionConstraint(expression, opts);
+    await this.adapter.execute(await this.pg.schemaCreation.accept(at));
   }
 
   async removeExclusionConstraint(
@@ -1314,10 +1304,10 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
         "Either expression or `name` option must be provided for removeExclusionConstraint.",
       );
     }
-    const excl = await this.exclusionConstraintForBang(tableName, expression ?? null, opts);
-    await this.pg.exec(
-      `ALTER TABLE ${this._qt(tableName)} DROP CONSTRAINT ${this.pg.quoteIdentifier(excl.name!)}`,
-    );
+    const exclNameToDelete = (
+      await this.exclusionConstraintForBang(tableName, expression ?? null, opts)
+    ).name!;
+    await this.removeConstraint(tableName, exclNameToDelete);
   }
 
   async exclusionConstraints(tableName: string): Promise<ExclusionConstraintDefinition[]> {
@@ -1357,7 +1347,10 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
         name: r.conname as string,
         using: using,
         where: predicate,
-        deferrable: deferrable || undefined,
+        // Rails passes `deferrable:` straight through: a non-deferrable
+        // constraint reads back as `false`, not absent (Ruby truthiness would
+        // otherwise collapse it to nil here).
+        deferrable,
       });
     });
   }
@@ -1440,7 +1433,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     const opts = this.uniqueConstraintOptions(tableName, columnName, options);
     const at = this.pg.createAlterTable(tableName) as PgAlterTable;
     at.addUniqueConstraint(columnName as string | string[], opts);
-    await this.pg.exec(await this.pg.schemaCreation.accept(at));
+    await this.adapter.execute(await this.pg.schemaCreation.accept(at));
   }
 
   async removeUniqueConstraint(
@@ -1466,10 +1459,9 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
         "Either `columnName`, `name`, or `usingIndex` option must be provided for removeUniqueConstraint.",
       );
     }
-    const uniq = await this.uniqueConstraintForBang(tableName, columnName, opts);
-    await this.pg.exec(
-      `ALTER TABLE ${this._qt(tableName)} DROP CONSTRAINT ${this.pg.quoteIdentifier(uniq.name!)}`,
-    );
+    const uniqueNameToDelete = (await this.uniqueConstraintForBang(tableName, columnName, opts))
+      .name!;
+    await this.removeConstraint(tableName, uniqueNameToDelete);
   }
 
   async uniqueConstraints(tableName: string): Promise<UniqueConstraintDefinition[]> {
@@ -1499,7 +1491,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
         return new UniqueConstraintDefinition(tableName, columns, {
           name: r.conname as string,
           nullsNotDistinct: nullsNotDistinct || undefined,
-          deferrable: deferrable || undefined,
+          deferrable,
         });
       }),
     );
@@ -1797,7 +1789,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
        FROM (
          SELECT indrelid, indkey, generate_subscripts(indkey, 1) idx
            FROM pg_index
-          WHERE indrelid = ${this.pg.quoteLiteral(this._qt(tableName))}::regclass
+          WHERE indrelid = ${this.pg.quoteLiteral(this.adapter.quoteTableName(tableName))}::regclass
             AND indisprimary
        ) i
        JOIN pg_attribute a

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -1291,11 +1291,6 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       typeof expressionOrOptions === "object" && expressionOrOptions !== null
         ? expressionOrOptions
         : options;
-    if (!expression && !opts.name) {
-      throw new ArgumentError(
-        "Either expression or `name` option must be provided for removeExclusionConstraint.",
-      );
-    }
     const exclNameToDelete = (
       await this.exclusionConstraintForBang(tableName, expression ?? null, opts)
     ).name!;
@@ -1439,11 +1434,6 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       !Array.isArray(columnNameOrOptions)
         ? columnNameOrOptions
         : options;
-    if (!columnName && !opts.name && !opts.usingIndex) {
-      throw new ArgumentError(
-        "Either `columnName`, `name`, or `usingIndex` option must be provided for removeUniqueConstraint.",
-      );
-    }
     const uniqueNameToDelete = (await this.uniqueConstraintForBang(tableName, columnName, opts))
       .name!;
     await this.removeConstraint(tableName, uniqueNameToDelete);

--- a/packages/activerecord/src/migration/exclusion-constraint.test.ts
+++ b/packages/activerecord/src/migration/exclusion-constraint.test.ts
@@ -17,7 +17,7 @@ import {
   PostgreSQLAdapter,
   PG_TEST_URL,
 } from "../adapters/postgresql/test-helper.js";
-import { rebuildCanonicalTables } from "../test-helpers/canonical-schema.js";
+import { rebuildCanonicalTables } from "../support/canonical-schema.js";
 
 const EXPRESSION = "daterange(start_date, end_date) WITH &&";
 

--- a/packages/activerecord/src/migration/exclusion-constraint.test.ts
+++ b/packages/activerecord/src/migration/exclusion-constraint.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Mirrors Rails activerecord/test/cases/migration/exclusion_constraint_test.rb
+ * (PostgreSQL-only — `supports_exclusion_constraints?`).
+ *
+ * The model-backed arms (test_added_exclusion_constraint_ensures_valid_values,
+ * test_added_deferrable_initially_immediate_exclusion_constraint) and the
+ * introspection arms that need Rails' `test_exclusion_constraints` fixture
+ * table are not ported here; this file covers the add/remove paths that
+ * PostgreSQL::SchemaStatements#add_exclusion_constraint and
+ * #remove_exclusion_constraint route through create_alter_table +
+ * schema_creation.accept.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { ArgumentError } from "@blazetrails/activemodel";
+import {
+  describeIfPg,
+  PostgreSQLAdapter,
+  PG_TEST_URL,
+} from "../adapters/postgresql/test-helper.js";
+import { rebuildCanonicalTables } from "../test-helpers/canonical-schema.js";
+
+const EXPRESSION = "daterange(start_date, end_date) WITH &&";
+
+describeIfPg("ActiveRecord::Migration", () => {
+  let connection: PostgreSQLAdapter;
+
+  beforeEach(async () => {
+    connection = new PostgreSQLAdapter(PG_TEST_URL);
+    await connection.createTable("invoices", { force: true }, (t) => {
+      t.date("start_date");
+      t.date("end_date");
+    });
+  });
+
+  afterEach(async () => {
+    await connection.dropTable("invoices", { ifExists: true });
+    // Rails' setup replaces `invoices` with a start_date/end_date table and its
+    // teardown drops it; restore the canonical shape so the shared per-worker
+    // database does not drift for the files that run next.
+    await rebuildCanonicalTables(connection, ["invoices"]);
+    await connection.close();
+  });
+
+  describe("ExclusionConstraintTest", () => {
+    it("add exclusion constraint", async () => {
+      await connection.addExclusionConstraint("invoices", EXPRESSION, { using: "gist" });
+
+      const exclusionConstraints = await connection.exclusionConstraints("invoices");
+      expect(exclusionConstraints.length).toBe(1);
+
+      const constraint = exclusionConstraints[0];
+      expect(constraint.tableName).toBe("invoices");
+      expect(constraint.name).toBe("excl_rails_74c9160f55");
+      expect(constraint.deferrable).toBe(false);
+      expect(constraint.expression).toBe(EXPRESSION);
+    });
+
+    it("add exclusion constraint deferrable false", async () => {
+      await connection.addExclusionConstraint("invoices", EXPRESSION, {
+        using: "gist",
+        deferrable: false,
+      });
+
+      const exclusionConstraints = await connection.exclusionConstraints("invoices");
+      expect(exclusionConstraints.length).toBe(1);
+
+      const constraint = exclusionConstraints[0];
+      expect(constraint.name).toBe("excl_rails_74c9160f55");
+      expect(constraint.deferrable).toBe(false);
+      expect(constraint.expression).toBe(EXPRESSION);
+    });
+
+    it("add exclusion constraint deferrable initially immediate", async () => {
+      await connection.addExclusionConstraint("invoices", EXPRESSION, {
+        using: "gist",
+        deferrable: "immediate",
+      });
+
+      const constraint = (await connection.exclusionConstraints("invoices"))[0];
+      expect(constraint.name).toBe("excl_rails_74c9160f55");
+      expect(constraint.deferrable).toBe("immediate");
+      expect(constraint.expression).toBe(EXPRESSION);
+    });
+
+    it("add exclusion constraint deferrable initially deferred", async () => {
+      await connection.addExclusionConstraint("invoices", EXPRESSION, {
+        using: "gist",
+        deferrable: "deferred",
+      });
+
+      const constraint = (await connection.exclusionConstraints("invoices"))[0];
+      expect(constraint.name).toBe("excl_rails_74c9160f55");
+      expect(constraint.deferrable).toBe("deferred");
+      expect(constraint.expression).toBe(EXPRESSION);
+    });
+
+    it("add exclusion constraint deferrable invalid", async () => {
+      await expect(
+        connection.addExclusionConstraint("invoices", EXPRESSION, {
+          using: "gist",
+          deferrable: true as never,
+        }),
+        // Rails' message names the Ruby symbols `:immediate` / `:deferred`;
+        // trails' analogues are the string literals, so the rendered message
+        // quotes them instead.
+      ).rejects.toThrow('deferrable must be `"immediate"` or `"deferred"`, got: `true`');
+    });
+
+    it("remove exclusion constraint", async () => {
+      expect((await connection.exclusionConstraints("invoices")).length).toBe(0);
+
+      await connection.addExclusionConstraint("invoices", EXPRESSION, {
+        using: "gist",
+        name: "invoices_date_overlap",
+      });
+      expect((await connection.exclusionConstraints("invoices")).length).toBe(1);
+
+      await connection.removeExclusionConstraint("invoices", { name: "invoices_date_overlap" });
+      expect((await connection.exclusionConstraints("invoices")).length).toBe(0);
+    });
+
+    it("remove non existing exclusion constraint", async () => {
+      await expect(
+        connection.removeExclusionConstraint("invoices", { name: "nonexistent" }),
+      ).rejects.toThrow(ArgumentError);
+    });
+  });
+});

--- a/packages/activerecord/src/migration/unique-constraint.test.ts
+++ b/packages/activerecord/src/migration/unique-constraint.test.ts
@@ -12,7 +12,7 @@ import {
   PostgreSQLAdapter,
   PG_TEST_URL,
 } from "../adapters/postgresql/test-helper.js";
-import { rebuildCanonicalTables } from "../test-helpers/canonical-schema.js";
+import { rebuildCanonicalTables } from "../support/canonical-schema.js";
 
 describeIfPg("ActiveRecord::Migration", () => {
   let connection: PostgreSQLAdapter;

--- a/packages/activerecord/src/migration/unique-constraint.test.ts
+++ b/packages/activerecord/src/migration/unique-constraint.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Mirrors Rails activerecord/test/cases/migration/unique_constraint_test.rb
+ * (PostgreSQL-only — `supports_unique_constraints?`).
+ *
+ * The model-backed and schema-scoped arms, and the arms that need Rails'
+ * `test_unique_constraints` fixture table, are not ported here.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { ArgumentError } from "@blazetrails/activemodel";
+import {
+  describeIfPg,
+  PostgreSQLAdapter,
+  PG_TEST_URL,
+} from "../adapters/postgresql/test-helper.js";
+import { rebuildCanonicalTables } from "../test-helpers/canonical-schema.js";
+
+describeIfPg("ActiveRecord::Migration", () => {
+  let connection: PostgreSQLAdapter;
+
+  beforeEach(async () => {
+    connection = new PostgreSQLAdapter(PG_TEST_URL);
+    await connection.createTable("sections", { force: true }, (t) => {
+      t.integer("position", { null: false });
+    });
+  });
+
+  afterEach(async () => {
+    await connection.dropTable("sections", { ifExists: true });
+    // Rails' setup replaces `sections` with a single-column table and its
+    // teardown drops it; restore the canonical shape so the shared per-worker
+    // database does not drift for the files that run next.
+    await rebuildCanonicalTables(connection, ["sections"]);
+    await connection.close();
+  });
+
+  describe("UniqueConstraintTest", () => {
+    it("add unique constraint without deferrable", async () => {
+      await connection.addUniqueConstraint("sections", ["position"]);
+
+      const uniqueConstraints = await connection.uniqueConstraints("sections");
+      expect(uniqueConstraints.length).toBe(1);
+
+      const constraint = uniqueConstraints[0];
+      expect(constraint.tableName).toBe("sections");
+      expect(constraint.name).toBe("uniq_rails_1e07660b77");
+      expect(constraint.deferrable).toBe(false);
+    });
+
+    it("add unique constraint with deferrable false", async () => {
+      await connection.addUniqueConstraint("sections", ["position"], { deferrable: false });
+
+      const constraint = (await connection.uniqueConstraints("sections"))[0];
+      expect(constraint.name).toBe("uniq_rails_1e07660b77");
+      expect(constraint.deferrable).toBe(false);
+    });
+
+    it("add unique constraint with deferrable immediate", async () => {
+      await connection.addUniqueConstraint("sections", ["position"], { deferrable: "immediate" });
+
+      const constraint = (await connection.uniqueConstraints("sections"))[0];
+      expect(constraint.name).toBe("uniq_rails_1e07660b77");
+      expect(constraint.deferrable).toBe("immediate");
+    });
+
+    it("add unique constraint with deferrable deferred", async () => {
+      await connection.addUniqueConstraint("sections", ["position"], { deferrable: "deferred" });
+
+      const constraint = (await connection.uniqueConstraints("sections"))[0];
+      expect(constraint.name).toBe("uniq_rails_1e07660b77");
+      expect(constraint.deferrable).toBe("deferred");
+    });
+
+    it("add unique constraint with deferrable invalid", async () => {
+      await expect(
+        connection.addUniqueConstraint("sections", ["position"], { deferrable: true as never }),
+      ).rejects.toThrow(ArgumentError);
+    });
+
+    it("add unique constraint with name and using index", async () => {
+      await connection.addIndex("sections", ["position"], { name: "unique_index", unique: true });
+      await connection.addUniqueConstraint("sections", null, {
+        name: "unique_constraint",
+        deferrable: "immediate",
+        usingIndex: "unique_index",
+      });
+
+      const uniqueConstraints = await connection.uniqueConstraints("sections");
+      expect(uniqueConstraints.length).toBe(1);
+
+      const constraint = uniqueConstraints[0];
+      expect(constraint.tableName).toBe("sections");
+      expect(constraint.name).toBe("unique_constraint");
+      expect(constraint.column).toEqual(["position"]);
+      expect(constraint.deferrable).toBe("immediate");
+    });
+
+    it("add unique constraint with only using index", async () => {
+      await connection.addIndex("sections", ["position"], { name: "unique_index", unique: true });
+      await connection.addUniqueConstraint("sections", null, { usingIndex: "unique_index" });
+
+      const constraint = (await connection.uniqueConstraints("sections"))[0];
+      expect(constraint.name).toBe("uniq_rails_79b901ffb4");
+      expect(constraint.column).toEqual(["position"]);
+      expect(constraint.deferrable).toBe(false);
+    });
+
+    it("add unique constraint with columns and using index", async () => {
+      await connection.addIndex("sections", ["position"], { name: "unique_index", unique: true });
+
+      await expect(
+        connection.addUniqueConstraint("sections", ["position"], { usingIndex: "unique_index" }),
+      ).rejects.toThrow(ArgumentError);
+    });
+
+    it("remove unique constraint", async () => {
+      await connection.addUniqueConstraint("sections", ["position"], {
+        name: "unique_section_position",
+      });
+      expect((await connection.uniqueConstraints("sections")).length).toBe(1);
+
+      await connection.removeUniqueConstraint("sections", { name: "unique_section_position" });
+      expect(await connection.uniqueConstraints("sections")).toEqual([]);
+    });
+
+    it("remove unique constraint by column", async () => {
+      await connection.addUniqueConstraint("sections", ["position"]);
+      expect((await connection.uniqueConstraints("sections")).length).toBe(1);
+
+      await connection.removeUniqueConstraint("sections", ["position"]);
+      expect(await connection.uniqueConstraints("sections")).toEqual([]);
+    });
+
+    it("remove non existing unique constraint", async () => {
+      await expect(
+        connection.removeUniqueConstraint("sections", { name: "nonexistent" }),
+      ).rejects.toThrow(ArgumentError);
+    });
+  });
+});

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
@@ -4,7 +4,7 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "add_column_for_alter",
     "call": "new",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Equivalent (RFC 0072 converge-pg-ddl-exec-primitive-and-quoting-routing): Rails' `super` is AbstractAdapter#add_column_for_alter, whose `new` is the ColumnDefinition instantiation; trails calls the same constructor via createTableDefinition(...).newColumnDefinition(...), so the `new` is one frame deeper than the extractor looks."
   },
   {
     "package": "activerecord",
@@ -32,69 +32,6 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "add_enum_value",
     "call": "values_at",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "add_exclusion_constraint",
-    "call": "accept",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "add_exclusion_constraint",
-    "call": "create_alter_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "add_exclusion_constraint",
-    "call": "execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "add_index",
-    "call": "accept",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "add_index",
-    "call": "build_create_index_definition",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "add_index",
-    "call": "execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "add_index",
-    "call": "index",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "add_index",
-    "call": "quote_column_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "add_unique_constraint",
-    "call": "execute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -156,23 +93,9 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "change_column_comment",
-    "call": "quote_column_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "change_column_comment",
-    "call": "quote_table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "change_column_for_alter",
     "call": "new",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Equivalent (RFC 0072 converge-pg-ddl-exec-primitive-and-quoting-routing): the ChangeColumnDefinition instantiation lives inside build_change_column_definition, which trails calls as buildChangeColumnDefinition — the `new` is one frame deeper than the extractor looks."
   },
   {
     "package": "activerecord",
@@ -186,14 +109,7 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "change_column_null_for_alter",
     "call": "new",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "change_column_null_for_alter",
-    "call": "quote_column_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Equivalent (RFC 0072 converge-pg-ddl-exec-primitive-and-quoting-routing): Rails' `Proc.new { ... }` is a bare arrow function in TS; the deferred change_column_null call it wraps IS threaded."
   },
   {
     "package": "activerecord",
@@ -424,6 +340,13 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "dbconsole",
     "call": "find_cmd_and_exec",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "default_sequence_name",
+    "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -688,6 +611,13 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "foreign_key_column_for",
+    "call": "extract_schema_qualified_name",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "foreign_keys",
     "call": "internal_exec_query",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -758,6 +688,13 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "index_name",
+    "call": "extract_schema_qualified_name",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "indexes",
     "call": "column_names_from_column_numbers",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -802,6 +739,13 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "inherited_table_names",
     "call": "query_values",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "inherited_table_names",
+    "call": "quoted_scope",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -905,6 +849,20 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "pk_and_sequence_for",
+    "call": "quote",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "pk_and_sequence_for",
+    "call": "quote_table_name",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "prepare_statement",
     "call": "prepare",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -926,13 +884,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "primary_keys",
-    "call": "quote_table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "quote",
     "call": "check_int_in_range",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -942,21 +893,21 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "quote_default_expression",
     "call": "include?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Equivalent (RFC 0072 converge-pg-ddl-exec-primitive-and-quoting-routing): the adapter method is a thin wrapper that forwards to the ported body in postgresql/quoting.ts#quoteDefaultExpression, where the quote/serialize/include? calls live."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "quote_default_expression",
     "call": "quote",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Equivalent (RFC 0072 converge-pg-ddl-exec-primitive-and-quoting-routing): the adapter method is a thin wrapper that forwards to the ported body in postgresql/quoting.ts#quoteDefaultExpression, where the quote/serialize/include? calls live."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "quote_default_expression",
     "call": "serialize",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Equivalent (RFC 0072 converge-pg-ddl-exec-primitive-and-quoting-routing): the adapter method is a thin wrapper that forwards to the ported body in postgresql/quoting.ts#quoteDefaultExpression, where the quote/serialize/include? calls live."
   },
   {
     "package": "activerecord",
@@ -975,15 +926,15 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "quoted_include_columns_for_index",
-    "call": "add_options_for_index_columns",
+    "rubyName": "quoted_scope",
+    "call": "extract_schema_qualified_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "quoted_include_columns_for_index",
-    "call": "quote_column_name",
+    "rubyName": "quoted_scope",
+    "call": "quote",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -1012,6 +963,13 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "reconnect",
     "call": "reset",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "reference_name_for_table",
+    "call": "extract_schema_qualified_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -1052,51 +1010,16 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "remove_exclusion_constraint",
-    "call": "remove_constraint",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "remove_index",
-    "call": "execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "remove_index",
-    "call": "index_algorithm",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "remove_index",
     "call": "index_exists?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Equivalent (RFC 0072 converge-pg-ddl-exec-primitive-and-quoting-routing): trails resolves the if_exists guard and the index name from a single already-fetched `indexes(table_name)` list via indexExistsForRemoveFrom / indexNameForRemoveFrom, rather than re-issuing introspection through index_exists? / index_name_for_remove."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "remove_index",
     "call": "index_name_for_remove",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "remove_index",
-    "call": "quote_table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "remove_unique_constraint",
-    "call": "remove_constraint",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Equivalent (RFC 0072 converge-pg-ddl-exec-primitive-and-quoting-routing): trails resolves the if_exists guard and the index name from a single already-fetched `indexes(table_name)` list via indexExistsForRemoveFrom / indexNameForRemoveFrom, rather than re-issuing introspection through index_exists? / index_name_for_remove."
   },
   {
     "package": "activerecord",
@@ -1192,6 +1115,27 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "reset_pk_sequence!",
+    "call": "query_value",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "reset_pk_sequence!",
+    "call": "quote",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "reset_pk_sequence!",
+    "call": "warn",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "returning_column_values",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -1269,6 +1213,27 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "set_pk_sequence!",
+    "call": "query_value",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "set_pk_sequence!",
+    "call": "quote",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "set_pk_sequence!",
+    "call": "warn",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "set_standard_conforming_strings",
     "call": "internal_execute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -1299,6 +1264,13 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "table_partition_definition",
     "call": "query_value",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "table_partition_definition",
+    "call": "quoted_scope",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -1362,41 +1334,6 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "update_typemap_for_default_timezone",
     "call": "new",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "validate_check_constraint",
-    "call": "check_constraint_for!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "validate_constraint",
-    "call": "accept",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "validate_constraint",
-    "call": "create_alter_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "validate_constraint",
-    "call": "execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "validate_foreign_key",
-    "call": "foreign_key_for!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
@@ -345,13 +345,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "default_sequence_name",
-    "call": "new",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "disable_extension",
     "call": "internal_exec_query",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -611,13 +604,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "foreign_key_column_for",
-    "call": "extract_schema_qualified_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "foreign_keys",
     "call": "internal_exec_query",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -688,13 +674,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "index_name",
-    "call": "extract_schema_qualified_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "indexes",
     "call": "column_names_from_column_numbers",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -739,13 +718,6 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "inherited_table_names",
     "call": "query_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "inherited_table_names",
-    "call": "quoted_scope",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -849,20 +821,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "pk_and_sequence_for",
-    "call": "quote",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "pk_and_sequence_for",
-    "call": "quote_table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "prepare_statement",
     "call": "prepare",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -926,20 +884,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "quoted_scope",
-    "call": "extract_schema_qualified_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "quoted_scope",
-    "call": "quote",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "reconfigure_connection_timezone",
     "call": "fetch",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -963,13 +907,6 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "reconnect",
     "call": "reset",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "reference_name_for_table",
-    "call": "extract_schema_qualified_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -1115,27 +1052,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "reset_pk_sequence!",
-    "call": "query_value",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "reset_pk_sequence!",
-    "call": "quote",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "reset_pk_sequence!",
-    "call": "warn",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "returning_column_values",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -1213,27 +1129,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "set_pk_sequence!",
-    "call": "query_value",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "set_pk_sequence!",
-    "call": "quote",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "set_pk_sequence!",
-    "call": "warn",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "set_standard_conforming_strings",
     "call": "internal_execute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -1264,13 +1159,6 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "table_partition_definition",
     "call": "query_value",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "table_partition_definition",
-    "call": "quoted_scope",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {


### PR DESCRIPTION
Routes the PostgreSQL alter-table / index / constraint DDL and its quoting
through the primitives Rails uses, instead of the hand-built template SQL the
#5334 include-resolution reseed exposed.

Rails anchors:
`vendor/rails/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb`.

## Alter-table routing

- `validateConstraint`, `addExclusionConstraint` — build an `AlterTable` node via
  `createAlterTable` and render it with `schemaCreation.accept`, matching
  `validate_constraint` / `add_exclusion_constraint`. `addUniqueConstraint` and
  `addForeignKey` already built the node; they now issue it through the public
  `execute` primitive rather than the private `exec`.
- `removeExclusionConstraint` / `removeUniqueConstraint` — drop through the
  ported `removeConstraint` instead of inline `ALTER TABLE … DROP CONSTRAINT`.
- `validateCheckConstraint` / `validateForeignKey` — resolve the constraint name
  through `checkConstraintForBang` / `foreignKeyForBang`, the same lookups
  `removeForeignKey` already uses, replacing a bespoke schema-aware FK matcher.
- `addIndex` — `buildCreateIndexDefinition` + `schemaCreation.accept`, with the
  `COMMENT ON INDEX` arm reading `createIndex.index.comment` as Rails does. This
  deletes ~55 lines of duplicated CREATE INDEX assembly (opclass, order, include,
  NULLS NOT DISTINCT, partial `WHERE`) that the visitor already renders.
- `removeIndex` — the algorithm now comes from `indexAlgorithm`, which is where
  Rails raises the `ArgumentError` for an unsupported algorithm.

## Quoting

`changeColumnComment`, `renameIndex`, `removeIndex`, `primaryKeys`,
`setPkSequence{,Bang}`, `resetPkSequence{,Bang}` and `changeColumnNullForAlter`
call `quoteTableName` / `quoteColumnName` directly rather than the trails-private
`_qt` / `_qi` abbreviations (and `quoteIdentifier`, its byte-identical synonym).
`quotedIncludeColumnsForIndex` threads its quoted map through
`addOptionsForIndexColumns`, as Rails does. `renameIndex` / `removeIndex` resolve
the schema qualifier with `extractSchemaQualifiedName` — the same
`Utils.extractSchemaQualifiedName` the private `parseSchemaQualifiedName` wrapped.

## Fidelity fixes found by the ported tests

- `exclusionConstraints()` / `uniqueConstraints()` passed
  `deferrable: deferrable || undefined`, so a non-deferrable constraint read back
  as `undefined` where Rails reports `false`. Ruby truthiness does not collapse
  `false` there; the value is now passed straight through.
- `uniqueConstraintOptions` threw a plain `Error` where Rails raises
  `ArgumentError` for `Cannot specify both column_name and :using_index`; same
  for `addUniqueConstraint`'s neither-given guard.

## Deliberate deviations

- `addIndex` no longer pre-raises `"CREATE INDEX CONCURRENTLY cannot run inside a
  transaction"`. Rails has no such guard — PostgreSQL raises it itself. The
  matching guard in `removeIndex` is untouched (out of scope here).
- The invalid-`deferrable` ArgumentError message names the string literals
  `"immediate"` / `"deferred"` rather than Ruby's `:immediate` / `:deferred`;
  the strings are trails' symbol analogue. Noted at the assertion.

## Tests

Two new files port the add/remove arms of the Rails migration constraint suites
verbatim:

- `migration/exclusion-constraint.test.ts` — `test_add_exclusion_constraint`, the
  three `deferrable` variants, `test_add_exclusion_constraint_deferrable_invalid`,
  `test_remove_exclusion_constraint`,
  `test_remove_non_existing_exclusion_constraint`.
- `migration/unique-constraint.test.ts` — `test_add_unique_constraint_without_deferrable`,
  the three `deferrable` variants and `_invalid`, the three `using_index` arms,
  `test_remove_unique_constraint`, `test_remove_unique_constraint_by_column`,
  `test_remove_non_existing_unique_constraint`.

The model-backed and schema-scoped arms are not ported. Both files restore the
canonical `invoices` / `sections` tables after Rails' teardown drops them. The
existing
`adapters/postgresql/active-schema.test.ts` (`PostgresqlActiveSchemaTest`) and
`adapters/postgresql/schema.test.ts` are the regression net for the `addIndex` /
`removeIndex` / `renameIndex` rewrites — they assert the generated DDL string and
the schema-qualified index paths, and both pass unchanged.

## Ratchet

`pnpm api:calls:wide` passes with a strictly smaller baseline. The
postgresql-adapter bucket goes **201 → 176**: 25 entries dropped from
`call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json`;
8 that cannot drop (nested-`new` attribution in the `*_for_alter` builders, the
`quote_default_expression` adapter wrapper, `remove_index`'s single-fetch index
resolution) carry specific reasons naming the equivalent path. The remaining
`query_value` / `internal_execute` entries belong to the follow-up story below
and keep their existing baseline reasons.

## Follow-up

The session/transaction half is registered as RFC 0072
`converge-pg-session-and-transaction-exec-primitive-routing`: the
`create_database` / `drop_database` / `create_schema` / `drop_schema` /
`rename_table` `execute` sites, the `internal_execute` session writers, and the
`query_value` / `query_values` read-side accessors.

## Rebase note

Rebased onto #5389, which converged the PG sequence and
schema-qualified-name helpers and overlapped this PR in three files. Where the
two agreed I took main's version — `renameIndex` had landed there in an
identical form, and #5389's `setPkSequence` / `resetPkSequence` rewrite (which
routes through `queryValue` and restores the `@logger.warn` arms) is strictly
better than the quoting-only change I had here, so mine is dropped entirely.
That is why the baseline delta is 25 rather than the 33 quoted earlier: the
`extract_schema_qualified_name` and pk-sequence entries were claimed by #5389
first. `validateForeignKey` is the one place I kept mine — main still carries
the bespoke schema-tolerant FK matcher this PR replaces with
`foreignKeyForBang`.

Closes-story: converge-pg-ddl-exec-primitive-and-quoting-routing
