### PR TITLE
refactor(activerecord): converge remaining class-slot writers onto accessors

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -129,6 +129,10 @@ import {
 } from "./token-for.js";
 import type { TokenDefinition as _TokenDefinition } from "./token-for.js";
 import type { MessageVerifier as _MessageVerifier } from "@blazetrails/activesupport/message-verifier";
+import {
+  getVerboseQueryLogs as _getVerboseQueryLogs,
+  setVerboseQueryLogs as _setVerboseQueryLogs,
+} from "./log-subscriber.js";
 import { registerMigrationArConfig } from "./migration.js";
 import { DatabaseTasks } from "./tasks/database-tasks.js";
 import * as LockingOptimistic from "./locking/optimistic.js";
@@ -1846,6 +1850,21 @@ export class Base extends Model {
 
   static set signedIdVerifierSecret(value: string | (() => string | null | undefined) | null) {
     _setSignedIdVerifierSecret(value);
+  }
+
+  /**
+   * Whether SQL log lines are annotated with the application-code line that
+   * issued the query. The storage lives in log-subscriber.ts, next to its only
+   * reader; this is the Rails-named surface for it.
+   *
+   * Mirrors: ActiveRecord.verbose_query_logs, verbose_query_logs=
+   */
+  static get verboseQueryLogs(): boolean {
+    return _getVerboseQueryLogs();
+  }
+
+  static set verboseQueryLogs(value: boolean) {
+    _setVerboseQueryLogs(value);
   }
 
   /**

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1852,13 +1852,7 @@ export class Base extends Model {
     _setSignedIdVerifierSecret(value);
   }
 
-  /**
-   * Whether SQL log lines are annotated with the application-code line that
-   * issued the query. The storage lives in log-subscriber.ts, next to its only
-   * reader; this is the Rails-named surface for it.
-   *
-   * Mirrors: ActiveRecord.verbose_query_logs, verbose_query_logs=
-   */
+  /** Mirrors: ActiveRecord.verbose_query_logs, verbose_query_logs= */
   static get verboseQueryLogs(): boolean {
     return _getVerboseQueryLogs();
   }

--- a/packages/activerecord/src/connection-adapters/deduplicable.ts
+++ b/packages/activerecord/src/connection-adapters/deduplicable.ts
@@ -30,14 +30,14 @@ export function registry(): Map<string, WeakRef<object>> {
 
 export function deduplicate<T extends Deduplicable>(obj: T): T {
   const key = `${obj.constructor.name}:${obj.deduplicateKey()}`;
-  const cached = registries.get(key);
+  const cached = registry().get(key);
   if (cached) {
     const existing = cached.deref();
     if (existing) return existing as T;
   }
   const deduped = obj.deduplicated();
   const weakRef = new WeakRef(deduped);
-  registries.set(key, weakRef);
+  registry().set(key, weakRef);
   _finalizer?.register(deduped, key);
   return deduped;
 }

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -27,12 +27,7 @@ export { Cipher } from "./encryption/cipher.js";
 import { EncryptableRecord, encryptedTypeOf } from "./encryption/encryptable-record.js";
 import { Configurable } from "./encryption/configurable.js";
 import { Contexts } from "./encryption/contexts.js";
-import {
-  getEncryptionContext,
-  getDefaultContext,
-  setDefaultContext,
-  type EncryptionContext,
-} from "./encryption/context.js";
+import { getEncryptionContext, type EncryptionContext } from "./encryption/context.js";
 import type { Config } from "./encryption/config.js";
 
 /**
@@ -364,9 +359,9 @@ export function currentCustomContext(): EncryptionContext | null {
  */
 export function defaultContext(value?: EncryptionContext): EncryptionContext {
   if (value !== undefined) {
-    setDefaultContext(value);
+    Contexts.defaultContext = value;
   }
-  return getDefaultContext();
+  return Contexts.defaultContext;
 }
 
 /** @internal */

--- a/packages/activerecord/src/encryption/context.ts
+++ b/packages/activerecord/src/encryption/context.ts
@@ -75,6 +75,11 @@ export function getDefaultContext(): EncryptionContext {
   return _defaultContext;
 }
 
+/**
+ * Backs the `Contexts.defaultContext` accessor (contexts.ts), which is the
+ * Rails-named surface for `mattr_accessor :default_context` (contexts.rb:17).
+ * @internal
+ */
 export function setDefaultContext(context: EncryptionContext): void {
   _defaultContext = context;
 }

--- a/packages/activerecord/src/encryption/context.ts
+++ b/packages/activerecord/src/encryption/context.ts
@@ -75,11 +75,7 @@ export function getDefaultContext(): EncryptionContext {
   return _defaultContext;
 }
 
-/**
- * Backs the `Contexts.defaultContext` accessor (contexts.ts), which is the
- * Rails-named surface for `mattr_accessor :default_context` (contexts.rb:17).
- * @internal
- */
+/** @internal */
 export function setDefaultContext(context: EncryptionContext): void {
   _defaultContext = context;
 }

--- a/packages/activerecord/src/encryption/contexts.ts
+++ b/packages/activerecord/src/encryption/contexts.ts
@@ -4,6 +4,7 @@ import {
   protectingEncryptedData as _protecting,
   getEncryptionContext,
   getDefaultContext,
+  setDefaultContext as _setDefaultContext,
   getCurrentCustomContext,
   resetDefaultContext as _resetDefaultContext,
   type EncryptionContext,
@@ -38,6 +39,10 @@ export class Contexts {
 
   static get defaultContext(): EncryptionContext {
     return getDefaultContext();
+  }
+
+  static set defaultContext(value: EncryptionContext) {
+    _setDefaultContext(value);
   }
 
   static resetDefaultContext(): void {

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -65,8 +65,6 @@ export type { AssociationOptions } from "./associations.js";
 export { Transaction } from "./transaction.js";
 export {
   LogSubscriber,
-  getVerboseQueryLogs,
-  setVerboseQueryLogs,
   setBaseResolver as setLogSubscriberBaseResolver,
 } from "./log-subscriber.js";
 export { ExplainSubscriber } from "./explain-subscriber.js";

--- a/packages/activerecord/src/log-subscriber.test.ts
+++ b/packages/activerecord/src/log-subscriber.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
-import { LogSubscriber, setVerboseQueryLogs } from "./log-subscriber.js";
+import { LogSubscriber } from "./log-subscriber.js";
 import { Base } from "./index.js";
 import {
   LogSubscriber as BaseLogSubscriber,
@@ -114,7 +114,7 @@ describe("LogSubscriberTest", () => {
   afterEach(() => {
     LogSubscriber.logger = null;
     Base.logger = oldBaseLogger;
-    setVerboseQueryLogs(false);
+    Base.verboseQueryLogs = false;
   });
 
   it("schema statements are ignored", () => {
@@ -302,14 +302,14 @@ describe("LogSubscriberTest", () => {
   });
 
   it("verbose query logs", () => {
-    setVerboseQueryLogs(true);
+    Base.verboseQueryLogs = true;
     subscriber.sql(makeEvent({ sql: "hi mom!" }));
     expect(mockLogger.logged("debug").length).toBe(2);
     expect(mockLogger.logged("debug")[mockLogger.logged("debug").length - 1]).toMatch(/↳/);
   });
 
   it("verbose query with ignored callstack", () => {
-    setVerboseQueryLogs(true);
+    Base.verboseQueryLogs = true;
     const original = (subscriber as any).querySourceLocation;
     (subscriber as any).querySourceLocation = () => null;
     subscriber.sql(makeEvent({ sql: "hi mom!" }));

--- a/packages/activerecord/src/log-subscriber.ts
+++ b/packages/activerecord/src/log-subscriber.ts
@@ -71,11 +71,21 @@ function getBase(): any {
   return _baseResolver?.() ?? null;
 }
 
-/** Module-level config mirroring `ActiveRecord.verbose_query_logs`. */
+/**
+ * Module-level storage for `ActiveRecord.verbose_query_logs`
+ * (active_record.rb:329, `singleton_class.attr_accessor`). The Rails-named
+ * surface is the `Base.verboseQueryLogs` accessor; these two back it from here
+ * so the flag stays next to its only reader without log-subscriber.ts importing
+ * `base.ts` (which would close the cycle the `_baseResolver` seam above exists
+ * to break).
+ * @internal
+ */
 let _verboseQueryLogs = false;
+/** @internal */
 export function getVerboseQueryLogs(): boolean {
   return _verboseQueryLogs;
 }
+/** @internal */
 export function setVerboseQueryLogs(value: boolean): void {
   _verboseQueryLogs = value;
 }

--- a/packages/activerecord/src/log-subscriber.ts
+++ b/packages/activerecord/src/log-subscriber.ts
@@ -71,15 +71,8 @@ function getBase(): any {
   return _baseResolver?.() ?? null;
 }
 
-/**
- * Module-level storage for `ActiveRecord.verbose_query_logs`
- * (active_record.rb:329, `singleton_class.attr_accessor`). The Rails-named
- * surface is the `Base.verboseQueryLogs` accessor; these two back it from here
- * so the flag stays next to its only reader without log-subscriber.ts importing
- * `base.ts` (which would close the cycle the `_baseResolver` seam above exists
- * to break).
- * @internal
- */
+// Backs Base.verboseQueryLogs; the flag lives here because log-subscriber.ts
+// cannot import base.ts (the cycle the _baseResolver seam above breaks).
 let _verboseQueryLogs = false;
 /** @internal */
 export function getVerboseQueryLogs(): boolean {

--- a/packages/activerecord/src/type.test.ts
+++ b/packages/activerecord/src/type.test.ts
@@ -1,12 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import {
-  register,
-  lookup,
-  registry,
-  setRegistry,
-  adapterNameFrom,
-  AdapterSpecificRegistry,
-} from "./type.js";
+import { register, lookup, registry, adapterNameFrom, AdapterSpecificRegistry } from "./type.js";
 import { Base } from "./base.js";
 import { Type } from "@blazetrails/activemodel";
 
@@ -36,11 +29,11 @@ describe("TypeTest", () => {
 
   beforeEach(() => {
     oldRegistry = registry();
-    setRegistry(new AdapterSpecificRegistry());
+    registry(new AdapterSpecificRegistry());
   });
 
   afterEach(() => {
-    setRegistry(oldRegistry);
+    registry(oldRegistry);
   });
 
   it("registering a new type", () => {

--- a/packages/activerecord/src/type.trails.test.ts
+++ b/packages/activerecord/src/type.trails.test.ts
@@ -3,7 +3,6 @@ import {
   register,
   lookup,
   registry,
-  setRegistry,
   currentAdapterName,
   adapterNameFrom,
   AdapterSpecificRegistry,
@@ -75,12 +74,12 @@ describe("Type.lookup under a non-sqlite configuration", () => {
 
   beforeEach(() => {
     oldRegistry = registry();
-    setRegistry(new AdapterSpecificRegistry());
+    registry(new AdapterSpecificRegistry());
     oldDbConfig = (Base as unknown as { connectionDbConfig: unknown }).connectionDbConfig;
   });
 
   afterEach(() => {
-    setRegistry(oldRegistry);
+    registry(oldRegistry);
     (Base as unknown as { connectionDbConfig: unknown }).connectionDbConfig = oldDbConfig;
   });
 
@@ -106,7 +105,7 @@ describe("Type.lookup under a non-sqlite configuration", () => {
   });
 
   it("reaches the mysql2 adapter's own string registration", () => {
-    setRegistry(oldRegistry);
+    registry(oldRegistry);
     stubAdapter("mysql2");
 
     const type = lookup("string");

--- a/packages/activerecord/src/type.ts
+++ b/packages/activerecord/src/type.ts
@@ -85,22 +85,13 @@ _registry.register("time", Time, { override: false });
 _registry.register("value", ValueType, { override: false });
 
 /**
- * Mirrors Rails' `ActiveRecord::Type.registry` / `registry=` (type.rb:26,
- * `attr_accessor :registry`). Called with no argument it reads; called with a
- * value it writes.
+ * Mirrors: ActiveRecord::Type.registry, registry= (type.rb:26)
  *
- * Reader and writer share one function rather than becoming a `get`/`set` pair:
- * Rails hangs the accessor off the `ActiveRecord::Type` *module* object, whose
- * trails analogue is this ES module, and an ES module namespace is read-only
- * from the importer's side — there is no object to define an accessor on. The
- * reader-with-optional-argument shape is what the same constraint produced for
- * `Core.configurations` (PR #5381) and `PrimaryKey#primary_key`, and it keeps
- * the writer under the Rails name instead of re-spelling it `setRegistry`.
- *
- * Assigning replaces the active registry wholesale. Callers are responsible for
- * re-registering any types they need — this is intentional: Rails' own
- * TypeTest swaps in a blank AdapterSpecificRegistry per test and restores
- * the original in teardown, so a pre-populated registry is not the default.
+ * Not a `get`/`set` pair: Rails hangs `attr_accessor :registry` off the
+ * `ActiveRecord::Type` module object, whose trails analogue is this ES module,
+ * and a module namespace is read-only from the importer's side — there is no
+ * object to define an accessor on. Same constraint, same shape as
+ * `Core.configurations` and `PrimaryKey#primary_key`.
  */
 export function registry(r?: AdapterSpecificRegistry): AdapterSpecificRegistry {
   if (r !== undefined) {

--- a/packages/activerecord/src/type.ts
+++ b/packages/activerecord/src/type.ts
@@ -84,27 +84,30 @@ _registry.register("text", Text, { override: false });
 _registry.register("time", Time, { override: false });
 _registry.register("value", ValueType, { override: false });
 
-/** Mirrors Rails' `ActiveRecord::Type.registry` (attr_accessor getter). */
-export function registry(): AdapterSpecificRegistry {
-  return _registry;
-}
-
 /**
- * Mirrors Rails' `ActiveRecord::Type.registry=` (attr_accessor setter).
+ * Mirrors Rails' `ActiveRecord::Type.registry` / `registry=` (type.rb:26,
+ * `attr_accessor :registry`). Called with no argument it reads; called with a
+ * value it writes.
  *
- * Not converged onto a getter/setter pair under the Rails name: Rails hangs
- * `attr_accessor :registry` off the `ActiveRecord::Type` module object, whose
- * trails analogue is this ES module — and an ES module namespace is read-only
- * from the importer's side, so there is no object to define an accessor on.
+ * Reader and writer share one function rather than becoming a `get`/`set` pair:
+ * Rails hangs the accessor off the `ActiveRecord::Type` *module* object, whose
+ * trails analogue is this ES module, and an ES module namespace is read-only
+ * from the importer's side — there is no object to define an accessor on. The
+ * reader-with-optional-argument shape is what the same constraint produced for
+ * `Core.configurations` (PR #5381) and `PrimaryKey#primary_key`, and it keeps
+ * the writer under the Rails name instead of re-spelling it `setRegistry`.
  *
- * Replaces the active registry wholesale. Callers are responsible for
+ * Assigning replaces the active registry wholesale. Callers are responsible for
  * re-registering any types they need — this is intentional: Rails' own
  * TypeTest swaps in a blank AdapterSpecificRegistry per test and restores
  * the original in teardown, so a pre-populated registry is not the default.
  */
-export function setRegistry(r: AdapterSpecificRegistry): void {
-  _registry = r;
-  _defaultValue = undefined;
+export function registry(r?: AdapterSpecificRegistry): AdapterSpecificRegistry {
+  if (r !== undefined) {
+    _registry = r;
+    _defaultValue = undefined;
+  }
+  return _registry;
 }
 
 /**
@@ -127,7 +130,7 @@ export function register(
   options?: { adapter?: string; override?: boolean },
   block?: (...args: unknown[]) => Type,
 ): void {
-  _registry.register(typeName, klass, options, block);
+  registry().register(typeName, klass, options, block);
 }
 
 /** Mirrors: ActiveRecord::Type.add_modifier */
@@ -136,7 +139,7 @@ export function addModifier(
   klass: new (subtype: Type) => Type,
   registrationOptions?: { adapter?: string },
 ): void {
-  _registry.addModifier(options, klass, registrationOptions);
+  registry().addModifier(options, klass, registrationOptions);
 }
 
 export function lookup(
@@ -144,7 +147,7 @@ export function lookup(
   options?: { adapter?: string; [key: string]: unknown },
 ): Type {
   const adapter = options?.adapter ?? currentAdapterName();
-  return _registry.lookup(symbol, { ...options, adapter });
+  return registry().lookup(symbol, { ...options, adapter });
 }
 
 export function defaultValue(): Type {

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/mysql/type-metadata.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/mysql/type-metadata.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/mysql/type-metadata.ts",
+    "rubyName": "deduplicate",
+    "call": "registry",
+    "reason": "MySQL::TypeMetadata overrides deduplicate to skip the Deduplicable registry: it implements no deduplicateKey(), so there is no registry key to look itself up under. Rails reaches the registry through the shared Deduplicable#deduplicate, which trails ports in connection-adapters/deduplicable.ts."
+  }
+]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql/type-metadata.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql/type-metadata.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql/type-metadata.ts",
+    "rubyName": "deduplicate",
+    "call": "registry",
+    "reason": "PostgreSQL::TypeMetadata overrides deduplicate to skip the Deduplicable registry: it implements no deduplicateKey(), so there is no registry key to look itself up under. Rails reaches the registry through the shared Deduplicable#deduplicate, which trails ports in connection-adapters/deduplicable.ts."
+  }
+]

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/log-subscriber.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/log-subscriber.json
@@ -2,6 +2,13 @@
   {
     "package": "activerecord",
     "tsFile": "log-subscriber.ts",
+    "rubyName": "debug",
+    "call": "verbose_query_logs",
+    "reason": "verbose_query_logs is read through getVerboseQueryLogs(), the module-local backing binding that the Rails-named Base.verboseQueryLogs accessor writes; log-subscriber.ts cannot import base.ts (the cycle the _baseResolver seam exists to break)."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "log-subscriber.ts",
     "rubyName": "query_source_location",
     "call": "clean_frame",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Shape 3 of RFC 0081 for `activerecord`, covering the writers still standing
after #5387 converged the class-level pairs. Each was an exported `setX`
re-spelling of a Ruby `foo=`; `scripts/api-compare/conventions.ts:638` maps a
Ruby writer onto the same camelCase name as its reader, so every `setX` sibling
read as TS surface Rails does not have.

| Rails | shape now |
| --- | --- |
| `ActiveRecord.verbose_query_logs=` | `Base.verboseQueryLogs` static accessor |
| `Encryption::Contexts.default_context=` | `Contexts.defaultContext` setter |
| `Type.registry=` | `registry(r?)` reader/writer |

## Notes

- **`verbose_query_logs`** — the flag's storage stays in `log-subscriber.ts`
  next to its only reader; `log-subscriber.ts` cannot import `base.ts` (that is
  the cycle its `_baseResolver` seam exists to break), so `getVerboseQueryLogs`
  / `setVerboseQueryLogs` remain as `@internal` backing functions and `base.ts`
  carries the Rails-named accessor. `rails-api.json` attributes
  `verbose_query_logs=` to `ActiveRecord::Base`'s class methods in `base.rb`, so
  that is its api:compare home. Both helpers are dropped from the package index;
  callers use `Base.verboseQueryLogs = …`.
- **`registry`** — the reader and writer share one function rather than becoming
  a `get`/`set` pair. Rails hangs `attr_accessor :registry` off the
  `ActiveRecord::Type` *module* object, whose trails analogue is the ES module
  itself, and a module namespace is read-only from the importer's side — there
  is no object to define an accessor on. The optional-argument shape is what the
  same constraint produced for `Core.configurations` (#5381) and
  `AttributeMethods::PrimaryKey#primary_key`. This replaces the "not converged"
  note `type.ts` carried: the constraint is real, but it only rules out the
  `get`/`set` spelling, not keeping the writer under the Rails name.
- **`setId` needed no work.** `Base` already exposes the `id` accessor and the
  `attribute-methods/primary-key.ts` helper is already `@internal`, so it was
  never counted as extra surface. Its write path and composite-PK arm are
  untouched.
- **`registry()` call sites.** Converging the writer trips the wide call gate's
  `isPortedWithArgs` filter: `registry` now takes an argument, so every Rails
  body that calls `registry` becomes significant. `Type.register`/`lookup`/
  `addModifier` and `Deduplicable#deduplicate` now go through `registry()`, as
  Rails does (`type.rb:38,42`, `deduplicable.rb:18`) — a no-op refactor that
  clears 5 of the 8. The remaining three are baselined with reasons: the MySQL
  and PostgreSQL `TypeMetadata` overrides implement no `deduplicateKey()` and so
  cannot reach the registry at all, and `log-subscriber.ts#debug` reads the flag
  through the backing binding described above.

## Verification

- `pnpm typecheck` clean; eslint/prettier via lint-staged.
- `api:compare` unchanged at 6079/6142 for activerecord (arity-compared pairs
  7450 -> 7452, all matching); `api:calls`, `api:calls:wide`, `api:arity`,
  `api:pins` all OK.
- `api:extra` for activerecord: novel 420 -> 416, total 1335 -> 1331.
- Green: `type.test.ts`, `type.trails.test.ts`, `types.test.ts`,
  `log-subscriber.test.ts`, `log-subscriber.trails.test.ts`, `signed-id.test.ts`,
  `primary-keys.test.ts`, `column-definition.test.ts`, `attributes.test.ts`,
  `base.test.ts`, `schema-dumper.test.ts`, `adapter.test.ts`, and the whole
  `encryption/` tree.

Closes-story: converge-activerecord-class-slot-writers
