### PR TITLE
refactor(activemodel): derive Timezone helper from Time.zone_default

### DIFF
--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -112,7 +112,6 @@ export { TimeType } from "./type/time.js";
 export {
   isUtc as isUtcTimezone,
   defaultTimezone as getDefaultTimezone,
-  setDefaultTimezone,
   configuredTimezone,
 } from "./type/helpers/timezone.js";
 

--- a/packages/activemodel/src/type/date-time.ts
+++ b/packages/activemodel/src/type/date-time.ts
@@ -7,7 +7,7 @@ import {
 } from "./internal/sentinels.js";
 import { ArgumentError } from "../attribute-assignment.js";
 import { AcceptsMultiparameterTime, isHash } from "./helpers/accepts-multiparameter-time.js";
-import { configuredTimezone } from "./helpers/timezone.js";
+import { configuredTimezone, isUtc } from "./helpers/timezone.js";
 import { ValueType } from "./value.js";
 
 export type DateTimeCastResult = Temporal.Instant | DateInfinityType | DateNegativeInfinityType;
@@ -113,6 +113,10 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
     ) as DateTimeCastResult | null;
   }
 
+  get isUtc(): boolean {
+    return isUtc();
+  }
+
   /**
    * Mirrors: AcceptsMultiparameterTime::InstanceMethods#assert_valid_value.
    * Runs eagerly at write_from_user time — this is how Rails surfaces
@@ -162,12 +166,8 @@ export class DateTimeType extends ValueType<DateTimeCastResult> {
       }
     }
     try {
-      // No offset — interpret in the default timezone configured via
-      // ActiveModel's helpers/timezone module (UTC by default, host-system
-      // local when set to "local"). ActiveRecord wires its own
-      // default_timezone setter into ActiveModel's so they stay in sync.
       return Temporal.PlainDateTime.from(datetimeString, { overflow: "reject" })
-        .toZonedDateTime(configuredTimezone())
+        .toZonedDateTime(configuredTimezone(this.isUtc))
         .toInstant();
     } catch {
       return null;

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -6,6 +6,10 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { configuredTimezone } from "./timezone.js";
 
+export interface TimezoneAware {
+  readonly isUtc: boolean;
+}
+
 export interface TimeValue {
   precision?: number;
   serializeCastValue(value: unknown): string | null;
@@ -137,6 +141,7 @@ export function userInputInTimeZone(
  * @internal Rails-private helper.
  */
 export function newTime(
+  this: TimezoneAware | void,
   year: number | null | undefined,
   mon: number | null | undefined,
   mday: number | null | undefined,
@@ -171,7 +176,7 @@ export function newTime(
       return offset === 0 ? instant : instant.subtract({ seconds: offset });
     }
     return Temporal.PlainDateTime.from(components, { overflow: "reject" })
-      .toZonedDateTime(configuredTimezone())
+      .toZonedDateTime(configuredTimezone(this?.isUtc))
       .toInstant();
   } catch {
     return null;
@@ -201,7 +206,7 @@ export function newTime(
  *
  * @internal Rails-private helper.
  */
-export function fastStringToTime(s: string): Temporal.Instant | null {
+export function fastStringToTime(this: TimezoneAware | void, s: string): Temporal.Instant | null {
   if (!s.includes("-")) return null;
   const normalized = s
     .replace(" ", "T")
@@ -213,7 +218,7 @@ export function fastStringToTime(s: string): Temporal.Instant | null {
   try {
     if (hasOffset) return Temporal.Instant.from(datetimeString);
     return Temporal.PlainDateTime.from(datetimeString, { overflow: "reject" })
-      .toZonedDateTime(configuredTimezone())
+      .toZonedDateTime(configuredTimezone(this?.isUtc))
       .toInstant();
   } catch {
     return null;

--- a/packages/activemodel/src/type/helpers/timezone.ts
+++ b/packages/activemodel/src/type/helpers/timezone.ts
@@ -1,18 +1,5 @@
-/**
- * Timezone helper — timezone awareness for type casting.
- *
- * Mirrors: ActiveModel::Type::Helpers::Timezone
- *
- * Provides helpers to check if the default timezone is UTC and
- * to retrieve the current default timezone setting.
- */
 import { getZoneDefault } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";
-
-export interface Timezone {
-  isUtc(): boolean;
-  defaultTimezone(): "utc" | "local";
-}
 
 export function isUtc(): boolean {
   const zoneDefault = getZoneDefault();
@@ -24,7 +11,6 @@ export function defaultTimezone(): "utc" | "local" {
   return isUtc() ? "utc" : "local";
 }
 
-/** Resolves to "UTC" when the default timezone is UTC, else the host system zone. */
 export function configuredTimezone(): string {
   return isUtc() ? "UTC" : Temporal.Now.timeZoneId();
 }

--- a/packages/activemodel/src/type/helpers/timezone.ts
+++ b/packages/activemodel/src/type/helpers/timezone.ts
@@ -6,6 +6,7 @@
  * Provides helpers to check if the default timezone is UTC and
  * to retrieve the current default timezone setting.
  */
+import { getZoneDefault } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 
 export interface Timezone {
@@ -13,28 +14,14 @@ export interface Timezone {
   defaultTimezone(): "utc" | "local";
 }
 
-let _defaultTimezone: "utc" | "local" = "utc";
-
 export function isUtc(): boolean {
-  return _defaultTimezone === "utc";
+  const zoneDefault = getZoneDefault();
+  if (zoneDefault) return zoneDefault.name === "UTC";
+  return true;
 }
 
 export function defaultTimezone(): "utc" | "local" {
-  return _defaultTimezone;
-}
-
-/**
- * Trails-only seam with no Rails counterpart. Rails' helper derives the zone
- * from `Time.zone_default` (timezone.rb:11) and exposes no setter at all;
- * trails has no `Time.zone_default` yet, so the value is held here and pushed
- * in by `activerecord`'s `setDefaultTimezone`. Converging this onto a real
- * `Time.zone_default` is tracked by RFC 0081's
- * `converge-activemodel-timezone-onto-time-zone-default` story.
- *
- * @internal
- */
-export function setDefaultTimezone(tz: "utc" | "local"): void {
-  _defaultTimezone = tz;
+  return isUtc() ? "utc" : "local";
 }
 
 /** Resolves to "UTC" when the default timezone is UTC, else the host system zone. */

--- a/packages/activemodel/src/type/helpers/timezone.ts
+++ b/packages/activemodel/src/type/helpers/timezone.ts
@@ -11,6 +11,6 @@ export function defaultTimezone(): "utc" | "local" {
   return isUtc() ? "utc" : "local";
 }
 
-export function configuredTimezone(): string {
-  return isUtc() ? "UTC" : Temporal.Now.timeZoneId();
+export function configuredTimezone(utc: boolean = isUtc()): string {
+  return utc ? "UTC" : Temporal.Now.timeZoneId();
 }

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -42,8 +42,7 @@ export class TimeZoneConverter extends ValueType<unknown> {
   }
 
   private get _subtypeIsUtc(): boolean | undefined {
-    const subtype = this._subtype as { isUtc?: boolean };
-    return typeof subtype.isUtc === "boolean" ? subtype.isUtc : undefined;
+    return resolveIsUtc(this._subtype);
   }
 
   override cast(value: unknown): unknown {
@@ -205,6 +204,25 @@ export class TimeZoneConverter extends ValueType<unknown> {
       ? sub.equals(other._subtype)
       : this._subtype === other._subtype;
   }
+}
+
+/**
+ * Walks the `subtype` chain the way Rails' OID::Range / OID::Array delegate to
+ * their subtype (range.rb:8-10, array.rb:12-13), so a wrapped
+ * ActiveRecord::Type::DateTime still supplies the `is_utc?` that
+ * Internal::Timezone gives it.
+ *
+ * @internal
+ */
+function resolveIsUtc(type: unknown): boolean | undefined {
+  let current = type as { isUtc?: unknown; subtype?: unknown } | null | undefined;
+  const seen = new Set<unknown>();
+  while (current != null && typeof current === "object" && !seen.has(current)) {
+    if (typeof current.isUtc === "boolean") return current.isUtc;
+    seen.add(current);
+    current = current.subtype as { isUtc?: unknown; subtype?: unknown } | undefined;
+  }
+  return undefined;
 }
 
 /** @internal */

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -41,12 +41,17 @@ export class TimeZoneConverter extends ValueType<unknown> {
     return this._subtype.type();
   }
 
+  private get _subtypeIsUtc(): boolean | undefined {
+    const subtype = this._subtype as { isUtc?: boolean };
+    return typeof subtype.isUtc === "boolean" ? subtype.isUtc : undefined;
+  }
+
   override cast(value: unknown): unknown {
     if (value == null) return null;
     // Hash (multiparameter attributes): cast via subtype, then treat wall-clock
     // components as local time in the current zone (set_time_zone_without_conversion).
     if (isPlainObject(value)) {
-      return setTimeZoneWithoutConversion(this._subtype.cast(value));
+      return setTimeZoneWithoutConversion(this._subtype.cast(value), this._subtypeIsUtc);
     }
     // TimeWithZone: move to current zone.
     if (value instanceof TimeWithZone) {
@@ -58,10 +63,9 @@ export class TimeZoneConverter extends ValueType<unknown> {
     }
     // PlainDateTime: wall-clock components from multiparameter assembly (no timezone).
     // Mirrors Rails' Hash branch: set_time_zone_without_conversion(super).
-    // Convert to instant via configuredTimezone() then re-interpret in current zone.
     if (value instanceof Temporal.PlainDateTime) {
-      const instant = value.toZonedDateTime(configuredTimezone()).toInstant();
-      return setTimeZoneWithoutConversion(instant);
+      const instant = value.toZonedDateTime(configuredTimezone(this._subtypeIsUtc)).toInstant();
+      return setTimeZoneWithoutConversion(instant, this._subtypeIsUtc);
     }
     // Strings: Rails gives String an in_time_zone method via CoreExt, so strings
     // take the respond_to?(:in_time_zone) branch and are parsed as local to
@@ -93,14 +97,16 @@ export class TimeZoneConverter extends ValueType<unknown> {
       // after ArrayType pre-casts them through the DateTime subtype; this.cast(v)
       // reaches convertTimeToTimeZone via the fallback path rather than through
       // ArrayType.cast again (which would be a no-op second pass).
-      return casted.map((v) => (isRangeLike(v) ? mapRange(v, castBoundInZone) : this.cast(v)));
+      return casted.map((v) =>
+        isRangeLike(v) ? mapRange(v, (b) => castBoundInZone(b, this._subtypeIsUtc)) : this.cast(v),
+      );
     }
     if (isRangeLike(casted)) {
       // Range-typed columns (tsrange/tstzrange): cast each bound through the
       // dedicated bound helper so string bounds are parsed in the current zone
       // and Instants are zone-wrapped — without routing through _subtype.cast
       // (which is RangeType and would misparse a timestamp string as a range literal).
-      return mapRange(casted, castBoundInZone);
+      return mapRange(casted, (b) => castBoundInZone(b, this._subtypeIsUtc));
     }
     return convertTimeToTimeZone(casted);
   }
@@ -219,7 +225,7 @@ function convertTimeToTimeZone(value: unknown): unknown {
 }
 
 /** @internal */
-function setTimeZoneWithoutConversion(value: unknown): unknown {
+function setTimeZoneWithoutConversion(value: unknown, subtypeIsUtc?: boolean): unknown {
   if (value == null) return null;
   const zone = getZone();
   if (!zone) return value;
@@ -229,7 +235,7 @@ function setTimeZoneWithoutConversion(value: unknown): unknown {
     // when :local). Extract wall-clock components using the SAME timezone so
     // we get the original component values, then re-interpret them as local
     // time in the current zone (mirrors Time.zone.local_to_utc(t).in_time_zone).
-    const zoned = value.toZonedDateTimeISO(configuredTimezone());
+    const zoned = value.toZonedDateTimeISO(configuredTimezone(subtypeIsUtc));
     const pdt = zoned.toPlainDateTime();
     // zone.local() takes milliseconds; get the ms-level result with correct DST
     // disambiguation, then add back sub-millisecond precision from the original.
@@ -320,14 +326,14 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
 }
 
 /** @internal */
-function castBoundInZone(value: unknown): unknown {
+function castBoundInZone(value: unknown, subtypeIsUtc?: boolean): unknown {
   if (value == null) return null;
   if (value instanceof TimeWithZone) return convertTimeToTimeZone(value);
   if (value instanceof Temporal.Instant) return convertTimeToTimeZone(value);
   if (value instanceof Temporal.ZonedDateTime) return convertTimeToTimeZone(value.toInstant());
   if (value instanceof Temporal.PlainDateTime) {
-    const instant = value.toZonedDateTime(configuredTimezone()).toInstant();
-    return setTimeZoneWithoutConversion(instant);
+    const instant = value.toZonedDateTime(configuredTimezone(subtypeIsUtc)).toInstant();
+    return setTimeZoneWithoutConversion(instant, subtypeIsUtc);
   }
   if (typeof value === "string") {
     const zone = getZone();

--- a/packages/activerecord/src/type/date-time.trails.test.ts
+++ b/packages/activerecord/src/type/date-time.trails.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
+import { TimeZone, TimeWithZone, setZone, resetZone } from "@blazetrails/activesupport";
+import { TimeZoneConverter } from "../attribute-methods/time-zone-conversion.js";
 import { DateTime } from "./date-time.js";
 import { setDefaultTimezone } from "./internal/timezone.js";
 
 afterEach(() => {
   setDefaultTimezone("utc");
+  resetZone();
 });
 
 describe("ActiveRecord::Type::DateTime timezone dispatch", () => {
@@ -42,5 +45,16 @@ describe("ActiveRecord::Type::DateTime timezone dispatch", () => {
     expect(
       (new DateTime({ timezone: "utc" }).cast(bare) as Temporal.Instant).epochNanoseconds,
     ).toBe(utc.epochNanoseconds);
+  });
+
+  it("preserves wall clock through the time zone aware wrapper", () => {
+    setZone(TimeZone.find("America/New_York"));
+    const converter = TimeZoneConverter.wrap(new DateTime({ timezone: "local" }));
+
+    const casted = converter.cast(Temporal.PlainDateTime.from("2024-01-02T12:00:00"));
+
+    expect(casted).toBeInstanceOf(TimeWithZone);
+    expect((casted as TimeWithZone).hour).toBe(12);
+    expect((casted as TimeWithZone).day).toBe(2);
   });
 });

--- a/packages/activerecord/src/type/date-time.trails.test.ts
+++ b/packages/activerecord/src/type/date-time.trails.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { Temporal } from "@blazetrails/activesupport/temporal";
+import { DateTime } from "./date-time.js";
+import { setDefaultTimezone } from "./internal/timezone.js";
+
+afterEach(() => {
+  setDefaultTimezone("utc");
+});
+
+describe("ActiveRecord::Type::DateTime timezone dispatch", () => {
+  it("is_utc? follows ActiveRecord.default_timezone", () => {
+    setDefaultTimezone("local");
+    expect(new DateTime().isUtc).toBe(false);
+    setDefaultTimezone("utc");
+    expect(new DateTime().isUtc).toBe(true);
+  });
+
+  it("is_utc? follows the per-type timezone override", () => {
+    setDefaultTimezone("utc");
+    expect(new DateTime({ timezone: "local" }).isUtc).toBe(false);
+    setDefaultTimezone("local");
+    expect(new DateTime({ timezone: "utc" }).isUtc).toBe(true);
+  });
+
+  it("casts bare strings in the zone chosen by is_utc?", () => {
+    const bare = "2024-01-02T12:00:00";
+    const utc = Temporal.PlainDateTime.from(bare).toZonedDateTime("UTC").toInstant();
+    const local = Temporal.PlainDateTime.from(bare)
+      .toZonedDateTime(Temporal.Now.timeZoneId())
+      .toInstant();
+
+    setDefaultTimezone("utc");
+    expect((new DateTime().cast(bare) as Temporal.Instant).epochNanoseconds).toBe(
+      utc.epochNanoseconds,
+    );
+
+    setDefaultTimezone("local");
+    expect((new DateTime().cast(bare) as Temporal.Instant).epochNanoseconds).toBe(
+      local.epochNanoseconds,
+    );
+
+    expect(
+      (new DateTime({ timezone: "utc" }).cast(bare) as Temporal.Instant).epochNanoseconds,
+    ).toBe(utc.epochNanoseconds);
+  });
+});

--- a/packages/activerecord/src/type/date-time.trails.test.ts
+++ b/packages/activerecord/src/type/date-time.trails.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { TimeZone, TimeWithZone, setZone, resetZone } from "@blazetrails/activesupport";
 import { TimeZoneConverter } from "../attribute-methods/time-zone-conversion.js";
+import { Range, RangeType } from "../connection-adapters/postgresql/oid/range.js";
 import { DateTime } from "./date-time.js";
 import { setDefaultTimezone } from "./internal/timezone.js";
 
@@ -56,5 +57,25 @@ describe("ActiveRecord::Type::DateTime timezone dispatch", () => {
     expect(casted).toBeInstanceOf(TimeWithZone);
     expect((casted as TimeWithZone).hour).toBe(12);
     expect((casted as TimeWithZone).day).toBe(2);
+  });
+
+  it("resolves is_utc? through a wrapping range subtype", () => {
+    setZone(TimeZone.find("America/New_York"));
+    const converter = TimeZoneConverter.wrap(
+      new RangeType(new DateTime({ timezone: "local" }), "tsrange"),
+    );
+
+    const casted = converter.cast(
+      new Range(
+        Temporal.PlainDateTime.from("2024-01-02T12:00:00"),
+        Temporal.PlainDateTime.from("2024-01-03T12:00:00"),
+        false,
+      ),
+    );
+
+    const begin = (casted as { begin: TimeWithZone }).begin;
+    expect(begin).toBeInstanceOf(TimeWithZone);
+    expect(begin.hour).toBe(12);
+    expect(begin.day).toBe(2);
   });
 });

--- a/packages/activerecord/src/type/internal/timezone.ts
+++ b/packages/activerecord/src/type/internal/timezone.ts
@@ -11,10 +11,7 @@ export interface TimezoneOptions {
   limit?: number;
 }
 
-import {
-  setDefaultTimezone as setActiveModelTimezone,
-  ArgumentError,
-} from "@blazetrails/activemodel";
+import { ArgumentError } from "@blazetrails/activemodel";
 
 let defaultTimezone: "utc" | "local" = "utc";
 
@@ -36,9 +33,6 @@ export function setDefaultTimezone(tz: "utc" | "local"): void {
       `"${tz}" is not a valid value for default_timezone. Valid values are :utc and :local`,
     );
   defaultTimezone = tz;
-  // Keep ActiveModel's parallel setting in lockstep so that DateTimeType.cast
-  // in activemodel honors the same configuration when called from activerecord.
-  setActiveModelTimezone(tz);
 }
 
 export function isUtc(timezone?: "utc" | "local"): boolean {


### PR DESCRIPTION
Rails' `ActiveModel::Type::Helpers::Timezone`
(`vendor/rails/activemodel/lib/active_model/type/helpers/timezone.rb:10-19`)
derives `is_utc?` / `default_timezone` from `::Time.zone_default` and exposes
no setter. Trails instead held a module-local `_defaultTimezone` plus a
`setDefaultTimezone` seam, and activerecord's
`type/internal/timezone.ts` pushed into it on every
`setDefaultTimezone` call to keep the two layers in lockstep.

This converges the helper onto the shared state:

- `isUtc()` now reads `getZoneDefault()` from `@blazetrails/activesupport`
  (already a faithful `Time.zone_default`) and mirrors Rails' shape exactly:
  UTC when the zone name is `"UTC"`, `true` when no zone default is set.
- `defaultTimezone()` derives from `isUtc()` as in Rails.
- `setDefaultTimezone` in activemodel is deleted (and unexported), along with
  the `setActiveModelTimezone` forwarding call in activerecord.
- `configuredTimezone()` is unchanged and keeps working for the non-UTC arm.

`pnpm api:extra` now reports `type/helpers/timezone.ts` with 1 novel export
(`configuredTimezone`) instead of 2.

Tests: activemodel `type/helpers/*` + `type/date-time.test.ts`, activerecord
`date-time`, `quoting`, `cache-key`, `temporal-wire`, `time-zone-conversion`
— 235 passing, names unchanged.

Closes-story: converge-activemodel-timezone-onto-time-zone-default

## Review follow-up

Reviewer was right that dropping the AR→AM push left AR datetime casting
reading the module-level default. Rails avoids this because `is_utc?` is an
*instance* method: `ActiveRecord::Type::DateTime` includes
`Internal::Timezone` (`activerecord/lib/active_record/type/date_time.rb:5-7`),
and `TimeValue#new_time` / `#fast_string_to_time`
(`activemodel/lib/active_model/type/helpers/time_value.rb:51-60`, `:91-94`)
branch on the receiver's `is_utc?`. Trails' helpers were free functions, so
they resolved globally.

Fixed by dispatching through the receiver rather than restoring the push:

- `DateTimeType` gains `get isUtc()` (the mixed-in `Helpers::Timezone#is_utc?`),
  which `ActiveRecord::Type::DateTime`'s existing `isUtc` getter overrides with
  `@timezone || ActiveRecord.default_timezone`.
- `parseString`, `newTime`, and `fastStringToTime` resolve the zone from the
  receiver's `isUtc` (`configuredTimezone(this?.isUtc)`), falling back to the
  ActiveModel module default when called without a receiver.
- New `packages/activerecord/src/type/date-time.trails.test.ts` covers
  `default_timezone = :local` and the per-type `timezone:` override; it fails
  without the dispatch fix (verified under `TZ=America/New_York`).

`api:compare` activemodel goes 686 → 687 ported methods (the `is_utc?` mixin
now maps); novel-extra counts unchanged apart from the removed setter.

### Second review round

`TimeZoneConverter` kept the receiver for `cast` but dropped it again in the
wall-clock reconstruction. Rails threads one receiver end to end
(`time_zone_conversion.rb:20-21` → `Type::DateTime` including
`Internal::Timezone` → `time_value.rb:51-60`), so the subtype's
`@timezone || ActiveRecord.default_timezone` now flows into all three sites:
`setTimeZoneWithoutConversion` (:236), the `PlainDateTime` arm of `cast` (:67),
and `castBoundInZone` for range bounds (:333). Covered by a new case in
`type/date-time.trails.test.ts`, verified failing without the threading under
`TZ=America/New_York`.

### Third review round

Rebased onto `main` (conflict was only the seam's new doc comment, which this
PR deletes along with the seam).

`_subtypeIsUtc` now walks the `subtype` chain — Rails' `OID::Range` and
`OID::Array` delegate to their subtype (`range.rb:8-10`, `array.rb:12-13`), so
a `TimeZoneConverter` wrapping a `RangeType(DateTime({timezone: "local"}))`
resolves `is_utc?` from the inner `Type::DateTime` rather than falling back to
`Time.zone_default`. Covered by a wrapped-`RangeType` case in
`type/date-time.trails.test.ts`.

Honest note on that case: it passes both with and without the unwrap. The
range/array bound paths are *symmetric* — the same flag builds the instant and
re-extracts the wall clock in `setTimeZoneWithoutConversion` — so the wrong
flag cancels out there and I could not construct a failing assertion. The
asymmetric path is the multiparameter/hash one, which is what the previous
round's failing test covers. The unwrap is applied because it is what Rails'
delegation says the value should be, not because it fixes an observed bug.
