### PR TITLE
docs(activerecord): audit setX functions with no Rails counterpart

### DIFF
--- a/packages/activemodel/src/type/helpers/timezone.ts
+++ b/packages/activemodel/src/type/helpers/timezone.ts
@@ -23,6 +23,16 @@ export function defaultTimezone(): "utc" | "local" {
   return _defaultTimezone;
 }
 
+/**
+ * Trails-only seam with no Rails counterpart. Rails' helper derives the zone
+ * from `Time.zone_default` (timezone.rb:11) and exposes no setter at all;
+ * trails has no `Time.zone_default` yet, so the value is held here and pushed
+ * in by `activerecord`'s `setDefaultTimezone`. Converging this onto a real
+ * `Time.zone_default` is tracked by RFC 0081's
+ * `converge-activemodel-timezone-onto-time-zone-default` story.
+ *
+ * @internal
+ */
 export function setDefaultTimezone(tz: "utc" | "local"): void {
   _defaultTimezone = tz;
 }

--- a/packages/activerecord/src/ar-config.ts
+++ b/packages/activerecord/src/ar-config.ts
@@ -125,6 +125,12 @@ export function setSchemaCacheIgnoredTables(value: ReadonlyArray<string | RegExp
  */
 export let permanentConnectionCheckout: true | "deprecated" | "disallowed" = true;
 
+/**
+ * Writer for the `ActiveRecord.permanent_connection_checkout=` module attribute
+ * (active_record.rb:314) — needed only because ESM live bindings are read-only
+ * for importers. Converging it onto a module-object accessor is RFC 0081's
+ * `module-level-config-accessor-shape` story, not a trails-only seam.
+ */
 export function setPermanentConnectionCheckout(value: true | "deprecated" | "disallowed"): void {
   if (value !== true && value !== "deprecated" && value !== "disallowed") {
     throw new ArgumentError(
@@ -317,6 +323,12 @@ export function setUseYamlUnsafeLoad(value: boolean): void {
  */
 export let raiseIntWiderThan64bit = true;
 
+/**
+ * Writer for the `ActiveRecord.raise_int_wider_than_64bit=` module attribute
+ * (`singleton_class.attr_accessor`, active_record.rb:446). Same ESM live-binding
+ * constraint as `setPermanentConnectionCheckout`; covered by RFC 0081's
+ * `module-level-config-accessor-shape` story.
+ */
 export function setRaiseIntWiderThan64bit(value: boolean): void {
   raiseIntWiderThan64bit = value;
 }

--- a/packages/activerecord/src/attribute-methods/primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.ts
@@ -225,6 +225,10 @@ export function getPrimaryKeyAttr(this: PrimaryKeyHost): string | string[] | nul
 
 /**
  * Mirrors: ActiveRecord::AttributeMethods::PrimaryKey::ClassMethods#primary_key=
+ *
+ * `Base` already exposes the Rails-named `static set primaryKey` accessor
+ * (base.ts:1157) that delegates here, so this export is redundant public
+ * surface; unexporting it is RFC 0081 shape-1 work, not a seam.
  * @internal
  */
 export function setPrimaryKeyAttr(this: PrimaryKeyHost, key: string | string[]): void {

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -1226,6 +1226,14 @@ export function assertValidEnumOptions(options: unknown): void {
 /** Default warn sink — overridable via setEnumWarn so hosts can route warnings. */
 let _enumWarn: (msg: string) => void = (msg) => console.warn(msg);
 
+/**
+ * Trails-only seam with no Rails counterpart. Rails writes the `not_`-prefix
+ * conflict warning through `logger.warn` (enum.rb:404), where the logger is
+ * already a swappable global; trails has no equivalent ambient logger at this
+ * layer, so the sink is injected instead. Not a writer for any Ruby attribute.
+ *
+ * @internal
+ */
 export function setEnumWarn(fn: (msg: string) => void): void {
   _enumWarn = fn;
 }

--- a/packages/activerecord/src/log-subscriber.ts
+++ b/packages/activerecord/src/log-subscriber.ts
@@ -55,6 +55,13 @@ let _baseResolver: (() => any) | null = null;
 /**
  * Set the resolver for ActiveRecord::Base, avoiding circular imports.
  * Called from index.ts during module initialization.
+ *
+ * Trails-only seam with no Rails counterpart: Rails' LogSubscriber references
+ * the `ActiveRecord::Base` constant directly (log_subscriber.rb), which Ruby
+ * resolves at call time; a static TS import would close the cycle
+ * `log-subscriber → base → index → log-subscriber`.
+ *
+ * @internal
  */
 export function setBaseResolver(resolver: () => any): void {
   _baseResolver = resolver;

--- a/packages/activerecord/src/store.ts
+++ b/packages/activerecord/src/store.ts
@@ -32,10 +32,12 @@ const _storeCoders = new WeakMap<typeof Base, Map<string, IndifferentCoder>>();
 
 /**
  * Trails-only seam with no Rails counterpart. Rails gets implicit store
- * serialization by having `store` call `serialize(store_attribute, coder: ...)`
- * (store.rb:104), which installs the coder as the attribute's type; trails
- * resolves the coder separately at read time, so the mapping needs its own
- * per-class registry. Not a writer for any Ruby attribute.
+ * serialization inside `ActiveRecord::Store::ClassMethods#store`
+ * (store.rb:106-109), which builds the coder and hands it straight to
+ * `serialize store_attribute, coder: IndifferentCoder.new(...)` (store.rb:108),
+ * installing it as the attribute's type; trails resolves the coder separately
+ * at read time, so the mapping needs its own per-class registry. Not a writer
+ * for any Ruby attribute.
  *
  * @internal
  */

--- a/packages/activerecord/src/store.ts
+++ b/packages/activerecord/src/store.ts
@@ -30,7 +30,15 @@ interface CoderLike {
  */
 const _storeCoders = new WeakMap<typeof Base, Map<string, IndifferentCoder>>();
 
-/** @internal */
+/**
+ * Trails-only seam with no Rails counterpart. Rails gets implicit store
+ * serialization by having `store` call `serialize(store_attribute, coder: ...)`
+ * (store.rb:104), which installs the coder as the attribute's type; trails
+ * resolves the coder separately at read time, so the mapping needs its own
+ * per-class registry. Not a writer for any Ruby attribute.
+ *
+ * @internal
+ */
 export function setStoreCoder(klass: typeof Base, attr: string, coder: IndifferentCoder): void {
   let map = _storeCoders.get(klass);
   if (!map) {

--- a/packages/activerecord/src/token-for.ts
+++ b/packages/activerecord/src/token-for.ts
@@ -40,6 +40,12 @@ let _secretGeneration = 0;
  * BLAZETRAILS_SIGNED_ID_SECRET env vars. Throws if no secret
  * is configured. Bumps the secret generation so cached verifiers are rebuilt
  * on the next token op (or `generated_token_verifier` read).
+ *
+ * Trails-only seam with no Rails counterpart: Rails resolves the token secret
+ * from `Rails.application.secret_key_base` inside `generated_token_verifier`'s
+ * default (token_for.rb:11 + railtie wiring), which is framework state trails
+ * has no analogue for. It is not a writer for any Ruby attribute — the Ruby
+ * attribute is `generated_token_verifier=`, which trails already ports.
  */
 export function setTokenForSecret(secret: string | (() => string) | null): void {
   _tokenForSecret = secret;

--- a/packages/activerecord/src/token-for.ts
+++ b/packages/activerecord/src/token-for.ts
@@ -41,11 +41,16 @@ let _secretGeneration = 0;
  * is configured. Bumps the secret generation so cached verifiers are rebuilt
  * on the next token op (or `generated_token_verifier` read).
  *
- * Trails-only seam with no Rails counterpart: Rails resolves the token secret
- * from `Rails.application.secret_key_base` inside `generated_token_verifier`'s
- * default (token_for.rb:11 + railtie wiring), which is framework state trails
- * has no analogue for. It is not a writer for any Ruby attribute — the Ruby
- * attribute is `generated_token_verifier=`, which trails already ports.
+ * Trails-only seam with no Rails counterpart. `token_for.rb` itself resolves no
+ * secret — line 11 only declares the `generated_token_verifier` class_attribute.
+ * The verifier is supplied by the railtie initializer
+ * `"active_record.generated_token_verifier"` (railtie.rb:328-334), which assigns
+ * `app.message_verifier("active_record/token_for")`; that resolves through
+ * `Rails::Application#message_verifiers` (application.rb:208-213) down to
+ * `#secret_key_base` (application.rb:477-479). All of that is railtie/application
+ * state trails has no analogue for, so the secret is injected here instead. Not a
+ * writer for any Ruby attribute — the Ruby attribute is
+ * `generated_token_verifier=`, which trails already ports.
  */
 export function setTokenForSecret(secret: string | (() => string) | null): void {
   _tokenForSecret = secret;

--- a/packages/activerecord/src/type.ts
+++ b/packages/activerecord/src/type.ts
@@ -102,6 +102,16 @@ export function setRegistry(r: AdapterSpecificRegistry): void {
   _defaultValue = undefined;
 }
 
+/**
+ * Trails-only seam with no Rails counterpart. Rails' `Type.lookup` reads the
+ * current adapter straight off `ActiveRecord::Base.connection_db_config.adapter`
+ * (type.rb:41), but a static import of `base.ts` from here would close the cycle
+ * `type.ts → base.ts → attributes → type.ts` and leave `Base` undefined at eval
+ * time. `base.ts` injects the resolver at module end instead (base.ts:5244), and
+ * `lookup` reads it lazily inside the call.
+ *
+ * @internal
+ */
 export function setCurrentAdapterResolver(resolver: () => AdapterNameSource): void {
   _currentAdapterResolver = resolver;
 }

--- a/packages/activerecord/src/type/internal/timezone.ts
+++ b/packages/activerecord/src/type/internal/timezone.ts
@@ -22,6 +22,14 @@ export function getDefaultTimezone(): "utc" | "local" {
   return defaultTimezone;
 }
 
+/**
+ * This is the port of `ActiveRecord.default_timezone=` (active_record.rb:218) —
+ * not of anything in `type/internal/timezone.rb`, which carries readers only.
+ * It lives here because the module-level state it writes is read by `isUtc` /
+ * `Timezone#defaultTimezone` below. Converging it onto `ar-config.ts` (where
+ * the rest of the `active_record.rb` module attributes live) is tracked by RFC
+ * 0081's `relocate-ar-default-timezone-to-ar-config` story.
+ */
 export function setDefaultTimezone(tz: "utc" | "local"): void {
   if (tz !== "utc" && tz !== "local")
     throw new ArgumentError(


### PR DESCRIPTION
# Audit: setX functions with no Rails counterpart (data layer)

## Summary

17 data-layer `setX` exports were classified as having no Ruby counterpart under
either spelling. Reading the vendored Rails source shows the classifier was wrong
about 5 of them and right about 10; 2 are false positives that the `setX` grep
over-collects. Nothing was fixed in place: the 5 convergeable members are covered
by existing RFC 0081 stories or by 3 newly registered ones, and the 10 genuine
seams now carry a call-site justification naming the Rails line they diverge from.
None were added to `extra-surface-allow.json`.

## Coverage

Rails source read: `active_record.rb` (:214-218, :310-314, :446-462),
`active_record/type.rb`, `active_record/type/internal/timezone.rb`,
`active_model/type/helpers/timezone.rb`, `active_record/store.rb`,
`active_record/enum.rb`, `active_record/token_for.rb`, `active_record/signed_id.rb`,
`active_record/attribute_methods/primary_key.rb`, `active_record/transactions.rb`,
`active_model/validations/callbacks.rb`.

TS source read: `ar-config.ts`, `type.ts`, `type/internal/timezone.ts`,
`activemodel/type/helpers/timezone.ts`, `associations/_scope-slots.ts`,
`associations/has-many-association.ts`, `encryption/context.ts`,
`encryption/encrypted-attribute-type.ts`, `log-subscriber.ts`, `store.ts`,
`enum.ts`, `attribute-methods/primary-key.ts`, `token-for.ts`,
`test-helpers/ddl-profile.ts`, `base.ts` (accessor + injection sites).

## Classification

### A — misclassified: a Ruby counterpart DOES exist (5)

| TS export                       | file                             | Ruby counterpart                                        | disposition                                    |
| ------------------------------- | -------------------------------- | ------------------------------------------------------- | ---------------------------------------------- |
| `setPermanentConnectionCheckout` | `ar-config.ts:128`               | `def self.permanent_connection_checkout=` (active_record.rb:314) | existing `module-level-config-accessor-shape`  |
| `setRaiseIntWiderThan64bit`     | `ar-config.ts:294`               | `singleton_class.attr_accessor :raise_int_wider_than_64bit` (active_record.rb:446) | existing `module-level-config-accessor-shape`  |
| `setDefaultTimezone` (AR)       | `type/internal/timezone.ts:25`   | `def self.default_timezone=` (active_record.rb:218)      | NEW story `relocate-ar-default-timezone-to-ar-config` |
| `setPrimaryKeyAttr`             | `attribute-methods/primary-key.ts:230` | `primary_key=` (primary_key.rb:130)                | NEW story `unexport-set-primary-key-attr-helper` |
| `setDefaultTimezone` (AM)       | `activemodel/type/helpers/timezone.ts:26` | no setter; Rails derives from `Time.zone_default` | NEW story `converge-activemodel-timezone-onto-time-zone-default` |

Why the classifier missed them: the first two are `def self.x=` / `singleton_class.attr_accessor`
on the `ActiveRecord` **module**, not on a class; the AR timezone writer is a faithful
port living outside its Rails-layout file (`type/internal/timezone.rb` has readers only);
`setPrimaryKeyAttr` carries an `Attr` suffix the name match doesn't strip. The AM
timezone entry is genuinely counterpart-less but still convergeable — Rails reads one
shared `Time.zone_default` where trails pushes state across a package boundary.

### B — genuine trails-only seams (10)

All are cycle-breakers or host-injection points with no Ruby analogue, because Ruby
resolves constants at call time and has ambient framework state (`logger`,
`secret_key_base`) that trails does not.

| TS export                          | file                                     | why no Rails counterpart                                                        |
| ---------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------- |
| `setCurrentAdapterResolver`        | `type.ts:105`                            | Rails reads `Base.connection_db_config.adapter` inline (type.rb:41); static import would cycle |
| `setBaseResolver`                  | `log-subscriber.ts:59`                   | Rails references the `Base` constant directly; TS import cycles via `index.ts`   |
| `setDjasScopeBuilder`              | `associations/_scope-slots.ts:21`        | already justified in the file header (TDZ / init-order)                          |
| `setAssociationRelationFactory`    | `associations/_scope-slots.ts:31`        | same                                                                             |
| `setGlobalPreviousSchemesFn`       | `encryption/encrypted-attribute-type.ts:26` | already justified (encryptable-record cycle)                                  |
| `setEncryptingOnlyEncryptorFactory` | `encryption/context.ts:18`              | already justified (eval-time cycle through Configurable)                         |
| `setStoreCoder`                    | `store.ts:34`                            | Rails installs the coder as the attribute type via `serialize` (store.rb:106-109)    |
| `setEnumWarn`                      | `enum.ts:1229`                           | Rails uses ambient `logger.warn` (enum.rb:404)                                   |
| `setTokenForSecret`                | `token-for.ts:44`                        | secret comes from the railtie (railtie.rb:328-334) via `secret_key_base` (application.rb:477-479)           |
| `setTestPathResolver` / `setCurrentFile` | `test-helpers/ddl-profile.ts:90,93`| test-only DDL profiling infra; no Rails equivalent at all (already justified)    |

(`setTestPathResolver`/`setCurrentFile` counted as one row, two exports.)

### C — false positives (2)

`setDifference` and `setIntersection` (`associations/has-many-association.ts:486,491`)
are not writers: they are the bodies of `HasManyAssociation#difference` / `#intersection`
(has_many_association.rb), over-collected by the `set[A-Z]` grep. Already `@internal`
with a call-site justification. No action.

## Changes shipped in this PR

Comment-only (no behavior change):

- Call-site justifications added for the 6 seams that lacked one:
  `setCurrentAdapterResolver`, `setBaseResolver`, `setStoreCoder`, `setEnumWarn`,
  `setTokenForSecret`, and activemodel's `setDefaultTimezone`.
- Pointers added on the 4 misclassified writers so they are not re-audited:
  `setPermanentConnectionCheckout`, `setRaiseIntWiderThan64bit`,
  AR `setDefaultTimezone`, `setPrimaryKeyAttr`.

## Follow-up stories registered

- `relocate-ar-default-timezone-to-ar-config` — move the `ActiveRecord.default_timezone=`
  port to `ar-config.ts` so `api:compare` can match it.
- `converge-activemodel-timezone-onto-time-zone-default` — introduce `Time.zone_default`
  and delete the cross-package push.
- `unexport-set-primary-key-attr-helper` — shape-1 member missed by PR #5390.

Closes-story: audit-setx-functions-without-rails-counterpart
