### PR TITLE
refactor(activerecord): converge PG remove_index and new_column_from_field call sets

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -537,7 +537,6 @@ describeIfPg("PostgreSQLAdapter", () => {
           `CREATE INDEX "things_Index" ON ${SCHEMA_NAME}.${TABLE_NAME} (${INDEX_A_COLUMN})`,
         );
 
-      // Rails: assert_nothing_raised { @connection.remove_index "things", name: "test_schema.things_Index" }
       await createIndex();
       await adapter.removeIndex(TABLE_NAME, { name: `${SCHEMA_NAME}.things_Index` });
 
@@ -549,8 +548,6 @@ describeIfPg("PostgreSQLAdapter", () => {
         name: `${SCHEMA_NAME}.things_Index`,
       });
 
-      // Rails: assert_raises(ArgumentError) — the index schema does not match the
-      // table schema.
       await createIndex();
       await expect(
         adapter.removeIndex(`${SCHEMA2_NAME}.${TABLE_NAME}`, {

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } 
 import { describeIfPg, PostgreSQLAdapter } from "./test-helper.js";
 import { itIfSupports } from "../../support/supports.js";
 import { StatementInvalid } from "../../errors.js";
+import { ArgumentError } from "@blazetrails/activemodel";
 import { makeThingModels, makeThing5Model, makeSongAlbumModels } from "./schema-ar-models.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
 import { dumpAllTableSchema } from "../../support/schema-dumping-helper.js";
@@ -531,11 +532,32 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("remove index when schema specified", async () => {
-      await adapter.setSchemaSearchPath(SCHEMA_NAME);
-      await adapter.addIndex(TABLE_NAME, ["email"], { name: "removable_idx" });
-      expect(await adapter.indexNameExists(TABLE_NAME, "removable_idx")).toBe(true);
-      await adapter.removeIndex(`${SCHEMA_NAME}.${TABLE_NAME}`, { name: "removable_idx" });
-      expect(await adapter.indexNameExists(TABLE_NAME, "removable_idx")).toBe(false);
+      const createIndex = () =>
+        adapter.exec(
+          `CREATE INDEX "things_Index" ON ${SCHEMA_NAME}.${TABLE_NAME} (${INDEX_A_COLUMN})`,
+        );
+
+      // Rails: assert_nothing_raised { @connection.remove_index "things", name: "test_schema.things_Index" }
+      await createIndex();
+      await adapter.removeIndex(TABLE_NAME, { name: `${SCHEMA_NAME}.things_Index` });
+
+      await createIndex();
+      await adapter.removeIndex(`${SCHEMA_NAME}.${TABLE_NAME}`, { name: "things_Index" });
+
+      await createIndex();
+      await adapter.removeIndex(`${SCHEMA_NAME}.${TABLE_NAME}`, {
+        name: `${SCHEMA_NAME}.things_Index`,
+      });
+
+      // Rails: assert_raises(ArgumentError) — the index schema does not match the
+      // table schema.
+      await createIndex();
+      await expect(
+        adapter.removeIndex(`${SCHEMA2_NAME}.${TABLE_NAME}`, {
+          name: `${SCHEMA_NAME}.things_Index`,
+        }),
+      ).rejects.toThrow(ArgumentError);
+      await adapter.exec(`DROP INDEX ${SCHEMA_NAME}."things_Index"`);
     });
 
     it("primary key with schema specified", async () => {

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -323,6 +323,12 @@ export interface AbstractAdapter {
     columns: string | string[] | null | undefined,
     options?: { name?: string; unique?: boolean; valid?: boolean },
   ): Promise<boolean>;
+  /** @internal */
+  indexNameForRemove(
+    tableName: string,
+    columnName: string | null | undefined,
+    options: { name?: string; column?: string | string[] },
+  ): Promise<string>;
   tableExists(tableName: string): Promise<boolean>;
   // Options SchemaMigration / InternalMetadata pass to `t.string` for their
   // primary key. Mixed in from SchemaStatements; declared here so those

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -13,7 +13,7 @@ import { Result } from "../result.js";
 import { HashLookupTypeMap } from "../type/hash-lookup-type-map.js";
 import { TypeMap } from "../type/type-map.js";
 import { getDefaultTimezone } from "../type/internal/timezone.js";
-import { Utils } from "./postgresql/utils.js";
+import { Name, Utils } from "./postgresql/utils.js";
 import {
   checkAllForeignKeysValidBang,
   disableReferentialIntegrity,
@@ -75,12 +75,7 @@ import { deprecator } from "../deprecator.js";
 import { captureUnwrappedExecute, dirtiesQueryCache } from "./abstract/query-cache.js";
 import { PostgreSQLSchemaStatements } from "./postgresql/schema-statements-class.js";
 import type { JoinTableOptions } from "./abstract/schema-statements.js";
-import {
-  SchemaStatements,
-  indexNameForRemoveFrom,
-  indexExistsForRemoveFrom,
-  canRemoveIndexByName,
-} from "./abstract/schema-statements.js";
+import { SchemaStatements } from "./abstract/schema-statements.js";
 import { StatementPool as GenericStatementPool } from "./statement-pool.js";
 import {
   transactionIsolationLevels,
@@ -4205,49 +4200,44 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       throw new Error("DROP INDEX CONCURRENTLY cannot run inside a transaction");
     }
 
-    // Rails strips the schema from the table (PG `index_name` resolves against
-    // the unqualified table) and, when a name is given, splits its schema off:
-    // the bare identifier becomes the name to match, the index is dropped in the
-    // table's schema (or the name's schema when the table is unqualified), and a
-    // conflicting schema pair raises.
-    const [tableSchema, bareTable] = this.extractSchemaQualifiedName(tableName);
-    let dropSchema = tableSchema;
+    // Rails: `table = Utils.extract_schema_qualified_name(table_name.to_s)`, and
+    // when a name is given its schema is split off: the bare identifier becomes
+    // the name to match, the index is dropped in the table's schema (or the
+    // name's schema when the table is unqualified), and a conflicting pair raises.
+    let table = Utils.extractSchemaQualifiedName(tableName);
     let resolveOpts = opts;
     if (opts.name != null) {
-      const [nameSchema, nameIdent] = this.extractSchemaQualifiedName(opts.name);
-      resolveOpts = { ...opts, name: nameIdent };
-      if (!tableSchema) dropSchema = nameSchema;
-      if (nameSchema && tableSchema && nameSchema !== tableSchema) {
+      const providedIndex = Utils.extractSchemaQualifiedName(opts.name);
+      resolveOpts = { ...opts, name: providedIndex.identifier };
+      const tableSchema = table.schema;
+      if (!tableSchema) table = new Name(providedIndex.schema, table.identifier);
+      if (providedIndex.schema && tableSchema && tableSchema !== providedIndex.schema) {
         throw new ArgumentError(
-          `Index schema '${nameSchema}' does not match table schema '${tableSchema}'`,
+          `Index schema '${providedIndex.schema}' does not match table schema '${tableSchema}'`,
         );
       }
     }
 
-    // A bare `{ name }` resolves without introspection (Rails
-    // `can_remove_index_by_name?`); otherwise (or for `ifExists`) fetch indexes.
-    const canRemoveByName = canRemoveIndexByName(columnName, resolveOpts);
-    const all =
-      opts.ifExists || !canRemoveByName
-        ? ((await this.indexes(tableName)) as Array<{ name: string; columns: string[] }>)
-        : [];
-    // Rails: `return if options[:if_exists] && !index_exists?(...)`.
-    const genName = (t: string, c: string | string[]) => this.generateIndexName(t, c);
-    if (
-      opts.ifExists &&
-      !indexExistsForRemoveFrom(genName, all, bareTable, columnName, resolveOpts)
-    ) {
+    // Rails: `return if options[:if_exists] && !index_exists?(table_name, column_name, **options)`.
+    if (opts.ifExists && !(await this.indexExists(tableName, columnName, resolveOpts))) {
       return;
     }
-    const indexName = indexNameForRemoveFrom(genName, all, bareTable, columnName, resolveOpts);
 
-    // Rails quotes a PostgreSQL::Name, which quotes the schema and the bare
-    // identifier separately — the index name itself can contain a dot (an index
-    // on a schema-qualified table), so it must not be re-split here.
-    const prefix = dropSchema ? `${this.quoteTableName(dropSchema)}.` : "";
+    // Rails: `index_name_for_remove(table.to_s, column_name, options)` — the
+    // schema-qualified name, so a generated index name matches the one addIndex
+    // would have produced for the same argument.
+    const positional = typeof columnName === "string" ? columnName : null;
+    const nameOpts = Array.isArray(columnName)
+      ? { ...resolveOpts, column: columnName }
+      : resolveOpts;
+    const indexToRemove = new Name(
+      table.schema,
+      await this.indexNameForRemove(table.toString(), positional, nameOpts),
+    );
+
     const algorithm = this.indexAlgorithm(opts.algorithm);
     await this.execute(
-      `DROP INDEX${algorithm ? ` ${algorithm}` : ""} ${prefix}${this.quoteColumnName(indexName)}`,
+      `DROP INDEX${algorithm ? ` ${algorithm}` : ""} ${this.quoteTableName(indexToRemove.toString())}`,
     );
   }
 
@@ -4813,40 +4803,61 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     field: unknown[],
     _definitions: unknown,
   ): Promise<Column> {
-    const [col, type, raw, notnull, oid, fmod, , , identity, gen] = field as [
-      string,
-      string,
-      string | null,
-      boolean,
-      number,
-      number,
-      unknown,
-      unknown,
-      string | null,
-      string | null,
-    ];
-    const meta = await this.fetchTypeMetadata(col, type, Number(oid), Number(fmod));
-    const split = gen ? null : splitPgDefault(raw);
+    const [columnName, type, default_, notnull, oid, fmod, collation, comment, identity, gen] =
+      field as [
+        string,
+        string,
+        string | null,
+        boolean,
+        number,
+        number,
+        string | null,
+        string | null,
+        string | null,
+        string | null,
+      ];
+    const typeMetadata = await this.fetchTypeMetadata(columnName, type, Number(oid), Number(fmod));
     // Store the raw default literal verbatim (Rails' extract_value_from_default);
     // deserialization is deferred to Attribute.from_database so
     // *_before_type_cast for a column default returns the raw String.
-    const rawLiteral = gen ? null : (split?.literal ?? null);
+    const defaultValue = this.extractValueFromDefault(default_);
+
+    let defaultFunction: string | null;
+    if (gen) {
+      defaultFunction = default_;
+    } else {
+      defaultFunction = this.extractDefaultFunction(defaultValue, default_);
+    }
+
+    // Rails: a column is serial only when its `nextval()` default names the very
+    // sequence `sequence_name_from_parts` would generate for this table+column.
+    let serial: boolean | undefined;
+    const match = defaultFunction?.match(
+      /^nextval\('"?(?<sequenceName>.+_(?<suffix>seq\d*))"?'::regclass\)$/,
+    );
+    if (match) {
+      const { sequenceName, suffix } = match.groups!;
+      serial = this.sequenceNameFromParts(tableName, columnName, suffix) === sequenceName;
+    }
+
     return new Column(
-      col,
-      rawLiteral,
+      columnName,
+      defaultValue,
       {
-        sqlType: meta.sqlType,
-        type: meta.type,
+        sqlType: typeMetadata.sqlType,
+        type: typeMetadata.type,
         oid: Number(oid),
         fmod: Number(fmod),
-        limit: meta.limit,
-        precision: meta.precision,
-        scale: meta.scale,
+        limit: typeMetadata.limit,
+        precision: typeMetadata.precision,
+        scale: typeMetadata.scale,
       },
       !notnull,
       {
-        defaultFunction: (gen ? raw : split?.fn) ?? undefined,
-        serial: this.serialFromDefaultFunction(tableName, col, (gen ? raw : split?.fn) ?? null),
+        defaultFunction: defaultFunction ?? undefined,
+        collation: collation ?? undefined,
+        comment: comment || null,
+        serial,
         array: type.endsWith("[]"),
         identity: identity || null,
         generated: gen || null,
@@ -5026,6 +5037,18 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     if (num) return num[1];
     // Object identifier (bare integer)
     if (/^-?\d+$/.test(defaultExpr)) return defaultExpr;
+    // Deviation from Rails, which only allows an optional `::bigint` suffix on
+    // the numeric branch above and therefore reflects these as *function*
+    // defaults. PG emits `(150.55)::numeric::money` for `DEFAULT 150.55` on a
+    // money column and `(3.14...)::numeric` for a decimal domain column, and
+    // both money_test.rb ("default") and the domain-default schema tests assert
+    // a literal default there, so the multi-cast numeric forms are parsed here.
+    const parenNum = /^\((-?\d+(?:\.\d+)?)\)(?:::[\w"\s.]+)+$/.exec(defaultExpr);
+    if (parenNum) return parenNum[1];
+    // N::type[::type2...] — PG normalizes multi-cast numerics to the parens form
+    // above; this branch is defensive.
+    const castNum = /^(-?\d+(?:\.\d+)?)(?:::[\w"\s.]+)+$/.exec(defaultExpr);
+    if (castNum) return castNum[1];
     return null;
   }
 
@@ -5381,57 +5404,6 @@ function _pgAdvisoryLockSql(
   if (typeof lockId === "bigint") return [`SELECT ${fn}($1::bigint) AS ${col}`, lockId.toString()];
   if (typeof lockId === "number") return [`SELECT ${fn}($1) AS ${col}`, lockId];
   return [`SELECT ${fn}(hashtext($1)) AS ${col}`, lockId];
-}
-
-/**
- * Parse a raw `pg_attrdef` default expression into a literal value or a
- * SQL function expression. Mirrors Rails' PG `extract_value_from_default`
- * / `extract_default_function` split — so schema reflection can carry
- * expression defaults as `defaultFunction` rather than applying them as
- * literal bind values.
- */
-export function splitPgDefault(raw: string | null): { literal: unknown; fn: string | null } {
-  if (raw == null) return { literal: null, fn: null };
-  // 'value'::type[] — array literal with a cast; {} is the PG empty-array literal.
-  // Return the raw PG array string so the call site can deserialize via the
-  // correct cast type (e.g. OID::Array<Integer> returns [4,4,2] not ["4","4","2"]).
-  const arrayLiteral = /^'((?:[^']|'')*)'::[\w"\s.(,)]+\[\]$/.exec(raw);
-  if (arrayLiteral) {
-    const content = arrayLiteral[1].replace(/''/g, "'");
-    return { literal: content, fn: null };
-  }
-  // 'value'::type — quoted literal with a single cast (intentionally single-cast;
-  // multi-cast quoted forms like 'x'::text::domain fall to DEFAULT_FUNCTION_RE
-  // and are treated as function defaults, consistent with the domain-cast policy).
-  const quoted = /^'((?:[^']|'')*)'::[\w"\s.]+$/.exec(raw);
-  if (quoted) return { literal: quoted[1].replace(/''/g, "'"), fn: null };
-  // (N)::type[::type2...] — numeric wrapped in parens with one or more casts.
-  // PG emits `(150.55)::numeric::money` for `DEFAULT 150.55::numeric::money`.
-  // Rails' extract_value_from_default (postgresql_adapter.rb:769) only allows
-  // an optional ::bigint suffix and would misclassify this as a function default;
-  // we go beyond Rails' implementation to match what money_test.rb:98 asserts.
-  const parenNum = /^\((-?\d+(?:\.\d+)?)\)(?:::[\w"\s.]+)+$/.exec(raw);
-  if (parenNum) return { literal: parenNum[1], fn: null };
-  // N::type[::type2...] — bare numeric with one or more casts. PG normalizes
-  // multi-cast numerics to the parens form above; this branch is defensive.
-  const castNum = /^(-?\d+(?:\.\d+)?)(?:::[\w"\s.]+)+$/.exec(raw);
-  if (castNum) return { literal: castNum[1], fn: null };
-  // Bare numeric / boolean / NULL literal.
-  if (/^-?\d+(?:\.\d+)?$/.test(raw)) return { literal: raw, fn: null };
-  // Rails' extract_value_from_default keeps the raw "true"/"false" string;
-  // deserialization to a JS boolean happens later in Attribute.from_database.
-  if (raw === "true" || raw === "false") return { literal: raw, fn: null };
-  if (raw === "NULL") return { literal: null, fn: null };
-  // Everything else: only treat as a SQL function expression if it matches
-  // Rails' has_default_function? regex — a function call, a parenthesized
-  // expression with a cast, or CURRENT_DATE/CURRENT_TIMESTAMP. Arithmetic-
-  // expression defaults like `(((4 + 4) * 2) / 4)` match none of these and
-  // Rails reflects them with both `default` and `default_function` as nil
-  // (the DB still applies the default on INSERT).
-  if (DEFAULT_FUNCTION_RE.test(raw)) {
-    return { literal: null, fn: raw };
-  }
-  return { literal: null, fn: null };
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -3958,11 +3958,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   /**
-   * Mirrors Rails `new_column_from_field`'s serial detection: a column is
-   * serial only when its `nextval()` default references the very sequence name
-   * `sequenceNameFromParts` would generate for this table+column. A plain
-   * `default: -> { "nextval('some_seq')" }` whose sequence doesn't follow the
-   * `<table>_<column>_seq` convention is NOT serial.
+   * The serial detection Rails inlines in `new_column_from_field`, extracted so
+   * PostgreSQLSchemaStatements#columns can share it: that path cannot delegate
+   * to newColumnFromField because it batch-preloads the row OIDs and resolves
+   * types through lookupCastTypeFromColumn, where fetchTypeMetadata would issue
+   * a per-column pg_type query.
    * @internal
    */
   serialFromDefaultFunction(
@@ -3970,10 +3970,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     columnName: string,
     defaultFunction: string | null,
   ): boolean {
-    if (defaultFunction == null) return false;
-    const match = /^nextval\('"?(.+_(seq\d*))"?'::regclass\)$/.exec(defaultFunction);
+    const match = defaultFunction?.match(SERIAL_SEQUENCE_RE);
     if (!match) return false;
-    const [, sequenceName, suffix] = match;
+    const { sequenceName, suffix } = match.groups!;
     return this.sequenceNameFromParts(tableName, columnName, suffix) === sequenceName;
   }
 
@@ -4200,10 +4199,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       throw new Error("DROP INDEX CONCURRENTLY cannot run inside a transaction");
     }
 
-    // Rails: `table = Utils.extract_schema_qualified_name(table_name.to_s)`, and
-    // when a name is given its schema is split off: the bare identifier becomes
-    // the name to match, the index is dropped in the table's schema (or the
-    // name's schema when the table is unqualified), and a conflicting pair raises.
     let table = Utils.extractSchemaQualifiedName(tableName);
     let resolveOpts = opts;
     if (opts.name != null) {
@@ -4218,14 +4213,13 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       }
     }
 
-    // Rails: `return if options[:if_exists] && !index_exists?(table_name, column_name, **options)`.
     if (opts.ifExists && !(await this.indexExists(tableName, columnName, resolveOpts))) {
       return;
     }
 
-    // Rails: `index_name_for_remove(table.to_s, column_name, options)` — the
-    // schema-qualified name, so a generated index name matches the one addIndex
-    // would have produced for the same argument.
+    // Rails resolves the name against `table.to_s` — the SCHEMA-QUALIFIED name,
+    // so a generated index name matches the one addIndex produced for the same
+    // argument. Passing the bare identifier here silently misses those.
     const positional = typeof columnName === "string" ? columnName : null;
     const nameOpts = Array.isArray(columnName)
       ? { ...resolveOpts, column: columnName }
@@ -4817,9 +4811,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         string | null,
       ];
     const typeMetadata = await this.fetchTypeMetadata(columnName, type, Number(oid), Number(fmod));
-    // Store the raw default literal verbatim (Rails' extract_value_from_default);
-    // deserialization is deferred to Attribute.from_database so
-    // *_before_type_cast for a column default returns the raw String.
+    // The literal stays a raw String: deserialization is deferred to
+    // Attribute.from_database so *_before_type_cast reads back the raw default.
     const defaultValue = this.extractValueFromDefault(default_);
 
     let defaultFunction: string | null;
@@ -4829,12 +4822,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       defaultFunction = this.extractDefaultFunction(defaultValue, default_);
     }
 
-    // Rails: a column is serial only when its `nextval()` default names the very
-    // sequence `sequence_name_from_parts` would generate for this table+column.
     let serial: boolean | undefined;
-    const match = defaultFunction?.match(
-      /^nextval\('"?(?<sequenceName>.+_(?<suffix>seq\d*))"?'::regclass\)$/,
-    );
+    const match = defaultFunction?.match(SERIAL_SEQUENCE_RE);
     if (match) {
       const { sequenceName, suffix } = match.groups!;
       serial = this.sequenceNameFromParts(tableName, columnName, suffix) === sequenceName;
@@ -5045,8 +5034,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     // a literal default there, so the multi-cast numeric forms are parsed here.
     const parenNum = /^\((-?\d+(?:\.\d+)?)\)(?:::[\w"\s.]+)+$/.exec(defaultExpr);
     if (parenNum) return parenNum[1];
-    // N::type[::type2...] — PG normalizes multi-cast numerics to the parens form
-    // above; this branch is defensive.
     const castNum = /^(-?\d+(?:\.\d+)?)(?:::[\w"\s.]+)+$/.exec(defaultExpr);
     if (castNum) return castNum[1];
     return null;
@@ -5413,6 +5400,9 @@ function _pgAdvisoryLockSql(
  * unrecognized expression and does not populate Column#default_function.
  */
 const DEFAULT_FUNCTION_RE = /\w+\(.*\)|\(.*\)::\w+|CURRENT_DATE|CURRENT_TIMESTAMP/;
+
+/** Mirrors the `nextval(...)` match inlined in Rails' `new_column_from_field`. */
+const SERIAL_SEQUENCE_RE = /^nextval\('"?(?<sequenceName>.+_(?<suffix>seq\d*))"?'::regclass\)$/;
 
 (PostgreSQLAdapter.prototype as any).performQuery = performQuery;
 (PostgreSQLAdapter.prototype as any).castResult = castResult;

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/interval.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/interval.ts
@@ -41,7 +41,7 @@ export class Interval extends ValueType<Duration> {
         // and SELECT interval results arrive in ISO 8601 form that
         // Duration.parse accepts directly. For schema reflection,
         // pg_get_expr returns a casted form like `'P3Y'::interval`; the
-        // adapter's splitPgDefault strips the cast before this method
+        // adapter's extractValueFromDefault strips the cast before this method
         // sees `"P3Y"`.
         return null;
       }

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -18,7 +18,6 @@ import { HashLookupTypeMap } from "../../type/hash-lookup-type-map.js";
 import { Column } from "./column.js";
 import { quoteColumnName as pgQuoteColumnName } from "./quoting.js";
 import { unquoteIdentifier, splitQuotedIdentifier, Name, Utils } from "./utils.js";
-import { splitPgDefault } from "../postgresql-adapter.js";
 import type { CreateDatabaseOptions, PgIndexDefinition } from "./schema-statements.js";
 import {
   type AlterTable as PgAlterTable,
@@ -74,6 +73,8 @@ interface PgSchemaAdapter {
     columnName: string,
     defaultFunction: string | null,
   ): boolean;
+  extractValueFromDefault(defaultExpr: string | null): unknown;
+  extractDefaultFunction(defaultValue: unknown, defaultExpr: string | null): string | null;
   nativeDatabaseTypes(): Record<string, string | { name?: string; limit?: number }>;
   createTableDefinition(name: string, options?: Record<string, unknown>): AbstractTableDefinition;
   createAlterTable(name: string): AlterTable;
@@ -729,9 +730,10 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
       // The raw literal is stored verbatim (Rails' extract_value_from_default);
       // deserialization is deferred to Attribute.from_database, so
       // *_before_type_cast for a column default returns the raw String.
-      const splitDefault = attgenerated ? null : splitPgDefault(rawDefault);
-      const defaultFunction = attgenerated ? rawDefault : (splitDefault?.fn ?? null);
-      const rawLiteral = attgenerated ? null : (splitDefault?.literal ?? null);
+      const defaultValue = this.pg.extractValueFromDefault(rawDefault);
+      const defaultFunction = attgenerated
+        ? rawDefault
+        : this.pg.extractDefaultFunction(defaultValue, rawDefault);
       const isSerial = this.pg.serialFromDefaultFunction(
         tableName,
         r.name as string,
@@ -740,7 +742,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
 
       return new Column(
         r.name as string,
-        rawLiteral,
+        defaultValue,
         {
           sqlType,
           type: castType.type(),

--- a/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude/activerecord/connection-adapters/postgresql-adapter.json
@@ -459,21 +459,21 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "exclusion_constraint_name",
     "call": "fetch",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Syntax-only (RFC 0072 converge-pg-remove-index-and-new-column-from-field-call-sets): Ruby `options.fetch(:name)`; JS property access on an object literal has no method equivalent."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "exclusion_constraint_name",
     "call": "first",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Syntax-only (RFC 0072 converge-pg-remove-index-and-new-column-from-field-call-sets): Ruby `Enumerable#first(n)` on the digest; JS uses `String#slice(0, n)`."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "exclusion_constraint_name",
     "call": "hexdigest",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Syntax-only (RFC 0072 converge-pg-remove-index-and-new-column-from-field-call-sets): Ruby `Digest::SHA256.hexdigest`; JS uses the WebCrypto/`createHash` hex digest. The derivation is byte-identical — schema-statements-class.trails.test.ts pins `excl_rails_74c9160f55` against Rails' own literal."
   },
   {
     "package": "activerecord",
@@ -766,57 +766,29 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "new_column_from_field",
-    "call": "extract_default_function",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "new_column_from_field",
-    "call": "extract_value_from_default",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "new_column_from_field",
-    "call": "match",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "new_column_from_field",
     "call": "presence",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "new_column_from_field",
-    "call": "sequence_name_from_parts",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Syntax-only (RFC 0072 converge-pg-remove-index-and-new-column-from-field-call-sets): Ruby `comment.presence` / `identity.presence` normalising \"\" to nil; JS uses `||` on the already-nullable string, which yields the same nil-or-non-empty value."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "pk_and_sequence_for",
     "call": "last",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Deviation, justified at the call site (RFC 0072 converge-pg-remove-index-and-new-column-from-field-call-sets): Rails runs two `query` calls (pg_depend, then a pg_attrdef fallback) and reads `result.last` off the row array. trails runs a single pg_index query whose LEFT JOIN on pg_attrdef folds Rails' fallback into the same result set, so there is no second result to take the last of. See PostgreSQLSchemaStatements#pkAndSequenceFor."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "pk_and_sequence_for",
     "call": "new",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Deviation, justified at the call site (RFC 0072 converge-pg-remove-index-and-new-column-from-field-call-sets): Rails returns `[pk, PostgreSQL::Name.new(*result)]`; trails returns a plain `{ schema, name }` pair. Converging the return type to Name ripples into setPkSequenceBang / resetPkSequenceBang / renameTable and is tracked separately. See PostgreSQLSchemaStatements#pkAndSequenceFor."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "pk_and_sequence_for",
     "call": "query",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Deviation, justified at the call site (RFC 0072 converge-pg-remove-index-and-new-column-from-field-call-sets): trails issues the single rewritten lookup through `schemaQuery` (query(sql, \"SCHEMA\")) rather than Rails' two `query` calls. See PostgreSQLSchemaStatements#pkAndSequenceFor."
   },
   {
     "package": "activerecord",
@@ -943,20 +915,6 @@
     "rubyName": "reload_type_map",
     "call": "synchronize",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "remove_index",
-    "call": "index_exists?",
-    "reason": "Equivalent (RFC 0072 converge-pg-ddl-exec-primitive-and-quoting-routing): trails resolves the if_exists guard and the index name from a single already-fetched `indexes(table_name)` list via indexExistsForRemoveFrom / indexNameForRemoveFrom, rather than re-issuing introspection through index_exists? / index_name_for_remove."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql-adapter.ts",
-    "rubyName": "remove_index",
-    "call": "index_name_for_remove",
-    "reason": "Equivalent (RFC 0072 converge-pg-ddl-exec-primitive-and-quoting-routing): trails resolves the if_exists guard and the index name from a single already-fetched `indexes(table_name)` list via indexExistsForRemoveFrom / indexNameForRemoveFrom, rather than re-issuing introspection through index_exists? / index_name_for_remove."
   },
   {
     "package": "activerecord",
@@ -1096,7 +1054,7 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "sequence_name_from_parts",
     "call": "sum",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Syntax-only (RFC 0072 converge-pg-remove-index-and-new-column-from-field-call-sets): Ruby `Array#sum(&:length)`; JS has no Array#sum, so the three lengths are added directly."
   },
   {
     "package": "activerecord",
@@ -1180,28 +1138,28 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "unique_constraint_name",
     "call": "fetch",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Syntax-only (RFC 0072 converge-pg-remove-index-and-new-column-from-field-call-sets): Ruby `options.fetch(:name)`; JS property access on an object literal has no method equivalent."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "unique_constraint_name",
     "call": "first",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Syntax-only (RFC 0072 converge-pg-remove-index-and-new-column-from-field-call-sets): Ruby `Enumerable#first(n)` on the digest; JS uses `String#slice(0, n)`."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "unique_constraint_name",
     "call": "hexdigest",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Syntax-only (RFC 0072 converge-pg-remove-index-and-new-column-from-field-call-sets): Ruby `Digest::SHA256.hexdigest`; JS uses the WebCrypto/`createHash` hex digest. The derivation is byte-identical — schema-statements-class.trails.test.ts pins `uniq_rails_1e07660b77` / `uniq_rails_79b901ffb4` against Rails' own literals."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "unique_constraint_name",
     "call": "map",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Syntax-only (RFC 0072 converge-pg-remove-index-and-new-column-from-field-call-sets): Ruby `Array#map(&:to_s)` coercing the column list; JS columns are already strings, so the join is direct."
   },
   {
     "package": "activerecord",


### PR DESCRIPTION
Remainder of the `converge-pg-sequence-and-schema-qualified-name-helpers`
cluster (RFC 0072).

### `remove_index`

`PostgreSQLAdapter#removeIndex` reimplemented Rails' body against the
free-function remove-index helpers (`indexExistsForRemoveFrom` /
`indexNameForRemoveFrom`) over a pre-fetched index list. It now mirrors
`PostgreSQL::SchemaStatements#remove_index` (`schema_statements.rb:543`):
build a `PostgreSQL::Name` for the table, short-circuit through
`indexExists`, resolve the concrete name via
`indexNameForRemove(table.toString(), ...)`, wrap it in a `Name` with the
table's schema, and drop through `quoteTableName`.

Two behavioural consequences, both toward Rails: the name-generation table is
now the schema-qualified `table.to_s` (matching what `addIndex` uses, so a
generated index name on a qualified table now resolves instead of silently
missing), and the index name goes through `quote_table_name`'s schema split
rather than a separately-quoted schema prefix. Like Rails, the `ifExists` path
now costs a second `indexes()` round trip.

### `new_column_from_field`

The serial detection routed through the bespoke `serialFromDefaultFunction`,
and default parsing through the bespoke `splitPgDefault`. `newColumnFromField`
now composes `extractValueFromDefault` / `extractDefaultFunction` /
`sequenceNameFromParts` the way Rails does (`schema_statements.rb:966`), and
passes `collation` / `comment` through (previously dropped on the floor).

The live reflection path — `columns()` in
`postgresql/schema-statements-class.ts` — is rewired onto the same two
helpers, and `splitPgDefault` is deleted. The multi-cast numeric forms it
recognised beyond Rails (`(150.55)::numeric::money` for money defaults,
`(3.14...)::numeric` for a decimal domain column) move into
`extractValueFromDefault` with the justification at the branch, since that is
where Rails hosts the numeric branch.

`columns()` still does not delegate to `newColumnFromField` the way Rails'
`SchemaStatements#columns` does: it batch-preloads the row OIDs and resolves
types through `lookupCastTypeFromColumn`, where `fetchTypeMetadata` would
issue a per-column `pg_type` query. The serial match the two paths share is
now one regex constant plus `serialFromDefaultFunction`, documented at that
method.

### `pk_and_sequence_for`

Deviation kept and justified in the baseline reason: the single rewritten
pg_index query folds Rails' pg_attrdef fallback into one result set (so there
is no second result to take `last` of), and converging the return type to
`PostgreSQL::Name` ripples into `setPkSequenceBang` / `resetPkSequenceBang` /
`renameTable`.

### Bucket-(b) reasons

`fetch` / `first` / `hexdigest` / `map` / `sum` / `presence` get explicit
Ruby-idiom reasons in place of the generic RFC 0047 seed text.

### Tests

`remove index when schema specified` now ports Rails'
`test_remove_index_when_schema_specified` (`schema_test.rb:411`) in full —
all three passing schema/name combinations plus the mismatched-schema
`ArgumentError`. The existing `serial column` / `not serial column` /
`bigserial column` / `not bigserial column` ports (`serial_test.rb`) cover the
rebuilt serial detection.

### Verification

- `pnpm api:calls:wide`: OK. `postgresql-adapter.ts` baseline 176 -> 170.
- `pnpm api:compare` (forced): Data layer 7718/7810, Overall 11696/17484 —
  identical to `origin/main`.
- `pnpm test:compare`: 14620/21663, 3941 extra — identical to `origin/main`.
- PostgreSQL 17 locally: all of
  `packages/activerecord/src/adapters/postgresql/` and
  `connection-adapters/postgresql*`, plus `defaults.test.ts`,
  `schema-dumper.test.ts` and `migration.test.ts`, pass. The only failure,
  `foreign-table.test.ts`, is the local FDW loopback and fails on a clean
  checkout too.

Closes-story: converge-pg-remove-index-and-new-column-from-field-call-sets
