### PR TITLE
fix(api-compare): fail loudly on a bare JSDoc tag inside a @noRailsEquivalent reason

### DIFF
--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -1155,8 +1155,10 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
       `\nextra-surface: ${staleTagged.length} STALE @noRailsEquivalent tag(s) on ` +
         "methods that no longer flag as extra surface — Rails gained the method, " +
         "the file mapping changed, the declaration is internal or `_`-prefixed " +
-        "(never counted), or the tag covers a moved (misplaced) port that belongs " +
-        "in its Rails-layout file. Delete the tag next to the code:\n" +
+        "(never counted), a bare `@tag` word inside the reason prose truncated " +
+        "the reason and was parsed as a real JSDoc tag, or the tag covers a moved " +
+        "(misplaced) port that belongs in its Rails-layout file. Delete the tag " +
+        "next to the code:\n" +
         staleTagged.map((e) => `  - ${e.package}  ${e.tsFile}  ${e.name}`).join("\n") +
         "\n",
     );

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -1513,4 +1513,33 @@ describe("extractFromProgram — @noRailsEquivalent JSDoc", () => {
       `),
     ).toThrow(/@noRailsEquivalent needs a reason/);
   });
+
+  it("throws when a bare tag name in the reason truncates it", () => {
+    expect(() =>
+      extractFromSource(`
+        class Foo {
+          /**
+           * @noRailsEquivalent wiring seam; @internal is the wrong tool here
+           * because the method is real Rails-facing surface.
+           */
+          initializeAssociations(): void {}
+        }
+      `),
+    ).toThrow(/truncated by a bare `@internal`/);
+  });
+
+  it("accepts a following tag that starts its own line", () => {
+    const foo = extractFromSource(`
+      class Foo {
+        /**
+         * @noRailsEquivalent wiring seam with no Rails counterpart
+         * @param name the model name
+         */
+        registerModel(name: string): void {}
+      }
+    `);
+    expect(foo.instanceMethods.find((m) => m.name === "registerModel")!.noRailsEquivalent).toBe(
+      "wiring seam with no Rails counterpart",
+    );
+  });
 });

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1346,7 +1346,42 @@ export function noRailsEquivalentReason(node: ts.Node): string | undefined {
           "state why this surface has no Rails counterpart.",
       );
     }
+    const inlineTag = inlineTagAfter(tag);
+    if (inlineTag !== undefined) {
+      const sf = node.getSourceFile();
+      const line = sf.getLineAndCharacterOfPosition(tag.getStart()).line + 1;
+      throw new Error(
+        `@noRailsEquivalent reason is truncated by a bare \`@${inlineTag}\` in its ` +
+          `prose: ${sf.fileName}:${line} — TypeScript parses it as a real JSDoc tag, ` +
+          "so the reason is cut short and the declaration can drop out of the " +
+          "compared surface entirely. Reword the prose to avoid the tag form.",
+      );
+    }
     return reason;
+  }
+  return undefined;
+}
+
+/**
+ * Name of the first JSDoc tag that follows `tag` in the same comment while
+ * starting mid-line — i.e. a bare `@word` written inside reason prose rather
+ * than a deliberate tag on its own line. TypeScript parses either shape as a
+ * real tag, which silently truncates the reason (and, for `@internal`, drops
+ * the declaration from the extracted surface). Returns undefined when every
+ * following tag starts its own line.
+ */
+function inlineTagAfter(tag: ts.JSDocTag): string | undefined {
+  const jsDoc = tag.parent;
+  if (!ts.isJSDoc(jsDoc) || jsDoc.tags === undefined) return undefined;
+  const text = jsDoc.getSourceFile().text;
+  for (const other of jsDoc.tags) {
+    if (other.getStart() <= tag.getStart()) continue;
+    let i = other.getStart() - 1;
+    while (i >= 0 && text[i] !== "\n") {
+      const ch = text[i];
+      if (ch !== " " && ch !== "\t" && ch !== "*") return other.tagName.text;
+      i--;
+    }
   }
   return undefined;
 }

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1346,10 +1346,10 @@ export function noRailsEquivalentReason(node: ts.Node): string | undefined {
           "state why this surface has no Rails counterpart.",
       );
     }
+    const sf = node.getSourceFile();
+    const line = sf.getLineAndCharacterOfPosition(tag.getStart()).line + 1;
     const inlineTag = inlineTagAfter(tag);
     if (inlineTag !== undefined) {
-      const sf = node.getSourceFile();
-      const line = sf.getLineAndCharacterOfPosition(tag.getStart()).line + 1;
       throw new Error(
         `@noRailsEquivalent reason is truncated by a bare \`@${inlineTag}\` in its ` +
           `prose: ${sf.fileName}:${line} — TypeScript parses it as a real JSDoc tag, ` +
@@ -1368,7 +1368,10 @@ export function noRailsEquivalentReason(node: ts.Node): string | undefined {
  * than a deliberate tag on its own line. TypeScript parses either shape as a
  * real tag, which silently truncates the reason (and, for `@internal`, drops
  * the declaration from the extracted surface). Returns undefined when every
- * following tag starts its own line.
+ * following tag starts its own line: a line-leading tag can't be told apart
+ * from a deliberate one, and `@internal` next to `@noRailsEquivalent` is a real
+ * pairing in the tree (schema-cache.ts `recordTouchedTables`), so only the
+ * mid-line shape is judged a mistake.
  */
 function inlineTagAfter(tag: ts.JSDocTag): string | undefined {
   const jsDoc = tag.parent;


### PR DESCRIPTION
A `@noRailsEquivalent` reason whose prose contains a bare `@internal` (or any
other `@tag` word) is parsed by TypeScript as a real JSDoc tag: the reason gets
truncated at that point, and for `@internal` the declaration is then filtered
out of the extracted TS surface entirely — the only symptom being a *stale tag*
report blaming Rails gaining the method or a file-mapping change. Hit for real
in #5368, where `initializeAssociations` silently vanished from the surface.

- `noRailsEquivalentReason` now detects a following JSDoc tag that starts
  mid-line (a bare `@word` in prose, as opposed to a deliberate tag on its own
  line) and throws with the `file:line`, matching the existing hard error for a
  reason-less tag.
- The stale-tag message in `extra-surface.ts` lists this cause.
- Regression test in `extract-ts-api.test.ts`, plus one pinning that a real
  `@param` on its own line after the tag still parses fine.

`pnpm api:compare` is clean on the current tree.

Closes-story: bare-tag-in-no-rails-equivalent-reason-silently-drops-surface
