### PR TITLE
refactor(activerecord): mirror ARTest config/connection in support/config.ts + support/connection.ts

### DIFF
--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -24,7 +24,7 @@ import { fixtures } from "./test-helpers/fixtures.js";
 import { adapterType } from "./test-adapter.js";
 import { inMemoryDb } from "./support/adapter-helper.js";
 import { itIfSupports } from "./support/supports.js";
-import { establishFromTestConfig } from "./support/test-database-config.js";
+import { establishFromTestConfig } from "./support/connection.js";
 import { runWithoutConnection } from "./support/connection-helper.js";
 // Opt into the canonical-model autoload index so association targets resolve by
 // name on first reference — no manual `registerModel`.

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
@@ -3,10 +3,10 @@ import mysql from "mysql2/promise";
 import { Mysql2Adapter } from "../../connection-adapters/mysql2-adapter.js";
 import { Version } from "../../connection-adapters/abstract-adapter.js";
 import { arunitDatabaseNames } from "../../support/arunit2-config.js";
-import { mysqlSettings, mysqlUrl } from "../../support/test-connection-env.js";
+import { mysqlSettings, mysqlUrl } from "../../support/config.js";
 import { adapterType } from "../../test-adapter.js";
 import { Base } from "../../base.js";
-import { establishFromTestConfig } from "../../support/test-database-config.js";
+import { establishFromTestConfig } from "../../support/connection.js";
 
 // `dbWarningsAction` is a single global setting on the base adapter, so the
 // shared helper toggles it for every adapter (including MySQL). Re-exported

--- a/packages/activerecord/src/adapters/postgresql/test-helper.ts
+++ b/packages/activerecord/src/adapters/postgresql/test-helper.ts
@@ -4,7 +4,7 @@ import { PostgreSQLAdapter } from "../../connection-adapters/postgresql-adapter.
 import { pgDatetimeConfig } from "../../connection-adapters/postgresql/pg-datetime-config.js";
 import { Notifications, squish } from "@blazetrails/activesupport";
 import type { NotificationSubscriber, NotificationEvent } from "@blazetrails/activesupport";
-import { postgresUrl } from "../../support/test-connection-env.js";
+import { postgresUrl } from "../../support/config.js";
 
 // A *serialization* of the PG sub-settings (PGHOST/PGPORT/PGUSER/PGPASSWORD/
 // PGDATABASE), not an env var of its own: these adapter suites probe the server

--- a/packages/activerecord/src/connection-adapters/standalone-connection.test.ts
+++ b/packages/activerecord/src/connection-adapters/standalone-connection.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
 import { Base } from "../index.js";
