### PR TITLE
refactor(activerecord): converge class-level writers onto static accessors

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -53,8 +53,6 @@ import {
   polymorphicClassFor,
   initializeInternalsCallback as inheritanceInitializeInternalsCallback,
   baseClass as _inheritanceBaseClass,
-  getAbstractClass as _getAbstractClass,
-  setAbstractClass as _setAbstractClass,
   isBaseClass as _isBaseClass,
   ensureProperType as _ensureProperType,
   narrowToProjectedColumns,
@@ -114,9 +112,10 @@ import {
   isMassAssignmentEmpty,
 } from "@blazetrails/activemodel";
 import { SignedGlobalID as _SignedGlobalIDCtor } from "@blazetrails/globalid/signed-global-id";
+import * as Inheritance from "./inheritance.js";
+import * as SignedId from "./signed-id.js";
 import {
   signedId as _signedId,
-  signedIdVerifier as _signedIdVerifier,
   signedIdVerifierSecret as _signedIdVerifierSecret,
   setSignedIdVerifierSecret as _setSignedIdVerifierSecret,
   findSigned as _findSigned,
@@ -1036,13 +1035,17 @@ export class Base extends Model {
     ModelSchema.protectedEnvironments.call(this, envs);
   }
 
-  static get abstractClass(): boolean {
-    return _getAbstractClass.call(this);
-  }
+  /**
+   * Mirrors: ActiveRecord::Inheritance::ClassMethods#abstract_class.
+   * Installed as a static accessor by `extend()` after the class body.
+   */
+  declare static abstractClass: boolean;
 
-  static set abstractClass(value: boolean) {
-    _setAbstractClass.call(this, value);
-  }
+  /**
+   * Mirrors: ActiveRecord::SignedId::ClassMethods#signed_id_verifier.
+   * Installed as a static accessor by `extend()` after the class body.
+   */
+  declare static signedIdVerifier: _MessageVerifier;
 
   static _requireConcreteClass(): void {
     // Rails: `abstract_class? || self == Base` (inheritance.rb:57) — Base
@@ -1163,13 +1166,7 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Locking::Optimistic.locking_column
    */
-  static get lockingColumn(): string {
-    return LockingOptimistic.lockingColumn(this);
-  }
-
-  static set lockingColumn(col: string) {
-    LockingOptimistic.setLockingColumn(this, col);
-  }
+  declare static lockingColumn: string;
 
   /**
    * Whether optimistic locking is enabled for this model (default true). Set to
@@ -1177,17 +1174,10 @@ export class Base extends Model {
    *
    * Mirrors: ActiveRecord::Base.lock_optimistically
    */
-  static get lockOptimistically(): boolean {
-    return LockingOptimistic.lockOptimistically(this);
-  }
+  declare static lockOptimistically: boolean;
 
-  static set lockOptimistically(value: boolean) {
-    LockingOptimistic.setLockOptimistically(this, value);
-  }
-
-  static get lockingEnabled(): boolean {
-    return LockingOptimistic.lockingEnabled(this);
-  }
+  /** Mirrors: ActiveRecord::Locking::Optimistic::ClassMethods#locking_enabled? */
+  declare static lockingEnabled: boolean;
 
   static get compositePrimaryKey(): boolean {
     return _isCompositePrimaryKey.call(this);
@@ -4105,7 +4095,7 @@ export class Base extends Model {
    * Mirrors: ActiveRecord::Base#to_sgid
    */
   toSgid(options?: ToSgidOptions): SignedGlobalIDType {
-    const verifier = _signedIdVerifier(this.constructor as typeof Base);
+    const verifier = (this.constructor as typeof Base).signedIdVerifier;
     return _SignedGlobalIDCtor.create(this as GlobalIDModel, { ...options, verifier });
   }
 
@@ -4165,7 +4155,7 @@ export class Base extends Model {
     input: string | _SignedGlobalIDType,
     options?: Omit<import("@blazetrails/globalid").LocateSignedOptions, "verifier">,
   ): Promise<unknown | null> {
-    const verifier = _signedIdVerifier(this);
+    const verifier = this.signedIdVerifier;
     return _Locator.locateSigned(input, { ...options, verifier });
   }
 
@@ -4786,6 +4776,9 @@ function _castEnumDirtyOpts(
 // ---------------------------------------------------------------------------
 
 extend(Base, ConnectionHandling.ClassMethods);
+extend(Base, Inheritance.ClassMethods);
+extend(Base, LockingOptimistic.ClassMethods);
+extend(Base, SignedId.ClassMethods);
 extend(Base, QueryCacheClassMethods.ClassMethods);
 
 // Re-define `connection` as a getter (accessor) after extend() overwrites it

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1035,16 +1035,10 @@ export class Base extends Model {
     ModelSchema.protectedEnvironments.call(this, envs);
   }
 
-  /**
-   * Mirrors: ActiveRecord::Inheritance::ClassMethods#abstract_class.
-   * Installed as a static accessor by `extend()` after the class body.
-   */
+  /** Mirrors: ActiveRecord::Inheritance::ClassMethods#abstract_class */
   declare static abstractClass: boolean;
 
-  /**
-   * Mirrors: ActiveRecord::SignedId::ClassMethods#signed_id_verifier.
-   * Installed as a static accessor by `extend()` after the class body.
-   */
+  /** Mirrors: ActiveRecord::SignedId::ClassMethods#signed_id_verifier */
   declare static signedIdVerifier: _MessageVerifier;
 
   static _requireConcreteClass(): void {

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -146,7 +146,7 @@ export { registerSubclass, findStiClass } from "./inheritance.js";
 // subclass (statics) or a Base instance (instance methods).
 // establishConnection requires node:fs — use subpath: @blazetrails/activerecord/connection-handling
 // signedId requires MessageVerifier (node:crypto) — use subpath: @blazetrails/activerecord/signed-id
-export { lockingColumn, lockingEnabled, LockingType } from "./locking/optimistic.js";
+export { LockingType } from "./locking/optimistic.js";
 // ModelSchema is consumed via the Base mixins — `User.columnNames()`,
 // `User.columnsHash()`, `User.contentColumns()`, `User.createTable()`, etc.
 // (mixed in via activesupport `extend()`). The underlying functions are

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -141,7 +141,7 @@ function descendsFromActiveRecordByHierarchy(modelClass: typeof Base): boolean {
   const parent = Object.getPrototypeOf(modelClass) as typeof Base | null;
   if (!parent || parent === Function.prototype || typeof parent.name !== "string") return true;
   // Rails: `elsif superclass.abstract_class?` → recurse through the abstract chain.
-  if (getAbstractClass.call(parent)) return descendsFromActiveRecordByHierarchy(parent);
+  if (parent.abstractClass) return descendsFromActiveRecordByHierarchy(parent);
   // Rails else branch begins with `superclass == Base`.
   return Object.prototype.hasOwnProperty.call(parent, "_isActiveRecordBase");
 }
@@ -203,7 +203,7 @@ export function setBaseClass(modelClass: typeof Base): void {
   // Rails: if superclass == Base || superclass.abstract_class? → self is root.
   // Use _isActiveRecordBase (existing sentinel) to identify the AR root class.
   const parentIsARBase = Object.prototype.hasOwnProperty.call(parent, "_isActiveRecordBase");
-  const parentIsAbstract = getAbstractClass.call(parent);
+  const parentIsAbstract = parent.abstractClass;
   if (parentIsARBase || parentIsAbstract) {
     (modelClass as any)._computedBaseClass = modelClass;
   } else {
@@ -445,34 +445,26 @@ export function baseClass(this: typeof Base): typeof Base {
 }
 
 /**
- * Mirrors: ActiveRecord::Inheritance::ClassMethods#abstract_class
- * @internal
+ * Class-level accessors mixed onto `Base` via `extend()` in base.ts.
+ *
+ * Rails' `abstract_class` / `abstract_class=` share one name, so the pair is
+ * ported as a getter/setter rather than a `set`-prefixed sibling.
+ *
+ * Mirrors: ActiveRecord::Inheritance::ClassMethods
  */
-export function getAbstractClass(this: typeof Base): boolean {
-  return Object.prototype.hasOwnProperty.call(this, "_abstractClass")
-    ? (this as any)._abstractClass
-    : false;
-}
+export const ClassMethods = {
+  /** Mirrors: ActiveRecord::Inheritance::ClassMethods#abstract_class */
+  get abstractClass(): boolean {
+    return Object.prototype.hasOwnProperty.call(this, "_abstractClass")
+      ? (this as any)._abstractClass
+      : false;
+  },
 
-/**
- * Mirrors: ActiveRecord::Inheritance::ClassMethods#abstract_class=
- * @internal
- */
-export function setAbstractClass(this: typeof Base, value: boolean): void {
-  (this as any)._abstractClass = value;
-}
-
-/**
- * Mirrors: ActiveRecord::Inheritance::ClassMethods#abstract_class,
- * abstract_class=, abstract_class?
- */
-export function abstractClass(this: typeof Base, value?: boolean): boolean {
-  if (value !== undefined) {
-    setAbstractClass.call(this, value);
-    return value;
-  }
-  return getAbstractClass.call(this);
-}
+  /** Mirrors: ActiveRecord::Inheritance::ClassMethods#abstract_class= */
+  set abstractClass(value: boolean) {
+    (this as any)._abstractClass = value;
+  },
+};
 
 /**
  * Get the STI base class for a model.

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -444,27 +444,20 @@ export function baseClass(this: typeof Base): typeof Base {
   return (this as any)._computedBaseClass as typeof Base;
 }
 
-/**
- * Class-level accessors mixed onto `Base` via `extend()` in base.ts.
- *
- * Rails' `abstract_class` / `abstract_class=` share one name, so the pair is
- * ported as a getter/setter rather than a `set`-prefixed sibling.
- *
- * Mirrors: ActiveRecord::Inheritance::ClassMethods
- */
-export const ClassMethods = {
+/** Mirrors: ActiveRecord::Inheritance::ClassMethods */
+export class ClassMethods {
   /** Mirrors: ActiveRecord::Inheritance::ClassMethods#abstract_class */
-  get abstractClass(): boolean {
+  static get abstractClass(): boolean {
     return Object.prototype.hasOwnProperty.call(this, "_abstractClass")
       ? (this as any)._abstractClass
       : false;
-  },
+  }
 
   /** Mirrors: ActiveRecord::Inheritance::ClassMethods#abstract_class= */
-  set abstractClass(value: boolean) {
+  static set abstractClass(value: boolean) {
     (this as any)._abstractClass = value;
-  },
-};
+  }
+}
 
 /**
  * Get the STI base class for a model.

--- a/packages/activerecord/src/locking.trails.test.ts
+++ b/packages/activerecord/src/locking.trails.test.ts
@@ -23,4 +23,22 @@ describe("OptimisticLockingTrailsTest", () => {
     const record = new LockCust();
     expect(record.readAttribute("custom_lock_version")).toBe(0);
   });
+
+  it("locking_column= stores value.to_s", () => {
+    class LockCoerce extends Base {
+      static {
+        this._tableName = "lock_without_defaults";
+      }
+    }
+
+    const untyped = LockCoerce as unknown as { lockingColumn: unknown };
+
+    untyped.lockingColumn = 123;
+    expect(LockCoerce.lockingColumn).toBe("123");
+
+    // Ruby's nil.to_s is "", so the reader yields "" rather than falling back
+    // to the "lock_version" default.
+    untyped.lockingColumn = null;
+    expect(LockCoerce.lockingColumn).toBe("");
+  });
 });

--- a/packages/activerecord/src/locking/optimistic.ts
+++ b/packages/activerecord/src/locking/optimistic.ts
@@ -112,55 +112,33 @@ export function resetLockingColumn(this: LockingHost): void {
   (this as unknown as typeof Base).lockingColumn = DEFAULT_LOCKING_COLUMN;
 }
 
-/**
- * Class-level accessors mixed onto `Base` via `extend()` in base.ts.
- *
- * Rails declares these as `class_attribute :lock_optimistically` plus an
- * `attr_accessor`-shaped `locking_column` / `locking_column=` pair on
- * `ClassMethods`; the reader and writer share one Ruby name, so they are
- * ported as a getter/setter pair rather than a `set`-prefixed sibling.
- *
- * Mirrors: ActiveRecord::Locking::Optimistic::ClassMethods
- */
-export const ClassMethods = {
+/** Mirrors: ActiveRecord::Locking::Optimistic::ClassMethods */
+export class ClassMethods {
   /** Mirrors: ActiveRecord::Locking::Optimistic::ClassMethods#locking_column */
-  get lockingColumn(): string {
+  static get lockingColumn(): string {
     return (this as any)._lockingColumn ?? DEFAULT_LOCKING_COLUMN;
-  },
+  }
 
-  set lockingColumn(column: string) {
+  static set lockingColumn(column: string) {
     reloadSchemaFromCache.call(this as any);
     (this as any)._lockingColumn = column;
-  },
+  }
 
-  /**
-   * Whether optimistic locking is enabled for the model — the
-   * `lock_optimistically` config is on AND a lock_version column exists.
-   *
-   * Mirrors: ActiveRecord::Locking::Optimistic::ClassMethods#locking_enabled?
-   * (`lock_optimistically && columns_hash.include?(locking_column)`).
-   */
-  get lockingEnabled(): boolean {
+  /** Mirrors: ActiveRecord::Locking::Optimistic::ClassMethods#locking_enabled? */
+  static get lockingEnabled(): boolean {
     const self = this as unknown as typeof Base;
     return self.lockOptimistically && self._attributeDefinitions.has(self.lockingColumn);
-  },
+  }
 
-  /**
-   * Rails: `class_attribute :lock_optimistically, instance_writer: false,
-   * default: true` — lets a model disable optimistic locking even when a
-   * lock_version column is present. Stored in the `_lockOptimistically` class
-   * field (inherited via the prototype chain), defaulting to true.
-   *
-   * Mirrors: ActiveRecord::Locking::Optimistic#lock_optimistically
-   */
-  get lockOptimistically(): boolean {
+  /** Mirrors: ActiveRecord::Locking::Optimistic#lock_optimistically */
+  static get lockOptimistically(): boolean {
     return (this as any)._lockOptimistically !== false;
-  },
+  }
 
-  set lockOptimistically(value: boolean) {
+  static set lockOptimistically(value: boolean) {
     (this as any)._lockOptimistically = value;
-  },
-};
+  }
+}
 
 /**
  * Mirrors: ActiveRecord::Locking::Optimistic::ClassMethods#update_counters

--- a/packages/activerecord/src/locking/optimistic.ts
+++ b/packages/activerecord/src/locking/optimistic.ts
@@ -15,60 +15,6 @@ import { reloadSchemaFromCache } from "../model-schema.js";
  */
 
 /**
- * Return the column name used for optimistic locking.
- *
- * Mirrors: ActiveRecord::Locking::Optimistic::ClassMethods#locking_column
- */
-export function lockingColumn(modelClass: typeof Base): string {
-  return (modelClass as any)._lockingColumn ?? "lock_version";
-}
-
-/**
- * Set the column name used for optimistic locking.
- *
- * Mirrors: ActiveRecord::Locking::Optimistic::ClassMethods#locking_column=
- * @internal
- */
-export function setLockingColumn(modelClass: typeof Base, column: string): void {
-  reloadSchemaFromCache.call(modelClass as any);
-  (modelClass as any)._lockingColumn = column;
-}
-
-/**
- * Whether optimistic locking is enabled for the model — the `lock_optimistically`
- * config is on AND a lock_version column exists.
- *
- * Mirrors: ActiveRecord::Locking::Optimistic::ClassMethods#locking_enabled?
- * (`lock_optimistically && columns_hash.include?(locking_column)`).
- */
-export function lockingEnabled(modelClass: typeof Base): boolean {
-  return (
-    lockOptimistically(modelClass) &&
-    modelClass._attributeDefinitions.has(lockingColumn(modelClass))
-  );
-}
-
-/**
- * Rails: `class_attribute :lock_optimistically, instance_writer: false,
- * default: true` — lets a model disable optimistic locking even when a
- * lock_version column is present. Stored in the `_lockOptimistically` class
- * field (inherited via the prototype chain), defaulting to true.
- *
- * Mirrors: ActiveRecord::Locking::Optimistic#lock_optimistically
- */
-export function lockOptimistically(modelClass: typeof Base): boolean {
-  return (modelClass as any)._lockOptimistically !== false;
-}
-
-/**
- * Mirrors: ActiveRecord::Locking::Optimistic#lock_optimistically=
- * @internal
- */
-export function setLockOptimistically(modelClass: typeof Base, value: boolean): void {
-  (modelClass as any)._lockOptimistically = value;
-}
-
-/**
  * Type wrapper for the lock_version column that ensures nil → 0 on
  * serialize/deserialize so passing nil doesn't trigger StaleObjectError.
  * cast() coerces null → 0; deserialize() and serialize() also coerce null → 0.
@@ -163,8 +109,58 @@ export async function incrementBang(
  * Mirrors: ActiveRecord::Locking::Optimistic::ClassMethods#reset_locking_column
  */
 export function resetLockingColumn(this: LockingHost): void {
-  setLockingColumn(this as unknown as typeof Base, DEFAULT_LOCKING_COLUMN);
+  (this as unknown as typeof Base).lockingColumn = DEFAULT_LOCKING_COLUMN;
 }
+
+/**
+ * Class-level accessors mixed onto `Base` via `extend()` in base.ts.
+ *
+ * Rails declares these as `class_attribute :lock_optimistically` plus an
+ * `attr_accessor`-shaped `locking_column` / `locking_column=` pair on
+ * `ClassMethods`; the reader and writer share one Ruby name, so they are
+ * ported as a getter/setter pair rather than a `set`-prefixed sibling.
+ *
+ * Mirrors: ActiveRecord::Locking::Optimistic::ClassMethods
+ */
+export const ClassMethods = {
+  /** Mirrors: ActiveRecord::Locking::Optimistic::ClassMethods#locking_column */
+  get lockingColumn(): string {
+    return (this as any)._lockingColumn ?? DEFAULT_LOCKING_COLUMN;
+  },
+
+  set lockingColumn(column: string) {
+    reloadSchemaFromCache.call(this as any);
+    (this as any)._lockingColumn = column;
+  },
+
+  /**
+   * Whether optimistic locking is enabled for the model — the
+   * `lock_optimistically` config is on AND a lock_version column exists.
+   *
+   * Mirrors: ActiveRecord::Locking::Optimistic::ClassMethods#locking_enabled?
+   * (`lock_optimistically && columns_hash.include?(locking_column)`).
+   */
+  get lockingEnabled(): boolean {
+    const self = this as unknown as typeof Base;
+    return self.lockOptimistically && self._attributeDefinitions.has(self.lockingColumn);
+  },
+
+  /**
+   * Rails: `class_attribute :lock_optimistically, instance_writer: false,
+   * default: true` — lets a model disable optimistic locking even when a
+   * lock_version column is present. Stored in the `_lockOptimistically` class
+   * field (inherited via the prototype chain), defaulting to true.
+   *
+   * Mirrors: ActiveRecord::Locking::Optimistic#lock_optimistically
+   */
+  get lockOptimistically(): boolean {
+    return (this as any)._lockOptimistically !== false;
+  },
+
+  set lockOptimistically(value: boolean) {
+    (this as any)._lockOptimistically = value;
+  },
+};
 
 /**
  * Mirrors: ActiveRecord::Locking::Optimistic::ClassMethods#update_counters
@@ -189,8 +185,8 @@ export async function updateCounters(
   counters: Record<string, number>,
   options?: { touch?: boolean | string | string[] },
 ): Promise<number> {
-  if (lockingEnabled(this)) {
-    counters = { ...counters, [lockingColumn(this)]: 1 };
+  if (this.lockingEnabled) {
+    counters = { ...counters, [this.lockingColumn]: 1 };
   }
   return superFn.call(this, id, counters, options);
 }

--- a/packages/activerecord/src/locking/optimistic.ts
+++ b/packages/activerecord/src/locking/optimistic.ts
@@ -121,7 +121,9 @@ export class ClassMethods {
 
   static set lockingColumn(column: string) {
     reloadSchemaFromCache.call(this as any);
-    (this as any)._lockingColumn = column;
+    // Rails stores `value.to_s`, and every call site assigns a Symbol
+    // (`self.locking_column = :version`). `nil.to_s` is "", not "null".
+    (this as any)._lockingColumn = column == null ? "" : String(column);
   }
 
   /** Mirrors: ActiveRecord::Locking::Optimistic::ClassMethods#locking_enabled? */

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -14,7 +14,6 @@ import {
 import {
   isBaseClass,
   baseClass,
-  getAbstractClass,
   lookupModuleTableNamePrefix,
   lookupModuleTableNameSuffix,
 } from "./inheritance.js";
@@ -162,7 +161,7 @@ function containedTableNamePrefix(this: typeof Base): string {
   const moduleName = (this as any).moduleName as string | undefined;
   if (!moduleName) return "";
   const parent = modelRegistry.get(moduleName);
-  if (!parent || getAbstractClass.call(parent as any)) return "";
+  if (!parent || (parent as any).abstractClass) return "";
   const contained =
     ((parent as any).pluralizeTableNames ?? true)
       ? singularize(parent.tableName)
@@ -663,7 +662,7 @@ export function resetTableName(this: SchemaHost): string {
   if (this.name === "Base") {
     return "";
   }
-  if (getAbstractClass.call(this as any)) {
+  if ((this as any).abstractClass) {
     const parent = Object.getPrototypeOf(this) as SchemaHost | null;
     if (parent?.tableName != null) {
       this._tableName = parent.tableName;
@@ -941,7 +940,7 @@ export function loadSchema(this: SchemaHost): void {
   // name even for abstract classes, so mirror the Rails effect by treating an
   // abstract class (or an explicitly cleared `table_name`) as table-less.
   const klass = this as unknown as typeof Base;
-  if (getAbstractClass.call(this as any) || !klass.tableName) {
+  if ((this as any).abstractClass || !klass.tableName) {
     throw new TableNotSpecified(
       `${klass.name} has no table configured. Set one with ${klass.name}.table_name=`,
     );
@@ -1225,7 +1224,7 @@ function applyColumnsHash(
  * @internal
  */
 export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
-  if (getAbstractClass.call(this as any)) return;
+  if ((this as any).abstractClass) return;
   let startingAdapter: SchemaHost["connection"] | undefined;
   try {
     startingAdapter = reflectionAdapter(this);
@@ -1415,7 +1414,7 @@ export async function reconcileVirtualAttributes(this: SchemaHost, reflect = fal
  * (caller may fall back to attribute-defs-derived metadata).
  */
 function loadSchemaFromCacheSync(host: SchemaHost): boolean {
-  if (getAbstractClass.call(host as any)) return false;
+  if ((host as any).abstractClass) return false;
   // Access can throw when no pool is configured; treat as "no adapter".
   let adapter: SchemaHost["connection"] | undefined;
   try {

--- a/packages/activerecord/src/signed-id.test.ts
+++ b/packages/activerecord/src/signed-id.test.ts
@@ -8,7 +8,7 @@ import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
 import { travel, travelBack } from "@blazetrails/activesupport";
 import { Base, RecordNotFound, registerModel } from "./index.js";
 import { UnknownPrimaryKey } from "./errors.js";
-import { setSignedIdVerifierSecret, setSignedIdVerifier, signedIdVerifier } from "./signed-id.js";
+import { setSignedIdVerifierSecret } from "./signed-id.js";
 import { Account } from "./test-helpers/models/account.js";
 import { Toy } from "./test-helpers/models/toy.js";
 import { Company } from "./test-helpers/models/company.js";
@@ -228,13 +228,13 @@ describe("SignedIdTest", () => {
   });
 
   it("use a custom verifier", async () => {
-    const oldVerifier = signedIdVerifier(Account);
-    setSignedIdVerifier(Account, new MessageVerifier("sekret"));
+    const oldVerifier = Account.signedIdVerifier;
+    Account.signedIdVerifier = new MessageVerifier("sekret");
     try {
-      expect(signedIdVerifier(Base)).not.toBe(signedIdVerifier(Account));
+      expect(Base.signedIdVerifier).not.toBe(Account.signedIdVerifier);
       expect((await Account.findSigned((account as any).signedId()))?.id).toBe(account.id);
     } finally {
-      setSignedIdVerifier(Account, oldVerifier);
+      Account.signedIdVerifier = oldVerifier;
     }
   });
 

--- a/packages/activerecord/src/signed-id.ts
+++ b/packages/activerecord/src/signed-id.ts
@@ -46,39 +46,47 @@ export function setSignedIdVerifierSecret(
 }
 
 /**
- * Get or create the MessageVerifier instance for signed IDs.
- * Uses SHA256 digest, JSON serializer, URL-safe encoding.
+ * Class-level accessors mixed onto `Base` via `extend()` in base.ts.
  *
- * Mirrors: ActiveRecord::SignedId::ClassMethods#signed_id_verifier
- */
-export function signedIdVerifier(modelClass: typeof Base): MessageVerifier {
-  if ((modelClass as any)._signedIdVerifier) {
-    return (modelClass as any)._signedIdVerifier;
-  }
-
-  const secret = _signedIdVerifierSecret;
-  const resolvedSecret = typeof secret === "function" ? secret() : secret;
-  if (!resolvedSecret) {
-    throw new Error("You must set ActiveRecord::Base.signed_id_verifier_secret to use signed ids");
-  }
-
-  const verifier = new MessageVerifier(resolvedSecret, {
-    digest: "sha256",
-    url_safe: true,
-  });
-  (modelClass as any)._signedIdVerifier = verifier;
-  _cachedVerifierClasses.add(modelClass);
-  return verifier;
-}
-
-/**
- * Set a custom verifier for signed IDs on a model class.
+ * Rails' `signed_id_verifier` / `signed_id_verifier=` share one name, so the
+ * pair is ported as a getter/setter rather than a `set`-prefixed sibling.
  *
- * Mirrors: ActiveRecord::SignedId::ClassMethods#signed_id_verifier=
+ * Mirrors: ActiveRecord::SignedId::ClassMethods
  */
-export function setSignedIdVerifier(modelClass: typeof Base, verifier: MessageVerifier): void {
-  (modelClass as any)._signedIdVerifier = verifier;
-}
+export const ClassMethods = {
+  /**
+   * Get or create the MessageVerifier instance for signed IDs.
+   * Uses SHA256 digest, JSON serializer, URL-safe encoding.
+   *
+   * Mirrors: ActiveRecord::SignedId::ClassMethods#signed_id_verifier
+   */
+  get signedIdVerifier(): MessageVerifier {
+    if ((this as any)._signedIdVerifier) {
+      return (this as any)._signedIdVerifier;
+    }
+
+    const secret = _signedIdVerifierSecret;
+    const resolvedSecret = typeof secret === "function" ? secret() : secret;
+    if (!resolvedSecret) {
+      throw new Error(
+        "You must set ActiveRecord::Base.signed_id_verifier_secret to use signed ids",
+      );
+    }
+
+    const verifier = new MessageVerifier(resolvedSecret, {
+      digest: "sha256",
+      url_safe: true,
+    });
+    (this as any)._signedIdVerifier = verifier;
+    _cachedVerifierClasses.add(this);
+    return verifier;
+  },
+
+  /** Mirrors: ActiveRecord::SignedId::ClassMethods#signed_id_verifier= */
+  set signedIdVerifier(verifier: MessageVerifier) {
+    (this as any)._signedIdVerifier = verifier;
+  },
+};
 
 function _hasPrimaryKey(pk: unknown): boolean {
   if (pk == null) return false;
@@ -106,7 +114,7 @@ export function signedId(
     throw new Error("Cannot get a signed_id for a new record");
   }
   const ctor = instance.constructor as typeof Base;
-  const verifier = signedIdVerifier(ctor);
+  const verifier = ctor.signedIdVerifier;
   // BigInt is not JSON-serializable; coerce to a plain number so the signed
   // payload round-trips (Rails signs an integer id).
   const coerce = (v: unknown): unknown => (typeof v === "bigint" ? Number(v) : v);
@@ -135,7 +143,7 @@ export async function findSigned<T extends typeof Base>(
   if (!_hasPrimaryKey(pk)) {
     throw new UnknownPrimaryKey(modelClass);
   }
-  const verifier = signedIdVerifier(modelClass);
+  const verifier = modelClass.signedIdVerifier;
   const id = verifier.verified(token, {
     purpose: combinePurposes(modelClass, options?.purpose),
   });
@@ -161,7 +169,7 @@ export async function findSignedBang<T extends typeof Base>(
   token: string,
   options?: { purpose?: string },
 ): Promise<InstanceType<T>> {
-  const verifier = signedIdVerifier(modelClass);
+  const verifier = modelClass.signedIdVerifier;
   const id = verifier.verify(token, {
     purpose: combinePurposes(modelClass, options?.purpose),
   });

--- a/packages/activerecord/src/signed-id.ts
+++ b/packages/activerecord/src/signed-id.ts
@@ -45,22 +45,10 @@ export function setSignedIdVerifierSecret(
   _cachedVerifierClasses.clear();
 }
 
-/**
- * Class-level accessors mixed onto `Base` via `extend()` in base.ts.
- *
- * Rails' `signed_id_verifier` / `signed_id_verifier=` share one name, so the
- * pair is ported as a getter/setter rather than a `set`-prefixed sibling.
- *
- * Mirrors: ActiveRecord::SignedId::ClassMethods
- */
-export const ClassMethods = {
-  /**
-   * Get or create the MessageVerifier instance for signed IDs.
-   * Uses SHA256 digest, JSON serializer, URL-safe encoding.
-   *
-   * Mirrors: ActiveRecord::SignedId::ClassMethods#signed_id_verifier
-   */
-  get signedIdVerifier(): MessageVerifier {
+/** Mirrors: ActiveRecord::SignedId::ClassMethods */
+export class ClassMethods {
+  /** Mirrors: ActiveRecord::SignedId::ClassMethods#signed_id_verifier */
+  static get signedIdVerifier(): MessageVerifier {
     if ((this as any)._signedIdVerifier) {
       return (this as any)._signedIdVerifier;
     }
@@ -80,13 +68,13 @@ export const ClassMethods = {
     (this as any)._signedIdVerifier = verifier;
     _cachedVerifierClasses.add(this);
     return verifier;
-  },
+  }
 
   /** Mirrors: ActiveRecord::SignedId::ClassMethods#signed_id_verifier= */
-  set signedIdVerifier(verifier: MessageVerifier) {
+  static set signedIdVerifier(verifier: MessageVerifier) {
     (this as any)._signedIdVerifier = verifier;
-  },
-};
+  }
+}
 
 function _hasPrimaryKey(pk: unknown): boolean {
   if (pk == null) return false;

--- a/packages/activerecord/src/test-helpers/models/doubloon.ts
+++ b/packages/activerecord/src/test-helpers/models/doubloon.ts
@@ -6,9 +6,8 @@ export class AbstractDoubloon extends Base {
   declare pirate: Pirate | null;
   declare loadBelongsTo: (name: "pirate") => Promise<Pirate | null>;
 
-  static abstractClass = true;
-
   static {
+    this.abstractClass = true;
     this.belongsTo("pirate");
   }
 }

--- a/packages/activerecord/src/type.ts
+++ b/packages/activerecord/src/type.ts
@@ -92,14 +92,10 @@ export function registry(): AdapterSpecificRegistry {
 /**
  * Mirrors Rails' `ActiveRecord::Type.registry=` (attr_accessor setter).
  *
- * Stays a `set`-prefixed function rather than converging onto a getter/setter
- * pair under the Rails name: `ActiveRecord::Type` is a Ruby module whose
- * `class << self; attr_accessor :registry` hangs off the module object, and
- * the trails analogue is this ES module. An ES module namespace is frozen and
- * read-only from the importer's side, so there is no object to define an
- * accessor on — unlike the class-level pairs (`abstract_class=`,
- * `locking_column=`, `signed_id_verifier=`), which converged onto static
- * accessors installed on `Base`.
+ * Not converged onto a getter/setter pair under the Rails name: Rails hangs
+ * `attr_accessor :registry` off the `ActiveRecord::Type` module object, whose
+ * trails analogue is this ES module — and an ES module namespace is read-only
+ * from the importer's side, so there is no object to define an accessor on.
  *
  * Replaces the active registry wholesale. Callers are responsible for
  * re-registering any types they need — this is intentional: Rails' own

--- a/packages/activerecord/src/type.ts
+++ b/packages/activerecord/src/type.ts
@@ -92,6 +92,15 @@ export function registry(): AdapterSpecificRegistry {
 /**
  * Mirrors Rails' `ActiveRecord::Type.registry=` (attr_accessor setter).
  *
+ * Stays a `set`-prefixed function rather than converging onto a getter/setter
+ * pair under the Rails name: `ActiveRecord::Type` is a Ruby module whose
+ * `class << self; attr_accessor :registry` hangs off the module object, and
+ * the trails analogue is this ES module. An ES module namespace is frozen and
+ * read-only from the importer's side, so there is no object to define an
+ * accessor on — unlike the class-level pairs (`abstract_class=`,
+ * `locking_column=`, `signed_id_verifier=`), which converged onto static
+ * accessors installed on `Base`.
+ *
  * Replaces the active registry wholesale. Callers are responsible for
  * re-registering any types they need — this is intentional: Rails' own
  * TypeTest swaps in a blank AdapterSpecificRegistry per test and restores

--- a/packages/activesupport/src/include.ts
+++ b/packages/activesupport/src/include.ts
@@ -198,12 +198,24 @@ export type Extended<M extends object> = CallableMethods<M>;
  *   // Now Base.connectedTo(...) works
  */
 export function extend(klass: AnyClass | object, mod: Module): void {
-  for (const key of Object.keys(mod)) {
-    const value = mod[key];
+  for (const [key, descriptor] of Object.entries(Object.getOwnPropertyDescriptors(mod))) {
+    if (!descriptor.enumerable || /^[A-Z]/.test(key)) continue;
+    // A Ruby `attr_accessor` on the module ports to a getter/setter pair; copy
+    // it as an accessor rather than reading `mod[key]`, which would invoke the
+    // getter with the module as receiver instead of the extending class.
+    if (descriptor.get || descriptor.set) {
+      Object.defineProperty(klass, key, {
+        get: descriptor.get,
+        set: descriptor.set,
+        configurable: true,
+        enumerable: false,
+      });
+      continue;
+    }
     // Ruby's extend copies only methods — skip non-functions and constants.
-    if (typeof value !== "function" || /^[A-Z]/.test(key)) continue;
+    if (typeof descriptor.value !== "function") continue;
     Object.defineProperty(klass, key, {
-      value,
+      value: descriptor.value,
       writable: true,
       configurable: true,
       enumerable: false,

--- a/packages/activesupport/src/include.ts
+++ b/packages/activesupport/src/include.ts
@@ -42,6 +42,8 @@ export const extended = Symbol.for("@blazetrails/activesupport:extended");
  */
 const includedKeys = Symbol.for("@blazetrails/activesupport:includedKeys");
 
+const STATIC_CLASS_KEYS = new Set(["prototype", "length", "name"]);
+
 function trackedKeys(proto: object): Set<string> {
   let set = (proto as any)[includedKeys] as Set<string> | undefined;
   if (!Object.prototype.hasOwnProperty.call(proto, includedKeys)) {
@@ -197,12 +199,20 @@ export type Extended<M extends object> = CallableMethods<M>;
  *   extend(Base, ConnectionHandlingMethods);
  *   // Now Base.connectedTo(...) works
  */
-export function extend(klass: AnyClass | object, mod: Module): void {
-  for (const [key, descriptor] of Object.entries(Object.getOwnPropertyDescriptors(mod))) {
-    if (!descriptor.enumerable || /^[A-Z]/.test(key)) continue;
-    // A Ruby `attr_accessor` on the module ports to a getter/setter pair; copy
-    // it as an accessor rather than reading `mod[key]`, which would invoke the
-    // getter with the module as receiver instead of the extending class.
+export function extend(klass: AnyClass | object, mod: Module | AnyClass): void {
+  // A class module carries its members as non-enumerable own statics, so read
+  // its property names directly; a plain-object module keeps the Object.keys
+  // (enumerable-only) semantics.
+  const isClassModule = typeof mod === "function" && (mod as AnyClass).prototype;
+  const keys = isClassModule
+    ? Object.getOwnPropertyNames(mod).filter((k) => !STATIC_CLASS_KEYS.has(k))
+    : Object.keys(mod);
+
+  for (const key of keys) {
+    const descriptor = Object.getOwnPropertyDescriptor(mod, key);
+    if (!descriptor || /^[A-Z]/.test(key)) continue;
+    // Copy accessors as accessors: reading `mod[key]` would invoke the getter
+    // with the module as receiver instead of the extending class.
     if (descriptor.get || descriptor.set) {
       Object.defineProperty(klass, key, {
         get: descriptor.get,

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/inheritance.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/inheritance.json
@@ -86,13 +86,6 @@
   {
     "package": "activerecord",
     "tsFile": "inheritance.ts",
-    "rubyName": "set_base_class",
-    "call": "abstract_class?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
     "rubyName": "sti_class_for",
     "call": "compute_type",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/locking/optimistic.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/locking/optimistic.json
@@ -30,13 +30,6 @@
   {
     "package": "activerecord",
     "tsFile": "locking/optimistic.ts",
-    "rubyName": "increment!",
-    "call": "locking_enabled?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "locking/optimistic.ts",
     "rubyName": "update_counters",
     "call": "merge",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/model-schema.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/model-schema.json
@@ -107,13 +107,6 @@
   {
     "package": "activerecord",
     "tsFile": "model-schema.ts",
-    "rubyName": "reset_table_name",
-    "call": "abstract_class?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
     "rubyName": "sequence_name",
     "call": "base_class?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/signed-id.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/signed-id.json
@@ -26,19 +26,5 @@
     "rubyName": "signed_id",
     "call": "combine_signed_id_purposes",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "signed-id.ts",
-    "rubyName": "signed_id_verifier",
-    "call": "call",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "signed-id.ts",
-    "rubyName": "signed_id_verifier",
-    "call": "signed_id_verifier_secret",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   }
 ]


### PR DESCRIPTION
Converges the ActiveRecord class-level reader/writer pairs that were ported as
`export function foo` + `export function setFoo` onto real getter/setter
accessors under the Rails name. `scripts/api-compare/conventions.ts` maps a Ruby
writer `foo=` onto the same camelCase name as its reader, so every `setFoo`
sibling was TS surface Rails does not have.

Each pair now lives in an exported `ClassMethods` **class module** in the
Rails-layout file and is mixed onto `Base` via `extend()`:

| Rails | file |
| --- | --- |
| `abstract_class` / `abstract_class=` | `inheritance.ts` |
| `locking_column` / `locking_column=`, `lock_optimistically` / `lock_optimistically=`, `locking_enabled?` | `locking/optimistic.ts` |
| `signed_id_verifier` / `signed_id_verifier=` | `signed-id.ts` |

`Base` previously carried hand-written `static get`/`static set` bodies
delegating to those functions; they are now `declare static` type-only
declarations, with the real accessors installed by `extend()`.

`extend()` in activesupport is now class-module aware and copies accessor
property descriptors, matching what `include()` already did for instance-side
mixins. Reading `mod[key]` would have invoked a getter with the module object as
receiver instead of the extending class.

The class-module shape (not an object literal) matters: with an object literal
the TS extractor does not see the accessors, and `locking_column`,
`signed_id_verifier` et al. resolved to `base.ts` as api:compare **moves**. As
classes they resolve in their Rails-layout file, and those moves are gone.

### Rails fidelity

- `locking_column=` calls `reload_schema_from_cache` then assigns
  (`locking/optimistic.rb:165`) — preserved.
- `locking_enabled?` is `lock_optimistically && columns_hash[locking_column]`
  (`:160`) — preserved via `_attributeDefinitions`.
- `reset_locking_column` assigns through the writer (`:174`) — now literally
  `this.lockingColumn = DEFAULT_LOCKING_COLUMN`.
- `abstract_class` is a plain `attr_accessor` (`inheritance.rb:164`), so the
  ivar is per-class and not inherited — the `hasOwnProperty` read preserves that.
- `signed_id_verifier` memoizes with `||=` and raises when the secret is unset
  (`signed_id.rb:82`) — preserved.

No behavior changes; the bodies are the previous ones re-hosted.

### Not converged (documented at the call site)

`ActiveRecord::Type.registry=` (`type.ts`) keeps its `setRegistry` form. Rails
hangs `attr_accessor :registry` off the `ActiveRecord::Type` module object,
whose trails analogue is an ES module — and an ES module namespace is read-only
from the importer's side, so there is no object to define an accessor on. The
reason is recorded in the JSDoc above `setRegistry`.

### Gate results

- **No stubs.** Every accessor carries the previous implementation.
- **api:compare delta 0** — matched methods 11695/17484 before and after
  (measured by checking out `origin/main` versions of the touched files,
  re-running `API_COMPARE_FORCE=1 pnpm api:compare`, and diffing
  `api-comparison.json`). `locking/optimistic.rb` 20/20, `signed_id.rb` 9/9,
  `inheritance.rb` 28/28 — all with the previously-reported `moves` for these
  names eliminated.
- **extra-surface delta −2** — activerecord novel surface 426 → 424.
  `setLockingColumn`, `setLockOptimistically` and `setSignedIdVerifier` are
  gone. One pre-existing divergence became newly *visible*: `instantiateSti`
  (public in `index.ts`, no Rails counterpart) was not reported while
  `inheritance.ts` held no class container. It is not new surface and not
  caused by this change; registered as
  `0072-api-compare-parity-burndown/converge-instantiate-sti-extra-surface`
  rather than allowlisted.
- **test:compare delta 0** — 14620/21663. No test name, file, or assertion
  count changed; the only edit is the receiver form inside the existing
  `use a custom verifier` test body.
- No new allowlist entries, no `@noRailsEquivalent` tags.

### Tests

`pnpm typecheck` and eslint clean. Green: `locking.test.ts`,
`inheritance.test.ts`, `signed-id.test.ts`, `base.test.ts`,
`persistence.test.ts`, `model-schema.test.ts`, `type.test.ts`,
`activesupport/include.test.ts` (493 passed, 16 skipped).

Closes-story: converge-ar-class-level-writers-onto-accessors
