### PR TITLE
refactor(activerecord): mark redundant writer helpers @internal

### DIFF
--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -145,12 +145,7 @@ export { registerSubclass, findStiClass } from "./inheritance.js";
 // subclass (statics) or a Base instance (instance methods).
 // establishConnection requires node:fs — use subpath: @blazetrails/activerecord/connection-handling
 // signedId requires MessageVerifier (node:crypto) — use subpath: @blazetrails/activerecord/signed-id
-export {
-  lockingColumn,
-  setLockingColumn,
-  lockingEnabled,
-  LockingType,
-} from "./locking/optimistic.js";
+export { lockingColumn, lockingEnabled, LockingType } from "./locking/optimistic.js";
 // ModelSchema is consumed via the Base mixins — `User.columnNames()`,
 // `User.columnsHash()`, `User.contentColumns()`, `User.createTable()`, etc.
 // (mixed in via activesupport `extend()`). The underlying functions are

--- a/packages/activerecord/src/locking/optimistic.ts
+++ b/packages/activerecord/src/locking/optimistic.ts
@@ -25,6 +25,9 @@ export function lockingColumn(modelClass: typeof Base): string {
 
 /**
  * Set the column name used for optimistic locking.
+ *
+ * Mirrors: ActiveRecord::Locking::Optimistic::ClassMethods#locking_column=
+ * @internal
  */
 export function setLockingColumn(modelClass: typeof Base, column: string): void {
   reloadSchemaFromCache.call(modelClass as any);
@@ -59,6 +62,7 @@ export function lockOptimistically(modelClass: typeof Base): boolean {
 
 /**
  * Mirrors: ActiveRecord::Locking::Optimistic#lock_optimistically=
+ * @internal
  */
 export function setLockOptimistically(modelClass: typeof Base, value: boolean): void {
   (modelClass as any)._lockOptimistically = value;

--- a/packages/activerecord/src/signed-id.ts
+++ b/packages/activerecord/src/signed-id.ts
@@ -33,6 +33,7 @@ export function signedIdVerifierSecret(): string | (() => string | null | undefi
  * Clears any cached verifiers so they pick up the new secret.
  *
  * Mirrors: ActiveRecord::Base.signed_id_verifier_secret=
+ * @internal
  */
 export function setSignedIdVerifierSecret(
   secret: string | (() => string | null | undefined) | null,

--- a/packages/activerecord/src/token-for.ts
+++ b/packages/activerecord/src/token-for.ts
@@ -228,6 +228,7 @@ export function tokenDefinitions(
  * this class's own registry entry (subclasses still inherit via the reader).
  *
  * Mirrors: ActiveRecord::TokenFor#token_definitions=
+ * @internal
  */
 export function setTokenDefinitions(
   modelClass: typeof Base,
@@ -261,6 +262,7 @@ export function generatedTokenVerifier(modelClass: typeof Base): MessageVerifier
  * builds this class's own verifier.
  *
  * Mirrors: ActiveRecord::TokenFor#generated_token_verifier=
+ * @internal
  */
 export function setGeneratedTokenVerifier(
   modelClass: typeof Base,


### PR DESCRIPTION
Shape 1 of RFC 0081: the Rails-named `static set x` accessor on `Base` already
exists and delegates to these helpers, so the helpers themselves are redundant
public surface. Tagging them `@internal` (they stay exported because `base.ts`
and the mixin install sites import them across modules) removes the
extra-surface entries with no behavior change, and `setLockingColumn` is
dropped from the package barrel.

- `setLockingColumn`, `setLockOptimistically` (`locking/optimistic.ts`)
- `setSignedIdVerifierSecret` (`signed-id.ts`)
- `setTokenDefinitions`, `setGeneratedTokenVerifier` (`token-for.ts`)

`setAbstractClass` (`inheritance.ts`) was already `@internal` on main and
reports no extra, so the story's 6 members net out to 5 remaining.

## Verification

- `pnpm api:extra`: activerecord total 1343 → 1338 (5 fewer), no new stale
  entries; allowlist still 36/36 matched.
- `pnpm api:compare` still matches the `foo=` writers.
- `pnpm typecheck` clean; `signed-id.test.ts`, `token-for.test.ts`,
  `locking.test.ts`, `locking.trails.test.ts` pass unchanged (101 passed).

Closes-story: unexport-redundant-writer-helpers-activerecord
