### PR TITLE
refactor(eslint): derive no-raw-sql scope-outs from one shared glob list

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,6 +24,7 @@ import testFixtureParity from "./eslint/test-fixture-parity.mjs";
 import requireTableTeardown from "./eslint/require-table-teardown.mjs";
 import requireCanonicalRebuild from "./eslint/require-canonical-rebuild.mjs";
 import noRawSql from "./eslint/no-raw-sql.mjs";
+import { noRawSqlFiles, noRawSqlIgnores } from "./eslint/no-raw-sql-scope.mjs";
 import noStandaloneAssociations from "./eslint/no-standalone-associations.mjs";
 import noInternalCanonicalLoaders from "./eslint/no-internal-canonical-loaders.mjs";
 import noExplicitAnyDisable from "./eslint/no-explicit-any-disable.mjs";
@@ -482,24 +483,11 @@ export default defineConfig(
   //    RFC-0022 `sql.replace`/`sql.concat` string-surgery pattern) outside the
   //    adapter/DDL layer. Build queries with @blazetrails/arel. The adapter
   //    layer, migrations, and schema dumpers legitimately render SQL and are
-  //    excluded. See eslint/no-raw-sql.mjs. ──
+  //    excluded. The scope globs are the single source of truth shared with the
+  //    rule's own filename check — see eslint/no-raw-sql-scope.mjs. ──
   {
-    files: ["packages/activerecord/src/**/*.ts"],
-    ignores: [
-      "packages/activerecord/src/**/*.test.ts",
-      "packages/activerecord/src/connection-adapters/**",
-      "packages/activerecord/src/adapters/**",
-      "packages/activerecord/src/tasks/**",
-      "packages/activerecord/src/**/schema-*.ts",
-      // Test-infra DDL helpers render SQL by design (never migrating to arel).
-      "packages/activerecord/src/test-helpers/**",
-      "packages/activerecord/src/support/**",
-      "packages/activerecord/src/fixtures.ts",
-      "packages/activerecord/src/test-fixtures.ts",
-      "packages/activerecord/src/test-fixtures/**",
-      "packages/activerecord/src/test-setup-*.ts",
-      "packages/activerecord/src/cases/helper.ts",
-    ],
+    files: noRawSqlFiles,
+    ignores: noRawSqlIgnores,
     rules: {
       "blazetrails/no-raw-sql": "error",
     },

--- a/eslint/no-raw-sql-scope.mjs
+++ b/eslint/no-raw-sql-scope.mjs
@@ -9,8 +9,11 @@
  * from the globs below: rename a scoped-out file, edit exactly this file.
  */
 
+/** Root the rule and its scope globs are anchored to (repo-relative). */
+export const noRawSqlRoot = "packages/activerecord/src";
+
 /** Files the rule applies to (repo-relative glob). */
-export const noRawSqlFiles = ["packages/activerecord/src/**/*.ts"];
+export const noRawSqlFiles = [`${noRawSqlRoot}/**/*.ts`];
 
 /**
  * Paths that legitimately render SQL → out of scope (repo-relative globs).
@@ -20,24 +23,24 @@ export const noRawSqlFiles = ["packages/activerecord/src/**/*.ts"];
  * burndown worklist reflects only real arel migration targets.
  */
 export const noRawSqlIgnores = [
-  "packages/activerecord/src/**/*.test.ts",
-  "packages/activerecord/src/connection-adapters/**",
-  "packages/activerecord/src/adapters/**",
-  "packages/activerecord/src/tasks/**",
-  "packages/activerecord/src/**/schema-*.ts",
-  "packages/activerecord/src/test-helpers/**",
+  "**/*.test.ts",
+  "connection-adapters/**",
+  "adapters/**",
+  "tasks/**",
+  "**/schema-*.ts",
+  "test-helpers/**",
   // The fixture machinery is `lib/active_record/fixtures.rb:595` /
   // `test_fixtures.rb:113` code (RFC 0064 bucket D); it renders DDL/DML
   // directly for the same reason the rest of the test-infra does. Anchored to
   // the exact ported files — matching `fixtures.ts` by basename would also
   // exempt any future same-named module elsewhere under activerecord/src.
-  "packages/activerecord/src/fixtures.ts",
-  "packages/activerecord/src/test-fixtures.ts",
-  "packages/activerecord/src/test-fixtures/**",
-  "packages/activerecord/src/support/**",
-  "packages/activerecord/src/test-setup-*.ts",
-  "packages/activerecord/src/cases/helper.ts",
-];
+  "fixtures.ts",
+  "test-fixtures.ts",
+  "test-fixtures/**",
+  "support/**",
+  "test-setup-*.ts",
+  "cases/helper.ts",
+].map((glob) => `${noRawSqlRoot}/${glob}`);
 
 /** Minimal glob → RegExp for the subset used above: `**`, `*`, literals. */
 function globToRegExp(glob) {
@@ -66,6 +69,13 @@ function globToRegExp(glob) {
 }
 
 const ignoreRes = noRawSqlIgnores.map(globToRegExp);
+
+/** Repo-relative path under the rule's root; null when the file is outside it. */
+export function repoRel(filename) {
+  const norm = filename.replace(/\\/g, "/");
+  const m = norm.match(new RegExp(`(?:^|/)(${noRawSqlRoot}/.+\\.ts)$`));
+  return m ? m[1] : null;
+}
 
 /** True when `rel` (a repo-relative path) is out of the rule's scope. */
 export function isExcludedPath(rel) {

--- a/eslint/no-raw-sql-scope.mjs
+++ b/eslint/no-raw-sql-scope.mjs
@@ -1,0 +1,73 @@
+/**
+ * Single source of truth for the `blazetrails/no-raw-sql` scope.
+ *
+ * The rule re-checks scope by filename (so it stays testable in isolation) and
+ * eslint.config.mjs applies the same scope as `files`/`ignores`. Those two lists
+ * used to be maintained separately — a regex list in the rule and a glob list in
+ * the config — so any test-infra file move (RFC 0064 does several) had to touch
+ * both, and missing one silently changed which files are linted. Both now derive
+ * from the globs below: rename a scoped-out file, edit exactly this file.
+ */
+
+/** Files the rule applies to (repo-relative glob). */
+export const noRawSqlFiles = ["packages/activerecord/src/**/*.ts"];
+
+/**
+ * Paths that legitimately render SQL → out of scope (repo-relative globs).
+ *
+ * Test-infra DDL helpers render SQL by design and will never migrate to
+ * @blazetrails/arel — scope them out rather than baseline them so the RFC-0022
+ * burndown worklist reflects only real arel migration targets.
+ */
+export const noRawSqlIgnores = [
+  "packages/activerecord/src/**/*.test.ts",
+  "packages/activerecord/src/connection-adapters/**",
+  "packages/activerecord/src/adapters/**",
+  "packages/activerecord/src/tasks/**",
+  "packages/activerecord/src/**/schema-*.ts",
+  "packages/activerecord/src/test-helpers/**",
+  // The fixture machinery is `lib/active_record/fixtures.rb:595` /
+  // `test_fixtures.rb:113` code (RFC 0064 bucket D); it renders DDL/DML
+  // directly for the same reason the rest of the test-infra does. Anchored to
+  // the exact ported files — matching `fixtures.ts` by basename would also
+  // exempt any future same-named module elsewhere under activerecord/src.
+  "packages/activerecord/src/fixtures.ts",
+  "packages/activerecord/src/test-fixtures.ts",
+  "packages/activerecord/src/test-fixtures/**",
+  "packages/activerecord/src/support/**",
+  "packages/activerecord/src/test-setup-*.ts",
+  "packages/activerecord/src/cases/helper.ts",
+];
+
+/** Minimal glob → RegExp for the subset used above: `**`, `*`, literals. */
+function globToRegExp(glob) {
+  let source = "";
+  for (let i = 0; i < glob.length; i++) {
+    const ch = glob[i];
+    if (ch === "*") {
+      if (glob[i + 1] === "*") {
+        i++;
+        if (glob[i + 1] === "/") {
+          i++;
+          source += "(?:.*/)?";
+        } else {
+          source += ".*";
+        }
+      } else {
+        source += "[^/]*";
+      }
+    } else if ("\\^$.|?+()[]{}".includes(ch)) {
+      source += `\\${ch}`;
+    } else {
+      source += ch;
+    }
+  }
+  return new RegExp(`^${source}$`);
+}
+
+const ignoreRes = noRawSqlIgnores.map(globToRegExp);
+
+/** True when `rel` (a repo-relative path) is out of the rule's scope. */
+export function isExcludedPath(rel) {
+  return ignoreRes.some((re) => re.test(rel));
+}

--- a/eslint/no-raw-sql-scope.test.mjs
+++ b/eslint/no-raw-sql-scope.test.mjs
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { isExcludedPath, noRawSqlFiles, noRawSqlIgnores } from "./no-raw-sql-scope.mjs";
+
+const SRC = "packages/activerecord/src";
+
+describe("no-raw-sql scope", () => {
+  it("keeps ordinary activerecord src files in scope", () => {
+    expect(isExcludedPath(`${SRC}/relation.ts`)).toBe(false);
+    expect(isExcludedPath(`${SRC}/relation/query-methods.ts`)).toBe(false);
+    expect(isExcludedPath(`${SRC}/cases/other.ts`)).toBe(false);
+  });
+
+  it("scopes out the adapter, DDL and test-infra paths", () => {
+    for (const rel of [
+      `${SRC}/relation.test.ts`,
+      `${SRC}/connection-adapters/sqlite.ts`,
+      `${SRC}/adapters/pg.ts`,
+      `${SRC}/tasks/database.ts`,
+      `${SRC}/schema-dumper.ts`,
+      `${SRC}/migration/schema-statements.ts`,
+      `${SRC}/test-helpers/test-schema.ts`,
+      `${SRC}/support/canonical-schema.ts`,
+      `${SRC}/test-setup-ar.ts`,
+      `${SRC}/cases/helper.ts`,
+    ]) {
+      expect(isExcludedPath(rel), rel).toBe(true);
+    }
+  });
+
+  it("exposes the globs the flat config applies", () => {
+    expect(noRawSqlFiles).toEqual([`${SRC}/**/*.ts`]);
+    expect(noRawSqlIgnores).toContain(`${SRC}/cases/helper.ts`);
+  });
+});

--- a/eslint/no-raw-sql-scope.test.mjs
+++ b/eslint/no-raw-sql-scope.test.mjs
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isExcludedPath, noRawSqlFiles, noRawSqlIgnores } from "./no-raw-sql-scope.mjs";
+import { isExcludedPath, noRawSqlFiles, noRawSqlIgnores, repoRel } from "./no-raw-sql-scope.mjs";
 
 const SRC = "packages/activerecord/src";
 
@@ -30,5 +30,21 @@ describe("no-raw-sql scope", () => {
   it("exposes the globs the flat config applies", () => {
     expect(noRawSqlFiles).toEqual([`${SRC}/**/*.ts`]);
     expect(noRawSqlIgnores).toContain(`${SRC}/cases/helper.ts`);
+    for (const glob of noRawSqlIgnores) expect(glob.startsWith(`${SRC}/`)).toBe(true);
+  });
+
+  it("anchors repoRel to the same root, absolute paths included", () => {
+    expect(repoRel(`/home/dev/trails/${SRC}/relation.ts`)).toBe(`${SRC}/relation.ts`);
+    expect(repoRel(`${SRC}/relation.ts`)).toBe(`${SRC}/relation.ts`);
+    expect(repoRel("packages/arel/src/nodes.ts")).toBe(null);
+    expect(repoRel(`${SRC}/relation.js`)).toBe(null);
+  });
+
+  it("matches `**` at any depth, `*` within one segment only", () => {
+    expect(isExcludedPath(`${SRC}/schema-dumper.ts`)).toBe(true);
+    expect(isExcludedPath(`${SRC}/a/b/schema-x.ts`)).toBe(true);
+    expect(isExcludedPath(`${SRC}/test-setup-ar.ts`)).toBe(true);
+    // `test-setup-*.ts` is one segment: a nested test-setup file is still linted.
+    expect(isExcludedPath(`${SRC}/nested/test-setup-ar.ts`)).toBe(false);
   });
 });

--- a/eslint/no-raw-sql.mjs
+++ b/eslint/no-raw-sql.mjs
@@ -1,4 +1,4 @@
-import { isExcludedPath } from "./no-raw-sql-scope.mjs";
+import { isExcludedPath, repoRel } from "./no-raw-sql-scope.mjs";
 
 /**
  * ESLint rule: no-raw-sql
@@ -21,13 +21,6 @@ import { isExcludedPath } from "./no-raw-sql-scope.mjs";
  * eslint.config.mjs — and is re-checked here so the rule is testable by
  * filename.
  */
-
-/** Repo-relative path under packages/activerecord/src; null if outside it. */
-function repoRel(filename) {
-  const norm = filename.replace(/\\/g, "/");
-  const m = norm.match(/(?:^|\/)(packages\/activerecord\/src\/.+\.ts)$/);
-  return m ? m[1] : null;
-}
 
 const SQL_RE = /^\s*(SELECT|INSERT|UPDATE|DELETE|ALTER|CREATE|DROP|TRUNCATE)\b/i;
 

--- a/eslint/no-raw-sql.mjs
+++ b/eslint/no-raw-sql.mjs
@@ -1,3 +1,5 @@
+import { isExcludedPath } from "./no-raw-sql-scope.mjs";
+
 /**
  * ESLint rule: no-raw-sql
  *
@@ -15,10 +17,9 @@
  *       ✗ connection.execute("SELECT …")   ✓ throw new Error("SELECT failed")
  *   - noSqlSurgery: `.replace(`/`.concat(` on a variable named `sql` (RFC-0022).
  *
- * Scope (also set in eslint.config.mjs; re-checked here so the rule is testable
- * by filename): activerecord src .ts, excluding test files, connection-adapters,
- * adapters, tasks, schema-*.ts, and the test-infra DDL helpers (test-helpers/, support/
- * and test-setup-*.ts) — those legitimately render SQL by design.
+ * Scope lives in eslint/no-raw-sql-scope.mjs — a single glob list shared with
+ * eslint.config.mjs — and is re-checked here so the rule is testable by
+ * filename.
  */
 
 /** Repo-relative path under packages/activerecord/src; null if outside it. */
@@ -26,31 +27,6 @@ function repoRel(filename) {
   const norm = filename.replace(/\\/g, "/");
   const m = norm.match(/(?:^|\/)(packages\/activerecord\/src\/.+\.ts)$/);
   return m ? m[1] : null;
-}
-
-/** Directories / file patterns that legitimately render SQL → out of scope. */
-function isExcludedPath(rel) {
-  if (rel.endsWith(".test.ts")) return true;
-  if (/(^|\/)connection-adapters\//.test(rel)) return true;
-  if (/(^|\/)adapters\//.test(rel)) return true;
-  if (/(^|\/)tasks\//.test(rel)) return true;
-  if (/(^|\/)schema-[^/]*\.ts$/.test(rel)) return true;
-  // Test-infra DDL helpers render SQL by design and will never migrate to
-  // @blazetrails/arel — scope them out rather than baseline them so the
-  // RFC-0022 burndown worklist reflects only real arel migration targets.
-  if (/(^|\/)test-helpers\//.test(rel)) return true;
-  // The fixture machinery is `lib/active_record/fixtures.rb:595` /
-  // `test_fixtures.rb:113` code (RFC 0064 bucket D); it renders DDL/DML
-  // directly for the same reason the rest of the test-infra does. Anchored to
-  // the exact ported files — matching `fixtures.ts` by basename would also
-  // exempt any future same-named module elsewhere under activerecord/src.
-  if (rel === "packages/activerecord/src/fixtures.ts") return true;
-  if (rel === "packages/activerecord/src/test-fixtures.ts") return true;
-  if (rel.startsWith("packages/activerecord/src/test-fixtures/")) return true;
-  if (/(^|\/)support\//.test(rel)) return true;
-  if (/(^|\/)test-setup-[^/]*\.ts$/.test(rel)) return true;
-  if (/(^|\/)cases\/helper\.ts$/.test(rel)) return true;
-  return false;
 }
 
 const SQL_RE = /^\s*(SELECT|INSERT|UPDATE|DELETE|ALTER|CREATE|DROP|TRUNCATE)\b/i;


### PR DESCRIPTION
`eslint/no-raw-sql.mjs` hardcoded its scope-out paths as regexes in `isExcludedPath()` while `eslint.config.mjs` listed the same paths as globs. The two had to be edited together and nothing enforced that — PR #5395's `test-setup-ar.ts` → `cases/helper.ts` rename silently fell out of the rule's regex list and was only caught because the story spelled it out.

Everything now derives from `eslint/no-raw-sql-scope.mjs`:

- `noRawSqlRoot` — the one spelling of `packages/activerecord/src`.
- `noRawSqlFiles` / `noRawSqlIgnores` — consumed directly as the flat config's `files`/`ignores`, and the ignore list is written as root-relative globs joined onto the root.
- `isExcludedPath()` / `repoRel()` — the rule's own by-filename check, built from those same globs via a minimal glob→RegExp for the `**`/`*` subset used. No new deps.

Renaming or moving a scoped-out test-infra file now means editing exactly one place.

Behavior unchanged: classifying all 1510 `.ts` files under `packages/activerecord/src` with the old regex list and the new glob-derived `isExcludedPath()` yields 0 differences. The old regexes were nominally broader in two spots — `(^|/)support/` and `(^|/)test-setup-*.ts` also matched nested paths — but the config globs (which run first in CI, and are the authoritative list) never did, and no such nested file exists. `cases/helper.ts` was the only sub-directory match and it is globbed explicitly.

Rebased onto main, which meanwhile added `fixtures.ts` / `test-fixtures.ts` / `test-fixtures/**` to both lists — exactly the duplicated-edit this PR removes; they now live once, in the shared list.

New `eslint/no-raw-sql-scope.test.mjs` covers in-scope files, every scope-out category, the root anchoring of `repoRel`, and the `**`-vs-`*` depth semantics.

Closes-story: converge-no-raw-sql-scope-out-paths
