### PR TITLE
refactor(activerecord): add support/load-schema-helper.ts port of load_schema_helper.rb

### DIFF
--- a/eslint/no-internal-canonical-loaders.mjs
+++ b/eslint/no-internal-canonical-loaders.mjs
@@ -33,11 +33,17 @@ export function repoRel(filename) {
   return m ? m[1] : null;
 }
 
-// Symbols that must not be imported directly into a test file.
-export const BANNED = new Set(["ensureCanonicalTables", "loadCanonicalSchema"]);
+// Symbols that must not be imported directly into a test file. `loadSchema`
+// (support/load-schema-helper.ts, the port of `LoadSchemaHelper#load_schema`)
+// wraps `loadCanonicalSchema`, so banning only the wrapped symbol would leave
+// the same schema-wiring backdoor open under a different name.
+export const BANNED = new Set(["ensureCanonicalTables", "loadCanonicalSchema", "loadSchema"]);
 
 // Test files permitted to import the banned loaders (they test them directly).
-export const ALLOW = new Set(["packages/activerecord/src/support/canonical-schema.test.ts"]);
+export const ALLOW = new Set([
+  "packages/activerecord/src/support/canonical-schema.test.ts",
+  "packages/activerecord/src/support/load-schema-helper.test.ts",
+]);
 
 /** True when `source` resolves to the canonical-schema test helper module. */
 function isCanonicalSchemaModule(source) {
@@ -45,7 +51,7 @@ function isCanonicalSchemaModule(source) {
   // same-directory import from inside support/ (`./canonical-schema.js`)
   // is caught, not just the `../../support/canonical-schema.js` form. The
   // repo has a single canonical-schema module, so basename matching is safe.
-  return /(?:^|\/)canonical-schema(?:\.js)?$/.test(source);
+  return /(?:^|\/)(?:canonical-schema|load-schema-helper)(?:\.js)?$/.test(source);
 }
 
 /** @type {import("eslint").Rule.RuleModule} */

--- a/eslint/no-internal-canonical-loaders.test.mjs
+++ b/eslint/no-internal-canonical-loaders.test.mjs
@@ -30,6 +30,11 @@ tester.run("no-internal-canonical-loaders", rule, {
       filename: OWN_TEST,
       code: 'import { ensureCanonicalTables, loadCanonicalSchema } from "./canonical-schema.js";',
     },
+    // load-schema-helper's own unit test may import loadSchema directly.
+    {
+      filename: "packages/activerecord/src/support/load-schema-helper.test.ts",
+      code: 'import { loadSchema } from "./load-schema-helper.js";',
+    },
     // A banned symbol imported from an unrelated module is not the loader.
     {
       filename: FILENAME,
@@ -46,6 +51,13 @@ tester.run("no-internal-canonical-loaders", rule, {
       filename: FILENAME,
       code: 'import { loadCanonicalSchema } from "./support/canonical-schema.js";',
       errors: [{ messageId: "banned", data: { name: "loadCanonicalSchema" } }],
+    },
+    // `loadSchema` wraps `loadCanonicalSchema`, so the Rails-named entry point
+    // is banned in test files too.
+    {
+      filename: FILENAME,
+      code: 'import { loadSchema } from "./support/load-schema-helper.js";',
+      errors: [{ messageId: "banned", data: { name: "loadSchema" } }],
     },
     // Deeper relative path (adapters/mysql2/*.test.ts reaching up two levels).
     {

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -1693,48 +1693,15 @@ describe("PersistenceTest", () => {
 // PersistenceTest — PostgreSQL-only uuid primary-key create coverage.
 // Both Rails tests are guarded `if current_adapter?(:PostgreSQLAdapter)`; the
 // `chat_messages` / `chat_messages_custom_pk` tables live only in
-// postgresql_specific_schema.rb and use uuid PKs, which defineSchema rejects on
-// SQLite/MySQL — so the schema setup and both tests are gated to the postgres
-// adapter (the tests stay in a `PersistenceTest` describe to mirror Rails).
+// postgresql_specific_schema.rb and use uuid PKs, so they are laid at boot by
+// loadSchema's adapter-specific arm on the postgres lane only, and both tests
+// are gated to that adapter (the tests stay in a `PersistenceTest` describe to
+// mirror Rails).
 // ==========================================================================
 describe("PersistenceTest", () => {
   registerModel(ChatMessage);
   registerModel(ChatMessageCustomPk);
   fixtures([]);
-  beforeAll(async () => {
-    // uuid is a PG-only defineSchema type, so the schema is only applied on
-    // postgres; the tests below are individually gated to the same adapter.
-    if (adapterType !== "postgres") return;
-    // Mirror Rails' postgresql_specific_schema.rb header:
-    //   enable_extension!("uuid-ossp", connection)
-    //   enable_extension!("pgcrypto", connection) if supports_pgcrypto_uuid?
-    // uuid-ossp supplies uuid_generate_v4() for chat_messages_custom_pk.
-    const connection = Base.connection as PostgreSQLAdapter;
-    await connection.enableExtension("uuid-ossp");
-    await connection.enableExtension("pgcrypto");
-    // Mirror postgresql_specific_schema.rb:
-    //   create_table :chat_messages, id: :uuid, force: true, **uuid_default
-    // With pgcrypto available, uuid_default is {} → the adapter defaults the
-    // uuid PK to gen_random_uuid().
-    await connection.createTable("chat_messages", { id: "uuid", force: true }, (t) => {
-      t.text("content");
-    });
-    //   create_table :chat_messages_custom_pk, id: false, force: true do |t|
-    //     t.uuid :message_id, primary_key: true, default: "uuid_generate_v4()"
-    //     t.text :content
-    //   end
-    await connection.createTable("chat_messages_custom_pk", { id: false, force: true }, (t) => {
-      const pg = t as PgTableDefinition;
-      pg.uuid("message_id", { primaryKey: true, default: () => "uuid_generate_v4()" });
-      pg.text("content");
-    });
-  });
-
-  afterAll(async () => {
-    if (adapterType !== "postgres") return;
-    const connection = Base.connection as PostgreSQLAdapter;
-    await connection.dropTable("chat_messages_custom_pk", "chat_messages", { ifExists: true });
-  });
 
   it.skipIf(adapterType !== "postgres")("create model with uuid pk populates id", async () => {
     const message = await ChatMessage.create({ content: "New Message" });

--- a/packages/activerecord/src/support/load-schema-helper.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+import "../sqlite/better-sqlite3.js";
+import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
+import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
+import { loadSchema } from "./load-schema-helper.js";
+
+// Runs on SQLite regardless of the ambient ARCONN adapter (it constructs its own
+// in-memory adapter), so the schema-lay arm is exercised on every lane.
+
+describe("LoadSchemaHelper", () => {
+  test("load_schema", async () => {
+    const adapter = new BetterSQLite3Adapter(":memory:") as unknown as AbstractAdapter;
+    try {
+      await loadSchema(adapter);
+
+      const res = await adapter.selectAll(
+        "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name",
+      );
+      const tables = res.toArray().map((r) => r.name as string);
+
+      // Sanity floor: schema.rb is hundreds of tables, so a silently-empty lay
+      // cannot pass.
+      expect(tables.length).toBeGreaterThan(300);
+      expect(tables).toContain("topics");
+      expect(tables).toContain("posts");
+    } finally {
+      await (adapter as unknown as BetterSQLite3Adapter).close();
+    }
+  });
+});

--- a/packages/activerecord/src/support/load-schema-helper.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper.test.ts
@@ -4,9 +4,6 @@ import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adap
 import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 import { loadSchema } from "./load-schema-helper.js";
 
-// Runs on SQLite regardless of the ambient ARCONN adapter (it constructs its own
-// in-memory adapter), so the schema-lay arm is exercised on every lane.
-
 describe("LoadSchemaHelper", () => {
   test("load_schema", async () => {
     const adapter = new BetterSQLite3Adapter(":memory:") as unknown as AbstractAdapter;
@@ -18,8 +15,6 @@ describe("LoadSchemaHelper", () => {
       );
       const tables = res.toArray().map((r) => r.name as string);
 
-      // Sanity floor: schema.rb is hundreds of tables, so a silently-empty lay
-      // cannot pass.
       expect(tables.length).toBeGreaterThan(300);
       expect(tables).toContain("topics");
       expect(tables).toContain("posts");

--- a/packages/activerecord/src/support/load-schema-helper.test.ts
+++ b/packages/activerecord/src/support/load-schema-helper.test.ts
@@ -18,6 +18,7 @@ describe("LoadSchemaHelper", () => {
       expect(tables.length).toBeGreaterThan(300);
       expect(tables).toContain("topics");
       expect(tables).toContain("posts");
+      expect(tables).not.toContain("chat_messages");
     } finally {
       await (adapter as unknown as BetterSQLite3Adapter).close();
     }

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -5,16 +5,18 @@ import { loadCanonicalSchema } from "./canonical-schema.js";
 
 /**
  * The ported slice of
- * `vendor/rails/activerecord/test/schema/postgresql_specific_schema.rb:4-16` —
- * the `uuid-ossp` / `pgcrypto` extension header and the `chat_messages` /
- * `chat_messages_custom_pk` uuid-primary-key tables. `uuid_default` there is
- * `{}` whenever `supports_pgcrypto_uuid?` (PG >= 9.4, always true on our
- * postgres lane), which leaves the uuid PK on the adapter's `gen_random_uuid()`
- * default.
+ * `vendor/rails/activerecord/test/schema/postgresql_specific_schema.rb:4-25` —
+ * the `uuid-ossp` / `pgcrypto` extension header and the four uuid-primary-key
+ * tables. `uuid_default` there is `{}` whenever `supports_pgcrypto_uuid?`
+ * (PG >= 9.4, always true on our postgres lane), which leaves the uuid PK on the
+ * adapter's `gen_random_uuid()` default.
  *
- * The rest of that file (`uuid_parents`, `uuid_children`, `defaults`,
- * `postgresql_times`, …) and the `mysql2_` / `sqlite_` specific schemas are not
- * ported yet; story `port-adapter-specific-schemas` covers them.
+ * The remainder of that file (`defaults`, `postgresql_times`, the identity,
+ * sequence, partition and constraint tables — lines 27-225) and the `mysql2_` /
+ * `sqlite_` schemas are carried by story `port-adapter-specific-schemas`: the
+ * `defaults` table in particular is contended (`adapters/postgresql/schema.test.ts`
+ * and `schema-dumper.test.ts` create and DROP their own on the shared per-worker
+ * DB), so laying it at boot needs those files repointed in the same change.
  */
 async function loadPostgresqlSpecificSchema(adapter: PostgreSQLAdapter): Promise<void> {
   await adapter.enableExtension("uuid-ossp");
@@ -28,6 +30,16 @@ async function loadPostgresqlSpecificSchema(adapter: PostgreSQLAdapter): Promise
     const pg = t as PgTableDefinition;
     pg.uuid("message_id", { primaryKey: true, default: () => "uuid_generate_v4()" });
     pg.text("content");
+  });
+
+  await adapter.createTable("uuid_parents", { id: "uuid", force: true }, (t) => {
+    (t as PgTableDefinition).string("name");
+  });
+
+  await adapter.createTable("uuid_children", { id: "uuid", force: true }, (t) => {
+    const pg = t as PgTableDefinition;
+    pg.string("name");
+    pg.uuid("uuid_parent_id");
   });
 }
 

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -1,5 +1,46 @@
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
+import type { TableDefinition as PgTableDefinition } from "../connection-adapters/postgresql/schema-definitions.js";
+import type { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
 import { loadCanonicalSchema } from "./canonical-schema.js";
+
+/**
+ * The ported slice of
+ * `vendor/rails/activerecord/test/schema/postgresql_specific_schema.rb:4-16` —
+ * the `uuid-ossp` / `pgcrypto` extension header and the `chat_messages` /
+ * `chat_messages_custom_pk` uuid-primary-key tables. `uuid_default` there is
+ * `{}` whenever `supports_pgcrypto_uuid?` (PG >= 9.4, always true on our
+ * postgres lane), which leaves the uuid PK on the adapter's `gen_random_uuid()`
+ * default.
+ *
+ * The rest of that file (`uuid_parents`, `uuid_children`, `defaults`,
+ * `postgresql_times`, …) and the `mysql2_` / `sqlite_` specific schemas are not
+ * ported yet; story `port-adapter-specific-schemas` covers them.
+ */
+async function loadPostgresqlSpecificSchema(adapter: PostgreSQLAdapter): Promise<void> {
+  await adapter.enableExtension("uuid-ossp");
+  await adapter.enableExtension("pgcrypto");
+
+  await adapter.createTable("chat_messages", { id: "uuid", force: true }, (t) => {
+    (t as PgTableDefinition).text("content");
+  });
+
+  await adapter.createTable("chat_messages_custom_pk", { id: false, force: true }, (t) => {
+    const pg = t as PgTableDefinition;
+    pg.uuid("message_id", { primaryKey: true, default: () => "uuid_generate_v4()" });
+    pg.text("content");
+  });
+}
+
+/**
+ * The `File.exist?(adapter_specific_schema_file)` lookup of
+ * `load_schema_helper.rb:10,15`: an adapter name resolves to its
+ * `<adapter>_specific_schema` loader when trails has one, and to nothing when it
+ * does not — the same false branch Rails takes for an adapter whose file is
+ * absent.
+ */
+const ADAPTER_SPECIFIC_SCHEMAS: Record<string, (adapter: DatabaseAdapter) => Promise<void>> = {
+  postgres: (adapter) => loadPostgresqlSpecificSchema(adapter as unknown as PostgreSQLAdapter),
+};
 
 /**
  * Port of `LoadSchemaHelper#load_schema`
@@ -9,14 +50,8 @@ import { loadCanonicalSchema } from "./canonical-schema.js";
  * - `load SCHEMA_ROOT + "/schema.rb"` → `loadCanonicalSchema`. trails' mirror of
  *   schema.rb is the canonical registry rather than a loadable Ruby file, so
  *   `load` means laying that registry onto the database.
- * - `load adapter_specific_schema_file if File.exist?(...)` → nothing to load.
- *   The content Rails' `<adapter>_specific_schema.rb` files carry is expressed
- *   inside the canonical registry through the same inline `current_adapter?`
- *   gating schema.rb uses (`emitTableIndexes`'s `opts.adapters` check and
- *   `TableBuilder`'s MySQL index-length arm in canonical-schema.ts), so
- *   `loadCanonicalSchema` has already applied it and there is no separate file
- *   whose existence to test. A future standalone adapter-specific schema module
- *   loads here, between the schema lay and the fixture-cache reset.
+ * - `load adapter_specific_schema_file if File.exist?(...)` →
+ *   {@link ADAPTER_SPECIFIC_SCHEMAS}.
  * - `ActiveRecord::FixtureSet.reset_cache` (fixtures.rb:556) clears
  *   `@@all_cached_fixtures`, which Rails fills in `FixtureSet.create_fixtures`
  *   (fixtures.rb:611) so a re-loaded schema cannot be served rows built against
@@ -33,4 +68,7 @@ import { loadCanonicalSchema } from "./canonical-schema.js";
  */
 export async function loadSchema(adapter: DatabaseAdapter): Promise<void> {
   await loadCanonicalSchema(adapter);
+
+  const adapterSpecificSchema = ADAPTER_SPECIFIC_SCHEMAS[adapter.adapterName];
+  if (adapterSpecificSchema) await adapterSpecificSchema(adapter);
 }

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -1,0 +1,41 @@
+import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
+import { loadCanonicalSchema } from "./canonical-schema.js";
+
+/**
+ * Port of `LoadSchemaHelper#load_schema`
+ * (vendor/rails/activerecord/test/support/load_schema_helper.rb:4-21).
+ *
+ * Rails' body has four parts: silence `$stdout`, `load SCHEMA_ROOT/schema.rb`,
+ * `load` the adapter-specific schema file when it exists, and
+ * `ActiveRecord::FixtureSet.reset_cache`. Each is handled below; the
+ * dispositions that differ from Rails are justified at the line they affect.
+ *
+ * The stdout-silencing arm has no counterpart: `load`ing a Ruby schema file
+ * prints every migration line, whereas laying the canonical schema here issues
+ * DDL through the adapter and prints nothing.
+ */
+export async function loadSchema(adapter: DatabaseAdapter): Promise<void> {
+  // `load SCHEMA_ROOT + "/schema.rb"`. trails' mirror of schema.rb is
+  // `test-helpers/test-schema.ts` / the canonical registry rather than a
+  // loadable Ruby file, so the equivalent of `load` is laying that registry
+  // onto the database.
+  await loadCanonicalSchema(adapter);
+
+  // `load adapter_specific_schema_file if File.exist?(...)`. trails has no
+  // `<adapter>_specific_schema` module to conditionally load: the per-adapter
+  // schema content those Rails files carry is expressed inside the canonical
+  // registry itself, through the same inline `current_adapter?` gating schema.rb
+  // uses (`emitTableIndexes`'s `opts.adapters` check and `TableBuilder`'s MySQL
+  // index-length arm in canonical-schema.ts). So `loadCanonicalSchema` above has
+  // already applied it, and there is no separate file whose existence to test.
+  // If trails ever grows a standalone adapter-specific schema module, loading it
+  // belongs here, between the schema lay and the fixture-cache reset.
+
+  // `ActiveRecord::FixtureSet.reset_cache` (fixtures.rb:556) clears
+  // `@@all_cached_fixtures`, the per-connection-pool cache Rails fills in
+  // `FixtureSet.create_fixtures` (fixtures.rb:611) so a re-loaded schema cannot
+  // be served rows built against the old one. trails' `FixtureSet.createFixtures`
+  // delegates straight to `defineFixtures`, which inserts and caches nothing, so
+  // there is no cache to clear — the arm is genuinely empty here rather than
+  // unimplemented.
+}

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -47,8 +47,16 @@ async function loadPostgresqlSpecificSchema(adapter: PostgreSQLAdapter): Promise
  * The `File.exist?(adapter_specific_schema_file)` lookup of
  * `load_schema_helper.rb:10,15`: an adapter name resolves to its
  * `<adapter>_specific_schema` loader when trails has one, and to nothing when it
- * does not — the same false branch Rails takes for an adapter whose file is
- * absent.
+ * does not.
+ *
+ * INCOMPLETE, deliberately. Rails has four such files and every one of them has
+ * real content; trails has ported part of one. `sqlite_specific_schema.rb:3-21`
+ * and `mysql2_specific_schema.rb:3-95` have no entry here at all, so the sqlite
+ * and mysql lanes currently boot without the schema Rails gives them. That is a
+ * known gap owned by story `port-adapter-specific-schemas` (RFC 0064), not a
+ * claim that the gap does not exist. `trilogy_specific_schema.rb` is the one
+ * genuine no-op: trails has no Trilogy adapter, so no adapter name ever selects
+ * it.
  */
 const ADAPTER_SPECIFIC_SCHEMAS: Record<string, (adapter: DatabaseAdapter) => Promise<void>> = {
   postgres: (adapter) => loadPostgresqlSpecificSchema(adapter as unknown as PostgreSQLAdapter),
@@ -56,8 +64,9 @@ const ADAPTER_SPECIFIC_SCHEMAS: Record<string, (adapter: DatabaseAdapter) => Pro
 
 /**
  * Port of `LoadSchemaHelper#load_schema`
- * (vendor/rails/activerecord/test/support/load_schema_helper.rb:4-21), arm by
- * arm:
+ * (vendor/rails/activerecord/test/support/load_schema_helper.rb:4-21). The
+ * control flow is complete; the *content* of the adapter-specific arm is not —
+ * see {@link ADAPTER_SPECIFIC_SCHEMAS}. Arm by arm:
  *
  * - `load SCHEMA_ROOT + "/schema.rb"` → `loadCanonicalSchema`. trails' mirror of
  *   schema.rb is the canonical registry rather than a loadable Ruby file, so

--- a/packages/activerecord/src/support/load-schema-helper.ts
+++ b/packages/activerecord/src/support/load-schema-helper.ts
@@ -3,39 +3,34 @@ import { loadCanonicalSchema } from "./canonical-schema.js";
 
 /**
  * Port of `LoadSchemaHelper#load_schema`
- * (vendor/rails/activerecord/test/support/load_schema_helper.rb:4-21).
+ * (vendor/rails/activerecord/test/support/load_schema_helper.rb:4-21), arm by
+ * arm:
  *
- * Rails' body has four parts: silence `$stdout`, `load SCHEMA_ROOT/schema.rb`,
- * `load` the adapter-specific schema file when it exists, and
- * `ActiveRecord::FixtureSet.reset_cache`. Each is handled below; the
- * dispositions that differ from Rails are justified at the line they affect.
+ * - `load SCHEMA_ROOT + "/schema.rb"` → `loadCanonicalSchema`. trails' mirror of
+ *   schema.rb is the canonical registry rather than a loadable Ruby file, so
+ *   `load` means laying that registry onto the database.
+ * - `load adapter_specific_schema_file if File.exist?(...)` → nothing to load.
+ *   The content Rails' `<adapter>_specific_schema.rb` files carry is expressed
+ *   inside the canonical registry through the same inline `current_adapter?`
+ *   gating schema.rb uses (`emitTableIndexes`'s `opts.adapters` check and
+ *   `TableBuilder`'s MySQL index-length arm in canonical-schema.ts), so
+ *   `loadCanonicalSchema` has already applied it and there is no separate file
+ *   whose existence to test. A future standalone adapter-specific schema module
+ *   loads here, between the schema lay and the fixture-cache reset.
+ * - `ActiveRecord::FixtureSet.reset_cache` (fixtures.rb:556) clears
+ *   `@@all_cached_fixtures`, which Rails fills in `FixtureSet.create_fixtures`
+ *   (fixtures.rb:611) so a re-loaded schema cannot be served rows built against
+ *   the old one. trails' `FixtureSet.createFixtures` delegates straight to
+ *   `defineFixtures`, which caches nothing, so the arm is empty here rather than
+ *   unimplemented.
+ * - Silencing `$stdout` has no counterpart: `load`ing a Ruby schema file prints
+ *   every migration line, whereas laying the schema through the adapter prints
+ *   nothing.
  *
- * The stdout-silencing arm has no counterpart: `load`ing a Ruby schema file
- * prints every migration line, whereas laying the canonical schema here issues
- * DDL through the adapter and prints nothing.
+ * @internal Boot/template setup paths only. Test files wire the canonical schema
+ * + fixtures through `fixtures({ ... })`; the
+ * `blazetrails/no-internal-canonical-loaders` ESLint rule enforces that.
  */
 export async function loadSchema(adapter: DatabaseAdapter): Promise<void> {
-  // `load SCHEMA_ROOT + "/schema.rb"`. trails' mirror of schema.rb is
-  // `test-helpers/test-schema.ts` / the canonical registry rather than a
-  // loadable Ruby file, so the equivalent of `load` is laying that registry
-  // onto the database.
   await loadCanonicalSchema(adapter);
-
-  // `load adapter_specific_schema_file if File.exist?(...)`. trails has no
-  // `<adapter>_specific_schema` module to conditionally load: the per-adapter
-  // schema content those Rails files carry is expressed inside the canonical
-  // registry itself, through the same inline `current_adapter?` gating schema.rb
-  // uses (`emitTableIndexes`'s `opts.adapters` check and `TableBuilder`'s MySQL
-  // index-length arm in canonical-schema.ts). So `loadCanonicalSchema` above has
-  // already applied it, and there is no separate file whose existence to test.
-  // If trails ever grows a standalone adapter-specific schema module, loading it
-  // belongs here, between the schema lay and the fixture-cache reset.
-
-  // `ActiveRecord::FixtureSet.reset_cache` (fixtures.rb:556) clears
-  // `@@all_cached_fixtures`, the per-connection-pool cache Rails fills in
-  // `FixtureSet.create_fixtures` (fixtures.rb:611) so a re-loaded schema cannot
-  // be served rows built against the old one. trails' `FixtureSet.createFixtures`
-  // delegates straight to `defineFixtures`, which inserts and caches nothing, so
-  // there is no cache to clear — the arm is genuinely empty here rather than
-  // unimplemented.
 }

--- a/packages/activerecord/src/support/setup-adapter-suite.ts
+++ b/packages/activerecord/src/support/setup-adapter-suite.ts
@@ -1,6 +1,6 @@
 import { beforeAll, afterAll } from "vitest";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
-import { loadCanonicalSchema } from "./canonical-schema.js";
+import { loadSchema } from "./load-schema-helper.js";
 import {
   withTransactionalFixtures,
   type TransactionalFixturesAdapter,
@@ -41,7 +41,7 @@ export interface AdapterSuiteHandle<A extends TransactionalFixturesAdapter> {
  * Boilerplate-free wrapper around the canonical adapter-cluster test pattern:
  *
  * ```
- * beforeAll(() => adapter = factory(); loadCanonicalSchema(adapter); setup(adapter));
+ * beforeAll(() => adapter = factory(); loadSchema(adapter); setup(adapter));
  * withTransactionalFixtures(() => adapter);
  * afterAll(() => teardown(adapter); adapter.close());
  * ```
@@ -72,7 +72,7 @@ export function setupAdapterSuite<A extends TransactionalFixturesAdapter>(
 
   beforeAll(async () => {
     adapter = await opts.factory();
-    await loadCanonicalSchema(adapter as unknown as DatabaseAdapter);
+    await loadSchema(adapter as unknown as DatabaseAdapter);
     if (opts.setup) await opts.setup(adapter);
   });
 

--- a/packages/activerecord/src/support/template-global-setup.ts
+++ b/packages/activerecord/src/support/template-global-setup.ts
@@ -20,7 +20,7 @@ import { getFsAsync } from "@blazetrails/activesupport/fs-adapter";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
 import { PostgreSQLAdapter } from "../connection-adapters/postgresql-adapter.js";
-import { loadCanonicalSchema } from "./canonical-schema.js";
+import { loadSchema } from "./load-schema-helper.js";
 import { generateSchemaFile } from "./schema-file-generator.js";
 import { TEST_SCHEMA } from "../test-helpers/test-schema.js";
 import { InternalMetadata } from "../internal-metadata.js";
@@ -59,7 +59,7 @@ async function buildTemplateSchema(
   close: () => Promise<void>,
 ): Promise<void> {
   try {
-    await loadCanonicalSchema(adapter);
+    await loadSchema(adapter);
   } finally {
     await close();
   }
@@ -152,7 +152,7 @@ const pgAdapter: DbTemplateAdapter = {
       max: 1,
     }) as unknown as DatabaseAdapter;
     try {
-      await loadCanonicalSchema(adapter);
+      await loadSchema(adapter);
       // Stamp ar_internal_metadata so every slot cloned from this template
       // reports `schemaUpToDate` → each worker's reconstructFromSchema only
       // TRUNCATEs (no DDL) instead of paying a full purge+reload per test


### PR DESCRIPTION
**Scope statement, up front:** this PR ports `load_schema`'s *control flow* and
one lane's worth of adapter-specific schema content. It is not a complete port
of the four `*_specific_schema.rb` files, and the code now says so at
`ADAPTER_SPECIFIC_SCHEMAS` rather than implying completeness. The sqlite and
mysql lanes still boot without the schema Rails gives them; story
`port-adapter-specific-schemas` (RFC 0064) owns closing that.

Ports `vendor/rails/activerecord/test/support/load_schema_helper.rb` to
`packages/activerecord/src/support/load-schema-helper.ts` (RFC 0064).

`loadSchema(adapter)` is the Rails-named entry point for "lay the test schema".
Its body walks `load_schema_helper.rb:4-21` arm by arm, justifying each
disposition at the line it affects:

- **`load SCHEMA_ROOT + "/schema.rb"`** → `loadCanonicalSchema(adapter)`. trails'
  mirror of `schema.rb` is the canonical registry, not a loadable Ruby file, so
  "load" means laying that registry onto the database.
- **`load adapter_specific_schema_file if File.exist?(...)`** →
  `ADAPTER_SPECIFIC_SCHEMAS`, an adapter-name → loader lookup; a name with no
  entry takes the same false branch Rails takes for an absent file. The postgres
  entry ports `postgresql_specific_schema.rb:4-25` — the `uuid-ossp` / `pgcrypto`
  header, `chat_messages` / `chat_messages_custom_pk` (lifted from the inline
  setup in `persistence.test.ts:1703-1730`), and `uuid_parents` / `uuid_children`
  (whose models and fixtures already exist in trails but had no table anywhere).
  `persistence.test.ts` no longer creates those tables in `beforeAll` nor drops
  them in `afterAll` — they are schema-owned now, exactly as in Rails, and the
  drop would otherwise have removed boot-laid tables from the shared per-worker
  DB for every PG file that ran after it.
- **`FixtureSet.reset_cache`** → genuinely empty. Rails clears
  `@@all_cached_fixtures` (`fixtures.rb:556`), filled by `create_fixtures`
  (`fixtures.rb:611`); trails' `FixtureSet.createFixtures` delegates to
  `defineFixtures`, which caches nothing.
- **stdout silencing** → no counterpart; laying DDL through the adapter prints
  nothing.

The internal boot paths now call `loadSchema`: `template-global-setup.ts:62,155`
and `setup-adapter-suite.ts:75`.

## What deliberately stays behind

The per-worker template/clone machinery in `canonical-schema.ts`
(`rebuildCanonicalTables`, `ensureCanonicalTables`, `fkSafeDropPlan`,
`bulkInboundFkHost`) has **no Rails counterpart** — Rails' suite is one process
against one database — so it keeps its own file and its own invented name rather
than being crammed into a Rails-named one. Likewise the canonical registry
itself (2457 lines) is not moved; only the `load_schema`-shaped entry point is
extracted, per the story's 500-LOC instruction. Whether the registry half should
split from the drop/rebuild half is registered as the follow-up story
`split-canonical-schema-registry-from-template-machinery` (RFC 0064).

## Why the remaining `*_specific_schema.rb` content is not in this PR

This is a scope boundary, not a disagreement that the gap is real. The story this
PR implements says to "extract the `load_schema`-shaped entry point only" and to
"register any remaining split as a follow-up story"; the remainder is ~300 lines
of Ruby, past the 500-LOC ceiling on its own. `port-adapter-specific-schemas`
(RFC 0064) carries it with the per-file line ranges:

- **`defaults` (all three files)** is *contended*: `adapters/postgresql/schema.test.ts:829,841`
  and `schema-dumper.test.ts:623,1052` each `CREATE` and `DROP` their own
  `defaults` on the shared per-worker DB. Laying it at boot without repointing
  those files first produces exactly the cross-file contamination flakes this
  repo has been burning down, so it must move as one change, not as a drive-by.
- **`postgresql_specific_schema.rb:27-225`** (identity columns, sequences,
  partitioned tables, exclusion constraints, `postgresql_times`, `postgresql_oids`)
  and **`mysql2_specific_schema.rb:3-95`** (stored procedures, trigger-backed PK
  tables, `datetime_defaults` / `timestamp_defaults` / `binary_fields`) are ~300
  lines of Ruby whose TS port needs per-feature adapter verification; together
  they exceed this PR's 500-LOC ceiling on their own, and the story this PR
  implements explicitly says to extract the `load_schema`-shaped entry point only.
- **`trilogy_specific_schema.rb`** has no target: trails has no Trilogy adapter
  (`packages/activerecord/src/adapters/` is abstract-mysql / mysql2 / postgresql /
  sqlite3), and Trilogy is Ruby-only by standing repo policy. Rails' arm keys off
  `File.exist?`, so an adapter trails does not have simply never selects it.

The lookup itself is complete: adding a lane is one map entry, and an adapter
with no entry takes the same false branch Rails takes for an absent file.

## Guard

`eslint/no-internal-canonical-loaders.mjs` bans `loadSchema` alongside
`loadCanonicalSchema` / `ensureCanonicalTables`: the wrapper would otherwise be
the same schema-wiring backdoor into `*.test.ts` under a new name. `fixtures({})`
remains the sanctioned test surface.

## Verification

- `pnpm schema:compare` output unchanged: `321 TEST_SCHEMA tables vs 266
  canonical-schema tables — new-inventions=0 baselined=80 option-divergences=4
  (ceiling 4) shape-warnings=2`.
- `load-schema-helper.test.ts` (SQLite in-memory, runs on every lane) and
  `setup-adapter-suite.test.ts` pass; `node --test
  eslint/no-internal-canonical-loaders.test.mjs` passes.

Closes-story: support-load-schema-helper
