### PR TITLE
refactor(core): back configurations with a single global registry

### DIFF
--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -92,19 +92,6 @@ function isBaseClass(klass: typeof Base): boolean {
   return Object.prototype.hasOwnProperty.call(klass, "_isActiveRecordBase");
 }
 
-// Ruby's `ActiveRecord::Base` constant, reached by walking the static
-// prototype chain rather than importing base.js (a runtime cycle). Rails'
-// registry is one class variable, so the sites Rails spells
-// `Base.configurations` must not pick up a subclass-local shadow.
-function activeRecordBase(klass: typeof Base): typeof Base {
-  for (let current: typeof Base = klass; ; ) {
-    if (isBaseClass(current)) return current;
-    const parent: unknown = Object.getPrototypeOf(current);
-    if (typeof parent !== "function") return current;
-    current = parent as typeof Base;
-  }
-}
-
 export function connectsTo(
   this: typeof Base,
   options: {
@@ -976,7 +963,7 @@ async function autoConnect(modelClass: typeof Base): Promise<void> {
   // `TestDatabases.create_and_load_schema` (which suffixes `_database`
   // per worker before reconnect). Falling back to disk would re-read
   // unmutated configs and reconnect to the wrong database.
-  const inMemory = activeRecordBase(modelClass).configurations();
+  const inMemory = modelClass.configurations();
   let configs: DatabaseConfigurations;
   if (!inMemory.empty) {
     configs = inMemory;
@@ -1128,7 +1115,7 @@ export function resolveConfigForConnection(
   // an own-property check so writing here doesn't bleed through JS static
   // inheritance into unrelated subclasses.
   (this as any)._connectionSpecificationName = isPrimaryClass.call(this) ? "Base" : this.name;
-  // Rails: `Base.configurations.resolve(config_or_env)` — the global registry,
-  // not the receiver's (connection_handling.rb:391).
-  return activeRecordBase(this).configurations().resolve(configOrEnv);
+  // Rails: `Base.configurations.resolve(config_or_env)` — `configurations` is
+  // one process-global registry (core.rb:71-79), so the receiver is immaterial.
+  return this.configurations().resolve(configOrEnv);
 }

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -32,6 +32,7 @@ import {
   currentRole as coreCurrentRole,
   currentShard as coreCurrentShard,
   isApplicationRecordClass as coreIsApplicationRecordClass,
+  configurations as baseConfigurations,
 } from "./core.js";
 import { IsolatedExecutionState } from "@blazetrails/activesupport";
 
@@ -963,7 +964,7 @@ async function autoConnect(modelClass: typeof Base): Promise<void> {
   // `TestDatabases.create_and_load_schema` (which suffixes `_database`
   // per worker before reconnect). Falling back to disk would re-read
   // unmutated configs and reconnect to the wrong database.
-  const inMemory = modelClass.configurations();
+  const inMemory = baseConfigurations();
   let configs: DatabaseConfigurations;
   if (!inMemory.empty) {
     configs = inMemory;
@@ -1115,7 +1116,8 @@ export function resolveConfigForConnection(
   // an own-property check so writing here doesn't bleed through JS static
   // inheritance into unrelated subclasses.
   (this as any)._connectionSpecificationName = isPrimaryClass.call(this) ? "Base" : this.name;
-  // Rails: `Base.configurations.resolve(config_or_env)` — `configurations` is
-  // one process-global registry (core.rb:71-79), so the receiver is immaterial.
-  return this.configurations().resolve(configOrEnv);
+  // Rails: `Base.configurations.resolve(config_or_env)` — the `Base` constant
+  // literally (connection_handling.rb:385-391), never `self`, so a model-local
+  // `configurations` cannot redirect resolution.
+  return baseConfigurations().resolve(configOrEnv);
 }

--- a/packages/activerecord/src/core.trails.test.ts
+++ b/packages/activerecord/src/core.trails.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { Topic } from "./test-helpers/models/topic.js";
 import { Base } from "./index.js";
+import { DatabaseConfigurations } from "./database-configurations.js";
 import { BetterSQLite3Adapter } from "./connection-adapters/better-sqlite3-adapter.js";
 
 describe("frozen / isFrozen", () => {
@@ -119,5 +120,35 @@ describe("connection checkout for directly-assigned adapters", () => {
   it("insertAll resolves through the assigned adapter without a pool", async () => {
     await DirectTopic.insertAll([{ title: "Bob" }]);
     expect(await DirectTopic.count()).toBe(1);
+  });
+});
+
+// Rails stores the registry in the class variable `@@configurations`
+// (core.rb:71-79), so there is one registry per process. JS statics would
+// instead shadow per class, which has no Rails counterpart test — hence
+// this trails-side guard.
+describe("configurations is a single process-global registry", () => {
+  let priorConfigs: DatabaseConfigurations;
+
+  beforeEach(() => {
+    priorConfigs = Base.configurations();
+  });
+
+  afterEach(() => {
+    Base.configurations(priorConfigs);
+  });
+
+  it("an assignment on a subclass replaces the registry for Base and its siblings", () => {
+    class LeftModel extends Base {}
+    class RightModel extends Base {}
+
+    LeftModel.configurations({
+      global_registry_env: { primary: { adapter: "sqlite3", database: "db/global.sqlite3" } },
+    });
+
+    for (const klass of [Base, LeftModel, RightModel]) {
+      const config = klass.configurations().configsFor({ envName: "global_registry_env" })[0];
+      expect(config.database).toBe("db/global.sqlite3");
+    }
   });
 });

--- a/packages/activerecord/src/core.trails.test.ts
+++ b/packages/activerecord/src/core.trails.test.ts
@@ -151,4 +151,30 @@ describe("configurations is a single process-global registry", () => {
       expect(config.database).toBe("db/global.sqlite3");
     }
   });
+
+  // Rails names the `Base` constant literally in
+  // `resolve_config_for_connection` (connection_handling.rb:385-391), so a
+  // model-local `configurations` is never consulted. JS would otherwise
+  // dispatch the read through the receiver.
+  it("resolveConfigForConnection ignores a model-local configurations override", async () => {
+    const { resolveConfigForConnection } = await import("./connection-handling.js");
+
+    Base.configurations({
+      global_registry_env: { primary: { adapter: "sqlite3", database: "db/global.sqlite3" } },
+    });
+
+    class OverridingModel extends Base {
+      static configurations(): DatabaseConfigurations {
+        return DatabaseConfigurations.fromEnv({
+          global_registry_env: { primary: { adapter: "sqlite3", database: "db/hijacked.sqlite3" } },
+        });
+      }
+    }
+
+    const resolved = resolveConfigForConnection.call(
+      OverridingModel as unknown as typeof Base,
+      "global_registry_env",
+    );
+    expect(resolved.database).toBe("db/global.sqlite3");
+  });
 });

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -438,9 +438,13 @@ let _configurations: DatabaseConfigurations | undefined;
 
 /**
  * Mirrors: ActiveRecord::Base.configurations / .configurations=
+ *
+ * Takes no `this`: Rails reads and writes the `@@configurations` class
+ * variable, so the receiver never participates. Callers that Rails spells
+ * `Base.configurations` therefore cannot be redirected by a model-local
+ * override.
  */
 export function configurations(
-  this: CoreHost,
   config?: RawConfigurations | DatabaseConfigurations | DatabaseConfig[],
 ): DatabaseConfigurations {
   if (config !== undefined) {

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -409,7 +409,6 @@ interface CoreHost {
   _destroyAssociationAsyncJob?: any;
   _findByStatementCache?: Map<boolean, Map<string, any>>;
   _generatedAssociationMethods?: Set<string>;
-  _configurations?: DatabaseConfigurations;
   _predicateBuilder?: any;
   arelTable?: any;
   prototype: any;
@@ -431,6 +430,12 @@ export function destroyAssociationAsyncJob(this: CoreHost, value?: any): any {
   return this._destroyAssociationAsyncJob ?? null;
 }
 
+// Rails backs `configurations` with the class variable `@@configurations`
+// (core.rb:71-79), so there is exactly one registry for the whole process:
+// assigning through any model class replaces `ActiveRecord::Base`'s value.
+// A per-class static would instead shadow through the JS prototype chain.
+let _configurations: DatabaseConfigurations | undefined;
+
 /**
  * Mirrors: ActiveRecord::Base.configurations / .configurations=
  */
@@ -439,14 +444,14 @@ export function configurations(
   config?: RawConfigurations | DatabaseConfigurations | DatabaseConfig[],
 ): DatabaseConfigurations {
   if (config !== undefined) {
-    this._configurations =
+    _configurations =
       config instanceof DatabaseConfigurations
         ? config
         : Array.isArray(config)
           ? new DatabaseConfigurations(config)
           : DatabaseConfigurations.fromEnv(config);
   }
-  return this._configurations ?? DatabaseConfigurations.fromEnv({});
+  return _configurations ?? DatabaseConfigurations.fromEnv({});
 }
 
 export function isApplicationRecordClass(this: CoreHost): boolean {


### PR DESCRIPTION
Rails backs `ActiveRecord::Base.configurations` with the class variable
`@@configurations` (core.rb:71-79), so there is exactly one registry per
process: assigning through any model class replaces the value every other
model reads.

trails kept the registry per class — `Core.configurations` wrote
`this._configurations`, which shadows through the JS static prototype chain.
#5381 converged the accessor itself but left that storage in place, working
around it by routing the two sites Rails spells `Base.configurations`
(`resolve_config_for_connection`, `autoConnect`) through an
`activeRecordBase()` prototype-chain walk. This finishes the job.

## Changes

- `core.ts`: `configurations` reads and writes a module-level binding rather
  than `this._configurations`; the `_configurations` member is gone from
  `CoreHost`. `Base.configurations({})` at load still seeds the empty
  registry (core.rb:74).
- `connection-handling.ts`: deleted `activeRecordBase()`. The two sites Rails
  spells `Base.configurations` call the ported accessor directly
  (`baseConfigurations()` imported from `core.js`) rather than dispatching
  through the receiver — Rails names the `Base` constant literally
  (connection_handling.rb:385-391), so a model-local `configurations` must not
  redirect resolution. `configurations` correspondingly takes no `this`: it
  reads and writes `@@configurations` and never consults its receiver.
- `core.trails.test.ts`: two guards — an assignment through a subclass is
  observable from `Base` and from sibling classes, and
  `resolveConfigForConnection` ignores a model-local `configurations`
  override. Rails has no counterpart
  test (Ruby cannot express the per-class shadow), hence the trails sibling
  file. It fails on baseline (the sibling class still sees the pre-assignment
  registry) and passes here. The override guard likewise resolves
  `db/hijacked.sqlite3` against receiver dispatch.

No test needed converting: #5381 had already moved every suite that assigned
configurations on a local model class (`connection-handling.test.ts`,
`connection-handlers-*.test.ts`, `shard-keys.test.ts`) onto `Base` with
save/restore.

## Verification

- `pnpm typecheck` clean; `eslint` clean on the changed files.
- `API_COMPARE_FORCE=1 pnpm api:compare --wide-calls` +
  `lint-call-mismatches-wide.ts`: `OK (4922 baselined)` — strictly under the
  4925 baseline, no new flags. Dropping the `activeRecordBase` indirection
  does not change any recorded call set.
- `api:extra --package activerecord`: no new novel surface (the deleted
  helper was module-private; nothing new is exported).
- Suites pass: connection-handling, shard-keys, test-databases,
  database-configurations, query-cache, connection-swapping-nested,
  connection-handlers-multi-db, connection-handlers-sharding-db,
  core.trails.
- Regression test confirmed failing against baseline `core.ts`.

Closes-story: converge-configurations-storage-onto-a-single-global-registry