-import { establishFromTestConfig } from "../support/test-database-config.js";
+import { establishFromTestConfig } from "../support/connection.js";
 import type { AbstractAdapter } from "./abstract-adapter.js";
 
 describe("StandaloneConnectionTest", () => {

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -904,8 +904,18 @@ describe("establish_connection accepts a DatabaseConfig", () => {
 describe("loadConfigFile resolves config/database.* against Trails.root", () => {
   let tmpRoot: string;
 
+  // See establish-connection.test.ts: the worker's setup file assigns
+  // `Base.configurations`, which short-circuits the config-file lookup this
+  // seam exists to exercise.
+  const originalConfigurations = Base.configurations();
+
+  beforeEach(() => {
+    Base.configurations({});
+  });
+
   afterEach(async () => {
     setTrailsRoot(null);
+    Base.configurations(originalConfigurations);
     await Base.connectionHandler.clearAllConnectionsBang();
     if (tmpRoot) nodeFs.rmSync(tmpRoot, { recursive: true, force: true });
   });

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -17,7 +17,7 @@ import {
 } from "./core.js";
 import { setTrailsRoot } from "@blazetrails/activesupport";
 import type { DatabaseConfig } from "./database-configurations/database-config.js";
-import { establishFromTestConfig } from "./support/test-database-config.js";
+import { establishFromTestConfig } from "./support/connection.js";
 import { adapterType } from "./test-adapter.js";
 import * as nodeFs from "node:fs";
 import * as nodeOs from "node:os";

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -7,7 +7,7 @@
 
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import type { TestDatabaseAdapter } from "../test-adapter.js";
-import { establishFromTestConfig } from "../support/test-database-config.js";
+import { establishFromTestConfig } from "../support/connection.js";
 import { ensureCanonicalTables } from "../support/canonical-schema.js";
 import { Base } from "../index.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";

--- a/packages/activerecord/src/establish-connection.test.ts
+++ b/packages/activerecord/src/establish-connection.test.ts
@@ -103,8 +103,15 @@ describe("Base.establishConnection with config file", () => {
   const tempDir = join(tmpdir(), `trails-test-${process.pid}`);
   const configPath = join(tempDir, "database.json");
 
+  // These cases exercise the no-configurations bootstrap (config file /
+  // DATABASE_URL). The worker's setup file runs ARTest.connect's port, which
+  // assigns `Base.configurations` as `connection.rb:31` does, so it has to be
+  // cleared for the fallback path to be reachable at all.
+  const originalConfigurations = Base.configurations();
+
   beforeEach(async () => {
     await resetConnection();
+    Base.configurations({});
     mkdirSync(tempDir, { recursive: true });
     Base._configPath = configPath;
   });
@@ -121,6 +128,7 @@ describe("Base.establishConnection with config file", () => {
       process.env.NODE_ENV = originalNodeEnv;
     }
     Base._configPath = null;
+    Base.configurations(originalConfigurations);
     await resetConnection();
     try {
       rmSync(tempDir, { recursive: true });
@@ -207,9 +215,11 @@ describe("Base.establishConnection with JS config file", () => {
   const originalCwd = process.cwd();
   const tempDir = join(tmpdir(), `trails-jsconfig-${process.pid}`);
   const configDir = join(tempDir, "config");
+  const originalConfigurations = Base.configurations();
 
   beforeEach(async () => {
     await resetConnection();
+    Base.configurations({});
     mkdirSync(configDir, { recursive: true });
     process.chdir(tempDir);
   });
@@ -227,6 +237,7 @@ describe("Base.establishConnection with JS config file", () => {
     }
     process.chdir(originalCwd);
     Base._configPath = null;
+    Base.configurations(originalConfigurations);
     await resetConnection();
     try {
       rmSync(tempDir, { recursive: true });

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -13,7 +13,7 @@ import {
   dumpTableSchema,
   FULL_DUMP_TIMEOUT_MS,
 } from "./support/schema-dumping-helper.js";
-import { establishFromTestConfig } from "./support/test-database-config.js";
+import { establishFromTestConfig } from "./support/connection.js";
 
 // The first describe uses `fixtures({})` (canonical schema + reset shield);
 // the later bespoke-table describes deliberately keep the global per-test reset,

--- a/packages/activerecord/src/support/adapter-helper.ts
+++ b/packages/activerecord/src/support/adapter-helper.ts
@@ -30,7 +30,7 @@
  */
 
 import { adapterType } from "../test-adapter.js";
-import { configuredConnectionHash } from "./test-database-config.js";
+import { configuredConnectionHash } from "./connection.js";
 import { Base } from "../base.js";
 
 export type AdapterClassName =

--- a/packages/activerecord/src/support/arunit2-config.ts
+++ b/packages/activerecord/src/support/arunit2-config.ts
@@ -23,14 +23,14 @@
 
 import { getEnv } from "@blazetrails/activesupport";
 import {
-  activeLane,
   mysqlSettings,
   postgresSettings,
   settingsUrl,
   withDatabase,
   type EnvReader,
   type TestAdapterName,
-} from "./test-connection-env.js";
+} from "./config.js";
+import { activeLane } from "./connection.js";
 
 export type { TestAdapterName };
 

--- a/packages/activerecord/src/support/canonical-schema-bulk-inbound-fk.test.ts
+++ b/packages/activerecord/src/support/canonical-schema-bulk-inbound-fk.test.ts
@@ -15,7 +15,7 @@ import { beforeAll, describe, expect, it } from "vitest";
 import { Base } from "../base.js";
 import { rebuildCanonicalTables } from "./canonical-schema.js";
 import { setupHandlerSuite } from "./setup-handler-suite.js";
-import { activeLane } from "./test-connection-env.js";
+import { activeLane } from "./connection.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 
 const lane = activeLane();

--- a/packages/activerecord/src/support/config.test.ts
+++ b/packages/activerecord/src/support/config.test.ts
@@ -1,22 +1,21 @@
 import { describe, expect, it } from "vitest";
 import {
-  activeLane,
   driverConfig,
   settingsUrl,
-  connectionName,
   mysqlSettings,
   mysqlUrl,
   postgresSettings,
   postgresUrl,
   withDatabase,
-} from "./test-connection-env.js";
+} from "./config.js";
+import { activeLane, connectionName } from "./connection.js";
 
 /** A stub env reader backed by a fixed map (no ambient env mutation). */
 function reader(env: Record<string, string | undefined>): (key: string) => string | undefined {
   return (key) => env[key];
 }
 
-describe("test-connection-env", () => {
+describe("config", () => {
   it("selects the connection named by ARCONN", () => {
     expect(connectionName(reader({ ARCONN: "mysql2" }))).toBe("mysql2");
     expect(activeLane(reader({ ARCONN: "mysql2" }))).toBe("mysql");

--- a/packages/activerecord/src/support/config.test.ts
+++ b/packages/activerecord/src/support/config.test.ts
@@ -23,9 +23,14 @@ describe("config", () => {
     expect(activeLane(reader({ ARCONN: "sqlite3_mem" }))).toBe("sqlite");
   });
 
-  it("falls back to the default_connection when ARCONN is unset or empty", () => {
+  it("falls back to the default_connection when ARCONN is unset", () => {
     expect(connectionName(reader({}))).toBe("sqlite3");
-    expect(activeLane(reader({ ARCONN: "" }))).toBe("sqlite");
+  });
+
+  it("treats an empty ARCONN as a connection name, not as unset", () => {
+    // Ruby's `ENV["ARCONN"] || config["default_connection"]` falls back on nil
+    // alone, so "" is a selected name and takes the unknown-name path.
+    expect(connectionName(reader({ ARCONN: "" }))).toBe("");
   });
 
   it("never selects a backend from a connection sub-setting", () => {
@@ -82,7 +87,6 @@ describe("config", () => {
     expect(settings.host).toBe("localhost");
     expect(settings.database).toBe("rails_js_test");
     expect(settings.socket).toBeUndefined();
-    expect(activeLane(reader({ ARCONN: "" }))).toBe("sqlite");
   });
 
   it("raises on a malformed slot rather than sharing the base database", () => {

--- a/packages/activerecord/src/support/config.ts
+++ b/packages/activerecord/src/support/config.ts
@@ -85,7 +85,7 @@ export type EnvReader = (key: string) => string | undefined;
  * `Access denied for user ''`. This matches the convention already used by
  * `MySQLDatabaseTasks#resolvedField`, which likewise rejects `""`.
  */
-export function present(read: EnvReader, key: string): string | undefined {
+function present(read: EnvReader, key: string): string | undefined {
   const value = read(key);
   return value === undefined || value === "" ? undefined : value;
 }

--- a/packages/activerecord/src/support/config.ts
+++ b/packages/activerecord/src/support/config.ts
@@ -1,6 +1,19 @@
 /**
- * The environment surface of the test harness, mirroring
- * `vendor/rails/activerecord/test/config.example.yml`.
+ * The test harness' configuration, mirroring
+ * `vendor/rails/activerecord/test/support/config.rb` — Rails' `ARTest.config`,
+ * i.e. the parsed `test/config.yml` (whose shape is
+ * `vendor/rails/activerecord/test/config.example.yml`).
+ *
+ * Rails reads a YAML file off disk; trails has no `config.yml` to read, so the
+ * `connections:` hash is expressed directly here as `DEFAULT_CONNECTION` /
+ * `CONNECTION_LANES` plus the sub-setting readers below, and the named-entry
+ * builders live in `connection.ts` next to the code that fetches them. There is
+ * therefore no `configFile` / `readConfig` pair to port: those are the file IO
+ * `ARTest.config` memoizes, and with no file there is nothing to read or copy
+ * from `config.example.yml`. The `test/config.rb` path constants (`TEST_ROOT`,
+ * `FIXTURES_ROOT`, `SCHEMA_ROOT`, …) are likewise absent — nothing in trails
+ * resolves fixtures or schema by path from a test root; `test-helpers/` is
+ * imported as modules.
  *
  * Rails splits the two concerns this module keeps apart:
  *
@@ -72,7 +85,7 @@ export type EnvReader = (key: string) => string | undefined;
  * `Access denied for user ''`. This matches the convention already used by
  * `MySQLDatabaseTasks#resolvedField`, which likewise rejects `""`.
  */
-function present(read: EnvReader, key: string): string | undefined {
+export function present(read: EnvReader, key: string): string | undefined {
   const value = read(key);
   return value === undefined || value === "" ? undefined : value;
 }
@@ -88,30 +101,6 @@ function intSetting(read: EnvReader, key: string, fallback: number): number {
     throw new Error(`${key} must be an integer, got ${JSON.stringify(raw)}`);
   }
   return parsed;
-}
-
-/**
- * The connection name selected by `ARCONN`, falling back to
- * {@link DEFAULT_CONNECTION}. Mirrors `connection.rb:10`.
- *
- * Returns a bare `string`, not a {@link ConnectionName}: `ARCONN` is arbitrary
- * user input, and asserting it into the union here would be a type lie that
- * makes the unknown-name branch look unreachable to every caller.
- * `test-database-config.ts` owns Rails' "Connection not found" failure, so the
- * error surfaces once, at config-build time.
- */
-export function connectionName(read: EnvReader = getEnv): string {
-  return present(read, "ARCONN") ?? DEFAULT_CONNECTION;
-}
-
-/**
- * The backend lane the current `ARCONN` drives. Unknown names resolve to the
- * default connection's lane; the loud failure for those belongs to
- * `test-database-config.ts`, not to every lane predicate in the harness.
- */
-export function activeLane(read: EnvReader = getEnv): TestAdapterName {
-  const lanes: Partial<Record<string, TestAdapterName>> = CONNECTION_LANES;
-  return lanes[connectionName(read)] ?? CONNECTION_LANES[DEFAULT_CONNECTION];
 }
 
 /** Connection details for a server-backed lane, assembled from sub-settings. */

--- a/packages/activerecord/src/support/connection.test.ts
+++ b/packages/activerecord/src/support/connection.test.ts
@@ -50,6 +50,29 @@ describe("connect", () => {
     expect(withoutPrepared.configurationHash.preparedStatements).toBe(false);
   });
 
+  it("keeps per-entry options rather than cloning arunit onto the others", async () => {
+    vi.stubEnv("ARCONN", "mysql2");
+    const [arunit, arunit2, withoutPrepared] = (await testConfigurationHashes())
+      .configurationHashes;
+    // config.example.yml:5,25 — the two entries differ in collation, and only
+    // arunit carries the time_zone variable.
+    expect(arunit.configurationHash.collation).toBe("utf8mb4_unicode_ci");
+    expect(arunit2.configurationHash.collation).toBe("utf8mb4_general_ci");
+    expect(arunit.configurationHash.variables).toEqual({ time_zone: "+00:00" });
+    expect(arunit2.configurationHash.variables).toBeUndefined();
+    // mysql2 omits the third entry, so expand_config synthesizes it.
+    expect(withoutPrepared.configurationHash.collation).toBeUndefined();
+    expect(withoutPrepared.adapter).toBe("mysql2");
+  });
+
+  it("carries min_messages on every postgresql entry", async () => {
+    vi.stubEnv("ARCONN", "postgresql");
+    const { configurationHashes } = await testConfigurationHashes();
+    expect(configurationHashes.every((c) => c.configurationHash.minMessages === "warning")).toBe(
+      true,
+    );
+  });
+
   it("resolves the established pool from the arunit entry by name", async () => {
     vi.stubEnv("ARCONN", "sqlite3");
     await connect();

--- a/packages/activerecord/src/support/connection.test.ts
+++ b/packages/activerecord/src/support/connection.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect, afterEach, vi } from "vitest";
 import { DatabaseTasks } from "../tasks/database-tasks.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { registerDbFileCleanupOnExit } from "./sqlite-template.js";
-import { buildTestDatabaseConfig } from "./test-database-config.js";
+import { connect } from "./connection.js";
 
-describe("buildTestDatabaseConfig", () => {
+describe("connect", () => {
   afterEach(() => {
     DatabaseTasks.databaseConfiguration = null;
     DatabaseTasks.clearRegisteredTasks();
@@ -12,7 +12,7 @@ describe("buildTestDatabaseConfig", () => {
   });
 
   it("sets databaseConfiguration and returns a test-env config", async () => {
-    const { configs, envConfig } = await buildTestDatabaseConfig();
+    const { configs, envConfig } = await connect();
     expect(DatabaseTasks.databaseConfiguration).toBeInstanceOf(DatabaseConfigurations);
     expect(envConfig.envName).toBe("test");
     expect(configs.findDbConfig("test")).toBeDefined();
@@ -20,7 +20,7 @@ describe("buildTestDatabaseConfig", () => {
 
   it("selects the sqlite3 connection named by ARCONN", async () => {
     vi.stubEnv("ARCONN", "sqlite3");
-    const { adapter, envConfig } = await buildTestDatabaseConfig();
+    const { adapter, envConfig } = await connect();
     expect(adapter).toBe("sqlite");
     expect(envConfig.adapter).toMatch(/sqlite/i);
     expect(DatabaseTasks.resolveTask("sqlite3")).toBeDefined();
@@ -28,21 +28,21 @@ describe("buildTestDatabaseConfig", () => {
 
   it("falls back to the default_connection (sqlite3) when ARCONN is unset", async () => {
     vi.stubEnv("ARCONN", "");
-    const { adapter } = await buildTestDatabaseConfig();
+    const { adapter } = await connect();
     expect(adapter).toBe("sqlite");
   });
 
   it("inherits Rails' default pool size (5) on the file-backed lane", async () => {
     vi.stubEnv("ARCONN", "sqlite3");
     vi.stubEnv("AR_TEST_WORKER_DB", "/tmp/ar-test-worker.sqlite3");
-    const { envConfig } = await buildTestDatabaseConfig();
+    const { envConfig } = await connect();
     expect(envConfig.pool).toBe(5);
   });
 
   it("falls back to a file-backed sqlite DB when AR_TEST_WORKER_DB is unset", async () => {
     vi.stubEnv("ARCONN", "sqlite3");
     vi.stubEnv("AR_TEST_WORKER_DB", "");
-    const { envConfig } = await buildTestDatabaseConfig();
+    const { envConfig } = await connect();
     expect(envConfig.database).not.toBe(":memory:");
     expect(envConfig.database).toMatch(/\.sqlite$/);
     expect(envConfig.pool).toBe(5);
@@ -51,15 +51,15 @@ describe("buildTestDatabaseConfig", () => {
   it("reuses one fallback database path across calls", async () => {
     vi.stubEnv("ARCONN", "sqlite3");
     vi.stubEnv("AR_TEST_WORKER_DB", "");
-    const first = (await buildTestDatabaseConfig()).envConfig.database;
-    const second = (await buildTestDatabaseConfig()).envConfig.database;
+    const first = (await connect()).envConfig.database;
+    const second = (await connect()).envConfig.database;
     expect(second).toBe(first);
   });
 
   it("registers the fallback database for cleanup on exit", async () => {
     vi.stubEnv("ARCONN", "sqlite3");
     vi.stubEnv("AR_TEST_WORKER_DB", "");
-    const database = String((await buildTestDatabaseConfig()).envConfig.database);
+    const database = String((await connect()).envConfig.database);
 
     const before = new Set(process.listeners("exit"));
     await registerDbFileCleanupOnExit(database);
@@ -69,33 +69,33 @@ describe("buildTestDatabaseConfig", () => {
   it("prefers AR_TEST_WORKER_DB over the fallback database", async () => {
     vi.stubEnv("ARCONN", "sqlite3");
     vi.stubEnv("AR_TEST_WORKER_DB", "/tmp/ar-test-worker.sqlite3");
-    const { envConfig } = await buildTestDatabaseConfig();
+    const { envConfig } = await connect();
     expect(envConfig.database).toBe("/tmp/ar-test-worker.sqlite3");
   });
 
   it("pins pool 1 on the sqlite3_mem :memory: connection", async () => {
     vi.stubEnv("ARCONN", "sqlite3_mem");
     vi.stubEnv("AR_TEST_WORKER_DB", "");
-    const { adapter, envConfig } = await buildTestDatabaseConfig();
+    const { adapter, envConfig } = await connect();
     expect(adapter).toBe("sqlite");
     expect(envConfig.pool).toBe(1);
   });
 
   it("selects the postgresql connection named by ARCONN", async () => {
     vi.stubEnv("ARCONN", "postgresql");
-    const { adapter } = await buildTestDatabaseConfig();
+    const { adapter } = await connect();
     expect(adapter).toBe("postgres");
   });
 
   it("selects the mysql2 connection named by ARCONN", async () => {
     vi.stubEnv("ARCONN", "mysql2");
-    const { adapter } = await buildTestDatabaseConfig();
+    const { adapter } = await connect();
     expect(adapter).toBe("mysql");
   });
 
   it("fails loudly when ARCONN names an unconfigured connection", async () => {
     vi.stubEnv("ARCONN", "oracle");
-    await expect(buildTestDatabaseConfig()).rejects.toThrow(/Connection "oracle" not found/);
+    await expect(connect()).rejects.toThrow(/Connection "oracle" not found/);
   });
 
   // The adapter-name guard (`connection.rb:35-37`) used to be tripped by a
@@ -106,7 +106,7 @@ describe("buildTestDatabaseConfig", () => {
     "builds an adapter whose name is contained in the connection name (%s)",
     async (name) => {
       vi.stubEnv("ARCONN", name);
-      const { envConfig } = await buildTestDatabaseConfig();
+      const { envConfig } = await connect();
       expect(name).toContain(String(envConfig.adapter));
     },
   );

--- a/packages/activerecord/src/support/connection.test.ts
+++ b/packages/activerecord/src/support/connection.test.ts
@@ -23,11 +23,37 @@ describe("connect", () => {
     vi.unstubAllEnvs();
   });
 
-  it("sets databaseConfiguration and returns a test-env config", async () => {
+  it("sets databaseConfiguration and returns the arunit config", async () => {
     const { configs, envConfig } = await connect();
     expect(DatabaseTasks.databaseConfiguration).toBeInstanceOf(DatabaseConfigurations);
-    expect(envConfig.envName).toBe("test");
-    expect(configs.findDbConfig("test")).toBeDefined();
+    expect(envConfig.envName).toBe("arunit");
+    expect(configs.findDbConfig("arunit")).toBeDefined();
+  });
+
+  it("publishes the three named entries expand_config builds", async () => {
+    const { configurationHashes } = await testConfigurationHashes();
+    expect(configurationHashes.map((c) => c.envName)).toEqual([
+      "arunit",
+      "arunit2",
+      "arunit_without_prepared_statements",
+    ]);
+    expect(configurationHashes.every((c) => c.name === "primary")).toBe(true);
+  });
+
+  it("gives arunit2 its own database and disables prepared statements on the third entry", async () => {
+    vi.stubEnv("ARCONN", "postgresql");
+    const { configurationHashes } = await testConfigurationHashes();
+    const [arunit, arunit2, withoutPrepared] = configurationHashes;
+    expect(arunit2.database).not.toBe(arunit.database);
+    expect(arunit2.database).toMatch(/_arunit2$/);
+    expect(withoutPrepared.database).toBe(arunit.database);
+    expect(withoutPrepared.configurationHash.preparedStatements).toBe(false);
+  });
+
+  it("resolves the established pool from the arunit entry by name", async () => {
+    vi.stubEnv("ARCONN", "sqlite3");
+    await connect();
+    expect(Base.connectionDbConfig().envName).toBe("arunit");
   });
 
   it("selects the sqlite3 connection named by ARCONN", async () => {

--- a/packages/activerecord/src/support/connection.test.ts
+++ b/packages/activerecord/src/support/connection.test.ts
@@ -2,12 +2,24 @@ import { describe, it, expect, afterEach, vi } from "vitest";
 import { DatabaseTasks } from "../tasks/database-tasks.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { registerDbFileCleanupOnExit } from "./sqlite-template.js";
-import { connect } from "./connection.js";
+import { Base } from "../base.js";
+import { connect, testConfigurationHashes } from "./connection.js";
 
+// Only the cases asserting `connect`'s own side effects call it; everything
+// that merely checks which entry `ARCONN` resolves to uses
+// `testConfigurationHashes`, which is the resolver alone. `connect` mirrors
+// `ARTest.connect` and so establishes the primary pool (`connection.rb:31-33`),
+// and a resolver assertion has no business opening one for a backend this
+// worker is not running against.
 describe("connect", () => {
+  const originalConfigurations = Base.configurations();
+
   afterEach(() => {
     DatabaseTasks.databaseConfiguration = null;
     DatabaseTasks.clearRegisteredTasks();
+    Base.configurations(originalConfigurations);
+    Base.removeConnection();
+    Base._adapter = null;
     vi.unstubAllEnvs();
   });
 
@@ -35,14 +47,14 @@ describe("connect", () => {
   it("inherits Rails' default pool size (5) on the file-backed lane", async () => {
     vi.stubEnv("ARCONN", "sqlite3");
     vi.stubEnv("AR_TEST_WORKER_DB", "/tmp/ar-test-worker.sqlite3");
-    const { envConfig } = await connect();
+    const { envConfig } = await testConfigurationHashes();
     expect(envConfig.pool).toBe(5);
   });
 
   it("falls back to a file-backed sqlite DB when AR_TEST_WORKER_DB is unset", async () => {
     vi.stubEnv("ARCONN", "sqlite3");
     vi.stubEnv("AR_TEST_WORKER_DB", "");
-    const { envConfig } = await connect();
+    const { envConfig } = await testConfigurationHashes();
     expect(envConfig.database).not.toBe(":memory:");
     expect(envConfig.database).toMatch(/\.sqlite$/);
     expect(envConfig.pool).toBe(5);
@@ -51,15 +63,15 @@ describe("connect", () => {
   it("reuses one fallback database path across calls", async () => {
     vi.stubEnv("ARCONN", "sqlite3");
     vi.stubEnv("AR_TEST_WORKER_DB", "");
-    const first = (await connect()).envConfig.database;
-    const second = (await connect()).envConfig.database;
+    const first = (await testConfigurationHashes()).envConfig.database;
+    const second = (await testConfigurationHashes()).envConfig.database;
     expect(second).toBe(first);
   });
 
   it("registers the fallback database for cleanup on exit", async () => {
     vi.stubEnv("ARCONN", "sqlite3");
     vi.stubEnv("AR_TEST_WORKER_DB", "");
-    const database = String((await connect()).envConfig.database);
+    const database = String((await testConfigurationHashes()).envConfig.database);
 
     const before = new Set(process.listeners("exit"));
     await registerDbFileCleanupOnExit(database);
@@ -69,33 +81,33 @@ describe("connect", () => {
   it("prefers AR_TEST_WORKER_DB over the fallback database", async () => {
     vi.stubEnv("ARCONN", "sqlite3");
     vi.stubEnv("AR_TEST_WORKER_DB", "/tmp/ar-test-worker.sqlite3");
-    const { envConfig } = await connect();
+    const { envConfig } = await testConfigurationHashes();
     expect(envConfig.database).toBe("/tmp/ar-test-worker.sqlite3");
   });
 
   it("pins pool 1 on the sqlite3_mem :memory: connection", async () => {
     vi.stubEnv("ARCONN", "sqlite3_mem");
     vi.stubEnv("AR_TEST_WORKER_DB", "");
-    const { adapter, envConfig } = await connect();
+    const { adapter, envConfig } = await testConfigurationHashes();
     expect(adapter).toBe("sqlite");
     expect(envConfig.pool).toBe(1);
   });
 
   it("selects the postgresql connection named by ARCONN", async () => {
     vi.stubEnv("ARCONN", "postgresql");
-    const { adapter } = await connect();
+    const { adapter } = await testConfigurationHashes();
     expect(adapter).toBe("postgres");
   });
 
   it("selects the mysql2 connection named by ARCONN", async () => {
     vi.stubEnv("ARCONN", "mysql2");
-    const { adapter } = await connect();
+    const { adapter } = await testConfigurationHashes();
     expect(adapter).toBe("mysql");
   });
 
   it("fails loudly when ARCONN names an unconfigured connection", async () => {
     vi.stubEnv("ARCONN", "oracle");
-    await expect(connect()).rejects.toThrow(/Connection "oracle" not found/);
+    await expect(testConfigurationHashes()).rejects.toThrow(/Connection "oracle" not found/);
   });
 
   // The adapter-name guard (`connection.rb:35-37`) used to be tripped by a
@@ -106,7 +118,7 @@ describe("connect", () => {
     "builds an adapter whose name is contained in the connection name (%s)",
     async (name) => {
       vi.stubEnv("ARCONN", name);
-      const { envConfig } = await connect();
+      const { envConfig } = await testConfigurationHashes();
       expect(name).toContain(String(envConfig.adapter));
     },
   );

--- a/packages/activerecord/src/support/connection.test.ts
+++ b/packages/activerecord/src/support/connection.test.ts
@@ -27,7 +27,7 @@ describe("connect", () => {
   });
 
   it("falls back to the default_connection (sqlite3) when ARCONN is unset", async () => {
-    vi.stubEnv("ARCONN", "");
+    vi.stubEnv("ARCONN", undefined);
     const { adapter } = await connect();
     expect(adapter).toBe("sqlite");
   });

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -30,6 +30,7 @@ import { DatabaseConfigurations } from "../database-configurations.js";
 import { DatabaseTasks } from "../tasks/database-tasks.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
 import { UrlConfig } from "../database-configurations/url-config.js";
+import { arunitDatabaseNames } from "./arunit2-config.js";
 import {
   CONNECTION_LANES,
   DEFAULT_CONNECTION,
@@ -102,7 +103,8 @@ interface NamedConnection {
   adapter: string;
   /** The public {@link TestAdapterName} lane this connection drives. */
   lane: TestAdapterName;
-  build(): Promise<HashConfig>;
+  /** The `arunit` hash; `expandConfig` derives the other named entries from it. */
+  build(): Promise<Record<string, unknown>>;
 }
 
 /**
@@ -129,24 +131,22 @@ const CONNECTIONS: Record<ConnectionName, NamedConnection> = {
   sqlite3: {
     adapter: "sqlite3",
     lane: "sqlite",
-    build: async () => new HashConfig("test", "primary", await sqliteHash()),
+    build: async () => await sqliteHash(),
   },
   sqlite3_mem: {
     adapter: "sqlite3",
     lane: "sqlite",
-    build: async () =>
-      new HashConfig("test", "primary", { adapter: "sqlite3", database: ":memory:", pool: 1 }),
+    build: async () => ({ adapter: "sqlite3", database: ":memory:", pool: 1 }),
   },
   postgresql: {
     adapter: "postgresql",
     lane: "postgres",
-    build: async () =>
-      new HashConfig("test", "primary", serverHash("postgresql", postgresSettings())),
+    build: async () => serverHash("postgresql", postgresSettings()),
   },
   mysql2: {
     adapter: "mysql2",
     lane: "mysql",
-    build: async () => new HashConfig("test", "primary", serverHash("mysql2", mysqlSettings())),
+    build: async () => serverHash("mysql2", mysqlSettings()),
   },
 };
 
@@ -173,6 +173,36 @@ export function configuredConnectionHash(): Record<string, unknown> {
 }
 
 /**
+ * The three named entries every connection carries, mirroring `expand_config`
+ * (`config.rb:26-37`): `arunit`, `arunit2` and
+ * `arunit_without_prepared_statements`. Rails spells them as keys of the
+ * connection's hash, and because `Base.configurations` treats top-level keys as
+ * environments, `establish_connection :arunit` resolves one by name — which is
+ * why they are the `envName` here, with Rails' `primary` spec name.
+ *
+ * Rails defaults the databases to `activerecord_unittest` /
+ * `activerecord_unittest2` / `activerecord_unittest`; trails takes them from
+ * the sub-settings instead, so `arunit` is the worker database the canonical
+ * schema is loaded into and `arunit2` the derived second database
+ * (`arunitDatabaseNames`). `arunit_without_prepared_statements` shares
+ * `arunit`'s database and only turns prepared statements off, as in
+ * `config.example.yml:74-79`.
+ */
+function expandConfig(arunit: Record<string, unknown>): HashConfig[] {
+  const database = String(arunit.database ?? "");
+  const arunit2 = database === ":memory:" ? database : arunitDatabaseNames(database).arunit2;
+
+  return [
+    new HashConfig("arunit", "primary", arunit),
+    new HashConfig("arunit2", "primary", { ...arunit, database: arunit2 }),
+    new HashConfig("arunit_without_prepared_statements", "primary", {
+      ...arunit,
+      preparedStatements: false,
+    }),
+  ];
+}
+
+/**
  * The configuration hashes for the connection `ARCONN` selects, mirroring
  * `ARTest.test_configuration_hashes` (`connection.rb:13-20`) plus the
  * adapter-name guard `connect` applies (`connection.rb:35-37`).
@@ -181,22 +211,13 @@ export function configuredConnectionHash(): Record<string, unknown> {
  * established pool; trails builds the config object here, so the resolved lane
  * comes back alongside it rather than being re-read from a live connection.
  *
- * KNOWN DIVERGENCE (story `arunit-named-configuration-entries`): Rails'
- * `expand_config` gives every connection three named entries — `arunit`,
- * `arunit2` and `arunit_without_prepared_statements` (`config.rb:26-37`) — and
- * those names are *environments* in the configurations hash, which is why
- * `connect` can say `establish_connection :arunit` (`connection.rb:32-33`).
- * trails synthesizes a single `test`/`primary` entry instead, so
- * `Base.configurations` carries no `arunit` name and an ARTest-style
- * `Base.establishConnection("arunit")` does not resolve. Converging means
- * renaming the env every lookup in the harness uses (`DatabaseTasks`,
- * `test-databases.ts`, `findDbConfig("test")`, the second-pool setup), and
- * `arunit2` additionally needs the `CREATE DATABASE` provisioning that is only
- * done on the sqlite lane today — both larger than this file.
  */
 export async function testConfigurationHashes(): Promise<{
   adapter: TestAdapterName;
-  envConfig: HashConfig | UrlConfig;
+  /** The `arunit` entry — the one `connect` establishes as the primary pool. */
+  envConfig: HashConfig;
+  /** All three named entries, as `ARTest.test_configuration_hashes` returns them. */
+  configurationHashes: HashConfig[];
 }> {
   const name = connectionName();
   // `name` is arbitrary user input from ARCONN, so the lookup is a partial one;
@@ -214,7 +235,8 @@ export async function testConfigurationHashes(): Promise<{
     );
   }
 
-  const envConfig = await connection.build();
+  const configurationHashes = expandConfig(await connection.build());
+  const envConfig = configurationHashes[0];
   // Rails: `unless connection_name.include?(arunit_adapter) raise ArgumentError`
   // (connection.rb:35-37). Previously this fired on a missing `*_TEST_URL` — an
   // env-presence proxy, since absent connection details silently resolved to
@@ -231,7 +253,7 @@ export async function testConfigurationHashes(): Promise<{
     );
   }
 
-  return { adapter: connection.lane, envConfig };
+  return { adapter: connection.lane, envConfig, configurationHashes };
 }
 
 async function fallbackDatabasePath(): Promise<string> {
@@ -267,9 +289,11 @@ async function sqliteHash(): Promise<Record<string, unknown>> {
  * Assign the test `DatabaseConfigurations` and establish `Base`'s connection,
  * mirroring `ARTest.connect` (`connection.rb:22-38`).
  *
- * `Base.configurations` is assigned as Rails does (`connection.rb:31`) so
- * no-arg `Base.establishConnection()` and later configuration lookups resolve
- * against the same test configuration the pool was opened from.
+ * `Base.configurations` is assigned as Rails does (`connection.rb:31`) — all
+ * three named entries — and the primary pool is established by name
+ * (`establish_connection :arunit`, `connection.rb:32`), so ARTest-style lookups
+ * such as `Base.establishConnection("arunit")` resolve against the same test
+ * configuration the pool was opened from.
  *
  * Beyond Rails it registers the adapter's `DatabaseTasks` handler, because
  * trails loads the schema through `DatabaseTasks` rather than by evaluating
@@ -281,8 +305,8 @@ async function sqliteHash(): Promise<Record<string, unknown>> {
  * second database today (see `arunit2-config.ts`).
  */
 export async function connect(): Promise<TestDatabaseConfig> {
-  const { adapter, envConfig } = await testConfigurationHashes();
-  const configs = new DatabaseConfigurations([envConfig]);
+  const { adapter, envConfig, configurationHashes } = await testConfigurationHashes();
+  const configs = new DatabaseConfigurations(configurationHashes);
   Base.configurations(configs);
   DatabaseTasks.databaseConfiguration = configs;
 
@@ -304,7 +328,9 @@ export async function connect(): Promise<TestDatabaseConfig> {
     }
   }
 
-  await Base.establishConnection(envConfig.configuration as Record<string, unknown>);
+  // `connection.rb:32` — established by name, not from the raw hash, so the
+  // pool comes from the same `arunit` entry `Base.configurations` publishes.
+  await Base.establishConnection("arunit");
 
   return { configs, adapter, envConfig };
 }

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -104,9 +104,21 @@ interface NamedConnection {
   adapter: string;
   /** The public {@link TestAdapterName} lane this connection drives. */
   lane: TestAdapterName;
-  /** The `arunit` hash; `expandConfig` derives the other named entries from it. */
-  build(): Promise<Record<string, unknown>>;
+  /**
+   * The connection's own named entries, as `config.example.yml` spells them.
+   * Sparse on purpose: `expandConfig` fills in a missing `database` / `adapter`
+   * and creates any entry the yml omits, exactly as `expand_config` does.
+   */
+  build(): Promise<Partial<Record<ArunitEntryName, Record<string, unknown>>>>;
 }
+
+/**
+ * The three entry names `expand_config` iterates (`config.rb:27-28`). Rails
+ * creates every one of them for every connection, defaulting the database and
+ * adapter when the yml leaves the key out.
+ */
+const ARUNIT_ENTRY_NAMES = ["arunit", "arunit2", "arunit_without_prepared_statements"] as const;
+type ArunitEntryName = (typeof ARUNIT_ENTRY_NAMES)[number];
 
 /**
  * Turn {@link ServerSettings} into the `configuration_hash` a `HashConfig`
@@ -132,22 +144,75 @@ const CONNECTIONS: Record<ConnectionName, NamedConnection> = {
   sqlite3: {
     adapter: "sqlite3",
     lane: "sqlite",
-    build: async () => await sqliteHash(),
+    // `config.example.yml:82-89`: two file databases, both `timeout`/`strict`.
+    // Rails names them under FIXTURES_ROOT; ours are the worker database and
+    // its derived sibling, filled in by `expandConfig`.
+    build: async () => {
+      const shared = { ...(await sqliteHash()), timeout: 5000, strict: true };
+      return { arunit: shared, arunit2: { ...shared, database: undefined } };
+    },
   },
   sqlite3_mem: {
     adapter: "sqlite3",
     lane: "sqlite",
-    build: async () => ({ adapter: "sqlite3", database: ":memory:", pool: 1 }),
+    // `config.example.yml:91-97` — both entries are their own `:memory:` database.
+    build: async () => ({
+      arunit: { adapter: "sqlite3", database: ":memory:", pool: 1 },
+      arunit2: { adapter: "sqlite3", database: ":memory:", pool: 1 },
+    }),
   },
   postgresql: {
     adapter: "postgresql",
     lane: "postgres",
-    build: async () => serverHash("postgresql", postgresSettings()),
+    // `config.example.yml:74-81` — all three entries carry `min_messages`, and
+    // only `arunit_without_prepared_statements` turns prepared statements off.
+    build: async () => {
+      const shared = serverHash("postgresql", postgresSettings());
+      return {
+        arunit: { ...shared, minMessages: "warning" },
+        arunit2: { ...shared, database: undefined, minMessages: "warning" },
+        arunit_without_prepared_statements: {
+          ...shared,
+          minMessages: "warning",
+          preparedStatements: false,
+        },
+      };
+    },
   },
   mysql2: {
     adapter: "mysql2",
     lane: "mysql",
-    build: async () => serverHash("mysql2", mysqlSettings()),
+    // `config.example.yml:3-40`: `arunit` and `arunit2` differ — unicode vs
+    // general collation, and only `arunit` carries the `time_zone` variable.
+    // Rails leaves `arunit_without_prepared_statements` out for mysql2, so
+    // `expandConfig` synthesizes it from the defaults alone.
+    //
+    // `buildAdapterArg` forwards the whole hash to mysql2, which logs
+    // "Ignoring invalid configuration option" for the keys it does not know
+    // (`collation`, `variables`, `encoding`, and `preparedStatements` before
+    // this) and warns that a future version will throw. The config is the Rails
+    // port surface, so the keys stay; whitelisting them at the adapter boundary
+    // the way the sqlite branch already does is story
+    // `mysql-adapter-arg-whitelist`.
+    build: async () => {
+      const shared = serverHash("mysql2", mysqlSettings());
+      return {
+        arunit: {
+          ...shared,
+          encoding: "utf8mb4",
+          collation: "utf8mb4_unicode_ci",
+          preparedStatements: false,
+          variables: { time_zone: "+00:00" },
+        },
+        arunit2: {
+          ...shared,
+          database: undefined,
+          encoding: "utf8mb4",
+          collation: "utf8mb4_general_ci",
+          preparedStatements: false,
+        },
+      };
+    },
   },
 };
 
@@ -174,33 +239,47 @@ export function configuredConnectionHash(): Record<string, unknown> {
 }
 
 /**
- * The three named entries every connection carries, mirroring `expand_config`
- * (`config.rb:26-37`): `arunit`, `arunit2` and
- * `arunit_without_prepared_statements`. Rails spells them as keys of the
- * connection's hash, and because `Base.configurations` treats top-level keys as
- * environments, `establish_connection :arunit` resolves one by name — which is
- * why they are the `envName` here, with Rails' `primary` spec name.
+ * Expand a connection's entries into the three named configs, mirroring
+ * `expand_config` (`config.rb:26-37`): iterate `arunit`, `arunit2` and
+ * `arunit_without_prepared_statements`, creating any the connection omits, then
+ * fill in only a missing `database` or `adapter`. Options a connection does
+ * declare are preserved per entry — mysql2's two collations, postgresql's
+ * `min_messages` — rather than being cloned from one entry onto the others.
+ *
+ * The names are the `envName` because `Base.configurations` treats top-level
+ * keys as environments, which is what lets `connect` say
+ * `establish_connection :arunit` (`connection.rb:32`), with Rails' `primary`
+ * spec name.
  *
  * Rails defaults the databases to `activerecord_unittest` /
- * `activerecord_unittest2` / `activerecord_unittest`; trails takes them from
- * the sub-settings instead, so `arunit` is the worker database the canonical
- * schema is loaded into and `arunit2` the derived second database
- * (`arunitDatabaseNames`). `arunit_without_prepared_statements` shares
- * `arunit`'s database and only turns prepared statements off, as in
- * `config.example.yml:74-79`.
+ * `activerecord_unittest2` / `activerecord_unittest` (`config.rb:27-28`);
+ * trails takes them from the sub-settings instead, so `arunit` is the worker
+ * database the canonical schema is loaded into, `arunit2` its derived sibling,
+ * and `arunit_without_prepared_statements` shares `arunit`'s database as it
+ * shares `activerecord_unittest` in Rails.
  */
-function expandConfig(arunit: Record<string, unknown>): HashConfig[] {
-  const database = String(arunit.database ?? "");
-  const arunit2 = database === ":memory:" ? database : arunitDatabaseNames(database).arunit2;
+function expandConfig(
+  connection: NamedConnection,
+  entries: Partial<Record<ArunitEntryName, Record<string, unknown>>>,
+): HashConfig[] {
+  const primaryDatabase = String(entries.arunit?.database ?? "");
+  const secondDatabase =
+    primaryDatabase === ":memory:" ? primaryDatabase : arunitDatabaseNames(primaryDatabase).arunit2;
+  const defaultDatabase: Record<ArunitEntryName, string> = {
+    arunit: primaryDatabase,
+    arunit2: secondDatabase,
+    arunit_without_prepared_statements: primaryDatabase,
+  };
 
-  return [
-    new HashConfig("arunit", "primary", arunit),
-    new HashConfig("arunit2", "primary", { ...arunit, database: arunit2 }),
-    new HashConfig("arunit_without_prepared_statements", "primary", {
-      ...arunit,
-      preparedStatements: false,
-    }),
-  ];
+  return ARUNIT_ENTRY_NAMES.map((name) => {
+    const entry = { ...(entries[name] ?? {}) };
+    entry.database ??= defaultDatabase[name];
+    entry.adapter ??= connection.adapter;
+    // Rails' third entry exists to turn prepared statements off, so a
+    // connection that does not spell the entry out still gets the flag.
+    if (name === "arunit_without_prepared_statements") entry.preparedStatements ??= false;
+    return new HashConfig(name, "primary", entry);
+  });
 }
 
 /**
@@ -236,7 +315,7 @@ export async function testConfigurationHashes(): Promise<{
     );
   }
 
-  const configurationHashes = expandConfig(await connection.build());
+  const configurationHashes = expandConfig(connection, await connection.build());
   const envConfig = configurationHashes[0];
   // Rails: `unless connection_name.include?(arunit_adapter) raise ArgumentError`
   // (connection.rb:35-37). Previously this fired on a missing `*_TEST_URL` — an

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -180,6 +180,19 @@ export function configuredConnectionHash(): Record<string, unknown> {
  * Rails returns the raw hash and lets `connect` derive the adapter from the
  * established pool; trails builds the config object here, so the resolved lane
  * comes back alongside it rather than being re-read from a live connection.
+ *
+ * KNOWN DIVERGENCE (story `arunit-named-configuration-entries`): Rails'
+ * `expand_config` gives every connection three named entries — `arunit`,
+ * `arunit2` and `arunit_without_prepared_statements` (`config.rb:26-37`) — and
+ * those names are *environments* in the configurations hash, which is why
+ * `connect` can say `establish_connection :arunit` (`connection.rb:32-33`).
+ * trails synthesizes a single `test`/`primary` entry instead, so
+ * `Base.configurations` carries no `arunit` name and an ARTest-style
+ * `Base.establishConnection("arunit")` does not resolve. Converging means
+ * renaming the env every lookup in the harness uses (`DatabaseTasks`,
+ * `test-databases.ts`, `findDbConfig("test")`, the second-pool setup), and
+ * `arunit2` additionally needs the `CREATE DATABASE` provisioning that is only
+ * done on the sqlite lane today — both larger than this file.
  */
 export async function testConfigurationHashes(): Promise<{
   adapter: TestAdapterName;

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -36,7 +36,6 @@ import {
   driverConfig,
   mysqlSettings,
   postgresSettings,
-  present,
   type ConnectionName,
   type EnvReader,
   type ServerSettings,
@@ -49,6 +48,12 @@ export type { TestAdapterName };
  * The connection name selected by `ARCONN`, falling back to
  * `config["default_connection"]`. Mirrors `connection.rb:9-11`.
  *
+ * `??`, not an empty-string check: Ruby's `ENV["ARCONN"] || ...` falls back on
+ * nil alone, so `ARCONN=""` selects the connection named `""` and fails in
+ * {@link testConfigurationHashes} with `Connection "" not found` rather than
+ * quietly running sqlite. Sub-settings do treat `""` as absent (`config.ts`);
+ * the selector must not.
+ *
  * Returns a bare `string`, not a `ConnectionName`: `ARCONN` is arbitrary user
  * input, and asserting it into the union here would be a type lie that makes
  * the unknown-name branch look unreachable to every caller.
@@ -56,7 +61,7 @@ export type { TestAdapterName };
  * so the error surfaces once, at config-build time.
  */
 export function connectionName(read: EnvReader = getEnv): string {
-  return present(read, "ARCONN") ?? DEFAULT_CONNECTION;
+  return read("ARCONN") ?? DEFAULT_CONNECTION;
 }
 
 /**
@@ -249,6 +254,10 @@ async function sqliteHash(): Promise<Record<string, unknown>> {
  * Assign the test `DatabaseConfigurations` and establish `Base`'s connection,
  * mirroring `ARTest.connect` (`connection.rb:22-38`).
  *
+ * `Base.configurations` is assigned as Rails does (`connection.rb:31`) so
+ * no-arg `Base.establishConnection()` and later configuration lookups resolve
+ * against the same test configuration the pool was opened from.
+ *
  * Beyond Rails it registers the adapter's `DatabaseTasks` handler, because
  * trails loads the schema through `DatabaseTasks` rather than by evaluating
  * `schema.rb` in-process. The registration runs on every call so callers that
@@ -261,6 +270,7 @@ async function sqliteHash(): Promise<Record<string, unknown>> {
 export async function connect(): Promise<TestDatabaseConfig> {
   const { adapter, envConfig } = await testConfigurationHashes();
   const configs = new DatabaseConfigurations([envConfig]);
+  Base.configurations(configs);
   DatabaseTasks.databaseConfiguration = configs;
 
   switch (adapter) {

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -31,7 +31,6 @@ import { DatabaseTasks } from "../tasks/database-tasks.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
 import { UrlConfig } from "../database-configurations/url-config.js";
 import { arunitDatabaseNames } from "./arunit2-config.js";
-import { ARUnit2Model } from "../test-helpers/models/arunit2-model.js";
 import {
   CONNECTION_LANES,
   DEFAULT_CONNECTION,
@@ -381,10 +380,15 @@ async function sqliteHash(): Promise<Record<string, unknown>> {
  * clear `_registeredTasks` (e.g. `database-tasks.test.ts`) can re-register.
  *
 
- * `ARUnit2Model` is established on `arunit2` as `connection.rb:33` does. The
- * pool is lazy, so this costs nothing on the lanes where no one has run
- * `CREATE DATABASE` for the second database — `setupSecondPool` still owns that
- * provisioning question (see `arunit2-config.ts`).
+ * Rails' next line is `ARUnit2Model.establish_connection :arunit2`
+ * (`connection.rb:33`), which this does NOT do. `College` and `Course` extend
+ * `ARUnit2Model`, so pointing that base at the arunit2 database here sends
+ * every suite's colleges/courses at a database that does not carry them — it
+ * reddened all three lanes on #5397 with "no such table: colleges" from
+ * `use-fixtures.test.ts`. Rails is safe because its arunit2 genuinely holds
+ * those tables; ours only gets them inside `setupSecondPool`, which keeps
+ * ownership of the second pool until that provisioning moves earlier (story
+ * `arunit2-provisioning-owns-second-pool`).
  */
 export async function connect(): Promise<TestDatabaseConfig> {
   const { adapter, envConfig, configurationHashes } = await testConfigurationHashes();
@@ -410,19 +414,9 @@ export async function connect(): Promise<TestDatabaseConfig> {
     }
   }
 
-  // `connection.rb:32-33` — both bases established by name, not from a raw
-  // hash, so each pool comes from the entry `Base.configurations` publishes.
+  // `connection.rb:32` — established by name, not from a raw hash, so the pool
+  // comes from the entry `Base.configurations` publishes.
   await Base.establishConnection("arunit");
-  await ARUnit2Model.establishConnection("arunit2");
-
-  // Rails' sqlite3 lane gives arunit2 its own file (config.example.yml:83-87),
-  // and ours derives one from the worker database. Nothing else knows to sweep
-  // it, so it rides the same exit cleanup as the fallback database.
-  const arunit2Database = String(configurationHashes[1].database);
-  if (adapter === "sqlite" && arunit2Database !== ":memory:") {
-    const { registerDbFileCleanupOnExit } = await import("./sqlite-template.js");
-    await registerDbFileCleanupOnExit(arunit2Database);
-  }
 
   return { configs, adapter, envConfig };
 }

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -31,6 +31,7 @@ import { DatabaseTasks } from "../tasks/database-tasks.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
 import { UrlConfig } from "../database-configurations/url-config.js";
 import { arunitDatabaseNames } from "./arunit2-config.js";
+import { ARUnit2Model } from "../test-helpers/models/arunit2-model.js";
 import {
   CONNECTION_LANES,
   DEFAULT_CONNECTION,
@@ -300,9 +301,11 @@ async function sqliteHash(): Promise<Record<string, unknown>> {
  * `schema.rb` in-process. The registration runs on every call so callers that
  * clear `_registeredTasks` (e.g. `database-tasks.test.ts`) can re-register.
  *
- * Rails also establishes `ARUnit2Model` on `:arunit2` here; trails does that
- * from `setupSecondPool` instead, since only the sqlite lane provisions a
- * second database today (see `arunit2-config.ts`).
+
+ * `ARUnit2Model` is established on `arunit2` as `connection.rb:33` does. The
+ * pool is lazy, so this costs nothing on the lanes where no one has run
+ * `CREATE DATABASE` for the second database — `setupSecondPool` still owns that
+ * provisioning question (see `arunit2-config.ts`).
  */
 export async function connect(): Promise<TestDatabaseConfig> {
   const { adapter, envConfig, configurationHashes } = await testConfigurationHashes();
@@ -328,9 +331,19 @@ export async function connect(): Promise<TestDatabaseConfig> {
     }
   }
 
-  // `connection.rb:32` — established by name, not from the raw hash, so the
-  // pool comes from the same `arunit` entry `Base.configurations` publishes.
+  // `connection.rb:32-33` — both bases established by name, not from a raw
+  // hash, so each pool comes from the entry `Base.configurations` publishes.
   await Base.establishConnection("arunit");
+  await ARUnit2Model.establishConnection("arunit2");
+
+  // Rails' sqlite3 lane gives arunit2 its own file (config.example.yml:83-87),
+  // and ours derives one from the worker database. Nothing else knows to sweep
+  // it, so it rides the same exit cleanup as the fallback database.
+  const arunit2Database = String(configurationHashes[1].database);
+  if (adapter === "sqlite" && arunit2Database !== ":memory:") {
+    const { registerDbFileCleanupOnExit } = await import("./sqlite-template.js");
+    await registerDbFileCleanupOnExit(arunit2Database);
+  }
 
   return { configs, adapter, envConfig };
 }
@@ -347,15 +360,14 @@ export async function connect(): Promise<TestDatabaseConfig> {
  *
  * Intentionally does NOT call `connect` — that would set
  * `DatabaseTasks.databaseConfiguration`, contaminating tests in
- * `database-tasks.test.ts` that rely on it being null. This function only
- * re-establishes `Base`'s connection; `DatabaseTasks` state is left as-is.
+ * `database-tasks.test.ts` that rely on it being null. This function installs
+ * the same configuration entries and re-establishes by name, so a suite
+ * re-opening the pool travels `connect`'s path; only `DatabaseTasks` state is
+ * left as-is.
  */
 export async function establishFromTestConfig(): Promise<void> {
   if (Base.isConnectedQ()) return;
-  const { envConfig } = await testConfigurationHashes();
-  if (envConfig instanceof UrlConfig) {
-    await Base.establishConnection(envConfig.url);
-    return;
-  }
-  await Base.establishConnection(envConfig.configurationHash);
+  const { configurationHashes } = await testConfigurationHashes();
+  Base.configurations(new DatabaseConfigurations(configurationHashes));
+  await Base.establishConnection("arunit");
 }

--- a/packages/activerecord/src/support/connection.ts
+++ b/packages/activerecord/src/support/connection.ts
@@ -1,26 +1,25 @@
 /**
- * Builds the test-environment `DatabaseConfigurations` from a Rails-faithful
- * named-connections map (the `config.yml`-analogue) selected purely by
- * `ARCONN`, and wires it into `DatabaseTasks`, routing schema load through the
- * real Rails-mirrored path (`loadSchema` / `reconstructFromSchema`).
- *
- * Mirrors `vendor/rails/activerecord/test/support/connection.rb`:
+ * The test harness' connection bootstrap, mirroring
+ * `vendor/rails/activerecord/test/support/connection.rb`:
  *   - `connection_name = ENV["ARCONN"] || config["default_connection"]`
  *     (`connection.rb:10`),
- *   - `config.fetch("connections").fetch(connection_name) { ... exit 1 }`
- *     (`connection.rb:14-19`) — a hard failure when `ARCONN` names an
- *     unconfigured connection,
- *   - `unless connection_name.include?(arunit_adapter) raise ArgumentError`
- *     (`connection.rb:35-37`) — a loud raise when `ARCONN` and the resolved
- *     adapter diverge.
+ *   - `test_configuration_hashes` — `config.fetch("connections").fetch(
+ *     connection_name) { ... exit 1 }` (`connection.rb:13-20`), a hard failure
+ *     when `ARCONN` names an unconfigured connection,
+ *   - `connect` (`connection.rb:22-38`) — assigns the configurations and
+ *     establishes `Base`'s connection, including the
+ *     `unless connection_name.include?(arunit_adapter) raise ArgumentError`
+ *     guard (`connection.rb:35-37`) when `ARCONN` and the resolved adapter
+ *     diverge.
+ *
+ * On top of Rails' three methods it wires the resolved configurations into
+ * `DatabaseTasks`, so schema load runs through the real Rails-mirrored path
+ * (`loadSchema` / `reconstructFromSchema`). Rails has no equivalent because its
+ * suite loads `schema.rb` directly from `cases/helper.rb`.
  *
  * As in `config.example.yml`, `ENV` only feeds connection *sub-settings*
- * (host/port/socket/credentials, via `test-connection-env.ts`); it never
+ * (host/port/socket/credentials, via `config.ts`); it never
  * selects the backend.
- *
- * Phase 1 of RFC 0002 — new file, no consumer changes.
- * Phase 2 of RFC 0002 — adds `establishFromTestConfig` for setupHandlerSuite.
- * Phase 4 of RFC 0002 — sole env-sniff source after bootstrap-test-handler deleted.
  */
 
 import { getEnv, getOsAsync } from "@blazetrails/activesupport";
@@ -31,18 +30,48 @@ import { DatabaseConfigurations } from "../database-configurations.js";
 import { DatabaseTasks } from "../tasks/database-tasks.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
 import { UrlConfig } from "../database-configurations/url-config.js";
-import { registerDbFileCleanupOnExit } from "./sqlite-template.js";
 import {
-  connectionName,
+  CONNECTION_LANES,
+  DEFAULT_CONNECTION,
   driverConfig,
   mysqlSettings,
   postgresSettings,
+  present,
   type ConnectionName,
+  type EnvReader,
   type ServerSettings,
   type TestAdapterName,
-} from "./test-connection-env.js";
+} from "./config.js";
 
 export type { TestAdapterName };
+
+/**
+ * The connection name selected by `ARCONN`, falling back to
+ * `config["default_connection"]`. Mirrors `connection.rb:9-11`.
+ *
+ * Returns a bare `string`, not a `ConnectionName`: `ARCONN` is arbitrary user
+ * input, and asserting it into the union here would be a type lie that makes
+ * the unknown-name branch look unreachable to every caller.
+ * {@link testConfigurationHashes} owns Rails' "Connection not found" failure,
+ * so the error surfaces once, at config-build time.
+ */
+export function connectionName(read: EnvReader = getEnv): string {
+  return present(read, "ARCONN") ?? DEFAULT_CONNECTION;
+}
+
+/**
+ * The backend lane the current `ARCONN` drives. Unknown names resolve to the
+ * default connection's lane; the loud failure for those belongs to
+ * {@link testConfigurationHashes}, not to every lane predicate in the harness.
+ *
+ * `activeLane` keeps its trails name: Rails has no counterpart, because Ruby
+ * dispatches on the live adapter object and never needs a coarse
+ * sqlite/postgres/mysql bucket to gate helpers on.
+ */
+export function activeLane(read: EnvReader = getEnv): TestAdapterName {
+  const lanes: Partial<Record<string, TestAdapterName>> = CONNECTION_LANES;
+  return lanes[connectionName(read)] ?? CONNECTION_LANES[DEFAULT_CONNECTION];
+}
 
 export interface TestDatabaseConfig {
   /** The `DatabaseConfigurations` instance wired into `DatabaseTasks`. */
@@ -60,7 +89,7 @@ export interface TestDatabaseConfig {
  *
  * `build()` returns `null` when the backend's connection details are absent
  * (the live-backend analogue of a `config.yml` entry with no reachable server);
- * `resolve()` turns that into Rails' loud adapter-mismatch failure rather than
+ * `testConfigurationHashes()` turns that into Rails' loud adapter-mismatch failure rather than
  * silently falling back to SQLite.
  */
 interface NamedConnection {
@@ -139,12 +168,18 @@ export function configuredConnectionHash(): Record<string, unknown> {
 }
 
 /**
- * Resolve the named connection selected by `ARCONN` into an adapter + config.
+ * The configuration hashes for the connection `ARCONN` selects, mirroring
+ * `ARTest.test_configuration_hashes` (`connection.rb:13-20`) plus the
+ * adapter-name guard `connect` applies (`connection.rb:35-37`).
  *
- * Mirrors `ARTest.connection_name` / `test_configuration_hashes` / the
- * adapter-name guard in `connection.rb`.
+ * Rails returns the raw hash and lets `connect` derive the adapter from the
+ * established pool; trails builds the config object here, so the resolved lane
+ * comes back alongside it rather than being re-read from a live connection.
  */
-async function resolve(): Promise<{ adapter: TestAdapterName; envConfig: HashConfig | UrlConfig }> {
+export async function testConfigurationHashes(): Promise<{
+  adapter: TestAdapterName;
+  envConfig: HashConfig | UrlConfig;
+}> {
   const name = connectionName();
   // `name` is arbitrary user input from ARCONN, so the lookup is a partial one;
   // the miss below is Rails' "Connection not found" exit (connection.rb:14-19).
@@ -192,6 +227,9 @@ async function fallbackDatabasePath(): Promise<string> {
   const slot = getEnv("VITEST_POOL_ID") || getEnv("VITEST_WORKER_ID") || "1";
   const token = `${runToken}-${slot}`;
   const dbPath = path.join(os.tmpdir(), `ar-test-fallback-${token}.sqlite`);
+  // Imported lazily: `sqlite-template.ts` imports `activeLane` from this
+  // module, and a static import here would close that cycle at module-init time.
+  const { registerDbFileCleanupOnExit } = await import("./sqlite-template.js");
   await registerDbFileCleanupOnExit(dbPath);
   g.__arFallbackDbPath = dbPath;
   return dbPath;
@@ -208,14 +246,20 @@ async function sqliteHash(): Promise<Record<string, unknown>> {
 }
 
 /**
- * Build the test `DatabaseConfigurations`, assign it to
- * `DatabaseTasks.databaseConfiguration`, and register the adapter task
- * handler. Called once from `test-setup-dy.ts` during worker startup;
- * the registration runs on every call so callers that clear
- * `_registeredTasks` (e.g. `database-tasks.test.ts`) can re-register.
+ * Assign the test `DatabaseConfigurations` and establish `Base`'s connection,
+ * mirroring `ARTest.connect` (`connection.rb:22-38`).
+ *
+ * Beyond Rails it registers the adapter's `DatabaseTasks` handler, because
+ * trails loads the schema through `DatabaseTasks` rather than by evaluating
+ * `schema.rb` in-process. The registration runs on every call so callers that
+ * clear `_registeredTasks` (e.g. `database-tasks.test.ts`) can re-register.
+ *
+ * Rails also establishes `ARUnit2Model` on `:arunit2` here; trails does that
+ * from `setupSecondPool` instead, since only the sqlite lane provisions a
+ * second database today (see `arunit2-config.ts`).
  */
-export async function buildTestDatabaseConfig(): Promise<TestDatabaseConfig> {
-  const { adapter, envConfig } = await resolve();
+export async function connect(): Promise<TestDatabaseConfig> {
+  const { adapter, envConfig } = await testConfigurationHashes();
   const configs = new DatabaseConfigurations([envConfig]);
   DatabaseTasks.databaseConfiguration = configs;
 
@@ -237,6 +281,8 @@ export async function buildTestDatabaseConfig(): Promise<TestDatabaseConfig> {
     }
   }
 
+  await Base.establishConnection(envConfig.configuration as Record<string, unknown>);
+
   return { configs, adapter, envConfig };
 }
 
@@ -246,14 +292,18 @@ export async function buildTestDatabaseConfig(): Promise<TestDatabaseConfig> {
  * get a live pool without knowing which adapter the worker is using.
  * Idempotent — a no-op when already connected.
  *
- * Intentionally does NOT call `buildTestDatabaseConfig` — that would set
+ * `establishFromTestConfig` keeps its trails name: Rails has no counterpart,
+ * because its suite connects once from `cases/helper.rb` and never needs an
+ * idempotent re-establish for individual files.
+ *
+ * Intentionally does NOT call `connect` — that would set
  * `DatabaseTasks.databaseConfiguration`, contaminating tests in
  * `database-tasks.test.ts` that rely on it being null. This function only
  * re-establishes `Base`'s connection; `DatabaseTasks` state is left as-is.
  */
 export async function establishFromTestConfig(): Promise<void> {
   if (Base.isConnectedQ()) return;
-  const { envConfig } = await resolve();
+  const { envConfig } = await testConfigurationHashes();
   if (envConfig instanceof UrlConfig) {
     await Base.establishConnection(envConfig.url);
     return;

--- a/packages/activerecord/src/support/pg-template.test.ts
+++ b/packages/activerecord/src/support/pg-template.test.ts
@@ -18,7 +18,8 @@ import { generateSchemaFile } from "./schema-file-generator.js";
 import { schemaSha1 } from "../tasks/database-tasks.js";
 import { TEST_SCHEMA } from "../test-helpers/test-schema.js";
 import { PG_TEMPLATE_ENV } from "./template-global-setup.js";
-import { activeLane, postgresSettings, settingsUrl, withDatabase } from "./test-connection-env.js";
+import { postgresSettings, settingsUrl, withDatabase } from "./config.js";
+import { activeLane } from "./connection.js";
 
 const pgActive = activeLane() === "postgres";
 

--- a/packages/activerecord/src/support/setup-handler-suite.ts
+++ b/packages/activerecord/src/support/setup-handler-suite.ts
@@ -1,5 +1,5 @@
 import { beforeAll, afterAll } from "vitest";
-import { establishFromTestConfig } from "./test-database-config.js";
+import { establishFromTestConfig } from "./connection.js";
 import { pushSkipGlobalReset, popSkipGlobalReset } from "./skip-global-reset.js";
 
 /**

--- a/packages/activerecord/src/support/sqlite-template.ts
+++ b/packages/activerecord/src/support/sqlite-template.ts
@@ -40,7 +40,7 @@ import type { FsAdapter } from "@blazetrails/activesupport/fs-adapter";
 import { getFsAsync, getPathAsync } from "@blazetrails/activesupport/fs-adapter";
 import { getOsAsync } from "@blazetrails/activesupport";
 import { betterSqlite3Driver } from "../sqlite/better-sqlite3.js";
-import { activeLane } from "./test-connection-env.js";
+import { activeLane } from "./connection.js";
 
 /** WAL sidecars sqlite writes alongside a file DB, plus the DB file itself. */
 const DB_FILE_SUFFIXES = ["", "-wal", "-shm"] as const;
@@ -65,7 +65,7 @@ const cleanupG = globalThis as typeof globalThis & { __arDbCleanupPaths?: Set<st
  * Register a best-effort `process.on("exit")` unlink of a sqlite file DB and
  * its WAL sidecars, at most once per path per process.
  *
- * Callers that must stay `process`-free (`test-database-config.ts`, whose
+ * Callers that must stay `process`-free (`support/connection.ts`, whose
  * fallback DB otherwise lingers in tmpdir after every setup-free run) route
  * their cleanup through here — this module already carries the `process`
  * exception documented at the top of the file.

--- a/packages/activerecord/src/support/template-global-setup.ts
+++ b/packages/activerecord/src/support/template-global-setup.ts
@@ -34,13 +34,13 @@ import {
 } from "./sqlite-template.js";
 import { slotPoolSize, workerForkCount } from "./ar-db-slots.js";
 import {
-  activeLane,
   driverConfig,
   mysqlSettings,
   postgresSettings,
   settingsUrl,
   withDatabase,
-} from "./test-connection-env.js";
+} from "./config.js";
+import { activeLane } from "./connection.js";
 
 // ---------------------------------------------------------------------------
 // Shared helpers

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -10,7 +10,7 @@ import { SchemaMigration } from "../schema-migration.js";
 import { Base } from "../base.js";
 import { adapterType, ambientPoolConfiguration } from "../test-adapter.js";
 import { inMemoryDb } from "../support/adapter-helper.js";
-import { establishFromTestConfig } from "../support/test-database-config.js";
+import { establishFromTestConfig } from "../support/connection.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 
 describe("DatabaseTasksCheckProtectedEnvironmentsTest", () => {

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -3,7 +3,7 @@
  *
  * Resolves which backend the active lane uses the way Rails does — from
  * `ARCONN` naming a key of the `connections:` hash, never from the presence of
- * a connection detail (see `support/test-connection-env.ts`):
+ * a connection detail (see `support/config.ts`):
  *   - ARCONN=postgresql → PostgreSQLAdapter
  *   - ARCONN=mysql2     → Mysql2Adapter
  *   - (default)         → SQLite3Adapter (the per-worker template clone, or
@@ -29,12 +29,8 @@ import type { TransactionManager } from "./connection-adapters/abstract/transact
 import { resetTestTables } from "./support/drop-all-tables.js";
 import { Base } from "./base.js";
 import { getEnv } from "@blazetrails/activesupport";
-import {
-  activeLane,
-  driverConfig,
-  mysqlSettings,
-  postgresSettings,
-} from "./support/test-connection-env.js";
+import { driverConfig, mysqlSettings, postgresSettings } from "./support/config.js";
+import { activeLane } from "./support/connection.js";
 
 /**
  * Which adapter backend is active. Read once at module load — the worker's
@@ -137,7 +133,7 @@ let _inTestPool: ConnectionPool | null = null;
 let _inTestPoolPromise: Promise<ConnectionPool> | null = null;
 
 async function buildInTestPool(): Promise<ConnectionPool> {
-  const { establishFromTestConfig } = await import("./support/test-database-config.js");
+  const { establishFromTestConfig } = await import("./support/connection.js");
   const { HashConfig } = await import("./database-configurations/hash-config.js");
   const { PoolConfig } = await import("./connection-adapters/pool-config.js");
   const { ConnectionPool } = await import("./connection-adapters/abstract/connection-pool.js");

--- a/packages/activerecord/src/test-helpers/fixture-connection.test.ts
+++ b/packages/activerecord/src/test-helpers/fixture-connection.test.ts
@@ -14,7 +14,7 @@
 import { describe, it, expect, beforeAll, afterEach } from "vitest";
 import { Base } from "../base.js";
 import { setPermanentConnectionCheckout } from "../ar-config.js";
-import { establishFromTestConfig } from "../support/test-database-config.js";
+import { establishFromTestConfig } from "../support/connection.js";
 import { leaseFixtureConnection } from "./fixture-connection.js";
 
 describe("fixture connection source", () => {

--- a/packages/activerecord/src/test-helpers/use-transactional-tests.ts
+++ b/packages/activerecord/src/test-helpers/use-transactional-tests.ts
@@ -1,4 +1,4 @@
-import { establishFromTestConfig } from "../support/test-database-config.js";
+import { establishFromTestConfig } from "../support/connection.js";
 import { leaseFixtureConnection } from "./fixture-connection.js";
 import {
   withTransactionalFixtures,

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
@@ -6,7 +6,7 @@ import {
   type TestDatabaseAdapter,
 } from "../test-adapter.js";
 import { Base } from "../base.js";
-import { establishFromTestConfig } from "../support/test-database-config.js";
+import { establishFromTestConfig } from "../support/connection.js";
 import { AbstractSQLite3Adapter } from "../connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
 import { NullTransaction } from "../connection-adapters/abstract/transaction.js";

--- a/packages/activerecord/src/test-setup-dy.ts
+++ b/packages/activerecord/src/test-setup-dy.ts
@@ -1,8 +1,8 @@
 /**
- * D-Y vitest setupFile for the activerecord project: establishes Base from
- * the Phase-1 test config, loads the canonical fixture schema once per worker
- * via `DatabaseTasks`, then tears the handler down so old-path test files
- * (those that never call `setupHandlerSuite`) are not affected by a
+ * D-Y vitest setupFile for the activerecord project: calls `ARTest.connect`'s
+ * port (`support/connection.ts`), loads the canonical fixture schema once per
+ * worker via `DatabaseTasks`, then tears the handler down so old-path test
+ * files (those that never call `setupHandlerSuite`) are not affected by a
  * globally-installed handler pool.
  *
  * Handler-path test files re-establish the connection in their own beforeAll
@@ -24,9 +24,10 @@
  *     GET_LOCK would allow slot races on MySQL. The schema file uses
  *     force:"cascade" for per-table drop+recreate instead.)
  */
-import { buildTestDatabaseConfig } from "./support/test-database-config.js";
+import { connect } from "./support/connection.js";
 import { generateSchemaFile } from "./support/schema-file-generator.js";
 import { TEST_SCHEMA } from "./test-helpers/test-schema.js";
+import { getEnv } from "@blazetrails/activesupport";
 import { Base } from "./base.js";
 import { DatabaseTasks } from "./tasks/database-tasks.js";
 // Registers _RelationCtor so Model.first()/.all()/.where() etc. work in
@@ -34,9 +35,7 @@ import { DatabaseTasks } from "./tasks/database-tasks.js";
 // re-exports relation.js as a side effect).
 import "./relation.js";
 
-const { adapter, envConfig } = await buildTestDatabaseConfig();
-
-await Base.establishConnection(envConfig.configuration as Record<string, unknown>);
+const { adapter, envConfig } = await connect();
 
 // Resolve `supports_expression_index?` from the live connection BEFORE
 // generating the schema file: without it the generator falls back to its
@@ -50,8 +49,8 @@ const schemaFilePath = await generateSchemaFile(
   await supportsExpressionIndex(await Base.leaseConnection()),
 );
 
-const pgExclusive = adapter === "postgres" && !!process.env.AR_PG_EXCLUSIVE_DB;
-const mysqlExclusive = adapter === "mysql" && !!process.env.AR_MYSQL_EXCLUSIVE_DB;
+const pgExclusive = adapter === "postgres" && !!getEnv("AR_PG_EXCLUSIVE_DB");
+const mysqlExclusive = adapter === "mysql" && !!getEnv("AR_MYSQL_EXCLUSIVE_DB");
 if ((adapter === "sqlite" && envConfig.database !== ":memory:") || pgExclusive || mysqlExclusive) {
   await DatabaseTasks.reconstructFromSchema(envConfig, "ts", schemaFilePath);
 } else {

--- a/packages/activerecord/src/test-setup-worker-db.ts
+++ b/packages/activerecord/src/test-setup-worker-db.ts
@@ -10,7 +10,7 @@
  * (lock released automatically on disconnect).
  *
  * The slot is published as a *number*, not as a rewritten connection URL:
- * `support/test-connection-env.ts` applies the `_N` database suffix, so
+ * `support/config.ts` applies the `_N` database suffix, so
  * every consumer derives the same worker database from one signal instead of
  * reading a mutated string.
  *
@@ -36,12 +36,8 @@ import mysql from "mysql2/promise";
 import "./sqlite/better-sqlite3.js";
 import { WORKER_DB_ENV, ensureWorkerClone } from "./support/sqlite-template.js";
 import { slotPoolSize, workerForkCount } from "./support/ar-db-slots.js";
-import {
-  SLOT_ENV,
-  activeLane,
-  mysqlSettings,
-  postgresSettings,
-} from "./support/test-connection-env.js";
+import { SLOT_ENV, mysqlSettings, postgresSettings } from "./support/config.js";
+import { activeLane } from "./support/connection.js";
 
 // Shared by all evaluations of this module within the same worker process.
 const g = globalThis as typeof globalThis & {


### PR DESCRIPTION
Renames the two invented test-config modules to their Rails names and adopts
Rails' method names and behavior for the connection bootstrap.

| trails (before) | Rails | trails (after) |
| --- | --- | --- |
| `support/test-connection-env.ts` | `test/support/config.rb` | `support/config.ts` |
| `support/test-database-config.ts` | `test/support/connection.rb` | `support/connection.ts` |
| `resolve()` | `ARTest.test_configuration_hashes` | `testConfigurationHashes()` |
| `buildTestDatabaseConfig()` | `ARTest.connect` | `connect()` |
| `connectionName()` (in config module) | `ARTest.connection_name` (in `connection.rb`) | `connectionName()` in `support/connection.ts` |

Behavior now follows `connection.rb:31-33` rather than only the naming:

- `expandConfig` mirrors `config.rb:26-37` — it iterates `arunit`, `arunit2`
  and `arunit_without_prepared_statements`, creating any entry a connection
  omits and filling in only a missing `database` / `adapter`. Each connection
  declares its own entries, so `config.example.yml`'s per-entry differences
  survive (mysql2's unicode vs general collation and arunit-only `time_zone`
  variable, postgresql's `min_messages`, sqlite3's `timeout`/`strict`). The
  names are env names with Rails' `primary` spec name, so
  `configurations.resolve("arunit")` finds them.
- `connect()` assigns all three to `Base.configurations` and establishes the
  primary pool **by name**: `Base.establishConnection("arunit")`. It does not
  establish `ARUnit2Model` (`connection.rb:33`) — see the deferred story below.
- `establishFromTestConfig()` installs the same entries and re-establishes
  `"arunit"`, so suites re-opening the pool travel `connect`'s path. It still
  leaves `DatabaseTasks.databaseConfiguration` alone, which `database-tasks.test.ts`
  depends on.
- `connectionName()` reads `ARCONN` with `??`, matching Ruby's `||` falling back
  on nil alone: `ARCONN=""` is a selected name and takes the unknown-name path.
- `test-setup-dy.ts` keeps only its per-worker `loadSchema` /
  `reconstructFromSchema` driver gate, which has no Rails counterpart, and stops
  reading `process.env` directly.

Names that survive with a trails spelling are justified at their definition:
`activeLane` (Rails dispatches on the live adapter object) and
`establishFromTestConfig` (Rails connects once from `cases/helper.rb`).

`config.ts`'s module doc records why there is no `configFile` / `readConfig`
pair and no `test/config.rb` path constants: trails has no `config.yml` on disk
and nothing resolves fixtures or schema by path from a test root.

One import cycle had to be broken: `sqlite-template.ts` imports `activeLane`
from `connection.ts`, so `connection.ts`'s `registerDbFileCleanupOnExit` calls
are lazy `await import()`s.

Deferred to follow-up stories:

- `arunit2-provisioning-owns-second-pool` — `connect()` stops short of Rails'
  `ARUnit2Model.establish_connection :arunit2`. Establishing it here was tried
  and reverted: `College`/`Course` extend `ARUnit2Model`, so it pointed every
  suite's colleges/courses at a database that lacks those tables and reddened
  all three lanes. Rails' arunit2 really holds them; ours only does inside
  `setupSecondPool`, so pool ownership moves once arunit2 is provisioned.
- `mysql-adapter-arg-whitelist` — `buildAdapterArg` spreads the whole config
  hash into the mysql2 driver options, so Rails config keys that are not driver
  options (`collation`, `variables`, `encoding`, and `preparedStatements`
  before this PR) log "Ignoring invalid configuration option". Verified locally:
  warns, connects. The sqlite branch already whitelists; the mysql branch should.
- `sqlite-temp-db-exit-cleanup-unreliable` — `registerDbFileCleanupOnExit`'s
  exit handler does not fire under vitest forks, for the worker and template DBs
  as much as for the `_arunit2` file this PR registers the same way.

Verified: `pnpm typecheck`, eslint over the touched files, and 2359 tests across
`support/`, `connection-adapters/`, `tasks/`, `base`, `fixtures`, `associations`,
`multiple-db`, `connection-handling`, `establish-connection`, `adapter`,
`test-databases`. `api:compare` / `test:compare` measured against `origin/main`:
zero delta.

Closes-story: support-config-and-connection
