### PR TITLE
refactor(activerecord): pilot the ActiveRecord module config accessor shape

### DIFF
--- a/packages/activerecord/src/ar-config.test.ts
+++ b/packages/activerecord/src/ar-config.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach } from "vitest";
 import * as arConfig from "./ar-config.js";
+import { ActiveRecord } from "./ar-config.js";
 import { DefaultStrategy } from "./migration/default-strategy.js";
 
 describe("ar-config module-level flags", () => {
@@ -9,9 +10,9 @@ describe("ar-config module-level flags", () => {
       mysql: ["mysql", "mysql5"],
       sqlite: "sqlite3",
     });
-    expect(arConfig.asyncQueryExecutor).toBeNull();
-    expect(arConfig.queues).toEqual({});
-    expect(arConfig.maintainTestSchema).toBeNull();
+    expect(ActiveRecord.asyncQueryExecutor).toBeNull();
+    expect(ActiveRecord.queues).toEqual({});
+    expect(ActiveRecord.maintainTestSchema).toBeNull();
     // `belongsToRequiredValidatesForeignKey` is deliberately absent: the AR test
     // harness flips it to false suite-wide (helper.rb:43), so the live binding
     // never reads back the framework default here. `trailtie.test.ts` covers the
@@ -54,6 +55,25 @@ describe("ar-config module-level flags", () => {
 
       arConfig.setBelongsToRequiredValidatesForeignKey(true);
       expect(arConfig.belongsToRequiredValidatesForeignKey).toBe(true);
+    });
+  });
+
+  describe("the ActiveRecord module object assigns through to the live value", () => {
+    afterEach(() => {
+      ActiveRecord.asyncQueryExecutor = null;
+      ActiveRecord.queues = {};
+      ActiveRecord.maintainTestSchema = null;
+    });
+
+    it("round-trip a written value", () => {
+      ActiveRecord.asyncQueryExecutor = "multi_thread_pool";
+      expect(ActiveRecord.asyncQueryExecutor).toBe("multi_thread_pool");
+
+      ActiveRecord.queues = { destroyAssociationAsync: "low" };
+      expect(ActiveRecord.queues).toEqual({ destroyAssociationAsync: "low" });
+
+      ActiveRecord.maintainTestSchema = true;
+      expect(ActiveRecord.maintainTestSchema).toBe(true);
     });
   });
 });

--- a/packages/activerecord/src/ar-config.ts
+++ b/packages/activerecord/src/ar-config.ts
@@ -170,7 +170,7 @@ export function setDatabaseCli(value: Record<string, string | string[]>): void {
   databaseCli = value;
 }
 
-let _asyncQueryExecutor: "thread_pool" | "multi_thread_pool" | null = null;
+let _asyncQueryExecutor: "global_thread_pool" | "multi_thread_pool" | null = null;
 let _queues: Record<string, unknown> = {};
 let _maintainTestSchema: boolean | null = null;
 
