### PR TITLE
fix(activesupport): tamper codec test messages with Rails' munge

### DIFF
--- a/packages/activesupport/src/messages/codec.trails.test.ts
+++ b/packages/activesupport/src/messages/codec.trails.test.ts
@@ -24,17 +24,8 @@ const FORMATS: Format[] = [
   "message_pack_allow_marshal",
 ];
 
-// Rails' munge (message_encryptor_test.rb:191-195): base64-decode a segment,
-// reverse the bytes, re-encode. Poking a single character instead cannot be
-// trusted — the message's trailing segment is hex, so rewriting its last
-// character to "0" reproduces the original 1/16 of the time.
 function munge(base64String: string): string {
   return Buffer.from(Buffer.from(base64String, "base64").reverse()).toString("base64");
-}
-
-function tamper(message: string): string {
-  const [payload, ...rest] = message.split("--");
-  return [munge(payload), ...rest].join("--");
 }
 
 describe("Messages::Codec (trails)", () => {
@@ -87,18 +78,20 @@ describe("Messages::Codec (trails)", () => {
   it("verify raises InvalidSignature on a tampered message", () => {
     const verifier = new MessageVerifier(SECRET);
     const message = verifier.generate("hello");
+    const [data, hash] = message.split("--");
 
-    expect(() => verifier.verify(tamper(message))).toThrow(InvalidSignature);
-    expect(verifier.verified(tamper(message))).toBeNull();
-    expect(verifier.validMessage(tamper(message))).toBe(false);
+    expect(() => verifier.verify(`${munge(data)}--${hash}`)).toThrow(InvalidSignature);
+    expect(verifier.verified(`${munge(data)}--${hash}`)).toBeNull();
+    expect(verifier.validMessage(`${munge(data)}--${hash}`)).toBe(false);
     expect(verifier.validMessage(message)).toBe(true);
   });
 
   it("decryptAndVerify raises InvalidMessage on a tampered message", () => {
     const encryptor = new MessageEncryptor(SECRET);
     const message = encryptor.encryptAndSign("hello");
+    const [text, hash] = message.split("--");
 
-    expect(() => encryptor.decryptAndVerify(tamper(message))).toThrow(InvalidMessage);
+    expect(() => encryptor.decryptAndVerify(`${munge(text)}--${hash}`)).toThrow(InvalidMessage);
     expect(() => encryptor.decryptAndVerify("not-a-message")).toThrow(InvalidMessage);
   });
 });

--- a/packages/activesupport/src/messages/codec.trails.test.ts
+++ b/packages/activesupport/src/messages/codec.trails.test.ts
@@ -24,6 +24,19 @@ const FORMATS: Format[] = [
   "message_pack_allow_marshal",
 ];
 
+// Rails' munge (message_encryptor_test.rb:191-195): base64-decode a segment,
+// reverse the bytes, re-encode. Poking a single character instead cannot be
+// trusted — the message's trailing segment is hex, so rewriting its last
+// character to "0" reproduces the original 1/16 of the time.
+function munge(base64String: string): string {
+  return Buffer.from(Buffer.from(base64String, "base64").reverse()).toString("base64");
+}
+
+function tamper(message: string): string {
+  const [payload, ...rest] = message.split("--");
+  return [munge(payload), ...rest].join("--");
+}
+
 describe("Messages::Codec (trails)", () => {
   it("subclasses default to the json serializer", () => {
     expect(MessageEncryptor.defaultSerializer).toBe("json");
@@ -75,9 +88,9 @@ describe("Messages::Codec (trails)", () => {
     const verifier = new MessageVerifier(SECRET);
     const message = verifier.generate("hello");
 
-    expect(() => verifier.verify(message.slice(0, -1) + "0")).toThrow(InvalidSignature);
-    expect(verifier.verified(message.slice(0, -1) + "0")).toBeNull();
-    expect(verifier.validMessage(message.slice(0, -1) + "0")).toBe(false);
+    expect(() => verifier.verify(tamper(message))).toThrow(InvalidSignature);
+    expect(verifier.verified(tamper(message))).toBeNull();
+    expect(verifier.validMessage(tamper(message))).toBe(false);
     expect(verifier.validMessage(message)).toBe(true);
   });
 
@@ -85,7 +98,7 @@ describe("Messages::Codec (trails)", () => {
     const encryptor = new MessageEncryptor(SECRET);
     const message = encryptor.encryptAndSign("hello");
 
-    expect(() => encryptor.decryptAndVerify(message.slice(0, -1) + "0")).toThrow(InvalidMessage);
+    expect(() => encryptor.decryptAndVerify(tamper(message))).toThrow(InvalidMessage);
     expect(() => encryptor.decryptAndVerify("not-a-message")).toThrow(InvalidMessage);
   });
 });


### PR DESCRIPTION
`codec.trails.test.ts` tampered with a signed message by rewriting its final
character to `"0"` (`message.slice(0, -1) + "0"`). The message's trailing
segment is hex, so its last character is uniform over the 16 hex digits — when
it was already `"0"` the "tampered" message was byte-for-byte the original, the
round trip succeeded, and the `toThrow` assertion failed. A 6.25%-per-run flake,
independent of any branch.

Measured over 20,000 encrypt/tamper cycles with `SECRET = "x".repeat(32)`:

```text
no-throw: 1247 / 20000 = 6.235%
last-char distribution: {"0":1247,"1":1238,"2":1243,"3":1304,"4":1277,"5":1218,
                         "6":1226,"7":1244,"8":1273,"9":1272,"a":1252,"b":1259,
                         "c":1256,"d":1278,"e":1246,"f":1167}
```

The no-throw count equals the `"0"` bucket exactly — the outcome was decided
solely by the random IV's last hex nibble. Observed in CI at
<https://github.com/blazetrailsdev/trails/actions/runs/30222596514/job/89847482424>.

Both affected tests (`verify raises InvalidSignature on a tampered message`,
which used the pattern three times, and `decryptAndVerify raises InvalidMessage
on a tampered message`) now tamper via a `munge` helper ported from Rails
(`vendor/rails/activesupport/test/message_encryptor_test.rb:191-195`, used at
`:38-40` and `:46-48`): base64-decode the segment, reverse the bytes, re-encode.
That cannot reproduce the original except for a palindromic byte string.

Test names are unchanged — `test:compare` keys off them.

## Verification

- Reproduced on the pre-fix pattern with a throwaway 20k-iteration measurement
  (deleted before committing): old pattern 1220/20000 no-throws (6.1%),
  `munge` 0/20000.
- `pnpm vitest run packages/activesupport/src/messages/` — 37 passed.
- `codec.trails.test.ts` run 40x consecutively — 40/40 × 20 passed.
- `pnpm typecheck`, `pnpm lint`.

Closes-story: codec-tamper-collision-flake
