### PR TITLE
fix(ci): build activerecord's full dep closure for the query-parity runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1561,18 +1561,8 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-pnpm
       - run: pnpm install --frozen-lockfile --prefer-offline
-      - name: Build dependency packages for trails query runner
-        # activerecord is needed for AR-style fixtures (ar-*): ar_dump.ts
-        # imports Base from @blazetrails/activerecord and fixture models.ts
-        # files do too. Built in dep order — a single `--filter` invocation
-        # races (pnpm may start activemodel before activesupport's dist
-        # lands), so step through each package explicitly.
-        run: |
-          pnpm --filter @blazetrails/activesupport build
-          pnpm --filter @blazetrails/activemodel build
-          pnpm --filter @blazetrails/arel build
-          pnpm --filter @blazetrails/globalid build
-          pnpm --filter @blazetrails/activerecord build
+      - name: Build activerecord and its workspace dependencies
+        run: pnpm --filter "@blazetrails/activerecord..." build
       - name: Run trails-side query dump
         run: pnpm tsx scripts/parity/run.ts --type=query --side=trails
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Problem

`Query Parity (trails side)` fails on `main` @41dd921f:

```
src/associations.ts(3,30): error TS2307: Cannot find module '@blazetrails/did-you-mean' or its corresponding type declarations.
[ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL] @blazetrails/activerecord@0.1.0 build: `tsc`
```

The job built activerecord's workspace dependencies from a hand-maintained list of six `pnpm --filter <pkg> build` lines. `@blazetrails/did-you-mean` is a `workspace:*` dependency of activerecord and is imported by `packages/activerecord/src/associations.ts`, but it was never added to that list, so activerecord's `tsc` could not resolve its types and the job died before running the dump.

## Fix

Replace the list with a single dependency-closure invocation:

```
pnpm --filter "@blazetrails/activerecord..." build
```

pnpm runs a closure recursively in topological order, so the list cannot drift out of sync with `packages/activerecord/package.json` again.

The list existed to avoid a race. That race was real for the command it replaced (#797), which passed several independent `--filter` flags — a *set* of packages with no dependency edges between them, which pnpm runs concurrently. The `...` closure form selects the dependency graph, so pnpm orders it.

## Verification

From a fully clean state (`packages/*/dist` and every `*.tsbuildinfo` removed), three consecutive runs of the new command build all six packages successfully, activesupport first — no ordering failures. Then `PARITY_FROZEN_AT=... pnpm tsx scripts/parity/run.ts --type=query --side=trails` completes and writes 202 dumps to `scripts/parity/.out/query/trails/`.

Closes-story: red-41dd921f
