### PR TITLE
test(activerecord): port ddl_helper, async_helper and fake_adapter to support/

### DIFF
--- a/packages/activerecord/src/cases/helper.ts
+++ b/packages/activerecord/src/cases/helper.ts
@@ -20,6 +20,7 @@ import {
 } from "../ar-config.js";
 import { resetTestAdapterState } from "../test-adapter.js";
 import { shouldSkipGlobalReset } from "../support/skip-global-reset.js";
+import { registerFakeAdapter } from "../support/fake-adapter.js";
 import { Configurable as EncryptionConfigurable } from "../encryption/configurable.js";
 import { installExtendedQueriesIfConfigured } from "../encryption/install.js";
 import {
@@ -33,6 +34,11 @@ import {
 // stays true). Use the versioned-defaults mechanism rather than poking Base
 // directly; this exercises the real code path that a consuming app would use.
 loadDefaults("7.0");
+
+// Mirror Rails activerecord/test/cases/helper.rb:46 — register the fake adapter
+// for the whole suite, before any model calls establish_connection(adapter:
+// "fake") at load time (test/models/contact.rb:6).
+registerFakeAdapter();
 
 // Mirror Rails activerecord/test/cases/helper.rb:29 — ban delegating a
 // relation/collection-proxy call into an `ActiveRecord::Base` method suite-wide

--- a/packages/activerecord/src/support/async-helper.test.ts
+++ b/packages/activerecord/src/support/async-helper.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { assertAsyncEqual } from "./async-helper.js";
+
+describe("AsyncHelper#assert_async_equal", () => {
+  it("unwraps the promise and compares the value", async () => {
+    await assertAsyncEqual(3, Promise.resolve(3));
+  });
+
+  it("fails when the value differs", async () => {
+    await expect(assertAsyncEqual(3, Promise.resolve(4))).rejects.toThrow();
+  });
+
+  it("fails when the result is not a promise", async () => {
+    await expect(assertAsyncEqual(3, 3)).rejects.toThrow(/ActiveRecord::Promise/);
+  });
+
+  it("takes the assert_nil arm when expected is nil", async () => {
+    await assertAsyncEqual(null, Promise.resolve(null));
+    // The nil arm is assert_nil, not assert_equal — a non-nil value fails even
+    // though `expected` is nil.
+    await expect(assertAsyncEqual(null, Promise.resolve(0))).rejects.toThrow();
+  });
+});

--- a/packages/activerecord/src/support/async-helper.test.ts
+++ b/packages/activerecord/src/support/async-helper.test.ts
@@ -16,8 +16,6 @@ describe("AsyncHelper#assert_async_equal", () => {
 
   it("takes the assert_nil arm when expected is nil", async () => {
     await assertAsyncEqual(null, Promise.resolve(null));
-    // The nil arm is assert_nil, not assert_equal — a non-nil value fails even
-    // though `expected` is nil.
     await expect(assertAsyncEqual(null, Promise.resolve(0))).rejects.toThrow();
   });
 });

--- a/packages/activerecord/src/support/async-helper.ts
+++ b/packages/activerecord/src/support/async-helper.ts
@@ -1,30 +1,6 @@
-/**
- * TS mirror of Rails' test-support `AsyncHelper`
- * (activerecord/test/support/async_helper.rb).
- */
-
 import { expect } from "vitest";
 
-/**
- * Mirrors: AsyncHelper#assert_async_equal
- *
- *   def assert_async_equal(expected, async_result)
- *     message = "Expected to return an ActiveRecord::Promise, got: #{async_result.inspect}"
- *     assert_equal(true, ActiveRecord::Promise === async_result, message)
- *
- *     if expected.nil?
- *       assert_nil async_result.value
- *     else
- *       assert_equal expected, async_result.value
- *     end
- *   end
- *
- * trails has no `ActiveRecord::Promise` wrapper — the `async*` methods return
- * the platform promise directly, so the type assertion checks thenability and
- * `.value` becomes the awaited result. The nil arm stays distinct from the
- * equality arm exactly as in Rails: `assert_nil` accepts only nil, whereas
- * `assert_equal expected, nil` would pass for a nil `expected`.
- */
+/** Mirrors: AsyncHelper#assert_async_equal */
 export async function assertAsyncEqual(expected: unknown, asyncResult: unknown): Promise<void> {
   const message = `Expected to return an ActiveRecord::Promise, got: ${String(asyncResult)}`;
   expect(typeof (asyncResult as { then?: unknown })?.then === "function", message).toBe(true);

--- a/packages/activerecord/src/support/async-helper.ts
+++ b/packages/activerecord/src/support/async-helper.ts
@@ -1,0 +1,38 @@
+/**
+ * TS mirror of Rails' test-support `AsyncHelper`
+ * (activerecord/test/support/async_helper.rb).
+ */
+
+import { expect } from "vitest";
+
+/**
+ * Mirrors: AsyncHelper#assert_async_equal
+ *
+ *   def assert_async_equal(expected, async_result)
+ *     message = "Expected to return an ActiveRecord::Promise, got: #{async_result.inspect}"
+ *     assert_equal(true, ActiveRecord::Promise === async_result, message)
+ *
+ *     if expected.nil?
+ *       assert_nil async_result.value
+ *     else
+ *       assert_equal expected, async_result.value
+ *     end
+ *   end
+ *
+ * trails has no `ActiveRecord::Promise` wrapper — the `async*` methods return
+ * the platform promise directly, so the type assertion checks thenability and
+ * `.value` becomes the awaited result. The nil arm stays distinct from the
+ * equality arm exactly as in Rails: `assert_nil` accepts only nil, whereas
+ * `assert_equal expected, nil` would pass for a nil `expected`.
+ */
+export async function assertAsyncEqual(expected: unknown, asyncResult: unknown): Promise<void> {
+  const message = `Expected to return an ActiveRecord::Promise, got: ${String(asyncResult)}`;
+  expect(typeof (asyncResult as { then?: unknown })?.then === "function", message).toBe(true);
+
+  const value = await (asyncResult as Promise<unknown>);
+  if (expected === null || expected === undefined) {
+    expect(value).toBeNull();
+  } else {
+    expect(value).toEqual(expected);
+  }
+}

--- a/packages/activerecord/src/support/ddl-helper.test.ts
+++ b/packages/activerecord/src/support/ddl-helper.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import { withExampleTable } from "./ddl-helper.js";
+import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
+
+function recordingConnection() {
+  const calls: string[] = [];
+  const connection = {
+    execute: vi.fn(async (sql: string) => {
+      calls.push(sql);
+    }),
+    dropTable: vi.fn(async (name: string) => {
+      calls.push(`DROP ${name}`);
+    }),
+  } as unknown as DatabaseAdapter;
+  return { connection, calls };
+}
+
+describe("DdlHelper#with_example_table", () => {
+  it("creates the table, yields, and drops it", async () => {
+    const { connection, calls } = recordingConnection();
+
+    await withExampleTable(connection, "ex", "id int", () => {
+      calls.push("yielded");
+    });
+
+    expect(calls).toEqual(["CREATE TABLE ex(id int)", "yielded", "DROP ex"]);
+  });
+
+  it("drops the table in the ensure even when the block raises", async () => {
+    const { connection, calls } = recordingConnection();
+
+    await expect(
+      withExampleTable(connection, "ex", "id int", () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    expect(calls).toEqual(["CREATE TABLE ex(id int)", "DROP ex"]);
+  });
+
+  it("defaults the definition to nil", async () => {
+    const { connection, calls } = recordingConnection();
+
+    await withExampleTable(connection, "ex", () => {});
+
+    expect(calls[0]).toBe("CREATE TABLE ex()");
+  });
+
+  it("returns the block's value", async () => {
+    const { connection } = recordingConnection();
+
+    await expect(withExampleTable(connection, "ex", null, () => 42)).resolves.toBe(42);
+  });
+});

--- a/packages/activerecord/src/support/ddl-helper.test.ts
+++ b/packages/activerecord/src/support/ddl-helper.test.ts
@@ -38,6 +38,26 @@ describe("DdlHelper#with_example_table", () => {
     expect(calls).toEqual(["CREATE TABLE ex(id int)", "DROP ex"]);
   });
 
+  it("drops the table in the ensure even when the create raises", async () => {
+    const calls: string[] = [];
+    const connection = {
+      execute: vi.fn(async () => {
+        throw new Error("bad ddl");
+      }),
+      dropTable: vi.fn(async (name: string) => {
+        calls.push(`DROP ${name}`);
+      }),
+    } as unknown as DatabaseAdapter;
+
+    await expect(
+      withExampleTable(connection, "ex", "id int", () => {
+        calls.push("yielded");
+      }),
+    ).rejects.toThrow("bad ddl");
+
+    expect(calls).toEqual(["DROP ex"]);
+  });
+
   it("defaults the definition to nil", async () => {
     const { connection, calls } = recordingConnection();
 

--- a/packages/activerecord/src/support/ddl-helper.ts
+++ b/packages/activerecord/src/support/ddl-helper.ts
@@ -1,0 +1,57 @@
+/**
+ * TS mirror of Rails' test-support `DdlHelper`
+ * (activerecord/test/support/ddl_helper.rb).
+ */
+
+import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
+
+// The two adapter methods `with_example_table` calls. Narrowed here because
+// `execute`/`dropTable` are mixed into AbstractAdapter and not on its own type.
+interface DdlConnection {
+  execute(sql: string): Promise<unknown>;
+  dropTable(name: string): Promise<unknown>;
+}
+
+/**
+ * Mirrors: DdlHelper#with_example_table
+ *
+ *   def with_example_table(connection, table_name, definition = nil)
+ *     connection.execute("CREATE TABLE #{table_name}(#{definition})")
+ *     yield
+ *   ensure
+ *     connection.drop_table(table_name)
+ *   end
+ *
+ * The drop lives in Ruby's `ensure`, so the table is removed even when the
+ * block raises — the `finally` below is that `ensure`.
+ */
+export async function withExampleTable<T>(
+  connection: AbstractAdapter,
+  tableName: string,
+  fn: () => Promise<T> | T,
+): Promise<T>;
+export async function withExampleTable<T>(
+  connection: AbstractAdapter,
+  tableName: string,
+  definition: string | null,
+  fn: () => Promise<T> | T,
+): Promise<T>;
+export async function withExampleTable<T>(
+  connection: AbstractAdapter,
+  tableName: string,
+  definitionOrFn: string | null | (() => Promise<T> | T),
+  maybeFn?: () => Promise<T> | T,
+): Promise<T> {
+  // Rails' `definition = nil` default, expressed against a trailing block.
+  const definition = typeof definitionOrFn === "function" ? null : definitionOrFn;
+  const fn = (typeof definitionOrFn === "function" ? definitionOrFn : maybeFn)!;
+
+  await (connection as unknown as DdlConnection).execute(
+    `CREATE TABLE ${tableName}(${definition ?? ""})`,
+  );
+  try {
+    return await fn();
+  } finally {
+    await (connection as unknown as DdlConnection).dropTable(tableName);
+  }
+}

--- a/packages/activerecord/src/support/ddl-helper.ts
+++ b/packages/activerecord/src/support/ddl-helper.ts
@@ -1,30 +1,11 @@
-/**
- * TS mirror of Rails' test-support `DdlHelper`
- * (activerecord/test/support/ddl_helper.rb).
- */
-
 import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 
-// The two adapter methods `with_example_table` calls. Narrowed here because
-// `execute`/`dropTable` are mixed into AbstractAdapter and not on its own type.
 interface DdlConnection {
   execute(sql: string): Promise<unknown>;
   dropTable(name: string): Promise<unknown>;
 }
 
-/**
- * Mirrors: DdlHelper#with_example_table
- *
- *   def with_example_table(connection, table_name, definition = nil)
- *     connection.execute("CREATE TABLE #{table_name}(#{definition})")
- *     yield
- *   ensure
- *     connection.drop_table(table_name)
- *   end
- *
- * The drop lives in Ruby's `ensure`, so the table is removed even when the
- * block raises — the `finally` below is that `ensure`.
- */
+/** Mirrors: DdlHelper#with_example_table */
 export async function withExampleTable<T>(
   connection: AbstractAdapter,
   tableName: string,
@@ -42,16 +23,14 @@ export async function withExampleTable<T>(
   definitionOrFn: string | null | (() => Promise<T> | T),
   maybeFn?: () => Promise<T> | T,
 ): Promise<T> {
-  // Rails' `definition = nil` default, expressed against a trailing block.
   const definition = typeof definitionOrFn === "function" ? null : definitionOrFn;
   const fn = (typeof definitionOrFn === "function" ? definitionOrFn : maybeFn)!;
 
-  await (connection as unknown as DdlConnection).execute(
-    `CREATE TABLE ${tableName}(${definition ?? ""})`,
-  );
+  const ddl = connection as unknown as DdlConnection;
+  await ddl.execute(`CREATE TABLE ${tableName}(${definition ?? ""})`);
   try {
     return await fn();
   } finally {
-    await (connection as unknown as DdlConnection).dropTable(tableName);
+    await ddl.dropTable(tableName);
   }
 }

--- a/packages/activerecord/src/support/ddl-helper.ts
+++ b/packages/activerecord/src/support/ddl-helper.ts
@@ -27,8 +27,8 @@ export async function withExampleTable<T>(
   const fn = (typeof definitionOrFn === "function" ? definitionOrFn : maybeFn)!;
 
   const ddl = connection as unknown as DdlConnection;
-  await ddl.execute(`CREATE TABLE ${tableName}(${definition ?? ""})`);
   try {
+    await ddl.execute(`CREATE TABLE ${tableName}(${definition ?? ""})`);
     return await fn();
   } finally {
     await ddl.dropTable(tableName);

--- a/packages/activerecord/src/support/fake-adapter.test.ts
+++ b/packages/activerecord/src/support/fake-adapter.test.ts
@@ -4,8 +4,6 @@ import { resolve } from "../connection-adapters.js";
 
 describe("FakeActiveRecordAdapter", () => {
   it("is registered under the name fake", async () => {
-    // Mirrors cases/helper.rb:46's suite-wide
-    // ConnectionAdapters.register("fake", "FakeActiveRecordAdapter", ...)
     await expect(resolve("fake")).resolves.toBe(
       FakeActiveRecordAdapter as unknown as Awaited<ReturnType<typeof resolve>>,
     );

--- a/packages/activerecord/src/support/fake-adapter.test.ts
+++ b/packages/activerecord/src/support/fake-adapter.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { FakeActiveRecordAdapter } from "./fake-adapter.js";
+import { resolve } from "../connection-adapters.js";
+
+describe("FakeActiveRecordAdapter", () => {
+  it("is registered under the name fake", async () => {
+    // Mirrors cases/helper.rb:46's suite-wide
+    // ConnectionAdapters.register("fake", "FakeActiveRecordAdapter", ...)
+    await expect(resolve("fake")).resolves.toBe(
+      FakeActiveRecordAdapter as unknown as Awaited<ReturnType<typeof resolve>>,
+    );
+  });
+
+  it("primary_key falls back to id", () => {
+    const adapter = new FakeActiveRecordAdapter();
+    expect(adapter.primaryKey("fake_widgets")).toBe("id");
+
+    adapter.primaryKeys = { fake_widgets: "widget_id" };
+    expect(adapter.primaryKey("fake_widgets")).toBe("widget_id");
+  });
+
+  it("merge_column appends synthetic columns readable through columns", () => {
+    const adapter = new FakeActiveRecordAdapter();
+    adapter.mergeColumn("fake_contacts", "name", "string");
+    adapter.mergeColumn("fake_contacts", "age", "integer", { null: false, default: 0 });
+
+    const columns = adapter.columns("fake_contacts");
+    expect(columns.map((c) => c.name)).toEqual(["name", "age"]);
+    expect(columns[1].null).toBe(false);
+    expect(columns[1].default).toBe(0);
+    expect(columns[0].sqlTypeMetadata?.sqlType).toBe("string");
+  });
+
+  it("columns is empty for an unknown table", () => {
+    const adapter = new FakeActiveRecordAdapter();
+    expect(adapter.columns("fake_nothing")).toEqual([]);
+  });
+
+  it("data_source_exists? and active? are always true", () => {
+    const adapter = new FakeActiveRecordAdapter();
+    expect(adapter.dataSourceExists()).toBe(true);
+    expect(adapter.active).toBe(true);
+  });
+
+  it("shares the synthetic column list across instances", () => {
+    new FakeActiveRecordAdapter().mergeColumn("fake_shared", "id", "integer");
+    const other = new FakeActiveRecordAdapter();
+    expect(other.columns("fake_shared").map((c) => c.name)).toEqual(["id"]);
+  });
+});

--- a/packages/activerecord/src/support/fake-adapter.ts
+++ b/packages/activerecord/src/support/fake-adapter.ts
@@ -77,4 +77,7 @@ export class FakeActiveRecordAdapter extends FakeAdapterBase {
   }
 }
 
-register("fake", async () => FakeActiveRecordAdapter as unknown as new () => AbstractAdapter);
+/** Mirrors: activerecord/test/cases/helper.rb:46 */
+export function registerFakeAdapter(): void {
+  register("fake", async () => FakeActiveRecordAdapter as unknown as new () => AbstractAdapter);
+}

--- a/packages/activerecord/src/support/fake-adapter.ts
+++ b/packages/activerecord/src/support/fake-adapter.ts
@@ -1,0 +1,104 @@
+/**
+ * TS mirror of Rails' test-support `FakeActiveRecordAdapter`
+ * (activerecord/test/support/fake_adapter.rb).
+ *
+ * Registered suite-wide under the name `"fake"` — the trails analogue of
+ * `cases/helper.rb:46`'s
+ * `ActiveRecord::ConnectionAdapters.register("fake", "FakeActiveRecordAdapter", …)`.
+ * Models that only need a column list without a real database (Rails' `Contact`
+ * via `ContactFakeColumns`) connect through it.
+ */
+
+import { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
+import { Column } from "../connection-adapters/column.js";
+import type { SqlTypeMetadata } from "../connection-adapters/sql-type-metadata.js";
+import { register } from "../connection-adapters.js";
+
+/**
+ * Rails' fake adapter deliberately redefines inherited members with
+ * incompatible shapes: `attr_accessor :data_sources` turns the `data_sources`
+ * *method* into a plain attribute, and `primary_key` / `columns` become
+ * synchronous in-memory lookups where AbstractAdapter's hit the database.
+ * TS forbids narrowing an inherited member that way, so the base is widened
+ * with those three members dropped — the alternative is renaming them, which
+ * would lose the Rails names this port exists to preserve.
+ */
+const FakeAdapterBase = AbstractAdapter as unknown as new () => Omit<
+  AbstractAdapter,
+  "dataSources" | "primaryKey" | "columns" | "active"
+>;
+
+interface MergeColumnOptions {
+  default?: unknown;
+  null?: boolean;
+}
+
+/**
+ * Mirrors: FakeActiveRecordAdapter
+ *
+ * Rails keeps the synthetic column list in a class-level
+ * `@columns = Hash.new { |h, k| h[k] = [] }` that every instance shares
+ * (`@columns = self.class.columns` in `initialize`), so columns merged through
+ * one connection are visible to the next. The static `columns` map below is
+ * that shared hash.
+ */
+export class FakeActiveRecordAdapter extends FakeAdapterBase {
+  static readonly columns = new Map<string, Column[]>();
+
+  dataSources: string[] = [];
+  primaryKeys: Record<string, string> = {};
+
+  private readonly _fakeColumns = FakeActiveRecordAdapter.columns;
+
+  /** Mirrors: FakeActiveRecordAdapter#primary_key */
+  primaryKey(table: string): string {
+    return this.primaryKeys[table] ?? "id";
+  }
+
+  /** Mirrors: FakeActiveRecordAdapter#merge_column */
+  mergeColumn(
+    tableName: string,
+    name: string,
+    sqlType: string | null = null,
+    options: MergeColumnOptions = {},
+  ): void {
+    const columns = this._fakeColumns.get(tableName) ?? [];
+    columns.push(
+      new Column(
+        String(name),
+        options.default,
+        this.fetchTypeMetadata(sqlType ?? ""),
+        options.null,
+      ),
+    );
+    this._fakeColumns.set(tableName, columns);
+  }
+
+  /** Mirrors: FakeActiveRecordAdapter#columns */
+  columns(tableName: string): Column[] {
+    const existing = this._fakeColumns.get(tableName);
+    if (existing) return existing;
+    // Ruby's `Hash.new { |h, k| h[k] = [] }` default block: reading an unknown
+    // table installs (and returns) a live empty array, so a later
+    // `merge_column` on the same key appends to what the reader received.
+    const created: Column[] = [];
+    this._fakeColumns.set(tableName, created);
+    return created;
+  }
+
+  /** Mirrors: FakeActiveRecordAdapter#data_source_exists? */
+  dataSourceExists(): boolean {
+    return true;
+  }
+
+  /** Mirrors: FakeActiveRecordAdapter#active? */
+  get active(): boolean {
+    return true;
+  }
+
+  private fetchTypeMetadata(sqlType: string): SqlTypeMetadata {
+    return (this as unknown as AbstractAdapter).schemaStatements().fetchTypeMetadata(sqlType);
+  }
+}
+
+register("fake", async () => FakeActiveRecordAdapter as unknown as new () => AbstractAdapter);

--- a/packages/activerecord/src/support/fake-adapter.ts
+++ b/packages/activerecord/src/support/fake-adapter.ts
@@ -1,27 +1,16 @@
-/**
- * TS mirror of Rails' test-support `FakeActiveRecordAdapter`
- * (activerecord/test/support/fake_adapter.rb).
- *
- * Registered suite-wide under the name `"fake"` — the trails analogue of
- * `cases/helper.rb:46`'s
- * `ActiveRecord::ConnectionAdapters.register("fake", "FakeActiveRecordAdapter", …)`.
- * Models that only need a column list without a real database (Rails' `Contact`
- * via `ContactFakeColumns`) connect through it.
- */
-
 import { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 import { Column } from "../connection-adapters/column.js";
 import type { SqlTypeMetadata } from "../connection-adapters/sql-type-metadata.js";
 import { register } from "../connection-adapters.js";
 
 /**
- * Rails' fake adapter deliberately redefines inherited members with
- * incompatible shapes: `attr_accessor :data_sources` turns the `data_sources`
- * *method* into a plain attribute, and `primary_key` / `columns` become
- * synchronous in-memory lookups where AbstractAdapter's hit the database.
- * TS forbids narrowing an inherited member that way, so the base is widened
- * with those three members dropped — the alternative is renaming them, which
- * would lose the Rails names this port exists to preserve.
+ * Rails' fake adapter redefines inherited members with incompatible shapes:
+ * `attr_accessor :data_sources` turns the `data_sources` method into a plain
+ * attribute, and `primary_key` / `columns` / `active?` become synchronous
+ * in-memory lookups where AbstractAdapter's reach the database. TS forbids
+ * narrowing an inherited member that way, so the base is widened with those
+ * members dropped — the alternative is renaming them, which would lose the
+ * Rails names this port exists to preserve.
  */
 const FakeAdapterBase = AbstractAdapter as unknown as new () => Omit<
   AbstractAdapter,
@@ -33,15 +22,7 @@ interface MergeColumnOptions {
   null?: boolean;
 }
 
-/**
- * Mirrors: FakeActiveRecordAdapter
- *
- * Rails keeps the synthetic column list in a class-level
- * `@columns = Hash.new { |h, k| h[k] = [] }` that every instance shares
- * (`@columns = self.class.columns` in `initialize`), so columns merged through
- * one connection are visible to the next. The static `columns` map below is
- * that shared hash.
- */
+/** Mirrors: FakeActiveRecordAdapter */
 export class FakeActiveRecordAdapter extends FakeAdapterBase {
   static readonly columns = new Map<string, Column[]>();
 
@@ -62,8 +43,7 @@ export class FakeActiveRecordAdapter extends FakeAdapterBase {
     sqlType: string | null = null,
     options: MergeColumnOptions = {},
   ): void {
-    const columns = this._fakeColumns.get(tableName) ?? [];
-    columns.push(
+    this.columns(tableName).push(
       new Column(
         String(name),
         options.default,
@@ -71,16 +51,12 @@ export class FakeActiveRecordAdapter extends FakeAdapterBase {
         options.null,
       ),
     );
-    this._fakeColumns.set(tableName, columns);
   }
 
   /** Mirrors: FakeActiveRecordAdapter#columns */
   columns(tableName: string): Column[] {
     const existing = this._fakeColumns.get(tableName);
     if (existing) return existing;
-    // Ruby's `Hash.new { |h, k| h[k] = [] }` default block: reading an unknown
-    // table installs (and returns) a live empty array, so a later
-    // `merge_column` on the same key appends to what the reader received.
     const created: Column[] = [];
     this._fakeColumns.set(tableName, created);
     return created;


### PR DESCRIPTION
Ports the three `vendor/rails/activerecord/test/support/*.rb` helpers that had
no trails file at all, into `packages/activerecord/src/support/`.

## What landed

- `support/ddl-helper.ts` — `withExampleTable(connection, tableName,
  definition?, fn)`. Rails' `ensure` drop is a `finally`, so the table is
  dropped even when the block raises; `definition = nil` is expressed as an
  overload with a trailing block.
- `support/async-helper.ts` — `assertAsyncEqual(expected, asyncResult)`.
  trails has no `ActiveRecord::Promise` wrapper (the `async*` methods return
  the platform promise), so the type assertion checks thenability and `.value`
  becomes the awaited result. Rails' `assert_nil` arm is kept distinct from the
  `assert_equal` arm — a nil `expected` still rejects a non-nil value.
- `support/fake-adapter.ts` — `FakeActiveRecordAdapter`, registered under
  `"fake"` through `connection-adapters.ts`'s `register()`, the trails analogue
  of `cases/helper.rb:46`. `primaryKey` / `mergeColumn` / `columns` /
  `dataSourceExists` / `active` mirror the Ruby bodies, including the
  class-level shared column hash and Ruby's `Hash.new { |h,k| h[k] = [] }`
  default-block semantics on an unknown table.

Each ships a test file next to it (14 tests, all green).

## Deviation, justified at the call site

`FakeActiveRecordAdapter` extends a widened `AbstractAdapter` (three members
omitted). Rails' fake adapter deliberately redefines inherited members with
incompatible shapes — `attr_accessor :data_sources` turns a method into a plain
attribute, and `primary_key`/`columns` become synchronous in-memory lookups
where the base hits the database. TS forbids narrowing an inherited member that
way; the alternative was renaming them, which would lose exactly the Rails
names this port exists to preserve. The reasoning is in a comment above the
cast.

## Not converted (deliberately)

`connection-adapters/postgresql/schema-statements-class.test.ts`'s
`makeFakeAdapter()` is not a fake *adapter* in Rails' sense — it is a duck-typed
host for `PostgreSQLSchemaStatements` needing an `execute` recorder and a
`schemaCache.clearDataSourceCacheBang` spy, none of which
`FakeActiveRecordAdapter` has. Swapping it would be a fidelity loss, not a gain.
`json-serialization.test.ts` no longer builds a fake adapter at all — its
`Contact`/`ContactSti` columns are declared on the model. Rewiring
`test-helpers/models/contact.ts` onto a real `establish_connection(adapter:
"fake")` is the follow-on that would give the registered adapter a production
consumer; it is model + connection-establishment work rather than support-helper
work, so it is left out of this PR rather than stretched into it.

Closes-story: port-missing-support-helpers
