### PR TITLE
refactor(activerecord): rename test-setup-ar.ts to cases/helper.ts

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -484,6 +484,7 @@ export default defineConfig(
       "packages/activerecord/src/test-helpers/**",
       "packages/activerecord/src/support/**",
       "packages/activerecord/src/test-setup-*.ts",
+      "packages/activerecord/src/cases/helper.ts",
     ],
     rules: {
       "blazetrails/no-raw-sql": "error",

--- a/eslint/no-raw-sql.mjs
+++ b/eslint/no-raw-sql.mjs
@@ -41,6 +41,8 @@ function isExcludedPath(rel) {
   if (/(^|\/)test-helpers\//.test(rel)) return true;
   if (/(^|\/)support\//.test(rel)) return true;
   if (/(^|\/)test-setup-[^/]*\.ts$/.test(rel)) return true;
+  if (/(^|\/)cases\/helper\.ts$/.test(rel)) return true;
+  if (/(^|\/)cases\/helper\.ts$/.test(rel)) return true;
   return false;
 }
 

--- a/eslint/no-raw-sql.mjs
+++ b/eslint/no-raw-sql.mjs
@@ -42,7 +42,6 @@ function isExcludedPath(rel) {
   if (/(^|\/)support\//.test(rel)) return true;
   if (/(^|\/)test-setup-[^/]*\.ts$/.test(rel)) return true;
   if (/(^|\/)cases\/helper\.ts$/.test(rel)) return true;
-  if (/(^|\/)cases\/helper\.ts$/.test(rel)) return true;
   return false;
 }
 

--- a/packages/activerecord/src/adapters/postgresql/transaction.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/transaction.test.ts
@@ -20,7 +20,7 @@ describeIfPg("PostgreSQLAdapter", () => {
 
   describe("PostgreSQLTransactionTest", () => {
     // Mirrors Rails' setup/teardown (samples table, value column). Created in
-    // beforeEach — after the global reset (test-setup-ar drops all tables).
+    // beforeEach — after the global reset (cases/helper.ts drops all tables).
     beforeEach(async () => {
       await adapter.exec("DROP TABLE IF EXISTS samples");
       await adapter.exec("CREATE TABLE samples (id int PRIMARY KEY, value integer)");

--- a/packages/activerecord/src/cases/helper.ts
+++ b/packages/activerecord/src/cases/helper.ts
@@ -1,33 +1,33 @@
 /**
- * AR-only vitest setupFile. Wired into the `activerecord` project in
- * `vitest.config.ts`; the sibling `test-setup.ts` is shared with the
- * non-AR `other` project, so anything that imports the AR test adapter
- * (and thus opens a DB connection at module load) belongs here, not
- * there.
+ * AR-only vitest setupFile, mirroring Rails'
+ * `activerecord/test/cases/helper.rb`. Wired into the `activerecord` project
+ * in `vitest.config.ts`; anything that imports the AR test adapter (and thus
+ * opens a DB connection at module load) belongs here rather than in a setup
+ * file shared with non-AR projects.
  */
 
 // Eagerly load the better-sqlite3 driver so the AR test adapter
 // (BetterSQLite3Adapter) can open a connection at module load. Lives here (not
 // in activerecord/index.ts) to keep better-sqlite3 a true optional peer for
 // non-test consumers.
-import "./sqlite/better-sqlite3.js";
+import "../sqlite/better-sqlite3.js";
 import { beforeEach } from "vitest";
-import { Base } from "./base.js";
-import { DelegateCache } from "./relation/delegation.js";
-import { loadDefaults } from "./trailtie.js";
+import { Base } from "../base.js";
+import { DelegateCache } from "../relation/delegation.js";
+import { loadDefaults } from "../trailtie.js";
 import {
   setBelongsToRequiredValidatesForeignKey,
   setRaiseOnAssignToAttrReadonly,
-} from "./ar-config.js";
-import { resetTestAdapterState } from "./test-adapter.js";
-import { shouldSkipGlobalReset } from "./support/skip-global-reset.js";
-import { Configurable as EncryptionConfigurable } from "./encryption/configurable.js";
-import { installExtendedQueriesIfConfigured } from "./encryption/install.js";
+} from "../ar-config.js";
+import { resetTestAdapterState } from "../test-adapter.js";
+import { shouldSkipGlobalReset } from "../support/skip-global-reset.js";
+import { Configurable as EncryptionConfigurable } from "../encryption/configurable.js";
+import { installExtendedQueriesIfConfigured } from "../encryption/install.js";
 import {
   TEST_PRIMARY_KEY,
   TEST_DETERMINISTIC_KEY,
   TEST_KEY_DERIVATION_SALT,
-} from "./encryption/test-keys.js";
+} from "../encryption/test-keys.js";
 
 // The test app runs with the Rails 7.0+ defaults (`config.load_defaults 7.0`),
 // which sets `config.active_record.partial_inserts = false` (partial_updates

--- a/packages/activerecord/src/cases/helper.ts
+++ b/packages/activerecord/src/cases/helper.ts
@@ -1,9 +1,8 @@
 /**
  * AR-only vitest setupFile, mirroring Rails'
- * `activerecord/test/cases/helper.rb`. Wired into the `activerecord` project
- * in `vitest.config.ts`; anything that imports the AR test adapter (and thus
- * opens a DB connection at module load) belongs here rather than in a setup
- * file shared with non-AR projects.
+ * `activerecord/test/cases/helper.rb`. Anything that imports the AR test
+ * adapter (and thus opens a DB connection at module load) belongs here rather
+ * than in a setup file shared with non-AR projects.
  */
 
 // Eagerly load the better-sqlite3 driver so the AR test adapter
@@ -75,8 +74,6 @@ EncryptionConfigurable.configure({
 EncryptionConfigurable.config.extendQueries = true;
 installExtendedQueriesIfConfigured();
 
-// Wipe shared test-adapter state before every test so each test starts
-// from a clean slate.
 beforeEach(async () => {
   if (shouldSkipGlobalReset()) return;
   await resetTestAdapterState();

--- a/packages/activerecord/src/defaults.test.ts
+++ b/packages/activerecord/src/defaults.test.ts
@@ -44,7 +44,7 @@ afterAll(() => {
 // tables are not in `schema.rb` and have no canonical home, so they are created
 // per-test through the migration DSL on `Base.connection` and dropped in
 // `afterEach`. Building in `beforeEach` (not `beforeAll`) because the shared
-// per-worker DB is reset by the global `beforeEach` in test-setup-ar.ts.
+// per-worker DB is reset by the global `beforeEach` in cases/helper.ts.
 
 // Rails asserts string equality on binary-column defaults; a binary column
 // deserializes to bytes in trails (BinaryType → Uint8Array), so decode the
@@ -486,7 +486,7 @@ describeIfMysql("DefaultsTestWithoutTransactionalFixtures", () => {
         static override tableName = "test_mysql_not_null_defaults";
         // Rails' AR test suite runs with the framework default
         // `partial_inserts = true` (dirty.rb:50), which the trails harness flips
-        // to false via `load_defaults 7.0` (test-setup-ar.ts). Restore the Rails
+        // to false via `load_defaults 7.0` (cases/helper.ts). Restore the Rails
         // test-env value here so `new` (no attrs) omits the NOT NULL columns from
         // the INSERT — letting the DB apply implicit 0/"" defaults in non-strict
         // mode — exactly as Rails exercises this test.

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -502,7 +502,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     // Rides the canonical reflection-based `EncryptedBook` (name via schema
     // reflection, non-null default `<untitled>`), mirroring Rails'
     // `EncryptedBook.create!`. Encryption is configured suite-wide before the
-    // model loads (test-setup-ar.ts), so the reflected column default is
+    // model loads (cases/helper.ts), so the reflected column default is
     // threaded into the EncryptedAttributeType and round-trips through the
     // plaintext-default guard on first read — no `Failed to deserialize`.
     await freshAdapter();
@@ -801,7 +801,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     // Rides the canonical reflection-based `EncryptedBookNormalized{First,Second}`
     // (name obtained via schema reflection, non-null default `<untitled>`), not
     // an explicit `attribute("name", ...)` declaration. Encryption is configured
-    // suite-wide before these models load (test-setup-ar.ts), so the bare
+    // suite-wide before these models load (cases/helper.ts), so the bare
     // `encrypts` builds its scheme against real key material.
     await freshAdapter();
     await assertEncryptedAttribute(

--- a/packages/activerecord/src/encryption/scheme.test.ts
+++ b/packages/activerecord/src/encryption/scheme.test.ts
@@ -89,7 +89,7 @@ describe("ActiveRecord::Encryption::SchemeTest", () => {
   });
 
   it("keyProvider returns undefined when no key/keyProvider/deterministic configured", () => {
-    // The suite-wide bootstrap (test-setup-ar.ts, mirroring Rails helper.rb)
+    // The suite-wide bootstrap (cases/helper.ts, mirroring Rails helper.rb)
     // configures a global primary key, so clear it locally to exercise the
     // truly-unconfigured resolution path.
     const c = Configurable.config;

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -30,7 +30,7 @@ export { withEncryptionContext, withoutEncryption, DecryptionError, EncryptionEr
 
 // ─── Test key material ────────────────────────────────────────────────────────
 
-// Single source of truth shared with the suite-wide bootstrap (test-setup-ar.ts).
+// Single source of truth shared with the suite-wide bootstrap (cases/helper.ts).
 export { TEST_PRIMARY_KEY, TEST_DETERMINISTIC_KEY, TEST_KEY_DERIVATION_SALT } from "./test-keys.js";
 import { TEST_PRIMARY_KEY, TEST_DETERMINISTIC_KEY, TEST_KEY_DERIVATION_SALT } from "./test-keys.js";
 

--- a/packages/activerecord/src/encryption/test-keys.ts
+++ b/packages/activerecord/src/encryption/test-keys.ts
@@ -1,6 +1,6 @@
 /**
  * Canonical encryption test key material — the single source of truth shared by
- * the suite-wide bootstrap (`test-setup-ar.ts`, mirroring Rails'
+ * the suite-wide bootstrap (`cases/helper.ts`, mirroring Rails'
  * `activerecord/test/cases/helper.rb:99-102`) and the encryption test helpers
  * (`configureEncryption`). Keeping one copy means fixtures encrypted at load
  * and rows written/read across suites always use the same keys.

--- a/packages/activerecord/src/hot-compatibility.test.ts
+++ b/packages/activerecord/src/hot-compatibility.test.ts
@@ -70,7 +70,7 @@ describe("HotCompatibilityTest", () => {
     // (dirty.rb:50); only attributes assigned away from their default are
     // written, so the dropped `bar` is simply omitted from the INSERT. The
     // trails test harness flips this to false via `load_defaults("7.0")`
-    // (test-setup-ar.ts), so restore the Rails-ambient default for this model.
+    // (cases/helper.ts), so restore the Rails-ambient default for this model.
     HotCompatibility.partialInserts = true;
 
     return { klass: HotCompatibility, adapter };

--- a/packages/activerecord/src/relation/delegation.test.ts
+++ b/packages/activerecord/src/relation/delegation.test.ts
@@ -49,7 +49,7 @@ describe("DelegationTest", () => {
     // is delegated-with-scoping, mutating the global scope — the bug the guard
     // bans from AR's own code.
     // The AR test harness bans base-method delegation suite-wide
-    // (test-setup-ar.ts, mirroring helper.rb:29), so restore that `false`
+    // (cases/helper.ts, mirroring helper.rb:29), so restore that `false`
     // default — not Rails' production `true` — after each case.
     afterEach(() => {
       DelegateCache.delegateBaseMethods = false;

--- a/packages/activerecord/src/support/skip-global-reset.ts
+++ b/packages/activerecord/src/support/skip-global-reset.ts
@@ -1,6 +1,6 @@
 /**
  * Refcount of active `withTransactionalFixtures` scopes. When > 0, the
- * global beforeEach in test-setup-ar.ts skips resetTestAdapterState() so a
+ * global beforeEach in cases/helper.ts skips resetTestAdapterState() so a
  * one-time schema set up in `beforeAll` survives across tests in the file.
  * Refcounted (not a bool) so nested describes / multiple suites that each
  * call withTransactionalFixtures don't clobber an outer scope's skip when

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -232,7 +232,7 @@ export function _resetPooledTestAdapterForTests(): void {
 /**
  * Reset every piece of module-level test-adapter state so the next test
  * starts from a clean slate. Called from a global `beforeEach` hook in
- * test-setup-ar.ts.
+ * cases/helper.ts.
  *
  * Row state is cleared by **truncating** the boot-laid canonical tables (RFC
  * 0059 lays the canonical schema once at boot and keeps it shape-stable, so

--- a/packages/activerecord/src/test-helpers/use-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.test.ts
@@ -81,7 +81,7 @@ async function setupScopedEncryption(): Promise<() => void> {
 }
 
 // Shield the WHOLE file from the global `resetTestAdapterState()` beforeEach
-// (test-setup-ar.ts), which drops every table on `Base.connection` — the
+// (cases/helper.ts), which drops every table on `Base.connection` — the
 // boot-laid canonical worker DB. The real-seeding describes below each shield
 // themselves (their `withTransactionalFixtures` push/pops the skip), but
 // the mock-adapter describes above them do NOT: their tests trigger the reset

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
@@ -120,7 +120,7 @@ function pooledAdapterPool(adapter: TransactionalFixturesAdapter): ConnectionPoo
  * `setup_fixtures` opens a transaction; `teardown_fixtures` rolls back).
  *
  * Files calling this helper opt out of the global `resetTestAdapterState`
- * beforeEach (in `test-setup-ar.ts`) for their duration, so a one-time
+ * beforeEach (in `cases/helper.ts`) for their duration, so a one-time
  * schema set up in `beforeAll` survives across tests. The helper runs
  * `resetTestAdapterState` in its own `afterAll` so other files are
  * unaffected.

--- a/packages/activerecord/src/test-setup-dy.ts
+++ b/packages/activerecord/src/test-setup-dy.ts
@@ -8,7 +8,7 @@
  * Handler-path test files re-establish the connection in their own beforeAll
  * via setupHandlerSuite() → establishFromTestConfig().
  *
- * Must run AFTER test-setup-ar.ts so better-sqlite3 is registered and
+ * Must run AFTER cases/helper.ts so better-sqlite3 is registered and
  * Base.establishConnection can open the pool.
  *
  * Driver gate (RFC 0002 §Design):

--- a/packages/activerecord/src/test-setup-worker-db.ts
+++ b/packages/activerecord/src/test-setup-worker-db.ts
@@ -29,7 +29,7 @@
 
 import pg from "pg";
 import mysql from "mysql2/promise";
-// Eagerly load better-sqlite3 here (not just in test-setup-ar.ts): this
+// Eagerly load better-sqlite3 here (not just in cases/helper.ts): this
 // setupFile runs first, and ensureWorkerClone() needs the driver's
 // restoreFromPath backup primitive to clone the template into the per-worker
 // file.

--- a/packages/activerecord/src/trailtie.test.ts
+++ b/packages/activerecord/src/trailtie.test.ts
@@ -65,7 +65,7 @@ describe("RailtieTest", () => {
     Base.partialInserts = savedPartialInserts;
     setRaiseOnAssignToAttrReadonly(savedRaiseOnAssignToAttrReadonly);
     // The suite boots with extended query support installed
-    // (test-setup-ar.ts, mirroring helper.rb:104-107); tests here uninstall it
+    // (cases/helper.ts, mirroring helper.rb:104-107); tests here uninstall it
     // to observe the initializer doing the install, so put it back.
     EncryptionConfigurable.config.extendQueries = savedExtendQueries;
     installExtendedQueriesIfConfigured();

--- a/packages/activerecord/src/view.test.ts
+++ b/packages/activerecord/src/view.test.ts
@@ -227,7 +227,7 @@ describe("UpdateableViewTest", () => {
     static override _primaryKey = "id";
     // Rails' AR test suite runs with the class default `partial_inserts = true`
     // (helper.rb never flips it — only a `config.load_defaults 7.0+` app does),
-    // while our test-setup-ar.ts deliberately runs loadDefaults("7.0"), i.e.
+    // while our cases/helper.ts deliberately runs loadDefaults("7.0"), i.e.
     // partialInserts=false. That difference is fatal here on MySQL only: the
     // updatable view reports its NOT-NULL `id` with a fabricated default "0"
     // (SHOW FULL FIELDS strips `auto_increment` from Extra, so the column is

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -80,7 +80,7 @@ const ADAPTER_SPECIFIC_EXCLUDE =
 
 // Low-level SQLite driver wrappers + the adapter driver-binding tests. These
 // are pure unit tests that construct adapters/drivers directly and must NOT
-// load test-setup-ar, whose connection bootstrap opens a DB at module load.
+// load cases/helper.ts, whose connection bootstrap opens a DB at module load.
 // Run them in their own setup-free project.
 const SQLITE_DRIVER_TESTS = [
   "packages/activerecord/src/sqlite/**/*.test.ts",
@@ -362,7 +362,7 @@ export default defineConfig({
           globalSetup: ["./packages/activerecord/src/support/template-global-setup.ts"],
           setupFiles: [
             "./packages/activerecord/src/test-setup-worker-db.ts",
-            "./packages/activerecord/src/test-setup-ar.ts",
+            "./packages/activerecord/src/cases/helper.ts",
             ...(process.env.ARCONN === "mysql2"
               ? ["./packages/activerecord/src/test-setup-mysql.ts"]
               : []),


### PR DESCRIPTION
Renames `packages/activerecord/src/test-setup-ar.ts` to
`packages/activerecord/src/cases/helper.ts`, matching the Rails file it is the
counterpart of (`activerecord/test/cases/helper.rb` — the file already carries
four `Mirror Rails .../helper.rb:NN` markers). `test-setup-ar.ts` was a trails
invention.

Single mechanical rename, no behavior change: the same settings run in the same
order, and the file stays the **second** setupFile — after
`test-setup-worker-db.ts` and before `test-setup-dy.ts`, which depends on the
better-sqlite3 driver this file registers.

Also updated:

- `vitest.config.ts` setupFiles entry + the boot-order prose above it.
- `eslint.config.mjs` `no-raw-sql` scope-out glob, and the hardcoded
  `/(^|\/)test-setup-[^/]*\.ts$/` regex in `eslint/no-raw-sql.mjs` — a
  `cases/helper.ts` path no longer matches it and would otherwise start failing
  `no-raw-sql`.
- The file's own stale header, which described a sibling `test-setup.ts` that no
  longer exists.
- Prose references to the old filename across `packages/activerecord`. (Stale
  mentions under `docs/activerecord/` are left alone — that tree is frozen by
  RFC 0011 Phase 4.)

Verified: `pnpm typecheck` (pre-push hook) and
`vitest run packages/activerecord/src/relation/delegation.test.ts`, which asserts
against a setting this setup file installs — 81 passed.

Closes-story: rename-test-setup-ar-to-cases-helper
