### PR TITLE
refactor(postgresql): route schema introspection through ported exec primitives

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -448,7 +448,7 @@ export interface AbstractAdapter {
     sql: string,
     name?: string | null,
     binds?: unknown[],
-    options?: { prepare?: boolean; allowRetry?: boolean },
+    options?: { prepare?: boolean; allowRetry?: boolean; materializeTransactions?: boolean },
   ): Promise<Result>;
   execInsertAll(sql: string, name?: string): Promise<Result>;
   execInsert(
@@ -523,7 +523,7 @@ export interface AbstractAdapter {
     sql: string,
     name?: string | null,
     binds?: unknown[],
-    options?: { prepare?: boolean; allowRetry?: boolean },
+    options?: { prepare?: boolean; allowRetry?: boolean; materializeTransactions?: boolean },
   ): Promise<Result>;
   /** @internal */
   castResult?(rawResult: unknown): Result;

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -516,7 +516,12 @@ export interface AbstractAdapter {
   internalExecute(
     sql: string,
     name?: string,
-    opts?: { materializeTransactions?: boolean; allowRetry?: boolean },
+    opts?: {
+      materializeTransactions?: boolean;
+      allowRetry?: boolean;
+      prepare?: boolean;
+      binds?: unknown[];
+    },
   ): Promise<unknown>;
   /** @internal */
   internalExecQuery(

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -115,7 +115,7 @@ export interface DatabaseStatementsHost {
   internalExecute?(
     sql: string,
     name?: string,
-    opts?: { materializeTransactions?: boolean; binds?: unknown[] },
+    opts?: { materializeTransactions?: boolean; allowRetry?: boolean; binds?: unknown[] },
   ): Promise<unknown>;
   /** @internal */
   internalExecQuery?(
@@ -1426,10 +1426,15 @@ export async function internalExecQuery(
     const tm = (this as any)._transactionManager as TransactionManager | undefined;
     if (tm && (options?.materializeTransactions ?? true)) await tm.materializeTransactions();
     if (this?.internalExecute) {
-      // Thread binds through so a bound INSERT ... RETURNING reaches the driver
-      // (Rails internal_exec_query(sql, name, binds) → internal_execute). trails
-      // carries binds in the opts object rather than positionally.
-      const rawResult = await this.internalExecute(sql, sqlName, { binds });
+      // Thread binds and exec options through so a bound INSERT ... RETURNING
+      // reaches the driver and allow_retry / materialize_transactions survive
+      // (Rails internal_exec_query(...) → internal_execute(...) → raw_execute).
+      // trails carries all of them in the opts object rather than positionally.
+      const rawResult = await this.internalExecute(sql, sqlName, {
+        binds,
+        allowRetry: options?.allowRetry,
+        materializeTransactions: options?.materializeTransactions,
+      });
       return this.castResult ? this.castResult(rawResult) : normalizeResult(rawResult);
     }
     if (binds && binds.length > 0) {

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -115,7 +115,12 @@ export interface DatabaseStatementsHost {
   internalExecute?(
     sql: string,
     name?: string,
-    opts?: { materializeTransactions?: boolean; allowRetry?: boolean; binds?: unknown[] },
+    opts?: {
+      materializeTransactions?: boolean;
+      allowRetry?: boolean;
+      prepare?: boolean;
+      binds?: unknown[];
+    },
   ): Promise<unknown>;
   /** @internal */
   internalExecQuery?(
@@ -1432,6 +1437,7 @@ export async function internalExecQuery(
       // trails carries all of them in the opts object rather than positionally.
       const rawResult = await this.internalExecute(sql, sqlName, {
         binds,
+        prepare: options?.prepare,
         allowRetry: options?.allowRetry,
         materializeTransactions: options?.materializeTransactions,
       });
@@ -1947,11 +1953,17 @@ export function internalExecute(
   this: DatabaseStatementsHost,
   sql: string,
   name: string = "SQL",
-  binds: unknown[] = [],
-  prepare = false,
-  _async = false,
-  allowRetry = false,
-  materializeTransactions = true,
+  {
+    binds = [],
+    prepare = false,
+    allowRetry = false,
+    materializeTransactions = true,
+  }: {
+    binds?: unknown[];
+    prepare?: boolean;
+    allowRetry?: boolean;
+    materializeTransactions?: boolean;
+  } = {},
 ): Promise<unknown> {
   const processed = preprocessQuery.call(this, sql);
   return (this as any).rawExecute(

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -122,7 +122,7 @@ export interface DatabaseStatementsHost {
     sql: string,
     name?: string | null,
     binds?: unknown[],
-    opts?: { prepare?: boolean; allowRetry?: boolean },
+    opts?: { prepare?: boolean; allowRetry?: boolean; materializeTransactions?: boolean },
   ): Promise<Result>;
   /** @internal */
   dirtyCurrentTransaction?(): void;
@@ -1418,12 +1418,13 @@ export async function internalExecQuery(
   sql: string,
   name?: string | null,
   binds?: unknown[],
+  options?: { prepare?: boolean; allowRetry?: boolean; materializeTransactions?: boolean },
 ): Promise<Result> {
   const sqlName = name ?? "SQL";
   return logSql(this, sql, sqlName, binds, async () => {
     // Materialize lazy transactions before executing SQL
     const tm = (this as any)._transactionManager as TransactionManager | undefined;
-    if (tm) await tm.materializeTransactions();
+    if (tm && (options?.materializeTransactions ?? true)) await tm.materializeTransactions();
     if (this?.internalExecute) {
       // Thread binds through so a bound INSERT ... RETURNING reaches the driver
       // (Rails internal_exec_query(sql, name, binds) → internal_execute). trails
@@ -1524,13 +1525,13 @@ interface DatabaseStatementsDefaultsHost {
     sql: string,
     name?: string | null,
     binds?: unknown[],
-    options?: { prepare?: boolean; allowRetry?: boolean },
+    options?: { prepare?: boolean; allowRetry?: boolean; materializeTransactions?: boolean },
   ): Promise<Result>;
   internalExecQuery(
     sql: string,
     name?: string | null,
     binds?: unknown[],
-    options?: { prepare?: boolean; allowRetry?: boolean },
+    options?: { prepare?: boolean; allowRetry?: boolean; materializeTransactions?: boolean },
   ): Promise<Result>;
 }
 
@@ -1680,7 +1681,7 @@ export const DatabaseStatements = {
     sql: string,
     name?: string | null,
     binds?: unknown[],
-    options?: { prepare?: boolean; allowRetry?: boolean },
+    options?: { prepare?: boolean; allowRetry?: boolean; materializeTransactions?: boolean },
   ): Promise<Result> {
     // options.allowRetry is captured here and will flow to withRawConnection
     // once pool integration lands (connection-pool track). Real adapters that

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1054,7 +1054,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     sql: string,
     name?: string | null,
     binds?: unknown[],
-    options?: { prepare?: boolean; allowRetry?: boolean },
+    options?: { prepare?: boolean; allowRetry?: boolean; materializeTransactions?: boolean },
   ): Promise<Result> {
     return this.internalExecQuery(sql, name, binds, options);
   }
@@ -1063,7 +1063,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     sql: string,
     name?: string | null,
     binds?: unknown[],
-    options?: { prepare?: boolean; allowRetry?: boolean },
+    options?: { prepare?: boolean; allowRetry?: boolean; materializeTransactions?: boolean },
   ): Promise<Result> {
     sql = this.preprocessQuery(sql);
     // Release the query client BEFORE any loadAdditionalTypes call —
@@ -1101,7 +1101,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
           // matching sqlite/MySQL and the Rails
           // `unprepared statement materializes transaction` assertion.
           const r = await this.withRawConnection(
-            { materializeTransactions: true, allowRetry: options?.allowRetry ?? false },
+            {
+              materializeTransactions: options?.materializeTransactions ?? true,
+              allowRetry: options?.allowRetry ?? false,
+            },
             async (conn) => {
               const client = conn as unknown as pg.Client;
               try {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3985,14 +3985,20 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   async foreignTables(): Promise<string[]> {
-    const rows = await this.schemaQuery(this.dataSourceSql(null, { type: "FOREIGN TABLE" }));
-    return rows.map((r) => r.relname as string);
+    const names = await this.queryValues(
+      this.dataSourceSql(null, { type: "FOREIGN TABLE" }),
+      "SCHEMA",
+    );
+    return names as string[];
   }
 
   async foreignTableExists(tableName: string): Promise<boolean> {
     if (!tableName) return false;
-    const rows = await this.schemaQuery(this.dataSourceSql(tableName, { type: "FOREIGN TABLE" }));
-    return rows.length > 0;
+    const names = await this.queryValues(
+      this.dataSourceSql(tableName, { type: "FOREIGN TABLE" }),
+      "SCHEMA",
+    );
+    return names.length > 0;
   }
 
   quotedIncludeColumnsForIndex(columnNames: string | string[]): string {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
@@ -129,7 +129,7 @@ describe("PostgreSQLSchemaStatements sequence helpers warn without a sequence", 
 describe("PostgreSQLSchemaStatements#indexNameExists", () => {
   it("parses the index name through quotedScope rather than quoting it raw", async () => {
     const { adapter, sql } = makeAdapter({
-      schemaQuery: async () => [{ cnt: 1 }],
+      queryValue: async () => 1,
     });
     const ss = new PostgreSQLSchemaStatements(adapter);
     expect(await ss.indexNameExists("my_schema.things", "my_schema.index_a")).toBe(true);

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -409,7 +409,6 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
 
   async tablePartitionDefinition(tableName: string): Promise<string | null> {
     const scope = this.pg.quotedScope(tableName, { type: "BASE TABLE" });
-    if (!scope.name) return null;
     const def = await this.pg.queryValue(
       `SELECT pg_catalog.pg_get_partkeydef(c.oid)
        FROM pg_catalog.pg_class c
@@ -424,7 +423,6 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
 
   async inheritedTableNames(tableName: string): Promise<string[]> {
     const scope = this.pg.quotedScope(tableName, { type: "BASE TABLE" });
-    if (!scope.name) return [];
     const names = await this.pg.queryValues(
       `SELECT parent.relname
        FROM pg_catalog.pg_inherits i
@@ -433,8 +431,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
        LEFT JOIN pg_namespace n ON n.oid = child.relnamespace
        WHERE child.relname = ${scope.name}
          AND child.relkind IN (${scope.type})
-         AND n.nspname = ${scope.schema}
-       ORDER BY i.inhseqno`,
+         AND n.nspname = ${scope.schema}`,
       "SCHEMA",
     );
     return names as string[];

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -36,7 +36,12 @@ import {
  */
 interface PgSchemaAdapter {
   schemaQuery(sql: string, binds?: unknown[]): Promise<Record<string, unknown>[]>;
-  internalExecQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;
+  internalExecQuery(
+    sql: string,
+    name?: string | null,
+    binds?: unknown[],
+    options?: { prepare?: boolean; allowRetry?: boolean; materializeTransactions?: boolean },
+  ): Promise<Result>;
   query(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown[][]>;
   queryValue(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown>;
   queryValues(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown[]>;
@@ -798,8 +803,6 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
        AND a.attnum IN (${safeNums.join(", ")})`,
       "SCHEMA",
     );
-    // Mirrors Rails' `Hash[query(...)].values_at(*column_numbers).compact`:
-    // pairs → hash, read back in the caller's column order, drop misses.
     const map = new Map(rows.map((r) => [Number(r[0]), r[1] as string]));
     return safeNums.map((n) => map.get(n)).filter((name): name is string => name != null);
   }
@@ -1184,6 +1187,8 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       ORDER BY c.conname
     `,
       "SCHEMA",
+      [],
+      { allowRetry: true, materializeTransactions: false },
     );
     return Promise.all(
       fkInfo.toArray().map(async (row) => {
@@ -1349,8 +1354,6 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
         predicate = constraintdef.slice(whereIdx + 7);
         excludePart = constraintdef.slice(0, whereIdx);
         predicate = predicate.replace(/ DEFERRABLE(?: INITIALLY (?:IMMEDIATE|DEFERRED))?/i, "");
-        // Mirrors Rails' `predicate.from(2).to(-3)`: pg_get_constraintdef wraps
-        // the WHERE clause in two paren levels, so strip two on each side.
         predicate = predicate.slice(2, -2);
       }
       const parts = excludePart.match(/EXCLUDE(?:\s+USING\s+(\S+))?\s+\((.+)\)/s);
@@ -1483,6 +1486,8 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
         AND n.nspname = ${scope.schema}
     `,
       "SCHEMA",
+      [],
+      { allowRetry: true, materializeTransactions: false },
     );
     return Promise.all(
       uniqueInfo.toArray().map(async (row) => {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -1275,6 +1275,8 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
          AND t.relname = ${scope.name!}
          AND n.nspname = ${scope.schema}`,
       "SCHEMA",
+      [],
+      { allowRetry: true, materializeTransactions: false },
     );
     return checkInfo.toArray().map((row) => {
       const expression = (row.constraintdef as string).match(/CHECK \((.+)\)/s)?.[1] ?? "";

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -15,6 +15,7 @@ import {
   type ColumnType,
 } from "../abstract/schema-definitions.js";
 import { HashLookupTypeMap } from "../../type/hash-lookup-type-map.js";
+import type { Result } from "../../result.js";
 import { Column } from "./column.js";
 import { quoteColumnName as pgQuoteColumnName } from "./quoting.js";
 import { unquoteIdentifier, splitQuotedIdentifier, Name, Utils } from "./utils.js";
@@ -35,6 +36,10 @@ import {
  */
 interface PgSchemaAdapter {
   schemaQuery(sql: string, binds?: unknown[]): Promise<Record<string, unknown>[]>;
+  internalExecQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;
+  query(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown[][]>;
+  queryValue(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown>;
+  queryValues(sql: string, name?: string | null, binds?: unknown[]): Promise<unknown[]>;
   exec(sql: string): Promise<void>;
   execute(sql: string): Promise<unknown>;
   clearCacheBang(): void;
@@ -237,8 +242,9 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   async indexNameExists(tableName: string, indexName: string): Promise<boolean> {
     const table = this.pg.quotedScope(tableName);
     const index = this.pg.quotedScope(indexName);
-    const rows = await this.pg.schemaQuery(`
-      SELECT COUNT(*) AS cnt
+    const count = await this.pg.queryValue(
+      `
+      SELECT COUNT(*)
       FROM pg_class t
       INNER JOIN pg_index d ON t.oid = d.indrelid
       INNER JOIN pg_class i ON d.indexrelid = i.oid
@@ -247,8 +253,10 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
         AND i.relname = ${index.name}
         AND t.relname = ${table.name}
         AND n.nspname = ${table.schema}
-    `);
-    return Number(rows[0].cnt) > 0;
+    `,
+      "SCHEMA",
+    );
+    return Number(count) > 0;
   }
 
   quotedIncludeColumnsForIndex(columnNames: string | string[]): string {
@@ -378,48 +386,53 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   }
 
   override async tableComment(tableName: string): Promise<string | null> {
-    const { schema, name } = this.pg.quotedScope(tableName);
-    if (!name) return null;
-    const rows = await this.pg.schemaQuery(`
-      SELECT pg_catalog.obj_description(c.oid, 'pg_class') AS comment
+    const scope = this.pg.quotedScope(tableName, { type: "BASE TABLE" });
+    if (!scope.name) return null;
+    const comment = await this.pg.queryValue(
+      `
+      SELECT pg_catalog.obj_description(c.oid, 'pg_class')
       FROM pg_catalog.pg_class c
       LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
-      WHERE c.relname = ${name}
-        AND c.relkind IN ('r','p')
-        AND n.nspname = ${schema}
-    `);
-    return (rows[0]?.comment as string | null) ?? null;
+      WHERE c.relname = ${scope.name}
+        AND c.relkind IN (${scope.type})
+        AND n.nspname = ${scope.schema}
+    `,
+      "SCHEMA",
+    );
+    return (comment as string | null) ?? null;
   }
 
   async tablePartitionDefinition(tableName: string): Promise<string | null> {
-    const { schema, name } = this.pg.quotedScope(tableName);
-    if (!name) return null;
-    const rows = await this.pg.schemaQuery(`
-      SELECT pg_catalog.pg_get_partkeydef(c.oid) AS def
-      FROM pg_catalog.pg_class c
-      LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
-      WHERE c.relname = ${name}
-        AND c.relkind IN ('r','p')
-        AND n.nspname = ${schema}
-    `);
-    return (rows[0]?.def as string | null) ?? null;
+    const scope = this.pg.quotedScope(tableName, { type: "BASE TABLE" });
+    if (!scope.name) return null;
+    const def = await this.pg.queryValue(
+      `SELECT pg_catalog.pg_get_partkeydef(c.oid)
+       FROM pg_catalog.pg_class c
+       LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
+       WHERE c.relname = ${scope.name}
+         AND c.relkind IN (${scope.type})
+         AND n.nspname = ${scope.schema}`,
+      "SCHEMA",
+    );
+    return (def as string | null) ?? null;
   }
 
   async inheritedTableNames(tableName: string): Promise<string[]> {
-    const { schema, name } = this.pg.quotedScope(tableName);
-    if (!name) return [];
-    const rows = await this.pg.schemaQuery(`
-      SELECT parent.relname AS name
-      FROM pg_catalog.pg_inherits i
-      JOIN pg_catalog.pg_class child  ON i.inhrelid  = child.oid
-      JOIN pg_catalog.pg_class parent ON i.inhparent = parent.oid
-      LEFT JOIN pg_namespace n ON n.oid = child.relnamespace
-      WHERE child.relname = ${name}
-        AND child.relkind IN ('r','p')
-        AND n.nspname = ${schema}
-      ORDER BY i.inhseqno
-    `);
-    return rows.map((r) => r.name as string);
+    const scope = this.pg.quotedScope(tableName, { type: "BASE TABLE" });
+    if (!scope.name) return [];
+    const names = await this.pg.queryValues(
+      `SELECT parent.relname
+       FROM pg_catalog.pg_inherits i
+       JOIN pg_catalog.pg_class child ON i.inhrelid = child.oid
+       JOIN pg_catalog.pg_class parent ON i.inhparent = parent.oid
+       LEFT JOIN pg_namespace n ON n.oid = child.relnamespace
+       WHERE child.relname = ${scope.name}
+         AND child.relkind IN (${scope.type})
+         AND n.nspname = ${scope.schema}
+       ORDER BY i.inhseqno`,
+      "SCHEMA",
+    );
+    return names as string[];
   }
 
   override async tableOptions(tableName: string): Promise<Record<string, unknown>> {
@@ -492,10 +505,15 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   // ---------------------------------------------------------------------------
 
   async schemaNames(): Promise<string[]> {
-    const rows = await this.pg.schemaQuery(
-      `SELECT nspname FROM pg_namespace WHERE nspname !~ '^pg_' AND nspname != 'information_schema' ORDER BY nspname`,
+    const names = await this.pg.queryValues(
+      `SELECT nspname
+         FROM pg_namespace
+        WHERE nspname !~ '^pg_.*'
+          AND nspname NOT IN ('information_schema')
+        ORDER by nspname`,
+      "SCHEMA",
     );
-    return rows.map((r) => r.nspname as string);
+    return names as string[];
   }
 
   async createSchema(
@@ -773,11 +791,17 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
         throw new TypeError("columnNumbers must contain only safe integers");
       return n;
     });
-    const rows = await this.pg.schemaQuery(
-      `SELECT a.attnum, a.attname FROM pg_attribute a WHERE a.attrelid = ${tableOid} AND a.attnum IN (${safeNums.join(", ")})`,
+    const rows = await this.pg.query(
+      `SELECT a.attnum, a.attname
+       FROM pg_attribute a
+       WHERE a.attrelid = ${tableOid}
+       AND a.attnum IN (${safeNums.join(", ")})`,
+      "SCHEMA",
     );
-    const map = Object.fromEntries(rows.map((r) => [Number(r.attnum), r.attname as string]));
-    return safeNums.map((n) => map[n]).filter(Boolean);
+    // Mirrors Rails' `Hash[query(...)].values_at(*column_numbers).compact`:
+    // pairs → hash, read back in the caller's column order, drop misses.
+    const map = new Map(rows.map((r) => [Number(r[0]), r[1] as string]));
+    return safeNums.map((n) => map.get(n)).filter((name): name is string => name != null);
   }
 
   override columnsForDistinct(
@@ -1142,7 +1166,8 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
 
   override async foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]> {
     const scope = this.pg.quotedScope(tableName);
-    const rows = await this.pg.schemaQuery(`
+    const fkInfo = await this.pg.internalExecQuery(
+      `
       SELECT t2.oid::regclass::text AS to_table, a1.attname AS column, a2.attname AS primary_key,
              c.conname AS name, c.confupdtype AS on_update, c.confdeltype AS on_delete,
              c.convalidated AS valid, c.condeferrable AS deferrable, c.condeferred AS deferred,
@@ -1157,9 +1182,11 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
         AND t1.relname = ${scope.name!}
         AND t3.nspname = ${scope.schema}
       ORDER BY c.conname
-    `);
+    `,
+      "SCHEMA",
+    );
     return Promise.all(
-      rows.map(async (row) => {
+      fkInfo.toArray().map(async (row) => {
         const toTable = unquoteIdentifier(row.to_table as string);
         const conkey = String(row.conkey).replace(/[{}]/g, "").split(",").map(Number);
         const confkey = String(row.confkey).replace(/[{}]/g, "").split(",").map(Number);
@@ -1234,7 +1261,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
 
   override async checkConstraints(tableName: string): Promise<CheckConstraintDefinition[]> {
     const scope = this.pg.quotedScope(tableName);
-    const rows = await this.pg.schemaQuery(
+    const checkInfo = await this.pg.internalExecQuery(
       `SELECT conname, pg_get_constraintdef(c.oid, true) AS constraintdef, c.convalidated AS valid
        FROM pg_constraint c
        JOIN pg_class t ON c.conrelid = t.oid
@@ -1242,8 +1269,9 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
        WHERE c.contype = 'c'
          AND t.relname = ${scope.name!}
          AND n.nspname = ${scope.schema}`,
+      "SCHEMA",
     );
-    return rows.map((row) => {
+    return checkInfo.toArray().map((row) => {
       const expression = (row.constraintdef as string).match(/CHECK \((.+)\)/s)?.[1] ?? "";
       return new CheckConstraintDefinition(
         tableName,
@@ -1299,7 +1327,8 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
 
   async exclusionConstraints(tableName: string): Promise<ExclusionConstraintDefinition[]> {
     const scope = this.pg.quotedScope(tableName);
-    const rows = await this.pg.schemaQuery(`
+    const exclusionInfo = await this.pg.internalExecQuery(
+      `
       SELECT conname, pg_get_constraintdef(c.oid) AS constraintdef, c.condeferrable, c.condeferred
       FROM pg_constraint c
       JOIN pg_class t ON c.conrelid = t.oid
@@ -1307,8 +1336,10 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       WHERE c.contype = 'x'
         AND t.relname = ${scope.name}
         AND n.nspname = ${scope.schema}
-    `);
-    return rows.map((row) => {
+    `,
+      "SCHEMA",
+    );
+    return exclusionInfo.toArray().map((row) => {
       const r = row;
       const constraintdef = r.constraintdef as string;
       const whereIdx = constraintdef.search(/ WHERE /i);
@@ -1318,10 +1349,9 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
         predicate = constraintdef.slice(whereIdx + 7);
         excludePart = constraintdef.slice(0, whereIdx);
         predicate = predicate.replace(/ DEFERRABLE(?: INITIALLY (?:IMMEDIATE|DEFERRED))?/i, "");
-        // strip outer parentheses added by pg_get_constraintdef
-        if (predicate.startsWith("((") && predicate.endsWith("))")) {
-          predicate = predicate.slice(1, -1);
-        }
+        // Mirrors Rails' `predicate.from(2).to(-3)`: pg_get_constraintdef wraps
+        // the WHERE clause in two paren levels, so strip two on each side.
+        predicate = predicate.slice(2, -2);
       }
       const parts = excludePart.match(/EXCLUDE(?:\s+USING\s+(\S+))?\s+\((.+)\)/s);
       const using = parts?.[1];
@@ -1441,7 +1471,8 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
 
   async uniqueConstraints(tableName: string): Promise<UniqueConstraintDefinition[]> {
     const scope = this.pg.quotedScope(tableName);
-    const rows = await this.pg.schemaQuery(`
+    const uniqueInfo = await this.pg.internalExecQuery(
+      `
       SELECT c.conname, c.conrelid, c.conkey, c.condeferrable, c.condeferred,
              pg_get_constraintdef(c.oid) AS constraintdef
       FROM pg_constraint c
@@ -1450,9 +1481,11 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       WHERE c.contype = 'u'
         AND t.relname = ${scope.name}
         AND n.nspname = ${scope.schema}
-    `);
+    `,
+      "SCHEMA",
+    );
     return Promise.all(
-      rows.map(async (row) => {
+      uniqueInfo.toArray().map(async (row) => {
         const r = row;
         const conkey = String(r.conkey).replace(/[{}]/g, "").split(",").map(Number);
         const columns = await this.columnNamesFromColumnNumbers(Number(r.conrelid), conkey);
@@ -1759,20 +1792,21 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   }
 
   async primaryKeys(tableName: string): Promise<string[]> {
-    const rows = await this.pg.schemaQuery(
-      `SELECT a.attname AS name
+    const names = await this.pg.queryValues(
+      `SELECT a.attname
        FROM (
          SELECT indrelid, indkey, generate_subscripts(indkey, 1) idx
            FROM pg_index
-          WHERE indrelid = ${this.pg.quoteLiteral(this.adapter.quoteTableName(tableName))}::regclass
+          WHERE indrelid = ${this.adapter.quote(this.adapter.quoteTableName(tableName))}::regclass
             AND indisprimary
        ) i
        JOIN pg_attribute a
          ON a.attrelid = i.indrelid
         AND a.attnum = i.indkey[i.idx]
        ORDER BY i.idx`,
+      "SCHEMA",
     );
-    return rows.map((r) => r.name as string);
+    return names as string[];
   }
 
   async pkAndSequenceFor(

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.test.ts
@@ -483,7 +483,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       const expectedConstraints = [
         {
           name: "test_unique_constraints_position_deferrable_false",
-          deferrable: undefined,
+          deferrable: false,
           column: ["position_1"],
         },
         {
@@ -545,7 +545,7 @@ describeIfPg("PostgreSQLAdapter", () => {
           expression: "daterange(start_date, end_date) WITH &&",
           where: "(start_date IS NOT NULL) AND (end_date IS NOT NULL)",
           using: "gist",
-          deferrable: undefined,
+          deferrable: false,
         },
         {
           name: "test_exclusion_constraints_valid_overlap",

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.test.ts
@@ -456,6 +456,119 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
   });
 
+  describe("UniqueConstraintTest", () => {
+    beforeEach(async () => {
+      await adapter.exec(
+        `CREATE TABLE ${SCHEMA_NAME}.test_unique_constraints (
+           id serial PRIMARY KEY,
+           position_1 integer,
+           position_2 integer,
+           position_3 integer,
+           position_4 integer,
+           CONSTRAINT test_unique_constraints_position_deferrable_false UNIQUE (position_1),
+           CONSTRAINT test_unique_constraints_position_deferrable_immediate UNIQUE (position_2)
+             DEFERRABLE INITIALLY IMMEDIATE,
+           CONSTRAINT test_unique_constraints_position_deferrable_deferred UNIQUE (position_3)
+             DEFERRABLE INITIALLY DEFERRED,
+           CONSTRAINT test_unique_constraints_position_nulls_not_distinct
+             UNIQUE NULLS NOT DISTINCT (position_4)
+         )`,
+      );
+    });
+
+    it("unique constraints", async () => {
+      const uniqueConstraints = await adapter.uniqueConstraints(
+        `${SCHEMA_NAME}.test_unique_constraints`,
+      );
+      const expectedConstraints = [
+        {
+          name: "test_unique_constraints_position_deferrable_false",
+          deferrable: undefined,
+          column: ["position_1"],
+        },
+        {
+          name: "test_unique_constraints_position_deferrable_immediate",
+          deferrable: "immediate",
+          column: ["position_2"],
+        },
+        {
+          name: "test_unique_constraints_position_deferrable_deferred",
+          deferrable: "deferred",
+          column: ["position_3"],
+        },
+      ];
+      expect(uniqueConstraints.length).toBe(expectedConstraints.length + 1);
+
+      for (const expected of expectedConstraints) {
+        const constraint = uniqueConstraints.find((c) => c.name === expected.name)!;
+        expect(constraint.tableName).toBe(`${SCHEMA_NAME}.test_unique_constraints`);
+        expect(constraint.name).toBe(expected.name);
+        expect(constraint.column).toEqual(expected.column);
+        expect(constraint.deferrable).toBe(expected.deferrable);
+      }
+
+      const nullsNotDistinct = uniqueConstraints.find(
+        (c) => c.name === "test_unique_constraints_position_nulls_not_distinct",
+      )!;
+      expect(nullsNotDistinct.column).toEqual(["position_4"]);
+      expect(nullsNotDistinct.nullsNotDistinct).toBe(true);
+    });
+  });
+
+  describe("ExclusionConstraintTest", () => {
+    beforeEach(async () => {
+      await adapter.exec(
+        `CREATE TABLE ${SCHEMA_NAME}.test_exclusion_constraints (
+           id serial PRIMARY KEY,
+           start_date date,
+           end_date date,
+           valid_from date,
+           valid_to date,
+           CONSTRAINT test_exclusion_constraints_date_overlap
+             EXCLUDE USING gist (daterange(start_date, end_date) WITH &&)
+             WHERE (start_date IS NOT NULL AND end_date IS NOT NULL),
+           CONSTRAINT test_exclusion_constraints_valid_overlap
+             EXCLUDE USING gist (daterange(valid_from, valid_to) WITH &&)
+             WHERE (valid_from IS NOT NULL AND valid_to IS NOT NULL)
+             DEFERRABLE INITIALLY IMMEDIATE
+         )`,
+      );
+    });
+
+    it("exclusion constraints", async () => {
+      const exclusionConstraints = await adapter.exclusionConstraints(
+        `${SCHEMA_NAME}.test_exclusion_constraints`,
+      );
+      const expectedConstraints = [
+        {
+          name: "test_exclusion_constraints_date_overlap",
+          expression: "daterange(start_date, end_date) WITH &&",
+          where: "(start_date IS NOT NULL) AND (end_date IS NOT NULL)",
+          using: "gist",
+          deferrable: undefined,
+        },
+        {
+          name: "test_exclusion_constraints_valid_overlap",
+          expression: "daterange(valid_from, valid_to) WITH &&",
+          where: "(valid_from IS NOT NULL) AND (valid_to IS NOT NULL)",
+          using: "gist",
+          deferrable: "immediate",
+        },
+      ];
+      expect(exclusionConstraints.length).toBe(expectedConstraints.length);
+
+      for (const expected of expectedConstraints) {
+        const constraint = exclusionConstraints.find((c) => c.name === expected.name)!;
+        expect(constraint.tableName).toBe(`${SCHEMA_NAME}.test_exclusion_constraints`);
+        expect(constraint.name).toBe(expected.name);
+        expect(constraint.expression).toBe(expected.expression);
+        expect(constraint.using).toBe(expected.using);
+        expect(constraint.where).toBe(expected.where);
+        expect(constraint.deferrable).toBe(expected.deferrable);
+      }
+    });
+  });
+
   describe("HelperMethodsTest", () => {
     it("foreignKeyColumnFor strips schema and singularizes", () => {
       expect(adapter.foreignKeyColumnFor("public.accounts")).toBe("account_id");

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
@@ -114,13 +114,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "check_constraints",
-    "call": "internal_exec_query",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "client_min_messages",
     "call": "query_value",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -151,21 +144,14 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "column_names_from_column_numbers",
     "call": "compact",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "column_names_from_column_numbers",
-    "call": "query",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Ruby-ism: `.compact` drops attnums with no matching row; trails uses `.filter((name) => name != null)` on the same line."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "column_names_from_column_numbers",
     "call": "values_at",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Ruby-ism: `Hash[...].values_at(*column_numbers)` reads the pair-hash back in caller order; trails builds a `Map` and does `safeNums.map((n) => map.get(n))` on the same line."
   },
   {
     "package": "activerecord",
@@ -480,28 +466,21 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "exclusion_constraints",
     "call": "from",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "exclusion_constraints",
-    "call": "internal_exec_query",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Ruby-ism: `predicate.from(2)` (String#from) is `predicate.slice(1, -1)` in TS, applied on the same paren-stripping line."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "exclusion_constraints",
     "call": "split",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Ruby-ism: Rails splits `constraintdef` on ' WHERE '; trails locates the same boundary with `search(/ WHERE /i)` + `slice`, which additionally makes the match case-insensitive."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "exclusion_constraints",
     "call": "to",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Ruby-ism: `predicate.to(-3)` (String#to) is the second argument of the same `predicate.slice(1, -1)` call."
   },
   {
     "package": "activerecord",
@@ -605,36 +584,15 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "foreign_keys",
-    "call": "internal_exec_query",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "foreign_keys",
     "call": "size",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Ruby-ism: `conkey.size > 1` is `conkey.length > 1` in TS; `length` is a property access, not a call the extractor can see."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "foreign_table_exists?",
     "call": "any?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "foreign_table_exists?",
-    "call": "query_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "foreign_tables",
-    "call": "query_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Ruby-ism: `query_values(...).any?` is `names.length > 0` in TS; `length` is a property access, not a call."
   },
   {
     "package": "activerecord",
@@ -676,49 +634,42 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "indexes",
     "call": "column_names_from_column_numbers",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "SQL-side equivalent: column names are computed inside the query via `ARRAY(SELECT pg_get_indexdef(ix.indexrelid, k + 1, true) FROM generate_subscripts(ix.indkey, 1) AS k WHERE k < ix.indnkeyatts)`, which is the `indkey` -> name resolution Rails does in Ruby with `column_names_from_column_numbers`."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "indexes",
     "call": "compact",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Ruby-ism: Rails' `[desc, nulls].compact.join(\" \")` drops a nil `desc`; trails writes `[desc, nulls].filter(Boolean).join(\" \")` on the same line."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "indexes",
     "call": "presence",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Ruby-ism: `include_columns.presence` / `comment.presence` map to trails' explicit blank checks on the same lines (`includeStr ? ... : undefined`, `comment?.trim() ? comment : undefined`)."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "indexes",
     "call": "query",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "SQL-side equivalent: trails' `indexes` runs its introspection SELECT through `schemaQuery` (postgresql/schema-statements-class.ts) because the body needs hash-keyed rows plus bind params for the `to_regclass` fast path; Rails' positional `query` has no bind-carrying form. Deliberately left for the separate `indexes` shape-convergence story."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "indexes",
     "call": "quoted_scope",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "SQL-side equivalent: trails' `indexes` resolves the table through `parseSchemaQualifiedName` + bind params ($1/$2) instead of interpolating `quoted_scope`'s pre-quoted literals, so the scope is carried by binds rather than by a quoted_scope hash."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "indexes",
     "call": "unquote_identifier",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "inherited_table_names",
-    "call": "query_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "SQL-side equivalent: `pg_get_indexdef(..., k + 1, true)` returns already-unquoted column names, so there is no quoted identifier left to strip; the INCLUDE list is unquoted inline with `.replace(/^\"|\"$/g, '')`."
   },
   {
     "package": "activerecord",
@@ -830,13 +781,6 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "prepare_statement",
     "call": "translate_exception_class",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "primary_keys",
-    "call": "query_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -1073,13 +1017,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "schema_names",
-    "call": "query_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "schema_search_path",
     "call": "query_value",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -1143,22 +1080,8 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "table_comment",
-    "call": "query_value",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "table_options",
     "call": "presence",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "table_partition_definition",
-    "call": "query_value",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -1208,14 +1131,7 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "unique_constraints",
     "call": "delete",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "unique_constraints",
-    "call": "internal_exec_query",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Ruby-ism: `row['conkey'].delete('{}')` strips the PG array braces; trails uses `String(r.conkey).replace(/[{}]/g, \"\")` on the same line."
   },
   {
     "package": "activerecord",


### PR DESCRIPTION
Converges the PostgreSQL schema-statements introspection call set onto Rails'
bodies (RFC 0072 fallout cluster from the #5334 include-resolution reseed).

## What changed

**Exec primitives.** Rails introspects through `query` / `query_value` /
`query_values` / `internal_exec_query`; trails routed everything through the
adapter-local `schemaQuery` helper. Now:

| method | primitive |
| --- | --- |
| `primary_keys`, `schema_names`, `inherited_table_names`, `foreign_tables`, `foreign_table_exists?` | `queryValues` |
| `table_partition_definition`, `table_comment`, `index_name_exists?` | `queryValue` |
| `column_names_from_column_numbers` | `query` |
| `foreign_keys`, `check_constraints`, `exclusion_constraints`, `unique_constraints` | `internalExecQuery` |

**Exec options.** `internalExecQuery` hardcoded `materializeTransactions: true`,
so the swap above would have started a pending lazy transaction that
`schemaQuery` left alone. Rails passes `allow_retry: true,
materialize_transactions: false` on three of its four PG `internal_exec_query`
call sites — `foreign_keys` (schema_statements.rb:586), `check_constraints`
(:640) and `unique_constraints` (:700); only `exclusion_constraints` (:666)
omits them. Both options are now threaded through `internalExecQuery` (PG
override + abstract mixin) and passed at exactly those three sites.

The abstract mixin also had to stop dropping them: it called
`internalExecute(sql, name, { binds })`, so nothing survived to the execution
primitive. Rails forwards everything through `internal_exec_query(...)` ->
`internal_execute(...)` -> `raw_execute`, where `materialize_transactions`
reaches `with_raw_connection` (abstract/database_statements.rb:546-547,
589-591). Now forwarded; the host interface gains the `allowRetry` key the
three adapters already destructure.

**`quoted_scope`.** Deleted the bespoke `pgQuotedScope` duplicate. Its callers
(`index_name_exists?`, `table_comment`, `table_partition_definition`,
`inherited_table_names`) now use the ported `quotedScope`, including its `type`
relkind list rather than a hardcoded `('r','p')`.

**Bug fix.** `exclusion_constraints` strips the parens `pg_get_constraintdef`
wraps around the WHERE clause. Rails' `predicate.from(2).to(-3)` removes **two**
levels; trails' `slice(1, -1)` removed one, so every exclusion constraint's
`where` carried a spurious outer paren pair
(`((a IS NOT NULL) AND (b IS NOT NULL))` instead of
`(a IS NOT NULL) AND (b IS NOT NULL)`).

## Baseline

`postgresql-adapter.json` wide call-mismatch entries: **225 -> 210**, 15 removed,
0 added. `pnpm api:calls:wide` passes. The 14 surviving entries in this cluster
are no longer RFC 0047 seed text — each names its concrete equivalent, e.g.
`indexes | column_names_from_column_numbers` points at the
`ARRAY(SELECT pg_get_indexdef(ix.indexrelid, k + 1, true) ...)` subquery that
does the `indkey` -> name resolution in SQL. `indexes` itself is left for a
separate shape-convergence story: its bind-carrying `to_regclass` fast path has
no positional-`query` counterpart, and the INCLUDE-column rejection branch needs
the whole body reshaped rather than a primitive swap.

## Tests

Added `UniqueConstraintTest > unique constraints` and
`ExclusionConstraintTest > exclusion constraints` to
`connection-adapters/postgresql/schema-statements.test.ts` — named verbatim after
Rails' `test_unique_constraints` / `test_exclusion_constraints`, asserting the
same `name` / `column` / `deferrable` / `nulls_not_distinct` and
`expression` / `using` / `where` / `deferrable` sets. These were the two
converged methods with no direct introspection coverage, and the exclusion one
fails on baseline (the extra parens above).

Green locally against PG 17: `connection-adapters/**` + `adapters/postgresql/**`
+ `schema-dumper` + `invertible-migration` + `transactions`, 2800+ tests
including all 10 `foreign-table.test.ts` FDW round-trips. Because the mixin
change is shared, the SQLite lane was re-run too (`connection-adapters/**` +
`adapters/sqlite3/**` + `sqlite/**` + `transactions`, 1988 passed), and the
MySQL adapter suites that exercise the transaction-control `internalExecute`
paths.

## Follow-ups filed

- `converge-pg-dumper-deferrable-truthiness` (0023-surfaced-deviations) —
  `postgresql/schema-dumper.ts:247,268` gate the dumped `deferrable:` option on
  `!== undefined`; Rails gates on truthiness (`postgresql/schema_dumper.rb:51,72`),
  so a non-deferrable constraint should emit no `deferrable:` at all. Live since
  #5383 made `extractConstraintDeferrable` return `false` instead of `undefined`
  — that return is correct and is what Rails asserts, but it makes the dumper's
  `!== undefined` check always true. Out of scope here: the file is not in this
  diff, and pinning it properly means strengthening the dumper tests to Rails'
  exact `assert_match` strings.

Closes-story: converge-pg-schema-statements-introspection-call-set

