### PR TITLE
fix(activerecord): repoint stale canonical-model-index imports at support/

### DIFF
--- a/packages/activerecord/src/relation/where-chain.test.ts
+++ b/packages/activerecord/src/relation/where-chain.test.ts
@@ -17,7 +17,7 @@ import { Essay } from "../test-helpers/models/essay.js";
 import { CpkAuthor, CpkBook } from "../test-helpers/models/cpk.js";
 // Zeitwerk analog: Cpk::Book's counter-cached/association targets (Cpk::Order)
 // are resolved by name, as Rails resolves them from the autoloaded models tree.
-import "../test-helpers/canonical-model-index.js";
+import "../support/canonical-model-index.js";
 
 registerModel(Post);
 registerModel(Comment);

--- a/packages/activerecord/src/token-for.test.ts
+++ b/packages/activerecord/src/token-for.test.ts
@@ -14,7 +14,7 @@ import { generatesTokenFor, setTokenForSecret } from "./token-for.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 // Zeitwerk analog: Cpk::Book's counter-cached/association targets (Cpk::Order)
 // are resolved by name, as Rails resolves them from the autoloaded models tree.
-import "./test-helpers/canonical-model-index.js";
+import "./support/canonical-model-index.js";
 
 // Rails: class User < ::User { generates_token_for :lookup; … }
 class TokenUser extends User {

--- a/packages/activerecord/src/validations/uniqueness-validation.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.test.ts
@@ -30,7 +30,7 @@ import { Essay } from "../test-helpers/models/essay.js";
 import { CpkAuthor, CpkBook } from "../test-helpers/models/cpk.js";
 // Zeitwerk analog: Cpk::Book's counter-cached/association targets (Cpk::Order)
 // are resolved by name, as Rails resolves them from the autoloaded models tree.
-import "../test-helpers/canonical-model-index.js";
+import "../support/canonical-model-index.js";
 
 const INT_MAX_VALUE = 2147483647;
 


### PR DESCRIPTION
Three AR test files merged concurrently with #5361 (which moved AR test support helpers to `support/`) still import `test-helpers/canonical-model-index.js`. The unresolved specifier failed collection on **every** AR shard on main @8cd1796f — SQLite, PostgreSQL 1/2, MariaDB 1/2.

Repoints the three imports at `support/canonical-model-index.js`:

- `token-for.test.ts`
- `relation/where-chain.test.ts`
- `validations/uniqueness-validation.test.ts`

Verified locally: 126 passed, 2 skipped across the three files.

Closes-story: red-8cd1796f
