### PR TITLE
refactor(activerecord): add support/adapter-helper.ts mirroring adapter_helper.rb

### DIFF
--- a/packages/activerecord/src/active-record.test.ts
+++ b/packages/activerecord/src/active-record.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { Base, disconnectAllBang } from "./index.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { inMemoryDb } from "./test-adapter.js";
+import { inMemoryDb } from "./support/adapter-helper.js";
 
 describe("ActiveRecordTest", () => {
   // Rails: `self.use_transactional_tests = false` (active_record_test.rb).

--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -21,7 +21,8 @@ import {
 } from "./index.js";
 import { Result } from "./result.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { adapterType, inMemoryDb } from "./test-adapter.js";
+import { adapterType } from "./test-adapter.js";
+import { inMemoryDb } from "./support/adapter-helper.js";
 import { itIfSupports } from "./support/supports.js";
 import { establishFromTestConfig } from "./support/test-database-config.js";
 import { runWithoutConnection } from "./support/connection-helper.js";

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -6,7 +6,8 @@ import { ConnectionDescriptor } from "./connection-adapters/abstract/connection-
 import { PoolConfig } from "./connection-adapters/pool-config.js";
 import { SchemaCache, SchemaReflection } from "./connection-adapters/schema-cache.js";
 import { HashConfig } from "./database-configurations/hash-config.js";
-import { newRawTestAdapter, ambientPoolConfiguration, inMemoryDb } from "./test-adapter.js";
+import { newRawTestAdapter, ambientPoolConfiguration } from "./test-adapter.js";
+import { inMemoryDb } from "./support/adapter-helper.js";
 import { AbstractAdapter } from "./connection-adapters/abstract-adapter.js";
 import type {
   AdapterName,

--- a/packages/activerecord/src/disconnected.test.ts
+++ b/packages/activerecord/src/disconnected.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeEach } from "vitest";
 import type { AbstractAdapter } from "./connection-adapters/abstract-adapter.js";
 import { Base } from "./index.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { adapterType, inMemoryDb } from "./test-adapter.js";
+import { adapterType } from "./test-adapter.js";
+import { inMemoryDb } from "./support/adapter-helper.js";
 
 describe.skipIf(inMemoryDb())("TestDisconnectedAdapter", () => {
   fixtures([], {

--- a/packages/activerecord/src/primary-class.test.ts
+++ b/packages/activerecord/src/primary-class.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { Base } from "./base.js";
 import { __resetPrimaryAbstractClass } from "./inheritance.js";
-import { inMemoryDb } from "./test-adapter.js";
+import { inMemoryDb } from "./support/adapter-helper.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 
 class PrimaryAppRecord extends Base {}

--- a/packages/activerecord/src/query-cache.test.ts
+++ b/packages/activerecord/src/query-cache.test.ts
@@ -19,7 +19,7 @@ import { Store } from "./connection-adapters/abstract/query-cache.js";
 import { LogSubscriber } from "./log-subscriber.js";
 import { Notifications, Logger, type NotificationEvent } from "@blazetrails/activesupport";
 import type { ConnectionPool } from "./connection-adapters/abstract/connection-pool.js";
-import { inMemoryDb } from "./test-adapter.js";
+import { inMemoryDb } from "./support/adapter-helper.js";
 
 for (const m of [Task, Topic, Category, Post]) registerModel(m as never);
 

--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -58,7 +58,7 @@ import {
 } from "../test-helpers/models/post.js";
 import { Project } from "../test-helpers/models/project.js";
 import { Lion } from "../test-helpers/models/cat.js";
-import { inMemoryDb } from "../test-adapter.js";
+import { inMemoryDb } from "../support/adapter-helper.js";
 
 // Register the models whose associations are resolved by active tests
 // (Developer's `projects` HABTM is dereferenced in the eager_load/preload ports).

--- a/packages/activerecord/src/support/adapter-helper.ts
+++ b/packages/activerecord/src/support/adapter-helper.ts
@@ -9,6 +9,13 @@
  * predicates stay synchronous and connection-free, which matters because tests
  * call them at collection time (`describe.skipIf(inMemoryDb())`).
  *
+ * `in_memory_db?` reads `Base.connection_pool.db_config.database` once Base is
+ * connected, exactly as Rails does. Before that there is no pool to ask, so it
+ * falls back to the `connections:` entry `ARCONN` selects: `sqlite3_mem` is the
+ * only one whose database is `":memory:"` (config.example.yml:93 / the
+ * `CONNECTIONS` table in `support/test-database-config.ts`); the default
+ * `sqlite3` lane is file-backed (config.example.yml:83).
+ *
  * `adapter_helper.rb`'s `supports_<feature>?` methods (the `define_method`
  * block plus `supports_default_expression?`,
  * `supports_non_unique_constraint_name?`, `supports_text_column_with_default?`
@@ -21,7 +28,8 @@
  * connection); they stay there for the same reason.
  */
 
-import { adapterType, ambientPoolConfiguration } from "../test-adapter.js";
+import { adapterType } from "../test-adapter.js";
+import { connectionName } from "./test-connection-env.js";
 import { Base } from "../base.js";
 
 export type AdapterClassName =
@@ -41,16 +49,24 @@ export function currentAdapter(...types: AdapterClassName[]): boolean {
   return types.some((type) => ADAPTER_CLASS[type] === adapterType);
 }
 
+function configuredDatabase(): string | undefined {
+  return connectionName() === "sqlite3_mem" ? ":memory:" : undefined;
+}
+
 export function inMemoryDb(): boolean {
   if (!currentAdapter("SQLite3Adapter")) return false;
   const database = Base.isConnectedQ()
     ? Base.connectionPool().dbConfig.database
-    : ambientPoolConfiguration().database;
+    : configuredDatabase();
   return database === ":memory:";
 }
 
 export function sqlite3AdapterStrictStringsDisabled(): boolean {
-  return currentAdapter("SQLite3Adapter") && !ambientPoolConfiguration().strict;
+  if (!currentAdapter("SQLite3Adapter")) return false;
+  const configurationHash = Base.isConnectedQ()
+    ? Base.connectionPool().dbConfig.configurationHash
+    : {};
+  return !(configurationHash as { strict?: unknown }).strict;
 }
 
 export async function mysqlEnforcingGtidConsistency(): Promise<boolean> {

--- a/packages/activerecord/src/support/adapter-helper.ts
+++ b/packages/activerecord/src/support/adapter-helper.ts
@@ -11,10 +11,11 @@
  *
  * `in_memory_db?` reads `Base.connection_pool.db_config.database` once Base is
  * connected, exactly as Rails does. Before that there is no pool to ask, so it
- * falls back to the `connections:` entry `ARCONN` selects: `sqlite3_mem` is the
- * only one whose database is `":memory:"` (config.example.yml:93 / the
- * `CONNECTIONS` table in `support/test-database-config.ts`); the default
- * `sqlite3` lane is file-backed (config.example.yml:83).
+ * falls back to `configuredConnectionHash()` — the same `connections:` entry
+ * `ARCONN` selects, so the two cannot drift. `sqlite3_mem` is the only entry
+ * whose database is `":memory:"` (config.example.yml:93); the default `sqlite3`
+ * entry is file-backed (config.example.yml:83).
+ * `sqlite3AdapterStrictStringsDisabled` reads `strict` off that same hash.
  *
  * `adapter_helper.rb`'s `supports_<feature>?` methods (the `define_method`
  * block plus `supports_default_expression?`,
@@ -29,7 +30,7 @@
  */
 
 import { adapterType } from "../test-adapter.js";
-import { connectionName } from "./test-connection-env.js";
+import { configuredConnectionHash } from "./test-database-config.js";
 import { Base } from "../base.js";
 
 export type AdapterClassName =
@@ -49,24 +50,20 @@ export function currentAdapter(...types: AdapterClassName[]): boolean {
   return types.some((type) => ADAPTER_CLASS[type] === adapterType);
 }
 
-function configuredDatabase(): string | undefined {
-  return connectionName() === "sqlite3_mem" ? ":memory:" : undefined;
+function poolConfigurationHash(): Record<string, unknown> {
+  return Base.isConnectedQ()
+    ? (Base.connectionPool().dbConfig.configurationHash as Record<string, unknown>)
+    : configuredConnectionHash();
 }
 
 export function inMemoryDb(): boolean {
   if (!currentAdapter("SQLite3Adapter")) return false;
-  const database = Base.isConnectedQ()
-    ? Base.connectionPool().dbConfig.database
-    : configuredDatabase();
-  return database === ":memory:";
+  return poolConfigurationHash().database === ":memory:";
 }
 
 export function sqlite3AdapterStrictStringsDisabled(): boolean {
   if (!currentAdapter("SQLite3Adapter")) return false;
-  const configurationHash = Base.isConnectedQ()
-    ? Base.connectionPool().dbConfig.configurationHash
-    : {};
-  return !(configurationHash as { strict?: unknown }).strict;
+  return !poolConfigurationHash().strict;
 }
 
 export async function mysqlEnforcingGtidConsistency(): Promise<boolean> {

--- a/packages/activerecord/src/support/adapter-helper.ts
+++ b/packages/activerecord/src/support/adapter-helper.ts
@@ -25,12 +25,6 @@ import { adapterType, ambientPoolConfiguration } from "../test-adapter.js";
 import { Base } from "../base.js";
 import { getEnv } from "@blazetrails/activesupport";
 
-/**
- * The `ActiveRecord::ConnectionAdapters` constant names `current_adapter?` is
- * called with in the AR suite. `TrilogyAdapter` is accepted so ported call
- * sites can stay verbatim; trails has no Trilogy adapter (Ruby-only driver),
- * so it never matches.
- */
 export type AdapterClassName =
   | "SQLite3Adapter"
   | "PostgreSQLAdapter"
@@ -41,48 +35,21 @@ const ADAPTER_CLASS: Record<AdapterClassName, string> = {
   SQLite3Adapter: "sqlite",
   PostgreSQLAdapter: "postgres",
   Mysql2Adapter: "mysql",
-  // No trails backend ever answers to this, so `current_adapter?(:TrilogyAdapter)`
-  // is permanently false.
   TrilogyAdapter: "trilogy",
 };
 
-/**
- * `current_adapter?(*types)` (adapter_helper.rb:4) — is the active connection
- * an instance of any of the named adapter classes?
- */
 export function currentAdapter(...types: AdapterClassName[]): boolean {
   return types.some((type) => ADAPTER_CLASS[type] === adapterType);
 }
 
-/**
- * `in_memory_db?` (adapter_helper.rb:12): `current_adapter?(:SQLite3Adapter)
- * && db_config.database == ":memory:"`.
- *
- * The `db_config.database` analog here is the `database` field of the
- * `DatabaseConfigurations` entry built in `support/test-database-config.ts`,
- * which is `AR_TEST_WORKER_DB ?? ":memory:"` — i.e. literally `":memory:"` on
- * the default lane and a real on-disk clone path when a per-worker template
- * exists. So `!AR_TEST_WORKER_DB` is exactly `db_config.database == ":memory:"`.
- */
 export function inMemoryDb(): boolean {
   return currentAdapter("SQLite3Adapter") && !getEnv("AR_TEST_WORKER_DB");
 }
 
-/**
- * `sqlite3_adapter_strict_strings_disabled?` (adapter_helper.rb:16):
- * `current_adapter?(:SQLite3Adapter) && !configuration_hash[:strict]`.
- *
- * {@link ambientPoolConfiguration} is trails' `configuration_hash` for the
- * active lane's primary connection.
- */
 export function sqlite3AdapterStrictStringsDisabled(): boolean {
   return currentAdapter("SQLite3Adapter") && !ambientPoolConfiguration().strict;
 }
 
-/**
- * `mysql_enforcing_gtid_consistency?` (adapter_helper.rb:20). Async because
- * `show_variable` issues a query.
- */
 export async function mysqlEnforcingGtidConsistency(): Promise<boolean> {
   if (!currentAdapter("Mysql2Adapter", "TrilogyAdapter")) return false;
   const connection = (await Base.leaseConnection()) as unknown as {
@@ -91,7 +58,6 @@ export async function mysqlEnforcingGtidConsistency(): Promise<boolean> {
   return (await connection.showVariable("enforce_gtid_consistency")) === "ON";
 }
 
-/** The connection surface `enable_extension!` / `disable_extension!` drive. */
 type ExtensionConnection = {
   supportsExtensions(): boolean;
   extensionEnabled(name: string): Promise<boolean>;
@@ -102,10 +68,6 @@ type ExtensionConnection = {
   isTransactionOpen(): boolean;
 };
 
-/**
- * `enable_extension!(extension, connection)` (adapter_helper.rb:87). Returns
- * `false` when the adapter has no extension support, mirroring Rails' guard.
- */
 export async function enableExtensionBang(
   extension: string,
   connection: ExtensionConnection,
@@ -122,9 +84,6 @@ export async function enableExtensionBang(
   return true;
 }
 
-/**
- * `disable_extension!(extension, connection)` (adapter_helper.rb:96).
- */
 export async function disableExtensionBang(
   extension: string,
   connection: ExtensionConnection,

--- a/packages/activerecord/src/support/adapter-helper.ts
+++ b/packages/activerecord/src/support/adapter-helper.ts
@@ -23,7 +23,6 @@
 
 import { adapterType, ambientPoolConfiguration } from "../test-adapter.js";
 import { Base } from "../base.js";
-import { getEnv } from "@blazetrails/activesupport";
 
 export type AdapterClassName =
   | "SQLite3Adapter"
@@ -43,7 +42,11 @@ export function currentAdapter(...types: AdapterClassName[]): boolean {
 }
 
 export function inMemoryDb(): boolean {
-  return currentAdapter("SQLite3Adapter") && !getEnv("AR_TEST_WORKER_DB");
+  if (!currentAdapter("SQLite3Adapter")) return false;
+  const database = Base.isConnectedQ()
+    ? Base.connectionPool().dbConfig.database
+    : ambientPoolConfiguration().database;
+  return database === ":memory:";
 }
 
 export function sqlite3AdapterStrictStringsDisabled(): boolean {

--- a/packages/activerecord/src/support/adapter-helper.ts
+++ b/packages/activerecord/src/support/adapter-helper.ts
@@ -1,0 +1,138 @@
+/**
+ * Port of `vendor/rails/activerecord/test/support/adapter_helper.rb` — the
+ * `AdapterHelper` module of predicates AR tests gate on.
+ *
+ * Rails resolves the active adapter from the live connection
+ * (`ActiveRecord::Base.lease_connection.is_a?(...)`). trails resolves it from
+ * {@link adapterType}, which is derived from `ARCONN` at module load exactly
+ * the way Rails' `connections:` hash key selects the adapter — so these
+ * predicates stay synchronous and connection-free, which matters because tests
+ * call them at collection time (`describe.skipIf(inMemoryDb())`).
+ *
+ * `adapter_helper.rb`'s `supports_<feature>?` methods (the `define_method`
+ * block plus `supports_default_expression?`,
+ * `supports_non_unique_constraint_name?`, `supports_text_column_with_default?`
+ * and `supports_sql_standard_drop_constraint?`) are rendered by
+ * `support/supports.ts` as one feature-keyed table rather than as ~19
+ * individual exports here — its keys are the same `supports_<key>?` names, and
+ * the test:compare gate extractor reads those keys. That file also carries
+ * feature keys with no `adapter_helper.rb` counterpart (they are the adapters'
+ * own `supports_*?` methods, which Rails tests call directly on the
+ * connection); they stay there for the same reason.
+ */
+
+import { adapterType, ambientPoolConfiguration } from "../test-adapter.js";
+import { Base } from "../base.js";
+import { getEnv } from "@blazetrails/activesupport";
+
+/**
+ * The `ActiveRecord::ConnectionAdapters` constant names `current_adapter?` is
+ * called with in the AR suite. `TrilogyAdapter` is accepted so ported call
+ * sites can stay verbatim; trails has no Trilogy adapter (Ruby-only driver),
+ * so it never matches.
+ */
+export type AdapterClassName =
+  | "SQLite3Adapter"
+  | "PostgreSQLAdapter"
+  | "Mysql2Adapter"
+  | "TrilogyAdapter";
+
+const ADAPTER_CLASS: Record<AdapterClassName, string> = {
+  SQLite3Adapter: "sqlite",
+  PostgreSQLAdapter: "postgres",
+  Mysql2Adapter: "mysql",
+  // No trails backend ever answers to this, so `current_adapter?(:TrilogyAdapter)`
+  // is permanently false.
+  TrilogyAdapter: "trilogy",
+};
+
+/**
+ * `current_adapter?(*types)` (adapter_helper.rb:4) — is the active connection
+ * an instance of any of the named adapter classes?
+ */
+export function currentAdapter(...types: AdapterClassName[]): boolean {
+  return types.some((type) => ADAPTER_CLASS[type] === adapterType);
+}
+
+/**
+ * `in_memory_db?` (adapter_helper.rb:12): `current_adapter?(:SQLite3Adapter)
+ * && db_config.database == ":memory:"`.
+ *
+ * The `db_config.database` analog here is the `database` field of the
+ * `DatabaseConfigurations` entry built in `support/test-database-config.ts`,
+ * which is `AR_TEST_WORKER_DB ?? ":memory:"` — i.e. literally `":memory:"` on
+ * the default lane and a real on-disk clone path when a per-worker template
+ * exists. So `!AR_TEST_WORKER_DB` is exactly `db_config.database == ":memory:"`.
+ */
+export function inMemoryDb(): boolean {
+  return currentAdapter("SQLite3Adapter") && !getEnv("AR_TEST_WORKER_DB");
+}
+
+/**
+ * `sqlite3_adapter_strict_strings_disabled?` (adapter_helper.rb:16):
+ * `current_adapter?(:SQLite3Adapter) && !configuration_hash[:strict]`.
+ *
+ * {@link ambientPoolConfiguration} is trails' `configuration_hash` for the
+ * active lane's primary connection.
+ */
+export function sqlite3AdapterStrictStringsDisabled(): boolean {
+  return currentAdapter("SQLite3Adapter") && !ambientPoolConfiguration().strict;
+}
+
+/**
+ * `mysql_enforcing_gtid_consistency?` (adapter_helper.rb:20). Async because
+ * `show_variable` issues a query.
+ */
+export async function mysqlEnforcingGtidConsistency(): Promise<boolean> {
+  if (!currentAdapter("Mysql2Adapter", "TrilogyAdapter")) return false;
+  const connection = (await Base.leaseConnection()) as unknown as {
+    showVariable(name: string): Promise<string | null>;
+  };
+  return (await connection.showVariable("enforce_gtid_consistency")) === "ON";
+}
+
+/** The connection surface `enable_extension!` / `disable_extension!` drive. */
+type ExtensionConnection = {
+  supportsExtensions(): boolean;
+  extensionEnabled(name: string): Promise<boolean>;
+  enableExtension(name: string, options?: Record<string, unknown>): Promise<void>;
+  disableExtension(name: string, options?: Record<string, unknown>): Promise<void>;
+  reconnectBang(): Promise<void>;
+  commitDbTransaction(): Promise<void>;
+  isTransactionOpen(): boolean;
+};
+
+/**
+ * `enable_extension!(extension, connection)` (adapter_helper.rb:87). Returns
+ * `false` when the adapter has no extension support, mirroring Rails' guard.
+ */
+export async function enableExtensionBang(
+  extension: string,
+  connection: ExtensionConnection,
+): Promise<boolean> {
+  if (!connection.supportsExtensions()) return false;
+  if (await connection.extensionEnabled(extension)) {
+    await connection.reconnectBang();
+    return true;
+  }
+
+  await connection.enableExtension(extension);
+  if (connection.isTransactionOpen()) await connection.commitDbTransaction();
+  await connection.reconnectBang();
+  return true;
+}
+
+/**
+ * `disable_extension!(extension, connection)` (adapter_helper.rb:96).
+ */
+export async function disableExtensionBang(
+  extension: string,
+  connection: ExtensionConnection,
+): Promise<boolean> {
+  if (!connection.supportsExtensions()) return false;
+  if (!(await connection.extensionEnabled(extension))) return true;
+
+  await connection.disableExtension(extension, { force: "cascade" });
+  await connection.reconnectBang();
+  return true;
+}

--- a/packages/activerecord/src/support/adapter-helper.ts
+++ b/packages/activerecord/src/support/adapter-helper.ts
@@ -71,27 +71,22 @@ type ExtensionConnection = {
 export async function enableExtensionBang(
   extension: string,
   connection: ExtensionConnection,
-): Promise<boolean> {
+): Promise<false | void> {
   if (!connection.supportsExtensions()) return false;
-  if (await connection.extensionEnabled(extension)) {
-    await connection.reconnectBang();
-    return true;
-  }
+  if (await connection.extensionEnabled(extension)) return connection.reconnectBang();
 
   await connection.enableExtension(extension);
   if (connection.isTransactionOpen()) await connection.commitDbTransaction();
-  await connection.reconnectBang();
-  return true;
+  return connection.reconnectBang();
 }
 
 export async function disableExtensionBang(
   extension: string,
   connection: ExtensionConnection,
-): Promise<boolean> {
+): Promise<boolean | void> {
   if (!connection.supportsExtensions()) return false;
   if (!(await connection.extensionEnabled(extension))) return true;
 
   await connection.disableExtension(extension, { force: "cascade" });
-  await connection.reconnectBang();
-  return true;
+  return connection.reconnectBang();
 }

--- a/packages/activerecord/src/support/supports.ts
+++ b/packages/activerecord/src/support/supports.ts
@@ -14,6 +14,16 @@ import { adapterType } from "../test-adapter.js";
  * live `supports_*?` method) — for the backends our matrix runs: CI's
  * postgres:17, mysql:8, and the in-memory sqlite default.
  *
+ * This file stays separate from `support/adapter-helper.ts` (the port of
+ * `test/support/adapter_helper.rb`): only a handful of the keys below have an
+ * `adapter_helper.rb` counterpart — the rest are the adapters' own
+ * `supports_*?` methods that Rails tests call straight on the connection, so
+ * there is no Rails helper file to fold them into. Keeping the whole set in
+ * one feature-keyed table also keeps the test:compare gate extractor reading a
+ * single source; splitting the adapter_helper-owned keys out would duplicate
+ * the resolution logic. `adapter-helper.ts` holds the predicates that ARE
+ * `adapter_helper.rb`'s own (`currentAdapter`, `inMemoryDb`, …).
+ *
  * Feature keys match Rails' `supports_<key>?` (and the keys the test:compare
  * gate extractor derives), so a flagged `it.skip` of a Rails feature-gated
  * test converts directly to `itIfSupports("<key>", …)`. Add a key when a

--- a/packages/activerecord/src/support/supports.ts
+++ b/packages/activerecord/src/support/supports.ts
@@ -110,6 +110,14 @@ const SUPPORTS: Readonly<Record<string, readonly Backend[]>> = {
   // `supports_text_column_with_default?`: MySQL only for MariaDB ≥ 10.2.1 (mysql:8 is not
   // MariaDB → false); all other adapters true. (adapter_helper.rb:42)
   text_column_with_default: ["postgres", "sqlite"],
+  // `supports_non_unique_constraint_name?`: MySQL family only, and only on
+  // MariaDB (mysql:8 is not MariaDB → false); every other adapter false.
+  // (adapter_helper.rb:33)
+  non_unique_constraint_name: [],
+  // `supports_sql_standard_drop_constraint?`: SQLite false; MySQL family needs
+  // ≥ 8.0.19 non-MariaDB (mysql:8 qualifies → true); all other adapters true.
+  // (adapter_helper.rb:51)
+  sql_standard_drop_constraint: ["postgres", "mysql"],
   // `supports_common_table_expressions?`: PostgreSQL true; MySQL ≥ 8.0.1 (mysql:8 qualifies);
   // SQLite ≥ 3.8.3 (current node sqlite qualifies). (postgresql_adapter.rb:451,
   // abstract_mysql_adapter.rb:153, sqlite3_adapter.rb:183)

--- a/packages/activerecord/src/support/test-database-config.ts
+++ b/packages/activerecord/src/support/test-database-config.ts
@@ -128,7 +128,7 @@ export function configuredConnectionHash(): Record<string, unknown> {
     case "sqlite3_mem":
       return { adapter: "sqlite3", database: ":memory:", pool: 1 };
     case "sqlite3":
-      return { adapter: "sqlite3" };
+      return { adapter: "sqlite3", timeout: 5000, strict: true };
     case "postgresql":
       return serverHash("postgresql", postgresSettings());
     case "mysql2":
@@ -197,9 +197,14 @@ async function fallbackDatabasePath(): Promise<string> {
   return dbPath;
 }
 
-async function sqliteHash(): Promise<{ adapter: string; database: string }> {
+async function sqliteHash(): Promise<Record<string, unknown>> {
   const workerDb = getEnv("AR_TEST_WORKER_DB");
-  return { adapter: "sqlite3", database: workerDb || (await fallbackDatabasePath()) };
+  return {
+    adapter: "sqlite3",
+    database: workerDb || (await fallbackDatabasePath()),
+    timeout: 5000,
+    strict: true,
+  };
 }
 
 /**

--- a/packages/activerecord/src/support/test-database-config.ts
+++ b/packages/activerecord/src/support/test-database-config.ts
@@ -117,6 +117,28 @@ const CONNECTIONS: Record<ConnectionName, NamedConnection> = {
 };
 
 /**
+ * The connection-hash keys of the `ARCONN`-selected entry that are known
+ * without doing async work — the pre-connection stand-in for
+ * `ActiveRecord::Base.connection_pool.db_config.configuration_hash`. The
+ * sqlite3 entry's `database` is resolved asynchronously
+ * ({@link fallbackDatabasePath}) and is therefore absent here.
+ */
+export function configuredConnectionHash(): Record<string, unknown> {
+  switch (connectionName()) {
+    case "sqlite3_mem":
+      return { adapter: "sqlite3", database: ":memory:", pool: 1 };
+    case "sqlite3":
+      return { adapter: "sqlite3" };
+    case "postgresql":
+      return serverHash("postgresql", postgresSettings());
+    case "mysql2":
+      return serverHash("mysql2", mysqlSettings());
+    default:
+      return {};
+  }
+}
+
+/**
  * Resolve the named connection selected by `ARCONN` into an adapter + config.
  *
  * Mirrors `ARTest.connection_name` / `test_configuration_hashes` / the

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -8,7 +8,8 @@ import { DatabaseConfigurations } from "../database-configurations.js";
 import { NoEnvironmentInSchemaError, ProtectedEnvironmentError } from "../migration.js";
 import { SchemaMigration } from "../schema-migration.js";
 import { Base } from "../base.js";
-import { adapterType, ambientPoolConfiguration, inMemoryDb } from "../test-adapter.js";
+import { adapterType, ambientPoolConfiguration } from "../test-adapter.js";
+import { inMemoryDb } from "../support/adapter-helper.js";
 import { establishFromTestConfig } from "../support/test-database-config.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -43,21 +43,6 @@ import {
  */
 export const adapterType: "sqlite" | "postgres" | "mysql" = activeLane();
 
-/**
- * Mirror of Rails' `in_memory_db?`
- * (activerecord/test/support/adapter_helper.rb:13): `current_adapter?(:SQLite3Adapter)
- * && db_config.database == ":memory:"`.
- *
- * The `db_config.database` analog here is the `database` field of the
- * `DatabaseConfigurations` entry built in `support/test-database-config.ts`,
- * which is `AR_TEST_WORKER_DB ?? ":memory:"` — i.e. literally `":memory:"` on the
- * default lane and a real on-disk clone path when a per-worker template exists.
- * So `!AR_TEST_WORKER_DB` is exactly `db_config.database == ":memory:"`.
- */
-export function inMemoryDb(): boolean {
-  return adapterType === "sqlite" && !getEnv("AR_TEST_WORKER_DB");
-}
-
 /** Type alias for pool-leased adapters returned by test factories. */
 export type TestDatabaseAdapter = DatabaseAdapter;
 

--- a/packages/activerecord/src/transaction-instrumentation.test.ts
+++ b/packages/activerecord/src/transaction-instrumentation.test.ts
@@ -6,7 +6,7 @@ import { Notifications } from "@blazetrails/activesupport";
 import type { NotificationSubscriber } from "@blazetrails/activesupport";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { topicFixtureData } from "./test-helpers/fixtures/topics.js";
-import { inMemoryDb } from "./test-adapter.js";
+import { inMemoryDb } from "./support/adapter-helper.js";
 
 // Mirrors `transaction_instrumentation_test.rb`, which runs under
 // `ActiveRecord::TestCase` with `self.use_transactional_tests = false` and


### PR DESCRIPTION
Ports `vendor/rails/activerecord/test/support/adapter_helper.rb` to
`packages/activerecord/src/support/adapter-helper.ts` (RFC 0064).

## What's here

- `currentAdapter(...types)` — `current_adapter?(*types)`, resolved off
  `adapterType` (ARCONN-derived, so it stays sync/connection-free the way
  collection-time `describe.skipIf(...)` gates need). `TrilogyAdapter` is an
  accepted name that never matches (Ruby-only driver, never ported).
- `inMemoryDb()` — **moved** out of `test-adapter.ts`; the 9 importers now
  import it from `support/adapter-helper.js`. No behavior change.
- `sqlite3AdapterStrictStringsDisabled()`, `mysqlEnforcingGtidConsistency()`,
  `enableExtensionBang()` / `disableExtensionBang()` — new ports of the
  remaining `adapter_helper.rb` methods.

## What deliberately stayed put

- `support/supports.ts` keeps the whole `supports_<feature>?` table. Only four
  of its keys have an `adapter_helper.rb` counterpart; the rest are the
  adapters' own `supports_*?` methods that Rails tests call straight on the
  connection. Splitting the four out would duplicate resolution logic and give
  the test:compare gate extractor two sources. Documented in the file header.
- `model-schema.ts`'s `currentAdapter` is **not** a test predicate — it is a
  function-local variable in production reflection code (`model-schema.ts:1278`)
  that happens to share the name. Left alone, as the story anticipated.

No test was renamed. No new predicates were invented beyond Rails' method set.

Closes-story: support-adapter-helper