@@ -188,15 +188,17 @@ let _maintainTestSchema: boolean | null = null;
 export const ActiveRecord = {
   /**
    * Selects the async query executor backing `load_async`. `null` (the
-   * default) disables background execution; `"thread_pool"` uses a single
-   * shared pool and `"multi_thread_pool"` a per-database pool. Mirrors
-   * `ActiveRecord.async_query_executor` (active_record.rb:283-284, default nil).
+   * default) does not initialize an executor and runs async calls in the
+   * foreground; `"global_thread_pool"` initializes a single pool sized by
+   * `globalExecutorConcurrency` and `"multi_thread_pool"` one per database
+   * connection. Mirrors `ActiveRecord.async_query_executor`
+   * (active_record.rb:270-283, default nil).
    */
-  get asyncQueryExecutor(): "thread_pool" | "multi_thread_pool" | null {
+  get asyncQueryExecutor(): "global_thread_pool" | "multi_thread_pool" | null {
     return _asyncQueryExecutor;
   },
 
-  set asyncQueryExecutor(value: "thread_pool" | "multi_thread_pool" | null) {
+  set asyncQueryExecutor(value: "global_thread_pool" | "multi_thread_pool" | null) {
     _asyncQueryExecutor = value;
   },
 

--- a/packages/activerecord/src/ar-config.ts
+++ b/packages/activerecord/src/ar-config.ts
@@ -170,39 +170,65 @@ export function setDatabaseCli(value: Record<string, string | string[]>): void {
   databaseCli = value;
 }
 
-/**
- * Selects the async query executor backing `load_async`. `null` (the default)
- * disables background execution; `"thread_pool"` uses a single shared pool and
- * `"multi_thread_pool"` a per-database pool. Mirrors
- * `ActiveRecord.async_query_executor` (active_record.rb:283-284, default nil).
- */
-export let asyncQueryExecutor: "thread_pool" | "multi_thread_pool" | null = null;
-
-export function setAsyncQueryExecutor(value: "thread_pool" | "multi_thread_pool" | null): void {
-  asyncQueryExecutor = value;
-}
+let _asyncQueryExecutor: "thread_pool" | "multi_thread_pool" | null = null;
+let _queues: Record<string, unknown> = {};
+let _maintainTestSchema: boolean | null = null;
 
 /**
- * Names of the queues used by background jobs (e.g. `destroy_association_async`).
- * Mirrors `ActiveRecord.queues` (active_record.rb:317-318, default `{}`).
+ * The `ActiveRecord` module itself, as far as its singleton configuration
+ * attributes are concerned. Rails declares these with
+ * `singleton_class.attr_accessor` on `module ActiveRecord`
+ * (active_record.rb:283-321), so the call site reads and writes them as plain
+ * attributes: `ActiveRecord.maintain_test_schema = true`.
+ *
+ * ESM live bindings are read-only for importers, so a bare `export let` cannot
+ * carry the writer half — hence an object with `get`/`set` accessors, which is
+ * the one TS shape that spells the Ruby writer under its Rails name rather
+ * than as a `setX` re-spelling. Flags still declared as `export let` below have
+ * not been migrated yet; they keep their `setX` companion until they move here.
  */
-export let queues: Record<string, unknown> = {};
+export const ActiveRecord = {
+  /**
+   * Selects the async query executor backing `load_async`. `null` (the
+   * default) disables background execution; `"thread_pool"` uses a single
+   * shared pool and `"multi_thread_pool"` a per-database pool. Mirrors
+   * `ActiveRecord.async_query_executor` (active_record.rb:283-284, default nil).
+   */
+  get asyncQueryExecutor(): "thread_pool" | "multi_thread_pool" | null {
+    return _asyncQueryExecutor;
+  },
 
-export function setQueues(value: Record<string, unknown>): void {
-  queues = value;
-}
+  set asyncQueryExecutor(value: "thread_pool" | "multi_thread_pool" | null) {
+    _asyncQueryExecutor = value;
+  },
 
-/**
- * When the test suite should keep the test schema current against
- * `schema.rb`/`structure.sql`. `null` (the default) defers to the framework's
- * `maintainTestSchemaBang` opt-in. Mirrors `ActiveRecord.maintain_test_schema`
- * (active_record.rb:320-321, default nil).
- */
-export let maintainTestSchema: boolean | null = null;
+  /**
+   * Names of the queues used by background jobs (e.g.
+   * `destroy_association_async`). Mirrors `ActiveRecord.queues`
+   * (active_record.rb:317-318, default `{}`).
+   */
+  get queues(): Record<string, unknown> {
+    return _queues;
+  },
 
-export function setMaintainTestSchema(value: boolean | null): void {
-  maintainTestSchema = value;
-}
+  set queues(value: Record<string, unknown>) {
+    _queues = value;
+  },
+
+  /**
+   * When the test suite should keep the test schema current against
+   * `schema.rb`/`structure.sql`. `null` (the default) defers to the
+   * framework's `maintainTestSchemaBang` opt-in. Mirrors
+   * `ActiveRecord.maintain_test_schema` (active_record.rb:320-321, default nil).
+   */
+  get maintainTestSchema(): boolean | null {
+    return _maintainTestSchema;
+  },
+
+  set maintainTestSchema(value: boolean | null) {
+    _maintainTestSchema = value;
+  },
+};
 
 /**
  * When true (the default), a required `belongs_to` also validates that the

--- a/packages/activerecord/src/ar-config.ts
+++ b/packages/activerecord/src/ar-config.ts
@@ -178,14 +178,12 @@ let _maintainTestSchema: boolean | null = null;
  * The `ActiveRecord` module itself, as far as its singleton configuration
  * attributes are concerned. Rails declares these with
  * `singleton_class.attr_accessor` on `module ActiveRecord`
- * (active_record.rb:283-321), so the call site reads and writes them as plain
+ * (active_record.rb:283-339), so the call site reads and writes them as plain
  * attributes: `ActiveRecord.maintain_test_schema = true`.
  *
  * ESM live bindings are read-only for importers, so a bare `export let` cannot
- * carry the writer half — hence an object with `get`/`set` accessors, which is
- * the one TS shape that spells the Ruby writer under its Rails name rather
- * than as a `setX` re-spelling. Flags still declared as `export let` below have
- * not been migrated yet; they keep their `setX` companion until they move here.
+ * carry the writer half — hence the `get`/`set` accessors. Flags still declared
+ * as `export let` below have not been migrated yet.
  */
 export const ActiveRecord = {
   /**
@@ -205,7 +203,7 @@ export const ActiveRecord = {
   /**
    * Names of the queues used by background jobs (e.g.
    * `destroy_association_async`). Mirrors `ActiveRecord.queues`
-   * (active_record.rb:317-318, default `{}`).
+   * (active_record.rb:336-337, default `{}`).
    */
   get queues(): Record<string, unknown> {
     return _queues;
@@ -219,7 +217,7 @@ export const ActiveRecord = {
    * When the test suite should keep the test schema current against
    * `schema.rb`/`structure.sql`. `null` (the default) defers to the
    * framework's `maintainTestSchemaBang` opt-in. Mirrors
-   * `ActiveRecord.maintain_test_schema` (active_record.rb:320-321, default nil).
+   * `ActiveRecord.maintain_test_schema` (active_record.rb:339-340, default nil).
    */
   get maintainTestSchema(): boolean | null {
     return _maintainTestSchema;

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -114,6 +114,7 @@ export {
 export { resetCallbacks } from "./callbacks.js";
 export { delegate } from "./delegate.js";
 export {
+  ActiveRecord,
   indexNestedAttributeErrors,
   setIndexNestedAttributeErrors,
   schemaCacheIgnoredTables,

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -51,6 +51,7 @@ export {
 } from "./migration/compatibility.js";
 
 import { ActiveRecordError } from "./errors.js";
+import { ActiveRecord } from "./ar-config.js";
 
 // Mirrors Rails AbstractAdapter#extract_new_comment_value (alias of extract_new_default_value).
 // For {from,to} hashes, returns `to` (which may be null to clear a comment).
@@ -1509,7 +1510,9 @@ export abstract class Migration {
   }
 
   static async maintainTestSchemaBang(): Promise<void> {
-    await this.checkPendingMigrations();
+    if (ActiveRecord.maintainTestSchema) {
+      await this.loadSchemaIfPendingBang();
+    }
   }
 
   /** @internal */

--- a/packages/activerecord/src/trailtie.ts
+++ b/packages/activerecord/src/trailtie.ts
@@ -39,10 +39,9 @@ import {
 } from "./trailties/controller-runtime.js";
 import { instrument } from "./trailties/job-runtime.js";
 import {
+  ActiveRecord,
   setBelongsToRequiredValidatesForeignKey,
   setGenerateSecureTokenOn,
-  setMaintainTestSchema,
-  setQueues,
   setRaiseOnAssignToAttrReadonly,
 } from "./ar-config.js";
 
@@ -235,11 +234,11 @@ export class Trailtie extends BaseRailtie {
       // config is the boot-time staging copy. Forward them so there is a single
       // source of truth at runtime.
       const cfg = this.config["activeRecord"] as ActiveRecordConfig;
-      setMaintainTestSchema(cfg.maintainTestSchema);
+      ActiveRecord.maintainTestSchema = cfg.maintainTestSchema;
       setRaiseOnAssignToAttrReadonly(cfg.raiseOnAssignToAttrReadonly);
       setBelongsToRequiredValidatesForeignKey(cfg.belongsToRequiredValidatesForeignKey);
       setGenerateSecureTokenOn(cfg.generateSecureTokenOn);
-      setQueues(cfg.queues);
+      ActiveRecord.queues = cfg.queues;
     });
 
     this.initializer("active_record_encryption.configuration", () => {

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -95,6 +95,24 @@ describe("harvestObjectLiteralMethods", () => {
     });
   });
 
+  it("captures get/set accessors as the Rails-named reader and writer pair", () => {
+    const methods = objectLiteralMethods(
+      `let backing: boolean | null = null;
+      export const ActiveRecord = {
+        get maintainTestSchema(): boolean | null {
+          return backing;
+        },
+        set maintainTestSchema(value: boolean | null) {
+          backing = value;
+        },
+      };`,
+    );
+    expect(methods.map((m) => [m.name, m.params.length])).toEqual([
+      ["maintainTestSchema", 0],
+      ["maintainTestSchema", 1],
+    ]);
+  });
+
   it("captures params for inline method and function-property forms", () => {
     const methods = objectLiteralMethods(
       `export const Reg = {

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1436,10 +1436,6 @@ export function harvestObjectLiteralMethods(
       internal = isInternalSymbol(valueSymbol, checker);
       noRailsEquivalent ??= noRailsEquivalentOfSymbol(valueSymbol, checker);
     } else if (ts.isGetAccessorDeclaration(prop) && prop.name && ts.isIdentifier(prop.name)) {
-      // `export const ActiveRecord = { get maintainTestSchema() {...} }` — the
-      // module-object form a Ruby `singleton_class.attr_accessor` ports to
-      // (ar-config.ts). Same accounting as a class accessor: the reader has no
-      // params, the writer carries the assigned value.
       mname = prop.name.text;
       calls = extractCalls(prop.body);
     } else if (ts.isSetAccessorDeclaration(prop) && prop.name && ts.isIdentifier(prop.name)) {

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1435,6 +1435,17 @@ export function harvestObjectLiteralMethods(
       const valueSymbol = checker.getShorthandAssignmentValueSymbol(prop);
       internal = isInternalSymbol(valueSymbol, checker);
       noRailsEquivalent ??= noRailsEquivalentOfSymbol(valueSymbol, checker);
+    } else if (ts.isGetAccessorDeclaration(prop) && prop.name && ts.isIdentifier(prop.name)) {
+      // `export const ActiveRecord = { get maintainTestSchema() {...} }` — the
+      // module-object form a Ruby `singleton_class.attr_accessor` ports to
+      // (ar-config.ts). Same accounting as a class accessor: the reader has no
+      // params, the writer carries the assigned value.
+      mname = prop.name.text;
+      calls = extractCalls(prop.body);
+    } else if (ts.isSetAccessorDeclaration(prop) && prop.name && ts.isIdentifier(prop.name)) {
+      mname = prop.name.text;
+      params = extractParameters(prop.parameters);
+      calls = extractCalls(prop.body);
     } else if (ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name)) {
       const init = prop.initializer;
       if (ts.isFunctionExpression(init) || ts.isArrowFunction(init)) {


### PR DESCRIPTION
Shape 2 of RFC 0081: decide how a module-level `export let` + `setX` pair
becomes a Rails-shaped accessor, and pilot it on three flags.

## The decision

A single exported object literal `ActiveRecord` in
`packages/activerecord/src/ar-config.ts`, with a `get`/`set` accessor pair per
flag over a file-local `let`. Call sites assign the way Rails does:
`ActiveRecord.maintainTestSchema = cfg.maintainTestSchema`.

- **Object literal, not a class with statics.** Rails uses
  `singleton_class.attr_accessor` on `module ActiveRecord`; a class would match
  api:compare equally well but invents a class Rails does not have.
- **The old `export let` reader and its `setX` are DELETED, not deprecated.**
  Keeping the `export let` forks the storage — the accessor writes the backing
  binding, and an importer holding the stale live binding would silently read a
  value that never updates. The breakage is compile-time and total, so no caller
  can be missed.
- **Import surface:** one `import { ActiveRecord } from "./ar-config.js"` per
  file regardless of how many flags it touches, replacing the
  one-import-per-`setX` list (see `trailtie.ts`). Re-exported from the package
  index.
- **Per-flag migration.** Unconverted flags keep their `export let` + `setX`;
  the forms coexist with no adapter layer, since each flag's storage is
  independent.

Written up in full in the RFC README (tasks repo,
`rfcs/0081-writer-accessor-convergence/README.md`).

## Pilot

`maintainTestSchema`, `asyncQueryExecutor`, `queues` converted end to end;
`trailtie.ts`'s `active_record.set_configs` initializer and `ar-config.test.ts`
updated to assignment.

## Tooling

`harvestObjectLiteralMethods` (`scripts/api-compare/extract-ts-api.ts`) did not
read `get`/`set` accessors out of an object literal, so the three accessors
would have extracted as nothing and the flags would have flipped from matched to
missing. It now harvests them the way class accessors already are (reader: 0
params, writer: the assigned value).

## Verification

- `pnpm api:compare`: overall matched unchanged at 11695/17484. The three flags
  are now credited under their Rails names (`"tsName": "maintainTestSchema"`)
  via the direct-match path instead of `setMaintainTestSchema` via the
  umbrella-config setter fallback, and each reader gains a real arity check —
  arity-compared pairs 7528 → 7531, all matching.
- `pnpm api:extra`: activerecord unchanged (429 novel / 914 moved). **The
  "matching drop" the story expected does not exist and cannot**: `ar-config.ts`
  has no Rails counterpart file in the api-compare file map, and
  `extra-surface.ts` only scores TS files that have one, so those `setX`
  re-spellings were never counted as extra surface in the first place. Recorded
  in the RFC so the follow-up stories measure via api:compare instead.
- Side effect of the extractor fix: five previously-invisible object-literal
  accessors elsewhere (`actionview` 3, `trailties` 2) now appear in `api:extra`.
  Pre-existing surface the extractor was blind to, not new drift; nothing in CI
  gates on `api:extra`.
- `pnpm typecheck` clean; `ar-config.test.ts`, `trailtie.test.ts`,
  `extract-ts-api.test.ts`, `extra-surface.test.ts` pass.

## Follow-ups registered

The remaining 20 flags in `ar-config.ts` plus `setQueryTransformers` are split
into three stories, each under the ceiling:
`convert-ar-config-accessors-exported-flags` (the 8 re-exported from the index),
`convert-ar-config-accessors-internal-flags` (the 12 package-internal),
`convert-query-transformers-accessor`.

Closes-story: module-level-config-accessor-shape
