### PR TITLE
refactor(postgresql): converge sequence and schema-qualified-name helper call sets

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -628,19 +628,19 @@ describeIfPg("PostgreSQLAdapter", () => {
       const before = await adapter.execute(`SELECT nextval('${seqName}') AS val`);
       expect(Number(before[0].val)).toBe(124);
 
-      await adapter.resetPkSequence(`${SCHEMA_NAME}.${UNMATCHED_PK_TABLE_NAME}`);
+      await adapter.resetPkSequenceBang(`${SCHEMA_NAME}.${UNMATCHED_PK_TABLE_NAME}`);
       const after = await adapter.execute(`SELECT nextval('${seqName}') AS val`);
       expect(Number(after[0].val)).toBe(1);
     });
 
     it("set pk sequence", async () => {
       const tableName = `${SCHEMA_NAME}.${PK_TABLE_NAME}`;
-      await adapter.setPkSequence(tableName, 123);
+      await adapter.setPkSequenceBang(tableName, 123);
       const result = await adapter.pkAndSequenceFor(`"${SCHEMA_NAME}"."${PK_TABLE_NAME}"`);
       const qualifiedSeq = `"${result![1]!.schema}"."${result![1]!.name}"`;
       const rows = await adapter.execute(`SELECT nextval('${qualifiedSeq}') AS val`);
       expect(Number(rows[0].val)).toBe(124);
-      await adapter.resetPkSequence(tableName);
+      await adapter.resetPkSequenceBang(tableName);
     });
 
     it("rename index", async () => {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4999,18 +4999,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return ` DEFERRABLE INITIALLY ${deferrable.toUpperCase()}`;
   }
 
-  private pgQuotedScope(
-    name: string,
-    _type: "BASE TABLE" | null,
-  ): { schema: string; name: string | null } {
-    const pgName = Utils.extractSchemaQualifiedName(name);
-    const schema = pgName.schema
-      ? this.quoteLiteral(pgName.schema)
-      : "ANY (current_schemas(false))";
-    const quotedName = pgName.identifier ? this.quoteLiteral(pgName.identifier) : null;
-    return { schema, name: quotedName };
-  }
-
   /**
    * Parse a raw `pg_attrdef` expression into a scalar default value.
    * Mirrors: PostgreSQLAdapter#extract_value_from_default

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3791,11 +3791,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   async renameIndex(tableName: string, oldName: string, newName: string): Promise<void> {
     this.schemaCache?.clearDataSourceCacheBang(this.pool, tableName);
     this.pgSchemaStatements().validateIndexLengthBang(tableName, newName);
-    const { schema } = this.parseSchemaQualifiedName(tableName);
-    const qualifiedOld = schema
-      ? `${this.quoteIdentifier(schema)}.${this.quoteIdentifier(oldName)}`
-      : this.quoteIdentifier(oldName);
-    await this.exec(`ALTER INDEX ${qualifiedOld} RENAME TO ${this.quoteIdentifier(newName)}`);
+    const [schema] = this.extractSchemaQualifiedName(tableName);
+    const qualifier = schema ? `${this.quoteTableName(schema)}.` : "";
+    await this.execute(
+      `ALTER INDEX ${qualifier}${this.quoteColumnName(oldName)} RENAME TO ${this.quoteTableName(newName)}`,
+    );
   }
 
   async columns(tableName: string): Promise<Column[]> {
@@ -4015,7 +4015,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     name?: string | null,
     options: { type?: string } = {},
   ): { schema: string; name: string | null; type: string | null } {
-    const { schema, table } = this.parseSchemaQualifiedName(name ?? "");
+    const [schema, table] = this.extractSchemaQualifiedName(name ?? "");
     let type: string | null = null;
     switch (options.type) {
       case "BASE TABLE":
@@ -4029,15 +4029,15 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         break;
     }
     return {
-      schema: schema ? this.quoteLiteral(schema) : "ANY (current_schemas(false))",
-      name: table ? this.quoteLiteral(table) : null,
+      schema: schema ? this.quote(schema) : "ANY (current_schemas(false))",
+      name: table ? this.quote(table) : null,
       type,
     };
   }
 
   /** @internal */
   referenceNameForTable(tableName: string): string {
-    const { table } = this.parseSchemaQualifiedName(tableName);
+    const [, table] = this.extractSchemaQualifiedName(tableName);
     return singularize(table);
   }
 
@@ -4047,8 +4047,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   async renameTable(oldName: string, newName: string): Promise<void> {
-    const { schema: oldSchema, table: unqualifiedOld } = this.parseSchemaQualifiedName(oldName);
-    const { table: unqualifiedNew } = this.parseSchemaQualifiedName(newName);
+    const [oldSchema, unqualifiedOld] = this.extractSchemaQualifiedName(oldName);
+    const [, unqualifiedNew] = this.extractSchemaQualifiedName(newName);
     this.schemaCache.clearDataSourceCacheBang(this.pool, oldName);
     this.schemaCache.clearDataSourceCacheBang(this.pool, newName);
     await this.exec(
@@ -4187,7 +4187,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     await this.exec(sql);
 
     if (options.comment?.trim()) {
-      const { schema } = this.parseSchemaQualifiedName(tableName);
+      const [schema] = this.extractSchemaQualifiedName(tableName);
       const qualifiedIndex = schema
         ? `${this.quoteIdentifier(schema)}.${this.quoteIdentifier(indexName)}`
         : this.quoteIdentifier(indexName);
@@ -4234,11 +4234,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     // the bare identifier becomes the name to match, the index is dropped in the
     // table's schema (or the name's schema when the table is unqualified), and a
     // conflicting schema pair raises.
-    const { schema: tableSchema, table: bareTable } = this.parseSchemaQualifiedName(tableName);
+    const [tableSchema, bareTable] = this.extractSchemaQualifiedName(tableName);
     let dropSchema = tableSchema;
     let resolveOpts = opts;
     if (opts.name != null) {
-      const { schema: nameSchema, table: nameIdent } = this.parseSchemaQualifiedName(opts.name);
+      const [nameSchema, nameIdent] = this.extractSchemaQualifiedName(opts.name);
       resolveOpts = { ...opts, name: nameIdent };
       if (!tableSchema) dropSchema = nameSchema;
       if (nameSchema && tableSchema && nameSchema !== tableSchema) {
@@ -4351,7 +4351,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   async enumValues(name: string): Promise<string[]> {
-    const { schema, table: enumName } = this.parseSchemaQualifiedName(name);
+    const [schema, enumName] = this.extractSchemaQualifiedName(name);
     let sql = `SELECT e.enumlabel AS value
        FROM pg_enum e
        JOIN pg_type t ON t.oid = e.enumtypid
@@ -4378,14 +4378,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // ---------------------------------------------------------------------------
   // Private helpers
   // ---------------------------------------------------------------------------
-
-  private parseSchemaQualifiedName(name: string): {
-    schema: string | null;
-    table: string;
-  } {
-    const pgName = Utils.extractSchemaQualifiedName(name);
-    return { schema: pgName.schema, table: pgName.identifier };
-  }
 
   // quoteIdentifier is NOT overridden: PG's identifier quoting is
   // byte-identical to AbstractAdapter's double-quote form (`"x"` with
@@ -4729,7 +4721,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     // name from the bare table (postgresql/schema_statements.rb), so a
     // `my_schema.values` table indexes as `index_values_on_value` — created in
     // `my_schema` via the schema-qualified table, keeping add/remove symmetric.
-    const { table } = this.parseSchemaQualifiedName(tableName);
+    const [, table] = this.extractSchemaQualifiedName(tableName);
     if (options.column != null) {
       if (options._usesLegacyIndexName) {
         const cols = Array.isArray(options.column) ? options.column : [options.column];

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
@@ -14,13 +14,10 @@ function makeAdapter(logger?: { warn: (msg: string) => void }) {
   } as unknown as DatabaseAdapter;
 }
 
-// Rails derives the generated constraint names from a SHA256 digest of an
-// identifier string (`postgresql/schema_statements.rb#exclusion_constraint_name`
-// / `#unique_constraint_name`). The expected digests are the literals asserted
-// in Rails' own migration/exclusion_constraint_test.rb and
-// migration/unique_constraint_test.rb, so any drift in the identifier shape or
-// the digest slice fails here rather than silently changing emitted DDL and
-// dumped schema.
+// Expected digests are the literals Rails asserts in
+// migration/exclusion_constraint_test.rb and migration/unique_constraint_test.rb,
+// so drift in the identifier shape or digest slice fails here rather than
+// silently changing emitted DDL and dumped schema.
 describe("PostgreSQLSchemaStatements constraint name digests", () => {
   it("derives the exclusion constraint name Rails derives", () => {
     const ss = new PostgreSQLSchemaStatements(makeAdapter());
@@ -56,8 +53,6 @@ describe("PostgreSQLSchemaStatements constraint name digests", () => {
   });
 });
 
-// Mirrors Rails' `@logger.warn "#{table} has primary key #{pk} with no default
-// sequence."` in set_pk_sequence! / reset_pk_sequence!.
 describe("PostgreSQLSchemaStatements sequence helpers warn without a sequence", () => {
   it("setPkSequenceBang warns when the table has a primary key but no sequence", async () => {
     const warn = vi.fn();

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
@@ -2,16 +2,50 @@ import { describe, expect, it, vi } from "vitest";
 import { PostgreSQLSchemaStatements } from "./schema-statements-class.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../abstract-adapter.js";
 
-function makeAdapter(logger?: { warn: (msg: string) => void }) {
-  return {
+interface FakeOptions {
+  logger?: { warn: (msg: string) => void };
+  schemaQuery?: (sql: string) => Promise<Record<string, unknown>[]>;
+  queryValue?: (sql: string) => Promise<unknown>;
+}
+
+function makeAdapter(options: FakeOptions = {}) {
+  const sql: string[] = [];
+  const adapter = {
     adapterName: "postgres" as const,
-    logger: logger ?? null,
+    logger: options.logger ?? null,
     quote: (v: unknown) => `'${String(v).replace(/'/g, "''")}'`,
     quoteColumnName: (n: string) => `"${n}"`,
-    quoteTableName: (n: string) => `"${n}"`,
-    queryValue: vi.fn(async () => null),
+    quoteLiteral: (v: unknown) => `'${String(v).replace(/'/g, "''")}'`,
+    // The real adapter quotes each dot-separated part; the tests below rely on
+    // a schema-qualified name surviving as `"a"."b"`.
+    quoteTableName: (n: string) =>
+      n
+        .split(".")
+        .map((part) => `"${part.replace(/^"|"$/g, "")}"`)
+        .join("."),
+    quotedScope(name?: string | null) {
+      const [schema, table] = this.extractSchemaQualifiedName(name ?? "");
+      return {
+        schema: schema ? this.quote(schema) : "ANY (current_schemas(false))",
+        name: table ? this.quote(table) : null,
+        type: null,
+      };
+    },
+    extractSchemaQualifiedName(name: string): [string | null, string] {
+      const parts = name.split(".").map((p) => p.replace(/^"|"$/g, ""));
+      return parts.length > 1 ? [parts[0], parts[1]] : [null, parts[0]];
+    },
+    schemaQuery: vi.fn(async (text: string) => {
+      sql.push(text);
+      return options.schemaQuery ? await options.schemaQuery(text) : [];
+    }),
+    queryValue: vi.fn(async (text: string) => {
+      sql.push(text);
+      return options.queryValue ? await options.queryValue(text) : null;
+    }),
     getDatabaseVersion: vi.fn(async () => 160000),
-  } as unknown as DatabaseAdapter;
+  };
+  return { adapter: adapter as unknown as DatabaseAdapter, sql };
 }
 
 // Expected digests are the literals Rails asserts in
@@ -20,7 +54,7 @@ function makeAdapter(logger?: { warn: (msg: string) => void }) {
 // silently changing emitted DDL and dumped schema.
 describe("PostgreSQLSchemaStatements constraint name digests", () => {
   it("derives the exclusion constraint name Rails derives", () => {
-    const ss = new PostgreSQLSchemaStatements(makeAdapter());
+    const ss = new PostgreSQLSchemaStatements(makeAdapter().adapter);
     expect(
       ss.exclusionConstraintName("invoices", {
         expression: "daterange(start_date, end_date) WITH &&",
@@ -29,21 +63,21 @@ describe("PostgreSQLSchemaStatements constraint name digests", () => {
   });
 
   it("derives the unique constraint name Rails derives from a column list", () => {
-    const ss = new PostgreSQLSchemaStatements(makeAdapter());
+    const ss = new PostgreSQLSchemaStatements(makeAdapter().adapter);
     expect(ss.uniqueConstraintName("sections", { column: ["position"] })).toBe(
       "uniq_rails_1e07660b77",
     );
   });
 
   it("derives the unique constraint name Rails derives from usingIndex", () => {
-    const ss = new PostgreSQLSchemaStatements(makeAdapter());
+    const ss = new PostgreSQLSchemaStatements(makeAdapter().adapter);
     expect(ss.uniqueConstraintName("sections", { usingIndex: "unique_index" })).toBe(
       "uniq_rails_79b901ffb4",
     );
   });
 
   it("returns an explicit :name option unchanged", () => {
-    const ss = new PostgreSQLSchemaStatements(makeAdapter());
+    const ss = new PostgreSQLSchemaStatements(makeAdapter().adapter);
     expect(ss.exclusionConstraintName("invoices", { name: "my_excl", expression: "x" })).toBe(
       "my_excl",
     );
@@ -56,7 +90,7 @@ describe("PostgreSQLSchemaStatements constraint name digests", () => {
 describe("PostgreSQLSchemaStatements sequence helpers warn without a sequence", () => {
   it("setPkSequenceBang warns when the table has a primary key but no sequence", async () => {
     const warn = vi.fn();
-    const ss = new PostgreSQLSchemaStatements(makeAdapter({ warn }));
+    const ss = new PostgreSQLSchemaStatements(makeAdapter({ logger: { warn } }).adapter);
     vi.spyOn(ss, "pkAndSequenceFor").mockResolvedValue(["id", null]);
     await ss.setPkSequenceBang("postgresql_uuids", 42);
     expect(warn).toHaveBeenCalledWith(
@@ -66,7 +100,7 @@ describe("PostgreSQLSchemaStatements sequence helpers warn without a sequence", 
 
   it("resetPkSequenceBang warns when the table has a primary key but no sequence", async () => {
     const warn = vi.fn();
-    const ss = new PostgreSQLSchemaStatements(makeAdapter({ warn }));
+    const ss = new PostgreSQLSchemaStatements(makeAdapter({ logger: { warn } }).adapter);
     vi.spyOn(ss, "pkAndSequenceFor").mockResolvedValue(["id", null]);
     await ss.resetPkSequenceBang("postgresql_uuids");
     expect(warn).toHaveBeenCalledWith(
@@ -75,16 +109,84 @@ describe("PostgreSQLSchemaStatements sequence helpers warn without a sequence", 
   });
 
   it("stays silent when no logger is configured", async () => {
-    const ss = new PostgreSQLSchemaStatements(makeAdapter());
+    const ss = new PostgreSQLSchemaStatements(makeAdapter().adapter);
     vi.spyOn(ss, "pkAndSequenceFor").mockResolvedValue(["id", null]);
     await expect(ss.setPkSequenceBang("postgresql_uuids", 42)).resolves.toBeUndefined();
   });
 
   it("does not warn when the table has no primary key at all", async () => {
     const warn = vi.fn();
-    const ss = new PostgreSQLSchemaStatements(makeAdapter({ warn }));
+    const ss = new PostgreSQLSchemaStatements(makeAdapter({ logger: { warn } }).adapter);
     vi.spyOn(ss, "pkAndSequenceFor").mockResolvedValue(null);
     await ss.setPkSequenceBang("postgresql_uuids", 42);
     expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+// Rails' index_name_exists? runs BOTH arguments through quoted_scope and
+// compares `i.relname = index[:name]` (schema_statements.rb:67-81), so a
+// schema-qualified index name matches on its bare identifier.
+describe("PostgreSQLSchemaStatements#indexNameExists", () => {
+  it("parses the index name through quotedScope rather than quoting it raw", async () => {
+    const { adapter, sql } = makeAdapter({
+      schemaQuery: async () => [{ cnt: 1 }],
+    });
+    const ss = new PostgreSQLSchemaStatements(adapter);
+    expect(await ss.indexNameExists("my_schema.things", "my_schema.index_a")).toBe(true);
+    expect(sql[0]).toContain("i.relname = 'index_a'");
+    expect(sql[0]).not.toContain("'my_schema.index_a'");
+  });
+});
+
+describe("PostgreSQLSchemaStatements#pkAndSequenceFor", () => {
+  // Rails' fallback query selects `nsp.nspname` — the TABLE's namespace — and a
+  // CASE that strips everything through the dot, so the sequence's own schema
+  // never survives (schema_statements.rb:382-407).
+  it("pairs the table schema with the bare sequence name on the default_expr fallback", async () => {
+    const { adapter } = makeAdapter({
+      schemaQuery: async () => [
+        {
+          pk: "id",
+          seq: null,
+          default_expr: "nextval('other_schema.things_id_seq'::regclass)",
+          schema_name: "public",
+        },
+      ],
+    });
+    const ss = new PostgreSQLSchemaStatements(adapter);
+    expect(await ss.pkAndSequenceFor("things")).toEqual([
+      "id",
+      { schema: "public", name: "things_id_seq" },
+    ]);
+  });
+
+  // Rails' bare `rescue nil` covers the whole method, not just unknown tables.
+  it("returns null when the lookup raises", async () => {
+    const { adapter } = makeAdapter({
+      schemaQuery: async () => {
+        throw new Error("boom");
+      },
+    });
+    const ss = new PostgreSQLSchemaStatements(adapter);
+    expect(await ss.pkAndSequenceFor("things")).toBeNull();
+  });
+});
+
+describe("PostgreSQLSchemaStatements#resetPkSequenceBang", () => {
+  // Ruby's `max_pk ? true : false` is a nil check; 0 is truthy in Ruby.
+  it("emits setval(..., 0, true) when the max primary key is 0", async () => {
+    const { adapter, sql } = makeAdapter({ queryValue: async () => 0 });
+    const ss = new PostgreSQLSchemaStatements(adapter);
+    await ss.resetPkSequenceBang("things", "id", "public.things_id_seq");
+    expect(sql.at(-1)).toContain(`SELECT setval('"public"."things_id_seq"', 0, true)`);
+  });
+
+  it("emits setval(..., minvalue, false) when the table is empty", async () => {
+    const { adapter, sql } = makeAdapter({
+      queryValue: async (text) => (text.includes("seqmin") ? 1 : null),
+    });
+    const ss = new PostgreSQLSchemaStatements(adapter);
+    await ss.resetPkSequenceBang("things", "id", "public.things_id_seq");
+    expect(sql.at(-1)).toContain(`SELECT setval('"public"."things_id_seq"', 1, false)`);
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.trails.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import { PostgreSQLSchemaStatements } from "./schema-statements-class.js";
+import type { AbstractAdapter as DatabaseAdapter } from "../abstract-adapter.js";
+
+function makeAdapter(logger?: { warn: (msg: string) => void }) {
+  return {
+    adapterName: "postgres" as const,
+    logger: logger ?? null,
+    quote: (v: unknown) => `'${String(v).replace(/'/g, "''")}'`,
+    quoteColumnName: (n: string) => `"${n}"`,
+    quoteTableName: (n: string) => `"${n}"`,
+    queryValue: vi.fn(async () => null),
+    getDatabaseVersion: vi.fn(async () => 160000),
+  } as unknown as DatabaseAdapter;
+}
+
+// Rails derives the generated constraint names from a SHA256 digest of an
+// identifier string (`postgresql/schema_statements.rb#exclusion_constraint_name`
+// / `#unique_constraint_name`). The expected digests are the literals asserted
+// in Rails' own migration/exclusion_constraint_test.rb and
+// migration/unique_constraint_test.rb, so any drift in the identifier shape or
+// the digest slice fails here rather than silently changing emitted DDL and
+// dumped schema.
+describe("PostgreSQLSchemaStatements constraint name digests", () => {
+  it("derives the exclusion constraint name Rails derives", () => {
+    const ss = new PostgreSQLSchemaStatements(makeAdapter());
+    expect(
+      ss.exclusionConstraintName("invoices", {
+        expression: "daterange(start_date, end_date) WITH &&",
+      }),
+    ).toBe("excl_rails_74c9160f55");
+  });
+
+  it("derives the unique constraint name Rails derives from a column list", () => {
+    const ss = new PostgreSQLSchemaStatements(makeAdapter());
+    expect(ss.uniqueConstraintName("sections", { column: ["position"] })).toBe(
+      "uniq_rails_1e07660b77",
+    );
+  });
+
+  it("derives the unique constraint name Rails derives from usingIndex", () => {
+    const ss = new PostgreSQLSchemaStatements(makeAdapter());
+    expect(ss.uniqueConstraintName("sections", { usingIndex: "unique_index" })).toBe(
+      "uniq_rails_79b901ffb4",
+    );
+  });
+
+  it("returns an explicit :name option unchanged", () => {
+    const ss = new PostgreSQLSchemaStatements(makeAdapter());
+    expect(ss.exclusionConstraintName("invoices", { name: "my_excl", expression: "x" })).toBe(
+      "my_excl",
+    );
+    expect(ss.uniqueConstraintName("sections", { name: "my_uniq", column: ["position"] })).toBe(
+      "my_uniq",
+    );
+  });
+});
+
+// Mirrors Rails' `@logger.warn "#{table} has primary key #{pk} with no default
+// sequence."` in set_pk_sequence! / reset_pk_sequence!.
+describe("PostgreSQLSchemaStatements sequence helpers warn without a sequence", () => {
+  it("setPkSequenceBang warns when the table has a primary key but no sequence", async () => {
+    const warn = vi.fn();
+    const ss = new PostgreSQLSchemaStatements(makeAdapter({ warn }));
+    vi.spyOn(ss, "pkAndSequenceFor").mockResolvedValue(["id", null]);
+    await ss.setPkSequenceBang("postgresql_uuids", 42);
+    expect(warn).toHaveBeenCalledWith(
+      "postgresql_uuids has primary key id with no default sequence.",
+    );
+  });
+
+  it("resetPkSequenceBang warns when the table has a primary key but no sequence", async () => {
+    const warn = vi.fn();
+    const ss = new PostgreSQLSchemaStatements(makeAdapter({ warn }));
+    vi.spyOn(ss, "pkAndSequenceFor").mockResolvedValue(["id", null]);
+    await ss.resetPkSequenceBang("postgresql_uuids");
+    expect(warn).toHaveBeenCalledWith(
+      "postgresql_uuids has primary key id with no default sequence.",
+    );
+  });
+
+  it("stays silent when no logger is configured", async () => {
+    const ss = new PostgreSQLSchemaStatements(makeAdapter());
+    vi.spyOn(ss, "pkAndSequenceFor").mockResolvedValue(["id", null]);
+    await expect(ss.setPkSequenceBang("postgresql_uuids", 42)).resolves.toBeUndefined();
+  });
+
+  it("does not warn when the table has no primary key at all", async () => {
+    const warn = vi.fn();
+    const ss = new PostgreSQLSchemaStatements(makeAdapter({ warn }));
+    vi.spyOn(ss, "pkAndSequenceFor").mockResolvedValue(null);
+    await ss.setPkSequenceBang("postgresql_uuids", 42);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -236,7 +236,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
 
   async indexNameExists(tableName: string, indexName: string): Promise<boolean> {
     const table = this.pg.quotedScope(tableName);
-    const idxName = this.pg.quoteLiteral(indexName);
+    const index = this.pg.quotedScope(indexName);
     const rows = await this.pg.schemaQuery(`
       SELECT COUNT(*) AS cnt
       FROM pg_class t
@@ -244,7 +244,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       INNER JOIN pg_class i ON d.indexrelid = i.oid
       LEFT JOIN pg_namespace n ON n.oid = t.relnamespace
       WHERE i.relkind IN ('i', 'I')
-        AND i.relname = ${idxName}
+        AND i.relname = ${index.name}
         AND t.relname = ${table.name}
         AND n.nspname = ${table.schema}
     `);
@@ -1811,76 +1811,82 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   async pkAndSequenceFor(
     tableName: string,
   ): Promise<[string, { schema: string; name: string } | null] | null> {
-    // Mirrors Rails pk_and_sequence_for's `#{quote(quote_table_name(table))}::regclass`:
-    // regclass resolves a schema-qualified or bare name itself, and the quoting
-    // keeps a mixed-case name like "CamelCase" case-sensitive.
-    //
-    // Deviation: `to_regclass(...)` rather than a bare `::regclass` cast. Rails
-    // wraps the whole method in `rescue nil`, so an unknown table yields nil;
-    // to_regclass yields NULL (hence no rows, hence nil) without raising, which
-    // matters here because a raised PG error would abort an enclosing
-    // transaction that Ruby's rescue leaves untouched.
-    const tableCondition = `t.oid = to_regclass(${this.pg.quote(this.pg.quoteTableName(tableName))})`;
+    // Rails wraps the whole of `pk_and_sequence_for` in a bare `rescue nil`, so
+    // ANY error — not just an unknown table — yields nil.
+    try {
+      // Mirrors Rails pk_and_sequence_for's `#{quote(quote_table_name(table))}::regclass`:
+      // regclass resolves a schema-qualified or bare name itself, and the quoting
+      // keeps a mixed-case name like "CamelCase" case-sensitive.
+      //
+      // Deviation: `to_regclass(...)` rather than a bare `::regclass` cast. The
+      // outer `rescue nil` already turns an unknown table into nil either way,
+      // but PG aborts the enclosing transaction when the cast raises — and a
+      // Ruby rescue leaves the transaction untouched. to_regclass yields NULL
+      // (hence no rows, hence nil) without ever entering the aborted state.
+      const tableCondition = `t.oid = to_regclass(${this.pg.quote(this.pg.quoteTableName(tableName))})`;
 
-    const rows = await this.pg.schemaQuery(
-      `SELECT a.attname AS pk,
-              pg_get_serial_sequence(quote_ident(n.nspname) || '.' || quote_ident(t.relname), a.attname) AS seq,
-              pg_get_expr(ad.adbin, ad.adrelid) AS default_expr,
-              n.nspname AS schema_name
-       FROM pg_index i
-       JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
-       JOIN pg_class t ON t.oid = i.indrelid
-       JOIN pg_namespace n ON n.oid = t.relnamespace
-       LEFT JOIN pg_attrdef ad ON ad.adrelid = t.oid AND ad.adnum = a.attnum
-       WHERE ${tableCondition}
-         AND i.indisprimary = true
-       -- Resolve the FIRST primary-key column deterministically (mirrors Rails
-       -- pk_and_sequence_for's cons.conkey[1]); without the ORDER BY a composite
-       -- PK's ANY(i.indkey) join could return an arbitrary column under LIMIT 1.
-       ORDER BY array_position(i.indkey, a.attnum)
-       LIMIT 1`,
-    );
+      const rows = await this.pg.schemaQuery(
+        `SELECT a.attname AS pk,
+                pg_get_serial_sequence(quote_ident(n.nspname) || '.' || quote_ident(t.relname), a.attname) AS seq,
+                pg_get_expr(ad.adbin, ad.adrelid) AS default_expr,
+                n.nspname AS schema_name
+         FROM pg_index i
+         JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+         JOIN pg_class t ON t.oid = i.indrelid
+         JOIN pg_namespace n ON n.oid = t.relnamespace
+         LEFT JOIN pg_attrdef ad ON ad.adrelid = t.oid AND ad.adnum = a.attnum
+         WHERE ${tableCondition}
+           AND i.indisprimary = true
+         -- Resolve the FIRST primary-key column deterministically (mirrors Rails
+         -- pk_and_sequence_for's cons.conkey[1]); without the ORDER BY a composite
+         -- PK's ANY(i.indkey) join could return an arbitrary column under LIMIT 1.
+         ORDER BY array_position(i.indkey, a.attnum)
+         LIMIT 1`,
+      );
 
-    if (rows.length === 0) return null;
+      if (rows.length === 0) return null;
 
-    const pk = rows[0].pk as string;
-    const tableSchema = rows[0].schema_name as string;
-    let seq: { schema: string; name: string } | null = null;
+      const pk = rows[0].pk as string;
+      const tableSchema = rows[0].schema_name as string;
+      let seq: { schema: string; name: string } | null = null;
 
-    if (rows[0].seq) {
-      const fullSeq = rows[0].seq as string;
-      const parts = splitQuotedIdentifier(fullSeq);
-      seq =
-        parts.length > 1
-          ? { schema: parts[0], name: parts[1] }
-          : { schema: tableSchema, name: parts[0] };
-    } else {
-      const defaultExpr = rows[0].default_expr as string | null;
-      if (defaultExpr) {
-        const match = defaultExpr.match(/nextval\('([^']+)'::regclass\)/);
-        if (match) {
-          const seqRef = match[1];
-          const parts = splitQuotedIdentifier(seqRef);
-          seq =
-            parts.length > 1
-              ? { schema: parts[0], name: parts[1] }
-              : { schema: tableSchema, name: parts[0] };
+      if (rows[0].seq) {
+        const fullSeq = rows[0].seq as string;
+        const parts = splitQuotedIdentifier(fullSeq);
+        seq =
+          parts.length > 1
+            ? { schema: parts[0], name: parts[1] }
+            : { schema: tableSchema, name: parts[0] };
+      } else {
+        const defaultExpr = rows[0].default_expr as string | null;
+        if (defaultExpr) {
+          const match = defaultExpr.match(/nextval\('([^']+)'::regclass\)/);
+          if (match) {
+            // Rails' fallback query pairs `nsp.nspname` — the TABLE's namespace —
+            // with a CASE that strips everything through the dot, so a
+            // `nextval('other_schema.seq')` default still yields
+            // `Name.new(table_schema, "seq")`. Keep the sequence identifier only.
+            const parts = splitQuotedIdentifier(match[1]);
+            seq = { schema: tableSchema, name: parts[parts.length - 1] };
+          }
         }
       }
-    }
 
-    if (seq) return [pk, seq];
+      if (seq) return [pk, seq];
 
-    // No owning sequence. Mirrors Rails pk_and_sequence_for: its fallback query
-    // matches `nextval|uuid_generate|gen_random_uuid` defaults, so a uuid-default
-    // pk still returns a row (with a nil sequence) → `[pk, nil]`, whereas a pk
-    // with no such default matches neither query and yields nil (the whole
-    // result). See uuid_test.rb#test_pk_and_sequence_for_with_uuid_primary_key.
-    const defaultExpr = rows[0].default_expr as string | null;
-    if (defaultExpr && /uuid_generate|gen_random_uuid/i.test(defaultExpr)) {
-      return [pk, null];
+      // No owning sequence. Mirrors Rails pk_and_sequence_for: its fallback query
+      // matches `nextval|uuid_generate|gen_random_uuid` defaults, so a uuid-default
+      // pk still returns a row (with a nil sequence) → `[pk, nil]`, whereas a pk
+      // with no such default matches neither query and yields nil (the whole
+      // result). See uuid_test.rb#test_pk_and_sequence_for_with_uuid_primary_key.
+      const defaultExpr = rows[0].default_expr as string | null;
+      if (defaultExpr && /uuid_generate|gen_random_uuid/i.test(defaultExpr)) {
+        return [pk, null];
+      }
+      return null;
+    } catch {
+      return null;
     }
-    return null;
   }
 
   async serialSequence(tableName: string, column: string): Promise<string | null> {
@@ -1985,8 +1991,10 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
           : await this.adapter.queryValue(`SELECT min_value FROM ${quotedSequence}`, "SCHEMA");
     }
 
+    // Ruby's `max_pk ? true : false` is a nil check — 0 is truthy in Ruby, so a
+    // table whose max primary key is 0 must still emit `true`.
     await this.adapter.queryValue(
-      `SELECT setval(${this.pg.quote(quotedSequence)}, ${maxPk ?? minvalue}, ${maxPk ? "true" : "false"})`,
+      `SELECT setval(${this.pg.quote(quotedSequence)}, ${maxPk ?? minvalue}, ${maxPk == null ? "false" : "true"})`,
       "SCHEMA",
     );
   }

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -41,7 +41,7 @@ interface PgSchemaAdapter {
   quoteIdentifier(name: string): string;
   quoteColumnName(name: string): string;
   quoteTableName(name: string): string;
-  readonly logger: unknown;
+  readonly logger: { warn?(message: string): void } | null;
   quoteLiteral(value: unknown): string;
   supportsNativePartitioning(): boolean;
   supportsIdentityColumns(): boolean;
@@ -49,7 +49,6 @@ interface PgSchemaAdapter {
   extractSchemaQualifiedName(string: string): [string | null, string];
   getDatabaseVersion(): Promise<number>;
   supportsIndexInclude(): boolean;
-  pgQuotedScope(name: string, type: "BASE TABLE" | null): { schema: string; name: string | null };
   dataSourceSql(name?: string | null, options?: { type?: string }): string;
   quotedScope(
     name?: string | null,
@@ -85,12 +84,6 @@ interface PgSchemaAdapter {
 export class PostgreSQLSchemaStatements extends SchemaStatements {
   private get pg(): PgSchemaAdapter {
     return this.adapter as unknown as PgSchemaAdapter;
-  }
-
-  // Mirrors Rails' `@logger` reader; the sequence helpers guard on it before
-  // warning, so a nil logger stays silent.
-  private get pgLogger(): { warn?: (msg: string) => void } | null {
-    return this.pg.logger as { warn?: (msg: string) => void } | null;
   }
 
   override async dropTable(...args: Parameters<SchemaStatements["dropTable"]>): Promise<void> {
@@ -242,7 +235,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   }
 
   async indexNameExists(tableName: string, indexName: string): Promise<boolean> {
-    const table = this.pg.pgQuotedScope(tableName, "BASE TABLE");
+    const table = this.pg.quotedScope(tableName);
     const idxName = this.pg.quoteLiteral(indexName);
     const rows = await this.pg.schemaQuery(`
       SELECT COUNT(*) AS cnt
@@ -386,7 +379,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   }
 
   override async tableComment(tableName: string): Promise<string | null> {
-    const { schema, name } = this.pg.pgQuotedScope(tableName, "BASE TABLE");
+    const { schema, name } = this.pg.quotedScope(tableName);
     if (!name) return null;
     const rows = await this.pg.schemaQuery(`
       SELECT pg_catalog.obj_description(c.oid, 'pg_class') AS comment
@@ -400,7 +393,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   }
 
   async tablePartitionDefinition(tableName: string): Promise<string | null> {
-    const { schema, name } = this.pg.pgQuotedScope(tableName, "BASE TABLE");
+    const { schema, name } = this.pg.quotedScope(tableName);
     if (!name) return null;
     const rows = await this.pg.schemaQuery(`
       SELECT pg_catalog.pg_get_partkeydef(c.oid) AS def
@@ -414,7 +407,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   }
 
   async inheritedTableNames(tableName: string): Promise<string[]> {
-    const { schema, name } = this.pg.pgQuotedScope(tableName, "BASE TABLE");
+    const { schema, name } = this.pg.quotedScope(tableName);
     if (!name) return [];
     const rows = await this.pg.schemaQuery(`
       SELECT parent.relname AS name
@@ -1950,7 +1943,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
         "SCHEMA",
       );
     } else {
-      this.pgLogger?.warn?.(`${tableName} has primary key ${pk} with no default sequence.`);
+      this.pg.logger?.warn?.(`${tableName} has primary key ${pk} with no default sequence.`);
     }
   }
 
@@ -1970,7 +1963,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     }
 
     if (pk && !sequence) {
-      this.pgLogger?.warn?.(`${tableName} has primary key ${pk} with no default sequence.`);
+      this.pg.logger?.warn?.(`${tableName} has primary key ${pk} with no default sequence.`);
     }
 
     if (!pk || !sequence) return;

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -16,7 +16,7 @@ import {
 import { HashLookupTypeMap } from "../../type/hash-lookup-type-map.js";
 import { Column } from "./column.js";
 import { quoteColumnName as pgQuoteColumnName } from "./quoting.js";
-import { unquoteIdentifier, splitQuotedIdentifier, Utils } from "./utils.js";
+import { unquoteIdentifier, splitQuotedIdentifier, Name, Utils } from "./utils.js";
 import { splitPgDefault } from "../postgresql-adapter.js";
 import type { CreateDatabaseOptions, PgIndexDefinition } from "./schema-statements.js";
 import {
@@ -39,12 +39,14 @@ interface PgSchemaAdapter {
   clearCacheBang(): void;
   quote(value: unknown): string;
   quoteIdentifier(name: string): string;
+  quoteColumnName(name: string): string;
   quoteTableName(name: string): string;
+  readonly logger: unknown;
   quoteLiteral(value: unknown): string;
   supportsNativePartitioning(): boolean;
   supportsIdentityColumns(): boolean;
   supportsVirtualColumns(): boolean;
-  parseSchemaQualifiedName(name: string): { schema: string | null; table: string };
+  extractSchemaQualifiedName(string: string): [string | null, string];
   getDatabaseVersion(): Promise<number>;
   supportsIndexInclude(): boolean;
   pgQuotedScope(name: string, type: "BASE TABLE" | null): { schema: string; name: string | null };
@@ -85,6 +87,12 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     return this.adapter as unknown as PgSchemaAdapter;
   }
 
+  // Mirrors Rails' `@logger` reader; the sequence helpers guard on it before
+  // warning, so a nil logger stays silent.
+  private get pgLogger(): { warn?: (msg: string) => void } | null {
+    return this.pg.logger as { warn?: (msg: string) => void } | null;
+  }
+
   override async dropTable(...args: Parameters<SchemaStatements["dropTable"]>): Promise<void> {
     const [tableNames, options] = this._splitTableNamesAndOptions(args);
     if (tableNames.length === 0) {
@@ -106,7 +114,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   async indexes(tableName: string): Promise<PgIndexDefinition[]> {
     // supportsIndexInclude() reads databaseVersion; ensure it's populated.
     await this.pg.getDatabaseVersion();
-    const { schema, table } = this.pg.parseSchemaQualifiedName(tableName);
+    const [schema, table] = this.pg.extractSchemaQualifiedName(tableName);
 
     let tableCondition: string;
     const binds: unknown[] = [];
@@ -301,7 +309,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   }
 
   async dataSourceExists(name: string): Promise<boolean> {
-    const { schema, table } = this.pg.parseSchemaQualifiedName(name);
+    const [schema, table] = this.pg.extractSchemaQualifiedName(name);
     if (schema) {
       const rows = await this.pg.schemaQuery(
         `SELECT COUNT(*) AS count FROM information_schema.tables WHERE table_schema = $1 AND table_name = $2`,
@@ -344,9 +352,9 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
    */
   private async relkindExists(name: string, relkinds: string[]): Promise<boolean> {
     // Rails' table_exists?(nil) / "" returns false; a null/empty name has no
-    // identifier to parse, so short-circuit before parseSchemaQualifiedName.
+    // identifier to parse, so short-circuit before extractSchemaQualifiedName.
     if (!name) return false;
-    const { schema, table } = this.pg.parseSchemaQualifiedName(name);
+    const [schema, table] = this.pg.extractSchemaQualifiedName(name);
     if (schema) {
       // $1=schema, $2=table, $3..=relkinds
       const relPlaceholders = relkinds.map((_, i) => `$${i + 3}`).join(", ");
@@ -361,7 +369,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       return rows.length > 0;
     }
     // $1=table, $2..=relkinds. Bind `table` (the unquoted identifier
-    // returned by parseSchemaQualifiedName), not the raw `name`
+    // returned by extractSchemaQualifiedName), not the raw `name`
     // argument — otherwise a quoted input like `"widgets"` gets
     // compared against `relname = '"widgets"'` in pg_class, which
     // never matches (the catalog stores names unquoted).
@@ -648,7 +656,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   // ---------------------------------------------------------------------------
 
   override async columns(tableName: string): Promise<Column[]> {
-    const { schema, table } = this.pg.parseSchemaQualifiedName(tableName);
+    const [schema, table] = this.pg.extractSchemaQualifiedName(tableName);
 
     let tableCondition: string;
     const binds: unknown[] = [];
@@ -1097,9 +1105,9 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     }
     if (!toTable) throw new ArgumentError("validateForeignKey requires toTable or options.name");
     const fks = await this.foreignKeys(fromTable);
-    const { schema: toSchema, table: toTbl } = this.pg.parseSchemaQualifiedName(toTable);
+    const [toSchema, toTbl] = this.pg.extractSchemaQualifiedName(toTable);
     const fk = (fks as any[]).find((f) => {
-      const { schema: fSchema, table: fTbl } = this.pg.parseSchemaQualifiedName(String(f.toTable));
+      const [fSchema, fTbl] = this.pg.extractSchemaQualifiedName(String(f.toTable));
       if (fTbl !== toTbl) return false;
       // When the FK record has no schema prefix (PostgreSQL omits "public." when it
       // is on the search_path), treat it as matching any schema lookup or "public".
@@ -1111,7 +1119,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   }
 
   override foreignKeyColumnFor(tableName: string, columnName = "id"): string {
-    const { table } = this.pg.parseSchemaQualifiedName(tableName);
+    const [, table] = this.pg.extractSchemaQualifiedName(tableName);
     return `${singularize(table)}_${columnName}`;
   }
 
@@ -1591,7 +1599,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     values: string[],
     _options?: Record<string, unknown>,
   ): Promise<void> {
-    const { schema, table: enumName } = this.pg.parseSchemaQualifiedName(name);
+    const [schema, enumName] = this.pg.extractSchemaQualifiedName(name);
     const qualifiedName = schema
       ? `${this.pg.quoteIdentifier(schema)}.${this.pg.quoteIdentifier(enumName)}`
       : this.pg.quoteIdentifier(enumName);
@@ -1619,7 +1627,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   }
 
   async dropEnum(name: string, options: { ifExists?: boolean } = {}): Promise<void> {
-    const { schema, table: enumName } = this.pg.parseSchemaQualifiedName(name);
+    const [schema, enumName] = this.pg.extractSchemaQualifiedName(name);
     const qualifiedName = schema
       ? `${this.pg.quoteIdentifier(schema)}.${this.pg.quoteIdentifier(enumName)}`
       : this.pg.quoteIdentifier(enumName);
@@ -1634,13 +1642,13 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
 
   async renameEnum(name: string, newNameOrOptions: string | { to: string }): Promise<void> {
     const newName = typeof newNameOrOptions === "string" ? newNameOrOptions : newNameOrOptions.to;
-    const { schema: newSchema } = this.pg.parseSchemaQualifiedName(newName);
+    const [newSchema] = this.pg.extractSchemaQualifiedName(newName);
     if (newSchema) {
       throw new Error(
         "PostgreSQLAdapter#renameEnum does not support changing enum schema; pass an unqualified type name.",
       );
     }
-    const { schema, table: enumName } = this.pg.parseSchemaQualifiedName(name);
+    const [schema, enumName] = this.pg.extractSchemaQualifiedName(name);
     const qualifiedName = schema
       ? `${this.pg.quoteIdentifier(schema)}.${this.pg.quoteIdentifier(enumName)}`
       : this.pg.quoteIdentifier(enumName);
@@ -1655,7 +1663,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     value: string,
     options: { before?: string; after?: string; ifNotExists?: boolean } = {},
   ): Promise<void> {
-    const { schema, table: enumName } = this.pg.parseSchemaQualifiedName(name);
+    const [schema, enumName] = this.pg.extractSchemaQualifiedName(name);
     const qualifiedName = schema
       ? `${this.pg.quoteIdentifier(schema)}.${this.pg.quoteIdentifier(enumName)}`
       : this.pg.quoteIdentifier(enumName);
@@ -1678,7 +1686,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   }
 
   async renameEnumValue(name: string, options: { from: string; to: string }): Promise<void> {
-    const { schema, table: enumName } = this.pg.parseSchemaQualifiedName(name);
+    const [schema, enumName] = this.pg.extractSchemaQualifiedName(name);
     const qualifiedName = schema
       ? `${this.pg.quoteIdentifier(schema)}.${this.pg.quoteIdentifier(enumName)}`
       : this.pg.quoteIdentifier(enumName);
@@ -1698,7 +1706,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     name: string,
     options: { subtype: string; subtypeDiff?: string },
   ): Promise<void> {
-    const { schema, table: rangeName } = this.pg.parseSchemaQualifiedName(name);
+    const [schema, rangeName] = this.pg.extractSchemaQualifiedName(name);
     const qualifiedName = schema
       ? `${this.pg.quoteIdentifier(schema)}.${this.pg.quoteIdentifier(rangeName)}`
       : this.pg.quoteIdentifier(rangeName);
@@ -1715,7 +1723,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
           `PostgreSQLAdapter#createRange: ${param} must have 1 or 2 dot-separated parts, got ${parts.length}: "${identifier}".`,
         );
       }
-      const { schema: s, table: t } = this.pg.parseSchemaQualifiedName(identifier);
+      const [s, t] = this.pg.extractSchemaQualifiedName(identifier);
       return s
         ? `${this.pg.quoteIdentifier(s)}.${this.pg.quoteIdentifier(t)}`
         : this.pg.quoteIdentifier(t);
@@ -1737,7 +1745,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   }
 
   async dropRange(name: string, options: { ifExists?: boolean } = {}): Promise<void> {
-    const { schema, table: rangeName } = this.pg.parseSchemaQualifiedName(name);
+    const [schema, rangeName] = this.pg.extractSchemaQualifiedName(name);
     const qualifiedName = schema
       ? `${this.pg.quoteIdentifier(schema)}.${this.pg.quoteIdentifier(rangeName)}`
       : this.pg.quoteIdentifier(rangeName);
@@ -1752,7 +1760,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   // ---------------------------------------------------------------------------
 
   override async primaryKey(tableName: string): Promise<string | string[] | null> {
-    const { schema, table } = this.pg.parseSchemaQualifiedName(tableName);
+    const [schema, table] = this.pg.extractSchemaQualifiedName(tableName);
 
     let tableCondition: string;
     const binds: unknown[] = [];
@@ -1810,21 +1818,16 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   async pkAndSequenceFor(
     tableName: string,
   ): Promise<[string, { schema: string; name: string } | null] | null> {
-    const { schema, table } = this.pg.parseSchemaQualifiedName(tableName);
-
-    let tableCondition: string;
-    const binds: unknown[] = [];
-
-    if (schema) {
-      binds.push(table, schema);
-      tableCondition = `t.relname = $1 AND n.nspname = $2`;
-    } else {
-      // Quote the identifier (mirrors Rails quote(quote_table_name(table)) in
-      // pk_and_sequence_for) so a mixed-case name like "CamelCase" resolves
-      // case-sensitively instead of folding to lowercase via a bare to_regclass.
-      binds.push(table);
-      tableCondition = `t.oid = to_regclass(quote_ident($1))`;
-    }
+    // Mirrors Rails pk_and_sequence_for's `#{quote(quote_table_name(table))}::regclass`:
+    // regclass resolves a schema-qualified or bare name itself, and the quoting
+    // keeps a mixed-case name like "CamelCase" case-sensitive.
+    //
+    // Deviation: `to_regclass(...)` rather than a bare `::regclass` cast. Rails
+    // wraps the whole method in `rescue nil`, so an unknown table yields nil;
+    // to_regclass yields NULL (hence no rows, hence nil) without raising, which
+    // matters here because a raised PG error would abort an enclosing
+    // transaction that Ruby's rescue leaves untouched.
+    const tableCondition = `t.oid = to_regclass(${this.pg.quote(this.pg.quoteTableName(tableName))})`;
 
     const rows = await this.pg.schemaQuery(
       `SELECT a.attname AS pk,
@@ -1843,7 +1846,6 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
        -- PK's ANY(i.indkey) join could return an arbitrary column under LIMIT 1.
        ORDER BY array_position(i.indkey, a.attnum)
        LIMIT 1`,
-      binds,
     );
 
     if (rows.length === 0) return null;
@@ -1906,14 +1908,14 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       if (!result) return null;
       return Utils.extractSchemaQualifiedName(result).toString();
     } catch {
-      return `${tableName}_${pk}_seq`;
+      return new Name(null, `${tableName}_${pk}_seq`).toString();
     }
   }
 
   /** @internal */
   sequenceNameFromParts(tableName: string, columnName: string, suffix: string): string {
     const maxLen = 63;
-    const { table: unqualifiedTable } = this.pg.parseSchemaQualifiedName(tableName);
+    const [, unqualifiedTable] = this.pg.extractSchemaQualifiedName(tableName);
     let overLength = unqualifiedTable.length + columnName.length + suffix.length + 2 - maxLen;
     let col = columnName;
     let tbl = unqualifiedTable;
@@ -1934,43 +1936,26 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   }
 
   async setPkSequence(tableName: string, value: number): Promise<void> {
-    const result = await this.pkAndSequenceFor(tableName);
-    if (!result) return;
-    const [, seq] = result;
-    if (!seq) return;
-    const seqName = `${seq.schema}.${seq.name}`;
-    await this.pg.schemaQuery(`SELECT setval($1::regclass, $2)`, [this._qt(seqName), value]);
+    await this.setPkSequenceBang(tableName, value);
   }
 
   async setPkSequenceBang(tableName: string, value: number): Promise<void> {
     const result = await this.pkAndSequenceFor(tableName);
-    if (!result) return;
-    const [, seq] = result;
-    if (!seq) return;
-    const seqName = `${seq.schema}.${seq.name}`;
-    await this.pg.schemaQuery(`SELECT setval($1::regclass, $2)`, [this._qt(seqName), value]);
+    const [pk, seq] = result ?? [null, null];
+    if (!pk) return;
+    if (seq) {
+      const quotedSequence = this.pg.quoteTableName(`${seq.schema}.${seq.name}`);
+      await this.adapter.queryValue(
+        `SELECT setval(${this.pg.quote(quotedSequence)}, ${value})`,
+        "SCHEMA",
+      );
+    } else {
+      this.pgLogger?.warn?.(`${tableName} has primary key ${pk} with no default sequence.`);
+    }
   }
 
   async resetPkSequence(tableName: string): Promise<void> {
-    const result = await this.pkAndSequenceFor(tableName);
-    if (!result) return;
-    const [pk, seq] = result;
-    if (!seq) return;
-    const qualifiedTable = this._qt(tableName);
-    const seqName = `${seq.schema}.${seq.name}`;
-
-    const maxRows = await this.pg.schemaQuery(
-      `SELECT COALESCE(MAX(${this._qi(pk)}), 0) AS max_val FROM ${qualifiedTable}`,
-    );
-    const maxVal = Number(maxRows[0].max_val);
-    if (maxVal === 0) {
-      await this.pg.schemaQuery(`SELECT setval($1::regclass, 1, false)`, [this._qt(seqName)]);
-    } else {
-      await this.pg.schemaQuery(`SELECT setval($1::regclass, $2, true)`, [
-        this._qt(seqName),
-        maxVal,
-      ]);
-    }
+    await this.resetPkSequenceBang(tableName);
   }
 
   async resetPkSequenceBang(
@@ -1979,33 +1964,37 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     sequence: string | null = null,
   ): Promise<void> {
     if (!pk || !sequence) {
-      const result = await this.pkAndSequenceFor(tableName);
-      if (!result) return;
-      const [defaultPk, defaultSeq] = result;
+      const [defaultPk, defaultSeq] = (await this.pkAndSequenceFor(tableName)) ?? [null, null];
       pk = pk ?? defaultPk;
       sequence = sequence ?? (defaultSeq ? `${defaultSeq.schema}.${defaultSeq.name}` : null);
     }
-    if (!pk || !sequence) return;
-    const quotedSeq = this._qt(sequence);
-    const maxRows = await this.pg.schemaQuery(
-      `SELECT MAX(${this._qi(pk)}) AS max_val FROM ${this._qt(tableName)}`,
-    );
-    const maxVal = maxRows[0]?.max_val;
-    if (maxVal == null) {
-      const dbVersion = await this.pg.getDatabaseVersion();
-      const minRows =
-        dbVersion >= 100000
-          ? await this.pg.schemaQuery(
-              `SELECT seqmin AS minvalue FROM pg_sequence WHERE seqrelid = $1::regclass`,
-              [quotedSeq],
-            )
-          : await this.pg.schemaQuery(`SELECT min_value AS minvalue FROM ${quotedSeq}`);
-      await this.pg.schemaQuery(`SELECT setval($1::regclass, $2, false)`, [
-        quotedSeq,
-        minRows[0]?.minvalue ?? 1,
-      ]);
-    } else {
-      await this.pg.schemaQuery(`SELECT setval($1::regclass, $2, true)`, [quotedSeq, maxVal]);
+
+    if (pk && !sequence) {
+      this.pgLogger?.warn?.(`${tableName} has primary key ${pk} with no default sequence.`);
     }
+
+    if (!pk || !sequence) return;
+
+    const quotedSequence = this.pg.quoteTableName(sequence);
+    const maxPk = await this.adapter.queryValue(
+      `SELECT MAX(${this.pg.quoteColumnName(pk)}) FROM ${this.pg.quoteTableName(tableName)}`,
+      "SCHEMA",
+    );
+    let minvalue: unknown = null;
+    if (maxPk == null) {
+      const dbVersion = await this.pg.getDatabaseVersion();
+      minvalue =
+        dbVersion >= 100000
+          ? await this.adapter.queryValue(
+              `SELECT seqmin FROM pg_sequence WHERE seqrelid = ${this.pg.quote(quotedSequence)}::regclass`,
+              "SCHEMA",
+            )
+          : await this.adapter.queryValue(`SELECT min_value FROM ${quotedSequence}`, "SCHEMA");
+    }
+
+    await this.adapter.queryValue(
+      `SELECT setval(${this.pg.quote(quotedSequence)}, ${maxPk ?? minvalue}, ${maxPk ? "true" : "false"})`,
+      "SCHEMA",
+    );
   }
 }

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
@@ -429,13 +429,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "default_sequence_name",
-    "call": "new",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "disable_extension",
     "call": "internal_exec_query",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -695,13 +688,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "foreign_key_column_for",
-    "call": "extract_schema_qualified_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "foreign_keys",
     "call": "internal_exec_query",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -767,13 +753,6 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "has_default_function?",
     "call": "match?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "index_name",
-    "call": "extract_schema_qualified_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -933,20 +912,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "pk_and_sequence_for",
-    "call": "quote",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "pk_and_sequence_for",
-    "call": "quote_table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "prepare_statement",
     "call": "prepare",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -1031,20 +996,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "quoted_scope",
-    "call": "extract_schema_qualified_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "quoted_scope",
-    "call": "quote",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "reconfigure_connection_timezone",
     "call": "fetch",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -1068,13 +1019,6 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "reconnect",
     "call": "reset",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "reference_name_for_table",
-    "call": "extract_schema_qualified_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -1124,13 +1068,6 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "remove_index",
     "call": "execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "remove_index",
-    "call": "extract_schema_qualified_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -1227,34 +1164,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "rename_index",
-    "call": "execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "rename_index",
-    "call": "extract_schema_qualified_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "rename_index",
-    "call": "quote_column_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "rename_index",
-    "call": "quote_table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "rename_table",
     "call": "execute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -1285,41 +1194,6 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "reset!",
     "call": "synchronize",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "reset_pk_sequence!",
-    "call": "query_value",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "reset_pk_sequence!",
-    "call": "quote",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "reset_pk_sequence!",
-    "call": "quote_column_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "reset_pk_sequence!",
-    "call": "quote_table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "reset_pk_sequence!",
-    "call": "warn",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -1397,34 +1271,6 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "set_constraints",
     "call": "include?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "set_pk_sequence!",
-    "call": "query_value",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "set_pk_sequence!",
-    "call": "quote",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "set_pk_sequence!",
-    "call": "quote_table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "set_pk_sequence!",
-    "call": "warn",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
@@ -807,13 +807,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "inherited_table_names",
-    "call": "quoted_scope",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "initialize",
     "call": "compact",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -1306,13 +1299,6 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "table_partition_definition",
     "call": "query_value",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "table_partition_definition",
-    "call": "quoted_scope",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {


### PR DESCRIPTION
Converges the PostgreSQL sequence / primary-key and schema-qualified-name
helpers onto the ported helpers Rails composes (RFC 0072 fallout cluster from
the #5334 include-resolution reseed).

## Name parsing

`PostgreSQLAdapter#parseSchemaQualifiedName` — a bespoke wrapper that returned
`{ schema, table }` — is retired. All ~30 call sites (in `postgresql-adapter.ts`
and `postgresql/schema-statements-class.ts`) now go through the ported
`extractSchemaQualifiedName`, which is Rails'
`[name.schema, name.identifier]` over `Utils.extract_schema_qualified_name`.
`quoted_scope` additionally quotes through `quote` rather than the private
`quoteLiteral`, matching `schema_statements.rb:1129`.

`pgQuotedScope` — a second bespoke copy of `quoted_scope` that ignored its
`type` argument — is deleted; its four callers (`index_name_exists?`,
`table_comment`, `table_partition_definition`, `inherited_table_names`) now
compose `quoted_scope` the way Rails does.

## Sequence helpers

- `set_pk_sequence!` and `reset_pk_sequence!` restore the `@logger.warn`
  Rails emits when a table has a primary key but **no** default sequence — the
  trails port was silent. Both now also compose `query_value`, `quote`,
  `quote_table_name` and `quote_column_name` instead of `schemaQuery` with
  binds and the `_qt`/`_qi` abbreviation wrappers.
- `reset_pk_sequence` / `set_pk_sequence` delegate to their bang forms; Rails
  has a single definition, and the two trails bodies had drifted (the non-bang
  reset used `COALESCE(MAX(pk), 0)` instead of the sequence's `minvalue`).
- `pk_and_sequence_for` resolves the table via
  `quote(quote_table_name(table))` and drops the bespoke schema/table branch.
  It wraps that in `to_regclass(...)` rather than a bare `::regclass` cast —
  justified at the call site: Rails' whole method is `rescue nil`, so an
  unknown table yields nil either way, but a raised PG error would abort an
  enclosing transaction that Ruby's rescue leaves untouched.
- `default_sequence_name`'s `StatementInvalid` fallback builds a
  `PostgreSQL::Name` (`Name.new(nil, "#{table}_#{pk}_seq").to_s`).

## Constraint name digests

Verified — the generated `excl_rails_*` / `uniq_rails_*` names already match
Rails byte-for-byte. `schema-statements-class.trails.test.ts` now pins them
against the literals asserted in Rails' own
`migration/exclusion_constraint_test.rb` and `migration/unique_constraint_test.rb`
(`excl_rails_74c9160f55`, `uniq_rails_1e07660b77`, `uniq_rails_79b901ffb4`), so
any drift in the identifier shape or digest slice fails here rather than
silently changing emitted DDL and dumped schema. No behaviour change was needed.

## Review fixes

Four fidelity bugs the review caught, each with a regression test that fails on
the previous implementation:

- `index_name_exists?` now runs the **index** name through `quoted_scope` too
  and compares `i.relname = index[:name]` (`schema_statements.rb:67-81`). It
  previously quoted the raw string, so a schema-qualified index name was
  compared as `'my_schema.index_a'` and never matched.
- `pk_and_sequence_for`'s `default_expr` fallback pairs the **table's**
  namespace with the bare sequence identifier. Rails' fallback query selects
  `nsp.nspname` plus a CASE stripping everything through the dot
  (`schema_statements.rb:382-407`), so the sequence's own schema never
  survives.
- `pk_and_sequence_for` restores Rails' method-level `rescue nil` — any error,
  not just an unknown-table lookup, yields nil. `to_regclass` covered only one
  error path. Kept inline rather than extracted into a helper, because the wide
  call gate resolves calls per method body.
- `reset_pk_sequence!` picks setval's third argument by nil check. Ruby's
  `max_pk ? true : false` treats `0` as truthy, so a table whose max primary
  key is 0 must emit `true` — JS truthiness emitted `false`.

## Gate

24 entries drop out of
`call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json`;
`pnpm api:calls:wide` passes at 4903 (was 4927).

## Deferred

`remove_index`, `new_column_from_field`, `pk_and_sequence_for`'s
`last`/`new`/`query` (converging the return type to `PostgreSQL::Name` ripples
into three callers), and the bucket-(b) Ruby-idiom entries
(`fetch`/`first`/`hexdigest`/`map`/`sum`) are registered as
`converge-pg-remove-index-and-new-column-from-field-call-sets` under RFC 0072
rather than fanned out here.

## Testing

`packages/activerecord/src/connection-adapters/postgresql` and
`.../adapters/postgresql` against live PG: 85 files / 1358 tests pass. The 4
`ForeignTableTest` failures are the known `postgres_fdw`-absent ad-hoc-stack
failures, identical on `main`. `schema-dumper.test.ts`, `adapter.test.ts`,
`migration.test.ts`, `comment.test.ts`, `primary-keys.test.ts` against PG:
293 pass. Same files under
the default SQLite adapter: 438 pass.

The ported PG schema tests (`adapters/postgresql/schema.test.ts`) now call the
bang sequence helpers Rails' own `schema_test.rb` calls, so
`reset_pk_sequence!` / `set_pk_sequence!` are exercised through the same entry
point Rails uses.

Closes-story: converge-pg-sequence-and-schema-qualified-name-helpers
